### PR TITLE
Allow access to AlertView and the ability to enable or disable

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
@@ -27,6 +27,7 @@ import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.services.android.navigation.ui.v5.camera.NavigationCamera;
 import com.mapbox.services.android.navigation.ui.v5.instruction.ImageCoordinator;
 import com.mapbox.services.android.navigation.ui.v5.instruction.InstructionView;
+import com.mapbox.services.android.navigation.ui.v5.instruction.NavigationAlertView;
 import com.mapbox.services.android.navigation.ui.v5.map.NavigationMapboxMap;
 import com.mapbox.services.android.navigation.ui.v5.map.NavigationMapboxMapInstanceState;
 import com.mapbox.services.android.navigation.ui.v5.summary.SummaryBottomSheet;
@@ -437,6 +438,16 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
    */
   public NavigationButton retrieveRecenterButton() {
     return recenterBtn;
+  }
+
+  /**
+   * Returns the {@link NavigationAlertView} that is shown during off-route events with
+   * "Report a Problem" text.
+   *
+   * @return alert view that is used in the instruction view
+   */
+  public NavigationAlertView retrieveAlertView() {
+    return instructionView.retrieveAlertView();
   }
 
   private void initializeView() {

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionView.java
@@ -116,6 +116,11 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
     initialize();
   }
 
+  /**
+   * Adds a listener that is triggered when the instruction list in InstructionView is shown or hidden.
+   *
+   * @param instructionListListener to be set
+   */
   public void setInstructionListListener(InstructionListListener instructionListListener) {
     this.instructionListListener = instructionListListener;
   }
@@ -372,6 +377,16 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
    */
   public NavigationButton retrieveFeedbackButton() {
     return feedbackButton;
+  }
+
+  /**
+   * Returns the {@link NavigationAlertView} that is shown during off-route events with
+   * "Report a Problem" text.
+   *
+   * @return alert view that is used in the instruction view
+   */
+  public NavigationAlertView retrieveAlertView() {
+    return alertView;
   }
 
   /**

--- a/libandroid-navigation-ui/src/main/res/values/strings.xml
+++ b/libandroid-navigation-ui/src/main/res/values/strings.xml
@@ -36,6 +36,12 @@
     <!-- Feedback type for Road Closed -->
     <string name="feedback_road_closure">Road\nClosed</string>
 
+    <!-- Shown after a feedback type has been submitted -->
+    <string name="feedback_submitted">Feedback Submitted</string>
+
+    <!-- Shown in off-route scenarios to provide feedback -->
+    <string name="report_problem">Report Problem</string>
+
     <!-- Test app dialog text -->
     <string name="dropoff_dialog_text">Do you want to navigate to next destination?</string>
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationConstants.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationConstants.java
@@ -118,11 +118,6 @@ public final class NavigationConstants {
   public static final double MINIMUM_DISTANCE_BEFORE_REROUTING = 50;
 
   /**
-   * Text to be shown in AlertView during off-route scenario.
-   */
-  public static final String REPORT_PROBLEM = "Report Problem";
-
-  /**
    * Duration in which the AlertView is shown with the "Report Problem" text.
    */
   public static final long ALERT_VIEW_PROBLEM_DURATION = 10000;
@@ -131,11 +126,6 @@ public final class NavigationConstants {
    * Duration in which the feedback BottomSheet is shown.
    */
   public static final long FEEDBACK_BOTTOM_SHEET_DURATION = 10000;
-
-  /**
-   * Shown in AlertView after a particular feedback item has been selected.
-   */
-  public static final String FEEDBACK_SUBMITTED = "Feedback Submitted";
 
   /**
    * If a set of light / dark themes been set in {@link android.content.SharedPreferences}


### PR DESCRIPTION
Closes #1462 Closes #1463 

Adds an API to `InstructionView` and `NavigationView` to enable / disable the `NavigationAlertView` (enabled by default).  

Also adds localization to `"Report Problem"` and `"Feedback Submitted"` strings used in the `NavigationAlertView`. 

@P-Zenker the Strings should be showing up in Transifex now.  If you'd like to add your translations, we will pull them down after they are updated.  Thanks! 