### PR TITLE
Resume navigation state based on MapboxNavigation running

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
@@ -111,10 +111,9 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
    * @param savedInstanceState to restore state if not null
    */
   public void onCreate(@Nullable Bundle savedInstanceState) {
-    resumeState = savedInstanceState != null;
     mapView.setStyleUrl(ThemeSwitcher.retrieveMapStyle(getContext()));
     mapView.onCreate(savedInstanceState);
-    navigationViewModel.onCreate(resumeState);
+    navigationViewModel.onCreate();
   }
 
   /**
@@ -151,6 +150,7 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
       summaryBehavior.getState());
     outState.putBoolean(getContext().getString(R.string.recenter_btn_visible),
       recenterBtn.getVisibility() == View.VISIBLE);
+    outState.putBoolean(getContext().getString(R.string.navigation_running), navigationViewModel.isRunning());
     mapView.onSaveInstanceState(outState);
   }
 
@@ -165,6 +165,7 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
     boolean isVisible = savedInstanceState.getBoolean(getContext().getString(R.string.recenter_btn_visible));
     recenterBtn.setVisibility(isVisible ? View.VISIBLE : View.INVISIBLE);
     int bottomSheetState = savedInstanceState.getInt(getContext().getString(R.string.bottom_sheet_state));
+    resumeState = savedInstanceState.getBoolean(getContext().getString(R.string.navigation_running));
     resetBottomSheetState(bottomSheetState);
   }
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
@@ -68,7 +68,7 @@ public class NavigationViewModel extends AndroidViewModel {
   private int unitType;
   @NavigationTimeFormat.Type
   private int timeFormatType;
-  private boolean resumeState;
+  private boolean isRunning;
   private String accessToken;
 
   public NavigationViewModel(Application application) {
@@ -79,9 +79,8 @@ public class NavigationViewModel extends AndroidViewModel {
     initNavigationLocationEngine();
   }
 
-  public void onCreate(boolean resumeState) {
-    this.resumeState = resumeState;
-    if (!resumeState) {
+  public void onCreate() {
+    if (!isRunning) {
       locationEngineConductor.onCreate();
     }
   }
@@ -162,7 +161,7 @@ public class NavigationViewModel extends AndroidViewModel {
     initLocaleInfo(navigationOptions);
     initTimeFormat(navigationOptions);
     initVoiceInstructions();
-    if (!resumeState) {
+    if (!isRunning) {
       locationEngineConductor.initializeLocationEngine(getApplication(), options.shouldSimulateRoute());
       initNavigation(getApplication(), navigationOptions);
       navigationViewRouteEngine.extractRouteOptions(getApplication(), options);
@@ -178,6 +177,10 @@ public class NavigationViewModel extends AndroidViewModel {
       this.screenshot = screenshot;
     }
     shouldRecordScreenshot.setValue(false);
+  }
+
+  boolean isRunning() {
+    return isRunning;
   }
 
   private void initConnectivityManager(Application application) {
@@ -257,8 +260,9 @@ public class NavigationViewModel extends AndroidViewModel {
 
   private NavigationEventListener navigationEventListener = new NavigationEventListener() {
     @Override
-    public void onRunning(boolean running) {
-      if (running) {
+    public void onRunning(boolean isRunning) {
+      NavigationViewModel.this.isRunning = isRunning;
+      if (isRunning) {
         navigationViewEventDispatcher.onNavigationRunning();
       } else {
         navigationViewEventDispatcher.onNavigationFinished();

--- a/libandroid-navigation-ui/src/main/res/values/strings.xml
+++ b/libandroid-navigation-ui/src/main/res/values/strings.xml
@@ -60,4 +60,6 @@
             translatable="false">recenter_btn_visible</string>
     <string name="bottom_sheet_state"
             translatable="false">bottom_sheet_state</string>
+    <string name="navigation_running"
+            translatable="false">navigation_running</string>
 </resources>


### PR DESCRIPTION
The UI was getting stuck when initialized in night mode - this is because the Android framework quickly recreates the activity when it 👀 sees it's in night mode so the `Bundle savedInstanceState` is not `null`.  But, navigation has not begun yet, so navigation was failing to start.  

This PR now makes the navigation view look at if navigation is running instead of the saved instance state being null - a much more reliable way to resume navigation after rotation. 