### PR TITLE
Fix vector drawables for < API 21 in test Application

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/ThemeSwitcher.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/ThemeSwitcher.java
@@ -9,6 +9,7 @@ import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatDelegate;
+import android.support.v7.content.res.AppCompatResources;
 import android.util.AttributeSet;
 import android.util.TypedValue;
 
@@ -60,14 +61,14 @@ public class ThemeSwitcher {
   public static Drawable retrieveThemeOverviewDrawable(Context context) {
     TypedValue destinationMarkerResId = resolveAttributeFromId(context, R.attr.navigationViewRouteOverviewDrawable);
     int overviewResId = destinationMarkerResId.resourceId;
-    return ContextCompat.getDrawable(context, overviewResId);
+    return AppCompatResources.getDrawable(context, overviewResId);
   }
 
   /**
    * Looks are current theme and retrieves the style
    * for the given resId set in the theme.
    *
-   * @param context to retrieve the resolved attribute
+   * @param context    to retrieve the resolved attribute
    * @param styleResId for the given style
    * @return resolved style resource Id
    */

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/feedback/FeedbackViewHolder.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/feedback/FeedbackViewHolder.java
@@ -1,6 +1,6 @@
 package com.mapbox.services.android.navigation.ui.v5.feedback;
 
-import android.support.v4.content.ContextCompat;
+import android.support.v7.content.res.AppCompatResources;
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
 import android.widget.ImageView;
@@ -22,7 +22,7 @@ class FeedbackViewHolder extends RecyclerView.ViewHolder {
   }
 
   void setFeedbackImage(int feedbackImageId) {
-    feedbackImage.setImageDrawable(ContextCompat.getDrawable(feedbackImage.getContext(), feedbackImageId));
+    feedbackImage.setImageDrawable(AppCompatResources.getDrawable(feedbackImage.getContext(), feedbackImageId));
   }
 
   void setFeedbackText(String feedbackText) {

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/NavigationMapRoute.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/NavigationMapRoute.java
@@ -16,6 +16,7 @@ import android.support.annotation.Size;
 import android.support.annotation.StyleRes;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.graphics.drawable.DrawableCompat;
+import android.support.v7.content.res.AppCompatResources;
 
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.api.directions.v5.models.RouteLeg;
@@ -414,8 +415,8 @@ public class NavigationMapRoute implements ProgressChangeListener, MapView.OnMap
     MapUtils.updateMapSourceFromFeatureCollection(
       mapboxMap, featureCollections.get(featureCollections.size() - 1), WAYPOINT_SOURCE_ID);
     drawWaypointMarkers(mapboxMap,
-      ContextCompat.getDrawable(mapView.getContext(), originWaypointIcon),
-      ContextCompat.getDrawable(mapView.getContext(), destinationWaypointIcon)
+      AppCompatResources.getDrawable(mapView.getContext(), originWaypointIcon),
+      AppCompatResources.getDrawable(mapView.getContext(), destinationWaypointIcon)
     );
   }
 
@@ -516,14 +517,14 @@ public class NavigationMapRoute implements ProgressChangeListener, MapView.OnMap
   }
 
   private void addArrowHeadIcon() {
-    Drawable head = DrawableCompat.wrap(ContextCompat.getDrawable(mapView.getContext(), R.drawable.ic_arrow_head));
+    Drawable head = DrawableCompat.wrap(AppCompatResources.getDrawable(mapView.getContext(), R.drawable.ic_arrow_head));
     DrawableCompat.setTint(head.mutate(), arrowColor);
     Bitmap icon = MapImageUtils.getBitmapFromDrawable(head);
     mapboxMap.addImage(ARROW_HEAD_ICON, icon);
   }
 
   private void addArrowHeadIconCasing() {
-    Drawable headCasing = DrawableCompat.wrap(ContextCompat.getDrawable(mapView.getContext(),
+    Drawable headCasing = DrawableCompat.wrap(AppCompatResources.getDrawable(mapView.getContext(),
       R.drawable.ic_arrow_head_casing));
     DrawableCompat.setTint(headCasing.mutate(), arrowBorderColor);
     Bitmap icon = MapImageUtils.getBitmapFromDrawable(headCasing);


### PR DESCRIPTION
Vector drawables were causing a `android.content.res.Resources$NotFoundException` on devices `< API 21` 

Does it make sense to do this for the developer in `NavigationView`?  🤔 