### PR TITLE
Update localization.md

### DIFF
--- a/localization.md
+++ b/localization.md
@@ -3,13 +3,13 @@
 | Language   | User interface | Mapbox Voice API | Android TextToSpeech
 |------------|:--------------:|:----------------:|:---------------------:
 | Catalan    | -              | —                | —
-| Chinese    | -              | ✅               | —
+| Chinese    | -              | ✅               | ✅
 | Danish     | -              | ✅               | ✅
 | Dutch      | -              | ✅               | ✅
 | English    | ✅             | ✅               | ✅
 | French     | -              | ✅               | ✅
 | German     | -              | ✅               | ✅
-| Hebrew     | -              | ✅               | —
+| Hebrew     | -              | -                | —
 | Hungarian  | -              | —                | ✅
 | Italian    | -              | ✅               | ✅
 | Portuguese | -              | ✅               | ✅


### PR DESCRIPTION
Keeping a running list of supported languages for Android `TextToSpeech` is difficult to track in a chart like this.  The languages that can be used with `TextToSpeech` vary from device to device.  So a device may not have `English (United Kingdom)` out-of-the-box, but a user can install the voice data needed to use if they choose.  

cc @1ec5 @brsbl 