### PR TITLE
Remove app name String resource from libandroid-navigation

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -3,6 +3,12 @@ host = https://www.transifex.com
 minimum_perc = 20
 lang_map = pt_BR: pt-rBR, pt_PT: pt-rPT
 
+[mapbox-navigation-sdk-for-android.test-app-strings-file]
+file_filter = app/src/main/res/values-<lang>/strings.xml
+source_file = app/src/main/res/values/strings.xml
+source_lang = en
+type = ANDROID
+
 [mapbox-navigation-sdk-for-android.libandroid-navigation-strings-file]
 file_filter = libandroid-navigation/src/main/res/values-<lang>/strings.xml
 source_file = libandroid-navigation/src/main/res/values/strings.xml

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -1,0 +1,17 @@
+<resources>
+    <string name="title_mock_navigation">Тестова навигация</string>
+    <string name="description_mock_navigation">Имитирай навигационна сесия с тестовия локализатор.</string>
+
+    <string name="title_off_route_detection">Откриване извън маршрута</string>
+    <string name="description_off_route_detection">Използва Route Utils клас за определяне дали потребител е извън маршрута.</string>
+
+    <string name="title_reroute">Пренасочване</string>
+    <string name="description_reroute">Тествай функцията за пренасочване вътре в SDK навигацията</string>
+
+    <string name="title_navigation_route_ui">Навигационен картов маршрут</string>
+    <string name="description_navigation_route_ui">Изчертава маршрут на картата</string>
+
+    <string name="title_navigation_view_ui">Навигационни изгледи</string>
+    <string name="description_navigation_view_ui">Drop-in UI experience</string>
+
+</resources>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">Android এর জন্য ম্যাপবক্স নেভিগেশন SDK</string>
+</resources>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -1,0 +1,17 @@
+<resources>
+    <string name="title_mock_navigation">Simular navegació</string>
+    <string name="description_mock_navigation">Simular una sessió de navegació amb un motor simulat d\'ubicació.</string>
+
+    <string name="title_off_route_detection">Detecció fora de ruta</string>
+    <string name="description_off_route_detection">Empra les classes Route Utils per determinar si un usuari és fora de la ruta.</string>
+
+    <string name="title_reroute">Redirigir</string>
+    <string name="description_reroute">Prova la funció de redirecció dins del SDK de navegació</string>
+
+    <string name="title_navigation_route_ui">Mapa de navegació de la ruta</string>
+    <string name="description_navigation_route_ui">Dibuixa una ruta al mapa</string>
+
+    <string name="title_navigation_view_ui">Vistes de navegació</string>
+    <string name="description_navigation_view_ui">Experiència UI casual</string>
+
+</resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -1,0 +1,17 @@
+<resources>
+    <string name="title_mock_navigation">Simulované navigování</string>
+    <string name="description_mock_navigation">Simulované navigování využívá simulované určování polohy.</string>
+
+    <string name="title_off_route_detection">Opuštění trasy</string>
+    <string name="description_off_route_detection">Používá třídu nástrojů trasování k určení, zda uživatelé opustili trasu.</string>
+
+    <string name="title_reroute">Přepočítat</string>
+    <string name="description_reroute">Testovat funkci přepočítání trasy uvnitř navigačního SDK</string>
+
+    <string name="title_navigation_route_ui">Mapa trasy</string>
+    <string name="description_navigation_route_ui">Zobrazit trasu na mapě</string>
+
+    <string name="title_navigation_view_ui">Režim navigace</string>
+    <string name="description_navigation_view_ui">Opustit uživatelské prostředí</string>
+
+</resources>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -1,0 +1,17 @@
+<resources>
+    <string name="title_mock_navigation">Mock navigation </string>
+    <string name="description_mock_navigation">Kør en navigationsession ved hjælp af en lokations simulering </string>
+
+    <string name="title_off_route_detection">tabt rute detektion </string>
+    <string name="description_off_route_detection">Brug Route Utils class til at bestemme om brugeren har forladt ruten.</string>
+
+    <string name="title_reroute">Omdirigere</string>
+    <string name="description_reroute">Test funktionen omdirigering inde i navigation SDK </string>
+
+    <string name="title_navigation_route_ui">Navigation kort rute</string>
+    <string name="description_navigation_route_ui">Tegner en rute på kortet </string>
+
+    <string name="title_navigation_view_ui">Navigation visninger</string>
+    <string name="description_navigation_view_ui">Drop-in UI oplevelse</string>
+
+</resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,0 +1,17 @@
+<resources>
+    <string name="title_mock_navigation">Simulierte Navigation</string>
+    <string name="description_mock_navigation">Simuliere eine Navigationssitzung durch Verwendung von simulierten Standorten</string>
+
+    <string name="title_off_route_detection">Abseits der Route-Erkennung</string>
+    <string name="description_off_route_detection">Verwendet die Routenwerkzeug-Klasse, um zu erkennen, ob ein Nutzer abseits der Route ist</string>
+
+    <string name="title_reroute">Routenneuberechnung</string>
+    <string name="description_reroute">Routenneuberechnung innerhalb des Navigation SDK ausprobieren</string>
+
+    <string name="title_navigation_route_ui">Navigation / Karte / Route</string>
+    <string name="description_navigation_route_ui">Zeichnet eine Route auf der Karte</string>
+
+    <string name="title_navigation_view_ui">Navigationsansichten</string>
+    <string name="description_navigation_view_ui">Eingebautes UI Erlebnis</string>
+
+</resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1,0 +1,15 @@
+<resources>
+    <string name="title_mock_navigation">Ejemplo de navegación</string>
+    <string name="description_mock_navigation">Simula una sesión de navegación usando un ejemplo del motor de localización</string>
+
+    <string name="title_off_route_detection">Apagar detección de ruta</string>
+    <string name="title_reroute">Enrutando</string>
+    <string name="description_reroute">Prueba la función de enrutación perteneciente al SDK de navegación</string>
+
+    <string name="title_navigation_route_ui">Ruta del mapa de navegación</string>
+    <string name="description_navigation_route_ui">Dibuja un ruta en el mapa</string>
+
+    <string name="title_navigation_view_ui">Vistas de navegación</string>
+    <string name="description_navigation_view_ui">Entra en la experiencia de la interfaz</string>
+
+</resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,0 +1,17 @@
+<resources>
+    <string name="title_mock_navigation">Navigation simulée</string>
+    <string name="description_mock_navigation">Simule une session de navigation en utilisant un moteur de localisation simulée.</string>
+
+    <string name="title_off_route_detection">Détection de sortie d’itinéraire</string>
+    <string name="description_off_route_detection">Utilise la classe Utilitaires d’Itinéraire pour déterminer is un utilisateur sort de l’itinéraire prévu.</string>
+
+    <string name="title_reroute">Recalcul d’itinéraire</string>
+    <string name="description_reroute">Teste la fonction de recalcul d’itinéraire du SDK de navigation</string>
+
+    <string name="title_navigation_route_ui">Itinéraire de navigation sur carte</string>
+    <string name="description_navigation_route_ui">Trace un itinéraire sur la carte</string>
+
+    <string name="title_navigation_view_ui">Vues de navigation</string>
+    <string name="description_navigation_view_ui">Expérimentation de l’interface utilisateur</string>
+
+</resources>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">Mapbox Navigation SDK for Android</string>
+</resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">Mapbox Navigációs SDK Androidhoz</string>
+</resources>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">Mapbox Navigation SDK for Android</string>
+</resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">Mapbox Navigation SDK per Android</string>
+</resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">SDK de Navegação Mapbox para Android</string>
+</resources>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -1,0 +1,17 @@
+<resources>
+    <string name="title_mock_navigation">Navegação Simulada</string>
+    <string name="description_mock_navigation">Simule uma sessão de navegação usando um serviço de localizações simuladas.</string>
+
+    <string name="title_off_route_detection">Deteção fora de percurso</string>
+    <string name="description_off_route_detection">Usa a classe Route Utils para determinar se o utilizador está fora do percurso.</string>
+
+    <string name="title_reroute">Redirecionar</string>
+    <string name="description_reroute">Teste a função de redirecionamento dentro do SDK de navegação</string>
+
+    <string name="title_navigation_route_ui">Mapa de Percurso de Navegação</string>
+    <string name="description_navigation_route_ui">Desenha um percurso no mapa</string>
+
+    <string name="title_navigation_view_ui">Vistas de Navegação</string>
+    <string name="description_navigation_view_ui">Experiência de UI Drop-In</string>
+
+</resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1,0 +1,17 @@
+<resources>
+    <string name="title_mock_navigation">Моделирование маршрута</string>
+    <string name="description_mock_navigation">Начать моделирование маршрута c помощью эмулятора местоположения.</string>
+
+    <string name="title_off_route_detection">Движение по бездорожью</string>
+    <string name="description_off_route_detection">Используйте класс Route Utils для обнаружения движения по бездорожью</string>
+
+    <string name="title_reroute">Объезд</string>
+    <string name="description_reroute">Проверить функциональность объезда внутри Navigation SDK</string>
+
+    <string name="title_navigation_route_ui">Маршрут на карте</string>
+    <string name="description_navigation_route_ui">Отобразить маршрут на карте</string>
+
+    <string name="title_navigation_view_ui">Отображения маршрута</string>
+    <string name="description_navigation_view_ui">Различное представление маршрута на экране</string>
+
+</resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -1,0 +1,17 @@
+<resources>
+    <string name="title_mock_navigation">Simulera Navigering</string>
+    <string name="description_mock_navigation">Simulera navigering med en platsmotor</string>
+
+    <string name="title_off_route_detection">Avvägsdetektering</string>
+    <string name="description_off_route_detection">Använder klassen RouteUtils för att avgöra om en användare är på rätt väg.</string>
+
+    <string name="title_reroute">Omdirigera</string>
+    <string name="description_reroute">Testa omdirigering via Navigations SDKt</string>
+
+    <string name="title_navigation_route_ui">Navigeringskarta Rutt</string>
+    <string name="description_navigation_route_ui">Rita en rutt på kartan</string>
+
+    <string name="title_navigation_view_ui">Navigationsvyer</string>
+    <string name="description_navigation_view_ui">Drop-in användarupplevelse</string>
+
+</resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -1,0 +1,17 @@
+<resources>
+    <string name="title_mock_navigation">Симуляція навігації</string>
+    <string name="description_mock_navigation">Симуляція навігації за маршрутом з використанням рушія підстановки даних про місцеположення.</string>
+
+    <string name="title_off_route_detection">Визначення сходу з маршруту</string>
+    <string name="description_off_route_detection">Використовує клас Route Utils для визначення сходу з маршруту.</string>
+
+    <string name="title_reroute">Зміна маршрут</string>
+    <string name="description_reroute">Перевірка функції зміни маршруту в середині SDK навігації</string>
+
+    <string name="title_navigation_route_ui">Навігація - Маршрут на мапі</string>
+    <string name="description_navigation_route_ui">Показує маршрут поверх мапи</string>
+
+    <string name="title_navigation_view_ui">Навігація - Вид</string>
+    <string name="description_navigation_view_ui">Інтерфейс для вводу місця призначення.</string>
+
+</resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -1,0 +1,17 @@
+<resources>
+    <string name="title_mock_navigation">Giả bộ Điều hướng</string>
+    <string name="description_mock_navigation">Giả bộ phiên điều hướng dùng máy định vị giả.</string>
+
+    <string name="title_off_route_detection">Nhận ra Lạc đường</string>
+    <string name="description_off_route_detection">Sử dụng lớp RouteUtils để xác định người dùng bị lạc đường.</string>
+
+    <string name="title_reroute">Tìm Đường đi Mới</string>
+    <string name="description_reroute">Thử chức năng tìm đường đi mới trong SDK Điều hướng</string>
+
+    <string name="title_navigation_route_ui">Tuyến đường trên Bản đồ Điều hướng</string>
+    <string name="description_navigation_route_ui">Vẽ tuyến đường trên bản đồ</string>
+
+    <string name="title_navigation_view_ui">Khung nhìn Điều hướng</string>
+    <string name="description_navigation_view_ui">Trải nghiệm giao diện người dùng có thể xen vào</string>
+
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,6 @@
 <resources>
