### PR TITLE
Do not remove OffRouteListeners onArrival

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEventDispatcher.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEventDispatcher.java
@@ -176,7 +176,6 @@ class NavigationEventDispatcher {
     if (metricEventListener != null && routeUtils.isArrivalEvent(routeProgress, milestone)) {
       metricEventListener.onArrival(routeProgress);
       if (routeUtils.isLastLeg(routeProgress)) {
-        removeOffRouteListener(null);
         metricEventListener = null;
       }
     }

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEventDispatcherTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEventDispatcherTest.java
@@ -339,21 +339,6 @@ public class NavigationEventDispatcherTest extends BaseTest {
   }
 
   @Test
-  public void onArrivalDuringLastLeg_offRouteListenerIsRemoved() {
-    String instruction = "";
-    Location location = mock(Location.class);
-    BannerInstructionMilestone milestone = mock(BannerInstructionMilestone.class);
-    RouteUtils routeUtils = mock(RouteUtils.class);
-    when(routeUtils.isArrivalEvent(routeProgress, milestone)).thenReturn(true);
-    when(routeUtils.isLastLeg(routeProgress)).thenReturn(true);
-    NavigationEventDispatcher navigationEventDispatcher = buildEventDispatcherHasArrived(instruction, routeUtils, milestone);
-
-    navigationEventDispatcher.onUserOffRoute(location);
-
-    verify(offRouteListener, times(0)).userOffRoute(location);
-  }
-
-  @Test
   public void onArrivalDuringLastLeg_metricEventListenerIsRemoved() {
     String instruction = "";
     Location location = mock(Location.class);


### PR DESCRIPTION
To prevent necessary re-routes after arrival, we used to remove all `OffRouteListener` instances from the `NavigationEventDispatcher` - `Navigator` is smart, and won't continue to fire off-route events after a route has been completed.  

This PR keeps all instances of `OffRouteListener` after arrival. 