### PR TITLE
Change Metric Listener Reset

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEventDispatcher.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEventDispatcher.java
@@ -23,7 +23,6 @@ class NavigationEventDispatcher {
   private List<ProgressChangeListener> progressChangeListeners;
   private List<OffRouteListener> offRouteListeners;
   private NavigationMetricListeners.EventListeners metricEventListeners;
-  private NavigationMetricListeners.DepartureListener metricDepartureListener;
   private NavigationMetricListeners.ArrivalListener metricArrivalListener;
 
   NavigationEventDispatcher() {
@@ -116,12 +115,6 @@ class NavigationEventDispatcher {
       // Update RouteProgress
       metricEventListeners.onRouteProgressUpdate(routeProgress);
 
-      // Check if user has departed and notify metric listener if so
-      if (RouteUtils.isDepartureEvent(routeProgress) && metricDepartureListener != null) {
-        metricDepartureListener.onDeparture(location, routeProgress);
-        metricDepartureListener = null;
-      }
-
       // Check if user has arrived and notify metric listener if so
       if (RouteUtils.isArrivalEvent(routeProgress) && metricArrivalListener != null) {
         metricArrivalListener.onArrival(location, routeProgress);
@@ -160,10 +153,6 @@ class NavigationEventDispatcher {
 
   void addMetricEventListeners(NavigationMetricListeners.EventListeners eventListeners) {
     this.metricEventListeners = eventListeners;
-  }
-
-  void addMetricDepartureListener(NavigationMetricListeners.DepartureListener departureListener) {
-    this.metricDepartureListener = departureListener;
   }
 
   void addMetricArrivalListener(NavigationMetricListeners.ArrivalListener arrivalListener) {

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationTelemetry.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationTelemetry.java
@@ -112,9 +112,9 @@ class NavigationTelemetry implements LocationEngineListener, NavigationMetricLis
     }
     if (!isConfigurationChange) {
       NavigationMetricsWrapper.departEvent(navigationSessionState, metricProgress, metricLocation.getLocation());
+      // Add the arrival listener
+      eventDispatcher.addMetricArrivalListener(this);
     }
-    // Add the arrival listener
-    eventDispatcher.addMetricArrivalListener(this);
   }
 
   @Override

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationTelemetry.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationTelemetry.java
@@ -467,7 +467,8 @@ class NavigationTelemetry implements LocationEngineListener, NavigationMetricLis
 
   private void sendRerouteEvent(RerouteEvent rerouteEvent) {
     // If there isn't an updated geometry, don't send
-    if (rerouteEvent.getNewRouteGeometry() == null) {
+    if (rerouteEvent.getNewRouteGeometry() == null
+      || rerouteEvent.getSessionState().startTimestamp() == null) {
       return;
     }
     // Create arrays with locations from before / after the reroute occurred
@@ -486,6 +487,9 @@ class NavigationTelemetry implements LocationEngineListener, NavigationMetricLis
   }
 
   private void sendFeedbackEvent(FeedbackEvent feedbackEvent) {
+    if (feedbackEvent.getSessionState().startTimestamp() == null) {
+      return;
+    }
     // Create arrays with locations from before / after the reroute occurred
     List<Location> beforeLocations = createLocationListBeforeEvent(feedbackEvent.getSessionState().eventDate());
     List<Location> afterLocations = createLocationListAfterEvent(feedbackEvent.getSessionState().eventDate());

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/metrics/NavigationMetricListeners.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/metrics/NavigationMetricListeners.java
@@ -13,11 +13,6 @@ public interface NavigationMetricListeners {
     void onOffRouteEvent(Location offRouteLocation);
   }
 
-  interface DepartureListener {
-
-    void onDeparture(Location location, RouteProgress routeProgress);
-  }
-
   interface ArrivalListener {
 
     void onArrival(Location location, RouteProgress routeProgress);

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/metrics/SessionState.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/metrics/SessionState.java
@@ -1,16 +1,15 @@
 package com.mapbox.services.android.navigation.v5.navigation.metrics;
 
 import android.location.Location;
-import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import com.google.auto.value.AutoValue;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.api.directions.v5.models.RouteLeg;
+import com.mapbox.core.constants.Constants;
 import com.mapbox.geojson.Point;
 import com.mapbox.geojson.utils.PolylineUtils;
 import com.mapbox.services.android.navigation.v5.routeprogress.MetricsRouteProgress;
-import com.mapbox.core.constants.Constants;
 
 import java.util.Date;
 import java.util.List;
@@ -96,6 +95,7 @@ public abstract class SessionState {
 
   public abstract int rerouteCount();
 
+  @Nullable
   public abstract Date startTimestamp();
 
   @Nullable
@@ -110,7 +110,6 @@ public abstract class SessionState {
       .eventRouteDistanceCompleted(0d)
       .sessionIdentifier("")
       .mockLocation(false)
-      .startTimestamp(new Date())
       .rerouteCount(0)
       .secondsSinceLastReroute(-1)
       .eventRouteProgress(new MetricsRouteProgress(null))
@@ -148,7 +147,7 @@ public abstract class SessionState {
 
     public abstract Builder rerouteCount(int rerouteCount);
 
-    public abstract Builder startTimestamp(@NonNull Date startTimeStamp);
+    public abstract Builder startTimestamp(Date startTimeStamp);
 
     public abstract Builder arrivalTimestamp(@Nullable Date arrivalTimestamp);
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/RouteUtils.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/RouteUtils.java
@@ -11,7 +11,6 @@ import java.util.List;
 
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.METERS_REMAINING_TILL_ARRIVAL;
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.STEP_MANEUVER_TYPE_ARRIVE;
-import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.STEP_MANEUVER_TYPE_DEPART;
 
 public final class RouteUtils {
 
@@ -59,18 +58,6 @@ public final class RouteUtils {
   public static boolean isArrivalEvent(@NonNull RouteProgress routeProgress) {
     return (upcomingStepIsArrival(routeProgress) || currentStepIsArrival(routeProgress))
       && routeProgress.currentLegProgress().distanceRemaining() <= METERS_REMAINING_TILL_ARRIVAL;
-  }
-
-  /**
-   * Looks at the current {@link RouteProgress} maneuverType for type "departure".
-   *
-   * @param routeProgress the current route progress
-   * @return true if in departure state, false if not
-   * @since 0.8.0
-   */
-  public static boolean isDepartureEvent(@NonNull RouteProgress routeProgress) {
-    return routeProgress.currentLegProgress().currentStep().maneuver() != null
-      && routeProgress.currentLegProgress().currentStep().maneuver().type().contains(STEP_MANEUVER_TYPE_DEPART);
   }
 
   /**

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEventDispatcherTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEventDispatcherTest.java
@@ -46,8 +46,6 @@ public class NavigationEventDispatcherTest extends BaseTest {
   @Mock
   NavigationMetricListeners.EventListeners eventListeners;
   @Mock
-  NavigationMetricListeners.DepartureListener departureListener;
-  @Mock
   NavigationMetricListeners.ArrivalListener arrivalListener;
   @Mock
   OffRouteListener offRouteListener;
@@ -302,40 +300,5 @@ public class NavigationEventDispatcherTest extends BaseTest {
     navigationEventDispatcher.onProgressChange(location, routeProgressDidArrive);
     verify(eventListeners, times(1)).onRouteProgressUpdate(routeProgressDidArrive);
     verify(arrivalListener, times(1)).onArrival(location, routeProgressDidArrive);
-  }
-
-  @Test
-  public void setNavigationDepartureListener_didNotGetTriggeredMoreThanOnce() throws Exception {
-
-    navigationEventDispatcher.addMetricEventListeners(eventListeners);
-    navigationEventDispatcher.addMetricDepartureListener(departureListener);
-
-    // Progress that hasn't arrived
-    RouteProgress routeProgressDidNotArrive = RouteProgress.builder()
-      .stepDistanceRemaining(100)
-      .legDistanceRemaining(100)
-      .distanceRemaining(100)
-      .directionsRoute(route)
-      .stepIndex(0)
-      .legIndex(0)
-      .build();
-
-    navigationEventDispatcher.onProgressChange(location, routeProgressDidNotArrive);
-    verify(eventListeners, times(1)).onRouteProgressUpdate(routeProgressDidNotArrive);
-    verify(departureListener, times(1)).onDeparture(location, routeProgressDidNotArrive);
-
-    // Progress that has arrived
-    RouteProgress routeProgressDidArrive = RouteProgress.builder()
-      .stepDistanceRemaining(30)
-      .legDistanceRemaining(30)
-      .distanceRemaining(30)
-      .directionsRoute(route)
-      .stepIndex(0)
-      .legIndex(0)
-      .build();
-
-    navigationEventDispatcher.onProgressChange(location, routeProgressDidArrive);
-    verify(eventListeners, times(1)).onRouteProgressUpdate(routeProgressDidArrive);
-    verify(departureListener, times(0)).onDeparture(location, routeProgressDidArrive);
   }
 }

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/utils/RouteUtilsTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/utils/RouteUtilsTest.java
@@ -55,27 +55,6 @@ public class RouteUtilsTest extends BaseTest {
   }
 
   @Test
-  public void isDepartureEvent_returnsTrueWhenManeuverTypeDepart() throws Exception {
-    RouteProgress defaultRouteProgress = obtainDefaultRouteProgress();
-
-    boolean isDepartureEvent = RouteUtils.isDepartureEvent(defaultRouteProgress);
-
-    assertTrue(isDepartureEvent);
-  }
-
-  @Test
-  public void isDepartureEvent_returnsFalseWhenManeuverTypeIsNotDepart() throws Exception {
-    RouteProgress defaultRouteProgress = obtainDefaultRouteProgress();
-    RouteProgress theRouteProgress = defaultRouteProgress.toBuilder()
-      .stepIndex(1)
-      .build();
-
-    boolean isDepartureEvent = RouteUtils.isDepartureEvent(theRouteProgress);
-
-    assertFalse(isDepartureEvent);
-  }
-
-  @Test
   public void isArrivalEvent_returnsTrueWhenManeuverTypeIsArrival_andIsValidMetersRemaining() throws Exception {
     DirectionsRoute aRoute = obtainADirectionsRoute();
     int lastStepIndex = obtainLastStepIndex(aRoute);


### PR DESCRIPTION
- We were previously checking to reset the arrival / departure listener (if new leg) on every progress update
- This PR adds the arrival listener only after the departure listener has fired
- It also adds logic to reset the departure listener only when the arrival listener fires and if we aren't on the last leg

cc @ericrwolfe 