### PR TITLE
Bump Maps SDK and Events versions

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,9 +8,9 @@ ext {
   ]
 
   version = [
-      mapboxMapSdk       : '6.6.2',
+      mapboxMapSdk       : '6.6.5',
       mapboxSdkServices  : '4.0.0',
-      mapboxEvents       : '3.4.0',
+      mapboxEvents       : '3.5.2',
       mapboxNavigator    : '3.2.1',
       autoValue          : '1.5.4',
       autoValueParcel    : '0.2.5',


### PR DESCRIPTION
- Bumps `mapbox-android-sdk` and `mapbox-android-telemetry` versions to `6.6.5` and `3.5.2` respectively