### PR TITLE
Example Activity updates and UI tweaks 

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExampleView.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExampleView.kt
@@ -9,8 +9,11 @@ import com.mapbox.geojson.Point
 import com.mapbox.mapboxsdk.camera.CameraUpdate
 import com.mapbox.mapboxsdk.geometry.LatLngBounds
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback
+import com.mapbox.mapboxsdk.plugins.locationlayer.modes.RenderMode
 import com.mapbox.services.android.navigation.ui.v5.route.OnRouteSelectionChangeListener
+import com.mapbox.services.android.navigation.v5.milestone.Milestone
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation
+import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress
 
 interface ExampleView: PermissionsListener, OnMapReadyCallback,
     OnFeatureClickListener, OnRouteSelectionChangeListener {
@@ -33,8 +36,6 @@ interface ExampleView: PermissionsListener, OnMapReadyCallback,
 
   fun updateDestinationMarker(destination: Point)
 
-  fun updateAutocompleteBottomSheetHideable(isHideable: Boolean)
-
   fun updateAutocompleteBottomSheetState(state: Int)
 
   fun updateAutocompleteProximity(location: Location?)
@@ -51,13 +52,11 @@ interface ExampleView: PermissionsListener, OnMapReadyCallback,
 
   fun updateSettingsFabVisibility(visibility: Int)
 
-  fun updateNavigationDataVisibility(visibility: Int)
+  fun updateInstructionViewVisibility(visibility: Int)
 
-  fun updateManeuverView(maneuverType: String?, maneuverModifier: String?)
+  fun updateInstructionViewWith(progress: RouteProgress)
 
-  fun updateStepDistanceRemaining(distance: String)
-
-  fun updateArrivalTime(time: String)
+  fun updateInstructionViewWith(progress: RouteProgress, milestone: Milestone)
 
   fun addMapProgressChangeListener(navigation: MapboxNavigation)
 
@@ -67,6 +66,8 @@ interface ExampleView: PermissionsListener, OnMapReadyCallback,
 
   fun makeToast(message: String)
 
+  fun transition()
+
   fun showSettings()
 
   fun adjustMapPaddingForNavigation()
@@ -74,4 +75,8 @@ interface ExampleView: PermissionsListener, OnMapReadyCallback,
   fun resetMapPadding()
 
   fun showAttributionDialog(attributionView: View)
+
+  fun showAlternativeRoutes(alternativesVisible: Boolean)
+
+  fun updateLocationRenderMode(@RenderMode.Mode renderMode: Int)
 }

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/autocomplete/AutocompleteBottomSheetBehavior.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/autocomplete/AutocompleteBottomSheetBehavior.kt
@@ -1,0 +1,23 @@
+package com.mapbox.services.android.navigation.testapp.example.ui.autocomplete
+
+import android.content.Context
+import android.support.design.widget.BottomSheetBehavior
+import android.support.design.widget.CoordinatorLayout
+import android.util.AttributeSet
+import android.view.MotionEvent
+import android.view.View
+
+class AutocompleteBottomSheetBehavior<V : View> : BottomSheetBehavior<V> {
+
+  constructor() : super()
+
+  constructor(context: Context, attrs: AttributeSet) : super(context, attrs)
+
+  override fun onInterceptTouchEvent(parent: CoordinatorLayout?, child: V, event: MotionEvent?): Boolean {
+    return false
+  }
+
+  override fun onTouchEvent(parent: CoordinatorLayout?, child: V, event: MotionEvent?): Boolean {
+    return false
+  }
+}

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/navigation/ExampleOffRouteListener.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/navigation/ExampleOffRouteListener.kt
@@ -7,6 +7,7 @@ import com.mapbox.services.android.navigation.v5.offroute.OffRouteListener
 class ExampleOffRouteListener(private val viewModel: ExampleViewModel) : OffRouteListener {
 
   override fun userOffRoute(location: Location?) {
+    viewModel.isOffRoute = true
     viewModel.findRouteToDestination()
   }
 }

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/navigation/ExampleRouteFinder.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/navigation/ExampleRouteFinder.kt
@@ -6,20 +6,20 @@ import com.mapbox.api.directions.v5.models.DirectionsResponse
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.geojson.Point
 import com.mapbox.services.android.navigation.testapp.NavigationApplication
+import com.mapbox.services.android.navigation.testapp.example.ui.ExampleViewModel
 import com.mapbox.services.android.navigation.v5.navigation.NavigationRoute
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
 import timber.log.Timber
 
