### PR TITLE
Make route property square instead of round

### DIFF
--- a/navigation/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/RerouteActivity.java
+++ b/navigation/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/RerouteActivity.java
@@ -126,23 +126,17 @@ public class RerouteActivity extends AppCompatActivity implements OnMapReadyCall
   @Override
   public void onResponse(Call<DirectionsResponse> call, Response<DirectionsResponse> response) {
     if (response.body() != null) {
-      Timber.d("response is null");
-      return;
-    }
-
-    DirectionsRoute route = response.body().getRoutes().get(0);
-    if (route == null) {
-      Timber.d("route is null");
-      return;
-    }
-
-    // First run
-    drawRoute(route);
-    if (!running) {
-      ((MockLocationEngine) locationEngine).setRoute(route);
-      navigation.startNavigation(route);
-    } else {
-      navigation.updateRoute(route);
+      if (response.body().getRoutes().size() > 0) {
+        DirectionsRoute route = response.body().getRoutes().get(0);
+        // First run
+        drawRoute(route);
+        if (!running) {
+          ((MockLocationEngine) locationEngine).setRoute(route);
+          navigation.startNavigation(route);
+        } else {
+          navigation.updateRoute(route);
+        }
+      }
     }
   }
 

--- a/navigation/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationMapRoute.java
+++ b/navigation/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationMapRoute.java
@@ -307,8 +307,8 @@ public class NavigationMapRoute implements ProgressChangeListener, MapView.OnMap
   private void addNavigationRouteLayer(float scale) {
     Layer routeLayer = new LineLayer(NavigationMapLayers.NAVIGATION_ROUTE_LAYER,
       NavigationMapSources.NAVIGATION_ROUTE_SOURCE).withProperties(
-      PropertyFactory.lineCap(Property.LINE_CAP_ROUND),
-      PropertyFactory.lineJoin(Property.LINE_JOIN_ROUND),
+      PropertyFactory.lineCap(Property.LINE_CAP_SQUARE),
+      PropertyFactory.lineJoin(Property.LINE_CAP_SQUARE),
       PropertyFactory.visibility(Property.NONE),
       PropertyFactory.lineWidth(Function.zoom(
         exponential(


### PR DESCRIPTION
This also fixes an if statement expression bug which was introduced in https://github.com/mapbox/mapbox-navigation-android/commit/c92d39e7e53d2acc15d9a02d9c5d10fdd3620018#commitcomment-22906772