### PR TITLE
Adjust sound layout margins

### DIFF
--- a/libandroid-navigation-ui/src/main/res/layout/instruction_view_layout.xml
+++ b/libandroid-navigation-ui/src/main/res/layout/instruction_view_layout.xml
@@ -62,7 +62,8 @@
         layout="@layout/sound_layout"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_margin="8dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginBottom="8dp"
         android:layout_alignParentEnd="true"
         android:layout_alignParentRight="true"
         android:layout_below="@id/extraInstructionContentLayout"/>


### PR DESCRIPTION
Fixes `8dp` margin regression from landscape updates:
![screen shot 2018-03-16 at 2 13 10 pm](https://user-images.githubusercontent.com/8434572/37537567-5de1c74e-2924-11e8-9b5d-a30de16ef87f.png)
