### PR TITLE
Add bearing to RouteEngine requests

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationService.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationService.java
@@ -12,7 +12,6 @@ import android.support.annotation.Nullable;
 
 import com.mapbox.api.directions.v5.models.DirectionsResponse;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
-import com.mapbox.geojson.Point;
 import com.mapbox.services.android.navigation.v5.milestone.Milestone;
 import com.mapbox.services.android.navigation.v5.navigation.notification.NavigationNotification;
 import com.mapbox.services.android.navigation.v5.route.RouteEngine;
@@ -146,15 +145,14 @@ public class NavigationService extends Service implements LocationEngineListener
    * Callback from the {@link NavigationEngine} - if fired with checkFasterRoute set
    * to true, a new {@link DirectionsRoute} should be fetched with {@link RouteEngine}.
    *
-   * @param location to create a new origin
-   * @param routeProgress for various {@link com.mapbox.api.directions.v5.models.LegStep} data
+   * @param location         to create a new origin
+   * @param routeProgress    for various {@link com.mapbox.api.directions.v5.models.LegStep} data
    * @param checkFasterRoute true if should check for faster route, false otherwise
    */
   @Override
   public void onCheckFasterRoute(Location location, RouteProgress routeProgress, boolean checkFasterRoute) {
     if (checkFasterRoute) {
-      Point origin = Point.fromLngLat(location.getLongitude(), location.getLatitude());
-      routeEngine.fetchRoute(origin, routeProgress);
+      routeEngine.fetchRoute(location, routeProgress);
     }
   }
 
@@ -162,7 +160,7 @@ public class NavigationService extends Service implements LocationEngineListener
    * Callback from the {@link RouteEngine} - if fired, a new and valid
    * {@link DirectionsRoute} has been successfully retrieved.
    *
-   * @param response with the new route
+   * @param response      with the new route
    * @param routeProgress holding necessary leg / step information
    */
   @Override
@@ -170,6 +168,17 @@ public class NavigationService extends Service implements LocationEngineListener
     if (mapboxNavigation.getFasterRouteEngine().isFasterRoute(response.body(), routeProgress)) {
       mapboxNavigation.getEventDispatcher().onFasterRouteEvent(response.body().routes().get(0));
     }
+  }
+
+  /**
+   * Callback from the {@link RouteEngine} - if fired, an error has occurred
+   * retrieving the {@link DirectionsRoute}.
+   *
+   * @param throwable with error
+   */
+  @Override
+  public void onErrorReceived(Throwable throwable) {
+    Timber.e(throwable);
   }
 
   /**

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/route/RouteEngine.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/route/RouteEngine.java
@@ -17,7 +17,7 @@ import retrofit2.Callback;
 import retrofit2.Response;
 
 /**
- * This class can be used to fetch new routes given a {@link Point} origin and
+ * This class can be used to fetch new routes given a {@link Location} origin and
  * {@link RouteOptions} provided by a {@link RouteProgress}.
  */
 public class RouteEngine implements Callback<DirectionsResponse> {
@@ -29,6 +29,17 @@ public class RouteEngine implements Callback<DirectionsResponse> {
     this.engineCallback = engineCallback;
   }
 
+  /**
+   * Calculates a new {@link com.mapbox.api.directions.v5.models.DirectionsRoute} given
+   * the current {@link Location} and {@link RouteProgress} along the route.
+   * <p>
+   * Uses {@link RouteOptions#coordinates()} and {@link RouteProgress#remainingWaypoints()}
+   * to determine the amount of remaining waypoints there are along the given route.
+   *
+   * @param location      current location of the device
+   * @param routeProgress for remaining waypoints along the route
+   * @since 0.10.0
+   */
   public void fetchRoute(Location location, RouteProgress routeProgress) {
     if (routeProgress == null) {
       return;
@@ -78,6 +89,11 @@ public class RouteEngine implements Callback<DirectionsResponse> {
     engineCallback.onErrorReceived(throwable);
   }
 
+  /**
+   * Callback to be passed into the constructor of {@link RouteEngine}.
+   * <p>
+   * Will fire when either a successful / failed response is received.
+   */
   public interface Callback {
     void onResponseReceived(Response<DirectionsResponse> response, RouteProgress routeProgress);
 

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/route/RouteEngineTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/route/RouteEngineTest.java
@@ -1,7 +1,0 @@
-package com.mapbox.services.android.navigation.v5.route;
-
-import com.mapbox.services.android.navigation.v5.BaseTest;
-
-public class RouteEngineTest extends BaseTest {
-
-}

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/route/RouteEngineTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/route/RouteEngineTest.java
@@ -1,0 +1,7 @@
+package com.mapbox.services.android.navigation.v5.route;
+
+import com.mapbox.services.android.navigation.v5.BaseTest;
+
+public class RouteEngineTest extends BaseTest {
+
+}


### PR DESCRIPTION
Faster route requests are not taking bearing into account.  Our checks should prevent a route like this from being fired to the listener, but this can lead to routes showing up going into the opposite direction, causing an immediate reroute.  

TODO:
- [x] Javadoc