### PR TITLE
Add telem current location engine being used track support

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -9,7 +9,8 @@ ext {
 
   version = [
       mapboxMapSdk       : '5.1.4',
-      mapboxServices     : '2.2.6',
+      // TODO Fix mapboxServices version when releasing next version of MAS (2.2.7)
+      mapboxServices     : '2.3.0-SNAPSHOT',
       locationLayerPlugin: '0.1.0',
       autoValue          : '1.4.1',
       autoValueParcel    : '0.2.5',

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/LocationViewModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/LocationViewModel.java
@@ -11,13 +11,13 @@ import android.location.Location;
 import android.preference.PreferenceManager;
 
 import com.mapbox.directions.v5.models.DirectionsRoute;
-import com.mapbox.mapboxsdk.location.LocationSource;
 import com.mapbox.services.android.navigation.v5.location.MockLocationEngine;
 import com.mapbox.services.android.navigation.v5.navigation.NavigationConstants;
 import com.mapbox.services.android.navigation.v5.navigation.NavigationRoute;
 import com.mapbox.services.android.telemetry.location.LocationEngine;
 import com.mapbox.services.android.telemetry.location.LocationEngineListener;
 import com.mapbox.services.android.telemetry.location.LocationEnginePriority;
+import com.mapbox.services.android.telemetry.location.LostLocationEngine;
 
 public class LocationViewModel extends AndroidViewModel implements LifecycleObserver, LocationEngineListener {
 
@@ -91,7 +91,7 @@ public class LocationViewModel extends AndroidViewModel implements LifecycleObse
   @SuppressWarnings( {"MissingPermission"})
   private void initLocation(Application application) {
     if (!shouldSimulateRoute()) {
-      modelLocationEngine = new LocationSource(application.getApplicationContext());
+      modelLocationEngine = new LostLocationEngine(application.getApplicationContext());
       modelLocationEngine.setPriority(LocationEnginePriority.HIGH_ACCURACY);
       modelLocationEngine.setFastestInterval(1000);
       modelLocationEngine.setInterval(0);

--- a/libandroid-navigation/build.gradle
+++ b/libandroid-navigation/build.gradle
@@ -42,9 +42,10 @@ android {
 
 dependencies {
   // Mapbox Android Services
-  compile 'com.mapbox.mapboxsdk:mapbox-android-telemetry:2.2.6'
-
-  compile ('com.mapbox.mapboxsdk:mapbox-android-services:2.2.6@aar') {
+  // TODO Fix mapboxServices version when releasing next version of MAS (2.2.7)
+  compile 'com.mapbox.mapboxsdk:mapbox-android-telemetry:2.3.0-SNAPSHOT'
+  // TODO Fix mapboxServices version when releasing next version of MAS (2.2.7)
+  compile ('com.mapbox.mapboxsdk:mapbox-android-services:2.3.0-SNAPSHOT@aar') {
     transitive = true
     exclude module: 'mapbox-java-geojson'
     exclude module: 'mapbox-java-core'

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
@@ -14,10 +14,10 @@ import com.mapbox.directions.v5.models.DirectionsRoute;
 import com.mapbox.services.android.location.LostLocationEngine;
 import com.mapbox.services.android.navigation.BuildConfig;
 import com.mapbox.services.android.navigation.v5.exception.NavigationException;
-import com.mapbox.services.android.navigation.v5.milestone.VoiceInstructionMilestone;
+import com.mapbox.services.android.navigation.v5.location.MockLocationEngine;
 import com.mapbox.services.android.navigation.v5.milestone.Milestone;
 import com.mapbox.services.android.navigation.v5.milestone.MilestoneEventListener;
-import com.mapbox.services.android.navigation.v5.location.MockLocationEngine;
+import com.mapbox.services.android.navigation.v5.milestone.VoiceInstructionMilestone;
 import com.mapbox.services.android.navigation.v5.offroute.OffRoute;
 import com.mapbox.services.android.navigation.v5.offroute.OffRouteDetector;
 import com.mapbox.services.android.navigation.v5.offroute.OffRouteListener;
@@ -32,7 +32,6 @@ import com.mapbox.services.android.telemetry.location.LocationEngine;
 import com.mapbox.services.android.telemetry.location.LocationEnginePriority;
 import com.mapbox.services.android.telemetry.utils.TelemetryUtils;
 import com.mapbox.services.utils.TextUtils;
-
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -637,7 +636,8 @@ public class MapboxNavigation implements ServiceConnection, ProgressChangeListen
   public void onProgressChange(Location location, RouteProgress routeProgress) {
     Timber.v("Arrived event occurred");
     sessionState = sessionState.toBuilder().arrivalTimestamp(new Date()).build();
-    NavigationMetricsWrapper.arriveEvent(sessionState, routeProgress, location);
+    String locationEngineName = obtainLocationEngineName();
+    NavigationMetricsWrapper.arriveEvent(sessionState, routeProgress, location, locationEngineName);
     // Remove all listeners except the onProgressChange by passing in null.
     navigationEventDispatcher.removeOffRouteListener(null);
     // Remove this listener so that the arrival event only occurs once.
@@ -690,5 +690,9 @@ public class MapboxNavigation implements ServiceConnection, ProgressChangeListen
     Timber.d("Disconnected from service.");
     navigationService = null;
     isBound = false;
+  }
+
+  private String obtainLocationEngineName() {
+    return locationEngine.getClass().getSimpleName();
   }
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationMetricsWrapper.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationMetricsWrapper.java
@@ -29,8 +29,9 @@ final class NavigationMetricsWrapper {
     // Empty private constructor for preventing initialization of this class.
   }
 
-  static void arriveEvent(SessionState sessionState, RouteProgress routeProgress, Location location) {
-    MapboxTelemetry.getInstance().pushEvent(MapboxNavigationEvent.buildArriveEvent(
+  static void arriveEvent(SessionState sessionState, RouteProgress routeProgress, Location location,
+                          String locationEngineName) {
+    Hashtable<String, Object> arriveEvent = MapboxNavigationEvent.buildArriveEvent(
       sdkIdentifier, BuildConfig.MAPBOX_NAVIGATION_VERSION_NAME,
       sessionState.sessionIdentifier(), location.getLatitude(), location.getLongitude(),
       sessionState.currentGeometry(), routeProgress.directionsRoute().routeOptions().profile(),
@@ -44,11 +45,14 @@ final class NavigationMetricsWrapper {
       sessionState.originalGeometry(), sessionState.originalDistance(),
       sessionState.originalDuration(), null, sessionState.currentStepCount(),
       sessionState.originalStepCount()
-    ));
+    );
+    MapboxTelemetry.getInstance().addLocationEngineName(locationEngineName, arriveEvent);
+    MapboxTelemetry.getInstance().pushEvent(arriveEvent);
   }
 
-  static void cancelEvent(SessionState sessionState, RouteProgress routeProgress, Location location) {
-    MapboxTelemetry.getInstance().pushEvent(MapboxNavigationEvent.buildCancelEvent(
+  static void cancelEvent(SessionState sessionState, RouteProgress routeProgress, Location location,
+                          String locationEngineName) {
+    Hashtable<String, Object> cancelEvent = MapboxNavigationEvent.buildCancelEvent(
       sdkIdentifier, BuildConfig.MAPBOX_NAVIGATION_VERSION_NAME,
       sessionState.sessionIdentifier(),
       location.getLatitude(), location.getLongitude(),
@@ -63,11 +67,14 @@ final class NavigationMetricsWrapper {
       sessionState.originalGeometry(),
       sessionState.originalDistance(), sessionState.originalDuration(), null,
       sessionState.arrivalTimestamp(), sessionState.currentStepCount(), sessionState.originalStepCount()
-    ));
+    );
+    MapboxTelemetry.getInstance().addLocationEngineName(locationEngineName, cancelEvent);
+    MapboxTelemetry.getInstance().pushEvent(cancelEvent);
   }
 
-  static void departEvent(SessionState sessionState, RouteProgress routeProgress, Location location) {
-    MapboxTelemetry.getInstance().pushEvent(MapboxNavigationEvent.buildDepartEvent(
+  static void departEvent(SessionState sessionState, RouteProgress routeProgress, Location location,
+                          String locationEngineName) {
+    Hashtable<String, Object> departEvent = MapboxNavigationEvent.buildDepartEvent(
       sdkIdentifier, BuildConfig.MAPBOX_NAVIGATION_VERSION_NAME,
       sessionState.sessionIdentifier(), location.getLatitude(), location.getLongitude(),
       sessionState.currentGeometry(), routeProgress.directionsRoute().routeOptions().profile(),
@@ -79,11 +86,13 @@ final class NavigationMetricsWrapper {
       null, sessionState.currentStepCount(), sessionState.originalStepCount(),
       (int) routeProgress.distanceTraveled(), (int) routeProgress.distanceRemaining(),
       (int) routeProgress.durationRemaining(), sessionState.startTimestamp()
-    ));
+    );
+    MapboxTelemetry.getInstance().addLocationEngineName(locationEngineName, departEvent);
+    MapboxTelemetry.getInstance().pushEvent(departEvent);
   }
 
-  static void rerouteEvent(SessionState sessionState, RouteProgress routeProgress, Location location) {
-
+  static void rerouteEvent(SessionState sessionState, RouteProgress routeProgress, Location location,
+                           String locationEngineName) {
     updateRouteProgressSessionData(routeProgress, sessionState);
 
     Hashtable<String, Object> rerouteEvent = MapboxNavigationEvent.buildRerouteEvent(
@@ -110,15 +119,15 @@ final class NavigationMetricsWrapper {
       (int) routeProgress.currentLegProgress().currentStepProgress().durationRemaining(),
       sessionState.currentStepCount(), sessionState.originalStepCount());
     rerouteEvent.put(MapboxNavigationEvent.KEY_CREATED, TelemetryUtils.generateCreateDate(location));
+    MapboxTelemetry.getInstance().addLocationEngineName(locationEngineName, rerouteEvent);
     MapboxTelemetry.getInstance().pushEvent(rerouteEvent);
   }
 
   static void feedbackEvent(SessionState sessionState, RouteProgress routeProgress, Location location,
-                            String description, String feedbackType, String screenshot) {
+                            String description, String feedbackType, String screenshot, String locationEngineName) {
     updateRouteProgressSessionData(routeProgress, sessionState);
 
-
-    MapboxTelemetry.getInstance().pushEvent(MapboxNavigationEvent.buildFeedbackEvent(sdkIdentifier,
+    Hashtable<String, Object> feedbackEvent = MapboxNavigationEvent.buildFeedbackEvent(sdkIdentifier,
       BuildConfig.MAPBOX_NAVIGATION_VERSION_NAME, sessionState.sessionIdentifier(), location.getLatitude(),
       location.getLongitude(), sessionState.currentGeometry(), routeProgress.directionsRoute().routeOptions().profile(),
       routeProgress.directionsRoute().distance().intValue(), routeProgress.directionsRoute().duration().intValue(),
@@ -134,9 +143,9 @@ final class NavigationMetricsWrapper {
       routeProgress.currentLegProgress().currentStep().duration().intValue(),
       (int) routeProgress.currentLegProgress().currentStepProgress().distanceRemaining(),
       (int) routeProgress.currentLegProgress().currentStepProgress().durationRemaining(),
-      sessionState.currentStepCount(), sessionState.originalStepCount()
-      )
-    );
+      sessionState.currentStepCount(), sessionState.originalStepCount());
+    MapboxTelemetry.getInstance().addLocationEngineName(locationEngineName, feedbackEvent);
+    MapboxTelemetry.getInstance().pushEvent(feedbackEvent);
   }
 
   static void turnstileEvent() {


### PR DESCRIPTION
Follow up work of https://github.com/mapbox/mapbox-navigation-android/pull/382 including latest changes from `master`.

- Fixes `NavigationMetricsWrapper` builder methods so that include the current location engine being used

https://github.com/mapbox/mapbox-java/pull/605 got merged.

TODO
- [ ] Bump MAS version when the new release (`2.2.7`) lands

👀 @zugaldia @cammace @electrostat @ericrwolfe 
