### PR TITLE
Add Callouts

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/callout/ExampleBubbleCallout.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/callout/ExampleBubbleCallout.java
@@ -1,0 +1,43 @@
+package com.mapbox.services.android.navigation.testapp.example.ui.callout;
+
+import com.mapbox.geojson.Point;
+
+public class ExampleBubbleCallout extends ExampleCallout {
+
+  private static final String KEY_STROKE_WIDTH = "callout_stroke_width";
+  private static final String KEY_STROKE_COLOR = "callout_stroke_color";
+  private static final String KEY_CORNER_RADIUS = "callout_radius";
+  private static final String KEY_ARROW_WIDTH = "callout_arrow_width";
+  private static final String KEY_ARROW_HEIGHT = "callout_arrow_height";
+
+  ExampleBubbleCallout(String id, String text, Point point, int textColor, int backgroundColor, float textSize,
+                       int[] padding, float strokeWidth, int strokeColor, float cornerRadius, float arrowWidth,
+                       float arrowHeight) {
+    super(id, text, point, textColor, backgroundColor, textSize, padding);
+    jsonObject.addProperty(KEY_STROKE_WIDTH, strokeWidth);
+    jsonObject.addProperty(KEY_STROKE_COLOR, strokeColor);
+    jsonObject.addProperty(KEY_CORNER_RADIUS, cornerRadius);
+    jsonObject.addProperty(KEY_ARROW_WIDTH, arrowWidth);
+    jsonObject.addProperty(KEY_ARROW_HEIGHT, arrowHeight);
+  }
+
+  public float getStrokeWidth() {
+    return jsonObject.get(KEY_STROKE_WIDTH).getAsFloat();
+  }
+
+  public int getStrokeColor() {
+    return jsonObject.get(KEY_STROKE_COLOR).getAsInt();
+  }
+
+  public float getCornerRadius() {
+    return jsonObject.get(KEY_CORNER_RADIUS).getAsFloat();
+  }
+
+  public float getArrowHeight() {
+    return jsonObject.get(KEY_ARROW_HEIGHT).getAsFloat();
+  }
+
+  public float getArrowWidth() {
+    return jsonObject.get(KEY_ARROW_WIDTH).getAsFloat();
+  }
+}

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/callout/ExampleBubbleCalloutOptions.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/callout/ExampleBubbleCalloutOptions.java
@@ -1,0 +1,47 @@
+package com.mapbox.services.android.navigation.testapp.example.ui.callout;
+
+import android.graphics.Color;
+
+public class ExampleBubbleCalloutOptions extends ExampleCalloutOptions {
+
+  private float strokeWidth = 2;
+  private int strokeColor = Color.DKGRAY;
+  private float cornerRadius = 12;
+  private float arrowHeight = 16;
+  private float arrowWidth = 16;
+
+  public ExampleBubbleCalloutOptions withStrokeWidth(float strokeWidth) {
+    this.strokeWidth = strokeWidth;
+    return this;
+  }
+
+  public ExampleBubbleCalloutOptions withStrokeColor(int strokeColor) {
+    this.strokeColor = strokeColor;
+    return this;
+  }
+
+  public ExampleBubbleCalloutOptions withCornerRadius(float cornerRadius) {
+    this.cornerRadius = cornerRadius;
+    return this;
+  }
+
+  public ExampleBubbleCalloutOptions withArrowWidth(float arrowWidth) {
+    this.arrowWidth = arrowWidth;
+    return this;
+  }
+
+  public ExampleBubbleCalloutOptions withArrowHeight(float arrowHeight) {
+    this.arrowHeight = arrowHeight;
+    return this;
+  }
+
+  @Override
+  ExampleCallout build(long id) {
+    validateInput();
+    return new ExampleBubbleCallout(
+      generateId(id), text, point, textColor, backgroundColor,
+      textSize, padding, strokeWidth, strokeColor,
+      cornerRadius, arrowWidth, arrowHeight
+    );
+  }
+}

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/callout/ExampleCallout.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/callout/ExampleCallout.java
@@ -1,0 +1,68 @@
+package com.mapbox.services.android.navigation.testapp.example.ui.callout;
+
+import com.google.gson.JsonObject;
+import com.mapbox.geojson.Feature;
+import com.mapbox.geojson.Point;
+
+public class ExampleCallout {
+
+  public static final String KEY_ID = "callout_id";
+  private static final String KEY_TEXT = "callout_text";
+  private static final String KEY_TEXT_COLOR = "callout_textcolor";
+  private static final String KEY_BG_COLOR = "callout_bgcolor";
+  private static final String KEY_TEXT_SIZE = "callout_size";
+  private static final String KEY_PADDING_LEFT = "callout_padding_left";
+  private static final String KEY_PADDING_TOP = "callout_padding_top";
+  private static final String KEY_PADDING_RIGHT = "callout_padding_right";
+  private static final String KEY_PADDING_BOTTOM = "callout_padding_bottom";
+
+  private final Point point;
+  protected final JsonObject jsonObject = new JsonObject();
+
+  ExampleCallout(String id, String text, Point point, int textColor,
+                 int backgroundColor, float textSize, int[] padding) {
+    this.point = point;
+    jsonObject.addProperty(KEY_ID, id);
+    jsonObject.addProperty(KEY_TEXT, text);
+    jsonObject.addProperty(KEY_TEXT_COLOR, textColor);
+    jsonObject.addProperty(KEY_BG_COLOR, backgroundColor);
+    jsonObject.addProperty(KEY_TEXT_SIZE, textSize);
+    jsonObject.addProperty(KEY_PADDING_LEFT, padding[0]);
+    jsonObject.addProperty(KEY_PADDING_TOP, padding[1]);
+    jsonObject.addProperty(KEY_PADDING_RIGHT, padding[2]);
+    jsonObject.addProperty(KEY_PADDING_BOTTOM, padding[3]);
+  }
+
+  public String getId() {
+    return jsonObject.get(KEY_ID).getAsString();
+  }
+
+  public String getText() {
+    return jsonObject.get(KEY_TEXT).getAsString();
+  }
+
+  public int getTextColor() {
+    return jsonObject.get(KEY_TEXT_COLOR).getAsInt();
+  }
+
+  public int getBackgroundColor() {
+    return jsonObject.get(KEY_BG_COLOR).getAsInt();
+  }
+
+  public float getTextSize() {
+    return jsonObject.get(KEY_TEXT_SIZE).getAsFloat();
+  }
+
+  public int[] getPadding() {
+    return new int[] {
+      jsonObject.get(KEY_PADDING_LEFT).getAsInt(),
+      jsonObject.get(KEY_PADDING_TOP).getAsInt(),
+      jsonObject.get(KEY_PADDING_RIGHT).getAsInt(),
+      jsonObject.get(KEY_PADDING_BOTTOM).getAsInt()
+    };
+  }
+
+  Feature toFeature() {
+    return Feature.fromGeometry(point, jsonObject);
+  }
+}

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/callout/ExampleCalloutManager.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/callout/ExampleCalloutManager.java
@@ -1,0 +1,165 @@
+package com.mapbox.services.android.navigation.testapp.example.ui.callout;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.os.AsyncTask;
+import android.support.annotation.NonNull;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.TextView;
+import com.mapbox.geojson.Feature;
+import com.mapbox.geojson.FeatureCollection;
+import com.mapbox.mapboxsdk.Mapbox;
+import com.mapbox.mapboxsdk.annotations.BubbleLayout;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.style.layers.SymbolLayer;
+import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
+import com.mapbox.services.android.navigation.testapp.R;
+
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import static com.mapbox.mapboxsdk.style.expressions.Expression.get;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.literal;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.string;
+import static com.mapbox.mapboxsdk.style.layers.Property.ICON_ANCHOR_BOTTOM;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconAllowOverlap;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconImage;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconIgnorePlacement;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconAnchor;
+
+public class ExampleCalloutManager {
+
+  private static final String SOURCE_ID = "mapbox_nav_callout_source_id";
+  private static final String LAYER_ID = "mapbox_nav_callout_source_id";
+
+  private long id;
+  private MapboxMap mapboxMap;
+  private GeoJsonSource geoJsonSource;
+  private List<Feature> featureList = new ArrayList<>();
+
+  public ExampleCalloutManager(MapboxMap mapboxMap) {
+    this.mapboxMap = mapboxMap;
+    this.geoJsonSource = new GeoJsonSource(SOURCE_ID);
+    mapboxMap.addSource(geoJsonSource);
+    mapboxMap.addLayer(new SymbolLayer(LAYER_ID, SOURCE_ID).withProperties(
+      iconImage(string(get(literal(ExampleCallout.KEY_ID)))),
+      iconAllowOverlap(true),
+      iconIgnorePlacement(true),
+      iconAnchor(ICON_ANCHOR_BOTTOM)
+    ));
+  }
+
+  public ExampleCallout add(ExampleCalloutOptions options) {
+    ExampleCallout callout = options.build(id++);
+    featureList.add(callout.toFeature());
+    new GenerateSymbolTask(mapboxMap, Mapbox.getApplicationContext()).execute(callout);
+    updateSource();
+    return callout;
+  }
+
+  public void removeAll() {
+    featureList.clear();
+    updateSource();
+  }
+
+  private void updateSource() {
+    geoJsonSource.setGeoJson(FeatureCollection.fromFeatures(featureList));
+  }
+
+  private static class GenerateSymbolTask extends AsyncTask<ExampleCallout, Void, HashMap<String, Bitmap>> {
+
+    private MapboxMap mapboxMap;
+    private WeakReference<Context> context;
+
+    GenerateSymbolTask(MapboxMap mapboxMap, Context context) {
+      this.mapboxMap = mapboxMap;
+      this.context = new WeakReference<>(context);
+    }
+
+    @SuppressWarnings("WrongThread")
+    @Override
+    protected HashMap<String, Bitmap> doInBackground(ExampleCallout... params) {
+      HashMap<String, Bitmap> imagesMap = new HashMap<>();
+      Context context = this.context.get();
+      if (context != null && params != null) {
+        ExampleCallout callout = params[0];
+        if (callout instanceof ExampleBubbleCallout) {
+          imagesMap.put(callout.getId(), generateBubbleText(context, (ExampleBubbleCallout) callout));
+        } else {
+          imagesMap.put(callout.getId(), generateText(context, callout));
+        }
+      }
+      return imagesMap;
+    }
+
+    private Bitmap generateBubbleText(Context context, ExampleBubbleCallout bubbleCallout) {
+      BubbleLayout bubbleLayout = (BubbleLayout) LayoutInflater.from(context).inflate(R.layout.callout, null);
+      bubbleLayout.setCornersRadius(bubbleCallout.getCornerRadius());
+      bubbleLayout.setStrokeColor(bubbleCallout.getStrokeColor());
+      bubbleLayout.setStrokeWidth(bubbleCallout.getStrokeWidth());
+      bubbleLayout.setBubbleColor(bubbleCallout.getBackgroundColor());
+      bubbleLayout.setArrowHeight(bubbleCallout.getArrowHeight());
+      bubbleLayout.setArrowWidth(bubbleCallout.getArrowWidth());
+      int[] padding = bubbleCallout.getPadding();
+      bubbleLayout.setPadding(padding[0], padding[1], padding[2], padding[3]);
+
+      TextView textView = bubbleLayout.findViewById(R.id.title);
+      textView.setText(bubbleCallout.getText());
+      textView.setTextColor(bubbleCallout.getTextColor());
+      textView.setTextSize(bubbleCallout.getTextSize());
+
+      // determine placement of arrow
+      int measureSpec = View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED);
+      bubbleLayout.measure(measureSpec, measureSpec);
+      int measuredWidth = bubbleLayout.getMeasuredWidth();
+      bubbleLayout.setArrowPosition((measuredWidth - bubbleCallout.getArrowWidth()) / 2);
+      return SymbolGenerator.generate(bubbleLayout);
+    }
+
+    private Bitmap generateText(Context context, ExampleCallout callout) {
+      TextView textView = new TextView(context);
+      textView.setBackgroundColor(callout.getBackgroundColor());
+      textView.setTextColor(callout.getTextColor());
+      textView.setText(callout.getText());
+      textView.setTextSize(callout.getTextSize());
+      int[] padding = callout.getPadding();
+      textView.setPadding(padding[0], padding[1], padding[2], padding[3]);
+      return SymbolGenerator.generate(textView);
+    }
+
+    @Override
+    protected void onPostExecute(HashMap<String, Bitmap> bitmapHashMap) {
+      super.onPostExecute(bitmapHashMap);
+      mapboxMap.addImages(bitmapHashMap);
+    }
+  }
+
+  private static class SymbolGenerator {
+
+    /**
+     * Generate a Bitmap from an Android SDK View.
+     *
+     * @param view the View to be drawn to a Bitmap
+     * @return the generated bitmap
+     */
+    static Bitmap generate(@NonNull View view) {
+      int measureSpec = View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED);
+      view.measure(measureSpec, measureSpec);
+
+      int measuredWidth = view.getMeasuredWidth();
+      int measuredHeight = view.getMeasuredHeight();
+
+      view.layout(0, 0, measuredWidth, measuredHeight);
+      Bitmap bitmap = Bitmap.createBitmap(measuredWidth, measuredHeight, Bitmap.Config.ARGB_8888);
+      bitmap.eraseColor(Color.TRANSPARENT);
+      Canvas canvas = new Canvas(bitmap);
+      view.draw(canvas);
+      return bitmap;
+    }
+  }
+}

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/callout/ExampleCalloutOptions.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/callout/ExampleCalloutOptions.java
@@ -1,0 +1,72 @@
+package com.mapbox.services.android.navigation.testapp.example.ui.callout;
+
+import android.graphics.Color;
+import android.support.annotation.ColorInt;
+import com.mapbox.geojson.Point;
+import com.mapbox.mapboxsdk.geometry.LatLng;
+
+public class ExampleCalloutOptions {
+
+  private static final String ID_TEMPLATE = "callout_%s";
+
+  protected String text;
+  protected Point point;
+  protected int textColor = Color.WHITE;
+  protected int backgroundColor = Color.BLACK;
+  protected float textSize = 12.0f;
+  protected int[] padding = new int[] {12, 8, 12, 8};
+
+  public ExampleCalloutOptions withText(String text) {
+    this.text = text;
+    return this;
+  }
+
+  public ExampleCalloutOptions withLatLng(LatLng latLng) {
+    this.point = Point.fromLngLat(latLng.getLongitude(), latLng.getLatitude());
+    return this;
+  }
+
+  public ExampleCalloutOptions withGeometry(Point point) {
+    this.point = point;
+    return this;
+  }
+
+  public ExampleCalloutOptions withTextColor(@ColorInt int textColor) {
+    this.textColor = textColor;
+    return this;
+  }
+
+  public ExampleCalloutOptions withBackgroundColor(@ColorInt int backgroundColor) {
+    this.backgroundColor = backgroundColor;
+    return this;
+  }
+
+  public ExampleCalloutOptions withTextSize(float textSize) {
+    this.textSize = textSize;
+    return this;
+  }
+
+  public ExampleCalloutOptions withPadding(int[] padding) {
+    this.padding = padding;
+    return this;
+  }
+
+  protected void validateInput() {
+    if (point == null) {
+      throw new IllegalArgumentException("LatLng is required to build a callout");
+    }
+
+    if (text == null) {
+      throw new IllegalArgumentException("Text is required to build a callout");
+    }
+  }
+
+  protected String generateId(long baseId) {
+    return String.format(ID_TEMPLATE, baseId);
+  }
+
+  ExampleCallout build(long id) {
+    validateInput();
+    return new ExampleCallout(generateId(id), text, point, textColor, backgroundColor, textSize, padding);
+  }
+}

