### PR TITLE
Locale distance formatter

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationActivity.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationActivity.java
@@ -116,9 +116,6 @@ public class NavigationActivity extends AppCompatActivity implements OnNavigatio
       .getBoolean(NavigationConstants.NAVIGATION_VIEW_SIMULATE_ROUTE, false));
 
     MapboxNavigationOptions navigationOptions = MapboxNavigationOptions.builder()
-      .unitType(preferences.getInt(NavigationConstants.NAVIGATION_VIEW_UNIT_TYPE,
-        NavigationUnitType.TYPE_IMPERIAL))
-      .locale(getResources().getConfiguration().locale)
       .build();
     options.navigationOptions(navigationOptions);
   }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationActivity.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationActivity.java
@@ -10,7 +10,6 @@ import com.mapbox.geojson.Point;
 import com.mapbox.services.android.navigation.ui.v5.listeners.NavigationListener;
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigationOptions;
 import com.mapbox.services.android.navigation.v5.navigation.NavigationConstants;
-import com.mapbox.services.android.navigation.v5.navigation.NavigationUnitType;
 
 import java.util.HashMap;
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationActivity.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationActivity.java
@@ -118,6 +118,7 @@ public class NavigationActivity extends AppCompatActivity implements OnNavigatio
     MapboxNavigationOptions navigationOptions = MapboxNavigationOptions.builder()
       .unitType(preferences.getInt(NavigationConstants.NAVIGATION_VIEW_UNIT_TYPE,
         NavigationUnitType.TYPE_IMPERIAL))
+      .locale(getResources().getConfiguration().locale)
       .build();
     options.navigationOptions(navigationOptions);
   }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
@@ -33,6 +33,7 @@ import com.mapbox.services.android.navigation.v5.offroute.OffRouteListener;
 import com.mapbox.services.android.navigation.v5.route.FasterRouteListener;
 import com.mapbox.services.android.navigation.v5.routeprogress.ProgressChangeListener;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
+import com.mapbox.services.android.navigation.v5.utils.LocaleUtils;
 import com.mapbox.services.android.telemetry.location.LocationEngine;
 
 public class NavigationViewModel extends AndroidViewModel implements ProgressChangeListener,
@@ -214,15 +215,7 @@ public class NavigationViewModel extends AndroidViewModel implements ProgressCha
    * @param options to init MapboxNavigation
    */
   void initializeNavigationOptions(Context context, MapboxNavigationOptions options) {
-    SharedPreferences.Editor editor = preferences.edit();
-
-    editor.putInt(NavigationConstants.NAVIGATION_VIEW_UNIT_TYPE, options.unitType());
-    if (options.locale() != null) {
-      editor.putString(NavigationConstants.NAVIGATION_VIEW_LOCALE_LANGUAGE, options.locale().getLanguage());
-      editor.putString(NavigationConstants.NAVIGATION_VIEW_LOCALE_COUNTRY, options.locale().getCountry());
-    }
-
-    editor.apply();
+    LocaleUtils.setLocale(context, options.locale(), options.unitType());
 
     initNavigation(context, options);
   }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
@@ -45,6 +45,7 @@ public class NavigationViewModel extends AndroidViewModel implements ProgressCha
   public final MutableLiveData<SummaryModel> summaryModel = new MutableLiveData<>();
   public final MutableLiveData<Boolean> isOffRoute = new MutableLiveData<>();
   public final MutableLiveData<Boolean> isFeedbackShowing = new MutableLiveData<>();
+
   final MutableLiveData<FeedbackItem> selectedFeedbackItem = new MutableLiveData<>();
   final MutableLiveData<Location> navigationLocation = new MutableLiveData<>();
   final MutableLiveData<DirectionsRoute> fasterRoute = new MutableLiveData<>();
@@ -52,14 +53,14 @@ public class NavigationViewModel extends AndroidViewModel implements ProgressCha
   final MutableLiveData<Boolean> isRunning = new MutableLiveData<>();
   final MutableLiveData<Boolean> shouldRecordScreenshot = new MutableLiveData<>();
 
+  private final SharedPreferences preferences;
+  private final Locale locale;
   private MapboxNavigation navigation;
   private NavigationInstructionPlayer instructionPlayer;
   private ConnectivityManager connectivityManager;
-  private SharedPreferences preferences;
   private int unitType;
   private String feedbackId;
   private String screenshot;
