### PR TITLE
Match min and max pitch values with iOS

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/camera/DynamicCamera.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/camera/DynamicCamera.java
@@ -19,8 +19,8 @@ import java.util.List;
 
 public class DynamicCamera extends SimpleCamera {
 
-  private static final double MAX_CAMERA_TILT = 50d;
-  private static final double MIN_CAMERA_TILT = 35d;
+  private static final double MAX_CAMERA_TILT = 60d;
+  private static final double MIN_CAMERA_TILT = 45d;
   private static final double MAX_CAMERA_ZOOM = 16d;
   private static final double MIN_CAMERA_ZOOM = 12d;
 

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/camera/DynamicCameraTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/camera/DynamicCameraTest.java
@@ -78,7 +78,7 @@ public class DynamicCameraTest extends BaseTest {
 
     double tilt = cameraEngine.tilt(routeInformation);
 
-    assertEquals(50d, tilt);
+    assertEquals(60d, tilt);
   }
 
   @Test
@@ -89,7 +89,7 @@ public class DynamicCameraTest extends BaseTest {
 
     double tilt = cameraEngine.tilt(routeInformation);
 
-    assertEquals(40d, tilt);
+    assertEquals(45d, tilt);
   }
 
   @Test
@@ -100,7 +100,7 @@ public class DynamicCameraTest extends BaseTest {
 
     double tilt = cameraEngine.tilt(routeInformation);
 
-    assertEquals(35d, tilt);
+    assertEquals(45d, tilt);
   }
 
   @Test


### PR DESCRIPTION
This PR changes the dynamic camera min and max values for pitch. 
These values match what the iOS implementation is using. 