### PR TITLE
Added Jacoco coverage report step

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -31,6 +31,9 @@ jobs:
             - ~/.gradle
           key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
       - run:
+          name: Jacoco test report
+          command: ./gradlew createDebugUnitTestCoverageReport
+      - run:
           name: Sonarcloud upload
           command: |
             ./gradlew sonarqube \


### PR DESCRIPTION
Added this to the circle ci script to occur before the sonarqube task.