### PR TITLE
Add example with MapboxNavigation driving separate UI components

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.mapbox.services.android.navigation.testapp">
 
+    <uses-permission android:name="android.permission.VIBRATE"/>
+
     <application
         android:name=".NavigationApplication"
         android:allowBackup="true"
@@ -92,7 +94,16 @@
 
         <activity
             android:name=".activity.navigationui.fragment.FragmentNavigationActivity"
-            android:label="@string/title_embedded_navigation">
+            android:label="@string/title_fragment_navigation">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".MainActivity"/>
+        </activity>
+
+        <activity
+            android:name=".activity.navigationui.ComponentNavigationActivity"
+            android:label="@string/title_component_navigation"
+            android:screenOrientation="portrait">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".MainActivity"/>

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/MainActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/MainActivity.java
@@ -16,6 +16,7 @@ import com.mapbox.android.core.permissions.PermissionsListener;
 import com.mapbox.android.core.permissions.PermissionsManager;
 import com.mapbox.services.android.navigation.testapp.activity.MockNavigationActivity;
 import com.mapbox.services.android.navigation.testapp.activity.RerouteActivity;
+import com.mapbox.services.android.navigation.testapp.activity.navigationui.ComponentNavigationActivity;
 import com.mapbox.services.android.navigation.testapp.activity.navigationui.DualNavigationMapActivity;
 import com.mapbox.services.android.navigation.testapp.activity.navigationui.EmbeddedNavigationActivity;
 import com.mapbox.services.android.navigation.testapp.activity.navigationui.EndNavigationActivity;
@@ -82,6 +83,11 @@ public class MainActivity extends AppCompatActivity implements PermissionsListen
         getString(R.string.title_fragment_navigation),
         getString(R.string.description_fragment_navigation),
         FragmentNavigationActivity.class
+      ),
+      new SampleItem(
+        getString(R.string.title_component_navigation),
+        getString(R.string.description_component_navigation),
+        ComponentNavigationActivity.class
       )
     ));
 
@@ -142,8 +148,8 @@ public class MainActivity extends AppCompatActivity implements PermissionsListen
 
       ViewHolder(View view) {
         super(view);
-        nameView = (TextView) view.findViewById(R.id.nameView);
-        descriptionView = (TextView) view.findViewById(R.id.descriptionView);
+        nameView = view.findViewById(R.id.nameView);
+        descriptionView = view.findViewById(R.id.descriptionView);
       }
     }
 
@@ -151,26 +157,24 @@ public class MainActivity extends AppCompatActivity implements PermissionsListen
       this.samples = samples;
     }
 
+    @NonNull
     @Override
-    public MainAdapter.ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+    public MainAdapter.ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
       View view = LayoutInflater
         .from(parent.getContext())
         .inflate(R.layout.item_main_feature, parent, false);
 
