### PR TITLE
Delay adding InstructionView default click listeners until subscribed

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/RerouteActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/RerouteActivity.java
@@ -8,6 +8,7 @@ import android.support.annotation.NonNull;
 import android.support.design.widget.Snackbar;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
+import android.widget.Toast;
 
 import com.mapbox.android.core.location.LocationEngineListener;
 import com.mapbox.api.directions.v5.models.DirectionsResponse;
@@ -87,6 +88,11 @@ public class RerouteActivity extends AppCompatActivity implements OnMapReadyCall
     navigation = new MapboxNavigation(getApplicationContext(), Mapbox.getAccessToken(), options);
     navigation.addNavigationEventListener(this);
     navigation.addMilestoneEventListener(this);
+
+    instructionView.retrieveSoundButton().show();
+    instructionView.retrieveSoundButton().addOnClickListener(
+      v -> Toast.makeText(RerouteActivity.this, "Sound button clicked!", Toast.LENGTH_SHORT).show()
+    );
   }
 
   @Override

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionView.java
@@ -209,6 +209,7 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
       }
     });
     subscribeAlertView();
+    initializeButtonListeners();
     showButtons();
   }
 
@@ -517,13 +518,7 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
     alertView.subscribe(navigationViewModel);
   }
 
-  private void initializeButtons() {
-    setupSoundButton();
-    setupFeedbackButton();
-  }
-
-  private void setupFeedbackButton() {
-    feedbackButton.hide();
+  private void initializeButtonListeners() {
     feedbackButton.addOnClickListener(new OnClickListener() {
       @Override
       public void onClick(View view) {
@@ -531,10 +526,6 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
         showFeedbackBottomSheet();
       }
     });
-  }
-
-  private void setupSoundButton() {
-    soundButton.hide();
     soundButton.addOnClickListener(new OnClickListener() {
       @Override
       public void onClick(View view) {
@@ -556,6 +547,11 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
     } else {
       initializePortraitListListener();
     }
+  }
+
+  private void initializeButtons() {
+    feedbackButton.hide();
+    soundButton.hide();
   }
 
   /**


### PR DESCRIPTION
The `InstructionView` was initializing with click listeners that contained the `NavigationViewModel`.  If the view never subscribed to the view model, a crash would occurs when clicking. 