### PR TITLE
Update Build Tools 28.0.3 

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     working_directory: ~/code
     docker:
-      - image: mbgl/feb0443038:android-ndk-r17
+      - image: mbgl/61abee1674:android-ndk-r18
     environment:
       JVM_OPTS: -Xmx3200m
       BUILDTYPE: Debug
@@ -98,7 +98,7 @@ jobs:
       only:
       - master
     docker:
-      - image: mbgl/feb0443038:android-ndk-r17
+      - image: mbgl/61abee1674:android-ndk-r18
     working_directory: ~/code
     environment:
       BUILDTYPE: Release

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -4,7 +4,7 @@ ext {
       minSdkVersion    : 14,
       targetSdkVersion : 27,
       compileSdkVersion: 27,
-      buildToolsVersion: '27.0.3'
+      buildToolsVersion: '28.0.3'
   ]
 
   version = [
@@ -40,7 +40,7 @@ ext {
       errorprone       : '0.0.13',
       coveralls        : '2.8.1',
       spotbugs         : '1.3',
-      gradle           : '3.1.2',
+      gradle           : '3.2.0',
       dependencyGraph  : '0.3.0',
       dependencyUpdates: '0.20.0'
   ]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Apr 13 11:18:29 EDT 2017
+#Tue Sep 25 12:54:35 EDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip


### PR DESCRIPTION
This PR updates our CI to the latest docker images and build tools (`28.0.3`) / Gradle (`3.2.0`)