### PR TITLE
Add check to remove listener from location engine in NavigationService

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationService.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationService.java
@@ -172,7 +172,7 @@ public class NavigationService extends Service implements LocationEngineListener
    * the thread, and finally stops this service from running in the background.
    */
   void endNavigation() {
-    locationEngine.removeLocationEngineListener(this);
+    removeLocationEngineListener();
     removeRouteEngineListener();
     unregisterMapboxNotificationReceiver();
     quitThread();
@@ -291,6 +291,12 @@ public class NavigationService extends Service implements LocationEngineListener
       location = routeUtils.createFirstLocationFromRoute(mapboxNavigation.getRoute());
     }
     queueLocationUpdateTask(location);
+  }
+
+  private void removeLocationEngineListener() {
+    if (locationEngine != null) {
+      locationEngine.removeLocationEngineListener(this);
+    }
   }
 
   private void removeRouteEngineListener() {


### PR DESCRIPTION
Seeing a NPE on removing this `LocationEngine` listener in CI.  Seems to be a race, when the `NavigationService` is created, navigation does not begin, and then the service is immediately destroyed.  

Noting: this `null` check is defensive and the service could use a larger refactor (there are many more null checks).  We should keep this in mind / how we can extract most of the logic in the service into their own Java classes to make it more testable.   