### PR TITLE
Bump mapbox-navigation-native version to 3.1.5

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -11,7 +11,7 @@ ext {
       mapboxMapSdk       : '6.5.0',
       mapboxSdkServices  : '4.0.0',
       mapboxEvents       : '3.2.0',
-      mapboxNavigator    : '3.1.3',
+      mapboxNavigator    : '3.1.5',
       locationLayerPlugin: '0.10.0',
       autoValue          : '1.5.4',
       autoValueParcel    : '0.2.5',


### PR DESCRIPTION
- Bumps `mapbox-navigation-native` version to `3.1.5`