### PR TITLE
Update TimeFormatter to include localized Strings

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/SummaryModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/SummaryModel.java
@@ -11,8 +11,8 @@ import com.mapbox.services.android.navigation.v5.utils.DistanceUtils;
 
 import java.util.Calendar;
 
-import static com.mapbox.services.android.navigation.v5.utils.time.TimeUtils.formatTime;
-import static com.mapbox.services.android.navigation.v5.utils.time.TimeUtils.formatTimeRemaining;
+import static com.mapbox.services.android.navigation.v5.utils.time.TimeFormatter.formatTime;
+import static com.mapbox.services.android.navigation.v5.utils.time.TimeFormatter.formatTimeRemaining;
 
 public class SummaryModel {
 
@@ -25,7 +25,7 @@ public class SummaryModel {
                       @NavigationTimeFormat.Type int timeFormatType) {
     distanceRemaining = new DistanceUtils(context, language, unitType)
       .formatDistance(progress.distanceRemaining()).toString();
-    timeRemaining = formatTimeRemaining(progress.durationRemaining());
+    timeRemaining = formatTimeRemaining(context, progress.durationRemaining());
     Calendar time = Calendar.getInstance();
     boolean isTwentyFourHourFormat = DateFormat.is24HourFormat(context);
     arrivalTime = formatTime(time, progress.durationRemaining(), timeFormatType, isTwentyFourHourFormat);

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationNotification.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationNotification.java
@@ -20,7 +20,7 @@ import com.mapbox.services.android.navigation.v5.navigation.notification.Navigat
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 import com.mapbox.services.android.navigation.v5.utils.DistanceUtils;
 import com.mapbox.services.android.navigation.v5.utils.ManeuverUtils;
-import com.mapbox.services.android.navigation.v5.utils.time.TimeUtils;
+import com.mapbox.services.android.navigation.v5.utils.time.TimeFormatter;
 
 import java.util.Locale;
 
@@ -188,7 +188,7 @@ class MapboxNavigationNotification implements NavigationNotification {
 
   private void updateArrivalTime(RouteProgress routeProgress) {
     if (currentArrivalTime == null || newArrivalTime(routeProgress)) {
-      currentArrivalTime = TimeUtils.formatArrivalTime(routeProgress.durationRemaining());
+      currentArrivalTime = TimeFormatter.formatArrivalTime(routeProgress.durationRemaining());
       String formattedArrivalText = String.format(Locale.getDefault(), etaFormat, currentArrivalTime);
       collapsedNotificationRemoteViews.setTextViewText(R.id.notificationArrivalText, formattedArrivalText);
       expandedNotificationRemoteViews.setTextViewText(R.id.notificationArrivalText, formattedArrivalText);
@@ -196,7 +196,7 @@ class MapboxNavigationNotification implements NavigationNotification {
   }
 
   private boolean newArrivalTime(RouteProgress routeProgress) {
-    return currentArrivalTime != null && !currentArrivalTime.equals(TimeUtils
+    return currentArrivalTime != null && !currentArrivalTime.equals(TimeFormatter
       .formatArrivalTime(routeProgress.durationRemaining()));
   }
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationTelemetry.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationTelemetry.java
@@ -25,7 +25,6 @@ import com.mapbox.services.android.navigation.v5.navigation.metrics.TelemetryEve
 import com.mapbox.services.android.navigation.v5.routeprogress.MetricsRouteProgress;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 import com.mapbox.services.android.navigation.v5.utils.RingBuffer;
-import com.mapbox.services.android.navigation.v5.utils.time.TimeUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -368,7 +367,7 @@ class NavigationTelemetry implements LocationEngineListener, NavigationMetricLis
   }
 
   private boolean shouldSendEvent(SessionState sessionState) {
-    return TimeUtils.dateDiff(sessionState.eventDate(), new Date(), TimeUnit.SECONDS) > TWENTY_SECOND_INTERVAL;
+    return dateDiff(sessionState.eventDate(), new Date(), TimeUnit.SECONDS) > TWENTY_SECOND_INTERVAL;
   }
 
   @NonNull
@@ -490,6 +489,11 @@ class NavigationTelemetry implements LocationEngineListener, NavigationMetricLis
     NavigationMetricsWrapper.feedbackEvent(feedbackSessionState, metricProgress,
       feedbackEvent.getSessionState().eventLocation(), feedbackEvent.getDescription(),
       feedbackEvent.getFeedbackType(), feedbackEvent.getScreenshot(), feedbackEvent.getFeedbackSource());
+  }
+
+  private long dateDiff(Date firstDate, Date secondDate, TimeUnit timeUnit) {
+    long diffInMillis = secondDate.getTime() - firstDate.getTime();
+    return timeUnit.convert(diffInMillis, TimeUnit.MILLISECONDS);
   }
 
   private TelemetryEvent findQueuedTelemetryEvent(String eventId) {

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/route/FasterRouteDetector.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/route/FasterRouteDetector.java
@@ -8,7 +8,6 @@ import com.mapbox.api.directions.v5.models.LegStep;
 import com.mapbox.api.directions.v5.models.RouteLeg;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteStepProgress;
-import com.mapbox.services.android.navigation.v5.utils.time.TimeUtils;
 
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
@@ -128,6 +127,11 @@ public class FasterRouteDetector extends FasterRoute {
   }
 
   private long secondsSinceLastCheck(Location location) {
-    return TimeUtils.dateDiff(new Date(lastCheckedLocation.getTime()), new Date(location.getTime()), TimeUnit.SECONDS);
+    return dateDiff(new Date(lastCheckedLocation.getTime()), new Date(location.getTime()), TimeUnit.SECONDS);
+  }
+
+  private long dateDiff(Date firstDate, Date secondDate, TimeUnit timeUnit) {
+    long diffInMillis = secondDate.getTime() - firstDate.getTime();
+    return timeUnit.convert(diffInMillis, TimeUnit.MILLISECONDS);
   }
 }

--- a/libandroid-navigation/src/main/res/values/strings.xml
+++ b/libandroid-navigation/src/main/res/values/strings.xml
@@ -8,4 +8,14 @@
     <string name="miles">mi</string>
     <string name="feet">ft</string>
     <string name="eta_format">%s ETA</string>
+
+    <!-- Time formatting -->
+    <plurals name="numberOfDays">
+        <item quantity="one">day</item>
+        <item quantity="other">days</item>
+    </plurals>
+    <!-- Hour -->
+    <string name="hr">hr</string>
+    <!-- Minute -->
+    <string name="min">min</string>
 </resources>

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/utils/time/TimeFormatterTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/utils/time/TimeFormatterTest.java
@@ -6,7 +6,7 @@ import java.util.Calendar;
 
 import static org.junit.Assert.assertEquals;
 
-public class TimeUtilsTest {
+public class TimeFormatterTest {
 
   @Test
   public void checksTwelveHoursTimeFormat() throws Exception {
@@ -22,7 +22,7 @@ public class TimeUtilsTest {
     int twelveHoursTimeFormatType = 0;
     boolean indifferentDeviceTwentyFourHourFormat = true;
 
-    String formattedTime = TimeUtils.formatTime(time, elevenMinutes, twelveHoursTimeFormatType,
+    String formattedTime = TimeFormatter.formatTime(time, elevenMinutes, twelveHoursTimeFormatType,
       indifferentDeviceTwentyFourHourFormat);
 
     assertEquals("6:29 pm", formattedTime);
@@ -42,7 +42,7 @@ public class TimeUtilsTest {
     int twentyFourHoursTimeFormatType = 1;
     boolean indifferentDeviceTwentyFourHourFormat = false;
 
-    String formattedTime = TimeUtils.formatTime(time, elevenMinutes, twentyFourHoursTimeFormatType,
+    String formattedTime = TimeFormatter.formatTime(time, elevenMinutes, twentyFourHoursTimeFormatType,
       indifferentDeviceTwentyFourHourFormat);
 
     assertEquals("18:29", formattedTime);
@@ -62,7 +62,7 @@ public class TimeUtilsTest {
     int noneSpecifiedTimeFormatType = -1;
     boolean deviceTwelveHourFormat = false;
 
-    String formattedTime = TimeUtils.formatTime(time, elevenMinutes, noneSpecifiedTimeFormatType,
+    String formattedTime = TimeFormatter.formatTime(time, elevenMinutes, noneSpecifiedTimeFormatType,
       deviceTwelveHourFormat);
 
     assertEquals("6:29 pm", formattedTime);
@@ -82,7 +82,7 @@ public class TimeUtilsTest {
     int noneSpecifiedTimeFormatType = -1;
     boolean deviceTwentyFourHourFormat = true;
 
-    String formattedTime = TimeUtils.formatTime(time, elevenMinutes, noneSpecifiedTimeFormatType,
+    String formattedTime = TimeFormatter.formatTime(time, elevenMinutes, noneSpecifiedTimeFormatType,
       deviceTwentyFourHourFormat);
 
     assertEquals("18:29", formattedTime);


### PR DESCRIPTION
Closes #1097 

We are currently using hard-coded constants for arrival time formatting.  This PR replaces them with `String` resources, which have also already been pushed to Transifex.  

Noting that this PR does not actually add the necessary translations but it does set up the code to be ready for them once we pull them from Transifex.  