### PR TITLE
Remove NavigationView lifecycle observer and add Fragment Example

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -59,7 +59,7 @@
         </activity>
 
         <activity
-            android:name=".activity.WaypointNavigationActivity"
+            android:name=".activity.navigationui.WaypointNavigationActivity"
             android:label="@string/title_waypoint_navigation">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
@@ -67,7 +67,15 @@
         </activity>
 
         <activity
-            android:name=".EmbeddedNavigationActivity"
+            android:name=".activity.navigationui.EmbeddedNavigationActivity"
+            android:label="@string/title_embedded_navigation">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".MainActivity"/>
+        </activity>
+
+        <activity
+            android:name=".activity.navigationui.fragment.FragmentNavigationActivity"
             android:label="@string/title_embedded_navigation">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/MainActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/MainActivity.java
@@ -15,9 +15,11 @@ import android.widget.Toast;
 
 import com.mapbox.services.android.navigation.testapp.activity.MockNavigationActivity;
 import com.mapbox.services.android.navigation.testapp.activity.RerouteActivity;
+import com.mapbox.services.android.navigation.testapp.activity.navigationui.EmbeddedNavigationActivity;
 import com.mapbox.services.android.navigation.testapp.activity.navigationui.NavigationMapRouteActivity;
 import com.mapbox.services.android.navigation.testapp.activity.navigationui.NavigationViewActivity;
-import com.mapbox.services.android.navigation.testapp.activity.WaypointNavigationActivity;
+import com.mapbox.services.android.navigation.testapp.activity.navigationui.WaypointNavigationActivity;
+import com.mapbox.services.android.navigation.testapp.activity.navigationui.fragment.FragmentNavigationActivity;
 import com.mapbox.services.android.telemetry.permissions.PermissionsListener;
 import com.mapbox.services.android.telemetry.permissions.PermissionsManager;
 
@@ -68,6 +70,11 @@ public class MainActivity extends AppCompatActivity implements PermissionsListen
         getString(R.string.title_embedded_navigation),
         getString(R.string.description_embedded_navigation),
         EmbeddedNavigationActivity.class
+      ),
+      new SampleItem(
+        getString(R.string.title_fragment_navigation),
+        getString(R.string.description_fragment_navigation),
+        FragmentNavigationActivity.class
       )
     ));
 

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/EmbeddedNavigationActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/EmbeddedNavigationActivity.java
@@ -1,4 +1,4 @@
-package com.mapbox.services.android.navigation.testapp;
+package com.mapbox.services.android.navigation.testapp.activity.navigationui;
 
 import android.location.Location;
 import android.os.Bundle;
@@ -15,6 +15,7 @@ import android.view.View;
 import android.widget.TextView;
 
 import com.mapbox.geojson.Point;
