### PR TITLE
Update time remaining TextView to auto-size for longer durations

### DIFF
--- a/libandroid-navigation-ui/src/main/res/layout/summary_peek_content_layout.xml
+++ b/libandroid-navigation-ui/src/main/res/layout/summary_peek_content_layout.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/summaryPeekContent"
     android:layout_width="wrap_content"
@@ -12,10 +13,16 @@
         android:id="@+id/timeRemainingText"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:textColor="?attr/navigationViewPrimaryText"
+        android:ellipsize="end"
         android:includeFontPadding="false"
+        android:maxLines="1"
+        android:textColor="?attr/navigationViewPrimaryText"
         android:textSize="26sp"
-        tools:text="5 min"/>
+        app:autoSizeMaxTextSize="26sp"
+        app:autoSizeMinTextSize="20sp"
+        app:autoSizeStepGranularity="1sp"
+        app:autoSizeTextType="uniform"
+        tools:text="3 days 12 hrs 5min"/>
 
     <LinearLayout
         android:layout_width="wrap_content"
@@ -26,10 +33,10 @@
             android:id="@+id/distanceRemainingText"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textColor="?attr/navigationViewSecondaryText"
+            android:ellipsize="end"
             android:includeFontPadding="false"
             android:maxLines="1"
-            android:ellipsize="end"
+            android:textColor="?attr/navigationViewSecondaryText"
             android:textSize="18sp"
             tools:text="17 miles"/>
 
@@ -37,12 +44,12 @@
             android:id="@+id/arrivalTimeText"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginLeft="16dp"
             android:layout_marginStart="16dp"
-            android:textColor="?attr/navigationViewSecondaryText"
+            android:layout_marginLeft="16dp"
+            android:ellipsize="end"
             android:includeFontPadding="false"
             android:maxLines="1"
-            android:ellipsize="end"
+            android:textColor="?attr/navigationViewSecondaryText"
             android:textSize="18sp"
             tools:text="10:38am"/>
 


### PR DESCRIPTION
Fixes #1445 

The time remaining `TextView` was not set to max line `1` to keep it from wrapping / producing the behavior seen in the ticket.  

This PR sets the max lines to 1 and also includes auto sizing, so if the text is pushed to the limit, it should downsize until it hits `20sp`.  In the worst case scenario we will also now ellipsize. 