### PR TITLE
Allow theme setting from NavigationViewOptions

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationLauncher.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationLauncher.java
@@ -55,6 +55,14 @@ public class NavigationLauncher {
     editor.putString(NavigationConstants.NAVIGATION_VIEW_AWS_POOL_ID, options.awsPoolId());
     editor.putBoolean(NavigationConstants.NAVIGATION_VIEW_SIMULATE_ROUTE, options.shouldSimulateRoute());
     editor.putInt(NavigationConstants.NAVIGATION_VIEW_UNIT_TYPE, options.navigationOptions().unitType());
+
+    boolean preferenceThemeSet = options.lightThemeResId() != null || options.darkThemeResId() != null;
+    int lightThemeResId = options.lightThemeResId() != null ? options.lightThemeResId() : 0;
+    int darkThemeResId = options.darkThemeResId() != null ? options.darkThemeResId() : 0;
+    editor.putBoolean(NavigationConstants.NAVIGATION_VIEW_PREFERENCE_SET_THEME, preferenceThemeSet);
+    editor.putInt(NavigationConstants.NAVIGATION_VIEW_LIGHT_THEME, lightThemeResId);
+    editor.putInt(NavigationConstants.NAVIGATION_VIEW_DARK_THEME, darkThemeResId);
+
     editor.apply();
 
     Intent navigationActivity = new Intent(activity, NavigationActivity.class);

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationLauncher.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationLauncher.java
@@ -43,25 +43,13 @@ public class NavigationLauncher {
     SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(activity);
     SharedPreferences.Editor editor = preferences.edit();
 
-    if (options.directionsRoute() != null) {
-      storeDirectionsRouteValue(options, editor);
-    } else if (options.origin() != null && options.destination() != null) {
-      storeCoordinateValues(options, editor);
-    } else {
-      throw new RuntimeException("A valid DirectionsRoute or origin and "
-        + "destination must be provided in NavigationViewOptions");
-    }
+    storeRouteOptions(options, editor);
 
     editor.putString(NavigationConstants.NAVIGATION_VIEW_AWS_POOL_ID, options.awsPoolId());
     editor.putBoolean(NavigationConstants.NAVIGATION_VIEW_SIMULATE_ROUTE, options.shouldSimulateRoute());
     editor.putInt(NavigationConstants.NAVIGATION_VIEW_UNIT_TYPE, options.navigationOptions().unitType());
 
-    boolean preferenceThemeSet = options.lightThemeResId() != null || options.darkThemeResId() != null;
-    int lightThemeResId = options.lightThemeResId() != null ? options.lightThemeResId() : 0;
-    int darkThemeResId = options.darkThemeResId() != null ? options.darkThemeResId() : 0;
-    editor.putBoolean(NavigationConstants.NAVIGATION_VIEW_PREFERENCE_SET_THEME, preferenceThemeSet);
-    editor.putInt(NavigationConstants.NAVIGATION_VIEW_LIGHT_THEME, lightThemeResId);
-    editor.putInt(NavigationConstants.NAVIGATION_VIEW_DARK_THEME, darkThemeResId);
+    setThemePreferences(options, editor);
 
     editor.apply();
 
@@ -113,6 +101,27 @@ public class NavigationLauncher {
     coordinates.put(NavigationConstants.NAVIGATION_VIEW_ORIGIN, origin);
     coordinates.put(NavigationConstants.NAVIGATION_VIEW_DESTINATION, destination);
     return coordinates;
+  }
+
+  private static void storeRouteOptions(NavigationViewOptions options, SharedPreferences.Editor editor) {
+    if (options.directionsRoute() != null) {
+      storeDirectionsRouteValue(options, editor);
+    } else if (options.origin() != null && options.destination() != null) {
+      storeCoordinateValues(options, editor);
+    } else {
+      throw new RuntimeException("A valid DirectionsRoute or origin and "
+        + "destination must be provided in NavigationViewOptions");
+    }
+  }
+
+  private static void setThemePreferences(NavigationViewOptions options, SharedPreferences.Editor editor) {
+    boolean preferenceThemeSet = options.lightThemeResId() != null || options.darkThemeResId() != null;
+    editor.putBoolean(NavigationConstants.NAVIGATION_VIEW_PREFERENCE_SET_THEME, preferenceThemeSet);
+
+    if (preferenceThemeSet) {
+      editor.putInt(NavigationConstants.NAVIGATION_VIEW_LIGHT_THEME, options.lightThemeResId());
+      editor.putInt(NavigationConstants.NAVIGATION_VIEW_DARK_THEME, options.darkThemeResId());
+    }
   }
 
   private static void storeDirectionsRouteValue(NavigationViewOptions options, SharedPreferences.Editor editor) {

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
@@ -96,7 +96,7 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
   public NavigationView(Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
     super(context, attrs, defStyleAttr);
     AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_AUTO);
-    ThemeSwitcher.setTheme(getContext(), attrs);
+    ThemeSwitcher.setTheme(context, attrs);
     init();
   }
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewOptions.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewOptions.java
@@ -30,6 +30,12 @@ public abstract class NavigationViewOptions {
 
   public abstract boolean shouldSimulateRoute();
 
+  @Nullable
+  public abstract Integer lightThemeResId();
+
+  @Nullable
+  public abstract Integer darkThemeResId();
+
   @AutoValue.Builder
   public abstract static class Builder {
 
@@ -46,6 +52,10 @@ public abstract class NavigationViewOptions {
     public abstract Builder navigationOptions(MapboxNavigationOptions navigationOptions);
 
     public abstract Builder shouldSimulateRoute(boolean shouldSimulateRoute);
+
+    public abstract Builder lightThemeResId(Integer lightThemeResId);
+
+    public abstract Builder darkThemeResId(Integer darkThemeResId);
 
     public abstract NavigationViewOptions build();
   }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/ThemeSwitcher.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/ThemeSwitcher.java
@@ -14,6 +14,7 @@ import com.mapbox.mapboxsdk.annotations.Icon;
 import com.mapbox.mapboxsdk.annotations.IconFactory;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.services.android.navigation.v5.navigation.NavigationConstants;
 
 /**
  * This class is used to switch theme colors in {@link NavigationView}.
@@ -49,6 +50,16 @@ public class ThemeSwitcher {
       & Configuration.UI_MODE_NIGHT_MASK;
     boolean darkThemeEnabled = uiMode == Configuration.UI_MODE_NIGHT_YES;
     updatePreferencesDarkEnabled(context, darkThemeEnabled);
+
+    // Check for custom theme from NavigationLauncher
+    if (shouldSetThemeFromPreferences(context)) {
+      int prefLightTheme = retrieveThemeResIdFromPreferences(context, NavigationConstants.NAVIGATION_VIEW_LIGHT_THEME);
+      int prefDarkTheme = retrieveThemeResIdFromPreferences(context, NavigationConstants.NAVIGATION_VIEW_DARK_THEME);
+      prefLightTheme = prefLightTheme == 0 ?  R.style.NavigationViewLight : prefLightTheme;
+      prefDarkTheme = prefLightTheme == 0 ?  R.style.NavigationViewDark : prefDarkTheme;
+      context.setTheme(darkThemeEnabled ? prefDarkTheme : prefLightTheme);
+      return;
+    }
 
     TypedArray styledAttributes = context.obtainStyledAttributes(attrs, R.styleable.NavigationView);
     int lightTheme = styledAttributes.getResourceId(R.styleable.NavigationView_navigationLightTheme,
@@ -109,5 +120,15 @@ public class ThemeSwitcher {
     SharedPreferences.Editor editor = preferences.edit();
     editor.putBoolean(context.getString(R.string.dark_theme_enabled), darkThemeEnabled);
     editor.apply();
+  }
+
+  private static boolean shouldSetThemeFromPreferences(Context context) {
+    SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
+    return preferences.getBoolean(NavigationConstants.NAVIGATION_VIEW_PREFERENCE_SET_THEME, false);
+  }
+
+  private static int retrieveThemeResIdFromPreferences(Context context, String key) {
+    SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
+    return preferences.getInt(key, 0);
   }
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationConstants.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationConstants.java
@@ -127,6 +127,21 @@ public final class NavigationConstants {
    */
   public static final String FEEDBACK_SUBMITTED = "Feedback Submitted";
 
+  /**
+   * If a set of light / dark themes been set in {@link android.content.SharedPreferences}
+   */
+  public static final String NAVIGATION_VIEW_PREFERENCE_SET_THEME = "navigation_view_theme_preference";
+
+  /**
+   * Key for the set light theme in preferences
+   */
+  public static final String NAVIGATION_VIEW_LIGHT_THEME = "navigation_view_light_theme";
+
+  /**
+   * Key for the set dark theme in preferences
+   */
+  public static final String NAVIGATION_VIEW_DARK_THEME = "navigation_view_dark_theme";
+
   // Bundle variable keys
   public static final String NAVIGATION_VIEW_ORIGIN_LAT_KEY = "origin_lat";
   public static final String NAVIGATION_VIEW_ORIGIN_LNG_KEY = "origin_long";


### PR DESCRIPTION
Closes #571 

- Allows a developer to set the theme from the `NavigationViewOptions` passed into `NavigationLauncher`

cc @ericrwolfe 