### PR TITLE
Add upcoming maneuver arrow on the route line

### DIFF
--- a/app/src/main/res/layout/activity_embedded_navigation.xml
+++ b/app/src/main/res/layout/activity_embedded_navigation.xml
@@ -8,7 +8,7 @@
         android:id="@+id/navigationView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:navigationLightTheme="@style/NavigationViewLight"
+        app:navigationLightTheme="@style/CustomNavigationView"
         app:navigationDarkTheme="@style/NavigationViewDark"/>
     <TextView
         android:layout_width="wrap_content"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -3,4 +3,5 @@
     <color name="colorPrimary">#8D64F9</color>
     <color name="colorPrimaryDark">#7845F3</color>
     <color name="colorAccent">#F56FA3</color>
+    <color name="red">#FF0000</color>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,5 +1,13 @@
 <resources>
 
+    <style name="CustomNavigationMapRoute" parent="NavigationMapRoute">
+        <item name="upcomingManeuverArrowBorderColor">@color/red</item>
+    </style>
+
+    <style name="CustomNavigationView" parent="NavigationViewLight">
+        <item name="navigationViewRouteStyle">@style/CustomNavigationMapRoute</item>
+    </style>
+
     <!-- Base application theme. -->
     <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
         <!-- Customize your theme here. -->

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
@@ -213,10 +213,6 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
   @Override
   public void onMapReady(MapboxMap mapboxMap) {
     map = mapboxMap;
-    initializeRoute();
-    initializeLocationLayer();
-    initializeMapPadding();
-    initializeLocationLayerObserver();
     initializeNavigationPresenter();
     initializeClickListeners();
     map.addOnScrollListener(NavigationView.this);
@@ -370,6 +366,10 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
       navigationViewModel.initializeNavigation(options);
       initializeNavigationListeners(options, navigationViewModel.getNavigation());
       initializeNavigationCamera();
+      initializeRoute();
+      initializeLocationLayer();
+      initializeMapPadding();
+      initializeLocationLayerObserver();
       subscribeViewModels();
       isInitialized = true;
     } else {
@@ -486,7 +486,7 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
    */
   private void initializeRoute() {
     int routeStyleRes = ThemeSwitcher.retrieveNavigationViewStyle(getContext(), R.attr.navigationViewRouteStyle);
-    mapRoute = new NavigationMapRoute(null, mapView, map, routeStyleRes);
+    mapRoute = new NavigationMapRoute(navigationViewModel.getNavigation(), mapView, map, routeStyleRes);
   }
 
   /**

--- a/libandroid-navigation-ui/src/main/res/drawable/ic_arrow_head.xml
+++ b/libandroid-navigation-ui/src/main/res/drawable/ic_arrow_head.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="72dp"
+        android:height="72dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="@color/mapbox_navigation_route_upcoming_maneuver_arrow_color"
+        android:pathData="M7,14l5,-5 5,5z"/>
+</vector>

--- a/libandroid-navigation-ui/src/main/res/drawable/ic_arrow_head_casing.xml
+++ b/libandroid-navigation-ui/src/main/res/drawable/ic_arrow_head_casing.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="96dp"
+        android:height="96dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="@color/mapbox_navigation_route_upcoming_maneuver_arrow_border_color"
+        android:pathData="M7,14l5,-5 5,5z"/>
+</vector>

--- a/libandroid-navigation-ui/src/main/res/values/attrs.xml
+++ b/libandroid-navigation-ui/src/main/res/values/attrs.xml
@@ -21,6 +21,8 @@
     <attr name="routeScale" format="float"/>
     <attr name="alternativeRouteScale" format="float"/>
 
+    <attr name="upcomingManeuverArrowColor" format="color"/>
+    <attr name="upcomingManeuverArrowBorderColor" format="color"/>
   </declare-styleable>
 
   <declare-styleable name="NavigationView">

--- a/libandroid-navigation-ui/src/main/res/values/colors.xml
+++ b/libandroid-navigation-ui/src/main/res/values/colors.xml
@@ -12,6 +12,9 @@
   <color name="mapbox_navigation_route_alternative_congestion_red">#B58281</color>
   <color name="mapbox_navigation_route_alternative_shield_color">#727E8D</color>
 
+  <color name="mapbox_navigation_route_upcoming_maneuver_arrow_color">#FFFFFF</color>
+  <color name="mapbox_navigation_route_upcoming_maneuver_arrow_border_color">#2D3F53</color>
+
   <!-- Default Light Theme -->
   <color name="mapbox_navigation_view_color_primary">#FFFFFF</color>
   <color name="mapbox_navigation_view_color_secondary">#28353D</color>

--- a/libandroid-navigation-ui/src/main/res/values/styles.xml
+++ b/libandroid-navigation-ui/src/main/res/values/styles.xml
@@ -10,6 +10,8 @@
 
         <!-- Scales -->
         <item name="routeScale">1.0</item>
+        <item name="upcomingManeuverArrowColor">@color/mapbox_navigation_route_upcoming_maneuver_arrow_color</item>
+        <item name="upcomingManeuverArrowBorderColor">@color/mapbox_navigation_route_upcoming_maneuver_arrow_border_color</item>
     </style>
 
     <style name="NavigationViewLight" parent="Theme.AppCompat.Light.NoActionBar">


### PR DESCRIPTION
- Fixes https://github.com/mapbox/mapbox-navigation-android/issues/604

![upcoming_maneuver_arrow](https://user-images.githubusercontent.com/1668582/40004469-117ea00c-5796-11e8-86c4-cad5c23576ee.gif)

TODO
- [ ] Unit tests
- [x] Make the arrow’s color styleable instead of always red/white
- [x] 👀 behavior when off route
- [x] Add _Expressions_ so that the arrow looks better under different zoom levels