### PR TITLE
Check for valid index before updating steps in NavigationRouteProcessor

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteProcessor.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteProcessor.java
@@ -106,9 +106,14 @@ class NavigationRouteProcessor {
   }
 
   private void updateSteps(DirectionsRoute route, int legIndex, int stepIndex, int upcomingStepIndex) {
-    currentLeg = route.legs().get(legIndex);
+    List<RouteLeg> legs = route.legs();
+    if (legIndex < legs.size()) {
+      currentLeg = legs.get(legIndex);
+    }
     List<LegStep> steps = currentLeg.steps();
-    currentStep = steps.get(stepIndex);
+    if (stepIndex < steps.size()) {
+      currentStep = steps.get(stepIndex);
+    }
     upcomingStep = upcomingStepIndex < steps.size() - ONE_INDEX ? steps.get(upcomingStepIndex) : null;
   }
 


### PR DESCRIPTION
Fixes #1413 

This could be a data edge case with `MapMatching` given @Danny-James setup, but still something we should guard against. 

cc @kevinkreiser something to look into here (could very well be a problem on our side) - `NavigationStatus` is providing leg / step indices that are out of bounds of the current route leg / step lists.  