+    <string name="app_name">Mapbox Navigation SDK for Android</string>
+
     <string name="title_mock_navigation">Mock Navigation</string>
     <string name="description_mock_navigation">Mock a navigation session using a mock location engine.</string>
 

--- a/libandroid-navigation/src/main/res/values-bg/strings.xml
+++ b/libandroid-navigation/src/main/res/values-bg/strings.xml
@@ -1,6 +1,4 @@
 <resources>
-    <string name="app_name">MapBox SDK навигация за Android</string>
-
     <!-- Notification Strings -->
     <string name="end_navigation">Крайна навигация</string>
 </resources>

--- a/libandroid-navigation/src/main/res/values-bn/strings.xml
+++ b/libandroid-navigation/src/main/res/values-bn/strings.xml
@@ -1,6 +1,4 @@
 <resources>
-    <string name="app_name">Android এর জন্য ম্যাপবক্স নেভিগেশন SDK</string>
-
     <!-- Notification Strings -->
     <string name="end_navigation">ন্যাভিগেশন শেষ</string>
     <string name="channel_name">ন্যাভিগেশন প্রজ্ঞাপন</string>

--- a/libandroid-navigation/src/main/res/values-ca/strings.xml
+++ b/libandroid-navigation/src/main/res/values-ca/strings.xml
@@ -1,6 +1,4 @@
 <resources>
