### PR TITLE
Check for IndexOutOfBounds when calculating foreground percentage

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/metrics/NavigationLifecycleMonitor.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/metrics/NavigationLifecycleMonitor.java
@@ -111,7 +111,9 @@ public class NavigationLifecycleMonitor implements Application.ActivityLifecycle
     }
     long resumePauseDiff = 0;
     for (int i = 0; i < tempResumes.size(); i++) {
-      resumePauseDiff = resumePauseDiff + (tempResumes.get(i) - pauses.get(i));
+      if (i < pauses.size()) {
+        resumePauseDiff = resumePauseDiff + (tempResumes.get(i) - pauses.get(i));
+      }
     }
     return currentTime - resumePauseDiff - startSessionTime;
   }


### PR DESCRIPTION
Closes #621 

@electrostat I ended up putting the check in the for loop.  The issue looks like what you described in https://github.com/mapbox/mapbox-navigation-android/issues/621#issuecomment-355040923 
> mismatch in resumes v pauses size

But maybe it should be:
```
if (tempResumes.size() < pauses.size() && pauses.size() > 0) {
     tempResumes.add(currentTime);
} else if (pauses.size() < tempResumes.size()) {
     pauses.add(currentTime);
}
```
Instead of returning `100` like we originally discussed - as the crash is a result of the pauses being smaller than the resumes.  Thanks for the help on this! 