### PR TITLE
Set a software layer type on ManeuverView

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/maneuver/ManeuverView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/maneuver/ManeuverView.java
@@ -60,6 +60,7 @@ public class ManeuverView extends View {
   @Override
   protected void onFinishInflate() {
     super.onFinishInflate();
+    setLayerType(LAYER_TYPE_SOFTWARE, null);
     initManeuverColor();
   }
 


### PR DESCRIPTION
When using `ManeuverView`, currently we must do 
`android:layerType="software"` in xml, otherwise the icons will be blurry.  This will be confusing for users as this is unusual to impose this (I wasted at least one hour because of this myself).

This change makes the call directly in the Java code so, it is no longer necessary to do it in xml.