### PR TITLE
Do not scroll Instruction RecyclerView while animating

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionListTransitionListener.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionListTransitionListener.java
@@ -3,26 +3,35 @@ package com.mapbox.services.android.navigation.ui.v5.instruction;
 import android.support.annotation.NonNull;
 import android.support.transition.Transition;
 import android.support.transition.TransitionListenerAdapter;
+import android.support.v7.widget.RecyclerView;
 
 import com.mapbox.services.android.navigation.ui.v5.summary.list.InstructionListAdapter;
 
 class InstructionListTransitionListener extends TransitionListenerAdapter {
 
+  private static final int TOP = 0;
+  private final RecyclerView rvInstructions;
   private final InstructionListAdapter instructionListAdapter;
 
-  InstructionListTransitionListener(InstructionListAdapter instructionListAdapter) {
+  InstructionListTransitionListener(RecyclerView rvInstructions, InstructionListAdapter instructionListAdapter) {
+    this.rvInstructions = rvInstructions;
     this.instructionListAdapter = instructionListAdapter;
   }
 
   @Override
   public void onTransitionEnd(@NonNull Transition transition) {
     super.onTransitionEnd(transition);
-    instructionListAdapter.notifyDataSetChanged();
+    onAnimationFinished();
   }
 
   @Override
   public void onTransitionCancel(@NonNull Transition transition) {
     super.onTransitionCancel(transition);
+    onAnimationFinished();
+  }
+
+  private void onAnimationFinished() {
     instructionListAdapter.notifyDataSetChanged();
+    rvInstructions.smoothScrollToPosition(TOP);
   }
 }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionView.java
@@ -80,7 +80,6 @@ import timber.log.Timber;
 public class InstructionView extends RelativeLayout implements FeedbackBottomSheetListener {
 
   private static final double VALID_DURATION_REMAINING = 70d;
-  private static final int TOP = 0;
 
   private ManeuverView upcomingManeuverView;
   private TextView upcomingDistanceText;
@@ -325,7 +324,6 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
       updateLandscapeConstraintsTo(R.layout.instruction_layout_alt);
     }
     instructionListLayout.setVisibility(VISIBLE);
-    rvInstructions.smoothScrollToPosition(TOP);
   }
 
   public boolean handleBackPressed() {
@@ -840,7 +838,7 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
 
   private void beginDelayedListTransition() {
     AutoTransition transition = new AutoTransition();
-    transition.addListener(new InstructionListTransitionListener(instructionListAdapter));
+    transition.addListener(new InstructionListTransitionListener(rvInstructions, instructionListAdapter));
     TransitionManager.beginDelayedTransition(this, transition);
   }
 


### PR DESCRIPTION
Fixes #1208 and possibly https://github.com/mapbox/mapbox-navigation-android/pull/959#issuecomment-394819272

We are not attaching the `ViewHolders` to the parent container ([see here](https://github.com/mapbox/mapbox-navigation-android/blob/master/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/list/InstructionListAdapter.java#L26)).  I've seen some issues where this is happening as a result of scrolling the `RecyclerView` and updating it at the same time during an animation.  Which I believe is what we are doing with the delayed transition.  

This will require some testing as it's an intermittent crash - maybe we can try to reproduce with Firebase.