### PR TITLE
Camera tracking modes selection with GPS and North as options

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationOnFlingListener.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationOnFlingListener.java
@@ -1,0 +1,23 @@
+package com.mapbox.services.android.navigation.ui.v5;
+
+import android.support.design.widget.BottomSheetBehavior;
+
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+
+public class NavigationOnFlingListener implements MapboxMap.OnFlingListener {
+
+  private final NavigationPresenter navigationPresenter;
+  private final BottomSheetBehavior summaryBehavior;
+
+  NavigationOnFlingListener(NavigationPresenter navigationPresenter, BottomSheetBehavior summaryBehavior) {
+    this.navigationPresenter = navigationPresenter;
+    this.summaryBehavior = summaryBehavior;
+  }
+
+  @Override
+  public void onFling() {
+    if (summaryBehavior.getState() != BottomSheetBehavior.STATE_HIDDEN) {
+      navigationPresenter.onMapScroll();
+    }
+  }
+}

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
@@ -78,6 +78,7 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
   private NavigationMapboxMap navigationMap;
   private OnNavigationReadyCallback onNavigationReadyCallback;
   private MapboxMap.OnMoveListener onMoveListener;
+  private MapboxMap.OnFlingListener onFlingListener;
   private NavigationMapboxMapInstanceState mapInstanceState;
   private boolean isMapInitialized;
   private boolean isSubscribed;
@@ -171,6 +172,7 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
   public void onDestroy() {
     if (navigationMap != null) {
       navigationMap.removeOnMoveListener(onMoveListener);
+      navigationMap.removeOnFlingListener(onFlingListener);
     }
     navigationViewEventDispatcher.onDestroy(navigationViewModel.retrieveNavigation());
     shutdown();
@@ -372,7 +374,6 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
     navigationViewModel.stopNavigation();
   }
 
