### PR TITLE
Decrease Robo tests time to 5 minutes

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -52,7 +52,7 @@ jobs:
           no_output_timeout: 1200
           shell: /bin/bash -euo pipefail
           command: |
-            gcloud firebase test android run --type robo --app app/build/outputs/apk/debug/app-debug.apk --device-ids shamu --os-version-ids 22 --locales en --orientations portrait --timeout 10m
+            gcloud firebase test android run --type robo --app app/build/outputs/apk/debug/app-debug.apk --device-ids shamu --os-version-ids 22 --locales en --orientations portrait --timeout 5m
       - run:
           name: Update Transifex
           command: |


### PR DESCRIPTION
- Decreases Robo tests time to 5 minutes in order to get faster builds

Fixes #310 

👀 @danesfeder @devotaaabel 