### PR TITLE
Reduce NavigationCamera Tilt

### DIFF
--- a/navigation/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/camera/NavigationCamera.java
+++ b/navigation/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/camera/NavigationCamera.java
@@ -27,7 +27,7 @@ import static android.content.res.Configuration.ORIENTATION_PORTRAIT;
 
 public class NavigationCamera implements ProgressChangeListener {
 
-  private static final int CAMERA_TILT = 57;
+  private static final int CAMERA_TILT = 50;
   private static int CAMERA_ZOOM = 17;
 
   private MapboxMap mapboxMap;


### PR DESCRIPTION
Currently seeing some issues with tiles loading (mainly with quicker camera movements around maneuvers) when the camera tilt is set to `57`:

![tilt_57](https://user-images.githubusercontent.com/8434572/30503627-ef081258-9a38-11e7-8979-8244161317ee.gif)

Issues seem to be reduced with tilt set to `50`: 

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/8434572/30503735-58374f64-9a39-11e7-8091-f8c383fcf70c.gif)

cc @ericrwolfe @kkaefer @tobrun 