### PR TITLE
Bump Mapbox Maps SDK to 6.2.1 version

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,7 +8,7 @@ ext {
   ]
 
   version = [
-      mapboxMapSdk       : '6.1.3',
+      mapboxMapSdk       : '6.2.1',
       mapboxSdkServices  : '3.3.0',
       mapboxEvents       : '3.1.3',
       locationLayerPlugin: '0.5.3',


### PR DESCRIPTION
- Bumps Mapbox Maps SDK to `6.2.1` version

Closes #1045 