### PR TITLE
Add dual navigation map example to the test app

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -51,6 +51,14 @@
         </activity>
 
         <activity
+            android:name=".activity.navigationui.DualNavigationMapActivity"
+            android:label="@string/title_dual_navigation_map">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".MainActivity"/>
+        </activity>
+
+        <activity
             android:name=".activity.navigationui.NavigationLauncherActivity"
             android:label="@string/title_navigation_launcher">
             <meta-data

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/MainActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/MainActivity.java
@@ -16,10 +16,11 @@ import com.mapbox.android.core.permissions.PermissionsListener;
 import com.mapbox.android.core.permissions.PermissionsManager;
 import com.mapbox.services.android.navigation.testapp.activity.MockNavigationActivity;
 import com.mapbox.services.android.navigation.testapp.activity.RerouteActivity;
+import com.mapbox.services.android.navigation.testapp.activity.navigationui.DualNavigationMapActivity;
 import com.mapbox.services.android.navigation.testapp.activity.navigationui.EmbeddedNavigationActivity;
 import com.mapbox.services.android.navigation.testapp.activity.navigationui.EndNavigationActivity;
-import com.mapbox.services.android.navigation.testapp.activity.navigationui.NavigationMapRouteActivity;
 import com.mapbox.services.android.navigation.testapp.activity.navigationui.NavigationLauncherActivity;
+import com.mapbox.services.android.navigation.testapp.activity.navigationui.NavigationMapRouteActivity;
 import com.mapbox.services.android.navigation.testapp.activity.navigationui.WaypointNavigationActivity;
 import com.mapbox.services.android.navigation.testapp.activity.navigationui.fragment.FragmentNavigationActivity;
 
@@ -46,6 +47,11 @@ public class MainActivity extends AppCompatActivity implements PermissionsListen
         getString(R.string.title_end_navigation),
         getString(R.string.description_end_navigation),
         EndNavigationActivity.class
