### PR TITLE
Fixing NullPointerException when navigationPresenter is not yet initialized

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
@@ -198,7 +198,8 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
    */
   @Override
   public void onScroll() {
-    if (summaryBehavior.getState() != BottomSheetBehavior.STATE_HIDDEN) {
+    int summaryBehaviorState = summaryBehavior.getState();
+    if (summaryBehaviorState != BottomSheetBehavior.STATE_HIDDEN && navigationPresenter != null) {
       navigationPresenter.onMapScroll();
     }
   }


### PR DESCRIPTION
Issue type: Bug
Affected devices: All tested

When trying to scroll map which is not being loaded immediately, application crashes, because navigationPresenter is not initialized at that moment. 