-    <string name="app_name">SDK de navegació per Android de Mapbox</string>
-
     <!-- Notification Strings -->
     <string name="end_navigation">Aturar navegació</string>
 </resources>

--- a/libandroid-navigation/src/main/res/values-cs/strings.xml
+++ b/libandroid-navigation/src/main/res/values-cs/strings.xml
@@ -1,6 +1,4 @@
 <resources>
-    <string name="app_name">Mapbox SDK navigace pro Android</string>
-
     <!-- Notification Strings -->
     <string name="end_navigation">Konec navigování</string>
     <string name="channel_name">Navigační upozornění</string>

--- a/libandroid-navigation/src/main/res/values-da/strings.xml
+++ b/libandroid-navigation/src/main/res/values-da/strings.xml
@@ -1,6 +1,4 @@
 <resources>
-    <string name="app_name">Mapbox Navigation SDK for Android</string>
-
     <!-- Notification Strings -->
     <string name="end_navigation">Slut navigation </string>
     <string name="channel_name">Navigation Notifikation </string>

--- a/libandroid-navigation/src/main/res/values-de/strings.xml
+++ b/libandroid-navigation/src/main/res/values-de/strings.xml
@@ -1,6 +1,4 @@
 <resources>
-    <string name="app_name">Mapbox Navigation SDK für Android</string>
-
     <!-- Notification Strings -->
     <string name="end_navigation">Navigation beenden</string>
     <string name="channel_name">Navigationsbenachrichtigungen</string>

