### PR TITLE
Ignore arrival checks after route has finished

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEventDispatcher.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEventDispatcher.java
@@ -173,7 +173,7 @@ class NavigationEventDispatcher {
   }
 
   private void checkForArrivalEvent(RouteProgress routeProgress, Milestone milestone) {
-    if (routeUtils.isArrivalEvent(routeProgress, milestone)) {
+    if (metricEventListener != null && routeUtils.isArrivalEvent(routeProgress, milestone)) {
       metricEventListener.onArrival(routeProgress);
       if (routeUtils.isLastLeg(routeProgress)) {
         removeOffRouteListener(null);

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEventDispatcherTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEventDispatcherTest.java
@@ -366,6 +366,21 @@ public class NavigationEventDispatcherTest extends BaseTest {
     verify(metricEventListener, times(0)).onOffRouteEvent(location);
   }
 
+  @Test
+  public void onArrivalAlreadyOccurred_arrivalCheckIsIgnored() {
+    String instruction = "";
+    Location location = mock(Location.class);
+    BannerInstructionMilestone milestone = mock(BannerInstructionMilestone.class);
+    RouteUtils routeUtils = mock(RouteUtils.class);
+    when(routeUtils.isArrivalEvent(routeProgress, milestone)).thenReturn(true);
+    when(routeUtils.isLastLeg(routeProgress)).thenReturn(true);
+    NavigationEventDispatcher dispatcher = buildEventDispatcherHasArrived(instruction, routeUtils, milestone);
+
+    dispatcher.onMilestoneEvent(routeProgress, instruction, milestone);
+
+    verify(metricEventListener, times(0)).onOffRouteEvent(location);
+  }
+
   @NonNull
   private NavigationEventDispatcher buildEventDispatcherHasArrived(String instruction, RouteUtils routeUtils,
                                                                    Milestone milestone) {


### PR DESCRIPTION
Closes #1086 

If we are setting the `metricEventListener` to `null` after arrival on the last leg, then we need to check for a null instance if the `onMilestoneListener` fires after the arrival event.  