### PR TITLE
Clean up ViewModel subscription in NavigationView

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationContract.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationContract.java
@@ -1,5 +1,7 @@
 package com.mapbox.services.android.navigation.ui.v5;
 
+import android.location.Location;
+
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.geojson.Point;
 
@@ -26,5 +28,11 @@ public interface NavigationContract {
     void finishNavigationView();
 
     void takeScreenshot();
+
+    void startCamera(DirectionsRoute directionsRoute);
+
+    void resumeCamera(Location location);
+
+    void updateLocationLayer(Location location);
   }
 }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationContract.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationContract.java
@@ -24,5 +24,7 @@ public interface NavigationContract {
     void addMarker(Point point);
 
     void finishNavigationView();
+
+    void takeScreenshot();
   }
 }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationPresenter.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationPresenter.java
@@ -41,4 +41,8 @@ class NavigationPresenter {
   void onDestinationUpdate(Point point) {
     view.addMarker(point);
   }
+
+  void onShouldRecordScreenshot() {
+    view.takeScreenshot();
+  }
 }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationPresenter.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationPresenter.java
@@ -1,5 +1,6 @@
 package com.mapbox.services.android.navigation.ui.v5;
 
+import android.location.Location;
 import android.support.design.widget.BottomSheetBehavior;
 
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
@@ -36,6 +37,7 @@ class NavigationPresenter {
 
   void onRouteUpdate(DirectionsRoute directionsRoute) {
     view.drawRoute(directionsRoute);
+    view.startCamera(directionsRoute);
   }
 
   void onDestinationUpdate(Point point) {
@@ -44,5 +46,10 @@ class NavigationPresenter {
 
   void onShouldRecordScreenshot() {
     view.takeScreenshot();
+  }
+
+  void onNavigationLocationUpdate(Location location) {
+    view.resumeCamera(location);
+    view.updateLocationLayer(location);
   }
 }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
@@ -264,6 +264,29 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
     navigationListener.onNavigationFinished();
   }
 
+  @Override
+  public void takeScreenshot() {
+    map.snapshot(new MapboxMap.SnapshotReadyCallback() {
+      @Override
+      public void onSnapshotReady(Bitmap snapshot) {
+        // Make the image visible
+        ImageView screenshotView = findViewById(R.id.screenshotView);
+        screenshotView.setVisibility(View.VISIBLE);
+        screenshotView.setImageBitmap(snapshot);
+
+        // Take a screenshot without the map
+        mapView.setVisibility(View.INVISIBLE);
+        Bitmap capture = ViewUtils.captureView(mapView);
+        String encoded = ViewUtils.encodeView(capture);
+        navigationViewModel.updateFeedbackScreenshot(encoded);
+
+        // Restore visibility
+        screenshotView.setVisibility(View.INVISIBLE);
+        mapView.setVisibility(View.VISIBLE);
+      }
+    });
+  }
+
   /**
    * Should be called when this view is completely initialized.
    *
@@ -568,30 +591,8 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
       @Override
       public void onChanged(@Nullable Boolean shouldRecordScreenshot) {
         if (shouldRecordScreenshot != null && shouldRecordScreenshot) {
-          takeScreenshot(mapView);
+          navigationPresenter.onShouldRecordScreenshot();
         }
-      }
-    });
-  }
-
-  private void takeScreenshot(final View view) {
-    map.snapshot(new MapboxMap.SnapshotReadyCallback() {
-      @Override
-      public void onSnapshotReady(Bitmap snapshot) {
-        // Make the image visible
-        ImageView screenshotView = findViewById(R.id.screenshotView);
-        screenshotView.setVisibility(View.VISIBLE);
-        screenshotView.setImageBitmap(snapshot);
-
-        // Take a screenshot without the map
-        mapView.setVisibility(View.INVISIBLE);
-        Bitmap capture = ViewUtils.captureView(view);
-        String encoded = ViewUtils.encodeView(capture);
-        navigationViewModel.updateFeedbackScreenshot(encoded);
-
-        // Restore visibility
-        screenshotView.setVisibility(View.INVISIBLE);
-        mapView.setVisibility(View.VISIBLE);
       }
     });
   }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
@@ -334,8 +334,8 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
 
     locationViewModel.updateShouldSimulateRoute(options.shouldSimulateRoute());
     routeViewModel.extractRouteOptions(options);
-    // Everything is setup, set up the model observer
-    initViewModelObserver();
+    // Everything is setup, subscribe to the view models
+    subscribeViewModels();
   }
 
   /**
@@ -409,9 +409,20 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
     camera = new NavigationCamera(this, map, navigationViewModel.getNavigation());
   }
 
-  private void initViewModelObserver() {
-    NavigationViewModelObserver observer = new NavigationViewModelObserver(navigationPresenter, navigationListener);
-    observer.subscribe(((LifecycleOwner) getContext()), locationViewModel, routeViewModel, navigationViewModel);
+  /**
+   * Subscribes the {@link InstructionView} and {@link SummaryBottomSheet} to the {@link NavigationViewModel}.
+   * <p>
+   * Then, creates an instance of {@link NavigationViewSubscriber}, which takes a presenter and listener.
+   * <p>
+   * The subscriber then subscribes to the view models, setting up the appropriate presenter / listener
+   * method calls based on the {@link android.arch.lifecycle.LiveData} updates.
+   */
+  private void subscribeViewModels() {
+    instructionView.subscribe(navigationViewModel);
+    summaryBottomSheet.subscribe(navigationViewModel);
+
+    NavigationViewSubscriber subscriber = new NavigationViewSubscriber(navigationPresenter, navigationListener);
+    subscriber.subscribe(((LifecycleOwner) getContext()), locationViewModel, routeViewModel, navigationViewModel);
   }
 
   /**

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModelObserver.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModelObserver.java
@@ -1,0 +1,10 @@
+package com.mapbox.services.android.navigation.ui.v5;
+
+import android.content.Context;
+
+public class NavigationViewModelObserver {
+
+  public NavigationViewModelObserver(Context context, NavigationPresenter presenter, NavigationViewListener listener) {
+
+  }
+}

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModelObserver.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModelObserver.java
@@ -1,10 +1,108 @@
 package com.mapbox.services.android.navigation.ui.v5;
 
-import android.content.Context;
+import android.arch.lifecycle.LifecycleOwner;
+import android.arch.lifecycle.Observer;
+import android.location.Location;
+import android.support.annotation.Nullable;
 
-public class NavigationViewModelObserver {
+import com.mapbox.api.directions.v5.models.DirectionsRoute;
+import com.mapbox.geojson.Point;
+import com.mapbox.services.android.navigation.ui.v5.location.LocationViewModel;
+import com.mapbox.services.android.navigation.ui.v5.route.RouteViewModel;
+import com.mapbox.services.android.telemetry.location.LocationEngine;
 
-  public NavigationViewModelObserver(Context context, NavigationPresenter presenter, NavigationViewListener listener) {
+class NavigationViewModelObserver {
 
+  private NavigationPresenter presenter;
+  private NavigationViewListener listener;
+
+  NavigationViewModelObserver(NavigationPresenter presenter, NavigationViewListener listener) {
+    this.presenter = presenter;
+    this.listener = listener;
+  }
+
+  /**
+   * Initiate observing of ViewModels by Views.
+   */
+  void subscribe(LifecycleOwner owner, final LocationViewModel locationViewModel,
+                 final RouteViewModel routeViewModel, final NavigationViewModel navigationViewModel) {
+
+    locationViewModel.rawLocation.observe(owner, new Observer<Location>() {
+      @Override
+      public void onChanged(@Nullable Location location) {
+        if (location != null) {
+          routeViewModel.updateRawLocation(location);
+        }
+      }
+    });
+
+    locationViewModel.locationEngine.observe(owner, new Observer<LocationEngine>() {
+      @Override
+      public void onChanged(@Nullable LocationEngine locationEngine) {
+        if (locationEngine != null) {
+          navigationViewModel.updateLocationEngine(locationEngine);
+        }
+      }
+    });
+
+    routeViewModel.route.observe(owner, new Observer<DirectionsRoute>() {
+      @Override
+      public void onChanged(@Nullable DirectionsRoute directionsRoute) {
+        if (directionsRoute != null) {
+          navigationViewModel.updateRoute(directionsRoute);
+          locationViewModel.updateRoute(directionsRoute);
+          presenter.onRouteUpdate(directionsRoute);
+        }
+      }
+    });
+
+    routeViewModel.destination.observe(owner, new Observer<Point>() {
+      @Override
+      public void onChanged(@Nullable Point point) {
+        if (point != null) {
+          presenter.onDestinationUpdate(point);
+        }
+      }
+    });
+
+    navigationViewModel.isRunning.observe(owner, new Observer<Boolean>() {
+      @Override
+      public void onChanged(@Nullable Boolean isRunning) {
+        if (isRunning != null) {
+          if (!isRunning) {
+            listener.onNavigationFinished();
+          }
+        }
+      }
+    });
+
+    navigationViewModel.navigationLocation.observe(owner, new Observer<Location>() {
+      @Override
+      public void onChanged(@Nullable Location location) {
+        if (location != null && location.getLongitude() != 0 && location.getLatitude() != 0) {
+          presenter.onNavigationLocationUpdate(location);
+        }
+      }
+    });
+
+    navigationViewModel.newOrigin.observe(owner, new Observer<Point>() {
+      @Override
+      public void onChanged(@Nullable Point newOrigin) {
+        if (newOrigin != null) {
+          routeViewModel.fetchRouteNewOrigin(newOrigin);
+          // To prevent from firing on rotation
+          navigationViewModel.newOrigin.setValue(null);
+        }
+      }
+    });
+
+    navigationViewModel.shouldRecordScreenshot.observe(owner, new Observer<Boolean>() {
+      @Override
+      public void onChanged(@Nullable Boolean shouldRecordScreenshot) {
+        if (shouldRecordScreenshot != null && shouldRecordScreenshot) {
+          presenter.onShouldRecordScreenshot();
+        }
+      }
+    });
   }
 }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewSubscriber.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewSubscriber.java
