### PR TITLE
Simplify will voice and will display APIs

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/EmbeddedNavigationActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/EmbeddedNavigationActivity.java
@@ -168,13 +168,13 @@ public class EmbeddedNavigationActivity extends AppCompatActivity implements OnN
   }
 
   @Override
-  public SpeechAnnouncement willVoice(SpeechAnnouncement announcement) {
-    return SpeechAnnouncement.builder().announcement("All announcements will be the same.").build();
+  public String willVoice(SpeechAnnouncement announcement) {
+    return "All announcements will be the same.";
   }
 
   @Override
-  public BannerInstructions willDisplay(BannerInstructions instructions) {
-    return instructions;
+  public String willDisplay(BannerInstructions instructions) {
+    return "All banners will be the same.";
   }
 
   private void startNavigation(DirectionsRoute directionsRoute) {

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/BannerInstructionsWrapper.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/BannerInstructionsWrapper.java
@@ -1,0 +1,21 @@
+package com.mapbox.services.android.navigation.ui.v5;
+
+import com.mapbox.api.directions.v5.models.BannerInstructions;
+
+class BannerInstructionsWrapper {
+  private final BannerInstructions bannerInstructions;
+  private final boolean isBannerTextOverridden;
+
+  BannerInstructionsWrapper(BannerInstructions bannerInstructions, boolean isBannerTextOverridden) {
+    this.bannerInstructions = bannerInstructions;
+    this.isBannerTextOverridden = isBannerTextOverridden;
+  }
+
+  public BannerInstructions getBannerInstructions() {
+    return bannerInstructions;
+  }
+
+  public boolean isBannerTextOverridden() {
+    return isBannerTextOverridden;
+  }
+}

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewEventDispatcher.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewEventDispatcher.java
@@ -5,6 +5,7 @@ import android.support.annotation.Nullable;
 import android.support.design.widget.BottomSheetBehavior.BottomSheetCallback;
 import android.view.View;
 
+import com.mapbox.api.directions.v5.models.BannerComponents;
 import com.mapbox.api.directions.v5.models.BannerInstructions;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.geojson.Point;
@@ -12,13 +13,16 @@ import com.mapbox.services.android.navigation.ui.v5.feedback.FeedbackItem;
 import com.mapbox.services.android.navigation.ui.v5.listeners.BannerInstructionsListener;
 import com.mapbox.services.android.navigation.ui.v5.listeners.FeedbackListener;
 import com.mapbox.services.android.navigation.ui.v5.listeners.InstructionListListener;
-import com.mapbox.services.android.navigation.ui.v5.listeners.SpeechAnnouncementListener;
 import com.mapbox.services.android.navigation.ui.v5.listeners.NavigationListener;
 import com.mapbox.services.android.navigation.ui.v5.listeners.RouteListener;
+import com.mapbox.services.android.navigation.ui.v5.listeners.SpeechAnnouncementListener;
 import com.mapbox.services.android.navigation.ui.v5.voice.SpeechAnnouncement;
 import com.mapbox.services.android.navigation.v5.milestone.MilestoneEventListener;
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation;
 import com.mapbox.services.android.navigation.v5.routeprogress.ProgressChangeListener;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * In charge of holding any {@link NavigationView} related listeners {@link NavigationListener},
@@ -27,6 +31,8 @@ import com.mapbox.services.android.navigation.v5.routeprogress.ProgressChangeLis
  */
 class NavigationViewEventDispatcher {
 
+  private static final int ONE = 1;
+  private static final int FIRST = 0;
   private ProgressChangeListener progressChangeListener;
   private MilestoneEventListener milestoneEventListener;
   private FeedbackListener feedbackListener;
@@ -167,14 +173,22 @@ class NavigationViewEventDispatcher {
 
   SpeechAnnouncement onAnnouncement(SpeechAnnouncement announcement) {
     if (speechAnnouncementListener != null) {
-      return speechAnnouncementListener.willVoice(announcement);
+      String textAnnouncement = speechAnnouncementListener.willVoice(announcement);
+      SpeechAnnouncement announcementToBeVoiced = SpeechAnnouncement.builder().announcement(textAnnouncement).build();
+      return announcementToBeVoiced;
     }
     return announcement;
   }
 
   BannerInstructions onBannerDisplay(BannerInstructions instructions) {
     if (bannerInstructionsListener != null) {
-      return bannerInstructionsListener.willDisplay(instructions);
+      String textBanner = bannerInstructionsListener.willDisplay(instructions);
+      List<BannerComponents> bannerComponents = new ArrayList<>(ONE);
+      bannerComponents.add(instructions.primary().components().get(FIRST).toBuilder().text(textBanner)
+        .abbreviation(textBanner).build());
+      BannerInstructions bannerToBeDisplayed = instructions.toBuilder().primary(instructions.primary().toBuilder()
+        .components(bannerComponents).build()).build();
+      return bannerToBeDisplayed;
     }
     return instructions;
   }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewEventDispatcher.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewEventDispatcher.java
@@ -180,7 +180,7 @@ class NavigationViewEventDispatcher {
     return announcement;
   }
 
-  BannerInstructions onBannerDisplay(BannerInstructions instructions) {
+  BannerInstructionsWrapper onBannerDisplay(BannerInstructions instructions) {
     if (bannerInstructionsListener != null) {
       String textBanner = bannerInstructionsListener.willDisplay(instructions);
       List<BannerComponents> bannerComponents = new ArrayList<>(ONE);
@@ -188,9 +188,9 @@ class NavigationViewEventDispatcher {
         .abbreviation(textBanner).build());
       BannerInstructions bannerToBeDisplayed = instructions.toBuilder().primary(instructions.primary().toBuilder()
         .components(bannerComponents).build()).build();
-      return bannerToBeDisplayed;
+      return new BannerInstructionsWrapper(bannerToBeDisplayed, true);
     }
-    return instructions;
+    return new BannerInstructionsWrapper(instructions, false);
   }
 
   private void assignProgressChangeListener(NavigationViewOptions navigationViewOptions, MapboxNavigation navigation) {

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionModel.java
@@ -20,6 +20,7 @@ public class InstructionModel {
   private RouteUtils routeUtils;
   private String language;
   private String unitType;
+  private boolean isBannerTextOverridden;
 
   public InstructionModel(Context context, RouteProgress progress, String language, String unitType) {
     this.progress = progress;
@@ -27,6 +28,14 @@ public class InstructionModel {
     this.unitType = unitType;
     routeUtils = new RouteUtils();
     buildInstructionModel(context, progress);
+  }
+
+  public boolean isBannerTextOverridden() {
+    return isBannerTextOverridden;
+  }
+
+  public void setBannerTextOverridden(boolean bannerTextOverridden) {
+    isBannerTextOverridden = bannerTextOverridden;
   }
 
   BannerText getPrimaryBannerText() {

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionView.java
@@ -715,7 +715,8 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
     String maneuverViewModifier = model.getManeuverModifier();
     double durationRemaining = model.getProgress().currentLegProgress().currentStepProgress().durationRemaining();
 
-    if (shouldShowTurnLanes(turnLanes, maneuverViewModifier, durationRemaining)) {
+    boolean isBannerTextOverridden = model.isBannerTextOverridden();
+    if (!isBannerTextOverridden && shouldShowTurnLanes(turnLanes, maneuverViewModifier, durationRemaining)) {
       if (turnLaneLayout.getVisibility() == GONE) {
         turnLaneAdapter.addTurnLanes(turnLanes, maneuverViewModifier);
         showTurnLanes();
@@ -759,7 +760,8 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
    * @param model to determine if the then step layout should be shown
    */
   private void updateThenStep(InstructionModel model) {
-    if (shouldShowThenStep(model)) {
+    boolean isBannerTextOverridden = model.isBannerTextOverridden();
+    if (!isBannerTextOverridden && shouldShowThenStep(model)) {
       String thenStepManeuverType = model.getStepResources().getThenStepManeuverType();
       String thenStepManeuverModifier = model.getStepResources().getThenStepManeuverModifier();
       thenManeuverView.setManeuverTypeAndModifier(thenStepManeuverType, thenStepManeuverModifier);
@@ -932,6 +934,10 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
    * @param model to provide the current steps and unit type
    */
   private void updateInstructionList(InstructionModel model) {
+    boolean isBannerTextOverridden = model.isBannerTextOverridden();
+    if (isBannerTextOverridden) {
+      instructionListAdapter.clearBannerInstructions();
+    }
     RouteProgress routeProgress = model.getProgress();
     boolean isListShowing = instructionListLayout.getVisibility() == VISIBLE;
     instructionListAdapter.updateBannerListWith(routeProgress, isListShowing);

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/listeners/BannerInstructionsListener.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/listeners/BannerInstructionsListener.java
@@ -19,8 +19,8 @@ public interface BannerInstructionsListener {
    * and it will be ignored.
    *
    * @param instructions about to be displayed
-   * @return instructions to be displayed; null if should be ignored
-   * @since 0.16.0
+   * @return instruction text to be displayed; null if should be ignored
+   * @since 0.18.0
    */
-  BannerInstructions willDisplay(BannerInstructions instructions);
+  String willDisplay(BannerInstructions instructions);
 }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/listeners/SpeechAnnouncementListener.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/listeners/SpeechAnnouncementListener.java
@@ -19,8 +19,8 @@ public interface SpeechAnnouncementListener {
    * and it will be ignored.
    *
    * @param announcement about to be announced
-   * @return announcement to be played; null if should be ignored
-   * @since 0.16.0
+   * @return text announcement to be played; null if should be ignored
+   * @since 0.18.0
    */
-  SpeechAnnouncement willVoice(SpeechAnnouncement announcement);
+  String willVoice(SpeechAnnouncement announcement);
 }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/list/InstructionListAdapter.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/list/InstructionListAdapter.java
@@ -53,4 +53,8 @@ public class InstructionListAdapter extends RecyclerView.Adapter<InstructionView
   public void updateDistanceFormatter(DistanceFormatter distanceFormatter) {
     presenter.updateDistanceFormatter(distanceFormatter);
   }
+
+  public void clearBannerInstructions() {
+    presenter.clearBannerInstructions();
+  }
 }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/list/InstructionListPresenter.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/list/InstructionListPresenter.java
@@ -55,6 +55,10 @@ public class InstructionListPresenter {
     }
   }
 
+  void clearBannerInstructions() {
+    instructions.clear();
+  }
+
   private boolean shouldUpdate(DistanceFormatter distanceFormatter) {
     return distanceFormatter != null
       && (this.distanceFormatter == null || !this.distanceFormatter.equals(distanceFormatter));

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewEventDispatcherTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewEventDispatcherTest.java
@@ -404,10 +404,10 @@ public class NavigationViewEventDispatcherTest {
     when(bannerInstructionsListener.willDisplay(originalInstructions)).thenReturn(textBanner);
     NavigationViewEventDispatcher eventDispatcher = buildViewEventDispatcher(bannerInstructionsListener);
 
-    BannerInstructions modifiedInstruction = eventDispatcher.onBannerDisplay(originalInstructions);
+    BannerInstructionsWrapper modifiedInstruction = eventDispatcher.onBannerDisplay(originalInstructions);
 
-    assertEquals("banner to be displayed", modifiedInstruction.primary().components().get(0).text());
-    assertEquals("banner to be displayed", modifiedInstruction.primary().components().get(0).abbreviation());
+    assertEquals("banner to be displayed", modifiedInstruction.getBannerInstructions().primary().components().get(0).text());
+    assertEquals("banner to be displayed", modifiedInstruction.getBannerInstructions().primary().components().get(0).abbreviation());
   }
 
   @Test


### PR DESCRIPTION
Fixes #1224 and https://github.com/mapbox/mapbox-navigation-android/pull/1107#issuecomment-409249523

Right now, it's pretty complicated to override `SpeechAnnouncement` and `BannerInstructions` objects without knowing their internals and clients of `willVoice` and `willDisplay` APIs are having a hard time to get them working. This PR simplifies `willVoice` and `willDisplay` APIs so they are user-friendly and work as expected. 

Ultimately, I think that what clients would want from them is just to voice / display the announcement / banner text they want.

I added the `DO NOT MERGE` label (for now) because I'd love to discuss if the changes introduced make sense / will benefit clients. What do you think @danesfeder @devotaaabel? I'd love to hear your thoughts 🙏

cc'ing @akitchen to know:
- also your inputs here 
- how this is implemented in iOS 

Refs. https://github.com/mapbox/mapbox-navigation-android/issues/1074