### PR TITLE
Waypoints support

### DIFF
--- a/navigation/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/MockLocationEngine.java
+++ b/navigation/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/MockLocationEngine.java
@@ -291,6 +291,7 @@ public class MockLocationEngine extends LocationEngine {
       currentStep++;
     } else if (currentLeg < route.getLegs().size() - 1) {
       currentLeg++;
+      currentStep = 0;
     }
 
     sliceRoute(line, distance);

--- a/navigation/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/AlertLevelState.java
+++ b/navigation/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/AlertLevelState.java
@@ -60,10 +60,20 @@ class AlertLevelState {
     double stepDistance = previousRouteProgress.getCurrentLegProgress().getCurrentStep().getDistance();
 
     int alertLevel = isUserDeparting(previousRouteProgress.getAlertUserLevel(), userSnapToStepDistanceFromManeuver,
-      options.getManeuverZoneRadius());
+      options.getManeuverZoneRadius()) ? NavigationConstants.DEPART_ALERT_LEVEL : NavigationConstants.HIGH_ALERT_LEVEL;
 
     if (userSnapToStepDistanceFromManeuver <= options.getManeuverZoneRadius()) {
-      alertLevel = isUserArriving(alertLevel, previousRouteProgress);
+      // If user is arriving
+      if (isUserArriving(previousRouteProgress)) {
+        // but it's not the last leg
+        if (previousRouteProgress.getLegIndex() < previousRouteProgress.getRoute().getLegs().size() - 1) {
+          alertLevel = NavigationConstants.WAYPOINT_ALERT_LEVEL;
+          increaseIndex(previousRouteProgress);
+        } else {
+          alertLevel = NavigationConstants.ARRIVE_ALERT_LEVEL;
+        }
+      }
+
       // Did the user reach the next steps maneuver?
       if (bearingMatchesManeuverFinalHeading(
         location, previousRouteProgress, options.getMaxTurnCompletionOffset())) {

--- a/navigation/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/AlertLevelState.java
+++ b/navigation/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/AlertLevelState.java
@@ -108,35 +108,23 @@ class AlertLevelState {
    *
    * @param alertLevel The currently calculated alert level.
    * @param distance   From the users snapped location to the next steps maneuver.
-   * @return either the original alert level (if the user's not departing) or an updated alert level value either
-   * representing {@link NavigationConstants#HIGH_ALERT_LEVEL} or {@link NavigationConstants#DEPART_ALERT_LEVEL}
+   * @return if the user is departing or not.
    * @since 0.2.0
    */
-  private static int isUserDeparting(int alertLevel, double distance, double maneuverZoneRadius) {
-    if (alertLevel == NavigationConstants.NONE_ALERT_LEVEL) {
-      if (distance > maneuverZoneRadius) {
-        alertLevel = NavigationConstants.DEPART_ALERT_LEVEL;
-      } else {
-        alertLevel = NavigationConstants.HIGH_ALERT_LEVEL;
-      }
-    }
-    return alertLevel;
+  private static boolean isUserDeparting(int alertLevel, double distance, double maneuverZoneRadius) {
+    return (alertLevel == NavigationConstants.NONE_ALERT_LEVEL) && (distance > maneuverZoneRadius);
   }
 
   /**
    * Checks whether the user is arriving to their final destination or not.
    *
-   * @param alertLevel    The currently calculated alert level.
    * @param routeProgress The most recent {@link RouteProgress} object that was created.
-   * @return either the original alert level (if the user's not arriving) or an updated alert level value.
+   * @return if the user is arriving or not.
    * @since 0.2.0
    */
-  private static int isUserArriving(int alertLevel, RouteProgress routeProgress) {
-    if (routeProgress.getCurrentLegProgress().getUpComingStep().getManeuver().getType()
-      .equals(com.mapbox.services.android.Constants.STEP_MANEUVER_TYPE_ARRIVE)) {
-      return NavigationConstants.ARRIVE_ALERT_LEVEL;
-    }
-    return alertLevel;
+  private static boolean isUserArriving(RouteProgress routeProgress) {
+    return routeProgress.getCurrentLegProgress().getUpComingStep().getManeuver().getType()
+      .equals(com.mapbox.services.android.Constants.STEP_MANEUVER_TYPE_ARRIVE);
   }
 
   /**

--- a/navigation/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/AlertLevelState.java
+++ b/navigation/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/AlertLevelState.java
@@ -214,8 +214,8 @@ class AlertLevelState {
    */
   private void increaseIndex(RouteProgress routeProgress) {
     // Check if we are in the last step in the current routeLeg and iterate it if needed.
-    if (stepIndex >= routeProgress.getRoute().getLegs().get(routeProgress.getLegIndex()).getSteps().size() - 1
-      && legIndex < routeProgress.getRoute().getLegs().size()) {
+    if (stepIndex >= routeProgress.getRoute().getLegs().get(routeProgress.getLegIndex()).getSteps().size() - 2
+      && legIndex < routeProgress.getRoute().getLegs().size() - 1) {
       legIndex += 1;
       stepIndex = 0;
     } else {

--- a/navigation/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/MapboxNavigation.java
+++ b/navigation/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/MapboxNavigation.java
@@ -362,7 +362,9 @@ public class MapboxNavigation {
     // Optionally set the bearing and radiuses if the developer provider the user bearing. A tolerance of 90 degrees
     // is given.
     if (userBearing != null) {
-      directionsBuilder.setBearings(new double[] {(double) userBearing, 90}, new double[] {});
+      double[][] bearings = new double[coordinates.size()][0];
+      bearings[0] = new double[] {(double) userBearing, 90};
+      directionsBuilder.setBearings(bearings);
     }
     directionsBuilder.build().enqueueCall(callback);
   }

--- a/navigation/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/NavigationConstants.java
+++ b/navigation/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/NavigationConstants.java
@@ -13,6 +13,7 @@ public class NavigationConstants {
   @Experimental public static final int MEDIUM_ALERT_LEVEL = 3;
   @Experimental public static final int HIGH_ALERT_LEVEL = 4;
   @Experimental public static final int ARRIVE_ALERT_LEVEL = 5;
+  @Experimental public static final int WAYPOINT_ALERT_LEVEL = 6;
 
   /**
    * Threshold user must be in within to count as completing a step. One of two heuristics used to know when a user

--- a/navigation/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/RouteUtils.java
+++ b/navigation/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/RouteUtils.java
@@ -395,7 +395,7 @@ public class RouteUtils {
    * Get the remaining route geometry from the position provided to the end of the directions route. This is useful
    * when the user location is traversing along the route and you don't want the past route geometry to show on the map.
    *
-   * @param position          the new starting postion of the route geometry. If using for navigation, this would
+   * @param position          the new starting position of the route geometry. If using for navigation, this would
    *                          typically be the users current location.
    * @param route             a Directions route.
    * @param geometryPrecision either {@link Constants#PRECISION_5} or {@link Constants#PRECISION_6}


### PR DESCRIPTION
Closes #27.

Hey guys,
Starting on implementing support for waypoints.

Test using the Navigation activity: place on the map up to 2 waypoints (according to traffic API).

Also wondering: should `MapboxNavigation` even provide a `getRoute()` function at all? It seems like it's a lot the same as what `MapboxDirections.Builder` does and user could just pass a `DirectionsRoute` object directly to `startRoute`. I guess it makes sense as waypoints wasn't supported and is supported on the `MapboxDirections` API but if it does, the `DirectionsRoute` route object is pretty much compatible between the 2 libraries so I think the `getRoute()` function is redundant.

Thanks!