### PR TITLE
Release Mapbox Navigation SDK for Android v0.1

### DIFF
--- a/navigation/bitrise.yml
+++ b/navigation/bitrise.yml
@@ -2,7 +2,11 @@
 format_version: 1.3.1
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 trigger_map:
-- push_branch: "*"
+- is_pull_request_allowed: false
+  pattern: scheduled
+  workflow: scheduled
+- is_pull_request_allowed: true
+  pattern: "*"
   workflow: primary
 workflows:
   primary:
@@ -65,6 +69,53 @@ workflows:
             by ${GIT_CLONE_COMMIT_COMMITER_NAME} failed"
         - icon_url: https://bitrise-public-content-production.s3.amazonaws.com/slack/bitrise-slack-icon-128.png
         - icon_url_on_error: https://bitrise-public-content-production.s3.amazonaws.com/slack/bitrise-slack-error-icon-128.png
+  scheduled:
+    steps:
+    - script:
+        inputs:
+        - content: |-
+            #!/bin/bash
+            apt-get install -y pkg-config python-pip python-dev build-essential
+            pip install awscli
+        title: Install Linux Dependencies
+    - script:
+        inputs:
+        - content: |-
+            #!/bin/bash
+            aws s3 cp s3://mapbox/android/signing-credentials/secring.gpg secring.gpg
+          opts:
+            is_expand: true
+        title: Fetch GPG Secring For SDK Signing
+    - script:
+        inputs:
+        - content: |-
+            #!/bin/bash
+            echo "NEXUS_USERNAME=$PUBLISH_NEXUS_USERNAME
+            NEXUS_PASSWORD=$PUBLISH_NEXUS_PASSWORD
+            signing.keyId=$SIGNING_KEYID
+            signing.password=$SIGNING_PASSWORD
+            signing.secretKeyRingFile=../../secring.gpg" >> navigation/gradle.properties
+          opts:
+            is_expand: true
+        title: Inject Signing And Publishing Credentials
+    - script:
+        inputs:
+        - content: |-
+            #!/bin/bash
+            make build-release
+        title: Build Navigation SDK
+    - script:
+        inputs:
+        - content: |-
+            #!/bin/bash
+            make test
+        title: Run Navigation SDK Unit Tests
+    - script:
+        inputs:
+        - content: |-
+            #!/bin/bash
+            make publish
+        title: Publish Navigation SDK To Maven Central
 app:
   envs:
   - opts:

--- a/navigation/gradle.properties
+++ b/navigation/gradle.properties
@@ -1,5 +1,5 @@
 # Project-wide Gradle settings.
-VERSION_NAME=0.1.0-SNAPSHOT
+VERSION_NAME=0.1.0
 GROUP=com.mapbox.mapboxsdk
 
 POM_URL=https://github.com/mapbox/mapbox-navigation-android

--- a/navigation/gradle.properties
+++ b/navigation/gradle.properties
@@ -1,5 +1,5 @@
 # Project-wide Gradle settings.
-VERSION_NAME=0.1.0
+VERSION_NAME=0.2.0-SNAPSHOT
 GROUP=com.mapbox.mapboxsdk
 
 POM_URL=https://github.com/mapbox/mapbox-navigation-android

--- a/navigation/libandroid-navigation/build.gradle
+++ b/navigation/libandroid-navigation/build.gradle
@@ -45,13 +45,9 @@ dependencies {
     })
 }
 
