### PR TITLE
Update Maps SDK 6.3.0 and Telem 3.1.4

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,9 +8,9 @@ ext {
   ]
 
   version = [
-      mapboxMapSdk       : '6.2.1',
+      mapboxMapSdk       : '6.3.0',
       mapboxSdkServices  : '3.3.0',
-      mapboxEvents       : '3.1.3',
+      mapboxEvents       : '3.1.4',
       locationLayerPlugin: '0.6.0',
       autoValue          : '1.5',
       autoValueParcel    : '0.2.5',


### PR DESCRIPTION
Updates Maps SDK to version `6.3.0` and Android telemetry to `3.1.4`