### PR TITLE
Add NavigationMapboxMap to set LocationLayer RenderMode

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/NavigationMapboxMap.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/NavigationMapboxMap.java
@@ -102,6 +102,11 @@ public class NavigationMapboxMap {
     this.layerInteractor = layerInteractor;
   }
 
+  // Package private (no modifier) for testing purposes
+  NavigationMapboxMap(LocationLayerPlugin locationLayer) {
+    this.locationLayer = locationLayer;
+  }
+
   /**
    * Adds a marker icon on the map at the given position.
    * <p>
@@ -135,6 +140,21 @@ public class NavigationMapboxMap {
   public void updateLocation(Location location) {
     locationLayer.forceLocationUpdate(location);
     updateMapWaynameWithLocation(location);
+  }
+
+  /**
+   * Updates how the user location is shown on the map.
+   * <p>
+   * <ul>
+   * <li>{@link RenderMode#NORMAL}: Shows user location, bearing ignored</li>
+   * <li>{@link RenderMode#COMPASS}: Shows user location with bearing considered from compass</li>
+   * <li>{@link RenderMode#GPS}: Shows user location with bearing considered from location</li>
+   * </ul>
+   *
+   * @param renderMode GPS, NORMAL, or COMPASS
+   */
+  public void updateLocationLayerRenderMode(@RenderMode.Mode int renderMode) {
+    locationLayer.setRenderMode(renderMode);
   }
 
   /**

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/map/NavigationMapboxMapTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/map/NavigationMapboxMapTest.java
@@ -1,5 +1,8 @@
 package com.mapbox.services.android.navigation.ui.v5.map;
 
+import com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerPlugin;
+import com.mapbox.mapboxsdk.plugins.locationlayer.modes.RenderMode;
+
 import org.junit.Test;
 
 import static org.mockito.ArgumentMatchers.eq;
@@ -48,5 +51,16 @@ public class NavigationMapboxMapTest {
     theNavigationMap.isTrafficVisible();
 
     verify(mockedMapLayerInteractor).isLayerVisible(eq("traffic"));
+  }
+
+  @Test
+  public void updateRenderMode_locationLayerIsUpdatedWithRenderMode() {
+    LocationLayerPlugin locationLayer = mock(LocationLayerPlugin.class);
+    NavigationMapboxMap theNavigationMap = new NavigationMapboxMap(locationLayer);
+    int renderMode = RenderMode.GPS;
+
+    theNavigationMap.updateLocationLayerRenderMode(renderMode);
+
+    verify(locationLayer).setRenderMode(eq(renderMode));
   }
 }


### PR DESCRIPTION
Adds the ability to update the `LocationLayerPlugin` `RenderMode` from the `NavigationMapboxMap`.  These will show different icons based on the `LocationLayerPlugin` options you provide in your given style (or the defaults if not specified otherwise).

