### PR TITLE
NavigationViewEventDispatcher remove navigation listeners in onDestroy

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
@@ -161,6 +161,7 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
    * In a {@link android.app.Fragment}, this should be in {@link Fragment#onDestroyView()}.
    */
   public void onDestroy() {
+    navigationViewEventDispatcher.onDestroy(navigationViewModel.getNavigation());
     shutdown();
   }
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewEventDispatcher.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewEventDispatcher.java
@@ -12,7 +12,9 @@ import com.mapbox.services.android.navigation.ui.v5.listeners.FeedbackListener;
 import com.mapbox.services.android.navigation.ui.v5.listeners.InstructionListListener;
 import com.mapbox.services.android.navigation.ui.v5.listeners.NavigationListener;
 import com.mapbox.services.android.navigation.ui.v5.listeners.RouteListener;
+import com.mapbox.services.android.navigation.v5.milestone.MilestoneEventListener;
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation;
+import com.mapbox.services.android.navigation.v5.routeprogress.ProgressChangeListener;
 
 /**
  * In charge of holding any {@link NavigationView} related listeners {@link NavigationListener},
@@ -21,6 +23,8 @@ import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation;
  */
 class NavigationViewEventDispatcher {
 
+  private ProgressChangeListener progressChangeListener;
+  private MilestoneEventListener milestoneEventListener;
   private FeedbackListener feedbackListener;
   private NavigationListener navigationListener;
   private RouteListener routeListener;
@@ -40,6 +44,13 @@ class NavigationViewEventDispatcher {
     assignProgressChangeListener(navigationViewOptions, navigation);
     assignMilestoneEventListener(navigationViewOptions, navigation);
     assignInstructionListListener(navigationViewOptions.instructionListListener());
+  }
+
+  void onDestroy(@Nullable MapboxNavigation navigation) {
+    if (navigation != null) {
+      removeProgressChangeListener(navigation);
+      removeMilestoneEventListener(navigation);
+    }
   }
 
   void assignFeedbackListener(@Nullable FeedbackListener feedbackListener) {
@@ -155,14 +166,28 @@ class NavigationViewEventDispatcher {
   }
 
   private void assignProgressChangeListener(NavigationViewOptions navigationViewOptions, MapboxNavigation navigation) {
-    if (navigationViewOptions.progressChangeListener() != null) {
-      navigation.addProgressChangeListener(navigationViewOptions.progressChangeListener());
+    this.progressChangeListener = navigationViewOptions.progressChangeListener();
+    if (progressChangeListener != null) {
+      navigation.addProgressChangeListener(progressChangeListener);
     }
   }
 
   private void assignMilestoneEventListener(NavigationViewOptions navigationViewOptions, MapboxNavigation navigation) {
-    if (navigationViewOptions.milestoneEventListener() != null) {
-      navigation.addMilestoneEventListener(navigationViewOptions.milestoneEventListener());
+    this.milestoneEventListener = navigationViewOptions.milestoneEventListener();
+    if (milestoneEventListener != null) {
+      navigation.addMilestoneEventListener(milestoneEventListener);
+    }
+  }
+
+  private void removeMilestoneEventListener(MapboxNavigation navigation) {
+    if (milestoneEventListener != null) {
+      navigation.removeMilestoneEventListener(milestoneEventListener);
+    }
+  }
+
+  private void removeProgressChangeListener(MapboxNavigation navigation) {
+    if (progressChangeListener != null) {
+      navigation.removeProgressChangeListener(progressChangeListener);
     }
   }
 }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/camera/NavigationCamera.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/camera/NavigationCamera.java
@@ -144,7 +144,18 @@ public class NavigationCamera implements LifecycleObserver {
   }
 
   /**
-   * Call in {@link FragmentActivity#onDestroy()} to properly remove the {@link ProgressChangeListener}
+   * Call in {@link FragmentActivity#onStart()} to properly add the {@link ProgressChangeListener}
+   * for the camera and prevent any leaks or further updates.
+   *
+   * @since 0.15.0
+   */
+  @OnLifecycleEvent(Lifecycle.Event.ON_START)
+  public void onStart() {
+    navigation.addProgressChangeListener(progressChangeListener);
+  }
+
+  /**
+   * Call in {@link FragmentActivity#onStop()} to properly remove the {@link ProgressChangeListener}
    * for the camera and prevent any leaks or further updates.
    *
    * @since 0.15.0

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/NavigationMapboxMap.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/NavigationMapboxMap.java
@@ -125,6 +125,8 @@ public class NavigationMapboxMap {
   @SuppressLint("MissingPermission")
   public void onStart() {
     locationLayer.onStart();
+    mapCamera.onStart();
+    mapRoute.onStart();
   }
 
   public void onStop() {

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/NavigationMapRoute.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/NavigationMapRoute.java
@@ -997,7 +997,23 @@ public class NavigationMapRoute implements ProgressChangeListener, MapView.OnMap
   /**
    * This method should be called only if you have passed {@link MapboxNavigation}
    * into the constructor.
+   * <p>
+   * This method will add the {@link ProgressChangeListener} that was originally added so updates
+   * to the {@link MapboxMap} continue.
    *
+   * @since 0.15.0
+   */
+  @OnLifecycleEvent(Lifecycle.Event.ON_START)
+  public void onStart() {
+    if (navigation != null) {
+      navigation.addProgressChangeListener(this);
+    }
+  }
+
+  /**
+   * This method should be called only if you have passed {@link MapboxNavigation}
+   * into the constructor.
+   * <p>
    * This method will remove the {@link ProgressChangeListener} that was originally added so updates
    * to the {@link MapboxMap} discontinue.
    *


### PR DESCRIPTION
Closes #981 

Because `MapboxNavigation` survives rotation, any listeners from the view must be removed before rotation or shutdown.  This was not the case for the `MilestoneEventListener` and `ProgressChangeListener` being added through `NavigationViewOptions`.  A memory leak would then result from the old listener instances.  