### PR TITLE
Add CameraPosition option for initializing NavigationView

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/EmbeddedNavigationActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/EmbeddedNavigationActivity.java
@@ -24,6 +24,8 @@ import com.mapbox.api.directions.v5.models.DirectionsResponse;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.geojson.Point;
 import com.mapbox.mapboxsdk.Mapbox;
+import com.mapbox.mapboxsdk.camera.CameraPosition;
+import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.services.android.navigation.testapp.R;
 import com.mapbox.services.android.navigation.ui.v5.NavigationView;
 import com.mapbox.services.android.navigation.ui.v5.NavigationViewOptions;
@@ -46,6 +48,7 @@ public class EmbeddedNavigationActivity extends AppCompatActivity implements OnN
 
   private static final Point ORIGIN = Point.fromLngLat(-77.03194990754128, 38.909664963450105);
   private static final Point DESTINATION = Point.fromLngLat(-77.0270025730133, 38.91057077063121);
+  private static final int INITIAL_ZOOM = 16;
 
   private NavigationView navigationView;
   private View spacer;
@@ -67,8 +70,12 @@ public class EmbeddedNavigationActivity extends AppCompatActivity implements OnN
     spacer = findViewById(R.id.spacer);
     setSpeedWidgetAnchor(R.id.summaryBottomSheet);
 
+    CameraPosition initialPosition = new CameraPosition.Builder()
+      .target(new LatLng(ORIGIN.latitude(), ORIGIN.longitude()))
+      .zoom(INITIAL_ZOOM)
+      .build();
     navigationView.onCreate(savedInstanceState);
-    navigationView.initialize(this);
+    navigationView.initialize(this, initialPosition);
   }
 
   @Override

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/NavigationLauncherActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/NavigationLauncherActivity.java
@@ -65,6 +65,7 @@ public class NavigationLauncherActivity extends AppCompatActivity implements OnM
   private static final int CAMERA_ANIMATION_DURATION = 1000;
   private static final int DEFAULT_CAMERA_ZOOM = 16;
   private static final int CHANGE_SETTING_REQUEST_CODE = 1;
+  private static final int INITIAL_ZOOM = 16;
 
   private LocationEngine locationEngine;
   private NavigationMapRoute mapRoute;
@@ -332,9 +333,12 @@ public class NavigationLauncherActivity extends AppCompatActivity implements OnM
     NavigationLauncherOptions.Builder optionsBuilder = NavigationLauncherOptions.builder()
       .shouldSimulateRoute(getShouldSimulateRouteFromSharedPreferences())
       .directionsProfile(getRouteProfileFromSharedPreferences());
-
+    CameraPosition initialPosition = new CameraPosition.Builder()
+      .target(new LatLng(currentLocation.latitude(), currentLocation.longitude()))
+      .zoom(INITIAL_ZOOM)
+      .build();
+    optionsBuilder.initialMapCameraPosition(initialPosition);
     optionsBuilder.directionsRoute(route);
-
     NavigationLauncher.startNavigation(this, optionsBuilder.build());
   }
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/MapboxNavigationActivity.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/MapboxNavigationActivity.java
@@ -2,12 +2,14 @@ package com.mapbox.services.android.navigation.ui.v5;
 
 import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.os.Parcelable;
 import android.preference.PreferenceManager;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
 
 import com.mapbox.api.directions.v5.DirectionsCriteria;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
+import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.services.android.navigation.ui.v5.listeners.NavigationListener;
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigationOptions;
 import com.mapbox.services.android.navigation.v5.navigation.NavigationConstants;
@@ -29,7 +31,7 @@ public class MapboxNavigationActivity extends AppCompatActivity implements OnNav
     setContentView(R.layout.activity_navigation);
     navigationView = findViewById(R.id.navigationView);
     navigationView.onCreate(savedInstanceState);
-    navigationView.initialize(this);
+    initialize();
   }
 
   @Override
