### PR TITLE
Notify InstructionListAdapter after animation finishes

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionListTransitionListener.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionListTransitionListener.java
@@ -1,0 +1,28 @@
+package com.mapbox.services.android.navigation.ui.v5.instruction;
+
+import android.support.annotation.NonNull;
+import android.support.transition.Transition;
+import android.support.transition.TransitionListenerAdapter;
+
+import com.mapbox.services.android.navigation.ui.v5.summary.list.InstructionListAdapter;
+
+class InstructionListTransitionListener extends TransitionListenerAdapter {
+
+  private final InstructionListAdapter instructionListAdapter;
+
+  InstructionListTransitionListener(InstructionListAdapter instructionListAdapter) {
+    this.instructionListAdapter = instructionListAdapter;
+  }
+
+  @Override
+  public void onTransitionEnd(@NonNull Transition transition) {
+    super.onTransitionEnd(transition);
+    instructionListAdapter.notifyDataSetChanged();
+  }
+
+  @Override
+  public void onTransitionCancel(@NonNull Transition transition) {
+    super.onTransitionCancel(transition);
+    instructionListAdapter.notifyDataSetChanged();
+  }
+}

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionView.java
@@ -12,6 +12,8 @@ import android.support.annotation.Nullable;
 import android.support.constraint.ConstraintLayout;
 import android.support.constraint.ConstraintSet;
 import android.support.design.widget.FloatingActionButton;
+import android.support.transition.AutoTransition;
+import android.support.transition.TransitionManager;
 import android.support.v4.app.FragmentActivity;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.graphics.drawable.DrawableCompat;
@@ -19,7 +21,6 @@ import android.support.v4.widget.TextViewCompat;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.text.TextUtils;
-import android.transition.TransitionManager;
 import android.util.AttributeSet;
 import android.util.TypedValue;
 import android.view.View;
@@ -318,14 +319,13 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
   public void showInstructionList() {
     onInstructionListVisibilityChanged(true);
     instructionLayout.requestFocus();
-    beginDelayedTransition();
+    beginDelayedListTransition();
     int orientation = getContext().getResources().getConfiguration().orientation;
     if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
       updateLandscapeConstraintsTo(R.layout.instruction_layout_alt);
     }
     instructionListLayout.setVisibility(VISIBLE);
     rvInstructions.smoothScrollToPosition(TOP);
-    instructionListAdapter.notifyDataSetChanged();
   }
 
   public boolean handleBackPressed() {
@@ -835,9 +835,13 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
   }
 
   private void beginDelayedTransition() {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-      TransitionManager.beginDelayedTransition(InstructionView.this);
-    }
+    TransitionManager.beginDelayedTransition(this);
+  }
+
+  private void beginDelayedListTransition() {
+    AutoTransition transition = new AutoTransition();
+    transition.addListener(new InstructionListTransitionListener(instructionListAdapter));
+    TransitionManager.beginDelayedTransition(this, transition);
   }
 
   private void cancelDelayedTransition() {

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/list/InstructionListPresenter.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/list/InstructionListPresenter.java
@@ -45,7 +45,8 @@ public class InstructionListPresenter {
   }
 
   boolean updateBannerListWith(RouteProgress routeProgress) {
-    return addBannerInstructions(routeProgress) && updateInstructionList(routeProgress);
+    addBannerInstructions(routeProgress);
+    return updateInstructionList(routeProgress);
   }
 
   void updateDistanceFormatter(DistanceFormatter distanceFormatter) {
@@ -107,8 +108,7 @@ public class InstructionListPresenter {
     }
   }
 
-  private boolean addBannerInstructions(RouteProgress routeProgress) {
-    boolean didAddInstructions = false;
+  private void addBannerInstructions(RouteProgress routeProgress) {
     if (isNewLeg(routeProgress)) {
       instructions = new ArrayList<>();
       currentLeg = routeProgress.currentLeg();
@@ -117,11 +117,9 @@ public class InstructionListPresenter {
         List<BannerInstructions> bannerInstructions = step.bannerInstructions();
         if (bannerInstructions != null && !bannerInstructions.isEmpty()) {
           instructions.addAll(bannerInstructions);
-          didAddInstructions = true;
         }
       }
     }
-    return didAddInstructions;
   }
 
   private boolean isNewLeg(RouteProgress routeProgress) {
@@ -129,6 +127,9 @@ public class InstructionListPresenter {
   }
 
   private boolean updateInstructionList(RouteProgress routeProgress) {
+    if (instructions.isEmpty()) {
+      return false;
+    }
     RouteLegProgress legProgress = routeProgress.currentLegProgress();
     LegStep currentStep = legProgress.currentStep();
     double stepDistanceRemaining = legProgress.currentStepProgress().distanceRemaining();


### PR DESCRIPTION
Fixes #1137 

Was able to reliably reproduce #1136 - looks like some sort of issue when updating the adapter with data / animation to show the list.  

This PR adjusts the adapter notification to happen before the animation begins.  @Guardiola31337 do you mind confirming this fixes on your devices as well?  Thanks!  