-      view.setOnClickListener(new View.OnClickListener() {
-        @Override
-        public void onClick(View view) {
-          int position = recyclerView.getChildLayoutPosition(view);
-          Intent intent = new Intent(view.getContext(), samples.get(position).getActivity());
-          startActivity(intent);
-        }
+      view.setOnClickListener(view1 -> {
+        int position = recyclerView.getChildLayoutPosition(view1);
+        Intent intent = new Intent(view1.getContext(), samples.get(position).getActivity());
+        startActivity(intent);
       });
 
       return new ViewHolder(view);
     }
 
     @Override
-    public void onBindViewHolder(MainAdapter.ViewHolder holder, int position) {
+    public void onBindViewHolder(@NonNull MainAdapter.ViewHolder holder, int position) {
       holder.nameView.setText(samples.get(position).getName());
       holder.descriptionView.setText(samples.get(position).getDescription());
     }

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/MainActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/MainActivity.java
@@ -164,9 +164,9 @@ public class MainActivity extends AppCompatActivity implements PermissionsListen
         .from(parent.getContext())
         .inflate(R.layout.item_main_feature, parent, false);
 
-      view.setOnClickListener(view1 -> {
-        int position = recyclerView.getChildLayoutPosition(view1);
-        Intent intent = new Intent(view1.getContext(), samples.get(position).getActivity());
+      view.setOnClickListener(clickedView -> {
+        int position = recyclerView.getChildLayoutPosition(clickedView);
+        Intent intent = new Intent(clickedView.getContext(), samples.get(position).getActivity());
         startActivity(intent);
       });
 

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/ComponentNavigationActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/ComponentNavigationActivity.java
@@ -1,0 +1,382 @@
+package com.mapbox.services.android.navigation.testapp.activity.navigationui;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.content.res.Resources;
+import android.location.Location;
+import android.os.Build;
+import android.os.Bundle;
+import android.os.VibrationEffect;
+import android.os.Vibrator;
+import android.support.annotation.NonNull;
+import android.support.constraint.ConstraintLayout;
+import android.support.design.widget.BaseTransientBottomBar;
+import android.support.design.widget.FloatingActionButton;
+import android.support.design.widget.Snackbar;
+import android.support.transition.TransitionManager;
+import android.support.v7.app.AppCompatActivity;
+import android.view.View;
+
+import com.mapbox.android.core.location.LocationEngine;
+import com.mapbox.android.core.location.LocationEngineListener;
+import com.mapbox.android.core.location.LocationEnginePriority;
+import com.mapbox.android.core.location.LocationEngineProvider;
+import com.mapbox.api.directions.v5.models.DirectionsResponse;
+import com.mapbox.api.directions.v5.models.DirectionsRoute;
+import com.mapbox.geojson.Point;
+import com.mapbox.mapboxsdk.Mapbox;
+import com.mapbox.mapboxsdk.camera.CameraPosition;
+import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
+import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.geometry.LatLngBounds;
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.services.android.navigation.testapp.R;
+import com.mapbox.services.android.navigation.ui.v5.camera.DynamicCamera;
+import com.mapbox.services.android.navigation.ui.v5.instruction.InstructionView;
+import com.mapbox.services.android.navigation.ui.v5.map.NavigationMapboxMap;
+import com.mapbox.services.android.navigation.ui.v5.voice.NavigationSpeechPlayer;
+import com.mapbox.services.android.navigation.ui.v5.voice.SpeechAnnouncement;
+import com.mapbox.services.android.navigation.ui.v5.voice.SpeechPlayerProvider;
+import com.mapbox.services.android.navigation.v5.milestone.Milestone;
+import com.mapbox.services.android.navigation.v5.milestone.MilestoneEventListener;
+import com.mapbox.services.android.navigation.v5.milestone.VoiceInstructionMilestone;
+import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation;
+import com.mapbox.services.android.navigation.v5.navigation.NavigationRoute;
+import com.mapbox.services.android.navigation.v5.offroute.OffRouteListener;
+import com.mapbox.services.android.navigation.v5.routeprogress.ProgressChangeListener;
+import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
+
+import java.util.List;
+import java.util.Locale;
+
+import butterknife.BindView;
+import butterknife.ButterKnife;
+import butterknife.OnClick;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+import timber.log.Timber;
+
+public class ComponentNavigationActivity extends AppCompatActivity implements OnMapReadyCallback,
+  MapboxMap.OnMapLongClickListener, LocationEngineListener, ProgressChangeListener,
+  MilestoneEventListener, OffRouteListener {
+
+  private static final String ACCESS_TOKEN = Mapbox.getAccessToken();
+  private static final int FIRST = 0;
+  private static final int ONE_HUNDRED_MILLISECONDS = 100;
+  private static final int BOTTOMSHEET_PADDING_MULTIPLIER = 4;
+  private static final int TWO_SECONDS = 2000;
+  private static final double BEARING_TOLERANCE = 90d;
+
+  @BindView(R.id.componentNavigationLayout)
+  ConstraintLayout navigationLayout;
+
+  @BindView(R.id.mapView)
+  MapView mapView;
+
+  @BindView(R.id.instructionView)
+  InstructionView instructionView;
+
+  @BindView(R.id.startNavigationFab)
+  FloatingActionButton startNavigationFab;
+
+  private LocationEngine locationEngine;
+  private MapboxNavigation navigation;
+  private NavigationSpeechPlayer speechPlayer;
+  private NavigationMapboxMap navigationMap;
+  private Location lastLocation;
+  private DirectionsRoute route;
+  private Point destination;
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    // For styling the InstructionView
+    setTheme(R.style.CustomInstructionView);
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_component_navigation);
+    ButterKnife.bind(this);
+    mapView.onCreate(savedInstanceState);
+
+    // Will call onMapReady
+    mapView.getMapAsync(this);
+  }
+
+  @Override
+  public void onMapReady(MapboxMap mapboxMap) {
+    navigationMap = new NavigationMapboxMap(mapView, mapboxMap);
+
+    // For voice instructions
+    initializeSpeechPlayer();
+
+    // For Location updates
+    initializeLocationEngine();
+
+    // For navigation logic / processing
+    initializeNavigation(mapboxMap);
+  }
+
+  @Override
+  public void onMapLongClick(@NonNull LatLng point) {
+    // Fetch the route with this given point
+    destination = Point.fromLngLat(point.getLongitude(), point.getLatitude());
+    calculateRouteWith(destination, false);
+    navigationMap.clearMarkers();
+    navigationMap.addMarker(this, destination);
+    moveCameraToInclude(destination);
+    vibrate();
+  }
+
+  @OnClick(R.id.startNavigationFab)
+  public void onStartNavigationClick(FloatingActionButton floatingActionButton) {
+    floatingActionButton.hide();
+
+    // Show the InstructionView
+    TransitionManager.beginDelayedTransition(navigationLayout);
+    instructionView.setVisibility(View.VISIBLE);
+
+    // Start navigation
+    adjustMapPaddingForNavigation();
+    navigation.startNavigation(route);
+
+    // Location updates will be received from ProgressChangeListener
+    removeLocationEngineListener();
+  }
+
+  /*
+   * LocationEngine listeners
+   */
+
+  @SuppressLint("MissingPermission")
+  @Override
+  public void onConnected() {
+    locationEngine.requestLocationUpdates();
+  }
+
+  @Override
+  public void onLocationChanged(Location location) {
+    if (lastLocation == null) {
+      // Move the navigationMap camera to the first Location
+      moveCameraTo(location);
+
+      // Allow navigationMap clicks now that we have the current Location
+      navigationMap.retrieveMap().addOnMapLongClickListener(this);
+      showSnackbar("Long press the map to select a destination.", BaseTransientBottomBar.LENGTH_LONG);
+    }
+
+    // Cache for fetching the route later
+    updateLocation(location);
+  }
+
+  /*
+   * Navigation listeners
+   */
+
+  @Override
+  public void onProgressChange(Location location, RouteProgress routeProgress) {
+    // Cache "snapped" Locations for re-route Directions API requests
+    updateLocation(location);
+
+    // Update InstructionView data from RouteProgress
+    instructionView.update(routeProgress);
+  }
+
+  @Override
+  public void onMilestoneEvent(RouteProgress routeProgress, String instruction, Milestone milestone) {
+    playAnnouncement(milestone);
+  }
+
+  @Override
+  public void userOffRoute(Location location) {
+    calculateRouteWith(destination, true);
+  }
+
+  /*
+   * Activity lifecycle methods
+   */
+
+  @Override
+  public void onResume() {
+    super.onResume();
+    mapView.onResume();
+  }
+
+  @Override
+  public void onPause() {
+    super.onPause();
+    mapView.onPause();
+  }
+
+  @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+    if (navigationMap != null) {
+      navigationMap.onStart();
+    }
+  }
+
+  @Override
+  protected void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    mapView.onSaveInstanceState(outState);
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapView.onStop();
+    if (navigationMap != null) {
+      navigationMap.onStop();
+    }
+  }
+
+  @Override
+  public void onLowMemory() {
+    super.onLowMemory();
+    mapView.onLowMemory();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mapView.onDestroy();
+
+    // Ensure proper shutdown of the SpeechPlayer
+    if (speechPlayer != null) {
+      speechPlayer.onDestroy();
+    }
+
+    // Prevent leaks
+    removeLocationEngineListener();
+
+    ((DynamicCamera) navigation.getCameraEngine()).clearMap();
+    // MapboxNavigation will shutdown the LocationEngine
+    navigation.onDestroy();
+  }
+
+  private void initializeSpeechPlayer() {
+    String en = Locale.US.getLanguage();
+    String accessToken = Mapbox.getAccessToken();
+    SpeechPlayerProvider speechPlayerProvider = new SpeechPlayerProvider(getApplication(), en, true, accessToken);
+    speechPlayer = new NavigationSpeechPlayer(speechPlayerProvider);
+  }
+
+  private void initializeLocationEngine() {
+    LocationEngineProvider locationEngineProvider = new LocationEngineProvider(this);
+    locationEngine = locationEngineProvider.obtainBestLocationEngineAvailable();
+    locationEngine.setPriority(LocationEnginePriority.HIGH_ACCURACY);
+    locationEngine.addLocationEngineListener(this);
+    locationEngine.setFastestInterval(1000);
+    locationEngine.activate();
+    showSnackbar("Searching for GPS...", BaseTransientBottomBar.LENGTH_SHORT);
+  }
+
+  private void initializeNavigation(MapboxMap mapboxMap) {
+    navigation = new MapboxNavigation(this, ACCESS_TOKEN);
+    navigation.setLocationEngine(locationEngine);
+    navigation.setCameraEngine(new DynamicCamera(mapboxMap));
+    navigation.addProgressChangeListener(this);
+    navigation.addMilestoneEventListener(this);
+    navigation.addOffRouteListener(this);
+    navigationMap.addProgressChangeListener(navigation);
+  }
+
+  private void showSnackbar(String text, int duration) {
+    Snackbar.make(navigationLayout, text, duration).show();
+  }
+
+  private void playAnnouncement(Milestone milestone) {
+    if (milestone instanceof VoiceInstructionMilestone) {
+      SpeechAnnouncement announcement = SpeechAnnouncement.builder()
+        .voiceInstructionMilestone((VoiceInstructionMilestone) milestone)
+        .build();
+      speechPlayer.play(announcement);
+    }
+  }
+
+  private void updateLocation(Location location) {
+    lastLocation = location;
+    navigationMap.updateLocation(location);
+  }
+
+  private void moveCameraTo(Location location) {
+    CameraPosition cameraPosition = new CameraPosition.Builder()
+      .zoom(12)
+      .target(new LatLng(location.getLatitude(), location.getLongitude()))
+      .bearing(location.getBearing())
+      .build();
+    navigationMap.retrieveMap().animateCamera(CameraUpdateFactory.newCameraPosition(cameraPosition), TWO_SECONDS);
+  }
+
+  private void moveCameraToInclude(Point destination) {
+    LatLng origin = new LatLng(lastLocation);
+    LatLngBounds bounds = new LatLngBounds.Builder()
+      .include(origin)
+      .include(new LatLng(destination.latitude(), destination.longitude()))
+      .build();
+    Resources resources = getResources();
+    int routeCameraPadding = (int) resources.getDimension(R.dimen.component_navigation_route_camera_padding);
+    int[] padding = {routeCameraPadding, routeCameraPadding, routeCameraPadding, routeCameraPadding};
+    CameraPosition cameraPosition = navigationMap.retrieveMap().getCameraForLatLngBounds(bounds, padding);
+    navigationMap.retrieveMap().animateCamera(CameraUpdateFactory.newCameraPosition(cameraPosition), TWO_SECONDS);
+  }
+
+  private void adjustMapPaddingForNavigation() {
+    Resources resources = getResources();
+    int mapViewHeight = mapView.getHeight();
+    int bottomSheetHeight = (int) resources.getDimension(R.dimen.component_navigation_bottomsheet_height);
+    int topPadding = mapViewHeight - (bottomSheetHeight * BOTTOMSHEET_PADDING_MULTIPLIER);
+    navigationMap.retrieveMap().setPadding(0, topPadding, 0, 0);
+  }
+
+  private void removeLocationEngineListener() {
+    if (locationEngine != null) {
+      locationEngine.removeLocationEngineListener(this);
+    }
+  }
+
+  private void calculateRouteWith(Point destination, boolean isOffRoute) {
+    Point origin = Point.fromLngLat(lastLocation.getLongitude(), lastLocation.getLatitude());
+    Double bearing = Float.valueOf(lastLocation.getBearing()).doubleValue();
+    NavigationRoute.builder(this)
+      .accessToken(ACCESS_TOKEN)
+      .origin(origin, bearing, BEARING_TOLERANCE)
+      .destination(destination)
+      .build()
+      .getRoute(new Callback<DirectionsResponse>() {
+        @Override
+        public void onResponse(@NonNull Call<DirectionsResponse> call, @NonNull Response<DirectionsResponse> response) {
+          handleRoute(response, isOffRoute);
+        }
+
+        @Override
+        public void onFailure(@NonNull Call<DirectionsResponse> call, @NonNull Throwable throwable) {
+          Timber.e(throwable);
+        }
+      });
+  }
+
+  private void handleRoute(Response<DirectionsResponse> response, boolean isOffRoute) {
+    List<DirectionsRoute> routes = response.body().routes();
+    if (!routes.isEmpty()) {
+      route = routes.get(FIRST);
+      navigationMap.drawRoute(route);
+      if (isOffRoute) {
+        navigation.startNavigation(route);
+      } else {
+        startNavigationFab.show();
+      }
+    }
+  }
+
+  private void vibrate() {
+    Vibrator vibrator = (Vibrator) getSystemService(Context.VIBRATOR_SERVICE);
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      vibrator.vibrate(VibrationEffect.createOneShot(ONE_HUNDRED_MILLISECONDS, VibrationEffect.DEFAULT_AMPLITUDE));
+    } else {
+      vibrator.vibrate(ONE_HUNDRED_MILLISECONDS);
+    }
+  }
+}