@@ -114,6 +116,15 @@ public class MapboxNavigationActivity extends AppCompatActivity implements OnNav
   @Override
   public void onNavigationRunning() {
     // Intentionally empty
+  }
+
+  private void initialize() {
+    Parcelable position = getIntent().getParcelableExtra(NavigationConstants.NAVIGATION_VIEW_INITIAL_MAP_POSITION);
+    if (position != null) {
+      navigationView.initialize(this, (CameraPosition) position);
+    } else {
+      navigationView.initialize(this);
+    }
   }
 
   private void extractRoute(NavigationViewOptions.Builder options) {

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationLauncher.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationLauncher.java
@@ -44,6 +44,7 @@ public class NavigationLauncher {
     editor.apply();
 
     Intent navigationActivity = new Intent(activity, MapboxNavigationActivity.class);
+    storeInitialMapPosition(options, navigationActivity);
     activity.startActivity(navigationActivity);
   }
 
@@ -85,6 +86,14 @@ public class NavigationLauncher {
       if (options.darkThemeResId() != null) {
         editor.putInt(NavigationConstants.NAVIGATION_VIEW_DARK_THEME, options.darkThemeResId());
       }
+    }
+  }
+
+  private static void storeInitialMapPosition(NavigationLauncherOptions options, Intent navigationActivity) {
+    if (options.initialMapCameraPosition() != null) {
+      navigationActivity.putExtra(
+        NavigationConstants.NAVIGATION_VIEW_INITIAL_MAP_POSITION, options.initialMapCameraPosition()
+      );
     }
   }
 }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationLauncherOptions.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationLauncherOptions.java
@@ -1,8 +1,11 @@
 package com.mapbox.services.android.navigation.ui.v5;
 
+import android.support.annotation.Nullable;
+
 import com.google.auto.value.AutoValue;
 import com.mapbox.api.directions.v5.DirectionsCriteria;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
+import com.mapbox.mapboxsdk.camera.CameraPosition;
 
 @AutoValue
 public abstract class NavigationLauncherOptions extends NavigationUiOptions {
@@ -10,6 +13,9 @@ public abstract class NavigationLauncherOptions extends NavigationUiOptions {
   public abstract boolean enableOffRouteDetection();
 
   public abstract boolean snapToRoute();
+
+  @Nullable
+  public abstract CameraPosition initialMapCameraPosition();
 
   @AutoValue.Builder
   public abstract static class Builder {
@@ -29,6 +35,8 @@ public abstract class NavigationLauncherOptions extends NavigationUiOptions {
     public abstract Builder enableOffRouteDetection(boolean enableOffRouteDetection);
 
     public abstract Builder snapToRoute(boolean snapToRoute);
+
+    public abstract Builder initialMapCameraPosition(@Nullable CameraPosition initialMapCameraPosition);
 
     public abstract NavigationLauncherOptions build();
   }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationConstants.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationConstants.java
@@ -143,6 +143,11 @@ public final class NavigationConstants {
   public static final String NAVIGATION_VIEW_DARK_THEME = "navigation_view_dark_theme";
 
   /**
+   * NavigationLauncher key for storing initial map position in Intent
+   */
+  public static final String NAVIGATION_VIEW_INITIAL_MAP_POSITION = "navigation_view_initial_map_position";
+
+  /**
    * In seconds, how quickly {@link com.mapbox.services.android.navigation.v5.route.FasterRouteDetector}
    * will tell {@link RouteProcessorBackgroundThread} to check
    * for a faster {@link com.mapbox.api.directions.v5.models.DirectionsRoute}.


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-navigation-android/issues/1245

We currently don't offer a way to start up the `NavigationView` with a camera position.  Our UX isn't ideal, zooming in from `0, 0` world view.  

This PR adds a new `NavigationView#initialize(OnNavigationReadyCallback, CameraPosition)` that will set the `MapboxMap` to that position as soon as it's ready. 

In the `EmbeddedNavigationActivity`, we went from this:

![ezgif com-video-to-gif 1](https://user-images.githubusercontent.com/8434572/47751659-cdaa4e00-dc68-11e8-85ac-d3ba7e4c2056.gif)

to this:

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/8434572/47751653-c71bd680-dc68-11e8-829f-0f3c7371c117.gif)

And also added the option in `NavigationLauncherOptions`:

![ezgif com-video-to-gif 2](https://user-images.githubusercontent.com/8434572/47751684-dbf86a00-dc68-11e8-9673-37c66998939e.gif)

cc @tobrun 