### PR TITLE
Return Milestone instead of identifier 

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/MockNavigationActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/MockNavigationActivity.java
@@ -29,6 +29,7 @@ import com.mapbox.services.android.navigation.testapp.Utils;
 import com.mapbox.services.android.navigation.ui.v5.route.NavigationMapRoute;
 import com.mapbox.services.android.navigation.v5.instruction.Instruction;
 import com.mapbox.services.android.navigation.v5.location.MockLocationEngine;
+import com.mapbox.services.android.navigation.v5.milestone.Milestone;
 import com.mapbox.services.android.navigation.v5.milestone.MilestoneEventListener;
 import com.mapbox.services.android.navigation.v5.milestone.RouteMilestone;
 import com.mapbox.services.android.navigation.v5.milestone.Trigger;
@@ -218,8 +219,8 @@ public class MockNavigationActivity extends AppCompatActivity implements OnMapRe
    */
 
   @Override
-  public void onMilestoneEvent(RouteProgress routeProgress, String instruction, int identifier) {
-    Timber.d("Milestone Event Occurred with id: %d", identifier);
+  public void onMilestoneEvent(RouteProgress routeProgress, String instruction, Milestone milestone) {
+    Timber.d("Milestone Event Occurred with id: %d", milestone.getIdentifier());
     Timber.d("Voice instruction: %s", instruction);
   }
 

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/RerouteActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/RerouteActivity.java
@@ -28,6 +28,7 @@ import com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerPlugin;
 import com.mapbox.services.Constants;
 import com.mapbox.services.android.navigation.testapp.R;
 import com.mapbox.services.android.navigation.v5.location.MockLocationEngine;
+import com.mapbox.services.android.navigation.v5.milestone.Milestone;
 import com.mapbox.services.android.navigation.v5.milestone.MilestoneEventListener;
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation;
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigationOptions;
@@ -219,7 +220,7 @@ public class RerouteActivity extends AppCompatActivity implements OnMapReadyCall
   }
 
   @Override
