### PR TITLE
Better clarify the Mapbox Navigator dependency

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,9 +1,3 @@
-The Mapbox Navigator dependency has the following license.
-
-Copyright © 2018 Mapbox, Inc. You may use this code with your Mapbox account and under the Mapbox Terms of Service (available at: https://www.mapbox.com/tos/). All other rights reserved.
-
-Code in this repo falls under:
-
 The MIT License (MIT)
 
 Copyright (c) 2018 Mapbox

--- a/README.md
+++ b/README.md
@@ -78,3 +78,7 @@ dependencies {
 ## Contributing
 
 We welcome feedback, translations, and code contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for details.
+
+## License of Dependencies
+
+This SDK uses [Mapbox Navigator](https://github.com/mapbox/mapbox-navigation-android/blob/45b2aeb5f21fe8d008f533d036774dbe891252d4/libandroid-navigation/build.gradle#L47), a private binary, as a dependency. The Mapbox Navigator binary may be used with a Mapbox account and under the [Mapbox TOS](https://www.mapbox.com/tos/). If you do not wish to use this binary, make sure you swap out this dependency in [libandroid-navigation/build.gradle](https://github.com/mapbox/mapbox-navigation-android/blob/master/libandroid-navigation/build.gradle). Code in this repo falls under the [MIT license](./LICENSE).


### PR DESCRIPTION
This morning we [cut and merged a PR](https://github.com/mapbox/mapbox-navigation-android/pull/1494) with the goal of clarifying for users of this repo the license terms of the [Mapbox Navigator dependency](https://github.com/mapbox/mapbox-navigation-android/blob/master/libandroid-navigation/build.gradle#L46). A few people have reached out to me to indicate that the PR was more confusing than clarifying as some thought it implied that use of the code in this repo requires individuals to operate under the Mapbox TOS. That was not the intent. To better clarify the intent, this PR moves the explanation out of the LICENSE file and into the README and includes instructions in how one can use this repo without using the TOS licensed dependency.