### PR TITLE
Add missing uturn step maneuver modifier to should flip modifiers set

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/maneuver/ManeuverView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/maneuver/ManeuverView.java
@@ -21,6 +21,8 @@ import static com.mapbox.services.android.navigation.v5.navigation.NavigationCon
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.STEP_MANEUVER_MODIFIER_LEFT;
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.STEP_MANEUVER_MODIFIER_SHARP_LEFT;
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.STEP_MANEUVER_MODIFIER_SLIGHT_LEFT;
+
+import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.STEP_MANEUVER_MODIFIER_UTURN;
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.STEP_MANEUVER_TYPE_ARRIVE;
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.STEP_MANEUVER_TYPE_EXIT_ROTARY;
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.STEP_MANEUVER_TYPE_FORK;
@@ -43,6 +45,7 @@ public class ManeuverView extends View {
       add(STEP_MANEUVER_MODIFIER_SLIGHT_LEFT);
       add(STEP_MANEUVER_MODIFIER_LEFT);
       add(STEP_MANEUVER_MODIFIER_SHARP_LEFT);
+      add(STEP_MANEUVER_MODIFIER_UTURN);
     }
   };
   private static final Set<String> ROUNDABOUT_MANEUVER_TYPES = new HashSet<String>() {


### PR DESCRIPTION
- Adds missing uturn step maneuver modifier to should flip modifiers set

Fixes 👇

![uturn_resource_should_flip](https://user-images.githubusercontent.com/1668582/39545811-2ab3ff1a-4e07-11e8-8d50-807ccc965d57.png)
