### PR TITLE
Fix NPE with MapRoute click listener

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/NavigationMapRoute.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/NavigationMapRoute.java
@@ -214,15 +214,6 @@ public class NavigationMapRoute implements ProgressChangeListener, MapView.OnMap
   }
 
   /**
-   * Adds source and layers to the map.
-   */
-  private void initialize() {
-    alternativesVisible = true;
-    getAttributes();
-    placeRouteBelow();
-  }
-
-  /**
    * Allows adding a single primary route for the user to traverse along. No alternative routes will
    * be drawn on top of the map.
    *
@@ -594,9 +585,12 @@ public class NavigationMapRoute implements ProgressChangeListener, MapView.OnMap
     return feature;
   }
 
-  /**
-   * Adds the necessary listeners
-   */
+  private void initialize() {
+    alternativesVisible = true;
+    getAttributes();
+    placeRouteBelow();
+  }
+
   private void addListeners() {
     mapboxMap.addOnMapClickListener(this);
     if (navigation != null) {

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/NavigationMapRoute.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/NavigationMapRoute.java
@@ -327,20 +327,8 @@ public class NavigationMapRoute implements ProgressChangeListener, MapView.OnMap
   }
 
   private void clearRoutes() {
-    if (!layerIds.isEmpty()) {
-      for (String id : layerIds) {
-        mapboxMap.removeLayer(id);
-      }
-    }
-    if (!directionsRoutes.isEmpty()) {
-      directionsRoutes.clear();
-    }
-    if (!routeLineStrings.isEmpty()) {
-      routeLineStrings.clear();
-    }
-    if (!featureCollections.isEmpty()) {
-      featureCollections.clear();
-    }
+    removeLayerIds();
+    clearRouteListData();
   }
 
   private void generateFeatureCollectionList(List<DirectionsRoute> directionsRoutes) {
@@ -447,6 +435,26 @@ public class NavigationMapRoute implements ProgressChangeListener, MapView.OnMap
           index == primaryRouteIndex ? routeDefaultColor : alternativeRouteDefaultColor)))
     );
     MapUtils.addLayerToMap(mapboxMap, routeLayer, belowLayer);
+  }
+
+  private void removeLayerIds() {
+    if (!layerIds.isEmpty()) {
+      for (String id : layerIds) {
+        mapboxMap.removeLayer(id);
+      }
+    }
+  }
+
+  private void clearRouteListData() {
+    if (!directionsRoutes.isEmpty()) {
+      directionsRoutes.clear();
+    }
+    if (!routeLineStrings.isEmpty()) {
+      routeLineStrings.clear();
+    }
+    if (!featureCollections.isEmpty()) {
+      featureCollections.clear();
+    }
   }
 
   /**
@@ -670,11 +678,10 @@ public class NavigationMapRoute implements ProgressChangeListener, MapView.OnMap
   private void checkNewRouteFound(int currentRouteIndex) {
     if (currentRouteIndex != primaryRouteIndex) {
       updateRoute();
-      if (onRouteSelectionChangeListener != null) {
-        if (primaryRouteIndex > 0 && primaryRouteIndex < directionsRoutes.size()) {
-          DirectionsRoute selectedRoute = directionsRoutes.get(primaryRouteIndex);
-          onRouteSelectionChangeListener.onNewPrimaryRouteSelected(selectedRoute);
-        }
+      boolean isValidPrimaryIndex = primaryRouteIndex > 0 && primaryRouteIndex < directionsRoutes.size();
+      if (isValidPrimaryIndex && onRouteSelectionChangeListener != null) {
+        DirectionsRoute selectedRoute = directionsRoutes.get(primaryRouteIndex);
+        onRouteSelectionChangeListener.onNewPrimaryRouteSelected(selectedRoute);
       }
     }
   }


### PR DESCRIPTION
Fixes regression from #703 

We weren't properly clearing all lists when adding a new set of routes, so crashes would occur after routes were drawn for the second time.