### PR TITLE
Fix upcoming maneuver arrow underneath road labels

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/NavigationMapRoute.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/NavigationMapRoute.java
@@ -125,6 +125,7 @@ public class NavigationMapRoute implements ProgressChangeListener, MapView.OnMap
   private static final float OPAQUE = 0.0f;
   private static final int ARROW_HIDDEN_ZOOM_LEVEL = 14;
   private static final float TRANSPARENT = 1.0f;
+  private static final String LAYER_ABOVE_UPCOMING_MANEUVER_ARROW = "com.mapbox.annotations.points";
 
   @StyleRes
   private int styleRes;
@@ -487,7 +488,7 @@ public class NavigationMapRoute implements ProgressChangeListener, MapView.OnMap
       addArrowHeadIcon();
       addArrowHeadIconCasing();
 
-      mapboxMap.addLayerAbove(shaftCasingLayer, belowLayer);
+      mapboxMap.addLayerBelow(shaftCasingLayer, LAYER_ABOVE_UPCOMING_MANEUVER_ARROW);
       mapboxMap.addLayerAbove(headCasingLayer, shaftCasingLayer.getId());
 
       mapboxMap.addLayerAbove(shaftLayer, headCasingLayer.getId());


### PR DESCRIPTION
- Fixes upcoming maneuver arrow underneath road labels

Closes #1048 

Edited:
~This PR places the upcoming maneuver arrow above the road labels and below the road shields 👀~ 

This PR places the upcoming maneuver arrow below the annotations layer but underneath annotations 👀 

![arrow_above_shields](https://user-images.githubusercontent.com/1668582/41778731-eecf12ea-762f-11e8-96a9-821d1bac217a.png)

Is that what we want @Cjballard? I'd love to hear your thoughts on this.