### PR TITLE
Check for at least two coordinates when creating snapped location

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationHelper.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationHelper.java
@@ -36,8 +36,11 @@ class NavigationHelper {
    * need to snap to the route in order to get the most accurate information.
    */
   static Point userSnappedToRoutePosition(Location location, List<Point> coordinates) {
-    Point locationToPoint = Point.fromLngLat(location.getLongitude(), location.getLatitude());
+    if (coordinates.size() < 2) {
+      return Point.fromLngLat(location.getLongitude(), location.getLatitude());
+    }
 
+    Point locationToPoint = Point.fromLngLat(location.getLongitude(), location.getLatitude());
 
     // Uses Turf's pointOnLine, which takes a Point and a LineString to calculate the closest
     // Point on the LineString.


### PR DESCRIPTION
In https://github.com/mapbox/mapbox-java/pull/689/, a check was added when using `Turf#pointOnLine` 

If we provide less than 2 coordinates, an exception is thrown by MAS.  This will ensure we don't ever provide less than 2. 

Note: this was found using `3.0.0-SNAPSHOT` and is not in the current `beta.1` which we are using in `master`