### PR TITLE
NavigationTelemetry update cue for changing configurations

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationActivity.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationActivity.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 public class NavigationActivity extends AppCompatActivity implements OnNavigationReadyCallback, NavigationListener {
 
   private NavigationView navigationView;
+  private boolean isConfigurationChange;
 
   @Override
   protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -31,6 +32,7 @@ public class NavigationActivity extends AppCompatActivity implements OnNavigatio
     navigationView = findViewById(R.id.navigationView);
     navigationView.onCreate(savedInstanceState);
     navigationView.getNavigationAsync(this);
+    isConfigurationChange = savedInstanceState != null;
   }
 
   @Override
@@ -69,8 +71,10 @@ public class NavigationActivity extends AppCompatActivity implements OnNavigatio
   public void onNavigationReady() {
     NavigationViewOptions.Builder options = NavigationViewOptions.builder();
     options.navigationListener(this);
-    extractRoute(options);
-    extractCoordinates(options);
+    if (!isConfigurationChange) {
+      extractRoute(options);
+      extractCoordinates(options);
+    }
     extractConfiguration(options);
     navigationView.startNavigation(options.build());
   }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
@@ -390,7 +390,6 @@ public class MapboxNavigation implements ServiceConnection {
       context.unbindService(this);
       isBound = false;
       navigationEventDispatcher.onNavigationEvent(false);
-      navigationTelemetry.endSession();
     }
   }
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationLifecycleMonitor.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationLifecycleMonitor.java
@@ -1,4 +1,4 @@
-package com.mapbox.services.android.navigation.v5.navigation.metrics;
+package com.mapbox.services.android.navigation.v5.navigation;
 
 import android.app.Activity;
 import android.app.Application;
@@ -18,7 +18,7 @@ public class NavigationLifecycleMonitor implements Application.ActivityLifecycle
   private long portraitStartTime = 0;
   private double portraitTimeInMillis = 0;
 
