### PR TITLE
Update String resources with new Transifex translations

### DIFF
--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -1,3 +1,10 @@
 <resources>
-    <string name="app_name">Mapbox Navigation SDK for Android</string>
+    <string name="title_mock_navigation">Navigasi Rekayasa</string>
+    <string name="title_reroute">Mengubah Rute</string>
+    <string name="title_navigation_route_ui">Navigasi Rute Peta</string>
+    <string name="description_navigation_route_ui">Gambar Rute pada Peta</string>
+
+    <string name="title_navigation_view_ui">Tampilan Navigasi</string>
+    <string name="description_navigation_view_ui">Coba Tampilan Drop-in</string>
+
 </resources>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -1,4 +1,6 @@
 <resources>
+    <string name="app_name">Navegação Mapbox SDK para Android</string>
+
     <string name="title_mock_navigation">Navegação Simulada</string>
     <string name="description_mock_navigation">Simule uma sessão de navegação usando um serviço de localizações simuladas.</string>
 
@@ -14,4 +16,20 @@
     <string name="title_navigation_view_ui">Vistas de Navegação</string>
     <string name="description_navigation_view_ui">Experiência de UI Drop-In</string>
 
+    <string name="title_waypoint_navigation">Navegação de Pontos de Passagem</string>
+    <string name="description_waypoint_navigation">Navegação com pontos de passagem entre destinos</string>
+
+    <string name="title_embedded_navigation">Navegação Embutida</string>
+    <string name="description_embedded_navigation">Navegação numa vista que contém outras vistas</string>
+
+    <string name="settings">Definições</string>
+    <string name="simulate_route">Simular Rota</string>
+    <string name="language">Idioma</string>
+    <string name="unit_type">Tipo de Unidade</string>
+    <string name="route_profile">Perfil da Rota</string>
+
+    <string name="error_route_not_available">A rota atual não está disponível</string>
+    <string name="error_select_longer_route">Por favor selecione uma rota mais longa</string>
+    <string name="error_valid_route_not_found">Não foi encontrada uma rota válida.</string>
+    <string name="explanation_long_press_waypoint">Toque longo no mapa para adicionar um ponto de passagem</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -1,4 +1,6 @@
 <resources>
+    <string name="app_name">SDK Điều hướng của Mapbox</string>
+
     <string name="title_mock_navigation">Giả bộ Điều hướng</string>
     <string name="description_mock_navigation">Giả bộ phiên điều hướng dùng máy định vị giả.</string>
 
@@ -14,4 +16,23 @@
     <string name="title_navigation_view_ui">Khung nhìn Điều hướng</string>
     <string name="description_navigation_view_ui">Trải nghiệm giao diện người dùng có thể xen vào</string>
 
+    <string name="title_waypoint_navigation">Điều hướng giữa các Tọa độ điểm</string>
+    <string name="description_waypoint_navigation">Điều hướng giữa các tọa độ điểm</string>
+
+    <string name="title_embedded_navigation">Điều hướng được Nhúng</string>
+    <string name="description_embedded_navigation">Điều hướng trong khung nhìn chứa các khung nhìn khác</string>
+
+    <string name="title_fragment_navigation">NavigationView thực hiện bằng Fragment</string>
+    <string name="description_fragment_navigation">NavigationView thực hiện bằng Fragment</string>
+
+    <string name="settings">Thiết lập</string>
+    <string name="simulate_route">Mô phỏng Tuyến đường</string>
+    <string name="language">Ngôn ngữ</string>
+    <string name="unit_type">Hệ Đo lường</string>
+    <string name="route_profile">Chế độ</string>
+
+    <string name="error_route_not_available">Tuyến đường hiện tại không có sẵn</string>
+    <string name="error_select_longer_route">Vui lòng chọn một tuyến đường dài hơn</string>
+    <string name="error_valid_route_not_found">Không tìm thấy tuyến đi được.</string>
+    <string name="explanation_long_press_waypoint">Chạm lâu vào bản đồ để thả ghim tọa độ điểm</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,11 +31,11 @@
     <string name="unit_type">Unit Type</string>
     <string name="route_profile">Route Profile</string>
 
-    <string name="unit_type_key">unit_type</string>
-    <string name="simulate_route_key">simulate_route</string>
-    <string name="language_key">language</string>
-    <string name="route_profile_key">route_profile</string>
-    <string name="language_default_value_device_locale">device_locale</string>
+    <string name="unit_type_key" translatable="false">unit_type</string>
+    <string name="simulate_route_key" translatable="false">simulate_route</string>
+    <string name="language_key" translatable="false">language</string>
+    <string name="route_profile_key" translatable="false">route_profile</string>
+    <string name="language_default_value_device_locale" translatable="false">device_locale</string>
 
     <string name="error_route_not_available">Current route is not available</string>
     <string name="error_select_longer_route">Please select a longer route</string>

--- a/libandroid-navigation-ui/src/main/res/values-bn/strings.xml
+++ b/libandroid-navigation-ui/src/main/res/values-bn/strings.xml
@@ -3,7 +3,7 @@
     <!-- Indicates that rerouting is in progress -->
     <string name="rerouting">রুট পরিবর্তন করা</string>
 
