### PR TITLE
DirectionsProfile for reroutes in NavigationView

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewOptions.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewOptions.java
@@ -3,6 +3,7 @@ package com.mapbox.services.android.navigation.ui.v5;
 import android.support.annotation.Nullable;
 
 import com.google.auto.value.AutoValue;
+import com.mapbox.api.directions.v5.DirectionsCriteria;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.geojson.Point;
 import com.mapbox.services.android.navigation.v5.navigation.NavigationUnitType;
@@ -12,6 +13,9 @@ public abstract class NavigationViewOptions {
 
   @Nullable
   public abstract DirectionsRoute directionsRoute();
+
+  @Nullable
+  public abstract String directionsProfile();
 
   @Nullable
   public abstract Point origin();
@@ -30,6 +34,8 @@ public abstract class NavigationViewOptions {
   public abstract static class Builder {
 
     public abstract Builder directionsRoute(DirectionsRoute directionsRoute);
+
+    public abstract Builder directionsProfile(@DirectionsCriteria.ProfileCriteria String directionsProfile);
 
     public abstract Builder origin(Point origin);
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/RouteViewModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/RouteViewModel.java
@@ -33,6 +33,7 @@ public class RouteViewModel extends AndroidViewModel implements Callback<Directi
   private Point origin;
   private Location rawLocation;
   private boolean extractLaunchData = true;
+  private String routeProfile;
   private String unitType;
 
   public RouteViewModel(@NonNull Application application) {
@@ -71,7 +72,7 @@ public class RouteViewModel extends AndroidViewModel implements Callback<Directi
   /**
    * Checks the options used to launch this {@link com.mapbox.services.android.navigation.ui.v5.NavigationView}.
    * <p>
-   * Will launch with either a {@link DirectionsRoute} or pair of {@link Point}s
+   * Will launch with either a {@link DirectionsRoute} or pair of {@link Point}s.
    *
    * @param options holds either a set of {@link Point} coordinates or a {@link DirectionsRoute}
    */
@@ -127,6 +128,7 @@ public class RouteViewModel extends AndroidViewModel implements Callback<Directi
         .accessToken(Mapbox.getAccessToken())
         .origin(origin, bearing, 90d)
         .voiceUnits(unitType)
+        .profile(routeProfile)
         .destination(destination).build().getRoute(this);
     }
   }
@@ -157,6 +159,8 @@ public class RouteViewModel extends AndroidViewModel implements Callback<Directi
   private void extractRoute(NavigationViewOptions options) {
     DirectionsRoute route = options.directionsRoute();
     if (route != null) {
+      String profile = options.directionsProfile();
+      routeProfile = profile != null ? profile : route.routeOptions().profile();
       RouteLeg lastLeg = route.legs().get(route.legs().size() - 1);
       LegStep lastStep = lastLeg.steps().get(lastLeg.steps().size() - 1);
       destination.setValue(lastStep.maneuver().location());
@@ -173,6 +177,8 @@ public class RouteViewModel extends AndroidViewModel implements Callback<Directi
    */
   private void extractCoordinates(NavigationViewOptions options) {
     if (options.origin() != null && options.destination() != null) {
+      String profile = options.directionsProfile();
+      routeProfile = profile != null ? profile : DirectionsCriteria.PROFILE_DRIVING_TRAFFIC;
       origin = options.origin();
       destination.setValue(options.destination());
       fetchRouteFromCoordinates();


### PR DESCRIPTION
- Add directions profile to navigation view options for reroute scenarios
- If no profile is provided, and the UI was launched with a `DirectionsRoute` the default for reroutes will be the profile from the route used to launch the UI 
- If no profile is provided, and the UI was launched with `Position` coordinates, the default will be `DirectionsCriteria.PROFILE_DRIVING_TRAFFIC`

cc @ericrwolfe 