### PR TITLE
Revert MAS version from 3.4.0 to 3.3.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -9,7 +9,7 @@ ext {
 
   version = [
       mapboxMapSdk       : '6.3.0',
-      mapboxSdkServices  : '3.4.0',
+      mapboxSdkServices  : '3.3.0',
       mapboxEvents       : '3.1.4',
       locationLayerPlugin: '0.7.1',
       autoValue          : '1.5.4',


### PR DESCRIPTION
- Reverts MAS version from `3.4.0` to `3.3.0`

Fixes #1199 

Noting that when it gets merged we need to reopen #1183 