-    <!-- Button title for resume tracking -->
+    <!-- Button title for re-centering tracking -->
     <string name="re_center">আবার কেন্দ্রে আনুন</string>
 
     <!-- Indicates voice instructions are muted -->

--- a/libandroid-navigation-ui/src/main/res/values-cs/strings.xml
+++ b/libandroid-navigation-ui/src/main/res/values-cs/strings.xml
@@ -3,7 +3,7 @@
     <!-- Indicates that rerouting is in progress -->
     <string name="rerouting">Přepočítávám...</string>
 
-    <!-- Button title for resume tracking -->
+    <!-- Button title for re-centering tracking -->
     <string name="re_center">Vystředit</string>
 
     <!-- Indicates voice instructions are muted -->

--- a/libandroid-navigation-ui/src/main/res/values-da/strings.xml
+++ b/libandroid-navigation-ui/src/main/res/values-da/strings.xml
@@ -3,7 +3,7 @@
     <!-- Indicates that rerouting is in progress -->
     <string name="rerouting">Omdirigere</string>
 
-    <!-- Button title for resume tracking -->
+    <!-- Button title for re-centering tracking -->
     <string name="re_center">Genoptag</string>
 
     <!-- Indicates voice instructions are muted -->

--- a/libandroid-navigation-ui/src/main/res/values-de/strings.xml
+++ b/libandroid-navigation-ui/src/main/res/values-de/strings.xml
@@ -3,7 +3,7 @@
     <!-- Indicates that rerouting is in progress -->
     <string name="rerouting">Routenneuberechnung...</string>
 
-    <!-- Button title for resume tracking -->
+    <!-- Button title for re-centering tracking -->
     <string name="re_center">Neu zentrieren</string>
 
     <!-- Indicates voice instructions are muted -->

--- a/libandroid-navigation-ui/src/main/res/values-es/strings.xml
+++ b/libandroid-navigation-ui/src/main/res/values-es/strings.xml
@@ -3,7 +3,7 @@
     <!-- Indicates that rerouting is in progress -->
     <string name="rerouting">Enrutando</string>
 
-    <!-- Button title for resume tracking -->
+    <!-- Button title for re-centering tracking -->
     <string name="re_center">Centrando</string>
 
     <!-- Indicates voice instructions are muted -->

--- a/libandroid-navigation-ui/src/main/res/values-fr/strings.xml
+++ b/libandroid-navigation-ui/src/main/res/values-fr/strings.xml
@@ -3,7 +3,7 @@
     <!-- Indicates that rerouting is in progress -->
     <string name="rerouting">Recalcul de l’itinéraire...</string>
 
-    <!-- Button title for resume tracking -->
+    <!-- Button title for re-centering tracking -->
     <string name="re_center">Recentrer</string>
 
     <!-- Indicates voice instructions are muted -->

--- a/libandroid-navigation-ui/src/main/res/values-he/strings.xml
+++ b/libandroid-navigation-ui/src/main/res/values-he/strings.xml
@@ -3,7 +3,7 @@
     <!-- Indicates that rerouting is in progress -->
     <string name="rerouting">מחשב מסלול מחדש...</string>
 
-    <!-- Button title for resume tracking -->
+    <!-- Button title for re-centering tracking -->
     <string name="re_center">מרכוז</string>
 
     <!-- Indicates voice instructions are muted -->
@@ -45,4 +45,4 @@
     <!-- Test app dialog text cancel navigation -->
     <string name="dropoff_dialog_negative_text">ביטול</string>
 
-    </resources>
+</resources>

--- a/libandroid-navigation-ui/src/main/res/values-ko/strings.xml
+++ b/libandroid-navigation-ui/src/main/res/values-ko/strings.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Indicates that rerouting is in progress -->
+    <string name="rerouting">경로 재지정</string>
+
+    <!-- Button title for re-centering tracking -->
+    <string name="re_center">중앙으로 복귀</string>
+
+    <!-- Indicates voice instructions are muted -->
+    <string name="muted">음소거</string>
+
+    <!-- Indicates voice instructions are unmuted -->
+    <string name="unmuted">음소거 해제</string>
+
+    <!-- Feedback type for Bad Route -->
+    <string name="feedback_bad_route">잘못된 \n경로</string>
+
+    <!-- Feedback type for Confusing Instruction -->
+    <string name="feedback_confusing_instruction">\n지시 혼동</string>
+
+    <!-- Feedback type for Other Map Issue Issue -->
+    <string name="feedback_general_issue">기타\n지도 이슈</string>
+
+    <!-- Feedback type for Missing Exit -->
+    <string name="feedback_missing_exit">없어진\n출구</string>
+
+    <!-- Feedback type for Missing Road -->
+    <string name="feedback_missing_road">없어진\n도로</string>
+
+    <!-- Feedback type for a maneuver that is Not Allowed -->
+    <string name="feedback_not_allowed">이용\n불가</string>
+
+    <!-- Feedback type for Report Traffic -->
+    <string name="feedback_report_traffic">교통\n안내</string>
+
+    <!-- Feedback type for Road Closed -->
+    <string name="feedback_road_closure">통행\n금지</string>
+
+    <!-- Test app dialog text -->
+    <string name="dropoff_dialog_text">다음 목적지로 이동하시겠습니까?</string>
+
+    <!-- Test app dialog text start next route -->
+    <string name="dropoff_dialog_positive_text">다음 목적지로 이동</string>
+
+    <!-- Test app dialog text cancel navigation -->
+    <string name="dropoff_dialog_negative_text">취소</string>
+
+</resources>

