### PR TITLE
Example activity long press destination selection

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExampleActivity.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExampleActivity.kt
@@ -93,6 +93,7 @@ class ExampleActivity : AppCompatActivity(), ExampleView {
 
   override fun onMapReady(mapboxMap: MapboxMap) {
     map = NavigationMapboxMap(mapView, mapboxMap)
+    mapboxMap.addOnMapLongClickListener{ presenter.onMapLongClick(it) }
     presenter.buildDynamicCameraFrom(mapboxMap)
   }
 

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExamplePresenter.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExamplePresenter.kt
@@ -173,6 +173,10 @@ class ExamplePresenter(private val view: ExampleView, private val viewModel: Exa
     }
   }
 
+  fun onMapLongClick(point: LatLng) {
+    viewModel.reverseGeocode(point);
+  }
+  
   fun onMilestoneUpdate(milestone: Milestone?) {
     milestone?.let {
       if (milestone is BannerInstructionMilestone) {
@@ -192,6 +196,11 @@ class ExamplePresenter(private val view: ExampleView, private val viewModel: Exa
     viewModel.route.observe(owner, Observer { onRouteFound(it) })
     viewModel.progress.observe(owner, Observer { onProgressUpdate(it) })
     viewModel.milestone.observe(owner, Observer { onMilestoneUpdate(it) })
+    viewModel.geocode.observe(owner, Observer {
+      it?.features()?.first()?.let {
+        onDestinationFound(it)
+      }
+    })
     viewModel.activateLocationEngine()
     viewModel.loadOfflineFiles(offlineCallback)
   }

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExampleViewModel.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExampleViewModel.kt
@@ -9,7 +9,12 @@ import com.mapbox.android.core.location.LocationEngine
 import com.mapbox.android.core.location.LocationEnginePriority
 import com.mapbox.android.core.location.LocationEngineProvider
 import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.api.geocoding.v5.GeocodingCriteria
+import com.mapbox.api.geocoding.v5.MapboxGeocoding
+import com.mapbox.api.geocoding.v5.models.GeocodingResponse
 import com.mapbox.geojson.Point
+import com.mapbox.mapboxsdk.Mapbox
+import com.mapbox.mapboxsdk.geometry.LatLng
 import com.mapbox.services.android.navigation.testapp.NavigationApplication
 import com.mapbox.services.android.navigation.testapp.NavigationApplication.Companion.instance
 import com.mapbox.services.android.navigation.testapp.R
@@ -21,6 +26,10 @@ import com.mapbox.services.android.navigation.ui.v5.voice.SpeechPlayerProvider
 import com.mapbox.services.android.navigation.v5.milestone.Milestone
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+import timber.log.Timber
 import java.util.Locale.US
 
 class ExampleViewModel(application: Application) : AndroidViewModel(application) {
@@ -34,6 +43,7 @@ class ExampleViewModel(application: Application) : AndroidViewModel(application)
   val progress: MutableLiveData<RouteProgress> = MutableLiveData()
   val milestone: MutableLiveData<Milestone> = MutableLiveData()
   val destination: MutableLiveData<Point> = MutableLiveData()
+  val geocode: MutableLiveData<GeocodingResponse> = MutableLiveData()
   var collapsedBottomSheet: Boolean = false
 
   private val locationEngine: LocationEngine
@@ -100,6 +110,23 @@ class ExampleViewModel(application: Application) : AndroidViewModel(application)
 
   fun retrieveNavigation(): MapboxNavigation {
     return navigation
+  }
+
+  fun reverseGeocode(point: LatLng) {
+    val reverseGeocode = MapboxGeocoding.builder()
+            .accessToken(Mapbox.getAccessToken()!!)
+            .query(Point.fromLngLat(point.longitude, point.latitude))
+            .geocodingTypes(GeocodingCriteria.TYPE_ADDRESS)
+            .build()
+    reverseGeocode.enqueueCall(object : Callback<GeocodingResponse> {
+      override fun onResponse(call: Call<GeocodingResponse>, response: Response<GeocodingResponse>) {
+        geocode.value = response.body()
+      }
+
+      override fun onFailure(call: Call<GeocodingResponse>, t: Throwable) {
+        Timber.e(t, "Geocoding request failed")
+      }
+    })
   }
 
   fun onDestroy() {


### PR DESCRIPTION
Fixes todo in list of https://github.com/mapbox/mapbox-navigation-android/pull/1317#issue-218368592:
> Long press to select destination

Currently this is only a placeholder PR with long press event + projection conversion implemented. To be able to feed this data to `onDestinationFound` I will need to convert the found feature object to a carmen feature. @danesfeder is there an easy way to do this? should I do a reverse geocode to get a CarmenFeature?
