### PR TITLE
Add Custom themes via XML for light / dark mode

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
@@ -94,7 +94,7 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
   public NavigationView(Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
     super(context, attrs, defStyleAttr);
     AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_AUTO);
-    ThemeSwitcher.setTheme(getContext());
+    ThemeSwitcher.setTheme(getContext(), attrs);
     init();
   }
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
@@ -359,7 +359,9 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
    * route.
    */
   private void initRoute() {
-    mapRoute = new NavigationMapRoute(mapView, map, NavigationConstants.ROUTE_BELOW_LAYER);
+    int routeStyleRes = ThemeSwitcher.retrieveNavigationViewRouteStyle(getContext());
+    mapRoute = new NavigationMapRoute(null, mapView, map,
+      routeStyleRes, NavigationConstants.ROUTE_BELOW_LAYER);
   }
 
   /**

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/ThemeSwitcher.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/ThemeSwitcher.java
@@ -8,6 +8,7 @@ import android.content.res.TypedArray;
 import android.preference.PreferenceManager;
 import android.support.v4.content.ContextCompat;
 import android.util.AttributeSet;
+import android.util.TypedValue;
 
 import com.mapbox.mapboxsdk.annotations.Icon;
 import com.mapbox.mapboxsdk.annotations.IconFactory;
@@ -35,10 +36,12 @@ public class ThemeSwitcher {
     editor.putBoolean(context.getString(R.string.dark_theme_enabled), darkThemeEnabled);
     editor.apply();
 
-    TypedArray array = context.obtainStyledAttributes(attrs, R.styleable.NavigationView);
-    int lightTheme = array.getResourceId(R.styleable.NavigationView_navigationLightTheme, R.style.NavigationViewLight);
-    int darkTheme = array.getResourceId(R.styleable.NavigationView_navigationDarkTheme, R.style.NavigationViewDark);
-    array.recycle();
+    TypedArray styledAttributes = context.obtainStyledAttributes(attrs, R.styleable.NavigationView);
+    int lightTheme = styledAttributes.getResourceId(R.styleable.NavigationView_navigationLightTheme,
+      R.style.NavigationViewLight);
+    int darkTheme = styledAttributes.getResourceId(R.styleable.NavigationView_navigationDarkTheme,
+      R.style.NavigationViewDark);
+    styledAttributes.recycle();
 
     context.setTheme(darkThemeEnabled ? darkTheme : lightTheme);
   }
@@ -64,11 +67,10 @@ public class ThemeSwitcher {
    * @param map     the style will be set on
    */
   static void setMapStyle(Context context, MapboxMap map, MapboxMap.OnStyleLoadedListener listener) {
-    SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
-    boolean darkThemeEnabled = preferences.getBoolean(context.getString(R.string.dark_theme_enabled), false);
-    String nightThemeUrl = context.getString(R.string.navigation_guidance_night_v2);
-    String dayThemeUrl = context.getString(R.string.navigation_guidance_day_v2);
-    map.setStyleUrl(darkThemeEnabled ? nightThemeUrl : dayThemeUrl, listener);
+    TypedValue mapStyleAttr = new TypedValue();
+    context.getTheme().resolveAttribute(R.attr.navigationViewMapStyle, mapStyleAttr, true);
+    String styleUrl = mapStyleAttr.string.toString();
+    map.setStyleUrl(styleUrl, listener);
   }
 
   /**
@@ -92,16 +94,9 @@ public class ThemeSwitcher {
    * @return color resource identifier for primary theme color
    */
   public static int retrieveNavigationViewPrimaryColor(Context context) {
-    SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
-    boolean darkThemeEnabled = preferences.getBoolean(context.getString(R.string.dark_theme_enabled), false);
-    TypedArray styleArray = context.obtainStyledAttributes(
-      darkThemeEnabled ? R.style.NavigationViewDark : R.style.NavigationViewLight,
-      R.styleable.NavigationView
-    );
-    int navigationViewPrimary = styleArray.getColor(R.styleable.NavigationView_navigationViewPrimary,
-      ContextCompat.getColor(context, R.color.mapbox_navigation_view_color_primary));
-    styleArray.recycle();
-    return navigationViewPrimary;
+    TypedValue outValue = new TypedValue();
+    context.getTheme().resolveAttribute(R.attr.navigationViewPrimary, outValue, true);
+    return ContextCompat.getColor(context, outValue.resourceId);
   }
 
   /**
@@ -112,16 +107,9 @@ public class ThemeSwitcher {
    * @return color resource identifier for secondary theme color
    */
   public static int retrieveNavigationViewSecondaryColor(Context context) {
-    SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
-    boolean darkThemeEnabled = preferences.getBoolean(context.getString(R.string.dark_theme_enabled), false);
-    TypedArray styleArray = context.obtainStyledAttributes(
-      darkThemeEnabled ? R.style.NavigationViewDark : R.style.NavigationViewLight,
-      R.styleable.NavigationView
-    );
-    int navigationViewSecondary = styleArray.getColor(R.styleable.NavigationView_navigationViewSecondary,
-      ContextCompat.getColor(context, R.color.mapbox_navigation_view_color_secondary));
-    styleArray.recycle();
-    return navigationViewSecondary;
+    TypedValue outValue = new TypedValue();
+    context.getTheme().resolveAttribute(R.attr.navigationViewSecondary, outValue, true);
+    return ContextCompat.getColor(context, outValue.resourceId);
   }
 
   /**
@@ -132,16 +120,9 @@ public class ThemeSwitcher {
    * @return color resource identifier for banner background color
    */
   public static int retrieveNavigationViewBannerBackgroundColor(Context context) {
-    SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
-    boolean darkThemeEnabled = preferences.getBoolean(context.getString(R.string.dark_theme_enabled), false);
-    TypedArray styleArray = context.obtainStyledAttributes(
-      darkThemeEnabled ? R.style.NavigationViewDark : R.style.NavigationViewLight,
-      R.styleable.NavigationView
-    );
-    int bannerBackground = styleArray.getColor(R.styleable.NavigationView_navigationViewBannerBackground,
-      ContextCompat.getColor(context, R.color.mapbox_navigation_view_color_banner_background));
-    styleArray.recycle();
-    return bannerBackground;
+    TypedValue outValue = new TypedValue();
+    context.getTheme().resolveAttribute(R.attr.navigationViewBannerBackground, outValue, true);
+    return ContextCompat.getColor(context, outValue.resourceId);
   }
 
   /**
@@ -152,16 +133,9 @@ public class ThemeSwitcher {
    * @return color resource identifier for banner maneuver primary theme color
    */
   public static int retrieveNavigationViewBannerManeuverPrimaryColor(Context context) {
-    SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
-    boolean darkThemeEnabled = preferences.getBoolean(context.getString(R.string.dark_theme_enabled), false);
-    TypedArray styleArray = context.obtainStyledAttributes(
-      darkThemeEnabled ? R.style.NavigationViewDark : R.style.NavigationViewLight,
-      R.styleable.NavigationView
-    );
-    int bannerManeuverPrimary = styleArray.getColor(R.styleable.NavigationView_navigationViewBannerManeuverPrimary,
-      ContextCompat.getColor(context, R.color.mapbox_navigation_view_color_banner_maneuver_primary));
-    styleArray.recycle();
-    return bannerManeuverPrimary;
+    TypedValue outValue = new TypedValue();
+    context.getTheme().resolveAttribute(R.attr.navigationViewBannerManeuverPrimary, outValue, true);
+    return ContextCompat.getColor(context, outValue.resourceId);
   }
 
   /**
@@ -172,16 +146,9 @@ public class ThemeSwitcher {
    * @return color resource identifier for banner maneuver secondary theme color
    */
   public static int retrieveNavigationViewBannerManeuverSecondaryColor(Context context) {
-    SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
-    boolean darkThemeEnabled = preferences.getBoolean(context.getString(R.string.dark_theme_enabled), false);
-    TypedArray styleArray = context.obtainStyledAttributes(
-      darkThemeEnabled ? R.style.NavigationViewDark : R.style.NavigationViewLight,
-      R.styleable.NavigationView
-    );
-    int bannerManeuverSecondary = styleArray.getColor(R.styleable.NavigationView_navigationViewBannerManeuverSecondary,
-      ContextCompat.getColor(context, R.color.mapbox_navigation_view_color_banner_maneuver_secondary));
-    styleArray.recycle();
-    return bannerManeuverSecondary;
+    TypedValue outValue = new TypedValue();
+    context.getTheme().resolveAttribute(R.attr.navigationViewBannerManeuverSecondary, outValue, true);
+    return ContextCompat.getColor(context, outValue.resourceId);
   }
 
   /**
@@ -192,16 +159,9 @@ public class ThemeSwitcher {
    * @return color resource identifier for progress color
    */
   public static int retrieveNavigationViewProgressColor(Context context) {
-    SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
-    boolean darkThemeEnabled = preferences.getBoolean(context.getString(R.string.dark_theme_enabled), false);
-    TypedArray styleArray = context.obtainStyledAttributes(
-      darkThemeEnabled ? R.style.NavigationViewDark : R.style.NavigationViewLight,
-      R.styleable.NavigationView
-    );
-    int progress = styleArray.getColor(R.styleable.NavigationView_navigationViewProgress,
-      ContextCompat.getColor(context, R.color.mapbox_navigation_view_color_progress));
-    styleArray.recycle();
-    return progress;
+    TypedValue outValue = new TypedValue();
+    context.getTheme().resolveAttribute(R.attr.navigationViewProgress, outValue, true);
+    return ContextCompat.getColor(context, outValue.resourceId);
   }
 
   /**
@@ -212,15 +172,8 @@ public class ThemeSwitcher {
    * @return color resource identifier for progress background color
    */
   public static int retrieveNavigationViewProgressBackgroundColor(Context context) {
-    SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
-    boolean darkThemeEnabled = preferences.getBoolean(context.getString(R.string.dark_theme_enabled), false);
-    TypedArray styleArray = context.obtainStyledAttributes(
-      darkThemeEnabled ? R.style.NavigationViewDark : R.style.NavigationViewLight,
-      R.styleable.NavigationView
-    );
-    int progressBackground = styleArray.getColor(R.styleable.NavigationView_navigationViewProgressBackground,
-      ContextCompat.getColor(context, R.color.mapbox_navigation_view_color_progress_background));
-    styleArray.recycle();
-    return progressBackground;
+    TypedValue outValue = new TypedValue();
+    context.getTheme().resolveAttribute(R.attr.navigationViewProgressBackground, outValue, true);
+    return ContextCompat.getColor(context, outValue.resourceId);
   }
 }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/ThemeSwitcher.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/ThemeSwitcher.java
