### PR TITLE
Example activity onbackpressed

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExampleActivity.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExampleActivity.kt
@@ -261,4 +261,11 @@ class ExampleActivity : AppCompatActivity(), ExampleView {
     val granted = PermissionsManager.areLocationPermissionsGranted(this)
     presenter.onPermissionResult(granted)
   }
+
+  override fun onBackPressed() {
+    val exitActivity = presenter.onBackPressed()
+    if (exitActivity) {
+      super.onBackPressed()
+    }
+  }
 }

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExamplePresenter.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExamplePresenter.kt
@@ -105,11 +105,15 @@ class ExamplePresenter(private val view: ExampleView, private val viewModel: Exa
   fun onAutocompleteBottomSheetStateChange(state: Int) {
     when (state) {
       BottomSheetBehavior.STATE_COLLAPSED -> {
+        viewModel.collapsedBottomSheet = true
         view.hideSoftKeyboard()
         if (this.state == PresenterState.SHOW_LOCATION) {
           view.updateLocationFabVisibility(VISIBLE)
           view.updateSettingsFabVisibility(VISIBLE)
         }
+      }
+      BottomSheetBehavior.STATE_EXPANDED -> {
+        viewModel.collapsedBottomSheet = false
       }
     }
   }
@@ -232,5 +236,13 @@ class ExamplePresenter(private val view: ExampleView, private val viewModel: Exa
       val padding = intArrayOf(left, top, right, bottom)
       view.updateMapCameraFor(bounds, padding, TWO_SECONDS)
     }
+  }
+
+  fun onBackPressed(): Boolean {
+    if (!viewModel.collapsedBottomSheet) {
+      view.updateAutocompleteBottomSheetState(BottomSheetBehavior.STATE_COLLAPSED)
+      return false
+    }
+    return true
   }
 }

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExampleViewModel.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExampleViewModel.kt
@@ -34,6 +34,7 @@ class ExampleViewModel(application: Application) : AndroidViewModel(application)
   val progress: MutableLiveData<RouteProgress> = MutableLiveData()
   val milestone: MutableLiveData<Milestone> = MutableLiveData()
   val destination: MutableLiveData<Point> = MutableLiveData()
+  var collapsedBottomSheet: Boolean = false
 
   private val locationEngine: LocationEngine
   private val locationEngineListener: ExampleLocationEngineListener


### PR DESCRIPTION
Fixes first todo in list of https://github.com/mapbox/mapbox-navigation-android/pull/1317#issue-218368592:
> ExampleActivity handle back press

For now I went with closing the expanded BottomSheet when opened. 

![ezgif com-video-to-gif 84](https://user-images.githubusercontent.com/2151639/46134987-774e8780-c244-11e8-84ce-bc560047dc0c.gif)

Wasn't sure about the best way to store state and interaction between the components. 
Looking for feedback.