### PR TITLE
Off-Route Bug Fixes

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEngine.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEngine.java
@@ -175,7 +175,7 @@ class NavigationEngine extends HandlerThread implements Handler.Callback, OffRou
         Timber.d("NAV-DEBUG ** ALERT Advancing step with stepDistanceRemaining: %s", stepDistanceRemaining);
       }
 
-      Timber.d("NAV-DEBUG ** Bearing matches final maneuver heading + stepDistanceRemaining < maneuverZone");
+      Timber.d("NAV-DEBUG ** Advancing step index --> Bearing matches final maneuver heading + stepDistanceRemaining < maneuverZone");
       // First increase the indices and then update the majority of information for the new
       // routeProgress.
       indices = increaseIndex(previousRouteProgress, indices);

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationHelper.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationHelper.java
@@ -11,6 +11,7 @@ import com.mapbox.geojson.LineString;
 import com.mapbox.geojson.Point;
 import com.mapbox.services.android.navigation.v5.milestone.Milestone;
 import com.mapbox.services.android.navigation.v5.offroute.OffRoute;
+import com.mapbox.services.android.navigation.v5.offroute.OffRouteDetector;
 import com.mapbox.services.android.navigation.v5.route.FasterRoute;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 import com.mapbox.services.android.navigation.v5.snap.Snap;
@@ -201,11 +202,11 @@ class NavigationHelper {
     return milestones;
   }
 
