### PR TITLE
Fix component navigation activity camera issues

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/ComponentNavigationActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/ComponentNavigationActivity.java
@@ -136,6 +136,7 @@ public class ComponentNavigationActivity extends AppCompatActivity implements On
 
     // For navigation logic / processing
     initializeNavigation(mapboxMap);
+    navigationMap.updateCameraTrackingEnabled(false);
   }
 
   @Override
@@ -160,6 +161,7 @@ public class ComponentNavigationActivity extends AppCompatActivity implements On
 
   @OnClick(R.id.startNavigationFab)
   public void onStartNavigationClick(FloatingActionButton floatingActionButton) {
+    navigationMap.updateCameraTrackingEnabled(true);
     // Transition to navigation state
     mapState = MapState.NAVIGATION;
 
@@ -182,6 +184,7 @@ public class ComponentNavigationActivity extends AppCompatActivity implements On
 
   @OnClick(R.id.cancelNavigationFab)
   public void onCancelNavigationClick(FloatingActionButton floatingActionButton) {
+    navigationMap.updateCameraTrackingEnabled(false);
     // Transition to info state
     mapState = MapState.INFO;
 


### PR DESCRIPTION
- Fixes `ComponentNavigationActivity` camera issues introduced by latest changes in the Location Layer Plugin

Follow up PR from https://github.com/mapbox/mapbox-navigation-android/pull/1373#issuecomment-428525554
> Going to open a PR that disables the camera tracking while not navigating.

