### PR TITLE
Remove navigation listeners before clearing NavigationEngineFactory

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
@@ -94,8 +94,8 @@ public class NavigationViewModel extends AndroidViewModel {
   public void onDestroy(boolean isChangingConfigurations) {
     if (!isChangingConfigurations) {
       locationEngineConductor.onDestroy();
-      endNavigation();
       deactivateInstructionPlayer();
+      endNavigation();
     }
     navigationViewEventDispatcher = null;
   }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
@@ -206,14 +206,13 @@ public class MapboxNavigation implements ServiceConnection {
    * also removes all listeners that have been attached.
    */
   public void onDestroy() {
-    Timber.d("MapboxNavigation onDestroy.");
     stopNavigation();
     disableLocationEngine();
-    navigationEngineFactory.clearEngines();
-    removeNavigationEventListener(null);
+    removeOffRouteListener(null);
     removeProgressChangeListener(null);
     removeMilestoneEventListener(null);
-    removeOffRouteListener(null);
+    removeNavigationEventListener(null);
+    navigationEngineFactory.clearEngines();
   }
 
   // Public APIs

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEngineFactory.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEngineFactory.java
@@ -25,6 +25,9 @@ class NavigationEngineFactory {
   }
 
   void updateOffRouteEngine(OffRoute offRouteEngine) {
+    if (offRouteEngine == null) {
+      return;
+    }
     this.offRouteEngine = offRouteEngine;
   }
 
@@ -33,6 +36,9 @@ class NavigationEngineFactory {
   }
 
   void updateFasterRouteEngine(FasterRoute fasterRouteEngine) {
+    if (fasterRouteEngine == null) {
+      return;
+    }
     this.fasterRouteEngine = fasterRouteEngine;
   }
 
@@ -41,6 +47,9 @@ class NavigationEngineFactory {
   }
 
   void updateSnapEngine(Snap snapEngine) {
+    if (snapEngine == null) {
+      return;
+    }
     this.snapEngine = snapEngine;
   }
 
@@ -49,6 +58,9 @@ class NavigationEngineFactory {
   }
 
   void updateCameraEngine(Camera cameraEngine) {
+    if (cameraEngine == null) {
+      return;
+    }
     this.cameraEngine = cameraEngine;
   }
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationHelper.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationHelper.java
@@ -472,9 +472,9 @@ public class NavigationHelper {
     if (!options.enableOffRouteDetection()) {
       return false;
     }
-    Location location = navigationLocationUpdate.location();
     OffRoute offRoute = navigationLocationUpdate.mapboxNavigation().getOffRouteEngine();
     setOffRouteDetectorCallback(offRoute, callback);
+    Location location = navigationLocationUpdate.location();
     return offRoute.isUserOffRoute(location, routeProgress, options);
   }
 

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationTest.java
@@ -10,7 +10,6 @@ import com.mapbox.services.android.navigation.v5.milestone.StepMilestone;
 import com.mapbox.services.android.navigation.v5.milestone.VoiceInstructionMilestone;
 import com.mapbox.services.android.navigation.v5.navigation.camera.SimpleCamera;
 import com.mapbox.services.android.navigation.v5.offroute.OffRoute;
-import com.mapbox.services.android.navigation.v5.offroute.OffRouteDetector;
 import com.mapbox.services.android.navigation.v5.snap.Snap;
 import com.mapbox.services.android.navigation.v5.snap.SnapToRoute;
 
@@ -246,7 +245,7 @@ public class MapboxNavigationTest extends BaseTest {
     OffRoute offRoute = mock(OffRoute.class);
     navigation.setOffRouteEngine(offRoute);
 
-    assertTrue(!(navigation.getOffRouteEngine() instanceof OffRouteDetector));
+    assertEquals(offRoute, navigation.getOffRouteEngine());
   }
 
   @Test
@@ -262,7 +261,7 @@ public class MapboxNavigationTest extends BaseTest {
   public void getCameraEngine_returnsSimpleCameraWhenNull() throws Exception {
     MapboxNavigation navigation = buildMapboxNavigation();
 
-    navigation.setOffRouteEngine(null);
+    navigation.setCameraEngine(null);
 
     assertTrue(navigation.getCameraEngine() instanceof SimpleCamera);
   }

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEngineFactoryTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEngineFactoryTest.java
@@ -70,4 +70,40 @@ public class NavigationEngineFactoryTest {
 
     assertNull(provider.retrieveFasterRouteEngine());
   }
+
+  @Test
+  public void updateFasterRouteEngine_ignoresNull() {
+    NavigationEngineFactory provider = new NavigationEngineFactory();
+
+    provider.updateFasterRouteEngine(null);
+
+    assertNotNull(provider.retrieveFasterRouteEngine());
+  }
+
+  @Test
+  public void updateOffRouteEngine_ignoresNull() {
+    NavigationEngineFactory provider = new NavigationEngineFactory();
+
+    provider.updateOffRouteEngine(null);
+
+    assertNotNull(provider.retrieveOffRouteEngine());
+  }
+
+  @Test
+  public void updateCameraEngine_ignoresNull() {
+    NavigationEngineFactory provider = new NavigationEngineFactory();
+
+    provider.updateCameraEngine(null);
+
+    assertNotNull(provider.retrieveCameraEngine());
+  }
+
+  @Test
+  public void updateSnapEngine_ignoresNull() {
+    NavigationEngineFactory provider = new NavigationEngineFactory();
+
+    provider.updateSnapEngine(null);
+
+    assertNotNull(provider.retrieveSnapEngine());
+  }
 }


### PR DESCRIPTION
Fixes #1139 

Clearing the engines in `NavigationEngineFactory` should be the last thing we do when shutting down in `onDestroy` (after we remove listeners as well) https://github.com/mapbox/mapbox-navigation-android/compare/dan-off-route-npe?expand=1#diff-667eeafdcc4161cea7ec77c7be674b6fR215

This way, it's not possible for updates to query the engines because the listeners are already removed before we clear the engines.  This PR also adds logic to ignore null engines in `NavigationEngineFactory`.  