### PR TITLE
Fix Proguard issues

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,8 +18,7 @@ android {
       testCoverageEnabled = false
     }
     release {
-      minifyEnabled false
-      proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+      minifyEnabled true
     }
   }
 

--- a/circle.yml
+++ b/circle.yml
@@ -41,6 +41,9 @@ jobs:
             ./gradlew accessToken
             ./gradlew app:assembleDebug
       - run:
+          name: Build release to test ProGuard rules
+          command: ./gradlew app:assembleRelease
+      - run:
           name: Log in to Google Cloud Platform
           shell: /bin/bash -euo pipefail
           command: |

--- a/libandroid-navigation-ui/build.gradle
+++ b/libandroid-navigation-ui/build.gradle
@@ -17,6 +17,7 @@ android {
         "MAPBOX_NAVIGATION_EVENTS_USER_AGENT", String.format("\"mapbox-navigation-ui-android/%s\"",
         project.VERSION_NAME
     )
+    consumerProguardFiles 'proguard-consumer.pro'
   }
 
   configurations {

--- a/libandroid-navigation-ui/proguard-consumer.pro
+++ b/libandroid-navigation-ui/proguard-consumer.pro
@@ -1,0 +1,18 @@
+# Consumer proguard rules for libandroid-navigation-ui
+
+# --- OkHttp ---
+-dontwarn okhttp3.**
+# A resource is loaded with a relative path so the package of this class must be preserved.
+-keepnames class okhttp3.internal.publicsuffix.PublicSuffixDatabase
+
+# --- Picasso ---
+-dontwarn com.squareup.okhttp.**
+
+# --- Java ---
+-dontwarn java.awt.Color
+
+# --- com.mapbox.api.directions.v5.MapboxDirections ---
+-dontwarn com.sun.xml.internal.ws.spi.db.BindingContextFactory
+
+# --- com.amazonaws.util.json.JacksonFactory ---
+-dontwarn com.fasterxml.jackson.core.**

--- a/libandroid-navigation/build.gradle
+++ b/libandroid-navigation/build.gradle
@@ -19,6 +19,7 @@ android {
         "MAPBOX_NAVIGATION_EVENTS_USER_AGENT", String.format("\"mapbox-navigation-android/%s\"",
         project.VERSION_NAME
     )
+    consumerProguardFiles 'proguard-consumer.pro'
   }
 
   configurations {
@@ -28,10 +29,6 @@ android {
   buildTypes {
     debug {
       testCoverageEnabled = true
-    }
-    release {
-      minifyEnabled false
-      proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
     }
   }
 

--- a/libandroid-navigation/proguard-consumer.pro
+++ b/libandroid-navigation/proguard-consumer.pro
@@ -1,0 +1,13 @@
+# Consumer proguard rules for libandroid-navigation
+
+# --- OkHttp ---
+-dontwarn okhttp3.**
+-dontwarn okio.**
+# A resource is loaded with a relative path so the package of this class must be preserved.
+-keepnames class okhttp3.internal.publicsuffix.PublicSuffixDatabase
+
+# --- Java ---
+-dontwarn java.awt.Color
+
+# --- com.mapbox.api.directions.v5.MapboxDirections ---
+-dontwarn com.sun.xml.internal.ws.spi.db.BindingContextFactory


### PR DESCRIPTION
- Adds Proguard rules to `libandroid-navigation` and `libandroid-navigation-ui` so that builds with Proguard enabled don't fail.
- Adds a step to the CI build to attempt to check if Proguard rules work.

- Fixes #824 

👀 @danesfeder @devotaaabel 