--- a/app/src/main/res/drawable/ic_close_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_close_black_24dp.xml
@@ -1,9 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:width="24dp"
-        android:height="24dp"
-        android:viewportWidth="24.0"
-        android:viewportHeight="24.0">
-    <path
-        android:fillColor="#FF000000"
-        android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z"/>
-</vector>

--- a/app/src/main/res/drawable/ic_close_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_close_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_expand_less_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_expand_less_black_24dp.xml
@@ -1,9 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:width="24dp"
-        android:height="24dp"
-        android:viewportWidth="24.0"
-        android:viewportHeight="24.0">
-    <path
-        android:fillColor="#FF000000"
-        android:pathData="M12,8l-6,6 1.41,1.41L12,10.83l4.59,4.58L18,14z"/>
-</vector>

--- a/app/src/main/res/drawable/ic_expand_more_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_expand_more_black_24dp.xml
@@ -1,9 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:width="24dp"
-        android:height="24dp"
-        android:viewportWidth="24.0"
-        android:viewportHeight="24.0">
-    <path
-        android:fillColor="#FF000000"
-        android:pathData="M16.59,8.59L12,13.17 7.41,8.59 6,10l6,6 6,-6z"/>
-</vector>

--- a/app/src/main/res/drawable/ic_my_location_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_my_location_black_24dp.xml
@@ -1,9 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:width="24dp"
-        android:height="24dp"
-        android:viewportWidth="24.0"
-        android:viewportHeight="24.0">
-    <path
-        android:fillColor="#FF000000"
-        android:pathData="M12,8c-2.21,0 -4,1.79 -4,4s1.79,4 4,4 4,-1.79 4,-4 -1.79,-4 -4,-4zM20.94,11c-0.46,-4.17 -3.77,-7.48 -7.94,-7.94L13,1h-2v2.06C6.83,3.52 3.52,6.83 3.06,11L1,11v2h2.06c0.46,4.17 3.77,7.48 7.94,7.94L11,23h2v-2.06c4.17,-0.46 7.48,-3.77 7.94,-7.94L23,13v-2h-2.06zM12,19c-3.87,0 -7,-3.13 -7,-7s3.13,-7 7,-7 7,3.13 7,7 -3.13,7 -7,7z"/>
-</vector>

