### PR TITLE
Reset Launcher route value if using coordinates

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationLauncher.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationLauncher.java
@@ -37,7 +37,6 @@ public class NavigationLauncher {
    * {@link com.mapbox.services.android.navigation.v5.navigation.NavigationRoute}
    *
    * @param activity must be launched from another {@link Activity}
-   * @param route    initial route in which the navigation will follow
    * @param options  with fields to customize the navigation view
    */
   public static void startNavigation(Activity activity, NavigationViewOptions options) {
@@ -114,6 +113,9 @@ public class NavigationLauncher {
   }
 
   private static void storeCoordinateValues(NavigationViewOptions options, SharedPreferences.Editor editor) {
+    // Reset any previous value for the route json
+    editor.putString(NavigationConstants.NAVIGATION_VIEW_ROUTE_KEY, "");
+    // Store the coordinates
     editor.putLong(NavigationConstants.NAVIGATION_VIEW_ORIGIN_LAT_KEY,
       Double.doubleToRawLongBits(options.origin().latitude()));
     editor.putLong(NavigationConstants.NAVIGATION_VIEW_ORIGIN_LNG_KEY,


### PR DESCRIPTION
- After launching once with a `DirectionsRoute`, the launcher would always use that route, even if an origin and destination were provided after - this resets the route so the coordinates are used properly 

cc @ericrwolfe 