### PR TITLE
Add support for baseUrl

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationActivity.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationActivity.java
@@ -104,7 +104,8 @@ public class NavigationActivity extends AppCompatActivity implements OnNavigatio
       .getString(NavigationConstants.NAVIGATION_VIEW_AWS_POOL_ID, null));
     options.shouldSimulateRoute(preferences
       .getBoolean(NavigationConstants.NAVIGATION_VIEW_SIMULATE_ROUTE, false));
-
+    options.baseUrl(preferences
+      .getString("baseUrl", null));
     MapboxNavigationOptions navigationOptions = MapboxNavigationOptions.builder()
       .unitType(preferences.getInt(NavigationConstants.NAVIGATION_VIEW_UNIT_TYPE,
         NavigationUnitType.TYPE_IMPERIAL))

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationLauncher.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationLauncher.java
@@ -48,7 +48,7 @@ public class NavigationLauncher {
     editor.putString(NavigationConstants.NAVIGATION_VIEW_AWS_POOL_ID, options.awsPoolId());
     editor.putBoolean(NavigationConstants.NAVIGATION_VIEW_SIMULATE_ROUTE, options.shouldSimulateRoute());
     editor.putInt(NavigationConstants.NAVIGATION_VIEW_UNIT_TYPE, options.navigationOptions().unitType());
-
+    editor.putString("baseUrl", options.baseUrl());
     setThemePreferences(options, editor);
 
     editor.apply();

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
@@ -181,6 +181,7 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
         initLocationLayer();
         initLifecycleObservers();
         initNavigationPresenter();
+        initNavigationEventDispatcher();
         initClickListeners();
         map.setOnScrollListener(NavigationView.this);
         onNavigationReadyCallback.onNavigationReady();
@@ -360,7 +361,6 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
     initViewModels();
     initNavigationViewObserver();
     initSummaryBottomSheet();
-    initNavigationEventDispatcher();
   }
 
   /**

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewOptions.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewOptions.java
@@ -56,6 +56,9 @@ public abstract class NavigationViewOptions {
   @Nullable
   public abstract MilestoneEventListener milestoneEventListener();
 
+  @Nullable
+  public abstract String baseUrl();
+
   @AutoValue.Builder
   public abstract static class Builder {
 
@@ -86,6 +89,8 @@ public abstract class NavigationViewOptions {
     public abstract Builder progressChangeListener(ProgressChangeListener progressChangeListener);
 
     public abstract Builder milestoneEventListener(MilestoneEventListener milestoneEventListener);
+
+    public abstract Builder baseUrl(String baseUrl);
 
     public abstract NavigationViewOptions build();
   }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/RouteViewModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/RouteViewModel.java
@@ -32,6 +32,7 @@ public class RouteViewModel extends AndroidViewModel implements Callback<Directi
   private boolean extractRouteOptions = true;
   private String routeProfile;
   private String unitType;
+  private String baseUrl;
 
   public RouteViewModel(@NonNull Application application) {
     super(application);
@@ -128,6 +129,7 @@ public class RouteViewModel extends AndroidViewModel implements Callback<Directi
       NavigationRoute.builder()
         .accessToken(Mapbox.getAccessToken())
         .origin(origin, bearing, 90d)
+        .baseUrl(baseUrl)
         .voiceUnits(unitType)
         .profile(routeProfile)
         .destination(destination).build().getRoute(this);
@@ -167,6 +169,7 @@ public class RouteViewModel extends AndroidViewModel implements Callback<Directi
       destination.setValue(lastStep.maneuver().location());
       this.route.setValue(route);
       extractRouteOptions = false;
+      baseUrl = options.baseUrl();
     }
   }
 


### PR DESCRIPTION
Related to #609 

Whenever a recalculation occurs, the fetchRoute method in RouteViewModel creates a new instance of NavigationRoute which only retains the destination of the original route. 

This fix takes care of the baseUrl, but does not address other parameters which get lost (waypoints etc..). Perhaps extending the NavigationViewOptions & RouteViewModel with an additional NavigationRoute member could help?