### PR TITLE
Mapbox Navigator online fixes

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionView.java
@@ -750,7 +750,10 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
   private void updateDataFromBannerInstruction(InstructionModel model) {
     updateManeuverView(model);
     if (model.getPrimaryBannerText() != null) {
-      createInstructionLoader(upcomingPrimaryText, model.getPrimaryBannerText()).loadInstruction();
+      InstructionLoader instructionLoader = createInstructionLoader(upcomingPrimaryText, model.getPrimaryBannerText());
+      if (instructionLoader != null) {
+        instructionLoader.loadInstruction();
+      }
     }
     if (model.getSecondaryBannerText() != null) {
       if (upcomingSecondaryText.getVisibility() == GONE) {
@@ -758,7 +761,11 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
         upcomingPrimaryText.setMaxLines(1);
         adjustBannerTextVerticalBias(0.65f);
       }
-      createInstructionLoader(upcomingSecondaryText, model.getSecondaryBannerText()).loadInstruction();
+      InstructionLoader instructionLoader = createInstructionLoader(upcomingSecondaryText,
+        model.getSecondaryBannerText());
+      if (instructionLoader != null) {
+        instructionLoader.loadInstruction();
+      }
     } else {
       upcomingPrimaryText.setMaxLines(2);
       upcomingSecondaryText.setVisibility(GONE);

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/milestone/VoiceInstructionMilestone.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/milestone/VoiceInstructionMilestone.java
@@ -1,6 +1,7 @@
 package com.mapbox.services.android.navigation.v5.milestone;
 
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
+import com.mapbox.navigator.VoiceInstruction;
 import com.mapbox.services.android.navigation.v5.instruction.Instruction;
 import com.mapbox.services.android.navigation.v5.navigation.VoiceInstructionLoader;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
@@ -104,10 +105,10 @@ public class VoiceInstructionMilestone extends Milestone {
   }
 
   private boolean updateCurrentAnnouncement(RouteProgress routeProgress) {
-    String currentAnnouncement = routeProgress.currentAnnouncement();
-    if (!currentAnnouncement.isEmpty() && !announcement.equals(currentAnnouncement)) {
-      announcement = currentAnnouncement;
-      ssmlAnnouncement = routeProgress.currentSsmlAnnouncement();
+    VoiceInstruction currentVoiceInstruction = routeProgress.voiceInstruction();
+    if (currentVoiceInstruction != null) {
+      announcement = currentVoiceInstruction.getAnnouncement();
+      ssmlAnnouncement = currentVoiceInstruction.getSsmlAnnouncement();
       cacheInstructions(routeProgress, false);
       return true;
     }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteProcessor.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteProcessor.java
@@ -124,9 +124,6 @@ class NavigationRouteProcessor {
 
   private void addVoiceInstructions(NavigationStatus status, RouteProgress.Builder progressBuilder) {
     VoiceInstruction voiceInstruction = status.getVoiceInstruction();
-    if (voiceInstruction != null) {
-      progressBuilder.currentAnnouncement(voiceInstruction.getAnnouncement());
-      progressBuilder.currentSsmlAnnouncement(voiceInstruction.getSsmlAnnouncement());
-    }
+    progressBuilder.voiceInstruction(voiceInstruction);
   }
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/RouteProcessorRunnable.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/RouteProcessorRunnable.java
@@ -59,7 +59,8 @@ class RouteProcessorRunnable implements Runnable {
     NavigationEngineFactory engineFactory = navigation.retrieveEngineFactory();
     final boolean userOffRoute = isUserOffRoute(options, status, rawLocation, routeProgress, engineFactory);
     final Location snappedLocation = findSnappedLocation(status, rawLocation, routeProgress, engineFactory);
-    final boolean checkFasterRoute = checkFasterRoute(options, rawLocation, routeProgress, engineFactory, userOffRoute);
+    final boolean checkFasterRoute = checkFasterRoute(options, snappedLocation, routeProgress, engineFactory,
+      userOffRoute);
     final List<Milestone> milestones = findTriggeredMilestones(navigation, routeProgress);
 
     sendUpdateToResponseHandler(userOffRoute, milestones, snappedLocation, checkFasterRoute, routeProgress);

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/routeprogress/RouteProgress.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/routeprogress/RouteProgress.java
@@ -9,6 +9,7 @@ import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.api.directions.v5.models.RouteLeg;
 import com.mapbox.api.directions.v5.models.StepIntersection;
 import com.mapbox.geojson.Point;
+import com.mapbox.navigator.VoiceInstruction;
 
 import java.util.List;
 
@@ -27,8 +28,6 @@ import java.util.List;
  */
 @AutoValue
 public abstract class RouteProgress {
-
-  private static final String EMPTY_ANNOUNCEMENT = "";
 
   /**
    * Get the route the navigation session is currently using. When a reroute occurs and a new
@@ -161,16 +160,13 @@ public abstract class RouteProgress {
   public abstract boolean inTunnel();
 
   /**
-   * @return current announcement
-   * @since 0.19.0
+   * Current voice instruction.
+   *
+   * @return current voice instruction
+   * @since 0.20.0
    */
-  public abstract String currentAnnouncement();
-
-  /**
-   * @return current announcement with SSML markup
-   * @since 0.19.0
-   */
-  public abstract String currentSsmlAnnouncement();
+  @Nullable
+  public abstract VoiceInstruction voiceInstruction();
 
   public abstract RouteProgress.Builder toBuilder();
 
@@ -251,9 +247,7 @@ public abstract class RouteProgress {
 
     public abstract Builder inTunnel(boolean inTunnel);
 
-    public abstract Builder currentAnnouncement(String announcement);
-
-    public abstract Builder currentSsmlAnnouncement(String ssmlAnnouncement);
+    public abstract Builder voiceInstruction(@Nullable VoiceInstruction voiceInstruction);
 
     abstract RouteProgress autoBuild(); // not public
 
@@ -279,8 +273,6 @@ public abstract class RouteProgress {
   }
 
   public static Builder builder() {
-    return new AutoValue_RouteProgress.Builder()
-      .currentAnnouncement(EMPTY_ANNOUNCEMENT)
-      .currentSsmlAnnouncement(EMPTY_ANNOUNCEMENT);
+    return new AutoValue_RouteProgress.Builder();
   }
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/snap/SnapToRoute.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/snap/SnapToRoute.java
@@ -24,6 +24,7 @@ public class SnapToRoute extends Snap {
     snappedLocation.setLatitude(status.getLocation().latitude());
     snappedLocation.setLongitude(status.getLocation().longitude());
     snappedLocation.setBearing(status.getBearing());
+    snappedLocation.setTime(status.getTime().getTime());
     return snappedLocation;
   }
 }

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/milestone/VoiceInstructionMilestoneTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/milestone/VoiceInstructionMilestoneTest.java
@@ -1,6 +1,7 @@
 package com.mapbox.services.android.navigation.v5.milestone;
 
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
+import com.mapbox.navigator.VoiceInstruction;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 
 import org.junit.Test;
@@ -8,6 +9,7 @@ import org.junit.Test;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertNotNull;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -23,26 +25,25 @@ public class VoiceInstructionMilestoneTest {
   @Test
   public void onSameInstructionOccurring_milestoneDoesNotTriggerTwice() {
     RouteProgress firstProgress = mock(RouteProgress.class);
-    when(firstProgress.currentAnnouncement()).thenReturn("instruction");
+    VoiceInstruction voiceInstruction = mock(VoiceInstruction.class);
+    when(firstProgress.voiceInstruction()).thenReturn(voiceInstruction, null);
+    when(voiceInstruction.getAnnouncement()).thenReturn("instruction");
     when(firstProgress.directionsRoute()).thenReturn(mock(DirectionsRoute.class));
-    RouteProgress secondProgress = mock(RouteProgress.class);
-    when(secondProgress.directionsRoute()).thenReturn(mock(DirectionsRoute.class));
-    when(secondProgress.currentAnnouncement()).thenReturn("instruction");
     VoiceInstructionMilestone milestone = buildVoiceInstructionMilestone();
 
     milestone.isOccurring(firstProgress, firstProgress);
-    boolean shouldNotBeOccurring = milestone.isOccurring(firstProgress, secondProgress);
+    boolean shouldNotBeOccurring = milestone.isOccurring(firstProgress, firstProgress);
 
     assertFalse(shouldNotBeOccurring);
   }
 
   @Test
   public void onOccurringMilestone_voiceSsmlInstructionsAreReturned() {
-    RouteProgress routeProgress = mock(RouteProgress.class);
+    RouteProgress routeProgress = mock(RouteProgress.class, RETURNS_DEEP_STUBS);
     when(routeProgress.directionsRoute()).thenReturn(mock(DirectionsRoute.class));
-    when(routeProgress.currentAnnouncement()).thenReturn("current announcement");
+    when(routeProgress.voiceInstruction().getAnnouncement()).thenReturn("current announcement");
     String currentSsmlAnnouncement = "current SSML announcement";
-    when(routeProgress.currentSsmlAnnouncement()).thenReturn(currentSsmlAnnouncement);
+    when(routeProgress.voiceInstruction().getSsmlAnnouncement()).thenReturn(currentSsmlAnnouncement);
     VoiceInstructionMilestone milestone = buildVoiceInstructionMilestone();
 
     milestone.isOccurring(routeProgress, routeProgress);
@@ -52,12 +53,12 @@ public class VoiceInstructionMilestoneTest {
 
   @Test
   public void onOccurringMilestone_voiceInstructionsAreReturned() {
-    RouteProgress routeProgress = mock(RouteProgress.class);
+    RouteProgress routeProgress = mock(RouteProgress.class, RETURNS_DEEP_STUBS);
     when(routeProgress.directionsRoute()).thenReturn(mock(DirectionsRoute.class));
     String currentAnnouncement = "current announcement";
-    when(routeProgress.currentAnnouncement()).thenReturn(currentAnnouncement);
+    when(routeProgress.voiceInstruction().getAnnouncement()).thenReturn(currentAnnouncement);
     String currentSsmlAnnouncement = "current SSML announcement";
-    when(routeProgress.currentSsmlAnnouncement()).thenReturn(currentSsmlAnnouncement);
+    when(routeProgress.voiceInstruction().getSsmlAnnouncement()).thenReturn(currentSsmlAnnouncement);
     VoiceInstructionMilestone milestone = buildVoiceInstructionMilestone();
 
     milestone.isOccurring(routeProgress, routeProgress);
@@ -67,12 +68,12 @@ public class VoiceInstructionMilestoneTest {
 
   @Test
   public void onOccurringMilestone_instructionsAreReturned() {
-    RouteProgress routeProgress = mock(RouteProgress.class);
+    RouteProgress routeProgress = mock(RouteProgress.class, RETURNS_DEEP_STUBS);
     when(routeProgress.directionsRoute()).thenReturn(mock(DirectionsRoute.class));
     String currentAnnouncement = "current announcement";
-    when(routeProgress.currentAnnouncement()).thenReturn(currentAnnouncement);
+    when(routeProgress.voiceInstruction().getAnnouncement()).thenReturn(currentAnnouncement);
     String currentSsmlAnnouncement = "current SSML announcement";
-    when(routeProgress.currentSsmlAnnouncement()).thenReturn(currentSsmlAnnouncement);
+    when(routeProgress.voiceInstruction().getSsmlAnnouncement()).thenReturn(currentSsmlAnnouncement);
     VoiceInstructionMilestone milestone = buildVoiceInstructionMilestone();
 
     milestone.isOccurring(routeProgress, routeProgress);

--- a/libandroid-navigation/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/libandroid-navigation/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
- Uses snapped location in `checkFasterRoute`
- Fixes voice instructions logic
- Add instruction loader `null` checks to prevent potential NPEs
- Opts-in mocking of final classes/methods and fixes `VoiceInstructionMilestoneTest`s