### PR TITLE
Null check on the notification manager

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationService.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationService.java
@@ -140,7 +140,9 @@ public class NavigationService extends Service implements LocationEngineListener
    */
   void endNavigation() {
     locationEngine.removeLocationEngineListener(this);
-    navNotificationManager.unregisterReceiver();
+    if (navNotificationManager != null) {
+      navNotificationManager.unregisterReceiver();
+    }
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
       thread.quitSafely();
     } else {


### PR DESCRIPTION
If the notification is disabled, the manager will be null when we end the navigation service.  Adding null check to ignore unregistering the receiver when the manager is null.