### PR TITLE
Add tunnels functionality

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/RerouteActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/RerouteActivity.java
@@ -63,8 +63,8 @@ public class RerouteActivity extends AppCompatActivity implements OnMapReadyCall
   @BindView(R.id.instructionView)
   InstructionView instructionView;
 
-  private Point origin = Point.fromLngLat(-87.6900, 41.8529);
-  private Point destination = Point.fromLngLat(-87.8921, 41.9794);
+  private Point origin = Point.fromLngLat(-0.358764, 39.494876);
+  private Point destination = Point.fromLngLat(-0.383524, 39.497825);
   private Polyline polyline;
 
   private LocationLayerPlugin locationLayerPlugin;
@@ -73,6 +73,7 @@ public class RerouteActivity extends AppCompatActivity implements OnMapReadyCall
   private MapboxMap mapboxMap;
   private boolean running;
   private boolean tracking;
+  private boolean wasInTunnel = false;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -214,6 +215,15 @@ public class RerouteActivity extends AppCompatActivity implements OnMapReadyCall
 
   @Override
   public void onProgressChange(Location location, RouteProgress routeProgress) {
+    boolean isInTunnel = routeProgress.inTunnel();
+    if (!wasInTunnel && isInTunnel) {
+      wasInTunnel = true;
+      Snackbar.make(contentLayout, "Enter tunnel!", Snackbar.LENGTH_SHORT).show();
+    }
+    if (wasInTunnel && !isInTunnel) {
+      wasInTunnel = false;
+      Snackbar.make(contentLayout, "Exit tunnel!", Snackbar.LENGTH_SHORT).show();
+    }
     if (tracking) {
       locationLayerPlugin.forceLocationUpdate(location);
       CameraPosition cameraPosition = new CameraPosition.Builder()
@@ -252,7 +262,7 @@ public class RerouteActivity extends AppCompatActivity implements OnMapReadyCall
 
   @Override
   public void onFailure(Call<DirectionsResponse> call, Throwable throwable) {
-    Timber.e("Getting directions failed: ", throwable);
+    Timber.e(throwable);
   }
 
   private void getRoute(Point origin, Point destination, Float bearing) {

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/EmbeddedNavigationActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/EmbeddedNavigationActivity.java
@@ -132,6 +132,7 @@ public class EmbeddedNavigationActivity extends AppCompatActivity implements OnN
     navigationView.onDestroy();
     if (isFinishing()) {
       saveNightModeToPreferences(AppCompatDelegate.MODE_NIGHT_AUTO);
+      AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_AUTO);
     }
   }
 

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/fragment/NavigationFragment.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/fragment/NavigationFragment.java
@@ -1,10 +1,15 @@
 package com.mapbox.services.android.navigation.testapp.activity.navigationui.fragment;
 
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.location.Location;
 import android.os.Bundle;
+import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentActivity;
+import android.support.v7.app.AppCompatDelegate;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -20,16 +25,19 @@ import com.mapbox.services.android.navigation.ui.v5.NavigationViewOptions;
 import com.mapbox.services.android.navigation.ui.v5.OnNavigationReadyCallback;
 import com.mapbox.services.android.navigation.ui.v5.listeners.NavigationListener;
 import com.mapbox.services.android.navigation.v5.navigation.NavigationRoute;
+import com.mapbox.services.android.navigation.v5.routeprogress.ProgressChangeListener;
+import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 
 import retrofit2.Call;
 import retrofit2.Response;
 
-public class NavigationFragment extends Fragment implements OnNavigationReadyCallback, NavigationListener {
+public class NavigationFragment extends Fragment implements OnNavigationReadyCallback, NavigationListener,
+  ProgressChangeListener {
 
-  private static final double ORIGIN_LONGITUDE = -77.04012393951416;
-  private static final double ORIGIN_LATITUDE = 38.9111117447887;
-  private static final double DESTINATION_LONGITUDE = -77.03847169876099;
-  private static final double DESTINATION_LATITUDE = 38.91113678979344;
+  private static final double ORIGIN_LONGITUDE = -3.714873;
+  private static final double ORIGIN_LATITUDE = 40.397389;
+  private static final double DESTINATION_LONGITUDE = -3.712331;
+  private static final double DESTINATION_LATITUDE = 40.401686;
 
   private NavigationView navigationView;
   private DirectionsRoute directionsRoute;
@@ -44,6 +52,7 @@ public class NavigationFragment extends Fragment implements OnNavigationReadyCal
   @Override
   public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
     super.onViewCreated(view, savedInstanceState);
+    updateNightMode();
     navigationView = view.findViewById(R.id.navigation_view_fragment);
     navigationView.onCreate(savedInstanceState);
     navigationView.initialize(this);
@@ -122,6 +131,31 @@ public class NavigationFragment extends Fragment implements OnNavigationReadyCal
     // no-op
   }
 
+  @Override
+  public void onProgressChange(Location location, RouteProgress routeProgress) {
+    boolean isInTunnel = routeProgress.inTunnel();
+    boolean wasInTunnel = wasInTunnel();
+    if (isInTunnel) {
+      if (!wasInTunnel) {
+        updateWasInTunnel(true);
+        updateCurrentNightMode(AppCompatDelegate.MODE_NIGHT_YES);
+      }
+    } else {
+      if (wasInTunnel) {
+        updateWasInTunnel(false);
+        updateCurrentNightMode(AppCompatDelegate.MODE_NIGHT_AUTO);
+      }
+    }
+  }
+
+  private void updateNightMode() {
+    if (wasNavigationStopped()) {
+      updateWasNavigationStopped(false);
+      AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_AUTO);
+      getActivity().recreate();
+    }
+  }
+
   private void fetchRoute(Point origin, Point destination) {
     NavigationRoute.builder(getContext())
       .accessToken(Mapbox.getAccessToken())
@@ -145,6 +179,7 @@ public class NavigationFragment extends Fragment implements OnNavigationReadyCal
       .directionsRoute(directionsRoute)
       .shouldSimulateRoute(true)
       .navigationListener(NavigationFragment.this)
+      .progressChangeListener(this)
       .build();
     navigationView.startNavigation(options);
   }
@@ -155,6 +190,41 @@ public class NavigationFragment extends Fragment implements OnNavigationReadyCal
       FragmentNavigationActivity fragmentNavigationActivity = (FragmentNavigationActivity) activity;
       fragmentNavigationActivity.showPlaceholderFragment();
       fragmentNavigationActivity.showNavigationFab();
+      updateWasNavigationStopped(true);
+      updateWasInTunnel(false);
     }