--- a/app/src/main/res/layout/activity_component_navigation.xml
+++ b/app/src/main/res/layout/activity_component_navigation.xml
@@ -2,6 +2,7 @@
 <android.support.constraint.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:mapbox="http://schemas.android.com/tools"
     android:id="@+id/componentNavigationLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
@@ -13,7 +14,8 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"/>
+        app:layout_constraintTop_toTopOf="parent"
+        mapbox:mapbox_styleUrl="mapbox://styles/designevokes/cjksybfj600xj2roja7iwnygu"/>
 
     <com.mapbox.services.android.navigation.ui.v5.instruction.InstructionView
         android:id="@+id/instructionView"

--- a/app/src/main/res/layout/activity_component_navigation.xml
+++ b/app/src/main/res/layout/activity_component_navigation.xml
@@ -36,4 +36,17 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"/>
 
+    <android.support.design.widget.FloatingActionButton
+        android:id="@+id/cancelNavigationFab"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginRight="16dp"
+        android:src="@drawable/ic_close"
+        android:visibility="invisible"
+        app:backgroundTint="@color/white"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/activity_component_navigation.xml
+++ b/app/src/main/res/layout/activity_component_navigation.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/componentNavigationLayout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.mapbox.mapboxsdk.maps.MapView
+        android:id="@+id/mapView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
+
+    <com.mapbox.services.android.navigation.ui.v5.instruction.InstructionView
+        android:id="@+id/instructionView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:visibility="invisible"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
+
+    <android.support.design.widget.FloatingActionButton
+        android:id="@+id/startNavigationFab"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginRight="16dp"
+        android:src="@drawable/ic_navigation"
+        android:visibility="invisible"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -4,4 +4,5 @@
     <color name="colorPrimaryDark">#7845F3</color>
     <color name="colorAccent">#F56FA3</color>
     <color name="red">#FF0000</color>
