### PR TITLE
Update to MAS 3.3.0 and add approaches / waypointNames to NavigationRoute

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -9,7 +9,7 @@ ext {
 
   version = [
       mapboxMapSdk       : '6.1.3',
-      mapboxSdkServices  : '3.2.0',
+      mapboxSdkServices  : '3.3.0',
       mapboxEvents       : '3.1.2',
       locationLayerPlugin: '0.5.3',
       autoValue          : '1.5',

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRoute.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRoute.java
@@ -441,6 +441,41 @@ public final class NavigationRoute {
     }
 
     /**
+     * Indicates from which side of the road to approach a waypoint.
+     * Accepts <tt>unrestricted</tt> (default), <tt>curb</tt> or <tt>null</tt>.
+     * If set to <tt>unrestricted</tt>, the route can approach waypoints
+     * from either side of the road. If set to <tt>curb</tt>, the route will be returned
+     * so that on arrival, the waypoint will be found on the side that corresponds with the
+     * <tt>driving_side</tt> of the region in which the returned route is located.
+     * If provided, the list of approaches must be the same length as the list of waypoints.
+     *
+     * @param approaches null if you'd like the default approaches,
+     *                   else one of the options found in
+     *                   {@link com.mapbox.api.directions.v5.DirectionsCriteria.ApproachesCriteria}.
+     * @return this builder for chaining options together
+     * @since 0.15.0
+     */
+    public Builder addApproaches(String... approaches) {
+      directionsBuilder.addApproaches(approaches);
+      return this;
+    }
+
+    /**
+     * Custom names for waypoints used for the arrival instruction,
+     * each separated by <tt>;</tt>. Values can be any string and total number of all characters cannot
+     * exceed 500. If provided, the list of <tt>waypointNames</tt> must be the same length as the list of
+     * coordinates, but you can skip a coordinate and show its position with the <tt>;</tt> separator.
+     *
+     * @param waypointNames Custom names for waypoints used for the arrival instruction.
+     * @return this builder for chaining options together
+     * @since 0.15.0
+     */
+    public Builder addWaypointNames(@Nullable String... waypointNames) {
+      directionsBuilder.addWaypointNames(waypointNames);
+      return this;
+    }
+
+    /**
      * Optionally create a {@link Builder} based on all variables
      * from given {@link RouteOptions}.
      * <p>
@@ -488,6 +523,16 @@ public final class NavigationRoute {
 
       if (!TextUtils.isEmpty(options.annotations())) {
         directionsBuilder.annotations(options.annotations());
+      }
+
+      if (!TextUtils.isEmpty(options.approaches())) {
+        String[] approaches = options.approaches().split(";");
+        directionsBuilder.addApproaches(approaches);
+      }
+
+      if (!TextUtils.isEmpty(options.waypointNames())) {
+        String[] waypointNames = options.waypointNames().split(";");
+        directionsBuilder.addWaypointNames(waypointNames);
       }
 
       return this;

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 
 public class NavigationRouteTest extends BaseTest {
+
   @Mock
   private Context context;
   @Mock
@@ -57,6 +58,34 @@ public class NavigationRouteTest extends BaseTest {
 
     assertThat(navigationRoute.getCall().request().url().toString(),
       containsString("/cycling/"));
+  }
+
+  @Test
+  public void addApproachesIncludedInRequest() {
+    NavigationRoute navigationRoute = NavigationRoute.builder(context, localeUtils)
+      .accessToken(ACCESS_TOKEN)
+      .origin(Point.fromLngLat(1.0, 2.0))
+      .destination(Point.fromLngLat(1.0, 5.0))
+      .profile(DirectionsCriteria.PROFILE_CYCLING)
+      .addApproaches(DirectionsCriteria.APPROACH_CURB, DirectionsCriteria.APPROACH_UNRESTRICTED)
+      .build();
+
+    assertThat(navigationRoute.getCall().request().url().toString(),
+      containsString("curb"));
+  }
+
+  @Test
+  public void addWaypointNamesIncludedInRequest() {
+    NavigationRoute navigationRoute = NavigationRoute.builder(context, localeUtils)
+      .accessToken(ACCESS_TOKEN)
+      .origin(Point.fromLngLat(1.0, 2.0))
+      .destination(Point.fromLngLat(1.0, 5.0))
+      .profile(DirectionsCriteria.PROFILE_CYCLING)
+      .addWaypointNames("Origin", "Destination")
+      .build();
+
+    assertThat(navigationRoute.getCall().request().url().toString(),
+      containsString("Destination"));
   }
 
   @Test
@@ -102,6 +131,8 @@ public class NavigationRouteTest extends BaseTest {
       .voiceUnits(DirectionsCriteria.METRIC)
       .user("example_user")
       .geometries("mocked_geometries")
+      .approaches("curb;unrestricted")
+      .waypointNames("Origin;Destination")
       .build();
 
     NavigationRoute navigationRoute = NavigationRoute.builder(context, localeUtils)
@@ -118,5 +149,7 @@ public class NavigationRouteTest extends BaseTest {
     assertThat(request, containsString("example_user"));
     assertThat(request, containsString("language=en"));
     assertThat(request, containsString("walking"));
+    assertThat(request, containsString("curb"));
+    assertThat(request, containsString("Origin"));
   }
 }


### PR DESCRIPTION
Closes #949 closes #971 

Note: current branch is using MAS `SNAPSHOT` - MAS `3.3.0` needs to be released and the `SNAPSHOT` dependency removed before this PR can merge.  

cc @osana 