### PR TITLE
Cancel outstanding Directions API requests onDestroy NavigationViewModel

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
@@ -65,7 +65,7 @@ public class NavigationViewModel extends AndroidViewModel {
   final MutableLiveData<Boolean> shouldRecordScreenshot = new MutableLiveData<>();
 
   private MapboxNavigation navigation;
-  private ViewRouteFetcher navigationViewRouteEngine;
+  private ViewRouteFetcher routeFetcher;
   private LocationEngineConductor locationEngineConductor;
   private NavigationViewEventDispatcher navigationViewEventDispatcher;
   private SpeechPlayer speechPlayer;
@@ -103,6 +103,7 @@ public class NavigationViewModel extends AndroidViewModel {
     this.isChangingConfigurations = isChangingConfigurations;
     if (!isChangingConfigurations) {
       locationEngineConductor.onDestroy();
+      routeFetcher.onDestroy();
       deactivateInstructionPlayer();
       endNavigation();
       isRunning = false;
@@ -187,7 +188,7 @@ public class NavigationViewModel extends AndroidViewModel {
       initializeNavigation(getApplication(), navigationOptions, locationEngine);
       addMilestones(options);
     }
-    navigationViewRouteEngine.extractRouteOptions(options);
+    routeFetcher.extractRouteOptions(options);
     return navigation;
   }
 
@@ -211,7 +212,7 @@ public class NavigationViewModel extends AndroidViewModel {
   }
 
   private void initializeNavigationRouteEngine() {
-    navigationViewRouteEngine = new ViewRouteFetcher(getApplication(), accessToken, routeEngineListener);
+    routeFetcher = new ViewRouteFetcher(getApplication(), accessToken, routeEngineListener);
   }
 
   private void initializeNavigationLocationEngine() {
@@ -361,7 +362,7 @@ public class NavigationViewModel extends AndroidViewModel {
   private LocationEngineConductorListener locationEngineCallback = new LocationEngineConductorListener() {
     @Override
     public void onLocationUpdate(Location location) {
-      navigationViewRouteEngine.updateRawLocation(location);
+      routeFetcher.updateRawLocation(location);
     }
   };
 
@@ -455,7 +456,7 @@ public class NavigationViewModel extends AndroidViewModel {
     if (navigationViewEventDispatcher != null && navigationViewEventDispatcher.allowRerouteFrom(newOrigin)) {
       navigationViewEventDispatcher.onOffRoute(newOrigin);
       OffRouteEvent event = new OffRouteEvent(newOrigin, routeProgress);
-      navigationViewRouteEngine.fetchRouteFromOffRouteEvent(event);
+      routeFetcher.fetchRouteFromOffRouteEvent(event);
       isOffRoute.setValue(true);
     }
   }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/ViewRouteFetcher.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/ViewRouteFetcher.java
@@ -75,6 +75,14 @@ public class ViewRouteFetcher extends RouteFetcher implements RouteListener {
     this.rawLocation = rawLocation;
   }
 
+  /**
+   * Call when your {@link android.app.Activity} or {@link android.app.Fragment} is being
+   * destroyed to cancel any outstanding Directions API calls.
+   */
+  public void onDestroy() {
+    cancelRouteCall();
+  }
+
   private void extractRouteFromOptions(NavigationViewOptions options) {
     DirectionsRoute route = options.directionsRoute();
     cacheRouteOptions(route.routeOptions());

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/ViewRouteFetcherTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/ViewRouteFetcherTest.java
@@ -31,7 +31,7 @@ public class ViewRouteFetcherTest extends BaseTest {
   private static final String DIRECTIONS_PRECISION_6 = "directions_v5_precision_6.json";
 
   @Test
-  public void sanity() throws Exception {
+  public void sanity() {
     ViewRouteListener routeEngineListener = mock(ViewRouteListener.class);
     ViewRouteFetcher routeEngine = buildRouteEngine(routeEngineListener);
 
@@ -76,7 +76,7 @@ public class ViewRouteFetcherTest extends BaseTest {
   }
 
   @Test
-  public void onErrorReceived_errorListenerIsTriggered() throws Exception {
+  public void onErrorReceived_errorListenerIsTriggered() {
     ViewRouteListener routeEngineListener = mock(ViewRouteListener.class);
     ViewRouteFetcher routeEngine = buildRouteEngine(routeEngineListener);
     Throwable throwable = mock(Throwable.class);

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRoute.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRoute.java
@@ -42,12 +42,12 @@ public final class NavigationRoute {
   private final MapboxDirections mapboxDirections;
 
   /**
-   * Private constructor used for the {@link Builder#build()} method.
+   * Package private constructor used for the {@link Builder#build()} method.
    *
    * @param mapboxDirections a new instance of a {@link MapboxDirections} class
    * @since 0.5.0
    */
-  private NavigationRoute(MapboxDirections mapboxDirections) {
+  NavigationRoute(MapboxDirections mapboxDirections) {
     this.mapboxDirections = mapboxDirections;
   }
 
@@ -81,7 +81,7 @@ public final class NavigationRoute {
   }
 
   /**
-   * Wrapper method for Retrofits {@link Call#clone()} call, useful for getting call information
+   * Wrapper method for Retrofit's {@link Call#clone()} call, useful for getting call information
    * and allowing you to perform additional functions on this {@link NavigationRoute} class.
    *
    * @return cloned call
@@ -91,8 +91,14 @@ public final class NavigationRoute {
     return mapboxDirections.cloneCall();
   }
 
+  /**
+   * Wrapper method for Retrofit's {@link Call#cancel()} call, important to manually cancel call if
+   * the user dismisses the calling activity or no longer needs the returned results.
+   */
   public void cancelCall() {
-    getCall().cancel();
+    if (!getCall().isExecuted()) {
+      getCall().cancel();
+    }
   }
 
   /**

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/route/RouteFetcher.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/route/RouteFetcher.java
@@ -40,6 +40,7 @@ public class RouteFetcher {
   private final String accessToken;
   private final WeakReference<Context> contextWeakReference;
 
+  private NavigationRoute navigationRoute;
   private RouteProgress routeProgress;
   private RouteUtils routeUtils;
 
@@ -49,12 +50,29 @@ public class RouteFetcher {
     routeUtils = new RouteUtils();
   }
 
+  // Package private (no modifier) for testing purposes
+  RouteFetcher(Context context, String accessToken, NavigationRoute navigationRoute) {
+    this.contextWeakReference = new WeakReference<>(context);
+    this.navigationRoute = navigationRoute;
+    this.accessToken = accessToken;
+  }
+
+  /**
+   * Adds a {@link RouteListener} to this class to be triggered when a route
+   * response has been received.
+   *
+   * @param listener to be added
+   */
   public void addRouteListener(RouteListener listener) {
     if (!routeListeners.contains(listener)) {
       routeListeners.add(listener);
     }
   }
 
+  /**
+   * Clears any listeners that have been added to this class via
+   * {@link RouteFetcher#addRouteListener(RouteListener)}.
+   */
   public void clearListeners() {
     routeListeners.clear();
   }
@@ -77,6 +95,15 @@ public class RouteFetcher {
     this.routeProgress = routeProgress;
     NavigationRoute.Builder builder = buildRequestFromLocation(location, routeProgress);
     executeRouteCall(builder);
+  }
+
+  /**
+   * Cancels the Directions API call if it has not been executed yet.
+   */
+  public void cancelRouteCall() {
+    if (navigationRoute != null) {
+      navigationRoute.cancelCall();
+    }
   }
 
   @Nullable
@@ -156,7 +183,8 @@ public class RouteFetcher {
   private void executeRouteCall(NavigationRoute.Builder builder) {
     if (builder != null) {
       builder.accessToken(accessToken);
-      builder.build().getRoute(directionsResponseCallback);
+      navigationRoute = builder.build();
+      navigationRoute.getRoute(directionsResponseCallback);
     }
   }
 

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteTest.java
@@ -3,6 +3,8 @@ package com.mapbox.services.android.navigation.v5.navigation;
 import android.content.Context;
 
 import com.mapbox.api.directions.v5.DirectionsCriteria;
+import com.mapbox.api.directions.v5.MapboxDirections;
+import com.mapbox.api.directions.v5.models.DirectionsResponse;
 import com.mapbox.api.directions.v5.models.RouteOptions;
 import com.mapbox.geojson.Point;
 import com.mapbox.services.android.navigation.v5.BaseTest;
@@ -18,9 +20,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
+import retrofit2.Call;
+
 import static junit.framework.Assert.assertNotNull;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class NavigationRouteTest extends BaseTest {
@@ -151,5 +158,31 @@ public class NavigationRouteTest extends BaseTest {
     assertThat(request, containsString("walking"));
     assertThat(request, containsString("curb"));
     assertThat(request, containsString("Origin"));
+  }
+
+  @Test
+  public void cancelCall_cancelsCallNotExecuted() {
+    MapboxDirections mapboxDirections = mock(MapboxDirections.class);
+    Call<DirectionsResponse> routeCall = mock(Call.class);
+    when(routeCall.isExecuted()).thenReturn(false);
+    when(mapboxDirections.cloneCall()).thenReturn(routeCall);
+    NavigationRoute navigationRoute = new NavigationRoute(mapboxDirections);
+
+    navigationRoute.cancelCall();
+
+    verify(routeCall).cancel();
+  }
+
+  @Test
+  public void cancelCall_doesNotCancelExecutedCall() {
+    MapboxDirections mapboxDirections = mock(MapboxDirections.class);
+    Call<DirectionsResponse> routeCall = mock(Call.class);
+    when(routeCall.isExecuted()).thenReturn(true);
+    when(mapboxDirections.cloneCall()).thenReturn(routeCall);
+    NavigationRoute navigationRoute = new NavigationRoute(mapboxDirections);
+
+    navigationRoute.cancelCall();
+
+    verify(routeCall, times(0)).cancel();
   }
 }

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/route/RouteFetcherTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/route/RouteFetcherTest.java
@@ -1,0 +1,24 @@
+package com.mapbox.services.android.navigation.v5.route;
+
+import android.content.Context;
+
+import com.mapbox.services.android.navigation.v5.navigation.NavigationRoute;
+
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class RouteFetcherTest {
+
+  @Test
+  public void cancelRouteCall_cancelsWithNonNullNavigationRoute() {
+    Context context = mock(Context.class);
+    NavigationRoute navigationRoute = mock(NavigationRoute.class);
+    RouteFetcher routeFetcher = new RouteFetcher(context, "pk.xx", navigationRoute);
+
+    routeFetcher.cancelRouteCall();
+
+    verify(navigationRoute).cancelCall();
+  }
+}


### PR DESCRIPTION
Closes #412 

We should cancel a Directions API request if it hasn't been executed when the `Activity` or `Fragment` is being destroyed (when not from configuration change).  