### PR TITLE
Bump Android Gradle plugin version to 3.2.1

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -41,7 +41,7 @@ ext {
       errorprone       : '0.0.13',
       coveralls        : '2.8.1',
       spotbugs         : '1.3',
-      gradle           : '3.2.0',
+      gradle           : '3.2.1',
       dependencyGraph  : '0.3.0',
       dependencyUpdates: '0.20.0'
   ]


### PR DESCRIPTION
- Bumps Android Gradle plugin version to `3.2.1`