### PR TITLE
Only reset night mode for EmbeddedNavigationActivity when isFinishing

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/EmbeddedNavigationActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/EmbeddedNavigationActivity.java
@@ -130,7 +130,9 @@ public class EmbeddedNavigationActivity extends AppCompatActivity implements OnN
   protected void onDestroy() {
     super.onDestroy();
     navigationView.onDestroy();
-    saveNightModeToPreferences(AppCompatDelegate.MODE_NIGHT_AUTO);
+    if (isFinishing()) {
+      saveNightModeToPreferences(AppCompatDelegate.MODE_NIGHT_AUTO);
+    }
   }
 
   @Override


### PR DESCRIPTION
Closes #1091 

We were always resetting night mode to `AUTO` when the `Activity` was being destroyed.  We should only do this if it's finishing.  