### PR TITLE
Create separate options for Launcher and View

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/NavigationViewSettingsActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/NavigationViewSettingsActivity.java
@@ -9,11 +9,17 @@ import android.preference.PreferenceManager;
 import com.mapbox.services.android.navigation.testapp.R;
 
 public class NavigationViewSettingsActivity extends PreferenceActivity {
+
   @Override
   public void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     getFragmentManager().beginTransaction().replace(
       android.R.id.content, new NavigationViewPreferenceFragment()).commit();
+  }
+
+  @Override
+  protected boolean isValidFragment(String fragmentName) {
+    return super.isValidFragment(fragmentName);
   }
 
   public static class NavigationViewPreferenceFragment extends PreferenceFragment {

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -27,4 +27,16 @@
         <item>1</item>
         <item>0</item>
     </string-array>
+
+    <string-array name="route_profile_array">
+        <item>Driving</item>
+        <item>Cycling</item>
+        <item>Walking</item>
+    </string-array>
+
+    <string-array name="route_profile_values_array">
+        <item>driving-traffic</item>
+        <item>cycling</item>
+        <item>walking</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,6 +27,7 @@
     <string name="simulate_route">Simulate Route</string>
     <string name="language">Language</string>
     <string name="unit_type">Unit Type</string>
+    <string name="route_profile">Route Profile</string>
 
     <string name="unit_type_key">unit_type</string>
     <string name="simulate_route_key">simulate_route</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,6 +32,11 @@
     <string name="unit_type_key">unit_type</string>
     <string name="simulate_route_key">simulate_route</string>
     <string name="language_key">language</string>
-
+    <string name="route_profile_key">route_profile</string>
     <string name="language_default_value_device_locale">device_locale</string>
+
+    <string name="error_route_not_available">Current route is not available</string>
+    <string name="error_select_longer_route">Please select a longer route</string>
+    <string name="error_valid_route_not_found">Valid route not found.</string>
+    <string name="explanation_long_press_waypoint">Long press map to place waypoint</string>
 </resources>

--- a/app/src/main/res/xml/fragment_navigation_view_preferences.xml
+++ b/app/src/main/res/xml/fragment_navigation_view_preferences.xml
@@ -23,6 +23,6 @@
         android:defaultValue="1"
         android:entries="@array/route_profile_array"
         android:entryValues="@array/route_profile_values_array"
-        android:key="route_profile"
+        android:key="@string/route_profile_key"
         android:title="@string/route_profile"/>
 </PreferenceScreen>

--- a/app/src/main/res/xml/fragment_navigation_view_preferences.xml
+++ b/app/src/main/res/xml/fragment_navigation_view_preferences.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_height="match_parent"
-    android:layout_width="match_parent">
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
     <CheckBoxPreference
         android:key="@string/simulate_route_key"
         android:title="@string/simulate_route"
@@ -19,4 +19,10 @@
         android:entries="@array/unit_type_array"
         android:entryValues="@array/unit_type_values_array"
         android:defaultValue="-1"/>
+    <ListPreference
+        android:defaultValue="1"
+        android:entries="@array/route_profile_array"
+        android:entryValues="@array/route_profile_values_array"
+        android:key="route_profile"
+        android:title="@string/route_profile"/>
 </PreferenceScreen>

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationActivity.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationActivity.java
@@ -97,14 +97,18 @@ public class NavigationActivity extends AppCompatActivity implements OnNavigatio
 
   @Override
   public void onNavigationReady() {
+    MapboxNavigationOptions.Builder navigationOptions = MapboxNavigationOptions.builder();
     NavigationViewOptions.Builder options = NavigationViewOptions.builder();
     options.navigationListener(this);
     if (!isRunning) {
       extractRoute(options);
       extractCoordinates(options);
     }
-    extractConfiguration(options);
-    extractLocale(options);
+    extractConfiguration(options, navigationOptions);
+    extractLocale(navigationOptions);
+    extractUnitType(navigationOptions);
+
+    options.navigationOptions(navigationOptions.build());
     navigationView.startNavigation(options.build());
     isRunning = true;
   }
@@ -138,7 +142,8 @@ public class NavigationActivity extends AppCompatActivity implements OnNavigatio
     }
   }
 
