### PR TITLE
Fix mock navigation activity leak and location puck flying

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/notification/CustomNavigationNotification.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/notification/CustomNavigationNotification.java
@@ -23,14 +23,10 @@ public class CustomNavigationNotification implements NavigationNotification {
   private final Notification customNotification;
   private final NotificationCompat.Builder customNotificationBuilder;
   private final NotificationManager notificationManager;
-  private final BroadcastReceiver stopNavigationReceiver;
+  private BroadcastReceiver stopNavigationReceiver;
   private int numberOfUpdates;
 
-  public CustomNavigationNotification(Context applicationContext, BroadcastReceiver stopNavigationReceiver) {
-    // Receiver for listening to clicks
-    this.stopNavigationReceiver = stopNavigationReceiver;
-    applicationContext.registerReceiver(stopNavigationReceiver, new IntentFilter(STOP_NAVIGATION_ACTION));
-
+  public CustomNavigationNotification(Context applicationContext) {
     notificationManager = (NotificationManager) applicationContext.getSystemService(Context.NOTIFICATION_SERVICE);
 
     customNotificationBuilder = new NotificationCompat.Builder(applicationContext, NAVIGATION_NOTIFICATION_CHANNEL)
@@ -63,6 +59,12 @@ public class CustomNavigationNotification implements NavigationNotification {
   @Override
   public void onNavigationStopped(Context context) {
     context.unregisterReceiver(stopNavigationReceiver);
+    notificationManager.cancel(CUSTOM_NOTIFICATION_ID);
+  }
+
+  public void register(BroadcastReceiver stopNavigationReceiver, Context applicationContext) {
+    this.stopNavigationReceiver = stopNavigationReceiver;
+    applicationContext.registerReceiver(stopNavigationReceiver, new IntentFilter(STOP_NAVIGATION_ACTION));
   }
 
   private PendingIntent createPendingStopIntent(Context context) {


### PR DESCRIPTION
- Fixes `MockNavigationActivity` location puck flying from current location to mock

![mock_navigation_activity_puck_flying](https://user-images.githubusercontent.com/1668582/45558253-c3123180-b83f-11e8-9cff-44944c07c830.gif)

- Fixes `MockNavigationActivity` leak

![mock_navigation_activity_leak](https://user-images.githubusercontent.com/1668582/45558285-d1f8e400-b83f-11e8-8911-b949d31e4470.png)
