### PR TITLE
Add InstructionListener for intercepting Voice / Banner Instructions

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/EmbeddedNavigationActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/EmbeddedNavigationActivity.java
@@ -19,6 +19,7 @@ import android.text.style.AbsoluteSizeSpan;
 import android.view.View;
 import android.widget.TextView;
 
+import com.mapbox.api.directions.v5.models.BannerInstructions;
 import com.mapbox.api.directions.v5.models.DirectionsResponse;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.geojson.Point;
@@ -27,8 +28,11 @@ import com.mapbox.services.android.navigation.testapp.R;
 import com.mapbox.services.android.navigation.ui.v5.NavigationView;
 import com.mapbox.services.android.navigation.ui.v5.NavigationViewOptions;
 import com.mapbox.services.android.navigation.ui.v5.OnNavigationReadyCallback;
+import com.mapbox.services.android.navigation.ui.v5.listeners.BannerInstructionsListener;
 import com.mapbox.services.android.navigation.ui.v5.listeners.InstructionListListener;
 import com.mapbox.services.android.navigation.ui.v5.listeners.NavigationListener;
+import com.mapbox.services.android.navigation.ui.v5.listeners.SpeechAnnouncementListener;
+import com.mapbox.services.android.navigation.ui.v5.voice.SpeechAnnouncement;
 import com.mapbox.services.android.navigation.v5.navigation.NavigationRoute;
 import com.mapbox.services.android.navigation.v5.routeprogress.ProgressChangeListener;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
@@ -37,7 +41,8 @@ import retrofit2.Call;
 import retrofit2.Response;
 
 public class EmbeddedNavigationActivity extends AppCompatActivity implements OnNavigationReadyCallback,
-  NavigationListener, ProgressChangeListener, InstructionListListener {
+  NavigationListener, ProgressChangeListener, InstructionListListener, SpeechAnnouncementListener,
+  BannerInstructionsListener {
 
   private static final Point ORIGIN = Point.fromLngLat(-77.03194990754128, 38.909664963450105);
   private static final Point DESTINATION = Point.fromLngLat(-77.0270025730133, 38.91057077063121);
@@ -160,6 +165,16 @@ public class EmbeddedNavigationActivity extends AppCompatActivity implements OnN
     }
   }
 
