### PR TITLE
Re-initialize arrow sources in NavigationMapRoute after style loaded

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/NavigationMapRouteActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/NavigationMapRouteActivity.java
@@ -55,7 +55,6 @@ public class NavigationMapRouteActivity extends AppCompatActivity implements OnM
 
   private Marker originMarker;
   private Marker destinationMarker;
-  private boolean alternativesVisible = true;
   private List<DirectionsRoute> routes = new ArrayList<>();
 
   @Override
@@ -91,7 +90,7 @@ public class NavigationMapRouteActivity extends AppCompatActivity implements OnM
     DirectionsResponse response = gson.fromJson(loadJsonFromAsset(DIRECTIONS_RESPONSE),
       DirectionsResponse.class);
     navigationMapRoute.addRoute(response.routes().get(0));
-    mapboxMap.setOnMapLongClickListener(this);
+    mapboxMap.addOnMapLongClickListener(this);
     navigationMapRoute.setOnRouteSelectionChangeListener(this);
   }
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/NavigationMapRoute.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/NavigationMapRoute.java
@@ -1017,6 +1017,7 @@ public class NavigationMapRoute implements MapView.OnMapChangedListener,
   public void onMapChanged(int change) {
     if (change == MapView.DID_FINISH_LOADING_STYLE) {
       placeRouteBelow();
+      initializeUpcomingManeuverArrow();
       drawRoutes();
       addDirectionWaypoints();
       showAlternativeRoutes(alternativesVisible);


### PR DESCRIPTION
Fixes #1071 

We weren't re-initializing the arrow sources after a map style re-load.  So when we tried to update their visibility (when the new route is drawn), a native crash was occurring because they didn't exist. 