### PR TITLE
make use of fixed duration for non tracking statuses

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -11,7 +11,7 @@ ext {
       mapboxMapSdk       : '6.6.1',
       mapboxSdkServices  : '4.0.0',
       mapboxEvents       : '3.4.0',
-      mapboxNavigator    : '3.1.5',
+      mapboxNavigator    : '3.2.0',
       locationLayerPlugin: '0.10.0',
       autoValue          : '1.5.4',
       autoValueParcel    : '0.2.5',

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteProcessor.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteProcessor.java
@@ -27,7 +27,7 @@ import static com.mapbox.services.android.navigation.v5.navigation.NavigationHel
 class NavigationRouteProcessor {
 
   private static final int ONE_INDEX = 1;
-  private static final long ONE_SECOND_IN_MILLISECONDS = 1000L;
+  private static final double ONE_SECOND_IN_MILLISECONDS = 1000.0;
   private RouteProgress previousRouteProgress;
   private DirectionsRoute route;
   private RouteLeg currentLeg;
@@ -71,8 +71,7 @@ class NavigationRouteProcessor {
     double routeDistanceRemaining = routeDistanceRemaining(legDistanceRemaining, legIndex, route);
     double stepDistanceRemaining = status.getRemainingStepDistance();
     double stepDistanceTraveled = currentStep.distance() - stepDistanceRemaining;
-    double legDurationRemaining = status.getRouteState() == RouteState.TRACKING
-      ? status.getRemainingLegDuration() / ONE_SECOND_IN_MILLISECONDS : route.duration();
+    double legDurationRemaining = status.getRemainingLegDuration() / ONE_SECOND_IN_MILLISECONDS;
 
     currentLegAnnotation = createCurrentAnnotation(currentLegAnnotation, currentLeg, legDistanceRemaining);
     StepIntersection currentIntersection = findCurrentIntersection(

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteProcessor.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteProcessor.java
@@ -9,7 +9,6 @@ import com.mapbox.api.directions.v5.models.RouteLeg;
 import com.mapbox.api.directions.v5.models.StepIntersection;
 import com.mapbox.geojson.Point;
 import com.mapbox.navigator.NavigationStatus;
-import com.mapbox.navigator.RouteState;
 import com.mapbox.navigator.VoiceInstruction;
 import com.mapbox.services.android.navigation.v5.routeprogress.CurrentLegAnnotation;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;


### PR DESCRIPTION
fixes #1404

This uses the latest native release to fix the issue regarding ETA when the user isn't navigating on the route, either after having just loaded the road (initialized status), just having completed the route (complete status) or having gone off route (offroute status). The initialized status will hold a duration that is that of the entire loaded route leg and will update once you beging tracking on the route. For complete the duration will be 0 and for off route the duration should be the last duration you saw before you went off route.