### PR TITLE
Update Maps SDK to 6.5.0 and Events to 3.2.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,7 +8,7 @@ ext {
   ]
 
   version = [
-      mapboxMapSdk       : '6.5.0-alpha.1',
+      mapboxMapSdk       : '6.5.0-alpha.2',
       mapboxSdkServices  : '3.4.1',
       mapboxEvents       : '3.1.5',
       locationLayerPlugin: '0.8.1',

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,9 +8,9 @@ ext {
   ]
 
   version = [
-      mapboxMapSdk       : '6.5.0-beta.1',
+      mapboxMapSdk       : '6.5.0',
       mapboxSdkServices  : '3.4.1',
-      mapboxEvents       : '3.1.5',
+      mapboxEvents       : '3.2.0',
       locationLayerPlugin: '0.8.1',
       autoValue          : '1.5.4',
       autoValueParcel    : '0.2.5',

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,7 +8,7 @@ ext {
   ]
 
   version = [
-      mapboxMapSdk       : '6.5.0-alpha.2',
+      mapboxMapSdk       : '6.5.0-beta.1',
       mapboxSdkServices  : '3.4.1',
       mapboxEvents       : '3.1.5',
       locationLayerPlugin: '0.8.1',

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,7 +8,7 @@ ext {
   ]
 
   version = [
-      mapboxMapSdk       : '6.4.0',
+      mapboxMapSdk       : '6.5.0-alpha.1',
       mapboxSdkServices  : '3.4.1',
       mapboxEvents       : '3.1.5',
       locationLayerPlugin: '0.8.1',


### PR DESCRIPTION
Didn't find any issues with maps, but in testing the alpha I found a few issues on our side:
1. End Navigation and Dual Navigation examples - `recenter` and `X` don't do anything
2. Navigation View w/ Fragment example- Clicking `X` shows `placeholder text` 