+  }
+
+  private boolean wasInTunnel() {
+    Context context = getActivity();
+    SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
+    return preferences.getBoolean(context.getString(R.string.was_in_tunnel), false);
+  }
+
+  private void updateWasInTunnel(boolean wasInTunnel) {
+    Context context = getActivity();
+    SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
+    SharedPreferences.Editor editor = preferences.edit();
+    editor.putBoolean(context.getString(R.string.was_in_tunnel), wasInTunnel);
+    editor.apply();
+  }
+
+  private void updateCurrentNightMode(int nightMode) {
+    AppCompatDelegate.setDefaultNightMode(nightMode);
+    getActivity().recreate();
+  }
+
+  private boolean wasNavigationStopped() {
+    Context context = getActivity();
+    SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
+    return preferences.getBoolean(getString(R.string.was_navigation_stopped), false);
+  }
+
+  public void updateWasNavigationStopped(boolean wasNavigationStopped) {
+    Context context = getActivity();
+    SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
+    SharedPreferences.Editor editor = preferences.edit();
+    editor.putBoolean(getString(R.string.was_navigation_stopped), wasNavigationStopped);
+    editor.apply();
   }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,6 +47,8 @@
     <string name="default_locale" translatable="false">default_for_device</string>
     <string name="default_unit_type" translatable="false">default_for_device</string>
     <string name="current_night_mode" translatable="false">current_night_mode</string>
+    <string name="was_in_tunnel" translatable="false">was_in_tunnel</string>
+    <string name="was_navigation_stopped" translatable="false">was_navigation_stopped</string>
 
     <string name="error_route_not_available">Current route is not available</string>
     <string name="error_select_longer_route">Please select a longer route</string>

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/MapboxNavigationActivity.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/MapboxNavigationActivity.java
@@ -5,7 +5,6 @@ import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
-import android.support.v7.app.AppCompatDelegate;
 
 import com.mapbox.api.directions.v5.DirectionsCriteria;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
@@ -27,7 +26,6 @@ public class MapboxNavigationActivity extends AppCompatActivity implements OnNav
   protected void onCreate(@Nullable Bundle savedInstanceState) {
     setTheme(R.style.Theme_AppCompat_NoActionBar);
     super.onCreate(savedInstanceState);
-    AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_AUTO);
     setContentView(R.layout.activity_navigation);
     navigationView = findViewById(R.id.navigationView);
     navigationView.onCreate(savedInstanceState);

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/ThemeSwitcher.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/ThemeSwitcher.java
@@ -8,7 +8,6 @@ import android.graphics.drawable.Drawable;
 import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.support.v4.content.ContextCompat;
