### PR TITLE
Fix SpeechAnnouncementListener example and add tests

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/EmbeddedNavigationActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/EmbeddedNavigationActivity.java
@@ -167,7 +167,7 @@ public class EmbeddedNavigationActivity extends AppCompatActivity implements OnN
 
   @Override
   public SpeechAnnouncement willVoice(SpeechAnnouncement announcement) {
-    return announcement.toBuilder().announcement("All announcments will be the same.").build();
+    return SpeechAnnouncement.builder().announcement("All announcements will be the same.").build();
   }
 
   @Override

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/voice/SpeechAnnouncement.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/voice/SpeechAnnouncement.java
@@ -79,6 +79,9 @@ public abstract class SpeechAnnouncement {
      * <p>
      * If you pass the milestone into the builder, {@link SpeechAnnouncement} will extract both the SSML
      * and normal speech announcements.
+     * <p>
+     * Note, the milestone, if passed will override {@link SpeechAnnouncement#announcement()} and
+     * {@link SpeechAnnouncement#ssmlAnnouncement()}.
      *
      * @param milestone optional {@link VoiceInstructionMilestone} with SSML / normal announcements
      * @return this builder for chaining options together

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/voice/SpeechAnnouncementTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/voice/SpeechAnnouncementTest.java
@@ -1,0 +1,40 @@
+package com.mapbox.services.android.navigation.ui.v5.voice;
+
+import com.mapbox.services.android.navigation.v5.milestone.VoiceInstructionMilestone;
+
+import org.junit.Test;
+
+import static junit.framework.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SpeechAnnouncementTest {
+
+  @Test
+  public void milestoneAnnouncement_isUsedWhenProvided() {
+    VoiceInstructionMilestone milestone = mock(VoiceInstructionMilestone.class);
+    String announcement = "Milestone announcement";
+    when(milestone.getAnnouncement()).thenReturn(announcement);
+
+    SpeechAnnouncement speechAnnouncement = SpeechAnnouncement.builder()
+      .voiceInstructionMilestone(milestone)
+      .build();
+
+    assertEquals(announcement, speechAnnouncement.announcement());
+  }
+
+  @Test
+  public void milestoneSsmlAnnouncement_isUsedWhenProvided() {
+    VoiceInstructionMilestone milestone = mock(VoiceInstructionMilestone.class);
+    String announcement = "Milestone announcement";
+    when(milestone.getAnnouncement()).thenReturn(announcement);
+    String ssmlAnnouncement = "Milestone SSML announcement";
+    when(milestone.getSsmlAnnouncement()).thenReturn(ssmlAnnouncement);
+
+    SpeechAnnouncement speechAnnouncement = SpeechAnnouncement.builder()
+      .voiceInstructionMilestone(milestone)
+      .build();
+
+    assertEquals(ssmlAnnouncement, speechAnnouncement.ssmlAnnouncement());
+  }
+}


### PR DESCRIPTION
For the example of `SpeechInstructionListener` in `EmbeddedNavigationActivity`, we were modifying a `SpeechAnnouncement` created with a `VoiceInstructionMilestone` (this will always be the case).  

Because it was create with the milestone, the milestone data was overriding the modification.  I added some javadoc to clearly state that this will happen as well.   