### PR TITLE
Add FasterRouteDetector to check for quicker routes while navigating 

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationLauncher.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationLauncher.java
@@ -10,13 +10,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.mapbox.api.directions.v5.DirectionsAdapterFactory;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
-import com.mapbox.geojson.BoundingBox;
-import com.mapbox.geojson.Geometry;
 import com.mapbox.geojson.Point;
-import com.mapbox.geojson.gson.BoundingBoxDeserializer;
-import com.mapbox.geojson.gson.GeoJsonAdapterFactory;
-import com.mapbox.geojson.gson.GeometryDeserializer;
-import com.mapbox.geojson.gson.PointDeserializer;
 import com.mapbox.services.android.navigation.v5.navigation.NavigationConstants;
 
 import java.util.HashMap;
@@ -75,17 +69,7 @@ public class NavigationLauncher {
   static DirectionsRoute extractRoute(Context context) {
     SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
     String directionsRouteJson = preferences.getString(NavigationConstants.NAVIGATION_VIEW_ROUTE_KEY, "");
-    return directionsRouteFromJson(directionsRouteJson);
-  }
-
-  private static DirectionsRoute directionsRouteFromJson(String json) {
-    GsonBuilder gson = new GsonBuilder();
-    gson.registerTypeAdapter(Point.class, new PointDeserializer());
-    gson.registerTypeAdapter(Geometry.class, new GeometryDeserializer());
-    gson.registerTypeAdapter(BoundingBox.class, new BoundingBoxDeserializer());
-    gson.registerTypeAdapterFactory(GeoJsonAdapterFactory.create());
-    gson.registerTypeAdapterFactory(DirectionsAdapterFactory.create());
-    return gson.create().fromJson(json, DirectionsRoute.class);
+    return DirectionsRoute.fromJson(directionsRouteJson);
   }
 
   /**

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
@@ -30,6 +30,7 @@ import com.mapbox.services.android.navigation.v5.navigation.NavigationConstants;
 import com.mapbox.services.android.navigation.v5.navigation.NavigationEventListener;
 import com.mapbox.services.android.navigation.v5.navigation.metrics.FeedbackEvent;
 import com.mapbox.services.android.navigation.v5.offroute.OffRouteListener;
+import com.mapbox.services.android.navigation.v5.route.FasterRouteListener;
 import com.mapbox.services.android.navigation.v5.routeprogress.ProgressChangeListener;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 import com.mapbox.services.android.telemetry.location.LocationEngine;
@@ -37,7 +38,7 @@ import com.mapbox.services.android.telemetry.location.LocationEngine;
 import java.text.DecimalFormat;
 
 public class NavigationViewModel extends AndroidViewModel implements ProgressChangeListener,
-  OffRouteListener, MilestoneEventListener, NavigationEventListener {
+  OffRouteListener, MilestoneEventListener, NavigationEventListener, FasterRouteListener {
 
   public final MutableLiveData<InstructionModel> instructionModel = new MutableLiveData<>();
   public final MutableLiveData<BannerInstructionModel> bannerInstructionModel = new MutableLiveData<>();
@@ -46,6 +47,7 @@ public class NavigationViewModel extends AndroidViewModel implements ProgressCha
   public final MutableLiveData<Boolean> isFeedbackShowing = new MutableLiveData<>();
   final MutableLiveData<FeedbackItem> selectedFeedbackItem = new MutableLiveData<>();
   final MutableLiveData<Location> navigationLocation = new MutableLiveData<>();
+  final MutableLiveData<DirectionsRoute> fasterRoute = new MutableLiveData<>();
   final MutableLiveData<Point> newOrigin = new MutableLiveData<>();
   final MutableLiveData<Boolean> isRunning = new MutableLiveData<>();
   final MutableLiveData<Boolean> shouldRecordScreenshot = new MutableLiveData<>();
@@ -142,6 +144,18 @@ public class NavigationViewModel extends AndroidViewModel implements ProgressCha
   @Override
   public void onRunning(boolean running) {
     isRunning.setValue(running);
+  }
+
+  /**
+   * Listener that will be fired if a faster {@link DirectionsRoute} is found
+   * while navigating.
+   *
+   * @param directionsRoute faster route retrieved
+   * @since 0.9.0
+   */
+  @Override
+  public void fasterRouteFound(DirectionsRoute directionsRoute) {
+    fasterRoute.setValue(directionsRoute);
   }
 
   public void setMuted(boolean isMuted) {
@@ -266,6 +280,7 @@ public class NavigationViewModel extends AndroidViewModel implements ProgressCha
       navigation.addOffRouteListener(this);
       navigation.addMilestoneEventListener(this);
       navigation.addNavigationEventListener(this);
+      navigation.addFasterRouteListener(this);
     }
   }
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewSubscriber.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewSubscriber.java
@@ -62,13 +62,14 @@ class NavigationViewSubscriber {
     routeViewModel.route.observe(owner, new Observer<DirectionsRoute>() {
       @Override
       public void onChanged(@Nullable DirectionsRoute directionsRoute) {
-        if (isOffRoute) {
-          navigationViewEventDispatcher.onRerouteAlong(directionsRoute);
-        }
         if (directionsRoute != null) {
           navigationViewModel.updateRoute(directionsRoute);
           locationViewModel.updateRoute(directionsRoute);
           navigationPresenter.onRouteUpdate(directionsRoute);
+
+          if (isOffRoute) {
+            navigationViewEventDispatcher.onRerouteAlong(directionsRoute);
+          }
         }
       }
     });
@@ -100,6 +101,19 @@ class NavigationViewSubscriber {
       public void onChanged(@Nullable Location location) {
         if (location != null && location.getLongitude() != 0 && location.getLatitude() != 0) {
           navigationPresenter.onNavigationLocationUpdate(location);
+        }
+      }
+    });
+
+    navigationViewModel.fasterRoute.observe(owner, new Observer<DirectionsRoute>() {
+      @Override
+      public void onChanged(@Nullable DirectionsRoute directionsRoute) {
+        if (directionsRoute != null) {
+          navigationViewModel.updateRoute(directionsRoute);
+          locationViewModel.updateRoute(directionsRoute);
+          navigationPresenter.onRouteUpdate(directionsRoute);
+          // To prevent from firing on rotation
+          navigationViewModel.fasterRoute.setValue(null);
         }
       }
     });

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/RouteViewModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/RouteViewModel.java
@@ -5,6 +5,7 @@ import android.arch.lifecycle.AndroidViewModel;
 import android.arch.lifecycle.MutableLiveData;
 import android.location.Location;
 import android.support.annotation.NonNull;
+import android.text.TextUtils;
 
 import com.mapbox.api.directions.v5.DirectionsCriteria;
 import com.mapbox.api.directions.v5.models.DirectionsResponse;
