### PR TITLE
Add debug logging support back

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationMetricsWrapper.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationMetricsWrapper.java
@@ -49,6 +49,10 @@ final class NavigationMetricsWrapper {
     mapboxTelemetry.enable();
   }
 
+  static void toggleLogging(boolean isDebugLoggingEnabled) {
+    mapboxTelemetry.updateDebugLoggingEnabled(isDebugLoggingEnabled);
+  }
+
   static void disable() {
     if (mapboxTelemetry != null) {
       mapboxTelemetry.disable();

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationTelemetry.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationTelemetry.java
@@ -127,17 +127,15 @@ class NavigationTelemetry implements LocationEngineListener, NavigationMetricLis
   void initialize(@NonNull Context context, @NonNull String accessToken,
                   MapboxNavigation navigation, LocationEngine locationEngine) {
     if (!isInitialized) {
-      // Setup the location engine
       updateLocationEngine(locationEngine);
 
       validateAccessToken(accessToken);
       NavigationMetricsWrapper.init(context, accessToken, BuildConfig.MAPBOX_NAVIGATION_EVENTS_USER_AGENT);
 
       MapboxNavigationOptions options = navigation.options();
-      // Set sdkIdentifier based on if from UI or not
-      String sdkIdentifier = updateSdkIdentifier(options);
-
+      String sdkIdentifier = obtainSdkIdentifier(options);
       NavigationMetricsWrapper.sdkIdentifier = sdkIdentifier;
+      NavigationMetricsWrapper.toggleLogging(options.isDebugLoggingEnabled());
       Event navTurnstileEvent = NavigationMetricsWrapper.turnstileEvent();
       // TODO Check if we are sending two turnstile events (Maps and Nav) and if so, do we want to track them
       // separately?
@@ -145,7 +143,6 @@ class NavigationTelemetry implements LocationEngineListener, NavigationMetricLis
 
       isInitialized = true;
     }
-    // Setup the listeners
     initEventDispatcherListeners(navigation);
   }
 
@@ -318,7 +315,7 @@ class NavigationTelemetry implements LocationEngineListener, NavigationMetricLis
   }
 
   @NonNull
-  private String updateSdkIdentifier(MapboxNavigationOptions options) {
+  private String obtainSdkIdentifier(MapboxNavigationOptions options) {
     String sdkIdentifier = MAPBOX_NAVIGATION_SDK_IDENTIFIER;
     if (options.isFromNavigationUi()) {
       sdkIdentifier = MAPBOX_NAVIGATION_UI_SDK_IDENTIFIER;


### PR DESCRIPTION
In https://github.com/mapbox/mapbox-navigation-android/pull/697 + https://github.com/mapbox/mapbox-navigation-android/pull/961 we removed `Enable extra logging in debug mode` option from `NavigationTelemetry` / `NavigationMetricsWrapper` by mistake.

This PR brings that functionality back.
