### PR TITLE
Always provide DirectionsRoute in NavigationActivity

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationActivity.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationActivity.java
@@ -7,6 +7,7 @@ import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
 
 import com.mapbox.api.directions.v5.DirectionsCriteria;
+import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.services.android.navigation.ui.v5.listeners.NavigationListener;
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigationOptions;
 import com.mapbox.services.android.navigation.v5.navigation.NavigationConstants;
@@ -19,7 +20,6 @@ import com.mapbox.services.android.navigation.v5.navigation.NavigationConstants;
 public class NavigationActivity extends AppCompatActivity implements OnNavigationReadyCallback, NavigationListener {
 
   private NavigationView navigationView;
-  private boolean isRunning;
 
   @Override
   protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -60,7 +60,6 @@ public class NavigationActivity extends AppCompatActivity implements OnNavigatio
   @Override
   protected void onSaveInstanceState(Bundle outState) {
     navigationView.onSaveInstanceState(outState);
-    outState.putBoolean(NavigationConstants.NAVIGATION_VIEW_RUNNING, isRunning);
     super.onSaveInstanceState(outState);
   }
 
@@ -68,7 +67,6 @@ public class NavigationActivity extends AppCompatActivity implements OnNavigatio
   protected void onRestoreInstanceState(Bundle savedInstanceState) {
     super.onRestoreInstanceState(savedInstanceState);
     navigationView.onRestoreInstanceState(savedInstanceState);
-    isRunning = savedInstanceState.getBoolean(NavigationConstants.NAVIGATION_VIEW_RUNNING);
   }
 
   @Override
@@ -94,14 +92,10 @@ public class NavigationActivity extends AppCompatActivity implements OnNavigatio
     MapboxNavigationOptions.Builder navigationOptions = MapboxNavigationOptions.builder();
     NavigationViewOptions.Builder options = NavigationViewOptions.builder();
     options.navigationListener(this);
-    if (!isRunning) {
-      extractRoute(options);
-    }
+    extractRoute(options);
     extractConfiguration(options, navigationOptions);
-
     options.navigationOptions(navigationOptions.build());
     navigationView.startNavigation(options.build());
-    isRunning = true;
   }
 
   @Override
