### PR TITLE
Extract NavigationEngine processing logic and add tests

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEngine.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEngine.java
@@ -6,54 +6,33 @@ import android.os.HandlerThread;
 import android.os.Message;
 import android.os.Process;
 
-import com.mapbox.api.directions.v5.models.DirectionsRoute;
-import com.mapbox.api.directions.v5.models.LegStep;
-import com.mapbox.api.directions.v5.models.RouteLeg;
-import com.mapbox.geojson.Point;
-import com.mapbox.geojson.utils.PolylineUtils;
 import com.mapbox.services.android.navigation.v5.milestone.Milestone;
-import com.mapbox.services.android.navigation.v5.offroute.OffRoute;
-import com.mapbox.services.android.navigation.v5.offroute.OffRouteCallback;
-import com.mapbox.services.android.navigation.v5.offroute.OffRouteDetector;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
-import com.mapbox.services.android.navigation.v5.utils.RouteUtils;
 
 import java.util.List;
 
-import static com.mapbox.core.constants.Constants.PRECISION_6;
-import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.checkBearingForStepCompletion;
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.checkMilestones;
-import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.getSnappedLocation;
-import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.increaseIndex;
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.isUserOffRoute;
-import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.legDistanceRemaining;
-import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.routeDistanceRemaining;
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.shouldCheckFasterRoute;
-import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.stepDistanceRemaining;
-import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.userSnappedToRoutePosition;
 
 /**
  * This class extends handler thread to run most of the navigation calculations on a separate
  * background thread.
  */
