### PR TITLE
Correct iconSize expression

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/NavigationMapRoute.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/NavigationMapRoute.java
@@ -873,10 +873,10 @@ public class NavigationMapRoute implements MapView.OnMapChangedListener,
         ),
         PropertyFactory.iconSize(interpolate(
           exponential(1.5f), zoom(),
-          stop(22f, 2.8f),
-          stop(12f, 1.3f),
+          stop(0f, 0.6f),
           stop(10f, 0.8f),
-          stop(0f, 0.6f)
+          stop(12f, 1.3f),
+          stop(22f, 2.8f)
         )),
         PropertyFactory.iconPitchAlignment(Property.ANCHOR_MAP),
         PropertyFactory.iconAllowOverlap(true),

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/NavigationMapRoute.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/NavigationMapRoute.java
@@ -878,7 +878,7 @@ public class NavigationMapRoute implements MapView.OnMapChangedListener,
           stop(12f, 1.3f),
           stop(22f, 2.8f)
         )),
-        PropertyFactory.iconPitchAlignment(Property.ANCHOR_MAP),
+        PropertyFactory.iconPitchAlignment(Property.ICON_PITCH_ALIGNMENT_MAP),
         PropertyFactory.iconAllowOverlap(true),
         PropertyFactory.iconIgnorePlacement(true)
       );


### PR DESCRIPTION
When testing out something downstream, I was seeing:
 
> Error setting property: icon-size [5]: Input/output pairs for "interpolate" expressions must be arranged with input values in strictly ascending order.

This PR fixes this issue + changed the iconPitchAlignment value (lint was showing a warning for this). 