+import com.mapbox.services.android.navigation.testapp.R;
 import com.mapbox.services.android.navigation.ui.v5.NavigationView;
 import com.mapbox.services.android.navigation.ui.v5.NavigationViewOptions;
 import com.mapbox.services.android.navigation.ui.v5.OnNavigationReadyCallback;

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/WaypointNavigationActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/WaypointNavigationActivity.java
@@ -1,4 +1,4 @@
-package com.mapbox.services.android.navigation.testapp.activity;
+package com.mapbox.services.android.navigation.testapp.activity.navigationui;
 
 import android.content.DialogInterface;
 import android.location.Location;

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/fragment/FragmentNavigationActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/fragment/FragmentNavigationActivity.java
@@ -1,0 +1,16 @@
+package com.mapbox.services.android.navigation.testapp.activity.navigationui.fragment;
+
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v7.app.AppCompatActivity;
+
+import com.mapbox.services.android.navigation.testapp.R;
+
+public class FragmentNavigationActivity extends AppCompatActivity {
+
+  @Override
+  protected void onCreate(@Nullable Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_navigation_fragment);
+  }
+}

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/fragment/NavigationFragment.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/fragment/NavigationFragment.java
@@ -17,6 +17,11 @@ import com.mapbox.services.android.navigation.ui.v5.listeners.NavigationListener
 
 public class NavigationFragment extends Fragment implements OnNavigationReadyCallback, NavigationListener {
 
+  private static final double ORIGIN_LONGITUDE = -77.04012393951416;
+  private static final double ORIGIN_LATITUDE = 38.9111117447887;
+  private static final double DESTINATION_LONGITUDE = -77.03847169876099;
+  private static final double DESTINATION_LATITUDE = 38.91113678979344;
+
   private NavigationView navigationView;
 
   @Nullable
@@ -86,8 +91,8 @@ public class NavigationFragment extends Fragment implements OnNavigationReadyCal
 
   @Override
   public void onNavigationReady() {
-    Point origin = Point.fromLngLat(-77.04012393951416, 38.9111117447887);
-    Point destination = Point.fromLngLat(-77.03847169876099, 38.91113678979344);
+    Point origin = Point.fromLngLat(ORIGIN_LONGITUDE, ORIGIN_LATITUDE);
+    Point destination = Point.fromLngLat(DESTINATION_LONGITUDE, DESTINATION_LATITUDE);
     NavigationViewOptions options = NavigationViewOptions.builder()
       .origin(origin)
       .destination(destination)

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/fragment/NavigationFragment.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/fragment/NavigationFragment.java
@@ -1,0 +1,118 @@
+package com.mapbox.services.android.navigation.testapp.activity.navigationui.fragment;
+
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.mapbox.geojson.Point;
+import com.mapbox.services.android.navigation.testapp.R;
+import com.mapbox.services.android.navigation.ui.v5.NavigationView;
+import com.mapbox.services.android.navigation.ui.v5.NavigationViewOptions;
+import com.mapbox.services.android.navigation.ui.v5.OnNavigationReadyCallback;
+import com.mapbox.services.android.navigation.ui.v5.listeners.NavigationListener;
+
+public class NavigationFragment extends Fragment implements OnNavigationReadyCallback, NavigationListener {
+
+  private NavigationView navigationView;
+
+  @Nullable
+  @Override
+  public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                           @Nullable Bundle savedInstanceState) {
+    return inflater.inflate(R.layout.navigation_view_fragment_layout, container);
+  }
+
+  @Override
+  public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+    super.onViewCreated(view, savedInstanceState);
+    navigationView = view.findViewById(R.id.navigation_view_fragment);
+    navigationView.onCreate(savedInstanceState);
+    navigationView.getNavigationAsync(this);
+  }
+
+  @Override
+  public void onStart() {
+    super.onStart();
+    navigationView.onStart();
+  }
+
+  @Override
+  public void onResume() {
+    super.onResume();
+    navigationView.onResume();
+  }
+
+  @Override
+  public void onSaveInstanceState(@NonNull Bundle outState) {
+    navigationView.onSaveInstanceState(outState);
+    super.onSaveInstanceState(outState);
+  }
+
+  @Override
+  public void onViewStateRestored(@Nullable Bundle savedInstanceState) {
+    super.onViewStateRestored(savedInstanceState);
+    if (savedInstanceState != null) {
+      navigationView.onRestoreInstanceState(savedInstanceState);
+    }
+  }
+
+  @Override
+  public void onPause() {
+    super.onPause();
+    navigationView.onPause();
+  }
+
+  @Override
+  public void onStop() {
+    super.onStop();
+    navigationView.onStop();
+  }
+
+  @Override
+  public void onLowMemory() {
+    super.onLowMemory();
+    navigationView.onLowMemory();
+  }
+
+  @Override
+  public void onDestroyView() {
+    super.onDestroyView();
+    navigationView.onDestroy();
+  }
+
+  @Override
+  public void onNavigationReady() {
+    Point origin = Point.fromLngLat(-77.04012393951416, 38.9111117447887);
+    Point destination = Point.fromLngLat(-77.03847169876099, 38.91113678979344);
+    NavigationViewOptions options = NavigationViewOptions.builder()
+      .origin(origin)
+      .destination(destination)
+      .shouldSimulateRoute(true)
+      .navigationListener(this)
+      .build();
+    navigationView.startNavigation(options);
+  }
+
+  @Override
+  public void onCancelNavigation() {
+    if (getActivity() != null) {
+      getActivity().finish();
+    }
+  }
+
+  @Override
+  public void onNavigationFinished() {
+    if (getActivity() != null) {
+      getActivity().finish();
+    }
+  }
+
+  @Override
+  public void onNavigationRunning() {
+    // no-op
+  }
+}

--- a/app/src/main/res/layout/activity_navigation_fragment.xml
+++ b/app/src/main/res/layout/activity_navigation_fragment.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <fragment
+        android:id="@+id/navigation_fragment"
+        android:name="com.mapbox.services.android.navigation.testapp.activity.navigationui.fragment.NavigationFragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginBottom="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
+
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/navigation_view_fragment_layout.xml
+++ b/app/src/main/res/layout/navigation_view_fragment_layout.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.mapbox.services.android.navigation.ui.v5.NavigationView
+        android:id="@+id/navigation_view_fragment"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:navigationDarkTheme="@style/NavigationViewDark"
+        app:navigationLightTheme="@style/NavigationViewLight"/>
+
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,6 +19,10 @@
 
     <string name="title_embedded_navigation">Embedded Navigation</string>
     <string name="description_embedded_navigation">Navigation in a view which contains other views</string>
+
+    <string name="title_fragment_navigation">NavigationView implemented with Fragment</string>
+    <string name="description_fragment_navigation">NavigationView implemented with Fragment</string>
+
     <string name="settings">Settings</string>
     <string name="simulate_route">Simulate Route</string>
     <string name="language">Language</string>

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationActivity.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationActivity.java
@@ -38,6 +38,18 @@ public class NavigationActivity extends AppCompatActivity implements OnNavigatio
   }
 
   @Override
+  public void onStart() {
+    super.onStart();
+    navigationView.onStart();
+  }
+
+  @Override
+  public void onResume() {
+    super.onResume();
+    navigationView.onResume();
+  }
+
+  @Override
   public void onLowMemory() {
     super.onLowMemory();
     navigationView.onLowMemory();
@@ -63,6 +75,18 @@ public class NavigationActivity extends AppCompatActivity implements OnNavigatio
     super.onRestoreInstanceState(savedInstanceState);
     navigationView.onRestoreInstanceState(savedInstanceState);
     isRunning = savedInstanceState.getBoolean(NavigationConstants.NAVIGATION_VIEW_RUNNING);
+  }
+
+  @Override
+  public void onPause() {
+    super.onPause();
+    navigationView.onPause();
+  }
+
+  @Override
+  public void onStop() {
+    super.onStop();
+    navigationView.onStop();
   }
 
   @Override


### PR DESCRIPTION
Closes #802, Closes #675 

When implemented with a `Fragment`, `NavigationView` would look at the `Activity` _and_ `Fragment` lifecycles, causing a Maps SDK crash intermittently.  

See https://github.com/mapbox/mapbox-navigation-android/issues/675#issuecomment-374603823 for full context on what was going on here.  