### PR TITLE
Use theme attribute to update MapView map style URL

### DIFF
--- a/app/src/main/res/drawable/ic_refresh.xml
+++ b/app/src/main/res/drawable/ic_refresh.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,6v3l4,-4 -4,-4v3c-4.42,0 -8,3.58 -8,8 0,1.57 0.46,3.03 1.24,4.26L6.7,14.8c-0.45,-0.83 -0.7,-1.79 -0.7,-2.8 0,-3.31 2.69,-6 6,-6zM18.76,7.74L17.3,9.2c0.44,0.84 0.7,1.79 0.7,2.8 0,3.31 -2.69,6 -6,6v-3l-4,4 4,4v-3c4.42,0 8,-3.58 8,-8 0,-1.57 -0.46,-3.03 -1.24,-4.26z"/>
+</vector>

--- a/app/src/main/res/layout/activity_embedded_navigation.xml
+++ b/app/src/main/res/layout/activity_embedded_navigation.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.design.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
@@ -8,28 +9,43 @@
         android:id="@+id/navigationView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:navigationLightTheme="@style/CustomNavigationView"
-        app:navigationDarkTheme="@style/NavigationViewDark"/>
-    <TextView
+        app:navigationDarkTheme="@style/NavigationViewDark"
+        app:navigationLightTheme="@style/CustomNavigationView"/>
+
+    <android.support.design.widget.FloatingActionButton
+        android:id="@+id/fabToggleNightMode"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:id="@+id/speed_limit"
-        android:textSize="35sp"
-        android:padding="6dp"
-        app:layout_anchorGravity="top"
-        android:layout_gravity="top"
-        android:gravity="center"
-        android:layout_marginLeft="16dp"
-        android:elevation="3dp"
+        android:layout_gravity="top|start"
+        android:layout_marginEnd="16dp"
+        android:layout_marginRight="16dp"
+        android:tint="@android:color/white"
         app:layout_anchor="@id/spacer"
-        android:textColor="@android:color/black"
+        app:layout_anchorGravity="top|end"
+        app:srcCompat="@drawable/ic_refresh"/>
+
+    <TextView
+        android:id="@+id/speed_limit"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="top"
+        android:layout_marginLeft="16dp"
         android:background="@android:color/white"
-        android:visibility="gone"/>
+        android:elevation="3dp"
+        android:gravity="center"
+        android:padding="6dp"
+        android:textColor="@android:color/black"
+        android:textSize="35sp"
+        android:visibility="gone"
+        app:layout_anchor="@id/spacer"
+        app:layout_anchorGravity="top"/>
+
     <View
+        android:id="@+id/spacer"
         android:layout_width="wrap_content"
         android:layout_height="6dp"
-        android:id="@+id/spacer"
+        android:layout_gravity="top"
         android:background="@android:color/transparent"
-        app:layout_anchorGravity="top"
-        android:layout_gravity="top"/>
+        app:layout_anchorGravity="top"/>
+
 </android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -37,6 +37,7 @@
     <string name="route_profile_key" translatable="false">route_profile</string>
     <string name="default_locale" translatable="false">default_for_device</string>
     <string name="default_unit_type" translatable="false">default_for_device</string>
+    <string name="current_night_mode" translatable="false">current_night_mode</string>
 
     <string name="error_route_not_available">Current route is not available</string>
     <string name="error_select_longer_route">Please select a longer route</string>

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/MapboxNavigationActivity.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/MapboxNavigationActivity.java
@@ -5,6 +5,7 @@ import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
+import android.support.v7.app.AppCompatDelegate;
 
 import com.mapbox.api.directions.v5.DirectionsCriteria;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
