### PR TITLE
Add onNavigationStopped callback for NavigationNotification

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/MockNavigationActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/MockNavigationActivity.java
@@ -1,6 +1,8 @@
 package com.mapbox.services.android.navigation.testapp.activity;
 
+import android.content.BroadcastReceiver;
 import android.content.Context;
+import android.content.Intent;
 import android.location.Location;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -81,6 +83,13 @@ public class MockNavigationActivity extends AppCompatActivity implements OnMapRe
   private Point destination;
   private Point waypoint;
 
+  private final BroadcastReceiver stopNavigationReceiver = new BroadcastReceiver() {
+    @Override
+    public void onReceive(Context context, Intent intent) {
+      navigation.stopNavigation();
+    }
+  };
+
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
@@ -90,11 +99,10 @@ public class MockNavigationActivity extends AppCompatActivity implements OnMapRe
     mapView.onCreate(savedInstanceState);
     mapView.getMapAsync(this);
 
-    // Use a custom notification
-    Context applicationContext = getApplicationContext();
-    CustomNavigationNotification customNavigationNotification = new CustomNavigationNotification(applicationContext);
+    Context context = getApplicationContext();
+    CustomNavigationNotification customNotification = new CustomNavigationNotification(context, stopNavigationReceiver);
     MapboxNavigationOptions options = MapboxNavigationOptions.builder()
-      .navigationNotification(customNavigationNotification)
+      .navigationNotification(customNotification)
       .build();
 
     navigation = new MapboxNavigation(this, Mapbox.getAccessToken(), options);

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/notification/CustomNavigationNotification.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/notification/CustomNavigationNotification.java
@@ -2,7 +2,11 @@ package com.mapbox.services.android.navigation.testapp.activity.notification;
 
 import android.app.Notification;
 import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.BroadcastReceiver;
 import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
 import android.support.v4.app.NotificationCompat;
 
 import com.mapbox.services.android.navigation.testapp.R;