+  @Override
+  public SpeechAnnouncement willVoice(SpeechAnnouncement announcement) {
+    return announcement.toBuilder().announcement("All announcments will be the same.").build();
+  }
+
+  @Override
+  public BannerInstructions willDisplay(BannerInstructions instructions) {
+    return instructions;
+  }
+
   private void startNavigation(DirectionsRoute directionsRoute) {
     NavigationViewOptions.Builder options =
       NavigationViewOptions.builder()
@@ -167,7 +182,9 @@ public class EmbeddedNavigationActivity extends AppCompatActivity implements OnN
         .directionsRoute(directionsRoute)
         .shouldSimulateRoute(true)
         .progressChangeListener(this)
-        .instructionListListener(this);
+        .instructionListListener(this)
+        .speechAnnouncementListener(this)
+        .bannerInstructionsListener(this);
     setBottomSheetCallback(options);
     setupNightModeFab();
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewOptions.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewOptions.java
@@ -6,8 +6,10 @@ import android.support.design.widget.BottomSheetBehavior.BottomSheetCallback;
 import com.google.auto.value.AutoValue;
 import com.mapbox.api.directions.v5.DirectionsCriteria;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
+import com.mapbox.services.android.navigation.ui.v5.listeners.BannerInstructionsListener;
 import com.mapbox.services.android.navigation.ui.v5.listeners.FeedbackListener;
 import com.mapbox.services.android.navigation.ui.v5.listeners.InstructionListListener;
+import com.mapbox.services.android.navigation.ui.v5.listeners.SpeechAnnouncementListener;
 import com.mapbox.services.android.navigation.ui.v5.listeners.NavigationListener;
 import com.mapbox.services.android.navigation.ui.v5.listeners.RouteListener;
 import com.mapbox.services.android.navigation.v5.milestone.Milestone;
@@ -46,6 +48,12 @@ public abstract class NavigationViewOptions extends NavigationUiOptions {
   @Nullable
   public abstract InstructionListListener instructionListListener();
 
+  @Nullable
+  public abstract SpeechAnnouncementListener speechAnnouncementListener();
+
+  @Nullable
+  public abstract BannerInstructionsListener bannerInstructionsListener();
+
   @AutoValue.Builder
   public abstract static class Builder {
 
@@ -78,6 +86,10 @@ public abstract class NavigationViewOptions extends NavigationUiOptions {
     public abstract Builder bottomSheetCallback(BottomSheetCallback bottomSheetCallback);
 
     public abstract Builder instructionListListener(InstructionListListener instructionListListener);
+
+    public abstract Builder speechAnnouncementListener(SpeechAnnouncementListener speechAnnouncementListener);
+
+    public abstract Builder bannerInstructionsListener(BannerInstructionsListener bannerInstructionsListener);
 
     public abstract NavigationViewOptions build();
   }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/BannerInstructionModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/BannerInstructionModel.java
@@ -3,16 +3,16 @@ package com.mapbox.services.android.navigation.ui.v5.instruction;
 import android.content.Context;
 
 import com.mapbox.api.directions.v5.DirectionsCriteria;
-import com.mapbox.services.android.navigation.v5.milestone.BannerInstructionMilestone;
+import com.mapbox.api.directions.v5.models.BannerInstructions;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 
 public class BannerInstructionModel extends InstructionModel {
 
-  public BannerInstructionModel(Context context, BannerInstructionMilestone milestone, RouteProgress progress,
+  public BannerInstructionModel(Context context, BannerInstructions instructions, RouteProgress progress,
                                 String language, @DirectionsCriteria.VoiceUnitCriteria String unitType) {
     super(context, progress, language, unitType);
-    primaryBannerText = milestone.getBannerInstructions().primary();
-    secondaryBannerText = milestone.getBannerInstructions().secondary();
+    primaryBannerText = instructions.primary();
+    secondaryBannerText = instructions.secondary();
   }
 
   @Override

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/listeners/BannerInstructionsListener.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/listeners/BannerInstructionsListener.java
@@ -1,0 +1,26 @@
+package com.mapbox.services.android.navigation.ui.v5.listeners;
+
+import com.mapbox.api.directions.v5.models.BannerInstructions;
+
+/**
+ * This listener will be triggered when a {@link BannerInstructions} is about to be displayed.
+ * <p>
+ * The listener gives you the option to override any values and pass as the return value,
+ * which will be the value used for the banner instructions.
+ *
+ * @since 0.16.0
+ */
+public interface BannerInstructionsListener {
+
+  /**
+   * Listener tied to {@link BannerInstructions} that are about to be displayed.
+   * <p>
+   * To prevent the given {@link BannerInstructions} from being displayed, you can return null
+   * and it will be ignored.
+   *
+   * @param instructions about to be displayed
+   * @return instructions to be displayed; null if should be ignored
+   * @since 0.16.0
+   */
+  BannerInstructions willDisplay(BannerInstructions instructions);
+}

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/listeners/SpeechAnnouncementListener.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/listeners/SpeechAnnouncementListener.java
@@ -1,0 +1,26 @@
+package com.mapbox.services.android.navigation.ui.v5.listeners;
+
+import com.mapbox.services.android.navigation.ui.v5.voice.SpeechAnnouncement;
+
+/**
+ * This listener will be triggered when a voice announcement is about to be voiced.
+ * <p>
+ * The listener gives you the option to override any values and pass as the return value,
+ * which will be the value used for the voice announcement.
+ *
+ * @since 0.16.0
+ */
+public interface SpeechAnnouncementListener {
+
+  /**
+   * Listener tied to voice announcements that are about to be voiced.
+   * <p>
+   * To prevent the given announcement from being announced, you can return null
+   * and it will be ignored.
+   *
+   * @param announcement about to be announced
+   * @return announcement to be played; null if should be ignored
+   * @since 0.16.0
+   */
+  SpeechAnnouncement willVoice(SpeechAnnouncement announcement);
+}

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/voice/MapboxSpeechPlayer.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/voice/MapboxSpeechPlayer.java
@@ -65,12 +65,16 @@ class MapboxSpeechPlayer implements SpeechPlayer {
   /**
    * Plays the specified text instruction using MapboxSpeech API, defaulting to SSML input type
    *
-   * @param speechAnnouncement with voice instruction to be synthesized and played
+   * @param announcement with voice instruction to be synthesized and played
    */
   @Override
-  public void play(SpeechAnnouncement speechAnnouncement) {
-    this.announcement = speechAnnouncement;
-    playAnnouncementTextAndTypeFrom(speechAnnouncement);
+  public void play(SpeechAnnouncement announcement) {
+    boolean isInvalidAnnouncement = announcement == null;
+    if (isInvalidAnnouncement) {
+      return;
+    }
+    this.announcement = announcement;
+    playAnnouncementTextAndTypeFrom(announcement);
   }
 
   @Override

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/voice/SpeechAnnouncement.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/voice/SpeechAnnouncement.java
@@ -20,7 +20,7 @@ import com.mapbox.services.android.navigation.v5.milestone.VoiceInstructionMiles
 public abstract class SpeechAnnouncement {
 
   /**
-   * Announcment text containing SSML Markup Language
+   * Announcement text containing SSML Markup Language
    *
    * @return announcement containing SSML text
    * @see <a href="https://docs.aws.amazon.com/polly/latest/dg/ssml.html">SSML Markup Language</a>
@@ -30,12 +30,25 @@ public abstract class SpeechAnnouncement {
   public abstract String ssmlAnnouncement();
 
   /**
-   * Announcment text without any type of markup.
+   * Announcement text without any type of markup.
    *
    * @return announcement text
    * @since 0.16.0
    */
   public abstract String announcement();
+
+  /**
+   * Convert the current {@link SpeechAnnouncement} to its builder holding the currently assigned
+   * values. This allows you to modify a single property and then rebuild the object resulting in
+   * an updated and modified {@link SpeechAnnouncement}.
+   * <p>
+   * Please note, the usage of this method creates a new instance of {@link SpeechAnnouncement}.
+   *
+   * @return a {@link SpeechAnnouncement.Builder} with the same values set to match the ones defined
+   * in this {@link SpeechAnnouncement}
+   * @since 0.16.0
+   */
+  public abstract Builder toBuilder();
 
   @Nullable
   abstract VoiceInstructionMilestone voiceInstructionMilestone();
@@ -44,7 +57,7 @@ public abstract class SpeechAnnouncement {
   public abstract static class Builder {
 
     /**
-     * Announcment text containing SSML Markup Language
+     * Announcement text containing SSML Markup Language
      *
      * @return this builder for chaining options together
      * @see <a href="https://docs.aws.amazon.com/polly/latest/dg/ssml.html">SSML Markup Language</a>
@@ -53,7 +66,7 @@ public abstract class SpeechAnnouncement {
     public abstract Builder ssmlAnnouncement(@Nullable String ssmlAnnouncement);
 
     /**
-     * Announcment text without any type of markup.
+     * Announcement text without any type of markup.
      *
      * @return this builder for chaining options together
      * @since 0.16.0
@@ -63,7 +76,7 @@ public abstract class SpeechAnnouncement {
     /**
      * The {@link com.mapbox.services.android.navigation.v5.milestone.MilestoneEventListener} can provide
      * voice instructions via {@link VoiceInstructionMilestone}.
-     *
+     * <p>
      * If you pass the milestone into the builder, {@link SpeechAnnouncement} will extract both the SSML
      * and normal speech announcements.
      *

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewEventDispatcherTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewEventDispatcherTest.java
@@ -2,13 +2,17 @@ package com.mapbox.services.android.navigation.ui.v5;
 
 import android.support.annotation.NonNull;
 
+import com.mapbox.api.directions.v5.models.BannerInstructions;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.geojson.Point;
 import com.mapbox.services.android.navigation.ui.v5.feedback.FeedbackItem;
+import com.mapbox.services.android.navigation.ui.v5.listeners.BannerInstructionsListener;
 import com.mapbox.services.android.navigation.ui.v5.listeners.FeedbackListener;
 import com.mapbox.services.android.navigation.ui.v5.listeners.InstructionListListener;
+import com.mapbox.services.android.navigation.ui.v5.listeners.SpeechAnnouncementListener;
 import com.mapbox.services.android.navigation.ui.v5.listeners.NavigationListener;
 import com.mapbox.services.android.navigation.ui.v5.listeners.RouteListener;
+import com.mapbox.services.android.navigation.ui.v5.voice.SpeechAnnouncement;
 import com.mapbox.services.android.navigation.v5.milestone.MilestoneEventListener;
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation;
 import com.mapbox.services.android.navigation.v5.routeprogress.ProgressChangeListener;
@@ -355,6 +359,47 @@ public class NavigationViewEventDispatcherTest {
 
     verify(navigation, times(1)).removeMilestoneEventListener(milestoneEventListener);
   }
+
+  @Test
+  public void onNewBannerInstruction_instructionListenerIsCalled() {
+    BannerInstructions modifiedInstructions = mock(BannerInstructions.class);
+    BannerInstructions originalInstructions = mock(BannerInstructions.class);
+    BannerInstructionsListener bannerInstructionsListener = mock(BannerInstructionsListener.class);
+    when(bannerInstructionsListener.willDisplay(originalInstructions)).thenReturn(modifiedInstructions);
+    NavigationViewEventDispatcher eventDispatcher = buildViewEventDispatcher(bannerInstructionsListener);
+
+    eventDispatcher.onBannerDisplay(originalInstructions);
+
+    verify(bannerInstructionsListener).willDisplay(originalInstructions);
+  }
+
+  @Test
+  public void onNewVoiceAnnouncement_instructionListenerIsCalled() {
+    SpeechAnnouncement modifiedAnnouncement = mock(SpeechAnnouncement.class);
+    SpeechAnnouncement originalAnnouncement = mock(SpeechAnnouncement.class);
+    SpeechAnnouncementListener speechAnnouncementListener = mock(SpeechAnnouncementListener.class);
+    when(speechAnnouncementListener.willVoice(originalAnnouncement)).thenReturn(modifiedAnnouncement);
+    NavigationViewEventDispatcher eventDispatcher = buildViewEventDispatcher(speechAnnouncementListener);
+
+    eventDispatcher.onAnnouncement(originalAnnouncement);
+
+    verify(speechAnnouncementListener).willVoice(originalAnnouncement);
+  }
+
+  @NonNull
+  private NavigationViewEventDispatcher buildViewEventDispatcher(SpeechAnnouncementListener speechAnnouncementListener) {
+    NavigationViewEventDispatcher eventDispatcher = new NavigationViewEventDispatcher();
+    eventDispatcher.assignSpeechAnnouncementListener(speechAnnouncementListener);
+    return eventDispatcher;
+  }
+
+  @NonNull
+  private NavigationViewEventDispatcher buildViewEventDispatcher(BannerInstructionsListener bannerInstructionsListener) {
+    NavigationViewEventDispatcher eventDispatcher = new NavigationViewEventDispatcher();
+    eventDispatcher.assignBannerInstructionsListener(bannerInstructionsListener);
+    return eventDispatcher;
+  }
+
 
   @NonNull
   private NavigationViewEventDispatcher buildViewEventDispatcher(InstructionListListener instructionListListener) {


### PR DESCRIPTION
Closes #1074 

This PR adds an `InstructionListener` that can be added to `NavigationViewOptions`.  This listener will allow developers to "intercept" voice or banner instructions when we are about to voice them with TTS or present them in the UI respectively. 

Example:
```
@Override
public SpeechAnnouncement willVoice(SpeechAnnouncement announcement) {
  return announcement.toBuilder().announcement("All announcments will be the same.").build();
}
```

TODO:
- [x] `InstructionListener` docs
