### PR TITLE
Added null check for crash found on firebase

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEventDispatcher.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEventDispatcher.java
@@ -174,7 +174,10 @@ class NavigationEventDispatcher {
 
   private void checkForArrivalEvent(RouteProgress routeProgress, Milestone milestone) {
     if (routeUtils.isArrivalEvent(routeProgress, milestone)) {
-      metricEventListener.onArrival(routeProgress);
+      if (metricEventListener != null) {
+        metricEventListener.onArrival(routeProgress);
+      }
+
       if (routeUtils.isLastLeg(routeProgress)) {
         removeOffRouteListener(null);
         metricEventListener = null;


### PR DESCRIPTION
Fixes the following crash found on Firebase:

java.lang.NullPointerException: Attempt to invoke interface method 'void com.mapbox.services.android.navigation.v5.navigation.metrics.NavigationMetricListener.onArrival(com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress)' on a null object reference
FATAL EXCEPTION: main
Process: com.mapbox.services.android.navigation.testapp, PID: 17735
java.lang.NullPointerException: Attempt to invoke interface method 'void com.mapbox.services.android.navigation.v5.navigation.metrics.NavigationMetricListener.onArrival(com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress)' on a null object reference
	at com.mapbox.services.android.navigation.v5.navigation.NavigationEventDispatcher.checkForArrivalEvent(NavigationEventDispatcher.java:177)
	at com.mapbox.services.android.navigation.v5.navigation.NavigationEventDispatcher.onMilestoneEvent(NavigationEventDispatcher.java:135)
	at com.mapbox.services.android.navigation.v5.navigation.NavigationService.onMilestoneTrigger(NavigationService.java:125)
	at com.mapbox.services.android.navigation.v5.navigation.NavigationEngine$1.run(NavigationEngine.java:93)
	at android.os.Handler.handleCallback(Handler.java:739)
	at android.os.Handler.dispatchMessage(Handler.java:95)
	at android.os.Looper.loop(Looper.java:135)
	at android.app.ActivityThread.main(ActivityThread.java:5254)
	at java.lang.reflect.Method.invoke(Native Method)
	at java.lang.reflect.Method.invoke(Method.java:372)
	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:903)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:698)