### PR TITLE
Fix multi-legs routes (fix #108)

### DIFF
--- a/navigation/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/MapboxNavigation.java
+++ b/navigation/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/MapboxNavigation.java
@@ -143,14 +143,20 @@ public class MapboxNavigation implements MilestoneEventListener {
     addMilestone(new StepMilestone.Builder()
       .setIdentifier(NavigationConstants.DEPARTURE_MILESTONE)
       .setTrigger(
-        Trigger.eq(TriggerProperty.FIRST_STEP, TriggerProperty.TRUE))
-      .build());
+        Trigger.all(
+          Trigger.eq(TriggerProperty.FIRST_STEP, TriggerProperty.TRUE),
+          Trigger.eq(TriggerProperty.FIRST_LEG, TriggerProperty.TRUE)
+        )
+      ).build());
 
     addMilestone(new StepMilestone.Builder()
       .setIdentifier(NavigationConstants.ARRIVAL_MILESTONE)
       .setTrigger(
-        Trigger.eq(TriggerProperty.LAST_STEP, TriggerProperty.TRUE))
-      .build());
+        Trigger.all(
+          Trigger.eq(TriggerProperty.LAST_STEP, TriggerProperty.TRUE),
+          Trigger.eq(TriggerProperty.LAST_LEG, TriggerProperty.TRUE)
+        )
+      ).build());
   }
 
   @Override

--- a/navigation/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/NavigationEngine.java
+++ b/navigation/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/NavigationEngine.java
@@ -182,8 +182,8 @@ class NavigationEngine {
    */
   private void increaseIndex(RouteProgress routeProgress) {
     // Check if we are in the last step in the current routeLeg and iterate it if needed.
-    if (stepIndex >= routeProgress.getRoute().getLegs().get(routeProgress.getLegIndex()).getSteps().size() - 1
-      && legIndex < routeProgress.getRoute().getLegs().size()) {
+    if (stepIndex >= routeProgress.getRoute().getLegs().get(routeProgress.getLegIndex()).getSteps().size() - 2
+      && legIndex < routeProgress.getRoute().getLegs().size() - 1) {
       legIndex += 1;
       stepIndex = 0;
     } else {

--- a/navigation/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/milestone/StepMilestone.java
+++ b/navigation/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/milestone/StepMilestone.java
@@ -49,6 +49,12 @@ public class StepMilestone extends Milestone {
       new Number[] {
         routeProgress.getCurrentLegProgress().getUpComingStep() != null
           ? routeProgress.getCurrentLegProgress().getUpComingStep().getDistance() : 0});
+    statementObjects.put(TriggerProperty.FIRST_LEG,
+      new Number[] {routeProgress.getLegIndex(), 0});
+    statementObjects.put(TriggerProperty.LAST_LEG,
+      new Number[] {routeProgress.getLegIndex(),
+        (routeProgress.getRoute().getLegs().size() - 1)});
+
 
     // Determine if the step index has changed and set called accordingly. This prevents multiple calls to
     // onMilestoneEvent per Step.

--- a/navigation/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/milestone/TriggerProperty.java
+++ b/navigation/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/milestone/TriggerProperty.java
@@ -51,6 +51,10 @@ public final class TriggerProperty {
 
   public static final int NEXT_STEP_DISTANCE_METERS = 0x00000007;
 
+  public static final int FIRST_LEG = 0x00000009;
+
+  public static final int LAST_LEG = 0x000000010;
+
 
   public static final int TRUE = 0x00000124;
 


### PR DESCRIPTION
Fix #108 
- Fix `increaseIndex()` that wasn't incrementing the current leg index properly.
- Fix Departure/Arriving milestones that were triggering at every new leg.