@@ -122,7 +116,8 @@ public class NavigationActivity extends AppCompatActivity implements OnNavigatio
   }
 
   private void extractRoute(NavigationViewOptions.Builder options) {
-    options.directionsRoute(NavigationLauncher.extractRoute(this));
+    DirectionsRoute route = NavigationLauncher.extractRoute(this);
+    options.directionsRoute(route);
   }
 
   private void extractConfiguration(NavigationViewOptions.Builder options,

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationLauncher.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationLauncher.java
@@ -10,22 +10,17 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.mapbox.api.directions.v5.DirectionsAdapterFactory;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
-import com.mapbox.geojson.Point;
 import com.mapbox.services.android.navigation.v5.navigation.NavigationConstants;
 
 /**
  * Use this class to launch the navigation UI
  * <p>
- * You can launch the UI with either a route you have already retrieved from
- * {@link com.mapbox.services.android.navigation.v5.navigation.NavigationRoute} or you can pass a
- * {@link Point} origin and {@link Point} destination and the UI will request the {@link DirectionsRoute}
- * while initializing.
- * </p><p>
- * You have an option to include a AWS Cognito Pool ID, which will initialize the UI with AWS Polly Voice instructions
+ * You can launch the UI a route you have already retrieved from
+ * {@link com.mapbox.services.android.navigation.v5.navigation.NavigationRoute}.
  * </p><p>
  * For testing, you can launch with simulation, in which our
  * {@link com.mapbox.services.android.navigation.v5.location.MockLocationEngine} will begin
- * following the given {@link DirectionsRoute} once the UI is initialized
+ * following the given {@link DirectionsRoute} once the UI is initialized.
  * </p>
  */
 public class NavigationLauncher {
@@ -41,7 +36,7 @@ public class NavigationLauncher {
     SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(activity);
     SharedPreferences.Editor editor = preferences.edit();
 
-    storeRouteOptions(options, editor);
+    storeDirectionsRouteValue(options, editor);
     storeConfiguration(options, editor);
 
     storeThemePreferences(options, editor);
@@ -67,13 +62,9 @@ public class NavigationLauncher {
     return DirectionsRoute.fromJson(directionsRouteJson);
   }
 
-  private static void storeRouteOptions(NavigationLauncherOptions options, SharedPreferences.Editor editor) {
-    if (options.directionsRoute() != null) {
-      storeDirectionsRouteValue(options, editor);
-    } else {
-      throw new RuntimeException("A valid DirectionsRoute or origin and "
-        + "destination must be provided in NavigationViewOptions");
-    }
+  private static void storeDirectionsRouteValue(NavigationLauncherOptions options, SharedPreferences.Editor editor) {
+    editor.putString(NavigationConstants.NAVIGATION_VIEW_ROUTE_KEY, new GsonBuilder()
+      .registerTypeAdapterFactory(DirectionsAdapterFactory.create()).create().toJson(options.directionsRoute()));
   }
 
   private static void storeConfiguration(NavigationLauncherOptions options, SharedPreferences.Editor editor) {
@@ -95,10 +86,5 @@ public class NavigationLauncher {
         editor.putInt(NavigationConstants.NAVIGATION_VIEW_DARK_THEME, options.darkThemeResId());
       }
     }
-  }
-
-  private static void storeDirectionsRouteValue(NavigationLauncherOptions options, SharedPreferences.Editor editor) {
-    editor.putString(NavigationConstants.NAVIGATION_VIEW_ROUTE_KEY, new GsonBuilder()
-      .registerTypeAdapterFactory(DirectionsAdapterFactory.create()).create().toJson(options.directionsRoute()));
   }
 }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
@@ -256,7 +256,6 @@ public class NavigationViewModel extends AndroidViewModel {
     @Override
     public void userOffRoute(Location location) {
       if (hasNetworkConnection()) {
-        instructionPlayer.onOffRoute();
         Point newOrigin = Point.fromLngLat(location.getLongitude(), location.getLatitude());
         sendEventOffRoute(newOrigin);
       }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/ViewRouteFetcher.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/ViewRouteFetcher.java
@@ -77,10 +77,8 @@ public class ViewRouteFetcher extends RouteFetcher implements RouteListener {
 
   private void extractRouteFromOptions(NavigationViewOptions options) {
     DirectionsRoute route = options.directionsRoute();
-    if (route != null) {
-      cacheRouteInformation(options, route);
-      updateCurrentRoute(route);
-    }
+    cacheRouteInformation(options, route);
+    updateCurrentRoute(route);
   }
 
   private void cacheRouteInformation(NavigationViewOptions options, DirectionsRoute route) {

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/voice/NavigationInstructionPlayer.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/voice/NavigationInstructionPlayer.java
@@ -56,7 +56,7 @@ public class NavigationInstructionPlayer implements InstructionListener {
   @Override
   public void onStart() {
     requestAudioFocus();
-    instructionQueue.remove();
+    instructionQueue.poll();
   }
 
   @Override
@@ -69,7 +69,7 @@ public class NavigationInstructionPlayer implements InstructionListener {
     if (isMapboxPlayer) {
       androidSpeechPlayer.play(instructionQueue.peek().getAnnouncement());
     } else {
-      instructionQueue.remove();
+      instructionQueue.poll();
     }
   }
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationConstants.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationConstants.java
@@ -185,13 +185,6 @@ public final class NavigationConstants {
   public static final int NAVIGATION_HIGH_ALERT_DURATION = 15;
 
   /**
-   * Constant used to store running state in navigation view.
-   *
-   * @since 0.10.0
-   */
-  public static final String NAVIGATION_VIEW_RUNNING = "navigation_view_running";
-
-  /**
    * Default location acceptable accuracy threshold
    * used in {@link com.mapbox.services.android.navigation.v5.location.LocationValidator}.
    * <p>


### PR DESCRIPTION
`NavigationLauncherOptions` now requires a `DirectionsRoute` every time you build an instance. 

This  PR updates `NavigationActivity` to always provide the original route stored in `SharedPreferences`.  This is okay because, when initializing, the `NavigationViewModel` ignores the route provided if it's already running (after rotation it will be already running because the view model survives rotation).