-  public void onMilestoneEvent(RouteProgress routeProgress, String instruction, int identifier) {
+  public void onMilestoneEvent(RouteProgress routeProgress, String instruction, Milestone milestone) {
     Timber.d("onMilestoneEvent - Current Instruction: " + instruction);
   }
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
@@ -19,13 +19,14 @@ import com.mapbox.services.android.navigation.ui.v5.instruction.InstructionModel
 import com.mapbox.services.android.navigation.ui.v5.summary.SummaryModel;
 import com.mapbox.services.android.navigation.ui.v5.voice.InstructionPlayer;
 import com.mapbox.services.android.navigation.ui.v5.voice.NavigationInstructionPlayer;
+import com.mapbox.services.android.navigation.v5.milestone.Milestone;
 import com.mapbox.services.android.navigation.v5.milestone.MilestoneEventListener;
-import com.mapbox.services.android.navigation.v5.navigation.metrics.FeedbackEvent;
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation;
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigationOptions;
 import com.mapbox.services.android.navigation.v5.navigation.NavigationConstants;
-import com.mapbox.services.android.navigation.v5.navigation.NavigationUnitType;
 import com.mapbox.services.android.navigation.v5.navigation.NavigationEventListener;
+import com.mapbox.services.android.navigation.v5.navigation.NavigationUnitType;
+import com.mapbox.services.android.navigation.v5.navigation.metrics.FeedbackEvent;
 import com.mapbox.services.android.navigation.v5.offroute.OffRouteListener;
 import com.mapbox.services.android.navigation.v5.routeprogress.ProgressChangeListener;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
@@ -113,11 +114,11 @@ public class NavigationViewModel extends AndroidViewModel implements LifecycleOb
    *
    * @param routeProgress ignored in this scenario
    * @param instruction   to be voiced by the {@link InstructionPlayer}
-   * @param identifier    used to determine the type of milestone
-   * @since 0.6.0
+   * @param milestone     the milestone being triggered
+   * @since 0.8.0
    */
   @Override
-  public void onMilestoneEvent(RouteProgress routeProgress, String instruction, int identifier) {
+  public void onMilestoneEvent(RouteProgress routeProgress, String instruction, Milestone milestone) {
     instructionPlayer.play(instruction);
   }
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/milestone/MilestoneEventListener.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/milestone/MilestoneEventListener.java
@@ -4,6 +4,6 @@ import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 
 public interface MilestoneEventListener {
 
-  void onMilestoneEvent(RouteProgress routeProgress, String instruction, int identifier);
+  void onMilestoneEvent(RouteProgress routeProgress, String instruction, Milestone milestone);
 
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/milestone/VoiceInstructionMilestone.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/milestone/VoiceInstructionMilestone.java
@@ -3,6 +3,7 @@ package com.mapbox.services.android.navigation.v5.milestone;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.api.directions.v5.models.LegStep;
 import com.mapbox.api.directions.v5.models.VoiceInstructions;
+import com.mapbox.services.android.navigation.v5.instruction.Instruction;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 
 import java.util.List;
@@ -14,7 +15,7 @@ public class VoiceInstructionMilestone extends Milestone {
   private LegStep currentStep;
   private List<VoiceInstructions> stepVoiceInstructions;
 
-  public VoiceInstructionMilestone(Builder builder) {
+  VoiceInstructionMilestone(Builder builder) {
     super(builder);
   }
 
@@ -36,8 +37,14 @@ public class VoiceInstructionMilestone extends Milestone {
     return false;
   }
 
-  public String announcement() {
-    return announcement;
+  @Override
+  public Instruction getInstruction() {
+    return new Instruction() {
+      @Override
+      public String buildInstruction(RouteProgress routeProgress) {
+        return announcement;
+      }
+    };
   }
 
   /**

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEventDispatcher.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEventDispatcher.java
@@ -4,6 +4,7 @@ import android.location.Location;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import com.mapbox.services.android.navigation.v5.milestone.Milestone;
 import com.mapbox.services.android.navigation.v5.milestone.MilestoneEventListener;
 import com.mapbox.services.android.navigation.v5.navigation.metrics.NavigationMetricListeners;
 import com.mapbox.services.android.navigation.v5.offroute.OffRouteListener;
@@ -104,9 +105,9 @@ class NavigationEventDispatcher {
     }
   }
 
-  void onMilestoneEvent(RouteProgress routeProgress, String instruction, int identifier) {
+  void onMilestoneEvent(RouteProgress routeProgress, String instruction, Milestone milestone) {
     for (MilestoneEventListener milestoneEventListener : milestoneEventListeners) {
-      milestoneEventListener.onMilestoneEvent(routeProgress, instruction, identifier);
+      milestoneEventListener.onMilestoneEvent(routeProgress, instruction, milestone);
     }
   }
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationHelper.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationHelper.java
@@ -4,24 +4,21 @@ import android.location.Location;
 
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.api.directions.v5.models.LegStep;
+import com.mapbox.core.constants.Constants;
 import com.mapbox.geojson.Feature;
 import com.mapbox.geojson.LineString;
 import com.mapbox.geojson.Point;
 import com.mapbox.services.android.navigation.v5.milestone.Milestone;
-import com.mapbox.services.android.navigation.v5.milestone.VoiceInstructionMilestone;
 import com.mapbox.services.android.navigation.v5.offroute.OffRoute;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 import com.mapbox.services.android.navigation.v5.snap.Snap;
 import com.mapbox.services.android.telemetry.utils.MathUtils;
-import com.mapbox.core.constants.Constants;
 import com.mapbox.turf.TurfConstants;
 import com.mapbox.turf.TurfMeasurement;
 import com.mapbox.turf.TurfMisc;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.VOICE_INSTRUCTION_MILESTONE_ID;
 
 /**
  * This contains several single purpose methods that help out when a new location update occurs and
@@ -56,8 +53,6 @@ class NavigationHelper {
     if (milestone.getInstruction() != null) {
       // Create a new custom instruction based on the Instruction packaged with the Milestone
       return milestone.getInstruction().buildInstruction(routeProgress);
-    } else if (milestone.getIdentifier() == VOICE_INSTRUCTION_MILESTONE_ID) {
-      return ((VoiceInstructionMilestone) milestone).announcement();
     }
     return "";
   }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationHelper.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationHelper.java
@@ -8,6 +8,7 @@ import com.mapbox.geojson.Feature;
 import com.mapbox.geojson.LineString;
 import com.mapbox.geojson.Point;
 import com.mapbox.services.android.navigation.v5.milestone.Milestone;
+import com.mapbox.services.android.navigation.v5.milestone.VoiceInstructionMilestone;
 import com.mapbox.services.android.navigation.v5.offroute.OffRoute;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 import com.mapbox.services.android.navigation.v5.snap.Snap;
@@ -19,6 +20,8 @@ import com.mapbox.turf.TurfMisc;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.VOICE_INSTRUCTION_MILESTONE_ID;
 
 /**
  * This contains several single purpose methods that help out when a new location update occurs and
@@ -53,6 +56,8 @@ class NavigationHelper {
     if (milestone.getInstruction() != null) {
       // Create a new custom instruction based on the Instruction packaged with the Milestone
       return milestone.getInstruction().buildInstruction(routeProgress);
+    } else if (milestone.getIdentifier() == VOICE_INSTRUCTION_MILESTONE_ID) {
+      return ((VoiceInstructionMilestone) milestone).announcement();
     }
     return "";
   }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationService.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationService.java
@@ -14,7 +14,6 @@ import android.support.annotation.Nullable;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.services.android.navigation.R;
 import com.mapbox.services.android.navigation.v5.milestone.Milestone;
-import com.mapbox.services.android.navigation.v5.milestone.VoiceInstructionMilestone;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 import com.mapbox.services.android.navigation.v5.utils.RingBuffer;
 import com.mapbox.services.android.telemetry.location.LocationEngine;
@@ -25,7 +24,6 @@ import java.util.List;
 import timber.log.Timber;
 
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.NAVIGATION_NOTIFICATION_ID;
-import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.VOICE_INSTRUCTION_MILESTONE_ID;
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.buildInstructionString;
 
 /**
@@ -210,11 +208,7 @@ public class NavigationService extends Service implements LocationEngineListener
   public void onMilestoneTrigger(List<Milestone> triggeredMilestones, RouteProgress routeProgress) {
     for (Milestone milestone : triggeredMilestones) {
       String instruction = buildInstructionString(routeProgress, milestone);
-      if (milestone.getIdentifier() == VOICE_INSTRUCTION_MILESTONE_ID) {
-        instruction = ((VoiceInstructionMilestone) milestone).announcement();
-      }
-      mapboxNavigation.getEventDispatcher().onMilestoneEvent(
-        routeProgress, instruction, milestone.getIdentifier());
+      mapboxNavigation.getEventDispatcher().onMilestoneEvent(routeProgress, instruction, milestone);
     }
   }
 

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEventDispatcherTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEventDispatcherTest.java
@@ -11,6 +11,7 @@ import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.api.directions.v5.models.RouteLeg;
 import com.mapbox.services.android.navigation.BuildConfig;
 import com.mapbox.services.android.navigation.v5.BaseTest;
+import com.mapbox.services.android.navigation.v5.milestone.Milestone;
 import com.mapbox.services.android.navigation.v5.milestone.MilestoneEventListener;
 import com.mapbox.services.android.navigation.v5.navigation.metrics.NavigationMetricListeners;
 import com.mapbox.services.android.navigation.v5.offroute.OffRouteListener;
@@ -53,6 +54,8 @@ public class NavigationEventDispatcherTest extends BaseTest {
   NavigationEventListener navigationEventListener;
   @Mock
   Location location;
+  @Mock
+  Milestone milestone;
 
   private NavigationEventDispatcher navigationEventDispatcher;
   private MapboxNavigation navigation;
@@ -89,32 +92,32 @@ public class NavigationEventDispatcherTest extends BaseTest {
 
   @Test
   public void addMilestoneEventListener_didAddListener() throws Exception {
-    navigationEventDispatcher.onMilestoneEvent(routeProgress, "", 0);
-    verify(milestoneEventListener, times(0)).onMilestoneEvent(routeProgress, "", 0);
+    navigationEventDispatcher.onMilestoneEvent(routeProgress, "", milestone);
+    verify(milestoneEventListener, times(0)).onMilestoneEvent(routeProgress, "", milestone);
 
     navigation.addMilestoneEventListener(milestoneEventListener);
-    navigationEventDispatcher.onMilestoneEvent(routeProgress, "", 0);
-    verify(milestoneEventListener, times(1)).onMilestoneEvent(routeProgress, "", 0);
+    navigationEventDispatcher.onMilestoneEvent(routeProgress, "", milestone);
+    verify(milestoneEventListener, times(1)).onMilestoneEvent(routeProgress, "", milestone);
   }
 
   @Test
   public void addMilestoneEventListener_onlyAddsListenerOnce() throws Exception {
-    navigationEventDispatcher.onMilestoneEvent(routeProgress, "", 0);
-    verify(milestoneEventListener, times(0)).onMilestoneEvent(routeProgress, "", 0);
+    navigationEventDispatcher.onMilestoneEvent(routeProgress, "", milestone);
+    verify(milestoneEventListener, times(0)).onMilestoneEvent(routeProgress, "", milestone);
 
     navigation.addMilestoneEventListener(milestoneEventListener);
     navigation.addMilestoneEventListener(milestoneEventListener);
     navigation.addMilestoneEventListener(milestoneEventListener);
-    navigationEventDispatcher.onMilestoneEvent(routeProgress, "", 0);
-    verify(milestoneEventListener, times(1)).onMilestoneEvent(routeProgress, "", 0);
+    navigationEventDispatcher.onMilestoneEvent(routeProgress, "", milestone);
+    verify(milestoneEventListener, times(1)).onMilestoneEvent(routeProgress, "", milestone);
   }
 
   @Test
   public void removeMilestoneEventListener_didRemoveListener() throws Exception {
     navigation.addMilestoneEventListener(milestoneEventListener);
     navigation.removeMilestoneEventListener(milestoneEventListener);
-    navigationEventDispatcher.onMilestoneEvent(routeProgress, "", 0);
-    verify(milestoneEventListener, times(0)).onMilestoneEvent(routeProgress, "", 0);
+    navigationEventDispatcher.onMilestoneEvent(routeProgress, "", milestone);
+    verify(milestoneEventListener, times(0)).onMilestoneEvent(routeProgress, "", milestone);
   }
 
   @Test
@@ -125,8 +128,8 @@ public class NavigationEventDispatcherTest extends BaseTest {
     navigation.addMilestoneEventListener(mock(MilestoneEventListener.class));
 
     navigation.removeMilestoneEventListener(null);
-    navigationEventDispatcher.onMilestoneEvent(routeProgress, "", 0);
-    verify(milestoneEventListener, times(0)).onMilestoneEvent(routeProgress, "", 0);
+    navigationEventDispatcher.onMilestoneEvent(routeProgress, "", milestone);
+    verify(milestoneEventListener, times(0)).onMilestoneEvent(routeProgress, "", milestone);
   }
 
   @Test


### PR DESCRIPTION
 _**API breaking change**_

- In the `onMilestoneEvent` listener we currently return the `Milestone` identifier.  
- This PR changes the listener to return the `Milestone` itself 
   - Will allow developers to create milestones that can return more than just instructions (our use case being api banner instructions)
   
cc @ericrwolfe 