### PR TITLE
Update InstructionView with BannerMilestone only with callback

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/BannerInstructionModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/BannerInstructionModel.java
@@ -3,27 +3,25 @@ package com.mapbox.services.android.navigation.ui.v5.instruction;
 import android.content.Context;
 
 import com.mapbox.api.directions.v5.DirectionsCriteria;
-import com.mapbox.api.directions.v5.models.BannerText;
 import com.mapbox.services.android.navigation.v5.milestone.BannerInstructionMilestone;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 
 public class BannerInstructionModel extends InstructionModel {
 
-  private BannerInstructionMilestone milestone;
-
   public BannerInstructionModel(Context context, BannerInstructionMilestone milestone, RouteProgress progress,
                                 String language, @DirectionsCriteria.VoiceUnitCriteria String unitType) {
     super(context, progress, language, unitType);
-    this.milestone = milestone;
+    primaryBannerText = milestone.getBannerInstructions().primary();
+    secondaryBannerText = milestone.getBannerInstructions().secondary();
   }
 
   @Override
-  BannerText getPrimaryBannerText() {
-    return milestone.getBannerInstructions().primary();
+  String getManeuverType() {
+    return primaryBannerText.type();
   }
 
   @Override
-  BannerText getSecondaryBannerText() {
-    return milestone.getBannerInstructions().secondary();
+  String getManeuverModifier() {
+    return primaryBannerText.modifier();
   }
 }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionModel.java
@@ -11,8 +11,8 @@ import com.mapbox.services.android.navigation.v5.utils.RouteUtils;
 
 public class InstructionModel {
 
-  private BannerText primaryBannerText;
-  private BannerText secondaryBannerText;
+  BannerText primaryBannerText;
+  BannerText secondaryBannerText;
   private BannerText thenBannerText;
   private Float roundaboutAngle = null;
   private InstructionStepResources stepResources;
@@ -48,6 +48,14 @@ public class InstructionModel {
 
   InstructionStepResources getStepResources() {
     return stepResources;
+  }
+
+  String getManeuverType() {
+    return stepResources.getManeuverViewType();
+  }
+
+  String getManeuverModifier() {
+    return stepResources.getManeuverViewModifier();
   }
 
   RouteProgress getProgress() {


### PR DESCRIPTION
Noticed this while testing:
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/8434572/40449951-2495041a-5ea8-11e8-8106-9bee73e261f3.gif)

This PR ensures we only update the `InstructionView` when the milestone listener is fired and not with every update which is what was happening previously.  

I also added the maneuver type and modifier from the `BannerText` object as well.