+      ),
+      new SampleItem(
+        getString(R.string.title_dual_navigation_map),
+        getString(R.string.description_dual_navigation_map),
+        DualNavigationMapActivity.class
       ),
       new SampleItem(
         getString(R.string.title_mock_navigation),

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/DualNavigationMapActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/DualNavigationMapActivity.java
@@ -1,0 +1,350 @@
+package com.mapbox.services.android.navigation.testapp.activity.navigationui;
+
+import android.location.Location;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.constraint.ConstraintLayout;
+import android.support.constraint.ConstraintSet;
+import android.support.design.widget.FloatingActionButton;
+import android.support.transition.TransitionManager;
+import android.support.v7.app.AppCompatActivity;
+import android.view.View;
+import android.widget.ProgressBar;
+
+import com.mapbox.android.core.location.LocationEngine;
+import com.mapbox.android.core.location.LocationEngineListener;
+import com.mapbox.android.core.location.LocationEngineProvider;
+import com.mapbox.api.directions.v5.models.DirectionsResponse;
+import com.mapbox.api.directions.v5.models.DirectionsRoute;
+import com.mapbox.geojson.Point;
+import com.mapbox.mapboxsdk.annotations.Marker;
+import com.mapbox.mapboxsdk.annotations.MarkerViewOptions;
+import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
+import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerPlugin;
+import com.mapbox.mapboxsdk.plugins.locationlayer.modes.RenderMode;
+import com.mapbox.services.android.navigation.testapp.R;
+import com.mapbox.services.android.navigation.ui.v5.NavigationView;
+import com.mapbox.services.android.navigation.ui.v5.NavigationViewOptions;
+import com.mapbox.services.android.navigation.ui.v5.OnNavigationReadyCallback;
+import com.mapbox.services.android.navigation.ui.v5.listeners.NavigationListener;
+import com.mapbox.services.android.navigation.ui.v5.route.NavigationMapRoute;
+import com.mapbox.services.android.navigation.ui.v5.route.OnRouteSelectionChangeListener;
+import com.mapbox.services.android.navigation.v5.navigation.NavigationRoute;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+import static com.mapbox.android.core.location.LocationEnginePriority.HIGH_ACCURACY;
+
+public class DualNavigationMapActivity extends AppCompatActivity implements OnNavigationReadyCallback,
+  NavigationListener, Callback<DirectionsResponse>, OnMapReadyCallback, MapboxMap.OnMapLongClickListener,
+  LocationEngineListener, OnRouteSelectionChangeListener {
+
+  private static final int CAMERA_ANIMATION_DURATION = 1000;
+  private static final int DEFAULT_CAMERA_ZOOM = 16;
+  private ConstraintLayout dualNavigationMap;
+  private NavigationView navigationView;
+  private MapView mapView;
+  private ProgressBar loading;
+  private FloatingActionButton launchNavigationFab;
+  private Point origin = Point.fromLngLat(-122.423579, 37.761689);
+  private Point destination = Point.fromLngLat(-122.426183, 37.760872);
+  private DirectionsRoute route;
+  private boolean isNavigationRunning;
+  private LocationLayerPlugin locationLayer;
+  private LocationEngine locationEngine;
+  private NavigationMapRoute mapRoute;
+  private MapboxMap mapboxMap;
+  private Marker currentMarker;
+  private boolean locationFound;
+  private ConstraintSet navigationMapConstraint;
+  private ConstraintSet navigationMapExpandedConstraint;
+  private boolean[] constraintChanged;
+
+
+  @Override
+  protected void onCreate(@Nullable Bundle savedInstanceState) {
+    setTheme(R.style.Theme_AppCompat_NoActionBar);
+    super.onCreate(savedInstanceState);
+    initializeViews(savedInstanceState);
+    navigationView.initialize(this);
+    navigationMapConstraint = new ConstraintSet();
+    navigationMapConstraint.clone(dualNavigationMap);
+    navigationMapExpandedConstraint = new ConstraintSet();
+    navigationMapExpandedConstraint.clone(this, R.layout.activity_dual_navigation_map_expanded);
+
+    constraintChanged = new boolean[] {false};
+    launchNavigationFab.setOnClickListener(v -> {
+      expandCollapse();
+      launchNavigation();
+    });
+  }
+
+  @Override
+  public void onNavigationReady(boolean isRunning) {
+    isNavigationRunning = isRunning;
+    fetchRoute();
+  }
+
+  @Override
+  public void onMapReady(MapboxMap mapboxMap) {
+    this.mapboxMap = mapboxMap;
+    this.mapboxMap.setOnMapLongClickListener(this);
+    initLocationEngine();
+    initLocationLayer();
+    initMapRoute();
+  }
+
+  @Override
+  public void onMapLongClick(@NonNull LatLng point) {
+    destination = Point.fromLngLat(point.getLongitude(), point.getLatitude());
+    updateLoadingTo(true);
+    setCurrentMarkerPosition(point);
+    if (origin != null) {
+      fetchRoute();
+    }
+  }
+
+  @Override
+  public void onResponse(Call<DirectionsResponse> call, Response<DirectionsResponse> response) {
+    if (validRouteResponse(response)) {
+      updateLoadingTo(false);
+      launchNavigationFab.setVisibility(View.VISIBLE);
+      launchNavigationFab.show();
+      route = response.body().routes().get(0);
+      mapRoute.addRoutes(response.body().routes());
+      if (isNavigationRunning) {
+        launchNavigation();
+      }
+    }
+  }
+
+  @Override
+  public void onFailure(Call<DirectionsResponse> call, Throwable throwable) {
+  }
+
+  @Override
+  public void onCancelNavigation() {
+    navigationView.stopNavigation();
+    expandCollapse();
+  }
+
+  @Override
+  public void onNavigationFinished() {
+  }
+
+  @Override
+  public void onNavigationRunning() {
+  }
+
+  @SuppressWarnings( {"MissingPermission"})
+  @Override
+  public void onConnected() {
+    locationEngine.requestLocationUpdates();
+  }
+
+  @Override
+  public void onLocationChanged(Location location) {
+    origin = Point.fromLngLat(location.getLongitude(), location.getLatitude());
+    onLocationFound(location);
+  }
+
+  @Override
+  public void onNewPrimaryRouteSelected(DirectionsRoute directionsRoute) {
+    route = directionsRoute;
+  }
+
+  @Override
+  public void onStart() {
+    super.onStart();
+    navigationView.onStart();
+    mapView.onStart();
+    if (locationLayer != null) {
+      locationLayer.onStart();
+    }
+  }
+
+  @Override
+  public void onResume() {
+    super.onResume();
+    navigationView.onResume();
+    mapView.onResume();
+    if (locationEngine != null) {
+      locationEngine.addLocationEngineListener(this);
+      if (!locationEngine.isConnected()) {
+        locationEngine.activate();
+      }
+    }
+  }
+
+  @Override
+  public void onLowMemory() {
+    super.onLowMemory();
+    navigationView.onLowMemory();
+    mapView.onLowMemory();
+  }
+
+  @Override
+  public void onBackPressed() {
+    if (!navigationView.onBackPressed()) {
+      super.onBackPressed();
+    }
+  }
+
+  @Override
+  protected void onSaveInstanceState(Bundle outState) {
+    navigationView.onSaveInstanceState(outState);
+    mapView.onSaveInstanceState(outState);
+    super.onSaveInstanceState(outState);
+  }
+
+  @Override
+  protected void onRestoreInstanceState(Bundle savedInstanceState) {
+    super.onRestoreInstanceState(savedInstanceState);
+    navigationView.onRestoreInstanceState(savedInstanceState);
+  }
+
+  @Override
+  public void onPause() {
+    super.onPause();
+    navigationView.onPause();
+    mapView.onPause();
+    if (locationEngine != null) {
+      locationEngine.removeLocationEngineListener(this);
+    }
+  }
+
+  @Override
+  public void onStop() {
+    super.onStop();
+    navigationView.onStop();
+    mapView.onStop();
+    if (locationLayer != null) {
+      locationLayer.onStop();
+    }
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    navigationView.onDestroy();
+    mapView.onDestroy();
+    if (locationEngine != null) {
+      locationEngine.removeLocationUpdates();
+      locationEngine.deactivate();
+    }
+  }
+
+  private void expandCollapse() {
+    TransitionManager.beginDelayedTransition(dualNavigationMap);
+    ConstraintSet constraint;
+    if (constraintChanged[0]) {
+      constraint = navigationMapConstraint;
+    } else {
+      constraint = navigationMapExpandedConstraint;
+    }
+    constraint.applyTo(dualNavigationMap);
+    constraintChanged[0] = !constraintChanged[0];
+  }
+
+  private void fetchRoute() {
+    NavigationRoute builder = NavigationRoute.builder(this)
+      .accessToken(getString(R.string.mapbox_access_token))
+      .origin(origin)
+      .destination(destination)
+      .alternatives(true)
+      .build();
+    builder.getRoute(this);
+  }
+
+  private void launchNavigation() {
+    launchNavigationFab.hide();
+    navigationView.setVisibility(View.VISIBLE);
+    NavigationViewOptions.Builder options = NavigationViewOptions.builder()
+      .navigationListener(this)
+      .directionsRoute(route);
+    navigationView.startNavigation(options.build());
+  }
+
+  private void initializeViews(@Nullable Bundle savedInstanceState) {
+    setContentView(R.layout.activity_dual_navigation_map);
+    dualNavigationMap = findViewById(R.id.dualNavigationMap);
+    mapView = findViewById(R.id.mapView);
+    navigationView = findViewById(R.id.navigationView);
+    loading = findViewById(R.id.loading);
+    launchNavigationFab = findViewById(R.id.launchNavigation);
+    navigationView.onCreate(savedInstanceState);
+    mapView.onCreate(savedInstanceState);
+    mapView.getMapAsync(this);
+  }
+
+  private void updateLoadingTo(boolean isVisible) {
+    if (isVisible) {
+      loading.setVisibility(View.VISIBLE);
+    } else {
+      loading.setVisibility(View.INVISIBLE);
+    }
+  }
+
+  private boolean validRouteResponse(Response<DirectionsResponse> response) {
+    return response.body() != null && !response.body().routes().isEmpty();
+  }
+
+
+  @SuppressWarnings( {"MissingPermission"})
+  private void initLocationEngine() {
+    locationEngine = new LocationEngineProvider(this).obtainBestLocationEngineAvailable();
+    locationEngine.setPriority(HIGH_ACCURACY);
+    locationEngine.setInterval(0);
+    locationEngine.setFastestInterval(1000);
+    locationEngine.addLocationEngineListener(this);
+    locationEngine.activate();
+
+    if (locationEngine.getLastLocation() != null) {
+      Location lastLocation = locationEngine.getLastLocation();
+      onLocationChanged(lastLocation);
+      origin = Point.fromLngLat(lastLocation.getLongitude(), lastLocation.getLatitude());
+    }
+  }
+
+  @SuppressWarnings( {"MissingPermission"})
+  private void initLocationLayer() {
+    locationLayer = new LocationLayerPlugin(mapView, mapboxMap, locationEngine);
+    locationLayer.setRenderMode(RenderMode.COMPASS);
+  }
+
+  private void initMapRoute() {
+    mapRoute = new NavigationMapRoute(mapView, mapboxMap);
+    mapRoute.setOnRouteSelectionChangeListener(this);
+  }
+
+  private void setCurrentMarkerPosition(LatLng position) {
+    if (position != null) {
+      if (currentMarker == null) {
+        MarkerViewOptions markerViewOptions = new MarkerViewOptions()
+          .position(position);
+        currentMarker = mapboxMap.addMarker(markerViewOptions);
+      } else {
+        currentMarker.setPosition(position);
+      }
+    }
+  }
+
+  private void onLocationFound(Location location) {
+    if (!locationFound) {
+      animateCamera(new LatLng(location.getLatitude(), location.getLongitude()));
+      locationFound = true;
+      updateLoadingTo(false);
+    }
+  }
+
+  private void animateCamera(LatLng point) {
+    mapboxMap.animateCamera(CameraUpdateFactory.newLatLngZoom(point, DEFAULT_CAMERA_ZOOM), CAMERA_ANIMATION_DURATION);
+  }
+}

--- a/app/src/main/res/layout/activity_dual_navigation_map.xml
+++ b/app/src/main/res/layout/activity_dual_navigation_map.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/dualNavigationMap"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.mapbox.services.android.navigation.ui.v5.NavigationView
+        android:id="@+id/navigationView"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:visibility="visible"
+        app:layout_constraintHeight_percent="0.5"
+        app:layout_constraintTop_toTopOf="@+id/dualNavigationMap"
+        app:navigationDarkTheme="@style/NavigationViewDark"
+        app:navigationLightTheme="@style/NavigationViewLight"/>
+
+    <com.mapbox.mapboxsdk.maps.MapView
+        android:id="@+id/mapView"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:visibility="visible"
+        app:layout_constraintBottom_toBottomOf="@+id/dualNavigationMap"
+        app:layout_constraintHeight_percent="0.5"/>
+
+    <ProgressBar
+        android:id="@+id/loading"
+        style="?android:attr/progressBarStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:indeterminate="true"
+        android:visibility="invisible"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
+
+    <android.support.design.widget.FloatingActionButton
+        android:id="@+id/launchNavigation"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginRight="16dp"
+        android:src="@drawable/ic_navigation"
+        android:tint="@android:color/white"
+        android:visibility="visible"
+        app:backgroundTint="@color/colorPrimary"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/activity_dual_navigation_map_expanded.xml
+++ b/app/src/main/res/layout/activity_dual_navigation_map_expanded.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/dualNavigationMap"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.mapbox.services.android.navigation.ui.v5.NavigationView
+        android:id="@+id/navigationView"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:visibility="visible"
+        app:layout_constraintHeight_percent="1"
+        app:layout_constraintTop_toTopOf="@+id/dualNavigationMap"
+        app:layout_constraintBottom_toBottomOf="@+id/dualNavigationMap"
+        app:navigationDarkTheme="@style/NavigationViewDark"
+        app:navigationLightTheme="@style/NavigationViewLight"/>
+
+    <com.mapbox.mapboxsdk.maps.MapView
+        android:id="@+id/mapView"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="@+id/dualNavigationMap"
+        app:layout_constraintHeight_percent="0"/>
+
+    <ProgressBar
+        android:id="@+id/loading"
+        style="?android:attr/progressBarStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:indeterminate="true"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
+
+    <android.support.design.widget.FloatingActionButton
+        android:id="@+id/launchNavigation"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginRight="16dp"
+        android:src="@drawable/ic_navigation"
+        android:tint="@android:color/white"
+        android:visibility="visible"
+        app:backgroundTint="@color/colorPrimary"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,6 +19,9 @@
     <string name="title_end_navigation">End Navigation</string>
     <string name="description_end_navigation">Shows how to end navigation using NavigationView</string>
 
+    <string name="title_dual_navigation_map">Dual Navigation Map</string>
+    <string name="description_dual_navigation_map">Shows how to add NavigationView and MapView in the same layout</string>
+
     <string name="title_waypoint_navigation">Waypoint Navigation</string>
     <string name="description_waypoint_navigation">Navigation with waypoints between destinations</string>
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -16,7 +16,7 @@ ext {
       autoValueParcel    : '0.2.5',
       junit              : '4.12',
       supportLibVersion  : '27.1.1',
-      constraintLayout   : '1.1.0',
+      constraintLayout   : '1.1.1',
       mockito            : '2.18.3',
       hamcrest           : '2.0.0.0',
       errorprone         : '2.3.1',


### PR DESCRIPTION
- Adds `DualNavigationMapActivity` to the test app which shows how to add `NavigationView` and `MapView` in the same layout and allows us to test https://github.com/mapbox/mapbox-navigation-android/pull/959#issuecomment-401430452
- Bumps `constraint-layout` version to `1.1.1`