### PR TITLE
Replace LocationLayerPlugin with LocationComponent

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,7 +42,6 @@ dependencies {
   // Mapbox Navigation SDK
   implementation project(':libandroid-navigation-ui')
   implementation dependenciesList.mapboxMapSdk
-  implementation dependenciesList.locationLayerPlugin
 
   // Support libraries
   implementation dependenciesList.supportAppcompatV7

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/RerouteActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/RerouteActivity.java
@@ -22,11 +22,11 @@ import com.mapbox.mapboxsdk.annotations.PolylineOptions;
 import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
 import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.location.LocationComponent;
+import com.mapbox.mapboxsdk.location.modes.RenderMode;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
-import com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerPlugin;
-import com.mapbox.mapboxsdk.plugins.locationlayer.modes.RenderMode;
 import com.mapbox.services.android.navigation.testapp.R;
 import com.mapbox.services.android.navigation.ui.v5.instruction.InstructionView;
 import com.mapbox.services.android.navigation.v5.location.replay.ReplayRouteLocationEngine;
@@ -66,7 +66,6 @@ public class RerouteActivity extends HistoryActivity implements OnMapReadyCallba
   private Point destination = Point.fromLngLat(-0.383524, 39.497825);
   private Polyline polyline;
 
-  private LocationLayerPlugin locationLayerPlugin;
   private ReplayRouteLocationEngine mockLocationEngine;
   private MapboxNavigation navigation;
   private MapboxMap mapboxMap;
@@ -102,14 +101,10 @@ public class RerouteActivity extends HistoryActivity implements OnMapReadyCallba
     mapView.onResume();
   }
 
-  @SuppressLint("MissingPermission")
   @Override
   protected void onStart() {
     super.onStart();
     mapView.onStart();
-    if (locationLayerPlugin != null) {
-      locationLayerPlugin.onStart();
-    }
   }
 
   @Override
@@ -124,10 +119,6 @@ public class RerouteActivity extends HistoryActivity implements OnMapReadyCallba
     mapView.onStop();
 
     shutdownLocationEngine();
-
-    if (locationLayerPlugin != null) {
-      locationLayerPlugin.onStop();
-    }
 
     if (navigation != null) {
       navigation.stopNavigation();
@@ -159,8 +150,10 @@ public class RerouteActivity extends HistoryActivity implements OnMapReadyCallba
     this.mapboxMap = mapboxMap;
     mapboxMap.addOnMapClickListener(this);
 
-    locationLayerPlugin = new LocationLayerPlugin(mapView, mapboxMap);
-    locationLayerPlugin.setRenderMode(RenderMode.GPS);
+    LocationComponent locationComponent = mapboxMap.getLocationComponent();
+    locationComponent.activateLocationComponent(this);
+    locationComponent.setLocationComponentEnabled(true);
+    locationComponent.setRenderMode(RenderMode.GPS);
 
     mockLocationEngine = new ReplayRouteLocationEngine();
     mockLocationEngine.addLocationEngineListener(this);
@@ -177,7 +170,7 @@ public class RerouteActivity extends HistoryActivity implements OnMapReadyCallba
   @Override
   public void onLocationChanged(Location location) {
     if (!tracking) {
-      locationLayerPlugin.forceLocationUpdate(location);
+      mapboxMap.getLocationComponent().forceLocationUpdate(location);
     }
   }
 
@@ -225,7 +218,7 @@ public class RerouteActivity extends HistoryActivity implements OnMapReadyCallba
       Snackbar.make(contentLayout, "Exit tunnel!", Snackbar.LENGTH_SHORT).show();
     }
     if (tracking) {
-      locationLayerPlugin.forceLocationUpdate(location);
+      mapboxMap.getLocationComponent().forceLocationUpdate(location);
       CameraPosition cameraPosition = new CameraPosition.Builder()
         .zoom(15)
         .target(new LatLng(location.getLatitude(), location.getLongitude()))

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/ComponentNavigationActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/ComponentNavigationActivity.java
@@ -34,6 +34,7 @@ import com.mapbox.services.android.navigation.testapp.R;
 import com.mapbox.services.android.navigation.testapp.activity.HistoryActivity;
 import com.mapbox.services.android.navigation.testapp.activity.location.FusedLocationEngine;
 import com.mapbox.services.android.navigation.ui.v5.camera.DynamicCamera;
+import com.mapbox.services.android.navigation.ui.v5.camera.NavigationCamera;
 import com.mapbox.services.android.navigation.ui.v5.instruction.InstructionView;
 import com.mapbox.services.android.navigation.ui.v5.map.NavigationMapboxMap;
 import com.mapbox.services.android.navigation.ui.v5.voice.NavigationSpeechPlayer;
@@ -131,7 +132,7 @@ public class ComponentNavigationActivity extends HistoryActivity implements OnMa
 
     // For navigation logic / processing
     initializeNavigation(mapboxMap);
-    navigationMap.updateCameraTrackingEnabled(false);
+    navigationMap.updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_NONE);
   }
 
   @Override
