### PR TITLE
Consolidate InstructionView DistanceFormatters

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
@@ -519,20 +519,21 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
   }
 
   private void establish(NavigationViewOptions options) {
-    establishLanguage(options);
-    establishUnitType(options);
+    LocaleUtils localeUtils = new LocaleUtils();
+    establishLanguage(localeUtils, options);
+    establishUnitType(localeUtils, options);
     establishTimeFormat(options);
   }
 
-  private void establishLanguage(NavigationViewOptions options) {
-    LocaleUtils localeUtils = new LocaleUtils();
+  private void establishLanguage(LocaleUtils localeUtils, NavigationViewOptions options) {
     String language = localeUtils.getNonEmptyLanguage(getContext(), options.directionsRoute().voiceLanguage());
     instructionView.setLanguage(language);
     summaryBottomSheet.setLanguage(language);
   }
 
-  private void establishUnitType(NavigationViewOptions options) {
-    String unitType = options.directionsRoute().routeOptions().voiceUnits();
+  private void establishUnitType(LocaleUtils localeUtils, NavigationViewOptions options) {
+    String voiceUnits = options.directionsRoute().routeOptions().voiceUnits();
+    String unitType = localeUtils.retrieveNonNullUnitType(getContext(), voiceUnits);
     instructionView.setUnitType(unitType);
     summaryBottomSheet.setUnitType(unitType);
   }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/list/InstructionListAdapter.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/list/InstructionListAdapter.java
@@ -1,13 +1,11 @@
 package com.mapbox.services.android.navigation.ui.v5.summary.list;
 
-import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
-import com.mapbox.api.directions.v5.DirectionsCriteria;
 import com.mapbox.services.android.navigation.ui.v5.R;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 import com.mapbox.services.android.navigation.v5.utils.DistanceFormatter;
@@ -52,8 +50,7 @@ public class InstructionListAdapter extends RecyclerView.Adapter<InstructionView
     }
   }
 
-  public void updateBannerFormat(Context context, String language,
-                                 @DirectionsCriteria.VoiceUnitCriteria String unitType) {
-    presenter.updateLanguageAndUnitType(context, language, unitType);
+  public void updateDistanceFormatter(DistanceFormatter distanceFormatter) {
+    presenter.updateDistanceFormatter(distanceFormatter);
   }
 }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/list/InstructionListPresenter.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/list/InstructionListPresenter.java
@@ -1,11 +1,9 @@
 package com.mapbox.services.android.navigation.ui.v5.summary.list;
 
-import android.content.Context;
 import android.support.annotation.NonNull;
 import android.text.SpannableString;
 import android.view.View;
 
-import com.mapbox.api.directions.v5.DirectionsCriteria;
 import com.mapbox.api.directions.v5.models.BannerInstructions;
 import com.mapbox.api.directions.v5.models.LegStep;
 import com.mapbox.api.directions.v5.models.RouteLeg;
