### PR TITLE
Prevent NavigationNotification update after unregistered

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationNotificationProvider.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationNotificationProvider.java
@@ -8,6 +8,7 @@ import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 class NavigationNotificationProvider {
 
   private NavigationNotification navigationNotification;
+  private boolean shouldUpdate = true;
 
   NavigationNotificationProvider(Context context, MapboxNavigation mapboxNavigation) {
     navigationNotification = buildNotificationFrom(context, mapboxNavigation);
@@ -18,14 +19,17 @@ class NavigationNotificationProvider {
   }
 
   void updateNavigationNotification(RouteProgress routeProgress) {
-    navigationNotification.updateNotification(routeProgress);
+    if (shouldUpdate) {
+      navigationNotification.updateNotification(routeProgress);
+    }
   }
 
-  void unregisterNotificationReceiver(Context context) {
+  void shutdown(Context context) {
     if (navigationNotification instanceof MapboxNavigationNotification) {
       ((MapboxNavigationNotification) navigationNotification).unregisterReceiver(context);
     }
     navigationNotification = null;
+    shouldUpdate = false;
   }
 
   private NavigationNotification buildNotificationFrom(Context context, MapboxNavigation mapboxNavigation) {

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationService.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationService.java
@@ -74,7 +74,7 @@ public class NavigationService extends Service {
   void endNavigation() {
     routeFetcher.clearListeners();
     locationProvider.removeLocationEngineListener();
-    notificationProvider.unregisterNotificationReceiver(getApplication());
+    notificationProvider.shutdown(getApplication());
     thread.quit();
   }
 

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationNotificationProviderTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationNotificationProviderTest.java
@@ -1,0 +1,53 @@
+package com.mapbox.services.android.navigation.v5.navigation;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+
+import com.mapbox.services.android.navigation.v5.navigation.notification.NavigationNotification;
+import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
+
+import org.junit.Test;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+public class NavigationNotificationProviderTest {
+
+  @Test
+  public void updateNavigationNotification() {
+    NavigationNotification notification = mock(NavigationNotification.class);
+    MapboxNavigation mapboxNavigation = buildNavigationWithNotificationOptions(notification);
+    Context context = mock(Context.class);
+    NavigationNotificationProvider provider = new NavigationNotificationProvider(context, mapboxNavigation);
+
+    RouteProgress routeProgress = mock(RouteProgress.class);
+    provider.updateNavigationNotification(routeProgress);
+
+    verify(notification).updateNotification(eq(routeProgress));
+  }
+
+  @Test
+  public void updateNavigationNotification_doesNotUpdateAfterShutdown() {
+    NavigationNotification notification = mock(NavigationNotification.class);
+    MapboxNavigation mapboxNavigation = buildNavigationWithNotificationOptions(notification);
+    Context context = mock(Context.class);
+    NavigationNotificationProvider provider = new NavigationNotificationProvider(context, mapboxNavigation);
+
+    provider.shutdown(context);
+    provider.updateNavigationNotification(mock(RouteProgress.class));
+
+    verifyZeroInteractions(notification);
+  }
+
+  @NonNull
+  private MapboxNavigation buildNavigationWithNotificationOptions(NavigationNotification notification) {
+    MapboxNavigation mapboxNavigation = mock(MapboxNavigation.class);
+    MapboxNavigationOptions options = mock(MapboxNavigationOptions.class);
+    when(options.navigationNotification()).thenReturn(notification);
+    when(mapboxNavigation.options()).thenReturn(options);
+    return mapboxNavigation;
+  }
+}


### PR DESCRIPTION
Closes #1116 Regression from #1066 

Added a boolean to prevent notification updates after the notification has been shut down.  