@@ -11,12 +11,12 @@ import com.mapbox.services.android.navigation.ui.v5.location.LocationViewModel;
 import com.mapbox.services.android.navigation.ui.v5.route.RouteViewModel;
 import com.mapbox.services.android.telemetry.location.LocationEngine;
 
-class NavigationViewModelObserver {
+class NavigationViewSubscriber {
 
   private NavigationPresenter presenter;
   private NavigationViewListener listener;
 
-  NavigationViewModelObserver(NavigationPresenter presenter, NavigationViewListener listener) {
+  NavigationViewSubscriber(NavigationPresenter presenter, NavigationViewListener listener) {
     this.presenter = presenter;
     this.listener = listener;
   }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewSubscriber.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewSubscriber.java
@@ -13,12 +13,12 @@ import com.mapbox.services.android.telemetry.location.LocationEngine;
 
 class NavigationViewSubscriber {
 
-  private NavigationPresenter presenter;
-  private NavigationViewListener listener;
+  private NavigationPresenter navigationPresenter;
+  private NavigationViewListener navigationViewListener;
 
-  NavigationViewSubscriber(NavigationPresenter presenter, NavigationViewListener listener) {
-    this.presenter = presenter;
-    this.listener = listener;
+  NavigationViewSubscriber(NavigationPresenter navigationPresenter, NavigationViewListener navigationViewListener) {
+    this.navigationPresenter = navigationPresenter;
+    this.navigationViewListener = navigationViewListener;
   }
 
   /**
@@ -51,7 +51,7 @@ class NavigationViewSubscriber {
         if (directionsRoute != null) {
           navigationViewModel.updateRoute(directionsRoute);
           locationViewModel.updateRoute(directionsRoute);
-          presenter.onRouteUpdate(directionsRoute);
+          navigationPresenter.onRouteUpdate(directionsRoute);
         }
       }
     });
@@ -60,7 +60,7 @@ class NavigationViewSubscriber {
       @Override
       public void onChanged(@Nullable Point point) {
         if (point != null) {
-          presenter.onDestinationUpdate(point);
+          navigationPresenter.onDestinationUpdate(point);
         }
       }
     });
@@ -70,7 +70,7 @@ class NavigationViewSubscriber {
       public void onChanged(@Nullable Boolean isRunning) {
         if (isRunning != null) {
           if (!isRunning) {
-            listener.onNavigationFinished();
+            navigationViewListener.onNavigationFinished();
           }
         }
       }
@@ -80,7 +80,7 @@ class NavigationViewSubscriber {
       @Override
       public void onChanged(@Nullable Location location) {
         if (location != null && location.getLongitude() != 0 && location.getLatitude() != 0) {
-          presenter.onNavigationLocationUpdate(location);
+          navigationPresenter.onNavigationLocationUpdate(location);
         }
       }
     });
@@ -100,7 +100,7 @@ class NavigationViewSubscriber {
       @Override
       public void onChanged(@Nullable Boolean shouldRecordScreenshot) {
         if (shouldRecordScreenshot != null && shouldRecordScreenshot) {
-          presenter.onShouldRecordScreenshot();
+          navigationPresenter.onShouldRecordScreenshot();
         }
       }
     });

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/location/LocationViewModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/location/LocationViewModel.java
@@ -70,7 +70,7 @@ public class LocationViewModel extends AndroidViewModel implements LifecycleObse
   }
 
   /**
-   * Checks {@link NavigationViewOptions} to see if the route
+   * Checks {@link com.mapbox.services.android.navigation.ui.v5.NavigationViewOptions} to see if the route
    * should be simulated with a {@link MockLocationEngine}.
    */
   public void updateShouldSimulateRoute(boolean shouldSimulateRoute) {

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/location/LocationViewModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/location/LocationViewModel.java
@@ -1,4 +1,4 @@
-package com.mapbox.services.android.navigation.ui.v5;
+package com.mapbox.services.android.navigation.ui.v5.location;
 
 import android.app.Application;
 import android.arch.lifecycle.AndroidViewModel;
@@ -19,8 +19,8 @@ import com.mapbox.services.android.telemetry.location.LostLocationEngine;
 
 public class LocationViewModel extends AndroidViewModel implements LifecycleObserver, LocationEngineListener {
 
-  final MutableLiveData<LocationEngine> locationEngine = new MutableLiveData<>();
-  final MutableLiveData<Location> rawLocation = new MutableLiveData<>();
+  public final MutableLiveData<LocationEngine> locationEngine = new MutableLiveData<>();
+  public final MutableLiveData<Location> rawLocation = new MutableLiveData<>();
   private LocationEngine modelLocationEngine;
   private boolean shouldSimulateRoute;
 
@@ -73,7 +73,7 @@ public class LocationViewModel extends AndroidViewModel implements LifecycleObse
    * Checks {@link NavigationViewOptions} to see if the route
    * should be simulated with a {@link MockLocationEngine}.
    */
-  void updateShouldSimulateRoute(boolean shouldSimulateRoute) {
+  public void updateShouldSimulateRoute(boolean shouldSimulateRoute) {
     this.shouldSimulateRoute = shouldSimulateRoute;
   }
 
@@ -83,7 +83,7 @@ public class LocationViewModel extends AndroidViewModel implements LifecycleObse
    *
    * @param route to be mocked
    */
-  void updateRoute(DirectionsRoute route) {
+  public void updateRoute(DirectionsRoute route) {
     if (shouldSimulateRoute) {
       activateMockLocationEngine(route);
     }


### PR DESCRIPTION
Creates a subscriber class to remove the `ViewModel` code that was previously in `NavigationView`

