### PR TITLE
bumped dependency num in readme to 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The snippet to add to your `build.gradle` file to use this SDK is the following:
 ```
 // Mapbox Navigation SDK for Android
 
-compile 'com.mapbox.mapboxsdk:mapbox-android-navigation:0.3.0'
+compile 'com.mapbox.mapboxsdk:mapbox-android-navigation:0.4.0'
 
 ```
 


### PR DESCRIPTION
Part of [the nav sdk 0.4.0 release](https://github.com/mapbox/mapbox-navigation-android/issues/152)