### PR TITLE
Improved snap to route bearing

### DIFF
--- a/navigation/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/snap/SnapToRoute.java
+++ b/navigation/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/snap/SnapToRoute.java
@@ -67,7 +67,8 @@ public class SnapToRoute extends Snap {
 
     Point currentPoint = TurfMeasurement.along(lineString, routeProgress.getDistanceTraveled(),
       TurfConstants.UNIT_METERS);
-    Point futurePoint = TurfMeasurement.along(lineString, routeProgress.getDistanceTraveled() + userDistanceBuffer,
+    Point futurePoint = TurfMeasurement.along(lineString, location.getSpeed() == 0.0 ? 1
+        : (routeProgress.getDistanceTraveled() + userDistanceBuffer),
       TurfConstants.UNIT_METERS);
 
     double azimuth = TurfMeasurement.bearing(currentPoint, futurePoint);


### PR DESCRIPTION
Simple fix to ensure we are always measuring the user bearing from their current distance to a none 0 distance ahead of them. Before, if the user was stopped and location.getSpeed = 0.0, it would cause two points to be taken at the same coordinate, these coordinates get passed into the bearing measurment which would then result in a bearing of 0 azimuth.

cc: @ericrwolfe 