### PR TITLE
Changed remoteViews height wrapcontent to match

### DIFF
--- a/navigation/libandroid-navigation/src/main/res/layout/layout_notification_default.xml
+++ b/navigation/libandroid-navigation/src/main/res/layout/layout_notification_default.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     style="@android:style/TextAppearance.StatusBar.EventContent"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
+    android:layout_height="match_parent"
     android:background="#4882C6"
     android:orientation="horizontal">
 

--- a/navigation/libandroid-navigation/src/main/res/layout/layout_notification_default_big.xml
+++ b/navigation/libandroid-navigation/src/main/res/layout/layout_notification_default_big.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     style="@android:style/TextAppearance.StatusBar.EventContent"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
+    android:layout_height="match_parent"
     android:background="#4882C6"
     android:orientation="vertical">
 


### PR DESCRIPTION
Closes #186 

Potential fix for #186, did some research and came across this [SO question](https://stackoverflow.com/questions/6209631/android-bad-notification-posted-couldnt-expand-remoteviews-for-statusbarno) and solution which points out that remote views should be match parent. 