### PR TITLE
Remove draw routes and add direction waypoints calls already being called

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/NavigationMapRoute.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/NavigationMapRoute.java
@@ -731,8 +731,6 @@ public class NavigationMapRoute implements ProgressChangeListener, MapView.OnMap
     // Check if the route's the same as the route currently drawn
     if (!routeProgress.directionsRoute().equals(directionsRoutes.get(primaryRouteIndex))) {
       addRoute(routeProgress.directionsRoute());
-      drawRoutes();
-      addDirectionWaypoints();
     }
   }
 


### PR DESCRIPTION
While testing https://github.com/mapbox/mapbox-navigation-android/pull/697 run into the following crash 👇

```
04-10 17:56:02.518 31795-31795/com.mapbox.services.android.navigation.testapp E/AndroidRuntime: FATAL EXCEPTION: main
                                                                                                Process: com.mapbox.services.android.navigation.testapp, PID: 31795
                                                                                                com.mapbox.mapboxsdk.style.layers.CannotAddLayerException: Layer mapbox-navigation-route-shield-layer-1 already exists
                                                                                                    at com.mapbox.mapboxsdk.maps.NativeMapView.nativeAddLayer(Native Method)
                                                                                                    at com.mapbox.mapboxsdk.maps.NativeMapView.addLayerBelow(NativeMapView.java:686)
                                                                                                    at com.mapbox.mapboxsdk.maps.MapboxMap.addLayerBelow(MapboxMap.java:318)
                                                                                                    at com.mapbox.services.android.navigation.ui.v5.utils.MapUtils.addLayerToMap(MapUtils.java:63)
                                                                                                    at com.mapbox.services.android.navigation.ui.v5.route.NavigationMapRoute.addRouteShieldLayer(NavigationMapRoute.java:474)
                                                                                                    at com.mapbox.services.android.navigation.ui.v5.route.NavigationMapRoute.drawRoutes(NavigationMapRoute.java:324)
                                                                                                    at com.mapbox.services.android.navigation.ui.v5.route.NavigationMapRoute.onProgressChange(NavigationMapRoute.java:720)
                                                                                                    at com.mapbox.services.android.navigation.v5.navigation.NavigationEventDispatcher.onProgressChange(NavigationEventDispatcher.java:156)
                                                                                                    at com.mapbox.services.android.navigation.v5.navigation.NavigationService.onNewRouteProgress(NavigationService.java:118)
                                                                                                    at com.mapbox.services.android.navigation.v5.navigation.NavigationEngine$1.run(NavigationEngine.java:91)
                                                                                                    at android.os.Handler.handleCallback(Handler.java:739)
                                                                                                    at android.os.Handler.dispatchMessage(Handler.java:95)
                                                                                                    at android.os.Looper.loop(Looper.java:135)
                                                                                                    at android.app.ActivityThread.main(ActivityThread.java:5312)
                                                                                                    at java.lang.reflect.Method.invoke(Native Method)
                                                                                                    at java.lang.reflect.Method.invoke(Method.java:372)
                                                                                                    at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:901)
                                                                                                    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:696)
```

This was launching the `MockNavigationActivity` from the test app. In that activity, we're creating a `NavigationMapRoute` instance passing a `MapboxNavigation` which adds a `ProgressChangeListener` by default and eventually the `onProgressChange` method is fired 👇 https://github.com/mapbox/mapbox-navigation-android/blob/d7d4f0001703bfa55a19411fe02994e96315403e/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/NavigationMapRoute.java#L720-L737 You cannot add the same layer twice. That operation is not allowed and it was the cause of the crash. Digging deeper we were calling `drawRoutes()` and `addDirectionWaypoints()` twice. So this PR 👇

- Removes `drawRoutes()` and `addDirectionWaypoints()` calls from `NavigationMapRoute#onProgressChange` method already being called within `addRoutes` method

👀 @danesfeder @devotaaabel 