### PR TITLE
Add RouteProgressState to RouteProgress for current Navigator information

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/WaypointNavigationActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/WaypointNavigationActivity.java
@@ -6,6 +6,7 @@ import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
+import android.widget.Toast;
 
 import com.mapbox.api.directions.v5.models.DirectionsResponse;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
@@ -153,6 +154,7 @@ public class WaypointNavigationActivity extends AppCompatActivity implements OnN
     if (!dropoffDialogShown && !points.isEmpty()) {
       showDropoffDialog();
       dropoffDialogShown = true; // Accounts for multiple arrival events
+      Toast.makeText(this, "You have arrived!", Toast.LENGTH_SHORT).show();
     }
   }
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
@@ -300,6 +300,7 @@ public class NavigationViewModel extends AndroidViewModel {
       instructionModel.setValue(new InstructionModel(distanceFormatter, routeProgress));
       summaryModel.setValue(new SummaryModel(getApplication(), distanceFormatter, routeProgress, timeFormatType));
       navigationLocation.setValue(location);
+      sendEventArrival(routeProgress);
     }
   };
 
@@ -319,7 +320,6 @@ public class NavigationViewModel extends AndroidViewModel {
     public void onMilestoneEvent(RouteProgress routeProgress, String instruction, Milestone milestone) {
       playVoiceAnnouncement(milestone);
       updateBannerInstruction(routeProgress, milestone);
-      sendEventArrival(routeProgress, milestone);
     }
   };
 
@@ -445,8 +445,8 @@ public class NavigationViewModel extends AndroidViewModel {
     }
   }
 