@@ -25,12 +23,9 @@ public class InstructionListPresenter {
   private static final float ONE_LINE_BIAS = 0.5f;
   private static final int FIRST_INSTRUCTION_INDEX = 0;
   private final RouteUtils routeUtils;
+  private DistanceFormatter distanceFormatter;
   private List<BannerInstructions> instructions;
   private RouteLeg currentLeg;
-  private DistanceFormatter distanceFormatter;
-  @DirectionsCriteria.VoiceUnitCriteria
-  private String unitType = "";
-  private String language = "";
 
   InstructionListPresenter(RouteUtils routeUtils, DistanceFormatter distanceFormatter) {
     this.routeUtils = routeUtils;
@@ -53,17 +48,15 @@ public class InstructionListPresenter {
     return addBannerInstructions(routeProgress) && updateInstructionList(routeProgress);
   }
 
-  void updateLanguageAndUnitType(Context context, String language,
-                                 @DirectionsCriteria.VoiceUnitCriteria String unitType) {
-    if (shouldUpdate(language, unitType)) {
-      distanceFormatter = new DistanceFormatter(context, language, unitType);
-      this.language = language;
-      this.unitType = unitType;
+  void updateDistanceFormatter(DistanceFormatter distanceFormatter) {
+    if (shouldUpdate(distanceFormatter)) {
+      this.distanceFormatter = distanceFormatter;
     }
   }
 
-  private boolean shouldUpdate(String language, @DirectionsCriteria.VoiceUnitCriteria String unitType) {
-    return distanceFormatter == null || !this.language.equals(language) || !this.unitType.equals(unitType);
+  private boolean shouldUpdate(DistanceFormatter distanceFormatter) {
+    return distanceFormatter != null
+      && (this.distanceFormatter == null || !this.distanceFormatter.equals(distanceFormatter));
   }
 
   private void updateListView(@NonNull InstructionListView listView, BannerInstructions bannerInstructions,

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/summary/list/InstructionListPresenterTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/summary/list/InstructionListPresenterTest.java
@@ -121,6 +121,36 @@ public class InstructionListPresenterTest extends BaseTest {
     assertFalse(didUpdate);
   }
 
+  @Test
+  public void updateDistanceFormatter_newFormatterIsUsed() throws Exception {
+    RouteProgress routeProgress = buildRouteProgress();
+    DistanceFormatter firstDistanceFormatter = buildDistanceFormatter();
+    InstructionListPresenter presenter = buildPresenter(routeProgress, firstDistanceFormatter);
+    presenter.updateBannerListWith(routeProgress);
+    InstructionListView listView = mock(InstructionListView.class);
+
+    DistanceFormatter secondDistanceFormatter = buildDistanceFormatter();
+    presenter.updateDistanceFormatter(secondDistanceFormatter);
+    presenter.onBindInstructionListViewAtPosition(0, listView);
+
+    verify(secondDistanceFormatter).formatDistance(anyDouble());
+  }
+
+  @Test
+  public void updateDistanceFormatter_doesNotAllowNullValues() throws Exception {
+    RouteProgress routeProgress = buildRouteProgress();
+    DistanceFormatter distanceFormatter = buildDistanceFormatter();
+    InstructionListPresenter presenter = buildPresenter(routeProgress, distanceFormatter);
+    presenter.updateBannerListWith(routeProgress);
+    InstructionListView listView = mock(InstructionListView.class);
+
+    presenter.updateDistanceFormatter(null);
+    presenter.onBindInstructionListViewAtPosition(0, listView);
+
+    verify(distanceFormatter).formatDistance(anyDouble());
+  }
+
+
   @NonNull
   private RouteProgress buildRouteProgress() throws Exception {
     DirectionsRoute route = buildTestDirectionsRoute();
@@ -136,11 +166,25 @@ public class InstructionListPresenterTest extends BaseTest {
   }
 
   @NonNull
+  private InstructionListPresenter buildPresenter(RouteProgress routeProgress, DistanceFormatter distanceFormatter) {
+    RouteUtils routeUtils = buildRouteUtils(routeProgress);
+    return new InstructionListPresenter(routeUtils, distanceFormatter);
+  }
+
+  @NonNull
   private RouteUtils buildRouteUtils(RouteProgress routeProgress) {
     RouteUtils routeUtils = mock(RouteUtils.class);
     BannerInstructions instructions = routeProgress.currentLegProgress().currentStep().bannerInstructions().get(FIRST);
     when(routeUtils.findCurrentBannerInstructions(any(LegStep.class), anyDouble())).thenReturn(instructions);
     return routeUtils;
+  }
+
+  @NonNull
+  private DistanceFormatter buildDistanceFormatter() {
+    SpannableString spannableString = mock(SpannableString.class);
+    DistanceFormatter distanceFormatter = mock(DistanceFormatter.class);
+    when(distanceFormatter.formatDistance(anyDouble())).thenReturn(spannableString);
+    return distanceFormatter;
   }
 
   private int retrieveInstructionSizeFrom(RouteLeg routeLeg) {

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/DistanceFormatter.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/DistanceFormatter.java
@@ -36,9 +36,14 @@ public class DistanceFormatter {
   private final String largeUnit;
   private final String smallUnit;
   private final LocaleUtils localeUtils;
+  private final String language;
+  private final String unitType;
 
   /**
-   * Creates a DistanceFormatter object with information about how to format distances
+   * Creates an instance of DistanceFormatter, which can format distances in meters
+   * based on a language format and unit type.
+   * <p>
+   * This constructor will infer device language and unit type using the device locale.
    *
    * @param context  from which to get localized strings from
    * @param language for which language
@@ -59,11 +64,13 @@ public class DistanceFormatter {
     } else {
       locale = new Locale(language);
     }
+    this.language = locale.getLanguage();
     numberFormat = NumberFormat.getNumberInstance(locale);
 
     if (!DirectionsCriteria.IMPERIAL.equals(unitType) && !DirectionsCriteria.METRIC.equals(unitType)) {
       unitType = localeUtils.getUnitTypeForDeviceLocale(context);
     }
+    this.unitType = unitType;
 
     largeUnit = DirectionsCriteria.IMPERIAL.equals(unitType) ? UNIT_MILES : UNIT_KILOMETERS;
     smallUnit = DirectionsCriteria.IMPERIAL.equals(unitType) ? UNIT_FEET : UNIT_METERS;
@@ -90,6 +97,18 @@ public class DistanceFormatter {
     } else {
       return getDistanceString(roundToDecimalPlace(distanceLargeUnit, 1), largeUnit);
     }
+  }
+
+  /**
+   * Method that can be used to check if an instance of {@link DistanceFormatter}
+   * needs to be updated based on the passed language / unitType.
+   *
+   * @param language to check against the current formatter language
+   * @param unitType to check against the current formatter unitType
+   * @return true if new formatter is needed, false otherwise
+   */
+  public boolean shouldUpdate(@NonNull String language, @NonNull String unitType) {
+    return !this.language.equals(language) || !this.unitType.equals(unitType);
   }
 
   /**

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/LocaleUtils.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/LocaleUtils.java
@@ -76,4 +76,19 @@ public class LocaleUtils {
   public String getUnitTypeForDeviceLocale(Context context) {
     return getUnitTypeForLocale(inferDeviceLocale(context));
   }
+
+  /**
+   * Returns the unitType passed in if it is not null, otherwise returns the a unitType
+   * based on the device Locale.
+   *
+   * @param context to get device locale
+   * @param unitType to check if it is null
+   * @return a non-null unitType, either the one passed in, or based on the device locale
+   */
+  public String retrieveNonNullUnitType(Context context, String unitType) {
+    if (unitType == null) {
+      return getUnitTypeForDeviceLocale(context);
+    }
+    return unitType;
+  }
 }


### PR DESCRIPTION
Closes #1169 

Found a couple things stemming from the crash in the ticket.  For context, the developer was using the `MapMatching` API, which looks like wasn't providing a `RouteOptions#voiceUnit`.  We were letting this pass all the way through to the `InstructionListPresenter` which was eventually throwing an NPE.  

To fix this, I re-worked some of the logic around the `DistanceFormatter` in `InstructionView` and created a new util for retrieving a non-null `String unitType`.

We now ignore `null` unit types or languages and create a new `DistanceFormatter` in the `InstructionView` only when necessary.   The presenter is then updated with the new formatter if needed. 

cc @riastrad 