### PR TITLE
Fix telem related tests

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/Telemetry.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/Telemetry.java
@@ -1,0 +1,48 @@
+package com.mapbox.services.android.navigation.v5.navigation;
+
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+
+import com.mapbox.services.android.navigation.BuildConfig;
+import com.mapbox.services.android.navigation.v5.exception.NavigationException;
+import com.mapbox.services.android.telemetry.MapboxEvent;
+import com.mapbox.services.android.telemetry.MapboxTelemetry;
+import com.mapbox.services.utils.TextUtils;
+
+import java.util.Locale;
+
+class Telemetry {
+  private static final String MAPBOX_NAVIGATION_SDK_IDENTIFIER = "mapbox-navigation-android";
+  private static final String MAPBOX_NAVIGATION_UI_SDK_IDENTIFIER = "mapbox-navigation-ui-android";
+
+  void initialize(@NonNull Context context, @NonNull String accessToken, boolean isFromNavigationUi,
+                  boolean debugLoggingEnabled) {
+    validateAccessToken(accessToken);
+    String sdkIdentifier = MAPBOX_NAVIGATION_SDK_IDENTIFIER;
+    if (isFromNavigationUi) {
+      sdkIdentifier = MAPBOX_NAVIGATION_UI_SDK_IDENTIFIER;
+    }
+    String userAgent = String.format("%s/%s", sdkIdentifier, BuildConfig.MAPBOX_NAVIGATION_VERSION_NAME);
+    MapboxTelemetry.getInstance().initialize(context, accessToken, userAgent, sdkIdentifier,
+      BuildConfig.MAPBOX_NAVIGATION_VERSION_NAME);
+    MapboxTelemetry.getInstance().newUserAgent(userAgent);
+
+    // Enable extra logging in debug mode
+    MapboxTelemetry.getInstance().setDebugLoggingEnabled(debugLoggingEnabled);
+
+    NavigationMetricsWrapper.sdkIdentifier = sdkIdentifier;
+    NavigationMetricsWrapper.turnstileEvent();
+    // TODO This should be removed when we figure out a solution in Telemetry
+    // Force pushing a TYPE_MAP_LOAD event to ensure that the Nav turnstile event is sent
+    MapboxTelemetry.getInstance().pushEvent(MapboxEvent.buildMapLoadEvent());
+  }
+
+  private void validateAccessToken(String accessToken) {
+    if (TextUtils.isEmpty(accessToken) || (!accessToken.toLowerCase(Locale.US).startsWith("pk.")
+      && !accessToken.toLowerCase(Locale.US).startsWith("sk."))) {
+      throw new NavigationException("A valid access token must be passed in when first initializing"
+        + " MapboxNavigation");
+    }
+  }
+}

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/ValidationUtils.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/ValidationUtils.java
@@ -12,7 +12,9 @@ public final class ValidationUtils {
 
   public static void validDirectionsRoute(DirectionsRoute directionsRoute,
                                           boolean defaultMilestonesEnabled) {
-    if (defaultMilestonesEnabled && !directionsRoute.routeOptions().voiceInstructions()) {
+    if (defaultMilestonesEnabled
+      && directionsRoute.routeOptions() != null
+      && !directionsRoute.routeOptions().voiceInstructions()) {
       throw new MissingFormatArgumentException("Using the default milestone requires the "
         + "directions route to include the voice instructions object.");
     }

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationTest.java
@@ -31,18 +31,16 @@ public class MapboxNavigationTest extends BaseTest {
   private MapboxNavigation navigation;
 
   @Before
-  @Ignore
   public void setUp() throws Exception {
-    navigation = new MapboxNavigation(mock(Context.class), ACCESS_TOKEN);
+    navigation = new MapboxNavigation(mock(Context.class), ACCESS_TOKEN, mock(Telemetry.class));
   }
 
   @Test
-  @Ignore
   public void sanityTest() {
     assertNotNull("should not be null", navigation);
     MapboxNavigationOptions options = MapboxNavigationOptions.builder().build();
     MapboxNavigation navigationWithOptions = new MapboxNavigation(mock(Context.class),
-      ACCESS_TOKEN, options);
+      ACCESS_TOKEN, options, mock(Telemetry.class));
     assertNotNull("should not be null", navigationWithOptions);
   }
 
@@ -53,16 +51,14 @@ public class MapboxNavigationTest extends BaseTest {
   }
 
   @Test
-  @Ignore
   public void defaultMilestones_onInitializationDoNotGetAdded() throws Exception {
     MapboxNavigationOptions options = MapboxNavigationOptions.builder().defaultMilestonesEnabled(false).build();
     MapboxNavigation navigationWithOptions = new MapboxNavigation(mock(Context.class),
-      ACCESS_TOKEN, options);
+      ACCESS_TOKEN, options, mock(Telemetry.class));
     assertEquals(0, navigationWithOptions.getMilestones().size());
   }
 
   @Test
-  @Ignore
   public void initializeLocationEngine_didInitialize() throws Exception {
     assertEquals(0, navigation.getLocationEngine().getInterval());
     assertEquals(1000, navigation.getLocationEngine().getFastestInterval());
@@ -71,14 +67,12 @@ public class MapboxNavigationTest extends BaseTest {
   }
 
   @Test
-  @Ignore
   public void defaultEngines_didGetInitialized() throws Exception {
     assertNotNull(navigation.getSnapEngine());
     assertNotNull(navigation.getOffRouteEngine());
   }
 
   @Test
-  @Ignore
   public void addMilestone_milestoneDidGetAdded() throws Exception {
     Milestone milestone = new StepMilestone.Builder().build();
     navigation.addMilestone(milestone);
@@ -86,11 +80,10 @@ public class MapboxNavigationTest extends BaseTest {
   }
 
   @Test
-  @Ignore
   public void addMilestone_milestoneOnlyGetsAddedOnce() throws Exception {
     MapboxNavigationOptions options = MapboxNavigationOptions.builder().defaultMilestonesEnabled(false).build();
     MapboxNavigation navigationWithOptions = new MapboxNavigation(mock(Context.class),
-      ACCESS_TOKEN, options);
+      ACCESS_TOKEN, options, mock(Telemetry.class));
     Milestone milestone = new StepMilestone.Builder().build();
     navigationWithOptions.addMilestone(milestone);
     navigationWithOptions.addMilestone(milestone);
@@ -98,11 +91,10 @@ public class MapboxNavigationTest extends BaseTest {
   }
 
   @Test
-  @Ignore
   public void removeMilestone_milestoneDidGetRemoved() throws Exception {
     MapboxNavigationOptions options = MapboxNavigationOptions.builder().defaultMilestonesEnabled(false).build();
     MapboxNavigation navigationWithOptions = new MapboxNavigation(mock(Context.class),
-      ACCESS_TOKEN, options);
+      ACCESS_TOKEN, options, mock(Telemetry.class));
     Milestone milestone = new StepMilestone.Builder().build();
     navigationWithOptions.addMilestone(milestone);
     assertEquals(1, navigationWithOptions.getMilestones().size());
@@ -111,11 +103,10 @@ public class MapboxNavigationTest extends BaseTest {
   }
 
   @Test
-  @Ignore
   public void removeMilestone_milestoneDoesNotExist() throws Exception {
     MapboxNavigationOptions options = MapboxNavigationOptions.builder().defaultMilestonesEnabled(false).build();
     MapboxNavigation navigationWithOptions = new MapboxNavigation(mock(Context.class),
-      ACCESS_TOKEN, options);
+      ACCESS_TOKEN, options, mock(Telemetry.class));
     Milestone milestone = new StepMilestone.Builder().build();
     navigationWithOptions.addMilestone(new StepMilestone.Builder().build());
     navigationWithOptions.removeMilestone(milestone);
@@ -123,11 +114,10 @@ public class MapboxNavigationTest extends BaseTest {
   }
 
   @Test
-  @Ignore
   public void removeMilestone_nullRemovesAllMilestones() throws Exception {
     MapboxNavigationOptions options = MapboxNavigationOptions.builder().defaultMilestonesEnabled(false).build();
     MapboxNavigation navigationWithOptions = new MapboxNavigation(mock(Context.class),
-      ACCESS_TOKEN, options);
+      ACCESS_TOKEN, options, mock(Telemetry.class));
     navigationWithOptions.addMilestone(new StepMilestone.Builder().build());
     navigationWithOptions.addMilestone(new StepMilestone.Builder().build());
     navigationWithOptions.addMilestone(new StepMilestone.Builder().build());
@@ -138,11 +128,10 @@ public class MapboxNavigationTest extends BaseTest {
   }
 
   @Test
-  @Ignore
   public void removeMilestone_correctMilestoneWithIdentifierGetsRemoved() throws Exception {
     MapboxNavigationOptions options = MapboxNavigationOptions.builder().defaultMilestonesEnabled(false).build();
     MapboxNavigation navigationWithOptions = new MapboxNavigation(mock(Context.class),
-      ACCESS_TOKEN, options);
+      ACCESS_TOKEN, options, mock(Telemetry.class));
     Milestone milestone = new StepMilestone.Builder().setIdentifier(5678).build();
     navigationWithOptions.addMilestone(milestone);
     assertEquals(1, navigationWithOptions.getMilestones().size());
@@ -151,11 +140,10 @@ public class MapboxNavigationTest extends BaseTest {
   }
 
   @Test
-  @Ignore
   public void removeMilestone_noMilestoneWithIdentifierFound() throws Exception {
     MapboxNavigationOptions options = MapboxNavigationOptions.builder().defaultMilestonesEnabled(false).build();
     MapboxNavigation navigationWithOptions = new MapboxNavigation(mock(Context.class),
-      ACCESS_TOKEN, options);
+      ACCESS_TOKEN, options, mock(Telemetry.class));
     navigationWithOptions.addMilestone(new StepMilestone.Builder().build());
     assertEquals(1, navigationWithOptions.getMilestones().size());
     navigationWithOptions.removeMilestone(5678);
@@ -163,7 +151,6 @@ public class MapboxNavigationTest extends BaseTest {
   }
 
   @Test
-  @Ignore
   public void getLocationEngine_returnsCorrectLocationEngine() throws Exception {
     LocationEngine locationEngine = mock(LocationEngine.class);
     LocationEngine locationEngine2 = mock(LocationEngine.class);
@@ -192,7 +179,6 @@ public class MapboxNavigationTest extends BaseTest {
   }
 
   @Test
-  @Ignore
   public void setSnapEngine_doesReplaceDefaultEngine() throws Exception {
     Snap snap = navigation.getSnapEngine();
     assertTrue(snap instanceof SnapToRoute);
@@ -203,7 +189,6 @@ public class MapboxNavigationTest extends BaseTest {
   }
 
   @Test
-  @Ignore
   public void setOffRouteEngine_doesReplaceDefaultEngine() throws Exception {
     OffRoute offRoute = navigation.getOffRouteEngine();
     assertTrue(offRoute instanceof OffRouteDetector);

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationTest.java
@@ -18,6 +18,7 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.VOICE_INSTRUCTION_MILESTONE_ID;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertNotSame;
@@ -45,9 +46,9 @@ public class MapboxNavigationTest extends BaseTest {
   }
 
   @Test
-  @Ignore
-  public void defaultMilestones_onInitializationDoGetAdded() throws Exception {
-    assertTrue(navigation.getMilestones().size() > 5);
+  public void voiceMilestone_onInitializationDoesGetAdded() throws Exception {
+    assertTrue(navigation.getMilestones().size() == 1
+      && navigation.getMilestones().get(0).getIdentifier() == VOICE_INSTRUCTION_MILESTONE_ID);
   }
 
   @Test
@@ -170,7 +171,6 @@ public class MapboxNavigationTest extends BaseTest {
   }
 
   @Test
-  @Ignore
   public void startNavigation_doesSendTrueToNavigationEvent() throws Exception {
     NavigationEventListener navigationEventListener = mock(NavigationEventListener.class);
     navigation.addNavigationEventListener(navigationEventListener);


### PR DESCRIPTION
- Fixes telem related tests (`MapboxNavigation`)
  - Removes `@Ignore` tag from a bunch of tests in `MapboxNavigationTest`
    - `endNavigation_doesSendFalseToNavigationEvent`, `defaultMilestones_onInitializationDoGetAdded` and `startNavigation_doesSendTrueToNavigationEvent` are failing because of other issues
      - [ ] Check if those are now out of date 👀 @cammace 
        - [ ] If not, fix them

👀 @cammace @danesfeder 

