### PR TITLE
Check for network connection before setting off-route

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/MainActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/MainActivity.java
@@ -1,5 +1,6 @@
 package com.mapbox.services.android.navigation.testapp;
 
+import android.Manifest;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -24,6 +25,9 @@ import java.util.Arrays;
 import java.util.List;
 
 public class MainActivity extends AppCompatActivity implements PermissionsListener {
+
+  private static final String[] PERMISSIONS = {Manifest.permission.ACCESS_FINE_LOCATION,
+    Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_NETWORK_STATE};
 
   private RecyclerView recyclerView;
   private PermissionsManager permissionsManager;
@@ -72,7 +76,7 @@ public class MainActivity extends AppCompatActivity implements PermissionsListen
     permissionsManager = new PermissionsManager(this);
     if (!PermissionsManager.areLocationPermissionsGranted(this)) {
       recyclerView.setEnabled(false);
-      permissionsManager.requestLocationPermissions(this);
+      permissionsManager.requestPermissions(this, PERMISSIONS);
     }
   }
 


### PR DESCRIPTION
Before we fire the off-route state, we should check that we have an internet connection.  If we don't have a connection, do not fire the off-route state.  

@cammace if we fire the off-route listener and don't update with a new `DirectionsRoute`, will the core logic continue to fire the off-route listener for each location update? 

cc @ericrwolfe 