### PR TITLE
Simplify will voice API

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/EmbeddedNavigationActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/EmbeddedNavigationActivity.java
@@ -168,8 +168,8 @@ public class EmbeddedNavigationActivity extends AppCompatActivity implements OnN
   }
 
   @Override
-  public SpeechAnnouncement willVoice(SpeechAnnouncement announcement) {
-    return SpeechAnnouncement.builder().announcement("All announcements will be the same.").build();
+  public String willVoice(SpeechAnnouncement announcement) {
+    return "All announcements will be the same.";
   }
 
   @Override

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewEventDispatcher.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewEventDispatcher.java
@@ -12,9 +12,9 @@ import com.mapbox.services.android.navigation.ui.v5.feedback.FeedbackItem;
 import com.mapbox.services.android.navigation.ui.v5.listeners.BannerInstructionsListener;
 import com.mapbox.services.android.navigation.ui.v5.listeners.FeedbackListener;
 import com.mapbox.services.android.navigation.ui.v5.listeners.InstructionListListener;
-import com.mapbox.services.android.navigation.ui.v5.listeners.SpeechAnnouncementListener;
 import com.mapbox.services.android.navigation.ui.v5.listeners.NavigationListener;
 import com.mapbox.services.android.navigation.ui.v5.listeners.RouteListener;
+import com.mapbox.services.android.navigation.ui.v5.listeners.SpeechAnnouncementListener;
 import com.mapbox.services.android.navigation.ui.v5.voice.SpeechAnnouncement;
 import com.mapbox.services.android.navigation.v5.milestone.MilestoneEventListener;
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation;
@@ -167,7 +167,9 @@ class NavigationViewEventDispatcher {
 
   SpeechAnnouncement onAnnouncement(SpeechAnnouncement announcement) {
     if (speechAnnouncementListener != null) {
-      return speechAnnouncementListener.willVoice(announcement);
+      String textAnnouncement = speechAnnouncementListener.willVoice(announcement);
+      SpeechAnnouncement announcementToBeVoiced = SpeechAnnouncement.builder().announcement(textAnnouncement).build();
+      return announcementToBeVoiced;
     }
     return announcement;
   }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/listeners/SpeechAnnouncementListener.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/listeners/SpeechAnnouncementListener.java
@@ -19,8 +19,8 @@ public interface SpeechAnnouncementListener {
    * and it will be ignored.
    *
    * @param announcement about to be announced
-   * @return announcement to be played; null if should be ignored
-   * @since 0.16.0
+   * @return text announcement to be played; null if should be ignored
+   * @since 0.19.0
    */
-  SpeechAnnouncement willVoice(SpeechAnnouncement announcement);
+  String willVoice(SpeechAnnouncement announcement);
 }

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewEventDispatcherTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewEventDispatcherTest.java
@@ -19,6 +19,7 @@ import com.mapbox.services.android.navigation.v5.routeprogress.ProgressChangeLis
 
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -375,15 +376,26 @@ public class NavigationViewEventDispatcherTest {
 
   @Test
   public void onNewVoiceAnnouncement_instructionListenerIsCalled() {
-    SpeechAnnouncement modifiedAnnouncement = mock(SpeechAnnouncement.class);
     SpeechAnnouncement originalAnnouncement = mock(SpeechAnnouncement.class);
     SpeechAnnouncementListener speechAnnouncementListener = mock(SpeechAnnouncementListener.class);
-    when(speechAnnouncementListener.willVoice(originalAnnouncement)).thenReturn(modifiedAnnouncement);
+    String textAnnouncement = "announcement to be voiced";
+    when(speechAnnouncementListener.willVoice(originalAnnouncement)).thenReturn(textAnnouncement);
     NavigationViewEventDispatcher eventDispatcher = buildViewEventDispatcher(speechAnnouncementListener);
 
     eventDispatcher.onAnnouncement(originalAnnouncement);
 
     verify(speechAnnouncementListener).willVoice(originalAnnouncement);
+  }
+
+  @Test
+  public void onNewVoiceAnnouncement_announcementToBeVoicedIsReturned() {
+    SpeechAnnouncement originalAnnouncement = SpeechAnnouncement.builder().announcement("announcement").build();
+    SpeechAnnouncementListener speechAnnouncementListener = mock(SpeechAnnouncementListener.class);
+    String textAnnouncement = "announcement to be voiced";
+    when(speechAnnouncementListener.willVoice(originalAnnouncement)).thenReturn(textAnnouncement);
+    NavigationViewEventDispatcher eventDispatcher = buildViewEventDispatcher(speechAnnouncementListener);
+    SpeechAnnouncement modifiedAnnouncement = eventDispatcher.onAnnouncement(originalAnnouncement);
+    assertEquals("announcement to be voiced", modifiedAnnouncement.announcement());
   }
 
   @NonNull


### PR DESCRIPTION
Per our discussion in https://github.com/mapbox/mapbox-navigation-android/pull/1233#issuecomment-419974505 this PR unblocks the voice instructions work from https://github.com/mapbox/mapbox-navigation-android/pull/1233 allowing us to rethink the display portion and decide the intended functionality separately.

- Simplifies `willVoice` API