-class NavigationEngine extends HandlerThread implements Handler.Callback, OffRouteCallback {
+class NavigationEngine extends HandlerThread implements Handler.Callback {
 
   private static final String THREAD_NAME = "NavThread";
 
-  private RouteProgress previousRouteProgress;
-  private List<Point> stepPoints;
-  private NavigationIndices indices;
   private Handler responseHandler;
   private Handler workerHandler;
   private Callback callback;
-
-  private boolean shouldIncreaseStepIndex;
+  private NavigationRouteProcessor routeProcessor;
 
   NavigationEngine(Handler responseHandler, Callback callback) {
     super(THREAD_NAME, Process.THREAD_PRIORITY_BACKGROUND);
     this.responseHandler = responseHandler;
     this.callback = callback;
-    indices = NavigationIndices.create(0, 0);
+    routeProcessor = new NavigationRouteProcessor();
   }
 
   @Override
@@ -61,11 +40,6 @@ class NavigationEngine extends HandlerThread implements Handler.Callback, OffRou
     NewLocationModel newLocationModel = (NewLocationModel) msg.obj;
     handleRequest(newLocationModel);
     return true;
-  }
-
-  @Override
-  public void onShouldIncreaseIndex() {
-    shouldIncreaseStepIndex = true;
   }
 
   void queueTask(int msgIdentifier, NewLocationModel newLocationModel) {
@@ -93,19 +67,20 @@ class NavigationEngine extends HandlerThread implements Handler.Callback, OffRou
     final Location rawLocation = newLocationModel.location();
 
     // Generate a new route progress given the raw location update
-    RouteProgress routeProgress = buildNewRouteProgress(mapboxNavigation, rawLocation);
+    RouteProgress routeProgress = routeProcessor.buildNewRouteProgress(mapboxNavigation, rawLocation);
 
     // Check if user has gone off-route
-    final boolean userOffRoute = isUserOffRoute(newLocationModel, routeProgress, this);
+    final boolean userOffRoute = isUserOffRoute(newLocationModel, routeProgress, routeProcessor);
 
     // If needed, increase step index and generate new route progress
-    checkIncreaseStepIndex(mapboxNavigation);
+    routeProcessor.checkIncreaseStepIndex(mapboxNavigation);
 
     // Check milestone list to see if any should be triggered
+    RouteProgress previousRouteProgress = routeProcessor.getPreviousRouteProgress();
     final List<Milestone> milestones = checkMilestones(previousRouteProgress, routeProgress, mapboxNavigation);
 
     // Create snapped location if enabled, otherwise return raw location
-    final Location location = buildSnappedLocation(mapboxNavigation, snapToRouteEnabled,
+    final Location location = routeProcessor.buildSnappedLocation(mapboxNavigation, snapToRouteEnabled,
       rawLocation, routeProgress, userOffRoute);
 
     // Check for faster route only if enabled and not off-route
@@ -115,7 +90,7 @@ class NavigationEngine extends HandlerThread implements Handler.Callback, OffRou
 
     // Copy route progress to final object for callback
     final RouteProgress finalRouteProgress = routeProgress;
-    previousRouteProgress = finalRouteProgress;
+    routeProcessor.setPreviousRouteProgress(finalRouteProgress);
 
     responseHandler.post(new Runnable() {
       @Override
@@ -126,178 +101,6 @@ class NavigationEngine extends HandlerThread implements Handler.Callback, OffRou
         callback.onCheckFasterRoute(location, finalRouteProgress, checkFasterRoute);
       }
     });
-  }
-
-  /**
-   * Will take a given location update and create a new {@link RouteProgress}
-   * based on our calculations of the distances remaining.
-   * <p>
-   * Also in charge of detecting if a step / leg has finished and incrementing the
-   * indices if needed ({@link NavigationEngine#advanceStepIndex(MapboxNavigation)} handles
-   * the decoding of the next step point list).
-   *
-   * @param mapboxNavigation for the current route / options
-   * @param location         for step / leg / route distance remaining
-   * @return new route progress along the route
-   */
-  private RouteProgress buildNewRouteProgress(MapboxNavigation mapboxNavigation, Location location) {
-    DirectionsRoute directionsRoute = mapboxNavigation.getRoute();
-    MapboxNavigationOptions options = mapboxNavigation.options();
-    double completionOffset = options.maxTurnCompletionOffset();
-    double maneuverZoneRadius = options.maneuverZoneRadius();
-
-    // Check if a new route has been provided
-    checkNewRoute(mapboxNavigation);
-
-    double stepDistanceRemaining = calculateStepDistanceRemaining(location, directionsRoute);
-    boolean withinManeuverRadius = stepDistanceRemaining < maneuverZoneRadius;
-    boolean bearingMatchesManeuver = checkBearingForStepCompletion(
-      location, previousRouteProgress, stepDistanceRemaining, completionOffset
-    );
-    boolean forceIncreaseStepIndex = stepDistanceRemaining == 0 && !bearingMatchesManeuver;
-
-    if ((bearingMatchesManeuver && withinManeuverRadius) || forceIncreaseStepIndex) {
-      // Advance the step index and create new step distance remaining
-      advanceStepIndex(mapboxNavigation);
-      // Re-calculate the step distance remaining based on the new index
-      stepDistanceRemaining = calculateStepDistanceRemaining(location, directionsRoute);
-    }
-
-    int legIndex = indices.legIndex();
-    int stepIndex = indices.stepIndex();
-    double legDistanceRemaining = legDistanceRemaining(stepDistanceRemaining, legIndex, stepIndex, directionsRoute);
-    double routeDistanceRemaining = routeDistanceRemaining(legDistanceRemaining, legIndex, directionsRoute);
-
-    // Create a RouteProgress.create object using the latest user location
-    return RouteProgress.builder()
-      .stepDistanceRemaining(stepDistanceRemaining)
-      .legDistanceRemaining(legDistanceRemaining)
-      .distanceRemaining(routeDistanceRemaining)
-      .directionsRoute(directionsRoute)
-      .stepIndex(stepIndex)
-      .legIndex(legIndex)
-      .build();
-  }
-
-  private void updateOffRouteDetectorStepPoints(OffRoute offRoute, List<Point> stepPoints) {
-    if (offRoute instanceof OffRouteDetector) {
-      ((OffRouteDetector) offRoute).updateStepPoints(stepPoints);
-      ((OffRouteDetector) offRoute).clearDistancesAwayFromManeuver();
-    }
-  }
-
-  /**
-   * If the {@link OffRouteCallback#onShouldIncreaseIndex()} has been called by the
-   * {@link com.mapbox.services.android.navigation.v5.offroute.OffRouteDetector}, shouldIncreaseStepIndex
-   * will be true and the {@link NavigationIndices} step index needs to be increased by one.
-   *
-   * @param navigation to get the next {@link LegStep#geometry()} and off-route engine
-   */
-  private void checkIncreaseStepIndex(MapboxNavigation navigation) {
-    if (shouldIncreaseStepIndex) {
-      advanceStepIndex(navigation);
-      shouldIncreaseStepIndex = false;
-    }
-  }
-
-  private Location buildSnappedLocation(MapboxNavigation mapboxNavigation, boolean snapToRouteEnabled,
-                                        Location rawLocation, RouteProgress routeProgress, boolean userOffRoute) {
-    final Location location;
-    if (!userOffRoute && snapToRouteEnabled) {
-      location = getSnappedLocation(mapboxNavigation, rawLocation, routeProgress, stepPoints);
-    } else {
-      location = rawLocation;
-    }
-    return location;
-  }
-
-  /**
-   * Increases the step index in {@link NavigationIndices} by 1.
-   * <p>
-   * Decodes the step points for the new step and clears the distances from
-   * maneuver stack, as the maneuver has now changed.
-   *
-   * @param mapboxNavigation to get the next {@link LegStep#geometry()} and {@link OffRoute}
-   */
-  private void advanceStepIndex(MapboxNavigation mapboxNavigation) {
-    // First increase the indices and then update the majority of information for the new routeProgress
-    indices = increaseIndex(previousRouteProgress, indices);
-
-    // First increase the indices and then update the majority of information for the new
-    stepPoints = decodeStepPoints(mapboxNavigation.getRoute(), indices.legIndex(), indices.stepIndex());
-    updateOffRouteDetectorStepPoints(mapboxNavigation.getOffRouteEngine(), stepPoints);
-  }
-
-  /**
-   * Given the current {@link DirectionsRoute} and leg / step index,
-   * return a list of {@link Point} representing the current step.
-   * <p>
-   * This method is only used on a per-step basis as {@link PolylineUtils#decode(String, int)}
-   * can be a heavy operation based on the length of the step.
-   *
-   * @param directionsRoute for list of steps
-   * @param legIndex        to get current step list
-   * @param stepIndex       to get current step
-   * @return list of {@link Point} representing the current step
-   */
-  private List<Point> decodeStepPoints(DirectionsRoute directionsRoute, int legIndex, int stepIndex) {
-    // Check for valid legs
-    List<RouteLeg> legs = directionsRoute.legs();
-    if (legs == null || legs.isEmpty()) {
-      return stepPoints;
-    }
-    // Check for valid steps
-    List<LegStep> steps = legs.get(legIndex).steps();
-    if (steps == null || steps.isEmpty()) {
-      return stepPoints;
-    }
-
-    String stepGeometry = steps.get(stepIndex).geometry();
-    if (stepGeometry != null) {
-      return PolylineUtils.decode(stepGeometry, PRECISION_6);
-    }
-    return stepPoints;
-  }
-
-  /**
-   * Checks if the route provided is a new route.  If it is, all {@link RouteProgress}
-   * data and {@link NavigationIndices} needs to be reset.
-   *
-   * @param mapboxNavigation to get the current route and off-route engine
-   */
-  private void checkNewRoute(MapboxNavigation mapboxNavigation) {
-    DirectionsRoute directionsRoute = mapboxNavigation.getRoute();
-    if (RouteUtils.isNewRoute(previousRouteProgress, directionsRoute)) {
-      // Decode the first steps geometry and hold onto the resulting Position objects till the users
-      // on the next step. Indices are both 0 since the user just started on the new route.
-      stepPoints = decodeStepPoints(directionsRoute, 0, 0);
-      updateOffRouteDetectorStepPoints(mapboxNavigation.getOffRouteEngine(), stepPoints);
-
-      previousRouteProgress = RouteProgress.builder()
-        .stepDistanceRemaining(directionsRoute.legs().get(0).steps().get(0).distance())
-        .legDistanceRemaining(directionsRoute.legs().get(0).distance())
-        .distanceRemaining(directionsRoute.distance())
-        .directionsRoute(directionsRoute)
-        .stepIndex(0)
-        .legIndex(0)
-        .build();
-
-      indices = NavigationIndices.create(0, 0);
-    }
-  }
-
-  /**
-   * Given a location update, calculate the current step distance remaining.
-   *
-   * @param location        for current coordinates
-   * @param directionsRoute for current {@link LegStep}
-   * @return distance remaining in meters
-   */
-  private double calculateStepDistanceRemaining(Location location, DirectionsRoute directionsRoute) {
-    Point snappedPosition = userSnappedToRoutePosition(location, stepPoints);
-    return stepDistanceRemaining(
-      snappedPosition, indices.legIndex(), indices.stepIndex(), directionsRoute, stepPoints
-    );
   }
 
   /**

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEngine.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEngine.java
@@ -66,29 +66,22 @@ class NavigationEngine extends HandlerThread implements Handler.Callback {
 
     final Location rawLocation = newLocationModel.location();
 
-    // Generate a new route progress given the raw location update
     RouteProgress routeProgress = routeProcessor.buildNewRouteProgress(mapboxNavigation, rawLocation);
 
-    // Check if user has gone off-route
     final boolean userOffRoute = isUserOffRoute(newLocationModel, routeProgress, routeProcessor);
 
-    // If needed, increase step index and generate new route progress
     routeProcessor.checkIncreaseStepIndex(mapboxNavigation);
 
-    // Check milestone list to see if any should be triggered
     RouteProgress previousRouteProgress = routeProcessor.getPreviousRouteProgress();
     final List<Milestone> milestones = checkMilestones(previousRouteProgress, routeProgress, mapboxNavigation);
 
-    // Create snapped location if enabled, otherwise return raw location
     final Location location = routeProcessor.buildSnappedLocation(mapboxNavigation, snapToRouteEnabled,
       rawLocation, routeProgress, userOffRoute);
 
-    // Check for faster route only if enabled and not off-route
     boolean fasterRouteEnabled = mapboxNavigation.options().enableFasterRouteDetection();
     final boolean checkFasterRoute = fasterRouteEnabled && !userOffRoute
       && shouldCheckFasterRoute(newLocationModel, routeProgress);
 
-    // Copy route progress to final object for callback
     final RouteProgress finalRouteProgress = routeProgress;
     routeProcessor.setPreviousRouteProgress(finalRouteProgress);
 

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/BaseTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/BaseTest.java
@@ -1,12 +1,19 @@
 package com.mapbox.services.android.navigation.v5;
 
+import android.location.Location;
+import android.support.annotation.NonNull;
+
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonParser;
 import com.mapbox.api.directions.v5.DirectionsAdapterFactory;
 import com.mapbox.api.directions.v5.models.DirectionsResponse;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
+import com.mapbox.geojson.Point;
+import com.mapbox.services.android.navigation.v5.offroute.OffRouteDetectorTest;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
+import com.mapbox.turf.TurfConstants;
+import com.mapbox.turf.TurfMeasurement;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -57,5 +64,31 @@ public class BaseTest {
     DirectionsRoute aRoute = response.routes().get(0);
 
     return aRoute;
+  }
+
+  protected Location buildDefaultLocationUpdate(double lng, double lat) {
+    return buildLocationUpdate(lng, lat, 30f, 10f, System.currentTimeMillis());
+  }
+
+  protected Location buildLocationUpdate(double lng, double lat, float speed, float horizontalAccuracy, long time) {
+    Location location = new Location(OffRouteDetectorTest.class.getSimpleName());
+    location.setLongitude(lng);
+    location.setLatitude(lat);
+    location.setSpeed(speed);
+    location.setAccuracy(horizontalAccuracy);
+    location.setTime(time);
+    return location;
+  }
+
+  @NonNull
+  protected Point buildPointAwayFromLocation(Location location, double distanceAway) {
+    Point fromLocation = Point.fromLngLat(
+      location.getLongitude(), location.getLatitude());
+    return TurfMeasurement.destination(fromLocation, distanceAway, 90, TurfConstants.UNIT_METERS);
+  }
+
+  @NonNull
+  protected Point buildPointAwayFromPoint(Point point, double distanceAway, double bearing) {
+    return TurfMeasurement.destination(point, distanceAway, bearing, TurfConstants.UNIT_METERS);
   }
 }

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/BaseTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/BaseTest.java
@@ -1,13 +1,19 @@
 package com.mapbox.services.android.navigation.v5;
 
-import static junit.framework.Assert.assertEquals;
-import static okhttp3.internal.Util.UTF_8;
-
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.JsonParser;
+import com.mapbox.api.directions.v5.DirectionsAdapterFactory;
+import com.mapbox.api.directions.v5.models.DirectionsResponse;
+import com.mapbox.api.directions.v5.models.DirectionsRoute;
+import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Scanner;
+
+import static junit.framework.Assert.assertEquals;
+import static okhttp3.internal.Util.UTF_8;
 
 public class BaseTest {
 
@@ -15,6 +21,7 @@ public class BaseTest {
   public static final double LARGE_DELTA = 0.1;
 
   public static final String ACCESS_TOKEN = "pk.XXX";
+  private static final String DIRECTIONS_PRECISION_6 = "directions_v5_precision_6.json";
 
   public void compareJson(String json1, String json2) {
     JsonParser parser = new JsonParser();
@@ -26,5 +33,29 @@ public class BaseTest {
     InputStream inputStream = classLoader.getResourceAsStream(filename);
     Scanner scanner = new Scanner(inputStream, UTF_8.name()).useDelimiter("\\A");
     return scanner.hasNext() ? scanner.next() : "";
+  }
+
+  protected RouteProgress buildDefaultRouteProgress() throws Exception {
+    DirectionsRoute aRoute = buildDirectionsRoute();
+    RouteProgress defaultRouteProgress = RouteProgress.builder()
+      .stepDistanceRemaining(100)
+      .legDistanceRemaining(100)
+      .distanceRemaining(100)
+      .directionsRoute(aRoute)
+      .stepIndex(0)
+      .legIndex(0)
+      .build();
+
+    return defaultRouteProgress;
+  }
+
+  protected DirectionsRoute buildDirectionsRoute() throws IOException {
+    Gson gson = new GsonBuilder()
+      .registerTypeAdapterFactory(DirectionsAdapterFactory.create()).create();
+    String body = loadJsonFixture(DIRECTIONS_PRECISION_6);
+    DirectionsResponse response = gson.fromJson(body, DirectionsResponse.class);
+    DirectionsRoute aRoute = response.routes().get(0);
+
+    return aRoute;
   }
 }

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/BaseTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/BaseTest.java
@@ -10,7 +10,6 @@ import com.mapbox.api.directions.v5.DirectionsAdapterFactory;
 import com.mapbox.api.directions.v5.models.DirectionsResponse;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.geojson.Point;
-import com.mapbox.services.android.navigation.v5.offroute.OffRouteDetectorTest;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 import com.mapbox.turf.TurfConstants;
 import com.mapbox.turf.TurfMeasurement;
@@ -21,6 +20,8 @@ import java.util.Scanner;
 
 import static junit.framework.Assert.assertEquals;
 import static okhttp3.internal.Util.UTF_8;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class BaseTest {
 
@@ -71,12 +72,12 @@ public class BaseTest {
   }
 
   protected Location buildLocationUpdate(double lng, double lat, float speed, float horizontalAccuracy, long time) {
-    Location location = new Location(OffRouteDetectorTest.class.getSimpleName());
-    location.setLongitude(lng);
-    location.setLatitude(lat);
-    location.setSpeed(speed);
-    location.setAccuracy(horizontalAccuracy);
-    location.setTime(time);
+    Location location = mock(Location.class);
+    when(location.getLongitude()).thenReturn(lng);
+    when(location.getLatitude()).thenReturn(lat);
+    when(location.getSpeed()).thenReturn(speed);
+    when(location.getAccuracy()).thenReturn(horizontalAccuracy);
+    when(location.getTime()).thenReturn(time);
     return location;
   }
 

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteProcessorTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteProcessorTest.java
@@ -66,7 +66,6 @@ public class NavigationRouteProcessorTest extends BaseTest {
 
   @Test
   public void onSnapToRouteEnabledAndUserOnRoute_snappedLocationReturns() throws Exception {
-    // Decode step points for snap-to-route logic
     RouteProgress progress = routeProcessor.buildNewRouteProgress(navigation, mock(Location.class));
 
     boolean snapEnabled = true;
@@ -91,7 +90,6 @@ public class NavigationRouteProcessorTest extends BaseTest {
 
   @Test
   public void onSnapToRouteDisabledAndUserOnRoute_rawLocationReturns() throws Exception {
-    // Decode step points for snap-to-route logic
     RouteProgress progress = routeProcessor.buildNewRouteProgress(navigation, mock(Location.class));
 
     boolean snapEnabled = false;
@@ -116,7 +114,6 @@ public class NavigationRouteProcessorTest extends BaseTest {
 
   @Test
   public void onSnapToRouteEnabledAndUserOffRoute_rawLocationReturns() throws Exception {
-    // Decode step points for snap-to-route logic
     RouteProgress progress = routeProcessor.buildNewRouteProgress(navigation, mock(Location.class));
 
     boolean snapEnabled = false;

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteProcessorTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteProcessorTest.java
@@ -3,6 +3,10 @@ package com.mapbox.services.android.navigation.v5.navigation;
 import android.content.Context;
 import android.location.Location;
 
+import com.mapbox.api.directions.v5.models.LegStep;
+import com.mapbox.core.constants.Constants;
+import com.mapbox.geojson.LineString;
+import com.mapbox.geojson.Point;
 import com.mapbox.services.android.navigation.BuildConfig;
 import com.mapbox.services.android.navigation.v5.BaseTest;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
@@ -13,6 +17,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
+
+import java.util.List;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
@@ -41,14 +47,14 @@ public class NavigationRouteProcessorTest extends BaseTest {
   }
 
   @Test
-  public void onFirstRouteProgressBuilt_NewRouteIsDecoded() throws Exception {
+  public void onFirstRouteProgressBuilt_newRouteIsDecoded() throws Exception {
     RouteProgress progress = routeProcessor.buildNewRouteProgress(navigation, mock(Location.class));
     assertEquals(0, progress.legIndex());
     assertEquals(0, progress.currentLegProgress().stepIndex());
   }
 
   @Test
-  public void onShouldIncreaseStepIndex_IndexIsIncreased() throws Exception {
+  public void onShouldIncreaseStepIndex_indexIsIncreased() throws Exception {
     RouteProgress progress = routeProcessor.buildNewRouteProgress(navigation, mock(Location.class));
     int currentStepIndex = progress.currentLegProgress().stepIndex();
     routeProcessor.onShouldIncreaseIndex();
@@ -58,5 +64,121 @@ public class NavigationRouteProcessorTest extends BaseTest {
     assertTrue(currentStepIndex != secondStepIndex);
   }
 
-  // TODO snapped location and bearing match booleans
+  @Test
+  public void onSnapToRouteEnabledAndUserOnRoute_snappedLocationReturns() throws Exception {
+    // Decode step points for snap-to-route logic
+    RouteProgress progress = routeProcessor.buildNewRouteProgress(navigation, mock(Location.class));
+
+    boolean snapEnabled = true;
+    boolean userOffRoute = false;
+
+    LegStep currentStep = progress.currentLegProgress().currentStep();
+
+    LineString lineString = LineString.fromPolyline(currentStep.geometry(), Constants.PRECISION_6);
+    List<Point> coordinates = lineString.coordinates();
+
+    Point lastPointInCurrentStep = coordinates.remove(coordinates.size() - 1);
+    Location rawLocation = buildDefaultLocationUpdate(
+      lastPointInCurrentStep.longitude(), lastPointInCurrentStep.latitude()
+    );
+
+    Location snappedLocation = routeProcessor.buildSnappedLocation(
+      navigation, snapEnabled, rawLocation, progress, userOffRoute
+    );
+
+    assertTrue(!rawLocation.equals(snappedLocation));
+  }
+
+  @Test
+  public void onSnapToRouteDisabledAndUserOnRoute_rawLocationReturns() throws Exception {
+    // Decode step points for snap-to-route logic
+    RouteProgress progress = routeProcessor.buildNewRouteProgress(navigation, mock(Location.class));
+
+    boolean snapEnabled = false;
+    boolean userOffRoute = false;
+
+    LegStep currentStep = progress.currentLegProgress().currentStep();
+
+    LineString lineString = LineString.fromPolyline(currentStep.geometry(), Constants.PRECISION_6);
+    List<Point> coordinates = lineString.coordinates();
+
+    Point lastPointInCurrentStep = coordinates.remove(coordinates.size() - 1);
+    Location rawLocation = buildDefaultLocationUpdate(
+      lastPointInCurrentStep.longitude(), lastPointInCurrentStep.latitude()
+    );
+
+    Location snappedLocation = routeProcessor.buildSnappedLocation(
+      navigation, snapEnabled, rawLocation, progress, userOffRoute
+    );
+
+    assertTrue(rawLocation.equals(snappedLocation));
+  }
+
+  @Test
+  public void onSnapToRouteEnabledAndUserOffRoute_rawLocationReturns() throws Exception {
+    // Decode step points for snap-to-route logic
+    RouteProgress progress = routeProcessor.buildNewRouteProgress(navigation, mock(Location.class));
+
+    boolean snapEnabled = false;
+    boolean userOffRoute = false;
+
+    LegStep currentStep = progress.currentLegProgress().currentStep();
+
+    LineString lineString = LineString.fromPolyline(currentStep.geometry(), Constants.PRECISION_6);
+    List<Point> coordinates = lineString.coordinates();
+
+    Point lastPointInCurrentStep = coordinates.remove(coordinates.size() - 1);
+    Location rawLocation = buildDefaultLocationUpdate(
+      lastPointInCurrentStep.longitude(), lastPointInCurrentStep.latitude()
+    );
+
+    Location snappedLocation = routeProcessor.buildSnappedLocation(
+      navigation, snapEnabled, rawLocation, progress, userOffRoute
+    );
+
+    assertTrue(rawLocation.equals(snappedLocation));
+  }
+
+  @Test
+  public void onStepDistanceRemainingZeroAndNoBearingMatch_stepIndexForceIncreased() throws Exception {
+    RouteProgress firstProgress = routeProcessor.buildNewRouteProgress(navigation, mock(Location.class));
+    int firstProgressIndex = firstProgress.currentLegProgress().stepIndex();
+
+    LegStep currentStep = firstProgress.currentLegProgress().currentStep();
+
+    LineString lineString = LineString.fromPolyline(currentStep.geometry(), Constants.PRECISION_6);
+    List<Point> coordinates = lineString.coordinates();
+
+    Point lastPointInCurrentStep = coordinates.remove(coordinates.size() - 1);
+    Location rawLocation = buildDefaultLocationUpdate(
+      lastPointInCurrentStep.longitude(), lastPointInCurrentStep.latitude()
+    );
+
+    RouteProgress secondProgress = routeProcessor.buildNewRouteProgress(navigation, rawLocation);
+    int secondProgressIndex = secondProgress.currentLegProgress().stepIndex();
+
+    assertTrue(firstProgressIndex != secondProgressIndex);
+  }
+
+  @Test
+  public void withinManeuverRadiusAndBearingMatches_stepIndexIsIncreased() throws Exception {
+    RouteProgress firstProgress = routeProcessor.buildNewRouteProgress(navigation, mock(Location.class));
+    int firstProgressIndex = firstProgress.currentLegProgress().stepIndex();
+
+    LegStep currentStep = firstProgress.currentLegProgress().currentStep();
+
+    LineString lineString = LineString.fromPolyline(currentStep.geometry(), Constants.PRECISION_6);
+    List<Point> coordinates = lineString.coordinates();
+
+    Point lastPointInCurrentStep = coordinates.remove(coordinates.size() - 2);
+    Location rawLocation = buildDefaultLocationUpdate(
+      lastPointInCurrentStep.longitude(), lastPointInCurrentStep.latitude()
+    );
+    rawLocation.setBearing(145f);
+
+    RouteProgress secondProgress = routeProcessor.buildNewRouteProgress(navigation, rawLocation);
+    int secondProgressIndex = secondProgress.currentLegProgress().stepIndex();
+
+    assertTrue(firstProgressIndex != secondProgressIndex);
+  }
 }

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteProcessorTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteProcessorTest.java
@@ -7,16 +7,12 @@ import com.mapbox.api.directions.v5.models.LegStep;
 import com.mapbox.core.constants.Constants;
 import com.mapbox.geojson.LineString;
 import com.mapbox.geojson.Point;
-import com.mapbox.services.android.navigation.BuildConfig;
 import com.mapbox.services.android.navigation.v5.BaseTest;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 import com.mapbox.services.android.telemetry.location.LocationEngine;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 import java.util.List;
 
@@ -24,16 +20,15 @@ import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-@RunWith(RobolectricTestRunner.class)
-@Config(constants = BuildConfig.class, manifest = Config.DEFAULT_MANIFEST_NAME)
 public class NavigationRouteProcessorTest extends BaseTest {
 
   private NavigationRouteProcessor routeProcessor;
   private MapboxNavigation navigation;
 
   @Before
-  public void setup() throws Exception {
+  public void before() throws Exception {
     routeProcessor = new NavigationRouteProcessor();
     MapboxNavigationOptions options = MapboxNavigationOptions.builder().build();
     navigation = new MapboxNavigation(mock(Context.class), ACCESS_TOKEN, options, mock(NavigationTelemetry.class),
@@ -67,15 +62,11 @@ public class NavigationRouteProcessorTest extends BaseTest {
   @Test
   public void onSnapToRouteEnabledAndUserOnRoute_snappedLocationReturns() throws Exception {
     RouteProgress progress = routeProcessor.buildNewRouteProgress(navigation, mock(Location.class));
-
     boolean snapEnabled = true;
     boolean userOffRoute = false;
-
     LegStep currentStep = progress.currentLegProgress().currentStep();
-
     LineString lineString = LineString.fromPolyline(currentStep.geometry(), Constants.PRECISION_6);
     List<Point> coordinates = lineString.coordinates();
-
     Point lastPointInCurrentStep = coordinates.remove(coordinates.size() - 1);
     Location rawLocation = buildDefaultLocationUpdate(
       lastPointInCurrentStep.longitude(), lastPointInCurrentStep.latitude()
@@ -91,15 +82,11 @@ public class NavigationRouteProcessorTest extends BaseTest {
   @Test
   public void onSnapToRouteDisabledAndUserOnRoute_rawLocationReturns() throws Exception {
     RouteProgress progress = routeProcessor.buildNewRouteProgress(navigation, mock(Location.class));
-
     boolean snapEnabled = false;
     boolean userOffRoute = false;
-
     LegStep currentStep = progress.currentLegProgress().currentStep();
-
     LineString lineString = LineString.fromPolyline(currentStep.geometry(), Constants.PRECISION_6);
     List<Point> coordinates = lineString.coordinates();
-
     Point lastPointInCurrentStep = coordinates.remove(coordinates.size() - 1);
     Location rawLocation = buildDefaultLocationUpdate(
       lastPointInCurrentStep.longitude(), lastPointInCurrentStep.latitude()
@@ -115,15 +102,11 @@ public class NavigationRouteProcessorTest extends BaseTest {
   @Test
   public void onSnapToRouteEnabledAndUserOffRoute_rawLocationReturns() throws Exception {
     RouteProgress progress = routeProcessor.buildNewRouteProgress(navigation, mock(Location.class));
-
     boolean snapEnabled = false;
     boolean userOffRoute = false;
-
     LegStep currentStep = progress.currentLegProgress().currentStep();
-
     LineString lineString = LineString.fromPolyline(currentStep.geometry(), Constants.PRECISION_6);
     List<Point> coordinates = lineString.coordinates();
-
     Point lastPointInCurrentStep = coordinates.remove(coordinates.size() - 1);
     Location rawLocation = buildDefaultLocationUpdate(
       lastPointInCurrentStep.longitude(), lastPointInCurrentStep.latitude()
@@ -140,12 +123,9 @@ public class NavigationRouteProcessorTest extends BaseTest {
   public void onStepDistanceRemainingZeroAndNoBearingMatch_stepIndexForceIncreased() throws Exception {
     RouteProgress firstProgress = routeProcessor.buildNewRouteProgress(navigation, mock(Location.class));
     int firstProgressIndex = firstProgress.currentLegProgress().stepIndex();
-
     LegStep currentStep = firstProgress.currentLegProgress().currentStep();
-
     LineString lineString = LineString.fromPolyline(currentStep.geometry(), Constants.PRECISION_6);
     List<Point> coordinates = lineString.coordinates();
-
     Point lastPointInCurrentStep = coordinates.remove(coordinates.size() - 1);
     Location rawLocation = buildDefaultLocationUpdate(
       lastPointInCurrentStep.longitude(), lastPointInCurrentStep.latitude()
@@ -161,17 +141,14 @@ public class NavigationRouteProcessorTest extends BaseTest {
   public void withinManeuverRadiusAndBearingMatches_stepIndexIsIncreased() throws Exception {
     RouteProgress firstProgress = routeProcessor.buildNewRouteProgress(navigation, mock(Location.class));
     int firstProgressIndex = firstProgress.currentLegProgress().stepIndex();
-
     LegStep currentStep = firstProgress.currentLegProgress().currentStep();
-
     LineString lineString = LineString.fromPolyline(currentStep.geometry(), Constants.PRECISION_6);
     List<Point> coordinates = lineString.coordinates();
-
     Point lastPointInCurrentStep = coordinates.remove(coordinates.size() - 2);
     Location rawLocation = buildDefaultLocationUpdate(
       lastPointInCurrentStep.longitude(), lastPointInCurrentStep.latitude()
     );
-    rawLocation.setBearing(145f);
+    when(rawLocation.getBearing()).thenReturn(145f);
 
     RouteProgress secondProgress = routeProcessor.buildNewRouteProgress(navigation, rawLocation);
     int secondProgressIndex = secondProgress.currentLegProgress().stepIndex();

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteProcessorTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteProcessorTest.java
@@ -1,0 +1,62 @@
+package com.mapbox.services.android.navigation.v5.navigation;
+
+import android.content.Context;
+import android.location.Location;
+
+import com.mapbox.services.android.navigation.BuildConfig;
+import com.mapbox.services.android.navigation.v5.BaseTest;
+import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
+import com.mapbox.services.android.telemetry.location.LocationEngine;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, manifest = Config.DEFAULT_MANIFEST_NAME)
+public class NavigationRouteProcessorTest extends BaseTest {
+
+  private NavigationRouteProcessor routeProcessor;
+  private MapboxNavigation navigation;
+
+  @Before
+  public void setup() throws Exception {
+    routeProcessor = new NavigationRouteProcessor();
+    MapboxNavigationOptions options = MapboxNavigationOptions.builder().build();
+    navigation = new MapboxNavigation(mock(Context.class), ACCESS_TOKEN, options, mock(NavigationTelemetry.class),
+      mock(LocationEngine.class));
+    navigation.startNavigation(buildDirectionsRoute());
+  }
+
+  @Test
+  public void sanity() throws Exception {
+    assertNotNull(routeProcessor);
+  }
+
+  @Test
+  public void onFirstRouteProgressBuilt_NewRouteIsDecoded() throws Exception {
+    RouteProgress progress = routeProcessor.buildNewRouteProgress(navigation, mock(Location.class));
+    assertEquals(0, progress.legIndex());
+    assertEquals(0, progress.currentLegProgress().stepIndex());
+  }
+
+  @Test
+  public void onShouldIncreaseStepIndex_IndexIsIncreased() throws Exception {
+    RouteProgress progress = routeProcessor.buildNewRouteProgress(navigation, mock(Location.class));
+    int currentStepIndex = progress.currentLegProgress().stepIndex();
+    routeProcessor.onShouldIncreaseIndex();
+    routeProcessor.checkIncreaseStepIndex(navigation);
+    RouteProgress secondProgress = routeProcessor.buildNewRouteProgress(navigation, mock(Location.class));
+    int secondStepIndex = secondProgress.currentLegProgress().stepIndex();
+    assertTrue(currentStepIndex != secondStepIndex);
+  }
+
+  // TODO snapped location and bearing match booleans
+}

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteDetectorTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteDetectorTest.java
@@ -1,7 +1,6 @@
 package com.mapbox.services.android.navigation.v5.offroute;
 
 import android.location.Location;
-import android.support.annotation.NonNull;
 
 import com.mapbox.api.directions.v5.models.LegStep;
 import com.mapbox.core.constants.Constants;
@@ -11,8 +10,6 @@ import com.mapbox.services.android.navigation.BuildConfig;
 import com.mapbox.services.android.navigation.v5.BaseTest;
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigationOptions;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
-import com.mapbox.turf.TurfConstants;
-import com.mapbox.turf.TurfMeasurement;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -227,34 +224,5 @@ public class OffRouteDetectorTest extends BaseTest {
     LineString lineString = LineString.fromPolyline(currentStep.geometry(), Constants.PRECISION_6);
     List<Point> stepPoints = lineString.coordinates();
     offRouteDetector.updateStepPoints(stepPoints);
-  }
-
-  /**
-   * @return {@link Location} with Mapbox DC coordinates
-   */
-  private Location buildDefaultLocationUpdate(double lng, double lat) {
-    return buildLocationUpdate(lng, lat, 30f, 10f, System.currentTimeMillis());
-  }
-
-  private Location buildLocationUpdate(double lng, double lat, float speed, float horizontalAccuracy, long time) {
-    Location location = new Location(OffRouteDetectorTest.class.getSimpleName());
-    location.setLongitude(lng);
-    location.setLatitude(lat);
-    location.setSpeed(speed);
-    location.setAccuracy(horizontalAccuracy);
-    location.setTime(time);
-    return location;
-  }
-
-  @NonNull
-  private Point buildPointAwayFromLocation(Location location, double distanceAway) {
-    Point fromLocation = Point.fromLngLat(
-      location.getLongitude(), location.getLatitude());
-    return TurfMeasurement.destination(fromLocation, distanceAway, 90, TurfConstants.UNIT_METERS);
-  }
-
-  @NonNull
-  private Point buildPointAwayFromPoint(Point point, double distanceAway, double bearing) {
-    return TurfMeasurement.destination(point, distanceAway, bearing, TurfConstants.UNIT_METERS);
   }
 }

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteDetectorTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteDetectorTest.java
@@ -3,11 +3,6 @@ package com.mapbox.services.android.navigation.v5.offroute;
 import android.location.Location;
 import android.support.annotation.NonNull;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.mapbox.api.directions.v5.DirectionsAdapterFactory;
