### PR TITLE
Delay start navigation until route received in MockNavigationActivity

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/MockNavigationActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/MockNavigationActivity.java
@@ -192,8 +192,6 @@ public class MockNavigationActivity extends AppCompatActivity implements OnMapRe
       Toast.makeText(this, "Only 2 waypoints supported", Toast.LENGTH_LONG).show();
     }
     mapboxMap.addMarker(new MarkerOptions().position(point));
-
-    startRouteButton.setVisibility(View.VISIBLE);
     calculateRoute();
   }
 
@@ -227,6 +225,7 @@ public class MockNavigationActivity extends AppCompatActivity implements OnMapRe
             DirectionsRoute directionsRoute = response.body().routes().get(0);
             MockNavigationActivity.this.route = directionsRoute;
             navigationMapRoute.addRoutes(response.body().routes());
+            startRouteButton.setVisibility(View.VISIBLE);
           }
         }
       }


### PR DESCRIPTION
Found in CI:

```
java.lang.IllegalArgumentException: Non-null and non-empty location list required.
FATAL EXCEPTION: ControllerMessenger
Process: com.mapbox.services.android.navigation.testapp, PID: 17023
java.lang.IllegalArgumentException: Non-null and non-empty location list required.
	at com.mapbox.services.android.navigation.v5.location.replay.ReplayLocationDispatcher.checkValidInput(ReplayLocationDispatcher.java:79)
	at com.mapbox.services.android.navigation.v5.location.replay.ReplayLocationDispatcher.<init>(ReplayLocationDispatcher.java:22)
	at com.mapbox.services.android.navigation.v5.location.replay.ReplayRouteLocationEngine.obtainDispatcher(ReplayRouteLocationEngine.java:180)
	at com.mapbox.services.android.navigation.v5.location.replay.ReplayRouteLocationEngine.start(ReplayRouteLocationEngine.java:170)
	at com.mapbox.services.android.navigation.v5.location.replay.ReplayRouteLocationEngine.assign(ReplayRouteLocationEngine.java:59)
	at com.mapbox.services.android.navigation.testapp.activity.MockNavigationActivity.onStartRouteClick(MockNavigationActivity.java:145)
	at com.mapbox.services.android.navigation.testapp.activity.MockNavigationActivity_ViewBinding$2.doClick(MockNavigationActivity_ViewBinding.java:50)
	at butterknife.internal.DebouncingOnClickListener.onClick(DebouncingOnClickListener.java:22)
	at android.view.View.performClick(View.java:4780)
	at android.view.View$PerformClick.run(View.java:19866)
	at android.os.Handler.handleCallback(Handler.java:739)
	at android.os.Handler.dispatchMessage(Handler.java:95)
	at androidx.test.espresso.base.Interrogator.a(Interrogator.java:19)
	at androidx.test.espresso.base.UiControllerImpl.a(UiControllerImpl.java:164)
	at androidx.test.espresso.base.UiControllerImpl.a(UiControllerImpl.java:156)
	at androidx.test.espresso.base.UiControllerImpl.a(UiControllerImpl.java:34)
	at androidx.test.espresso.action.MotionEvents.a(MotionEvents.java:75)
	at androidx.test.espresso.action.MotionEvents.a(MotionEvents.java:50)
	at androidx.test.espresso.action.Tap.c(Tap.java:9)
	at androidx.test.espresso.action.Tap.a(Tap.java:19)
	at androidx.test.espresso.action.Tap$1.b(Tap.java:2)
	at androidx.test.espresso.action.GeneralClickAction.perform(GeneralClickAction.java:22)
	at androidx.test.espresso.ViewInteraction$SingleExecutionViewAction.perform(ViewInteraction.java:9)
	at androidx.test.espresso.ViewInteraction.a(ViewInteraction.java:78)
	at androidx.test.espresso.ViewInteraction.a(ViewInteraction.java:94)
	at androidx.test.espresso.ViewInteraction$1.call(ViewInteraction.java:3)
	at java.util.concurrent.FutureTask.run(FutureTask.java:237)
	at android.os.Handler.handleCallback(Handler.java:739)
	at android.os.Handler.dispatchMessage(Handler.java:95)
	at android.os.Looper.loop(Looper.java:135)
	at android.app.ActivityThread.main(ActivityThread.java:5254)
	at java.lang.reflect.Method.invoke(Native Method)
	at java.lang.reflect.Method.invoke(Method.java:372)
	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:903)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:698)
```