--- a/libandroid-navigation/src/main/res/values-es/strings.xml
+++ b/libandroid-navigation/src/main/res/values-es/strings.xml
@@ -1,6 +1,4 @@
 <resources>
-    <string name="app_name"> Navegación Mapbox SDK para Android</string>
-
     <!-- Notification Strings -->
     <string name="end_navigation">Finaliza navegación</string>
     <string name="channel_name">Notificaciones de navegación</string>

--- a/libandroid-navigation/src/main/res/values-fr/strings.xml
+++ b/libandroid-navigation/src/main/res/values-fr/strings.xml
@@ -1,6 +1,4 @@
 <resources>
-    <string name="app_name">SDK de navigation Mapbox pour Android</string>
-
     <!-- Notification Strings -->
     <string name="end_navigation">Fin de navigation</string>
     <string name="channel_name">Notifications de navigation</string>

--- a/libandroid-navigation/src/main/res/values-he/strings.xml
+++ b/libandroid-navigation/src/main/res/values-he/strings.xml
@@ -1,6 +1,4 @@
 <resources>
-    <string name="app_name">Mapbox Navigation SDK for Android</string>
-
     <!-- Notification Strings -->
     <string name="end_navigation">סיום ניווט</string>
     <string name="channel_name">הודעות ניווט</string>

--- a/libandroid-navigation/src/main/res/values-hu/strings.xml
+++ b/libandroid-navigation/src/main/res/values-hu/strings.xml
@@ -1,6 +1,4 @@
 <resources>
-    <string name="app_name">Mapbox Navigációs SDK Androidhoz</string>
-
     <!-- Notification Strings -->
     <string name="end_navigation">Navigáció vége</string>
     <string name="channel_name">Navigációs értesítések</string>

