### PR TITLE
Update Default Zoom Level

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationCamera.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationCamera.java
@@ -1,4 +1,4 @@
-package com.mapbox.services.android.navigation.ui.v5.camera;
+package com.mapbox.services.android.navigation.ui.v5;
 
 import android.content.Context;
 import android.content.res.Configuration;
@@ -26,7 +26,7 @@ import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
  *
  * @since 0.6.0
  */
-public class NavigationCamera implements ProgressChangeListener {
+class NavigationCamera implements ProgressChangeListener {
 
   private MapboxMap mapboxMap;
   private MapboxNavigation navigation;
@@ -43,7 +43,7 @@ public class NavigationCamera implements ProgressChangeListener {
    * @param navigation for listening to location updates
    * @since 0.6.0
    */
-  public NavigationCamera(@NonNull View view, @NonNull MapboxMap mapboxMap,
+  NavigationCamera(@NonNull View view, @NonNull MapboxMap mapboxMap,
                           @NonNull MapboxNavigation navigation) {
     this.mapboxMap = mapboxMap;
     this.navigation = navigation;

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
@@ -32,7 +32,6 @@ import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerMode;
 import com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerPlugin;
-import com.mapbox.services.android.navigation.ui.v5.camera.NavigationCamera;
 import com.mapbox.services.android.navigation.ui.v5.instruction.InstructionLoader;
 import com.mapbox.services.android.navigation.ui.v5.instruction.InstructionView;
 import com.mapbox.services.android.navigation.ui.v5.location.LocationViewModel;

--- a/libandroid-navigation/build.gradle
+++ b/libandroid-navigation/build.gradle
@@ -45,13 +45,11 @@ dependencies {
   // Mapbox Android Services
   api (dependenciesList.mapboxServices) {
     transitive = true
-    exclude module: 'mapbox-java-geojson'
-    exclude module: 'mapbox-java-core'
-    exclude module: 'mapbox-java-services'
   }
-
+  api dependenciesList.mapboxMapSdk
   api dependenciesList.mapboxSdkServices
   api dependenciesList.mapboxSdkTurf
+
   // Support
   implementation dependenciesList.supportAppcompatV7
 

--- a/libandroid-navigation/build.gradle
+++ b/libandroid-navigation/build.gradle
@@ -46,7 +46,7 @@ dependencies {
   api (dependenciesList.mapboxServices) {
     transitive = true
   }
-  api dependenciesList.mapboxMapSdk
+
   api dependenciesList.mapboxSdkServices
   api dependenciesList.mapboxSdkTurf
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
@@ -14,6 +14,8 @@ import com.mapbox.services.android.navigation.v5.milestone.BannerInstructionMile
 import com.mapbox.services.android.navigation.v5.milestone.Milestone;
 import com.mapbox.services.android.navigation.v5.milestone.MilestoneEventListener;
 import com.mapbox.services.android.navigation.v5.milestone.VoiceInstructionMilestone;
+import com.mapbox.services.android.navigation.v5.navigation.camera.Camera;
+import com.mapbox.services.android.navigation.v5.navigation.camera.SimpleCamera;
 import com.mapbox.services.android.navigation.v5.navigation.metrics.FeedbackEvent;
 import com.mapbox.services.android.navigation.v5.offroute.OffRoute;
 import com.mapbox.services.android.navigation.v5.offroute.OffRouteDetector;
@@ -61,6 +63,7 @@ public class MapboxNavigation implements ServiceConnection {
   private Context context;
   private boolean isBound;
   private NavigationTelemetry navigationTelemetry = null;
+  private Camera cameraEngine;
 
   /**
    * Constructs a new instance of this class using the default options. This should be used over
@@ -139,6 +142,7 @@ public class MapboxNavigation implements ServiceConnection {
     navigationEventDispatcher = new NavigationEventDispatcher();
 
     initializeDefaultLocationEngine();
+    initializeDefaultCameraEngine();
     initializeTelemetry();
 
     // Create and add default milestones if enabled.
@@ -199,6 +203,10 @@ public class MapboxNavigation implements ServiceConnection {
       locationEngine.removeLocationUpdates();
       locationEngine.deactivate();
     }
+  }
+
+  private void initializeDefaultCameraEngine() {
+    cameraEngine = new SimpleCamera();
   }
 
   // Lifecycle
@@ -333,6 +341,14 @@ public class MapboxNavigation implements ServiceConnection {
   @NonNull
   public LocationEngine getLocationEngine() {
     return locationEngine;
+  }
+
+  public void setCameraEngine(@NonNull Camera cameraEngine) {
+    this.cameraEngine = cameraEngine;
+  }
+
+  public Camera getCameraEngine() {
+    return cameraEngine;
   }
 
   /**

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
@@ -343,10 +343,23 @@ public class MapboxNavigation implements ServiceConnection {
     return locationEngine;
   }
 
+  /**
+   * Navigation uses a camera engine to determine the camera position while routing.
+   * By default, it uses a {@link SimpleCamera}. If you would like to customize how the camera is
+   * positioned, create a new {@link Camera} and set it here.
+   * @param cameraEngine camera engine used to configure camera position while routing
+   * @since 0.8.0
+   */
   public void setCameraEngine(@NonNull Camera cameraEngine) {
     this.cameraEngine = cameraEngine;
   }
 
+  /**
+   * Returns the current camera engine used to configure the camera position while routing. By default,
+   * a {@link SimpleCamera} is used.
+   * @return camera engine used to configure camera position while routing
+   * @since 0.8.0
+   */
   public Camera getCameraEngine() {
     return cameraEngine;
   }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/camera/Camera.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/camera/Camera.java
@@ -1,7 +1,6 @@
 package com.mapbox.services.android.navigation.v5.navigation.camera;
 
-
-import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.geojson.Point;
 
 public abstract class Camera {
 
@@ -13,7 +12,7 @@ public abstract class Camera {
   /**
    * The location that the camera is pointing at.
    */
-  public abstract LatLng target(RouteInformation routeInformation);
+  public abstract Point target(RouteInformation routeInformation);
 
   /**
    * The angle, in degrees, of the camera angle from the nadir (directly facing the Earth).
@@ -26,4 +25,5 @@ public abstract class Camera {
    * zoom level.
    */
   public abstract double zoom(RouteInformation routeInformation);
+
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/camera/Camera.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/camera/Camera.java
@@ -2,6 +2,15 @@ package com.mapbox.services.android.navigation.v5.navigation.camera;
 
 import com.mapbox.geojson.Point;
 
+/**
+ * This class handles calculating all properties necessary to configure the camera position while
+ * routing. The {@link com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation} uses
+ * a {@link SimpleCamera} by default. If you would like to customize the camera position, create a
+ * concrete implementation of this class or subclass {@link SimpleCamera} and update
+ * {@link com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation#setCameraEngine(Camera)}.
+ *
+ * @since 0.8.1
+ */
 public abstract class Camera {
 
   /**

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/camera/Camera.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/camera/Camera.java
@@ -1,0 +1,29 @@
+package com.mapbox.services.android.navigation.v5.navigation.camera;
+
+
+import com.mapbox.mapboxsdk.geometry.LatLng;
+
+public abstract class Camera {
+
+  /**
+   * Direction that the camera is pointing in, in degrees clockwise from north.
+   */
+  public abstract double bearing(RouteInformation routeInformation);
+
+  /**
+   * The location that the camera is pointing at.
+   */
+  public abstract LatLng target(RouteInformation routeInformation);
+
+  /**
+   * The angle, in degrees, of the camera angle from the nadir (directly facing the Earth).
+   * See tilt(float) for details of restrictions on the range of values.
+   */
+  public abstract double tilt(RouteInformation routeInformation);
+
+  /**
+   * Zoom level near the center of the screen. See zoom(float) for the definition of the camera's
+   * zoom level.
+   */
+  public abstract double zoom(RouteInformation routeInformation);
+}

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/camera/RouteInformation.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/camera/RouteInformation.java
@@ -9,26 +9,62 @@ import com.google.auto.value.AutoValue;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 
+/**
+ * This class holds all information related to a route and a user's progress along the route. It
+ * also provides useful information (screen configuration and target distance) which can be used to
+ * make additional configuration changes to the map's camera.
+ *
+ * @since 0.8.1
+ */
 @AutoValue
 public abstract class RouteInformation {
 
+  /**
+   * The device's current configuration which can be used to return different zoom values given
+   * it's orientation.
+   * @return device's current configuration
+   * @since 0.8.1
+   */
   @NonNull
   public abstract Configuration configuration();
 
+  /**
+   * The camera target distance as a percentage of the total phone screen the view uses.
+   * @return camera target distance
+   * @since 0.8.1
+   */
   public abstract double targetDistance();
 
+  /**
+   * The current route the user is navigating along. This value will update when reroutes occur
+   * and it will be null if the {@link RouteInformation} is generated from an update to route
+   * progress or from an orientation change.
+   * @return current route
+   * @since 0.8.1
+   */
   @Nullable
   public abstract DirectionsRoute route();
 
+  /**
+   * The user's current location along the route. This value will update when orientation changes
+   * occur as well as when progress along a route changes.
+   * @return current location
+   * @since 0.8.1
+   */
   @Nullable
   public abstract Location location();
 
+  /**
+   * The user's current progress along the route.
+   * @return current progress along the route.
+   * @since 0.8.1
+   */
   @Nullable
   public abstract RouteProgress routeProgress();
 
-  public static RouteInformation create(Configuration configuration, double targetDistance,
-                                        DirectionsRoute route, Location location,
-                                        RouteProgress routeProgress) {
+  public static RouteInformation create(@NonNull Configuration configuration, double targetDistance,
+                                        @Nullable DirectionsRoute route, @Nullable Location location,
+                                        @Nullable RouteProgress routeProgress) {
     return new AutoValue_RouteInformation(configuration, targetDistance, route, location,
             routeProgress);
   }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/camera/RouteInformation.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/camera/RouteInformation.java
@@ -1,0 +1,35 @@
+package com.mapbox.services.android.navigation.v5.navigation.camera;
+
+import android.content.res.Configuration;
+import android.location.Location;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.google.auto.value.AutoValue;
+import com.mapbox.api.directions.v5.models.DirectionsRoute;
+import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
+
+@AutoValue
+public abstract class RouteInformation {
+
+  @NonNull
+  public abstract Configuration configuration();
+
+  public abstract double targetDistance();
+
+  @Nullable
+  public abstract DirectionsRoute route();
+
+  @Nullable
+  public abstract Location location();
+
+  @Nullable
+  public abstract RouteProgress routeProgress();
+
+  public static RouteInformation create(Configuration configuration, double targetDistance,
+                                        DirectionsRoute route, Location location,
+                                        RouteProgress routeProgress) {
+    return new AutoValue_RouteInformation(configuration, targetDistance, route, location,
+            routeProgress);
+  }
+}

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/camera/SimpleCamera.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/camera/SimpleCamera.java
@@ -1,0 +1,105 @@
+package com.mapbox.services.android.navigation.v5.navigation.camera;
+
+import android.util.SparseArray;
+
+import com.mapbox.api.directions.v5.models.DirectionsRoute;
+import com.mapbox.core.constants.Constants;
+import com.mapbox.geojson.Point;
+import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.services.commons.geojson.LineString;
+import com.mapbox.turf.TurfConstants;
+import com.mapbox.turf.TurfMeasurement;
+
+import static android.content.res.Configuration.ORIENTATION_LANDSCAPE;
+import static android.content.res.Configuration.ORIENTATION_PORTRAIT;
+
+public class SimpleCamera extends Camera {
+
+  private static final int CAMERA_TILT = 45;
+
+  DirectionsRoute initialRoute;
+  LineString lineString;
+  double initialBearing;
+  OrientationMap orientationMap;
+
+  public SimpleCamera() {
+    orientationMap = new OrientationMap();
+  }
+
+  @Override
+  public double bearing(RouteInformation routeInformation) {
+    if (routeInformation.route() != null) {
+      setupLineStringAndBearing(routeInformation.route());
+      return initialBearing;
+    }
+    else if (routeInformation.location() != null) {
+      return routeInformation.location().getBearing();
+    }
+    return 0;
+  }
+
+  @Override
+  public LatLng target(RouteInformation routeInformation) {
+    double lng = 0;
+    double lat = 0;
+    double bearing = 0;
+    if (routeInformation.route() != null) {
+      setupLineStringAndBearing(routeInformation.route());
+      lng = lineString.getCoordinates().get(0).getLongitude();
+      lat = lineString.getCoordinates().get(0).getLatitude();
+      bearing = initialBearing;
+    } else if (routeInformation.location() != null) {
+      lng = routeInformation.location().getLongitude();
+      lat = routeInformation.location().getLatitude();
+      bearing = routeInformation.location().getBearing();
+    }
+
+    Point targetPoint = TurfMeasurement.destination(
+            Point.fromLngLat(lng, lat),
+            routeInformation.targetDistance(), bearing, TurfConstants.UNIT_METERS
+    );
+    LatLng target = new LatLng(
+            targetPoint.latitude(),
+            targetPoint.longitude()
+    );
+
+    return target;
+  }
+
+  @Override
+  public double tilt(RouteInformation routeInformation) {
+    return CAMERA_TILT;
+  }
+
+  @Override
+  public double zoom(RouteInformation routeInformation) {
+    return orientationMap.get(routeInformation.configuration().orientation);
+  }
+
+  private void setupLineStringAndBearing(DirectionsRoute route) {
+    if (initialRoute != null && route.equals(initialRoute)) {
+      return; //no need to recalculate these values
+    }
+    lineString = LineString.fromPolyline(route.geometry(), Constants.PRECISION_6);
+    initialBearing = TurfMeasurement.bearing(
+            Point.fromLngLat(
+                    lineString.getCoordinates().get(0).getLongitude(), lineString.getCoordinates().get(0).getLatitude()
+            ),
+            Point.fromLngLat(
+                    lineString.getCoordinates().get(1).getLongitude(), lineString.getCoordinates().get(1).getLatitude()
+            )
+    );
+  }
+
+  /**
+   * Holds the two different screen orientations
+   * and their corresponding zoom levels.
+   */
+  static class OrientationMap extends SparseArray<Integer> {
+
+    OrientationMap() {
+      put(ORIENTATION_PORTRAIT, 17);
+      put(ORIENTATION_LANDSCAPE, 16);
+    }
+  }
+}

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/camera/SimpleCamera.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/camera/SimpleCamera.java
@@ -5,7 +5,6 @@ import android.util.SparseArray;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.core.constants.Constants;
 import com.mapbox.geojson.Point;
-import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.services.commons.geojson.LineString;
 import com.mapbox.turf.TurfConstants;
 import com.mapbox.turf.TurfMeasurement;
@@ -39,7 +38,7 @@ public class SimpleCamera extends Camera {
   }
 
   @Override
-  public LatLng target(RouteInformation routeInformation) {
+  public Point target(RouteInformation routeInformation) {
     double lng = 0;
     double lat = 0;
     double bearing = 0;
@@ -58,12 +57,8 @@ public class SimpleCamera extends Camera {
             Point.fromLngLat(lng, lat),
             routeInformation.targetDistance(), bearing, TurfConstants.UNIT_METERS
     );
-    LatLng target = new LatLng(
-            targetPoint.latitude(),
-            targetPoint.longitude()
-    );
 
-    return target;
+    return targetPoint;
   }
 
   @Override

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/camera/SimpleCamera.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/camera/SimpleCamera.java
@@ -12,6 +12,11 @@ import com.mapbox.turf.TurfMeasurement;
 import static android.content.res.Configuration.ORIENTATION_LANDSCAPE;
 import static android.content.res.Configuration.ORIENTATION_PORTRAIT;
 
+/**
+ * The default camera used by {@link com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation}.
+ *
+ * @since 0.8.1
+ */
 public class SimpleCamera extends Camera {
 
   private static final int CAMERA_TILT = 45;
@@ -30,8 +35,7 @@ public class SimpleCamera extends Camera {
     if (routeInformation.route() != null) {
       setupLineStringAndBearing(routeInformation.route());
       return initialBearing;
-    }
-    else if (routeInformation.location() != null) {
+    } else if (routeInformation.location() != null) {
       return routeInformation.location().getBearing();
     }
     return 0;

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/camera/SimpleCamera.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/camera/SimpleCamera.java
@@ -93,8 +93,8 @@ public class SimpleCamera extends Camera {
   static class OrientationMap extends SparseArray<Integer> {
 
     OrientationMap() {
-      put(ORIENTATION_PORTRAIT, 17);
-      put(ORIENTATION_LANDSCAPE, 16);
+      put(ORIENTATION_PORTRAIT, 16);
+      put(ORIENTATION_LANDSCAPE, 15);
     }
   }
 }


### PR DESCRIPTION
This PR lays the foundation for providing an easy way to customize the camera via a new abstract `Camera` class which can be set with `MapboxNavigation#setCameraEngine`. It moves the camera positioning logic from `NavigationCamera` into a new class `SimpleCamera`. By default, `MapboxNavigation` now uses an instance of `SimpleCamera` to determine how the camera should be position while routing. `SimpleCamera`'s default zoom values have also been updated so that they are consistent with iOS.

Further work can use the properties passed in `RouteInformation` to determine whether the user is starting the route, in the middle of it, or at their destination.

- [x] Provide screenshot references
- [ ] Add test coverage for SimpleCamera (verify correct values returned, verify initial values cached)

Closes #602 