### PR TITLE
Update NavigationView to guard against duplicate initializations

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
@@ -74,7 +74,7 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
   private NavigationMapboxMap navigationMap;
   private OnNavigationReadyCallback onNavigationReadyCallback;
   private MapboxMap.OnMoveListener onMoveListener;
-  private boolean isInitialized;
+  private boolean isMapInitialized;
 
   public NavigationView(Context context) {
     this(context, null);
@@ -202,6 +202,7 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
   public void onMapReady(MapboxMap mapboxMap) {
     initializeNavigationMap(mapView, mapboxMap);
     onNavigationReadyCallback.onNavigationReady(navigationViewModel.isRunning());
+    isMapInitialized = true;
   }
 
   @Override
@@ -347,11 +348,7 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
    * @param options with containing route / coordinate data
    */
   public void startNavigation(NavigationViewOptions options) {
-    if (!isInitialized) {
-      initializeNavigation(options);
-    } else {
-      navigationViewModel.updateNavigation(options);
-    }
+    initializeNavigation(options);
   }
 
   /**
@@ -374,7 +371,11 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
    */
   public void initialize(OnNavigationReadyCallback onNavigationReadyCallback) {
     this.onNavigationReadyCallback = onNavigationReadyCallback;
-    mapView.getMapAsync(this);
+    if (!isMapInitialized) {
+      mapView.getMapAsync(this);
+    } else {
+      onNavigationReadyCallback.onNavigationReady(navigationViewModel.isRunning());
+    }
   }
 
   /**
@@ -513,7 +514,6 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
     setupNavigationMapboxMap(options);
 
     subscribeViewModels();
-    isInitialized = true;
   }
 
   private void initializeClickListeners() {

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
@@ -104,6 +104,7 @@ public class NavigationViewModel extends AndroidViewModel {
       locationEngineConductor.onDestroy();
       deactivateInstructionPlayer();
       endNavigation();
+      isRunning = false;
     }
     clearDynamicCameraMap();
     navigationViewEventDispatcher = null;
@@ -188,10 +189,6 @@ public class NavigationViewModel extends AndroidViewModel {
       navigationViewRouteEngine.extractRouteOptions(options);
     }
     return navigation;
-  }
-
-  void updateNavigation(NavigationViewOptions options) {
-    navigationViewRouteEngine.extractRouteOptions(options);
   }
 
   void updateFeedbackScreenshot(String screenshot) {


### PR DESCRIPTION
This PR aims addresses the original issue found in #1209 and removes the immediate need for #1239 

In the `NavigationView` we were saying the `View` was "initialized" when navigation started.  I think it makes more sense to check if `NavigationMapboxMap` is initialized and then have `NavigationViewModel` be the single source of truth for running navigation.  

This should ensure 1 `NavigationMapboxMap` per 1 `NavigationView`.  Creating more than one map per view was the issue I believe with the instrumentation tests.  