### PR TITLE
Force first location update without last location

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationService.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationService.java
@@ -286,9 +286,6 @@ public class NavigationService extends Service implements LocationEngineListener
    */
   @SuppressWarnings("MissingPermission")
   private boolean isValidLocationUpdate(Location location) {
-    if (locationEngine.getLastLocation() == null) {
-      return true;
-    }
     // If the locations the same as previous, no need to recalculate things
     return !(location.equals(locationEngine.getLastLocation())
       || (location.getSpeed() <= 0 && location.hasSpeed())

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationService.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationService.java
@@ -311,14 +311,11 @@ public class NavigationService extends Service implements LocationEngineListener
    */
   @SuppressWarnings("MissingPermission")
   private void forceLocationUpdate() {
-    Location forcedLocation;
-    Location lastLocation = locationEngine.getLastLocation();
-    if (isValidLocationUpdate(lastLocation)) {
-      forcedLocation = lastLocation;
-    } else {
-      forcedLocation = RouteUtils.createFirstLocationFromRoute(mapboxNavigation.getRoute());
+    Location location = locationEngine.getLastLocation();
+    if (!isValidLocationUpdate(location)) {
+      location = RouteUtils.createFirstLocationFromRoute(mapboxNavigation.getRoute());
     }
-    queueLocationUpdateTask(forcedLocation);
+    queueLocationUpdateTask(location);
   }
 
   /**

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationService.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationService.java
@@ -98,7 +98,7 @@ public class NavigationService extends Service implements LocationEngineListener
   @Override
   public void onLocationChanged(Location location) {
     Timber.d("onLocationChanged");
-    if (location != null && isValidLocationUpdate(location)) {
+    if (isValidLocationUpdate(location)) {
       queueLocationUpdateTask(location);
     }
   }
@@ -286,6 +286,9 @@ public class NavigationService extends Service implements LocationEngineListener
    */
   @SuppressWarnings("MissingPermission")
   private boolean isValidLocationUpdate(Location location) {
+    if (location == null) {
+      return false;
+    }
     // If the locations the same as previous, no need to recalculate things
     return !(location.equals(locationEngine.getLastLocation())
       || (location.getSpeed() <= 0 && location.hasSpeed())
@@ -310,7 +313,7 @@ public class NavigationService extends Service implements LocationEngineListener
   private void forceLocationUpdate() {
     Location forcedLocation;
     Location lastLocation = locationEngine.getLastLocation();
-    if (lastLocation != null && isValidLocationUpdate(lastLocation)) {
+    if (isValidLocationUpdate(lastLocation)) {
       forcedLocation = lastLocation;
     } else {
       forcedLocation = RouteUtils.createFirstLocationFromRoute(mapboxNavigation.getRoute());

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/RouteUtils.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/RouteUtils.java
@@ -1,5 +1,6 @@
 package com.mapbox.services.android.navigation.v5.utils;
 
+import android.location.Location;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
@@ -15,6 +16,8 @@ import static com.mapbox.services.android.navigation.v5.navigation.NavigationCon
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.STEP_MANEUVER_TYPE_ARRIVE;
 
 public final class RouteUtils {
+
+  private static final String FORCED_LOCATION = "Forced Location";
 
   private RouteUtils() {
     // Utils class therefore, shouldn't be initialized.
@@ -100,6 +103,26 @@ public final class RouteUtils {
     }
     coordinates.subList(0, routeProgress.remainingWaypoints()).clear();
     return coordinates;
+  }
+
+  /**
+   * If navigation begins, a location update is sometimes needed to force a
+   * progress change update as soon as navigation is started.
+   * <p>
+   * This method creates a location update from the first coordinate (origin) that created
+   * the route.
+   *
+   * @param route with list of coordinates
+   * @return {@link Location} from first coordinate
+   * @since 0.10.0
+   */
+  public static Location createFirstLocationFromRoute(DirectionsRoute route) {
+    List<Point> coordinates = route.routeOptions().coordinates();
+    Point origin = coordinates.get(0);
+    Location forcedLocation = new Location(FORCED_LOCATION);
+    forcedLocation.setLatitude(origin.latitude());
+    forcedLocation.setLongitude(origin.longitude());
+    return forcedLocation;
   }
 
   private static boolean upcomingStepIsArrival(@NonNull RouteProgress routeProgress) {

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/RouteUtils.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/RouteUtils.java
@@ -18,6 +18,7 @@ import static com.mapbox.services.android.navigation.v5.navigation.NavigationCon
 public final class RouteUtils {
 
   private static final String FORCED_LOCATION = "Forced Location";
+  private static final int FIRST_COORDINATE = 0;
 
   private RouteUtils() {
     // Utils class therefore, shouldn't be initialized.
@@ -118,7 +119,7 @@ public final class RouteUtils {
    */
   public static Location createFirstLocationFromRoute(DirectionsRoute route) {
     List<Point> coordinates = route.routeOptions().coordinates();
-    Point origin = coordinates.get(0);
+    Point origin = coordinates.get(FIRST_COORDINATE);
     Location forcedLocation = new Location(FORCED_LOCATION);
     forcedLocation.setLatitude(origin.latitude());
     forcedLocation.setLongitude(origin.longitude());


### PR DESCRIPTION
Sometimes a given `LocationEngine` won't have a last known location (`LocationEngine#getLastLocation()`). 

Now, if this is the case, we create a location update from the first coordinate of the route to fire the `ProgressChangeListener` and populate a given UI. 
