### PR TITLE
Example activity hide keyboard on launch

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,7 +18,7 @@
         <activity
             android:name=".example.ui.ExampleActivity"
             android:screenOrientation="portrait"
-            android:windowSoftInputMode="adjustNothing">
+            android:windowSoftInputMode="stateHidden|adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>


### PR DESCRIPTION
From my comment in https://github.com/mapbox/mapbox-navigation-android/pull/1317#issuecomment-425051764:  to me it feel strange showing the keyboard on activity launch with current design. Suggesting to not show it using the AndroidManifest configuration: 
```xml
<activity
    ...
    android:windowSoftInputMode="stateHidden|adjustResize"
    ...
>
```