### PR TITLE
Check dispatcher on announcement and instruction events in ViewModel

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
@@ -365,7 +365,7 @@ public class NavigationViewModel extends AndroidViewModel {
     if (milestone instanceof VoiceInstructionMilestone) {
       SpeechAnnouncement announcement = SpeechAnnouncement.builder()
         .voiceInstructionMilestone((VoiceInstructionMilestone) milestone).build();
-      announcement = navigationViewEventDispatcher.onAnnouncement(announcement);
+      announcement = retrieveAnnouncementFromSpeechEvent(announcement);
       instructionPlayer.play(announcement);
     }
   }
@@ -373,7 +373,7 @@ public class NavigationViewModel extends AndroidViewModel {
   private void updateBannerInstruction(RouteProgress routeProgress, Milestone milestone) {
     if (milestone instanceof BannerInstructionMilestone) {
       BannerInstructions instructions = ((BannerInstructionMilestone) milestone).getBannerInstructions();
-      instructions = navigationViewEventDispatcher.onBannerDisplay(instructions);
+      instructions = retrieveInstructionsFromBannerEvent(instructions);
       if (instructions != null) {
         BannerInstructionModel model = new BannerInstructionModel(getApplication(), instructions,
           routeProgress, language, unitType);
@@ -432,5 +432,19 @@ public class NavigationViewModel extends AndroidViewModel {
     if (navigationViewEventDispatcher != null && isOffRoute()) {
       navigationViewEventDispatcher.onRerouteAlong(route);
     }
+  }
+
+  private SpeechAnnouncement retrieveAnnouncementFromSpeechEvent(SpeechAnnouncement announcement) {
+    if (navigationViewEventDispatcher != null) {
+      announcement = navigationViewEventDispatcher.onAnnouncement(announcement);
+    }
+    return announcement;
+  }
+
+  private BannerInstructions retrieveInstructionsFromBannerEvent(BannerInstructions instructions) {
+    if (navigationViewEventDispatcher != null) {
+      instructions = navigationViewEventDispatcher.onBannerDisplay(instructions);
+    }
+    return instructions;
   }
 }


### PR DESCRIPTION
Found in CI: 
```
Fatal Exception: java.lang.NullPointerException
Attempt to invoke virtual method 'com.mapbox.services.android.navigation.ui.v5.voice.SpeechAnnouncement com.mapbox.services.android.navigation.ui.v5.NavigationViewEventDispatcher.onAnnouncement(com.mapbox.services.android.navigation.ui.v5.voice.SpeechAnnouncement)' on a null object reference
com.mapbox.services.android.navigation.ui.v5.NavigationViewModel.playVoiceAnnouncement (NavigationViewModel.java:368)
com.mapbox.services.android.navigation.ui.v5.NavigationViewModel.access$700 (NavigationViewModel.java:47)
com.mapbox.services.android.navigation.ui.v5.NavigationViewModel$3.onMilestoneEvent (NavigationViewModel.java:282)
com.mapbox.services.android.navigation.v5.navigation.NavigationEventDispatcher.onMilestoneEvent (NavigationEventDispatcher.java:137)
com.mapbox.services.android.navigation.v5.navigation.RouteProcessorThreadListener.onMilestoneTrigger (RouteProcessorThreadListener.java:46)
com.mapbox.services.android.navigation.v5.navigation.RouteProcessorHandlerCallback$1.run (RouteProcessorHandlerCallback.java:98)
```

These `NavigationViewDispatcherEvents` were added in #1107 and were not accompanied with a null check.  Every time we use the dispatcher in `NavigationViewModel` we need to double check it isn't `null` because we set it to `null` during rotation to prevent leaks from the `NavigationView` being destroyed.  