-import android.support.v7.app.AppCompatDelegate;
 import android.support.v7.content.res.AppCompatResources;
 import android.util.AttributeSet;
 import android.util.TypedValue;
@@ -86,7 +85,6 @@ public class ThemeSwitcher {
    */
   static void setTheme(Context context, AttributeSet attrs) {
     boolean nightModeEnabled = isNightModeEnabled(context);
-    updatePreferencesDarkEnabled(context, nightModeEnabled);
 
     if (shouldSetThemeFromPreferences(context)) {
       int prefLightTheme = retrieveThemeResIdFromPreferences(context, NavigationConstants.NAVIGATION_VIEW_LIGHT_THEME);
@@ -114,23 +112,10 @@ public class ThemeSwitcher {
 
   /**
    * Returns true if the current UI_MODE_NIGHT is enabled, false otherwise.
-   *
-   * @param context to retrieve the current configuration
    */
   private static boolean isNightModeEnabled(Context context) {
-    if (isNightModeFollowSystem()) {
-      AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_AUTO);
-    }
-    int uiMode = retrieveCurrentUiMode(context);
-    return uiMode == Configuration.UI_MODE_NIGHT_YES;
-  }
-
-  /**
-   * Returns true if the current UI_MODE_NIGHT is undefined, false otherwise.
-   */
-  private static boolean isNightModeFollowSystem() {
-    int nightMode = AppCompatDelegate.getDefaultNightMode();
-    return nightMode == AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM;
+    int currentNightMode = retrieveCurrentUiMode(context);
+    return currentNightMode == Configuration.UI_MODE_NIGHT_YES;
   }
 
   private static int retrieveCurrentUiMode(Context context) {
@@ -143,13 +128,6 @@ public class ThemeSwitcher {
     TypedValue outValue = new TypedValue();
     context.getTheme().resolveAttribute(resId, outValue, true);
     return outValue;
-  }
-
-  private static void updatePreferencesDarkEnabled(Context context, boolean darkThemeEnabled) {
-    SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
-    SharedPreferences.Editor editor = preferences.edit();
-    editor.putBoolean(context.getString(R.string.dark_theme_enabled), darkThemeEnabled);
-    editor.apply();
   }
 
   private static boolean shouldSetThemeFromPreferences(Context context) {

--- a/libandroid-navigation-ui/src/main/res/values/strings.xml
+++ b/libandroid-navigation-ui/src/main/res/values/strings.xml
@@ -50,8 +50,6 @@
             translatable="false">mapbox://styles/mapbox/navigation-guidance-day-v4</string>
     <string name="navigation_guidance_night"
             translatable="false">mapbox://styles/mapbox/navigation-guidance-night-v4</string>
-    <string name="dark_theme_enabled"
-            translatable="false">dark_theme_enabled</string>
     <string name="navigation_view_instance_state"
             translatable="false">navigation_view_instance_state</string>
     <string name="navigation_running"


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-navigation-android/issues/835
- Adds tunnels functionality
  - ~~Adds a new option (`TunnelListener`) to `NavigationViewOptions`~~
    - Should we expose new APIs in `MapboxNavigation` for adding / removing this listener? Or even remove this listener altogether? Currently it's possible to get the same `inTunnel` information attaching to `ProgressChangeListener` and querying the `RouteProgress` 👀 https://github.com/mapbox/mapbox-navigation-android/blob/9c8d687e11da7788b813c7f8423ff30e9f3279b1/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/RerouteActivity.java#L218 Is this adding a duplicated behavior or making the API more friendly? Thoughts @danesfeder @devotaaabel? 👉 https://github.com/mapbox/mapbox-navigation-android/pull/1392#issuecomment-427094945
  - The SDK doesn't change day-night mode automatically anymore. Clients should be responsible of this moving forward. We 👀 if `isNightModeEnabled` and set the theme accordingly though. Kinda revert https://github.com/mapbox/mapbox-navigation-android/pull/1018
  - Adds day-night mode (UI) switching when entering / exiting a tunnel to some examples from the test app in order to showcase how to implement that behavior from a client point of view

TODOs

- [ ] Noticed that in the `EmbeddedNavigationActivity` and `FragmentNavigationActivity` examples from the test app voice instructions are "duplicated" after recreating the `Activity`