### PR TITLE
Add onDestroy as a method that must be implemented for NavigationView

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationActivity.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationActivity.java
@@ -60,6 +60,12 @@ public class NavigationActivity extends AppCompatActivity implements OnNavigatio
   }
 
   @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    navigationView.onDestroy();
+  }
+
+  @Override
   public void onNavigationReady() {
     NavigationViewOptions.Builder options = NavigationViewOptions.builder();
     options.navigationListener(this);

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
@@ -1,6 +1,7 @@
 package com.mapbox.services.android.navigation.ui.v5;
 
 import android.app.Activity;
+import android.app.Fragment;
 import android.arch.lifecycle.Lifecycle;
 import android.arch.lifecycle.LifecycleObserver;
 import android.arch.lifecycle.LifecycleOwner;
@@ -159,6 +160,19 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
     recenterBtn.setVisibility(isVisible ? View.VISIBLE : View.INVISIBLE);
     int bottomSheetState = savedInstanceState.getInt(getContext().getString(R.string.bottom_sheet_state));
     resetBottomSheetState(bottomSheetState);
+  }
+
+
+  /**
+   * Called to ensure the {@link MapView} is destroyed
+   * properly.
+   * <p>
+   * In an {@link Activity} this should be in {@link Activity#onDestroy()}.
+   * <p>
+   * In a {@link android.app.Fragment}, this should be in {@link Fragment#onDestroyView()}.
+   */
+  public void onDestroy() {
+    mapView.onDestroy();
   }
 
   /**
@@ -476,6 +490,7 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
 
   /**
    * Sets up the listeners in the dispatcher, as well as the listeners in the {@link MapboxNavigation}
+   *
    * @param navigationViewOptions that contains all listeners to attach
    */
   private void setupListeners(NavigationViewOptions navigationViewOptions) {
@@ -556,10 +571,5 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
   @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
   public void onStop() {
     mapView.onStop();
-  }
-
-  @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
-  public void onDestroy() {
-    mapView.onDestroy();
   }
 }


### PR DESCRIPTION
If using the `NavigationView` in a `Fragment` implementation, the `MapView` is not properly destroyed.  

This is because the we are using the `Activity` context to look for the onDestroy lifecycle event using the new architecture components. 

In a `Fragment`, `MapView#onDestroy` needs to be called in `Fragment#onDestroyView`.   This PR re-exposes the lifecycle method to allow developers to do this.

cc @ericrwolfe @tobrun @langsmith 
  