### PR TITLE
Fix flashing InstructionView list during re-routes

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionView.java
@@ -72,7 +72,6 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
 
   private static final double VALID_DURATION_REMAINING = 70d;
 
-  public boolean isMuted;
   private ManeuverView upcomingManeuverView;
   private TextView upcomingDistanceText;
   private TextView upcomingPrimaryText;
@@ -99,6 +98,7 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
   private LegStep currentStep;
   private NavigationViewModel navigationViewModel;
   private boolean isRerouting;
+  public boolean isMuted;
 
   public InstructionView(Context context) {
     this(context, null);
@@ -280,51 +280,47 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
   }
 
   /**
-   * Hide the instruction list and show the sound button.
+   * Hide the instruction list.
    * <p>
    * This is based on orientation so the different layouts (for portrait vs. landscape)
    * can be animated appropriately.
    */
   public void hideInstructionList() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+      TransitionManager.beginDelayedTransition(InstructionView.this);
+    }
     int orientation = getContext().getResources().getConfiguration().orientation;
     if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
       ConstraintSet collapsed = new ConstraintSet();
       collapsed.clone(getContext(), R.layout.instruction_layout);
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-        TransitionManager.beginDelayedTransition(InstructionView.this);
-      }
       collapsed.applyTo(instructionLayout);
-      instructionListLayout.setVisibility(INVISIBLE);
+      instructionListLayout.setVisibility(GONE);
     } else {
-      Animation slideUp = AnimationUtils.loadAnimation(getContext(), R.anim.slide_up_top);
-      slideUp.setInterpolator(new AccelerateInterpolator());
-      instructionListLayout.startAnimation(slideUp);
-      instructionListLayout.setVisibility(INVISIBLE);
+      instructionListLayout.setVisibility(GONE);
     }
   }
 
   /**
-   * Show the instruction list and hide the sound button.
+   * Show the instruction list.
    * <p>
    * This is based on orientation so the different layouts (for portrait vs. landscape)
    * can be animated appropriately.
    */
   public void showInstructionList() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+      TransitionManager.beginDelayedTransition(InstructionView.this);
+    }
     int orientation = getContext().getResources().getConfiguration().orientation;
     if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
       ConstraintSet expanded = new ConstraintSet();
       expanded.clone(getContext(), R.layout.instruction_layout_alt);
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-        TransitionManager.beginDelayedTransition(InstructionView.this);
-      }
       expanded.applyTo(instructionLayout);
       instructionListLayout.setVisibility(VISIBLE);
     } else {
-      Animation slideDown = AnimationUtils.loadAnimation(getContext(), R.anim.slide_down_top);
-      slideDown.setInterpolator(new DecelerateInterpolator());
       instructionListLayout.setVisibility(VISIBLE);
-      instructionListLayout.startAnimation(slideDown);
     }
+    // Scroll to top of directions list
+    rvInstructions.scrollToPosition(0);
   }
 
   /**

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionView.java
@@ -290,7 +290,7 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
     beginDelayedTransition();
     int orientation = getContext().getResources().getConfiguration().orientation;
     if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
-      updateLandscapeConstraints(R.layout.instruction_layout);
+      updateLandscapeConstraintsTo(R.layout.instruction_layout);
     }
     instructionListLayout.setVisibility(GONE);
   }
@@ -305,7 +305,7 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
     beginDelayedTransition();
     int orientation = getContext().getResources().getConfiguration().orientation;
     if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
-      updateLandscapeConstraints(R.layout.instruction_layout_alt);
+      updateLandscapeConstraintsTo(R.layout.instruction_layout_alt);
     }
     instructionListLayout.setVisibility(VISIBLE);
     rvInstructions.scrollToPosition(TOP);
@@ -781,9 +781,9 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
     }
   }
 
-  private void updateLandscapeConstraints(int newLayoutResId) {
+  private void updateLandscapeConstraintsTo(int layoutRes) {
     ConstraintSet collapsed = new ConstraintSet();
-    collapsed.clone(getContext(), newLayoutResId);
+    collapsed.clone(getContext(), layoutRes);
     collapsed.applyTo(instructionLayout);
   }
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionView.java
@@ -71,6 +71,7 @@ import java.util.List;
 public class InstructionView extends RelativeLayout implements FeedbackBottomSheetListener {
 
   private static final double VALID_DURATION_REMAINING = 70d;
+  private static final int TOP = 0;
 
   private ManeuverView upcomingManeuverView;
   private TextView upcomingDistanceText;
@@ -98,7 +99,7 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
   private LegStep currentStep;
   private NavigationViewModel navigationViewModel;
   private boolean isRerouting;
-  public boolean isMuted;
+  private boolean isMuted;
 
   public InstructionView(Context context) {
     this(context, null);
@@ -286,18 +287,12 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
    * can be animated appropriately.
    */
   public void hideInstructionList() {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-      TransitionManager.beginDelayedTransition(InstructionView.this);
-    }
+    beginDelayedTransition();
     int orientation = getContext().getResources().getConfiguration().orientation;
     if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
