### PR TITLE
Fix IllegalArgumentException when updating InstructionList

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/list/InstructionListPresenter.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/list/InstructionListPresenter.java
@@ -122,7 +122,7 @@ public class InstructionListPresenter {
       List<LegStep> steps = currentLeg.steps();
       for (LegStep step : steps) {
         List<BannerInstructions> bannerInstructions = step.bannerInstructions();
-        if (bannerInstructions != null) {
+        if (bannerInstructions != null && !bannerInstructions.isEmpty()) {
           instructions.addAll(bannerInstructions);
           didAddInstructions = true;
         }
@@ -142,6 +142,9 @@ public class InstructionListPresenter {
     BannerInstructions currentBannerInstructions = routeUtils.findCurrentBannerInstructions(
       currentStep, stepDistanceRemaining
     );
+    if (!instructions.contains(currentBannerInstructions)) {
+      return false;
+    }
     int currentInstructionIndex = instructions.indexOf(currentBannerInstructions);
     return removeInstructionsFrom(currentInstructionIndex);
   }
@@ -150,8 +153,8 @@ public class InstructionListPresenter {
     if (currentInstructionIndex == FIRST_INSTRUCTION_INDEX) {
       instructions.remove(FIRST_INSTRUCTION_INDEX);
       return true;
-    } else if (currentInstructionIndex < instructions.size() - 1) {
-      instructions.subList(0, currentInstructionIndex).clear();
+    } else if (currentInstructionIndex <= instructions.size()) {
+      instructions.subList(FIRST_INSTRUCTION_INDEX, currentInstructionIndex).clear();
       return true;
     }
     return false;

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/summary/list/InstructionListPresenterTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/summary/list/InstructionListPresenterTest.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyDouble;
@@ -107,6 +108,19 @@ public class InstructionListPresenterTest extends BaseTest {
     assertTrue(didUpdate);
   }
 
+  @Test
+  public void updateBannerListWith_emptyInstructionsReturnFalse() throws Exception {
+    RouteProgress routeProgress = buildRouteProgress();
+    RouteUtils routeUtils = buildRouteUtils(routeProgress);
+    clearInstructions(routeProgress);
+    DistanceFormatter distanceFormatter = mock(DistanceFormatter.class);
+    InstructionListPresenter presenter = new InstructionListPresenter(routeUtils, distanceFormatter);
+
+    boolean didUpdate = presenter.updateBannerListWith(routeProgress);
+
+    assertFalse(didUpdate);
+  }
+
   @NonNull
   private RouteProgress buildRouteProgress() throws Exception {
     DirectionsRoute route = buildTestDirectionsRoute();
@@ -139,5 +153,14 @@ public class InstructionListPresenterTest extends BaseTest {
       }
     }
     return instructions.size() - 1;
+  }
+
+  private void clearInstructions(RouteProgress routeProgress) {
+    for (LegStep step : routeProgress.currentLeg().steps()) {
+      List<BannerInstructions> instructions = step.bannerInstructions();
+      if (instructions != null) {
+        instructions.clear();
+      }
+    }
   }
 }


### PR DESCRIPTION
Found 🐛 in CI - regression from #1064

```
FATAL EXCEPTION: ControllerMessenger
Process: com.mapbox.services.android.navigation.testapp, PID: 26365
java.lang.IllegalArgumentException
	at java.util.AbstractList.subList(AbstractList.java:736)
	at com.mapbox.services.android.navigation.ui.v5.summary.list.InstructionListPresenter.removeInstructionsFrom(InstructionListPresenter.java:154)
	at com.mapbox.services.android.navigation.ui.v5.summary.list.InstructionListPresenter.updateInstructionList(InstructionListPresenter.java:146)
	at com.mapbox.services.android.navigation.ui.v5.summary.list.InstructionListPresenter.updateBannerListWith(InstructionListPresenter.java:53)
	at com.mapbox.services.android.navigation.ui.v5.summary.list.InstructionListAdapter.updateBannerListWith(InstructionListAdapter.java:49)
	at com.mapbox.services.android.navigation.ui.v5.instruction.InstructionView.updateInstructionList(InstructionView.java:918)
	at com.mapbox.services.android.navigation.ui.v5.instruction.InstructionView.updateDataFromInstruction(InstructionView.java:841)
	at com.mapbox.services.android.navigation.ui.v5.instruction.InstructionView.access$000(InstructionView.java:79)
	at com.mapbox.services.android.navigation.ui.v5.instruction.InstructionView$1.onChanged(InstructionView.java:190)
	at com.mapbox.services.android.navigation.ui.v5.instruction.InstructionView$1.onChanged(InstructionView.java:186)
	at android.arch.lifecycle.LiveData.considerNotify(LiveData.java:109)
	at android.arch.lifecycle.LiveData.dispatchingValue(LiveData.java:126)
	at android.arch.lifecycle.LiveData.setValue(LiveData.java:282)
	at android.arch.lifecycle.MutableLiveData.setValue(MutableLiveData.java:33)
	at com.mapbox.services.android.navigation.ui.v5.NavigationViewModel$1.onProgressChange(NavigationViewModel.java:262)
	at com.mapbox.services.android.navigation.v5.navigation.NavigationEventDispatcher.onProgressChange(NavigationEventDispatcher.java:144)
	at com.mapbox.services.android.navigation.v5.navigation.RouteProcessorThreadListener.onNewRouteProgress(RouteProcessorThreadListener.java:34)
	at com.mapbox.services.android.navigation.v5.navigation.RouteProcessorHandlerCallback$1.run(RouteProcessorHandlerCallback.java:97)
	at android.os.Handler.handleCallback(Handler.java:739)
	at android.os.Handler.dispatchMessage(Handler.java:95)
	at androidx.test.espresso.base.Interrogator.a(Interrogator.java:19)
	at androidx.test.espresso.base.UiControllerImpl.a(UiControllerImpl.java:142)
	at androidx.test.espresso.base.UiControllerImpl.a(UiControllerImpl.java:134)
	at androidx.test.espresso.base.UiControllerImpl.a(UiControllerImpl.java:34)
	at androidx.test.espresso.action.MotionEvents.a(MotionEvents.java:74)
	at androidx.test.espresso.action.MotionEvents.a(MotionEvents.java:52)
	at androidx.test.espresso.action.Tap.c(Tap.java:9)
	at androidx.test.espresso.action.Tap.a(Tap.java:19)
	at androidx.test.espresso.action.Tap$1.b(Tap.java:2)
	at androidx.test.espresso.action.GeneralClickAction.perform(GeneralClickAction.java:22)
	at androidx.test.espresso.ViewInteraction$SingleExecutionViewAction.perform(ViewInteraction.java:9)
	at androidx.test.espresso.ViewInteraction.a(ViewInteraction.java:78)
	at androidx.test.espresso.ViewInteraction.a(ViewInteraction.java:94)
	at androidx.test.espresso.ViewInteraction$1.call(ViewInteraction.java:3)
	at java.util.concurrent.FutureTask.run(FutureTask.java:237)
	at android.os.Handler.handleCallback(Handler.java:739)
	at android.os.Handler.dispatchMessage(Handler.java:95)
	at android.os.Looper.loop(Looper.java:135)
	at android.app.ActivityThread.main(ActivityThread.java:5254)
	at java.lang.reflect.Method.invoke(Native Method)
	at java.lang.reflect.Method.invoke(Method.java:372)
	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:903)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:698)
```