### PR TITLE
Remove translation path for offline initialization

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/OfflineRerouteActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/OfflineRerouteActivity.java
@@ -281,10 +281,8 @@ public class OfflineRerouteActivity extends AppCompatActivity implements OnMapRe
   private void findRoute() {
     String tilesDirPath = obtainOfflineDirectoryFor("tiles");
     Timber.d("Tiles directory path: %s", tilesDirPath);
-    String translationsDirPath = obtainOfflineDirectoryFor("translations");
-    Timber.d("Translations directory path: %s", translationsDirPath);
 
-    navigation.initializeOfflineData(tilesDirPath, translationsDirPath, () -> {
+    navigation.initializeOfflineData(tilesDirPath, () -> {
       OfflineRoute offlineRoute = obtainOfflineRoute(origin, destination);
       route = navigation.findOfflineRoute(offlineRoute);
       handleNewRoute(route);

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
@@ -721,13 +721,11 @@ public class MapboxNavigation implements ServiceConnection {
    * Configures the navigator for getting offline routes
    *
    * @param tilesDirPath        directory path where the tiles are located
-   * @param translationsDirPath directory path where the translations are located
    * @param callback            a callback that will be fired when the offline data is initialized and
    *                            {@link MapboxNavigation#findOfflineRoute(OfflineRoute)} could be called safely
    */
-  public void initializeOfflineData(String tilesDirPath, String translationsDirPath,
-                                    OnOfflineDataInitialized callback) {
-    mapboxNavigator.configureRouter(tilesDirPath, translationsDirPath, callback);
+  public void initializeOfflineData(String tilesDirPath, OnOfflineDataInitialized callback) {
+    mapboxNavigator.configureRouter(tilesDirPath, callback);
   }
 
   /**

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigator.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigator.java
@@ -12,6 +12,7 @@ import java.util.Date;
 
 class MapboxNavigator {
 
+  private static final String EMPTY_TRANSLATIONS_DIR_PATH = "";
   private final Navigator navigator;
 
   MapboxNavigator(Navigator navigator) {
@@ -38,8 +39,8 @@ class MapboxNavigator {
     }
   }
 
-  void configureRouter(String tileFilePath, String translationsDirPath, OnOfflineDataInitialized callback) {
-    new ConfigureRouterTask(navigator, tileFilePath, translationsDirPath, callback).execute();
+  void configureRouter(String tileFilePath, OnOfflineDataInitialized callback) {
+    new ConfigureRouterTask(navigator, tileFilePath, EMPTY_TRANSLATIONS_DIR_PATH, callback).execute();
   }
 
   /**
@@ -75,7 +76,7 @@ class MapboxNavigator {
     navigator.toggleHistory(isEnabled);
   }
 
-  FixLocation buildFixLocationFromLocation(Location location) {
+  private FixLocation buildFixLocationFromLocation(Location location) {
     Date time = new Date();
     Point rawPoint = Point.fromLngLat(location.getLongitude(), location.getLatitude());
     Float speed = checkFor(location.getSpeed());


### PR DESCRIPTION
This is no longer necessary per @kevinkreiser, but the API param still exists for now.  Passing `""` is confirmed 👍 

cc @mcwhittemore @kevinkreiser 