### PR TITLE
Remove last location check from location validation

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEngine.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEngine.java
@@ -70,7 +70,7 @@ class NavigationEngine extends HandlerThread implements Handler.Callback {
 
     final boolean userOffRoute = isUserOffRoute(newLocationModel, routeProgress, routeProcessor);
 
-    routeProcessor.checkIncreaseStepIndex(mapboxNavigation);
+    routeProcessor.checkIncreaseIndex(mapboxNavigation);
 
     RouteProgress previousRouteProgress = routeProcessor.getPreviousRouteProgress();
     final List<Milestone> milestones = checkMilestones(previousRouteProgress, routeProgress, mapboxNavigation);

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationHelper.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationHelper.java
@@ -174,14 +174,23 @@ class NavigationHelper {
    */
   static NavigationIndices increaseIndex(RouteProgress routeProgress,
                                          NavigationIndices previousIndices) {
-    // Check if we are in the last step in the current routeLeg and iterate it if needed.
-    if (previousIndices.stepIndex()
-      >= routeProgress.directionsRoute().legs().get(routeProgress.legIndex())
-      .steps().size() - 2
-      && previousIndices.legIndex() < routeProgress.directionsRoute().legs().size() - 1) {
-      return NavigationIndices.create((previousIndices.legIndex() + 1), 0);
+    DirectionsRoute route = routeProgress.directionsRoute();
+    int previousStepIndex = previousIndices.stepIndex();
+    int previousLegIndex = previousIndices.legIndex();
+    int routeLegSize = route.legs().size();
+    int legStepSize = route.legs().get(routeProgress.legIndex()).steps().size();
+
+    boolean isOnLastLeg = previousLegIndex == routeLegSize - 1;
+    boolean isOnLastStep = previousStepIndex == legStepSize - 1;
+
+    if (isOnLastStep && !isOnLastLeg) {
+      return NavigationIndices.create((previousLegIndex + 1), 0);
     }
-    return NavigationIndices.create(previousIndices.legIndex(), (previousIndices.stepIndex() + 1));
+
+    if (isOnLastStep) {
+      return previousIndices;
+    }
+    return NavigationIndices.create(previousLegIndex, (previousStepIndex + 1));
   }
 
   static List<Milestone> checkMilestones(RouteProgress previousRouteProgress,

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationService.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationService.java
@@ -45,6 +45,7 @@ public class NavigationService extends Service implements LocationEngineListener
 
   // Message id used when a new location update occurs and we send to the thread.
   private static final int MSG_LOCATION_UPDATED = 1001;
+  private static final int HORIZONTAL_ACCURACY_THRESHOLD = 100;
 
   private final IBinder localBinder = new LocalBinder();
 
@@ -286,7 +287,9 @@ public class NavigationService extends Service implements LocationEngineListener
    */
   @SuppressWarnings("MissingPermission")
   private boolean isValidLocationUpdate(Location location) {
-    return location != null && location.hasSpeed() && location.getAccuracy() <= 100;
+    return location != null
+      && location.hasSpeed()
+      && location.getAccuracy() <= HORIZONTAL_ACCURACY_THRESHOLD;
   }
 
   /**

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationService.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationService.java
@@ -286,13 +286,7 @@ public class NavigationService extends Service implements LocationEngineListener
    */
   @SuppressWarnings("MissingPermission")
   private boolean isValidLocationUpdate(Location location) {
-    if (location == null) {
-      return false;
-    }
-    // If the locations the same as previous, no need to recalculate things
-    return !(location.equals(locationEngine.getLastLocation())
-      || (location.getSpeed() <= 0 && location.hasSpeed())
-      || location.getAccuracy() >= 100);
+    return location != null && location.hasSpeed() && location.getAccuracy() <= 100;
   }
 
   /**

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationService.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationService.java
@@ -45,7 +45,7 @@ public class NavigationService extends Service implements LocationEngineListener
 
   // Message id used when a new location update occurs and we send to the thread.
   private static final int MSG_LOCATION_UPDATED = 1001;
-  private static final int HORIZONTAL_ACCURACY_THRESHOLD = 100;
+  private static final int HORIZONTAL_ACCURACY_THRESHOLD_IN_METERS = 100;
 
   private final IBinder localBinder = new LocalBinder();
 
@@ -289,7 +289,7 @@ public class NavigationService extends Service implements LocationEngineListener
   private boolean isValidLocationUpdate(Location location) {
     return location != null
       && location.hasSpeed()
-      && location.getAccuracy() <= HORIZONTAL_ACCURACY_THRESHOLD;
+      && location.getAccuracy() <= HORIZONTAL_ACCURACY_THRESHOLD_IN_METERS;
   }
 
   /**

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/BaseTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/BaseTest.java
@@ -9,6 +9,9 @@ import com.google.gson.JsonParser;
 import com.mapbox.api.directions.v5.DirectionsAdapterFactory;
 import com.mapbox.api.directions.v5.models.DirectionsResponse;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
+import com.mapbox.api.directions.v5.models.LegStep;
+import com.mapbox.core.constants.Constants;
+import com.mapbox.geojson.LineString;
 import com.mapbox.geojson.Point;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 import com.mapbox.turf.TurfConstants;
@@ -16,6 +19,7 @@ import com.mapbox.turf.TurfMeasurement;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.List;
 import java.util.Scanner;
 
 import static junit.framework.Assert.assertEquals;
@@ -91,5 +95,12 @@ public class BaseTest {
   @NonNull
   protected Point buildPointAwayFromPoint(Point point, double distanceAway, double bearing) {
     return TurfMeasurement.destination(point, distanceAway, bearing, TurfConstants.UNIT_METERS);
+  }
+
+  @NonNull
+  protected List<Point> createCoordinatesFromCurrentStep(RouteProgress progress) {
+    LegStep currentStep = progress.currentLegProgress().currentStep();
+    LineString lineString = LineString.fromPolyline(currentStep.geometry(), Constants.PRECISION_6);
+    return lineString.coordinates();
   }
 }

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteProcessorTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteProcessorTest.java
@@ -53,9 +53,11 @@ public class NavigationRouteProcessorTest extends BaseTest {
     RouteProgress progress = routeProcessor.buildNewRouteProgress(navigation, mock(Location.class));
     int currentStepIndex = progress.currentLegProgress().stepIndex();
     routeProcessor.onShouldIncreaseIndex();
-    routeProcessor.checkIncreaseStepIndex(navigation);
+    routeProcessor.checkIncreaseIndex(navigation);
+
     RouteProgress secondProgress = routeProcessor.buildNewRouteProgress(navigation, mock(Location.class));
     int secondStepIndex = secondProgress.currentLegProgress().stepIndex();
+
     assertTrue(currentStepIndex != secondStepIndex);
   }
 
@@ -135,6 +137,34 @@ public class NavigationRouteProcessorTest extends BaseTest {
     int secondProgressIndex = secondProgress.currentLegProgress().stepIndex();
 
     assertTrue(firstProgressIndex != secondProgressIndex);
+  }
+
+  @Test
+  public void onInvalidNextLeg_indexIsNotIncreased() throws Exception {
+    routeProcessor.buildNewRouteProgress(navigation, mock(Location.class));
+    int legSize = navigation.getRoute().legs().size();
+
+    for (int i = 0; i < legSize; i++) {
+      routeProcessor.onShouldIncreaseIndex();
+      routeProcessor.checkIncreaseIndex(navigation);
+    }
+    RouteProgress progress = routeProcessor.buildNewRouteProgress(navigation, mock(Location.class));
+
+    assertTrue(progress.legIndex() == legSize - 1);
+  }
+
+  @Test
+  public void onInvalidNextStep_indexIsNotIncreased() throws Exception {
+    routeProcessor.buildNewRouteProgress(navigation, mock(Location.class));
+    int stepSize = navigation.getRoute().legs().get(0).steps().size();
+
+    for (int i = 0; i < stepSize; i++) {
+      routeProcessor.onShouldIncreaseIndex();
+      routeProcessor.checkIncreaseIndex(navigation);
+    }
+    RouteProgress progress = routeProcessor.buildNewRouteProgress(navigation, mock(Location.class));
+
+    assertTrue(progress.currentLegProgress().stepIndex() == stepSize - 1);
   }
 
   @Test

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteProcessorTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteProcessorTest.java
@@ -3,9 +3,6 @@ package com.mapbox.services.android.navigation.v5.navigation;
 import android.content.Context;
 import android.location.Location;
 
-import com.mapbox.api.directions.v5.models.LegStep;
-import com.mapbox.core.constants.Constants;
-import com.mapbox.geojson.LineString;
 import com.mapbox.geojson.Point;
 import com.mapbox.services.android.navigation.v5.BaseTest;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
@@ -66,9 +63,7 @@ public class NavigationRouteProcessorTest extends BaseTest {
     RouteProgress progress = routeProcessor.buildNewRouteProgress(navigation, mock(Location.class));
     boolean snapEnabled = true;
     boolean userOffRoute = false;
-    LegStep currentStep = progress.currentLegProgress().currentStep();
-    LineString lineString = LineString.fromPolyline(currentStep.geometry(), Constants.PRECISION_6);
-    List<Point> coordinates = lineString.coordinates();
+    List<Point> coordinates = createCoordinatesFromCurrentStep(progress);
     Point lastPointInCurrentStep = coordinates.remove(coordinates.size() - 1);
     Location rawLocation = buildDefaultLocationUpdate(
       lastPointInCurrentStep.longitude(), lastPointInCurrentStep.latitude()
@@ -86,9 +81,7 @@ public class NavigationRouteProcessorTest extends BaseTest {
     RouteProgress progress = routeProcessor.buildNewRouteProgress(navigation, mock(Location.class));
     boolean snapEnabled = false;
     boolean userOffRoute = false;
-    LegStep currentStep = progress.currentLegProgress().currentStep();
-    LineString lineString = LineString.fromPolyline(currentStep.geometry(), Constants.PRECISION_6);
-    List<Point> coordinates = lineString.coordinates();
+    List<Point> coordinates = createCoordinatesFromCurrentStep(progress);
     Point lastPointInCurrentStep = coordinates.remove(coordinates.size() - 1);
     Location rawLocation = buildDefaultLocationUpdate(
       lastPointInCurrentStep.longitude(), lastPointInCurrentStep.latitude()
@@ -106,9 +99,7 @@ public class NavigationRouteProcessorTest extends BaseTest {
     RouteProgress progress = routeProcessor.buildNewRouteProgress(navigation, mock(Location.class));
     boolean snapEnabled = false;
     boolean userOffRoute = false;
-    LegStep currentStep = progress.currentLegProgress().currentStep();
-    LineString lineString = LineString.fromPolyline(currentStep.geometry(), Constants.PRECISION_6);
-    List<Point> coordinates = lineString.coordinates();
+    List<Point> coordinates = createCoordinatesFromCurrentStep(progress);
     Point lastPointInCurrentStep = coordinates.remove(coordinates.size() - 1);
     Location rawLocation = buildDefaultLocationUpdate(
       lastPointInCurrentStep.longitude(), lastPointInCurrentStep.latitude()
@@ -125,9 +116,7 @@ public class NavigationRouteProcessorTest extends BaseTest {
   public void onStepDistanceRemainingZeroAndNoBearingMatch_stepIndexForceIncreased() throws Exception {
     RouteProgress firstProgress = routeProcessor.buildNewRouteProgress(navigation, mock(Location.class));
     int firstProgressIndex = firstProgress.currentLegProgress().stepIndex();
-    LegStep currentStep = firstProgress.currentLegProgress().currentStep();
-    LineString lineString = LineString.fromPolyline(currentStep.geometry(), Constants.PRECISION_6);
-    List<Point> coordinates = lineString.coordinates();
+    List<Point> coordinates = createCoordinatesFromCurrentStep(firstProgress);
     Point lastPointInCurrentStep = coordinates.remove(coordinates.size() - 1);
     Location rawLocation = buildDefaultLocationUpdate(
       lastPointInCurrentStep.longitude(), lastPointInCurrentStep.latitude()
@@ -171,9 +160,7 @@ public class NavigationRouteProcessorTest extends BaseTest {
   public void withinManeuverRadiusAndBearingMatches_stepIndexIsIncreased() throws Exception {
     RouteProgress firstProgress = routeProcessor.buildNewRouteProgress(navigation, mock(Location.class));
     int firstProgressIndex = firstProgress.currentLegProgress().stepIndex();
-    LegStep currentStep = firstProgress.currentLegProgress().currentStep();
-    LineString lineString = LineString.fromPolyline(currentStep.geometry(), Constants.PRECISION_6);
-    List<Point> coordinates = lineString.coordinates();
+    List<Point> coordinates = createCoordinatesFromCurrentStep(firstProgress);
     Point lastPointInCurrentStep = coordinates.remove(coordinates.size() - 2);
     Location rawLocation = buildDefaultLocationUpdate(
       lastPointInCurrentStep.longitude(), lastPointInCurrentStep.latitude()


### PR DESCRIPTION
Found that when starting navigation, the forced location update from `LocationEngine#getLastLocation` would never be considered valid and we would subsequently fall back to to creating the location update from the first point on the route:  

`master`:
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/8434572/37680788-56d4028e-2c5b-11e8-871a-0719438a5049.gif)

I removed the check, as this should be an edge case (I'm not even sure if the location apis would ever fire with the `getLastLocation` twice in a row) 🤔 