### PR TITLE
Create MultiOnClickListener before View is attached

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/FeedbackButton.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/FeedbackButton.java
@@ -7,7 +7,7 @@ import android.util.AttributeSet;
 
 public class FeedbackButton extends ConstraintLayout implements NavigationButton {
   private FloatingActionButton feedbackFab;
-  private MultiOnClickListener multiOnClickListener;
+  private MultiOnClickListener multiOnClickListener = new MultiOnClickListener();
 
   public FeedbackButton(Context context) {
     this(context, null);
@@ -78,7 +78,6 @@ public class FeedbackButton extends ConstraintLayout implements NavigationButton
 
 
   private void setupOnClickListeners() {
-    multiOnClickListener = new MultiOnClickListener();
     feedbackFab.setOnClickListener(multiOnClickListener);
   }
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/SoundButton.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/SoundButton.java
@@ -23,7 +23,7 @@ public class SoundButton extends ConstraintLayout implements NavigationButton {
   private TextView soundChipText;
   private AnimationSet fadeInSlowOut;
   private boolean isMuted;
-  private MultiOnClickListener multiOnClickListener;
+  private MultiOnClickListener multiOnClickListener = new MultiOnClickListener();
 
   public SoundButton(Context context) {
     this(context, null);
@@ -105,7 +105,6 @@ public class SoundButton extends ConstraintLayout implements NavigationButton {
   }
 
   private void setupOnClickListeners() {
-    multiOnClickListener = new MultiOnClickListener();
     setOnClickListener(multiOnClickListener);
   }
 


### PR DESCRIPTION
If a developer wants to add click listeners to either `Sound` or `FeedbackButton` before the `View`s are attached, `multiOnClickListener` will be `null` and cause a crash.