### PR TITLE
Null check camera tracking

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
@@ -240,7 +240,9 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
 
   @Override
   public void setCameraTrackingEnabled(boolean isEnabled) {
-    camera.setCameraTrackingLocation(isEnabled);
+    if (camera != null) {
+      camera.setCameraTrackingLocation(isEnabled);
+    }
   }
 
   @Override


### PR DESCRIPTION
Closes #702 

If a user manipulates the map without `NavigationView#startNavigation` (which finishes the view initialization, including the camera) being called, setting the tracking with throw a NPE
