### PR TITLE
Prevent to use the map route until the map is ready and the route fetched

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/DualNavigationMapActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/DualNavigationMapActivity.java
@@ -89,7 +89,6 @@ public class DualNavigationMapActivity extends AppCompatActivity implements OnNa
   @Override
   public void onNavigationReady(boolean isRunning) {
     isNavigationRunning = isRunning;
-    fetchRoute();
   }
 
   @Override
@@ -99,6 +98,7 @@ public class DualNavigationMapActivity extends AppCompatActivity implements OnNa
     initLocationEngine();
     initLocationLayer();
     initMapRoute();
+    fetchRoute();
   }
 
   @Override
@@ -115,7 +115,6 @@ public class DualNavigationMapActivity extends AppCompatActivity implements OnNa
   public void onResponse(Call<DirectionsResponse> call, Response<DirectionsResponse> response) {
     if (validRouteResponse(response)) {
       updateLoadingTo(false);
-      launchNavigationFab.setVisibility(View.VISIBLE);
       launchNavigationFab.show();
       route = response.body().routes().get(0);
       mapRoute.addRoutes(response.body().routes());

--- a/app/src/main/res/layout/activity_dual_navigation_map.xml
+++ b/app/src/main/res/layout/activity_dual_navigation_map.xml
@@ -45,7 +45,7 @@
         android:layout_marginRight="16dp"
         android:src="@drawable/ic_navigation"
         android:tint="@android:color/white"
-        android:visibility="visible"
+        android:visibility="invisible"
         app:backgroundTint="@color/colorPrimary"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"/>

--- a/app/src/main/res/layout/activity_dual_navigation_map_expanded.xml
+++ b/app/src/main/res/layout/activity_dual_navigation_map_expanded.xml
@@ -46,7 +46,7 @@
         android:layout_marginRight="16dp"
         android:src="@drawable/ic_navigation"
         android:tint="@android:color/white"
-        android:visibility="visible"
+        android:visibility="gone"
         app:backgroundTint="@color/colorPrimary"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"/>


### PR DESCRIPTION
- Prevents to use the `mapRoute` until the map is ready and the route fetched
- Hides the `launchNavigationFab` until a route is fetched to avoid `Null directionsRoute` `NullPointerException` 👇 

```
07-20 16:14:17.712 6771-6771/com.mapbox.services.android.navigation.testapp E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.mapbox.services.android.navigation.testapp, PID: 6771
    java.lang.NullPointerException: Null directionsRoute
        at com.mapbox.services.android.navigation.ui.v5.AutoValue_NavigationViewOptions$Builder.directionsRoute(AutoValue_NavigationViewOptions.java:288)
        at com.mapbox.services.android.navigation.testapp.activity.navigationui.DualNavigationMapActivity.launchNavigation(DualNavigationMapActivity.java:271)
        at com.mapbox.services.android.navigation.testapp.activity.navigationui.DualNavigationMapActivity.lambda$onCreate$0$DualNavigationMapActivity(DualNavigationMapActivity.java:85)
        at com.mapbox.services.android.navigation.testapp.activity.navigationui.DualNavigationMapActivity$$Lambda$0.onClick(Unknown Source)
        at android.view.View.performClick(View.java:5198)
        at android.view.View$PerformClick.run(View.java:21147)
        at android.os.Handler.handleCallback(Handler.java:739)
        at android.os.Handler.dispatchMessage(Handler.java:95)
        at android.os.Looper.loop(Looper.java:148)
        at android.app.ActivityThread.main(ActivityThread.java:5417)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616)
```

Closes #1130 