### PR TITLE
Add language to NavigationViewOptions with default from RouteOptions

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewOptions.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewOptions.java
@@ -13,6 +13,8 @@ import com.mapbox.services.android.navigation.v5.milestone.MilestoneEventListene
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigationOptions;
 import com.mapbox.services.android.navigation.v5.routeprogress.ProgressChangeListener;
 
+import java.util.Locale;
+
 @AutoValue
 public abstract class NavigationViewOptions {
 
@@ -23,7 +25,7 @@ public abstract class NavigationViewOptions {
   public abstract String directionsProfile();
 
   @Nullable
-  public abstract String directionsLanguage();
+  public abstract Locale directionsLanguage();
 
   @Nullable
   public abstract Point origin();
@@ -66,7 +68,7 @@ public abstract class NavigationViewOptions {
 
     public abstract Builder directionsProfile(@DirectionsCriteria.ProfileCriteria String directionsProfile);
 
-    public abstract Builder directionsLanguage(String directionsLanguage);
+    public abstract Builder directionsLanguage(Locale directionsLanguage);
 
     public abstract Builder origin(Point origin);
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewOptions.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewOptions.java
@@ -23,6 +23,9 @@ public abstract class NavigationViewOptions {
   public abstract String directionsProfile();
 
   @Nullable
+  public abstract String directionsLanguage();
+
+  @Nullable
   public abstract Point origin();
 
   @Nullable
@@ -62,6 +65,8 @@ public abstract class NavigationViewOptions {
     public abstract Builder directionsRoute(DirectionsRoute directionsRoute);
 
     public abstract Builder directionsProfile(@DirectionsCriteria.ProfileCriteria String directionsProfile);
+
+    public abstract Builder directionsLanguage(String directionsLanguage);
 
     public abstract Builder origin(Point origin);
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/RouteViewModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/RouteViewModel.java
@@ -31,6 +31,7 @@ public class RouteViewModel extends AndroidViewModel implements Callback<Directi
   private Location rawLocation;
   private String routeProfile;
   private String unitType;
+  private String language;
 
   public RouteViewModel(@NonNull Application application) {
     super(application);
@@ -154,13 +155,27 @@ public class RouteViewModel extends AndroidViewModel implements Callback<Directi
   private void extractRouteFromOptions(NavigationViewOptions options) {
     DirectionsRoute route = options.directionsRoute();
     if (route != null) {
-      String profile = options.directionsProfile();
-      routeProfile = profile != null ? profile : route.routeOptions().profile();
-      RouteLeg lastLeg = route.legs().get(route.legs().size() - 1);
-      LegStep lastStep = lastLeg.steps().get(lastLeg.steps().size() - 1);
-      destination.setValue(lastStep.maneuver().location());
+      cacheRouteProfile(options, route);
+      cacheRouteLanguage(options, route);
+      cacheRouteDestination(route);
       this.route.setValue(route);
     }
+  }
+
+  private void cacheRouteDestination(DirectionsRoute route) {
+    RouteLeg lastLeg = route.legs().get(route.legs().size() - 1);
+    LegStep lastStep = lastLeg.steps().get(lastLeg.steps().size() - 1);
+    destination.setValue(lastStep.maneuver().location());
+  }
+
+  private void cacheRouteProfile(NavigationViewOptions options, DirectionsRoute route) {
+    String profile = options.directionsProfile();
+    routeProfile = profile != null ? profile : route.routeOptions().profile();
+  }
+
+  private void cacheRouteLanguage(NavigationViewOptions options, DirectionsRoute route) {
+    String language = options.directionsLanguage();
+    this.language = language != null ? language : route.routeOptions().language();
   }
 
   /**

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/RouteViewModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/RouteViewModel.java
@@ -165,17 +165,43 @@ public class RouteViewModel extends AndroidViewModel implements Callback<Directi
     }
   }
 
+  /**
+   * Looks at the given {@link DirectionsRoute} and extracts the destination based on
+   * the last {@link LegStep} maneuver.
+   *
+   * @param route to extract destination from
+   */
   private void cacheRouteDestination(DirectionsRoute route) {
     RouteLeg lastLeg = route.legs().get(route.legs().size() - 1);
     LegStep lastStep = lastLeg.steps().get(lastLeg.steps().size() - 1);
     destination.setValue(lastStep.maneuver().location());
   }
 
+  /**
+   * Looks for a route profile provided by {@link NavigationViewOptions} to be
+   * stored for reroute requests.
+   * <p>
+   * If not found, look at the {@link com.mapbox.api.directions.v5.models.RouteOptions} for
+   * the profile from the original route.
+   *
+   * @param options to look for set profile
+   * @param route   as backup if view options profile not found
+   */
   private void cacheRouteProfile(NavigationViewOptions options, DirectionsRoute route) {
     String profile = options.directionsProfile();
     routeProfile = profile != null ? profile : route.routeOptions().profile();
   }
 
+  /**
+   * Looks for a route language provided by {@link NavigationViewOptions} to be
+   * stored for reroute requests.
+   * <p>
+   * If not found, look at the {@link com.mapbox.api.directions.v5.models.RouteOptions} for
+   * the language from the original route.
+   *
+   * @param options to look for set language
+   * @param route   as backup if view options language not found
+   */
   private void cacheRouteLanguage(NavigationViewOptions options, DirectionsRoute route) {
     Locale language = options.directionsLanguage();
     this.language = language != null ? language : new Locale(route.routeOptions().language());

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/RouteViewModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/RouteViewModel.java
@@ -18,6 +18,8 @@ import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation;
 import com.mapbox.services.android.navigation.v5.navigation.NavigationRoute;
 import com.mapbox.services.android.navigation.v5.navigation.NavigationUnitType;
 
+import java.util.Locale;
+
 import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
@@ -31,7 +33,7 @@ public class RouteViewModel extends AndroidViewModel implements Callback<Directi
   private Location rawLocation;
   private String routeProfile;
   private String unitType;
-  private String language;
+  private Locale language;
 
   public RouteViewModel(@NonNull Application application) {
     super(application);
@@ -128,6 +130,7 @@ public class RouteViewModel extends AndroidViewModel implements Callback<Directi
         .origin(origin, bearing, 90d)
         .voiceUnits(unitType)
         .profile(routeProfile)
+        .language(language)
         .destination(destination).build().getRoute(this);
     }
   }
@@ -174,8 +177,8 @@ public class RouteViewModel extends AndroidViewModel implements Callback<Directi
   }
 
   private void cacheRouteLanguage(NavigationViewOptions options, DirectionsRoute route) {
-    String language = options.directionsLanguage();
-    this.language = language != null ? language : route.routeOptions().language();
+    Locale language = options.directionsLanguage();
+    this.language = language != null ? language : new Locale(route.routeOptions().language());
   }
 
   /**


### PR DESCRIPTION
Closes #633 

Currently, if a reroute occurs with the `NavigationView`, `RouteViewModel` will override the language for the new route request.  

This PR will look to cache the language from `NavigationViewOptions` - if one is not provided, we will look to the `RouteOptions` provided by the `DirectionsRoute`
  