### PR TITLE
Example activity logo and attribution

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExampleActivity.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExampleActivity.kt
@@ -7,6 +7,7 @@ import android.os.Bundle
 import android.support.design.widget.BottomSheetBehavior
 import android.support.transition.TransitionManager
 import android.support.v7.app.AppCompatActivity
+import android.view.View
 import android.widget.Toast
 import com.mapbox.android.core.permissions.PermissionsManager
 import com.mapbox.api.directions.v5.models.DirectionsRoute
@@ -15,6 +16,7 @@ import com.mapbox.geojson.Point
 import com.mapbox.mapboxsdk.camera.CameraUpdate
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory
 import com.mapbox.mapboxsdk.geometry.LatLngBounds
+import com.mapbox.mapboxsdk.maps.AttributionDialogManager
 import com.mapbox.mapboxsdk.maps.MapboxMap
 import com.mapbox.services.android.navigation.testapp.NavigationSettingsActivity
 import com.mapbox.services.android.navigation.testapp.R
@@ -225,6 +227,12 @@ class ExampleActivity : AppCompatActivity(), ExampleView {
     startActivity(Intent(this, NavigationSettingsActivity::class.java))
   }
 
+  override fun showAttributionDialog(attributionView: View) {
+    map?.retrieveMap().let {
+      AttributionDialogManager(attributionView.context, it!!).onClick(attributionView)
+    }
+  }
+
   override fun adjustMapPaddingForNavigation() {
     val mapViewHeight = mapView.height
     val bottomSheetHeight = resources.getDimension(R.dimen.bottom_sheet_peek_height).toInt()
@@ -257,6 +265,7 @@ class ExampleActivity : AppCompatActivity(), ExampleView {
     directionsFab.setOnClickListener { presenter.onDirectionsFabClick() }
     navigationFab.setOnClickListener { presenter.onNavigationFabClick() }
     cancelFab.setOnClickListener { presenter.onCancelFabClick() }
+    attribution.setOnClickListener{ presenter.onAttributionsClick(it) }
 
     val granted = PermissionsManager.areLocationPermissionsGranted(this)
     presenter.onPermissionResult(granted)

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExamplePresenter.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExamplePresenter.kt
@@ -4,6 +4,7 @@ import android.arch.lifecycle.LifecycleOwner
 import android.arch.lifecycle.Observer
 import android.location.Location
 import android.support.design.widget.BottomSheetBehavior
+import android.view.View
 import android.view.View.INVISIBLE
 import android.view.View.VISIBLE
 import com.mapbox.api.directions.v5.models.DirectionsRoute
@@ -57,6 +58,10 @@ class ExamplePresenter(private val view: ExampleView, private val viewModel: Exa
     view.updateSettingsFabVisibility(INVISIBLE)
     view.updateAutocompleteBottomSheetHideable(false)
     view.updateAutocompleteBottomSheetState(BottomSheetBehavior.STATE_EXPANDED)
+  }
+
+  fun onAttributionsClick(attributionView: View) {
+    view.showAttributionDialog(attributionView)
   }
 
   fun onSettingsFabClick() {

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExampleView.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExampleView.kt
@@ -1,6 +1,7 @@
 package com.mapbox.services.android.navigation.testapp.example.ui
 
 import android.location.Location
+import android.view.View
 import com.mapbox.android.core.permissions.PermissionsListener
 import com.mapbox.android.search.autocomplete.OnFeatureClickListener
 import com.mapbox.api.directions.v5.models.DirectionsRoute
@@ -69,4 +70,6 @@ interface ExampleView: PermissionsListener, OnMapReadyCallback, OnFeatureClickLi
   fun adjustMapPaddingForNavigation()
 
   fun resetMapPadding()
+
+  fun showAttributionDialog(attributionView: View)
 }

--- a/app/src/main/res/layout/activity_example.xml
+++ b/app/src/main/res/layout/activity_example.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/mainLayout"
@@ -16,7 +15,9 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"/>
+        app:layout_constraintTop_toTopOf="parent"
+        app:mapbox_uiAttribution="false"
+        app:mapbox_uiLogo="false" />
 
     <android.support.design.widget.CoordinatorLayout
         android:layout_width="match_parent"
@@ -25,6 +26,36 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
+
+        <RelativeLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="top"
+            app:layout_anchor="@id/autocompleteBottomSheet"
+            app:layout_anchorGravity="top|start">
+
+            <ImageView
+                android:id="@+id/logo"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/fab_margin_end"
+                android:layout_marginLeft="@dimen/fab_margin_end"
+                android:layout_marginBottom="@dimen/fab_margin_bottom"
+                android:clickable="false"
+                android:focusable="false"
+                android:src="@drawable/mapbox_logo_icon" />
+
+            <ImageView
+                android:id="@+id/attribution"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/attribution_margin_start"
+                android:layout_marginLeft="@dimen/attribution_margin_start"
+                android:layout_toRightOf="@id/logo"
+                android:layout_toEndOf="@id/logo"
+                android:src="@drawable/mapbox_info_bg_selector" />
+
+        </RelativeLayout>
 
         <FrameLayout
             android:id="@+id/fabFrameLayout"
@@ -38,23 +69,23 @@
                 android:id="@+id/locationFab"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/fab_margin_bottom"
                 android:layout_marginEnd="@dimen/fab_margin_end"
-                app:srcCompat="@drawable/ic_my_location"/>
+                android:layout_marginBottom="@dimen/fab_margin_bottom"
+                app:srcCompat="@drawable/ic_my_location" />
 
             <android.support.design.widget.FloatingActionButton
                 android:id="@+id/directionsFab"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:visibility="invisible"
-                app:srcCompat="@drawable/ic_directions"/>
+                app:srcCompat="@drawable/ic_directions" />
 
             <android.support.design.widget.FloatingActionButton
                 android:id="@+id/navigationFab"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:visibility="invisible"
-                app:srcCompat="@drawable/ic_navigation"/>
+                app:srcCompat="@drawable/ic_navigation" />
 
             <android.support.design.widget.FloatingActionButton
                 android:id="@+id/cancelFab"
@@ -62,7 +93,7 @@
                 android:layout_height="wrap_content"
                 android:visibility="invisible"
                 app:backgroundTint="@android:color/holo_red_light"
-                app:srcCompat="@drawable/ic_cancel"/>
+                app:srcCompat="@drawable/ic_cancel" />
 
         </FrameLayout>
 
@@ -75,18 +106,18 @@
             app:fabSize="mini"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:srcCompat="@drawable/ic_settings"/>
+            app:srcCompat="@drawable/ic_settings" />
 
         <android.support.constraint.ConstraintLayout
             android:id="@+id/autocompleteBottomSheet"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_marginEnd="8dp"
             android:layout_marginStart="8dp"
+            android:layout_marginEnd="8dp"
             android:background="@drawable/autocomplete_bottomsheet_background"
             android:elevation="@dimen/autocomplete_bottomsheet_elevation"
-            android:paddingBottom="@dimen/autocomplete_bottomsheet_padding"
             android:paddingTop="@dimen/autocomplete_bottomsheet_padding"
+            android:paddingBottom="@dimen/autocomplete_bottomsheet_padding"
             app:layout_behavior="android.support.design.widget.BottomSheetBehavior">
 
             <android.support.v7.widget.CardView
@@ -105,7 +136,7 @@
                     android:hint="@string/hint_where_to"
                     android:inputType="text"
                     android:maxLines="1"
-                    android:padding="@dimen/autocomplete_padding"/>
+                    android:padding="@dimen/autocomplete_padding" />
 
             </android.support.v7.widget.CardView>
 
@@ -133,7 +164,7 @@
                 android:id="@+id/maneuverView"
                 android:layout_width="@dimen/maneuver_view_width"
                 android:layout_height="@dimen/maneuver_view_height"
-                android:layout_margin="@dimen/maneuver_view_margin"/>
+                android:layout_margin="@dimen/maneuver_view_margin" />
 
             <LinearLayout
                 android:layout_width="wrap_content"
@@ -151,7 +182,7 @@
                     android:includeFontPadding="false"
                     android:textSize="@dimen/data_text_size"
                     android:textStyle="bold"
-                    tools:text="@tools:sample/lorem"/>
+                    tools:text="@tools:sample/lorem" />
 
                 <TextView
                     android:id="@+id/arrivalTimeTextView"
@@ -159,7 +190,7 @@
                     android:layout_height="wrap_content"
                     android:includeFontPadding="false"
                     android:textSize="@dimen/data_text_size"
-                    tools:text="@tools:sample/lorem"/>
+                    tools:text="@tools:sample/lorem" />
 
             </LinearLayout>
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -24,6 +24,7 @@
     <dimen name="step_distance_remaining_margin_bottom">8dp</dimen>
     <dimen name="fab_margin_bottom">16dp</dimen>
     <dimen name="fab_margin_end">8dp</dimen>
+    <dimen name="attribution_margin_start">4dp</dimen>
     <dimen name="fab_margin_default">16dp</dimen>
     <dimen name="data_text_size">18sp</dimen>
     <dimen name="offline_dialog_text_size">18sp</dimen>


### PR DESCRIPTION
Fixes todo in list of https://github.com/mapbox/mapbox-navigation-android/pull/1317#issue-218368592:
> Logo + attribution adjustment for Bottomsheet

![ezgif com-video-to-gif 85](https://user-images.githubusercontent.com/2151639/46139287-73276780-c24e-11e8-884f-dc87144cdb98.gif)

This PR adds two ImageViews to the coordinator layout for automatic adjustments when opening the bottomsheet. I'm showing the default attribution dialog when clicking the "i" icon.  