### PR TITLE
Makes gradle.properties license listing consisting with repo

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,8 +7,8 @@ POM_SCM_URL=https://github.com/mapbox/mapbox-navigation-android
 POM_SCM_CONNECTION=scm:git@github.com:mapbox/mapbox-navigation-android.git
 POM_SCM_DEV_CONNECTION=scm:git@github.com:mapbox/mapbox-navigation-android.git
 
-POM_LICENCE_NAME=The Apache Software License, Version 2.0
-POM_LICENCE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt
+POM_LICENCE_NAME=The MIT License
+POM_LICENCE_URL=https://opensource.org/licenses/MIT
 POM_LICENCE_DIST=repo
 
 POM_DEVELOPER_ID=mapbox


### PR DESCRIPTION
We're currently using the [MIT License](https://github.com/mapbox/mapbox-navigation-android/blob/master/LICENSE) in this repo but Gradle properties (used by our Maven publication script) had inconsistent content. Note that this PR does not suggest a change of license, it only updates one of our script to accurately list the license we're currently including with the repo.

/cc: @kathleenlu09 