### PR TITLE
Fix for listener bug

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
@@ -181,7 +181,6 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
         initLocationLayer();
         initLifecycleObservers();
         initNavigationPresenter();
-        initNavigationEventDispatcher();
         initClickListeners();
         map.setOnScrollListener(NavigationView.this);
         onNavigationReadyCallback.onNavigationReady();
@@ -361,6 +360,7 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
     initViewModels();
     initNavigationViewObserver();
     initSummaryBottomSheet();
+    initNavigationEventDispatcher();
   }
 
   /**


### PR DESCRIPTION
One fix to consider for preventing inability to add listeners to dispatcher before it's initialized is initializing it earlier. Whether this fix is adopted or not, I think we need to add more information to the documentation about when the user can safely add listeners and start navigation.

cc. @danesfeder @ericrwolfe 