### PR TITLE
Stop scrolling before notifying InstructionListAdapter

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionListTransitionListener.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionListTransitionListener.java
@@ -31,6 +31,7 @@ class InstructionListTransitionListener extends TransitionListenerAdapter {
   }
 
   private void onAnimationFinished() {
+    rvInstructions.stopScroll();
     instructionListAdapter.notifyDataSetChanged();
     rvInstructions.smoothScrollToPosition(TOP);
   }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionView.java
@@ -832,6 +832,7 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
   private void updateInstructionList(InstructionModel model) {
     RouteProgress routeProgress = model.retrieveProgress();
     boolean isListShowing = instructionListLayout.getVisibility() == VISIBLE;
+    rvInstructions.stopScroll();
     instructionListAdapter.updateBannerListWith(routeProgress, isListShowing);
   }
 }


### PR DESCRIPTION
The epic saga of fixing the instruction list `RecyclerView` continues.  Seeing an `IllegalStateException` occurring when trying to update the `InstructionListAdapter` while the `RecyclerView` is still scrolling:

```
Fatal Exception: java.lang.IllegalStateException
Cannot call this method while RecyclerView is computing a layout or scrolling android.support.v7.widget.RecyclerView{3139e9ac VFED.... ......ID 0,0-480,618 #7f0800bb app:id/rvInstructions}, adapter:com.mapbox.services.android.navigation.ui.v5.summary.list.InstructionListAdapter@10f27ae3, layout:android.support.v7.widget.LinearLayoutManager@741ace0, context:com.mapbox.logistics.ui.LogisticsActivity@2bce6a5d
android.support.v7.widget.RecyclerView.assertNotInLayoutOrScroll (RecyclerView.java:2769)
android.support.v7.widget.RecyclerView$Adapter.notifyDataSetChanged (RecyclerView.java:6961)
com.mapbox.services.android.navigation.ui.v5.instruction.InstructionListTransitionListener.onAnimationFinished (InstructionListTransitionListener.java:34)
com.mapbox.services.android.navigation.ui.v5.instruction.InstructionListTransitionListener.onTransitionEnd (InstructionListTransitionListener.java:24)
```