### PR TITLE
Update UrlDensityMap for more screen densities

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionView.java
@@ -14,12 +14,10 @@ import android.support.transition.TransitionManager;
 import android.support.v4.app.FragmentActivity;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.graphics.drawable.DrawableCompat;
-import android.support.v4.widget.TextViewCompat;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.text.TextUtils;
 import android.util.AttributeSet;
-import android.util.TypedValue;
 import android.view.View;
 import android.view.animation.Animation;
 import android.view.animation.AnimationUtils;
@@ -409,7 +407,6 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
     rvInstructions = findViewById(R.id.rvInstructions);
     soundButton = findViewById(R.id.soundLayout);
     feedbackButton = findViewById(R.id.feedbackLayout);
-    initializeInstructionAutoSize();
   }
 
   /**
@@ -437,17 +434,6 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
         DrawableCompat.setTint(turnLaneBackground, navigationViewListBackgroundColor);
       }
     }
-  }
-
-  /**
-   * Called after we bind the views, this will allow the step instruction {@link TextView}
-   * to automatically re-size based on the length of the text.
-   */
-  private void initializeInstructionAutoSize() {
-    TextViewCompat.setAutoSizeTextTypeUniformWithConfiguration(upcomingPrimaryText,
-      26, 30, 1, TypedValue.COMPLEX_UNIT_SP);
-    TextViewCompat.setAutoSizeTextTypeUniformWithConfiguration(upcomingSecondaryText,
-      20, 26, 1, TypedValue.COMPLEX_UNIT_SP);
   }
 
   /**

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/UrlDensityMap.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/UrlDensityMap.java
@@ -28,6 +28,24 @@ class UrlDensityMap extends SparseArray<String> {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
       put(DisplayMetrics.DENSITY_XXXHIGH, FOUR_X + DOT_PNG);
     }
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+      put(DisplayMetrics.DENSITY_400, THREE_X + DOT_PNG);
+    }
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+      put(DisplayMetrics.DENSITY_560, FOUR_X + DOT_PNG);
+    }
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
+      put(DisplayMetrics.DENSITY_280, TWO_X + DOT_PNG);
+    }
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      put(DisplayMetrics.DENSITY_360, THREE_X + DOT_PNG);
+      put(DisplayMetrics.DENSITY_420, THREE_X + DOT_PNG);
+    }
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
+      put(DisplayMetrics.DENSITY_260, TWO_X + DOT_PNG);
+      put(DisplayMetrics.DENSITY_300, TWO_X + DOT_PNG);
+      put(DisplayMetrics.DENSITY_340, THREE_X + DOT_PNG);
+    }
   }
 
   public String get(String url) {

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/list/InstructionListPresenter.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/list/InstructionListPresenter.java
@@ -15,7 +15,7 @@ import com.mapbox.services.android.navigation.v5.utils.RouteUtils;
 import java.util.ArrayList;
 import java.util.List;
 
-public class InstructionListPresenter {
+class InstructionListPresenter {
 
   private static final int TWO_LINES = 2;
   private static final int ONE_LINE = 1;

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/list/InstructionViewHolder.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/list/InstructionViewHolder.java
@@ -2,10 +2,8 @@ package com.mapbox.services.android.navigation.ui.v5.summary.list;
 
 import android.content.res.Configuration;
 import android.support.constraint.ConstraintLayout;
-import android.support.v4.widget.TextViewCompat;
 import android.support.v7.widget.RecyclerView;
 import android.text.SpannableString;
-import android.util.TypedValue;
 import android.view.View;
 import android.widget.TextView;
 
@@ -13,14 +11,6 @@ import com.mapbox.services.android.navigation.ui.v5.R;
 import com.mapbox.services.android.navigation.ui.v5.instruction.maneuver.ManeuverView;
 
 class InstructionViewHolder extends RecyclerView.ViewHolder implements InstructionListView {
-
-  private static final int PRIMARY_MIN_TEXT_SIZE_SP = 26;
-  private static final int PRIMARY_MAX_TEXT_SIZE_SP = 28;
-  private static final int SECONDARY_MIN_TEXT_SIZE_SP = 20;
-  private static final int SECONDARY_MAX_TEXT_SIZE_SP = 26;
-  private static final int DISTANCE_MIN_TEXT_SIZE_SP = 16;
-  private static final int DISTANCE_MAX_TEXT_SIZE_SP = 20;
-  private static final int AUTO_SIZE_STEP_GRANULARITY = 1;
 
   private ManeuverView maneuverView;
   private TextView distanceText;
@@ -35,7 +25,6 @@ class InstructionViewHolder extends RecyclerView.ViewHolder implements Instructi
     primaryText = itemView.findViewById(R.id.stepPrimaryText);
     secondaryText = itemView.findViewById(R.id.stepSecondaryText);
     instructionLayoutText = itemView.findViewById(R.id.instructionLayoutText);
-    initInstructionAutoSize();
   }
 
   @Override
@@ -76,15 +65,6 @@ class InstructionViewHolder extends RecyclerView.ViewHolder implements Instructi
   @Override
   public void updateBannerVerticalBias(float percentBias) {
     adjustBannerVerticalBias(percentBias);
-  }
-
-  private void initInstructionAutoSize() {
-    TextViewCompat.setAutoSizeTextTypeUniformWithConfiguration(primaryText,
-      PRIMARY_MIN_TEXT_SIZE_SP, PRIMARY_MAX_TEXT_SIZE_SP, AUTO_SIZE_STEP_GRANULARITY, TypedValue.COMPLEX_UNIT_SP);
-    TextViewCompat.setAutoSizeTextTypeUniformWithConfiguration(secondaryText,
-      SECONDARY_MIN_TEXT_SIZE_SP, SECONDARY_MAX_TEXT_SIZE_SP, AUTO_SIZE_STEP_GRANULARITY, TypedValue.COMPLEX_UNIT_SP);
-    TextViewCompat.setAutoSizeTextTypeUniformWithConfiguration(distanceText,
-      DISTANCE_MIN_TEXT_SIZE_SP, DISTANCE_MAX_TEXT_SIZE_SP, AUTO_SIZE_STEP_GRANULARITY, TypedValue.COMPLEX_UNIT_SP);
   }
 
   private void adjustBannerVerticalBias(float percentBias) {


### PR DESCRIPTION
Also removes `TextViewCompat.setAutoSizeTextTypeUniformWithConfiguration` which could be causing some shield image artifacts - I don't believe this is as necessary anymore with the abbreviation work added in #887 