### PR TITLE
Added checks for low point ammounts

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/NavigationMapRoute.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/NavigationMapRoute.java
@@ -99,7 +99,7 @@ public class NavigationMapRoute implements MapView.OnMapChangedListener,
   private static final String WAYPOINT_LAYER_ID = "mapbox-navigation-waypoint-layer";
   private static final String ID_FORMAT = "%s-%d";
   private static final String GENERIC_ROUTE_SHIELD_LAYER_ID = "mapbox-navigation-route-shield-layer";
-  private static final int TWO_MANEUVERS = 2;
+  private static final int TWO_POINTS = 2;
   private static final int THIRTY = 30;
   private static final String ARROW_BEARING = "mapbox-navigation-arrow-bearing";
   private static final String ARROW_SHAFT_SOURCE_ID = "mapbox-navigation-arrow-shaft-source";
@@ -445,7 +445,10 @@ public class NavigationMapRoute implements MapView.OnMapChangedListener,
   }
 
   private void addUpcomingManeuverArrow(RouteProgress routeProgress) {
-    if (routeProgress.upcomingStepPoints() == null || routeProgress.upcomingStepPoints().size() < TWO_MANEUVERS) {
+    boolean invalidUpcomingStepPoints = routeProgress.upcomingStepPoints() == null
+            || routeProgress.upcomingStepPoints().size() < TWO_POINTS;
+    boolean invalidCurrentStepPoints = routeProgress.currentStepPoints().size() < TWO_POINTS;
+    if (invalidUpcomingStepPoints || invalidCurrentStepPoints) {
       updateArrowLayersVisibilityTo(false);
       return;
     }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteDetector.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteDetector.java
@@ -23,6 +23,7 @@ public class OffRouteDetector extends OffRoute {
   private Point lastReroutePoint;
   private OffRouteCallback callback;
   private RingBuffer<Integer> distancesAwayFromManeuver = new RingBuffer<>(3);
+  private static final int TWO_POINTS = 2;
 
   /**
    * Method in charge of running a series of test based on the device current location
@@ -208,8 +209,9 @@ public class OffRouteDetector extends OffRoute {
                                                 RingBuffer<Integer> distancesAwayFromManeuver,
                                                 List<Point> stepPoints,
                                                 Point currentPoint) {
-
-    if (routeProgress.currentLegProgress().upComingStep() == null || stepPoints.isEmpty()) {
+    boolean invalidUpcomingStep = routeProgress.currentLegProgress().upComingStep() == null;
+    boolean invalidStepPointSize = stepPoints.size() < TWO_POINTS;
+    if (invalidUpcomingStep || invalidStepPointSize) {
       return false;
     }
 

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteDetectorTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/offroute/OffRouteDetectorTest.java
@@ -90,6 +90,21 @@ public class OffRouteDetectorTest extends BaseTest {
   }
 
   @Test
+  public void isUserOffRoute_StepPointSize() throws Exception {
+    RouteProgress routeProgress = buildDefaultTestRouteProgress();
+    Point stepManeuverPoint = routeProgress.directionsRoute().legs().get(0).steps().get(0).maneuver().location();
+    removeAllButOneStepPoints(routeProgress);
+    Location firstUpdate = buildDefaultLocationUpdate(-77.0339782574523, 38.89993519985637);
+    offRouteDetector.isUserOffRoute(firstUpdate, routeProgress, options);
+    Point offRoutePoint = buildPointAwayFromPoint(stepManeuverPoint, 50, 90);
+    Location secondUpdate = buildDefaultLocationUpdate(offRoutePoint.longitude(), offRoutePoint.latitude());
+
+    boolean isUserOffRoute = offRouteDetector.isUserOffRoute(secondUpdate, routeProgress, options);
+
+    assertFalse(isUserOffRoute);
+  }
+
+  @Test
   public void isUserOffRoute_AssertFalseWhenOnStep() throws Exception {
     RouteProgress routeProgress = buildDefaultTestRouteProgress();
     Point stepManeuverPoint = routeProgress.directionsRoute().legs().get(0).steps().get(0).maneuver().location();
@@ -224,5 +239,11 @@ public class OffRouteDetectorTest extends BaseTest {
     boolean isOffRoute = offRouteDetector.isUserOffRoute(location, routeProgress, options);
 
     assertTrue(isOffRoute);
+  }
+
+  private void removeAllButOneStepPoints(RouteProgress routeProgress) {
+    for (int i = routeProgress.currentStepPoints().size() - 2; i >= 0; i--) {
+      routeProgress.currentStepPoints().remove(i);
+    }
   }
 }


### PR DESCRIPTION
While experimenting with the SDK I found two potential issues in the the code.

In `NavigationMapRoute#addUpcomingManeuverArrow` there is a check if the `upcomingStepPoints` are at least of size 2, but there is no check for the `currentStepPoints`. In `obtainArrowPointsFrom` the function `TurfMisc.lineSliceAlong` requires the points to be at least a size of 2. Both the upcoming as well als current steps are put into this method.

In `OffRouteDetector#movingAwayFromManeuver` I found a similar issue, there the stepPoints are check for the empty condition, but are put into `TurfMisc.nearestPointOnLine` which also requires at least a size of 2.

In both cases `TurfMisc` throws a `TurfException` which is not catched and can crash the SDK.

Unfortunately, I am not sure yet how to write a test for both cases :). If I am not mistaken, there are no tests for the NavigationMapRoute class yet? I had issues reproducing the case via OffRouteDetectorTest. So any hints regarding the tests would be highly appreciated.