### PR TITLE
Reset EventDispatcher in onDestroy

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
@@ -91,6 +91,7 @@ public class NavigationViewModel extends AndroidViewModel {
       endNavigation();
       deactivateInstructionPlayer();
     }
+    navigationViewEventDispatcher = null;
   }
 
   public void setMuted(boolean isMuted) {


### PR DESCRIPTION
@devotaaabel and I were seeing a leak, I believe a regression resulting from #923.  

`NavigationViewModel` was holding the instance of `NavigationViewEventDispatcher` on rotation.