### PR TITLE
Check for null camera engine before returning from MapboxNavigation

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
@@ -360,7 +360,11 @@ public class MapboxNavigation implements ServiceConnection {
    * @return camera engine used to configure camera position while routing
    * @since 0.10.0
    */
+  @NonNull
   public Camera getCameraEngine() {
+    if (cameraEngine == null) {
+      return new SimpleCamera();
+    }
     return cameraEngine;
   }
 

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationTest.java
@@ -192,8 +192,9 @@ public class MapboxNavigationTest extends BaseTest {
     MapboxNavigationOptions options = MapboxNavigationOptions.builder().defaultMilestonesEnabled(false).build();
     MapboxNavigation navigationWithOptions = buildMapboxNavigationWithOptions(options);
     navigationWithOptions.addMilestone(new StepMilestone.Builder().build());
+    int removedMilestoneIdentifier = 5678;
 
-    navigationWithOptions.removeMilestone(5678);
+    navigationWithOptions.removeMilestone(removedMilestoneIdentifier);
 
     assertEquals(1, navigationWithOptions.getMilestones().size());
   }

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationTest.java
@@ -6,13 +6,13 @@ import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.services.android.navigation.v5.BaseTest;
 import com.mapbox.services.android.navigation.v5.milestone.Milestone;
 import com.mapbox.services.android.navigation.v5.milestone.StepMilestone;
+import com.mapbox.services.android.navigation.v5.navigation.camera.SimpleCamera;
 import com.mapbox.services.android.navigation.v5.offroute.OffRoute;
 import com.mapbox.services.android.navigation.v5.offroute.OffRouteDetector;
 import com.mapbox.services.android.navigation.v5.snap.Snap;
 import com.mapbox.services.android.navigation.v5.snap.SnapToRoute;
 import com.mapbox.services.android.telemetry.location.LocationEngine;
 
-import org.junit.Before;
 import org.junit.Test;
 
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.BANNER_INSTRUCTION_MILESTONE_ID;
@@ -28,46 +28,60 @@ import static org.mockito.Mockito.verify;
 
 public class MapboxNavigationTest extends BaseTest {
 
-  private MapboxNavigation navigation;
+  @Test
+  public void sanityTest() {
+    MapboxNavigation navigation = buildMapboxNavigation();
 
-  @Before
-  public void before() throws Exception {
-    navigation = new MapboxNavigation(mock(Context.class), ACCESS_TOKEN, mock(NavigationTelemetry.class),
-      mock(LocationEngine.class));
+    assertNotNull(navigation);
   }
 
   @Test
-  public void sanityTest() {
-    assertNotNull("should not be null", navigation);
+  public void sanityTestWithOptions() {
     MapboxNavigationOptions options = MapboxNavigationOptions.builder().build();
-    MapboxNavigation navigationWithOptions = new MapboxNavigation(mock(Context.class),
-      ACCESS_TOKEN, options, mock(NavigationTelemetry.class), mock(LocationEngine.class));
-    assertNotNull("should not be null", navigationWithOptions);
+    MapboxNavigation navigationWithOptions = buildMapboxNavigationWithOptions(options);
+
+    assertNotNull(navigationWithOptions);
   }
 
   @Test
   public void voiceMilestone_onInitializationDoesGetAdded() throws Exception {
-    assertTrue(navigation.getMilestones().get(0).getIdentifier() == VOICE_INSTRUCTION_MILESTONE_ID);
+    MapboxNavigation navigation = buildMapboxNavigation();
+
+    int identifier = navigation.getMilestones().get(0).getIdentifier();
+
+    assertEquals(identifier, VOICE_INSTRUCTION_MILESTONE_ID);
   }
 
   @Test
   public void bannerMilestone_onInitializationDoesGetAdded() throws Exception {
-    assertTrue(navigation.getMilestones().get(1).getIdentifier() == BANNER_INSTRUCTION_MILESTONE_ID);
+    MapboxNavigation navigation = buildMapboxNavigation();
+
+    int identifier = navigation.getMilestones().get(1).getIdentifier();
+
+    assertEquals(identifier, BANNER_INSTRUCTION_MILESTONE_ID);
   }
 
 
   @Test
   public void defaultMilestones_onInitializationDoNotGetAdded() throws Exception {
     MapboxNavigationOptions options = MapboxNavigationOptions.builder().defaultMilestonesEnabled(false).build();
-    MapboxNavigation navigationWithOptions = new MapboxNavigation(mock(Context.class),
-      ACCESS_TOKEN, options, mock(NavigationTelemetry.class), mock(LocationEngine.class));
+    MapboxNavigation navigationWithOptions = buildMapboxNavigationWithOptions(options);
+
     assertEquals(0, navigationWithOptions.getMilestones().size());
   }
 
   @Test
-  public void defaultEngines_didGetInitialized() throws Exception {
-    assertNotNull(navigation.getSnapEngine());
+  public void defaultEngines_offRouteEngineDidGetInitialized() throws Exception {
+    MapboxNavigation navigation = buildMapboxNavigation();
+
     assertNotNull(navigation.getOffRouteEngine());
+  }
+
+  @Test
+  public void defaultEngines_snapEngineDidGetInitialized() throws Exception {
+    MapboxNavigation navigation = buildMapboxNavigation();
+
+    assertNotNull(navigation.getSnapEngine());
   }
 
   @Test
@@ -75,9 +89,9 @@ public class MapboxNavigationTest extends BaseTest {
     MapboxNavigationOptions options = MapboxNavigationOptions.builder()
       .enableOffRouteDetection(false)
       .build();
-    navigation = new MapboxNavigation(mock(Context.class), ACCESS_TOKEN, options, mock(NavigationTelemetry.class),
-      mock(LocationEngine.class));
-    assertNull(navigation.getOffRouteEngine());
+    MapboxNavigation navigationWithOptions = buildMapboxNavigationWithOptions(options);
+
+    assertNull(navigationWithOptions.getOffRouteEngine());
   }
 
   @Test
@@ -85,9 +99,9 @@ public class MapboxNavigationTest extends BaseTest {
     MapboxNavigationOptions options = MapboxNavigationOptions.builder()
       .snapToRoute(false)
       .build();
-    navigation = new MapboxNavigation(mock(Context.class), ACCESS_TOKEN, options, mock(NavigationTelemetry.class),
-      mock(LocationEngine.class));
-    assertNull(navigation.getSnapEngine());
+    MapboxNavigation navigationWithOptions = buildMapboxNavigationWithOptions(options);
+
+    assertNull(navigationWithOptions.getSnapEngine());
   }
 
   @Test
@@ -95,132 +109,175 @@ public class MapboxNavigationTest extends BaseTest {
     MapboxNavigationOptions options = MapboxNavigationOptions.builder()
       .enableFasterRouteDetection(false)
       .build();
-    navigation = new MapboxNavigation(mock(Context.class), ACCESS_TOKEN, options, mock(NavigationTelemetry.class),
-      mock(LocationEngine.class));
-    assertNull(navigation.getFasterRouteEngine());
+    MapboxNavigation navigationWithOptions = buildMapboxNavigationWithOptions(options);
+
+    assertNull(navigationWithOptions.getFasterRouteEngine());
   }
 
   @Test
   public void addMilestone_milestoneDidGetAdded() throws Exception {
+    MapboxNavigation navigation = buildMapboxNavigation();
     Milestone milestone = new StepMilestone.Builder().build();
+
     navigation.addMilestone(milestone);
+
     assertTrue(navigation.getMilestones().contains(milestone));
   }
 
   @Test
   public void addMilestone_milestoneOnlyGetsAddedOnce() throws Exception {
     MapboxNavigationOptions options = MapboxNavigationOptions.builder().defaultMilestonesEnabled(false).build();
-    MapboxNavigation navigationWithOptions = new MapboxNavigation(mock(Context.class),
-      ACCESS_TOKEN, options, mock(NavigationTelemetry.class), mock(LocationEngine.class));
+    MapboxNavigation navigationWithOptions = buildMapboxNavigationWithOptions(options);
+
     Milestone milestone = new StepMilestone.Builder().build();
     navigationWithOptions.addMilestone(milestone);
     navigationWithOptions.addMilestone(milestone);
+
     assertEquals(1, navigationWithOptions.getMilestones().size());
   }
 
   @Test
   public void removeMilestone_milestoneDidGetRemoved() throws Exception {
     MapboxNavigationOptions options = MapboxNavigationOptions.builder().defaultMilestonesEnabled(false).build();
-    MapboxNavigation navigationWithOptions = new MapboxNavigation(mock(Context.class),
-      ACCESS_TOKEN, options, mock(NavigationTelemetry.class), mock(LocationEngine.class));
+    MapboxNavigation navigationWithOptions = buildMapboxNavigationWithOptions(options);
+
     Milestone milestone = new StepMilestone.Builder().build();
     navigationWithOptions.addMilestone(milestone);
-    assertEquals(1, navigationWithOptions.getMilestones().size());
     navigationWithOptions.removeMilestone(milestone);
+
     assertEquals(0, navigationWithOptions.getMilestones().size());
   }
 
   @Test
   public void removeMilestone_milestoneDoesNotExist() throws Exception {
     MapboxNavigationOptions options = MapboxNavigationOptions.builder().defaultMilestonesEnabled(false).build();
-    MapboxNavigation navigationWithOptions = new MapboxNavigation(mock(Context.class),
-      ACCESS_TOKEN, options, mock(NavigationTelemetry.class), mock(LocationEngine.class));
+    MapboxNavigation navigationWithOptions = buildMapboxNavigationWithOptions(options);
+
     Milestone milestone = new StepMilestone.Builder().build();
     navigationWithOptions.addMilestone(new StepMilestone.Builder().build());
     navigationWithOptions.removeMilestone(milestone);
+
     assertEquals(1, navigationWithOptions.getMilestones().size());
   }
 
   @Test
   public void removeMilestone_nullRemovesAllMilestones() throws Exception {
     MapboxNavigationOptions options = MapboxNavigationOptions.builder().defaultMilestonesEnabled(false).build();
-    MapboxNavigation navigationWithOptions = new MapboxNavigation(mock(Context.class),
-      ACCESS_TOKEN, options, mock(NavigationTelemetry.class), mock(LocationEngine.class));
+    MapboxNavigation navigationWithOptions = buildMapboxNavigationWithOptions(options);
     navigationWithOptions.addMilestone(new StepMilestone.Builder().build());
     navigationWithOptions.addMilestone(new StepMilestone.Builder().build());
     navigationWithOptions.addMilestone(new StepMilestone.Builder().build());
     navigationWithOptions.addMilestone(new StepMilestone.Builder().build());
-    assertEquals(4, navigationWithOptions.getMilestones().size());
+
     navigationWithOptions.removeMilestone(null);
+
     assertEquals(0, navigationWithOptions.getMilestones().size());
   }
 
   @Test
   public void removeMilestone_correctMilestoneWithIdentifierGetsRemoved() throws Exception {
     MapboxNavigationOptions options = MapboxNavigationOptions.builder().defaultMilestonesEnabled(false).build();
-    MapboxNavigation navigationWithOptions = new MapboxNavigation(mock(Context.class),
-      ACCESS_TOKEN, options, mock(NavigationTelemetry.class), mock(LocationEngine.class));
-    Milestone milestone = new StepMilestone.Builder().setIdentifier(5678).build();
+    MapboxNavigation navigationWithOptions = buildMapboxNavigationWithOptions(options);
+    int removedMilestoneIdentifier = 5678;
+    Milestone milestone = new StepMilestone.Builder().setIdentifier(removedMilestoneIdentifier).build();
     navigationWithOptions.addMilestone(milestone);
-    assertEquals(1, navigationWithOptions.getMilestones().size());
-    navigationWithOptions.removeMilestone(5678);
+
+    navigationWithOptions.removeMilestone(removedMilestoneIdentifier);
+
     assertEquals(0, navigationWithOptions.getMilestones().size());
   }
 
   @Test
   public void removeMilestone_noMilestoneWithIdentifierFound() throws Exception {
     MapboxNavigationOptions options = MapboxNavigationOptions.builder().defaultMilestonesEnabled(false).build();
-    MapboxNavigation navigationWithOptions = new MapboxNavigation(mock(Context.class),
-      ACCESS_TOKEN, options, mock(NavigationTelemetry.class), mock(LocationEngine.class));
+    MapboxNavigation navigationWithOptions = buildMapboxNavigationWithOptions(options);
     navigationWithOptions.addMilestone(new StepMilestone.Builder().build());
-    assertEquals(1, navigationWithOptions.getMilestones().size());
+
     navigationWithOptions.removeMilestone(5678);
+
     assertEquals(1, navigationWithOptions.getMilestones().size());
   }
 
   @Test
   public void getLocationEngine_returnsCorrectLocationEngine() throws Exception {
+    MapboxNavigation navigation = buildMapboxNavigation();
     LocationEngine locationEngine = mock(LocationEngine.class);
-    LocationEngine locationEngine2 = mock(LocationEngine.class);
+    LocationEngine locationEngineInstanceNotUsed = mock(LocationEngine.class);
+
     navigation.setLocationEngine(locationEngine);
-    assertNotSame(locationEngine2, navigation.getLocationEngine());
+
+    assertNotSame(locationEngineInstanceNotUsed, navigation.getLocationEngine());
     assertEquals(locationEngine, navigation.getLocationEngine());
   }
 
   @Test
   public void endNavigation_doesSendFalseToNavigationEvent() throws Exception {
+    MapboxNavigation navigation = buildMapboxNavigation();
     NavigationEventListener navigationEventListener = mock(NavigationEventListener.class);
+
     navigation.addNavigationEventListener(navigationEventListener);
     navigation.startNavigation(mock(DirectionsRoute.class));
     navigation.endNavigation();
+
     verify(navigationEventListener, times(1)).onRunning(false);
   }
 
   @Test
   public void startNavigation_doesSendTrueToNavigationEvent() throws Exception {
+    MapboxNavigation navigation = buildMapboxNavigation();
     NavigationEventListener navigationEventListener = mock(NavigationEventListener.class);
+
     navigation.addNavigationEventListener(navigationEventListener);
     navigation.startNavigation(mock(DirectionsRoute.class));
+
     verify(navigationEventListener, times(1)).onRunning(true);
   }
 
   @Test
   public void setSnapEngine_doesReplaceDefaultEngine() throws Exception {
-    Snap snap = navigation.getSnapEngine();
-    assertTrue(snap instanceof SnapToRoute);
-    snap = mock(Snap.class);
+    MapboxNavigation navigation = buildMapboxNavigation();
+
+    Snap snap = mock(Snap.class);
     navigation.setSnapEngine(snap);
+
     assertTrue(!(navigation.getSnapEngine() instanceof SnapToRoute));
-    assertTrue(navigation.getSnapEngine() instanceof Snap);
   }
 
   @Test
   public void setOffRouteEngine_doesReplaceDefaultEngine() throws Exception {
-    OffRoute offRoute = navigation.getOffRouteEngine();
-    assertTrue(offRoute instanceof OffRouteDetector);
-    offRoute = mock(OffRoute.class);
+    MapboxNavigation navigation = buildMapboxNavigation();
+
+    OffRoute offRoute = mock(OffRoute.class);
     navigation.setOffRouteEngine(offRoute);
+
     assertTrue(!(navigation.getOffRouteEngine() instanceof OffRouteDetector));
-    assertTrue(navigation.getOffRouteEngine() instanceof OffRoute);
+  }
+
+  @Test
+  public void getCameraEngine_returnsNonNullEngine() throws Exception {
+    MapboxNavigation navigation = buildMapboxNavigation();
+
+    navigation.setOffRouteEngine(null);
+
+    assertNotNull(navigation.getCameraEngine());
+  }
+
+  @Test
+  public void getCameraEngine_returnsSimpleCameraWhenNull() throws Exception {
+    MapboxNavigation navigation = buildMapboxNavigation();
+
+    navigation.setOffRouteEngine(null);
+
+    assertTrue(navigation.getCameraEngine() instanceof SimpleCamera);
+  }
+
+  private MapboxNavigation buildMapboxNavigation() {
+    return new MapboxNavigation(mock(Context.class), ACCESS_TOKEN, mock(NavigationTelemetry.class),
+      mock(LocationEngine.class));
+  }
+
+  private MapboxNavigation buildMapboxNavigationWithOptions(MapboxNavigationOptions options) {
+    return new MapboxNavigation(mock(Context.class), ACCESS_TOKEN, options, mock(NavigationTelemetry.class),
+      mock(LocationEngine.class));
   }
 }


### PR DESCRIPTION
Closes #842 

Always return default `SimpleCamera` engine if one hasn't already been initialized.

Took a moment to clean up `MapboxNavigationTest` as well. 
