### PR TITLE
Check for null raw location before setting bearing in RouteViewModel

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/RouteViewModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/RouteViewModel.java
@@ -94,8 +94,11 @@ public class RouteViewModel extends ViewModel implements Callback<DirectionsResp
    */
   private void fetchRoute(Point origin, Point destination) {
     if (origin != null && destination != null) {
-      Double bearing
-        = rawLocation.hasBearing() ? Float.valueOf(rawLocation.getBearing()).doubleValue() : null;
+
+      Double bearing = null;
+      if (rawLocation != null) {
+        bearing = rawLocation.hasBearing() ? Float.valueOf(rawLocation.getBearing()).doubleValue() : null;
+      }
 
       NavigationRoute.builder()
         .accessToken(Mapbox.getAccessToken())


### PR DESCRIPTION
- If the raw location in `RouteViewModel` is null, do not try to use it for a bearing value