### PR TITLE
Add NavigationMapboxMap APIs for showing multiple routes on map

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/NavigationMapboxMap.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/NavigationMapboxMap.java
@@ -28,6 +28,7 @@ import com.mapbox.services.android.navigation.ui.v5.R;
 import com.mapbox.services.android.navigation.ui.v5.ThemeSwitcher;
 import com.mapbox.services.android.navigation.ui.v5.camera.NavigationCamera;
 import com.mapbox.services.android.navigation.ui.v5.route.NavigationMapRoute;
+import com.mapbox.services.android.navigation.ui.v5.route.OnRouteSelectionChangeListener;
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation;
 
 import java.util.ArrayList;
@@ -105,6 +106,11 @@ public class NavigationMapboxMap {
   // Package private (no modifier) for testing purposes
   NavigationMapboxMap(LocationLayerPlugin locationLayer) {
     this.locationLayer = locationLayer;
+  }
+
+  // Package private (no modifier) for testing purposes
+  NavigationMapboxMap(NavigationMapRoute mapRoute) {
+    this.mapRoute = mapRoute;
   }
 
   /**
@@ -219,6 +225,43 @@ public class NavigationMapboxMap {
    */
   public void drawRoute(@NonNull DirectionsRoute route) {
     mapRoute.addRoute(route);
+  }
+
+  /**
+   * Will draw the given list of {@link DirectionsRoute} on the map using the colors defined
+   * in your given style.
+   * <p>
+   * The primary route will default to the first route in the directions route list.
+   * All other routes in the list will be drawn on the map using the alternative route style.
+   *
+   * @param routes to be drawn
+   */
+  public void drawRoutes(@NonNull List<DirectionsRoute> routes) {
+    mapRoute.addRoutes(routes);
+  }
+
+  /**
+   * Set a {@link OnRouteSelectionChangeListener} to know which route the user has currently
+   * selected as their primary route.
+   *
+   * @param listener a listener which lets you know when the user has changed
+   *                 the primary route and provides the current direction
+   *                 route which the user has selected
+   */
+  public void setOnRouteSelectionChangeListener(@NonNull OnRouteSelectionChangeListener listener) {
+    mapRoute.setOnRouteSelectionChangeListener(listener);
+  }
+
+  /**
+   * Toggle whether or not you'd like the map to display the alternative routes. This option can be used
+   * for when the user actually begins the navigation session and alternative routes aren't needed
+   * anymore.
+   *
+   * @param alternativesVisible true if you'd like alternative routes to be displayed on the map,
+   *                            else false
+   */
+  public void showAlternativeRoutes(boolean alternativesVisible) {
+    mapRoute.showAlternativeRoutes(alternativesVisible);
   }
 
   /**

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/map/NavigationMapboxMapTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/map/NavigationMapboxMapTest.java
@@ -2,8 +2,14 @@ package com.mapbox.services.android.navigation.ui.v5.map;
 
 import com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerPlugin;
 import com.mapbox.mapboxsdk.plugins.locationlayer.modes.RenderMode;
+import com.mapbox.api.directions.v5.models.DirectionsRoute;
+import com.mapbox.services.android.navigation.ui.v5.route.NavigationMapRoute;
+import com.mapbox.services.android.navigation.ui.v5.route.OnRouteSelectionChangeListener;
 
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -62,5 +68,38 @@ public class NavigationMapboxMapTest {
     theNavigationMap.updateLocationLayerRenderMode(renderMode);
 
     verify(locationLayer).setRenderMode(eq(renderMode));
+  }
+
+  @Test
+  public void drawRoutes_mapRoutesAreAdded() {
+    NavigationMapRoute mapRoute = mock(NavigationMapRoute.class);
+    NavigationMapboxMap theNavigationMap = new NavigationMapboxMap(mapRoute);
+    List<DirectionsRoute> routes = new ArrayList<>();
+
+    theNavigationMap.drawRoutes(routes);
+
+    verify(mapRoute).addRoutes(eq(routes));
+  }
+
+  @Test
+  public void setOnRouteSelectionChangeListener_listenerIsSet() {
+    NavigationMapRoute mapRoute = mock(NavigationMapRoute.class);
+    NavigationMapboxMap theNavigationMap = new NavigationMapboxMap(mapRoute);
+    OnRouteSelectionChangeListener listener = mock(OnRouteSelectionChangeListener.class);
+
+    theNavigationMap.setOnRouteSelectionChangeListener(listener);
+
+    verify(mapRoute).setOnRouteSelectionChangeListener(eq(listener));
+  }
+
+  @Test
+  public void showAlternativeRoutes_correctVisibilityIsSet() {
+    NavigationMapRoute mapRoute = mock(NavigationMapRoute.class);
+    NavigationMapboxMap theNavigationMap = new NavigationMapboxMap(mapRoute);
+    boolean notVisible = false;
+
+    theNavigationMap.showAlternativeRoutes(notVisible);
+
+    verify(mapRoute).showAlternativeRoutes(notVisible);
   }
 }


### PR DESCRIPTION
This PR adds the ability to draw multiple routes with a `NavigationMapboxMap`.  It also exposes the APIs to listen to if a user has selected an alternative / hide and show those same alternatives. 