-      ConstraintSet collapsed = new ConstraintSet();
-      collapsed.clone(getContext(), R.layout.instruction_layout);
-      collapsed.applyTo(instructionLayout);
-      instructionListLayout.setVisibility(GONE);
-    } else {
-      instructionListLayout.setVisibility(GONE);
+      updateLandscapeConstraints(R.layout.instruction_layout);
     }
+    instructionListLayout.setVisibility(GONE);
   }
 
   /**
@@ -307,20 +302,13 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
    * can be animated appropriately.
    */
   public void showInstructionList() {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-      TransitionManager.beginDelayedTransition(InstructionView.this);
-    }
+    beginDelayedTransition();
     int orientation = getContext().getResources().getConfiguration().orientation;
     if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
-      ConstraintSet expanded = new ConstraintSet();
-      expanded.clone(getContext(), R.layout.instruction_layout_alt);
-      expanded.applyTo(instructionLayout);
-      instructionListLayout.setVisibility(VISIBLE);
-    } else {
-      instructionListLayout.setVisibility(VISIBLE);
+      updateLandscapeConstraints(R.layout.instruction_layout_alt);
     }
-    // Scroll to top of directions list
-    rvInstructions.scrollToPosition(0);
+    instructionListLayout.setVisibility(VISIBLE);
+    rvInstructions.scrollToPosition(TOP);
   }
 
   /**
@@ -706,9 +694,7 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
    */
   private void showTurnLanes() {
     if (turnLaneLayout.getVisibility() == GONE) {
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-        TransitionManager.beginDelayedTransition(this);
-      }
+      beginDelayedTransition();
       turnLaneLayout.setVisibility(VISIBLE);
     }
   }
@@ -718,9 +704,7 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
    */
   private void hideTurnLanes() {
     if (turnLaneLayout.getVisibility() == VISIBLE) {
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-        TransitionManager.beginDelayedTransition(this);
-      }
+      beginDelayedTransition();
       turnLaneLayout.setVisibility(GONE);
     }
   }
@@ -762,9 +746,7 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
    */
   private void showThenStepLayout() {
     if (thenStepLayout.getVisibility() == GONE) {
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-        TransitionManager.beginDelayedTransition(this);
-      }
+      beginDelayedTransition();
       thenStepLayout.setVisibility(VISIBLE);
     }
   }
@@ -774,9 +756,7 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
    */
   private void hideThenStepLayout() {
     if (thenStepLayout.getVisibility() == VISIBLE) {
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-        TransitionManager.beginDelayedTransition(this);
-      }
+      beginDelayedTransition();
       thenStepLayout.setVisibility(GONE);
     }
   }
@@ -795,6 +775,17 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
     }
   }
 
+  private void beginDelayedTransition() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+      TransitionManager.beginDelayedTransition(InstructionView.this);
+    }
+  }
+
+  private void updateLandscapeConstraints(int newLayoutResId) {
+    ConstraintSet collapsed = new ConstraintSet();
+    collapsed.clone(getContext(), newLayoutResId);
+    collapsed.applyTo(instructionLayout);
+  }
 
   /**
    * Used to update the instructions list with the current steps.


### PR DESCRIPTION
Noticed on certain re-routes, the instruction list would flash.  I think this is because we were reusing the re-route animation for the list animation.  

I removed that logic and ensured this can't happen by changing the hidden visibility of the instruction list: `INVISIBLE` -> `GONE`

Bonus logic: Scroll to the top of the instruction list (if previously scrolled) before showing it 

cc @ericrwolfe 