-  private void extractConfiguration(NavigationViewOptions.Builder options) {
+  private void extractConfiguration(NavigationViewOptions.Builder options,
+                                    MapboxNavigationOptions.Builder navigationOptions) {
     SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(this);
     options.awsPoolId(preferences
       .getString(NavigationConstants.NAVIGATION_VIEW_AWS_POOL_ID, null));
@@ -146,14 +151,14 @@ public class NavigationActivity extends AppCompatActivity implements OnNavigatio
       .getBoolean(NavigationConstants.NAVIGATION_VIEW_SIMULATE_ROUTE, false));
     options.directionsProfile(preferences
       .getString(NavigationConstants.NAVIGATION_VIEW_ROUTE_PROFILE_KEY, ""));
+    navigationOptions.enableOffRouteDetection(preferences
+      .getBoolean(NavigationConstants.NAVIGATION_VIEW_OFF_ROUTE_ENABLED_KEY, true));
   }
 
-  private void extractLocale(NavigationViewOptions.Builder options) {
+  private void extractLocale(MapboxNavigationOptions.Builder navigationOptions) {
     SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(this);
-
     String country = preferences.getString(NavigationConstants.NAVIGATION_VIEW_LOCALE_COUNTRY, "");
     String language = preferences.getString(NavigationConstants.NAVIGATION_VIEW_LOCALE_LANGUAGE, "");
-    int unitType = preferences.getInt(NavigationConstants.NAVIGATION_VIEW_UNIT_TYPE, NONE_SPECIFIED);
 
     Locale locale;
     if (!language.isEmpty()) {
@@ -162,10 +167,12 @@ public class NavigationActivity extends AppCompatActivity implements OnNavigatio
       locale = LocaleUtils.getDeviceLocale(this);
     }
 
-    MapboxNavigationOptions navigationOptions = MapboxNavigationOptions.builder()
-      .locale(locale)
-      .unitType(unitType)
-      .build();
-    options.navigationOptions(navigationOptions);
+    navigationOptions.locale(locale);
+  }
+
+  private void extractUnitType(MapboxNavigationOptions.Builder navigationOptions) {
+    SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(this);
+    int unitType = preferences.getInt(NavigationConstants.NAVIGATION_VIEW_UNIT_TYPE, NONE_SPECIFIED);
+    navigationOptions.unitType(unitType);
   }
 }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationActivity.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationActivity.java
