### PR TITLE
Add baseUrl to NavigationRoute and Turf conversion

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -10,7 +10,7 @@ ext {
   version = [
       mapboxMapSdk       : '5.5.0',
       mapboxServices     : '2.2.10',
-      mapboxSdkServices  : '3.0.0-beta.3',
+      mapboxSdkServices  : '3.0.0-beta.4',
       locationLayerPlugin: '0.4.0',
       autoValue          : '1.5',
       autoValueParcel    : '0.2.5',

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/NavigationMapRoute.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/NavigationMapRoute.java
@@ -671,7 +671,7 @@ public class NavigationMapRoute implements ProgressChangeListener, MapView.OnMap
       linePoints.add(com.mapbox.geojson.Point.fromLngLat(pos.getLongitude(), pos.getLatitude()));
     }
 
-    com.mapbox.geojson.Feature feature = TurfMisc.pointOnLine(clickPoint, linePoints);
+    com.mapbox.geojson.Feature feature = TurfMisc.nearestPointOnLine(clickPoint, linePoints);
     return (com.mapbox.geojson.Point) feature.geometry();
   }
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/location/MockLocationEngine.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/location/MockLocationEngine.java
@@ -201,7 +201,7 @@ public class MockLocationEngine extends LocationEngine {
    * @since 2.2.0
    */
   private void sliceRoute(LineString lineString, double distance) {
-    double distanceKm = TurfMeasurement.lineDistance(lineString, TurfConstants.UNIT_KILOMETERS);
+    double distanceKm = TurfMeasurement.length(lineString, TurfConstants.UNIT_KILOMETERS);
     Timber.d("Route distance in km: %f", distanceKm);
     if (distanceKm <= 0) {
       return;

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationHelper.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationHelper.java
@@ -48,7 +48,7 @@ class NavigationHelper {
 
     // Uses Turf's pointOnLine, which takes a Point and a LineString to calculate the closest
     // Point on the LineString.
-    Feature feature = TurfMisc.pointOnLine(locationToPoint, coordinates);
+    Feature feature = TurfMisc.nearestPointOnLine(locationToPoint, coordinates);
     return ((Point) feature.geometry());
   }
 
@@ -81,7 +81,7 @@ class NavigationHelper {
       return 0;
     }
     LineString slicedLine = TurfMisc.lineSlice(snappedPosition, nextManeuverPosition, lineString);
-    return TurfMeasurement.lineDistance(slicedLine, TurfConstants.UNIT_METERS);
+    return TurfMeasurement.length(slicedLine, TurfConstants.UNIT_METERS);
   }
 
   /**

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRoute.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRoute.java
@@ -436,6 +436,10 @@ public final class NavigationRoute {
      */
     public Builder routeOptions(RouteOptions options) {
 
+      if (!TextUtils.isEmpty(options.baseUrl())) {
+        directionsBuilder.baseUrl(options.baseUrl());
+      }
+
       if (!TextUtils.isEmpty(options.language())) {
         directionsBuilder.language(new Locale(options.language()));
       }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteDetector.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteDetector.java
@@ -221,14 +221,14 @@ public class OffRouteDetector extends OffRoute {
 
     LineString stepLineString = LineString.fromLngLats(stepPoints);
     Point maneuverPoint = stepPoints.get(stepPoints.size() - 1);
-    Point userPointOnStep = (Point) TurfMisc.pointOnLine(currentPoint, stepPoints).geometry();
+    Point userPointOnStep = (Point) TurfMisc.nearestPointOnLine(currentPoint, stepPoints).geometry();
 
     if (userPointOnStep == null || maneuverPoint.equals(userPointOnStep)) {
       return false;
     }
 
     LineString remainingStepLineString = TurfMisc.lineSlice(userPointOnStep, maneuverPoint, stepLineString);
-    double userDistanceToManeuver = TurfMeasurement.lineDistance(remainingStepLineString, TurfConstants.UNIT_METERS);
+    double userDistanceToManeuver = TurfMeasurement.length(remainingStepLineString, TurfConstants.UNIT_METERS);
 
     boolean hasDistances = !distancesAwayFromManeuver.isEmpty();
     boolean validOffRouteDistanceTraveled = hasDistances && distancesAwayFromManeuver.peekLast()

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/snap/SnapToRoute.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/snap/SnapToRoute.java
@@ -53,7 +53,7 @@ public class SnapToRoute extends Snap {
     // Uses Turf's pointOnLine, which takes a Point and a LineString to calculate the closest
     // Point on the LineString.
     if (stepCoordinates.size() > 1) {
-      Feature feature = TurfMisc.pointOnLine(locationToPoint, stepCoordinates);
+      Feature feature = TurfMisc.nearestPointOnLine(locationToPoint, stepCoordinates);
       Point point = ((Point) feature.geometry());
       snappedLocation.setLongitude(point.longitude());
       snappedLocation.setLatitude(point.latitude());

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/DistanceUtils.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/DistanceUtils.java
@@ -66,8 +66,8 @@ public class DistanceUtils {
    * relative size of .65 times the size of the number
    */
   public SpannableString formatDistance(double distance) {
-    double distanceSmallUnit = TurfConversion.convertDistance(distance, TurfConstants.UNIT_METERS, smallUnit);
-    double distanceLargeUnit = TurfConversion.convertDistance(distance, TurfConstants.UNIT_METERS, largeUnit);
+    double distanceSmallUnit = TurfConversion.convertLength(distance, TurfConstants.UNIT_METERS, smallUnit);
+    double distanceLargeUnit = TurfConversion.convertLength(distance, TurfConstants.UNIT_METERS, largeUnit);
 
     // If the distance is greater than 10 miles/kilometers, then round to nearest mile/kilometer
     if (distanceLargeUnit > LARGE_UNIT_THRESHOLD) {

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/MeasurementUtils.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/MeasurementUtils.java
@@ -48,7 +48,7 @@ public final class MeasurementUtils {
         UNIT_METERS);
     }
 
-    Feature feature = TurfMisc.pointOnLine(usersRawLocation, lineString.coordinates());
+    Feature feature = TurfMisc.nearestPointOnLine(usersRawLocation, lineString.coordinates());
     Point snappedPoint = (Point) feature.geometry();
 
     if (snappedPoint == null) {

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/ToleranceUtils.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/ToleranceUtils.java
@@ -26,7 +26,7 @@ public final class ToleranceUtils {
       intersectionsPoints.add(intersection.location());
     }
 
-    Point closestIntersection = TurfClassification.nearest(snappedPoint, intersectionsPoints);
+    Point closestIntersection = TurfClassification.nearestPoint(snappedPoint, intersectionsPoints);
 
     if (closestIntersection.equals(snappedPoint)) {
       return NavigationConstants.MINIMUM_DISTANCE_BEFORE_REROUTING;

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteTest.java
@@ -75,6 +75,7 @@ public class NavigationRouteTest extends BaseTest {
 
     RouteOptions routeOptions = RouteOptions.builder()
       .accessToken(ACCESS_TOKEN)
+      .baseUrl("https://api-directions-traf.com")
       .requestUuid("XYZ_UUID")
       .alternatives(true)
       .language(Locale.US.getLanguage())
@@ -91,6 +92,7 @@ public class NavigationRouteTest extends BaseTest {
       .build();
 
     String request = navigationRoute.getCall().request().url().toString();
+    assertThat(request, containsString("https://api-directions-traf.com"));
     assertThat(request, containsString("alternatives=true"));
     assertThat(request, containsString(ACCESS_TOKEN));
     assertThat(request, containsString("voice_units=metric"));

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/routeprogress/RouteStepProgressTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/routeprogress/RouteStepProgressTest.java
@@ -7,25 +7,21 @@ import com.mapbox.api.directions.v5.models.DirectionsResponse;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.api.directions.v5.models.LegStep;
 import com.mapbox.api.directions.v5.models.RouteLeg;
+import com.mapbox.core.constants.Constants;
 import com.mapbox.geojson.LineString;
 import com.mapbox.geojson.Point;
 import com.mapbox.geojson.utils.PolylineUtils;
 import com.mapbox.services.android.navigation.v5.BaseTest;
-import com.mapbox.core.constants.Constants;
 import com.mapbox.turf.TurfConstants;
 import com.mapbox.turf.TurfMeasurement;
 import com.mapbox.turf.TurfMisc;
 
-import junit.framework.Assert;
-
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.util.List;
 
-import static junit.framework.Assert.*;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
 
@@ -93,7 +89,7 @@ public class RouteStepProgressTest extends BaseTest {
   public void distanceRemaining_equalsStepDistanceAtBeginning() {
     LineString lineString
       = LineString.fromPolyline(firstLeg.steps().get(5).geometry(), Constants.PRECISION_6);
-    double stepDistance = TurfMeasurement.lineDistance(lineString, TurfConstants.UNIT_METERS);
+    double stepDistance = TurfMeasurement.length(lineString, TurfConstants.UNIT_METERS);
 
     RouteProgress routeProgress = RouteProgress.builder()
       .stepDistanceRemaining(firstLeg.steps().get(5).distance())
@@ -112,7 +108,7 @@ public class RouteStepProgressTest extends BaseTest {
   public void distanceRemaining_equalsCorrectValueAtIntervals() {
     LineString lineString
       = LineString.fromPolyline(firstStep.geometry(), Constants.PRECISION_6);
-    double stepDistance = TurfMeasurement.lineDistance(lineString, TurfConstants.UNIT_METERS);
+    double stepDistance = TurfMeasurement.length(lineString, TurfConstants.UNIT_METERS);
 
     double stepSegments = 5; // meters
 
@@ -127,7 +123,7 @@ public class RouteStepProgressTest extends BaseTest {
       LineString slicedLine = TurfMisc.lineSlice(point,
         route.legs().get(0).steps().get(1).maneuver().location(), lineString);
 
-      double distance = TurfMeasurement.lineDistance(slicedLine, TurfConstants.UNIT_METERS);
+      double distance = TurfMeasurement.length(slicedLine, TurfConstants.UNIT_METERS);
       RouteProgress routeProgress = RouteProgress.builder()
         .stepDistanceRemaining(distance)
         .legDistanceRemaining(firstLeg.distance())
@@ -185,7 +181,7 @@ public class RouteStepProgressTest extends BaseTest {
       LineString slicedLine = TurfMisc.lineSlice(point,
         route.legs().get(0).steps().get(1).maneuver().location(), lineString);
 
-      double distance = TurfMeasurement.lineDistance(slicedLine, TurfConstants.UNIT_METERS);
+      double distance = TurfMeasurement.length(slicedLine, TurfConstants.UNIT_METERS);
       distance = firstStep.distance() - distance;
       if (distance < 0) {
         distance = 0;
@@ -250,7 +246,7 @@ public class RouteStepProgressTest extends BaseTest {
       LineString slicedLine = TurfMisc.lineSlice(point,
         route.legs().get(0).steps().get(1).maneuver().location(), lineString);
 
-      double distance = TurfMeasurement.lineDistance(slicedLine, TurfConstants.UNIT_METERS);
+      double distance = TurfMeasurement.length(slicedLine, TurfConstants.UNIT_METERS);
 
       RouteProgress routeProgress = RouteProgress.builder()
         .stepDistanceRemaining(distance)
@@ -316,7 +312,7 @@ public class RouteStepProgressTest extends BaseTest {
       LineString slicedLine = TurfMisc.lineSlice(point,
         route.legs().get(0).steps().get(1).maneuver().location(), lineString);
 
-      double distance = TurfMeasurement.lineDistance(slicedLine, TurfConstants.UNIT_METERS);
+      double distance = TurfMeasurement.length(slicedLine, TurfConstants.UNIT_METERS);
 
       RouteProgress routeProgress = RouteProgress.builder()
         .stepDistanceRemaining(distance)


### PR DESCRIPTION
Adds baseUrl for re-routes with `RouteOptions` and converts codebase to new Turf method names