### PR TITLE
Remove NavigationViewModel as lifecycle observer

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
@@ -174,6 +174,7 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
    */
   public void onDestroy() {
     mapView.onDestroy();
+    navigationViewModel.onDestroy();
   }
 
   /**
@@ -480,7 +481,6 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
     try {
       ((LifecycleOwner) getContext()).getLifecycle().addObserver(locationLayer);
       ((LifecycleOwner) getContext()).getLifecycle().addObserver(locationViewModel);
-      ((LifecycleOwner) getContext()).getLifecycle().addObserver(navigationViewModel);
     } catch (ClassCastException exception) {
       throw new ClassCastException("Please ensure that the provided Context is a valid LifecycleOwner");
     }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
@@ -2,10 +2,7 @@ package com.mapbox.services.android.navigation.ui.v5;
 
 import android.app.Application;
 import android.arch.lifecycle.AndroidViewModel;
-import android.arch.lifecycle.Lifecycle;
-import android.arch.lifecycle.LifecycleObserver;
 import android.arch.lifecycle.MutableLiveData;
-import android.arch.lifecycle.OnLifecycleEvent;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.location.Location;
@@ -37,7 +34,7 @@ import com.mapbox.services.android.telemetry.location.LocationEngine;
 
 import java.text.DecimalFormat;
 
-public class NavigationViewModel extends AndroidViewModel implements LifecycleObserver, ProgressChangeListener,
+public class NavigationViewModel extends AndroidViewModel implements ProgressChangeListener,
   OffRouteListener, MilestoneEventListener, NavigationEventListener {
 
   public final MutableLiveData<InstructionModel> instructionModel = new MutableLiveData<>();
@@ -67,7 +64,6 @@ public class NavigationViewModel extends AndroidViewModel implements LifecycleOb
     initDecimalFormat();
   }
 
-  @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
   public void onDestroy() {
     endNavigation();
     deactivateInstructionPlayer();


### PR DESCRIPTION
Closes #623 

When using a `Fragment` implementation of `NavigationView` the `NavigationViewModel` will still use the `Activity` `Context` when adding `NavigationViewModel` as a lifecycle observer.   

This means that the view model isn't properly shutdown if the `Fragment` is hidden and not destroyed (and the `Activity` is still running).  

This PR removes the `NavigationViewModel` as a `LifecycleObserver` and moves the lifecycle method `onDestroy` to `NavigationView#onDestroy`, allowing the developer to call this whenever they chose (like `Fragment#onDestroyView`).