### PR TITLE
RouteMilestone

### DIFF
--- a/navigation/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/MockNavigationActivity.java
+++ b/navigation/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/MockNavigationActivity.java
@@ -33,7 +33,6 @@ import com.mapbox.services.android.navigation.v5.listeners.NavigationEventListen
 import com.mapbox.services.android.navigation.v5.routeprogress.ProgressChangeListener;
 import com.mapbox.services.android.navigation.v5.milestone.MilestoneEventListener;
 import com.mapbox.services.android.navigation.v5.milestone.RouteMilestone;
-import com.mapbox.services.android.navigation.v5.milestone.StepMilestone;
 import com.mapbox.services.android.navigation.v5.milestone.Trigger;
 import com.mapbox.services.android.navigation.v5.milestone.TriggerProperty;
 import com.mapbox.services.android.telemetry.location.LocationEngine;

--- a/navigation/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/MockNavigationActivity.java
+++ b/navigation/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/MockNavigationActivity.java
@@ -32,6 +32,7 @@ import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 import com.mapbox.services.android.navigation.v5.listeners.NavigationEventListener;
 import com.mapbox.services.android.navigation.v5.routeprogress.ProgressChangeListener;
 import com.mapbox.services.android.navigation.v5.milestone.MilestoneEventListener;
+import com.mapbox.services.android.navigation.v5.milestone.RouteMilestone;
 import com.mapbox.services.android.navigation.v5.milestone.StepMilestone;
 import com.mapbox.services.android.navigation.v5.milestone.Trigger;
 import com.mapbox.services.android.navigation.v5.milestone.TriggerProperty;
@@ -87,12 +88,13 @@ public class MockNavigationActivity extends AppCompatActivity implements OnMapRe
 
     navigation = new MapboxNavigation(this, Mapbox.getAccessToken());
 
-    navigation.addMilestone(new StepMilestone.Builder()
+    navigation.addMilestone(new RouteMilestone.Builder()
       .setIdentifier(BEGIN_ROUTE_MILESTONE)
       .setTrigger(
         Trigger.all(
           Trigger.lt(TriggerProperty.STEP_INDEX, 3),
-          Trigger.gt(TriggerProperty.STEP_DISTANCE_TOTAL_METERS, 200)
+          Trigger.gt(TriggerProperty.STEP_DISTANCE_TOTAL_METERS, 200),
+          Trigger.gte(TriggerProperty.STEP_DISTANCE_TRAVELED_METERS, 75)
         )
       ).build());
   }

--- a/navigation/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/milestone/RouteMilestone.java
+++ b/navigation/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/milestone/RouteMilestone.java
@@ -32,7 +32,7 @@ public class RouteMilestone extends Milestone {
   }
 
   /**
-   * Build a new {@link StepMilestone}
+   * Build a new {@link RouteMilestone}
    *
    * @since 0.4.0
    */

--- a/navigation/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/milestone/RouteMilestone.java
+++ b/navigation/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/milestone/RouteMilestone.java
@@ -1,23 +1,24 @@
 package com.mapbox.services.android.navigation.v5.milestone;
 
 import com.mapbox.services.android.navigation.v5.NavigationException;