+    <color name="white">#FFFFFF</color>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -7,4 +7,6 @@
     <dimen name="fab_margin">16dp</dimen>
     <dimen name="speed_text_size">50sp</dimen>
     <dimen name="mph_text_size">10sp</dimen>
+    <dimen name="component_navigation_bottomsheet_height">56dp</dimen>
+    <dimen name="component_navigation_route_camera_padding">56dp</dimen>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -7,6 +7,6 @@
     <dimen name="fab_margin">16dp</dimen>
     <dimen name="speed_text_size">50sp</dimen>
     <dimen name="mph_text_size">10sp</dimen>
-    <dimen name="component_navigation_bottomsheet_height">56dp</dimen>
+    <dimen name="component_navigation_bottomsheet_height">96dp</dimen>
     <dimen name="component_navigation_route_camera_padding">56dp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,6 +31,9 @@
     <string name="title_fragment_navigation">NavigationView implemented with Fragment</string>
     <string name="description_fragment_navigation">NavigationView implemented with Fragment</string>
 
+    <string name="title_component_navigation">MapboxNavigation with UI components</string>
+    <string name="description_component_navigation">MapboxNavigation with UI components</string>
+
     <string name="settings">Settings</string>
     <string name="simulate_route">Simulate Route</string>
     <string name="language">Language</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -8,6 +8,36 @@
         <item name="navigationViewRouteStyle">@style/CustomNavigationMapRoute</item>
     </style>
 
