### PR TITLE
Bump MAS version to 3.4.1

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -9,7 +9,7 @@ ext {
 
   version = [
       mapboxMapSdk       : '6.3.0',
-      mapboxSdkServices  : '3.3.0',
+      mapboxSdkServices  : '3.4.1',
       mapboxEvents       : '3.1.4',
       locationLayerPlugin: '0.7.1',
       autoValue          : '1.5.4',


### PR DESCRIPTION
- Bumps MAS version to `3.4.1`

Fixes #1183

cc @osana 