### PR TITLE
Fix recenter show logic by adding MoveListener again in lifecycle

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
@@ -175,6 +175,7 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
     mapView.onStart();
     if (navigationMap != null) {
       navigationMap.onStart();
+      navigationMap.addOnMoveListener(onMoveListener);
     }
   }
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
@@ -79,6 +79,7 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
   private NavigationMapboxMapInstanceState mapInstanceState;
   private boolean isMapInitialized;
   private boolean isSubscribed;
+  private boolean isMoveListenerRemoved = false;
 
   public NavigationView(Context context) {
     this(context, null);
@@ -175,7 +176,9 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
     mapView.onStart();
     if (navigationMap != null) {
       navigationMap.onStart();
-      navigationMap.addOnMoveListener(onMoveListener);
+      if (isMoveListenerRemoved) {
+        navigationMap.addOnMoveListener(onMoveListener);
+      }
     }
   }
 
@@ -191,6 +194,7 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
     mapView.onStop();
     if (navigationMap != null) {
       navigationMap.onStop();
+      isMoveListenerRemoved = true;
       navigationMap.removeOnMoveListener(onMoveListener);
     }
   }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
@@ -79,7 +79,6 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
   private NavigationMapboxMapInstanceState mapInstanceState;
   private boolean isMapInitialized;
   private boolean isSubscribed;
-  private boolean isMoveListenerRemoved = false;
 
   public NavigationView(Context context) {
     this(context, null);
@@ -168,6 +167,9 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
    * In a {@link android.app.Fragment}, this should be in {@link Fragment#onDestroyView()}.
    */
   public void onDestroy() {
+    if ( navigationMap != null) {
+      navigationMap.removeOnMoveListener(onMoveListener);
+    }
     navigationViewEventDispatcher.onDestroy(navigationViewModel.retrieveNavigation());
     shutdown();
   }
@@ -176,9 +178,6 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
     mapView.onStart();
     if (navigationMap != null) {
       navigationMap.onStart();
-      if (isMoveListenerRemoved) {
-        navigationMap.addOnMoveListener(onMoveListener);
-      }
     }
   }
 
@@ -194,8 +193,6 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
     mapView.onStop();
     if (navigationMap != null) {
       navigationMap.onStop();
-      isMoveListenerRemoved = true;
-      navigationMap.removeOnMoveListener(onMoveListener);
     }
   }
 


### PR DESCRIPTION
I realize when we switch between apps the recenter logic does not work anymore(v16 tested) because we remove the MoveListener in onStop. I added it in onStart. At first I wanted to check if onMoveListener is null or not but as long as it's working on mainThread both onMoveListener and navigationMap init together; So should I add null check or my assumption is right?