### PR TITLE
Fix ReplayRouteLocationConverter.java that function calculateMockLoca…

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/location/replay/ReplayRouteLocationConverter.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/location/replay/ReplayRouteLocationConverter.java
@@ -81,7 +81,7 @@ class ReplayRouteLocationConverter {
       Location mockedLocation = createMockLocationFrom(point);
 
       if (pointsToCopy.size() >= 2) {
-        double bearing = TurfMeasurement.bearing(point, points.get(1));
+        double bearing = TurfMeasurement.bearing(point, pointsToCopy.get(1));
         mockedLocation.setBearing((float) bearing);
       }
       time += delay * ONE_SECOND_IN_MILLISECONDS;


### PR DESCRIPTION
Fix ReplayRouteLocationConverter.java that function calculateMockLocations return points with wrong bearing.