@@ -7,6 +7,7 @@ import android.content.res.Configuration;
 import android.content.res.TypedArray;
 import android.preference.PreferenceManager;
 import android.support.v4.content.ContextCompat;
+import android.util.AttributeSet;
 
 import com.mapbox.mapboxsdk.annotations.Icon;
 import com.mapbox.mapboxsdk.annotations.IconFactory;
@@ -23,8 +24,9 @@ public class ThemeSwitcher {
    * and set the theme colors accordingly.
    *
    * @param context {@link NavigationView} where the theme will be set
+   * @param attrs   holding custom styles if any are set
    */
-  static void setTheme(Context context) {
+  static void setTheme(Context context, AttributeSet attrs) {
     int uiMode = context.getResources().getConfiguration().uiMode
       & Configuration.UI_MODE_NIGHT_MASK;
     boolean darkThemeEnabled = uiMode == Configuration.UI_MODE_NIGHT_YES;
@@ -32,7 +34,13 @@ public class ThemeSwitcher {
     SharedPreferences.Editor editor = preferences.edit();
     editor.putBoolean(context.getString(R.string.dark_theme_enabled), darkThemeEnabled);
     editor.apply();
-    context.setTheme(darkThemeEnabled ? R.style.NavigationViewDark : R.style.NavigationViewLight);
+
+    TypedArray array = context.obtainStyledAttributes(attrs, R.styleable.NavigationView);
+    int lightTheme = array.getResourceId(R.styleable.NavigationView_navigationLightTheme, R.style.NavigationViewLight);
+    int darkTheme = array.getResourceId(R.styleable.NavigationView_navigationDarkTheme, R.style.NavigationViewDark);
+    array.recycle();
+
+    context.setTheme(darkThemeEnabled ? darkTheme : lightTheme);
   }
 
   /**

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/ThemeSwitcher.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/ThemeSwitcher.java
@@ -1,6 +1,5 @@
 package com.mapbox.services.android.navigation.ui.v5;
 
-import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
@@ -31,10 +30,7 @@ public class ThemeSwitcher {
     int uiMode = context.getResources().getConfiguration().uiMode
       & Configuration.UI_MODE_NIGHT_MASK;
     boolean darkThemeEnabled = uiMode == Configuration.UI_MODE_NIGHT_YES;
-    SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
-    SharedPreferences.Editor editor = preferences.edit();
-    editor.putBoolean(context.getString(R.string.dark_theme_enabled), darkThemeEnabled);
-    editor.apply();
+    updatePreferencesDarkEnabled(context, darkThemeEnabled);
 
     TypedArray styledAttributes = context.obtainStyledAttributes(attrs, R.styleable.NavigationView);
     int lightTheme = styledAttributes.getResourceId(R.styleable.NavigationView_navigationLightTheme,
@@ -44,20 +40,6 @@ public class ThemeSwitcher {
     styledAttributes.recycle();
 
     context.setTheme(darkThemeEnabled ? darkTheme : lightTheme);
-  }
-
-  /**
-   * Can be called to toggle the theme based on the current theme setting.
-   *
-   * @param activity {@link NavigationView} where the theme will be set
-   */
-  static void toggleTheme(Activity activity) {
-    SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(activity);
-    boolean darkThemeEnabled = preferences.getBoolean(activity.getString(R.string.dark_theme_enabled), false);
-    SharedPreferences.Editor editor = preferences.edit();
-    editor.putBoolean(activity.getString(R.string.dark_theme_enabled), !darkThemeEnabled);
-    editor.apply();
-    activity.recreate();
   }
 
   /**
@@ -87,93 +69,35 @@ public class ThemeSwitcher {
   }
 
   /**
-   * Looks are current theme and retrieves the primary color
+   * Looks are current theme and retrieves the color attribute
    * for the given set theme.
    *
-   * @param context to retrieve {@link SharedPreferences} and color with {@link ContextCompat}
+   * @param context to retrieve the set theme and resolved attribute and then color res Id with {@link ContextCompat}
    * @return color resource identifier for primary theme color
    */
-  public static int retrieveNavigationViewPrimaryColor(Context context) {
+  public static int retrieveNavigationViewThemeColor(Context context, int resId) {
     TypedValue outValue = new TypedValue();
-    context.getTheme().resolveAttribute(R.attr.navigationViewPrimary, outValue, true);
+    context.getTheme().resolveAttribute(resId, outValue, true);
     return ContextCompat.getColor(context, outValue.resourceId);
   }
 
   /**
-   * Looks are current theme and retrieves the secondary color
+   * Looks are current theme and retrieves the route style
    * for the given set theme.
    *
-   * @param context to retrieve {@link SharedPreferences} and color with {@link ContextCompat}
-   * @return color resource identifier for secondary theme color
+   * @param context to retrieve the resolved attribute
+   * @return style resource Id for the route
    */
-  public static int retrieveNavigationViewSecondaryColor(Context context) {
+  public static int retrieveNavigationViewRouteStyle(Context context) {
     TypedValue outValue = new TypedValue();
-    context.getTheme().resolveAttribute(R.attr.navigationViewSecondary, outValue, true);
-    return ContextCompat.getColor(context, outValue.resourceId);
+    context.getTheme().resolveAttribute(R.attr.navigationViewRouteStyle, outValue, true);
+    return outValue.resourceId;
   }
 
-  /**
-   * Looks are current theme and retrieves the banner background color
-   * for the given set theme.
-   *
-   * @param context to retrieve {@link SharedPreferences} and color with {@link ContextCompat}
-   * @return color resource identifier for banner background color
-   */
-  public static int retrieveNavigationViewBannerBackgroundColor(Context context) {
-    TypedValue outValue = new TypedValue();
-    context.getTheme().resolveAttribute(R.attr.navigationViewBannerBackground, outValue, true);
-    return ContextCompat.getColor(context, outValue.resourceId);
-  }
-
-  /**
-   * Looks are current theme and retrieves the banner maneuver primary color
-   * for the given set theme.
-   *
-   * @param context to retrieve {@link SharedPreferences} and color with {@link ContextCompat}
-   * @return color resource identifier for banner maneuver primary theme color
-   */
-  public static int retrieveNavigationViewBannerManeuverPrimaryColor(Context context) {
-    TypedValue outValue = new TypedValue();
-    context.getTheme().resolveAttribute(R.attr.navigationViewBannerManeuverPrimary, outValue, true);
-    return ContextCompat.getColor(context, outValue.resourceId);
-  }
-
-  /**
-   * Looks are current theme and retrieves the banner maneuver secondary color
-   * for the given set theme.
-   *
-   * @param context to retrieve {@link SharedPreferences} and color with {@link ContextCompat}
-   * @return color resource identifier for banner maneuver secondary theme color
-   */
-  public static int retrieveNavigationViewBannerManeuverSecondaryColor(Context context) {
-    TypedValue outValue = new TypedValue();
-    context.getTheme().resolveAttribute(R.attr.navigationViewBannerManeuverSecondary, outValue, true);
-    return ContextCompat.getColor(context, outValue.resourceId);
-  }
-
-  /**
-   * Looks are current theme and retrieves the progress color
-   * for the given set theme.
-   *
-   * @param context to retrieve {@link SharedPreferences} and color with {@link ContextCompat}
-   * @return color resource identifier for progress color
-   */
-  public static int retrieveNavigationViewProgressColor(Context context) {
-    TypedValue outValue = new TypedValue();
-    context.getTheme().resolveAttribute(R.attr.navigationViewProgress, outValue, true);
-    return ContextCompat.getColor(context, outValue.resourceId);
-  }
-
-  /**
-   * Looks are current theme and retrieves the progress background color
-   * for the given set theme.
-   *
-   * @param context to retrieve {@link SharedPreferences} and color with {@link ContextCompat}
-   * @return color resource identifier for progress background color
-   */
-  public static int retrieveNavigationViewProgressBackgroundColor(Context context) {
-    TypedValue outValue = new TypedValue();
-    context.getTheme().resolveAttribute(R.attr.navigationViewProgressBackground, outValue, true);
-    return ContextCompat.getColor(context, outValue.resourceId);
+  private static void updatePreferencesDarkEnabled(Context context, boolean darkThemeEnabled) {
+    SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
+    SharedPreferences.Editor editor = preferences.edit();
+    editor.putBoolean(context.getString(R.string.dark_theme_enabled), darkThemeEnabled);
+    editor.apply();
   }
 }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/ThemeSwitcher.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/ThemeSwitcher.java
@@ -5,6 +5,7 @@ import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.content.res.TypedArray;
 import android.preference.PreferenceManager;
+import android.support.annotation.NonNull;
 import android.support.v4.content.ContextCompat;
 import android.util.AttributeSet;
 import android.util.TypedValue;
@@ -18,6 +19,18 @@ import com.mapbox.mapboxsdk.maps.MapboxMap;
  * This class is used to switch theme colors in {@link NavigationView}.
  */
 public class ThemeSwitcher {
+
+  /**
+   * Looks are current theme and retrieves the color attribute
+   * for the given set theme.
+   *
+   * @param context to retrieve the set theme and resolved attribute and then color res Id with {@link ContextCompat}
+   * @return color resource identifier for primary theme color
+   */
+  public static int retrieveNavigationViewThemeColor(Context context, int resId) {
+    TypedValue outValue = obtainTypedValue(context, resId);
+    return ContextCompat.getColor(context, outValue.resourceId);
+  }
 
   /**
    * Called in onCreate() to check the UI Mode (day or night)
@@ -49,8 +62,7 @@ public class ThemeSwitcher {
    * @param map     the style will be set on
    */
   static void setMapStyle(Context context, MapboxMap map, MapboxMap.OnStyleLoadedListener listener) {
-    TypedValue mapStyleAttr = new TypedValue();
-    context.getTheme().resolveAttribute(R.attr.navigationViewMapStyle, mapStyleAttr, true);
+    TypedValue mapStyleAttr = obtainTypedValue(context, R.attr.navigationViewMapStyle);
     String styleUrl = mapStyleAttr.string.toString();
     map.setStyleUrl(styleUrl, listener);
   }
@@ -69,29 +81,22 @@ public class ThemeSwitcher {
   }
 
   /**
-   * Looks are current theme and retrieves the color attribute
-   * for the given set theme.
-   *
-   * @param context to retrieve the set theme and resolved attribute and then color res Id with {@link ContextCompat}
-   * @return color resource identifier for primary theme color
-   */
-  public static int retrieveNavigationViewThemeColor(Context context, int resId) {
-    TypedValue outValue = new TypedValue();
-    context.getTheme().resolveAttribute(resId, outValue, true);
-    return ContextCompat.getColor(context, outValue.resourceId);
-  }
-
-  /**
    * Looks are current theme and retrieves the route style
    * for the given set theme.
    *
    * @param context to retrieve the resolved attribute
    * @return style resource Id for the route
    */
-  public static int retrieveNavigationViewRouteStyle(Context context) {
-    TypedValue outValue = new TypedValue();
-    context.getTheme().resolveAttribute(R.attr.navigationViewRouteStyle, outValue, true);
+  static int retrieveNavigationViewRouteStyle(Context context) {
+    TypedValue outValue = obtainTypedValue(context, R.attr.navigationViewRouteStyle);
     return outValue.resourceId;
+  }
+
+  @NonNull
+  private static TypedValue obtainTypedValue(Context context, int resId) {
+    TypedValue outValue = new TypedValue();
+    context.getTheme().resolveAttribute(resId, outValue, true);
+    return outValue;
   }
 
   private static void updatePreferencesDarkEnabled(Context context, boolean darkThemeEnabled) {

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/alert/AlertView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/alert/AlertView.java
@@ -125,8 +125,10 @@ public class AlertView extends CardView {
 
   private void initBackground() {
     if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.LOLLIPOP) {
-      int progressColor = ThemeSwitcher.retrieveNavigationViewProgressColor(getContext());
-      int progressBackgroundColor = ThemeSwitcher.retrieveNavigationViewProgressBackgroundColor(getContext());
+      int progressColor = ThemeSwitcher.retrieveNavigationViewThemeColor(getContext(),
+        R.attr.navigationViewProgress);
+      int progressBackgroundColor = ThemeSwitcher.retrieveNavigationViewThemeColor(getContext(),
+        R.attr.navigationViewProgressBackground);
 
       LayerDrawable progressBarDrawable = (LayerDrawable) alertProgressBar.getProgressDrawable();
       // ProgressBar progress color

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/feedback/FeedbackBottomSheet.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/feedback/FeedbackBottomSheet.java
@@ -167,8 +167,10 @@ public class FeedbackBottomSheet extends BottomSheetDialogFragment implements Fe
 
   private void initBackground(View view) {
     if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.LOLLIPOP) {
-      int navigationViewPrimaryColor = ThemeSwitcher.retrieveNavigationViewPrimaryColor(getContext());
-      int navigationViewSecondaryColor = ThemeSwitcher.retrieveNavigationViewSecondaryColor(getContext());
+      int navigationViewPrimaryColor = ThemeSwitcher.retrieveNavigationViewThemeColor(getContext(),
+        R.attr.navigationViewPrimary);
+      int navigationViewSecondaryColor = ThemeSwitcher.retrieveNavigationViewThemeColor(getContext(),
+        R.attr.navigationViewSecondary);
       // BottomSheet background
       Drawable bottomSheetBackground = DrawableCompat.wrap(view.getBackground()).mutate();
       DrawableCompat.setTint(bottomSheetBackground, navigationViewPrimaryColor);

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/feedback/FeedbackViewHolder.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/feedback/FeedbackViewHolder.java
@@ -31,7 +31,8 @@ class FeedbackViewHolder extends RecyclerView.ViewHolder {
 
   private void initTextColor(TextView feedbackText) {
     if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.LOLLIPOP) {
-      int navigationViewSecondaryColor = ThemeSwitcher.retrieveNavigationViewSecondaryColor(feedbackText.getContext());
+      int navigationViewSecondaryColor = ThemeSwitcher.retrieveNavigationViewThemeColor(feedbackText.getContext(),
+        R.attr.navigationViewSecondary);
       // Text color
       feedbackText.setTextColor(navigationViewSecondaryColor);
     }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionView.java
@@ -350,8 +350,10 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
    */
   private void initBackground() {
     if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.LOLLIPOP) {
-      int navigationViewPrimaryColor = ThemeSwitcher.retrieveNavigationViewPrimaryColor(getContext());
-      int navigationViewBannerBackgroundColor = ThemeSwitcher.retrieveNavigationViewBannerBackgroundColor(getContext());
+      int navigationViewPrimaryColor = ThemeSwitcher.retrieveNavigationViewThemeColor(getContext(),
+        R.attr.navigationViewPrimary);
+      int navigationViewBannerBackgroundColor = ThemeSwitcher.retrieveNavigationViewThemeColor(getContext(),
+        R.attr.navigationViewBannerBackground);
       // Instruction Layout landscape - banner background
       if (getContext().getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE) {
         View instructionLayoutManeuver = findViewById(R.id.instructionManeuverLayout);

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/maneuver/ManeuverView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/maneuver/ManeuverView.java
@@ -7,6 +7,7 @@ import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.view.View;
 
+import com.mapbox.services.android.navigation.ui.v5.R;
 import com.mapbox.services.android.navigation.ui.v5.ThemeSwitcher;
 import com.mapbox.services.android.navigation.v5.navigation.NavigationConstants;
 
@@ -65,8 +66,10 @@ public class ManeuverView extends View {
   }
 
   private void initManeuverColor() {
-    this.primaryColor = ThemeSwitcher.retrieveNavigationViewBannerManeuverPrimaryColor(getContext());
-    this.secondaryColor = ThemeSwitcher.retrieveNavigationViewBannerManeuverSecondaryColor(getContext());
+    this.primaryColor = ThemeSwitcher.retrieveNavigationViewThemeColor(getContext(),
+      R.attr.navigationViewBannerManeuverPrimary);
+    this.secondaryColor = ThemeSwitcher.retrieveNavigationViewThemeColor(getContext(),
+      R.attr.navigationViewBannerManeuverSecondary);
   }
 
   public void setManeuverType(String maneuverType) {

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/turnlane/TurnLaneView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/turnlane/TurnLaneView.java
@@ -9,6 +9,7 @@ import android.util.AttributeSet;
 import android.view.View;
 
 import com.mapbox.directions.v5.models.IntersectionLanes;
+import com.mapbox.services.android.navigation.ui.v5.R;
 import com.mapbox.services.android.navigation.ui.v5.ThemeSwitcher;
 import com.mapbox.services.commons.utils.TextUtils;
 
@@ -114,7 +115,9 @@ public class TurnLaneView extends View {
   }
 
   private void initManeuverColor() {
-    this.primaryColor = ThemeSwitcher.retrieveNavigationViewBannerManeuverPrimaryColor(getContext());
-    this.secondaryColor = ThemeSwitcher.retrieveNavigationViewBannerManeuverSecondaryColor(getContext());
+    this.primaryColor = ThemeSwitcher.retrieveNavigationViewThemeColor(getContext(),
+      R.attr.navigationViewBannerManeuverPrimary);
+    this.secondaryColor = ThemeSwitcher.retrieveNavigationViewThemeColor(getContext(),
+      R.attr.navigationViewBannerManeuverSecondary);
   }
 }

--- a/libandroid-navigation-ui/src/main/res/layout/activity_navigation.xml
+++ b/libandroid-navigation-ui/src/main/res/layout/activity_navigation.xml
@@ -9,6 +9,8 @@
         android:id="@+id/navigationView"
         android:layout_width="0dp"
         android:layout_height="0dp"
+        app:navigationLightTheme="@style/NavigationViewLight"
+        app:navigationDarkTheme="@style/NavigationViewDark"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/libandroid-navigation-ui/src/main/res/values/attrs.xml
+++ b/libandroid-navigation-ui/src/main/res/values/attrs.xml
@@ -41,8 +41,16 @@
     <attr name="navigationViewBannerManeuverPrimary" format="color"/>
     <attr name="navigationViewBannerManeuverSecondary" format="color"/>
 
+    <!-- Progress Bars -->
     <attr name="navigationViewProgress" format="color"/>
     <attr name="navigationViewProgressBackground" format="color"/>
+
+    <!-- Map style -->
+    <attr name="navigationViewMapStyle" format="string"/>
+
+    <!-- For setting the styles in XML -->
+    <attr name="navigationLightTheme" format="reference"/>
+    <attr name="navigationDarkTheme" format="reference"/>
 
   </declare-styleable>
 </resources>

--- a/libandroid-navigation-ui/src/main/res/values/attrs.xml
+++ b/libandroid-navigation-ui/src/main/res/values/attrs.xml
@@ -48,6 +48,9 @@
     <!-- Map style -->
     <attr name="navigationViewMapStyle" format="string"/>
 
+    <!-- Route style -->
+    <attr name="navigationViewRouteStyle" format="reference"/>
+
     <!-- For setting the styles in XML -->
     <attr name="navigationLightTheme" format="reference"/>
     <attr name="navigationDarkTheme" format="reference"/>

--- a/libandroid-navigation-ui/src/main/res/values/styles.xml
+++ b/libandroid-navigation-ui/src/main/res/values/styles.xml
@@ -29,6 +29,8 @@
 
         <item name="navigationViewProgress">@color/mapbox_navigation_view_color_progress</item>
         <item name="navigationViewProgressBackground">@color/mapbox_navigation_view_color_progress_background</item>
+
+        <item name="navigationViewMapStyle">@string/navigation_guidance_day_v2</item>
     </style>
 
     <style name="NavigationViewDark" parent="Theme.AppCompat.Light.NoActionBar">
@@ -48,6 +50,8 @@
 
         <item name="navigationViewProgress">@color/mapbox_navigation_view_color_progress_dark</item>
         <item name="navigationViewProgressBackground">@color/mapbox_navigation_view_color_progress_background_dark</item>
+
+        <item name="navigationViewMapStyle">@string/navigation_guidance_night_v2</item>
     </style>
 
 </resources>

--- a/libandroid-navigation-ui/src/main/res/values/styles.xml
+++ b/libandroid-navigation-ui/src/main/res/values/styles.xml
@@ -30,6 +30,8 @@
         <item name="navigationViewProgress">@color/mapbox_navigation_view_color_progress</item>
         <item name="navigationViewProgressBackground">@color/mapbox_navigation_view_color_progress_background</item>
 
+        <item name="navigationViewRouteStyle">@style/NavigationMapRoute</item>
+
         <item name="navigationViewMapStyle">@string/navigation_guidance_day_v2</item>
     </style>
 
@@ -50,6 +52,8 @@
 
         <item name="navigationViewProgress">@color/mapbox_navigation_view_color_progress_dark</item>
         <item name="navigationViewProgressBackground">@color/mapbox_navigation_view_color_progress_background_dark</item>
+
+        <item name="navigationViewRouteStyle">@style/NavigationMapRoute</item>
 
         <item name="navigationViewMapStyle">@string/navigation_guidance_night_v2</item>
     </style>


### PR DESCRIPTION
Will allows developers to add a light and dark theme via the `NavigationView` XML:

```
<com.mapbox.services.android.navigation.ui.v5.NavigationView
        android:id="@+id/navigationView"
        android:layout_width="0dp"
        android:layout_height="0dp"
        app:navigationLightTheme="@style/NavigationViewLight"
        app:navigationDarkTheme="@style/NavigationViewDark"
        ...
        />
```

This also adds the map style URLs to the themes.

cc @ericrwolfe 