### PR TITLE
Check for valid geocoding response in ExamplePresenter

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExamplePresenter.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExamplePresenter.kt
@@ -9,6 +9,7 @@ import android.view.View.INVISIBLE
 import android.view.View.VISIBLE
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.geocoding.v5.models.CarmenFeature
+import com.mapbox.api.geocoding.v5.models.GeocodingResponse
 import com.mapbox.geojson.Point
 import com.mapbox.mapboxsdk.camera.CameraPosition
 import com.mapbox.mapboxsdk.camera.CameraUpdate
@@ -199,11 +200,7 @@ class ExamplePresenter(private val view: ExampleView, private val viewModel: Exa
     viewModel.routes.observe(owner, Observer { onRouteFound(it) })
     viewModel.progress.observe(owner, Observer { onProgressUpdate(it) })
     viewModel.milestone.observe(owner, Observer { onMilestoneUpdate(it) })
-    viewModel.geocode.observe(owner, Observer {
-      it?.features()?.first()?.let {
-        onDestinationFound(it)
-      }
-    })
+    viewModel.geocode.observe(owner, Observer { onGeocodingResponse(it) })
     viewModel.activateLocationEngine()
   }
 
@@ -245,6 +242,16 @@ class ExamplePresenter(private val view: ExampleView, private val viewModel: Exa
       val bottom = resources.getDimension(R.dimen.route_overview_padding_bottom).toInt()
       val padding = intArrayOf(left, top, right, bottom)
       view.updateMapCameraFor(bounds, padding, TWO_SECONDS)
+    }
+  }
+
+  private fun onGeocodingResponse(it: GeocodingResponse?) {
+    val features = it?.features()
+    val isValidFeatureList = features?.isNotEmpty() ?: false
+    if (isValidFeatureList) {
+      features?.first()?.let { firstFeature ->
+        onDestinationFound(firstFeature)
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes CI failing due to 🐛 introduced by #1317 

```
java.util.NoSuchElementException: List is empty.
FATAL EXCEPTION: ControllerMessenger
Process: com.mapbox.services.android.navigation.testapp, PID: 17059
java.util.NoSuchElementException: List is empty.
	at kotlin.collections.CollectionsKt___CollectionsKt.first(_Collections.kt:184)
	at com.mapbox.services.android.navigation.testapp.example.ui.ExamplePresenter$subscribe$5.onChanged(ExamplePresenter.kt:203)
	at com.mapbox.services.android.navigation.testapp.example.ui.ExamplePresenter$subscribe$5.onChanged(ExamplePresenter.kt:32)
	at android.arch.lifecycle.LiveData.considerNotify(LiveData.java:109)
	at android.arch.lifecycle.LiveData.dispatchingValue(LiveData.java:126)
	at android.arch.lifecycle.LiveData.setValue(LiveData.java:282)
	at android.arch.lifecycle.MutableLiveData.setValue(MutableLiveData.java:33)
	at com.mapbox.services.android.navigation.testapp.example.ui.ExampleViewModel$reverseGeocode$1.onResponse(ExampleViewModel.kt:127)
```