### PR TITLE
Do not update MockLocationEngine route on rotation

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
@@ -74,13 +74,14 @@ public class NavigationViewModel extends AndroidViewModel {
   private String feedbackId;
   private String screenshot;
   private String language;
+  private RouteUtils routeUtils;
+  private LocaleUtils localeUtils;
+  private DistanceFormatter distanceFormatter;
+  private String accessToken;
   @NavigationTimeFormat.Type
   private int timeFormatType;
   private boolean isRunning;
-  private RouteUtils routeUtils;
-  private LocaleUtils localeUtils;
-  private String accessToken;
-  private DistanceFormatter distanceFormatter;
+  private boolean isChangingConfigurations;
 
   public NavigationViewModel(Application application) {
     super(application);
@@ -99,6 +100,7 @@ public class NavigationViewModel extends AndroidViewModel {
   }
 
   public void onDestroy(boolean isChangingConfigurations) {
+    this.isChangingConfigurations = isChangingConfigurations;
     if (!isChangingConfigurations) {
       locationEngineConductor.onDestroy();
       deactivateInstructionPlayer();
@@ -156,7 +158,7 @@ public class NavigationViewModel extends AndroidViewModel {
 
   /**
    * Returns the current instance of {@link MapboxNavigation}.
-   *
+   * <p>
    * Will be null if navigation has not been initialized.
    */
   @Nullable
@@ -361,7 +363,8 @@ public class NavigationViewModel extends AndroidViewModel {
   private void updateRoute(DirectionsRoute route) {
     this.route.setValue(route);
     startNavigation(route);
-    locationEngineConductor.updateRoute(route);
+    updateSimulatedRoute(route);
+    resetConfigurationFlag();
     sendEventOnRerouteAlong(route);
     isOffRoute.setValue(false);
   }
@@ -465,6 +468,18 @@ public class NavigationViewModel extends AndroidViewModel {
   private void sendEventFailedReroute(String errorMessage) {
     if (navigationViewEventDispatcher != null) {
       navigationViewEventDispatcher.onFailedReroute(errorMessage);
+    }
+  }
+
+  private void updateSimulatedRoute(DirectionsRoute route) {
+    if (!isChangingConfigurations) {
+      locationEngineConductor.updateSimulatedRoute(route);
+    }
+  }
+
+  private void resetConfigurationFlag() {
+    if (isChangingConfigurations) {
+      isChangingConfigurations = false;
     }
   }
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/location/LocationEngineConductor.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/location/LocationEngineConductor.java
@@ -31,11 +31,11 @@ public class LocationEngineConductor {
     deactivateLocationEngine();
   }
 
-  public void initializeLocationEngine(Context context, boolean simulateRoute) {
-    initLocationEngine(context, simulateRoute);
+  public void initializeLocationEngine(Context context, boolean shouldReplayRoute) {
+    initLocationEngine(context, shouldReplayRoute);
   }
 
-  public void updateRoute(DirectionsRoute route) {
+  public void updateSimulatedRoute(DirectionsRoute route) {
     if (locationEngine instanceof ReplayRouteLocationEngine) {
       ((ReplayRouteLocationEngine) locationEngine).assign(route);
     }


### PR DESCRIPTION
After https://github.com/mapbox/mapbox-navigation-android/pull/1275 landed, we update the `MockLocationEngine` route every time we rotate the screen.  When simulating, this can be seen as the navigation session restarting.  This PR adds a check to determine certain times to update the route (if it currently isn't replaying or if we are in an off-route state).  