@@ -14,23 +18,27 @@ import static com.mapbox.services.android.navigation.v5.navigation.NavigationCon
 public class CustomNavigationNotification implements NavigationNotification {
 
   private static final int CUSTOM_NOTIFICATION_ID = 91234821;
+  private static final String STOP_NAVIGATION_ACTION = "stop_navigation_action";
 
-  private Notification customNotification;
-  private NotificationCompat.Builder customNotificationBuilder;
-  private NotificationManager notificationManager;
+  private final Notification customNotification;
+  private final NotificationCompat.Builder customNotificationBuilder;
+  private final NotificationManager notificationManager;
+  private final BroadcastReceiver stopNavigationReceiver;
   private int numberOfUpdates;
 
-  public CustomNavigationNotification(Context applicationContext) {
-    // Get the notification manager to update your notification
+  public CustomNavigationNotification(Context applicationContext, BroadcastReceiver stopNavigationReceiver) {
+    // Receiver for listening to clicks
+    this.stopNavigationReceiver = stopNavigationReceiver;
+    applicationContext.registerReceiver(stopNavigationReceiver, new IntentFilter(STOP_NAVIGATION_ACTION));
+
     notificationManager = (NotificationManager) applicationContext.getSystemService(Context.NOTIFICATION_SERVICE);
 
-    // Store the builder to update later
     customNotificationBuilder = new NotificationCompat.Builder(applicationContext, NAVIGATION_NOTIFICATION_CHANNEL)
       .setSmallIcon(R.drawable.ic_navigation)
       .setContentTitle("Custom Navigation Notification")
-      .setContentText("Display your own content here!");
+      .setContentText("Display your own content here!")
+      .setContentIntent(createPendingStopIntent(applicationContext));
 
-    // Build the notification
     customNotification = customNotificationBuilder.build();
   }
 
@@ -49,7 +57,16 @@ public class CustomNavigationNotification implements NavigationNotification {
     // Update the builder with a new number of updates
     customNotificationBuilder.setContentText("Number of updates: " + numberOfUpdates++);
 
-    // Notify the notification manager
     notificationManager.notify(CUSTOM_NOTIFICATION_ID, customNotificationBuilder.build());
+  }
+
+  @Override
+  public void onNavigationStopped(Context context) {
+    context.unregisterReceiver(stopNavigationReceiver);
+  }
+
+  private PendingIntent createPendingStopIntent(Context context) {
+    Intent stopNavigationIntent = new Intent(STOP_NAVIGATION_ACTION);
+    return PendingIntent.getBroadcast(context, 0, stopNavigationIntent, 0);
   }
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationNotification.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationNotification.java
@@ -75,13 +75,9 @@ class MapboxNavigationNotification implements NavigationNotification {
     updateNotificationViews(routeProgress);
   }
 
-  void unregisterReceiver(Context context) {
-    if (context != null) {
-      context.unregisterReceiver(endNavigationBtnReceiver);
-    }
-    if (notificationManager != null) {
-      notificationManager.cancel(NAVIGATION_NOTIFICATION_ID);
-    }
+  @Override
+  public void onNavigationStopped(Context context) {
+    unregisterReceiver(context);
   }
 
   private void initialize(Context context, MapboxNavigation mapboxNavigation) {
@@ -170,6 +166,15 @@ class MapboxNavigationNotification implements NavigationNotification {
     updateManeuverImage(step);
 
     notificationManager.notify(NAVIGATION_NOTIFICATION_ID, notificationBuilder.build());
+  }
+
+  private void unregisterReceiver(Context context) {
+    if (context != null) {
+      context.unregisterReceiver(endNavigationBtnReceiver);
+    }
+    if (notificationManager != null) {
+      notificationManager.cancel(NAVIGATION_NOTIFICATION_ID);
+    }
   }
 
   private void updateInstructionText(LegStep step) {

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationNotificationProvider.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationNotificationProvider.java
@@ -25,9 +25,7 @@ class NavigationNotificationProvider {
   }
 
   void shutdown(Context context) {
-    if (navigationNotification instanceof MapboxNavigationNotification) {
-      ((MapboxNavigationNotification) navigationNotification).unregisterReceiver(context);
-    }
+    navigationNotification.onNavigationStopped(context);
     navigationNotification = null;
     shouldUpdate = false;
   }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/notification/NavigationNotification.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/notification/NavigationNotification.java
@@ -1,7 +1,9 @@
 package com.mapbox.services.android.navigation.v5.navigation.notification;
 
 import android.app.Notification;
+import android.content.Context;
 
+import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 
 /**
@@ -38,4 +40,13 @@ public interface NavigationNotification {
    * @param routeProgress with the latest progress data
    */
   void updateNotification(RouteProgress routeProgress);
+
+  /**
+   * Callback for when navigation is stopped via {@link MapboxNavigation#stopNavigation()}.
+   * <p>
+   * This callback may be used to clean up any listeners or receivers, preventing leaks.
+   *
+   * @param context to be used if needed for Android-related work
+   */
+  void onNavigationStopped(Context context);
 }

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationNotificationProviderTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationNotificationProviderTest.java
@@ -10,8 +10,8 @@ import org.junit.Test;
 
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 public class NavigationNotificationProviderTest {
@@ -35,11 +35,24 @@ public class NavigationNotificationProviderTest {
     MapboxNavigation mapboxNavigation = buildNavigationWithNotificationOptions(notification);
     Context context = mock(Context.class);
     NavigationNotificationProvider provider = new NavigationNotificationProvider(context, mapboxNavigation);
+    RouteProgress routeProgress = mock(RouteProgress.class);
 
     provider.shutdown(context);
-    provider.updateNavigationNotification(mock(RouteProgress.class));
+    provider.updateNavigationNotification(routeProgress);
 
-    verifyZeroInteractions(notification);
+    verify(notification, times(0)).updateNotification(routeProgress);
+  }
+
+  @Test
+  public void onShutdown_onNavigationStoppedIsCalled() {
+    NavigationNotification notification = mock(NavigationNotification.class);
+    MapboxNavigation mapboxNavigation = buildNavigationWithNotificationOptions(notification);
+    Context context = mock(Context.class);
+    NavigationNotificationProvider provider = new NavigationNotificationProvider(context, mapboxNavigation);
+
+    provider.shutdown(context);
+
+    verify(notification).onNavigationStopped(context);
   }
 
   @NonNull


### PR DESCRIPTION
Closes #1282 

We currently don't offer a callback to let a custom `NavigationNotification` know navigation is stopped and to relinquish any outstanding resources / listeners.  For the default `MapboxNavigationNotification`, for example, we need to unregister the broadcast receiver used to detect that someone has clicked `"End Navigation"`.  

Ultimately, this cleans up some of our own code in the `NavigationNotificationProvider`, as we no longer need to check for / cast the `NavigationNotification` to a `MapboxNavigationNotification` to unregister the receiver.  

Thanks for the feedback prompting this @cmahopper and let us know if you think this solution works for you.  