-  private void sendEventArrival(RouteProgress routeProgress, Milestone milestone) {
-    if (navigationViewEventDispatcher != null && routeUtils.isArrivalEvent(routeProgress, milestone)) {
+  private void sendEventArrival(RouteProgress routeProgress) {
+    if (navigationViewEventDispatcher != null && routeUtils.isArrivalEvent(routeProgress)) {
       navigationViewEventDispatcher.onArrival();
     }
   }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEventDispatcher.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEventDispatcher.java
@@ -132,7 +132,7 @@ class NavigationEventDispatcher {
   }
 
   void onMilestoneEvent(RouteProgress routeProgress, String instruction, Milestone milestone) {
-    checkForArrivalEvent(routeProgress, milestone);
+    checkForArrivalEvent(routeProgress);
     for (MilestoneEventListener milestoneEventListener : milestoneEventListeners) {
       milestoneEventListener.onMilestoneEvent(routeProgress, instruction, milestone);
     }
@@ -172,8 +172,8 @@ class NavigationEventDispatcher {
     }
   }
 
-  private void checkForArrivalEvent(RouteProgress routeProgress, Milestone milestone) {
-    if (metricEventListener != null && routeUtils.isArrivalEvent(routeProgress, milestone)) {
+  private void checkForArrivalEvent(RouteProgress routeProgress) {
+    if (metricEventListener != null && routeUtils.isArrivalEvent(routeProgress)) {
       metricEventListener.onArrival(routeProgress);
       if (routeUtils.isLastLeg(routeProgress)) {
         metricEventListener = null;

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteProcessor.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteProcessor.java
@@ -9,9 +9,12 @@ import com.mapbox.api.directions.v5.models.RouteLeg;
 import com.mapbox.api.directions.v5.models.StepIntersection;
 import com.mapbox.geojson.Point;
 import com.mapbox.navigator.NavigationStatus;
+import com.mapbox.navigator.RouteState;
 import com.mapbox.navigator.VoiceInstruction;
 import com.mapbox.services.android.navigation.v5.routeprogress.CurrentLegAnnotation;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
+import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgressState;
+import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgressStateMap;
 
 import java.util.List;
 
@@ -27,6 +30,7 @@ class NavigationRouteProcessor {
 
   private static final int ONE_INDEX = 1;
   private static final double ONE_SECOND_IN_MILLISECONDS = 1000.0;
+  private final RouteProgressStateMap progressStateMap = new RouteProgressStateMap();
   private RouteProgress previousRouteProgress;
   private DirectionsRoute route;
   private RouteLeg currentLeg;
@@ -79,6 +83,8 @@ class NavigationRouteProcessor {
     StepIntersection upcomingIntersection = findUpcomingIntersection(
       currentIntersections, upcomingStep, currentIntersection
     );
+    RouteState routeState = status.getRouteState();
+    RouteProgressState currentRouteState = progressStateMap.get(routeState);
 
     RouteProgress.Builder progressBuilder = RouteProgress.builder()
       .distanceRemaining(routeDistanceRemaining)
@@ -95,7 +101,8 @@ class NavigationRouteProcessor {
       .upcomingIntersection(upcomingIntersection)
       .intersectionDistancesAlongStep(currentIntersectionDistances)
       .currentLegAnnotation(currentLegAnnotation)
-      .inTunnel(status.getInTunnel());
+      .inTunnel(status.getInTunnel())
+      .currentState(currentRouteState);
 
     // TODO build banner instructions from status here
     addVoiceInstructions(status, progressBuilder);

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/routeprogress/RouteProgress.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/routeprogress/RouteProgress.java
@@ -168,6 +168,15 @@ public abstract class RouteProgress {
   @Nullable
   public abstract VoiceInstruction voiceInstruction();
 
+  /**
+   * Returns the current state of progress along the route.  Provides route and location tracking
+   * information.
+   *
+   * @return the current state of progress along the route.
+   */
+  @Nullable
+  public abstract RouteProgressState currentState();
+
   public abstract RouteProgress.Builder toBuilder();
 
   abstract int stepIndex();
@@ -254,6 +263,8 @@ public abstract class RouteProgress {
     public abstract Builder inTunnel(boolean inTunnel);
 
     public abstract Builder voiceInstruction(@Nullable VoiceInstruction voiceInstruction);
+
+    public abstract Builder currentState(@Nullable RouteProgressState currentState);
 
     abstract RouteProgress autoBuild(); // not public
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/routeprogress/RouteProgressState.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/routeprogress/RouteProgressState.java
@@ -1,0 +1,41 @@
+package com.mapbox.services.android.navigation.v5.routeprogress;
+
+import com.mapbox.api.directions.v5.models.DirectionsRoute;
+
+/**
+ * Contains the various progress states that can occur while navigating.
+ */
+public enum RouteProgressState {
+
+  /**
+   * The {@link com.mapbox.api.directions.v5.models.DirectionsRoute} provided
+   * via {@link com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation#startNavigation(DirectionsRoute)}
+   * is not valid.
+   */
+  ROUTE_INVALID,
+
+  /**
+   * The {@link DirectionsRoute} is valid
+   * and {@link com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation} is waiting for
+   * sufficient {@link android.location.Location} updates
+   * from the {@link com.mapbox.android.core.location.LocationEngine}.
+   */
+  ROUTE_INITIALIZED,
+
+  /**
+   * The user has arrived at the destination of the given {@link com.mapbox.api.directions.v5.models.RouteLeg}.
+   */
+  ROUTE_ARRIVED,
+
+  /**
+   * {@link com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation} is now confidently tracking the
+   * location updates and processing them against the route.
+   */
+  LOCATION_TRACKING,
+
+  /**
+   * A lack of {@link android.location.Location} updates from the phone has caused lack of confidence in the
+   * progress updates being sent.
+   */
+  LOCATION_STALE
+}

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/routeprogress/RouteProgressStateMap.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/routeprogress/RouteProgressStateMap.java
@@ -1,0 +1,17 @@
+package com.mapbox.services.android.navigation.v5.routeprogress;
+
+import com.mapbox.navigator.RouteState;
+
+import java.util.HashMap;
+
+public final class RouteProgressStateMap extends HashMap<RouteState, RouteProgressState> {
+
+  public RouteProgressStateMap() {
+    put(RouteState.INVALID, RouteProgressState.ROUTE_INVALID);
+    put(RouteState.INITIALIZED, RouteProgressState.ROUTE_INITIALIZED);
+    put(RouteState.COMPLETE, RouteProgressState.ROUTE_ARRIVED);
+    put(RouteState.TRACKING, RouteProgressState.LOCATION_TRACKING);
+    put(RouteState.STALE, RouteProgressState.LOCATION_STALE);
+    put(RouteState.OFFROUTE, null); // Ignore off-route (info already provided via listener)
+  }
+}

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/RouteUtils.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/RouteUtils.java
@@ -14,9 +14,8 @@ import com.mapbox.api.directions.v5.models.RouteOptions;
 import com.mapbox.api.directions.v5.models.VoiceInstructions;
 import com.mapbox.core.utils.TextUtils;
 import com.mapbox.geojson.Point;
-import com.mapbox.services.android.navigation.v5.milestone.BannerInstructionMilestone;
-import com.mapbox.services.android.navigation.v5.milestone.Milestone;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
+import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgressState;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -77,31 +76,15 @@ public class RouteUtils {
   }
 
   /**
-   * Looks at the current {@link RouteProgress} maneuverType for type "arrival", then
-   * checks if the arrival meter threshold has been hit.
+   * Looks at the current {@link RouteProgressState} and returns if
+   * is {@link RouteProgressState#ROUTE_ARRIVED}.
    *
    * @param routeProgress the current route progress
-   * @param milestone     the current milestone from the MilestoneEventListener
    * @return true if in arrival state, false if not
-   * @since 0.8.0
    */
-  public boolean isArrivalEvent(@NonNull RouteProgress routeProgress, @NonNull Milestone milestone) {
-    if (!(milestone instanceof BannerInstructionMilestone)) {
-      return false;
-    }
-    boolean isValidArrivalManeuverType = upcomingStepIsArrivalManeuverType(routeProgress)
-      || currentStepIsArrivalManeuverType(routeProgress);
-    if (isValidArrivalManeuverType) {
-      LegStep currentStep = routeProgress.currentLegProgress().currentStep();
-      BannerInstructions currentInstructions = ((BannerInstructionMilestone) milestone).getBannerInstructions();
-      List<BannerInstructions> bannerInstructions = currentStep.bannerInstructions();
-      if (hasValidInstructions(bannerInstructions, currentInstructions)) {
-        int lastInstructionIndex = bannerInstructions.size() - 1;
-        BannerInstructions lastInstructions = bannerInstructions.get(lastInstructionIndex);
-        return currentInstructions.equals(lastInstructions);
-      }
-    }
-    return false;
+  public boolean isArrivalEvent(@NonNull RouteProgress routeProgress) {
+    RouteProgressState currentState = routeProgress.currentState();
+    return currentState != null && currentState == RouteProgressState.ROUTE_ARRIVED;
   }
 
   /**

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEventDispatcherTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEventDispatcherTest.java
@@ -315,7 +315,7 @@ public class NavigationEventDispatcherTest extends BaseTest {
     String instruction = "";
     BannerInstructionMilestone milestone = mock(BannerInstructionMilestone.class);
     RouteUtils routeUtils = mock(RouteUtils.class);
-    when(routeUtils.isArrivalEvent(routeProgress, milestone)).thenReturn(false);
+    when(routeUtils.isArrivalEvent(routeProgress)).thenReturn(false);
     NavigationEventDispatcher navigationEventDispatcher = new NavigationEventDispatcher(routeUtils);
     navigationEventDispatcher.addMetricEventListeners(metricEventListener);
 
@@ -329,7 +329,7 @@ public class NavigationEventDispatcherTest extends BaseTest {
     String instruction = "";
     BannerInstructionMilestone milestone = mock(BannerInstructionMilestone.class);
     RouteUtils routeUtils = mock(RouteUtils.class);
-    when(routeUtils.isArrivalEvent(routeProgress, milestone)).thenReturn(true);
+    when(routeUtils.isArrivalEvent(routeProgress)).thenReturn(true);
     NavigationEventDispatcher navigationEventDispatcher = new NavigationEventDispatcher(routeUtils);
     navigationEventDispatcher.addMetricEventListeners(metricEventListener);
 
@@ -344,7 +344,7 @@ public class NavigationEventDispatcherTest extends BaseTest {
     Location location = mock(Location.class);
     BannerInstructionMilestone milestone = mock(BannerInstructionMilestone.class);
     RouteUtils routeUtils = mock(RouteUtils.class);
-    when(routeUtils.isArrivalEvent(routeProgress, milestone)).thenReturn(true);
+    when(routeUtils.isArrivalEvent(routeProgress)).thenReturn(true);
     when(routeUtils.isLastLeg(routeProgress)).thenReturn(true);
     NavigationEventDispatcher dispatcher = buildEventDispatcherHasArrived(instruction, routeUtils, milestone);
 
@@ -359,7 +359,7 @@ public class NavigationEventDispatcherTest extends BaseTest {
     Location location = mock(Location.class);
     BannerInstructionMilestone milestone = mock(BannerInstructionMilestone.class);
     RouteUtils routeUtils = mock(RouteUtils.class);
-    when(routeUtils.isArrivalEvent(routeProgress, milestone)).thenReturn(true);
+    when(routeUtils.isArrivalEvent(routeProgress)).thenReturn(true);
     when(routeUtils.isLastLeg(routeProgress)).thenReturn(true);
     NavigationEventDispatcher dispatcher = buildEventDispatcherHasArrived(instruction, routeUtils, milestone);
 

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/utils/RouteUtilsTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/utils/RouteUtilsTest.java
@@ -7,7 +7,6 @@ import com.mapbox.api.directions.v5.models.BannerInstructions;
 import com.mapbox.api.directions.v5.models.BannerText;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.api.directions.v5.models.LegStep;
-import com.mapbox.api.directions.v5.models.RouteLeg;
 import com.mapbox.api.directions.v5.models.RouteOptions;
 import com.mapbox.api.directions.v5.models.VoiceInstructions;
 import com.mapbox.geojson.Point;
@@ -15,6 +14,7 @@ import com.mapbox.services.android.navigation.v5.BaseTest;
 import com.mapbox.services.android.navigation.v5.milestone.BannerInstructionMilestone;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteLegProgress;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
+import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgressState;
 
 import org.junit.Test;
 
@@ -65,66 +65,23 @@ public class RouteUtilsTest extends BaseTest {
   }
 
   @Test
-  public void isArrivalEvent_returnsTrueWhenManeuverTypeIsArrival_andIsLastInstruction() throws Exception {
-    DirectionsRoute route = buildTestDirectionsRoute();
-    int first = 0;
-    int lastInstruction = 1;
-    RouteLeg routeLeg = route.legs().get(first);
-    List<LegStep> routeSteps = routeLeg.steps();
-    int currentStepIndex = routeSteps.size() - 2;
-    int upcomingStepIndex = routeSteps.size() - 1;
-    LegStep currentStep = routeSteps.get(currentStepIndex);
-    LegStep upcomingStep = routeSteps.get(upcomingStepIndex);
-    RouteProgress routeProgress = buildRouteProgress(first, route, currentStep, upcomingStep);
-    BannerInstructionMilestone bannerInstructionMilestone = mock(BannerInstructionMilestone.class);
-    List<BannerInstructions> currentStepBannerInstructions = currentStep.bannerInstructions();
-    buildBannerInstruction(lastInstruction, bannerInstructionMilestone, currentStepBannerInstructions);
-
+  public void isArrivalEvent_returnsTrueWhenRouteProgressStateIsArrived() {
+    RouteProgress routeProgress = mock(RouteProgress.class);
+    when(routeProgress.currentState()).thenReturn(RouteProgressState.ROUTE_ARRIVED);
     RouteUtils routeUtils = new RouteUtils();
 
-    boolean isArrivalEvent = routeUtils.isArrivalEvent(routeProgress, bannerInstructionMilestone);
+    boolean isArrivalEvent = routeUtils.isArrivalEvent(routeProgress);
 
     assertTrue(isArrivalEvent);
   }
 
   @Test
-  public void isArrivalEvent_returnsFalseWhenManeuverTypeIsArrival_andIsNotLastInstruction() throws Exception {
-    DirectionsRoute route = buildTestDirectionsRoute();
-    int first = 0;
-    RouteLeg routeLeg = route.legs().get(first);
-    List<LegStep> routeSteps = routeLeg.steps();
-    int currentStepIndex = routeSteps.size() - 2;
-    int upcomingStepIndex = routeSteps.size() - 1;
-    LegStep currentStep = routeSteps.get(currentStepIndex);
-    LegStep upcomingStep = routeSteps.get(upcomingStepIndex);
-    RouteProgress routeProgress = buildRouteProgress(first, route, currentStep, upcomingStep);
-    BannerInstructionMilestone bannerInstructionMilestone = mock(BannerInstructionMilestone.class);
-    List<BannerInstructions> currentStepBannerInstructions = currentStep.bannerInstructions();
-    buildBannerInstruction(first, bannerInstructionMilestone, currentStepBannerInstructions);
-
+  public void isArrivalEvent_returnsFalseWhenRouteProgressStateIsNotArrived() {
+    RouteProgress routeProgress = mock(RouteProgress.class);
+    when(routeProgress.currentState()).thenReturn(RouteProgressState.LOCATION_TRACKING);
     RouteUtils routeUtils = new RouteUtils();
 
-    boolean isArrivalEvent = routeUtils.isArrivalEvent(routeProgress, bannerInstructionMilestone);
-
-    assertFalse(isArrivalEvent);
-  }
-
-  @Test
-  public void isArrivalEvent_returnsFalseWhenManeuverTypeIsNotArrival() throws Exception {
-    DirectionsRoute route = buildTestDirectionsRoute();
-    int first = 0;
-    RouteLeg routeLeg = route.legs().get(first);
-    List<LegStep> routeSteps = routeLeg.steps();
-    LegStep currentStep = routeSteps.get(first);
-    LegStep upcomingStep = routeSteps.get(first + 1);
-    RouteProgress routeProgress = buildRouteProgress(first, route, currentStep, upcomingStep);
-    BannerInstructionMilestone bannerInstructionMilestone = mock(BannerInstructionMilestone.class);
-    List<BannerInstructions> currentStepBannerInstructions = currentStep.bannerInstructions();
-    buildBannerInstruction(first, bannerInstructionMilestone, currentStepBannerInstructions);
-
-    RouteUtils routeUtils = new RouteUtils();
-
-    boolean isArrivalEvent = routeUtils.isArrivalEvent(routeProgress, bannerInstructionMilestone);
+    boolean isArrivalEvent = routeUtils.isArrivalEvent(routeProgress);
 
     assertFalse(isArrivalEvent);
   }


### PR DESCRIPTION
Closes #1501 @navdeepg to confirm

This is an example of a last step from the Directions API (containing the maneuver type `"arrive"`):

```
       {
        "intersections": [{
          "in": 0,
          "entry": [true],
          "bearings": [252],
          "location": [-71.068719, 42.352396]
        }],
        "driving_side": "right",
        "geometry": "wo~woA|aupfC",
        "mode": "driving",
        "maneuver": {
          "bearing_after": 0,
          "bearing_before": 72,
          "location": [-71.068719, 42.352396],
          "type": "arrive",
          "instruction": "You have arrived at your destination"
        },
        "ref": "MA 2",
        "weight": 0,
        "duration": 0,
        "name": "Boylston Street (MA 2)",
        "distance": 0,
        "voiceInstructions": [],
        "bannerInstructions": []
      }
```

As you can see, the step has a single point that represents the geometry.  `Navigator` ignores the step, making it impossible for a user to be "on the step" and have `maneuver type == "arrive"`.

This PR adds a `RouteProgressState` that not only gives information about when a user has arrived, but also a lot of other information given to us via the `Navigator` `RouteState`.  Even if we did allow navigation on this step, it would be very hard to get a location update that was snapped to this geometry.

Example usage to detect when a user has arrived at the end of the given `RouteLeg`:
```
  @Override
  public void onProgressChange(Location location, RouteProgress routeProgress) {
    Integer currentState = routeProgress.currentState();
    if (currentState != null && currentState == RouteProgressState.ROUTE_ARRIVED) {
      // Arrived at the end of the leg!
    }
  }
```

This is marked `SEMVER` because it breaks `RouteUtils`.

cc @kevinkreiser 