### PR TITLE
Remove dynamic padding way name adjustment for MapWayname

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
@@ -238,6 +238,7 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
   @Override
   public void resetCameraPosition() {
     if (navigationMap != null) {
+      navigationMap.resetPadding();
       navigationMap.resetCameraPositionWith(NavigationCamera.NAVIGATION_TRACKING_MODE_GPS);
     }
   }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/MapPaddingAdjustor.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/MapPaddingAdjustor.java
@@ -9,51 +9,67 @@ import com.mapbox.services.android.navigation.ui.v5.R;
 
 class MapPaddingAdjustor {
 
-  private static final int[] ZERO_MAP_PADDING = {0, 0, 0, 0};
   private static final int BOTTOMSHEET_PADDING_MULTIPLIER = 4;
   private static final int WAYNAME_PADDING_MULTIPLIER = 2;
 
-  private final int defaultTopPadding;
-  private final int waynameTopPadding;
-  private MapboxMap mapboxMap;
+  private final MapboxMap mapboxMap;
+  private final int[] defaultPadding;
+  private int[] customPadding;
 
   MapPaddingAdjustor(MapView mapView, MapboxMap mapboxMap) {
     this.mapboxMap = mapboxMap;
-    defaultTopPadding = calculateTopPaddingDefault(mapView);
-    waynameTopPadding = calculateTopPaddingWithWayname(mapView.getContext(), defaultTopPadding);
+    defaultPadding = calculateDefaultPadding(mapView);
   }
 
-  void updateTopPaddingWithWayname() {
-    updateTopPadding(waynameTopPadding);
+  // Testing only
+  MapPaddingAdjustor(MapboxMap mapboxMap, int[] defaultPadding) {
+    this.mapboxMap = mapboxMap;
+    this.defaultPadding = defaultPadding;
   }
 
-  void updateTopPaddingWithDefault() {
-    updateTopPadding(defaultTopPadding);
+  void updatePaddingWithDefault() {
+    customPadding = null;
+    updatePaddingWith(defaultPadding);
   }
 
-  void removeAllPadding() {
-    updatePadding(ZERO_MAP_PADDING);
+  void adjustLocationIconWith(int[] customPadding) {
+    this.customPadding = customPadding;
+    updatePaddingWith(customPadding);
   }
 
-  private int calculateTopPaddingDefault(MapView mapView) {
+  int[] retrieveCurrentPadding() {
+    return mapboxMap.getPadding();
+  }
+
+  boolean isUsingDefault() {
+    return customPadding == null;
+  }
+
+  void updatePaddingWith(int[] padding) {
+    mapboxMap.setPadding(padding[0], padding[1], padding[2], padding[3]);
+  }
+
+  void resetPadding() {
+    if (isUsingDefault()) {
+      updatePaddingWithDefault();
+    } else {
+      adjustLocationIconWith(customPadding);
+    }
+  }
+
+  private int[] calculateDefaultPadding(MapView mapView) {
+    int defaultTopPadding = calculateTopPaddingWithoutWayname(mapView);
+    Resources resources = mapView.getContext().getResources();
+    int waynameLayoutHeight = (int) resources.getDimension(R.dimen.wayname_view_height);
+    int topPadding = defaultTopPadding - (waynameLayoutHeight * WAYNAME_PADDING_MULTIPLIER);
+    return new int[] {0, topPadding, 0, 0};
+  }
+
+  private int calculateTopPaddingWithoutWayname(MapView mapView) {
     Context context = mapView.getContext();
     Resources resources = context.getResources();
     int mapViewHeight = mapView.getHeight();
     int bottomSheetHeight = (int) resources.getDimension(R.dimen.summary_bottomsheet_height);
     return mapViewHeight - (bottomSheetHeight * BOTTOMSHEET_PADDING_MULTIPLIER);
-  }
-
-  private int calculateTopPaddingWithWayname(Context context, int defaultTopPadding) {
-    Resources resources = context.getResources();
-    int waynameLayoutHeight = (int) resources.getDimension(R.dimen.wayname_view_height);
-    return defaultTopPadding - (waynameLayoutHeight * WAYNAME_PADDING_MULTIPLIER);
-  }
-
-  private void updatePadding(int[] padding) {
-    mapboxMap.setPadding(padding[0], padding[1], padding[2], padding[3]);
-  }
-
-  private void updateTopPadding(int topPadding) {
-    mapboxMap.setPadding(0, topPadding, 0, 0);
   }
 }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/MapPaddingInstanceState.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/MapPaddingInstanceState.java
@@ -1,0 +1,51 @@
+package com.mapbox.services.android.navigation.ui.v5.map;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+class MapPaddingInstanceState implements Parcelable {
+
+  private final int[] currentPadding;
+  private final boolean shouldUseDefault;
+
+  MapPaddingInstanceState(int[] currentPadding, boolean shouldUseDefault) {
+    this.currentPadding = currentPadding;
+    this.shouldUseDefault = shouldUseDefault;
+  }
+
+  int[] retrieveCurrentPadding() {
+    return currentPadding;
+  }
+
+  boolean shouldUseDefault() {
+    return shouldUseDefault;
+  }
+
+  private MapPaddingInstanceState(Parcel in) {
+    currentPadding = in.createIntArray();
+    shouldUseDefault = in.readByte() != 0;
+  }
+
+  @Override
+  public void writeToParcel(Parcel dest, int flags) {
+    dest.writeIntArray(currentPadding);
+    dest.writeByte((byte) (shouldUseDefault ? 1 : 0));
+  }
+
+  @Override
+  public int describeContents() {
+    return 0;
+  }
+
+  public static final Creator<MapPaddingInstanceState> CREATOR = new Creator<MapPaddingInstanceState>() {
+    @Override
+    public MapPaddingInstanceState createFromParcel(Parcel in) {
+      return new MapPaddingInstanceState(in);
+    }
+
+    @Override
+    public MapPaddingInstanceState[] newArray(int size) {
+      return new MapPaddingInstanceState[size];
+    }
+  };
+}

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/MapWayname.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/MapWayname.java
@@ -27,7 +27,6 @@ class MapWayname {
   private WaynameLayoutProvider layoutProvider;
   private MapLayerInteractor layerInteractor;
   private WaynameFeatureFinder featureInteractor;
-  private MapPaddingAdjustor paddingAdjustor;
   private List<Point> currentStepPoints = new ArrayList<>();
   private Location currentLocation = null;
   private MapboxNavigation navigation;
@@ -42,7 +41,7 @@ class MapWayname {
     this.layoutProvider = layoutProvider;
     this.layerInteractor = layerInteractor;
     this.featureInteractor = featureInteractor;
-    this.paddingAdjustor = paddingAdjustor;
+    paddingAdjustor.updatePaddingWithDefault();
   }
 
   void updateWaynameWithPoint(PointF point, SymbolLayer waynameLayer) {
@@ -52,7 +51,6 @@ class MapWayname {
     List<Feature> roads = findRoadLabelFeatures(point);
     boolean shouldBeVisible = !roads.isEmpty();
     adjustWaynameVisibility(shouldBeVisible, waynameLayer);
-    adjustMapPadding(shouldBeVisible);
     if (!shouldBeVisible) {
       return;
     }
@@ -67,7 +65,6 @@ class MapWayname {
 
   void updateWaynameVisibility(boolean isVisible, SymbolLayer waynameLayer) {
     this.isVisible = isVisible;
-    adjustMapPadding(isVisible);
     if (checkWaynameVisibility(isVisible, waynameLayer)) {
       return;
     }
@@ -190,14 +187,6 @@ class MapWayname {
         updateWaynameVisibility(true, waynameLayer);
         updateWaynameLayer(wayname, waynameLayer);
       }
-    }
-  }
-
-  private void adjustMapPadding(boolean isVisible) {
-    if (isVisible) {
-      paddingAdjustor.updateTopPaddingWithWayname();
-    } else {
-      paddingAdjustor.updateTopPaddingWithDefault();
     }
   }
 }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/NavigationMapboxMapInstanceState.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/NavigationMapboxMapInstanceState.java
@@ -9,40 +9,43 @@ public class NavigationMapboxMapInstanceState implements Parcelable {
 
   private final boolean isWaynameVisible;
   private final String waynameText;
-  private final boolean isCameraTracking;
+  private final MapPaddingInstanceState mapPaddingInstanceState;
 
   @NavigationCamera.TrackingMode
   private final int cameraTrackingMode;
 
-  NavigationMapboxMapInstanceState(boolean isWaynameVisible, String waynameText, boolean isCameraTracking,
+  NavigationMapboxMapInstanceState(boolean isWaynameVisible,
+                                   String waynameText,
+                                   int[] currentPadding,
+                                   boolean shouldUseDefaultPadding,
                                    @NavigationCamera.TrackingMode int cameraTrackingMode) {
     this.isWaynameVisible = isWaynameVisible;
     this.waynameText = waynameText;
-    this.isCameraTracking = isCameraTracking;
+    this.mapPaddingInstanceState = new MapPaddingInstanceState(currentPadding, shouldUseDefaultPadding);
     this.cameraTrackingMode = cameraTrackingMode;
   }
 
-  public boolean isWaynameVisible() {
+  boolean isWaynameVisible() {
     return isWaynameVisible;
   }
 
-  public String retrieveWayname() {
+  String retrieveWayname() {
     return waynameText;
   }
 
-  public boolean isCameraTracking() {
-    return isCameraTracking;
+  MapPaddingInstanceState retrieveMapPadding() {
+    return mapPaddingInstanceState;
   }
 
   @NavigationCamera.TrackingMode
-  public int getCameraTrackingMode() {
+  int getCameraTrackingMode() {
     return cameraTrackingMode;
   }
 
   private NavigationMapboxMapInstanceState(Parcel in) {
     isWaynameVisible = in.readByte() != 0;
     waynameText = in.readString();
-    isCameraTracking = in.readByte() != 0;
+    mapPaddingInstanceState = in.readParcelable(MapPaddingInstanceState.class.getClassLoader());
     cameraTrackingMode = in.readInt();
   }
 
@@ -50,7 +53,7 @@ public class NavigationMapboxMapInstanceState implements Parcelable {
   public void writeToParcel(Parcel dest, int flags) {
     dest.writeByte((byte) (isWaynameVisible ? 1 : 0));
     dest.writeString(waynameText);
-    dest.writeByte((byte) (isCameraTracking ? 1 : 0));
+    dest.writeParcelable(mapPaddingInstanceState, flags);
     dest.writeInt(cameraTrackingMode);
   }
 
@@ -61,6 +64,7 @@ public class NavigationMapboxMapInstanceState implements Parcelable {
 
   public static final Creator<NavigationMapboxMapInstanceState> CREATOR =
     new Creator<NavigationMapboxMapInstanceState>() {
+
       @Override
       public NavigationMapboxMapInstanceState createFromParcel(Parcel in) {
         return new NavigationMapboxMapInstanceState(in);

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/map/MapPaddingAdjustorTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/map/MapPaddingAdjustorTest.java
@@ -1,0 +1,97 @@
+package com.mapbox.services.android.navigation.ui.v5.map;
+
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+
+import org.junit.Test;
+
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.TestCase.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class MapPaddingAdjustorTest {
+
+  @Test
+  public void adjustLocationIconWith_customPaddingIsSet() {
+    MapboxMap mapboxMap = mock(MapboxMap.class);
+    int[] defaultPadding = {0, 250, 0, 0};
+    int[] customPadding = {0, 0, 0, 0};
+    MapPaddingAdjustor paddingAdjustor = new MapPaddingAdjustor(mapboxMap, defaultPadding);
+
+    paddingAdjustor.adjustLocationIconWith(customPadding);
+
+    verify(mapboxMap).setPadding(0, 0, 0, 0);
+  }
+
+  @Test
+  public void isUsingDefault_falseAfterCustomPaddingIsSet() {
+    MapboxMap mapboxMap = mock(MapboxMap.class);
+    int[] defaultPadding = {0, 250, 0, 0};
+    int[] customPadding = {0, 0, 0, 0};
+    MapPaddingAdjustor paddingAdjustor = new MapPaddingAdjustor(mapboxMap, defaultPadding);
+
+    paddingAdjustor.adjustLocationIconWith(customPadding);
+
+    assertFalse(paddingAdjustor.isUsingDefault());
+  }
+
+  @Test
+  public void isUsingDefault_trueWithoutCustomPadding() {
+    MapboxMap mapboxMap = mock(MapboxMap.class);
+    int[] defaultPadding = {0, 250, 0, 0};
+
+    MapPaddingAdjustor paddingAdjustor = new MapPaddingAdjustor(mapboxMap, defaultPadding);
+
+    assertTrue(paddingAdjustor.isUsingDefault());
+  }
+
+  @Test
+  public void updatePaddingWithZero_updatesMapToZeroPadding() {
+    MapboxMap mapboxMap = mock(MapboxMap.class);
+    int[] defaultPadding = {0, 250, 0, 0};
+    MapPaddingAdjustor paddingAdjustor = new MapPaddingAdjustor(mapboxMap, defaultPadding);
+
+    paddingAdjustor.updatePaddingWith(new int[]{0, 0, 0, 0});
+
+    verify(mapboxMap).setPadding(0, 0, 0, 0);
+  }
+
+  @Test
+  public void updatePaddingWithZero_retainsCustomPadding() {
+    MapboxMap mapboxMap = mock(MapboxMap.class);
+    int[] defaultPadding = {0, 250, 0, 0};
+    int[] customPadding = {0, 350, 0, 0};
+    MapPaddingAdjustor paddingAdjustor = new MapPaddingAdjustor(mapboxMap, defaultPadding);
+    paddingAdjustor.adjustLocationIconWith(customPadding);
+    paddingAdjustor.updatePaddingWith(new int[]{0, 0, 0, 0});
+
+    paddingAdjustor.resetPadding();
+
+    verify(mapboxMap, times(2)).setPadding(0, 350, 0, 0);
+  }
+
+  @Test
+  public void updatePaddingWithDefault_defaultIsRestoredAfterCustom() {
+    MapboxMap mapboxMap = mock(MapboxMap.class);
+    int[] defaultPadding = {0, 250, 0, 0};
+    int[] customPadding = {0, 0, 0, 0};
+    MapPaddingAdjustor paddingAdjustor = new MapPaddingAdjustor(mapboxMap, defaultPadding);
+    paddingAdjustor.adjustLocationIconWith(customPadding);
+
+    paddingAdjustor.updatePaddingWithDefault();
+
+    verify(mapboxMap).setPadding(0, 250, 0, 0);
+  }
+
+  @Test
+  public void retrieveCurrentPadding_returnsCurrentMapPadding() {
+    MapboxMap mapboxMap = mock(MapboxMap.class);
+    int[] defaultPadding = {0, 250, 0, 0};
+    MapPaddingAdjustor paddingAdjustor = new MapPaddingAdjustor(mapboxMap, defaultPadding);
+
+    paddingAdjustor.retrieveCurrentPadding();
+
+    verify(mapboxMap).getPadding();
+  }
+}

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/map/MapWaynameTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/map/MapWaynameTest.java
@@ -98,11 +98,10 @@ public class MapWaynameTest {
     MapLayerInteractor layerInteractor = mock(MapLayerInteractor.class);
     when(layerInteractor.retrieveLayerFromId(MAPBOX_WAYNAME_LAYER)).thenReturn(waynameLayer);
     MapPaddingAdjustor paddingAdjustor = mock(MapPaddingAdjustor.class);
-    MapWayname mapWayname = buildMapWayname(layerInteractor, paddingAdjustor);
 
-    mapWayname.updateWaynameVisibility(false, waynameLayer);
+    buildMapWayname(layerInteractor, paddingAdjustor);
 
-    verify(paddingAdjustor).updateTopPaddingWithDefault();
+    verify(paddingAdjustor).updatePaddingWithDefault();
   }
 
   @Test
@@ -116,7 +115,7 @@ public class MapWaynameTest {
 
     mapWayname.updateWaynameVisibility(true, waynameLayer);
 
-    verify(paddingAdjustor).updateTopPaddingWithWayname();
+    verify(paddingAdjustor).updatePaddingWithDefault();
   }
 
   @Test


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-navigation-android/issues/1465

As reported by @hurrba, we are dynamically adjusting the map top padding based on the visibility of the way name pill.  If a developer want's to adjust the top padding themselves, or just wants to center the icon, we should make this easier and not override with unexpected behavior.  

![ezgif com-video-to-gif 1](https://user-images.githubusercontent.com/8434572/47665520-b0e21d80-db77-11e8-8c16-a832fe74765f.gif)

This PR also adds a more straightforward API to center the location icon, which also let's us account for centering when rotating the device:

```
// To center the icon
int[] customPadding = {0, 0, 0, 0};
navigationView.retrieveNavigationMapboxMap().updateLocationIconWith(customPadding);
```
