### PR TITLE
Update repositories block in build.gradle to have google() as the first entry

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,9 +5,9 @@ buildscript {
   apply from: "${rootDir}/gradle/dependencies.gradle"
 
   repositories {
-    maven { url 'https://plugins.gradle.org/m2' }
     google()
     jcenter()
+    maven { url 'https://plugins.gradle.org/m2' }
   }
   dependencies {
     classpath pluginDependencies.gradle
@@ -24,9 +24,9 @@ task testReport(type: TestReport, group: 'Build') {
 
 allprojects {
   repositories {
-    maven { url 'https://plugins.gradle.org/m2' }
     google()
     jcenter()
+    maven { url 'https://plugins.gradle.org/m2' }
   }
 
   group = GROUP


### PR DESCRIPTION
- Updates repositories block in `build.gradle` to have `google()` as the first entry in order to avoid build CI issues