--- a/libandroid-navigation-ui/src/main/res/values-pt-rPT/strings.xml
+++ b/libandroid-navigation-ui/src/main/res/values-pt-rPT/strings.xml
@@ -3,7 +3,7 @@
     <!-- Indicates that rerouting is in progress -->
     <string name="rerouting">Redirecionando...</string>
 
-    <!-- Button title for resume tracking -->
+    <!-- Button title for re-centering tracking -->
     <string name="re_center">Recentrar</string>
 
     <!-- Indicates voice instructions are muted -->

--- a/libandroid-navigation-ui/src/main/res/values-ru/strings.xml
+++ b/libandroid-navigation-ui/src/main/res/values-ru/strings.xml
@@ -3,7 +3,7 @@
     <!-- Indicates that rerouting is in progress -->
     <string name="rerouting">Пересчёт маршрута…</string>
 
-    <!-- Button title for resume tracking -->
+    <!-- Button title for re-centering tracking -->
     <string name="re_center">Возобновить</string>
 
     <!-- Indicates voice instructions are muted -->
@@ -45,4 +45,4 @@
     <!-- Test app dialog text cancel navigation -->
     <string name="dropoff_dialog_negative_text">Отмена</string>
 
-    </resources>
+</resources>

--- a/libandroid-navigation-ui/src/main/res/values-sv/strings.xml
+++ b/libandroid-navigation-ui/src/main/res/values-sv/strings.xml
@@ -3,7 +3,7 @@
     <!-- Indicates that rerouting is in progress -->
     <string name="rerouting">Uppdaterar rutt…</string>
 
-    <!-- Button title for resume tracking -->
+    <!-- Button title for re-centering tracking -->
     <string name="re_center">Centrera</string>
 
     <!-- Indicates voice instructions are muted -->
@@ -45,4 +45,4 @@
     <!-- Test app dialog text cancel navigation -->
     <string name="dropoff_dialog_negative_text">Avbryt</string>
 
-    </resources>
+</resources>

--- a/libandroid-navigation-ui/src/main/res/values-uk/strings.xml
+++ b/libandroid-navigation-ui/src/main/res/values-uk/strings.xml
@@ -3,7 +3,7 @@
     <!-- Indicates that rerouting is in progress -->
     <string name="rerouting">Зміна маршруту…</string>
 
-    <!-- Button title for resume tracking -->
+    <!-- Button title for re-centering tracking -->
     <string name="re_center">Центрувати</string>
 
     <!-- Indicates voice instructions are muted -->

--- a/libandroid-navigation-ui/src/main/res/values-vi/strings.xml
+++ b/libandroid-navigation-ui/src/main/res/values-vi/strings.xml
@@ -3,7 +3,7 @@
     <!-- Indicates that rerouting is in progress -->
     <string name="rerouting">Đang Tìm Đường đi Mới…</string>
 
-    <!-- Button title for resume tracking -->
+    <!-- Button title for re-centering tracking -->
     <string name="re_center">Quay về Đường đi</string>
 
     <!-- Indicates voice instructions are muted -->

--- a/libandroid-navigation/src/main/res/values-ko/strings.xml
+++ b/libandroid-navigation/src/main/res/values-ko/strings.xml
@@ -1,8 +1,8 @@
 <resources>
     <!-- Notification Strings -->
-    <string name="end_navigation">Terminar Navegação</string>
-    <string name="channel_name">Notificações de Navegação</string>
-    <string name="notification_arrival_time_format">Chegada às %s</string>
+    <string name="end_navigation">네비게이션 종료</string>
+    <string name="channel_name">네비게이션 알림</string>
+    <string name="notification_arrival_time_format">%s 에 도착</string>
     <string name="kilometers">km</string>
     <string name="meters">m</string>
     <string name="miles">mi</string>

--- a/libandroid-navigation/src/main/res/values-vi/strings.xml
+++ b/libandroid-navigation/src/main/res/values-vi/strings.xml
@@ -3,4 +3,8 @@
     <string name="end_navigation">Kết thúc Điều hướng</string>
     <string name="channel_name">Thông báo Điều hướng</string>
     <string name="notification_arrival_time_format">Đến nơi %s</string>
+    <string name="kilometers">km</string>
+    <string name="meters">m</string>
+    <string name="miles">dặm</string>
+    <string name="feet">foot</string>
 </resources>


### PR DESCRIPTION
Closes #888 

We also had uploaded test app strings being used as keys, which are not translatable.  I marked them as such [here](https://github.com/mapbox/mapbox-navigation-android/compare/dan-update-tx?expand=1#diff-01dafb3fd0217441330103cfc8300094R34). 