### PR TITLE
Update MapRouteProgressChangeListener to be aware of route visibility

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/MapRouteProgressChangeListener.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/MapRouteProgressChangeListener.java
@@ -11,6 +11,7 @@ import java.util.List;
 class MapRouteProgressChangeListener implements ProgressChangeListener {
 
   private final NavigationMapRoute mapRoute;
+  private boolean isVisible = true;
 
   MapRouteProgressChangeListener(NavigationMapRoute mapRoute) {
     this.mapRoute = mapRoute;
@@ -18,11 +19,18 @@ class MapRouteProgressChangeListener implements ProgressChangeListener {
 
   @Override
   public void onProgressChange(Location location, RouteProgress routeProgress) {
+    if (!isVisible) {
+      return;
+    }
     DirectionsRoute currentRoute = routeProgress.directionsRoute();
     List<DirectionsRoute> directionsRoutes = mapRoute.retrieveDirectionsRoutes();
     int primaryRouteIndex = mapRoute.retrievePrimaryRouteIndex();
     addNewRoute(currentRoute, directionsRoutes, primaryRouteIndex);
     mapRoute.addUpcomingManeuverArrow(routeProgress);
+  }
+
+  void updateVisibility(boolean isVisible) {
+    this.isVisible = isVisible;
   }
 
   private void addNewRoute(DirectionsRoute currentRoute, List<DirectionsRoute> directionsRoutes,

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/NavigationMapRoute.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/NavigationMapRoute.java
@@ -172,7 +172,7 @@ public class NavigationMapRoute implements MapView.OnMapChangedListener,
   private GeoJsonSource arrowHeadGeoJsonSource;
   private Feature arrowShaftGeoJsonFeature = Feature.fromGeometry(Point.fromLngLat(0, 0));
   private Feature arrowHeadGeoJsonFeature = Feature.fromGeometry(Point.fromLngLat(0, 0));
-  private ProgressChangeListener progressChangeListener = new MapRouteProgressChangeListener(this);
+  private MapRouteProgressChangeListener progressChangeListener = new MapRouteProgressChangeListener(this);
 
   /**
    * Construct an instance of {@link NavigationMapRoute}.
@@ -413,12 +413,14 @@ public class NavigationMapRoute implements MapView.OnMapChangedListener,
       addRouteShieldLayer(layerIds.get(layerIds.size() - 2), sourceId, index);
       addRouteLayer(layerIds.get(layerIds.size() - 1), sourceId, index);
     }
+    progressChangeListener.updateVisibility(true);
   }
 
   private void clearRoutes() {
     removeLayerIds();
-    updateArrowLayersVisibilityTo(false);
     clearRouteListData();
+    updateArrowLayersVisibilityTo(false);
+    progressChangeListener.updateVisibility(false);
   }
 
   private void generateFeatureCollectionList(List<DirectionsRoute> directionsRoutes) {


### PR DESCRIPTION
Fixes #1293 

The `MapRouteProgressChangeListener` was immediately re-drawing the route after removal with the next progress update.  It should be aware of the current state of `NavigationMapRoute` and ignore updates if the current route isn't visible.  