### PR TITLE
Rename MapView id included in NavigationView

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationSnapshotReadyCallback.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationSnapshotReadyCallback.java
@@ -35,7 +35,7 @@ class NavigationSnapshotReadyCallback implements MapboxMap.SnapshotReadyCallback
   }
 
   private void updateFeedbackScreenshot() {
-    MapView mapView = navigationView.findViewById(R.id.mapView);
+    MapView mapView = navigationView.findViewById(R.id.navigationMapView);
     mapView.setVisibility(View.INVISIBLE);
     Bitmap capture = ViewUtils.captureView(mapView);
     String encoded = ViewUtils.encodeView(capture);
@@ -44,7 +44,7 @@ class NavigationSnapshotReadyCallback implements MapboxMap.SnapshotReadyCallback
 
   private void resetViewVisibility(ImageView screenshotView) {
     screenshotView.setVisibility(View.INVISIBLE);
-    MapView mapView = navigationView.findViewById(R.id.mapView);
+    MapView mapView = navigationView.findViewById(R.id.navigationMapView);
     mapView.setVisibility(View.VISIBLE);
   }
 }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
@@ -400,7 +400,7 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
   }
 
   private void bind() {
-    mapView = findViewById(R.id.mapView);
+    mapView = findViewById(R.id.navigationMapView);
     instructionView = findViewById(R.id.instructionView);
     summaryBottomSheet = findViewById(R.id.summaryBottomSheet);
     cancelBtn = findViewById(R.id.cancelBtn);

--- a/libandroid-navigation-ui/src/main/res/layout-land/navigation_view_layout.xml
+++ b/libandroid-navigation-ui/src/main/res/layout-land/navigation_view_layout.xml
@@ -8,7 +8,7 @@
     android:orientation="vertical">
 
     <com.mapbox.mapboxsdk.maps.MapView
-        android:id="@+id/mapView"
+        android:id="@+id/navigationMapView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:mapbox_uiAttribution="false"

--- a/libandroid-navigation-ui/src/main/res/layout/navigation_view_layout.xml
+++ b/libandroid-navigation-ui/src/main/res/layout/navigation_view_layout.xml
@@ -8,7 +8,7 @@
     android:orientation="vertical">
 
     <com.mapbox.mapboxsdk.maps.MapView
-        android:id="@+id/mapView"
+        android:id="@+id/navigationMapView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:mapbox_uiAttribution="false"


### PR DESCRIPTION
- Refactor renames `MapView` id included in `NavigationView` from `mapView` to `navigationMapView` to avoid clashes when including `NavigationView` and `MapView` in the same layout