### PR TITLE
Stop scroll of InstructionList before hiding

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionView.java
@@ -295,6 +295,7 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
    * can be animated appropriately.
    */
   public void hideInstructionList() {
+    rvInstructions.stopScroll();
     beginDelayedTransition();
     int orientation = getContext().getResources().getConfiguration().orientation;
     if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
@@ -316,7 +317,7 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
       updateLandscapeConstraintsTo(R.layout.instruction_layout_alt);
     }
     instructionListLayout.setVisibility(VISIBLE);
-    rvInstructions.scrollToPosition(TOP);
+    rvInstructions.smoothScrollToPosition(TOP);
   }
 
   /**
@@ -499,7 +500,6 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
     instructionListAdapter = new InstructionListAdapter(getContext(), locale, unitType);
     rvInstructions.setAdapter(instructionListAdapter);
     rvInstructions.setHasFixedSize(true);
-    rvInstructions.setNestedScrollingEnabled(true);
     rvInstructions.setItemAnimator(new DefaultItemAnimator());
     rvInstructions.setLayoutManager(new LinearLayoutManager(getContext()));
   }


### PR DESCRIPTION
Closes #761 

An `IllegalStateException` was intermittently being thrown when the instruction list was scrolling quickly and then being hidden directly after with `TransitionManager`.

Stopping the scrolling before hiding the list fixes this:
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/8434572/37483100-0359a2b0-285c-11e8-91ca-2aa8da860f2f.gif)
