### PR TITLE
Make navigation map null when shutting navigation view down

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationSnapshotReadyCallback.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationSnapshotReadyCallback.java
@@ -9,7 +9,7 @@ import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.services.android.navigation.ui.v5.utils.ViewUtils;
 
-class NavigationSnapshotReadyCallback implements MapboxMap.SnapshotReadyCallback {
+public class NavigationSnapshotReadyCallback implements MapboxMap.SnapshotReadyCallback {
 
   private NavigationView navigationView;
   private NavigationViewModel navigationViewModel;

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/NavigationMapboxMap.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/NavigationMapboxMap.java
@@ -20,6 +20,7 @@ import com.mapbox.mapboxsdk.plugins.locationlayer.modes.RenderMode;
 import com.mapbox.mapboxsdk.style.layers.LineLayer;
 import com.mapbox.mapboxsdk.style.layers.SymbolLayer;
 import com.mapbox.mapboxsdk.style.sources.VectorSource;
+import com.mapbox.services.android.navigation.ui.v5.NavigationSnapshotReadyCallback;
 import com.mapbox.services.android.navigation.ui.v5.R;
 import com.mapbox.services.android.navigation.ui.v5.ThemeSwitcher;
 import com.mapbox.services.android.navigation.ui.v5.camera.NavigationCamera;
@@ -151,6 +152,24 @@ public class NavigationMapboxMap {
   @SuppressLint("MissingPermission")
   public void updateLocationLayerVisibilityTo(boolean isVisible) {
     locationLayer.setLocationLayerEnabled(isVisible);
+  }
+
+  public MapboxMap retrieveMap() {
+    return mapboxMap;
+  }
+
+  public void addOnMoveListener(@NonNull MapboxMap.OnMoveListener onMoveListener) {
+    mapboxMap.addOnMoveListener(onMoveListener);
+  }
+
+  public void removeOnMoveListener(MapboxMap.OnMoveListener onMoveListener) {
+    if (onMoveListener != null) {
+      mapboxMap.removeOnMoveListener(onMoveListener);
+    }
+  }
+
+  public void takeScreenshot(NavigationSnapshotReadyCallback navigationSnapshotReadyCallback) {
+    mapboxMap.snapshot(navigationSnapshotReadyCallback);
   }
 
   private void initializeLocationLayer(MapView mapView, MapboxMap map) {


### PR DESCRIPTION
- Makes `navigationMap` `null` when shutting `NavigationView` down ((preventing the instance to be retained) and remove the `map` instance from `NavigationView` completely (moving remaining functionality into `NavigationMapboxMap` class)

Fixes #1109 