### PR TITLE
Add maven functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,7 @@ checkstyle:
 
 test:
 	# See navigation/libandroid-navigation/build.gradle for details
-	cd navigation; ./gradlew :libandroid-navigation:copyResourcesToClasses
-	cd navigation; ./gradlew :libandroid-navigation:testDebugUnitTest
+	cd navigation; ./gradlew :libandroid-navigation:test
 
 build-release:
 	cd navigation; ./gradlew :libandroid-navigation:assembleRelease

--- a/navigation/gradle.properties
+++ b/navigation/gradle.properties
@@ -1,4 +1,18 @@
 # Project-wide Gradle settings.
+VERSION_NAME=0.1.0-SNAPSHOT
+GROUP=com.mapbox.mapboxsdk
+
+POM_URL=https://github.com/mapbox/mapbox-navigation-android
+POM_SCM_URL=https://github.com/mapbox/mapbox-navigation-android
+POM_SCM_CONNECTION=scm:git@github.com:mapbox/mapbox-navigation-android.git
+POM_SCM_DEV_CONNECTION=scm:git@github.com:mapbox/mapbox-navigation-android.git
+
+POM_LICENCE_NAME=The Apache Software License, Version 2.0
+POM_LICENCE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt
+POM_LICENCE_DIST=repo
+
+POM_DEVELOPER_ID=mapbox
+POM_DEVELOPER_NAME=Mapbox
 
 # IDE (e.g. Android Studio) users:
 # Gradle settings configured through the IDE *will override*

--- a/navigation/libandroid-navigation/build.gradle
+++ b/navigation/libandroid-navigation/build.gradle
@@ -69,4 +69,6 @@ tasks.whenTaskAdded { task ->
         task.dependsOn('copyResourcesToClassesRelease')
 }
 
+apply from: 'javadoc.gradle'
+apply from: '../mvn-push-android.gradle'
 apply from: '../checkstyle.gradle'

--- a/navigation/libandroid-navigation/gradle.properties
+++ b/navigation/libandroid-navigation/gradle.properties
@@ -1,0 +1,4 @@
+POM_ARTIFACT_ID=mapbox-android-navigation
+POM_NAME=Mapbox Android Navigation
+POM_DESCRIPTION=Mapbox Android Navigation
+POM_PACKAGING=aar

--- a/navigation/libandroid-navigation/javadoc.gradle
+++ b/navigation/libandroid-navigation/javadoc.gradle
@@ -1,0 +1,17 @@
+android.libraryVariants.all { variant ->
+    def name = variant.name
+    task "javadoc$name"(type: Javadoc) {
+        description = "Generates javadoc for build $name"
+        failOnError = false
+        destinationDir = new File(destinationDir, variant.baseName)
+        source = files(variant.javaCompile.source)
+        classpath = files(variant.javaCompile.classpath.files) + files(android.bootClasspath)
+        options.windowTitle("Mapbox Android Navigation SDK $VERSION_NAME Reference")
+        options.docTitle("Mapbox Android Navigation SDK $VERSION_NAME")
+        options.header("Mapbox Android Navigation SDK $VERSION_NAME Reference")
+        options.bottom("&copy; 2017 Mapbox. All rights reserved.")
+        options.links("http://docs.oracle.com/javase/7/docs/api/")
+        options.linksOffline("http://d.android.com/reference/", "$System.env.ANDROID_HOME/docs/reference")
+        exclude '**/R.java', '**/BuildConfig.java'
+    }
+}

--- a/navigation/mvn-push-android.gradle
+++ b/navigation/mvn-push-android.gradle
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2013 Chris Banes
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+apply plugin: 'maven'
+apply plugin: 'signing'
+
+def isReleaseBuild() {
+    return VERSION_NAME.contains("SNAPSHOT") == false
+}
+
+def isLocalBuild() {
+    if (System.getenv('IS_LOCAL_DEVELOPMENT') != null) {
+        return System.getenv('IS_LOCAL_DEVELOPMENT').toBoolean()
+    }
+    return true
+}
+
+def getReleaseRepositoryUrl() {
+    return hasProperty('RELEASE_REPOSITORY_URL') ? RELEASE_REPOSITORY_URL
+            : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+}
+
+def getSnapshotRepositoryUrl() {
+    return hasProperty('SNAPSHOT_REPOSITORY_URL') ? SNAPSHOT_REPOSITORY_URL
+            : "https://oss.sonatype.org/content/repositories/snapshots/"
+}
+
+def obtainMavenLocalUrl() {
+    return getRepositories().mavenLocal().getUrl()
+}
+
+def getRepositoryUsername() {
+    return hasProperty('NEXUS_USERNAME') ? NEXUS_USERNAME : ""
+}
+
+def getRepositoryPassword() {
+    return hasProperty('NEXUS_PASSWORD') ? NEXUS_PASSWORD : ""
+}
+
+afterEvaluate { project ->
+    uploadArchives {
+        repositories {
+            mavenDeployer {
+                beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+
+                pom.groupId = GROUP
+                pom.artifactId = POM_ARTIFACT_ID
+                pom.version = VERSION_NAME
+
+                if (isLocalBuild()) {
+                    repository(url: obtainMavenLocalUrl())
+                } else {
+                    repository(url: getReleaseRepositoryUrl()) {
+                        authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
+                    }
+                    snapshotRepository(url: getSnapshotRepositoryUrl()) {
+                        authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
+                    }
+                }
+
+                pom.project {
+                    name POM_NAME
+                    packaging POM_PACKAGING
+                    description POM_DESCRIPTION
+                    url POM_URL
+
+                    scm {
+                        url POM_SCM_URL
+                        connection POM_SCM_CONNECTION
+                        developerConnection POM_SCM_DEV_CONNECTION
+                    }
+
+                    licenses {
+                        license {
+                            name POM_LICENCE_NAME
+                            url POM_LICENCE_URL
+                            distribution POM_LICENCE_DIST
+                        }
+                    }
+
+                    developers {
+                        developer {
+                            id POM_DEVELOPER_ID
+                            name POM_DEVELOPER_NAME
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    signing {
+        required { isReleaseBuild() && gradle.taskGraph.hasTask("uploadArchives") }
+        sign configurations.archives
+    }
+
+    task androidJavadocs(type: Javadoc) {
+        source = android.sourceSets.main.java.srcDirs
+        classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+    }
+
+    task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
+        classifier = 'javadoc'
+        from androidJavadocs.destinationDir
+    }
+
+    task androidSourcesJar(type: Jar) {
+        classifier = 'sources'
+        from android.sourceSets.main.java.sourceFiles
+    }
+
+    artifacts {
+        archives androidSourcesJar
+        archives androidJavadocsJar
+    }
+}
+
+// See: https://github.com/chrisbanes/gradle-mvn-push/issues/43#issuecomment-84140513
+afterEvaluate { project ->
+    android.libraryVariants.all { variant ->
+        tasks.androidJavadocs.doFirst {
+            classpath += files(variant.javaCompile.classpath.files)
+        }
+    }
+}


### PR DESCRIPTION
Fixes #3 

- [x] Fix `Makefile` `test` when #7 is merged. It's not necessary to execute both `copyResourcesToClasses` and `testDebugUnitTest` commands anymore. Fixed there to use only one command (`test`).

👀  @zugaldia @cammace 

cc/ @danesfeder 