### PR TITLE
Simplify find current banner and voice instructions algorithms

### DIFF
--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/utils/RouteUtilsTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/utils/RouteUtilsTest.java
@@ -216,20 +216,6 @@ public class RouteUtilsTest extends BaseTest {
   }
 
   @Test
-  public void findCurrentBannerInstructions_clearsAllInvalidInstructions() throws Exception {
-    RouteProgress routeProgress = buildDefaultTestRouteProgress();
-    LegStep currentStep = routeProgress.currentLegProgress().currentStep();
-    double stepDistanceRemaining = 400;
-    RouteUtils routeUtils = new RouteUtils();
-
-    BannerInstructions currentBannerInstructions = routeUtils.findCurrentBannerInstructions(
-      currentStep, stepDistanceRemaining
-    );
-
-    assertNull(currentBannerInstructions);
-  }
-
-  @Test
   public void findCurrentBannerInstructions_returnsCorrectCurrentInstruction() throws Exception {
     RouteProgress routeProgress = buildDefaultTestRouteProgress();
     LegStep currentStep = routeProgress.currentLegProgress().currentStep();


### PR DESCRIPTION
Follow up from https://github.com/mapbox/mapbox-navigation-android/pull/1095

- Simplifies `findCurrentBannerInstructions` and `findCurrentVoiceInstructions` algorithms from `RouteUtils`

cc @dsilvera 