### PR TITLE
Fix Recent Distances from maneuver Off-Route

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/NavigationViewActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/NavigationViewActivity.java
@@ -270,12 +270,9 @@ public class NavigationViewActivity extends AppCompatActivity implements OnMapRe
   }
 
   private void fetchRoute() {
-    Point origin = Point.fromLngLat(-118.05008299999997,34.14601600000003);
-    Point destination = Point.fromLngLat(-118.06110999999999,34.14892299999997);
-
     NavigationRoute.Builder builder = NavigationRoute.builder()
       .accessToken(Mapbox.getAccessToken())
-      .origin(origin)
+      .origin(currentLocation)
       .destination(destination)
       .alternatives(true);
     setFieldsFromSharedPreferences(builder);

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/NavigationViewActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/NavigationViewActivity.java
@@ -270,9 +270,12 @@ public class NavigationViewActivity extends AppCompatActivity implements OnMapRe
   }
 
   private void fetchRoute() {
+    Point origin = Point.fromLngLat(-118.05008299999997,34.14601600000003);
+    Point destination = Point.fromLngLat(-118.06110999999999,34.14892299999997);
+
     NavigationRoute.Builder builder = NavigationRoute.builder()
       .accessToken(Mapbox.getAccessToken())
-      .origin(currentLocation)
+      .origin(origin)
       .destination(destination)
       .alternatives(true);
     setFieldsFromSharedPreferences(builder);

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationHelper.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationHelper.java
@@ -12,6 +12,7 @@ import com.mapbox.geojson.Point;
 import com.mapbox.services.android.navigation.v5.milestone.Milestone;
 import com.mapbox.services.android.navigation.v5.offroute.OffRoute;
 import com.mapbox.services.android.navigation.v5.offroute.OffRouteCallback;
+import com.mapbox.services.android.navigation.v5.offroute.OffRouteDetector;
 import com.mapbox.services.android.navigation.v5.route.FasterRoute;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 import com.mapbox.services.android.navigation.v5.snap.Snap;
@@ -197,9 +198,11 @@ class NavigationHelper {
 
   static boolean isUserOffRoute(NewLocationModel newLocationModel, RouteProgress routeProgress,
                                 OffRouteCallback callback) {
+    MapboxNavigationOptions options = newLocationModel.mapboxNavigation().options();
+    Location location = newLocationModel.location();
     OffRoute offRoute = newLocationModel.mapboxNavigation().getOffRouteEngine();
-    return offRoute.isUserOffRoute(newLocationModel.location(), routeProgress,
-      newLocationModel.mapboxNavigation().options(), newLocationModel.distancesAwayFromManeuver(), callback);
+    setOffRouteDetectorCallback(offRoute, callback);
+    return offRoute.isUserOffRoute(location, routeProgress, options);
   }
 
   static boolean shouldCheckFasterRoute(NewLocationModel newLocationModel, RouteProgress routeProgress) {
@@ -223,5 +226,11 @@ class NavigationHelper {
       return steps.get(stepIndex + 1).maneuver().location();
     }
     return !coords.isEmpty() ? coords.get(coords.size() - 1) : coords.get(coords.size());
+  }
+
+  private static void setOffRouteDetectorCallback(OffRoute offRoute, OffRouteCallback callback) {
+    if (offRoute instanceof OffRouteDetector) {
+      ((OffRouteDetector) offRoute).setOffRouteCallback(callback);
+    }
   }
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NewLocationModel.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NewLocationModel.java
@@ -3,20 +3,15 @@ package com.mapbox.services.android.navigation.v5.navigation;
 import android.location.Location;
 
 import com.google.auto.value.AutoValue;
-import com.mapbox.services.android.navigation.v5.utils.RingBuffer;
 
 @AutoValue
 abstract class NewLocationModel {
 
-  static NewLocationModel create(Location location, MapboxNavigation mapboxNavigation,
-                                 RingBuffer distancesAwayFromManeuver) {
-    return new AutoValue_NewLocationModel(location, mapboxNavigation,
-      distancesAwayFromManeuver);
+  static NewLocationModel create(Location location, MapboxNavigation mapboxNavigation) {
+    return new AutoValue_NewLocationModel(location, mapboxNavigation);
   }
 
   abstract Location location();
 
   abstract MapboxNavigation mapboxNavigation();
-
-  abstract RingBuffer distancesAwayFromManeuver();
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/offroute/OffRoute.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/offroute/OffRoute.java
@@ -4,12 +4,9 @@ import android.location.Location;
 
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigationOptions;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
-import com.mapbox.services.android.navigation.v5.utils.RingBuffer;
 
 public abstract class OffRoute {
 
   public abstract boolean isUserOffRoute(Location location, RouteProgress routeProgress,
-                                         MapboxNavigationOptions options,
-                                         RingBuffer<Integer> distancesAwayFromManeuver,
-                                         OffRouteCallback callback);
+                                         MapboxNavigationOptions options);
 }


### PR DESCRIPTION
A check was previously put in place to check if we are currently moving towards / away the approaching maneuver.  The idea here is if we make a u-turn, we will still be considered on the route, but we are actually moving away from the maneuver.  If we received three location updates that were each farther than the last from the maneuver location, we would send an off-route event (even if we are within the off-route radius).  

The bug fixed here is a result of how we made the measurement to the upcoming maneuver.  We were previously using the absolute distance to the maneuver.  For roundabouts though, this doesn't work, as we actually are moving farther away from the maneuver before we begin moving closer.  We need to consider the actual distance of the route `LineString` when measuring the distance to the maneuver.

### This PR:
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/8434572/37005506-54e42ef0-20a2-11e8-96bb-8007b8eac1c4.gif)

### `master`:
![ezgif com-video-to-gif copy](https://user-images.githubusercontent.com/8434572/37005439-1185dc44-20a2-11e8-8afd-6239e825cda2.gif)

