### PR TITLE
Fix same point being added twice for LatLngBounds

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/camera/DynamicCamera.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/camera/DynamicCamera.java
@@ -131,10 +131,12 @@ public class DynamicCamera extends SimpleCamera {
       Point stepManeuverPoint = upComingStep.maneuver().location();
 
       List<LatLng> latLngs = new ArrayList<>();
-      latLngs.add(new LatLng(stepManeuverPoint.latitude(), stepManeuverPoint.longitude()));
-      latLngs.add(new LatLng(location));
+      LatLng currentLatLng = new LatLng(location);
+      LatLng maneuverLatLng = new LatLng(stepManeuverPoint.latitude(), stepManeuverPoint.longitude());
+      latLngs.add(currentLatLng);
+      latLngs.add(maneuverLatLng);
 
-      if (latLngs.size() < 1) {
+      if (latLngs.size() < 1 || currentLatLng.equals(maneuverLatLng)) {
         return mapboxMap.getCameraPosition();
       }
 


### PR DESCRIPTION
At the end of step, our current location can be the same as the maneuver point.  `LatLngBounds.Builder` ignores duplicate points and this results in a crash because then there's only one point.