### PR TITLE
Do not allow multiple ViewModel subscriptions in NavigationView

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
@@ -78,6 +78,7 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
   private MapboxMap.OnMoveListener onMoveListener;
   private NavigationMapboxMapInstanceState mapInstanceState;
   private boolean isMapInitialized;
+  private boolean isSubscribed;
 
   public NavigationView(Context context) {
     this(context, null);
@@ -513,14 +514,16 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
   }
 
   private void initializeNavigation(NavigationViewOptions options) {
-    initializeClickListeners();
-    initializeOnMoveListener();
     establish(options);
     MapboxNavigation navigation = navigationViewModel.initialize(options);
     initializeNavigationListeners(options, navigation);
     setupNavigationMapboxMap(options);
 
-    subscribeViewModels();
+    if (!isSubscribed) {
+      initializeClickListeners();
+      initializeOnMoveListener();
+      subscribeViewModels();
+    }
   }
 
   private void initializeClickListeners() {
@@ -584,6 +587,7 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
 
     NavigationViewSubscriber subscriber = new NavigationViewSubscriber(navigationPresenter);
     subscriber.subscribe(((LifecycleOwner) getContext()), navigationViewModel);
+    isSubscribed = true;
   }
 
   private void shutdown() {


### PR DESCRIPTION
In https://github.com/mapbox/mapbox-navigation-android/pull/1247, we added a guard against duplicate `MapView` initializations.  

In the process, we removed the check for multiple navigation "starts" while the `NavigationView` is inflated.  This means we opened the ability to subscribe to `NavigationViewModel`.  This can't happen because for each time we subscribe to the `LiveData`, we get +1 update.  If you start navigation 3 times with the view for example you'll get 3 duplicate updates.  

Great catch here @devotaaabel 