### PR TITLE
Rebuild RemoteViews for MapboxNavigationNotification on each update

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationNotification.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationNotification.java
@@ -49,6 +49,7 @@ class MapboxNavigationNotification implements NavigationNotification {
   private String etaFormat;
   private final Context applicationContext;
   private PendingIntent pendingOpenIntent;
+  private PendingIntent pendingCloseIntent;
 
   private BroadcastReceiver endNavigationBtnReceiver = new BroadcastReceiver() {
     @Override
@@ -89,14 +90,8 @@ class MapboxNavigationNotification implements NavigationNotification {
     notificationManager = (NotificationManager) applicationContext.getSystemService(Context.NOTIFICATION_SERVICE);
     isTwentyFourHourFormat = DateFormat.is24HourFormat(applicationContext);
 
-    collapsedNotificationRemoteViews = new RemoteViews(applicationContext.getPackageName(),
-      R.layout.collapsed_navigation_notification_layout);
-    expandedNotificationRemoteViews = new RemoteViews(applicationContext.getPackageName(),
-      R.layout.expanded_navigation_notification_layout);
-
     pendingOpenIntent = createPendingOpenIntent(applicationContext);
-    PendingIntent pendingCloseIntent = createPendingCloseIntent(applicationContext);
-    expandedNotificationRemoteViews.setOnClickPendingIntent(R.id.endNavigationBtn, pendingCloseIntent);
+    pendingCloseIntent = createPendingCloseIntent(applicationContext);
 
     registerReceiver(applicationContext);
     createNotificationChannel(applicationContext);
@@ -138,6 +133,14 @@ class MapboxNavigationNotification implements NavigationNotification {
       .build();
   }
 
+  private void buildRemoteViews() {
+    collapsedNotificationRemoteViews = new RemoteViews(applicationContext.getPackageName(),
+      R.layout.collapsed_navigation_notification_layout);
+    expandedNotificationRemoteViews = new RemoteViews(applicationContext.getPackageName(),
+      R.layout.expanded_navigation_notification_layout);
+    expandedNotificationRemoteViews.setOnClickPendingIntent(R.id.endNavigationBtn, pendingCloseIntent);
+  }
+
   private PendingIntent createPendingOpenIntent(Context applicationContext) {
     PackageManager pm = applicationContext.getPackageManager();
     Intent intent = pm.getLaunchIntentForPackage(applicationContext.getPackageName());
@@ -157,6 +160,7 @@ class MapboxNavigationNotification implements NavigationNotification {
   }
 
   private void updateNotificationViews(RouteProgress routeProgress) {
+    buildRemoteViews();
     updateInstructionText(routeProgress.currentLegProgress().currentStep());
     updateDistanceText(routeProgress);
     updateArrivalTime(routeProgress);


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-navigation-android/issues/1188

Unfortunately https://github.com/mapbox/mapbox-navigation-android/pull/1441 and https://github.com/mapbox/mapbox-navigation-android/pull/1455 didn't address the `TransactionTooLargeException`.

If the data is being built-up in the `RemoteView`, then it may make sense to rebuild the views on each update?  I'm concerned about performance here, as this could be costly to do every second.  Should we be smarter about it?  Maybe only do this after a certain amount of time has passed?  

I guess first we should test that it fixes it at all and then worry about performance implications.  

cc @akitchen @taraniduncan 