### PR TITLE
Prevent multiple firing of departure metric events

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationTelemetry.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationTelemetry.java
@@ -37,6 +37,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
+import timber.log.Timber;
+
 class NavigationTelemetry implements LocationEngineListener, NavigationMetricListener {
 
   private static final String MAPBOX_NAVIGATION_SDK_IDENTIFIER = "mapbox-navigation-android";
@@ -55,6 +57,7 @@ class NavigationTelemetry implements LocationEngineListener, NavigationMetricLis
   private RingBuffer<Location> locationBuffer;
 
   private String vendorId;
+  private boolean hasDeparted;
   private boolean isOffRoute;
 
   NavigationTelemetry() {
@@ -88,7 +91,10 @@ class NavigationTelemetry implements LocationEngineListener, NavigationMetricLis
     if (metricProgress == null) {
       metricProgress = new MetricsRouteProgress(routeProgress);
     }
-    NavigationMetricsWrapper.departEvent(navigationSessionState, metricProgress, location);
+    if (!hasDeparted) {
+      NavigationMetricsWrapper.departEvent(navigationSessionState, metricProgress, location);
+      hasDeparted = true;
+    }
   }
 
   @Override

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationTelemetry.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationTelemetry.java
@@ -37,8 +37,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
-import timber.log.Timber;
-
 class NavigationTelemetry implements LocationEngineListener, NavigationMetricListener {
 
   private static final String MAPBOX_NAVIGATION_SDK_IDENTIFIER = "mapbox-navigation-android";


### PR DESCRIPTION
- Adds a boolean to prevent multiple firing of departure events.  This would previously fire for each location update during a maneuver type departure `LegStep`

cc @ericrwolfe  - is there another way to do this based on `RouteProgress` data?  