### PR TITLE
Send departure event with a valid distance traveled

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationTelemetry.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationTelemetry.java
@@ -101,7 +101,9 @@ class NavigationTelemetry implements LocationEngineListener, NavigationMetricLis
   public void onRouteProgressUpdate(RouteProgress routeProgress) {
     this.metricProgress = new MetricsRouteProgress(routeProgress);
 
-    if (navigationSessionState.startTimestamp() == null) {
+    boolean isValidDeparture = navigationSessionState.startTimestamp() == null
+      && routeProgress.currentLegProgress().distanceTraveled() > 0;
+    if (isValidDeparture) {
       // Set departure timestamp
       navigationSessionState = navigationSessionState.toBuilder()
         .startTimestamp(new Date())

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationTelemetry.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationTelemetry.java
@@ -104,12 +104,10 @@ class NavigationTelemetry implements LocationEngineListener, NavigationMetricLis
     boolean isValidDeparture = navigationSessionState.startTimestamp() == null
       && routeProgress.currentLegProgress().distanceTraveled() > 0;
     if (isValidDeparture) {
-      // Set departure timestamp
       navigationSessionState = navigationSessionState.toBuilder()
         .startTimestamp(new Date())
         .build();
       updateLifecyclePercentages();
-      // Send departure event for the start of this session
       NavigationMetricsWrapper.departEvent(navigationSessionState, metricProgress, metricLocation.getLocation());
     }
   }


### PR DESCRIPTION
Forcing the first location update caused the departure event to fire without a valid location.  So departure events were firing from null island `0,0`.   This PR adds a check to ensure we have a valid distance traveled before we send the event.