### PR TITLE
package delivery/ride sharing waypoint demo

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -49,5 +49,13 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".MainActivity"/>
         </activity>
+
+        <activity
+            android:name="com.mapbox.services.android.navigation.ui.v5.WaypointNavigationActivity"
+            android:label="@string/title_waypoint_navigation">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".MainActivity"/>
+        </activity>
     </application>
 </manifest>

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/MainActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/MainActivity.java
@@ -16,6 +16,7 @@ import com.mapbox.services.android.navigation.testapp.activity.MockNavigationAct
 import com.mapbox.services.android.navigation.testapp.activity.RerouteActivity;
 import com.mapbox.services.android.navigation.testapp.activity.navigationui.NavigationMapRouteActivity;
 import com.mapbox.services.android.navigation.testapp.activity.navigationui.NavigationViewActivity;
+import com.mapbox.services.android.navigation.ui.v5.WaypointNavigationActivity;
 import com.mapbox.services.android.telemetry.permissions.PermissionsListener;
 import com.mapbox.services.android.telemetry.permissions.PermissionsManager;
 
@@ -53,6 +54,11 @@ public class MainActivity extends AppCompatActivity implements PermissionsListen
         getString(R.string.title_navigation_route_ui),
         getString(R.string.description_navigation_route_ui),
         NavigationMapRouteActivity.class
+      ),
+      new SampleItem(
+        getString(R.string.title_navigation_route_ui),
+        getString(R.string.description_navigation_route_ui),
+        WaypointNavigationActivity.class
       )
     ));
 

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/MainActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/MainActivity.java
@@ -56,8 +56,8 @@ public class MainActivity extends AppCompatActivity implements PermissionsListen
         NavigationMapRouteActivity.class
       ),
       new SampleItem(
-        getString(R.string.title_navigation_route_ui),
-        getString(R.string.description_navigation_route_ui),
+        getString(R.string.title_waypoint_navigation),
+        getString(R.string.description_waypoint_navigation),
         WaypointNavigationActivity.class
       )
     ));

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,4 +13,7 @@
 
     <string name="title_navigation_view_ui">Navigation Views</string>
     <string name="description_navigation_view_ui">Drop-in UI experience</string>
+
+    <string name="title_waypoint_navigation">Waypoint Navigation</string>
+    <string name="description_waypoint_navigation">Navigation with waypoints between destinations</string>
 </resources>

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
@@ -181,7 +181,6 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
         initLocationLayer();
         initLifecycleObservers();
         initNavigationPresenter();
-        initNavigationEventDispatcher();
         initClickListeners();
         map.setOnScrollListener(NavigationView.this);
         onNavigationReadyCallback.onNavigationReady();
@@ -361,6 +360,7 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
     initViewModels();
     initNavigationViewObserver();
     initSummaryBottomSheet();
+    initNavigationEventDispatcher();
   }
 
   /**

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
@@ -346,9 +346,7 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
    * @param options with containing route / coordinate data
    */
   public void startNavigation(NavigationViewOptions options) {
-    for (int i = 0; i < markers.size(); i++) {
-      map.removeMarker(markers.remove(i));
-    }
+    clearMarkers();
 
     // Initialize navigation with options from NavigationViewOptions
     navigationViewModel.initializeNavigationOptions(getContext().getApplicationContext(),
@@ -562,6 +560,15 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
       public void onSlide(@NonNull View bottomSheet, float slideOffset) {
       }
     });
+  }
+
+  /**
+   * Removes any markers on the map that were added using addMarker()
+   */
+  private void clearMarkers() {
+    for (int i = 0; i < markers.size(); i++) {
+      map.removeMarker(markers.remove(i));
+    }
   }
 
   @OnLifecycleEvent(Lifecycle.Event.ON_START)

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
@@ -24,6 +24,7 @@ import android.widget.ImageView;
 
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.geojson.Point;
+import com.mapbox.mapboxsdk.annotations.Marker;
 import com.mapbox.mapboxsdk.annotations.MarkerOptions;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.maps.MapView;
@@ -41,6 +42,9 @@ import com.mapbox.services.android.navigation.ui.v5.utils.ViewUtils;
 import com.mapbox.services.android.navigation.v5.location.MockLocationEngine;
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation;
 import com.mapbox.services.android.navigation.v5.navigation.NavigationRoute;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * View that creates the drop-in UI.
@@ -85,6 +89,7 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
   private LocationLayerPlugin locationLayer;
   private OnNavigationReadyCallback onNavigationReadyCallback;
   private boolean resumeState;
