### PR TITLE
Fix OffRoute engine cleared before service shutdown

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
@@ -15,6 +15,7 @@ import com.mapbox.api.directions.v5.models.BannerInstructions;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.geojson.Point;
 import com.mapbox.mapboxsdk.Mapbox;
+import com.mapbox.services.android.navigation.ui.v5.camera.DynamicCamera;
 import com.mapbox.services.android.navigation.ui.v5.feedback.FeedbackItem;
 import com.mapbox.services.android.navigation.ui.v5.instruction.BannerInstructionModel;
 import com.mapbox.services.android.navigation.ui.v5.instruction.InstructionModel;
@@ -35,6 +36,7 @@ import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation;
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigationOptions;
 import com.mapbox.services.android.navigation.v5.navigation.NavigationEventListener;
 import com.mapbox.services.android.navigation.v5.navigation.NavigationTimeFormat;
+import com.mapbox.services.android.navigation.v5.navigation.camera.Camera;
 import com.mapbox.services.android.navigation.v5.navigation.metrics.FeedbackEvent;
 import com.mapbox.services.android.navigation.v5.offroute.OffRouteListener;
 import com.mapbox.services.android.navigation.v5.route.FasterRouteListener;
@@ -96,6 +98,11 @@ public class NavigationViewModel extends AndroidViewModel {
       locationEngineConductor.onDestroy();
       deactivateInstructionPlayer();
       endNavigation();
+    }
+    Camera cameraEngine = navigation.getCameraEngine();
+    boolean isDynamicCamera = cameraEngine instanceof DynamicCamera;
+    if (isDynamicCamera) {
+      ((DynamicCamera) cameraEngine).clearMap();
     }
     navigationViewEventDispatcher = null;
   }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/camera/DynamicCamera.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/camera/DynamicCamera.java
@@ -77,6 +77,10 @@ public class DynamicCamera extends SimpleCamera {
     forceUpdateZoom = true;
   }
 
+  public void clearMap() {
+    mapboxMap = null;
+  }
+
   /**
    * Creates a tilt value based on the distance remaining for the current {@link LegStep}.
    * <p>

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
@@ -212,7 +212,6 @@ public class MapboxNavigation implements ServiceConnection {
     removeProgressChangeListener(null);
     removeMilestoneEventListener(null);
     removeNavigationEventListener(null);
-    navigationEngineFactory.clearEngines();
   }
 
   // Public APIs

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEngineFactory.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEngineFactory.java
@@ -64,13 +64,6 @@ class NavigationEngineFactory {
     this.cameraEngine = cameraEngine;
   }
 
-  void clearEngines() {
-    offRouteEngine = null;
-    fasterRouteEngine = null;
-    snapEngine = null;
-    cameraEngine = null;
-  }
-
   private void initializeDefaultEngines() {
     cameraEngine = new SimpleCamera();
     snapEngine = new SnapToRoute();

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEngineFactoryTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEngineFactoryTest.java
@@ -3,7 +3,6 @@ package com.mapbox.services.android.navigation.v5.navigation;
 import org.junit.Test;
 
 import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertNull;
 
 public class NavigationEngineFactoryTest {
 
@@ -33,42 +32,6 @@ public class NavigationEngineFactoryTest {
     NavigationEngineFactory provider = new NavigationEngineFactory();
 
     assertNotNull(provider.retrieveFasterRouteEngine());
-  }
-
-  @Test
-  public void clearEngines_cameraEngineIsRemoved() {
-    NavigationEngineFactory provider = new NavigationEngineFactory();
-
-    provider.clearEngines();
-
-    assertNull(provider.retrieveCameraEngine());
-  }
-
-  @Test
-  public void clearEngines_offRouteEngineIsRemoved() {
-    NavigationEngineFactory provider = new NavigationEngineFactory();
-
-    provider.clearEngines();
-
-    assertNull(provider.retrieveOffRouteEngine());
-  }
-
-  @Test
-  public void clearEngines_snapEngineIsRemoved() {
-    NavigationEngineFactory provider = new NavigationEngineFactory();
-
-    provider.clearEngines();
-
-    assertNull(provider.retrieveSnapEngine());
-  }
-
-  @Test
-  public void clearEngines_fasterRouteEngineIsRemoved() {
-    NavigationEngineFactory provider = new NavigationEngineFactory();
-
-    provider.clearEngines();
-
-    assertNull(provider.retrieveFasterRouteEngine());
   }
 
   @Test


### PR DESCRIPTION
Actually Fixes #1139 

We are setting the camera engine to `null` here because it holds onto `MapboxMap` and is then given to `MapboxNavigation`.  

For the turn-by-turn UI, `MapboxNavigation` survives rotation, so we need to set it to null so it doesn't leak. 