### PR TITLE
Update Maps SDK to 6.2.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,9 +8,9 @@ ext {
   ]
 
   version = [
-      mapboxMapSdk       : '6.1.3',
+      mapboxMapSdk       : '6.2.0',
       mapboxSdkServices  : '3.3.0',
-      mapboxEvents       : '3.1.2',
+      mapboxEvents       : '3.1.3',
       locationLayerPlugin: '0.5.3',
       autoValue          : '1.5',
       autoValueParcel    : '0.2.5',


### PR DESCRIPTION
Updates the Maps SDK for `libandroid-navigation-ui` to the latest release