### PR TITLE
Notification check for valid BannerInstructions before updating 

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationNotification.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationNotification.java
@@ -47,6 +47,13 @@ class MapboxNavigationNotification implements NavigationNotification {
   private int currentManeuverId;
   private int distanceUnitType;
 
+  private BroadcastReceiver endNavigationBtnReceiver = new BroadcastReceiver() {
+    @Override
+    public void onReceive(final Context context, final Intent intent) {
+      MapboxNavigationNotification.this.onEndNavigationBtnClick();
+    }
+  };
+
   MapboxNavigationNotification(Context context, MapboxNavigation mapboxNavigation) {
     this.mapboxNavigation = mapboxNavigation;
     this.distanceUnitType = mapboxNavigation.options().unitType();
@@ -145,16 +152,18 @@ class MapboxNavigationNotification implements NavigationNotification {
   }
 
   private void updateInstructionText(LegStep step) {
-    if (instructionText == null || newInstructionText(step)) {
+    if (hasInstructions(step) && (instructionText == null || newInstructionText(step))) {
       instructionText = step.bannerInstructions().get(0).primary().text();
       notificationRemoteViews.setTextViewText(R.id.notificationInstructionText, instructionText);
     }
   }
 
+  private boolean hasInstructions(LegStep step) {
+    return step.bannerInstructions() != null && !step.bannerInstructions().isEmpty();
+  }
+
   private boolean newInstructionText(LegStep step) {
-    return step.bannerInstructions() != null
-      && !step.bannerInstructions().isEmpty()
-      && !instructionText.equals(step.bannerInstructions().get(0).primary().text());
+    return !instructionText.equals(step.bannerInstructions().get(0).primary().text());
   }
 
   private void updateDistanceText(RouteProgress routeProgress) {
@@ -208,11 +217,4 @@ class MapboxNavigationNotification implements NavigationNotification {
       mapboxNavigation.endNavigation();
     }
   }
-
-  private BroadcastReceiver endNavigationBtnReceiver = new BroadcastReceiver() {
-    @Override
-    public void onReceive(final Context context, final Intent intent) {
-      MapboxNavigationNotification.this.onEndNavigationBtnClick();
-    }
-  };
 }


### PR DESCRIPTION
- Prevents `IndexOutOfBounds` with empty `BannerInstructions` list is found
