### PR TITLE
Clean dependencies exposed

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,14 +41,15 @@ sonarqube {
 dependencies {
   // Mapbox Navigation SDK
   implementation project(':libandroid-navigation-ui')
+  implementation dependenciesList.mapboxMapSdk
+  implementation dependenciesList.locationLayerPlugin
 
   // Support libraries
   implementation dependenciesList.supportAppcompatV7
+  implementation dependenciesList.supportDesign
+  implementation dependenciesList.supportRecyclerView
   implementation dependenciesList.supportConstraintLayout
-
-  // Architecture libraries
-  implementation dependenciesList.lifecycleExtensions
-  annotationProcessor dependenciesList.lifecycleCompiler
+  implementation dependenciesList.supportCardView
 
   // Logging
   implementation dependenciesList.timber

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -15,14 +15,14 @@ ext {
       autoValue          : '1.5',
       autoValueParcel    : '0.2.5',
       junit              : '4.12',
-      supportLibVersion  : '27.0.0',
+      supportLibVersion  : '27.0.2',
       constraintLayout   : '1.0.2',
       mockito            : '2.11.0',
       hamcrest           : '2.0.0.0',
       errorprone         : '2.0.21',
       butterknife        : '8.8.1',
       leakCanaryVersion  : '1.5.4',
-      timber             : '4.5.1',
+      timber             : '4.6.0',
       awsPolly           : '2.3.8',
       testRunnerVersion  : '1.0.1',
       espressoVersion    : '3.0.1',
@@ -46,8 +46,8 @@ ext {
 
   dependenciesList = [
       // mapbox
-      mapboxMapSdk           : "com.mapbox.mapboxsdk:mapbox-android-sdk:${version.mapboxMapSdk}@aar",
-      mapboxServices         : "com.mapbox.mapboxsdk:mapbox-android-services:${version.mapboxServices}@aar",
+      mapboxMapSdk           : "com.mapbox.mapboxsdk:mapbox-android-sdk:${version.mapboxMapSdk}",
+      mapboxServices         : "com.mapbox.mapboxsdk:mapbox-android-services:${version.mapboxServices}",
       mapboxJavaServices     : "com.mapbox.mapboxsdk:mapbox-java-services:${version.mapboxServices}",
       mapboxSdkServices      : "com.mapbox.mapboxsdk:mapbox-sdk-services:${version.mapboxSdkServices}",
       mapboxSdkTurf          : "com.mapbox.mapboxsdk:mapbox-sdk-turf:${version.mapboxSdkServices}",

--- a/libandroid-navigation-ui/build.gradle
+++ b/libandroid-navigation-ui/build.gradle
@@ -18,6 +18,7 @@ android {
         project.VERSION_NAME
     )
   }
+
   configurations {
     javadocDeps
   }
@@ -34,37 +35,31 @@ dependencies {
   api project(':libandroid-navigation')
 
   // Mapbox Map SDK
-  api(dependenciesList.mapboxMapSdk) {
-    transitive = true
+  implementation(dependenciesList.mapboxMapSdk) {
     exclude module: 'lost'
     exclude module: 'mapbox-java-geojson'
     exclude module: 'mapbox-android-telemetry'
   }
 
   // Support libraries
-  api dependenciesList.supportAppcompatV7
-  api dependenciesList.supportDesign
-  api dependenciesList.supportRecyclerView
-  api dependenciesList.supportConstraintLayout
-  api dependenciesList.supportCardView
+  implementation dependenciesList.supportDesign
+  implementation dependenciesList.supportRecyclerView
+  implementation dependenciesList.supportConstraintLayout
+  implementation dependenciesList.supportCardView
 
   // Architecture libraries
   implementation dependenciesList.lifecycleExtensions
   annotationProcessor dependenciesList.lifecycleCompiler
 
   // Mapbox plugins
-  api(dependenciesList.locationLayerPlugin) {
+  implementation(dependenciesList.locationLayerPlugin) {
     exclude module: 'mapbox-android-services'
     exclude module: 'mapbox-android-sdk'
   }
-  api dependenciesList.mapboxJavaServices
 
   // AutoValues
   annotationProcessor dependenciesList.autoValue
   compileOnly dependenciesList.autoValue
-
-  // Logging
-  implementation dependenciesList.timber
 
   // AWS Polly
   implementation dependenciesList.polly

--- a/libandroid-navigation/build.gradle
+++ b/libandroid-navigation/build.gradle
@@ -43,9 +43,7 @@ android {
 
 dependencies {
   // Mapbox Android Services
-  api (dependenciesList.mapboxServices) {
-    transitive = true
-  }
+  api dependenciesList.mapboxServices
 
   api dependenciesList.mapboxSdkServices
   api dependenciesList.mapboxSdkTurf


### PR DESCRIPTION
- Cleans the dependencies exposed fixing `build.gradle` files and taking advantage of the new Gradle keywords `api` and `implementation` to only expose the libraries strictly necessary.
- Bumps `supportLibVersion` to `27.0.2`
- Bumps `timber` version to `4.6.0`

We were leaking some unnecessary dependencies to the end users.

👀 @danesfeder @devotaaabel 