### PR TITLE
Fix exception when adding routes in NavigationMapRoute

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/MapRouteProgressChangeListener.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/MapRouteProgressChangeListener.java
@@ -1,0 +1,40 @@
+package com.mapbox.services.android.navigation.ui.v5.route;
+
+import android.location.Location;
+
+import com.mapbox.api.directions.v5.models.DirectionsRoute;
+import com.mapbox.services.android.navigation.v5.routeprogress.ProgressChangeListener;
+import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
+
+import java.util.List;
+
+class MapRouteProgressChangeListener implements ProgressChangeListener {
+
+  private final NavigationMapRoute mapRoute;
+
+  MapRouteProgressChangeListener(NavigationMapRoute mapRoute) {
+    this.mapRoute = mapRoute;
+  }
+
+  @Override
+  public void onProgressChange(Location location, RouteProgress routeProgress) {
+    DirectionsRoute currentRoute = routeProgress.directionsRoute();
+    List<DirectionsRoute> directionsRoutes = mapRoute.retrieveDirectionsRoutes();
+    int primaryRouteIndex = mapRoute.retrievePrimaryRouteIndex();
+    addNewRoute(currentRoute, directionsRoutes, primaryRouteIndex);
+    mapRoute.addUpcomingManeuverArrow(routeProgress);
+  }
+
+  private void addNewRoute(DirectionsRoute currentRoute, List<DirectionsRoute> directionsRoutes,
+                           int primaryRouteIndex) {
+    if (isANewRoute(currentRoute, directionsRoutes, primaryRouteIndex)) {
+      mapRoute.addRoute(currentRoute);
+    }
+  }
+
+  private boolean isANewRoute(DirectionsRoute currentRoute, List<DirectionsRoute> directionsRoutes,
+                              int primaryRouteIndex) {
+    boolean noRoutes = directionsRoutes.isEmpty();
+    return noRoutes || !currentRoute.equals(directionsRoutes.get(primaryRouteIndex));
+  }
+}

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/route/MapRouteProgressChangeListenerTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/route/MapRouteProgressChangeListenerTest.java
@@ -1,0 +1,33 @@
+package com.mapbox.services.android.navigation.ui.v5.route;
+
+import android.location.Location;
+
+import com.mapbox.api.directions.v5.models.DirectionsRoute;
+import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
+
+import org.junit.Test;
+
+import edu.emory.mathcs.backport.java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class MapRouteProgressChangeListenerTest {
+
+  @Test
+  public void onProgressChange_newRouteWithEmptyDirectionsRouteList() {
+    NavigationMapRoute mapRoute = mock(NavigationMapRoute.class);
+    when(mapRoute.retrieveDirectionsRoutes()).thenReturn(Collections.emptyList());
+    when(mapRoute.retrievePrimaryRouteIndex()).thenReturn(0);
+    MapRouteProgressChangeListener progressChangeListener = new MapRouteProgressChangeListener(mapRoute);
+    RouteProgress routeProgress = mock(RouteProgress.class);
+    DirectionsRoute newRoute = mock(DirectionsRoute.class);
+    when(routeProgress.directionsRoute()).thenReturn(newRoute);
+
+    progressChangeListener.onProgressChange(mock(Location.class), routeProgress);
+
+    verify(mapRoute).addRoute(eq(newRoute));
+  }
+}


### PR DESCRIPTION
Found in CI:
```
Fatal Exception: java.lang.IndexOutOfBoundsException
Index: 0, Size: 0
java.util.ArrayList.get (ArrayList.java:437)
com.mapbox.services.android.navigation.ui.v5.route.NavigationMapRoute$1.onProgressChange (NavigationMapRoute.java:180)
com.mapbox.services.android.navigation.v5.navigation.NavigationEventDispatcher.onProgressChange (NavigationEventDispatcher.java:144)
com.mapbox.services.android.navigation.v5.navigation.RouteProcessorThreadListener.onNewRouteProgress (RouteProcessorThreadListener.java:34)
com.mapbox.services.android.navigation.v5.navigation.RouteProcessorHandlerCallback$1.run (RouteProcessorHandlerCallback.java:97)
```

The boolean logic updated in #1093 still allows the `IndexOutOfBoundsException` to occur.  This PR extracts the listener into its own class and adds a test for the crash.  