@@ -203,8 +204,13 @@ public class RouteViewModel extends AndroidViewModel implements Callback<Directi
    * @param route   as backup if view options language not found
    */
   private void cacheRouteLanguage(NavigationViewOptions options, DirectionsRoute route) {
-    Locale language = options.directionsLanguage();
-    this.language = language != null ? language : new Locale(route.routeOptions().language());
+    if (options.directionsLanguage() != null) {
+      language = options.directionsLanguage();
+    } else if (!TextUtils.isEmpty(route.routeOptions().language())) {
+      language = new Locale(route.routeOptions().language());
+    } else {
+      language = Locale.getDefault();
+    }
   }
 
   /**

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
@@ -20,6 +20,7 @@ import com.mapbox.services.android.navigation.v5.offroute.OffRouteDetector;
 import com.mapbox.services.android.navigation.v5.offroute.OffRouteListener;
 import com.mapbox.services.android.navigation.v5.route.FasterRoute;
 import com.mapbox.services.android.navigation.v5.route.FasterRouteDetector;
+import com.mapbox.services.android.navigation.v5.route.FasterRouteListener;
 import com.mapbox.services.android.navigation.v5.routeprogress.ProgressChangeListener;
 import com.mapbox.services.android.navigation.v5.snap.Snap;
 import com.mapbox.services.android.navigation.v5.snap.SnapToRoute;
@@ -549,6 +550,44 @@ public class MapboxNavigation implements ServiceConnection {
    */
   public void removeNavigationEventListener(@Nullable NavigationEventListener navigationEventListener) {
     navigationEventDispatcher.removeNavigationEventListener(navigationEventListener);
+  }
+
+  /**
+   * This adds a new faster route listener which is invoked when a new, faster {@link DirectionsRoute}
+   * has been retrieved by the specified criteria in {@link FasterRoute}.
+   * <p>
+   * The behavior that causes this listeners callback to get invoked vary depending on whether a
+   * custom faster route engine has been set using {@link #setFasterRouteEngine(FasterRoute)}.
+   * </p><p>
+   * It is not possible to add the same listener implementation more then once and a warning will be
+   * printed in the log if attempted.
+   * </p>
+   *
+   * @param fasterRouteListener an implementation of {@code FasterRouteListener}
+   * @see FasterRouteListener
+   * @since 0.9.0
+   */
+  public void addFasterRouteListener(@NonNull FasterRouteListener fasterRouteListener) {
+    navigationEventDispatcher.addFasterRouteListener(fasterRouteListener);
+  }
+
+  /**
+   * This removes a specific faster route listener by passing in the instance of it or you can pass in
+   * null to remove all the listeners. When {@link #onDestroy()} is called, all listeners
+   * get removed automatically, removing the requirement for developers to manually handle this.
+   * <p>
+   * If the listener you are trying to remove does not exist in the list, a warning will be printed
+   * in the log.
+   * </p>
+   *
+   * @param fasterRouteListener an implementation of {@code FasterRouteListener} which currently exist in
+   *                            the fasterRouteListeners list
+   * @see FasterRouteListener
+   * @since 0.9.0
+   */
+  @SuppressWarnings("WeakerAccess") // Public exposed for usage outside SDK
+  public void removeFasterRouteListener(@Nullable FasterRouteListener fasterRouteListener) {
+    navigationEventDispatcher.removeFasterRouteListener(fasterRouteListener);
   }
 
   // Custom engines

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
@@ -19,6 +19,7 @@ import com.mapbox.services.android.navigation.v5.offroute.OffRoute;
 import com.mapbox.services.android.navigation.v5.offroute.OffRouteDetector;
 import com.mapbox.services.android.navigation.v5.offroute.OffRouteListener;
 import com.mapbox.services.android.navigation.v5.route.FasterRoute;
+import com.mapbox.services.android.navigation.v5.route.FasterRouteDetector;
 import com.mapbox.services.android.navigation.v5.routeprogress.ProgressChangeListener;
 import com.mapbox.services.android.navigation.v5.snap.Snap;
 import com.mapbox.services.android.navigation.v5.snap.SnapToRoute;
@@ -150,6 +151,9 @@ public class MapboxNavigation implements ServiceConnection {
     }
     if (options.enableOffRouteDetection()) {
       offRouteEngine = new OffRouteDetector();
+    }
+    if (options().enableFasterRouteDetection()) {
+      fasterRouteEngine = new FasterRouteDetector();
     }
   }
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
@@ -18,6 +18,7 @@ import com.mapbox.services.android.navigation.v5.navigation.metrics.FeedbackEven
 import com.mapbox.services.android.navigation.v5.offroute.OffRoute;
 import com.mapbox.services.android.navigation.v5.offroute.OffRouteDetector;
 import com.mapbox.services.android.navigation.v5.offroute.OffRouteListener;
+import com.mapbox.services.android.navigation.v5.route.FasterRoute;
 import com.mapbox.services.android.navigation.v5.routeprogress.ProgressChangeListener;
 import com.mapbox.services.android.navigation.v5.snap.Snap;
 import com.mapbox.services.android.navigation.v5.snap.SnapToRoute;
