### PR TITLE
Add MapboxNavigationOptions to adjust location validation thresholds

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/location/LocationValidator.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/location/LocationValidator.java
@@ -12,12 +12,14 @@ public class LocationValidator {
   private static final int ONE_SECOND_IN_MILLIS = 1000;
 
   private Location lastValidLocation;
+  private int locationAcceptableAccuracyThreshold;
   private int locationPercentAccuracyThreshold;
   private int locationUpdateTimeThreshold;
   private int locationVelocityThreshold;
 
-  public LocationValidator(int locationPercentAccuracyThreshold, int locationUpdateTimeThreshold,
-                           int locationVelocityThreshold) {
+  public LocationValidator(int locationAcceptableAccuracyThreshold, int locationPercentAccuracyThreshold,
+                           int locationUpdateTimeThreshold, int locationVelocityThreshold) {
+    this.locationAcceptableAccuracyThreshold = locationAcceptableAccuracyThreshold;
     this.locationPercentAccuracyThreshold = locationPercentAccuracyThreshold;
     this.locationUpdateTimeThreshold = locationUpdateTimeThreshold;
     this.locationVelocityThreshold = locationVelocityThreshold;
@@ -58,7 +60,10 @@ public class LocationValidator {
   }
 
   /**
-   * New location update is acceptable, even with worse accuracy, if it is from
+   * New location accuracy is acceptable if it is less than or equal to
+   * {@link LocationValidator#locationAcceptableAccuracyThreshold}.
+   * <p>
+   * Otherwise, new location update is acceptable, even with worse accuracy, if it is from
    * the same provider and is no more than {@link LocationValidator#locationPercentAccuracyThreshold} worse.
    *
    * @param location new location received
@@ -66,6 +71,10 @@ public class LocationValidator {
    */
   private boolean isAccuracyAcceptable(@NonNull Location location) {
     float currentAccuracy = location.getAccuracy();
+    if (currentAccuracy <= locationAcceptableAccuracyThreshold) {
+      return true;
+    }
+
     float previousAccuracy = lastValidLocation.getAccuracy();
     float accuracyDifference = Math.abs(previousAccuracy - currentAccuracy);
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/location/LocationValidator.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/location/LocationValidator.java
@@ -81,7 +81,8 @@ public class LocationValidator {
     boolean improvedAccuracy = currentAccuracy <= previousAccuracy;
     boolean currentAccuracyWorse = currentAccuracy > previousAccuracy;
     boolean hasSameProvider = lastValidLocation.getProvider().equals(location.getProvider());
-    boolean lessThanPercentThreshold = (accuracyDifference <= (previousAccuracy / locationPercentAccuracyThreshold));
+    double percentThreshold = locationPercentAccuracyThreshold / 100.0;
+    boolean lessThanPercentThreshold = (accuracyDifference <= (previousAccuracy * percentThreshold));
     boolean lessAccuracyAcceptable = currentAccuracyWorse && hasSameProvider && lessThanPercentThreshold;
 
     return improvedAccuracy || lessAccuracyAcceptable;

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/location/LocationValidator.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/location/LocationValidator.java
@@ -12,17 +12,17 @@ public class LocationValidator {
   private static final int ONE_SECOND_IN_MILLIS = 1000;
 
   private Location lastValidLocation;
-  private int locationAcceptableAccuracyThreshold;
-  private int locationPercentAccuracyThreshold;
-  private int locationUpdateTimeThreshold;
-  private int locationVelocityThreshold;
+  private int locationAcceptableAccuracyInMetersThreshold;
+  private int locationAccuracyPercentThreshold;
+  private int locationUpdateTimeInMillisThreshold;
+  private int locationVelocityInMetersPerSecondThreshold;
 
-  public LocationValidator(int locationAcceptableAccuracyThreshold, int locationPercentAccuracyThreshold,
-                           int locationUpdateTimeThreshold, int locationVelocityThreshold) {
-    this.locationAcceptableAccuracyThreshold = locationAcceptableAccuracyThreshold;
-    this.locationPercentAccuracyThreshold = locationPercentAccuracyThreshold;
-    this.locationUpdateTimeThreshold = locationUpdateTimeThreshold;
-    this.locationVelocityThreshold = locationVelocityThreshold;
+  public LocationValidator(int locationAcceptableAccuracyInMetersThreshold, int locationAccuracyPercentThreshold,
+                           int locationUpdateTimeInMillisThreshold, int locationVelocityInMetersPerSecondThreshold) {
+    this.locationAcceptableAccuracyInMetersThreshold = locationAcceptableAccuracyInMetersThreshold;
+    this.locationAccuracyPercentThreshold = locationAccuracyPercentThreshold;
+    this.locationUpdateTimeInMillisThreshold = locationUpdateTimeInMillisThreshold;
+    this.locationVelocityInMetersPerSecondThreshold = locationVelocityInMetersPerSecondThreshold;
   }
 
   public boolean isValidUpdate(@NonNull Location location) {
@@ -61,17 +61,17 @@ public class LocationValidator {
 
   /**
    * New location accuracy is acceptable if it is less than or equal to
-   * {@link LocationValidator#locationAcceptableAccuracyThreshold}.
+   * {@link LocationValidator#locationAcceptableAccuracyInMetersThreshold}.
    * <p>
    * Otherwise, new location update is acceptable, even with worse accuracy, if it is from
-   * the same provider and is no more than {@link LocationValidator#locationPercentAccuracyThreshold} worse.
+   * the same provider and is no more than {@link LocationValidator#locationAccuracyPercentThreshold} worse.
    *
    * @param location new location received
    * @return true if acceptable accuracy, false otherwise
    */
   private boolean isAccuracyAcceptable(@NonNull Location location) {
     float currentAccuracy = location.getAccuracy();
-    if (currentAccuracy <= locationAcceptableAccuracyThreshold) {
+    if (currentAccuracy <= locationAcceptableAccuracyInMetersThreshold) {
       return true;
     }
 
@@ -81,7 +81,7 @@ public class LocationValidator {
     boolean improvedAccuracy = currentAccuracy <= previousAccuracy;
     boolean currentAccuracyWorse = currentAccuracy > previousAccuracy;
     boolean hasSameProvider = lastValidLocation.getProvider().equals(location.getProvider());
-    double percentThreshold = locationPercentAccuracyThreshold / 100.0;
+    double percentThreshold = locationAccuracyPercentThreshold / 100.0;
     boolean lessThanPercentThreshold = (accuracyDifference <= (previousAccuracy * percentThreshold));
     boolean lessAccuracyAcceptable = currentAccuracyWorse && hasSameProvider && lessThanPercentThreshold;
 
@@ -105,7 +105,7 @@ public class LocationValidator {
 
     double velocityInMetersPerSecond = distanceInMeters / (timeSinceLastValidUpdate / ONE_SECOND_IN_MILLIS);
 
-    return velocityInMetersPerSecond <= locationVelocityThreshold;
+    return velocityInMetersPerSecond <= locationVelocityInMetersPerSecondThreshold;
   }
 
   /**
@@ -117,6 +117,6 @@ public class LocationValidator {
    * @return true if valid location, false otherwise
    */
   private boolean isValidLocation(boolean accuracyAcceptable, long timeSinceLastValidUpdate) {
-    return accuracyAcceptable || timeSinceLastValidUpdate > locationUpdateTimeThreshold;
+    return accuracyAcceptable || timeSinceLastValidUpdate > locationUpdateTimeInMillisThreshold;
   }
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationOptions.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationOptions.java
@@ -59,13 +59,13 @@ public abstract class MapboxNavigationOptions {
   @NavigationTimeFormat.Type
   public abstract int timeFormatType();
 
-  public abstract int locationAcceptableAccuracyThreshold();
+  public abstract int locationAcceptableAccuracyInMetersThreshold();
 
-  public abstract int locationPercentAccuracyThreshold();
+  public abstract int locationAccuracyPercentThreshold();
 
-  public abstract int locationUpdateTimeThreshold();
+  public abstract int locationUpdateTimeInMillisThreshold();
 
-  public abstract int locationVelocityThreshold();
+  public abstract int locationVelocityInMetersPerSecondThreshold();
 
   public abstract Builder toBuilder();
 
@@ -114,13 +114,13 @@ public abstract class MapboxNavigationOptions {
 
     public abstract Builder timeFormatType(@NavigationTimeFormat.Type int type);
 
-    public abstract Builder locationAcceptableAccuracyThreshold(int locationAcceptableAccuracyThreshold);
+    public abstract Builder locationAcceptableAccuracyInMetersThreshold(int accuracyInMetersThreshold);
 
-    public abstract Builder locationPercentAccuracyThreshold(int locationPercentAccuracyThreshold);
+    public abstract Builder locationAccuracyPercentThreshold(int accuracyPercentThreshold);
 
-    public abstract Builder locationUpdateTimeThreshold(int locationUpdateTimeThreshold);
+    public abstract Builder locationUpdateTimeInMillisThreshold(int timeInMillisThreshold);
 
-    public abstract Builder locationVelocityThreshold(int locationVelocityThreshold);
+    public abstract Builder locationVelocityInMetersPerSecondThreshold(int metersPerSecondThreshold);
 
     public abstract MapboxNavigationOptions build();
   }
@@ -146,9 +146,9 @@ public abstract class MapboxNavigationOptions {
       .isDebugLoggingEnabled(false)
       .unitType(NavigationUnitType.NONE_SPECIFIED)
       .timeFormatType(NavigationTimeFormat.NONE_SPECIFIED)
-      .locationAcceptableAccuracyThreshold(NavigationConstants.FIFTY_METER_ACCEPTABLE_ACCURACY_THRESHOLD)
-      .locationPercentAccuracyThreshold(NavigationConstants.TEN_PERCENT_ACCURACY_THRESHOLD)
-      .locationUpdateTimeThreshold(NavigationConstants.FIVE_SECONDS_IN_MILLIS_UPDATE_THRESHOLD)
-      .locationVelocityThreshold(NavigationConstants.TWO_HUNDRED_METERS_PER_SECOND_VELOCITY_THRESHOLD);
+      .locationAcceptableAccuracyInMetersThreshold(NavigationConstants.FIFTY_METER_ACCEPTABLE_ACCURACY_THRESHOLD)
+      .locationAccuracyPercentThreshold(NavigationConstants.TEN_PERCENT_ACCURACY_THRESHOLD)
+      .locationUpdateTimeInMillisThreshold(NavigationConstants.FIVE_SECONDS_IN_MILLIS_UPDATE_THRESHOLD)
+      .locationVelocityInMetersPerSecondThreshold(NavigationConstants.TWO_HUNDRED_METERS_PER_SECOND_VELOCITY_THRESHOLD);
   }
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationOptions.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationOptions.java
@@ -59,6 +59,8 @@ public abstract class MapboxNavigationOptions {
   @NavigationTimeFormat.Type
   public abstract int timeFormatType();
 
+  public abstract int locationAcceptableAccuracyThreshold();
+
   public abstract int locationPercentAccuracyThreshold();
 
   public abstract int locationUpdateTimeThreshold();
@@ -112,6 +114,8 @@ public abstract class MapboxNavigationOptions {
 
     public abstract Builder timeFormatType(@NavigationTimeFormat.Type int type);
 
+    public abstract Builder locationAcceptableAccuracyThreshold(int locationAcceptableAccuracyThreshold);
+
     public abstract Builder locationPercentAccuracyThreshold(int locationPercentAccuracyThreshold);
 
     public abstract Builder locationUpdateTimeThreshold(int locationUpdateTimeThreshold);
@@ -142,6 +146,7 @@ public abstract class MapboxNavigationOptions {
       .isDebugLoggingEnabled(false)
       .unitType(NavigationUnitType.NONE_SPECIFIED)
       .timeFormatType(NavigationTimeFormat.NONE_SPECIFIED)
+      .locationAcceptableAccuracyThreshold(NavigationConstants.FIFTY_METER_ACCEPTABLE_ACCURACY_THRESHOLD)
       .locationPercentAccuracyThreshold(NavigationConstants.TEN_PERCENT_ACCURACY_THRESHOLD)
       .locationUpdateTimeThreshold(NavigationConstants.FIVE_SECONDS_IN_MILLIS_UPDATE_THRESHOLD)
       .locationVelocityThreshold(NavigationConstants.TWO_HUNDRED_METERS_PER_SECOND_VELOCITY_THRESHOLD);

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationOptions.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationOptions.java
@@ -59,6 +59,12 @@ public abstract class MapboxNavigationOptions {
   @NavigationTimeFormat.Type
   public abstract int timeFormatType();
 
+  public abstract int locationPercentAccuracyThreshold();
+
+  public abstract int locationUpdateTimeThreshold();
+
+  public abstract int locationVelocityThreshold();
+
   public abstract Builder toBuilder();
 
   @AutoValue.Builder
@@ -106,6 +112,12 @@ public abstract class MapboxNavigationOptions {
 
     public abstract Builder timeFormatType(@NavigationTimeFormat.Type int type);
 
+    public abstract Builder locationPercentAccuracyThreshold(int locationPercentAccuracyThreshold);
+
+    public abstract Builder locationUpdateTimeThreshold(int locationUpdateTimeThreshold);
+
+    public abstract Builder locationVelocityThreshold(int locationVelocityThreshold);
+
     public abstract MapboxNavigationOptions build();
   }
 
@@ -129,6 +141,9 @@ public abstract class MapboxNavigationOptions {
       .isFromNavigationUi(false)
       .isDebugLoggingEnabled(false)
       .unitType(NavigationUnitType.NONE_SPECIFIED)
-      .timeFormatType(NavigationTimeFormat.NONE_SPECIFIED);
+      .timeFormatType(NavigationTimeFormat.NONE_SPECIFIED)
+      .locationPercentAccuracyThreshold(NavigationConstants.TEN_PERCENT_ACCURACY_THRESHOLD)
+      .locationUpdateTimeThreshold(NavigationConstants.FIVE_SECONDS_IN_MILLIS_UPDATE_THRESHOLD)
+      .locationVelocityThreshold(NavigationConstants.TWO_HUNDRED_METERS_PER_SECOND_VELOCITY_THRESHOLD);
   }
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationConstants.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationConstants.java
@@ -192,17 +192,16 @@ public final class NavigationConstants {
   public static final String NAVIGATION_VIEW_RUNNING = "navigation_view_running";
 
   /**
-   * Default location time threshold
+   * Default location acceptable accuracy threshold
    * used in {@link com.mapbox.services.android.navigation.v5.location.LocationValidator}.
    * <p>
-   * If a device receives invalid updates for more than 5 seconds, the next location update will
-   * be considered valid, even if it does not meet the other validation criteria.
-   * <p>
-   * This is used as a last effort to push data to the SDK.
+   * If a new {@link android.location.Location} update is received from the LocationEngine that has
+   * an accuracy less than this threshold, the update will be considered valid and all other validation
+   * is not considered.
    *
    * @since 0.12.0
    */
-  static final int FIVE_SECONDS_IN_MILLIS_UPDATE_THRESHOLD = 5000;
+  static final int FIFTY_METER_ACCEPTABLE_ACCURACY_THRESHOLD = 50;
 
   /**
    * Default location accuracy threshold
@@ -214,6 +213,19 @@ public final class NavigationConstants {
    * @since 0.12.0
    */
   static final int TEN_PERCENT_ACCURACY_THRESHOLD = 10;
+
+  /**
+   * Default location time threshold
+   * used in {@link com.mapbox.services.android.navigation.v5.location.LocationValidator}.
+   * <p>
+   * If a device receives invalid updates for more than 5 seconds, the next location update will
+   * be considered valid, even if it does not meet the other validation criteria.
+   * <p>
+   * This is used as a last effort to push data to the SDK.
+   *
+   * @since 0.12.0
+   */
+  static final int FIVE_SECONDS_IN_MILLIS_UPDATE_THRESHOLD = 5000;
 
   /**
    * Default location velocity threshold

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationConstants.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationConstants.java
@@ -191,6 +191,41 @@ public final class NavigationConstants {
    */
   public static final String NAVIGATION_VIEW_RUNNING = "navigation_view_running";
 
+  /**
+   * Default location time threshold
+   * used in {@link com.mapbox.services.android.navigation.v5.location.LocationValidator}.
+   * <p>
+   * If a device receives invalid updates for more than 5 seconds, the next location update will
+   * be considered valid, even if it does not meet the other validation criteria.
+   * <p>
+   * This is used as a last effort to push data to the SDK.
+   *
+   * @since 0.12.0
+   */
+  static final int FIVE_SECONDS_IN_MILLIS_UPDATE_THRESHOLD = 5000;
+
+  /**
+   * Default location accuracy threshold
+   * used in {@link com.mapbox.services.android.navigation.v5.location.LocationValidator}.
+   * <p>
+   * If a new {@link android.location.Location} update is received from the LocationEngine that has
+   * 10 percent worse accuracy compared to the last update, the new update will be considered invalid.
+   *
+   * @since 0.12.0
+   */
+  static final int TEN_PERCENT_ACCURACY_THRESHOLD = 10;
+
+  /**
+   * Default location velocity threshold
+   * used in {@link com.mapbox.services.android.navigation.v5.location.LocationValidator}.
+   * <p>
+   * If a new {@link android.location.Location} update is received from the LocationEngine that has
+   * traveled faster the 200 meters per second from the last update, the new update will be considered invalid.
+   *
+   * @since 0.12.0
+   */
+  static final int TWO_HUNDRED_METERS_PER_SECOND_VELOCITY_THRESHOLD = 200;
+
   // Bundle variable keys
   public static final String NAVIGATION_VIEW_ORIGIN_LAT_KEY = "origin_lat";
   public static final String NAVIGATION_VIEW_ORIGIN_LNG_KEY = "origin_long";

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationService.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationService.java
@@ -278,10 +278,12 @@ public class NavigationService extends Service implements LocationEngineListener
    */
   private void initLocationValidator() {
     MapboxNavigationOptions options = mapboxNavigation.options();
-    int accuracyThreshold = options.locationPercentAccuracyThreshold();
+    int accuracyAcceptableThreshold = options.locationAcceptableAccuracyThreshold();
+    int accuracyPercentThreshold = options.locationPercentAccuracyThreshold();
     int timeThreshold = options.locationUpdateTimeThreshold();
     int velocityThreshold = options.locationVelocityThreshold();
-    this.locationValidator = new LocationValidator(accuracyThreshold, timeThreshold, velocityThreshold);
+    this.locationValidator = new LocationValidator(accuracyAcceptableThreshold, accuracyPercentThreshold,
+      timeThreshold, velocityThreshold);
   }
 
   /**

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationService.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationService.java
@@ -278,12 +278,12 @@ public class NavigationService extends Service implements LocationEngineListener
    */
   private void initLocationValidator() {
     MapboxNavigationOptions options = mapboxNavigation.options();
-    int accuracyAcceptableThreshold = options.locationAcceptableAccuracyThreshold();
-    int accuracyPercentThreshold = options.locationPercentAccuracyThreshold();
-    int timeThreshold = options.locationUpdateTimeThreshold();
-    int velocityThreshold = options.locationVelocityThreshold();
+    int accuracyAcceptableThreshold = options.locationAcceptableAccuracyInMetersThreshold();
+    int accuracyPercentThreshold = options.locationAccuracyPercentThreshold();
+    int timeInMillisThreshold = options.locationUpdateTimeInMillisThreshold();
+    int velocityInMetersPerSecondThreshold = options.locationVelocityInMetersPerSecondThreshold();
     this.locationValidator = new LocationValidator(accuracyAcceptableThreshold, accuracyPercentThreshold,
-      timeThreshold, velocityThreshold);
+      timeInMillisThreshold, velocityInMetersPerSecondThreshold);
   }
 
   /**

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationService.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationService.java
@@ -277,7 +277,11 @@ public class NavigationService extends Service implements LocationEngineListener
    * location updates from the location engine.
    */
   private void initLocationValidator() {
-    this.locationValidator = new LocationValidator();
+    MapboxNavigationOptions options = mapboxNavigation.options();
+    int accuracyThreshold = options.locationPercentAccuracyThreshold();
+    int timeThreshold = options.locationUpdateTimeThreshold();
+    int velocityThreshold = options.locationVelocityThreshold();
+    this.locationValidator = new LocationValidator(accuracyThreshold, timeThreshold, velocityThreshold);
   }
 
   /**


### PR DESCRIPTION
We introduced `LocationValidator` to filter incoming GPS updates.  This currently has static constants as thresholds.  This PR enables developers to adjust these as needed for their given requirements.  