### PR TITLE
Update Gson to 2.8.5

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -100,7 +100,6 @@ ext {
       gmsLocation            : "com.google.android.gms:play-services-location:${version.gmsLocation}",
 
       errorprone             : "com.google.errorprone:error_prone_core:${version.errorprone}"
-
   ]
 
   pluginDependencies = [

--- a/libandroid-navigation/build.gradle
+++ b/libandroid-navigation/build.gradle
@@ -39,12 +39,18 @@ android {
 }
 
 dependencies {
-  api dependenciesList.mapboxEvents
-  api dependenciesList.mapboxSdkServices
+  api (dependenciesList.mapboxEvents) {
+    exclude group: 'com.google.code.gson', module: 'gson'
+  }
+  api (dependenciesList.mapboxSdkServices) {
+    exclude group: 'com.google.code.gson', module: 'gson'
+  }
   api dependenciesList.mapboxSdkTurf
 
   // Support
   implementation dependenciesList.supportAppcompatV7
+
+  api 'com.google.code.gson:gson:2.8.5'
 
   // Logging
   implementation dependenciesList.timber


### PR DESCRIPTION
Working to resolve a Gson crash when robo-testing in Firebase.