-import com.mapbox.api.directions.v5.models.DirectionsResponse;
-import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.api.directions.v5.models.LegStep;
 import com.mapbox.core.constants.Constants;
 import com.mapbox.geojson.LineString;
@@ -27,7 +22,6 @@ import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-import java.io.IOException;
 import java.util.List;
 
 import static junit.framework.Assert.assertFalse;
@@ -40,7 +34,6 @@ import static org.mockito.Mockito.verify;
 @Config(constants = BuildConfig.class, manifest = Config.DEFAULT_MANIFEST_NAME)
 public class OffRouteDetectorTest extends BaseTest {
 
-  private static final String DIRECTIONS_PRECISION_6 = "directions_v5_precision_6.json";
   @Mock
   private Location mockLocation;
   @Mock
@@ -263,29 +256,5 @@ public class OffRouteDetectorTest extends BaseTest {
   @NonNull
   private Point buildPointAwayFromPoint(Point point, double distanceAway, double bearing) {
     return TurfMeasurement.destination(point, distanceAway, bearing, TurfConstants.UNIT_METERS);
-  }
-
-  private RouteProgress buildDefaultRouteProgress() throws Exception {
-    DirectionsRoute aRoute = buildDirectionsRoute();
-    RouteProgress defaultRouteProgress = RouteProgress.builder()
-      .stepDistanceRemaining(100)
-      .legDistanceRemaining(100)
-      .distanceRemaining(100)
-      .directionsRoute(aRoute)
-      .stepIndex(0)
-      .legIndex(0)
-      .build();
-
-    return defaultRouteProgress;
-  }
-
-  private DirectionsRoute buildDirectionsRoute() throws IOException {
-    Gson gson = new GsonBuilder()
-      .registerTypeAdapterFactory(DirectionsAdapterFactory.create()).create();
-    String body = loadJsonFixture(DIRECTIONS_PRECISION_6);
-    DirectionsResponse response = gson.fromJson(body, DirectionsResponse.class);
-    DirectionsRoute aRoute = response.routes().get(0);
-
-    return aRoute;
   }
 }

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteDetectorTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteDetectorTest.java
@@ -6,18 +6,14 @@ import com.mapbox.api.directions.v5.models.LegStep;
 import com.mapbox.core.constants.Constants;
 import com.mapbox.geojson.LineString;
 import com.mapbox.geojson.Point;
-import com.mapbox.services.android.navigation.BuildConfig;
 import com.mapbox.services.android.navigation.v5.BaseTest;
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigationOptions;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 import java.util.List;
 
@@ -26,9 +22,8 @@ import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertTrue;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-@RunWith(RobolectricTestRunner.class)
-@Config(constants = BuildConfig.class, manifest = Config.DEFAULT_MANIFEST_NAME)
 public class OffRouteDetectorTest extends BaseTest {
 
   @Mock
@@ -116,7 +111,7 @@ public class OffRouteDetectorTest extends BaseTest {
 
     Point offRoutePoint = buildPointAwayFromPoint(stepManeuverPoint, 250, 90);
     Location secondUpdate = buildDefaultLocationUpdate(offRoutePoint.longitude(), offRoutePoint.latitude());
-    secondUpdate.setAccuracy(300f);
+    when(secondUpdate.getAccuracy()).thenReturn(300f);
 
     boolean isUserOffRoute = offRouteDetector.isUserOffRoute(secondUpdate, routeProgress, options);
     assertFalse(isUserOffRoute);

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/utils/RouteUtilsTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/utils/RouteUtilsTest.java
@@ -1,9 +1,5 @@
 package com.mapbox.services.android.navigation.v5.utils;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.mapbox.api.directions.v5.DirectionsAdapterFactory;
-import com.mapbox.api.directions.v5.models.DirectionsResponse;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.api.directions.v5.models.RouteLeg;
 import com.mapbox.services.android.navigation.v5.BaseTest;
@@ -18,14 +14,12 @@ import static junit.framework.Assert.assertTrue;
 
 public class RouteUtilsTest extends BaseTest {
 
-  private static final String PRECISION_6 = "directions_v5_precision_6.json";
-
   @Test
   public void isNewRoute_returnsTrueWhenPreviousGeometriesNull() throws Exception {
-    RouteProgress defaultRouteProgress = obtainDefaultRouteProgress();
+    RouteProgress defaultRouteProgress = buildDefaultRouteProgress();
     boolean isNewRoute = RouteUtils.isNewRoute(null, defaultRouteProgress);
     assertTrue(isNewRoute);
-    RouteProgress previousRouteProgress = obtainDefaultRouteProgress();
+    RouteProgress previousRouteProgress = buildDefaultRouteProgress();
 
     isNewRoute = RouteUtils.isNewRoute(previousRouteProgress, defaultRouteProgress);
 
@@ -34,7 +28,7 @@ public class RouteUtilsTest extends BaseTest {
 
   @Test
   public void isNewRoute_returnsFalseWhenGeometriesEqualEachOther() throws Exception {
-    RouteProgress previousRouteProgress = obtainDefaultRouteProgress();
+    RouteProgress previousRouteProgress = buildDefaultRouteProgress();
 
     boolean isNewRoute = RouteUtils.isNewRoute(previousRouteProgress, previousRouteProgress);
 
@@ -43,8 +37,8 @@ public class RouteUtilsTest extends BaseTest {
 
   @Test
   public void isNewRoute_returnsTrueWhenGeometriesDoNotEqual() throws Exception {
-    DirectionsRoute aRoute = obtainADirectionsRoute();
-    RouteProgress defaultRouteProgress = obtainDefaultRouteProgress();
+    DirectionsRoute aRoute = buildDirectionsRoute();
+    RouteProgress defaultRouteProgress = buildDefaultRouteProgress();
     RouteProgress previousRouteProgress = defaultRouteProgress.toBuilder()
       .directionsRoute(aRoute.toBuilder().geometry("vfejnqiv").build())
       .build();
@@ -56,9 +50,9 @@ public class RouteUtilsTest extends BaseTest {
 
   @Test
   public void isArrivalEvent_returnsTrueWhenManeuverTypeIsArrival_andIsValidMetersRemaining() throws Exception {
-    DirectionsRoute aRoute = obtainADirectionsRoute();
+    DirectionsRoute aRoute = buildDirectionsRoute();
     int lastStepIndex = obtainLastStepIndex(aRoute);
-    RouteProgress defaultRouteProgress = obtainDefaultRouteProgress();
+    RouteProgress defaultRouteProgress = buildDefaultRouteProgress();
     RouteProgress theRouteProgress = defaultRouteProgress.toBuilder()
       .stepDistanceRemaining(30)
       .legDistanceRemaining(30)
@@ -73,9 +67,9 @@ public class RouteUtilsTest extends BaseTest {
 
   @Test
   public void isArrivalEvent_returnsFalseWhenManeuverTypeIsArrival_andIsNotValidMetersRemaining() throws Exception {
-    DirectionsRoute aRoute = obtainADirectionsRoute();
+    DirectionsRoute aRoute = buildDirectionsRoute();
     int lastStepIndex = obtainLastStepIndex(aRoute);
-    RouteProgress defaultRouteProgress = obtainDefaultRouteProgress();
+    RouteProgress defaultRouteProgress = buildDefaultRouteProgress();
     RouteProgress theRouteProgress = defaultRouteProgress.toBuilder()
       .stepIndex(lastStepIndex)
       .legDistanceRemaining(100)
@@ -88,9 +82,9 @@ public class RouteUtilsTest extends BaseTest {
 
   @Test
   public void isArrivalEvent_returnsTrueWhenUpcomingManeuverTypeIsArrival_andIsValidMetersRemaining() throws Exception {
-    DirectionsRoute aRoute = obtainADirectionsRoute();
+    DirectionsRoute aRoute = buildDirectionsRoute();
     int lastStepIndex = obtainLastStepIndex(aRoute);
-    RouteProgress defaultRouteProgress = obtainDefaultRouteProgress();
+    RouteProgress defaultRouteProgress = buildDefaultRouteProgress();
     RouteProgress theRouteProgress = defaultRouteProgress.toBuilder()
       .legDistanceRemaining(30)
       .stepIndex(lastStepIndex - 1)
@@ -103,9 +97,9 @@ public class RouteUtilsTest extends BaseTest {
 
   @Test
   public void isArrivalEvent_returnsFalseWhenManeuverTypeIsNotArrival_andIsNotValidMetersRemaining() throws Exception {
-    DirectionsRoute aRoute = obtainADirectionsRoute();
+    DirectionsRoute aRoute = buildDirectionsRoute();
     int lastStepIndex = obtainLastStepIndex(aRoute);
-    RouteProgress defaultRouteProgress = obtainDefaultRouteProgress();
+    RouteProgress defaultRouteProgress = buildDefaultRouteProgress();
     RouteProgress theRouteProgress = defaultRouteProgress.toBuilder()
       .stepDistanceRemaining(200)
       .legDistanceRemaining(300)
@@ -116,30 +110,6 @@ public class RouteUtilsTest extends BaseTest {
     boolean isArrivalEvent = RouteUtils.isArrivalEvent(theRouteProgress);
 
     assertFalse(isArrivalEvent);
-  }
-
-  private RouteProgress obtainDefaultRouteProgress() throws Exception {
-    DirectionsRoute aRoute = obtainADirectionsRoute();
-    RouteProgress defaultRouteProgress = RouteProgress.builder()
-      .stepDistanceRemaining(100)
-      .legDistanceRemaining(100)
-      .distanceRemaining(100)
-      .directionsRoute(aRoute)
-      .stepIndex(0)
-      .legIndex(0)
-      .build();
-
-    return defaultRouteProgress;
-  }
-
-  private DirectionsRoute obtainADirectionsRoute() throws IOException {
-    Gson gson = new GsonBuilder()
-      .registerTypeAdapterFactory(DirectionsAdapterFactory.create()).create();
-    String body = loadJsonFixture(PRECISION_6);
-    DirectionsResponse response = gson.fromJson(body, DirectionsResponse.class);
-    DirectionsRoute aRoute = response.routes().get(0);
-
-    return aRoute;
   }
 
   private int obtainLastStepIndex(DirectionsRoute route) throws IOException {


### PR DESCRIPTION
Extracted logic from `NavigationEngine` into `NavigationRouteProcessor` and added tests.

Also fixes a bug where an `IndexOutOfBounds` was thrown when decoding the last step of a route.  Regression from #350.

Still TODO:
- [x] Finish tests for `NavigationRouteProcessor`

cc @akitchen for testing 👀 