### PR TITLE
Validate route profile passed into RouteViewModel

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/NavigationViewActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/NavigationViewActivity.java
@@ -313,7 +313,9 @@ public class NavigationViewActivity extends AppCompatActivity implements OnMapRe
 
   private String getRouteProfile() {
     SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
-    return sharedPreferences.getString(getString(R.string.route_profile_key), DirectionsCriteria.PROFILE_DRIVING_TRAFFIC);
+    return sharedPreferences.getString(
+      getString(R.string.route_profile_key), DirectionsCriteria.PROFILE_DRIVING_TRAFFIC
+    );
   }
 
   private void launchNavigationWithRoute() {

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/NavigationViewActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/NavigationViewActivity.java
@@ -17,6 +17,7 @@ import android.widget.FrameLayout;
 import android.widget.ProgressBar;
 import android.widget.Toast;
 
+import com.mapbox.api.directions.v5.DirectionsCriteria;
 import com.mapbox.api.directions.v5.models.DirectionsResponse;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.geojson.LineString;
@@ -312,7 +313,7 @@ public class NavigationViewActivity extends AppCompatActivity implements OnMapRe
 
   private String getRouteProfile() {
     SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
-    return sharedPreferences.getString(getString(R.string.route_profile_key), "");
+    return sharedPreferences.getString(getString(R.string.route_profile_key), DirectionsCriteria.PROFILE_DRIVING_TRAFFIC);
   }
 
   private void launchNavigationWithRoute() {

--- a/app/src/main/res/xml/fragment_navigation_view_preferences.xml
+++ b/app/src/main/res/xml/fragment_navigation_view_preferences.xml
@@ -20,7 +20,6 @@
         android:entryValues="@array/unit_type_values_array"
         android:defaultValue="-1"/>
     <ListPreference
-        android:defaultValue="1"
         android:entries="@array/route_profile_array"
         android:entryValues="@array/route_profile_values_array"
         android:key="@string/route_profile_key"

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/RouteViewModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/RouteViewModel.java
@@ -22,6 +22,7 @@ import com.mapbox.services.android.navigation.v5.navigation.NavigationRoute;
 import com.mapbox.services.android.navigation.v5.navigation.NavigationUnitType;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 import com.mapbox.services.android.navigation.v5.utils.LocaleUtils;
+import com.mapbox.services.android.navigation.v5.utils.RouteUtils;
 
 import java.util.List;
 import java.util.Locale;
@@ -295,7 +296,7 @@ public class RouteViewModel extends AndroidViewModel implements Callback<Directi
   }
 
   private void addNavigationViewOptions(NavigationRoute.Builder builder) {
-    if (!TextUtils.isEmpty(routeProfile)) {
+    if (RouteUtils.isValidRouteProfile(routeProfile)) {
       builder.profile(routeProfile);
     }
     builder

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/RouteUtils.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/RouteUtils.java
@@ -12,7 +12,9 @@ import com.mapbox.geojson.Point;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.METERS_REMAINING_TILL_ARRIVAL;
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.STEP_MANEUVER_TYPE_ARRIVE;
@@ -21,6 +23,14 @@ public final class RouteUtils {
 
   private static final String FORCED_LOCATION = "Forced Location";
   private static final int FIRST_COORDINATE = 0;
+  private static final Set<String> VALID_PROFILES = new HashSet<String>() {
+    {
+      add(DirectionsCriteria.PROFILE_DRIVING_TRAFFIC);
+      add(DirectionsCriteria.PROFILE_DRIVING);
+      add(DirectionsCriteria.PROFILE_CYCLING);
+      add(DirectionsCriteria.PROFILE_WALKING);
+    }
+  };
 
   private RouteUtils() {
     // Utils class therefore, shouldn't be initialized.
@@ -137,11 +147,7 @@ public final class RouteUtils {
    * @since 0.13.0
    */
   public static boolean isValidRouteProfile(String routeProfile) {
-    return !TextUtils.isEmpty(routeProfile)
-      && routeProfile.contentEquals(DirectionsCriteria.PROFILE_DRIVING_TRAFFIC)
-      || routeProfile.contentEquals(DirectionsCriteria.PROFILE_DRIVING)
-      || routeProfile.contentEquals(DirectionsCriteria.PROFILE_CYCLING)
-      || routeProfile.contentEquals(DirectionsCriteria.PROFILE_WALKING);
+    return !TextUtils.isEmpty(routeProfile) && VALID_PROFILES.contains(routeProfile);
   }
 
   private static boolean upcomingStepIsArrival(@NonNull RouteProgress routeProgress) {

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/RouteUtils.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/RouteUtils.java
@@ -3,7 +3,9 @@ package com.mapbox.services.android.navigation.v5.utils;
 import android.location.Location;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.text.TextUtils;
 
+import com.mapbox.api.directions.v5.DirectionsCriteria;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.api.directions.v5.models.RouteLeg;
 import com.mapbox.geojson.Point;
@@ -124,6 +126,22 @@ public final class RouteUtils {
     forcedLocation.setLatitude(origin.latitude());
     forcedLocation.setLongitude(origin.longitude());
     return forcedLocation;
+  }
+
+  /**
+   * Checks if the {@link String} route profile provided is a valid profile
+   * that can be used with the directions API.
+   *
+   * @param routeProfile being validated
+   * @return true if valid, false if not
+   * @since 0.13.0
+   */
+  public static boolean isValidRouteProfile(String routeProfile) {
+    return !TextUtils.isEmpty(routeProfile)
+      && routeProfile.contentEquals(DirectionsCriteria.PROFILE_DRIVING_TRAFFIC)
+      || routeProfile.contentEquals(DirectionsCriteria.PROFILE_DRIVING)
+      || routeProfile.contentEquals(DirectionsCriteria.PROFILE_CYCLING)
+      || routeProfile.contentEquals(DirectionsCriteria.PROFILE_WALKING);
   }
 
   private static boolean upcomingStepIsArrival(@NonNull RouteProgress routeProgress) {

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/utils/RouteUtilsTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/utils/RouteUtilsTest.java
@@ -1,5 +1,6 @@
 package com.mapbox.services.android.navigation.v5.utils;
 
+import com.mapbox.api.directions.v5.DirectionsCriteria;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.api.directions.v5.models.RouteLeg;
 import com.mapbox.services.android.navigation.v5.BaseTest;
@@ -110,6 +111,24 @@ public class RouteUtilsTest extends BaseTest {
     boolean isArrivalEvent = RouteUtils.isArrivalEvent(theRouteProgress);
 
     assertFalse(isArrivalEvent);
+  }
+
+  @Test
+  public void isValidRouteProfile_returnsTrueWithValidProfile() throws Exception {
+    String routeProfile = DirectionsCriteria.PROFILE_DRIVING_TRAFFIC;
+
+    boolean isValidProfile = RouteUtils.isValidRouteProfile(routeProfile);
+
+    assertTrue(isValidProfile);
+  }
+
+  @Test
+  public void isValidRouteProfile_returnsFalseWithInvalidProfile() throws Exception {
+    String routeProfile = "invalid_profile";
+
+    boolean isValidProfile = RouteUtils.isValidRouteProfile(routeProfile);
+
+    assertFalse(isValidProfile);
   }
 
   private int obtainLastStepIndex(DirectionsRoute route) throws IOException {

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/utils/RouteUtilsTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/utils/RouteUtilsTest.java
@@ -114,19 +114,55 @@ public class RouteUtilsTest extends BaseTest {
   }
 
   @Test
-  public void isValidRouteProfile_returnsTrueWithValidProfile() throws Exception {
-    String routeProfile = DirectionsCriteria.PROFILE_DRIVING_TRAFFIC;
+  public void isValidRouteProfile_returnsTrueWithDrivingTrafficProfile() throws Exception {
+    String routeProfileDrivingTraffic = DirectionsCriteria.PROFILE_DRIVING_TRAFFIC;
 
-    boolean isValidProfile = RouteUtils.isValidRouteProfile(routeProfile);
+    boolean isValidProfile = RouteUtils.isValidRouteProfile(routeProfileDrivingTraffic);
+
+    assertTrue(isValidProfile);
+  }
+
+  @Test
+  public void isValidRouteProfile_returnsTrueWithDrivingProfile() throws Exception {
+    String routeProfileDriving = DirectionsCriteria.PROFILE_DRIVING;
+
+    boolean isValidProfile = RouteUtils.isValidRouteProfile(routeProfileDriving);
+
+    assertTrue(isValidProfile);
+  }
+
+  @Test
+  public void isValidRouteProfile_returnsTrueWithCyclingProfile() throws Exception {
+    String routeProfileCycling = DirectionsCriteria.PROFILE_CYCLING;
+
+    boolean isValidProfile = RouteUtils.isValidRouteProfile(routeProfileCycling);
+
+    assertTrue(isValidProfile);
+  }
+
+  @Test
+  public void isValidRouteProfile_returnsTrueWithWalkingProfile() throws Exception {
+    String routeProfileWalking = DirectionsCriteria.PROFILE_WALKING;
+
+    boolean isValidProfile = RouteUtils.isValidRouteProfile(routeProfileWalking);
 
     assertTrue(isValidProfile);
   }
 
   @Test
   public void isValidRouteProfile_returnsFalseWithInvalidProfile() throws Exception {
-    String routeProfile = "invalid_profile";
+    String invalidProfile = "invalid_profile";
 
-    boolean isValidProfile = RouteUtils.isValidRouteProfile(routeProfile);
+    boolean isValidProfile = RouteUtils.isValidRouteProfile(invalidProfile);
+
+    assertFalse(isValidProfile);
+  }
+
+  @Test
+  public void isValidRouteProfile_returnsFalseWithNullProfile() throws Exception {
+    String nullProfile = null;
+
+    boolean isValidProfile = RouteUtils.isValidRouteProfile(nullProfile);
 
     assertFalse(isValidProfile);
   }


### PR DESCRIPTION
Currently, we would use whatever profile a user sets, breaking the route requests.

Found this because we were defaulting the profile to `"1"` in the settings XML.