-// To run the unit tests from the command line you need to execute the following command:
-//
-//   $ ./gradlew test
-//
-// This is necessary to copy the fixtures into the resources folder, this
-// is a known issue: https://issuetracker.google.com/issues/37020423
-// guaranteeing the fixtures are looked for inside the right folders.
+// The following is necessary to copy the fixtures into the resources folder,
+// guaranteeing that the fixtures are looked for inside the right folders.
+// (This is a known issue: https://issuetracker.google.com/issues/37020423.)
 task copyResourcesToClassesDebug(type: Copy) {
     from "${projectDir}/src/test/res"
     into "${buildDir}/intermediates/classes/test/debug/res"

--- a/navigation/libandroid-navigation/gradle.properties
+++ b/navigation/libandroid-navigation/gradle.properties
@@ -1,4 +1,4 @@
 POM_ARTIFACT_ID=mapbox-android-navigation
-POM_NAME=Mapbox Android Navigation
-POM_DESCRIPTION=Mapbox Android Navigation
+POM_NAME=Mapbox Android Navigation SDK
+POM_DESCRIPTION=Mapbox Android Navigation SDK
 POM_PACKAGING=aar

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1,0 +1,237 @@
+'''
+Utility to schedule Navigation SDK builds in Bitrise.
+
+Examples:
+
+- Publish a snapshot from master (release.py uses the current branch)
+
+	$ git branch
+	* master
+	  1234-fix-crash
+	$ python release.py --stage snapshot
+
+- Publish a snapshot from a feature branch (same as before, just switch branchs with git):
+
+	$ git branch
+	  master
+	* 1234-fix-crash
+	$ python release.py --stage snapshot
+
+- Publish a beta from a pre-release branch:
+
+	$ git branch
+	  master
+	* release-android-420-beta1
+	$ python release.py --stage beta --version 2.0.0-beta.1
+
+- Publish a beta from a release branch:
+
+	$ git branch
+	  master
+	* release-android-420
+	$ python release.py --stage final --version 2.0.0
+
+TODO:
+
+- Add a flag to wait until the release has been built (Bitrise) and published (Maven).
+
+'''
+
+import click
+import json
+import os
+import requests
+import subprocess
+
+# Three stages, from less stable to more stable
+ALLOWED_STAGES = ['snapshot', 'beta', 'final']
+
+# Get the version from GRADLE_PROPERTIES_PATH below
+CURRENT_VERSION_TAG = 'current'
+
+# You can find the API token in https://www.bitrise.io/app/82d6356fb9d86849#/code -> API token
+BITRISE_API_TOKEN_ENV_VAR = 'BITRISE_API_TOKEN_NAVIGATION'
+
+# In the future we might want to consider alpha, or rc.
+ALLOWED_PRE_RELEASE = ['beta']
+
+# We get the default version from here
+MAPBOX_GL_ANDROID_SDK_PATH = '../navigation'
+GRADLE_PROPERTIES_PATH = '%s/gradle.properties' % MAPBOX_GL_ANDROID_SDK_PATH
+GRADLE_TOKEN = 'VERSION_NAME='
+
+# Bitrise
+URL_BITRISE = 'https://www.bitrise.io/app/82d6356fb9d86849/build/start.json'
+
+# We support three parameters: stage, branch, and version
+@click.command()
+@click.option('--stage', default=ALLOWED_STAGES[0], type=click.Choice(ALLOWED_STAGES), prompt='Set stage', help='The release stage.')
+@click.option('--version', default=CURRENT_VERSION_TAG, prompt='Set version', help='The version you want to publish. E.g: 2.0.0-SNAPSHOT, 2.0.0-beta.1, or 2.0.0. If you set the version to "%s", the script will default to the current SNAPSHOT version.' % CURRENT_VERSION_TAG)
+def release(stage, version):
+	# Validate params
+	final_stage = validate_stage(stage=stage)
+	final_branch = validate_branch(stage=final_stage)
+	final_version = validate_version(stage=final_stage, branch=final_branch, version=version)
+
+	# Get user confirmation
+	click.echo('\n===== Build information =====')
+	click.echo('- Stage: %s' % final_stage)
+	click.echo('- Branch: %s' % final_branch)
+	click.echo('- Version: %s' % final_version)
+	click.confirm('\nDoes it look right?', abort=True)
+
+	# Proceed
+	if (final_stage == 'snapshot'):
+		publish_snapshot(branch=final_branch, version=final_version)
+	elif (final_stage == 'beta'):
+		publish_beta(branch=final_branch, version=final_version)
+	elif (final_stage == 'final'):
+		publish_final(branch=final_branch, version=final_version)
+
+def validate_stage(stage):
+	if stage not in ALLOWED_STAGES:
+		abort_with_message('Invalid stage: %s' % stage)
+	return stage
+
+def validate_branch(stage):
+	branch = git_get_current_branch()
+	if not branch:
+		abort_with_message('The current folder is not a git repository.')
+	if branch == 'master' and stage != 'snapshot':
+		abort_with_message('You need to swtich to a release branch for a beta or a final release.')
+	return branch
+
+def validate_version(stage, branch, version):
+	if stage == 'snapshot' and branch == 'master' and version != CURRENT_VERSION_TAG:
+		abort_with_message('You cannot specify a custom version if you are building a snapshot from master.')
+
+	if not version or version == CURRENT_VERSION_TAG:
+		version = get_current_version(file_path=GRADLE_PROPERTIES_PATH, file_var=GRADLE_TOKEN)
+
+	if stage == 'snapshot':
+		if not 'SNAPSHOT' in version:
+			abort_with_message('Version should contain the word SNAPSHOT: %s' % version)
+	elif stage == 'beta':
+		if not ALLOWED_PRE_RELEASE[0] in version:
+			abort_with_message('Version should contain the word %s: %s' % (ALLOWED_PRE_RELEASE[0], version))
+	elif stage == 'final':
+		if not version or 'SNAPSHOT' in version or ALLOWED_PRE_RELEASE[0] in version:
+			abort_with_message('Version cannot be empty, or contain the words SNAPSHOT or %s: %s' % (ALLOWED_PRE_RELEASE[0], version))
+
+	return version
+
+def publish_snapshot(branch, version):
+	click.echo('Publishing snapshot for branch: %s (version: %s).' % (branch, version))
+	if branch != 'master':
+		dirty_gradle = update_current_version(file_path=GRADLE_PROPERTIES_PATH, file_var=GRADLE_TOKEN, version=version)
+		if dirty_gradle:
+			git_add(path=GRADLE_PROPERTIES_PATH)
+			git_commit_and_push(branch=branch, version=version)
+	do_bitrise_request(build_params={'branch': branch, 'workflow_id': 'scheduled'})
+
+def publish_beta(branch, version):
+	click.echo('Publishing beta from branch: %s (version: %s).' % (branch, version))
+	dirty_gradle = update_current_version(file_path=GRADLE_PROPERTIES_PATH, file_var=GRADLE_TOKEN, version=version)
+	if dirty_gradle:
+		git_add(path=GRADLE_PROPERTIES_PATH)
+		git_commit_and_push(branch=branch, version=version)
+	do_bitrise_request(build_params={'branch': branch, 'workflow_id': 'scheduled'})
+
+def publish_final(branch, version):
+	click.echo('Publishing final release from branch: %s (version: %s).' % (branch, version))
+	dirty_gradle = update_current_version(file_path=GRADLE_PROPERTIES_PATH, file_var=GRADLE_TOKEN, version=version)
+	if dirty_gradle:
+		git_add(path=GRADLE_PROPERTIES_PATH)
+		git_commit_and_push(branch=branch, version=version)
+	do_bitrise_request(build_params={'branch': branch, 'workflow_id': 'scheduled'})
+
+#
+# Utils
+#
+
+def abort_with_message(message):
+	click.echo(message)
+	click.get_current_context().abort()
+
+def execute_call(command):
+	click.echo('Executing: %s' % command)
+	result = subprocess.call(command, shell=True)
+	if result != 0:
+		abort_with_message('Command failed: %s' % command)
+
+#
+# Bitrise
+#
+
+def get_bitrise_api_token():
+	bitrise_api_token = os.environ.get(BITRISE_API_TOKEN_ENV_VAR)
+	if not bitrise_api_token:
+		abort_with_message('You need to set the BITRISE_API_TOKEN_NAVIGATION environment variable.')
+	click.echo('Found Bitrise API token.')
+	return bitrise_api_token
+
+def do_bitrise_request(build_params):
+	data = {
+		'hook_info': {'type': 'bitrise', 'api_token': get_bitrise_api_token()},
+		'build_params' : build_params}
+	click.echo('Bitrise request data: %s' % json.dumps(data))
+	click.confirm('\nDo you want to start a build?', abort=True)
+
+	r = requests.post(URL_BITRISE, data=json.dumps(data))
+	click.echo('- Bitrise response code: %s' % r.status_code)
+	click.echo('- Bitrise response content: %s' % r.text)
+
+#
+# Git
+#
+
+def git_get_current_branch():
+	return subprocess.check_output('git symbolic-ref --short HEAD'.split(' ')).strip()
+
+def git_add(path):
+	execute_call(command='git add %s' % path)
+
+def git_commit_and_push(branch, version):
+	message = '[android] [auto] Update properties to version %s in preparation for build.' % version
+	commands = [
+		'git commit -m "%s"' % message,
+		'git push -u origin %s' % branch]
+	for command in commands:
+		execute_call(command=command)
+
+#
+# Read and update properties files
+#
+
+def get_current_version(file_path, file_var):
+	click.echo('Getting current version from %s.' % file_path)
+	with open(file_path, 'r') as f:
+		for line in f:
+			if line.startswith(file_var):
+				version_name = line[len(file_var):].strip()
+				click.echo('Current version is %s.' % version_name)
+				return version_name
+	return None
+
+def update_current_version(file_path, file_var, version):
+	dirty = False
+	click.echo('Updating file to version %s: %s.' % (version, file_path))
+	with open(file_path, 'r') as f:
+		file_lines = f.readlines()
+	for line_number in range(len(file_lines)):
+		if file_lines[line_number].startswith(file_var):
+			content_old = file_lines[line_number]
+			content_new = '%s%s\n' % (file_var, version)
+			if (content_old != content_new):
+				click.echo('%s -> %s' % (content_old.strip(), content_new.strip()))
+				file_lines[line_number] = content_new
+				dirty = True
+	if dirty:
+		with open(file_path, 'w') as f:
+			f.writelines(file_lines)
+	else:
+		click.echo('File already has the right version.')
+	return dirty
+
+if __name__ == '__main__':
+	release()


### PR DESCRIPTION
This PR:

- Adds a new scheduled build in CI for releases (the Bitrise rules are the same we were already using in `mapbox-java`)
- Brings back daily SNAPSHOTS. 
- Adds a `release.py` script, also adapted from `mapbox-java`.
- Edits descriptions in some Gradle files.

References https://github.com/mapbox/mapbox-navigation-android/issues/4.