-class ExampleRouteFinder(private val routes: MutableLiveData<List<DirectionsRoute>>,
+class ExampleRouteFinder(private val viewModel: ExampleViewModel,
+                         private val routes: MutableLiveData<List<DirectionsRoute>>,
                          private val accessToken: String) : Callback<DirectionsResponse> {
 
   companion object {
     const val BEARING_TOLERANCE = 90.0
   }
-
-  var primaryRoute: DirectionsRoute? = null
 
   fun findRoute(location: Location, destination: Point) {
     find(location, destination)
@@ -55,6 +55,11 @@ class ExampleRouteFinder(private val routes: MutableLiveData<List<DirectionsRout
 
   private fun updateRoutes(routes: List<DirectionsRoute>) {
     this.routes.value = routes
-    primaryRoute = routes.first()
+    viewModel.primaryRoute = routes.first()
+
+    // Handle off-route scenarios
+    if (viewModel.isOffRoute) {
+      viewModel.startNavigation()
+    }
   }
 }

--- a/app/src/main/res/layout/activity_example.xml
+++ b/app/src/main/res/layout/activity_example.xml
@@ -17,6 +17,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
+        app:mapbox_styleUrl="mapbox://styles/mapbox/navigation-guidance-day-v4"
         app:mapbox_uiAttribution="false"
         app:mapbox_uiLogo="false"/>
 
@@ -111,6 +112,13 @@
             app:layout_constraintTop_toTopOf="parent"
             app:srcCompat="@drawable/ic_settings"/>
 
+        <com.mapbox.services.android.navigation.ui.v5.instruction.InstructionView
+            android:id="@+id/instructionView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="top"
+            android:visibility="invisible"/>
+
         <android.support.constraint.ConstraintLayout
             android:id="@+id/autocompleteBottomSheet"
             android:layout_width="match_parent"
@@ -121,7 +129,8 @@
             android:elevation="@dimen/autocomplete_bottomsheet_elevation"
             android:paddingTop="@dimen/autocomplete_bottomsheet_padding"
             android:paddingBottom="@dimen/autocomplete_bottomsheet_padding"
-            app:layout_behavior="android.support.design.widget.BottomSheetBehavior">
+            app:behavior_hideable="true"
+            app:layout_behavior="@string/autocompleteBehavior">
 
             <android.support.v7.widget.CardView
                 android:id="@+id/autocompleteCardView"
@@ -146,61 +155,5 @@
         </android.support.constraint.ConstraintLayout>
 
     </android.support.design.widget.CoordinatorLayout>
-
-    <android.support.v7.widget.CardView
-        android:id="@+id/navigationDataCardView"
-        android:layout_width="@dimen/data_card_view_width"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/data_card_view_start_padding"
-        android:layout_marginLeft="@dimen/data_card_view_start_padding"
-        android:layout_marginTop="@dimen/data_card_view_top_padding"
-        android:visibility="invisible"
-        app:cardCornerRadius="@dimen/autocomplete_cardview_corner_radius"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
-
-            <com.mapbox.services.android.navigation.ui.v5.instruction.maneuver.ManeuverView
-                android:id="@+id/maneuverView"
-                android:layout_width="@dimen/maneuver_view_width"
-                android:layout_height="@dimen/maneuver_view_height"
-                android:layout_margin="@dimen/maneuver_view_margin"/>
-
-            <LinearLayout
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                android:layout_marginStart="@dimen/data_margin_start"
-                android:layout_marginLeft="@dimen/data_margin_left"
-                android:gravity="center_vertical"
-                android:orientation="vertical">
-
-                <TextView
-                    android:id="@+id/stepDistanceRemainingTextView"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginBottom="@dimen/step_distance_remaining_margin_bottom"
-                    android:includeFontPadding="false"
-                    android:textSize="@dimen/data_text_size"
-                    android:textStyle="bold"
-                    tools:text="@tools:sample/lorem"/>
-
-                <TextView
-                    android:id="@+id/arrivalTimeTextView"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:includeFontPadding="false"
-                    android:textSize="@dimen/data_text_size"
-                    tools:text="@tools:sample/lorem"/>
-
-            </LinearLayout>
-
-        </LinearLayout>
-
-    </android.support.v7.widget.CardView>
 
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -28,7 +28,7 @@
     <dimen name="data_text_size">18sp</dimen>
     <dimen name="offline_dialog_text_size">18sp</dimen>
     <dimen name="bottom_sheet_peek_height">125dp</dimen>
-    <dimen name="route_overview_padding_top">50dp</dimen>
+    <dimen name="route_overview_padding_top">100dp</dimen>
     <dimen name="route_overview_padding_bottom">150dp</dimen>
     <dimen name="route_overview_padding_left">50dp</dimen>
     <dimen name="route_overview_padding_right">50dp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -60,4 +60,5 @@
 
     <string name="hint_where_to">Where to?</string>
     <string name="offline_routing">Offline routing</string>
+    <string name="autocompleteBehavior" translatable="false">com.mapbox.services.android.navigation.testapp.example.ui.autocomplete.AutocompleteBottomSheetBehavior</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -44,8 +44,5 @@
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
-
-        <item name="navigationViewBannerManeuverPrimary">@color/colorPrimary</item>
-        <item name="navigationViewBannerManeuverSecondary">@color/mapbox_navigation_view_color_banner_maneuver_secondary</item>
     </style>
 </resources>


### PR DESCRIPTION
This PR addresses some of the feedback provided by @Guardiola31337 and the broken re-routing (thanks for catching this @mcwhittemore).  

I also removed the need for a `ExamplePresenter#onDestroy` as the `ExampleViewModel` will now use the `onCleared` callback to shutdown any outstanding resources. 