--- a/app/src/main/res/layout/callout.xml
+++ b/app/src/main/res/layout/callout.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<com.mapbox.mapboxsdk.annotations.BubbleLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:mapbox_bl_arrowDirection="bottom">
+
+    <!-- 4dp padding bottom is added to work around BubbleLayout layout issue -->
+    <TextView
+            android:id="@+id/title"
+            android:gravity="center"
+            android:paddingBottom="4dp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"/>
+
+</com.mapbox.mapboxsdk.annotations.BubbleLayout>


### PR DESCRIPTION
This PR adds the ability to add callouts, atm part of the example but can be moved to the SDK instead. Callouts allow to add texts in either a bubble form or square form to the map at a certain point. This is useful to show information of a destination or as an eta on top of a route.

![device-2018-09-28-134939](https://user-images.githubusercontent.com/2151639/46207266-0cc24800-c327-11e8-9b5b-856f89905097.png)


We expose the following API:

#### Rectangular callout:

```kotlin
        exampleCalloutManager.add(
                ExampleCalloutOptions()
                        .withLatLng(it)
                        .withText("15 min")
                        .withBackgroundColor(Color.RED)
                        .withTextColor(Color.BLUE)
                        .withTextSize(16.0f)
                        .withPadding(intArrayOf(0,0,0,0))
        )
```

#### Bubble callout:

```kotlin
        exampleCalloutManager.add(
                ExampleBubbleCalloutOptions()
                        .withArrowHeight(20f)
                        .withArrowWidth(20f)
                        .withCornerRadius(20f)
                        .withStrokeColor(Color.YELLOW)
                        .withStrokeWidth(6.0f)
                        .withLatLng(it)
                        .withText("Pickup")
                        .withBackgroundColor(Color.RED)
                        .withTextColor(Color.BLUE)
                        .withTextSize(16.0f)
                        .withPadding(intArrayOf(0,0,0,0))
        )
```

The configuration above leads to the following result:

![device-2018-09-28-135551](https://user-images.githubusercontent.com/2151639/46207304-30858e00-c327-11e8-9c0b-63730ccece1b.png)


