### PR TITLE
Update NavigationActivity naming to avoid naming collisions

### DIFF
--- a/libandroid-navigation-ui/src/main/AndroidManifest.xml
+++ b/libandroid-navigation-ui/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android">
 
   <application>
-    <activity android:name=".NavigationActivity"/>
+    <activity android:name=".MapboxNavigationActivity"/>
   </application>
 
 </manifest>

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/MapboxNavigationActivity.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/MapboxNavigationActivity.java
@@ -17,7 +17,8 @@ import com.mapbox.services.android.navigation.v5.navigation.NavigationConstants;
  * <p>
  * Demonstrates the proper setup and usage of the view, including all lifecycle methods.
  */
-public class NavigationActivity extends AppCompatActivity implements OnNavigationReadyCallback, NavigationListener {
+public class MapboxNavigationActivity extends AppCompatActivity implements OnNavigationReadyCallback,
+  NavigationListener {
 
   private NavigationView navigationView;
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationLauncher.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationLauncher.java
@@ -43,7 +43,7 @@ public class NavigationLauncher {
 
     editor.apply();
 
-    Intent navigationActivity = new Intent(activity, NavigationActivity.class);
+    Intent navigationActivity = new Intent(activity, MapboxNavigationActivity.class);
     activity.startActivity(navigationActivity);
   }
 


### PR DESCRIPTION
Closes #998 

If a user of `libandroid-navigation-ui` creates their own `Activity` and names it `NavigationActivity`, the naming collides with the `NavigationActivity` we bundle for use with `NavigationLauncher`.  

This PR updates the naming of `NavigationActivity` > `MapboxNavigationActivity` to make the naming more specific to the SDK.  