+    <style name="CustomInstructionView" parent="Theme.AppCompat.Light.NoActionBar">
+        <item name="navigationViewPrimary">@color/mapbox_navigation_view_color_primary</item>
+        <item name="navigationViewSecondary">@color/mapbox_navigation_view_color_secondary</item>
+        <item name="navigationViewAccent">@color/mapbox_navigation_view_color_accent</item>
+        <item name="navigationViewPrimaryText">@color/mapbox_navigation_view_color_secondary</item>
+        <item name="navigationViewSecondaryText">@color/mapbox_navigation_view_color_accent_text</item>
+        <item name="navigationViewDivider">@color/mapbox_navigation_view_color_divider</item>
+
+        <item name="navigationViewListBackground">@color/mapbox_navigation_view_color_list_background</item>
+
+        <item name="navigationViewBannerBackground">@color/mapbox_navigation_view_color_banner_background</item>
+        <item name="navigationViewBannerPrimaryText">@color/mapbox_navigation_view_color_banner_primary_text</item>
+        <item name="navigationViewBannerSecondaryText">@color/mapbox_navigation_view_color_banner_secondary_text</item>
+        <item name="navigationViewBannerManeuverPrimary">@color/mapbox_navigation_view_color_banner_maneuver_primary</item>
+        <item name="navigationViewBannerManeuverSecondary">@color/mapbox_navigation_view_color_banner_maneuver_secondary</item>
+
+        <item name="navigationViewProgress">@color/mapbox_navigation_view_color_progress</item>
+        <item name="navigationViewProgressBackground">@color/mapbox_navigation_view_color_progress_background</item>
+
+        <item name="navigationViewRouteStyle">@style/NavigationMapRoute</item>
+
+        <item name="navigationViewLocationLayerStyle">@style/mapbox_LocationLayer</item>
+
+        <item name="navigationViewDestinationMarker">@drawable/map_marker_light</item>
+
+        <item name="navigationViewRouteOverviewDrawable">@drawable/ic_route_preview</item>
+
+        <item name="navigationViewMapStyle">@string/navigation_guidance_day</item>
+    </style>
+
     <!-- Base application theme. -->
     <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
         <!-- Customize your theme here. -->


### PR DESCRIPTION
Adds an example to the test application demonstrating `MapboxNavigation` setup / updating an `InstructionView` + `NavigationMapboxMap`

Currently uses default styling for map, instruction view, and route line.

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/8434572/44223541-e325d680-a155-11e8-8bbd-877d9aefc592.gif)

cc @nitaliano @d-prukop @bsudekum 