-
   /**
    * Should be called after {@link NavigationView#onCreate(Bundle)}.
    * <p>
@@ -553,6 +554,7 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
     if (!isSubscribed) {
       initializeClickListeners();
       initializeOnMoveListener();
+      initializeOnFlingListener();
       subscribeViewModels();
     }
   }
@@ -566,6 +568,11 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
   private void initializeOnMoveListener() {
     onMoveListener = new NavigationOnMoveListener(navigationPresenter, summaryBehavior);
     navigationMap.addOnMoveListener(onMoveListener);
+  }
+
+  private void initializeOnFlingListener() {
+    onFlingListener = new NavigationOnFlingListener(navigationPresenter, summaryBehavior);
+    navigationMap.addOnFlingListener(onFlingListener);
   }
 
   private void establish(NavigationViewOptions options) {

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/NavigationMapboxMap.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/NavigationMapboxMap.java
@@ -192,8 +192,10 @@ public class NavigationMapboxMap {
     boolean isVisible = mapWayname.isVisible();
     String waynameText = mapWayname.retrieveWayname();
     boolean isCameraTracking = mapCamera.isTrackingEnabled();
+    @NavigationCamera.TrackingMode
+    int cameraTrackingMode = mapCamera.getCameraTrackingMode();
     NavigationMapboxMapInstanceState instanceState = new NavigationMapboxMapInstanceState(
-      isVisible, waynameText, isCameraTracking
+      isVisible, waynameText, isCameraTracking, cameraTrackingMode
     );
     outState.putParcelable(key, instanceState);
   }
@@ -215,8 +217,8 @@ public class NavigationMapboxMap {
     if (isVisible) {
       updateWaynameView(instanceState.retrieveWayname());
     }
-    boolean cameraTracking = instanceState.isCameraTracking();
-    updateCameraTrackingEnabled(cameraTracking);
+    updateCameraTrackingEnabled(instanceState.isCameraTracking());
+    updateCameraTrackingMode(instanceState.getCameraTrackingMode());
   }
 
   /**
@@ -294,6 +296,16 @@ public class NavigationMapboxMap {
    */
   public void updateCameraTrackingEnabled(boolean isEnabled) {
     mapCamera.updateCameraTrackingLocation(isEnabled);
+  }
+
+  /**
+   * Updates the {@link NavigationCamera.TrackingMode} that will be used when camera tracking is enabled.
+   *
+   * @param trackingMode the tracking mode
+   * @since 0.21.0
+   */
+  public void updateCameraTrackingMode(@NavigationCamera.TrackingMode int trackingMode) {
+    mapCamera.updateCameraTrackingMode(trackingMode);
   }
 
   /**
@@ -456,9 +468,19 @@ public class NavigationMapboxMap {
     mapboxMap.addOnMoveListener(onMoveListener);
   }
 
+  public void addOnFlingListener(MapboxMap.OnFlingListener onFlingListener) {
+    mapboxMap.addOnFlingListener(onFlingListener);
+  }
+
   public void removeOnMoveListener(MapboxMap.OnMoveListener onMoveListener) {
     if (onMoveListener != null) {
       mapboxMap.removeOnMoveListener(onMoveListener);
+    }
+  }
+
+  public void removeOnFlingListener(MapboxMap.OnFlingListener onFlingListener) {
+    if (onFlingListener != null) {
+      mapboxMap.removeOnFlingListener(onFlingListener);
     }
   }
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/NavigationMapboxMapInstanceState.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/NavigationMapboxMapInstanceState.java
@@ -3,16 +3,23 @@ package com.mapbox.services.android.navigation.ui.v5.map;
 import android.os.Parcel;
 import android.os.Parcelable;
 
+import com.mapbox.services.android.navigation.ui.v5.camera.NavigationCamera;
+
 public class NavigationMapboxMapInstanceState implements Parcelable {
 
   private final boolean isWaynameVisible;
   private final String waynameText;
   private final boolean isCameraTracking;
 
-  NavigationMapboxMapInstanceState(boolean isWaynameVisible, String waynameText, boolean isCameraTracking) {
+  @NavigationCamera.TrackingMode
+  private final int cameraTrackingMode;
+
+  NavigationMapboxMapInstanceState(boolean isWaynameVisible, String waynameText, boolean isCameraTracking,
+                                   @NavigationCamera.TrackingMode int cameraTrackingMode) {
     this.isWaynameVisible = isWaynameVisible;
     this.waynameText = waynameText;
     this.isCameraTracking = isCameraTracking;
+    this.cameraTrackingMode = cameraTrackingMode;
   }
 
   public boolean isWaynameVisible() {
@@ -27,10 +34,16 @@ public class NavigationMapboxMapInstanceState implements Parcelable {
     return isCameraTracking;
   }
 
+  @NavigationCamera.TrackingMode
+  public int getCameraTrackingMode() {
+    return cameraTrackingMode;
+  }
+
   private NavigationMapboxMapInstanceState(Parcel in) {
     isWaynameVisible = in.readByte() != 0;
     waynameText = in.readString();
     isCameraTracking = in.readByte() != 0;
+    cameraTrackingMode = in.readInt();
   }
 
   @Override
@@ -38,6 +51,7 @@ public class NavigationMapboxMapInstanceState implements Parcelable {
     dest.writeByte((byte) (isWaynameVisible ? 1 : 0));
     dest.writeString(waynameText);
     dest.writeByte((byte) (isCameraTracking ? 1 : 0));
+    dest.writeInt(cameraTrackingMode);
   }
 
   @Override
@@ -47,14 +61,14 @@ public class NavigationMapboxMapInstanceState implements Parcelable {
 
   public static final Creator<NavigationMapboxMapInstanceState> CREATOR =
     new Creator<NavigationMapboxMapInstanceState>() {
-    @Override
-    public NavigationMapboxMapInstanceState createFromParcel(Parcel in) {
-      return new NavigationMapboxMapInstanceState(in);
-    }
+      @Override
+      public NavigationMapboxMapInstanceState createFromParcel(Parcel in) {
+        return new NavigationMapboxMapInstanceState(in);
+      }
 
-    @Override
-    public NavigationMapboxMapInstanceState[] newArray(int size) {
-      return new NavigationMapboxMapInstanceState[size];
-    }
-  };
+      @Override
+      public NavigationMapboxMapInstanceState[] newArray(int size) {
+        return new NavigationMapboxMapInstanceState[size];
+      }
+    };
 }

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/camera/DynamicCameraTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/camera/DynamicCameraTest.java
@@ -61,16 +61,6 @@ public class DynamicCameraTest extends BaseTest {
   }
 
   @Test
-  public void onInformationFromRoute_engineCreatesCorrectBearing() throws Exception {
-    DynamicCamera cameraEngine = buildDynamicCamera();
-    RouteInformation routeInformation = RouteInformation.create(buildDirectionsRoute(), null, null);
-
-    double bearing = cameraEngine.bearing(routeInformation);
-
-    assertEquals(-99, Math.round(bearing));
-  }
-
-  @Test
   public void onHighDistanceRemaining_engineCreatesCorrectTilt() throws Exception {
     DynamicCamera cameraEngine = buildDynamicCamera();
     RouteInformation routeInformation = RouteInformation.create(null,
@@ -101,17 +91,6 @@ public class DynamicCameraTest extends BaseTest {
     double tilt = cameraEngine.tilt(routeInformation);
 
     assertEquals(45d, tilt);
-  }
-
-  @Test
-  public void onInformationFromLocationAndProgress_engineCreatesCorrectBearing() throws Exception {
-    DynamicCamera cameraEngine = buildDynamicCamera();
-    RouteInformation routeInformation = RouteInformation.create(null,
-      buildDefaultLocationUpdate(-77.0339782574523, 38.89993519985637), buildDefaultRouteProgress(null));
-
-    double bearing = cameraEngine.bearing(routeInformation);
-
-    assertEquals(100f, bearing, DELTA);
   }
 
   @Test

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/camera/Camera.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/camera/Camera.java
@@ -5,20 +5,15 @@ import com.mapbox.geojson.Point;
 import java.util.List;
 
 /**
- * This class handles calculating all properties necessary to configure the camera position while
- * routing. The {@link com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation} uses
- * a {@link SimpleCamera} by default. If you would like to customize the camera position, create a
+ * This class handles calculating camera's zoom and tilt properties while routing.
+ * The {@link com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation} uses
+ * a {@link SimpleCamera} by default. If you would like to customize the camera properties, create a
  * concrete implementation of this class or subclass {@link SimpleCamera} and update
  * {@link com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation#setCameraEngine(Camera)}.
  *
  * @since 0.10.0
  */
 public abstract class Camera {
-
-  /**
-   * Direction that the camera is pointing in, in degrees clockwise from north.
-   */
-  public abstract double bearing(RouteInformation routeInformation);
 
   /**
    * The angle, in degrees, of the camera angle from the nadir (directly facing the Earth).
@@ -32,6 +27,8 @@ public abstract class Camera {
    */
   public abstract double zoom(RouteInformation routeInformation);
 
-
+  /**
+   * Return a list of route coordinates that should be visible when creating the route's overview.
+   */
   public abstract List<Point> overview(RouteInformation routeInformation);
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/camera/SimpleCamera.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/camera/SimpleCamera.java
@@ -4,7 +4,6 @@ import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.core.constants.Constants;
 import com.mapbox.geojson.LineString;
 import com.mapbox.geojson.Point;
-import com.mapbox.turf.TurfMeasurement;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -21,19 +20,7 @@ public class SimpleCamera extends Camera {
   protected static final double DEFAULT_ZOOM = 15d;
 
   private List<Point> routeCoordinates = new ArrayList<>();
-  private double initialBearing;
   private DirectionsRoute initialRoute;
-
-  @Override
-  public double bearing(RouteInformation routeInformation) {
-    if (routeInformation.route() != null) {
-      setupLineStringAndBearing(routeInformation.route());
-      return initialBearing;
-    } else if (routeInformation.location() != null) {
-      return routeInformation.location().getBearing();
-    }
-    return 0;
-  }
 
   @Override
   public double tilt(RouteInformation routeInformation) {
@@ -63,15 +50,11 @@ public class SimpleCamera extends Camera {
   }
 
   private void setupLineStringAndBearing(DirectionsRoute route) {
-    if (initialRoute != null && route.equals(initialRoute)) {
+    if (route.equals(initialRoute)) {
       return; //no need to recalculate these values
     }
     initialRoute = route;
     routeCoordinates = generateRouteCoordinates(route);
-    initialBearing = TurfMeasurement.bearing(
-      Point.fromLngLat(routeCoordinates.get(0).longitude(), routeCoordinates.get(0).latitude()),
-      Point.fromLngLat(routeCoordinates.get(1).longitude(), routeCoordinates.get(1).latitude())
-    );
   }
 
   private List<Point> generateRouteCoordinates(DirectionsRoute route) {


### PR DESCRIPTION
Added `NAVIGATION_TRACKING_MODE_GPS` and `NAVIGATION_TRACKING_MODE_NORTH` as camera tracking options that can be set via `NavigationMapboxMap#updateCameraTrackingMode`.

![ezgif com-video-to-gif 5](https://user-images.githubusercontent.com/16925074/46345717-e44b8e00-c645-11e8-82b2-03d3123dd12b.gif)

Code used for the example:
```
    navigationView.retrieveNavigationMapboxMap().retrieveMap().addOnMapClickListener(new MapboxMap.OnMapClickListener() {

      private boolean isNorth;
      private Camera standardEngine = navigationView.retrieveMapboxNavigation().getCameraEngine();
      private Camera northEngine = new NorthCamera();

      @Override
      public void onMapClick(@NonNull LatLng point) {
        navigationView.retrieveNavigationMapboxMap().updateCameraTrackingMode(
          isNorth ? NavigationCamera.NAVIGATION_TRACKING_MODE_GPS : NavigationCamera.NAVIGATION_TRACKING_MODE_NORTH
        );
        navigationView.retrieveMapboxNavigation().setCameraEngine(
          isNorth ? standardEngine : northEngine
        );
        isNorth = !isNorth;
      }
    });
```
and
```
  private static class NorthCamera extends SimpleCamera {
    @Override
    public double tilt(RouteInformation routeInformation) {
      return 0;
    }
  }
```