@@ -26,6 +27,7 @@ public class MapboxNavigationActivity extends AppCompatActivity implements OnNav
   protected void onCreate(@Nullable Bundle savedInstanceState) {
     setTheme(R.style.Theme_AppCompat_NoActionBar);
     super.onCreate(savedInstanceState);
+    AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_AUTO);
     setContentView(R.layout.activity_navigation);
     navigationView = findViewById(R.id.navigationView);
     navigationView.onCreate(savedInstanceState);

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
@@ -13,13 +13,13 @@ import android.support.annotation.Nullable;
 import android.support.design.widget.BottomSheetBehavior;
 import android.support.design.widget.CoordinatorLayout;
 import android.support.v4.app.FragmentActivity;
-import android.support.v7.app.AppCompatDelegate;
 import android.util.AttributeSet;
 import android.view.View;
 import android.widget.ImageButton;
 
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.geojson.Point;
+import com.mapbox.mapboxsdk.constants.MapboxConstants;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
@@ -84,7 +84,6 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
 
   public NavigationView(Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
     super(context, attrs, defStyleAttr);
-    AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_AUTO);
     ThemeSwitcher.setTheme(context, attrs);
     initializeView();
   }
@@ -95,7 +94,7 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
    * @param savedInstanceState to restore state if not null
    */
   public void onCreate(@Nullable Bundle savedInstanceState) {
-    mapView.setStyleUrl(ThemeSwitcher.retrieveMapStyle(getContext()));
+    updateSavedInstanceStateMapStyle(savedInstanceState);
     mapView.onCreate(savedInstanceState);
     updatePresenterState(savedInstanceState);
     navigationViewModel.onCreate();
@@ -405,6 +404,13 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
   private void initializeInstructionListListener() {
     instructionView.setInstructionListListener(new NavigationInstructionListListener(navigationPresenter,
       navigationViewEventDispatcher));
+  }
+
+  private void updateSavedInstanceStateMapStyle(@Nullable Bundle savedInstanceState) {
+    if (savedInstanceState != null) {
+      String mapStyleUrl = ThemeSwitcher.retrieveMapStyle(getContext());
+      savedInstanceState.putString(MapboxConstants.STATE_STYLE_URL, mapStyleUrl);
+    }
   }
 
   /**

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/ThemeSwitcher.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/ThemeSwitcher.java
@@ -105,6 +105,11 @@ public class ThemeSwitcher {
     context.setTheme(darkThemeEnabled ? darkTheme : lightTheme);
   }
 
+  static String retrieveMapStyle(Context context) {
+    TypedValue mapStyleAttr = resolveAttributeFromId(context, R.attr.navigationViewMapStyle);
+    return mapStyleAttr.string.toString();
+  }
+
   /**
    * Returns true if the current UI_MODE_NIGHT is enabled, false otherwise.
    *
@@ -114,11 +119,6 @@ public class ThemeSwitcher {
     int uiMode = context.getResources().getConfiguration().uiMode
       & Configuration.UI_MODE_NIGHT_MASK;
     return uiMode == Configuration.UI_MODE_NIGHT_YES;
-  }
-
-  static String retrieveMapStyle(Context context) {
-    TypedValue mapStyleAttr = resolveAttributeFromId(context, R.attr.navigationViewMapStyle);
-    return mapStyleAttr.string.toString();
   }
 
   @NonNull

--- a/libandroid-navigation-ui/src/main/res/layout/navigation_view_layout.xml
+++ b/libandroid-navigation-ui/src/main/res/layout/navigation_view_layout.xml
@@ -12,6 +12,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:mapbox_uiAttribution="false"
+        app:mapbox_styleUrl="?attr/navigationViewMapStyle"
         app:mapbox_uiCompass="false"
         app:mapbox_uiLogo="false"/>
 


### PR DESCRIPTION
Closes #994 

@mapbox/maps-android the `mapbox_styleUrl` is taken into account every time the `MapView` is rendered for the first time correct?  

If we set the style URL from `navigationViewMapStyle` there shouldn't be any possible issues with caching and we can remove that method from `ThemeSwitcher`.

FWIW, I created an example that used the cancel btn to change the theme and recreate (simulating if this we to happen mid-drive) and I wasn't able to reproduce.  @Guardiola31337 if you can provide a reliable way to reproduce, that would be great. 