-import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
+import com.mapbox.services.android.navigation.v5.RouteProgress;
 
 import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Using a Step Milestone will result in {@link MilestoneEventListener#onMilestoneEvent(RouteProgress, String, int)}
- * being invoked every step if the condition validation returns true.
+ * Using a Route Milestone will result in {@link MilestoneEventListener#onMilestoneEvent(RouteProgress, String, int)}
+ * being invoked only once during a navigation session.
  *
  * @since 0.4.0
  */
-public class StepMilestone extends Milestone {
+public class RouteMilestone extends Milestone {
+
 
   private Builder builder;
   private boolean called;
 
-  private StepMilestone(Builder builder) {
+  private RouteMilestone(Builder builder) {
     super(builder);
     this.builder = builder;
   }
@@ -52,12 +53,6 @@ public class StepMilestone extends Milestone {
         routeProgress.getCurrentLegProgress().getUpComingStep() != null
           ? routeProgress.getCurrentLegProgress().getUpComingStep().getDistance() : 0});
 
-    // Determine if the step index has changed and set called accordingly. This prevents multiple calls to
-    // onMilestoneEvent per Step.
-    if (previousRouteProgress.getCurrentLegProgress().getStepIndex()
-      != routeProgress.getCurrentLegProgress().getStepIndex()) {
-      called = false;
-    }
     if (builder.getTrigger().isOccurring(statementObjects) && !called) {
       called = true;
       return true;
@@ -90,8 +85,8 @@ public class StepMilestone extends Milestone {
     }
 
     @Override
-    public StepMilestone build() throws NavigationException {
-      return new StepMilestone(this);
+    public RouteMilestone build() throws NavigationException {
+      return new RouteMilestone(this);
     }
   }
 }

--- a/navigation/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/milestone/RouteMilestone.java
+++ b/navigation/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/milestone/RouteMilestone.java
@@ -3,9 +3,6 @@ package com.mapbox.services.android.navigation.v5.milestone;
 import com.mapbox.services.android.navigation.v5.NavigationException;
 import com.mapbox.services.android.navigation.v5.RouteProgress;
 
-import java.util.HashMap;
-import java.util.Map;
-
 /**
  * Using a Route Milestone will result in {@link MilestoneEventListener#onMilestoneEvent(RouteProgress, String, int)}
  * being invoked only once during a navigation session.
@@ -25,35 +22,9 @@ public class RouteMilestone extends Milestone {
 
   @Override
   public boolean isOccurring(RouteProgress previousRouteProgress, RouteProgress routeProgress) {
-    // Build hashMap matching the trigger properties to their corresponding current values.
-    Map<Integer, Number[]> statementObjects = new HashMap<>();
-    statementObjects.put(TriggerProperty.STEP_DISTANCE_TOTAL_METERS,
-      new Number[] {routeProgress.getCurrentLegProgress().getCurrentStep().getDistance()});
-    statementObjects.put(TriggerProperty.STEP_DURATION_TOTAL_SECONDS,
-      new Number[] {routeProgress.getCurrentLegProgress().getCurrentStep().getDuration()});
-    statementObjects.put(TriggerProperty.STEP_DISTANCE_REMAINING_METERS,
-      new Number[] {routeProgress.getCurrentLegProgress().getCurrentStepProgress().getDistanceRemaining()});
-    statementObjects.put(TriggerProperty.STEP_DURATION_REMAINING_SECONDS,
-      new Number[] {routeProgress.getCurrentLegProgress().getCurrentStepProgress().getDurationRemaining()});
-    statementObjects.put(TriggerProperty.STEP_DISTANCE_TRAVELED_METERS,
-      new Number[] {routeProgress.getCurrentLegProgress().getCurrentStepProgress().getDistanceTraveled()});
-    statementObjects.put(TriggerProperty.STEP_INDEX,
-      new Number[] {routeProgress.getCurrentLegProgress().getStepIndex()});
-    statementObjects.put(TriggerProperty.NEW_STEP,
-      new Number[] {
-        previousRouteProgress.getCurrentLegProgress().getStepIndex(),
-        routeProgress.getCurrentLegProgress().getStepIndex()});
-    statementObjects.put(TriggerProperty.LAST_STEP,
-      new Number[] {routeProgress.getCurrentLegProgress().getStepIndex(),
-        (routeProgress.getCurrentLeg().getSteps().size() - 1)});
-    statementObjects.put(TriggerProperty.FIRST_STEP,
-      new Number[] {routeProgress.getCurrentLegProgress().getStepIndex(), 0});
-    statementObjects.put(TriggerProperty.NEXT_STEP_DISTANCE_METERS,
-      new Number[] {
-        routeProgress.getCurrentLegProgress().getUpComingStep() != null
-          ? routeProgress.getCurrentLegProgress().getUpComingStep().getDistance() : 0});
 
-    if (builder.getTrigger().isOccurring(statementObjects) && !called) {
+    if (builder.getTrigger().isOccurring(
+      TriggerProperty.getSparseArray(previousRouteProgress, routeProgress)) && !called) {
       called = true;
       return true;
     }

--- a/navigation/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/milestone/RouteMilestone.java
+++ b/navigation/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/milestone/RouteMilestone.java
@@ -1,7 +1,7 @@
 package com.mapbox.services.android.navigation.v5.milestone;
 
 import com.mapbox.services.android.navigation.v5.NavigationException;
-import com.mapbox.services.android.navigation.v5.RouteProgress;
+import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 
 /**
  * Using a Route Milestone will result in {@link MilestoneEventListener#onMilestoneEvent(RouteProgress, String, int)}

--- a/navigation/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/milestone/StepMilestone.java
+++ b/navigation/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/milestone/StepMilestone.java
@@ -3,9 +3,6 @@ package com.mapbox.services.android.navigation.v5.milestone;
 import com.mapbox.services.android.navigation.v5.NavigationException;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 
-import java.util.HashMap;
-import java.util.Map;
-
 /**
  * Using a Step Milestone will result in {@link MilestoneEventListener#onMilestoneEvent(RouteProgress, String, int)}
  * being invoked every step if the condition validation returns true.
@@ -24,33 +21,6 @@ public class StepMilestone extends Milestone {
 
   @Override
   public boolean isOccurring(RouteProgress previousRouteProgress, RouteProgress routeProgress) {
-    // Build hashMap matching the trigger properties to their corresponding current values.
-    Map<Integer, Number[]> statementObjects = new HashMap<>();
-    statementObjects.put(TriggerProperty.STEP_DISTANCE_TOTAL_METERS,
-      new Number[] {routeProgress.getCurrentLegProgress().getCurrentStep().getDistance()});
-    statementObjects.put(TriggerProperty.STEP_DURATION_TOTAL_SECONDS,
-      new Number[] {routeProgress.getCurrentLegProgress().getCurrentStep().getDuration()});
-    statementObjects.put(TriggerProperty.STEP_DISTANCE_REMAINING_METERS,
-      new Number[] {routeProgress.getCurrentLegProgress().getCurrentStepProgress().getDistanceRemaining()});
-    statementObjects.put(TriggerProperty.STEP_DURATION_REMAINING_SECONDS,
-      new Number[] {routeProgress.getCurrentLegProgress().getCurrentStepProgress().getDurationRemaining()});
-    statementObjects.put(TriggerProperty.STEP_DISTANCE_TRAVELED_METERS,
-      new Number[] {routeProgress.getCurrentLegProgress().getCurrentStepProgress().getDistanceTraveled()});
-    statementObjects.put(TriggerProperty.STEP_INDEX,
-      new Number[] {routeProgress.getCurrentLegProgress().getStepIndex()});
-    statementObjects.put(TriggerProperty.NEW_STEP,
-      new Number[] {
-        previousRouteProgress.getCurrentLegProgress().getStepIndex(),
-        routeProgress.getCurrentLegProgress().getStepIndex()});
-    statementObjects.put(TriggerProperty.LAST_STEP,
-      new Number[] {routeProgress.getCurrentLegProgress().getStepIndex(),
-        (routeProgress.getCurrentLeg().getSteps().size() - 1)});
-    statementObjects.put(TriggerProperty.FIRST_STEP,
-      new Number[] {routeProgress.getCurrentLegProgress().getStepIndex(), 0});
-    statementObjects.put(TriggerProperty.NEXT_STEP_DISTANCE_METERS,
-      new Number[] {
-        routeProgress.getCurrentLegProgress().getUpComingStep() != null
-          ? routeProgress.getCurrentLegProgress().getUpComingStep().getDistance() : 0});
 
     // Determine if the step index has changed and set called accordingly. This prevents multiple calls to
     // onMilestoneEvent per Step.
@@ -58,7 +28,8 @@ public class StepMilestone extends Milestone {
       != routeProgress.getCurrentLegProgress().getStepIndex()) {
       called = false;
     }
-    if (builder.getTrigger().isOccurring(statementObjects) && !called) {
+    if (builder.getTrigger().isOccurring(
+      TriggerProperty.getSparseArray(previousRouteProgress, routeProgress)) && !called) {
       called = true;
       return true;
     }

--- a/navigation/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/milestone/Trigger.java
+++ b/navigation/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/milestone/Trigger.java
@@ -1,5 +1,7 @@
 package com.mapbox.services.android.navigation.v5.milestone;
 
+import android.util.SparseArray;
+
 import java.util.Map;
 
 /**
@@ -27,7 +29,7 @@ public class Trigger {
      * @return true if the statement is valid, otherwise false
      * @since 0.4.0
      */
-    public abstract boolean isOccurring(Map<Integer, Number[]> statementObjects);
+    public abstract boolean isOccurring(SparseArray<Number[]> statementObjects);
   }
 
   /*
@@ -47,7 +49,7 @@ public class Trigger {
     }
 
     @Override
-    public boolean isOccurring(Map<Integer, Number[]> statementObjects) {
+    public boolean isOccurring(SparseArray<Number[]> statementObjects) {
       boolean all = true;
       for (Statement statement : statements) {
         if (!statement.isOccurring(statementObjects)) {
@@ -71,7 +73,7 @@ public class Trigger {
     }
 
     @Override
-    public boolean isOccurring(Map<Integer, Number[]> statementObjects) {
+    public boolean isOccurring(SparseArray<Number[]> statementObjects) {
       for (Statement statement : statements) {
         if (statement.isOccurring(statementObjects)) {
           return false;
@@ -94,7 +96,7 @@ public class Trigger {
     }
 
     @Override
-    public boolean isOccurring(Map<Integer, Number[]> statementObjects) {
+    public boolean isOccurring(SparseArray<Number[]> statementObjects) {
       for (Statement statement : statements) {
         if (statement.isOccurring(statementObjects)) {
           return true;
@@ -124,7 +126,7 @@ public class Trigger {
     }
 
     @Override
-    public boolean isOccurring(Map<Integer, Number[]> statementObjects) {
+    public boolean isOccurring(SparseArray<Number[]> statementObjects) {
       return Operation.greaterThan(statementObjects.get(key), (Number) value);
     }
   }
@@ -145,7 +147,7 @@ public class Trigger {
     }
 
     @Override
-    public boolean isOccurring(Map<Integer, Number[]> statementObjects) {
+    public boolean isOccurring(SparseArray<Number[]> statementObjects) {
       return Operation.greaterThanEqual(statementObjects.get(key), (Number) value);
     }
   }
@@ -165,7 +167,7 @@ public class Trigger {
     }
 
     @Override
-    public boolean isOccurring(Map<Integer, Number[]> statementObjects) {
+    public boolean isOccurring(SparseArray<Number[]> statementObjects) {
       return Operation.lessThan(statementObjects.get(key), (Number) value);
     }
   }
@@ -186,7 +188,7 @@ public class Trigger {
     }
 
     @Override
-    public boolean isOccurring(Map<Integer, Number[]> statementObjects) {
+    public boolean isOccurring(SparseArray<Number[]> statementObjects) {
       return Operation.lessThanEqual(statementObjects.get(key), (Number) value);
     }
   }
@@ -206,7 +208,7 @@ public class Trigger {
     }
 
     @Override
-    public boolean isOccurring(Map<Integer, Number[]> statementObjects) {
+    public boolean isOccurring(SparseArray<Number[]> statementObjects) {
       return Operation.notEqual(statementObjects.get(key), (Number) values[0]);
     }
   }
@@ -226,7 +228,7 @@ public class Trigger {
     }
 
     @Override
-    public boolean isOccurring(Map<Integer, Number[]> statementObjects) {
+    public boolean isOccurring(SparseArray<Number[]> statementObjects) {
       return Operation.equal(statementObjects.get(key), (Number) value);
     }
   }

--- a/navigation/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/milestone/TriggerProperty.java
+++ b/navigation/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/milestone/TriggerProperty.java
@@ -36,6 +36,8 @@ public final class TriggerProperty {
    */
   public static final int STEP_DURATION_TOTAL_SECONDS = 0x00000003;
 
+  public static final int STEP_DISTANCE_TRAVELED_METERS = 0x00000009;
+
   /**
    * The Milestone will be triggered based on the current step index.
    *

--- a/navigation/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/milestone/TriggerProperty.java
+++ b/navigation/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/milestone/TriggerProperty.java
@@ -64,7 +64,7 @@ public final class TriggerProperty {
 
   static SparseArray<Number[]> getSparseArray(RouteProgress previousRouteProgress, RouteProgress routeProgress) {
     // Build hashMap matching the trigger properties to their corresponding current values.
-    SparseArray<Number[]> statementObjects = new SparseArray<>();
+    SparseArray<Number[]> statementObjects = new SparseArray<>(10);
     statementObjects.put(TriggerProperty.STEP_DISTANCE_TOTAL_METERS,
       new Number[] {routeProgress.getCurrentLegProgress().getCurrentStep().getDistance()});
     statementObjects.put(TriggerProperty.STEP_DURATION_TOTAL_SECONDS,

--- a/navigation/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/milestone/TriggerProperty.java
+++ b/navigation/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/milestone/TriggerProperty.java
@@ -1,5 +1,9 @@
 package com.mapbox.services.android.navigation.v5.milestone;
 
+import android.util.SparseArray;
+
+import com.mapbox.services.android.navigation.v5.RouteProgress;
+
 /**
  * The currently support properties used for triggering a milestone.
  *
@@ -57,4 +61,35 @@ public final class TriggerProperty {
   public static final int TRUE = 0x00000124;
 
   public static final int FALSE = 0x00000100;
+
+  static SparseArray<Number[]> getSparseArray(RouteProgress previousRouteProgress, RouteProgress routeProgress) {
+    // Build hashMap matching the trigger properties to their corresponding current values.
+    SparseArray<Number[]> statementObjects = new SparseArray<>();
+    statementObjects.put(TriggerProperty.STEP_DISTANCE_TOTAL_METERS,
+      new Number[] {routeProgress.getCurrentLegProgress().getCurrentStep().getDistance()});
+    statementObjects.put(TriggerProperty.STEP_DURATION_TOTAL_SECONDS,
+      new Number[] {routeProgress.getCurrentLegProgress().getCurrentStep().getDuration()});
+    statementObjects.put(TriggerProperty.STEP_DISTANCE_REMAINING_METERS,
+      new Number[] {routeProgress.getCurrentLegProgress().getCurrentStepProgress().getDistanceRemaining()});
+    statementObjects.put(TriggerProperty.STEP_DURATION_REMAINING_SECONDS,
+      new Number[] {routeProgress.getCurrentLegProgress().getCurrentStepProgress().getDurationRemaining()});
+    statementObjects.put(TriggerProperty.STEP_DISTANCE_TRAVELED_METERS,
+      new Number[] {routeProgress.getCurrentLegProgress().getCurrentStepProgress().getDistanceTraveled()});
+    statementObjects.put(TriggerProperty.STEP_INDEX,
+      new Number[] {routeProgress.getCurrentLegProgress().getStepIndex()});
+    statementObjects.put(TriggerProperty.NEW_STEP,
+      new Number[] {
+        previousRouteProgress.getCurrentLegProgress().getStepIndex(),
+        routeProgress.getCurrentLegProgress().getStepIndex()});
+    statementObjects.put(TriggerProperty.LAST_STEP,
+      new Number[] {routeProgress.getCurrentLegProgress().getStepIndex(),
+        (routeProgress.getCurrentLeg().getSteps().size() - 1)});
+    statementObjects.put(TriggerProperty.FIRST_STEP,
+      new Number[] {routeProgress.getCurrentLegProgress().getStepIndex(), 0});
+    statementObjects.put(TriggerProperty.NEXT_STEP_DISTANCE_METERS,
+      new Number[] {
+        routeProgress.getCurrentLegProgress().getUpComingStep() != null
+          ? routeProgress.getCurrentLegProgress().getUpComingStep().getDistance() : 0});
+    return statementObjects;
+  }
 }

--- a/navigation/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/milestone/TriggerProperty.java
+++ b/navigation/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/milestone/TriggerProperty.java
@@ -2,7 +2,7 @@ package com.mapbox.services.android.navigation.v5.milestone;
 
 import android.util.SparseArray;
 
-import com.mapbox.services.android.navigation.v5.RouteProgress;
+import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 
 /**
  * The currently support properties used for triggering a milestone.

--- a/navigation/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/milestone/StepMilestoneTest.java
+++ b/navigation/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/milestone/StepMilestoneTest.java
@@ -3,6 +3,7 @@ package com.mapbox.services.android.navigation.v5.milestone;
 import android.location.Location;
 
 import com.google.gson.Gson;
+import com.mapbox.services.android.navigation.BuildConfig;
 import com.mapbox.services.android.navigation.v5.BaseTest;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 import com.mapbox.services.api.directions.v5.models.DirectionsResponse;
@@ -12,8 +13,13 @@ import junit.framework.Assert;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mockito;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class)
 public class StepMilestoneTest extends BaseTest {
 
   // Fixtures

--- a/navigation/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/milestone/TriggerPropertyTest.java
+++ b/navigation/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/milestone/TriggerPropertyTest.java
@@ -3,6 +3,7 @@ package com.mapbox.services.android.navigation.v5.milestone;
 import android.location.Location;
 
 import com.google.gson.Gson;
+import com.mapbox.services.android.navigation.BuildConfig;
 import com.mapbox.services.android.navigation.v5.BaseTest;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 import com.mapbox.services.api.directions.v5.models.DirectionsResponse;
@@ -12,8 +13,13 @@ import junit.framework.Assert;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mockito;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class)
 public class TriggerPropertyTest extends BaseTest {
 
   // Fixtures

--- a/navigation/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/milestone/TriggerTest.java
+++ b/navigation/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/milestone/TriggerTest.java
@@ -3,6 +3,7 @@ package com.mapbox.services.android.navigation.v5.milestone;
 import android.location.Location;
 
 import com.google.gson.Gson;
+import com.mapbox.services.android.navigation.BuildConfig;
 import com.mapbox.services.android.navigation.v5.BaseTest;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 import com.mapbox.services.api.directions.v5.models.DirectionsResponse;
@@ -12,8 +13,13 @@ import junit.framework.Assert;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mockito;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class)
 public class TriggerTest extends BaseTest {
 
   // Fixtures


### PR DESCRIPTION
StepMilestones have the limitation of getting reset when the user reaches a new step (this is done so that urgent could get triggered in each step). Another useful type of milestone would be a RouteMilestone which only gets triggered once during the entire route. An example use case for this is to announce the estimated arrival time only once at the beginning of the nav session.