-  public NavigationLifecycleMonitor(Application application) {
+  NavigationLifecycleMonitor(Application application) {
     application.registerActivityLifecycleCallbacks(this);
     startSessionTime = System.currentTimeMillis();
     resumes = new ArrayList<>();
@@ -54,6 +54,9 @@ public class NavigationLifecycleMonitor implements Application.ActivityLifecycle
 
   @Override
   public void onActivityDestroyed(Activity activity) {
+    if (activity.isChangingConfigurations()) {
+      NavigationTelemetry.getInstance().onConfigurationChange();
+    }
     if (activity.isFinishing()) {
       activity.getApplication().unregisterActivityLifecycleCallbacks(this);
     }
@@ -78,7 +81,7 @@ public class NavigationLifecycleMonitor implements Application.ActivityLifecycle
 
   //endregion
 
-  public int obtainPortraitPercentage() {
+  int obtainPortraitPercentage() {
     // If no changes to landscape
     if (currentOrientation.equals(Configuration.ORIENTATION_PORTRAIT) && portraitTimeInMillis == 0) {
       return ONE_HUNDRED_PERCENT;
@@ -88,7 +91,7 @@ public class NavigationLifecycleMonitor implements Application.ActivityLifecycle
     return (int) (ONE_HUNDRED_PERCENT * portraitFraction);
   }
 
-  public int obtainForegroundPercentage() {
+  int obtainForegroundPercentage() {
     long currentTime = System.currentTimeMillis();
     double foregroundTime = calculateForegroundTime(currentTime);
     return (int) (100 * (foregroundTime / (currentTime - startSessionTime)));

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationLifecycleMonitor.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationLifecycleMonitor.java
@@ -54,10 +54,8 @@ public class NavigationLifecycleMonitor implements Application.ActivityLifecycle
 
   @Override
   public void onActivityDestroyed(Activity activity) {
-    if (activity.isChangingConfigurations()) {
-      NavigationTelemetry.getInstance().onConfigurationChange();
-    }
     if (activity.isFinishing()) {
+      NavigationTelemetry.getInstance().endSession(activity.isChangingConfigurations());
       activity.getApplication().unregisterActivityLifecycleCallbacks(this);
     }
   }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationLifecycleMonitor.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationLifecycleMonitor.java
@@ -54,8 +54,8 @@ public class NavigationLifecycleMonitor implements Application.ActivityLifecycle
 
   @Override
   public void onActivityDestroyed(Activity activity) {
+    NavigationTelemetry.getInstance().endSession(activity.isChangingConfigurations());
     if (activity.isFinishing()) {
-      NavigationTelemetry.getInstance().endSession(activity.isChangingConfigurations());
       activity.getApplication().unregisterActivityLifecycleCallbacks(this);
     }
   }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationService.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationService.java
@@ -3,7 +3,6 @@ package com.mapbox.services.android.navigation.v5.navigation;
 import android.app.Notification;
 import android.app.Service;
 import android.content.Intent;
-import android.content.res.Configuration;
 import android.location.Location;
 import android.os.Binder;
 import android.os.Build;
@@ -62,12 +61,6 @@ public class NavigationService extends Service implements LocationEngineListener
     thread.start();
     thread.prepareHandler();
     recentDistancesFromManeuverInMeters = new RingBuffer<>(3);
-  }
-
-  @Override
-  public void onConfigurationChanged(Configuration newConfig) {
-    super.onConfigurationChanged(newConfig);
-    NavigationTelemetry.getInstance().onConfigurationChange();
   }
 
   /**

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationTelemetry.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationTelemetry.java
@@ -196,7 +196,6 @@ class NavigationTelemetry implements LocationEngineListener, NavigationMetricLis
         .originalRequestIdentifier(directionsRoute.routeOptions().requestUuid())
         .requestIdentifier(directionsRoute.routeOptions().requestUuid())
         .currentDirectionRoute(directionsRoute)
-        .sessionIdentifier(TelemetryUtils.buildUUID())
         .eventRouteDistanceCompleted(0)
         .mockLocation(metricLocation.getLocation().getProvider().equals(MOCK_PROVIDER))
         .rerouteCount(0)

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationTelemetry.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationTelemetry.java
@@ -146,9 +146,6 @@ class NavigationTelemetry implements LocationEngineListener, NavigationMetricLis
 
       validateAccessToken(accessToken);
 
-      // Setup the listeners
-      initEventDispatcherListeners(navigation);
-
       MapboxNavigationOptions options = navigation.options();
       // Set sdkIdentifier based on if from UI or not
       String sdkIdentifier = updateSdkIdentifier(options);
@@ -168,6 +165,8 @@ class NavigationTelemetry implements LocationEngineListener, NavigationMetricLis
 
       isInitialized = true;
     }
+    // Setup the listeners
+    initEventDispatcherListeners(navigation);
   }
 
   /**
@@ -200,16 +199,16 @@ class NavigationTelemetry implements LocationEngineListener, NavigationMetricLis
         .mockLocation(metricLocation.getLocation().getProvider().equals(MOCK_PROVIDER))
         .rerouteCount(0)
         .build();
-    } else {
-      isConfigurationChange = false;
     }
+    isConfigurationChange = false;
   }
 
   /**
    * Flushes any remaining events from the reroute / feedback queue and fires
    * a cancel event indicating a terminated session.
    */
-  void endSession() {
+  void endSession(boolean isConfigurationChange) {
+    this.isConfigurationChange = isConfigurationChange;
     if (!isConfigurationChange) {
       if (navigationSessionState.startTimestamp() != null) {
         flushEventQueues();
@@ -272,10 +271,6 @@ class NavigationTelemetry implements LocationEngineListener, NavigationMetricLis
       String locationEngineName = locationEngine.getClass().getName();
       navigationSessionState.toBuilder().locationEngineName(locationEngineName);
     }
-  }
-
-  void onConfigurationChange() {
-    isConfigurationChange = true;
   }
 
   /**

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationTelemetry.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationTelemetry.java
@@ -15,7 +15,6 @@ import com.mapbox.services.android.navigation.BuildConfig;
 import com.mapbox.services.android.navigation.v5.exception.NavigationException;
 import com.mapbox.services.android.navigation.v5.location.MetricsLocation;
 import com.mapbox.services.android.navigation.v5.navigation.metrics.FeedbackEvent;
-import com.mapbox.services.android.navigation.v5.navigation.metrics.NavigationLifecycleMonitor;
 import com.mapbox.services.android.navigation.v5.navigation.metrics.NavigationMetricListeners;
 import com.mapbox.services.android.navigation.v5.navigation.metrics.RerouteEvent;
 import com.mapbox.services.android.navigation.v5.navigation.metrics.SessionState;
@@ -192,6 +191,7 @@ class NavigationTelemetry implements LocationEngineListener, NavigationMetricLis
   void startSession(DirectionsRoute directionsRoute) {
     if (!isConfigurationChange) {
       navigationSessionState = navigationSessionState.toBuilder()
+        .sessionIdentifier(TelemetryUtils.buildUUID())
         .originalDirectionRoute(directionsRoute)
         .originalRequestIdentifier(directionsRoute.routeOptions().requestUuid())
         .requestIdentifier(directionsRoute.routeOptions().requestUuid())

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/metrics/SessionState.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/metrics/SessionState.java
@@ -22,16 +22,26 @@ public abstract class SessionState {
    * Original route values
    */
   public String originalGeometry() {
+    if (originalDirectionRoute() == null || TextUtils.isEmpty(originalDirectionRoute().geometry())) {
+      return "";
+    }
+
     List<Point> geometryPositions
       = PolylineUtils.decode(originalDirectionRoute().geometry(), Constants.PRECISION_6);
     return PolylineUtils.encode(geometryPositions, Constants.PRECISION_5);
   }
 
   public int originalDistance() {
+    if (originalDirectionRoute() == null) {
+      return 0;
+    }
     return originalDirectionRoute().distance().intValue();
   }
 
   public int originalStepCount() {
+    if (originalDirectionRoute() == null) {
+      return 0;
+    }
     int stepCount = 0;
     for (RouteLeg leg : originalDirectionRoute().legs()) {
       stepCount += leg.steps().size();
@@ -40,6 +50,9 @@ public abstract class SessionState {
   }
 
   public int originalDuration() {
+    if (originalDirectionRoute() == null) {
+      return 0;
+    }
     return originalDirectionRoute().duration().intValue();
   }
 
@@ -47,6 +60,9 @@ public abstract class SessionState {
    * Current route values
    */
   public int currentStepCount() {
+    if (currentDirectionRoute() == null) {
+      return 0;
+    }
     int stepCount = 0;
     for (RouteLeg leg : currentDirectionRoute().legs()) {
       stepCount += leg.steps().size();

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/metrics/SessionState.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/metrics/SessionState.java
@@ -11,7 +11,6 @@ import com.mapbox.core.constants.Constants;
 import com.mapbox.geojson.Point;
 import com.mapbox.geojson.utils.PolylineUtils;
 import com.mapbox.services.android.navigation.v5.routeprogress.MetricsRouteProgress;
-import com.mapbox.services.android.telemetry.utils.TelemetryUtils;
 
 import java.util.Date;
 import java.util.List;
@@ -118,7 +117,7 @@ public abstract class SessionState {
   public static Builder builder() {
     return new AutoValue_SessionState.Builder()
       .eventRouteDistanceCompleted(0d)
-      .sessionIdentifier(TelemetryUtils.buildUUID())
+      .sessionIdentifier("")
       .mockLocation(false)
       .rerouteCount(0)
       .secondsSinceLastReroute(-1)

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/metrics/SessionState.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/metrics/SessionState.java
@@ -11,6 +11,7 @@ import com.mapbox.core.constants.Constants;
 import com.mapbox.geojson.Point;
 import com.mapbox.geojson.utils.PolylineUtils;
 import com.mapbox.services.android.navigation.v5.routeprogress.MetricsRouteProgress;
+import com.mapbox.services.android.telemetry.utils.TelemetryUtils;
 
 import java.util.Date;
 import java.util.List;
@@ -117,7 +118,7 @@ public abstract class SessionState {
   public static Builder builder() {
     return new AutoValue_SessionState.Builder()
       .eventRouteDistanceCompleted(0d)
-      .sessionIdentifier("")
+      .sessionIdentifier(TelemetryUtils.buildUUID())
       .mockLocation(false)
       .rerouteCount(0)
       .secondsSinceLastReroute(-1)


### PR DESCRIPTION
Sometimes the session state is updated with a new UUID - this should never happen, so should set it once in the `builder()`

cc @ericrwolfe 