### PR TITLE
Bump mapbox-android-plugin-locationlayer dependency to 0.9.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -12,7 +12,7 @@ ext {
       mapboxSdkServices  : '4.0.0',
       mapboxEvents       : '3.2.0',
       mapboxNavigator    : '3.1.3',
-      locationLayerPlugin: '0.8.1',
+      locationLayerPlugin: '0.9.0',
       autoValue          : '1.5.4',
       autoValueParcel    : '0.2.5',
       junit              : '4.12',


### PR DESCRIPTION
- Bumps `mapbox-android-plugin-locationlayer` dependency to `0.9.0`