### PR TITLE
Cancel notification when service is destroyed 

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationNotification.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationNotification.java
@@ -111,6 +111,9 @@ class NavigationNotification {
     if (context != null) {
       context.unregisterReceiver(endNavigationBtnReceiver);
     }
+    if (notificationManager != null) {
+      notificationManager.cancel(NAVIGATION_NOTIFICATION_ID);
+    }
   }
 
   private boolean newStepName(RouteProgress routeProgress) {
@@ -215,9 +218,6 @@ class NavigationNotification {
   };
 
   private void onEndNavigationBtnClick() {
-    if (notificationManager != null) {
-      notificationManager.cancel(NAVIGATION_NOTIFICATION_ID);
-    }
     if (mapboxNavigation != null) {
       mapboxNavigation.endNavigation();
     }


### PR DESCRIPTION
Cancel notification when the service is destroyed, not just when notification button `End Navigation` is clicked