### PR TITLE
Update Maps SDK to 6.6.2

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,7 +8,7 @@ ext {
   ]
 
   version = [
-      mapboxMapSdk       : '6.6.1',
+      mapboxMapSdk       : '6.6.2',
       mapboxSdkServices  : '4.0.0',
       mapboxEvents       : '3.4.0',
       mapboxNavigator    : '3.2.1',


### PR DESCRIPTION
Holding on events `4.0.0` as it has breaking changes for the `LocationEngine` APIs that will take some time to update. 