### PR TITLE
Use stopSelf to kill service

### DIFF
--- a/navigation/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
+++ b/navigation/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
@@ -369,7 +369,7 @@ public class MapboxNavigation implements ServiceConnection, ProgressChangeListen
   public void endNavigation() {
     Timber.d("MapboxNavigation endNavigation called");
     if (isServiceAvailable()) {
-      navigationService.onDestroy();
+      navigationService.stopSelf();
       context.unbindService(this);
       isBound = false;
       navigationEventDispatcher.onNavigationEvent(false);

--- a/navigation/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationService.java
+++ b/navigation/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationService.java
@@ -77,6 +77,7 @@ public class NavigationService extends Service implements LocationEngineListener
 
   @Override
   public void onDestroy() {
+    super.onDestroy();
     // User canceled navigation session
     if (routeProgress != null && location != null) {
       NavigationMetricsWrapper.cancelEvent(mapboxNavigation.getSessionState(), routeProgress,
@@ -86,7 +87,6 @@ public class NavigationService extends Service implements LocationEngineListener
     if (notificationManager != null) {
       notificationManager.onDestroy();
     }
-    super.onDestroy();
   }
 
   /**
@@ -124,7 +124,6 @@ public class NavigationService extends Service implements LocationEngineListener
     } else {
       thread.quit();
     }
-    stopSelf();
   }
 
   /**


### PR DESCRIPTION
Avoids `onDestroy` being called twice in `NavigationService`