### PR TITLE
Fix Javadocs so that supports JDK 8

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionView.java
@@ -156,7 +156,7 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
    * Subscribes to a {@link NavigationViewModel} for
    * updates from {@link android.arch.lifecycle.LiveData}.
    * <p>
-   * Updates all views with fresh data / shows & hides re-route state.
+   * Updates all views with fresh data / shows &amp; hides re-route state.
    *
    * @param navigationViewModel to which this View is subscribing
    * @since 0.6.2

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/milestone/Milestone.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/milestone/Milestone.java
@@ -20,7 +20,7 @@ public abstract class Milestone {
 
   /**
    * Milestone specific identifier as an {@code int} value, useful for deciphering which milestone
-   * invoked {@link MilestoneEventListener#onMilestoneEvent(RouteProgress, String, int)}.
+   * invoked {@link MilestoneEventListener#onMilestoneEvent(RouteProgress, String, Milestone)}.
    *
    * @return {@code int} representing the identifier
    * @since 0.4.0
@@ -34,7 +34,7 @@ public abstract class Milestone {
    * instruction specified by the superclass.
    *
    * @return {@link Instruction} to be used to build the {@link String} passed to
-   * {@link MilestoneEventListener#onMilestoneEvent(RouteProgress, String, int)}
+   * {@link MilestoneEventListener#onMilestoneEvent(RouteProgress, String, Milestone)}
    * @since 0.4.0
    */
   public Instruction getInstruction() {
@@ -70,7 +70,7 @@ public abstract class Milestone {
 
     /**
      * Milestone specific identifier as an {@code int} value, useful for deciphering which milestone
-     * invoked {@link MilestoneEventListener#onMilestoneEvent(RouteProgress, String, int)}.
+     * invoked {@link MilestoneEventListener#onMilestoneEvent(RouteProgress, String, Milestone)}.
      *
      * @return {@code int} representing the identifier
      * @since 0.4.0
@@ -81,7 +81,7 @@ public abstract class Milestone {
 
     /**
      * Milestone specific identifier as an {@code int} value, useful for deciphering which milestone
-     * invoked {@link MilestoneEventListener#onMilestoneEvent(RouteProgress, String, int)}.
+     * invoked {@link MilestoneEventListener#onMilestoneEvent(RouteProgress, String, Milestone)}.
      *
      * @param identifier an {@code int} used to identify this milestone instance
      * @return this builder
@@ -110,7 +110,7 @@ public abstract class Milestone {
 
     /**
      * The list of triggers that are used to determine whether this milestone should invoke
-     * {@link MilestoneEventListener#onMilestoneEvent(RouteProgress, String, int)}
+     * {@link MilestoneEventListener#onMilestoneEvent(RouteProgress, String, Milestone)}
      *
      * @param trigger a single simple statement or compound statement found in {@link Trigger}
      * @return this builder

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/milestone/RouteMilestone.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/milestone/RouteMilestone.java
@@ -4,7 +4,7 @@ import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 
 /**
  * Using a Route Milestone will result in
- * {@link MilestoneEventListener#onMilestoneEvent(RouteProgress, String, int)} being invoked only
+ * {@link MilestoneEventListener#onMilestoneEvent(RouteProgress, String, Milestone)} being invoked only
  * once during a navigation session.
  *
  * @since 0.4.0

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/milestone/StepMilestone.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/milestone/StepMilestone.java
@@ -4,7 +4,8 @@ import com.mapbox.services.android.navigation.v5.exception.NavigationException;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 
 /**
- * Using a Step Milestone will result in {@link MilestoneEventListener#onMilestoneEvent(RouteProgress, String, int)}
+ * Using a Step Milestone will result in
+ * {@link MilestoneEventListener#onMilestoneEvent(RouteProgress, String, Milestone)}
  * being invoked every step if the condition validation returns true.
  *
  * @since 0.4.0

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationConstants.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationConstants.java
@@ -28,7 +28,7 @@ public final class NavigationConstants {
   /**
    * String channel used to post the navigation notification (custom or default).
    * <p>
-   * If > Android O, a notification channel needs to be created to properly post the notification.
+   * If &gt; Android O, a notification channel needs to be created to properly post the notification.
    *
    * @since 0.8.0
    */

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteDetector.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteDetector.java
@@ -29,14 +29,14 @@ public class OffRouteDetector extends OffRoute {
    * <p>
    * Test #2:
    * Distance from the step. This test is checked against the max of the dynamic rerouting tolerance or the
-   * accuracy based tolerance.  If this test passes, this method then also checks if there have been >= 3
-   * location updates moving away from the maneuver point.  If false, this method will return false early.
+   * accuracy based tolerance. If this test passes, this method then also checks if there have been &gt;= 3
+   * location updates moving away from the maneuver point. If false, this method will return false early.
    * <p>
    * Test #3:
    * Checks if the user is close the upcoming step.  At this point, the user is considered off-route.
    * But, if the location update is within the {@link MapboxNavigationOptions#maneuverZoneRadius()} of the
    * upcoming step, this method will return false as well as send fire {@link OffRouteCallback#onShouldIncreaseIndex()}
-   * to let the {@link com.mapbox.services.android.navigation.v5.navigation.NavigationEngine} know that the
+   * to let the <tt>NavigationEngine</tt> know that the
    * step index should be increased on the next location update.
    *
    * @return true if the users off-route, else false.
@@ -126,8 +126,7 @@ public class OffRouteDetector extends OffRoute {
    * is within the maneuver radius.
    * <p>
    * If it is, fire {@link OffRouteCallback#onShouldIncreaseIndex()} to increase the step
-   * index in the {@link com.mapbox.services.android.navigation.v5.navigation.NavigationEngine}
-   * and return true.
+   * index in the <tt>NavigationEngine</tt> and return true.
    *
    * @param options      for maneuver zone radius
    * @param callback     to increase step index

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/route/FasterRoute.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/route/FasterRoute.java
@@ -27,8 +27,7 @@ public abstract class FasterRoute {
    * be retrieved by {@link RouteEngine}.
    * <p>
    * It will also be called every time
-   * the {@link com.mapbox.services.android.navigation.v5.navigation.NavigationEngine} gets a valid
-   * {@link Location} update.
+   * the <tt>NavigationEngine</tt> gets a valid {@link Location} update.
    * <p>
    * The most recent snapped location and route progress are provided.  Both can be used to
    * determine if a new route should be fetched or not.


### PR DESCRIPTION
- Fixes Javadocs so that supports JDK 8 (_doclint_)

Trying to publish the artifacts locally I noticed that when running `make publish-local` the `androidJavadocs` task was failing. I'm using the JDK 8 locally which introduces _doclint_ which adds a bunch of stricter Javadoc rules 👀

> Up to JDK 7, the Javadoc tool was pretty lenient. As a developer, you could write anything that vaguely resembled HTML and the tool would rarely complain beyond warnings. Thus you could have @link references that were inaccurate (such as due to refactoring) and the tool would simply provide a warning.
>
> With JDK 8, a new part has been added to Javadoc called doclint and it changes that friendly behaviour. In particular, the tool aim to get conforming W3C HTML 4.01 HTML (despite the fact that humans are very bad at matching conformance wrt HTML).
>
> With JDK 8, you are unable to get Javadoc unless your tool meets the standards of doclint.

This PR adds the Javadoc changes needed to comply the new _doclint_ rules introduced and now we're able to run `Makefile` commands locally (as we do in CI) even using JDK 8.

👀 @danesfeder @devotaaabel 
