### PR TITLE
Remove Location filter and check Location#getAccuracy

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/location/LocationValidator.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/location/LocationValidator.java
@@ -3,43 +3,17 @@ package com.mapbox.services.android.navigation.v5.location;
 import android.location.Location;
 import android.support.annotation.NonNull;
 
-import com.mapbox.geojson.Point;
-import com.mapbox.turf.TurfConstants;
-import com.mapbox.turf.TurfMeasurement;
-
 public class LocationValidator {
 
-  private static final int ONE_SECOND_IN_MILLIS = 1000;
-
   private Location lastValidLocation;
-  private int locationAcceptableAccuracyInMetersThreshold;
-  private int locationAccuracyPercentThreshold;
-  private int locationUpdateTimeInMillisThreshold;
-  private int locationVelocityInMetersPerSecondThreshold;
+  private final int accuracyThreshold;
 
-  public LocationValidator(int locationAcceptableAccuracyInMetersThreshold, int locationAccuracyPercentThreshold,
-                           int locationUpdateTimeInMillisThreshold, int locationVelocityInMetersPerSecondThreshold) {
-    this.locationAcceptableAccuracyInMetersThreshold = locationAcceptableAccuracyInMetersThreshold;
-    this.locationAccuracyPercentThreshold = locationAccuracyPercentThreshold;
-    this.locationUpdateTimeInMillisThreshold = locationUpdateTimeInMillisThreshold;
-    this.locationVelocityInMetersPerSecondThreshold = locationVelocityInMetersPerSecondThreshold;
+  public LocationValidator(int accuracyThreshold) {
+    this.accuracyThreshold = accuracyThreshold;
   }
 
   public boolean isValidUpdate(@NonNull Location location) {
-    if (checkLastValidLocation(location)) {
-      return true;
-    }
-    long timeSinceLastValidUpdate = location.getTime() - lastValidLocation.getTime();
-
-    boolean accuracyAcceptable = isAccuracyAcceptable(location);
-    boolean validVelocity = isValidVelocity(location, timeSinceLastValidUpdate);
-    boolean validLocation = isValidLocation(accuracyAcceptable, timeSinceLastValidUpdate);
-
-    if (validVelocity && validLocation) {
-      lastValidLocation = location;
-      return true;
-    }
-    return false;
+    return checkLastValidLocation(location) || location.getAccuracy() < accuracyThreshold;
   }
 
   /**
@@ -57,66 +31,5 @@ public class LocationValidator {
       return true;
     }
     return false;
-  }
-
-  /**
-   * New location accuracy is acceptable if it is less than or equal to
-   * {@link LocationValidator#locationAcceptableAccuracyInMetersThreshold}.
-   * <p>
-   * Otherwise, new location update is acceptable, even with worse accuracy, if it is from
-   * the same provider and is no more than {@link LocationValidator#locationAccuracyPercentThreshold} worse.
-   *
-   * @param location new location received
-   * @return true if acceptable accuracy, false otherwise
-   */
-  private boolean isAccuracyAcceptable(@NonNull Location location) {
-    float currentAccuracy = location.getAccuracy();
-    if (currentAccuracy <= locationAcceptableAccuracyInMetersThreshold) {
-      return true;
-    }
-
-    float previousAccuracy = lastValidLocation.getAccuracy();
-    float accuracyDifference = Math.abs(previousAccuracy - currentAccuracy);
-
-    boolean improvedAccuracy = currentAccuracy <= previousAccuracy;
-    boolean currentAccuracyWorse = currentAccuracy > previousAccuracy;
-    boolean hasSameProvider = lastValidLocation.getProvider().equals(location.getProvider());
-    double percentThreshold = locationAccuracyPercentThreshold / 100.0;
-    boolean lessThanPercentThreshold = (accuracyDifference <= (previousAccuracy * percentThreshold));
-    boolean lessAccuracyAcceptable = currentAccuracyWorse && hasSameProvider && lessThanPercentThreshold;
-
-    return improvedAccuracy || lessAccuracyAcceptable;
-  }
-
-  /**
-   * Calculates the velocity between the new location update and the last update
-   * that has been stored.
-   * <p>
-   * Average velocity = distance traveled over time (distance / time).
-   *
-   * @param location                 new location received
-   * @param timeSinceLastValidUpdate in millis, how long it has been since the new and last update
-   * @return true if valid velocity, false otherwise
-   */
-  private boolean isValidVelocity(@NonNull Location location, long timeSinceLastValidUpdate) {
-    Point currentPoint = Point.fromLngLat(location.getLongitude(), location.getLatitude());
-    Point previousValidPoint = Point.fromLngLat(lastValidLocation.getLongitude(), lastValidLocation.getLatitude());
-    double distanceInMeters = TurfMeasurement.distance(previousValidPoint, currentPoint, TurfConstants.UNIT_METERS);
-
-    double velocityInMetersPerSecond = distanceInMeters / (timeSinceLastValidUpdate / ONE_SECOND_IN_MILLIS);
-
-    return velocityInMetersPerSecond <= locationVelocityInMetersPerSecondThreshold;
-  }
-
-  /**
-   * Location update is valid if it has better accuracy, has been over 5 seconds since the last update,
-   * or the new update has worse accuracy but it is still acceptable.
-   *
-   * @param accuracyAcceptable       new location accuracy is acceptable or not
-   * @param timeSinceLastValidUpdate in millis, how long it has been since the new and last update
-   * @return true if valid location, false otherwise
-   */
-  private boolean isValidLocation(boolean accuracyAcceptable, long timeSinceLastValidUpdate) {
-    return accuracyAcceptable || timeSinceLastValidUpdate > locationUpdateTimeInMillisThreshold;
   }
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationOptions.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationOptions.java
@@ -51,12 +51,6 @@ public abstract class MapboxNavigationOptions {
 
   public abstract int locationAcceptableAccuracyInMetersThreshold();
 
-  public abstract int locationAccuracyPercentThreshold();
-
-  public abstract int locationUpdateTimeInMillisThreshold();
-
-  public abstract int locationVelocityInMetersPerSecondThreshold();
-
   public abstract Builder toBuilder();
 
   @AutoValue.Builder
@@ -100,12 +94,6 @@ public abstract class MapboxNavigationOptions {
 
     public abstract Builder locationAcceptableAccuracyInMetersThreshold(int accuracyInMetersThreshold);
 
-    public abstract Builder locationAccuracyPercentThreshold(int accuracyPercentThreshold);
-
-    public abstract Builder locationUpdateTimeInMillisThreshold(int timeInMillisThreshold);
-
-    public abstract Builder locationVelocityInMetersPerSecondThreshold(int metersPerSecondThreshold);
-
     public abstract MapboxNavigationOptions build();
   }
 
@@ -128,9 +116,6 @@ public abstract class MapboxNavigationOptions {
       .isFromNavigationUi(false)
       .isDebugLoggingEnabled(false)
       .timeFormatType(NavigationTimeFormat.NONE_SPECIFIED)
-      .locationAcceptableAccuracyInMetersThreshold(NavigationConstants.FIFTY_METER_ACCEPTABLE_ACCURACY_THRESHOLD)
-      .locationAccuracyPercentThreshold(NavigationConstants.TEN_PERCENT_ACCURACY_THRESHOLD)
-      .locationUpdateTimeInMillisThreshold(NavigationConstants.FIVE_SECONDS_IN_MILLIS_UPDATE_THRESHOLD)
-      .locationVelocityInMetersPerSecondThreshold(NavigationConstants.TWO_HUNDRED_METERS_PER_SECOND_VELOCITY_THRESHOLD);
+      .locationAcceptableAccuracyInMetersThreshold(NavigationConstants.ONE_HUNDRED_METER_ACCEPTABLE_ACCURACY_THRESHOLD);
   }
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationConstants.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationConstants.java
@@ -192,44 +192,9 @@ public final class NavigationConstants {
    * an accuracy less than this threshold, the update will be considered valid and all other validation
    * is not considered.
    *
-   * @since 0.12.0
+   * @since 0.17.0
    */
-  static final int FIFTY_METER_ACCEPTABLE_ACCURACY_THRESHOLD = 50;
-
-  /**
-   * Default location accuracy threshold
-   * used in {@link com.mapbox.services.android.navigation.v5.location.LocationValidator}.
-   * <p>
-   * If a new {@link android.location.Location} update is received from the LocationEngine that has
-   * 10 percent worse accuracy compared to the last update, the new update will be considered invalid.
-   *
-   * @since 0.12.0
-   */
-  static final int TEN_PERCENT_ACCURACY_THRESHOLD = 10;
-
-  /**
-   * Default location time threshold
-   * used in {@link com.mapbox.services.android.navigation.v5.location.LocationValidator}.
-   * <p>
-   * If a device receives invalid updates for more than 5 seconds, the next location update will
-   * be considered valid, even if it does not meet the other validation criteria.
-   * <p>
-   * This is used as a last effort to push data to the SDK.
-   *
-   * @since 0.12.0
-   */
-  static final int FIVE_SECONDS_IN_MILLIS_UPDATE_THRESHOLD = 5000;
-
-  /**
-   * Default location velocity threshold
-   * used in {@link com.mapbox.services.android.navigation.v5.location.LocationValidator}.
-   * <p>
-   * If a new {@link android.location.Location} update is received from the LocationEngine that has
-   * traveled faster the 200 meters per second from the last update, the new update will be considered invalid.
-   *
-   * @since 0.12.0
-   */
-  static final int TWO_HUNDRED_METERS_PER_SECOND_VELOCITY_THRESHOLD = 200;
+  static final int ONE_HUNDRED_METER_ACCEPTABLE_ACCURACY_THRESHOLD = 100;
 
   static final String NON_NULL_APPLICATION_CONTEXT_REQUIRED = "Non-null application context required.";
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationService.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationService.java
@@ -119,20 +119,12 @@ public class NavigationService extends Service {
 
   private void initializeLocationProvider(MapboxNavigation mapboxNavigation) {
     LocationEngine locationEngine = mapboxNavigation.getLocationEngine();
-    LocationValidator validator = initializeLocationValidator(mapboxNavigation.options());
+    int accuracyThreshold = mapboxNavigation.options().locationAcceptableAccuracyInMetersThreshold();
+    LocationValidator validator = new LocationValidator(accuracyThreshold);
     NavigationLocationEngineListener listener = new NavigationLocationEngineListener(
       thread, mapboxNavigation, locationEngine, validator
     );
     locationProvider = new NavigationLocationEngineUpdater(locationEngine, listener);
-  }
-
-  private LocationValidator initializeLocationValidator(MapboxNavigationOptions options) {
-    int accuracyAcceptableThreshold = options.locationAcceptableAccuracyInMetersThreshold();
-    int accuracyPercentThreshold = options.locationAccuracyPercentThreshold();
-    int timeInMillisThreshold = options.locationUpdateTimeInMillisThreshold();
-    int velocityInMetersPerSecondThreshold = options.locationVelocityInMetersPerSecondThreshold();
-    return new LocationValidator(accuracyAcceptableThreshold, accuracyPercentThreshold,
-      timeInMillisThreshold, velocityInMetersPerSecondThreshold);
   }
 
   private void startForegroundNotification(NavigationNotification navigationNotification) {

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/location/LocationValidatorTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/location/LocationValidatorTest.java
@@ -1,0 +1,58 @@
+package com.mapbox.services.android.navigation.v5.location;
+
+import android.location.Location;
+
+import org.junit.Test;
+
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class LocationValidatorTest {
+
+  @Test
+  public void isValidUpdate_trueOnFirstUpdate() {
+    Location location = buildLocationWithAccuracy(10);
+    int accuracyThreshold = 100;
+    LocationValidator validator = new LocationValidator(accuracyThreshold);
+
+    boolean isValid = validator.isValidUpdate(location);
+
+    assertTrue(isValid);
+  }
+
+  @Test
+  public void isValidUpdate_trueWhenUnder100MeterAccuracyThreshold() {
+    Location location = buildLocationWithAccuracy(90);
+    LocationValidator validator = buildValidatorWithUpdate();
+
+    boolean isValid = validator.isValidUpdate(location);
+
+    assertTrue(isValid);
+  }
+
+  @Test
+  public void isValidUpdate_falseWhenOver100MeterAccuracyThreshold() {
+    Location location = buildLocationWithAccuracy(110);
+    LocationValidator validator = buildValidatorWithUpdate();
+
+    boolean isValid = validator.isValidUpdate(location);
+
+    assertFalse(isValid);
+  }
+
+  private LocationValidator buildValidatorWithUpdate() {
+    Location location = buildLocationWithAccuracy(10);
+    int accuracyThreshold = 100;
+    LocationValidator validator = new LocationValidator(accuracyThreshold);
+    validator.isValidUpdate(location);
+    return validator;
+  }
+
+  private Location buildLocationWithAccuracy(float accuracy) {
+    Location location = mock(Location.class);
+    when(location.getAccuracy()).thenReturn(accuracy);
+    return location;
+  }
+}


### PR DESCRIPTION
We are seeing issues with what I think to have tracked down is the velocity check in the `LocationValidator`.  I think it's best to roll back the filtering here in favor of the less aggressive filter we had prior.  

Capturing some discussion with @Guardiola31337, this filter is not ideal as it can "build up" to eventually be accepting poor updates.  We should continue to look into filtering out erroneous data for situations like urban canyons and such.

TODO:
- [x] Allow setting of accuracy threshold in `MapboxNavigationOptions` (default `100`)