@@ -53,6 +54,7 @@ public class MapboxNavigation implements ServiceConnection {
   private List<Milestone> milestones;
   private final String accessToken;
   private OffRoute offRouteEngine;
+  private FasterRoute fasterRouteEngine;
   private Snap snapEngine;
   private Context context;
   private boolean isBound;
@@ -143,7 +145,6 @@ public class MapboxNavigation implements ServiceConnection {
       addMilestone(new VoiceInstructionMilestone.Builder().setIdentifier(VOICE_INSTRUCTION_MILESTONE_ID).build());
       addMilestone(new BannerInstructionMilestone.Builder().setIdentifier(BANNER_INSTRUCTION_MILESTONE_ID).build());
     }
-
     if (options.snapToRoute()) {
       snapEngine = new SnapToRoute();
     }
@@ -612,6 +613,38 @@ public class MapboxNavigation implements ServiceConnection {
   @NonNull
   public OffRoute getOffRouteEngine() {
     return offRouteEngine;
+  }
+
+  /**
+   * This API is used to pass in a custom implementation of the faster-route detection logic, A default
+   * faster-route detection engine is attached when this class is first initialized; setting a custom
+   * one will replace it with your own implementation.
+   * <p>
+   * The engine can be changed at anytime, even during a navigation session.
+   * </p>
+   *
+   * @param fasterRouteEngine a custom implementation of the {@link FasterRoute} class
+   * @see FasterRoute
+   * @since 0.9.0
+   */
+  @SuppressWarnings("WeakerAccess") // Public exposed for usage outside SDK
+  public void setFasterRouteEngine(@NonNull FasterRoute fasterRouteEngine) {
+    this.fasterRouteEngine = fasterRouteEngine;
+  }
+
+  /**
+   * This will return the currently set faster-route engine which will or is being used during the
+   * navigation session. If no faster-route engine has been set yet, the default engine will be
+   * returned.
+   *
+   * @return the faster-route engine currently set and will/is being used for the navigation session
+   * @see FasterRoute
+   * @since 0.9.0
+   */
+  @SuppressWarnings("WeakerAccess") // Public exposed for usage outside SDK
+  @NonNull
+  public FasterRoute getFasterRouteEngine() {
+    return fasterRouteEngine;
   }
 
   /**

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationOptions.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationOptions.java
@@ -106,7 +106,7 @@ public abstract class MapboxNavigationOptions {
       .userLocationSnapDistance(NavigationConstants.USER_LOCATION_SNAPPING_DISTANCE)
       .secondsBeforeReroute(NavigationConstants.SECONDS_BEFORE_REROUTE)
       .enableOffRouteDetection(true)
-      .enableFasterRouteDetection(false)
+      .enableFasterRouteDetection(true)
       .snapToRoute(true)
       .manuallyEndNavigationUponCompletion(false)
       .defaultMilestonesEnabled(true)

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationOptions.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationOptions.java
@@ -31,6 +31,8 @@ public abstract class MapboxNavigationOptions {
 
   public abstract boolean enableOffRouteDetection();
 
+  public abstract boolean enableFasterRouteDetection();
+
   public abstract boolean manuallyEndNavigationUponCompletion();
 
   public abstract boolean enableNotification();
@@ -73,6 +75,8 @@ public abstract class MapboxNavigationOptions {
 
     public abstract Builder enableOffRouteDetection(boolean enableOffRouteDetection);
 
+    public abstract Builder enableFasterRouteDetection(boolean enableFasterRouteDetection);
+
     public abstract Builder manuallyEndNavigationUponCompletion(boolean manuallyEndNavigation);
 
     public abstract Builder enableNotification(boolean enableNotification);
@@ -102,6 +106,7 @@ public abstract class MapboxNavigationOptions {
       .userLocationSnapDistance(NavigationConstants.USER_LOCATION_SNAPPING_DISTANCE)
       .secondsBeforeReroute(NavigationConstants.SECONDS_BEFORE_REROUTE)
       .enableOffRouteDetection(true)
+      .enableFasterRouteDetection(false)
       .snapToRoute(true)
       .manuallyEndNavigationUponCompletion(false)
       .defaultMilestonesEnabled(true)

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationOptions.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationOptions.java
@@ -106,7 +106,7 @@ public abstract class MapboxNavigationOptions {
       .userLocationSnapDistance(NavigationConstants.USER_LOCATION_SNAPPING_DISTANCE)
       .secondsBeforeReroute(NavigationConstants.SECONDS_BEFORE_REROUTE)
       .enableOffRouteDetection(true)
-      .enableFasterRouteDetection(true)
+      .enableFasterRouteDetection(false)
       .snapToRoute(true)
       .manuallyEndNavigationUponCompletion(false)
       .defaultMilestonesEnabled(true)

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationConstants.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationConstants.java
@@ -151,6 +151,15 @@ public final class NavigationConstants {
    */
   public static final String NAVIGATION_VIEW_DARK_THEME = "navigation_view_dark_theme";
 
+  /**
+   * In seconds, how quickly {@link com.mapbox.services.android.navigation.v5.route.FasterRouteDetector}
+   * will tell {@link NavigationEngine} to check
+   * for a faster {@link com.mapbox.api.directions.v5.models.DirectionsRoute}.
+   *
+   * @since 0.9.0
+   */
+  public static final int NAVIGATION_CHECK_FASTER_ROUTE_INTERVAL = 120;
+
   // Bundle variable keys
   public static final String NAVIGATION_VIEW_ORIGIN_LAT_KEY = "origin_lat";
   public static final String NAVIGATION_VIEW_ORIGIN_LNG_KEY = "origin_long";

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationConstants.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationConstants.java
@@ -160,6 +160,14 @@ public final class NavigationConstants {
    */
   public static final int NAVIGATION_CHECK_FASTER_ROUTE_INTERVAL = 120;
 
+  /**
+   * 70 seconds remaining is considered a medium alert level when
+   * navigating along a {@link com.mapbox.api.directions.v5.models.LegStep}.
+   *
+   * @since 0.9.0
+   */
+  public static final int NAVIGATION_MEDIUM_ALERT_DURATION = 70;
+
   // Bundle variable keys
   public static final String NAVIGATION_VIEW_ORIGIN_LAT_KEY = "origin_lat";
   public static final String NAVIGATION_VIEW_ORIGIN_LNG_KEY = "origin_long";

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEngine.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEngine.java
@@ -16,6 +16,7 @@ import com.mapbox.services.android.navigation.v5.utils.RouteUtils;
 
 import java.util.List;
 
+import static com.mapbox.core.constants.Constants.PRECISION_6;
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.bearingMatchesManeuverFinalHeading;
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.checkMilestones;
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.getSnappedLocation;
@@ -26,7 +27,6 @@ import static com.mapbox.services.android.navigation.v5.navigation.NavigationHel
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.shouldCheckFasterRoute;
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.stepDistanceRemaining;
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.userSnappedToRoutePosition;
-import static com.mapbox.core.constants.Constants.PRECISION_6;
 
 /**
  * This class extends handler thread to run most of the navigation calculations on a separate
@@ -93,7 +93,7 @@ class NavigationEngine extends HandlerThread implements Handler.Callback {
         callback.onNewRouteProgress(location, routeProgress);
         callback.onMilestoneTrigger(milestones, routeProgress);
         callback.onUserOffRoute(location, userOffRoute);
-        callback.onCheckFasterRoute(location, checkFasterRoute);
+        callback.onCheckFasterRoute(location, routeProgress, checkFasterRoute);
       }
     });
   }
@@ -173,6 +173,6 @@ class NavigationEngine extends HandlerThread implements Handler.Callback {
 
     void onUserOffRoute(Location location, boolean userOffRoute);
 
-    void onCheckFasterRoute(Location location, boolean checkFasterRoute);
+    void onCheckFasterRoute(Location location, RouteProgress routeProgress, boolean checkFasterRoute);
   }
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEngine.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEngine.java
@@ -83,7 +83,7 @@ class NavigationEngine extends HandlerThread implements Handler.Callback {
       : newLocationModel.location();
 
     // Check for faster route only if not off-route
-    final boolean checkFasterRoute = !userOffRoute && shouldCheckFasterRoute(newLocationModel);
+    final boolean checkFasterRoute = !userOffRoute && shouldCheckFasterRoute(newLocationModel, routeProgress);
 
     previousRouteProgress = routeProgress;
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEngine.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEngine.java
@@ -82,8 +82,9 @@ class NavigationEngine extends HandlerThread implements Handler.Callback {
       routeProgress, stepPositions)
       : newLocationModel.location();
 
-    // Check for faster route only if not off-route
-    final boolean checkFasterRoute = !userOffRoute && shouldCheckFasterRoute(newLocationModel, routeProgress);
+    // Check for faster route only if enabled and not off-route
+    final boolean checkFasterRoute = newLocationModel.mapboxNavigation().options().enableFasterRouteDetection()
+      && !userOffRoute && shouldCheckFasterRoute(newLocationModel, routeProgress);
 
     previousRouteProgress = routeProgress;
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEventDispatcher.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEventDispatcher.java
@@ -4,10 +4,12 @@ import android.location.Location;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.services.android.navigation.v5.milestone.Milestone;
 import com.mapbox.services.android.navigation.v5.milestone.MilestoneEventListener;
 import com.mapbox.services.android.navigation.v5.navigation.metrics.NavigationMetricListeners;
 import com.mapbox.services.android.navigation.v5.offroute.OffRouteListener;
+import com.mapbox.services.android.navigation.v5.route.FasterRouteListener;
 import com.mapbox.services.android.navigation.v5.routeprogress.ProgressChangeListener;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 import com.mapbox.services.android.navigation.v5.utils.RouteUtils;
@@ -23,6 +25,7 @@ class NavigationEventDispatcher {
   private List<MilestoneEventListener> milestoneEventListeners;
   private List<ProgressChangeListener> progressChangeListeners;
   private List<OffRouteListener> offRouteListeners;
+  private List<FasterRouteListener> fasterRouteListeners;
   private NavigationMetricListeners.EventListeners metricEventListeners;
   private NavigationMetricListeners.ArrivalListener metricArrivalListener;
 
@@ -31,6 +34,7 @@ class NavigationEventDispatcher {
     milestoneEventListeners = new ArrayList<>();
     progressChangeListeners = new ArrayList<>();
     offRouteListeners = new ArrayList<>();
+    fasterRouteListeners = new ArrayList<>();
   }
 
   void addMilestoneEventListener(@NonNull MilestoneEventListener milestoneEventListener) {
@@ -105,6 +109,24 @@ class NavigationEventDispatcher {
     }
   }
 
+  void addFasterRouteListener(@NonNull FasterRouteListener fasterRouteListener) {
+    if (fasterRouteListeners.contains(fasterRouteListener)) {
+      Timber.w("The specified FasterRouteListener has already been added to the stack.");
+      return;
+    }
+    fasterRouteListeners.add(fasterRouteListener);
+  }
+
+  void removeFasterRouteListener(@Nullable FasterRouteListener fasterRouteListener) {
+    if (fasterRouteListener == null) {
+      fasterRouteListeners.clear();
+    } else if (!fasterRouteListeners.contains(fasterRouteListener)) {
+      Timber.w("The specified FasterRouteListener isn't found in stack, therefore, cannot be removed.");
+    } else {
+      fasterRouteListeners.remove(fasterRouteListener);
+    }
+  }
+
   void onMilestoneEvent(RouteProgress routeProgress, String instruction, Milestone milestone) {
     for (MilestoneEventListener milestoneEventListener : milestoneEventListeners) {
       milestoneEventListener.onMilestoneEvent(routeProgress, instruction, milestone);
@@ -149,6 +171,12 @@ class NavigationEventDispatcher {
   void onNavigationEvent(boolean isRunning) {
     for (NavigationEventListener navigationEventListener : navigationEventListeners) {
       navigationEventListener.onRunning(isRunning);
+    }
+  }
+
+  void onFasterRouteEvent(DirectionsRoute directionsRoute) {
+    for (FasterRouteListener fasterRouteListener : fasterRouteListeners) {
+      fasterRouteListener.fasterRouteFound(directionsRoute);
     }
   }
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationHelper.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationHelper.java
@@ -10,6 +10,7 @@ import com.mapbox.geojson.LineString;
 import com.mapbox.geojson.Point;
 import com.mapbox.services.android.navigation.v5.milestone.Milestone;
 import com.mapbox.services.android.navigation.v5.offroute.OffRoute;
+import com.mapbox.services.android.navigation.v5.route.FasterRoute;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 import com.mapbox.services.android.navigation.v5.snap.Snap;
 import com.mapbox.services.android.telemetry.utils.MathUtils;
@@ -183,6 +184,11 @@ class NavigationHelper {
     return offRoute.isUserOffRoute(newLocationModel.location(), routeProgress,
       newLocationModel.mapboxNavigation().options(),
       newLocationModel.recentDistancesFromManeuverInMeters());
+  }
+
+  static boolean shouldCheckFasterRoute(NewLocationModel newLocationModel) {
+    FasterRoute fasterRoute = newLocationModel.mapboxNavigation().getFasterRouteEngine();
+    return fasterRoute.shouldCheckFasterRoute(newLocationModel.location());
   }
 
   static Location getSnappedLocation(MapboxNavigation mapboxNavigation, Location location,

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationHelper.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationHelper.java
@@ -186,9 +186,9 @@ class NavigationHelper {
       newLocationModel.recentDistancesFromManeuverInMeters());
   }
 
-  static boolean shouldCheckFasterRoute(NewLocationModel newLocationModel) {
+  static boolean shouldCheckFasterRoute(NewLocationModel newLocationModel, RouteProgress routeProgress) {
     FasterRoute fasterRoute = newLocationModel.mapboxNavigation().getFasterRouteEngine();
-    return fasterRoute.shouldCheckFasterRoute(newLocationModel.location());
+    return fasterRoute.shouldCheckFasterRoute(newLocationModel.location(), routeProgress);
   }
 
   static Location getSnappedLocation(MapboxNavigation mapboxNavigation, Location location,

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRoute.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRoute.java
@@ -3,6 +3,7 @@ package com.mapbox.services.android.navigation.v5.navigation;
 import android.support.annotation.FloatRange;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.text.TextUtils;
 
 import com.mapbox.api.directions.v5.DirectionsCriteria;
 import com.mapbox.api.directions.v5.DirectionsCriteria.AnnotationCriteria;
@@ -12,6 +13,7 @@ import com.mapbox.api.directions.v5.DirectionsCriteria.VoiceUnitCriteria;
 import com.mapbox.api.directions.v5.MapboxDirections;
 import com.mapbox.api.directions.v5.models.DirectionsResponse;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
+import com.mapbox.api.directions.v5.models.RouteOptions;
 import com.mapbox.core.exceptions.ServicesException;
 import com.mapbox.geojson.Point;
 
@@ -417,6 +419,43 @@ public final class NavigationRoute {
      */
     public Builder baseUrl(String baseUrl) {
       directionsBuilder.baseUrl(baseUrl);
+      return this;
+    }
+
+    /**
+     * Optionally create a {@link Builder} based on all variables
+     * from given {@link RouteOptions}.
+     *
+     * @param options containing all variables for request
+     * @return this builder for chaining options together
+     * @since 0.9.0
+     */
+    public Builder routeOptions(RouteOptions options) {
+      directionsBuilder.language(new Locale(options.language()));
+      directionsBuilder.alternatives(options.alternatives());
+
+      if (!TextUtils.isEmpty(options.profile())) {
+        directionsBuilder.profile(options.profile());
+      }
+
+      if (options.bannerInstructions() != null) {
+        directionsBuilder.bannerInstructions(options.bannerInstructions());
+      }
+
+      if (options.continueStraight() != null) {
+        directionsBuilder.continueStraight(options.continueStraight());
+      }
+
+      if (options.alternatives() != null) {
+        directionsBuilder.alternatives(options.alternatives());
+      }
+
+      if (!TextUtils.isEmpty(options.voiceUnits())) {
+        directionsBuilder.voiceUnits(options.voiceUnits());
+      }
+
+      // TODO add missing options here
+
       return this;
     }
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRoute.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRoute.java
@@ -425,25 +425,27 @@ public final class NavigationRoute {
     /**
      * Optionally create a {@link Builder} based on all variables
      * from given {@link RouteOptions}.
+     * <p>
+     * Note: {@link RouteOptions#bearings()} are excluded because it's better
+     * to recalculate these at the time of the request, as your location bearing
+     * is constantly changing.
      *
      * @param options containing all variables for request
      * @return this builder for chaining options together
      * @since 0.9.0
      */
     public Builder routeOptions(RouteOptions options) {
-      directionsBuilder.language(new Locale(options.language()));
-      directionsBuilder.alternatives(options.alternatives());
+
+      if (!TextUtils.isEmpty(options.language())) {
+        directionsBuilder.language(new Locale(options.language()));
+      }
+
+      if (options.alternatives() != null) {
+        directionsBuilder.alternatives(options.alternatives());
+      }
 
       if (!TextUtils.isEmpty(options.profile())) {
         directionsBuilder.profile(options.profile());
-      }
-
-      if (options.bannerInstructions() != null) {
-        directionsBuilder.bannerInstructions(options.bannerInstructions());
-      }
-
-      if (options.continueStraight() != null) {
-        directionsBuilder.continueStraight(options.continueStraight());
       }
 
       if (options.alternatives() != null) {
@@ -454,7 +456,17 @@ public final class NavigationRoute {
         directionsBuilder.voiceUnits(options.voiceUnits());
       }
 
-      // TODO add missing options here
+      if (!TextUtils.isEmpty(options.user())) {
+        directionsBuilder.user(options.user());
+      }
+
+      if (!TextUtils.isEmpty(options.accessToken())) {
+        directionsBuilder.accessToken(options.accessToken());
+      }
+
+      if (!TextUtils.isEmpty(options.annotations())) {
+        directionsBuilder.annotations(options.annotations());
+      }
 
       return this;
     }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationService.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationService.java
@@ -167,7 +167,7 @@ public class NavigationService extends Service implements LocationEngineListener
    */
   @Override
   public void onResponseReceived(Response<DirectionsResponse> response, RouteProgress routeProgress) {
-    if (mapboxNavigation.getFasterRouteEngine().isFasterRoute(response, routeProgress)) {
+    if (mapboxNavigation.getFasterRouteEngine().isFasterRoute(response.body(), routeProgress)) {
       mapboxNavigation.getEventDispatcher().onFasterRouteEvent(response.body().routes().get(0));
     }
   }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationService.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationService.java
@@ -11,8 +11,10 @@ import android.os.IBinder;
 import android.support.annotation.Nullable;
 
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
+import com.mapbox.geojson.Point;
 import com.mapbox.services.android.navigation.v5.milestone.Milestone;
 import com.mapbox.services.android.navigation.v5.navigation.notification.NavigationNotification;
+import com.mapbox.services.android.navigation.v5.route.RouteEngine;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 import com.mapbox.services.android.navigation.v5.utils.RingBuffer;
 import com.mapbox.services.android.telemetry.location.LocationEngine;
@@ -36,7 +38,7 @@ import static com.mapbox.services.android.navigation.v5.navigation.NavigationHel
  * </p>
  */
 public class NavigationService extends Service implements LocationEngineListener,
-  NavigationEngine.Callback {
+  NavigationEngine.Callback, RouteEngine.Callback {
 
   // Message id used when a new location update occurs and we send to the thread.
   private static final int MSG_LOCATION_UPDATED = 1001;
@@ -46,6 +48,7 @@ public class NavigationService extends Service implements LocationEngineListener
 
   private NavigationNotification navigationNotification;
   private MapboxNavigation mapboxNavigation;
+  private RouteEngine routeEngine;
   private LocationEngine locationEngine;
   private NavigationEngine thread;
 
@@ -136,6 +139,21 @@ public class NavigationService extends Service implements LocationEngineListener
     }
   }
 
+  // TODO add javadoc
+  @Override
+  public void onCheckFasterRoute(Location location, boolean checkFasterRoute) {
+    if (checkFasterRoute) {
+      Point origin = Point.fromLngLat(location.getLongitude(), location.getLatitude());
+      routeEngine.fetchFasterRoute(origin, mapboxNavigation.getRoute().routeOptions());
+    }
+  }
+
+  // TODO add javadoc
+  @Override
+  public void onFasterRouteFound(DirectionsRoute route) {
+    mapboxNavigation.startNavigation(route);
+  }
+
   /**
    * This gets called when {@link MapboxNavigation#startNavigation(DirectionsRoute)} is called and
    * setups variables among other things on the Navigation Service side.
@@ -143,6 +161,7 @@ public class NavigationService extends Service implements LocationEngineListener
   void startNavigation(MapboxNavigation mapboxNavigation) {
     this.mapboxNavigation = mapboxNavigation;
     initNotification(mapboxNavigation);
+    initRouteEngine(mapboxNavigation);
     acquireLocationEngine();
     forceLocationUpdate();
   }
@@ -200,6 +219,20 @@ public class NavigationService extends Service implements LocationEngineListener
       Notification notification = navigationNotification.getNotification();
       int notificationId = navigationNotification.getNotificationId();
       startForegroundNotification(notification, notificationId);
+    }
+  }
+
+  /**
+   * Builds a new route engine which can be used to find faster routes
+   * during a navigation session based on traffic.
+   * <p>
+   * Check to see if this functionality is enabled / disabled first.
+   *
+   * @param mapboxNavigation for options to check if enabled / disabled
+   */
+  private void initRouteEngine(MapboxNavigation mapboxNavigation) {
+    if (mapboxNavigation.options().enableFasterRouteDetection()) {
+      routeEngine = new RouteEngine(this);
     }
   }
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/route/FasterRoute.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/route/FasterRoute.java
@@ -14,8 +14,8 @@ import retrofit2.Response;
  * To provide your implementation,
  * use {@link com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation#setFasterRouteEngine(FasterRoute)}.
  * <p>
- * {@link FasterRoute#shouldCheckFasterRoute(Location, RouteProgress)} determines how quickly a new route will be fetched
- * by {@link RouteEngine}.
+ * {@link FasterRoute#shouldCheckFasterRoute(Location, RouteProgress)} determines how quickly a
+ * new route will be fetched by {@link RouteEngine}.
  * <p>
  * {@link FasterRoute#isFasterRoute(Response, RouteProgress)} determines if the new route
  * retrieved by {@link RouteEngine} is actually faster than the current route.

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/route/FasterRoute.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/route/FasterRoute.java
@@ -5,8 +5,6 @@ import android.location.Location;
 import com.mapbox.api.directions.v5.models.DirectionsResponse;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 
-import retrofit2.Response;
-
 /**
  * This class can be subclassed to provide custom logic for checking / determining
  * new / faster routes while navigating.
@@ -17,7 +15,7 @@ import retrofit2.Response;
  * {@link FasterRoute#shouldCheckFasterRoute(Location, RouteProgress)} determines how quickly a
  * new route will be fetched by {@link RouteEngine}.
  * <p>
- * {@link FasterRoute#isFasterRoute(Response, RouteProgress)} determines if the new route
+ * {@link FasterRoute#isFasterRoute(DirectionsResponse, RouteProgress)} determines if the new route
  * retrieved by {@link RouteEngine} is actually faster than the current route.
  *
  * @since 0.9.0
@@ -50,5 +48,5 @@ public abstract class FasterRoute {
    * @param routeProgress current route progress
    * @return true if the new route is considered faster, false if not
    */
-  public abstract boolean isFasterRoute(Response<DirectionsResponse> response, RouteProgress routeProgress);
+  public abstract boolean isFasterRoute(DirectionsResponse response, RouteProgress routeProgress);
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/route/FasterRoute.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/route/FasterRoute.java
@@ -1,0 +1,8 @@
+package com.mapbox.services.android.navigation.v5.route;
+
+import android.location.Location;
+
+public abstract class FasterRoute {
+
+  public abstract boolean shouldCheckFasterRoute(Location location);
+}

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/route/FasterRoute.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/route/FasterRoute.java
@@ -2,7 +2,9 @@ package com.mapbox.services.android.navigation.v5.route;
 
 import android.location.Location;
 
+import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
+
 public abstract class FasterRoute {
 
-  public abstract boolean shouldCheckFasterRoute(Location location);
+  public abstract boolean shouldCheckFasterRoute(Location location, RouteProgress routeProgress);
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/route/FasterRoute.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/route/FasterRoute.java
@@ -2,9 +2,53 @@ package com.mapbox.services.android.navigation.v5.route;
 
 import android.location.Location;
 
+import com.mapbox.api.directions.v5.models.DirectionsResponse;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 
+import retrofit2.Response;
+
+/**
+ * This class can be subclassed to provide custom logic for checking / determining
+ * new / faster routes while navigating.
+ * <p>
+ * To provide your implementation,
+ * use {@link com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation#setFasterRouteEngine(FasterRoute)}.
+ * <p>
+ * {@link FasterRoute#shouldCheckFasterRoute(Location, RouteProgress)} determines how quickly a new route will be fetched
+ * by {@link RouteEngine}.
+ * <p>
+ * {@link FasterRoute#isFasterRoute(Response, RouteProgress)} determines if the new route
+ * retrieved by {@link RouteEngine} is actually faster than the current route.
+ *
+ * @since 0.9.0
+ */
 public abstract class FasterRoute {
 
+  /**
+   * This method determine if a new {@link DirectionsResponse} should
+   * be retrieved by {@link RouteEngine}.
+   * <p>
+   * It will also be called every time
+   * the {@link com.mapbox.services.android.navigation.v5.navigation.NavigationEngine} gets a valid
+   * {@link Location} update.
+   * <p>
+   * The most recent snapped location and route progress are provided.  Both can be used to
+   * determine if a new route should be fetched or not.
+   *
+   * @param location      current snapped location
+   * @param routeProgress current route progress
+   * @return true if should check, false if not
+   * @since 0.9.0
+   */
   public abstract boolean shouldCheckFasterRoute(Location location, RouteProgress routeProgress);
+
+  /**
+   * This method will be used to determine if the route retrieved is
+   * faster than the one that's currently being navigated.
+   *
+   * @param response      provided by {@link RouteEngine}
+   * @param routeProgress current route progress
+   * @return true if the new route is considered faster, false if not
+   */
+  public abstract boolean isFasterRoute(Response<DirectionsResponse> response, RouteProgress routeProgress);
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/route/FasterRouteDetector.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/route/FasterRouteDetector.java
@@ -2,15 +2,58 @@ package com.mapbox.services.android.navigation.v5.route;
 
 import android.location.Location;
 
+import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
+import com.mapbox.services.android.navigation.v5.routeprogress.RouteStepProgress;
+import com.mapbox.services.android.navigation.v5.utils.time.TimeUtils;
+
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.NAVIGATION_CHECK_FASTER_ROUTE_INTERVAL;
+
 public class FasterRouteDetector extends FasterRoute {
 
-  private Location lastLocation;
+  private static final int MEDIUM_ALERT_DURATION_REMAINING = 70;
+  private static final int VALID_ROUTE_DURATION_REMAINING = 600;
+
+  private Location lastCheckedLocation;
 
   @Override
-  public boolean shouldCheckFasterRoute(Location location) {
-    if (lastLocation == null) {
+  public boolean shouldCheckFasterRoute(Location location, RouteProgress routeProgress) {
+    if (location == null || routeProgress == null) {
       return false;
     }
+    // On first pass through detector, last checked location will be null
+    if (lastCheckedLocation == null) {
+      lastCheckedLocation = location;
+    }
+
+    // Check if the faster route time interval has been exceeded
+    if (secondsSinceLastCheck(location) > NAVIGATION_CHECK_FASTER_ROUTE_INTERVAL) {
+      lastCheckedLocation = location;
+      // Check for both valid route and step durations remaining
+      if (validRouteDurationRemaining(routeProgress) && validStepDurationRemaining(routeProgress)) {
+        return true;
+      }
+    }
     return false;
+  }
+
+  private boolean validRouteDurationRemaining(RouteProgress routeProgress) {
+    // Total route duration remaining in seconds
+    int routeDurationRemaining = (int) routeProgress.durationRemaining();
+    return routeDurationRemaining > VALID_ROUTE_DURATION_REMAINING;
+  }
+
+  private boolean validStepDurationRemaining(RouteProgress routeProgress) {
+    RouteStepProgress currentStepProgress = routeProgress.currentLegProgress().currentStepProgress();
+    // Current step duration remaining in seconds
+    int currentStepDurationRemaining = (int) currentStepProgress.durationRemaining();
+    return currentStepDurationRemaining > MEDIUM_ALERT_DURATION_REMAINING;
+  }
+
+  private long secondsSinceLastCheck(Location location) {
+    return TimeUtils.dateDiff(new Date(lastCheckedLocation.getTime()),
+      new Date(location.getTime()), TimeUnit.SECONDS);
   }
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/route/FasterRouteDetector.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/route/FasterRouteDetector.java
@@ -13,8 +13,6 @@ import com.mapbox.services.android.navigation.v5.utils.time.TimeUtils;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
-import retrofit2.Response;
-
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.NAVIGATION_CHECK_FASTER_ROUTE_INTERVAL;
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.NAVIGATION_MEDIUM_ALERT_DURATION;
 
@@ -45,11 +43,11 @@ public class FasterRouteDetector extends FasterRoute {
   }
 
   @Override
-  public boolean isFasterRoute(Response<DirectionsResponse> response, RouteProgress routeProgress) {
+  public boolean isFasterRoute(DirectionsResponse response, RouteProgress routeProgress) {
     if (validRouteResponse(response)) {
 
       double currentDurationRemaining = routeProgress.durationRemaining();
-      DirectionsRoute newRoute = response.body().routes().get(0);
+      DirectionsRoute newRoute = response.routes().get(0);
 
       if (hasLegs(newRoute)) {
         // Extract the first leg
@@ -111,9 +109,9 @@ public class FasterRouteDetector extends FasterRoute {
    * @param response to be checked
    * @return true if valid, false if not
    */
-  private boolean validRouteResponse(Response<DirectionsResponse> response) {
-    return response.body() != null
-      && !response.body().routes().isEmpty();
+  private boolean validRouteResponse(DirectionsResponse response) {
+    return response != null
+      && !response.routes().isEmpty();
   }
 
   private boolean validRouteDurationRemaining(RouteProgress routeProgress) {

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/route/FasterRouteDetector.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/route/FasterRouteDetector.java
@@ -1,0 +1,16 @@
+package com.mapbox.services.android.navigation.v5.route;
+
+import android.location.Location;
+
+public class FasterRouteDetector extends FasterRoute {
+
+  private Location lastLocation;
+
+  @Override
+  public boolean shouldCheckFasterRoute(Location location) {
+    if (lastLocation == null) {
+      return false;
+    }
+    return false;
+  }
+}

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/route/FasterRouteDetector.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/route/FasterRouteDetector.java
@@ -32,7 +32,7 @@ public class FasterRouteDetector extends FasterRoute {
       lastCheckedLocation = location;
     }
     // Check if the faster route time interval has been exceeded
-    if (secondsSinceLastCheck(location) > NAVIGATION_CHECK_FASTER_ROUTE_INTERVAL) {
+    if (secondsSinceLastCheck(location) >= NAVIGATION_CHECK_FASTER_ROUTE_INTERVAL) {
       lastCheckedLocation = location;
       // Check for both valid route and step durations remaining
       if (validRouteDurationRemaining(routeProgress) && validStepDurationRemaining(routeProgress)) {

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/route/FasterRouteDetector.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/route/FasterRouteDetector.java
@@ -2,6 +2,10 @@ package com.mapbox.services.android.navigation.v5.route;
 
 import android.location.Location;
 
+import com.mapbox.api.directions.v5.models.DirectionsResponse;
+import com.mapbox.api.directions.v5.models.DirectionsRoute;
+import com.mapbox.api.directions.v5.models.LegStep;
+import com.mapbox.api.directions.v5.models.RouteLeg;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteStepProgress;
 import com.mapbox.services.android.navigation.v5.utils.time.TimeUtils;
@@ -9,11 +13,13 @@ import com.mapbox.services.android.navigation.v5.utils.time.TimeUtils;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
+import retrofit2.Response;
+
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.NAVIGATION_CHECK_FASTER_ROUTE_INTERVAL;
+import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.NAVIGATION_MEDIUM_ALERT_DURATION;
 
 public class FasterRouteDetector extends FasterRoute {
 
-  private static final int MEDIUM_ALERT_DURATION_REMAINING = 70;
   private static final int VALID_ROUTE_DURATION_REMAINING = 600;
 
   private Location lastCheckedLocation;
@@ -27,7 +33,6 @@ public class FasterRouteDetector extends FasterRoute {
     if (lastCheckedLocation == null) {
       lastCheckedLocation = location;
     }
-
     // Check if the faster route time interval has been exceeded
     if (secondsSinceLastCheck(location) > NAVIGATION_CHECK_FASTER_ROUTE_INTERVAL) {
       lastCheckedLocation = location;
@@ -37,6 +42,78 @@ public class FasterRouteDetector extends FasterRoute {
       }
     }
     return false;
+  }
+
+  @Override
+  public boolean isFasterRoute(Response<DirectionsResponse> response, RouteProgress routeProgress) {
+    if (validRouteResponse(response)) {
+
+      double currentDurationRemaining = routeProgress.durationRemaining();
+      DirectionsRoute newRoute = response.body().routes().get(0);
+
+      if (hasLegs(newRoute)) {
+        // Extract the first leg
+        RouteLeg routeLeg = newRoute.legs().get(0);
+        if (hasAtLeastTwoSteps(routeLeg)) {
+          // Extract the first two steps
+          LegStep firstStep = routeLeg.steps().get(0);
+          LegStep secondStep = routeLeg.steps().get(1);
+          // Check for valid first and second steps of the new route
+          if (!validFirstStep(firstStep) || !validSecondStep(secondStep, routeProgress)) {
+            return false;
+          }
+        }
+      }
+      // New route must be at least 10% faster
+      if (newRoute.duration() <= (0.9 * currentDurationRemaining)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private boolean hasLegs(DirectionsRoute newRoute) {
+    return newRoute.legs() != null && !newRoute.legs().isEmpty();
+  }
+
+  private boolean hasAtLeastTwoSteps(RouteLeg routeLeg) {
+    return routeLeg.steps() != null && routeLeg.steps().size() > 2;
+  }
+
+  /**
+   * The second step of the new route is valid if
+   * it equals the current route upcoming step.
+   *
+   * @param secondStep of the new route
+   * @param routeProgress current route progress
+   * @return true if valid, false if not
+   */
+  private boolean validSecondStep(LegStep secondStep, RouteProgress routeProgress) {
+    return routeProgress.currentLegProgress().upComingStep() != null
+      && routeProgress.currentLegProgress().upComingStep().equals(secondStep);
+  }
+
+  /**
+   * First step is valid if it is greater than
+   * {@link com.mapbox.services.android.navigation.v5.navigation.NavigationConstants#NAVIGATION_MEDIUM_ALERT_DURATION}.
+   *
+   * @param firstStep of the new route
+   * @return true if valid, false if not
+   */
+  private boolean validFirstStep(LegStep firstStep) {
+    return firstStep.duration() > NAVIGATION_MEDIUM_ALERT_DURATION;
+  }
+
+  /**
+   * Checks if we have at least one {@link DirectionsRoute} in the given
+   * {@link DirectionsResponse}.
+   *
+   * @param response to be checked
+   * @return true if valid, false if not
+   */
+  private boolean validRouteResponse(Response<DirectionsResponse> response) {
+    return response.body() != null
+      && !response.body().routes().isEmpty();
   }
 
   private boolean validRouteDurationRemaining(RouteProgress routeProgress) {
@@ -49,11 +126,10 @@ public class FasterRouteDetector extends FasterRoute {
     RouteStepProgress currentStepProgress = routeProgress.currentLegProgress().currentStepProgress();
     // Current step duration remaining in seconds
     int currentStepDurationRemaining = (int) currentStepProgress.durationRemaining();
-    return currentStepDurationRemaining > MEDIUM_ALERT_DURATION_REMAINING;
+    return currentStepDurationRemaining > NAVIGATION_MEDIUM_ALERT_DURATION;
   }
 
   private long secondsSinceLastCheck(Location location) {
-    return TimeUtils.dateDiff(new Date(lastCheckedLocation.getTime()),
-      new Date(location.getTime()), TimeUnit.SECONDS);
+    return TimeUtils.dateDiff(new Date(lastCheckedLocation.getTime()), new Date(location.getTime()), TimeUnit.SECONDS);
   }
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/route/FasterRouteListener.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/route/FasterRouteListener.java
@@ -1,0 +1,18 @@
+package com.mapbox.services.android.navigation.v5.route;
+
+import com.mapbox.api.directions.v5.models.DirectionsRoute;
+
+/**
+ * Listener that can be added to monitor faster routes retrieved
+ * based on the logic set in {@link FasterRoute}.
+ */
+public interface FasterRouteListener {
+
+  /**
+   * Will be fired when a faster route has been found based on the logic
+   * provided by {@link FasterRoute}.
+   *
+   * @param directionsRoute faster route retrieved
+   */
+  void fasterRouteFound(DirectionsRoute directionsRoute);
+}

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/route/RouteEngine.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/route/RouteEngine.java
@@ -1,0 +1,62 @@
+package com.mapbox.services.android.navigation.v5.route;
+
+import android.support.annotation.NonNull;
+
+import com.mapbox.api.directions.v5.models.DirectionsResponse;
+import com.mapbox.api.directions.v5.models.DirectionsRoute;
+import com.mapbox.api.directions.v5.models.RouteOptions;
+import com.mapbox.geojson.Point;
+import com.mapbox.services.android.navigation.v5.navigation.NavigationRoute;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+public class RouteEngine implements Callback<DirectionsResponse> {
+
+  private Callback engineCallback;
+
+  public RouteEngine(Callback engineCallback) {
+    this.engineCallback = engineCallback;
+  }
+
+  public void fetchFasterRoute(Point origin, RouteOptions options) {
+    if (options == null) {
+      return;
+    }
+
+    NavigationRoute.builder()
+      .origin(origin)
+      .routeOptions(options)
+      .build()
+      .getRoute(this);
+  }
+
+  @Override
+  public void onResponse(@NonNull Call<DirectionsResponse> call, @NonNull Response<DirectionsResponse> response) {
+    // Check for successful response
+    if (!response.isSuccessful()) {
+      return;
+    }
+
+    if (isFasterRoute(response.body())) {
+      engineCallback.onFasterRouteFound(response.body().routes().get(0));
+    }
+  }
+
+  @Override
+  public void onFailure(@NonNull Call<DirectionsResponse> call, @NonNull Throwable throwable) {
+
+  }
+
+  public interface Callback {
+    void onFasterRouteFound(DirectionsRoute route);
+  }
+
+  private boolean isFasterRoute(DirectionsResponse response) {
+
+    // TODO determine is faster route
+
+    return false;
+  }
+}

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/route/RouteEngine.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/route/RouteEngine.java
@@ -8,6 +8,8 @@ import com.mapbox.geojson.Point;
 import com.mapbox.services.android.navigation.v5.navigation.NavigationRoute;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 
+import java.util.List;
+
 import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
@@ -32,13 +34,22 @@ public class RouteEngine implements Callback<DirectionsResponse> {
       this.routeProgress = routeProgress;
     }
 
+    // Calculate remaining waypoints
+    List<Point> coordinates = routeProgress.directionsRoute().routeOptions().coordinates();
+    List<Point> remainingCoordinates = coordinates.subList(0, routeProgress.remainingWaypoints());
+    Point destination = remainingCoordinates.remove(remainingCoordinates.size() - 1);
+
     // Build new route request with current route options
     RouteOptions currentOptions = routeProgress.directionsRoute().routeOptions();
-    NavigationRoute.builder()
+     NavigationRoute.Builder builder = NavigationRoute.builder()
       .origin(origin)
-      .routeOptions(currentOptions) // TODO Route options should have waypoints
-      .build()
-      .getRoute(this);
+      .routeOptions(currentOptions);
+
+    // Add waypoints with the remaining coordinate values
+    addWaypoints(remainingCoordinates, builder);
+
+    builder.destination(destination);
+    builder.build().getRoute(this);
   }
 
   @Override
@@ -57,5 +68,13 @@ public class RouteEngine implements Callback<DirectionsResponse> {
 
   public interface Callback {
     void onResponseReceived(Response<DirectionsResponse> response, RouteProgress routeProgress);
+  }
+
+  private void addWaypoints(List<Point> remainingCoordinates, NavigationRoute.Builder builder) {
+    if (!remainingCoordinates.isEmpty()) {
+      for (Point coordinate : remainingCoordinates) {
+        builder.addWaypoint(coordinate);
+      }
+    }
   }
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/route/RouteEngine.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/route/RouteEngine.java
@@ -41,7 +41,7 @@ public class RouteEngine implements Callback<DirectionsResponse> {
 
     // Build new route request with current route options
     RouteOptions currentOptions = routeProgress.directionsRoute().routeOptions();
-     NavigationRoute.Builder builder = NavigationRoute.builder()
+    NavigationRoute.Builder builder = NavigationRoute.builder()
       .origin(origin)
       .routeOptions(currentOptions);
 

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/FasterRouteDetectorTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/FasterRouteDetectorTest.java
@@ -1,0 +1,136 @@
+package com.mapbox.services.android.navigation.v5.navigation;
+
+import android.content.Context;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.mapbox.api.directions.v5.DirectionsAdapterFactory;
+import com.mapbox.api.directions.v5.models.DirectionsResponse;
+import com.mapbox.api.directions.v5.models.DirectionsRoute;
+import com.mapbox.services.android.navigation.v5.BaseTest;
+import com.mapbox.services.android.navigation.v5.route.FasterRoute;
+import com.mapbox.services.android.navigation.v5.route.FasterRouteDetector;
+import com.mapbox.services.android.navigation.v5.route.FasterRouteListener;
+import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
+import com.mapbox.services.android.telemetry.location.LocationEngine;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.io.IOException;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+public class FasterRouteDetectorTest extends BaseTest {
+
+  private static final String PRECISION_6 = "directions_v5_precision_6.json";
+
+  @Mock
+  FasterRouteListener fasterRouteListener;
+
+  private MapboxNavigation navigation;
+
+  @Before
+  public void setup() throws IOException {
+    MockitoAnnotations.initMocks(this);
+    navigation = new MapboxNavigation(mock(Context.class), ACCESS_TOKEN, mock(NavigationTelemetry.class),
+      mock(LocationEngine.class));
+  }
+
+  @Test
+  public void sanity() throws Exception {
+    FasterRouteDetector fasterRouteDetector = new FasterRouteDetector();
+    assertNotNull(fasterRouteDetector);
+  }
+
+  @Test
+  public void defaultFasterRouteEngine_didGetAddedOnInitialization() throws Exception {
+    assertNotNull(navigation.getFasterRouteEngine());
+  }
+
+  @Test
+  public void addFasterRouteEngine_didGetAdded() throws Exception {
+    FasterRoute fasterRouteEngine = mock(FasterRoute.class);
+    navigation.setFasterRouteEngine(fasterRouteEngine);
+    assertEquals(navigation.getFasterRouteEngine(), fasterRouteEngine);
+  }
+
+  @Test
+  public void onFasterRouteResponse_isFasterRouteIsTrue() throws Exception {
+    navigation.addFasterRouteListener(fasterRouteListener);
+    FasterRoute fasterRouteEngine = navigation.getFasterRouteEngine();
+
+    // Create current progress
+    RouteProgress currentProgress = obtainDefaultRouteProgress();
+    DirectionsRoute longerRoute = currentProgress.directionsRoute().toBuilder()
+      .duration(10000000d)
+      .build();
+    currentProgress = currentProgress.toBuilder()
+      .directionsRoute(longerRoute)
+      .build();
+
+    // Create new direction response
+    DirectionsResponse response = obtainADirectionsResponse();
+
+    boolean isFasterRoute = fasterRouteEngine.isFasterRoute(response, currentProgress);
+    assertTrue(isFasterRoute);
+  }
+
+  @Test
+  public void onSlowerRouteResponse_isFasterRouteIsFalse() throws Exception {
+    navigation.addFasterRouteListener(fasterRouteListener);
+    FasterRoute fasterRouteEngine = navigation.getFasterRouteEngine();
+
+    // Create current progress
+    RouteProgress currentProgress = obtainDefaultRouteProgress();
+    DirectionsRoute longerRoute = currentProgress.directionsRoute().toBuilder()
+      .duration(1000d)
+      .build();
+    currentProgress = currentProgress.toBuilder()
+      .directionsRoute(longerRoute)
+      .build();
+
+    // Create new direction response
+    DirectionsResponse response = obtainADirectionsResponse();
+
+    boolean isFasterRoute = fasterRouteEngine.isFasterRoute(response, currentProgress);
+    assertFalse(isFasterRoute);
+  }
+
+  private RouteProgress obtainDefaultRouteProgress() throws Exception {
+    DirectionsRoute aRoute = obtainADirectionsRoute();
+    RouteProgress defaultRouteProgress = RouteProgress.builder()
+      .stepDistanceRemaining(100)
+      .legDistanceRemaining(700)
+      .distanceRemaining(1000)
+      .directionsRoute(aRoute)
+      .stepIndex(0)
+      .legIndex(0)
+      .build();
+
+    return defaultRouteProgress;
+  }
+
+  private DirectionsRoute obtainADirectionsRoute() throws IOException {
+    Gson gson = new GsonBuilder()
+      .registerTypeAdapterFactory(DirectionsAdapterFactory.create()).create();
+    String body = loadJsonFixture(PRECISION_6);
+    DirectionsResponse response = gson.fromJson(body, DirectionsResponse.class);
+    DirectionsRoute aRoute = response.routes().get(0);
+    return aRoute;
+  }
+
+  private DirectionsResponse obtainADirectionsResponse() throws IOException {
+    Gson gson = new GsonBuilder()
+      .registerTypeAdapterFactory(DirectionsAdapterFactory.create()).create();
+    String body = loadJsonFixture(PRECISION_6);
+    DirectionsResponse response = gson.fromJson(body, DirectionsResponse.class);
+    return response;
+  }
+}

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/FasterRouteDetectorTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/FasterRouteDetectorTest.java
@@ -33,7 +33,10 @@ public class FasterRouteDetectorTest extends BaseTest {
 
   @Before
   public void setup() throws IOException {
-    navigation = new MapboxNavigation(mock(Context.class), ACCESS_TOKEN, mock(NavigationTelemetry.class),
+    MapboxNavigationOptions options = MapboxNavigationOptions.builder()
+      .enableFasterRouteDetection(true)
+      .build();
+    navigation = new MapboxNavigation(mock(Context.class), ACCESS_TOKEN, options, mock(NavigationTelemetry.class),
       mock(LocationEngine.class));
   }
 

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEventDispatcherTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEventDispatcherTest.java
@@ -15,6 +15,7 @@ import com.mapbox.services.android.navigation.v5.milestone.Milestone;
 import com.mapbox.services.android.navigation.v5.milestone.MilestoneEventListener;
 import com.mapbox.services.android.navigation.v5.navigation.metrics.NavigationMetricListeners;
 import com.mapbox.services.android.navigation.v5.offroute.OffRouteListener;
+import com.mapbox.services.android.navigation.v5.route.FasterRouteListener;
 import com.mapbox.services.android.navigation.v5.routeprogress.ProgressChangeListener;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 import com.mapbox.services.android.telemetry.location.LocationEngine;
@@ -52,6 +53,8 @@ public class NavigationEventDispatcherTest extends BaseTest {
   OffRouteListener offRouteListener;
   @Mock
   NavigationEventListener navigationEventListener;
+  @Mock
+  FasterRouteListener fasterRouteListener;
   @Mock
   Location location;
   @Mock
@@ -259,6 +262,50 @@ public class NavigationEventDispatcherTest extends BaseTest {
     navigationEventDispatcher.onNavigationEvent(true);
     verify(navigationEventListener, times(0)).onRunning(true);
   }
+
+  @Test
+  public void addFasterRouteListener_didAddListener() throws Exception {
+    navigationEventDispatcher.onFasterRouteEvent(route);
+    verify(fasterRouteListener, times(0)).fasterRouteFound(route);
+
+    navigation.addFasterRouteListener(fasterRouteListener);
+    navigationEventDispatcher.onFasterRouteEvent(route);
+    verify(fasterRouteListener, times(1)).fasterRouteFound(route);
+  }
+
+  @Test
+  public void addFasterRouteListener_onlyAddsListenerOnce() throws Exception {
+    navigationEventDispatcher.onFasterRouteEvent(route);
+    verify(fasterRouteListener, times(0)).fasterRouteFound(route);
+
+    navigation.addFasterRouteListener(fasterRouteListener);
+    navigation.addFasterRouteListener(fasterRouteListener);
+    navigation.addFasterRouteListener(fasterRouteListener);
+    navigationEventDispatcher.onFasterRouteEvent(route);
+    verify(fasterRouteListener, times(1)).fasterRouteFound(route);
+  }
+
+  @Test
+  public void removeFasterRouteListener_didRemoveListener() throws Exception {
+    navigation.addFasterRouteListener(fasterRouteListener);
+    navigation.removeFasterRouteListener(fasterRouteListener);
+    navigationEventDispatcher.onFasterRouteEvent(route);
+    verify(fasterRouteListener, times(0)).fasterRouteFound(route);
+  }
+
+  @Test
+  public void removeFasterRouteListener_nullRemovesAllListeners() throws Exception {
+    navigation.addFasterRouteListener(fasterRouteListener);
+    navigation.addFasterRouteListener(mock(FasterRouteListener.class));
+    navigation.addFasterRouteListener(mock(FasterRouteListener.class));
+    navigation.addFasterRouteListener(mock(FasterRouteListener.class));
+    navigation.addFasterRouteListener(mock(FasterRouteListener.class));
+
+    navigation.removeFasterRouteListener(null);
+    navigationEventDispatcher.onFasterRouteEvent(route);
+    verify(fasterRouteListener, times(0)).fasterRouteFound(route);
+  }
+
 
   @Test
   public void setNavigationMetricListener_didGetSet() throws Exception {

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/utils/MeasurementUtilsTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/utils/MeasurementUtilsTest.java
@@ -22,7 +22,8 @@ public class MeasurementUtilsTest extends BaseTest {
 
     List<Point> geometryPoints = new ArrayList<>();
     geometryPoints.add(futurePoint);
-    LegStep step = createTestStep(geometryPoints);
+    double[] rawLocation = {0, 0};
+    LegStep step = getLegStep(rawLocation, geometryPoints);
 
     double distance = MeasurementUtils.userTrueDistanceFromStep(futurePoint, step);
     assertEquals(0d, distance, DELTA);
@@ -34,7 +35,8 @@ public class MeasurementUtilsTest extends BaseTest {
 
     List<Point> geometryPoints = new ArrayList<>();
     geometryPoints.add(Point.fromLngLat(-95.8427, 29.7757));
-    LegStep step = createTestStep(geometryPoints);
+    double[] rawLocation = {0, 0};
+    LegStep step = getLegStep(rawLocation, geometryPoints);
 
     double distance = MeasurementUtils.userTrueDistanceFromStep(futurePoint, step);
     assertEquals(45900.73617999494, distance, DELTA);
@@ -47,7 +49,8 @@ public class MeasurementUtilsTest extends BaseTest {
     List<Point> geometryPoints = new ArrayList<>();
     geometryPoints.add(Point.fromLngLat(-95.8427, 29.7757));
     geometryPoints.add(futurePoint);
-    LegStep step = createTestStep(geometryPoints);
+    double[] rawLocation = {0, 0};
+    LegStep step = getLegStep(rawLocation, geometryPoints);
 
     double distance = MeasurementUtils.userTrueDistanceFromStep(futurePoint, step);
     assertEquals(0.04457271773629306d, distance, DELTA);
@@ -66,6 +69,17 @@ public class MeasurementUtilsTest extends BaseTest {
       .duration(1000d)
       .maneuver(maneuver)
       .weight(0d)
+      .build();
+  }
+
+  private LegStep getLegStep(double[] rawLocation, List<Point> geometryPoints) {
+    return LegStep.builder()
+      .geometry(PolylineUtils.encode(geometryPoints, PRECISION_6))
+      .mode("driving")
+      .distance(0)
+      .duration(0)
+      .maneuver(StepManeuver.builder().rawLocation(rawLocation).build())
+      .weight(0)
       .build();
   }
 }

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/utils/MeasurementUtilsTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/utils/MeasurementUtilsTest.java
@@ -56,22 +56,6 @@ public class MeasurementUtilsTest extends BaseTest {
     assertEquals(0.04457271773629306d, distance, DELTA);
   }
 
-  private LegStep createTestStep(List<Point> geometryPoints) {
-    double[] location = {0d, 0d};
-    StepManeuver maneuver = StepManeuver.builder()
-      .rawLocation(location)
-      .build();
-
-    return LegStep.builder()
-      .geometry(PolylineUtils.encode(geometryPoints, PRECISION_6))
-      .mode("driving")
-      .distance(2000d)
-      .duration(1000d)
-      .maneuver(maneuver)
-      .weight(0d)
-      .build();
-  }
-
   private LegStep getLegStep(double[] rawLocation, List<Point> geometryPoints) {
     return LegStep.builder()
       .geometry(PolylineUtils.encode(geometryPoints, PRECISION_6))


### PR DESCRIPTION
Closes #129 

- Adds `FasterRouteDetector` and `RouteEngine` to check for / retrieve faster routes while navigating 
- `FasterRoute` can be subclassed to allow users to set exactly how quickly they'd like to check for a new, possibly faster route.  
- Also adds the ability to provide `RouteOptions` to `NavigationRoute` to create a route request mirroring the options from the `DirectionsRoute` that provided the `RouteOptions`

cc @ericrwolfe 