### PR TITLE
Bump mapbox-navigation-native version to 3.2.1

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -11,7 +11,7 @@ ext {
       mapboxMapSdk       : '6.6.1',
       mapboxSdkServices  : '4.0.0',
       mapboxEvents       : '3.4.0',
-      mapboxNavigator    : '3.2.0',
+      mapboxNavigator    : '3.2.1',
       autoValue          : '1.5.4',
       autoValueParcel    : '0.2.5',
       junit              : '4.12',


### PR DESCRIPTION
- Bumps `mapbox-navigation-native` version to `3.2.1`