-  static boolean isUserOffRoute(NewLocationModel newLocationModel, RouteProgress routeProgress) {
+  static boolean isUserOffRoute(NewLocationModel newLocationModel, RouteProgress routeProgress,
+                                OffRouteDetector.IncreaseStepIndexCallback callback) {
     OffRoute offRoute = newLocationModel.mapboxNavigation().getOffRouteEngine();
     return offRoute.isUserOffRoute(newLocationModel.location(), routeProgress,
-      newLocationModel.mapboxNavigation().options(),
-      newLocationModel.recentDistancesFromManeuverInMeters());
+      newLocationModel.mapboxNavigation().options(), newLocationModel.distancesAwayFromManeuver(), callback);
   }
 
   static boolean shouldCheckFasterRoute(NewLocationModel newLocationModel, RouteProgress routeProgress) {

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationHelper.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationHelper.java
@@ -133,7 +133,6 @@ class NavigationHelper {
    */
   static boolean checkBearingForStepCompletion(Location userLocation, RouteProgress previousRouteProgress,
                                                double stepDistanceRemaining, double maxTurnCompletionOffset) {
-
     if (previousRouteProgress.currentLegProgress().upComingStep() == null) {
       return false;
     }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NewLocationModel.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NewLocationModel.java
@@ -9,14 +9,14 @@ import com.mapbox.services.android.navigation.v5.utils.RingBuffer;
 abstract class NewLocationModel {
 
   static NewLocationModel create(Location location, MapboxNavigation mapboxNavigation,
-                                 RingBuffer recentDistancesFromManeuverInMeters) {
+                                 RingBuffer distancesAwayFromManeuver) {
     return new AutoValue_NewLocationModel(location, mapboxNavigation,
-      recentDistancesFromManeuverInMeters);
+      distancesAwayFromManeuver);
   }
 
   abstract Location location();
 
   abstract MapboxNavigation mapboxNavigation();
 
-  abstract RingBuffer recentDistancesFromManeuverInMeters();
+  abstract RingBuffer distancesAwayFromManeuver();
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/offroute/OffRoute.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/offroute/OffRoute.java
@@ -10,5 +10,6 @@ public abstract class OffRoute {
 
   public abstract boolean isUserOffRoute(Location location, RouteProgress routeProgress,
                                          MapboxNavigationOptions options,
-                                         RingBuffer<Integer> recentDistancesFromManeuverInMeters);
+                                         RingBuffer<Integer> distancesAwayFromManevuer,
+                                         OffRouteDetector.IncreaseStepIndexCallback callback);
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/offroute/OffRoute.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/offroute/OffRoute.java
@@ -10,6 +10,6 @@ public abstract class OffRoute {
 
   public abstract boolean isUserOffRoute(Location location, RouteProgress routeProgress,
                                          MapboxNavigationOptions options,
-                                         RingBuffer<Integer> distancesAwayFromManevuer,
-                                         OffRouteDetector.IncreaseStepIndexCallback callback);
+                                         RingBuffer<Integer> distancesAwayFromManeuver,
+                                         OffRouteCallback callback);
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteCallback.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteCallback.java
@@ -1,0 +1,13 @@
+package com.mapbox.services.android.navigation.v5.offroute;
+
+import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
+
+public interface OffRouteCallback {
+  /**
+   * This callback will fire when the {@link OffRouteDetector} determines that the user
+   * location is close enough to the upcoming {@link com.mapbox.api.directions.v5.models.LegStep}.
+   * <p>
+   * In this case, the step index needs to be increased for the next {@link RouteProgress} generation.
+   */
+  void onShouldIncreaseIndex();
+}

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteDetector.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteDetector.java
@@ -39,7 +39,9 @@ public class OffRouteDetector extends OffRoute {
 
     Point currentUserPoint = Point.fromLngLat(location.getLongitude(), location.getLatitude());
 
-    double offRouteRadius = ToleranceUtils.dynamicRerouteDistanceTolerance(currentUserPoint, routeProgress);
+    double dynamicTolerance = ToleranceUtils.dynamicRerouteDistanceTolerance(currentUserPoint, routeProgress);
+    double accuracyTolerance = location.getSpeed() * options.deadReckoningTimeInterval();
+    double offRouteRadius = Math.max(dynamicTolerance, accuracyTolerance);
     Timber.d("NAV-DEBUG xx Radius: %s", offRouteRadius);
 
     // Get interpolated point based on our current speed
@@ -80,7 +82,9 @@ public class OffRouteDetector extends OffRoute {
     if (upComingStep != null) {
       double distanceFromUpcomingStep = userTrueDistanceFromStep(currentUserPoint, upComingStep);
       Timber.d("NAV-DEBUG xx Distance from upComingStep: %s", distanceFromStep);
-      isCloseToUpcomingStep = distanceFromUpcomingStep < offRouteRadius;
+      double maneuverZoneRadius = options.maneuverZoneRadius();
+      Timber.d("NAV-DEBUG xx Maneuver zone radius: %s", maneuverZoneRadius);
+      isCloseToUpcomingStep = distanceFromUpcomingStep < maneuverZoneRadius;
       if (isCloseToUpcomingStep) {
         // TODO increment step index
         // TODO this needs to happen or the movement will just stop

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteDetector.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteDetector.java
@@ -179,11 +179,12 @@ public class OffRouteDetector extends OffRoute {
     );
 
     boolean hasDistances = !distancesAwayFromManeuver.isEmpty();
-    boolean validOffRouteDistanceTraveled = distancesAwayFromManeuver.peekLast()
+    boolean validOffRouteDistanceTraveled = hasDistances && distancesAwayFromManeuver.peekLast()
       - distancesAwayFromManeuver.peekFirst() < MINIMUM_BACKUP_DISTANCE_FOR_OFF_ROUTE;
-    boolean exceedsManeuverDistancesThreshold = distancesAwayFromManeuver.size() >= 3;
+    boolean exceedsManeuverDistancesThreshold = validOffRouteDistanceTraveled
+      && distancesAwayFromManeuver.size() >= 3;
 
-    if (hasDistances && validOffRouteDistanceTraveled && exceedsManeuverDistancesThreshold) {
+    if (exceedsManeuverDistancesThreshold) {
       // User's moving away from maneuver position, thus offRoute.
       return true;
     }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteDetector.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteDetector.java
@@ -178,10 +178,12 @@ public class OffRouteDetector extends OffRoute {
       currentPoint, TurfConstants.UNIT_METERS
     );
 
-    if (!distancesAwayFromManeuver.isEmpty()
-      && distancesAwayFromManeuver.peekLast()
-      - distancesAwayFromManeuver.peekFirst() < MINIMUM_BACKUP_DISTANCE_FOR_OFF_ROUTE
-      && distancesAwayFromManeuver.size() >= 3) {
+    boolean hasDistances = !distancesAwayFromManeuver.isEmpty();
+    boolean validOffRouteDistanceTraveled = distancesAwayFromManeuver.peekLast()
+      - distancesAwayFromManeuver.peekFirst() < MINIMUM_BACKUP_DISTANCE_FOR_OFF_ROUTE;
+    boolean exceedsManeuverDistancesThreshold = distancesAwayFromManeuver.size() >= 3;
+
+    if (hasDistances && validOffRouteDistanceTraveled && exceedsManeuverDistancesThreshold) {
       // User's moving away from maneuver position, thus offRoute.
       return true;
     }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteDetector.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteDetector.java
@@ -7,12 +7,12 @@ import com.mapbox.geojson.Point;
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigationOptions;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 import com.mapbox.services.android.navigation.v5.utils.RingBuffer;
-import com.mapbox.services.android.navigation.v5.utils.ToleranceUtils;
 import com.mapbox.turf.TurfConstants;
 import com.mapbox.turf.TurfMeasurement;
 
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.MINIMUM_BACKUP_DISTANCE_FOR_OFF_ROUTE;
 import static com.mapbox.services.android.navigation.v5.utils.MeasurementUtils.userTrueDistanceFromStep;
+import static com.mapbox.services.android.navigation.v5.utils.ToleranceUtils.dynamicRerouteDistanceTolerance;
 
 public class OffRouteDetector extends OffRoute {
 
@@ -39,7 +39,7 @@ public class OffRouteDetector extends OffRoute {
     double distanceFromCurrentStep = userTrueDistanceFromStep(currentPoint, currentStep);
 
     // Create off-route radius from the max of our dynamic or accuracy based tolerances
-    double dynamicTolerance = ToleranceUtils.dynamicRerouteDistanceTolerance(currentPoint, routeProgress);
+    double dynamicTolerance = dynamicRerouteDistanceTolerance(currentPoint, routeProgress);
     double accuracyTolerance = location.getSpeed() * options.deadReckoningTimeInterval();
     double offRouteRadius = Math.max(dynamicTolerance, accuracyTolerance);
 
@@ -95,7 +95,7 @@ public class OffRouteDetector extends OffRoute {
     return distanceFromLastReroute > options.minimumDistanceBeforeRerouting();
   }
 
-  private boolean closeToUpcomingStep(MapboxNavigationOptions options, OffRouteCallback callback,
+  private static boolean closeToUpcomingStep(MapboxNavigationOptions options, OffRouteCallback callback,
                                       Point currentPoint, LegStep upComingStep) {
     boolean isCloseToUpcomingStep;
     if (upComingStep != null) {

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/snap/Snap.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/snap/Snap.java
@@ -11,9 +11,4 @@ public abstract class Snap {
 
   public abstract Location getSnappedLocation(Location location, RouteProgress routeProgress,
                                               List<Point> coords);
-
-  public boolean validLocationToSnap(Location location) {
-    // If users not moving, don't snap their position or bearing
-    return location.getSpeed() > 0d;
-  }
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/snap/SnapToRoute.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/snap/SnapToRoute.java
@@ -1,12 +1,15 @@
 package com.mapbox.services.android.navigation.v5.snap;
 
 import android.location.Location;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import com.mapbox.geojson.Feature;
 import com.mapbox.geojson.LineString;
 import com.mapbox.geojson.Point;
+import com.mapbox.services.android.navigation.v5.routeprogress.RouteLegProgress;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
+import com.mapbox.services.android.navigation.v5.routeprogress.RouteStepProgress;
 import com.mapbox.services.android.telemetry.utils.MathUtils;
 import com.mapbox.turf.TurfConstants;
 import com.mapbox.turf.TurfMeasurement;
@@ -28,8 +31,8 @@ public class SnapToRoute extends Snap {
 
   @Override
   public Location getSnappedLocation(Location location, RouteProgress routeProgress,
-                                     @Nullable List<Point> coords) {
-    Location snappedLocation = snapLocationLatLng(location, coords);
+                                     @Nullable List<Point> stepCoordinates) {
+    Location snappedLocation = snapLocationLatLng(location, stepCoordinates);
     snappedLocation.setBearing(snapLocationBearing(routeProgress));
     return snappedLocation;
   }
@@ -39,18 +42,18 @@ public class SnapToRoute extends Snap {
    * step.
    *
    * @param location        the raw location
-   * @param coords          the list of step geometry coordinates
+   * @param stepCoordinates the list of step geometry coordinates
    * @return the altered user location
    * @since 0.4.0
    */
-  private static Location snapLocationLatLng(Location location, List<Point> coords) {
+  private static Location snapLocationLatLng(Location location, List<Point> stepCoordinates) {
     Location snappedLocation = new Location(location);
     Point locationToPoint = Point.fromLngLat(location.getLongitude(), location.getLatitude());
 
     // Uses Turf's pointOnLine, which takes a Point and a LineString to calculate the closest
     // Point on the LineString.
-    if (coords.size() > 1) {
-      Feature feature = TurfMisc.pointOnLine(locationToPoint, coords);
+    if (stepCoordinates.size() > 1) {
+      Feature feature = TurfMisc.pointOnLine(locationToPoint, stepCoordinates);
       Point point = ((Point) feature.geometry());
       snappedLocation.setLongitude(point.longitude());
       snappedLocation.setLatitude(point.latitude());
@@ -58,22 +61,66 @@ public class SnapToRoute extends Snap {
     return snappedLocation;
   }
 
+  /**
+   * Creates a snapped bearing for the snapped {@link Location}.
+   * <p>
+   * This is done by measuring 1 meter ahead of the current step distance traveled and
+   * creating a {@link Point} with this distance using {@link TurfMeasurement#along(LineString, double, String)}.
+   * <p>
+   * If the step distance remaining is zero, the distance ahead is 1 meter into the upcoming step.
+   * This way, an accurate bearing is upheld transitioning between steps.
+   *
+   * @param routeProgress for all current progress values
+   * @return float bearing snapped to route
+   */
   private static float snapLocationBearing(RouteProgress routeProgress) {
-    LineString lineString = LineString.fromPolyline(
-      routeProgress.currentLegProgress().currentStep().geometry(), PRECISION_6);
 
-    Point currentPoint = TurfMeasurement.along(
-      lineString, routeProgress.currentLegProgress().currentStepProgress().distanceTraveled(),
-      TurfConstants.UNIT_METERS);
-    // Measure 1 meter ahead of the users current location
-    Point futurePoint = TurfMeasurement.along(
-      lineString,
-      routeProgress.currentLegProgress().currentStepProgress().distanceTraveled() + 1,
-      TurfConstants.UNIT_METERS);
+    RouteLegProgress legProgress = routeProgress.currentLegProgress();
+    RouteStepProgress stepProgress = legProgress.currentStepProgress();
+    double distanceTraveled = stepProgress.distanceTraveled();
+    double distanceRemaining = stepProgress.distanceRemaining();
+    boolean distanceRemainingZero = distanceRemaining == 0;
 
-    double azimuth = TurfMeasurement.bearing(currentPoint, futurePoint);
+    // Either want to measure our current step distance traveled + 1 or 1 meter into the upcoming step
+    double distanceAhead = distanceRemainingZero ? 1 : distanceTraveled + 1;
+    // Create the step linestring from the geometry
+    LineString upcomingLineString = createUpcomingLineString(legProgress, distanceRemainingZero);
+    LineString currentLineString = createCurrentLineString(legProgress);
+
+    // Measure 1 meter ahead of the users current location, only if the distance remaining isn't zero
+    Point futurePoint = createFuturePoint(distanceAhead, upcomingLineString, currentLineString);
+    Point currentPoint = TurfMeasurement.along(currentLineString, distanceTraveled, TurfConstants.UNIT_METERS);
 
     // Get bearing and convert azimuth to degrees
+    double azimuth = TurfMeasurement.bearing(currentPoint, futurePoint);
     return (float) MathUtils.wrap(azimuth, 0, 360);
+  }
+
+  @NonNull
+  private static LineString createCurrentLineString(RouteLegProgress legProgress) {
+    String currentGeometry = legProgress.currentStep().geometry();
+    return LineString.fromPolyline(currentGeometry, PRECISION_6);
+  }
+
+  @Nullable
+  private static LineString createUpcomingLineString(RouteLegProgress legProgress, boolean distanceRemainingZero) {
+    LineString upcomingLineString = null;
+    if (distanceRemainingZero && legProgress.upComingStep() != null) {
+      String upcomingGeometry = legProgress.upComingStep().geometry();
+      upcomingLineString = LineString.fromPolyline(upcomingGeometry, PRECISION_6);
+    }
+    return upcomingLineString;
+  }
+
+  @NonNull
+  private static Point createFuturePoint(double distanceAhead, LineString upcomingLineString,
+                                         LineString currentLineString) {
+    Point futurePoint;
+    if (upcomingLineString != null) {
+      futurePoint = TurfMeasurement.along(upcomingLineString, distanceAhead, TurfConstants.UNIT_METERS);
+    } else {
+      futurePoint = TurfMeasurement.along(currentLineString, distanceAhead, TurfConstants.UNIT_METERS);
+    }
+    return futurePoint;
   }
 }

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteDetectorTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteDetectorTest.java
@@ -1,16 +1,165 @@
 package com.mapbox.services.android.navigation.v5.offroute;
 
-import static junit.framework.Assert.assertNotNull;
+import android.location.Location;
+import android.support.annotation.NonNull;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.mapbox.api.directions.v5.DirectionsAdapterFactory;
+import com.mapbox.api.directions.v5.models.DirectionsResponse;
+import com.mapbox.api.directions.v5.models.DirectionsRoute;
+import com.mapbox.geojson.Point;
+import com.mapbox.services.android.navigation.BuildConfig;
 import com.mapbox.services.android.navigation.v5.BaseTest;
+import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigationOptions;
+import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
+import com.mapbox.services.android.navigation.v5.utils.RingBuffer;
+import com.mapbox.turf.TurfConstants;
+import com.mapbox.turf.TurfMeasurement;
 
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
+import java.io.IOException;
+
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertTrue;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, manifest = Config.DEFAULT_MANIFEST_NAME)
 public class OffRouteDetectorTest extends BaseTest {
+
+  private static final String DIRECTIONS_PRECISION_6 = "directions_v5_precision_6.json";
+
+  private OffRoute offRouteDetector;
+  private MapboxNavigationOptions options;
+  private RingBuffer<Integer> distances;
+
+  @Mock
+  Location mockLocation;
+  @Mock
+  RouteProgress mockProgress;
+  @Mock
+  OffRouteCallback mockCallback;
+
+  @Before
+  public void setup() throws Exception {
+    MockitoAnnotations.initMocks(this);
+
+    offRouteDetector = new OffRouteDetector();
+    options = MapboxNavigationOptions.builder().build();
+    distances = new RingBuffer<>(3);
+  }
 
   @Test
   public void sanity() throws Exception {
-    OffRoute offRoute = new OffRouteDetector();
-    assertNotNull(offRoute);
+    assertNotNull(offRouteDetector);
+  }
+
+  @Test
+  public void invalidOffRoute_onFirstLocationUpdate() throws Exception {
+    boolean isUserOffRoute = offRouteDetector.isUserOffRoute(
+      mockLocation, mockProgress, options, distances, mockCallback
+    );
+    assertFalse(isUserOffRoute);
+  }
+
+  @Test
+  public void validOffRoute_onMinimumDistanceBeforeReroutingPassed() throws Exception {
+    Location mapboxOffice = buildDefaultLocationUpdate(-77.0339782574523,38.89993519985637);
+    RouteProgress routeProgress = buildDefaultRouteProgress();
+
+    // First update sets the last re-route location
+    boolean isUserOffRoute = offRouteDetector.isUserOffRoute(
+      mapboxOffice, mockProgress, options, distances, mockCallback
+    );
+    assertFalse(isUserOffRoute);
+
+    // Second update 1 meter greater than minimum distance before re-routing
+    Point target = buildPointAwayFromLocation(mapboxOffice, options.minimumDistanceBeforeRerouting() + 1);
+
+    Location locationOverMinimumDistance = buildDefaultLocationUpdate(target.longitude(), target.latitude());
+    // Location is valid 21 meters away from mapboxOffice location
+    boolean validOffRoute = offRouteDetector.isUserOffRoute(
+      locationOverMinimumDistance, routeProgress, options, distances, mockCallback
+    );
+    assertTrue(validOffRoute);
+  }
+
+  @Test
+  public void isUserOffRoute_AssertTrueWhenTooFarFromStep() throws Exception {
+    RouteProgress routeProgress = buildDefaultRouteProgress();
+    Point stepManeuverPoint = routeProgress.directionsRoute().legs().get(0).steps().get(0).maneuver().location();
+
+    // First update sets the last re-route location
+    Location firstUpdate = buildDefaultLocationUpdate(-77.0339782574523,38.89993519985637);
+    offRouteDetector.isUserOffRoute(firstUpdate, routeProgress, options, distances, mockCallback);
+
+    // Second update is 100 meters away from the step --> off route
+    Point offRoutePoint = buildPointAwayFromPoint(stepManeuverPoint, 100);
+    Location secondUpdate = buildDefaultLocationUpdate(offRoutePoint.longitude(), offRoutePoint.latitude());
+    boolean isUserOffRoute = offRouteDetector.isUserOffRoute(
+      secondUpdate, routeProgress, options, distances, mockCallback
+    );
+    assertTrue(isUserOffRoute);
+  }
+
+  /**
+   * @return {@link Location} with Mapbox DC coordinates
+   */
+  private static Location buildDefaultLocationUpdate(double lng, double lat) {
+    return buildLocationUpdate(lng,lat, 30f, 10f, System.currentTimeMillis());
+  }
+
+  private static Location buildLocationUpdate(double lng, double lat, float speed, float horizontalAccuracy, long time) {
+    Location location = new Location(OffRouteDetectorTest.class.getSimpleName());
+    location.setLongitude(lng);
+    location.setLatitude(lat);
+    location.setSpeed(speed);
+    location.setAccuracy(horizontalAccuracy);
+    location.setTime(time);
+    return location;
+  }
+
+  @NonNull
+  private static Point buildPointAwayFromLocation(Location location, double distanceAway) {
+    Point fromLocation = Point.fromLngLat(
+      location.getLongitude(), location.getLatitude());
+    return TurfMeasurement.destination(fromLocation, distanceAway, 90, TurfConstants.UNIT_METERS);
+  }
+
+  @NonNull
+  private static Point buildPointAwayFromPoint(Point point, double distanceAway) {
+    return TurfMeasurement.destination(point, distanceAway, 90, TurfConstants.UNIT_METERS);
+  }
+
+  private RouteProgress buildDefaultRouteProgress() throws Exception {
+    DirectionsRoute aRoute = buildDirectionsRoute();
+    RouteProgress defaultRouteProgress = RouteProgress.builder()
+      .stepDistanceRemaining(100)
+      .legDistanceRemaining(100)
+      .distanceRemaining(100)
+      .directionsRoute(aRoute)
+      .stepIndex(0)
+      .legIndex(0)
+      .build();
+
+    return defaultRouteProgress;
+  }
+
+  private DirectionsRoute buildDirectionsRoute() throws IOException {
+    Gson gson = new GsonBuilder()
+      .registerTypeAdapterFactory(DirectionsAdapterFactory.create()).create();
+    String body = loadJsonFixture(DIRECTIONS_PRECISION_6);
+    DirectionsResponse response = gson.fromJson(body, DirectionsResponse.class);
+    DirectionsRoute aRoute = response.routes().get(0);
+
+    return aRoute;
   }
 }

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteDetectorTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteDetectorTest.java
@@ -8,6 +8,9 @@ import com.google.gson.GsonBuilder;
 import com.mapbox.api.directions.v5.DirectionsAdapterFactory;
 import com.mapbox.api.directions.v5.models.DirectionsResponse;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
+import com.mapbox.api.directions.v5.models.LegStep;
+import com.mapbox.core.constants.Constants;
+import com.mapbox.geojson.LineString;
 import com.mapbox.geojson.Point;
 import com.mapbox.services.android.navigation.BuildConfig;
 import com.mapbox.services.android.navigation.v5.BaseTest;
@@ -26,10 +29,13 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import java.io.IOException;
+import java.util.List;
 
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(constants = BuildConfig.class, manifest = Config.DEFAULT_MANIFEST_NAME)
@@ -101,13 +107,173 @@ public class OffRouteDetectorTest extends BaseTest {
     Location firstUpdate = buildDefaultLocationUpdate(-77.0339782574523,38.89993519985637);
     offRouteDetector.isUserOffRoute(firstUpdate, routeProgress, options, distances, mockCallback);
 
-    // Second update is 100 meters away from the step --> off route
-    Point offRoutePoint = buildPointAwayFromPoint(stepManeuverPoint, 100);
+    // Second update is 100 meters away from the step --> off-route
+    Point offRoutePoint = buildPointAwayFromPoint(stepManeuverPoint, 100, 90);
     Location secondUpdate = buildDefaultLocationUpdate(offRoutePoint.longitude(), offRoutePoint.latitude());
+
     boolean isUserOffRoute = offRouteDetector.isUserOffRoute(
       secondUpdate, routeProgress, options, distances, mockCallback
     );
     assertTrue(isUserOffRoute);
+  }
+
+  @Test
+  public void isUserOffRoute_AssertFalseWhenOnStep() throws Exception {
+    RouteProgress routeProgress = buildDefaultRouteProgress();
+    Point stepManeuverPoint = routeProgress.directionsRoute().legs().get(0).steps().get(0).maneuver().location();
+
+    // First update sets the last re-route location
+    Location firstUpdate = buildDefaultLocationUpdate(-77.0339782574523,38.89993519985637);
+    offRouteDetector.isUserOffRoute(firstUpdate, routeProgress, options, distances, mockCallback);
+
+    // Second update is 10 meters away from the step --> is not off-route
+    Point offRoutePoint = buildPointAwayFromPoint(stepManeuverPoint, 10, 90);
+    Location secondUpdate = buildDefaultLocationUpdate(offRoutePoint.longitude(), offRoutePoint.latitude());
+
+    boolean isUserOffRoute = offRouteDetector.isUserOffRoute(
+      secondUpdate, routeProgress, options, distances, mockCallback
+    );
+    assertFalse(isUserOffRoute);
+  }
+
+  @Test
+  public void isUserOffRoute_AssertFalseWhenWithinRadiusAndStepLocationHasBadAccuracy() throws Exception {
+    RouteProgress routeProgress = buildDefaultRouteProgress();
+    Point stepManeuverPoint = routeProgress.directionsRoute().legs().get(0).steps().get(0).maneuver().location();
+
+    // First update sets the last re-route location
+    Location firstUpdate = buildDefaultLocationUpdate(-77.0339782574523,38.89993519985637);
+    offRouteDetector.isUserOffRoute(firstUpdate, routeProgress, options, distances, mockCallback);
+
+    // Second update is 250m away from the step, but 300m accuracy --> not off-route
+    Point offRoutePoint = buildPointAwayFromPoint(stepManeuverPoint, 250, 90);
+    Location secondUpdate = buildDefaultLocationUpdate(offRoutePoint.longitude(), offRoutePoint.latitude());
+    secondUpdate.setAccuracy(300f);
+
+    boolean isUserOffRoute = offRouteDetector.isUserOffRoute(
+      secondUpdate, routeProgress, options, distances, mockCallback
+    );
+    assertFalse(isUserOffRoute);
+  }
+
+  @Test
+  public void isUserOffRoute_AssertFalseWhenOffRouteButCloseToUpcomingStep() throws Exception {
+    RouteProgress routeProgress = buildDefaultRouteProgress();
+    Point upcomingStepManeuverPoint = routeProgress.currentLegProgress().upComingStep().maneuver().location();
+
+    // First update sets the last re-route location
+    Location firstUpdate = buildDefaultLocationUpdate(-77.0339782574523,38.89993519985637);
+    offRouteDetector.isUserOffRoute(firstUpdate, routeProgress, options, distances, mockCallback);
+
+    // Second update is 30m away from the upcoming step
+    // --> considered off-route of the current step
+    // --> but not actually off-route because close to upcoming step
+    Point offRoutePoint = buildPointAwayFromPoint(upcomingStepManeuverPoint, 30, 180);
+    Location secondUpdate = buildDefaultLocationUpdate(offRoutePoint.longitude(), offRoutePoint.latitude());
+
+    boolean isUserOffRoute = offRouteDetector.isUserOffRoute(
+      secondUpdate, routeProgress, options, distances, mockCallback
+    );
+    assertFalse(isUserOffRoute);
+    // Also verify the callback to increase the step index is called
+    verify(mockCallback, times(1)).onShouldIncreaseIndex();
+  }
+
+  @Test
+  public void isUserOffRoute_AssertTrueWhenOnRouteButMovingAwayFromManeuver() throws Exception {
+    RouteProgress routeProgress = buildDefaultRouteProgress();
+    LegStep currentStep = routeProgress.currentLegProgress().currentStep();
+
+    // Get the lineString and corresponding coordinates from the step geometry
+    LineString lineString = LineString.fromPolyline(currentStep.geometry(), Constants.PRECISION_6);
+    List<Point> coordinates = lineString.coordinates();
+
+    // First update sets the last re-route location
+    Location firstLocationUpdate = buildDefaultLocationUpdate(-77.0339782574523,38.89993519985637);
+    offRouteDetector.isUserOffRoute(firstLocationUpdate, routeProgress, options, distances, mockCallback);
+
+    // Second update is on current step (1) --> not off-route
+    Point lastPointInCurrentStep = coordinates.remove(coordinates.size() - 1);
+    Location secondLocationUpdate = buildDefaultLocationUpdate(
+      lastPointInCurrentStep.longitude(), lastPointInCurrentStep.latitude()
+    );
+    boolean isUserOffRouteFirstTry = offRouteDetector.isUserOffRoute(
+      secondLocationUpdate, routeProgress, options, distances, mockCallback
+    );
+    assertFalse(isUserOffRouteFirstTry);
+
+    // Third update is on current step, moving away from maneuver (2) --> still not off-route
+    Point secondLastPointInCurrentStep = coordinates.remove(coordinates.size() - 1);
+    Location thirdLocationUpdate = buildDefaultLocationUpdate(
+      secondLastPointInCurrentStep.longitude(), secondLastPointInCurrentStep.latitude()
+    );
+    boolean isUserOffRouteSecondTry = offRouteDetector.isUserOffRoute(
+      thirdLocationUpdate, routeProgress, options, distances, mockCallback
+    );
+    assertFalse(isUserOffRouteSecondTry);
+
+    // Fourth update is on current step, moving away from maneuver (3) --> still not off-route
+    Point thirdLastPointInCurrentStep = coordinates.remove(coordinates.size() - 1);
+    Location fourthLocationUpdate = buildDefaultLocationUpdate(
+      thirdLastPointInCurrentStep.longitude(), thirdLastPointInCurrentStep.latitude()
+    );
+    boolean isUserOffRouteThirdTry = offRouteDetector.isUserOffRoute(
+      fourthLocationUpdate, routeProgress, options, distances, mockCallback
+    );
+    assertFalse(isUserOffRouteThirdTry);
+
+    // Fifth update is on current step, but now we have >= 3 updates away from the maneuver --> off-route
+    Point fourthLastPointInCurrentStep = coordinates.remove(coordinates.size() - 1);
+    Location fifthLocationUpdate = buildDefaultLocationUpdate(
+      fourthLastPointInCurrentStep.longitude(), fourthLastPointInCurrentStep.latitude()
+    );
+    boolean isUserOffRouteFourthTry = offRouteDetector.isUserOffRoute(
+      fifthLocationUpdate, routeProgress, options, distances, mockCallback
+    );
+    assertTrue(isUserOffRouteFourthTry);
+  }
+
+  @Test
+  public void isUserOffRoute_AssertFalseTwoUpdatesAwayFromManeuverThenOneTowards() throws Exception {
+    RouteProgress routeProgress = buildDefaultRouteProgress();
+    LegStep currentStep = routeProgress.currentLegProgress().currentStep();
+
+    // Get the lineString and corresponding coordinates from the step geometry
+    LineString lineString = LineString.fromPolyline(currentStep.geometry(), Constants.PRECISION_6);
+    List<Point> coordinates = lineString.coordinates();
+
+    // First update sets the last re-route location
+    Location firstLocationUpdate = buildDefaultLocationUpdate(-77.0339782574523,38.89993519985637);
+    offRouteDetector.isUserOffRoute(firstLocationUpdate, routeProgress, options, distances, mockCallback);
+
+    // Second update is on current step (1) --> not off-route
+    Point lastPointInCurrentStep = coordinates.remove(coordinates.size() - 1);
+    Location secondLocationUpdate = buildDefaultLocationUpdate(
+      lastPointInCurrentStep.longitude(), lastPointInCurrentStep.latitude()
+    );
+    boolean isUserOffRouteFirstTry = offRouteDetector.isUserOffRoute(
+      secondLocationUpdate, routeProgress, options, distances, mockCallback
+    );
+    assertFalse(isUserOffRouteFirstTry);
+
+    // Third update is on current step, moving away from maneuver (2) --> still not off-route
+    Point secondLastPointInCurrentStep = coordinates.remove(coordinates.size() - 1);
+    Location thirdLocationUpdate = buildDefaultLocationUpdate(
+      secondLastPointInCurrentStep.longitude(), secondLastPointInCurrentStep.latitude()
+    );
+    boolean isUserOffRouteSecondTry = offRouteDetector.isUserOffRoute(
+      thirdLocationUpdate, routeProgress, options, distances, mockCallback
+    );
+    assertFalse(isUserOffRouteSecondTry);
+
+    // Fourth update is on current step, moving towards the maneuver, clear the stack --> not off-route
+    Location fourthLocationUpdate = buildDefaultLocationUpdate(
+      lastPointInCurrentStep.longitude(), lastPointInCurrentStep.latitude()
+    );
+    boolean isUserOffRouteThirdTry = offRouteDetector.isUserOffRoute(
+      fourthLocationUpdate, routeProgress, options, distances, mockCallback
+    );
+    assertFalse(isUserOffRouteThirdTry);
   }
 
   /**
@@ -135,8 +301,8 @@ public class OffRouteDetectorTest extends BaseTest {
   }
 
   @NonNull
-  private static Point buildPointAwayFromPoint(Point point, double distanceAway) {
-    return TurfMeasurement.destination(point, distanceAway, 90, TurfConstants.UNIT_METERS);
+  private static Point buildPointAwayFromPoint(Point point, double distanceAway, double bearing) {
+    return TurfMeasurement.destination(point, distanceAway, bearing, TurfConstants.UNIT_METERS);
   }
 
   private RouteProgress buildDefaultRouteProgress() throws Exception {


### PR DESCRIPTION
Closes #603 #578 

Running into three scenarios where off-route events are triggered when the user location is not actually off-route:

###  1st Scenario:
- Increment the step index too quickly --> the step distance remaining, when we increment the step index, is a larger distance than our off-route radius --> off-route event
  - In this scenario, the bearing match check (user bearing vs. maneuver final bearing) we do is true + the `stepDistanceRemaining` is < the `maneuverZoneRadius` (set to 40)
  - We increase the step index by 1 and finishing creating the new `RouteProgress`
  - We then run the off route check on this new `RouteProgress` and what just was the `stepDistanceRemaining` now becomes our distance away from the step.  
    - Depending on our current radius of off-route, this will trigger `offRoute = true` 

### Fix
 - [x] The premature turn completion logic iOS has added should help here https://github.com/mapbox/mapbox-navigation-ios/blob/master/MapboxCoreNavigation/RouteController.swift#L814-L831 
     - We will now check the expected turn angle of the maneuver and if it's less than our threshold of `30`, we will wait for the step distance remaining to be `0` before we increment the step index.

### 2nd Scenario 
 - We don’t advance the step at all --> As we drive away from the step, an off-route is triggered as our distance away from the step increases 
   - The bearing match check (user bearing vs. maneuver final bearing) we do never returns true, so we never increment the step index  
   - This issue seems to be mostly caused by a bug in the directions API, but we should also ensure that our check `isCloseToUpcomingStep` returns true in this case and overrides the fact that the bearings never match.

### Fix
- [x] Ensure that `isCloseToUpcomingStep` returns true when we are off-route of the current step but within the off-route radius of the upcoming step.
     - If this happens, we need to increase the step index or updates will halt while we continue towards the upcoming step  
### 3rd Scenario
- We don't return early if we find that we are on-route at the beginning of our off-route checks.  If the first check doesn't have us exit early, only then should the logic check the following additional conditions:

1. Check to see if the user is moving away from the maneuver. (if yes, off route)
2. Check and see if the user is near a future step. (if yes, on route)
3. If the user is > the reroute threshold of that future step, then off route

- We currently check all of the off-route logic, every time and for on / off-ramps + roundabouts, even though we are considered on-route, this extra logic fires an off-route scenario at time.

### Fix 
- [x] This should be simply rearranging the off-route logic to return early if we find the interpolated location is within the off-route radius 

TODO:
- [x] Complete fixes for all three scenarios
- [x] Fix any other bugs that may result from changing this logic
- [x] Remove logging statements
- [x] Write unit tests to ensure the logic stands

cc @ericrwolfe please add or correct any of these findings / fixes if needed 