### PR TITLE
Check if hex value is provided by attribute before Res Id

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/ThemeSwitcher.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/ThemeSwitcher.java
@@ -29,7 +29,12 @@ public class ThemeSwitcher {
    */
   public static int retrieveNavigationViewThemeColor(Context context, int resId) {
     TypedValue outValue = obtainTypedValue(context, resId);
-    return ContextCompat.getColor(context, outValue.resourceId);
+    if (outValue.type >= TypedValue.TYPE_FIRST_COLOR_INT
+      && outValue.type <= TypedValue.TYPE_LAST_COLOR_INT) {
+      return outValue.data;
+    } else {
+      return ContextCompat.getColor(context, outValue.resourceId);
+    }
   }
 
   /**


### PR DESCRIPTION
- Fixes issue if someone provides a direct hex value in a custom style 
- Checks for data hex value before looking for valid resource Id 