### PR TITLE
Show turn lanes when sub BannerText is not present

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionView.java
@@ -642,7 +642,9 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
 
   private boolean shouldShowTurnLanes(List<IntersectionLanes> turnLanes,
                                       String maneuverViewModifier, double durationRemaining) {
-    return turnLanes != null && !TextUtils.isEmpty(maneuverViewModifier)
+    return subStepLayout.getVisibility() != VISIBLE
+      && turnLanes != null
+      && !TextUtils.isEmpty(maneuverViewModifier)
       && durationRemaining <= VALID_DURATION_REMAINING;
   }
 


### PR DESCRIPTION
The turn lanes will now only show when the `sub()` `BannerText` is not currently showing.  This prevents the views from competing to be shown, which was previously possible.  