+  private List<Marker> markers = new ArrayList<>();
 
   public NavigationView(Context context) {
     this(context, null);
@@ -264,9 +269,9 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
   public void addMarker(Point position) {
     LatLng markerPosition = new LatLng(position.latitude(),
       position.longitude());
-    map.addMarker(new MarkerOptions()
+    markers.add(map.addMarker(new MarkerOptions()
       .position(markerPosition)
-      .icon(ThemeSwitcher.retrieveMapMarker(getContext())));
+      .icon(ThemeSwitcher.retrieveMapMarker(getContext()))));
   }
 
   /**
@@ -341,6 +346,11 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
    * @param options with containing route / coordinate data
    */
   public void startNavigation(NavigationViewOptions options) {
+    for (Marker marker : markers) {
+      map.removeMarker(marker);
+      markers.remove(marker);
+    }
+
     // Initialize navigation with options from NavigationViewOptions
     navigationViewModel.initializeNavigationOptions(getContext().getApplicationContext(),
       options.navigationOptions().toBuilder().isFromNavigationUi(true).build());

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
@@ -346,9 +346,8 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
    * @param options with containing route / coordinate data
    */
   public void startNavigation(NavigationViewOptions options) {
-    for (Marker marker : markers) {
-      map.removeMarker(marker);
-      markers.remove(marker);
+    for (int i = 0; i < markers.size(); i++) {
+      map.removeMarker(markers.remove(i));
     }
 
     // Initialize navigation with options from NavigationViewOptions

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/WaypointNavigationActivity.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/WaypointNavigationActivity.java
@@ -1,0 +1,152 @@
+package com.mapbox.services.android.navigation.ui.v5;
+
+import android.content.DialogInterface;
+import android.content.SharedPreferences;
+import android.location.Location;
+import android.os.Bundle;
+import android.preference.PreferenceManager;
+import android.support.annotation.Nullable;
+import android.support.v7.app.AlertDialog;
+import android.support.v7.app.AppCompatActivity;
+
+import com.mapbox.geojson.Point;
+import com.mapbox.services.android.navigation.ui.v5.listeners.NavigationListener;
+import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigationOptions;
+import com.mapbox.services.android.navigation.v5.navigation.NavigationConstants;
+import com.mapbox.services.android.navigation.v5.navigation.NavigationUnitType;
+import com.mapbox.services.android.navigation.v5.routeprogress.ProgressChangeListener;
+import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
+import com.mapbox.services.android.navigation.v5.utils.RouteUtils;
+
+import java.util.HashMap;
+
+/**
+ * Serves as a launching point for the custom drop-in UI, {@link NavigationView}.
+ * <p>
+ * Demonstrates the proper setup and usage of the view, including all lifecycle methods.
+ */
+public class WaypointNavigationActivity extends AppCompatActivity implements OnNavigationReadyCallback, NavigationListener, ProgressChangeListener {
+
+  private NavigationView navigationView;
+  private boolean dropoffDialogShown;
+
+  @Override
+  protected void onCreate(@Nullable Bundle savedInstanceState) {
+    setTheme(R.style.Theme_AppCompat_NoActionBar);
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_navigation);
+    navigationView = findViewById(R.id.navigationView);
+    navigationView.onCreate(savedInstanceState);
+    navigationView.getNavigationAsync(this);
+  }
+
+  @Override
+  public void onLowMemory() {
+    super.onLowMemory();
+    navigationView.onLowMemory();
+  }
+
+  @Override
+  public void onBackPressed() {
+    // If the navigation view didn't need to do anything, call super
+    if (!navigationView.onBackPressed()) {
+      super.onBackPressed();
+    }
+  }
+
+  @Override
+  protected void onSaveInstanceState(Bundle outState) {
+    navigationView.onSaveInstanceState(outState);
+    super.onSaveInstanceState(outState);
+  }
+
+  @Override
+  protected void onRestoreInstanceState(Bundle savedInstanceState) {
+    super.onRestoreInstanceState(savedInstanceState);
+    navigationView.onRestoreInstanceState(savedInstanceState);
+  }
+
+  @Override
+  public void onNavigationReady() {
+    NavigationViewOptions.Builder options = NavigationViewOptions.builder();
+    options.navigationListener(this);
+    options.progressChangeListener(this);
+    extractRoute(options);
+    extractCoordinates(options);
+    extractConfiguration(options);
+    navigationView.startNavigation(options.build());
+  }
+
+  @Override
+  public void onCancelNavigation() {
+    // Navigation canceled, finish the activity
+    finish();
+  }
+
+  @Override
+  public void onNavigationFinished() {
+    // Navigation finished, finish the activity
+    finish();
+  }
+
+  @Override
+  public void onNavigationRunning() {
+    // Intentionally empty
+  }
+
+  private void extractRoute(NavigationViewOptions.Builder options) {
+    options.directionsRoute(NavigationLauncher.extractRoute(this));
+  }
+
+  private void extractCoordinates(NavigationViewOptions.Builder options) {
+    HashMap<String, Point> coordinates = NavigationLauncher.extractCoordinates(this);
+    if (coordinates.size() > 0) {
+      options.origin(coordinates.get(NavigationConstants.NAVIGATION_VIEW_ORIGIN));
+      options.destination(coordinates.get(NavigationConstants.NAVIGATION_VIEW_DESTINATION));
+    }
+  }
+
+  private void extractConfiguration(NavigationViewOptions.Builder options) {
+    SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(this);
+    options.awsPoolId(preferences
+      .getString(NavigationConstants.NAVIGATION_VIEW_AWS_POOL_ID, null));
+    options.shouldSimulateRoute(preferences
+      .getBoolean(NavigationConstants.NAVIGATION_VIEW_SIMULATE_ROUTE, false));
+
+    MapboxNavigationOptions navigationOptions = MapboxNavigationOptions.builder()
+      .unitType(preferences.getInt(NavigationConstants.NAVIGATION_VIEW_UNIT_TYPE,
+        NavigationUnitType.TYPE_IMPERIAL))
+      .build();
+    options.navigationOptions(navigationOptions);
+  }
+
+  @Override
+  public void onProgressChange(Location location, RouteProgress routeProgress) {
+    if (RouteUtils.isArrivalEvent(routeProgress)) {
+
+      if (!dropoffDialogShown) {
+        showDropoffDialog();
+        dropoffDialogShown = true;
+      }
+    }
+  }
+
+  private void showDropoffDialog() {
+    AlertDialog alertDialog = new AlertDialog.Builder(this).create();
+    alertDialog.setMessage("Do you want to navigate to next destination?");
+    alertDialog.setButton(AlertDialog.BUTTON_POSITIVE, "Start Next", new DialogInterface.OnClickListener() {
+      @Override
+      public void onClick(DialogInterface dialogInterface, int i) {
+
+      }
+    });
+    alertDialog.setButton(DialogInterface.BUTTON_NEGATIVE, "Cancel", new DialogInterface.OnClickListener() {
+      @Override
+      public void onClick(DialogInterface dialogInterface, int i) {
+
+      }
+    });
+
+    alertDialog.show();
+  }
+}

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/WaypointNavigationActivity.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/WaypointNavigationActivity.java
@@ -118,15 +118,15 @@ public class WaypointNavigationActivity extends AppCompatActivity implements OnN
 
   private void showDropoffDialog() {
     AlertDialog alertDialog = new AlertDialog.Builder(this).create();
-    alertDialog.setMessage("Do you want to navigate to next destination?");
-    alertDialog.setButton(AlertDialog.BUTTON_POSITIVE, "Start Next", new DialogInterface.OnClickListener() {
+    alertDialog.setMessage(getString(R.string.dropoff_dialog_text));
+    alertDialog.setButton(AlertDialog.BUTTON_POSITIVE, getString(R.string.dropoff_dialog_positive_text), new DialogInterface.OnClickListener() {
       @Override
       public void onClick(DialogInterface dialogInterface, int in) {
         navigationView.startNavigation(
           setupOptions(Point.fromLngLat(lastKnownLocation.getLongitude(), lastKnownLocation.getLatitude())));
       }
     });
-    alertDialog.setButton(DialogInterface.BUTTON_NEGATIVE, "Cancel", new DialogInterface.OnClickListener() {
+    alertDialog.setButton(DialogInterface.BUTTON_NEGATIVE, getString(R.string.dropoff_dialog_negative_text), new DialogInterface.OnClickListener() {
       @Override
       public void onClick(DialogInterface dialogInterface, int in) {
         // Do nothing

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/WaypointNavigationActivity.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/WaypointNavigationActivity.java
@@ -16,11 +16,6 @@ import com.mapbox.services.android.navigation.v5.utils.RouteUtils;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * Serves as a launching point for the custom drop-in UI, {@link NavigationView}.
- * <p>
- * Demonstrates the proper setup and usage of the view, including all lifecycle methods.
- */
 public class WaypointNavigationActivity extends AppCompatActivity implements OnNavigationReadyCallback,
   NavigationListener, ProgressChangeListener {
 
@@ -96,8 +91,7 @@ public class WaypointNavigationActivity extends AppCompatActivity implements OnN
 
   @Override
   public void onNavigationFinished() {
-    // Navigation finished, finish the activity
-    finish();
+    // Intentionally empty
   }
 
   @Override

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/WaypointNavigationActivity.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/WaypointNavigationActivity.java
@@ -55,6 +55,12 @@ public class WaypointNavigationActivity extends AppCompatActivity implements OnN
   }
 
   @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    navigationView.onDestroy();
+  }
+
+  @Override
   protected void onSaveInstanceState(Bundle outState) {
     navigationView.onSaveInstanceState(outState);
     super.onSaveInstanceState(outState);

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/WaypointNavigationActivity.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/WaypointNavigationActivity.java
@@ -119,19 +119,21 @@ public class WaypointNavigationActivity extends AppCompatActivity implements OnN
   private void showDropoffDialog() {
     AlertDialog alertDialog = new AlertDialog.Builder(this).create();
     alertDialog.setMessage(getString(R.string.dropoff_dialog_text));
-    alertDialog.setButton(AlertDialog.BUTTON_POSITIVE, getString(R.string.dropoff_dialog_positive_text), new DialogInterface.OnClickListener() {
-      @Override
-      public void onClick(DialogInterface dialogInterface, int in) {
-        navigationView.startNavigation(
-          setupOptions(Point.fromLngLat(lastKnownLocation.getLongitude(), lastKnownLocation.getLatitude())));
-      }
-    });
-    alertDialog.setButton(DialogInterface.BUTTON_NEGATIVE, getString(R.string.dropoff_dialog_negative_text), new DialogInterface.OnClickListener() {
-      @Override
-      public void onClick(DialogInterface dialogInterface, int in) {
-        // Do nothing
-      }
-    });
+    alertDialog.setButton(AlertDialog.BUTTON_POSITIVE, getString(R.string.dropoff_dialog_positive_text),
+      new DialogInterface.OnClickListener() {
+        @Override
+        public void onClick(DialogInterface dialogInterface, int in) {
+          navigationView.startNavigation(
+            setupOptions(Point.fromLngLat(lastKnownLocation.getLongitude(), lastKnownLocation.getLatitude())));
+        }
+      });
+    alertDialog.setButton(DialogInterface.BUTTON_NEGATIVE, getString(R.string.dropoff_dialog_negative_text),
+      new DialogInterface.OnClickListener() {
+        @Override
+        public void onClick(DialogInterface dialogInterface, int in) {
+          // Do nothing
+        }
+      });
 
     alertDialog.show();
   }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/location/LocationViewModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/location/LocationViewModel.java
@@ -85,8 +85,8 @@ public class LocationViewModel extends AndroidViewModel implements LifecycleObse
    */
   public void updateRoute(DirectionsRoute route) {
     // MockLocationEngine is deactivated first to avoid weird behavior with subsequent navigation sessions
-    deactivateLocationEngine();
     if (shouldSimulateRoute) {
+      deactivateLocationEngine();
       activateMockLocationEngine(route);
     }
   }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/location/LocationViewModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/location/LocationViewModel.java
@@ -84,6 +84,8 @@ public class LocationViewModel extends AndroidViewModel implements LifecycleObse
    * @param route to be mocked
    */
   public void updateRoute(DirectionsRoute route) {
+    // MockLocationEngine is deactivated first to avoid weird behavior with subsequent navigation sessions
+    deactivateLocationEngine();
     if (shouldSimulateRoute) {
       activateMockLocationEngine(route);
     }

--- a/libandroid-navigation-ui/src/main/res/values/strings.xml
+++ b/libandroid-navigation-ui/src/main/res/values/strings.xml
@@ -19,4 +19,7 @@
             translatable="false">recenter_btn_visible</string>
     <string name="bottom_sheet_state"
             translatable="false">bottom_sheet_state</string>
+    <string name="dropoff_dialog_text">Do you want to navigate to next destination?</string>
+    <string name="dropoff_dialog_positive_text">Start next</string>
+    <string name="dropoff_dialog_negative_text">Cancel</string>
 </resources>


### PR DESCRIPTION
This PR is for the example for a Package Delivery/Ride Share service that needs to be able to navigate to multiple destinations. On arrival, the driver is given an alert dialog which gives them the option to navigate to next destination, or to cancel.

![ezgif com-optimize 1](https://user-images.githubusercontent.com/14295757/34741585-1afdfb3e-f551-11e7-9246-be1fff8eab46.gif)

A few things I wanted to bring up for discussion:
* Should the origin/destination markers be removed once the next leg of navigation is started?
* The choppiness of the MockLocationEngine, starting after the first destination is reached. The first leg of the trip was smooth, but everything after was choppy
* The pivoting of the camera when transitioning from arriving at a destination to starting the next leg of navigation

cc. @ericrwolfe @danesfeder 