### PR TITLE
Add telem current location engine being used track support

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -9,7 +9,8 @@ ext {
 
   version = [
       mapboxMapSdk       : '5.1.4',
-      mapboxServices     : '2.2.6',
+      // TODO Fix mapboxServices version when https://github.com/mapbox/mapbox-java/pull/605 lands
+      mapboxServices     : '2.3.0-SNAPSHOT',
       locationLayerPlugin: '0.1.0',
       autoValue          : '1.4.1',
       autoValueParcel    : '0.2.5',

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -9,7 +9,7 @@ ext {
 
   version = [
       mapboxMapSdk       : '5.1.4',
-      // TODO Fix mapboxServices version when https://github.com/mapbox/mapbox-java/pull/605 lands
+      // TODO Fix mapboxServices version when PR https://github.com/mapbox/mapbox-java/pull/605 lands
       mapboxServices     : '2.3.0-SNAPSHOT',
       locationLayerPlugin: '0.1.0',
       autoValue          : '1.4.1',

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/LocationViewModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/LocationViewModel.java
@@ -10,13 +10,13 @@ import android.content.SharedPreferences;
 import android.location.Location;
 import android.preference.PreferenceManager;
 
-import com.mapbox.mapboxsdk.location.LocationSource;
 import com.mapbox.services.android.location.MockLocationEngine;
 import com.mapbox.services.android.navigation.v5.navigation.NavigationConstants;
 import com.mapbox.services.android.navigation.v5.navigation.NavigationRoute;
 import com.mapbox.services.android.telemetry.location.LocationEngine;
 import com.mapbox.services.android.telemetry.location.LocationEngineListener;
 import com.mapbox.services.android.telemetry.location.LocationEnginePriority;
+import com.mapbox.services.android.telemetry.location.LostLocationEngine;
 import com.mapbox.services.api.directions.v5.models.DirectionsRoute;
 
 public class LocationViewModel extends AndroidViewModel implements LifecycleObserver, LocationEngineListener {
@@ -91,7 +91,7 @@ public class LocationViewModel extends AndroidViewModel implements LifecycleObse
   @SuppressWarnings( {"MissingPermission"})
   private void initLocation(Application application) {
     if (!shouldSimulateRoute()) {
-      modelLocationEngine = new LocationSource(application.getApplicationContext());
+      modelLocationEngine = new LostLocationEngine(application.getApplicationContext());
       modelLocationEngine.setPriority(LocationEnginePriority.HIGH_ACCURACY);
       modelLocationEngine.setFastestInterval(1000);
       modelLocationEngine.setInterval(0);

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
@@ -309,6 +309,8 @@ public class MapboxNavigation implements ServiceConnection, ProgressChangeListen
     // Notify service to get new location engine.
     if (isServiceAvailable()) {
       navigationService.acquireLocationEngine();
+      // Update location engine name in the session state
+      sessionState.toBuilder().locationEngineName(locationEngine.getClass().getSimpleName());
     }
   }
 
@@ -357,6 +359,7 @@ public class MapboxNavigation implements ServiceConnection, ProgressChangeListen
         .previousRouteDistancesCompleted(0)
         .startTimestamp(new Date())
         .rerouteCount(0)
+        .locationEngineName(locationEngine.getClass().getSimpleName())
         .mockLocation(locationEngine instanceof MockLocationEngine)
         .build();
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationMetricsWrapper.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationMetricsWrapper.java
@@ -12,6 +12,8 @@ import com.mapbox.services.android.telemetry.utils.TelemetryUtils;
 import java.util.Hashtable;
 import java.util.List;
 
+import timber.log.Timber;
+
 class NavigationMetricsWrapper {
   static String sdkIdentifier;
 
@@ -34,7 +36,8 @@ class NavigationMetricsWrapper {
       sessionState.originalDuration(), null, sessionState.currentStepCount(),
       sessionState.originalStepCount()
     );
-    MapboxTelemetry.getInstance().addLocationEngineName("placeholder", arriveEvent);
+    Timber.d("Arrive Location Engine name: " + sessionState.locationEngineName());
+    MapboxTelemetry.getInstance().addLocationEngineName(sessionState.locationEngineName(), arriveEvent);
     MapboxTelemetry.getInstance().pushEvent(arriveEvent);
   }
 
@@ -54,7 +57,8 @@ class NavigationMetricsWrapper {
       sessionState.originalDistance(), sessionState.originalDuration(), null,
       sessionState.arrivalTimestamp(), sessionState.currentStepCount(), sessionState.originalStepCount()
     );
-    MapboxTelemetry.getInstance().addLocationEngineName("placeholder", cancelEvent);
+    Timber.d("Cancel Location Engine name: " + sessionState.locationEngineName());
+    MapboxTelemetry.getInstance().addLocationEngineName(sessionState.locationEngineName(), cancelEvent);
     MapboxTelemetry.getInstance().pushEvent(cancelEvent);
   }
 
@@ -71,7 +75,8 @@ class NavigationMetricsWrapper {
       (int) routeProgress.distanceTraveled(), (int) routeProgress.distanceRemaining(),
       (int) routeProgress.durationRemaining(), sessionState.startTimestamp()
     );
-    MapboxTelemetry.getInstance().addLocationEngineName("placeholder", departEvent);
+    Timber.d("Depart Location Engine name: " + sessionState.locationEngineName());
+    MapboxTelemetry.getInstance().addLocationEngineName(sessionState.locationEngineName(), departEvent);
     MapboxTelemetry.getInstance().pushEvent(departEvent);
   }
 
@@ -129,7 +134,8 @@ class NavigationMetricsWrapper {
       (int) routeProgress.currentLegProgress().currentStepProgress().durationRemaining(),
       sessionState.currentStepCount(), sessionState.originalStepCount()
     );
-    MapboxTelemetry.getInstance().addLocationEngineName("placeholder", rerouteEvent);
+    Timber.d("Reroute Location Engine name: " + sessionState.locationEngineName());
+    MapboxTelemetry.getInstance().addLocationEngineName(sessionState.locationEngineName(), rerouteEvent);
     MapboxTelemetry.getInstance().pushEvent(rerouteEvent);
   }
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationMetricsWrapper.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationMetricsWrapper.java
@@ -9,6 +9,7 @@ import com.mapbox.services.android.telemetry.MapboxTelemetry;
 import com.mapbox.services.android.telemetry.navigation.MapboxNavigationEvent;
 import com.mapbox.services.android.telemetry.utils.TelemetryUtils;
 
+import java.util.Hashtable;
 import java.util.List;
 
 class NavigationMetricsWrapper {
@@ -19,7 +20,7 @@ class NavigationMetricsWrapper {
   }
 
   static void arriveEvent(SessionState sessionState, RouteProgress routeProgress, Location location) {
-    MapboxTelemetry.getInstance().pushEvent(MapboxNavigationEvent.buildArriveEvent(
+    Hashtable<String, Object> arriveEvent = MapboxNavigationEvent.buildArriveEvent(
       sdkIdentifier, BuildConfig.MAPBOX_NAVIGATION_VERSION_NAME,
       sessionState.sessionIdentifier(), location.getLatitude(), location.getLongitude(),
       sessionState.currentGeometry(), "unknown",
@@ -32,11 +33,13 @@ class NavigationMetricsWrapper {
       sessionState.originalGeometry(), sessionState.originalDistance(),
       sessionState.originalDuration(), null, sessionState.currentStepCount(),
       sessionState.originalStepCount()
-    ));
+    );
+    MapboxTelemetry.getInstance().addLocationEngineName("placeholder", arriveEvent);
+    MapboxTelemetry.getInstance().pushEvent(arriveEvent);
   }
 
   static void cancelEvent(SessionState sessionState, RouteProgress routeProgress, Location location) {
-    MapboxTelemetry.getInstance().pushEvent(MapboxNavigationEvent.buildCancelEvent(
+    Hashtable<String, Object> cancelEvent = MapboxNavigationEvent.buildCancelEvent(
       sdkIdentifier, BuildConfig.MAPBOX_NAVIGATION_VERSION_NAME,
       sessionState.sessionIdentifier(),
       location.getLatitude(), location.getLongitude(),
@@ -50,11 +53,13 @@ class NavigationMetricsWrapper {
       null, null, sessionState.originalGeometry(),
       sessionState.originalDistance(), sessionState.originalDuration(), null,
       sessionState.arrivalTimestamp(), sessionState.currentStepCount(), sessionState.originalStepCount()
-    ));
+    );
+    MapboxTelemetry.getInstance().addLocationEngineName("placeholder", cancelEvent);
+    MapboxTelemetry.getInstance().pushEvent(cancelEvent);
   }
 
   static void departEvent(SessionState sessionState, RouteProgress routeProgress, Location location) {
-    MapboxTelemetry.getInstance().pushEvent(MapboxNavigationEvent.buildDepartEvent(
+    Hashtable<String, Object> departEvent = MapboxNavigationEvent.buildDepartEvent(
       sdkIdentifier, BuildConfig.MAPBOX_NAVIGATION_VERSION_NAME,
       sessionState.sessionIdentifier(), location.getLatitude(), location.getLongitude(),
       sessionState.currentGeometry(), "unknown",
@@ -65,7 +70,9 @@ class NavigationMetricsWrapper {
       null, sessionState.currentStepCount(), sessionState.originalStepCount(),
       (int) routeProgress.distanceTraveled(), (int) routeProgress.distanceRemaining(),
       (int) routeProgress.durationRemaining(), sessionState.startTimestamp()
-    ));
+    );
+    MapboxTelemetry.getInstance().addLocationEngineName("placeholder", departEvent);
+    MapboxTelemetry.getInstance().pushEvent(departEvent);
   }
 
   static void rerouteEvent(SessionState sessionState, RouteProgress routeProgress, Location location) {
@@ -98,7 +105,7 @@ class NavigationMetricsWrapper {
 
     String previousName = routeProgress.currentLegProgress().currentStep().getName();
 
-    MapboxTelemetry.getInstance().pushEvent(MapboxNavigationEvent.buildRerouteEvent(
+    Hashtable<String, Object> rerouteEvent = MapboxNavigationEvent.buildRerouteEvent(
       sdkIdentifier, BuildConfig.MAPBOX_NAVIGATION_VERSION_NAME, sessionState.sessionIdentifier(),
       location.getLatitude(), location.getLongitude(),
       sessionState.currentGeometry(), "unknown",
@@ -121,7 +128,9 @@ class NavigationMetricsWrapper {
       (int) routeProgress.currentLegProgress().currentStepProgress().distanceRemaining(),
       (int) routeProgress.currentLegProgress().currentStepProgress().durationRemaining(),
       sessionState.currentStepCount(), sessionState.originalStepCount()
-    ));
+    );
+    MapboxTelemetry.getInstance().addLocationEngineName("placeholder", rerouteEvent);
+    MapboxTelemetry.getInstance().pushEvent(rerouteEvent);
   }
 
   static void turnstileEvent() {

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationMetricsWrapper.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationMetricsWrapper.java
@@ -12,8 +12,6 @@ import com.mapbox.services.android.telemetry.utils.TelemetryUtils;
 import java.util.Hashtable;
 import java.util.List;
 
-import timber.log.Timber;
-
 class NavigationMetricsWrapper {
   static String sdkIdentifier;
 
@@ -21,7 +19,8 @@ class NavigationMetricsWrapper {
     // Empty private constructor for preventing initialization of this class.
   }
 
-  static void arriveEvent(SessionState sessionState, RouteProgress routeProgress, Location location) {
+  static void arriveEvent(SessionState sessionState, RouteProgress routeProgress, Location location,
+                          String locationEngineName) {
     Hashtable<String, Object> arriveEvent = MapboxNavigationEvent.buildArriveEvent(
       sdkIdentifier, BuildConfig.MAPBOX_NAVIGATION_VERSION_NAME,
       sessionState.sessionIdentifier(), location.getLatitude(), location.getLongitude(),
@@ -36,12 +35,12 @@ class NavigationMetricsWrapper {
       sessionState.originalDuration(), null, sessionState.currentStepCount(),
       sessionState.originalStepCount()
     );
-    Timber.d("Arrive Location Engine name: " + sessionState.locationEngineName());
-    MapboxTelemetry.getInstance().addLocationEngineName(sessionState.locationEngineName(), arriveEvent);
+    MapboxTelemetry.getInstance().addLocationEngineName(locationEngineName, arriveEvent);
     MapboxTelemetry.getInstance().pushEvent(arriveEvent);
   }
 
-  static void cancelEvent(SessionState sessionState, RouteProgress routeProgress, Location location) {
+  static void cancelEvent(SessionState sessionState, RouteProgress routeProgress, Location location,
+                          String locationEngineName) {
     Hashtable<String, Object> cancelEvent = MapboxNavigationEvent.buildCancelEvent(
       sdkIdentifier, BuildConfig.MAPBOX_NAVIGATION_VERSION_NAME,
       sessionState.sessionIdentifier(),
@@ -57,12 +56,12 @@ class NavigationMetricsWrapper {
       sessionState.originalDistance(), sessionState.originalDuration(), null,
       sessionState.arrivalTimestamp(), sessionState.currentStepCount(), sessionState.originalStepCount()
     );
-    Timber.d("Cancel Location Engine name: " + sessionState.locationEngineName());
-    MapboxTelemetry.getInstance().addLocationEngineName(sessionState.locationEngineName(), cancelEvent);
+    MapboxTelemetry.getInstance().addLocationEngineName(locationEngineName, cancelEvent);
     MapboxTelemetry.getInstance().pushEvent(cancelEvent);
   }
 
-  static void departEvent(SessionState sessionState, RouteProgress routeProgress, Location location) {
+  static void departEvent(SessionState sessionState, RouteProgress routeProgress, Location location,
+                          String locationEngineName) {
     Hashtable<String, Object> departEvent = MapboxNavigationEvent.buildDepartEvent(
       sdkIdentifier, BuildConfig.MAPBOX_NAVIGATION_VERSION_NAME,
       sessionState.sessionIdentifier(), location.getLatitude(), location.getLongitude(),
@@ -75,12 +74,12 @@ class NavigationMetricsWrapper {
       (int) routeProgress.distanceTraveled(), (int) routeProgress.distanceRemaining(),
       (int) routeProgress.durationRemaining(), sessionState.startTimestamp()
     );
-    Timber.d("Depart Location Engine name: " + sessionState.locationEngineName());
-    MapboxTelemetry.getInstance().addLocationEngineName(sessionState.locationEngineName(), departEvent);
+    MapboxTelemetry.getInstance().addLocationEngineName(locationEngineName, departEvent);
     MapboxTelemetry.getInstance().pushEvent(departEvent);
   }
 
-  static void rerouteEvent(SessionState sessionState, RouteProgress routeProgress, Location location) {
+  static void rerouteEvent(SessionState sessionState, RouteProgress routeProgress, Location location,
+                           String locationEngineName) {
     String upcomingInstruction = null;
     String previousInstruction = null;
     String upcomingModifier = null;
@@ -134,8 +133,7 @@ class NavigationMetricsWrapper {
       (int) routeProgress.currentLegProgress().currentStepProgress().durationRemaining(),
       sessionState.currentStepCount(), sessionState.originalStepCount()
     );
-    Timber.d("Reroute Location Engine name: " + sessionState.locationEngineName());
-    MapboxTelemetry.getInstance().addLocationEngineName(sessionState.locationEngineName(), rerouteEvent);
+    MapboxTelemetry.getInstance().addLocationEngineName(locationEngineName, rerouteEvent);
     MapboxTelemetry.getInstance().pushEvent(rerouteEvent);
   }
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationService.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationService.java
@@ -56,6 +56,7 @@ public class NavigationService extends Service implements LocationEngineListener
   private long timeIntervalSinceLastOffRoute;
   private MapboxNavigation mapboxNavigation;
   private LocationEngine locationEngine;
+  private String locationEngineName;
   private RouteProgress routeProgress;
   private boolean firstProgressUpdate = true;
   private boolean queuedRerouteEvent;
@@ -105,7 +106,7 @@ public class NavigationService extends Service implements LocationEngineListener
     // User canceled navigation session
     if (routeProgress != null && rawLocation != null) {
       NavigationMetricsWrapper.cancelEvent(mapboxNavigation.getSessionState(), routeProgress,
-        rawLocation);
+        rawLocation, locationEngineName);
     }
     endNavigation();
     super.onDestroy();
@@ -162,6 +163,7 @@ public class NavigationService extends Service implements LocationEngineListener
   void acquireLocationEngine() {
     locationEngine = mapboxNavigation.getLocationEngine();
     locationEngine.addLocationEngineListener(this);
+    locationEngineName = obtainLocationEngineName();
   }
 
   /**
@@ -225,7 +227,7 @@ public class NavigationService extends Service implements LocationEngineListener
 
     if (firstProgressUpdate) {
       NavigationMetricsWrapper.departEvent(mapboxNavigation.getSessionState(), routeProgress,
-        rawLocation);
+        rawLocation, locationEngineName);
       firstProgressUpdate = false;
     }
     if (mapboxNavigation.options().enableNotification()) {
@@ -305,7 +307,7 @@ public class NavigationService extends Service implements LocationEngineListener
         locationBuffer.clear();
 
         NavigationMetricsWrapper.rerouteEvent(mapboxNavigation.getSessionState(), routeProgress,
-          rawLocation);
+          rawLocation, locationEngineName);
         queuedRerouteEvent = false;
       }
     };
@@ -317,5 +319,9 @@ public class NavigationService extends Service implements LocationEngineListener
       Timber.d("Local binder called.");
       return NavigationService.this;
     }
+  }
+
+  private String obtainLocationEngineName() {
+    return locationEngine.getClass().getSimpleName();
   }
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/SessionState.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/SessionState.java
@@ -101,8 +101,6 @@ abstract class SessionState {
   @Nullable
   abstract RouteProgress routeProgressBeforeReroute();
 
-  abstract String locationEngineName();
-
   abstract Builder toBuilder();
 
   static Builder builder() {
@@ -141,8 +139,6 @@ abstract class SessionState {
     abstract Builder arrivalTimestamp(@Nullable Date arrivalTimestamp);
 
     abstract Builder previousRouteDistancesCompleted(double previousRouteDistancesCompleted);
-
-    abstract Builder locationEngineName(String locationEngineName);
 
     abstract SessionState build();
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/SessionState.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/SessionState.java
@@ -101,6 +101,8 @@ abstract class SessionState {
   @Nullable
   abstract RouteProgress routeProgressBeforeReroute();
 
+  abstract String locationEngineName();
+
   abstract Builder toBuilder();
 
   static Builder builder() {
@@ -139,6 +141,8 @@ abstract class SessionState {
     abstract Builder arrivalTimestamp(@Nullable Date arrivalTimestamp);
 
     abstract Builder previousRouteDistancesCompleted(double previousRouteDistancesCompleted);
+
+    abstract Builder locationEngineName(String locationEngineName);
 
     abstract SessionState build();
 


### PR DESCRIPTION
- Fixes `NavigationMetricsWrapper` builder methods so that include the current location engine being used

In order to merge this PR https://github.com/mapbox/mapbox-java/pull/605 needs to get merged first.

TODO
- [x] Decide where to include location engine name being used so it could be pulled in from `NavigationMetricsWrapper` builder methods (now there is a `"placeholder"`) @cammace @danesfeder 
- [ ] [Bump `mapboxServices` version when https://github.com/mapbox/mapbox-java/pull/605 gets merged](https://github.com/mapbox/mapbox-navigation-android/blob/3b0c7ac44f49d226553f354646d428a259dcd51e/gradle/dependencies.gradle#L12-L13)

👀 @zugaldia @cammace @electrostat @ericrwolfe 