### PR TITLE
Fix sub BannerText loading shields for first time

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionTarget.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionTarget.java
@@ -91,6 +91,10 @@ public class InstructionTarget implements Target {
 
   private static CharSequence truncateImageSpan(Spannable instructionSpannable, TextView textView) {
     int availableSpace = textView.getWidth() - textView.getPaddingRight() - textView.getPaddingLeft();
-    return TextUtils.ellipsize(instructionSpannable, textView.getPaint(), availableSpace, TextUtils.TruncateAt.END);
+    if (availableSpace > 0) {
+      return TextUtils.ellipsize(instructionSpannable, textView.getPaint(), availableSpace, TextUtils.TruncateAt.END);
+    } else {
+      return instructionSpannable;
+    }
   }
 }


### PR DESCRIPTION
The first time we are showing the `sub_instruction_layout.xml`, `TextView#getWidth()` is returning `0`, because it hasn't been drawn on the screen yet.  Our `truncateImageSpan` method was seeing this and returning `""` because it thinks there isn't any room to show anything.  We should check the available space before we run that truncation code.  FWIW, this truncation code should be less necessary with the abbreviation work.  

We were seeing:

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/8434572/47313801-dcac5300-d60d-11e8-91f9-6f778d93c2c8.gif)

This PR:

![ezgif com-video-to-gif 1](https://user-images.githubusercontent.com/8434572/47314026-8095fe80-d60e-11e8-8f1f-e189952edbe1.gif)



