### PR TITLE
Update Maps SDK Release 6.7.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,7 +8,7 @@ ext {
   ]
 
   version = [
-      mapboxMapSdk       : '6.6.5',
+      mapboxMapSdk       : '6.7.0',
       mapboxSdkServices  : '4.0.0',
       mapboxEvents       : '3.5.2',
       mapboxNavigator    : '3.3.1',


### PR DESCRIPTION
This PR will serve as a CI testing ground for all maps `alpha` and `beta` releases - resulting in the eventual `6.7.0` update. 

cc @mapbox/maps-android 