### PR TITLE
Add software layer type programmatically for Maneuver and Lane View

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/maneuver/ManeuverView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/maneuver/ManeuverView.java
@@ -60,6 +60,7 @@ public class ManeuverView extends View {
   @Override
   protected void onFinishInflate() {
     super.onFinishInflate();
+    setLayerType(LAYER_TYPE_SOFTWARE, null);
     initManeuverColor();
   }
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/turnlane/TurnLaneView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/turnlane/TurnLaneView.java
@@ -44,6 +44,7 @@ public class TurnLaneView extends View {
   @Override
   protected void onFinishInflate() {
     super.onFinishInflate();
+    setLayerType(LAYER_TYPE_SOFTWARE, null);
     initManeuverColor();
   }
 

--- a/libandroid-navigation-ui/src/main/res/layout-land/instruction_content_layout.xml
+++ b/libandroid-navigation-ui/src/main/res/layout-land/instruction_content_layout.xml
@@ -27,8 +27,7 @@
             android:id="@+id/maneuverView"
             android:layout_width="40dp"
             android:layout_height="40dp"
-            android:layout_margin="8dp"
-            android:layerType="software"/>
+            android:layout_margin="8dp"/>
 
         <TextView
             android:id="@+id/stepDistanceText"

--- a/libandroid-navigation-ui/src/main/res/layout-land/instruction_layout.xml
+++ b/libandroid-navigation-ui/src/main/res/layout-land/instruction_layout.xml
@@ -30,7 +30,6 @@
             android:layout_width="40dp"
             android:layout_height="40dp"
             android:layout_margin="8dp"
-            android:layerType="software"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"/>

--- a/libandroid-navigation-ui/src/main/res/layout-land/instruction_layout_alt.xml
+++ b/libandroid-navigation-ui/src/main/res/layout-land/instruction_layout_alt.xml
@@ -29,8 +29,7 @@
             android:id="@+id/maneuverView"
             android:layout_width="40dp"
             android:layout_height="40dp"
-            android:layout_margin="8dp"
-            android:layerType="software"/>
+            android:layout_margin="8dp"/>
 
         <TextView
             android:id="@+id/stepDistanceText"

--- a/libandroid-navigation-ui/src/main/res/layout/instruction_content_layout.xml
+++ b/libandroid-navigation-ui/src/main/res/layout/instruction_content_layout.xml
@@ -26,7 +26,6 @@
             android:id="@+id/maneuverView"
             android:layout_width="40dp"
             android:layout_height="40dp"
-            android:layerType="software"
             app:layout_constraintBottom_toTopOf="@+id/stepDistanceText"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/libandroid-navigation-ui/src/main/res/layout/then_instruction_layout.xml
+++ b/libandroid-navigation-ui/src/main/res/layout/then_instruction_layout.xml
@@ -13,7 +13,6 @@
         android:layout_width="24dp"
         android:layout_height="24dp"
         android:layout_margin="8dp"
-        android:layerType="software"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/guideline"
         app:layout_constraintStart_toStartOf="parent"

--- a/libandroid-navigation-ui/src/main/res/layout/turn_lane_listitem_layout.xml
+++ b/libandroid-navigation-ui/src/main/res/layout/turn_lane_listitem_layout.xml
@@ -9,7 +9,6 @@
     <com.mapbox.services.android.navigation.ui.v5.instruction.turnlane.TurnLaneView
         android:id="@+id/turnLaneView"
         android:layout_width="24dp"
-        android:layout_height="24dp"
-        android:layerType="software"/>
+        android:layout_height="24dp"/>
 
 </RelativeLayout>


### PR DESCRIPTION
- Adds software layer type in the `View` code (required by PaintCode)
- Removes the layer type set with the XML attributes

As pointed out in #513, this is not immediately obvious for developers to set this in their XML if they want to use either the `ManeuverView` or `TurnLaneView` in their own XML layouts

cc @ericrwolfe 