@@ -132,7 +132,7 @@ public class NavigationActivity extends AppCompatActivity implements OnNavigatio
 
   private void extractCoordinates(NavigationViewOptions.Builder options) {
     HashMap<String, Point> coordinates = NavigationLauncher.extractCoordinates(this);
-    if (coordinates.size() > 0) {
+    if (options.build().directionsRoute() == null && coordinates.size() > 0) {
       options.origin(coordinates.get(NavigationConstants.NAVIGATION_VIEW_ORIGIN));
       options.destination(coordinates.get(NavigationConstants.NAVIGATION_VIEW_DESTINATION));
     }
@@ -144,6 +144,8 @@ public class NavigationActivity extends AppCompatActivity implements OnNavigatio
       .getString(NavigationConstants.NAVIGATION_VIEW_AWS_POOL_ID, null));
     options.shouldSimulateRoute(preferences
       .getBoolean(NavigationConstants.NAVIGATION_VIEW_SIMULATE_ROUTE, false));
+    options.directionsProfile(preferences
+      .getString(NavigationConstants.NAVIGATION_VIEW_ROUTE_PROFILE_KEY, ""));
   }
 
   private void extractLocale(NavigationViewOptions.Builder options) {

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationActivity.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationActivity.java
@@ -24,6 +24,8 @@ import static com.mapbox.services.android.navigation.v5.navigation.NavigationUni
  */
 public class NavigationActivity extends AppCompatActivity implements OnNavigationReadyCallback, NavigationListener {
 
+  private static final String EMPTY_STRING = "";
+
   private NavigationView navigationView;
   private boolean isRunning;
 
@@ -150,15 +152,15 @@ public class NavigationActivity extends AppCompatActivity implements OnNavigatio
     options.shouldSimulateRoute(preferences
       .getBoolean(NavigationConstants.NAVIGATION_VIEW_SIMULATE_ROUTE, false));
     options.directionsProfile(preferences
-      .getString(NavigationConstants.NAVIGATION_VIEW_ROUTE_PROFILE_KEY, ""));
+      .getString(NavigationConstants.NAVIGATION_VIEW_ROUTE_PROFILE_KEY, EMPTY_STRING));
     navigationOptions.enableOffRouteDetection(preferences
       .getBoolean(NavigationConstants.NAVIGATION_VIEW_OFF_ROUTE_ENABLED_KEY, true));
   }
 
   private void extractLocale(MapboxNavigationOptions.Builder navigationOptions) {
     SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(this);
-    String country = preferences.getString(NavigationConstants.NAVIGATION_VIEW_LOCALE_COUNTRY, "");
-    String language = preferences.getString(NavigationConstants.NAVIGATION_VIEW_LOCALE_LANGUAGE, "");
+    String country = preferences.getString(NavigationConstants.NAVIGATION_VIEW_LOCALE_COUNTRY, EMPTY_STRING);
+    String language = preferences.getString(NavigationConstants.NAVIGATION_VIEW_LOCALE_LANGUAGE, EMPTY_STRING);
 
     Locale locale;
     if (!language.isEmpty()) {

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationLauncher.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationLauncher.java
@@ -119,6 +119,7 @@ public class NavigationLauncher {
     editor.putString(NavigationConstants.NAVIGATION_VIEW_AWS_POOL_ID, options.awsPoolId());
     editor.putBoolean(NavigationConstants.NAVIGATION_VIEW_SIMULATE_ROUTE, options.shouldSimulateRoute());
     editor.putString(NavigationConstants.NAVIGATION_VIEW_ROUTE_PROFILE_KEY, options.directionsProfile());
+    editor.putBoolean(NavigationConstants.NAVIGATION_VIEW_OFF_ROUTE_ENABLED_KEY, options.enableOffRouteDetection());
   }
 
   private static void storeThemePreferences(NavigationLauncherOptions options, SharedPreferences.Editor editor) {

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationLauncher.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationLauncher.java
@@ -5,7 +5,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
-import android.support.annotation.NonNull;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -13,6 +12,7 @@ import com.mapbox.api.directions.v5.DirectionsAdapterFactory;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.geojson.Point;
 import com.mapbox.services.android.navigation.v5.navigation.NavigationConstants;
+import com.mapbox.services.android.navigation.v5.navigation.NavigationUnitType;
 import com.mapbox.services.android.navigation.v5.utils.LocaleUtils;
 
 import java.util.HashMap;
@@ -49,8 +49,8 @@ public class NavigationLauncher {
     storeRouteOptions(options, editor);
     storeConfiguration(options, editor);
 
-    Locale locale = storeLocale(activity, options, editor);
-    storeUnitType(options, editor, locale);
+    storeLocale(activity, options, editor);
+    storeUnitType(options, editor);
     storeThemePreferences(options, editor);
 
     editor.apply();
@@ -136,25 +136,22 @@ public class NavigationLauncher {
     }
   }
 
-  private static void storeUnitType(NavigationLauncherOptions options, SharedPreferences.Editor editor,
-                                    Locale locale) {
+  private static void storeUnitType(NavigationLauncherOptions options, SharedPreferences.Editor editor) {
     Integer unitType = options.unitType();
     if (unitType == null) {
-      unitType = LocaleUtils.getUnitTypeForLocale(locale);
+      unitType = NavigationUnitType.NONE_SPECIFIED;
     }
     editor.putInt(NavigationConstants.NAVIGATION_VIEW_UNIT_TYPE, unitType);
   }
 
-  @NonNull
-  private static Locale storeLocale(Activity activity, NavigationLauncherOptions options,
-                                    SharedPreferences.Editor editor) {
+  private static void storeLocale(Activity activity, NavigationLauncherOptions options,
+                                  SharedPreferences.Editor editor) {
     Locale locale = options.locale();
     if (locale == null) {
       locale = LocaleUtils.getDeviceLocale(activity);
     }
     editor.putString(NavigationConstants.NAVIGATION_VIEW_LOCALE_LANGUAGE, locale.getLanguage());
     editor.putString(NavigationConstants.NAVIGATION_VIEW_LOCALE_COUNTRY, locale.getCountry());
-    return locale;
   }
 
   private static void storeDirectionsRouteValue(NavigationLauncherOptions options, SharedPreferences.Editor editor) {

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationLauncher.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationLauncher.java
@@ -24,7 +24,7 @@ import java.util.Locale;
  * You can launch the UI with either a route you have already retrieved from
  * {@link com.mapbox.services.android.navigation.v5.navigation.NavigationRoute} or you can pass a
  * {@link Point} origin and {@link Point} destination and the UI will request the {@link DirectionsRoute}
- * while initializing.`
+ * while initializing.
  * </p><p>
  * You have an option to include a AWS Cognito Pool ID, which will initialize the UI with AWS Polly Voice instructions
  * </p><p>

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationLauncherOptions.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationLauncherOptions.java
@@ -1,0 +1,53 @@
+package com.mapbox.services.android.navigation.ui.v5;
+
+import android.support.annotation.Nullable;
+
+import com.google.auto.value.AutoValue;
+import com.mapbox.api.directions.v5.DirectionsCriteria;
+import com.mapbox.api.directions.v5.models.DirectionsRoute;
+import com.mapbox.geojson.Point;
+import com.mapbox.services.android.navigation.v5.navigation.NavigationUnitType;
+
+import java.util.Locale;
+
+@AutoValue
+public abstract class NavigationLauncherOptions extends NavigationOptions {
+
+  @Nullable
+  public abstract Locale locale();
+
+  @Nullable
+  public abstract Integer unitType();
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    public abstract Builder directionsRoute(DirectionsRoute directionsRoute);
+
+    public abstract Builder directionsProfile(@DirectionsCriteria.ProfileCriteria String directionsProfile);
+
+    public abstract Builder origin(Point origin);
+
+    public abstract Builder destination(Point destination);
+
+    public abstract Builder awsPoolId(String awsPoolId);
+
+    public abstract Builder lightThemeResId(Integer lightThemeResId);
+
+    public abstract Builder darkThemeResId(Integer darkThemeResId);
+
+    public abstract Builder shouldSimulateRoute(boolean shouldSimulateRoute);
+
+    public abstract Builder locale(Locale locale);
+
+    public abstract Builder unitType(@NavigationUnitType.UnitType Integer unitType);
+
+    public abstract NavigationLauncherOptions build();
+  }
+
+  public static NavigationLauncherOptions.Builder builder() {
+    return new AutoValue_NavigationLauncherOptions.Builder()
+      .awsPoolId(null)
+      .shouldSimulateRoute(false);
+  }
+}

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationLauncherOptions.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationLauncherOptions.java
@@ -19,6 +19,8 @@ public abstract class NavigationLauncherOptions extends NavigationOptions {
   @Nullable
   public abstract Integer unitType();
 
+  public abstract boolean enableOffRouteDetection();
+
   @AutoValue.Builder
   public abstract static class Builder {
 
@@ -42,12 +44,15 @@ public abstract class NavigationLauncherOptions extends NavigationOptions {
 
     public abstract Builder unitType(@NavigationUnitType.UnitType Integer unitType);
 
+    public abstract Builder enableOffRouteDetection(boolean enableOffRouteDetection);
+
     public abstract NavigationLauncherOptions build();
   }
 
   public static NavigationLauncherOptions.Builder builder() {
     return new AutoValue_NavigationLauncherOptions.Builder()
       .awsPoolId(null)
-      .shouldSimulateRoute(false);
+      .shouldSimulateRoute(false)
+      .enableOffRouteDetection(true);
   }
 }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationOptions.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationOptions.java
@@ -1,0 +1,32 @@
+package com.mapbox.services.android.navigation.ui.v5;
+
+import android.support.annotation.Nullable;
+
+import com.mapbox.api.directions.v5.models.DirectionsRoute;
+import com.mapbox.geojson.Point;
+
+public abstract class NavigationOptions {
+
+  @Nullable
+  public abstract DirectionsRoute directionsRoute();
+
+  @Nullable
+  public abstract String directionsProfile();
+
+  @Nullable
+  public abstract Point origin();
+
+  @Nullable
+  public abstract Point destination();
+
+  @Nullable
+  public abstract String awsPoolId();
+
+  @Nullable
+  public abstract Integer lightThemeResId();
+
+  @Nullable
+  public abstract Integer darkThemeResId();
+
+  public abstract boolean shouldSimulateRoute();
+}

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewOptions.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewOptions.java
@@ -15,32 +15,9 @@ import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigationOpti
 import com.mapbox.services.android.navigation.v5.routeprogress.ProgressChangeListener;
 
 @AutoValue
-public abstract class NavigationViewOptions {
-
-  @Nullable
-  public abstract DirectionsRoute directionsRoute();
-
-  @Nullable
-  public abstract String directionsProfile();
-
-  @Nullable
-  public abstract Point origin();
-
-  @Nullable
-  public abstract Point destination();
-
-  @Nullable
-  public abstract String awsPoolId();
+public abstract class NavigationViewOptions extends NavigationOptions {
 
   public abstract MapboxNavigationOptions navigationOptions();
-
-  public abstract boolean shouldSimulateRoute();
-
-  @Nullable
-  public abstract Integer lightThemeResId();
-
-  @Nullable
-  public abstract Integer darkThemeResId();
 
   @Nullable
   public abstract FeedbackListener feedbackListener();
@@ -73,13 +50,13 @@ public abstract class NavigationViewOptions {
 
     public abstract Builder awsPoolId(String awsPoolId);
 
-    public abstract Builder navigationOptions(MapboxNavigationOptions navigationOptions);
-
-    public abstract Builder shouldSimulateRoute(boolean shouldSimulateRoute);
-
     public abstract Builder lightThemeResId(Integer lightThemeResId);
 
     public abstract Builder darkThemeResId(Integer darkThemeResId);
+
+    public abstract Builder shouldSimulateRoute(boolean shouldSimulateRoute);
+
+    public abstract Builder navigationOptions(MapboxNavigationOptions navigationOptions);
 
     public abstract Builder feedbackListener(FeedbackListener feedbackListener);
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionStepResources.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionStepResources.java
@@ -90,7 +90,7 @@ class InstructionStepResources {
 
   private void formatStepDistance(Context context, RouteProgress progress,
                                   Locale locale, @NavigationUnitType.UnitType int unitType) {
-    if (distanceUtils == null || this.locale != locale || this.unitType != unitType) {
+    if (distanceUtils == null || this.locale.equals(locale) || this.unitType != unitType) {
       distanceUtils = new DistanceUtils(context, locale, unitType);
       this.locale = locale;
       this.unitType = unitType;

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionStepResources.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionStepResources.java
@@ -90,7 +90,7 @@ class InstructionStepResources {
 
   private void formatStepDistance(Context context, RouteProgress progress,
                                   Locale locale, @NavigationUnitType.UnitType int unitType) {
-    if (distanceUtils == null || this.locale.equals(locale) || this.unitType != unitType) {
+    if (distanceUtils == null || !this.locale.equals(locale) || this.unitType != unitType) {
       distanceUtils = new DistanceUtils(context, locale, unitType);
       this.locale = locale;
       this.unitType = unitType;

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/RouteViewModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/RouteViewModel.java
@@ -295,6 +295,8 @@ public class RouteViewModel extends AndroidViewModel implements Callback<Directi
     if (routeProfile != null) {
       builder.profile(routeProfile);
     }
-    builder.language(locale).voiceUnits(unitType);
+    builder
+      .language(locale)
+      .voiceUnits(unitType);
   }
 }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/list/InstructionListAdapter.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/list/InstructionListAdapter.java
@@ -72,7 +72,7 @@ public class InstructionListAdapter extends RecyclerView.Adapter<InstructionView
 
   public void updateSteps(Context context, RouteProgress routeProgress,
                           Locale locale, @NavigationUnitType.UnitType int unitType) {
-    if (distanceUtils == null || this.locale != locale || this.unitType != unitType) {
+    if (distanceUtils == null || this.locale.equals(locale) || this.unitType != unitType) {
       distanceUtils = new DistanceUtils(context, locale, unitType);
       this.locale = locale;
       this.unitType = unitType;

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/list/InstructionListAdapter.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/list/InstructionListAdapter.java
@@ -72,7 +72,7 @@ public class InstructionListAdapter extends RecyclerView.Adapter<InstructionView
 
   public void updateSteps(Context context, RouteProgress routeProgress,
                           Locale locale, @NavigationUnitType.UnitType int unitType) {
-    if (distanceUtils == null || this.locale.equals(locale) || this.unitType != unitType) {
+    if (distanceUtils == null || !this.locale.equals(locale) || this.unitType != unitType) {
       distanceUtils = new DistanceUtils(context, locale, unitType);
       this.locale = locale;
       this.unitType = unitType;

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationConstants.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationConstants.java
@@ -203,6 +203,7 @@ public final class NavigationConstants {
   public static final String NAVIGATION_VIEW_UNIT_TYPE = "navigation_view_unit_type";
   public static final String NAVIGATION_VIEW_SIMULATE_ROUTE = "navigation_view_simulate_route";
   public static final String NAVIGATION_VIEW_ROUTE_PROFILE_KEY = "navigation_view_route_profile";
+  public static final String NAVIGATION_VIEW_OFF_ROUTE_ENABLED_KEY = "navigation_view_off_route_enabled";
   public static final String NAVIGATION_VIEW_LOCALE_LANGUAGE = "navigation_view_locale_language";
   public static final String NAVIGATION_VIEW_LOCALE_COUNTRY = "navigation_view_locale_country";
   public static final String NAVIGATION_VIEW_REROUTING = "Rerouting";

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationConstants.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationConstants.java
@@ -201,6 +201,8 @@ public final class NavigationConstants {
   public static final String NAVIGATION_VIEW_ROUTE_KEY = "route_json";
   public static final String NAVIGATION_VIEW_AWS_POOL_ID = "navigation_view_aws_pool_id";
   public static final String NAVIGATION_VIEW_UNIT_TYPE = "navigation_view_unit_type";
+  public static final String NAVIGATION_VIEW_SIMULATE_ROUTE = "navigation_view_simulate_route";
+  public static final String NAVIGATION_VIEW_ROUTE_PROFILE_KEY = "navigation_view_route_profile";
   public static final String NAVIGATION_VIEW_LOCALE_LANGUAGE = "navigation_view_locale_language";
   public static final String NAVIGATION_VIEW_LOCALE_COUNTRY = "navigation_view_locale_country";
   public static final String NAVIGATION_VIEW_REROUTING = "Rerouting";
@@ -271,5 +273,4 @@ public final class NavigationConstants {
   public static final String TURN_LANE_INDICATION_RIGHT = "right";
   public static final String TURN_LANE_INDICATION_SLIGHT_RIGHT = "slight right";
   public static final String TURN_LANE_INDICATION_UTURN = "uturn";
-  public static final String NAVIGATION_VIEW_SIMULATE_ROUTE = "navigation_view_simulate_route";
 }


### PR DESCRIPTION
Closes #779, Closes #754, Closes #794 

This PR introduces `NavigationLauncherOptions` to be used with `NavigationLauncher`.  Both `NavigationLauncherOptions` and `NavigationViewOptions` subclass `NavigationOptions` as there a few shared variables between both options objects.    

Previously `NavigationViewOptions` were used with `NavigationLauncher` as well as `NavigationView#startNavigation`.  This didn't make sense because `NavigationLauncher` wasn't considering all of the variables passed from `NavigationViewOptions`, such as the listeners.  
