### PR TITLE
Add gradle-dependency-graph-generator-plugin to the project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,10 @@ publish-local:
 	export IS_LOCAL_DEVELOPMENT=true; ./gradlew :libandroid-navigation:uploadArchives
 	export IS_LOCAL_DEVELOPMENT=true; ./gradlew :libandroid-navigation-ui:uploadArchives
 
+graphs:
+	./gradlew :libandroid-navigation:generateDependencyGraphMapboxLibraries
+	./gradlew :libandroid-navigation-ui:generateDependencyGraphMapboxLibraries
+
 dex-count:
 	./gradlew countDebugDexMethods
 	./gradlew countReleaseDexMethods

--- a/gradle/dependencies-graph.gradle
+++ b/gradle/dependencies-graph.gradle
@@ -1,0 +1,29 @@
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath pluginDependencies.dependencyGraph
+    }
+}
+
+import com.vanniktech.dependency.graph.generator.DependencyGraphGeneratorPlugin
+import com.vanniktech.dependency.graph.generator.DependencyGraphGeneratorExtension.Generator
+import com.vanniktech.dependency.graph.generator.dot.GraphFormattingOptions
+import com.vanniktech.dependency.graph.generator.dot.Color
+import com.vanniktech.dependency.graph.generator.dot.Shape
+import com.vanniktech.dependency.graph.generator.dot.Style
+
+plugins.apply(DependencyGraphGeneratorPlugin)
+
+def mapboxGenerator = new Generator(
+        "mapboxLibraries", // Suffix for our Gradle task.
+        "", // Root suffix that we don't want in this case.
+        { dependency -> dependency.getModuleGroup().startsWith("com.mapbox.mapboxsdk") }, // Only want Mapbox libs.
+        { dependency -> true }, // Include transitive dependencies.
+)
+
+dependencyGraphGenerator {
+    generators = [mapboxGenerator]
+}

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -34,14 +34,15 @@ ext {
   ]
 
   pluginVersion = [
-      checkstyle: '8.2',
-      pmd       : '5.8.1',
-      jacoco    : '0.7.9',
-      errorprone: '0.0.13',
-      coveralls : '2.8.1',
-      spotbugs  : '1.3',
-      sonarqube : '2.6-rc1',
-      gradle    : '3.0.1'
+      checkstyle     : '8.2',
+      pmd            : '5.8.1',
+      jacoco         : '0.7.9',
+      errorprone     : '0.0.13',
+      coveralls      : '2.8.1',
+      spotbugs       : '1.3',
+      sonarqube      : '2.6-rc1',
+      gradle         : '3.0.1',
+      dependencyGraph: '0.3.0'
   ]
 
   dependenciesList = [
@@ -104,11 +105,12 @@ ext {
   ]
 
   pluginDependencies = [
-      gradle    : "com.android.tools.build:gradle:${pluginVersion.gradle}",
-      checkstyle: "com.puppycrawl.tools:checkstyle:${pluginVersion.checkstyle}",
-      spotbugs  : "gradle.plugin.com.github.spotbugs:gradlePlugin:${pluginVersion.spotbugs}",
-      sonarqube : "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:${pluginVersion.sonarqube}",
-      coveralls : "org.kt3k.gradle.plugin:coveralls-gradle-plugin:${pluginVersion.coveralls}",
-      errorprone: "net.ltgt.gradle:gradle-errorprone-plugin:${pluginVersion.errorprone}"
+      gradle         : "com.android.tools.build:gradle:${pluginVersion.gradle}",
+      checkstyle     : "com.puppycrawl.tools:checkstyle:${pluginVersion.checkstyle}",
+      spotbugs       : "gradle.plugin.com.github.spotbugs:gradlePlugin:${pluginVersion.spotbugs}",
+      sonarqube      : "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:${pluginVersion.sonarqube}",
+      coveralls      : "org.kt3k.gradle.plugin:coveralls-gradle-plugin:${pluginVersion.coveralls}",
+      errorprone     : "net.ltgt.gradle:gradle-errorprone-plugin:${pluginVersion.errorprone}",
+      dependencyGraph: "com.vanniktech:gradle-dependency-graph-generator-plugin:${pluginVersion.dependencyGraph}"
   ]
 }

--- a/libandroid-navigation-ui/.gitignore
+++ b/libandroid-navigation-ui/.gitignore
@@ -1,0 +1,1 @@
+dependency-graph-mapbox-libraries.png

--- a/libandroid-navigation-ui/build.gradle
+++ b/libandroid-navigation-ui/build.gradle
@@ -81,3 +81,4 @@ apply from: 'javadoc.gradle'
 apply from: "${rootDir}/gradle/mvn-push-android.gradle"
 apply from: "${rootDir}/gradle/checkstyle.gradle"
 apply from: "${rootDir}/gradle/jacoco.gradle"
+apply from: "${rootDir}/gradle/dependencies-graph.gradle"

--- a/libandroid-navigation/.gitignore
+++ b/libandroid-navigation/.gitignore
@@ -1,0 +1,1 @@
+dependency-graph-mapbox-libraries.png

--- a/libandroid-navigation/build.gradle
+++ b/libandroid-navigation/build.gradle
@@ -67,3 +67,4 @@ apply from: 'javadoc.gradle'
 apply from: "${rootDir}/gradle/mvn-push-android.gradle"
 apply from: "${rootDir}/gradle/checkstyle.gradle"
 apply from: "${rootDir}/gradle/jacoco.gradle"
+apply from: "${rootDir}/gradle/dependencies-graph.gradle"


### PR DESCRIPTION
This helps us visualize the dependency tree for Mapbox dependencies. To generate the charts, run the following Gradle tasks (`libandroid-navigation` or `libandroid-navigation-ui` respectively)

```
$> ./gradlew :libandroid-navigation:generateDependencyGraphMapboxLibraries
```
```
$> ./gradlew :libandroid-navigation-ui:generateDependencyGraphMapboxLibraries
```

or

```
$> make graphs
```

Graphviz needs to be installed following the instructions on the [plugin README](https://github.com/vanniktech/gradle-dependency-graph-generator-plugin).

Related:
https://github.com/mapbox/mapbox-gl-native/pull/11603
https://github.com/mapbox/mapbox-android-demo/pull/671

cc @zugaldia 