### PR TITLE
Revert maps SDK version to 6.1.3

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,7 +8,7 @@ ext {
   ]
 
   version = [
-      mapboxMapSdk       : '6.2.0',
+      mapboxMapSdk       : '6.1.3',
       mapboxSdkServices  : '3.3.0',
       mapboxEvents       : '3.1.3',
       locationLayerPlugin: '0.5.3',


### PR DESCRIPTION
- Reverts maps SDK version to `6.1.3` because route lines were showing black 👀 

![black_route](https://user-images.githubusercontent.com/1668582/41739680-17f36fe4-7596-11e8-8c6c-a624751b1c88.png)