@@ -156,7 +157,7 @@ public class ComponentNavigationActivity extends HistoryActivity implements OnMa
 
   @OnClick(R.id.startNavigationFab)
   public void onStartNavigationClick(FloatingActionButton floatingActionButton) {
-    navigationMap.updateCameraTrackingEnabled(true);
+    navigationMap.updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_GPS);
     // Transition to navigation state
     mapState = MapState.NAVIGATION;
 
@@ -177,7 +178,7 @@ public class ComponentNavigationActivity extends HistoryActivity implements OnMa
 
   @OnClick(R.id.cancelNavigationFab)
   public void onCancelNavigationClick(FloatingActionButton floatingActionButton) {
-    navigationMap.updateCameraTrackingEnabled(false);
+    navigationMap.updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_NONE);
     // Transition to info state
     mapState = MapState.INFO;
 

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/DualNavigationMapActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/DualNavigationMapActivity.java
@@ -22,11 +22,11 @@ import com.mapbox.mapboxsdk.annotations.Marker;
 import com.mapbox.mapboxsdk.annotations.MarkerViewOptions;
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
 import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.location.LocationComponent;
+import com.mapbox.mapboxsdk.location.modes.RenderMode;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
-import com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerPlugin;
-import com.mapbox.mapboxsdk.plugins.locationlayer.modes.RenderMode;
 import com.mapbox.services.android.navigation.testapp.R;
 import com.mapbox.services.android.navigation.ui.v5.NavigationView;
 import com.mapbox.services.android.navigation.ui.v5.NavigationViewOptions;
@@ -56,17 +56,15 @@ public class DualNavigationMapActivity extends AppCompatActivity implements OnNa
   private Point origin = Point.fromLngLat(-122.423579, 37.761689);
   private Point destination = Point.fromLngLat(-122.426183, 37.760872);
   private DirectionsRoute route;
-  private boolean isNavigationRunning;
-  private LocationLayerPlugin locationLayer;
   private LocationEngine locationEngine;
   private NavigationMapRoute mapRoute;
   private MapboxMap mapboxMap;
   private Marker currentMarker;
+  private boolean isNavigationRunning;
   private boolean locationFound;
+  private boolean[] constraintChanged;
   private ConstraintSet navigationMapConstraint;
   private ConstraintSet navigationMapExpandedConstraint;
-  private boolean[] constraintChanged;
-
 
   @Override
   protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -94,9 +92,9 @@ public class DualNavigationMapActivity extends AppCompatActivity implements OnNa
   @Override
   public void onMapReady(MapboxMap mapboxMap) {
     this.mapboxMap = mapboxMap;
-    this.mapboxMap.setOnMapLongClickListener(this);
+    this.mapboxMap.addOnMapLongClickListener(this);
     initLocationEngine();
-    initLocationLayer();
+    initializeLocationLayer();
     initMapRoute();
     fetchRoute();
   }
@@ -164,9 +162,6 @@ public class DualNavigationMapActivity extends AppCompatActivity implements OnNa
     super.onStart();
     navigationView.onStart();
     mapView.onStart();
-    if (locationLayer != null) {
-      locationLayer.onStart();
-    }
   }
 
   @Override
@@ -224,9 +219,6 @@ public class DualNavigationMapActivity extends AppCompatActivity implements OnNa
     super.onStop();
     navigationView.onStop();
     mapView.onStop();
-    if (locationLayer != null) {
-      locationLayer.onStop();
-    }
   }
 
   @Override
@@ -313,9 +305,11 @@ public class DualNavigationMapActivity extends AppCompatActivity implements OnNa
   }
 
   @SuppressWarnings( {"MissingPermission"})
