### PR TITLE
Fix shields not showing up for some display densities

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/UrlDensityMap.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/UrlDensityMap.java
@@ -1,6 +1,7 @@
 package com.mapbox.services.android.navigation.ui.v5.instruction;
 
 import android.content.Context;
+import android.os.Build;
 import android.util.DisplayMetrics;
 import android.util.SparseArray;
 
@@ -17,11 +18,34 @@ class UrlDensityMap extends SparseArray<String> {
   UrlDensityMap(Context context) {
     super(4);
     displayDensity = context.getResources().getDisplayMetrics().densityDpi;
+    put(DisplayMetrics.DENSITY_LOW, ONE_X + DOT_PNG);
     put(DisplayMetrics.DENSITY_MEDIUM, ONE_X + DOT_PNG);
     put(DisplayMetrics.DENSITY_HIGH, TWO_X + DOT_PNG);
     put(DisplayMetrics.DENSITY_XHIGH, THREE_X + DOT_PNG);
-    put(DisplayMetrics.DENSITY_XXHIGH, THREE_X + DOT_PNG);
-    put(DisplayMetrics.DENSITY_XXXHIGH, FOUR_X + DOT_PNG);
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+      put(DisplayMetrics.DENSITY_XXHIGH, THREE_X + DOT_PNG);
+    }
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+      put(DisplayMetrics.DENSITY_XXXHIGH, FOUR_X + DOT_PNG);
+    }
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+      put(DisplayMetrics.DENSITY_400, THREE_X + DOT_PNG);
+    }
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+      put(DisplayMetrics.DENSITY_560, FOUR_X + DOT_PNG);
+    }
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
+      put(DisplayMetrics.DENSITY_280, TWO_X + DOT_PNG);
+    }
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      put(DisplayMetrics.DENSITY_360, THREE_X + DOT_PNG);
+      put(DisplayMetrics.DENSITY_420, THREE_X + DOT_PNG);
+    }
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
+      put(DisplayMetrics.DENSITY_260, TWO_X + DOT_PNG);
+      put(DisplayMetrics.DENSITY_300, TWO_X + DOT_PNG);
+      put(DisplayMetrics.DENSITY_340, THREE_X + DOT_PNG);
+    }
   }
 
   public String get(String url) {


### PR DESCRIPTION
- Fixes shields not showing up for some display densities

Fixes #992 - noting that this PR doesn't fix https://github.com/mapbox/mapbox-navigation-android/issues/992#issuecomment-394731090
> we currently don't load shields in the sub banner