### PR TITLE
Current step removed from instruction list 

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/NavigationViewActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/NavigationViewActivity.java
@@ -225,6 +225,7 @@ public class NavigationViewActivity extends AppCompatActivity implements OnMapRe
 
     if (locationEngine.getLastLocation() != null) {
       Location lastLocation = locationEngine.getLastLocation();
+      onLocationChanged(lastLocation);
       currentLocation = Point.fromLngLat(lastLocation.getLongitude(), lastLocation.getLatitude());
     }
   }


### PR DESCRIPTION
- Update adapter to remove current and upcoming steps from instruction list
- Also update on new leg, comparing leg objects instead of index.  Should prevent stale list on reroute.

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/8434572/32196366-a287f5ac-bd7d-11e7-8a4f-da9a669a3bc8.gif)

cc @ericrwolfe 