-  private void initLocationLayer() {
-    locationLayer = new LocationLayerPlugin(mapView, mapboxMap, locationEngine);
-    locationLayer.setRenderMode(RenderMode.COMPASS);
+  private void initializeLocationLayer() {
+    LocationComponent locationComponent = mapboxMap.getLocationComponent();
+    locationComponent.activateLocationComponent(this, locationEngine);
+    locationComponent.setLocationComponentEnabled(true);
+    locationComponent.setRenderMode(RenderMode.COMPASS);
   }
 
   private void initMapRoute() {

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -12,7 +12,6 @@ ext {
       mapboxSdkServices  : '4.0.0',
       mapboxEvents       : '3.4.0',
       mapboxNavigator    : '3.2.0',
-      locationLayerPlugin: '0.10.0',
       autoValue          : '1.5.4',
       autoValueParcel    : '0.2.5',
       junit              : '4.12',
@@ -53,7 +52,6 @@ ext {
       mapboxSdkTurf          : "com.mapbox.mapboxsdk:mapbox-sdk-turf:${version.mapboxSdkServices}",
       mapboxEvents           : "com.mapbox.mapboxsdk:mapbox-android-telemetry:${version.mapboxEvents}",
       mapboxNavigator        : "com.mapbox.navigator:mapbox-navigation-native:${version.mapboxNavigator}",
-      locationLayerPlugin    : "com.mapbox.mapboxsdk:mapbox-android-plugin-locationlayer:${version.locationLayerPlugin}",
 
       // AutoValue
       autoValue              : "com.google.auto.value:auto-value:${version.autoValue}",

--- a/libandroid-navigation-ui/build.gradle
+++ b/libandroid-navigation-ui/build.gradle
@@ -48,9 +48,6 @@ dependencies {
   implementation dependenciesList.lifecycleExtensions
   annotationProcessor dependenciesList.lifecycleCompiler
 
-  // Mapbox plugins
-  implementation dependenciesList.locationLayerPlugin
-
   // AutoValues
   annotationProcessor dependenciesList.autoValue
   compileOnly dependenciesList.autoValue

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationContract.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationContract.java
@@ -4,6 +4,7 @@ import android.location.Location;
 
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.geojson.Point;
+import com.mapbox.services.android.navigation.ui.v5.camera.NavigationCamera;
 
 public interface NavigationContract {
 
@@ -17,7 +18,7 @@ public interface NavigationContract {
 
     void updateWaynameVisibility(boolean isVisible);
 
-    void updateCameraTrackingEnabled(boolean isEnabled);
+    void updateCameraTrackingMode(@NavigationCamera.TrackingMode int trackingMode);
 
     void resetCameraPosition();
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationOnCameraTrackingChangedListener.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationOnCameraTrackingChangedListener.java
@@ -2,7 +2,7 @@ package com.mapbox.services.android.navigation.ui.v5;
 
 import android.support.design.widget.BottomSheetBehavior;
 
-import com.mapbox.mapboxsdk.plugins.locationlayer.OnCameraTrackingChangedListener;
+import com.mapbox.mapboxsdk.location.OnCameraTrackingChangedListener;
 
 /**
  * Listener used to detect user interaction with the map while driving.

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationPresenter.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationPresenter.java
@@ -5,6 +5,7 @@ import android.support.design.widget.BottomSheetBehavior;
 
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.geojson.Point;
+import com.mapbox.services.android.navigation.ui.v5.camera.NavigationCamera;
 
 class NavigationPresenter {
 
@@ -31,7 +32,7 @@ class NavigationPresenter {
     if (!view.isSummaryBottomSheetHidden()) {
       view.setSummaryBehaviorHideable(true);
       view.setSummaryBehaviorState(BottomSheetBehavior.STATE_HIDDEN);
-      view.updateCameraTrackingEnabled(false);
+      view.updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_NONE);
       view.updateWaynameVisibility(false);
     }
   }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
@@ -24,6 +24,7 @@ import com.mapbox.mapboxsdk.constants.MapboxConstants;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.services.android.navigation.ui.v5.camera.NavigationCamera;
 import com.mapbox.services.android.navigation.ui.v5.instruction.ImageCoordinator;
 import com.mapbox.services.android.navigation.ui.v5.instruction.InstructionView;
 import com.mapbox.services.android.navigation.ui.v5.map.NavigationMapboxMap;
@@ -225,17 +226,18 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
     return summaryBehavior.getState() == BottomSheetBehavior.STATE_HIDDEN;
   }
 
+
   @Override
-  public void updateCameraTrackingEnabled(boolean isEnabled) {
+  public void updateCameraTrackingMode(int trackingMode) {
     if (navigationMap != null) {
-      navigationMap.updateCameraTrackingEnabled(isEnabled);
+      navigationMap.updateCameraTrackingMode(trackingMode);
     }
   }
 
   @Override
   public void resetCameraPosition() {
     if (navigationMap != null) {
-      navigationMap.resetCameraPosition();
+      navigationMap.resetCameraPositionWith(NavigationCamera.NAVIGATION_TRACKING_MODE_GPS);
     }
   }
 

--- a/libandroid-navigation-ui/src/main/res/values/styles.xml
+++ b/libandroid-navigation-ui/src/main/res/values/styles.xml
@@ -74,7 +74,7 @@
         <item name="navigationViewMapStyle">@string/navigation_guidance_night</item>
     </style>
     
-    <style name="NavigationLocationLayerStyle" parent="@style/mapbox_LocationLayer">
+    <style name="NavigationLocationLayerStyle" parent="@style/mapbox_LocationComponent">
         <item name="mapbox_trackingAnimationDurationMultiplier">2.0</item>
     </style>
 

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/camera/NavigationCameraTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/camera/NavigationCameraTest.java
@@ -1,8 +1,8 @@
 package com.mapbox.services.android.navigation.ui.v5.camera;
 
+import com.mapbox.mapboxsdk.location.LocationComponent;
+import com.mapbox.mapboxsdk.location.modes.CameraMode;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
-import com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerPlugin;
-import com.mapbox.mapboxsdk.plugins.locationlayer.modes.CameraMode;
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation;
 import com.mapbox.services.android.navigation.v5.routeprogress.ProgressChangeListener;
 
@@ -18,58 +18,58 @@ import static org.mockito.Mockito.verify;
 public class NavigationCameraTest {
 
   @Test
-  public void sanity() throws Exception {
+  public void sanity() {
     NavigationCamera camera = buildCamera();
 
     assertNotNull(camera);
   }
 
   @Test
-  public void setTrackingEnabled_trackingIsEnabled() throws Exception {
-    LocationLayerPlugin locationLayerPlugin = mock(LocationLayerPlugin.class);
-    NavigationCamera camera = buildCamera(locationLayerPlugin);
+  public void setTrackingEnabled_trackingIsEnabled() {
+    LocationComponent locationComponent = mock(LocationComponent.class);
+    NavigationCamera camera = buildCamera(locationComponent);
 
-    verify(locationLayerPlugin, times(1)).setCameraMode(CameraMode.TRACKING_GPS);
-    verify(locationLayerPlugin, times(0)).setCameraMode(CameraMode.NONE);
+    verify(locationComponent, times(1)).setCameraMode(CameraMode.TRACKING_GPS);
+    verify(locationComponent, times(0)).setCameraMode(CameraMode.NONE);
 
-    camera.updateCameraTrackingLocation(false);
-    verify(locationLayerPlugin, times(1)).setCameraMode(CameraMode.NONE);
+    camera.updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_NONE);
+    verify(locationComponent, times(1)).setCameraMode(CameraMode.NONE);
 
-    camera.updateCameraTrackingLocation(true);
-    verify(locationLayerPlugin, times(2)).setCameraMode(CameraMode.TRACKING_GPS);
+    camera.updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_GPS);
+    verify(locationComponent, times(2)).setCameraMode(CameraMode.TRACKING_GPS);
 
     assertTrue(camera.isTrackingEnabled());
   }
 
   @Test
-  public void setTrackingDisabled_trackingIsDisabled() throws Exception {
-    LocationLayerPlugin locationLayerPlugin = mock(LocationLayerPlugin.class);
-    NavigationCamera camera = buildCamera(locationLayerPlugin);
+  public void setTrackingDisabled_trackingIsDisabled() {
+    LocationComponent locationComponent = mock(LocationComponent.class);
+    NavigationCamera camera = buildCamera(locationComponent);
 
-    verify(locationLayerPlugin, times(1)).setCameraMode(CameraMode.TRACKING_GPS);
-    verify(locationLayerPlugin, times(0)).setCameraMode(CameraMode.NONE);
+    verify(locationComponent, times(1)).setCameraMode(CameraMode.TRACKING_GPS);
+    verify(locationComponent, times(0)).setCameraMode(CameraMode.NONE);
 
-    camera.updateCameraTrackingLocation(true);
-    verify(locationLayerPlugin, times(2)).setCameraMode(CameraMode.TRACKING_GPS);
+    camera.updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_GPS);
+    verify(locationComponent, times(2)).setCameraMode(CameraMode.TRACKING_GPS);
 
-    camera.updateCameraTrackingLocation(false);
-    verify(locationLayerPlugin, times(1)).setCameraMode(CameraMode.NONE);
+    camera.updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_NONE);
+    verify(locationComponent, times(1)).setCameraMode(CameraMode.NONE);
 
     assertFalse(camera.isTrackingEnabled());
   }
 
   @Test
-  public void onResetCamera_trackingIsResumed() throws Exception {
+  public void onResetCamera_trackingIsResumed() {
     NavigationCamera camera = buildCamera();
 
-    camera.updateCameraTrackingLocation(false);
-    camera.resetCameraPosition();
+    camera.updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_NONE);
+    camera.resetCameraPositionWith(NavigationCamera.NAVIGATION_TRACKING_MODE_GPS);
 
     assertTrue(camera.isTrackingEnabled());
   }
 
   @Test
-  public void onStartWithNullRoute_progressListenerIsAdded() throws Exception {
+  public void onStartWithNullRoute_progressListenerIsAdded() {
     MapboxNavigation navigation = mock(MapboxNavigation.class);
     ProgressChangeListener listener = mock(ProgressChangeListener.class);
     NavigationCamera camera = buildCamera(navigation, listener);
@@ -80,7 +80,7 @@ public class NavigationCameraTest {
   }
 
   @Test
-  public void onResumeWithNullLocation_progressListenerIsAdded() throws Exception {
+  public void onResumeWithNullLocation_progressListenerIsAdded() {
     MapboxNavigation navigation = mock(MapboxNavigation.class);
     ProgressChangeListener listener = mock(ProgressChangeListener.class);
     NavigationCamera camera = buildCamera(navigation, listener);
@@ -91,14 +91,14 @@ public class NavigationCameraTest {
   }
 
   private NavigationCamera buildCamera() {
-    return new NavigationCamera(mock(MapboxMap.class), mock(MapboxNavigation.class), mock(LocationLayerPlugin.class));
+    return new NavigationCamera(mock(MapboxMap.class), mock(MapboxNavigation.class), mock(LocationComponent.class));
   }
 
-  private NavigationCamera buildCamera(LocationLayerPlugin locationLayerPlugin) {
-    return new NavigationCamera(mock(MapboxMap.class), mock(MapboxNavigation.class), locationLayerPlugin);
+  private NavigationCamera buildCamera(LocationComponent locationComponent) {
+    return new NavigationCamera(mock(MapboxMap.class), mock(MapboxNavigation.class), locationComponent);
   }
 
   private NavigationCamera buildCamera(MapboxNavigation navigation, ProgressChangeListener listener) {
-    return new NavigationCamera(mock(MapboxMap.class), navigation, listener, mock(LocationLayerPlugin.class));
+    return new NavigationCamera(mock(MapboxMap.class), navigation, listener, mock(LocationComponent.class));
   }
 }

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/map/NavigationMapboxMapTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/map/NavigationMapboxMapTest.java
@@ -1,8 +1,8 @@
 package com.mapbox.services.android.navigation.ui.v5.map;
 
-import com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerPlugin;
-import com.mapbox.mapboxsdk.plugins.locationlayer.modes.RenderMode;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
+import com.mapbox.mapboxsdk.location.LocationComponent;
+import com.mapbox.mapboxsdk.location.modes.RenderMode;
 import com.mapbox.services.android.navigation.ui.v5.route.NavigationMapRoute;
 import com.mapbox.services.android.navigation.ui.v5.route.OnRouteSelectionChangeListener;
 
@@ -60,14 +60,14 @@ public class NavigationMapboxMapTest {
   }
 
   @Test
-  public void updateRenderMode_locationLayerIsUpdatedWithRenderMode() {
-    LocationLayerPlugin locationLayer = mock(LocationLayerPlugin.class);
-    NavigationMapboxMap theNavigationMap = new NavigationMapboxMap(locationLayer);
+  public void updateRenderMode_locationComponentIsUpdatedWithRenderMode() {
+    LocationComponent locationComponent = mock(LocationComponent.class);
+    NavigationMapboxMap theNavigationMap = new NavigationMapboxMap(locationComponent);
     int renderMode = RenderMode.GPS;
 
     theNavigationMap.updateLocationLayerRenderMode(renderMode);
 
-    verify(locationLayer).setRenderMode(eq(renderMode));
+    verify(locationComponent).setRenderMode(eq(renderMode));
   }
 
   @Test


### PR DESCRIPTION
Closes #1431 

This PR replaces the `LocationLayerPlugin` with `MapboxMap#getLocationComponent`.  We no longer need to pull in a separate dependency at this is now part of the Maps SDK.  Noting (and also labeled) that this PR breaks SEMVER in a few places that we can note in the release notes. 

- TODO:
   - [x] Update tests
   - [x] Update javadoc
   - [x] Run through test app 

