### PR TITLE
Fix bug with MapRoute onClick

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/NavigationMapRoute.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/NavigationMapRoute.java
@@ -610,13 +610,11 @@ public class NavigationMapRoute implements ProgressChangeListener, MapView.OnMap
     if (invalidMapClick()) {
       return;
     }
-
     final int currentRouteIndex = primaryRouteIndex;
 
     if (findClickedRoute(point)) {
       return;
     }
-
     checkNewRouteFound(currentRouteIndex);
   }
 
@@ -633,7 +631,6 @@ public class NavigationMapRoute implements ProgressChangeListener, MapView.OnMap
     if (calculateClickDistancesFromRoutes(routeDistancesAwayFromClick, clickPoint)) {
       return true;
     }
-
     List<Double> distancesAwayFromClick = new ArrayList<>(routeDistancesAwayFromClick.keySet());
     Collections.sort(distancesAwayFromClick);
 
@@ -645,16 +642,12 @@ public class NavigationMapRoute implements ProgressChangeListener, MapView.OnMap
   private boolean calculateClickDistancesFromRoutes(HashMap<Double, DirectionsRoute> routeDistancesAwayFromClick,
                                                     com.mapbox.geojson.Point clickPoint) {
     for (LineString lineString : routeLineStrings.keySet()) {
-
       com.mapbox.geojson.Point pointOnLine = findPointOnLine(clickPoint, lineString);
 
       if (pointOnLine == null) {
         return true;
       }
-
       double distance = TurfMeasurement.distance(clickPoint, pointOnLine, TurfConstants.UNIT_METERS);
-
-      // Put the current route and corresponding distance away from click into the map
       routeDistancesAwayFromClick.put(distance, routeLineStrings.get(lineString));
     }
     return false;
@@ -741,8 +734,6 @@ public class NavigationMapRoute implements ProgressChangeListener, MapView.OnMap
     final List<Feature> features = new ArrayList<>();
     LineString originalGeometry = LineString.fromPolyline(route.geometry(), Constants.PRECISION_6);
     buildRouteFeatureFromGeometry(index, features, originalGeometry);
-
-    // Store geometry and corresponding route for click logic
     routeLineStrings.put(originalGeometry, route);
 
     LineString lineString = LineString.fromPolyline(route.geometry(), Constants.PRECISION_6);

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/NavigationMapRoute.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/NavigationMapRoute.java
@@ -607,16 +607,18 @@ public class NavigationMapRoute implements ProgressChangeListener, MapView.OnMap
 
   @Override
   public void onMapClick(@NonNull LatLng point) {
+
     if (routeLineStrings == null || routeLineStrings.isEmpty() || !alternativesVisible) {
       return;
     }
-    // Cache current route index
-    int currentRouteIndex = primaryRouteIndex;
 
     HashMap<Double, DirectionsRoute> routeDistancesAwayFromClick = new HashMap<>();
 
     com.mapbox.geojson.Point clickPoint
       = com.mapbox.geojson.Point.fromLngLat(point.getLongitude(), point.getLatitude());
+
+    // Cache current route index
+    final int currentRouteIndex = primaryRouteIndex;
 
     if (calculateClickDistancesFromRoutes(routeDistancesAwayFromClick, clickPoint)) {
       return;


### PR DESCRIPTION
Closes #701 

Also fixed up some of the logic in regard to how we handle clicking on alternatives.  Previously, if both routes were within the `250m` padding, the logic would sometimes still choose the index for the already clicked route even if we clicked on the alternative.

Current `master`: 
![ezgif com-video-to-gif 1](https://user-images.githubusercontent.com/8434572/36213991-32040314-1176-11e8-8ce9-c971c835e206.gif)

This PR:
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/8434572/36213720-7662abec-1175-11e8-8d1e-01f9ec691d6b.gif)

cc @cammace 