### PR TITLE
Added null check to make sure a file is actually returned

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/voice/InstructionDownloadTask.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/voice/InstructionDownloadTask.java
@@ -1,6 +1,7 @@
 package com.mapbox.services.android.navigation.ui.v5.voice;
 
 import android.os.AsyncTask;
+import android.support.annotation.NonNull;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -81,7 +82,7 @@ class InstructionDownloadTask extends AsyncTask<ResponseBody, Void, File> {
   }
 
   public interface TaskListener {
-    void onFinishedDownloading(File file);
+    void onFinishedDownloading(@NonNull File file);
 
     void onErrorDownloading();
   }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/voice/InstructionDownloadTask.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/voice/InstructionDownloadTask.java
@@ -73,7 +73,11 @@ class InstructionDownloadTask extends AsyncTask<ResponseBody, Void, File> {
 
   @Override
   protected void onPostExecute(File instructionFile) {
-    taskListener.onFinishedDownloading(instructionFile);
+    if (instructionFile == null) {
+      taskListener.onErrorDownloading();
+    } else {
+      taskListener.onFinishedDownloading(instructionFile);
+    }
   }
 
   public interface TaskListener {

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/voice/InstructionListener.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/voice/InstructionListener.java
@@ -1,6 +1,6 @@
 package com.mapbox.services.android.navigation.ui.v5.voice;
 
-public interface InstructionListener {
+interface InstructionListener {
 
   void onStart();
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/voice/MapboxSpeechPlayer.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/voice/MapboxSpeechPlayer.java
@@ -245,7 +245,7 @@ public class MapboxSpeechPlayer implements InstructionPlayer {
   private void executeInstructionTask(ResponseBody responseBody) {
     new InstructionDownloadTask(mapboxCache.getPath(), new InstructionDownloadTask.TaskListener() {
       @Override
-      public void onFinishedDownloading(File instructionFile) {
+      public void onFinishedDownloading(@NonNull File instructionFile) {
         playInstructionIfUpNext(instructionFile);
         instructionQueue.add(instructionFile);
       }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/voice/NavigationInstructionPlayer.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/voice/NavigationInstructionPlayer.java
@@ -67,9 +67,9 @@ public class NavigationInstructionPlayer implements InstructionListener {
 
   @Override
   public void onError(boolean isMapboxPlayer) {
-    if (isMapboxPlayer) { // If mapbox player failed, try android speech player
+    if (isMapboxPlayer) {
       androidSpeechPlayer.play(instructionQueue.peek().getAnnouncement());
-    } else { // If android speech player fails, just drop the instruction
+    } else {
       instructionQueue.remove();
     }
   }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/voice/NavigationInstructionPlayer.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/voice/NavigationInstructionPlayer.java
@@ -18,7 +18,6 @@ public class NavigationInstructionPlayer implements InstructionListener {
   private AudioFocusRequest instructionFocusRequest;
   private MapboxSpeechPlayer mapboxSpeechPlayer;
   private AndroidSpeechPlayer androidSpeechPlayer;
-  private InstructionListener instructionListener;
   private Queue<VoiceInstructionMilestone> instructionQueue;
   private boolean isMuted;
 
@@ -55,35 +54,19 @@ public class NavigationInstructionPlayer implements InstructionListener {
     androidSpeechPlayer.onDestroy();
   }
 
-  public void setInstructionListener(InstructionListener instructionListener) {
-    this.instructionListener = instructionListener;
-  }
-
   @Override
   public void onStart() {
-    if (instructionListener != null) {
-      instructionListener.onStart();
-    }
-
     requestAudioFocus();
     instructionQueue.remove();
   }
 
   @Override
   public void onDone() {
-    if (instructionListener != null) {
-      instructionListener.onDone();
-    }
-
     abandonAudioFocus();
   }
 
   @Override
   public void onError(boolean isMapboxPlayer) {
-    if (instructionListener != null) {
-      instructionListener.onError(isMapboxPlayer);
-    }
-
     if (isMapboxPlayer) { // If mapbox player failed, try android speech player
       androidSpeechPlayer.play(instructionQueue.peek().getAnnouncement());
     } else { // If android speech player fails, just drop the instruction


### PR DESCRIPTION
I had made the false assumption that this code would only be reached if a file was successfully downloaded. Now, when there is an error, `onErrorDownloading` is called instead of `onFinishedDownloading`.


Fixes #921 

