### PR TITLE
Add Mapbox Navigator TOS to the license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,9 @@
+The Mapbox Navigator dependency has the following license.
+
+Copyright © 2018 Mapbox, Inc. You may use this code with your Mapbox account and under the Mapbox Terms of Service (available at: https://www.mapbox.com/tos/). All other rights reserved.
+
+Code in this repo falls under:
+
 The MIT License (MIT)
 
 Copyright (c) 2018 Mapbox


### PR DESCRIPTION
@danesfeder - As our work to have a landing page for Navigator has been delayed, thoughts on adding the Navigator License to this project? I think this should help clear up and close #1391.

If so, we should do this for https://github.com/mapbox/mapbox-navigation-ios as well.

cc @frederoni @akitchen @1ec5 @karussell 