### PR TITLE
Delay initializing runtime styling on startup

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
@@ -102,7 +102,7 @@ public class NavigationView extends CoordinatorLayout implements OnMapReadyCallb
 
   public void onCreate(@Nullable Bundle savedInstanceState) {
     resumeState = savedInstanceState != null;
-    initMap(savedInstanceState);
+    mapView.onCreate(savedInstanceState);
   }
 
   public void onStart() {
@@ -158,13 +158,18 @@ public class NavigationView extends CoordinatorLayout implements OnMapReadyCallb
     map = mapboxMap;
     map.setOnScrollListener(this);
     setMapPadding(0, 0, 0, summaryBehavior.getPeekHeight());
-    initRoute();
-    initCamera();
-    initLocationLayer();
-    initLifecycleObservers();
-    initNavigationPresenter();
-    subscribeViews();
-    navigationListener.onNavigationReady();
+    ThemeSwitcher.setMapStyle(getContext(), map, new MapboxMap.OnStyleLoadedListener() {
+      @Override
+      public void onStyleLoaded(String style) {
+        initRoute();
+        initCamera();
+        initLocationLayer();
+        initLifecycleObservers();
+        initNavigationPresenter();
+        subscribeViews();
+        navigationListener.onNavigationReady();
+      }
+    });
   }
 
   /**
@@ -412,16 +417,6 @@ public class NavigationView extends CoordinatorLayout implements OnMapReadyCallb
         navigationPresenter.onMuteClick(instructionView.toggleMute());
       }
     });
-  }
-
-  /**
-   * Sets up the {@link MapboxMap}.
-   *
-   * @param savedInstanceState from onCreate()
-   */
-  private void initMap(Bundle savedInstanceState) {
-    mapView.onCreate(savedInstanceState);
-    ThemeSwitcher.setMapStyle(getContext(), mapView);
   }
 
   /**

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/ThemeSwitcher.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/ThemeSwitcher.java
@@ -11,6 +11,7 @@ import android.support.v4.content.ContextCompat;
 import com.mapbox.mapboxsdk.annotations.Icon;
 import com.mapbox.mapboxsdk.annotations.IconFactory;
 import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
 
 /**
  * This class is used to switch theme colors in {@link NavigationView}.
@@ -52,14 +53,14 @@ public class ThemeSwitcher {
    * Sets the {@link MapView} style based on the current theme setting.
    *
    * @param context to retrieve {@link SharedPreferences}
-   * @param mapView  the style will be set on
+   * @param map     the style will be set on
    */
-  static void setMapStyle(Context context, MapView mapView) {
+  static void setMapStyle(Context context, MapboxMap map, MapboxMap.OnStyleLoadedListener listener) {
     SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
     boolean darkThemeEnabled = preferences.getBoolean(context.getString(R.string.dark_theme_enabled), false);
     String nightThemeUrl = context.getString(R.string.navigation_guidance_night_v2);
     String dayThemeUrl = context.getString(R.string.navigation_guidance_day_v2);
-    mapView.setStyleUrl(darkThemeEnabled ? nightThemeUrl : dayThemeUrl);
+    map.setStyleUrl(darkThemeEnabled ? nightThemeUrl : dayThemeUrl, listener);
   }
 
   /**


### PR DESCRIPTION
- Wait for map style to load before initializing run time styling
- Client side fix for native crash we were seeing when launching the "drop-in" UI 

cc @ericrwolfe @brunoabinader 