### PR TITLE
Add NavigationLauncherOption snap-to-route enabled

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationActivity.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationActivity.java
@@ -154,6 +154,8 @@ public class NavigationActivity extends AppCompatActivity implements OnNavigatio
       .getString(NavigationConstants.NAVIGATION_VIEW_ROUTE_PROFILE_KEY, DirectionsCriteria.PROFILE_DRIVING_TRAFFIC));
     navigationOptions.enableOffRouteDetection(preferences
       .getBoolean(NavigationConstants.NAVIGATION_VIEW_OFF_ROUTE_ENABLED_KEY, true));
+    navigationOptions.snapToRoute(preferences
+      .getBoolean(NavigationConstants.NAVIGATION_VIEW_SNAP_ENABLED_KEY, true));
   }
 
   private void extractLocale(MapboxNavigationOptions.Builder navigationOptions) {

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationLauncher.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationLauncher.java
@@ -119,6 +119,7 @@ public class NavigationLauncher {
     editor.putBoolean(NavigationConstants.NAVIGATION_VIEW_SIMULATE_ROUTE, options.shouldSimulateRoute());
     editor.putString(NavigationConstants.NAVIGATION_VIEW_ROUTE_PROFILE_KEY, options.directionsProfile());
     editor.putBoolean(NavigationConstants.NAVIGATION_VIEW_OFF_ROUTE_ENABLED_KEY, options.enableOffRouteDetection());
+    editor.putBoolean(NavigationConstants.NAVIGATION_VIEW_SNAP_ENABLED_KEY, options.snapToRoute());
   }
 
   private static void storeThemePreferences(NavigationLauncherOptions options, SharedPreferences.Editor editor) {

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationLauncherOptions.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationLauncherOptions.java
@@ -21,6 +21,8 @@ public abstract class NavigationLauncherOptions extends NavigationOptions {
 
   public abstract boolean enableOffRouteDetection();
 
+  public abstract boolean snapToRoute();
+
   @AutoValue.Builder
   public abstract static class Builder {
 
@@ -44,12 +46,15 @@ public abstract class NavigationLauncherOptions extends NavigationOptions {
 
     public abstract Builder enableOffRouteDetection(boolean enableOffRouteDetection);
 
+    public abstract Builder snapToRoute(boolean snapToRoute);
+
     public abstract NavigationLauncherOptions build();
   }
 
   public static NavigationLauncherOptions.Builder builder() {
     return new AutoValue_NavigationLauncherOptions.Builder()
       .shouldSimulateRoute(false)
-      .enableOffRouteDetection(true);
+      .enableOffRouteDetection(true)
+      .snapToRoute(true);
   }
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationConstants.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationConstants.java
@@ -250,9 +250,9 @@ public final class NavigationConstants {
   public static final String NAVIGATION_VIEW_SIMULATE_ROUTE = "navigation_view_simulate_route";
   public static final String NAVIGATION_VIEW_ROUTE_PROFILE_KEY = "navigation_view_route_profile";
   public static final String NAVIGATION_VIEW_OFF_ROUTE_ENABLED_KEY = "navigation_view_off_route_enabled";
+  public static final String NAVIGATION_VIEW_SNAP_ENABLED_KEY = "navigation_view_snap_enabled";
   public static final String NAVIGATION_VIEW_LOCALE_LANGUAGE = "navigation_view_locale_language";
   public static final String NAVIGATION_VIEW_LOCALE_COUNTRY = "navigation_view_locale_country";
-  public static final String NAVIGATION_VIEW_REROUTING = "Rerouting";
 
   // Step Maneuver Types
   public static final String STEP_MANEUVER_TYPE_TURN = "turn";


### PR DESCRIPTION
Closes #847 

Currently we offer the ability to enable / disable off-route detection from `NavigationLauncherOptions` but we don't offer the same ability for snapping to the route.  These two go hand-in-hand, because if you disable off-route detection, it can look like the puck has become stuck (because we are still snapping to the route -- see https://github.com/mapbox/mapbox-navigation-android/issues/847#issuecomment-380799617).  