--- a/libandroid-navigation/src/main/res/values-id/strings.xml
+++ b/libandroid-navigation/src/main/res/values-id/strings.xml
@@ -1,6 +1,4 @@
 <resources>
-    <string name="app_name">Mapbox Navigation SDK for Android</string>
-
     <!-- Notification Strings -->
     <string name="end_navigation">Akhir Navigasi</string>
 </resources>

--- a/libandroid-navigation/src/main/res/values-it/strings.xml
+++ b/libandroid-navigation/src/main/res/values-it/strings.xml
@@ -1,6 +1,4 @@
 <resources>
-    <string name="app_name">Mapbox Navigation SDK per Android</string>
-
     <!-- Notification Strings -->
     <string name="end_navigation">Termina Navigazione</string>
 </resources>

--- a/libandroid-navigation/src/main/res/values-pt-rBR/strings.xml
+++ b/libandroid-navigation/src/main/res/values-pt-rBR/strings.xml
@@ -1,6 +1,4 @@
 <resources>
-    <string name="app_name">SDK de Navegação Mapbox para Android</string>
-
     <!-- Notification Strings -->
     <string name="end_navigation">Finalizar navegação</string>
 </resources>

--- a/libandroid-navigation/src/main/res/values-pt-rPT/strings.xml
+++ b/libandroid-navigation/src/main/res/values-pt-rPT/strings.xml
@@ -1,6 +1,4 @@
 <resources>
-    <string name="app_name">SDK de Navegação Mapbox para Android</string>
-
     <!-- Notification Strings -->
     <string name="end_navigation">Terminar Navegação</string>
     <string name="channel_name">Notificações de Navegação</string>

--- a/libandroid-navigation/src/main/res/values-ru/strings.xml
+++ b/libandroid-navigation/src/main/res/values-ru/strings.xml
@@ -1,6 +1,4 @@
 <resources>
-    <string name="app_name">Навигация Mapbox для Android</string>
-
     <!-- Notification Strings -->
     <string name="end_navigation">Завершить</string>
     <string name="channel_name">Оповещения навигации</string>

--- a/libandroid-navigation/src/main/res/values-sv/strings.xml
+++ b/libandroid-navigation/src/main/res/values-sv/strings.xml
@@ -1,6 +1,4 @@
 <resources>
-    <string name="app_name">Mapbox Navigation SDK for Android</string>
-
     <!-- Notification Strings -->
     <string name="end_navigation">Avsluta Navigering</string>
     <string name="channel_name">Navigationsmeddelanden</string>

--- a/libandroid-navigation/src/main/res/values-uk/strings.xml
+++ b/libandroid-navigation/src/main/res/values-uk/strings.xml
@@ -1,6 +1,4 @@
 <resources>
-    <string name="app_name">Mapbox Navigation SDK для Android</string>
-
     <!-- Notification Strings -->
     <string name="end_navigation">Закінчити навігацію</string>
     <string name="channel_name">Навігаційні повідомлення</string>

--- a/libandroid-navigation/src/main/res/values-vi/strings.xml
+++ b/libandroid-navigation/src/main/res/values-vi/strings.xml
@@ -1,6 +1,4 @@
 <resources>
-    <string name="app_name">SDK Điều hướng của Mapbox</string>
-
     <!-- Notification Strings -->
     <string name="end_navigation">Kết thúc Điều hướng</string>
     <string name="channel_name">Thông báo Điều hướng</string>

--- a/libandroid-navigation/src/main/res/values/strings.xml
+++ b/libandroid-navigation/src/main/res/values/strings.xml
@@ -1,6 +1,4 @@
 <resources>
-    <string name="app_name">Mapbox Navigation SDK for Android</string>
-
     <!-- Notification Strings -->
     <string name="end_navigation">End Navigation</string>
     <string name="channel_name">Navigation Notifications</string>


### PR DESCRIPTION
Closes #883 

We are currently including a `String` `app_name` in our `libandroid-navigation`.  This should be removed from the library becuase it's only being used in the test app and causing conflicts with developers' `String`s that are using our library.

I also updated the Transifex config to include our test app.  There were translated strings available in Transifex that weren't being pulled down into the nav repo.  