### PR TITLE
Set original and current request identifier

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationTelemetry.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationTelemetry.java
@@ -176,8 +176,8 @@ class NavigationTelemetry implements LocationEngineListener, NavigationMetricLis
     if (!isConfigurationChange) {
       navigationSessionState = navigationSessionState.toBuilder()
         .originalDirectionRoute(directionsRoute)
-        .originalRequestIdentifier(directionsRoute.routeOptions() != null
-          ? directionsRoute.routeOptions().requestUuid() : null)
+        .originalRequestIdentifier(directionsRoute.routeOptions().requestUuid())
+        .requestIdentifier(directionsRoute.routeOptions().requestUuid())
         .currentDirectionRoute(directionsRoute)
         .sessionIdentifier(TelemetryUtils.buildUUID())
         .eventRouteDistanceCompleted(0)


### PR DESCRIPTION
- At the beginning of a telemetry session, set both the original and current request identifiers 