### PR TITLE
README bump to 0.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The snippet to add to your `build.gradle` file to use this SDK is the following:
 ```
 // Mapbox Navigation SDK for Android
 
-compile 'com.mapbox.mapboxsdk:mapbox-android-navigation:0.6.0'
+compile 'com.mapbox.mapboxsdk:mapbox-android-navigation:0.6.1'
 
 ```
 


### PR DESCRIPTION
Bumped to 0.6.1

Part of [the 0.6.1 release](https://github.com/mapbox/mapbox-navigation-android/issues/281)