### PR TITLE
Add FusedLocationEngine to Test App

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/location/ForwardingLocationCallback.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/location/ForwardingLocationCallback.java
@@ -1,0 +1,21 @@
+package com.mapbox.services.android.navigation.testapp.activity.location;
+
+import android.location.Location;
+
+import com.google.android.gms.location.LocationCallback;
+import com.google.android.gms.location.LocationResult;
+
+class ForwardingLocationCallback extends LocationCallback {
+
+  private final FusedLocationEngine locationEngine;
+
+  ForwardingLocationCallback(FusedLocationEngine locationEngine) {
+    this.locationEngine = locationEngine;
+  }
+
+  @Override
+  public void onLocationResult(LocationResult locationResult) {
+    Location location = locationResult.getLastLocation();
+    locationEngine.notifyListenersOnLocationChanged(location);
+  }
+}

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/location/ForwardingLocationCallback.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/location/ForwardingLocationCallback.java
@@ -5,8 +5,11 @@ import android.location.Location;
 import com.google.android.gms.location.LocationCallback;
 import com.google.android.gms.location.LocationResult;
 
+import java.util.List;
+
 class ForwardingLocationCallback extends LocationCallback {
 
+  private static final int FIRST = 0;
   private final FusedLocationEngine locationEngine;
 
   ForwardingLocationCallback(FusedLocationEngine locationEngine) {
@@ -15,7 +18,11 @@ class ForwardingLocationCallback extends LocationCallback {
 
   @Override
   public void onLocationResult(LocationResult locationResult) {
-    Location location = locationResult.getLastLocation();
-    locationEngine.notifyListenersOnLocationChanged(location);
+    List<Location> locations = locationResult.getLocations();
+    boolean hasLocation = !locations.isEmpty();
+    if (hasLocation) {
+      Location newLocation = locations.get(FIRST);
+      locationEngine.notifyListenersOnLocationChanged(newLocation);
+    }
   }
 }

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/location/FusedLocationEngine.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/location/FusedLocationEngine.java
@@ -15,6 +15,8 @@ import com.google.android.gms.location.SettingsClient;
 import com.mapbox.android.core.location.LocationEngine;
 import com.mapbox.android.core.location.LocationEngineListener;
 
+import java.util.Date;
+
 import timber.log.Timber;
 
 public class FusedLocationEngine extends LocationEngine {
@@ -58,7 +60,10 @@ public class FusedLocationEngine extends LocationEngine {
   @Override
   @SuppressWarnings("MissingPermission")
   public Location getLastLocation() {
-    fusedLocationClient.getLastLocation().addOnSuccessListener(location -> lastLocation = location);
+    fusedLocationClient.getLastLocation().addOnSuccessListener(location -> {
+      location.setTime((new Date()).getTime()); //match system clock
+      lastLocation = location;
+    });
     return lastLocation;
   }
 
@@ -82,6 +87,7 @@ public class FusedLocationEngine extends LocationEngine {
   }
 
   void notifyListenersOnLocationChanged(Location location) {
+    location.setTime((new Date()).getTime()); //match system clock
     for (LocationEngineListener listener : locationListeners) {
       listener.onLocationChanged(location);
     }

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/location/FusedLocationEngine.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/location/FusedLocationEngine.java
@@ -15,8 +15,6 @@ import com.google.android.gms.location.SettingsClient;
 import com.mapbox.android.core.location.LocationEngine;
 import com.mapbox.android.core.location.LocationEngineListener;
 
-import java.util.Date;
-
 import timber.log.Timber;
 
 public class FusedLocationEngine extends LocationEngine {
@@ -60,10 +58,7 @@ public class FusedLocationEngine extends LocationEngine {
   @Override
   @SuppressWarnings("MissingPermission")
   public Location getLastLocation() {
-    fusedLocationClient.getLastLocation().addOnSuccessListener(location -> {
-      location.setTime((new Date()).getTime()); //match system clock
-      lastLocation = location;
-    });
+    fusedLocationClient.getLastLocation().addOnSuccessListener(location -> lastLocation = location);
     return lastLocation;
   }
 
@@ -87,7 +82,6 @@ public class FusedLocationEngine extends LocationEngine {
   }
 
   void notifyListenersOnLocationChanged(Location location) {
-    location.setTime((new Date()).getTime()); //match system clock
     for (LocationEngineListener listener : locationListeners) {
       listener.onLocationChanged(location);
     }

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/location/FusedLocationEngine.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/location/FusedLocationEngine.java
@@ -1,0 +1,137 @@
+package com.mapbox.services.android.navigation.testapp.activity.location;
+
+import android.app.Activity;
+import android.location.Location;
+import android.os.Looper;
+import android.support.annotation.NonNull;
+
+import com.google.android.gms.common.api.ApiException;
+import com.google.android.gms.location.FusedLocationProviderClient;
+import com.google.android.gms.location.LocationRequest;
+import com.google.android.gms.location.LocationServices;
+import com.google.android.gms.location.LocationSettingsRequest;
+import com.google.android.gms.location.LocationSettingsStatusCodes;
+import com.google.android.gms.location.SettingsClient;
+import com.mapbox.android.core.location.LocationEngine;
+import com.mapbox.android.core.location.LocationEngineListener;
+
+import timber.log.Timber;
+
+public class FusedLocationEngine extends LocationEngine {
+
+  private static final long UPDATE_INTERVAL_IN_MILLISECONDS = 1000;
+  private static final long FASTEST_UPDATE_INTERVAL_IN_MILLISECONDS = 500;
+
+  private FusedLocationProviderClient fusedLocationClient;
+  private SettingsClient settingsClient;
+  private LocationRequest locationRequest;
+  private LocationSettingsRequest locationSettingsRequest;
+  private boolean isConnected = false;
+  private boolean receivingUpdates = false;
+  private Location lastLocation = null;
+  private final ForwardingLocationCallback forwardingCallback = new ForwardingLocationCallback(this);
+
+  public FusedLocationEngine(@NonNull Activity activity) {
+    super();
+    fusedLocationClient = LocationServices.getFusedLocationProviderClient(activity);
+    settingsClient = LocationServices.getSettingsClient(activity);
+  }
+
+  @Override
+  public void activate() {
+    if (!isConnected) {
+      startLocationUpdates();
+    }
+  }
+
+  @Override
+  public void deactivate() {
+    stopLocationUpdates();
+    isConnected = false;
+  }
+
+  @Override
+  public boolean isConnected() {
+    return isConnected;
+  }
+
+  @Override
+  @SuppressWarnings("MissingPermission")
+  public Location getLastLocation() {
+    fusedLocationClient.getLastLocation().addOnSuccessListener(location -> lastLocation = location);
+    return lastLocation;
+  }
+
+  @Override
+  @SuppressWarnings( {"MissingPermission"})
+  public void requestLocationUpdates() {
+    if (isConnected && !receivingUpdates) {
+      fusedLocationClient.requestLocationUpdates(locationRequest, forwardingCallback, Looper.myLooper())
+        .addOnSuccessListener(aVoid -> receivingUpdates = true);
+    }
+  }
+
+  @Override
+  public void removeLocationUpdates() {
+    stopLocationUpdates();
+  }
+
+  @Override
+  public Type obtainType() {
+    return Type.GOOGLE_PLAY_SERVICES;
+  }
+
+  void notifyListenersOnLocationChanged(Location location) {
+    for (LocationEngineListener listener : locationListeners) {
+      listener.onLocationChanged(location);
+    }
+  }
+
+  private void createLocationRequest() {
+    locationRequest = new LocationRequest();
+    locationRequest.setInterval(UPDATE_INTERVAL_IN_MILLISECONDS);
+    locationRequest.setFastestInterval(FASTEST_UPDATE_INTERVAL_IN_MILLISECONDS);
+    locationRequest.setPriority(LocationRequest.PRIORITY_HIGH_ACCURACY);
+  }
+
+  private void buildLocationSettingsRequest() {
+    LocationSettingsRequest.Builder builder = new LocationSettingsRequest.Builder();
+    builder.addLocationRequest(locationRequest);
+    locationSettingsRequest = builder.build();
+  }
+
+  private void startLocationUpdates() {
+    createLocationRequest();
+    buildLocationSettingsRequest();
+    settingsClient.checkLocationSettings(locationSettingsRequest)
+      .addOnSuccessListener(locationSettingsResponse -> {
+        isConnected = true;
+        notifyListenersOnConnected();
+      })
+      .addOnFailureListener(exception -> {
+        isConnected = false;
+        int statusCode = ((ApiException) exception).getStatusCode();
+        switch (statusCode) {
+          case LocationSettingsStatusCodes.RESOLUTION_REQUIRED:
+            Timber.e("Location settings are not satisfied. Upgrade location settings");
+            break;
+          case LocationSettingsStatusCodes.SETTINGS_CHANGE_UNAVAILABLE:
+            Timber.e("Location settings are inadequate, and cannot be fixed here. Fix in Settings.");
+            break;
+          default:
+            break;
+        }
+      });
+  }
+
+  private void notifyListenersOnConnected() {
+    for (LocationEngineListener listener : locationListeners) {
+      listener.onConnected();
+    }
+  }
+
+  private void stopLocationUpdates() {
+    fusedLocationClient.removeLocationUpdates(forwardingCallback)
+      .addOnCompleteListener(task -> receivingUpdates = false);
+  }
+}

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/location/FusedLocationEngine.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/location/FusedLocationEngine.java
@@ -1,6 +1,6 @@
 package com.mapbox.services.android.navigation.testapp.activity.location;
 
-import android.app.Activity;
+import android.content.Context;
 import android.location.Location;
 import android.os.Looper;
 import android.support.annotation.NonNull;
@@ -21,7 +21,6 @@ public class FusedLocationEngine extends LocationEngine {
 
   private static final long UPDATE_INTERVAL_IN_MILLISECONDS = 1000;
   private static final long FASTEST_UPDATE_INTERVAL_IN_MILLISECONDS = 500;
-
   private FusedLocationProviderClient fusedLocationClient;
   private SettingsClient settingsClient;
   private LocationRequest locationRequest;
@@ -31,10 +30,10 @@ public class FusedLocationEngine extends LocationEngine {
   private Location lastLocation = null;
   private final ForwardingLocationCallback forwardingCallback = new ForwardingLocationCallback(this);
 
-  public FusedLocationEngine(@NonNull Activity activity) {
+  public FusedLocationEngine(@NonNull Context context) {
     super();
-    fusedLocationClient = LocationServices.getFusedLocationProviderClient(activity);
-    settingsClient = LocationServices.getSettingsClient(activity);
+    fusedLocationClient = LocationServices.getFusedLocationProviderClient(context);
+    settingsClient = LocationServices.getSettingsClient(context);
   }
 
   @Override
@@ -89,6 +88,7 @@ public class FusedLocationEngine extends LocationEngine {
 
   private void createLocationRequest() {
     locationRequest = new LocationRequest();
+    //TODO: unhardcode these
     locationRequest.setInterval(UPDATE_INTERVAL_IN_MILLISECONDS);
     locationRequest.setFastestInterval(FASTEST_UPDATE_INTERVAL_IN_MILLISECONDS);
     locationRequest.setPriority(LocationRequest.PRIORITY_HIGH_ACCURACY);

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/ComponentNavigationActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/ComponentNavigationActivity.java
@@ -20,7 +20,6 @@ import android.view.View;
 import com.mapbox.android.core.location.LocationEngine;
 import com.mapbox.android.core.location.LocationEngineListener;
 import com.mapbox.android.core.location.LocationEnginePriority;
-import com.mapbox.android.core.location.LocationEngineProvider;
 import com.mapbox.api.directions.v5.models.DirectionsResponse;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.geojson.Point;
@@ -33,6 +32,7 @@ import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.services.android.navigation.testapp.R;
+import com.mapbox.services.android.navigation.testapp.activity.location.FusedLocationEngine;
 import com.mapbox.services.android.navigation.ui.v5.camera.DynamicCamera;
 import com.mapbox.services.android.navigation.ui.v5.instruction.InstructionView;
 import com.mapbox.services.android.navigation.ui.v5.map.NavigationMapboxMap;
@@ -268,6 +268,7 @@ public class ComponentNavigationActivity extends AppCompatActivity implements On
   public void onPause() {
     super.onPause();
     mapView.onPause();
+    locationEngine.deactivate();
   }
 
   @Override
@@ -326,11 +327,11 @@ public class ComponentNavigationActivity extends AppCompatActivity implements On
   }
 
   private void initializeLocationEngine() {
-    LocationEngineProvider locationEngineProvider = new LocationEngineProvider(this);
-    locationEngine = locationEngineProvider.obtainBestLocationEngineAvailable();
+    locationEngine = new FusedLocationEngine(this);
     locationEngine.setPriority(LocationEnginePriority.HIGH_ACCURACY);
     locationEngine.addLocationEngineListener(this);
-    locationEngine.setFastestInterval(ONE_SECOND_INTERVAL);
+    locationEngine.setInterval(1000);
+    locationEngine.setFastestInterval(500);
     locationEngine.activate();
     showSnackbar(SEARCHING_FOR_GPS_MESSAGE, BaseTransientBottomBar.LENGTH_SHORT);
   }

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/ComponentNavigationActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/ComponentNavigationActivity.java
@@ -326,10 +326,10 @@ public class ComponentNavigationActivity extends AppCompatActivity implements On
   }
 
   private void initializeLocationEngine() {
-    locationEngine = new FusedLocationEngine(this);
+    locationEngine = new FusedLocationEngine(getApplicationContext());
     locationEngine.setPriority(LocationEnginePriority.HIGH_ACCURACY);
     locationEngine.addLocationEngineListener(this);
-    locationEngine.setInterval(1000);
+    locationEngine.setInterval(ONE_SECOND_INTERVAL);
     locationEngine.setFastestInterval(500);
     locationEngine.activate();
     showSnackbar(SEARCHING_FOR_GPS_MESSAGE, BaseTransientBottomBar.LENGTH_SHORT);

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/ComponentNavigationActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/ComponentNavigationActivity.java
@@ -268,7 +268,6 @@ public class ComponentNavigationActivity extends AppCompatActivity implements On
   public void onPause() {
     super.onPause();
     mapView.onPause();
-    locationEngine.deactivate();
   }
 
   @Override

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigator.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigator.java
@@ -60,8 +60,8 @@ class MapboxNavigator {
   }
 
   FixLocation buildFixLocationFromLocation(Location location) {
+    Date time = new Date();
     Point rawPoint = Point.fromLngLat(location.getLongitude(), location.getLatitude());
-    Date time = new Date(location.getTime());
     Float speed = checkFor(location.getSpeed());
     Float bearing = checkFor(location.getBearing());
     Float altitude = checkFor((float) location.getAltitude());


### PR DESCRIPTION
I've been testing with the sample app and have seen that the location updates using `LocationEngine` are coming in between every 2 and 3 seconds on average. In practice sometimes we get no location updates for much longer periods of time. Additionally when sitting still we dont get updates with the conventionally `LocationEngine`. This leads to a problem where we can't tell if we are sitting still or have no signal when navigating.

I've been able to take a sample application, fork it, and instrument it to see that indeed my device is capable of secondly gps updates (even when sitting still). This work is here: https://github.com/kevinkreiser/android-play-location/blob/master/LocationUpdates/app/src/main/java/com/google/android/gms/location/sample/locationupdates/MainActivity.java

@Guardiola31337 suggested that the fastest way for me to try this approach within the SDK was to simply write an `AlternativeLocationEngine` that extended the conventional one so that is what I did. So far the results are promising. As with the other test app, I am getting secondly updates.