-  private Locale locale;
 
   public NavigationViewModel(Application application) {
     super(application);

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
@@ -86,8 +86,8 @@ public class NavigationViewModel extends AndroidViewModel implements ProgressCha
    */
   @Override
   public void onProgressChange(Location location, RouteProgress routeProgress) {
-    instructionModel.setValue(new InstructionModel(routeProgress, locale, unitType));
-    summaryModel.setValue(new SummaryModel(routeProgress, locale, unitType));
+    instructionModel.setValue(new InstructionModel(getApplication(), routeProgress, locale, unitType));
+    summaryModel.setValue(new SummaryModel(getApplication(), routeProgress, locale, unitType));
     navigationLocation.setValue(location);
   }
 
@@ -324,7 +324,7 @@ public class NavigationViewModel extends AndroidViewModel implements ProgressCha
 
   private void updateBannerInstruction(RouteProgress routeProgress, Milestone milestone) {
     if (milestone instanceof BannerInstructionMilestone) {
-      bannerInstructionModel.setValue(new BannerInstructionModel((BannerInstructionMilestone) milestone,
+      bannerInstructionModel.setValue(new BannerInstructionModel(getApplication(), (BannerInstructionMilestone) milestone,
         routeProgress, locale, unitType));
     }
   }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
@@ -35,7 +35,7 @@ import com.mapbox.services.android.navigation.v5.routeprogress.ProgressChangeLis
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 import com.mapbox.services.android.telemetry.location.LocationEngine;
 
-import java.text.DecimalFormat;
+import java.util.Locale;
 
 public class NavigationViewModel extends AndroidViewModel implements ProgressChangeListener,
   OffRouteListener, MilestoneEventListener, NavigationEventListener, FasterRouteListener {
@@ -56,17 +56,17 @@ public class NavigationViewModel extends AndroidViewModel implements ProgressCha
   private NavigationInstructionPlayer instructionPlayer;
   private ConnectivityManager connectivityManager;
   private SharedPreferences preferences;
-  private DecimalFormat decimalFormat;
   private int unitType;
   private String feedbackId;
   private String screenshot;
+  private Locale locale;
 
   public NavigationViewModel(Application application) {
     super(application);
     preferences = PreferenceManager.getDefaultSharedPreferences(application);
+    locale = application.getResources().getConfiguration().locale;
     initVoiceInstructions(application);
     initConnectivityManager(application);
-    initDecimalFormat();
   }
 
   public void onDestroy() {
@@ -86,8 +86,8 @@ public class NavigationViewModel extends AndroidViewModel implements ProgressCha
    */
   @Override
   public void onProgressChange(Location location, RouteProgress routeProgress) {
-    instructionModel.setValue(new InstructionModel(routeProgress, decimalFormat, unitType));
-    summaryModel.setValue(new SummaryModel(routeProgress, decimalFormat, unitType));
+    instructionModel.setValue(new InstructionModel(routeProgress, locale, unitType));
+    summaryModel.setValue(new SummaryModel(routeProgress, locale, unitType));
     navigationLocation.setValue(location);
   }
 
@@ -263,14 +263,6 @@ public class NavigationViewModel extends AndroidViewModel implements ProgressCha
   }
 
   /**
-   * Initializes decimal format to be used to populate views with
-   * distance remaining.
-   */
-  private void initDecimalFormat() {
-    decimalFormat = new DecimalFormat(NavigationConstants.DECIMAL_FORMAT);
-  }
-
-  /**
    * Adds this class as a listener for progress,
    * milestones, and off route events.
    */
@@ -333,7 +325,7 @@ public class NavigationViewModel extends AndroidViewModel implements ProgressCha
   private void updateBannerInstruction(RouteProgress routeProgress, Milestone milestone) {
     if (milestone instanceof BannerInstructionMilestone) {
       bannerInstructionModel.setValue(new BannerInstructionModel((BannerInstructionMilestone) milestone,
-        routeProgress, decimalFormat, unitType));
+        routeProgress, locale, unitType));
     }
   }
 }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
@@ -45,7 +45,6 @@ public class NavigationViewModel extends AndroidViewModel implements ProgressCha
   public final MutableLiveData<SummaryModel> summaryModel = new MutableLiveData<>();
   public final MutableLiveData<Boolean> isOffRoute = new MutableLiveData<>();
   public final MutableLiveData<Boolean> isFeedbackShowing = new MutableLiveData<>();
-
   final MutableLiveData<FeedbackItem> selectedFeedbackItem = new MutableLiveData<>();
   final MutableLiveData<Location> navigationLocation = new MutableLiveData<>();
   final MutableLiveData<DirectionsRoute> fasterRoute = new MutableLiveData<>();

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewOptions.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewOptions.java
@@ -14,8 +14,6 @@ import com.mapbox.services.android.navigation.v5.milestone.MilestoneEventListene
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigationOptions;
 import com.mapbox.services.android.navigation.v5.routeprogress.ProgressChangeListener;
 
-import java.util.Locale;
-
 @AutoValue
 public abstract class NavigationViewOptions {
 
@@ -24,9 +22,6 @@ public abstract class NavigationViewOptions {
 
   @Nullable
   public abstract String directionsProfile();
-
-  @Nullable
-  public abstract Locale directionsLanguage();
 
   @Nullable
   public abstract Point origin();
@@ -71,8 +66,6 @@ public abstract class NavigationViewOptions {
     public abstract Builder directionsRoute(DirectionsRoute directionsRoute);
 
     public abstract Builder directionsProfile(@DirectionsCriteria.ProfileCriteria String directionsProfile);
-
-    public abstract Builder directionsLanguage(Locale directionsLanguage);
 
     public abstract Builder origin(Point origin);
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/BannerInstructionModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/BannerInstructionModel.java
@@ -1,5 +1,7 @@
 package com.mapbox.services.android.navigation.ui.v5.instruction;
 
+import android.content.Context;
+
 import com.mapbox.api.directions.v5.models.BannerText;
 import com.mapbox.services.android.navigation.v5.milestone.BannerInstructionMilestone;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
@@ -10,9 +12,9 @@ public class BannerInstructionModel extends InstructionModel {
 
   private BannerInstructionMilestone milestone;
 
-  public BannerInstructionModel(BannerInstructionMilestone milestone, RouteProgress progress,
+  public BannerInstructionModel(Context context, BannerInstructionMilestone milestone, RouteProgress progress,
                                 Locale locale, int unitType) {
-    super(progress, locale, unitType);
+    super(context, progress, locale, unitType);
     this.milestone = milestone;
   }
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/BannerInstructionModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/BannerInstructionModel.java
@@ -6,15 +6,12 @@ import com.mapbox.api.directions.v5.models.BannerText;
 import com.mapbox.services.android.navigation.v5.milestone.BannerInstructionMilestone;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 
-import java.util.Locale;
-
 public class BannerInstructionModel extends InstructionModel {
 
   private BannerInstructionMilestone milestone;
 
-  public BannerInstructionModel(Context context, BannerInstructionMilestone milestone, RouteProgress progress,
-                                Locale locale, int unitType) {
-    super(context, progress, locale, unitType);
+  public BannerInstructionModel(Context context, BannerInstructionMilestone milestone, RouteProgress progress) {
+    super(context, progress);
     this.milestone = milestone;
   }
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/BannerInstructionModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/BannerInstructionModel.java
@@ -4,15 +4,15 @@ import com.mapbox.api.directions.v5.models.BannerText;
 import com.mapbox.services.android.navigation.v5.milestone.BannerInstructionMilestone;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 
-import java.text.DecimalFormat;
+import java.util.Locale;
 
 public class BannerInstructionModel extends InstructionModel {
 
   private BannerInstructionMilestone milestone;
 
   public BannerInstructionModel(BannerInstructionMilestone milestone, RouteProgress progress,
-                                DecimalFormat decimalFormat, int unitType) {
-    super(progress, decimalFormat, unitType);
+                                Locale locale, int unitType) {
+    super(progress, locale, unitType);
     this.milestone = milestone;
   }
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionModel.java
@@ -1,5 +1,7 @@
 package com.mapbox.services.android.navigation.ui.v5.instruction;
 
+import android.content.Context;
+
 import com.mapbox.api.directions.v5.models.BannerInstructions;
 import com.mapbox.api.directions.v5.models.BannerText;
 import com.mapbox.services.android.navigation.v5.navigation.NavigationUnitType;
@@ -17,11 +19,11 @@ public class InstructionModel {
   private RouteProgress progress;
   private int unitType;
 
-  public InstructionModel(RouteProgress progress, Locale locale,
+  public InstructionModel(Context context, RouteProgress progress, Locale locale,
                           @NavigationUnitType.UnitType int unitType) {
     this.progress = progress;
     this.unitType = unitType;
-    buildInstructionModel(progress, locale);
+    buildInstructionModel(context, progress, locale);
   }
 
   BannerText getPrimaryBannerText() {
@@ -48,8 +50,8 @@ public class InstructionModel {
     return unitType;
   }
 
-  private void buildInstructionModel(RouteProgress progress, Locale locale) {
-    stepResources = new InstructionStepResources(progress, locale, unitType);
+  private void buildInstructionModel(Context context, RouteProgress progress, Locale locale) {
+    stepResources = new InstructionStepResources(context, progress, locale, unitType);
     extractStepInstructions(progress);
   }
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionModel.java
@@ -5,8 +5,8 @@ import com.mapbox.api.directions.v5.models.BannerText;
 import com.mapbox.services.android.navigation.v5.navigation.NavigationUnitType;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 
-import java.text.DecimalFormat;
 import java.util.List;
+import java.util.Locale;
 
 public class InstructionModel {
 
@@ -17,11 +17,11 @@ public class InstructionModel {
   private RouteProgress progress;
   private int unitType;
 
-  public InstructionModel(RouteProgress progress, DecimalFormat decimalFormat,
+  public InstructionModel(RouteProgress progress, Locale locale,
                           @NavigationUnitType.UnitType int unitType) {
     this.progress = progress;
     this.unitType = unitType;
-    buildInstructionModel(progress, decimalFormat, unitType);
+    buildInstructionModel(progress, locale);
   }
 
   BannerText getPrimaryBannerText() {
@@ -48,8 +48,8 @@ public class InstructionModel {
     return unitType;
   }
 
-  private void buildInstructionModel(RouteProgress progress, DecimalFormat decimalFormat, int unitType) {
-    stepResources = new InstructionStepResources(progress, decimalFormat, unitType);
+  private void buildInstructionModel(RouteProgress progress, Locale locale) {
+    stepResources = new InstructionStepResources(progress, locale, unitType);
     extractStepInstructions(progress);
   }
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionModel.java
@@ -4,11 +4,9 @@ import android.content.Context;
 
 import com.mapbox.api.directions.v5.models.BannerInstructions;
 import com.mapbox.api.directions.v5.models.BannerText;
-import com.mapbox.services.android.navigation.v5.navigation.NavigationUnitType;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 
 import java.util.List;
-import java.util.Locale;
 
 public class InstructionModel {
 
@@ -17,13 +15,10 @@ public class InstructionModel {
   private BannerText thenBannerText;
   private InstructionStepResources stepResources;
   private RouteProgress progress;
-  private int unitType;
 
-  public InstructionModel(Context context, RouteProgress progress, Locale locale,
-                          @NavigationUnitType.UnitType int unitType) {
+  public InstructionModel(Context context, RouteProgress progress) {
     this.progress = progress;
-    this.unitType = unitType;
-    buildInstructionModel(context, progress, locale);
+    buildInstructionModel(context, progress);
   }
 
   BannerText getPrimaryBannerText() {
@@ -46,12 +41,8 @@ public class InstructionModel {
     return progress;
   }
 
-  int getUnitType() {
-    return unitType;
-  }
-
-  private void buildInstructionModel(Context context, RouteProgress progress, Locale locale) {
-    stepResources = new InstructionStepResources(context, progress, locale, unitType);
+  private void buildInstructionModel(Context context, RouteProgress progress) {
+    stepResources = new InstructionStepResources(context, progress);
     extractStepInstructions(progress);
   }
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionStepResources.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionStepResources.java
@@ -1,5 +1,6 @@
 package com.mapbox.services.android.navigation.ui.v5.instruction;
 
+import android.content.Context;
 import android.text.SpannableString;
 
 import com.mapbox.api.directions.v5.models.IntersectionLanes;
@@ -21,8 +22,8 @@ class InstructionStepResources {
   private boolean shouldShowThenStep;
   private List<IntersectionLanes> turnLanes;
 
-  InstructionStepResources(RouteProgress progress, Locale locale, int unitType) {
-    formatStepDistance(progress, locale, unitType);
+  InstructionStepResources(Context context, RouteProgress progress, Locale locale, int unitType) {
+    formatStepDistance(context, progress, locale, unitType);
     extractStepResources(progress);
   }
 
@@ -79,9 +80,9 @@ class InstructionStepResources {
     }
   }
 
-  private void formatStepDistance(RouteProgress progress, Locale locale, int unitType) {
-    stepDistanceRemaining = DistanceUtils.formatDistance(progress.currentLegProgress()
-      .currentStepProgress().distanceRemaining(), locale, unitType);
+  private void formatStepDistance(Context context, RouteProgress progress, Locale locale, int unitType) {
+    stepDistanceRemaining = new DistanceUtils(context, locale, unitType)
+      .formatDistance(progress.currentLegProgress().currentStepProgress().distanceRemaining());
   }
 
   private void intersectionTurnLanes(LegStep step) {

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionStepResources.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionStepResources.java
@@ -1,6 +1,6 @@
 package com.mapbox.services.android.navigation.ui.v5.instruction;
 
-import android.text.SpannableStringBuilder;
+import android.text.SpannableString;
 
 import com.mapbox.api.directions.v5.models.IntersectionLanes;
 import com.mapbox.api.directions.v5.models.LegStep;
@@ -13,7 +13,7 @@ import java.util.List;
 
 class InstructionStepResources {
 
-  private SpannableStringBuilder stepDistanceRemaining;
+  private SpannableString stepDistanceRemaining;
   private String maneuverViewModifier;
   private String maneuverViewType;
   private String thenStepManeuverModifier;
@@ -26,7 +26,7 @@ class InstructionStepResources {
     extractStepResources(progress);
   }
 
-  SpannableStringBuilder getStepDistanceRemaining() {
+  SpannableString getStepDistanceRemaining() {
     return stepDistanceRemaining;
   }
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionStepResources.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionStepResources.java
@@ -80,7 +80,7 @@ class InstructionStepResources {
   }
 
   private void formatStepDistance(RouteProgress progress, DecimalFormat decimalFormat, int unitType) {
-    stepDistanceRemaining = DistanceUtils.distanceFormatter(progress.currentLegProgress()
+    stepDistanceRemaining = DistanceUtils.formatDistance(progress.currentLegProgress()
       .currentStepProgress().distanceRemaining(), decimalFormat, true, unitType);
   }
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionStepResources.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionStepResources.java
@@ -8,8 +8,8 @@ import com.mapbox.api.directions.v5.models.StepIntersection;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 import com.mapbox.services.android.navigation.v5.utils.DistanceUtils;
 
-import java.text.DecimalFormat;
 import java.util.List;
+import java.util.Locale;
 
 class InstructionStepResources {
 
@@ -21,8 +21,8 @@ class InstructionStepResources {
   private boolean shouldShowThenStep;
   private List<IntersectionLanes> turnLanes;
 
-  InstructionStepResources(RouteProgress progress, DecimalFormat decimalFormat, int unitType) {
-    formatStepDistance(progress, decimalFormat, unitType);
+  InstructionStepResources(RouteProgress progress, Locale locale, int unitType) {
+    formatStepDistance(progress, locale, unitType);
     extractStepResources(progress);
   }
 
@@ -79,9 +79,9 @@ class InstructionStepResources {
     }
   }
 
-  private void formatStepDistance(RouteProgress progress, DecimalFormat decimalFormat, int unitType) {
+  private void formatStepDistance(RouteProgress progress, Locale locale, int unitType) {
     stepDistanceRemaining = DistanceUtils.formatDistance(progress.currentLegProgress()
-      .currentStepProgress().distanceRemaining(), decimalFormat, true, unitType);
+      .currentStepProgress().distanceRemaining(), locale, unitType);
   }
 
   private void intersectionTurnLanes(LegStep step) {

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionStepResources.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionStepResources.java
@@ -10,7 +10,6 @@ import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 import com.mapbox.services.android.navigation.v5.utils.DistanceUtils;
 
 import java.util.List;
-import java.util.Locale;
 
 class InstructionStepResources {
 
@@ -22,8 +21,8 @@ class InstructionStepResources {
   private boolean shouldShowThenStep;
   private List<IntersectionLanes> turnLanes;
 
-  InstructionStepResources(Context context, RouteProgress progress, Locale locale, int unitType) {
-    formatStepDistance(context, progress, locale, unitType);
+  InstructionStepResources(Context context, RouteProgress progress) {
+    formatStepDistance(context, progress);
     extractStepResources(progress);
   }
 
@@ -80,8 +79,8 @@ class InstructionStepResources {
     }
   }
 
-  private void formatStepDistance(Context context, RouteProgress progress, Locale locale, int unitType) {
-    stepDistanceRemaining = new DistanceUtils(context, locale, unitType)
+  private void formatStepDistance(Context context, RouteProgress progress) {
+    stepDistanceRemaining = new DistanceUtils(context)
       .formatDistance(progress.currentLegProgress().currentStepProgress().distanceRemaining());
   }
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionView.java
@@ -198,7 +198,7 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
   @SuppressWarnings("UnusedDeclaration")
   public void update(RouteProgress routeProgress, @NavigationUnitType.UnitType int unitType) {
     if (routeProgress != null && !isRerouting) {
-      InstructionModel model = new InstructionModel(routeProgress, locale, unitType);
+      InstructionModel model = new InstructionModel(getContext(), routeProgress, locale, unitType);
       updateViews(model);
       updateTextInstruction(model);
     }
@@ -487,7 +487,7 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
    * Sets up the {@link RecyclerView} that is used to display the list of instructions.
    */
   private void initDirectionsRecyclerView() {
-    instructionListAdapter = new InstructionListAdapter(locale);
+    instructionListAdapter = new InstructionListAdapter(getContext(), locale);
     rvInstructions.setAdapter(instructionListAdapter);
     rvInstructions.setHasFixedSize(true);
     rvInstructions.setNestedScrollingEnabled(true);

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionView.java
@@ -51,7 +51,7 @@ import com.mapbox.services.android.navigation.v5.offroute.OffRouteListener;
 import com.mapbox.services.android.navigation.v5.routeprogress.ProgressChangeListener;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 
-import java.text.DecimalFormat;
+import java.util.Locale;
 
 /**
  * A view that can be used to display upcoming maneuver information and control
@@ -93,10 +93,10 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
   private Animation rerouteSlideUpTop;
   private Animation rerouteSlideDownTop;
   private AnimationSet fadeInSlowOut;
-  private DecimalFormat decimalFormat;
   private LegStep currentStep;
   private NavigationViewModel navigationViewModel;
   private boolean isRerouting;
+  private Locale locale;
 
   public InstructionView(Context context) {
     this(context, null);
@@ -108,6 +108,7 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
 
   public InstructionView(Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
     super(context, attrs, defStyleAttr);
+    locale = context.getResources().getConfiguration().locale;
     init();
   }
 
@@ -124,7 +125,6 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
     initBackground();
     initTurnLaneRecyclerView();
     initDirectionsRecyclerView();
-    initDecimalFormat();
     initAnimations();
   }
 
@@ -198,7 +198,7 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
   @SuppressWarnings("UnusedDeclaration")
   public void update(RouteProgress routeProgress, @NavigationUnitType.UnitType int unitType) {
     if (routeProgress != null && !isRerouting) {
-      InstructionModel model = new InstructionModel(routeProgress, decimalFormat, unitType);
+      InstructionModel model = new InstructionModel(routeProgress, locale, unitType);
       updateViews(model);
       updateTextInstruction(model);
     }
@@ -487,20 +487,12 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
    * Sets up the {@link RecyclerView} that is used to display the list of instructions.
    */
   private void initDirectionsRecyclerView() {
-    instructionListAdapter = new InstructionListAdapter();
+    instructionListAdapter = new InstructionListAdapter(locale);
     rvInstructions.setAdapter(instructionListAdapter);
     rvInstructions.setHasFixedSize(true);
     rvInstructions.setNestedScrollingEnabled(true);
     rvInstructions.setItemAnimator(new DefaultItemAnimator());
     rvInstructions.setLayoutManager(new LinearLayoutManager(getContext()));
-  }
-
-  /**
-   * Initializes decimal format to be used to populate views with
-   * distance remaining.
-   */
-  private void initDecimalFormat() {
-    decimalFormat = new DecimalFormat(NavigationConstants.DECIMAL_FORMAT);
   }
 
   /**

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionView.java
@@ -50,8 +50,6 @@ import com.mapbox.services.android.navigation.v5.offroute.OffRouteListener;
 import com.mapbox.services.android.navigation.v5.routeprogress.ProgressChangeListener;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 
-import java.util.Locale;
-
 /**
  * A view that can be used to display upcoming maneuver information and control
  * voice instruction mute / unmute.
@@ -69,7 +67,6 @@ import java.util.Locale;
 public class InstructionView extends RelativeLayout implements FeedbackBottomSheetListener {
 
   public boolean isMuted;
-  private final Locale locale;
   private ManeuverView upcomingManeuverView;
   private TextView upcomingDistanceText;
   private TextView upcomingPrimaryText;
@@ -107,7 +104,6 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
 
   public InstructionView(Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
     super(context, attrs, defStyleAttr);
-    locale = context.getResources().getConfiguration().locale;
     init();
   }
 
@@ -485,7 +481,7 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
    * Sets up the {@link RecyclerView} that is used to display the list of instructions.
    */
   private void initDirectionsRecyclerView() {
-    instructionListAdapter = new InstructionListAdapter(getContext(), locale);
+    instructionListAdapter = new InstructionListAdapter(getContext());
     rvInstructions.setAdapter(instructionListAdapter);
     rvInstructions.setHasFixedSize(true);
     rvInstructions.setNestedScrollingEnabled(true);

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionView.java
@@ -70,6 +70,7 @@ import java.util.Locale;
 public class InstructionView extends RelativeLayout implements FeedbackBottomSheetListener {
 
   public boolean isMuted;
+  private final Locale locale;
   private ManeuverView upcomingManeuverView;
   private TextView upcomingDistanceText;
   private TextView upcomingPrimaryText;
@@ -96,7 +97,6 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
   private LegStep currentStep;
   private NavigationViewModel navigationViewModel;
   private boolean isRerouting;
-  private Locale locale;
 
   public InstructionView(Context context) {
     this(context, null);

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionView.java
@@ -45,7 +45,6 @@ import com.mapbox.services.android.navigation.ui.v5.instruction.maneuver.Maneuve
 import com.mapbox.services.android.navigation.ui.v5.instruction.turnlane.TurnLaneAdapter;
 import com.mapbox.services.android.navigation.ui.v5.summary.list.InstructionListAdapter;
 import com.mapbox.services.android.navigation.v5.navigation.NavigationConstants;
-import com.mapbox.services.android.navigation.v5.navigation.NavigationUnitType;
 import com.mapbox.services.android.navigation.v5.navigation.metrics.FeedbackEvent;
 import com.mapbox.services.android.navigation.v5.offroute.OffRouteListener;
 import com.mapbox.services.android.navigation.v5.routeprogress.ProgressChangeListener;
@@ -192,13 +191,12 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
    * uses it to update the views.
    *
    * @param routeProgress used to provide navigation / routeProgress data
-   * @param unitType      either imperial or metric
    * @since 0.6.2
    */
   @SuppressWarnings("UnusedDeclaration")
-  public void update(RouteProgress routeProgress, @NavigationUnitType.UnitType int unitType) {
+  public void update(RouteProgress routeProgress) {
     if (routeProgress != null && !isRerouting) {
-      InstructionModel model = new InstructionModel(getContext(), routeProgress, locale, unitType);
+      InstructionModel model = new InstructionModel(getContext(), routeProgress);
       updateViews(model);
       updateTextInstruction(model);
     }
@@ -784,6 +782,6 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
    * @param model to provide the current steps and unit type
    */
   private void updateInstructionList(InstructionModel model) {
-    instructionListAdapter.updateSteps(model.getProgress(), model.getUnitType());
+    instructionListAdapter.updateSteps(model.getProgress());
   }
 }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/RouteViewModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/RouteViewModel.java
@@ -204,8 +204,8 @@ public class RouteViewModel extends AndroidViewModel implements Callback<Directi
    * @param route   as backup if view options language not found
    */
   private void cacheRouteLanguage(NavigationViewOptions options, DirectionsRoute route) {
-    if (options.directionsLanguage() != null) {
-      language = options.directionsLanguage();
+    if (options.navigationOptions().locale() != null) {
+      language = options.navigationOptions().locale();
     } else if (!TextUtils.isEmpty(route.routeOptions().language())) {
       language = new Locale(route.routeOptions().language());
     } else {

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/SummaryBottomSheet.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/SummaryBottomSheet.java
@@ -73,7 +73,7 @@ public class SummaryBottomSheet extends FrameLayout {
         if (summaryModel != null && !isRerouting) {
           arrivalTimeText.setText(summaryModel.getArrivalTime());
           timeRemainingText.setText(summaryModel.getTimeRemaining());
-          distanceRemainingText.setText(summaryModel.getDistanceRemaining());
+          distanceRemainingText.setText(summaryModel.getDistanceRemaining().toString());
         }
       }
     });

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/SummaryBottomSheet.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/SummaryBottomSheet.java
@@ -13,12 +13,10 @@ import android.widget.TextView;
 
 import com.mapbox.services.android.navigation.ui.v5.NavigationViewModel;
 import com.mapbox.services.android.navigation.ui.v5.R;
-import com.mapbox.services.android.navigation.v5.navigation.NavigationUnitType;
 import com.mapbox.services.android.navigation.v5.routeprogress.ProgressChangeListener;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 
 import java.text.DecimalFormat;
-import java.util.Locale;
 
 /**
  * A view with {@link android.support.design.widget.BottomSheetBehavior}
@@ -32,7 +30,6 @@ import java.util.Locale;
 public class SummaryBottomSheet extends FrameLayout {
 
   private static final String EMPTY_STRING = "";
-  private final Locale locale;
   private TextView distanceRemainingText;
   private TextView timeRemainingText;
   private TextView arrivalTimeText;
@@ -49,7 +46,6 @@ public class SummaryBottomSheet extends FrameLayout {
 
   public SummaryBottomSheet(Context context, AttributeSet attrs, int defStyleAttr) {
     super(context, attrs, defStyleAttr);
-    locale = context.getResources().getConfiguration().locale;
     init();
   }
 
@@ -95,13 +91,12 @@ public class SummaryBottomSheet extends FrameLayout {
    * uses it to update the views.
    *
    * @param routeProgress used to provide navigation / routeProgress data
-   * @param unitType      either imperial or metric
    * @since 0.6.2
    */
   @SuppressWarnings("UnusedDeclaration")
-  public void update(RouteProgress routeProgress, @NavigationUnitType.UnitType int unitType) {
+  public void update(RouteProgress routeProgress) {
     if (routeProgress != null && !isRerouting) {
-      SummaryModel model = new SummaryModel(getContext(), routeProgress, locale, unitType);
+      SummaryModel model = new SummaryModel(getContext(), routeProgress);
       arrivalTimeText.setText(model.getArrivalTime());
       timeRemainingText.setText(model.getTimeRemaining());
       distanceRemainingText.setText(model.getDistanceRemaining());

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/SummaryBottomSheet.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/SummaryBottomSheet.java
@@ -13,12 +13,12 @@ import android.widget.TextView;
 
 import com.mapbox.services.android.navigation.ui.v5.NavigationViewModel;
 import com.mapbox.services.android.navigation.ui.v5.R;
-import com.mapbox.services.android.navigation.v5.navigation.NavigationConstants;
 import com.mapbox.services.android.navigation.v5.navigation.NavigationUnitType;
 import com.mapbox.services.android.navigation.v5.routeprogress.ProgressChangeListener;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 
 import java.text.DecimalFormat;
+import java.util.Locale;
 
 /**
  * A view with {@link android.support.design.widget.BottomSheetBehavior}
@@ -37,8 +37,8 @@ public class SummaryBottomSheet extends FrameLayout {
   private TextView timeRemainingText;
   private TextView arrivalTimeText;
   private ProgressBar rerouteProgressBar;
+  private final Locale locale;
 
-  private DecimalFormat decimalFormat;
   private boolean isRerouting;
 
   public SummaryBottomSheet(Context context) {
@@ -51,6 +51,7 @@ public class SummaryBottomSheet extends FrameLayout {
 
   public SummaryBottomSheet(Context context, AttributeSet attrs, int defStyleAttr) {
     super(context, attrs, defStyleAttr);
+    locale = context.getResources().getConfiguration().locale;
     init();
   }
 
@@ -63,7 +64,6 @@ public class SummaryBottomSheet extends FrameLayout {
   protected void onFinishInflate() {
     super.onFinishInflate();
     bind();
-    initDecimalFormat();
   }
 
   public void subscribe(NavigationViewModel navigationViewModel) {
@@ -103,7 +103,7 @@ public class SummaryBottomSheet extends FrameLayout {
   @SuppressWarnings("UnusedDeclaration")
   public void update(RouteProgress routeProgress, @NavigationUnitType.UnitType int unitType) {
     if (routeProgress != null && !isRerouting) {
-      SummaryModel model = new SummaryModel(routeProgress, decimalFormat, unitType);
+      SummaryModel model = new SummaryModel(routeProgress, locale, unitType);
       arrivalTimeText.setText(model.getArrivalTime());
       timeRemainingText.setText(model.getTimeRemaining());
       distanceRemainingText.setText(model.getDistanceRemaining());
@@ -147,14 +147,6 @@ public class SummaryBottomSheet extends FrameLayout {
     timeRemainingText = findViewById(R.id.timeRemainingText);
     arrivalTimeText = findViewById(R.id.arrivalTimeText);
     rerouteProgressBar = findViewById(R.id.rerouteProgressBar);
-  }
-
-  /**
-   * Initializes decimal format to be used to populate views with
-   * distance remaining.
-   */
-  private void initDecimalFormat() {
-    decimalFormat = new DecimalFormat(NavigationConstants.DECIMAL_FORMAT);
   }
 
   /**

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/SummaryBottomSheet.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/SummaryBottomSheet.java
@@ -32,13 +32,11 @@ import java.util.Locale;
 public class SummaryBottomSheet extends FrameLayout {
 
   private static final String EMPTY_STRING = "";
-
+  private final Locale locale;
   private TextView distanceRemainingText;
   private TextView timeRemainingText;
   private TextView arrivalTimeText;
   private ProgressBar rerouteProgressBar;
-  private final Locale locale;
-
   private boolean isRerouting;
 
   public SummaryBottomSheet(Context context) {

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/SummaryBottomSheet.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/SummaryBottomSheet.java
@@ -101,7 +101,7 @@ public class SummaryBottomSheet extends FrameLayout {
   @SuppressWarnings("UnusedDeclaration")
   public void update(RouteProgress routeProgress, @NavigationUnitType.UnitType int unitType) {
     if (routeProgress != null && !isRerouting) {
-      SummaryModel model = new SummaryModel(routeProgress, locale, unitType);
+      SummaryModel model = new SummaryModel(getContext(), routeProgress, locale, unitType);
       arrivalTimeText.setText(model.getArrivalTime());
       timeRemainingText.setText(model.getTimeRemaining());
       distanceRemainingText.setText(model.getDistanceRemaining());

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/SummaryBottomSheet.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/SummaryBottomSheet.java
@@ -73,7 +73,7 @@ public class SummaryBottomSheet extends FrameLayout {
         if (summaryModel != null && !isRerouting) {
           arrivalTimeText.setText(summaryModel.getArrivalTime());
           timeRemainingText.setText(summaryModel.getTimeRemaining());
-          distanceRemainingText.setText(summaryModel.getDistanceRemaining().toString());
+          distanceRemainingText.setText(summaryModel.getDistanceRemaining());
         }
       }
     });

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/SummaryModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/SummaryModel.java
@@ -1,6 +1,5 @@
 package com.mapbox.services.android.navigation.ui.v5.summary;
 
-import android.text.SpannableString;
 import android.text.SpannableStringBuilder;
 
 import com.mapbox.services.android.navigation.v5.navigation.NavigationUnitType;
@@ -14,17 +13,17 @@ import static com.mapbox.services.android.navigation.v5.utils.time.TimeUtils.for
 
 public class SummaryModel {
 
-  private SpannableString distanceRemaining;
+  private String distanceRemaining;
   private SpannableStringBuilder timeRemaining;
   private String arrivalTime;
 
   public SummaryModel(RouteProgress progress, Locale locale, @NavigationUnitType.UnitType int unitType) {
-    distanceRemaining = formatDistance(progress.distanceRemaining(), locale, unitType);
+    distanceRemaining = formatDistance(progress.distanceRemaining(), locale, unitType).toString();
     timeRemaining = formatTimeRemaining(progress.durationRemaining());
     arrivalTime = formatArrivalTime(progress.durationRemaining());
   }
 
-  SpannableString getDistanceRemaining() {
+  String getDistanceRemaining() {
     return distanceRemaining;
   }
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/SummaryModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/SummaryModel.java
@@ -3,11 +3,8 @@ package com.mapbox.services.android.navigation.ui.v5.summary;
 import android.content.Context;
 import android.text.SpannableStringBuilder;
 
-import com.mapbox.services.android.navigation.v5.navigation.NavigationUnitType;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 import com.mapbox.services.android.navigation.v5.utils.DistanceUtils;
-
-import java.util.Locale;
 
 import static com.mapbox.services.android.navigation.v5.utils.time.TimeUtils.formatArrivalTime;
 import static com.mapbox.services.android.navigation.v5.utils.time.TimeUtils.formatTimeRemaining;
@@ -18,8 +15,8 @@ public class SummaryModel {
   private final SpannableStringBuilder timeRemaining;
   private final String arrivalTime;
 
-  public SummaryModel(Context context, RouteProgress progress, Locale locale, @NavigationUnitType.UnitType int unitType) {
-    distanceRemaining = new DistanceUtils(context, locale, unitType)
+  public SummaryModel(Context context, RouteProgress progress) {
+    distanceRemaining = new DistanceUtils(context)
       .formatDistance(progress.distanceRemaining()).toString();
     timeRemaining = formatTimeRemaining(progress.durationRemaining());
     arrivalTime = formatArrivalTime(progress.durationRemaining());

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/SummaryModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/SummaryModel.java
@@ -1,13 +1,14 @@
 package com.mapbox.services.android.navigation.ui.v5.summary;
 
+import android.content.Context;
 import android.text.SpannableStringBuilder;
 
 import com.mapbox.services.android.navigation.v5.navigation.NavigationUnitType;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
+import com.mapbox.services.android.navigation.v5.utils.DistanceUtils;
 
 import java.util.Locale;
 
-import static com.mapbox.services.android.navigation.v5.utils.DistanceUtils.formatDistance;
 import static com.mapbox.services.android.navigation.v5.utils.time.TimeUtils.formatArrivalTime;
 import static com.mapbox.services.android.navigation.v5.utils.time.TimeUtils.formatTimeRemaining;
 
@@ -17,8 +18,9 @@ public class SummaryModel {
   private final SpannableStringBuilder timeRemaining;
   private final String arrivalTime;
 
-  public SummaryModel(RouteProgress progress, Locale locale, @NavigationUnitType.UnitType int unitType) {
-    distanceRemaining = formatDistance(progress.distanceRemaining(), locale, unitType).toString();
+  public SummaryModel(Context context, RouteProgress progress, Locale locale, @NavigationUnitType.UnitType int unitType) {
+    distanceRemaining = new DistanceUtils(context, locale, unitType)
+      .formatDistance(progress.distanceRemaining()).toString();
     timeRemaining = formatTimeRemaining(progress.durationRemaining());
     arrivalTime = formatArrivalTime(progress.durationRemaining());
   }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/SummaryModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/SummaryModel.java
@@ -20,7 +20,7 @@ public class SummaryModel {
   public SummaryModel(RouteProgress progress, DecimalFormat decimalFormat,
                       @NavigationUnitType.UnitType int unitType) {
     distanceRemaining = formatDistance(progress.distanceRemaining(),
-      decimalFormat, false, unitType);
+      decimalFormat, true, unitType);
     timeRemaining = formatTimeRemaining(progress.durationRemaining());
     arrivalTime = formatArrivalTime(progress.durationRemaining());
   }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/SummaryModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/SummaryModel.java
@@ -13,9 +13,9 @@ import static com.mapbox.services.android.navigation.v5.utils.time.TimeUtils.for
 
 public class SummaryModel {
 
-  private String distanceRemaining;
-  private SpannableStringBuilder timeRemaining;
-  private String arrivalTime;
+  private final String distanceRemaining;
+  private final SpannableStringBuilder timeRemaining;
+  private final String arrivalTime;
 
   public SummaryModel(RouteProgress progress, Locale locale, @NavigationUnitType.UnitType int unitType) {
     distanceRemaining = formatDistance(progress.distanceRemaining(), locale, unitType).toString();

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/SummaryModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/SummaryModel.java
@@ -7,7 +7,7 @@ import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 
 import java.text.DecimalFormat;
 
-import static com.mapbox.services.android.navigation.v5.utils.DistanceUtils.distanceFormatter;
+import static com.mapbox.services.android.navigation.v5.utils.DistanceUtils.formatDistance;
 import static com.mapbox.services.android.navigation.v5.utils.time.TimeUtils.formatArrivalTime;
 import static com.mapbox.services.android.navigation.v5.utils.time.TimeUtils.formatTimeRemaining;
 
@@ -19,7 +19,7 @@ public class SummaryModel {
 
   public SummaryModel(RouteProgress progress, DecimalFormat decimalFormat,
                       @NavigationUnitType.UnitType int unitType) {
-    distanceRemaining = distanceFormatter(progress.distanceRemaining(),
+    distanceRemaining = formatDistance(progress.distanceRemaining(),
       decimalFormat, false, unitType);
     timeRemaining = formatTimeRemaining(progress.durationRemaining());
     arrivalTime = formatArrivalTime(progress.durationRemaining());

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/SummaryModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/SummaryModel.java
@@ -6,7 +6,7 @@ import android.text.SpannableStringBuilder;
 import com.mapbox.services.android.navigation.v5.navigation.NavigationUnitType;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 
-import java.text.DecimalFormat;
+import java.util.Locale;
 
 import static com.mapbox.services.android.navigation.v5.utils.DistanceUtils.formatDistance;
 import static com.mapbox.services.android.navigation.v5.utils.time.TimeUtils.formatArrivalTime;
@@ -18,10 +18,8 @@ public class SummaryModel {
   private SpannableStringBuilder timeRemaining;
   private String arrivalTime;
 
-  public SummaryModel(RouteProgress progress, DecimalFormat decimalFormat,
-                      @NavigationUnitType.UnitType int unitType) {
-    distanceRemaining = formatDistance(progress.distanceRemaining(),
-      decimalFormat, true, unitType);
+  public SummaryModel(RouteProgress progress, Locale locale, @NavigationUnitType.UnitType int unitType) {
+    distanceRemaining = formatDistance(progress.distanceRemaining(), locale, unitType);
     timeRemaining = formatTimeRemaining(progress.durationRemaining());
     arrivalTime = formatArrivalTime(progress.durationRemaining());
   }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/SummaryModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/SummaryModel.java
@@ -1,5 +1,6 @@
 package com.mapbox.services.android.navigation.ui.v5.summary;
 
+import android.text.SpannableString;
 import android.text.SpannableStringBuilder;
 
 import com.mapbox.services.android.navigation.v5.navigation.NavigationUnitType;
@@ -13,7 +14,7 @@ import static com.mapbox.services.android.navigation.v5.utils.time.TimeUtils.for
 
 public class SummaryModel {
 
-  private SpannableStringBuilder distanceRemaining;
+  private SpannableString distanceRemaining;
   private SpannableStringBuilder timeRemaining;
   private String arrivalTime;
 
@@ -25,7 +26,7 @@ public class SummaryModel {
     arrivalTime = formatArrivalTime(progress.durationRemaining());
   }
 
-  SpannableStringBuilder getDistanceRemaining() {
+  SpannableString getDistanceRemaining() {
     return distanceRemaining;
   }
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/list/InstructionListAdapter.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/list/InstructionListAdapter.java
@@ -1,5 +1,6 @@
 package com.mapbox.services.android.navigation.ui.v5.summary.list;
 
+import android.content.Context;
 import android.content.res.Configuration;
 import android.support.constraint.ConstraintLayout;
 import android.support.v7.widget.RecyclerView;
@@ -23,14 +24,17 @@ import java.util.Locale;
 
 public class InstructionListAdapter extends RecyclerView.Adapter<InstructionViewHolder> {
   private final Locale locale;
+  private final Context context;
   private List<LegStep> stepList;
   private RouteLeg currentLeg;
   private LegStep currentStep;
   private int unitType;
+  private DistanceUtils distanceUtils;
 
-  public InstructionListAdapter(Locale locale) {
+  public InstructionListAdapter(Context context, Locale locale) {
     stepList = new ArrayList<>();
     this.locale = locale;
+    this.context = context;
   }
 
   @Override
@@ -52,7 +56,11 @@ public class InstructionListAdapter extends RecyclerView.Adapter<InstructionView
         updateSecondaryText(holder, null);
       }
       updateManeuverView(holder, step);
-      SpannableString distanceText = DistanceUtils.formatDistance(step.distance(), locale, unitType);
+      if (distanceUtils == null) {
+        distanceUtils = new DistanceUtils(context, locale, unitType);
+      }
+
+      SpannableString distanceText = distanceUtils.formatDistance(step.distance());
       holder.stepDistanceText.setText(distanceText);
     }
   }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/list/InstructionListAdapter.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/list/InstructionListAdapter.java
@@ -31,7 +31,6 @@ public class InstructionListAdapter extends RecyclerView.Adapter<InstructionView
   public InstructionListAdapter(Locale locale) {
     stepList = new ArrayList<>();
     this.locale = locale;
-
   }
 
   @Override

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/list/InstructionListAdapter.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/list/InstructionListAdapter.java
@@ -17,23 +17,21 @@ import com.mapbox.services.android.navigation.v5.navigation.NavigationUnitType;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 import com.mapbox.services.android.navigation.v5.utils.DistanceUtils;
 
-import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 public class InstructionListAdapter extends RecyclerView.Adapter<InstructionViewHolder> {
-
+  private final Locale locale;
   private List<LegStep> stepList;
-  private DecimalFormat decimalFormat;
-
   private RouteLeg currentLeg;
   private LegStep currentStep;
-  private LegStep currentUpcomingStep;
   private int unitType;
 
-  public InstructionListAdapter() {
+  public InstructionListAdapter(Locale locale) {
     stepList = new ArrayList<>();
-    decimalFormat = new DecimalFormat(NavigationConstants.DECIMAL_FORMAT);
+    this.locale = locale;
+
   }
 
   @Override
@@ -55,8 +53,7 @@ public class InstructionListAdapter extends RecyclerView.Adapter<InstructionView
         updateSecondaryText(holder, null);
       }
       updateManeuverView(holder, step);
-      SpannableString distanceText = DistanceUtils
-        .formatDistance(step.distance(), decimalFormat, true, unitType);
+      SpannableString distanceText = DistanceUtils.formatDistance(step.distance(), locale, unitType);
       holder.stepDistanceText.setText(distanceText);
     }
   }
@@ -175,7 +172,6 @@ public class InstructionListAdapter extends RecyclerView.Adapter<InstructionView
   private boolean newStep(RouteProgress routeProgress) {
     boolean newStep = currentStep == null || !currentStep.equals(routeProgress.currentLegProgress().currentStep());
     currentStep = routeProgress.currentLegProgress().currentStep();
-    currentUpcomingStep = routeProgress.currentLegProgress().upComingStep();
     return newStep;
   }
 }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/list/InstructionListAdapter.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/list/InstructionListAdapter.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class InstructionListAdapter extends RecyclerView.Adapter<InstructionViewHolder> {
-  private final Context context;
   private List<LegStep> stepList;
   private RouteLeg currentLeg;
   private LegStep currentStep;
@@ -29,7 +28,7 @@ public class InstructionListAdapter extends RecyclerView.Adapter<InstructionView
 
   public InstructionListAdapter(Context context) {
     stepList = new ArrayList<>();
-    this.context = context;
+    distanceUtils = new DistanceUtils(context);
   }
 
   @Override
@@ -51,9 +50,6 @@ public class InstructionListAdapter extends RecyclerView.Adapter<InstructionView
         updateSecondaryText(holder, null);
       }
       updateManeuverView(holder, step);
-      if (distanceUtils == null) {
-        distanceUtils = new DistanceUtils(context);
-      }
 
       SpannableString distanceText = distanceUtils.formatDistance(step.distance());
       holder.stepDistanceText.setText(distanceText);

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/list/InstructionListAdapter.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/list/InstructionListAdapter.java
@@ -19,7 +19,6 @@ import com.mapbox.services.android.navigation.v5.utils.DistanceUtils;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 
 public class InstructionListAdapter extends RecyclerView.Adapter<InstructionViewHolder> {
   private final Context context;
@@ -28,7 +27,7 @@ public class InstructionListAdapter extends RecyclerView.Adapter<InstructionView
   private LegStep currentStep;
   private DistanceUtils distanceUtils;
 
-  public InstructionListAdapter(Context context, Locale locale) {
+  public InstructionListAdapter(Context context) {
     stepList = new ArrayList<>();
     this.context = context;
   }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/list/InstructionListAdapter.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/list/InstructionListAdapter.java
@@ -3,7 +3,7 @@ package com.mapbox.services.android.navigation.ui.v5.summary.list;
 import android.content.res.Configuration;
 import android.support.constraint.ConstraintLayout;
 import android.support.v7.widget.RecyclerView;
-import android.text.SpannableStringBuilder;
+import android.text.SpannableString;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -55,7 +55,7 @@ public class InstructionListAdapter extends RecyclerView.Adapter<InstructionView
         updateSecondaryText(holder, null);
       }
       updateManeuverView(holder, step);
-      SpannableStringBuilder distanceText = DistanceUtils
+      SpannableString distanceText = DistanceUtils
         .formatDistance(step.distance(), decimalFormat, true, unitType);
       holder.stepDistanceText.setText(distanceText);
     }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/list/InstructionListAdapter.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/list/InstructionListAdapter.java
@@ -56,7 +56,7 @@ public class InstructionListAdapter extends RecyclerView.Adapter<InstructionView
       }
       updateManeuverView(holder, step);
       SpannableStringBuilder distanceText = DistanceUtils
-        .distanceFormatter(step.distance(), decimalFormat, true, unitType);
+        .formatDistance(step.distance(), decimalFormat, true, unitType);
       holder.stepDistanceText.setText(distanceText);
     }
   }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/list/InstructionListAdapter.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/list/InstructionListAdapter.java
@@ -14,7 +14,6 @@ import com.mapbox.api.directions.v5.models.LegStep;
 import com.mapbox.api.directions.v5.models.RouteLeg;
 import com.mapbox.services.android.navigation.ui.v5.R;
 import com.mapbox.services.android.navigation.v5.navigation.NavigationConstants;
-import com.mapbox.services.android.navigation.v5.navigation.NavigationUnitType;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 import com.mapbox.services.android.navigation.v5.utils.DistanceUtils;
 
@@ -23,17 +22,14 @@ import java.util.List;
 import java.util.Locale;
 
 public class InstructionListAdapter extends RecyclerView.Adapter<InstructionViewHolder> {
-  private final Locale locale;
   private final Context context;
   private List<LegStep> stepList;
   private RouteLeg currentLeg;
   private LegStep currentStep;
-  private int unitType;
   private DistanceUtils distanceUtils;
 
   public InstructionListAdapter(Context context, Locale locale) {
     stepList = new ArrayList<>();
-    this.locale = locale;
     this.context = context;
   }
 
@@ -57,7 +53,7 @@ public class InstructionListAdapter extends RecyclerView.Adapter<InstructionView
       }
       updateManeuverView(holder, step);
       if (distanceUtils == null) {
-        distanceUtils = new DistanceUtils(context, locale, unitType);
+        distanceUtils = new DistanceUtils(context);
       }
 
       SpannableString distanceText = distanceUtils.formatDistance(step.distance());
@@ -76,8 +72,7 @@ public class InstructionListAdapter extends RecyclerView.Adapter<InstructionView
     holder.itemView.clearAnimation();
   }
 
-  public void updateSteps(RouteProgress routeProgress, @NavigationUnitType.UnitType int unitType) {
-    this.unitType = unitType;
+  public void updateSteps(RouteProgress routeProgress) {
     addLegSteps(routeProgress);
     updateStepList(routeProgress);
   }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationNotification.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationNotification.java
@@ -46,6 +46,7 @@ class MapboxNavigationNotification implements NavigationNotification {
   private String instructionText;
   private int currentManeuverId;
   private int distanceUnitType;
+  private Locale locale;
 
   private BroadcastReceiver endNavigationBtnReceiver = new BroadcastReceiver() {
     @Override
@@ -57,6 +58,7 @@ class MapboxNavigationNotification implements NavigationNotification {
   MapboxNavigationNotification(Context context, MapboxNavigation mapboxNavigation) {
     this.mapboxNavigation = mapboxNavigation;
     this.distanceUnitType = mapboxNavigation.options().unitType();
+    this.locale = mapboxNavigation.options().locale();
     initialize(context);
   }
 
@@ -170,7 +172,7 @@ class MapboxNavigationNotification implements NavigationNotification {
     if (currentDistanceText == null || newDistanceText(routeProgress)) {
       currentDistanceText = DistanceUtils.formatDistance(
         routeProgress.currentLegProgress().currentStepProgress().distanceRemaining(),
-        decimalFormat, true, distanceUnitType);
+        locale, distanceUnitType);
       notificationRemoteViews.setTextViewText(R.id.notificationDistanceText, currentDistanceText);
     }
   }
@@ -179,7 +181,7 @@ class MapboxNavigationNotification implements NavigationNotification {
     return currentDistanceText != null
       && !currentDistanceText.toString().equals(DistanceUtils.formatDistance(
       routeProgress.currentLegProgress().currentStepProgress().distanceRemaining(),
-      decimalFormat, true, distanceUnitType).toString());
+      locale, distanceUnitType).toString());
   }
 
   private void updateArrivalTime(RouteProgress routeProgress) {

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationNotification.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationNotification.java
@@ -31,7 +31,7 @@ import static com.mapbox.services.android.navigation.v5.navigation.NavigationCon
  */
 class MapboxNavigationNotification implements NavigationNotification {
   private static final String END_NAVIGATION_ACTION = "com.mapbox.intent.action.END_NAVIGATION";
-  private final Locale locale;
+  private final DistanceUtils distanceUtils;
   private NotificationCompat.Builder notificationBuilder;
   private NotificationManager notificationManager;
   private Notification notification;
@@ -41,7 +41,6 @@ class MapboxNavigationNotification implements NavigationNotification {
   private String currentArrivalTime;
   private String instructionText;
   private int currentManeuverId;
-  private int distanceUnitType;
 
   private BroadcastReceiver endNavigationBtnReceiver = new BroadcastReceiver() {
     @Override
@@ -52,8 +51,7 @@ class MapboxNavigationNotification implements NavigationNotification {
 
   MapboxNavigationNotification(Context context, MapboxNavigation mapboxNavigation) {
     this.mapboxNavigation = mapboxNavigation;
-    this.distanceUnitType = mapboxNavigation.options().unitType();
-    this.locale = mapboxNavigation.options().locale();
+    this.distanceUtils = new DistanceUtils(context, mapboxNavigation.options().locale(), mapboxNavigation.options().unitType());
     initialize(context);
   }
 
@@ -164,18 +162,16 @@ class MapboxNavigationNotification implements NavigationNotification {
 
   private void updateDistanceText(RouteProgress routeProgress) {
     if (currentDistanceText == null || newDistanceText(routeProgress)) {
-      currentDistanceText = DistanceUtils.formatDistance(
-        routeProgress.currentLegProgress().currentStepProgress().distanceRemaining(),
-        locale, distanceUnitType);
+      currentDistanceText = distanceUtils.formatDistance(
+        routeProgress.currentLegProgress().currentStepProgress().distanceRemaining());
       notificationRemoteViews.setTextViewText(R.id.notificationDistanceText, currentDistanceText);
     }
   }
 
   private boolean newDistanceText(RouteProgress routeProgress) {
     return currentDistanceText != null
-      && !currentDistanceText.toString().equals(DistanceUtils.formatDistance(
-      routeProgress.currentLegProgress().currentStepProgress().distanceRemaining(),
-      locale, distanceUnitType).toString());
+      && !currentDistanceText.toString().equals(distanceUtils.formatDistance(
+      routeProgress.currentLegProgress().currentStepProgress().distanceRemaining()).toString());
   }
 
   private void updateArrivalTime(RouteProgress routeProgress) {

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationNotification.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationNotification.java
@@ -168,7 +168,7 @@ class MapboxNavigationNotification implements NavigationNotification {
 
   private void updateDistanceText(RouteProgress routeProgress) {
     if (currentDistanceText == null || newDistanceText(routeProgress)) {
-      currentDistanceText = DistanceUtils.distanceFormatter(
+      currentDistanceText = DistanceUtils.formatDistance(
         routeProgress.currentLegProgress().currentStepProgress().distanceRemaining(),
         decimalFormat, true, distanceUnitType);
       notificationRemoteViews.setTextViewText(R.id.notificationDistanceText, currentDistanceText);
@@ -177,7 +177,7 @@ class MapboxNavigationNotification implements NavigationNotification {
 
   private boolean newDistanceText(RouteProgress routeProgress) {
     return currentDistanceText != null
-      && !currentDistanceText.toString().equals(DistanceUtils.distanceFormatter(
+      && !currentDistanceText.toString().equals(DistanceUtils.formatDistance(
       routeProgress.currentLegProgress().currentStepProgress().distanceRemaining(),
       decimalFormat, true, distanceUnitType).toString());
   }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationNotification.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationNotification.java
@@ -21,7 +21,6 @@ import com.mapbox.services.android.navigation.v5.utils.DistanceUtils;
 import com.mapbox.services.android.navigation.v5.utils.ManeuverUtils;
 import com.mapbox.services.android.navigation.v5.utils.time.TimeUtils;
 
-import java.text.DecimalFormat;
 import java.util.Locale;
 
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.NAVIGATION_NOTIFICATION_CHANNEL;
@@ -31,22 +30,19 @@ import static com.mapbox.services.android.navigation.v5.navigation.NavigationCon
  * This is in charge of creating the persistent navigation session notification and updating it.
  */
 class MapboxNavigationNotification implements NavigationNotification {
-
   private static final String END_NAVIGATION_ACTION = "com.mapbox.intent.action.END_NAVIGATION";
 
+  private final Locale locale;
   private NotificationCompat.Builder notificationBuilder;
   private NotificationManager notificationManager;
   private Notification notification;
   private RemoteViews notificationRemoteViews;
   private MapboxNavigation mapboxNavigation;
-
   private SpannableString currentDistanceText;
-  private DecimalFormat decimalFormat;
   private String currentArrivalTime;
   private String instructionText;
   private int currentManeuverId;
   private int distanceUnitType;
-  private Locale locale;
 
   private BroadcastReceiver endNavigationBtnReceiver = new BroadcastReceiver() {
     @Override
@@ -88,7 +84,6 @@ class MapboxNavigationNotification implements NavigationNotification {
 
   private void initialize(Context context) {
     notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-    decimalFormat = new DecimalFormat(NavigationConstants.DECIMAL_FORMAT);
     createNotificationChannel(context);
     buildNotification(context);
     registerReceiver(context);

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationNotification.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationNotification.java
@@ -51,7 +51,7 @@ class MapboxNavigationNotification implements NavigationNotification {
 
   MapboxNavigationNotification(Context context, MapboxNavigation mapboxNavigation) {
     this.mapboxNavigation = mapboxNavigation;
-    this.distanceUtils = new DistanceUtils(context, mapboxNavigation.options().locale(), mapboxNavigation.options().unitType());
+    this.distanceUtils = new DistanceUtils(context);
     initialize(context);
   }
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationNotification.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationNotification.java
@@ -10,7 +10,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.Build;
 import android.support.v4.app.NotificationCompat;
-import android.text.SpannableStringBuilder;
+import android.text.SpannableString;
 import android.widget.RemoteViews;
 
 import com.mapbox.api.directions.v5.models.LegStep;
@@ -40,7 +40,7 @@ class MapboxNavigationNotification implements NavigationNotification {
   private RemoteViews notificationRemoteViews;
   private MapboxNavigation mapboxNavigation;
 
-  private SpannableStringBuilder currentDistanceText;
+  private SpannableString currentDistanceText;
   private DecimalFormat decimalFormat;
   private String currentArrivalTime;
   private String instructionText;

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationNotification.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationNotification.java
@@ -31,7 +31,6 @@ import static com.mapbox.services.android.navigation.v5.navigation.NavigationCon
  */
 class MapboxNavigationNotification implements NavigationNotification {
   private static final String END_NAVIGATION_ACTION = "com.mapbox.intent.action.END_NAVIGATION";
-
   private final Locale locale;
   private NotificationCompat.Builder notificationBuilder;
   private NotificationManager notificationManager;

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationOptions.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationOptions.java
@@ -47,8 +47,7 @@ public abstract class MapboxNavigationOptions {
 
   public abstract boolean isDebugLoggingEnabled();
 
-  @Nullable
-  public abstract Integer unitType();
+  public abstract int unitType();
 
   @Nullable
   public abstract Locale locale();
@@ -95,7 +94,7 @@ public abstract class MapboxNavigationOptions {
 
     public abstract Builder isDebugLoggingEnabled(boolean debugLoggingEnabled);
 
-    public abstract Builder unitType(@NavigationUnitType.UnitType Integer unitType);
+    public abstract Builder unitType(int unitType);
 
     public abstract Builder navigationNotification(NavigationNotification notification);
 
@@ -122,6 +121,7 @@ public abstract class MapboxNavigationOptions {
       .metersRemainingTillArrival(NavigationConstants.METERS_REMAINING_TILL_ARRIVAL)
       .enableNotification(true)
       .isFromNavigationUi(false)
-      .isDebugLoggingEnabled(false);
+      .isDebugLoggingEnabled(false)
+      .unitType(-1);
   }
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationOptions.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationOptions.java
@@ -121,6 +121,7 @@ public abstract class MapboxNavigationOptions {
       .enableNotification(true)
       .isFromNavigationUi(false)
       .isDebugLoggingEnabled(false)
-      .unitType(NavigationUnitType.TYPE_IMPERIAL);
+      .unitType(NavigationUnitType.TYPE_IMPERIAL)
+      .locale(Locale.US);
   }
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationOptions.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationOptions.java
@@ -47,8 +47,10 @@ public abstract class MapboxNavigationOptions {
 
   public abstract boolean isDebugLoggingEnabled();
 
-  public abstract int unitType();
+  @Nullable
+  public abstract Integer unitType();
 
+  @Nullable
   public abstract Locale locale();
 
   @Nullable
@@ -93,7 +95,7 @@ public abstract class MapboxNavigationOptions {
 
     public abstract Builder isDebugLoggingEnabled(boolean debugLoggingEnabled);
 
-    public abstract Builder unitType(@NavigationUnitType.UnitType int unitType);
+    public abstract Builder unitType(@NavigationUnitType.UnitType Integer unitType);
 
     public abstract Builder navigationNotification(NavigationNotification notification);
 
@@ -120,8 +122,6 @@ public abstract class MapboxNavigationOptions {
       .metersRemainingTillArrival(NavigationConstants.METERS_REMAINING_TILL_ARRIVAL)
       .enableNotification(true)
       .isFromNavigationUi(false)
-      .isDebugLoggingEnabled(false)
-      .unitType(NavigationUnitType.TYPE_IMPERIAL)
-      .locale(Locale.US);
+      .isDebugLoggingEnabled(false);
   }
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationOptions.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationOptions.java
@@ -5,6 +5,8 @@ import android.support.annotation.Nullable;
 import com.google.auto.value.AutoValue;
 import com.mapbox.services.android.navigation.v5.navigation.notification.NavigationNotification;
 
+import java.util.Locale;
+
 /**
  * Immutable and can't be changed after passing into {@link MapboxNavigation}.
  */
@@ -46,6 +48,8 @@ public abstract class MapboxNavigationOptions {
   public abstract boolean isDebugLoggingEnabled();
 
   public abstract int unitType();
+
+  public abstract Locale locale();
 
   @Nullable
   public abstract NavigationNotification navigationNotification();
@@ -92,6 +96,8 @@ public abstract class MapboxNavigationOptions {
     public abstract Builder unitType(@NavigationUnitType.UnitType int unitType);
 
     public abstract Builder navigationNotification(NavigationNotification notification);
+
+    public abstract Builder locale(Locale locale);
 
     public abstract MapboxNavigationOptions build();
   }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationOptions.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationOptions.java
@@ -94,7 +94,7 @@ public abstract class MapboxNavigationOptions {
 
     public abstract Builder isDebugLoggingEnabled(boolean debugLoggingEnabled);
 
-    public abstract Builder unitType(int unitType);
+    public abstract Builder unitType(@NavigationUnitType.UnitType int unitType);
 
     public abstract Builder navigationNotification(NavigationNotification notification);
 
@@ -122,6 +122,6 @@ public abstract class MapboxNavigationOptions {
       .enableNotification(true)
       .isFromNavigationUi(false)
       .isDebugLoggingEnabled(false)
-      .unitType(-1);
+      .unitType(NavigationUnitType.NONE_SPECIFIED);
   }
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationConstants.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationConstants.java
@@ -178,8 +178,9 @@ public final class NavigationConstants {
   public static final String NAVIGATION_VIEW_ROUTE_KEY = "route_json";
   public static final String NAVIGATION_VIEW_AWS_POOL_ID = "navigation_view_aws_pool_id";
   public static final String NAVIGATION_VIEW_UNIT_TYPE = "navigation_view_unit_type";
+  public static final String NAVIGATION_VIEW_LOCALE_LANGUAGE = "navigation_view_locale_language";
+  public static final String NAVIGATION_VIEW_LOCALE_COUNTRY = "navigation_view_locale_country";
   public static final String NAVIGATION_VIEW_REROUTING = "Rerouting";
-  public static final String DECIMAL_FORMAT = "#.#";
 
   // Step Maneuver Types
   public static final String STEP_MANEUVER_TYPE_TURN = "turn";

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationUnitType.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationUnitType.java
@@ -9,11 +9,12 @@ public class NavigationUnitType {
 
   @Retention(RetentionPolicy.SOURCE)
 
-  @IntDef( {TYPE_IMPERIAL, TYPE_METRIC})
+  @IntDef( {NONE_SPECIFIED, TYPE_IMPERIAL, TYPE_METRIC})
 
   public @interface UnitType {
   }
 
+  public static final int NONE_SPECIFIED = -1;
   public static final int TYPE_IMPERIAL = 0;
   public static final int TYPE_METRIC = 1;
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/DistanceUtils.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/DistanceUtils.java
@@ -107,7 +107,8 @@ public class DistanceUtils {
     SpannableString spannableString = new SpannableString(String.format("%s %s", distance, UNIT_STRINGS.get(unit)));
 
     spannableString.setSpan(new StyleSpan(Typeface.BOLD), 0, distance.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
-    spannableString.setSpan(new RelativeSizeSpan(0.65f), distance.length() + 1, spannableString.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+    spannableString.setSpan(new RelativeSizeSpan(0.65f),distance.length() + 1,
+      spannableString.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
 
     return spannableString;
   }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/DistanceUtils.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/DistanceUtils.java
@@ -13,7 +13,6 @@ import android.text.style.StyleSpan;
 import com.mapbox.geojson.Point;
 import com.mapbox.services.android.navigation.R;
 import com.mapbox.services.android.navigation.v5.navigation.NavigationConstants;
-import com.mapbox.services.android.navigation.v5.navigation.NavigationUnitType;
 import com.mapbox.services.android.navigation.v5.routeprogress.MetricsRouteProgress;
 import com.mapbox.turf.TurfConstants;
 import com.mapbox.turf.TurfConversion;
@@ -48,9 +47,16 @@ public class DistanceUtils {
 
     int unitType = preferences.getInt(NavigationConstants.NAVIGATION_VIEW_UNIT_TYPE, -1);
 
-    String localeLanguage = preferences.getString(NavigationConstants.NAVIGATION_VIEW_LOCALE_LANGUAGE, Locale.US.getLanguage());
-    String localeCountry = preferences.getString(NavigationConstants.NAVIGATION_VIEW_LOCALE_COUNTRY, Locale.US.getCountry());
-    Locale locale = new Locale(localeLanguage, localeCountry);
+    String localeLanguage = preferences.getString(NavigationConstants.NAVIGATION_VIEW_LOCALE_LANGUAGE, Locale.getDefault().getLanguage());
+    String localeCountry = preferences.getString(NavigationConstants.NAVIGATION_VIEW_LOCALE_COUNTRY, Locale.getDefault().getCountry());
+
+    Locale locale;
+
+    if (localeCountry.isEmpty()) { // Country is not required for a locale
+      locale = new Locale(localeLanguage);
+    } else {
+      locale = new Locale(localeLanguage, localeCountry);
+    }
 
     if (locale == null) { // If locale isn't specified, use device locale
       locale = context.getResources().getConfiguration().locale;

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/DistanceUtils.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/DistanceUtils.java
@@ -1,10 +1,8 @@
 package com.mapbox.services.android.navigation.v5.utils;
 
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.graphics.Typeface;
 import android.location.Location;
-import android.preference.PreferenceManager;
 import android.text.SpannableString;
 import android.text.Spanned;
 import android.text.style.RelativeSizeSpan;
@@ -12,7 +10,6 @@ import android.text.style.StyleSpan;
 
 import com.mapbox.geojson.Point;
 import com.mapbox.services.android.navigation.R;
-import com.mapbox.services.android.navigation.v5.navigation.NavigationConstants;
 import com.mapbox.services.android.navigation.v5.routeprogress.MetricsRouteProgress;
 import com.mapbox.turf.TurfConstants;
 import com.mapbox.turf.TurfConversion;
@@ -23,7 +20,6 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
-import static com.mapbox.services.android.navigation.v5.navigation.NavigationUnitType.TYPE_IMPERIAL;
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationUnitType.TYPE_METRIC;
 import static com.mapbox.turf.TurfConstants.UNIT_FEET;
 import static com.mapbox.turf.TurfConstants.UNIT_KILOMETERS;
@@ -43,44 +39,15 @@ public class DistanceUtils {
    * @param context from which to get localized strings from
    */
   public DistanceUtils(Context context) {
-    SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
-
-    int unitType = preferences.getInt(NavigationConstants.NAVIGATION_VIEW_UNIT_TYPE, -1);
-
-    String localeLanguage = preferences.getString(
-      NavigationConstants.NAVIGATION_VIEW_LOCALE_LANGUAGE, Locale.getDefault().getLanguage());
-    String localeCountry = preferences.getString(
-      NavigationConstants.NAVIGATION_VIEW_LOCALE_COUNTRY, Locale.getDefault().getCountry());
-
-    Locale locale;
-
-    if (localeCountry.isEmpty()) { // Country is not required for a locale
-      locale = new Locale(localeLanguage);
-    } else {
-      locale = new Locale(localeLanguage, localeCountry);
-    }
-
-    if (locale == null) { // If locale isn't specified, use device locale
-      locale = context.getResources().getConfiguration().locale;
-    }
-
-    if (unitType == -1) { // If unit type isn't specified, use default for locale
-      switch (locale.getCountry()) {
-        case "US": // US
-        case "LR": // Liberia
-        case "MM": // Burma
-          unitType = TYPE_IMPERIAL;
-          break;
-        default:
-          unitType = TYPE_METRIC;
-      }
-    }
-
-    numberFormat = NumberFormat.getNumberInstance(locale);
     unitStrings.put(UNIT_KILOMETERS, context.getString(R.string.kilometers));
     unitStrings.put(UNIT_METERS, context.getString(R.string.meters));
     unitStrings.put(UNIT_MILES, context.getString(R.string.miles));
     unitStrings.put(UNIT_FEET, context.getString(R.string.feet));
+
+    Locale locale = LocaleUtils.getLocale(context);
+    int unitType = LocaleUtils.getUnitType(context, locale);
+
+    numberFormat = NumberFormat.getNumberInstance(locale);
 
     largeUnit = unitType == TYPE_METRIC ? UNIT_KILOMETERS : UNIT_MILES;
     smallUnit = unitType == TYPE_METRIC ? UNIT_METERS : UNIT_FEET;

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/DistanceUtils.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/DistanceUtils.java
@@ -29,10 +29,18 @@ public class DistanceUtils {
   private static final String KILOMETER = " km";
   private static final String METER = " m";
 
-  public static SpannableStringBuilder distanceFormatter(double distance,
-                                                         DecimalFormat decimalFormat,
-                                                         boolean spansEnabled,
-                                                         int unitType) {
+  /**
+   *
+   * @param distance in meters
+   * @param decimalFormat
+   * @param spansEnabled
+   * @param unitType
+   * @return
+   */
+  public static SpannableStringBuilder formatDistance(double distance,
+                                                      DecimalFormat decimalFormat,
+                                                      boolean spansEnabled,
+                                                      int unitType) {
 
     boolean isImperialUnitType = unitType == NavigationUnitType.TYPE_IMPERIAL;
 
@@ -52,6 +60,8 @@ public class DistanceUtils {
     }
     return formattedString;
   }
+
+
 
   private static SpannableStringBuilder roundByFiftyFeet(double distance, boolean spansEnabled,
                                                          String smallUnitFormat, String smallFinalUnit) {

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/DistanceUtils.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/DistanceUtils.java
@@ -1,8 +1,10 @@
 package com.mapbox.services.android.navigation.v5.utils;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.graphics.Typeface;
 import android.location.Location;
+import android.preference.PreferenceManager;
 import android.text.SpannableString;
 import android.text.Spanned;
 import android.text.style.RelativeSizeSpan;
@@ -10,6 +12,7 @@ import android.text.style.StyleSpan;
 
 import com.mapbox.geojson.Point;
 import com.mapbox.services.android.navigation.R;
+import com.mapbox.services.android.navigation.v5.navigation.NavigationConstants;
 import com.mapbox.services.android.navigation.v5.navigation.NavigationUnitType;
 import com.mapbox.services.android.navigation.v5.routeprogress.MetricsRouteProgress;
 import com.mapbox.turf.TurfConstants;

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/DistanceUtils.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/DistanceUtils.java
@@ -31,9 +31,9 @@ import static com.mapbox.turf.TurfConstants.UNIT_METERS;
 import static com.mapbox.turf.TurfConstants.UNIT_MILES;
 
 public class DistanceUtils {
-  private final int LARGE_UNIT_THRESHOLD = 10;
-  private final int SMALL_UNIT_THRESHOLD = 401;
-  private final Map<String, String> UNIT_STRINGS = new HashMap<>();
+  private static final int LARGE_UNIT_THRESHOLD = 10;
+  private static final int SMALL_UNIT_THRESHOLD = 401;
+  private final Map<String, String> unitStrings = new HashMap<>();
   private final NumberFormat numberFormat;
   private final String largeUnit;
   private final String smallUnit;
@@ -47,8 +47,10 @@ public class DistanceUtils {
 
     int unitType = preferences.getInt(NavigationConstants.NAVIGATION_VIEW_UNIT_TYPE, -1);
 
-    String localeLanguage = preferences.getString(NavigationConstants.NAVIGATION_VIEW_LOCALE_LANGUAGE, Locale.getDefault().getLanguage());
-    String localeCountry = preferences.getString(NavigationConstants.NAVIGATION_VIEW_LOCALE_COUNTRY, Locale.getDefault().getCountry());
+    String localeLanguage = preferences.getString(
+      NavigationConstants.NAVIGATION_VIEW_LOCALE_LANGUAGE, Locale.getDefault().getLanguage());
+    String localeCountry = preferences.getString(
+      NavigationConstants.NAVIGATION_VIEW_LOCALE_COUNTRY, Locale.getDefault().getCountry());
 
     Locale locale;
 
@@ -75,10 +77,10 @@ public class DistanceUtils {
     }
 
     numberFormat = NumberFormat.getNumberInstance(locale);
-    UNIT_STRINGS.put(UNIT_KILOMETERS, context.getString(R.string.kilometers));
-    UNIT_STRINGS.put(UNIT_METERS, context.getString(R.string.meters));
-    UNIT_STRINGS.put(UNIT_MILES, context.getString(R.string.miles));
-    UNIT_STRINGS.put(UNIT_FEET, context.getString(R.string.feet));
+    unitStrings.put(UNIT_KILOMETERS, context.getString(R.string.kilometers));
+    unitStrings.put(UNIT_METERS, context.getString(R.string.meters));
+    unitStrings.put(UNIT_MILES, context.getString(R.string.miles));
+    unitStrings.put(UNIT_FEET, context.getString(R.string.feet));
 
     largeUnit = unitType == TYPE_METRIC ? UNIT_KILOMETERS : UNIT_MILES;
     smallUnit = unitType == TYPE_METRIC ? UNIT_METERS : UNIT_FEET;
@@ -137,7 +139,7 @@ public class DistanceUtils {
    * @return String with bolded distance and shrunken units
    */
   private SpannableString getDistanceString(String distance, String unit) {
-    SpannableString spannableString = new SpannableString(String.format("%s %s", distance, UNIT_STRINGS.get(unit)));
+    SpannableString spannableString = new SpannableString(String.format("%s %s", distance, unitStrings.get(unit)));
 
     spannableString.setSpan(new StyleSpan(Typeface.BOLD), 0, distance.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
     spannableString.setSpan(new RelativeSizeSpan(0.65f),distance.length() + 1,

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/DistanceUtils.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/DistanceUtils.java
@@ -2,7 +2,7 @@ package com.mapbox.services.android.navigation.v5.utils;
 
 import android.graphics.Typeface;
 import android.location.Location;
-import android.text.SpannableStringBuilder;
+import android.text.SpannableString;
 import android.text.style.RelativeSizeSpan;
 import android.text.style.StyleSpan;
 
@@ -10,8 +10,8 @@ import com.mapbox.geojson.Point;
 import com.mapbox.services.android.navigation.v5.navigation.NavigationUnitType;
 import com.mapbox.services.android.navigation.v5.routeprogress.MetricsRouteProgress;
 import com.mapbox.services.android.navigation.v5.utils.span.SpanItem;
-import com.mapbox.services.android.navigation.v5.utils.span.TextSpanItem;
 import com.mapbox.services.android.navigation.v5.utils.span.SpanUtils;
+import com.mapbox.services.android.navigation.v5.utils.span.TextSpanItem;
 import com.mapbox.turf.TurfConstants;
 import com.mapbox.turf.TurfConversion;
 import com.mapbox.turf.TurfMeasurement;
@@ -37,10 +37,10 @@ public class DistanceUtils {
    * @param unitType
    * @return
    */
-  public static SpannableStringBuilder formatDistance(double distance,
-                                                      DecimalFormat decimalFormat,
-                                                      boolean spansEnabled,
-                                                      int unitType) {
+  public static SpannableString formatDistance(double distance,
+                                               DecimalFormat decimalFormat,
+                                               boolean spansEnabled,
+                                               int unitType) {
 
     boolean isImperialUnitType = unitType == NavigationUnitType.TYPE_IMPERIAL;
 
@@ -49,7 +49,7 @@ public class DistanceUtils {
     String largeFinalUnit = isImperialUnitType ? TurfConstants.UNIT_MILES : TurfConstants.UNIT_KILOMETERS;
     String smallFinalUnit = isImperialUnitType ? TurfConstants.UNIT_FEET : TurfConstants.UNIT_METERS;
 
-    SpannableStringBuilder formattedString;
+    SpannableString formattedString;
     if (longDistance(distance, largeFinalUnit)) {
       formattedString = roundToNearestMile(distance, spansEnabled, largeFinalUnit, largeUnitFormat);
     } else if (mediumDistance(distance, largeFinalUnit, smallFinalUnit)) {
@@ -63,8 +63,8 @@ public class DistanceUtils {
 
 
 
-  private static SpannableStringBuilder roundByFiftyFeet(double distance, boolean spansEnabled,
-                                                         String smallUnitFormat, String smallFinalUnit) {
+  private static SpannableString roundByFiftyFeet(double distance, boolean spansEnabled,
+                                                  String smallUnitFormat, String smallFinalUnit) {
     distance = TurfConversion.convertDistance(distance, TurfConstants.UNIT_METERS, smallFinalUnit);
 
     // Distance value
@@ -74,13 +74,13 @@ public class DistanceUtils {
     if (spansEnabled) {
       return generateSpannedText(String.valueOf(roundedNumber), smallUnitFormat);
     } else {
-      return new SpannableStringBuilder(String.valueOf(roundedNumber) + smallUnitFormat);
+      return new SpannableString(String.valueOf(roundedNumber) + smallUnitFormat);
     }
   }
 
-  private static SpannableStringBuilder roundOneDecimalPlace(double distance, DecimalFormat decimalFormat,
-                                                             boolean spansEnabled, String largeFinalUnit,
-                                                             String largeUnitFormat) {
+  private static SpannableString roundOneDecimalPlace(double distance, DecimalFormat decimalFormat,
+                                                      boolean spansEnabled, String largeFinalUnit,
+                                                      String largeUnitFormat) {
     distance = TurfConversion.convertDistance(distance, TurfConstants.UNIT_METERS, largeFinalUnit);
 
     // Distance value
@@ -90,12 +90,12 @@ public class DistanceUtils {
     if (spansEnabled) {
       return generateSpannedText(roundedDecimal, largeUnitFormat);
     } else {
-      return new SpannableStringBuilder(roundedDecimal + largeUnitFormat);
+      return new SpannableString(roundedDecimal + largeUnitFormat);
     }
   }
 
-  private static SpannableStringBuilder roundToNearestMile(double distance, boolean spansEnabled,
-                                                           String largeFinalUnit, String largeUnitFormat) {
+  private static SpannableString roundToNearestMile(double distance, boolean spansEnabled,
+                                                    String largeFinalUnit, String largeUnitFormat) {
     distance = TurfConversion.convertDistance(distance, TurfConstants.UNIT_METERS, largeFinalUnit);
 
     // Distance value
@@ -104,7 +104,7 @@ public class DistanceUtils {
     if (spansEnabled) {
       return generateSpannedText(String.valueOf(roundedNumber), largeUnitFormat);
     } else {
-      return new SpannableStringBuilder(String.valueOf(roundedNumber) + largeUnitFormat);
+      return new SpannableString(String.valueOf(roundedNumber) + largeUnitFormat);
     }
   }
 
@@ -125,10 +125,11 @@ public class DistanceUtils {
     return (int) TurfMeasurement.distance(currentPoint, finalPoint, TurfConstants.UNIT_METERS);
   }
 
-  private static SpannableStringBuilder generateSpannedText(String distance, String unit) {
+  private static SpannableString generateSpannedText(String distance, String unit) {
     List<SpanItem> spans = new ArrayList<>();
     spans.add(new TextSpanItem(new StyleSpan(Typeface.BOLD), distance));
     spans.add(new TextSpanItem(new RelativeSizeSpan(0.65f), unit));
-    return SpanUtils.combineSpans(spans);
+//    return SpanUtils.combineSpans(spans);
+    return new SpannableString("");
   }
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/DistanceUtils.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/DistanceUtils.java
@@ -39,6 +39,8 @@ public class DistanceUtils {
 
   private static NumberFormat numberFormat;
 
+
+
   /**
    * Returns a formatted SpannableString with bold and size formatting. I.e., "10 mi", "350 m"
    * @param distance in meters
@@ -49,7 +51,7 @@ public class DistanceUtils {
    */
   public static SpannableString formatDistance(double distance,
                                                Locale locale,
-                                               int unitType) {
+                                               @NavigationUnitType.UnitType int unitType) {
     numberFormat = NumberFormat.getNumberInstance(locale);
 
     boolean isImperialUnitType = unitType == NavigationUnitType.TYPE_IMPERIAL;
@@ -105,7 +107,7 @@ public class DistanceUtils {
     SpannableString spannableString = new SpannableString(String.format("%s %s", distance, UNIT_STRINGS.get(unit)));
 
     spannableString.setSpan(new StyleSpan(Typeface.BOLD), 0, distance.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
-    spannableString.setSpan(new RelativeSizeSpan(0.65f), distance.length() + 1, spannableString.length() - 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+    spannableString.setSpan(new RelativeSizeSpan(0.65f), distance.length() + 1, spannableString.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
 
     return spannableString;
   }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/DistanceUtils.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/DistanceUtils.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
+import static com.mapbox.services.android.navigation.v5.navigation.NavigationUnitType.TYPE_IMPERIAL;
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationUnitType.TYPE_METRIC;
 import static com.mapbox.turf.TurfConstants.UNIT_FEET;
 import static com.mapbox.turf.TurfConstants.UNIT_KILOMETERS;
@@ -41,10 +42,32 @@ public class DistanceUtils {
   /**
    * Creates a DistanceUtils object with information about how to format distances
    * @param context from which to get localized strings from
-   * @param locale from which to format numbers
-   * @param unitType NavigationUnitType.TYPE_IMPERIAL or NavigationUnitType.TYPE_METRIC
    */
-  public DistanceUtils(Context context, Locale locale, @NavigationUnitType.UnitType int unitType) {
+  public DistanceUtils(Context context) {
+    SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
+
+    int unitType = preferences.getInt(NavigationConstants.NAVIGATION_VIEW_UNIT_TYPE, -1);
+
+    String localeLanguage = preferences.getString(NavigationConstants.NAVIGATION_VIEW_LOCALE_LANGUAGE, Locale.US.getLanguage());
+    String localeCountry = preferences.getString(NavigationConstants.NAVIGATION_VIEW_LOCALE_COUNTRY, Locale.US.getCountry());
+    Locale locale = new Locale(localeLanguage, localeCountry);
+
+    if (locale == null) { // If locale isn't specified, use device locale
+      locale = context.getResources().getConfiguration().locale;
+    }
+
+    if (unitType == -1) { // If unit type isn't specified, use default for locale
+      switch (locale.getCountry()) {
+        case "US": // US
+        case "LR": // Liberia
+        case "MM": // Burma
+          unitType = TYPE_IMPERIAL;
+          break;
+        default:
+          unitType = TYPE_METRIC;
+      }
+    }
+
     numberFormat = NumberFormat.getNumberInstance(locale);
     UNIT_STRINGS.put(UNIT_KILOMETERS, context.getString(R.string.kilometers));
     UNIT_STRINGS.put(UNIT_METERS, context.getString(R.string.meters));

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/LocaleUtils.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/LocaleUtils.java
@@ -69,6 +69,6 @@ public class LocaleUtils {
    * @return unit type
    */
   public static @NavigationUnitType.UnitType int getUnitType(Context context) {
-    getUnitType(context, getLocale(context));
+    return getUnitType(context, getLocale(context));
   }
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/LocaleUtils.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/LocaleUtils.java
@@ -44,6 +44,24 @@ public class LocaleUtils {
   }
 
   /**
+   * Sets locale and unitType into SharedPreferences for later use
+   * @param context where SharedPreferences exist
+   * @param locale to set language
+   * @param unitType to set unitType to use
+   */
+  public static void setLocale(Context context, Locale locale, @NavigationUnitType.UnitType int unitType) {
+    SharedPreferences.Editor editor = PreferenceManager.getDefaultSharedPreferences(context).edit();
+
+    editor.putInt(NavigationConstants.NAVIGATION_VIEW_UNIT_TYPE, unitType);
+    if (locale != null) {
+      editor.putString(NavigationConstants.NAVIGATION_VIEW_LOCALE_LANGUAGE, locale.getLanguage());
+      editor.putString(NavigationConstants.NAVIGATION_VIEW_LOCALE_COUNTRY, locale.getCountry());
+    }
+
+    editor.apply();
+  }
+
+  /**
    * Returns the unit type to use, or the unit type for specified locale if no unit type is specified
    * @param context where SharedPreferences are stored
    * @param locale to use for default

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/LocaleUtils.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/LocaleUtils.java
@@ -2,6 +2,7 @@ package com.mapbox.services.android.navigation.v5.utils;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.os.Build;
 import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 
@@ -34,7 +35,11 @@ public class LocaleUtils {
     } else if (!localeLanguage.isEmpty()) { // Country is not required for a locale
       return new Locale(localeLanguage);
     } else { // If locale isn't specified, use device locale
-      return context.getResources().getConfiguration().locale;
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+        return context.getResources().getConfiguration().getLocales().get(0);
+      } else {
+        return context.getResources().getConfiguration().locale;
+      }
     }
   }
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/LocaleUtils.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/LocaleUtils.java
@@ -1,0 +1,74 @@
+package com.mapbox.services.android.navigation.v5.utils;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+import android.support.annotation.NonNull;
+
+import com.mapbox.services.android.navigation.v5.navigation.NavigationConstants;
+import com.mapbox.services.android.navigation.v5.navigation.NavigationUnitType;
+
+import java.util.Locale;
+
+import static com.mapbox.services.android.navigation.v5.navigation.NavigationUnitType.NONE_SPECIFIED;
+import static com.mapbox.services.android.navigation.v5.navigation.NavigationUnitType.TYPE_IMPERIAL;
+import static com.mapbox.services.android.navigation.v5.navigation.NavigationUnitType.TYPE_METRIC;
+
+public class LocaleUtils {
+
+  /**
+   * Returns the locale specified in SharedPreferences, or the device Locale if not specified
+   * @param context where SharedPreferences are stored
+   * @return locale specified in SharedPrefs, or the device locale
+   */
+  public static Locale getLocale(Context context) {
+    SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
+
+    String localeLanguage = preferences.getString(
+      NavigationConstants.NAVIGATION_VIEW_LOCALE_LANGUAGE, "");
+    String localeCountry = preferences.getString(
+      NavigationConstants.NAVIGATION_VIEW_LOCALE_COUNTRY, "");
+
+    if (!localeCountry.isEmpty() && !localeLanguage.isEmpty()) {
+      return new Locale(localeLanguage, localeCountry);
+    } else if (!localeLanguage.isEmpty()) { // Country is not required for a locale
+      return new Locale(localeLanguage);
+    } else { // If locale isn't specified, use device locale
+      return context.getResources().getConfiguration().locale;
+    }
+  }
+
+  /**
+   * Returns the unit type to use, or the unit type for specified locale if no unit type is specified
+   * @param context where SharedPreferences are stored
+   * @param locale to use for default
+   * @return unit type
+   */
+  public static @NavigationUnitType.UnitType int getUnitType(Context context, @NonNull Locale locale) {
+    int unitType = PreferenceManager.getDefaultSharedPreferences(context)
+      .getInt(NavigationConstants.NAVIGATION_VIEW_UNIT_TYPE, NONE_SPECIFIED);
+
+    if (unitType != NONE_SPECIFIED) {
+      return unitType;
+    }
+
+    // If unit type isn't specified, use default for locale
+    switch (locale.getCountry()) {
+      case "US": // US
+      case "LR": // Liberia
+      case "MM": // Burma
+        return TYPE_IMPERIAL;
+      default:
+        return TYPE_METRIC;
+    }
+  }
+
+  /**
+   * Returns the unit type to use, or the unit type for specified locale if no unit type is specified
+   * @param context where SharedPreferences are stored
+   * @return unit type
+   */
+  public static @NavigationUnitType.UnitType int getUnitType(Context context) {
+    getUnitType(context, getLocale(context));
+  }
+}

--- a/libandroid-navigation/src/main/res/values/strings.xml
+++ b/libandroid-navigation/src/main/res/values/strings.xml
@@ -5,4 +5,8 @@
     <string name="end_navigation">End Navigation</string>
     <string name="channel_name">Navigation Notifications</string>
     <string name="notification_arrival_time_format">Arrive at %s</string>
+    <string name="kilometers">km</string>
+    <string name="meters">m</string>
+    <string name="miles">mi</string>
+    <string name="feet">ft</string>
 </resources>

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/utils/DistanceUtilsTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/utils/DistanceUtilsTest.java
@@ -1,14 +1,26 @@
 package com.mapbox.services.android.navigation.v5.utils;
 
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import com.mapbox.services.android.navigation.R;
+import com.mapbox.services.android.navigation.v5.navigation.NavigationConstants;
 import com.mapbox.services.android.navigation.v5.navigation.NavigationUnitType;
 
 import junit.framework.Assert;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.robolectric.RobolectricTestRunner;
 
 import java.util.Locale;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricTestRunner.class)
 public class DistanceUtilsTest {
@@ -17,51 +29,121 @@ public class DistanceUtilsTest {
   private static final double SMALL_SMALL_UNIT = 13.71;
   private static final double LARGE_SMALL_UNIT = 109.73;
 
+  @Mock
+  private SharedPreferences sharedPreferences;
+  @Mock
+  private Context context;
+
+  @Before
+  public void setup() {
+    sharedPreferences = Mockito.mock(SharedPreferences.class);
+    context = Mockito.mock(Context.class);
+    when(context.getSharedPreferences(anyString(), anyInt())).thenReturn(sharedPreferences);
+    when(context.getString(R.string.kilometers)).thenReturn("km");
+    when(context.getString(R.string.meters)).thenReturn("m");
+    when(context.getString(R.string.miles)).thenReturn("mi");
+    when(context.getString(R.string.feet)).thenReturn("ft");
+  }
+
+  private void setupSharedPreferences(Locale locale, int navigationUnitType) {
+    when(sharedPreferences.getString(NavigationConstants.NAVIGATION_VIEW_LOCALE_LANGUAGE, Locale.getDefault().getLanguage())).thenReturn(locale.getLanguage());
+    when(sharedPreferences.getString(NavigationConstants.NAVIGATION_VIEW_LOCALE_COUNTRY, Locale.getDefault().getCountry())).thenReturn(locale.getCountry());
+    when(sharedPreferences.getInt(NavigationConstants.NAVIGATION_VIEW_UNIT_TYPE, -1)).thenReturn(navigationUnitType);
+  }
+
+  @Test
+  public void testFormatDistance_noLocaleCountry() {
+    setupSharedPreferences(new Locale(Locale.ENGLISH.getLanguage()), NavigationUnitType.TYPE_IMPERIAL);
+
+    assertOutput("11 mi", LARGE_LARGE_UNIT);
+  }
+
+  @Test
+  public void testFormatDistance_noLocale() {
+    setupSharedPreferences(new Locale("", ""), NavigationUnitType.TYPE_IMPERIAL);
+
+    assertOutput("11 mi", LARGE_LARGE_UNIT);
+  }
+
+  @Test
+  public void testFormatDistance_unitTypeDifferentFromLocale() {
+    setupSharedPreferences(Locale.US, NavigationUnitType.TYPE_METRIC);
+
+    assertOutput("18 km", LARGE_LARGE_UNIT);
+  }
+
   @Test
   public void testFormatDistance_largeMiles() {
-    assertOutput("11 mi", LARGE_LARGE_UNIT, NavigationUnitType.TYPE_IMPERIAL, Locale.US);
+    setupSharedPreferences(Locale.US, NavigationUnitType.TYPE_IMPERIAL);
+
+    assertOutput("11 mi", LARGE_LARGE_UNIT);
   }
 
   @Test
   public void testFormatDistance_largeKilometers() {
-    assertOutput("18 km", LARGE_LARGE_UNIT, NavigationUnitType.TYPE_METRIC, Locale.FRANCE);
+    setupSharedPreferences(Locale.FRANCE, NavigationUnitType.TYPE_METRIC);
+
+    assertOutput("18 km", LARGE_LARGE_UNIT);
+  }
+
+  @Test
+  public void testFormatDistance_largeKilometerNoUnitTypeButMetricLocale() {
+    setupSharedPreferences(Locale.FRANCE, -1);
+
+    assertOutput("18 km", LARGE_LARGE_UNIT);
   }
 
   @Test
   public void testFormatDistance_mediumMiles() {
-    assertOutput("6.1 mi", MEDIUM_LARGE_UNIT, NavigationUnitType.TYPE_IMPERIAL, Locale.US);
+    setupSharedPreferences(Locale.US, NavigationUnitType.TYPE_IMPERIAL);
+
+    assertOutput("6.1 mi", MEDIUM_LARGE_UNIT);
   }
 
   @Test
   public void testFormatDistance_mediumKilometers() {
-    assertOutput("9,8 km", MEDIUM_LARGE_UNIT, NavigationUnitType.TYPE_METRIC, Locale.FRANCE);
+    setupSharedPreferences(Locale.FRANCE, NavigationUnitType.TYPE_METRIC);
+
+    assertOutput("9,8 km", MEDIUM_LARGE_UNIT);
+  }
+
+  @Test
+  public void testFormatDistance_mediumKilometersUnitTypeDifferentFromLocale() {
+    setupSharedPreferences(Locale.FRANCE, NavigationUnitType.TYPE_IMPERIAL);
+
+    assertOutput("6,1 mi", MEDIUM_LARGE_UNIT);
   }
 
   @Test
   public void testFormatDistance_smallFeet() {
-    assertOutput("50 ft", SMALL_SMALL_UNIT, NavigationUnitType.TYPE_IMPERIAL, Locale.US);
+    setupSharedPreferences(Locale.US, NavigationUnitType.TYPE_IMPERIAL);
+
+    assertOutput("50 ft", SMALL_SMALL_UNIT);
   }
 
   @Test
   public void testFormatDistance_smallMeters() {
-    assertOutput("50 m", SMALL_SMALL_UNIT, NavigationUnitType.TYPE_METRIC, Locale.FRANCE);
+    setupSharedPreferences(Locale.FRANCE, NavigationUnitType.TYPE_METRIC);
+
+    assertOutput("50 m", SMALL_SMALL_UNIT);
   }
 
   @Test
   public void testFormatDistance_largeFeet() {
-    assertOutput("350 ft", LARGE_SMALL_UNIT, NavigationUnitType.TYPE_IMPERIAL, Locale.US);
+    setupSharedPreferences(Locale.US, NavigationUnitType.TYPE_IMPERIAL);
+
+    assertOutput("350 ft", LARGE_SMALL_UNIT);
   }
 
   @Test
   public void testFormatDistance_largeMeters() {
-    assertOutput("100 m", LARGE_SMALL_UNIT, NavigationUnitType.TYPE_METRIC, Locale.FRANCE);
+    setupSharedPreferences(Locale.FRANCE, NavigationUnitType.TYPE_METRIC);
+
+    assertOutput("100 m", LARGE_SMALL_UNIT);
   }
 
-  private void assertOutput(String output, double distance, int unitType, Locale locale) {
+  private void assertOutput(String output, double distance) {
     Assert.assertEquals(output,
-      DistanceUtils.formatDistance(
-        distance,
-        locale,
-        unitType).toString());
+      new DistanceUtils(context).formatDistance(distance).toString());
   }
 }

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/utils/DistanceUtilsTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/utils/DistanceUtilsTest.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.content.res.Resources;
+import android.os.LocaleList;
 
 import com.mapbox.services.android.navigation.R;
 import com.mapbox.services.android.navigation.v5.navigation.NavigationConstants;
@@ -49,7 +50,7 @@ public class DistanceUtilsTest {
     when(context.getSharedPreferences(anyString(), anyInt())).thenReturn(sharedPreferences);
     when(context.getResources()).thenReturn(resources);
     when(resources.getConfiguration()).thenReturn(configuration);
-    configuration.locale = Locale.getDefault();
+    when(configuration.getLocales()).thenReturn(LocaleList.getDefault());
     when(context.getString(R.string.kilometers)).thenReturn("km");
     when(context.getString(R.string.meters)).thenReturn("m");
     when(context.getString(R.string.miles)).thenReturn("mi");

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/utils/DistanceUtilsTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/utils/DistanceUtilsTest.java
@@ -1,6 +1,5 @@
 package com.mapbox.services.android.navigation.v5.utils;
 
-import com.mapbox.services.android.navigation.v5.navigation.NavigationConstants;
 import com.mapbox.services.android.navigation.v5.navigation.NavigationUnitType;
 
 import junit.framework.Assert;
@@ -9,58 +8,57 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
-import java.text.DecimalFormat;
+import java.util.Locale;
 
 @RunWith(RobolectricTestRunner.class)
 public class DistanceUtilsTest {
 
   @Test
   public void testFormatDistance_largeMiles() {
-    assertOutput("11 mi", 18024.65, NavigationUnitType.TYPE_IMPERIAL);
+    assertOutput("11 mi", 18024.65, NavigationUnitType.TYPE_IMPERIAL, Locale.US);
   }
 
   @Test
   public void testFormatDistance_mediumMiles() {
-    assertOutput("5.6 mi", 9012.33, NavigationUnitType.TYPE_IMPERIAL);
+    assertOutput("5.6 mi", 9012.33, NavigationUnitType.TYPE_IMPERIAL, Locale.US);
   }
 
   @Test
   public void testFormatDistance_smallFeet() {
-    assertOutput("50 ft", 13.71, NavigationUnitType.TYPE_IMPERIAL);
+    assertOutput("50 ft", 13.71, NavigationUnitType.TYPE_IMPERIAL, Locale.US);
   }
 
   @Test
   public void testFormatDistance_largeFeet() {
-    assertOutput("350 ft", 109.73, NavigationUnitType.TYPE_IMPERIAL);
+    assertOutput("350 ft", 109.73, NavigationUnitType.TYPE_IMPERIAL, Locale.US);
   }
 
 
   @Test
   public void testFormatDistance_largeKilometers() {
-    assertOutput("18 km", 18124.65, NavigationUnitType.TYPE_METRIC);
+    assertOutput("18 km", 18124.65, NavigationUnitType.TYPE_METRIC, Locale.FRANCE);
   }
 
   @Test
   public void testFormatDistance_mediumKilometers() {
-    assertOutput("9.8 km", 9812.33, NavigationUnitType.TYPE_METRIC);
+    assertOutput("9,8 km", 9812.33, NavigationUnitType.TYPE_METRIC, Locale.FRANCE);
   }
 
   @Test
   public void testFormatDistance_smallMeters() {
-    assertOutput("50 m", 48.72, NavigationUnitType.TYPE_METRIC);
+    assertOutput("50 m", 48.72, NavigationUnitType.TYPE_METRIC, Locale.FRANCE);
   }
 
   @Test
   public void testFormatDistance_largeMeters() {
-    assertOutput("100 m", 109.73, NavigationUnitType.TYPE_METRIC);
+    assertOutput("100 m", 109.73, NavigationUnitType.TYPE_METRIC, Locale.FRANCE);
   }
 
-  private void assertOutput(String output, double distance, int unitType) {
+  private void assertOutput(String output, double distance, int unitType, Locale locale) {
     Assert.assertEquals(output,
       DistanceUtils.formatDistance(
         distance,
-        new DecimalFormat(NavigationConstants.DECIMAL_FORMAT),
-        false,
+        locale,
         unitType).toString());
   }
 }

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/utils/DistanceUtilsTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/utils/DistanceUtilsTest.java
@@ -1,0 +1,26 @@
+package com.mapbox.services.android.navigation.v5.utils;
+
+import com.mapbox.services.android.navigation.v5.navigation.NavigationConstants;
+import com.mapbox.services.android.navigation.v5.navigation.NavigationUnitType;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.text.DecimalFormat;
+
+@RunWith(RobolectricTestRunner.class)
+public class DistanceUtilsTest {
+  private static final double largeMiles = 18024.65;
+
+  @Test
+  public void testDistanceFormatter() {
+    Assert.assertEquals("11 mi", DistanceUtils.formatDistance(
+      largeMiles,
+      new DecimalFormat(NavigationConstants.DECIMAL_FORMAT),
+      false,
+      NavigationUnitType.TYPE_IMPERIAL).toString().toString());
+  }
+}

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/utils/DistanceUtilsTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/utils/DistanceUtilsTest.java
@@ -13,14 +13,54 @@ import java.text.DecimalFormat;
 
 @RunWith(RobolectricTestRunner.class)
 public class DistanceUtilsTest {
-  private static final double largeMiles = 18024.65;
 
   @Test
-  public void testDistanceFormatter() {
-    Assert.assertEquals("11 mi", DistanceUtils.formatDistance(
-      largeMiles,
-      new DecimalFormat(NavigationConstants.DECIMAL_FORMAT),
-      false,
-      NavigationUnitType.TYPE_IMPERIAL).toString().toString());
+  public void testFormatDistance_largeMiles() {
+    assertOutput("11 mi", 18024.65, NavigationUnitType.TYPE_IMPERIAL);
+  }
+
+  @Test
+  public void testFormatDistance_mediumMiles() {
+    assertOutput("5.6 mi", 9012.33, NavigationUnitType.TYPE_IMPERIAL);
+  }
+
+  @Test
+  public void testFormatDistance_smallFeet() {
+    assertOutput("50 ft", 13.71, NavigationUnitType.TYPE_IMPERIAL);
+  }
+
+  @Test
+  public void testFormatDistance_largeFeet() {
+    assertOutput("350 ft", 109.73, NavigationUnitType.TYPE_IMPERIAL);
+  }
+
+
+  @Test
+  public void testFormatDistance_largeKilometers() {
+    assertOutput("18 km", 18124.65, NavigationUnitType.TYPE_METRIC);
+  }
+
+  @Test
+  public void testFormatDistance_mediumKilometers() {
+    assertOutput("9.8 km", 9812.33, NavigationUnitType.TYPE_METRIC);
+  }
+
+  @Test
+  public void testFormatDistance_smallMeters() {
+    assertOutput("50 m", 48.72, NavigationUnitType.TYPE_METRIC);
+  }
+
+  @Test
+  public void testFormatDistance_largeMeters() {
+    assertOutput("100 m", 109.73, NavigationUnitType.TYPE_METRIC);
+  }
+
+  private void assertOutput(String output, double distance, int unitType) {
+    Assert.assertEquals(output,
+      DistanceUtils.formatDistance(
+        distance,
+        new DecimalFormat(NavigationConstants.DECIMAL_FORMAT),
+        false,
+        unitType).toString());
   }
 }

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/utils/DistanceUtilsTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/utils/DistanceUtilsTest.java
@@ -12,45 +12,49 @@ import java.util.Locale;
 
 @RunWith(RobolectricTestRunner.class)
 public class DistanceUtilsTest {
+  private static final double LARGE_LARGE_UNIT = 18124.65;
+  private static final double MEDIUM_LARGE_UNIT = 9812.33;
+  private static final double SMALL_SMALL_UNIT = 13.71;
+  private static final double LARGE_SMALL_UNIT = 109.73;
 
   @Test
   public void testFormatDistance_largeMiles() {
-    assertOutput("11 mi", 18124.65, NavigationUnitType.TYPE_IMPERIAL, Locale.US);
-  }
-
-  @Test
-  public void testFormatDistance_mediumMiles() {
-    assertOutput("5.6 mi", 9012.33, NavigationUnitType.TYPE_IMPERIAL, Locale.US);
-  }
-
-  @Test
-  public void testFormatDistance_smallFeet() {
-    assertOutput("50 ft", 13.71, NavigationUnitType.TYPE_IMPERIAL, Locale.US);
-  }
-
-  @Test
-  public void testFormatDistance_largeFeet() {
-    assertOutput("350 ft", 109.73, NavigationUnitType.TYPE_IMPERIAL, Locale.US);
+    assertOutput("11 mi", LARGE_LARGE_UNIT, NavigationUnitType.TYPE_IMPERIAL, Locale.US);
   }
 
   @Test
   public void testFormatDistance_largeKilometers() {
-    assertOutput("18 km", 18124.65, NavigationUnitType.TYPE_METRIC, Locale.FRANCE);
+    assertOutput("18 km", LARGE_LARGE_UNIT, NavigationUnitType.TYPE_METRIC, Locale.FRANCE);
+  }
+
+  @Test
+  public void testFormatDistance_mediumMiles() {
+    assertOutput("6.1 mi", MEDIUM_LARGE_UNIT, NavigationUnitType.TYPE_IMPERIAL, Locale.US);
   }
 
   @Test
   public void testFormatDistance_mediumKilometers() {
-    assertOutput("9,8 km", 9812.33, NavigationUnitType.TYPE_METRIC, Locale.FRANCE);
+    assertOutput("9,8 km", MEDIUM_LARGE_UNIT, NavigationUnitType.TYPE_METRIC, Locale.FRANCE);
+  }
+
+  @Test
+  public void testFormatDistance_smallFeet() {
+    assertOutput("50 ft", SMALL_SMALL_UNIT, NavigationUnitType.TYPE_IMPERIAL, Locale.US);
   }
 
   @Test
   public void testFormatDistance_smallMeters() {
-    assertOutput("50 m", 48.72, NavigationUnitType.TYPE_METRIC, Locale.FRANCE);
+    assertOutput("50 m", SMALL_SMALL_UNIT, NavigationUnitType.TYPE_METRIC, Locale.FRANCE);
+  }
+
+  @Test
+  public void testFormatDistance_largeFeet() {
+    assertOutput("350 ft", LARGE_SMALL_UNIT, NavigationUnitType.TYPE_IMPERIAL, Locale.US);
   }
 
   @Test
   public void testFormatDistance_largeMeters() {
-    assertOutput("100 m", 109.73, NavigationUnitType.TYPE_METRIC, Locale.FRANCE);
+    assertOutput("100 m", LARGE_SMALL_UNIT, NavigationUnitType.TYPE_METRIC, Locale.FRANCE);
   }
 
   private void assertOutput(String output, double distance, int unitType, Locale locale) {

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/utils/DistanceUtilsTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/utils/DistanceUtilsTest.java
@@ -15,7 +15,7 @@ public class DistanceUtilsTest {
 
   @Test
   public void testFormatDistance_largeMiles() {
-    assertOutput("11 mi", 18024.65, NavigationUnitType.TYPE_IMPERIAL, Locale.US);
+    assertOutput("11 mi", 18124.65, NavigationUnitType.TYPE_IMPERIAL, Locale.US);
   }
 
   @Test
@@ -32,7 +32,6 @@ public class DistanceUtilsTest {
   public void testFormatDistance_largeFeet() {
     assertOutput("350 ft", 109.73, NavigationUnitType.TYPE_IMPERIAL, Locale.US);
   }
-
 
   @Test
   public void testFormatDistance_largeKilometers() {

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/utils/DistanceUtilsTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/utils/DistanceUtilsTest.java
@@ -2,6 +2,8 @@ package com.mapbox.services.android.navigation.v5.utils;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.content.res.Configuration;
+import android.content.res.Resources;
 
 import com.mapbox.services.android.navigation.R;
 import com.mapbox.services.android.navigation.v5.navigation.NavigationConstants;
@@ -33,12 +35,21 @@ public class DistanceUtilsTest {
   private SharedPreferences sharedPreferences;
   @Mock
   private Context context;
+  @Mock
+  private Resources resources;
+  @Mock
+  private Configuration configuration;
 
   @Before
   public void setup() {
     sharedPreferences = Mockito.mock(SharedPreferences.class);
     context = Mockito.mock(Context.class);
+    resources = Mockito.mock(Resources.class);
+    configuration = Mockito.mock(Configuration.class);
     when(context.getSharedPreferences(anyString(), anyInt())).thenReturn(sharedPreferences);
+    when(context.getResources()).thenReturn(resources);
+    when(resources.getConfiguration()).thenReturn(configuration);
+    configuration.locale = Locale.getDefault();
     when(context.getString(R.string.kilometers)).thenReturn("km");
     when(context.getString(R.string.meters)).thenReturn("m");
     when(context.getString(R.string.miles)).thenReturn("mi");
@@ -46,9 +57,9 @@ public class DistanceUtilsTest {
   }
 
   private void setupSharedPreferences(Locale locale, int navigationUnitType) {
-    when(sharedPreferences.getString(NavigationConstants.NAVIGATION_VIEW_LOCALE_LANGUAGE, Locale.getDefault().getLanguage())).thenReturn(locale.getLanguage());
-    when(sharedPreferences.getString(NavigationConstants.NAVIGATION_VIEW_LOCALE_COUNTRY, Locale.getDefault().getCountry())).thenReturn(locale.getCountry());
-    when(sharedPreferences.getInt(NavigationConstants.NAVIGATION_VIEW_UNIT_TYPE, -1)).thenReturn(navigationUnitType);
+    when(sharedPreferences.getString(NavigationConstants.NAVIGATION_VIEW_LOCALE_LANGUAGE, "")).thenReturn(locale.getLanguage());
+    when(sharedPreferences.getString(NavigationConstants.NAVIGATION_VIEW_LOCALE_COUNTRY, "")).thenReturn(locale.getCountry());
+    when(sharedPreferences.getInt(NavigationConstants.NAVIGATION_VIEW_UNIT_TYPE, NavigationUnitType.NONE_SPECIFIED)).thenReturn(navigationUnitType);
   }
 
   @Test


### PR DESCRIPTION
Refactored the distance formatter for simplicity, and also added `locale` to options, so that the numbers can be formatted properly for the given locale. I also added a test to verify that the refactored code behavior matched the previous behavior, and to test the locale formatting. Unit type is still specified in the options separately. We could potentially use the locale to pick the unit type if no unit type is specified.

Output from tests:

Meters | Locale | Formatted String
-------|--------|-----------------
18124.65		|en_US	|	11 mi
18124.65	|	fr_FR	|	18 km
109.73	|	en_US	|	350 ft
109.73	|	fr_FR	|	100 m
9812.33	|fr_FR	|	9,8 km
9812.33	|	en_US	|	6.1 mi
13.71	|	fr_FR	|	50 m
13.71	|	en_US	|	50 ft

