### PR TITLE
OffRoute roundabout/rotary fix

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteDetector.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteDetector.java
@@ -44,7 +44,9 @@ public class OffRouteDetector extends OffRoute {
     // Check to see if the user is moving away from the maneuver. Here, we store an array of
     // distances. If the current distance is greater than the last distance, add it to the array. If
     // the array grows larger than x, reroute the user.
-    if (movingAwayFromManeuver(routeProgress, recentDistancesFromManeuverInMeters, futurePoint)) {
+    if (movingAwayFromManeuver(routeProgress, recentDistancesFromManeuverInMeters, futurePoint) &&
+            !routeProgress.currentLegProgress().currentStep().maneuver().type().equals("roundabout") &&
+            !routeProgress.currentLegProgress().currentStep().maneuver().type().equals("rotary")) {
       updateLastReroutePoint(location);
       return true;
     }


### PR DESCRIPTION
The offRoute method in OffRouteDetector checks whether a recalculation is needed in 2 independent ways - if either of them is true the user will be rerouted. 

The first checks if the calculated future position is within the radius of the current step's polyline. 
The second is a bit more tricky, and involves checking if a user is moving away from the point of the next maneuver . This does not work in the case of roundabouts/rotaries (or any steps in which the curvature between two maneuvers is high enough (see #603) ) since the angle that you have to take in order to traverse the step geometry is also one which takes you away from the next maneuver. 

The frequent recalculations caused by this can be very annoying and will probably cause users to miss their roundabout exits since they will be getting conflicting voice instructions on which exit to take. 
