### PR TITLE
Bump Location Layer Plugin version to 0.8.1

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/MockNavigationActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/MockNavigationActivity.java
@@ -150,7 +150,7 @@ public class MockNavigationActivity extends AppCompatActivity implements OnMapRe
   public void onMapReady(MapboxMap mapboxMap) {
     this.mapboxMap = mapboxMap;
 
-    locationLayerPlugin = new LocationLayerPlugin(mapView, mapboxMap, null);
+    locationLayerPlugin = new LocationLayerPlugin(mapView, mapboxMap);
     locationLayerPlugin.setRenderMode(RenderMode.GPS);
     navigationMapRoute = new NavigationMapRoute(navigation, mapView, mapboxMap);
 

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/RerouteActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/RerouteActivity.java
@@ -153,7 +153,7 @@ public class RerouteActivity extends AppCompatActivity implements OnMapReadyCall
     this.mapboxMap = mapboxMap;
     mapboxMap.setOnMapClickListener(this);
 
-    locationLayerPlugin = new LocationLayerPlugin(mapView, mapboxMap, null);
+    locationLayerPlugin = new LocationLayerPlugin(mapView, mapboxMap);
     locationLayerPlugin.setRenderMode(RenderMode.GPS);
 
     // Setup the mockLocationEngine

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -11,7 +11,7 @@ ext {
       mapboxMapSdk       : '6.4.0',
       mapboxSdkServices  : '3.4.1',
       mapboxEvents       : '3.1.5',
-      locationLayerPlugin: '0.7.1',
+      locationLayerPlugin: '0.8.1',
       autoValue          : '1.5.4',
       autoValueParcel    : '0.2.5',
       junit              : '4.12',


### PR DESCRIPTION
Edited:
- Bumps Location Layer Plugin version to ~~`0.8.0`~~`0.8.1`

Noting that with the latest changes introduced, now you cannot use the constructor [`LocationLayerPlugin(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap, @Nullable LocationEngine locationEngine)`](https://github.com/mapbox/mapbox-plugins-android/blob/master/plugin-locationlayer/src/main/java/com/mapbox/mapboxsdk/plugins/locationlayer/LocationLayerPlugin.java#L188-L189) passing `null` as `LocationEngine`, you get the following building error:

```
error: reference to LocationLayerPlugin is ambiguous
both constructor LocationLayerPlugin(MapView,MapboxMap,LocationLayerOptions) in LocationLayerPlugin and constructor LocationLayerPlugin(MapView,MapboxMap,LocationEngine) in LocationLayerPlugin match
```

Edited:
Fixed in `0.8.1`

Also, I noticed a 📉 in the performance 😭

![llp_0_8_0_jumpy](https://user-images.githubusercontent.com/1668582/44977966-d2ed6400-af69-11e8-9527-8517924b456f.gif)

`0.8.0` Nexus 5 - Android 6.0

![llp_0_7_1_smooth](https://user-images.githubusercontent.com/1668582/44978038-03350280-af6a-11e8-836c-f50cd053d4a5.gif)

`0.7.1` Nexus 5 - Android 6.0

Note how the puck is more "jumpy" when using `0.8.0` version.

After some 🕵️ I believe this was introduced in `0.7.2` https://github.com/mapbox/mapbox-plugins-android/pull/615 (noting that we didn't bump to `0.7.2`, we're still using `0.7.1`). I've tested the same scenario using `0.7.2` and I'm 👀 the same "jumpy" puck behavior. Could this be the reason? Would you mind helping me here @LukasPaczos @danesfeder @langsmith?

