### PR TITLE
Use most recent raw Location when building snapped Location

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ buildscript {
     classpath pluginDependencies.coveralls
     classpath pluginDependencies.errorprone
     classpath pluginDependencies.dependencyUpdates
+    classpath pluginDependencies.jacoco
   }
 }
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -107,7 +107,8 @@ ext {
       gradle           : '3.2.0',
       dependencyGraph  : '0.3.0',
       dependencyUpdates: '0.20.0',
-      kotlin           : '1.2.61'
+      kotlin           : '1.2.61',
+      jacoco           : '0.8.2'
   ]
 
   pluginDependencies = [
@@ -118,6 +119,7 @@ ext {
       coveralls        : "org.kt3k.gradle.plugin:coveralls-gradle-plugin:${pluginVersion.coveralls}",
       errorprone       : "net.ltgt.gradle:gradle-errorprone-plugin:${pluginVersion.errorprone}",
       dependencyGraph  : "com.vanniktech:gradle-dependency-graph-generator-plugin:${pluginVersion.dependencyGraph}",
-      dependencyUpdates: "com.github.ben-manes:gradle-versions-plugin:${pluginVersion.dependencyUpdates}"
+      dependencyUpdates: "com.github.ben-manes:gradle-versions-plugin:${pluginVersion.dependencyUpdates}",
+      jacoco           : "com.github.ben-manes:gradle-versions-plugin:${pluginVersion.jacoco}"
   ]
 }

--- a/libandroid-navigation/build.gradle
+++ b/libandroid-navigation/build.gradle
@@ -36,6 +36,14 @@ android {
     unitTests.returnDefaultValues = true
     unitTests.includeAndroidResources = true
   }
+
+  testOptions {
+    unitTests.all {
+      jacoco {
+        includeNoLocationClasses = true
+      }
+    }
+  }
 }
 
 dependencies {

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/RouteProcessorRunnable.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/RouteProcessorRunnable.java
@@ -82,7 +82,7 @@ class RouteProcessorRunnable implements Runnable {
                                        NavigationEngineFactory engineFactory) {
     Snap snap = engineFactory.retrieveSnapEngine();
     if (snap instanceof SnapToRoute) {
-      return ((SnapToRoute) snap).getSnappedLocationWith(status);
+      return ((SnapToRoute) snap).getSnappedLocationWith(status, rawLocation);
     }
     return snap.getSnappedLocation(rawLocation, routeProgress);
   }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/snap/SnapToRoute.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/snap/SnapToRoute.java
@@ -8,21 +8,19 @@ import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 
 public class SnapToRoute extends Snap {
 
-  private static final String NAVIGATOR_SNAPPED_LOCATION = "NavigatorSnappedLocation";
-
   @Override
   public Location getSnappedLocation(Location location, RouteProgress routeProgress) {
     // No impl
     return location;
   }
 
-  public Location getSnappedLocationWith(NavigationStatus status) {
-    return buildSnappedLocation(status);
+  public Location getSnappedLocationWith(NavigationStatus status, Location rawLocation) {
+    return buildSnappedLocation(status, rawLocation);
   }
 
   @NonNull
-  private Location buildSnappedLocation(NavigationStatus status) {
-    Location snappedLocation = new Location(NAVIGATOR_SNAPPED_LOCATION);
+  private Location buildSnappedLocation(NavigationStatus status, Location rawLocation) {
+    Location snappedLocation = new Location(rawLocation);
     snappedLocation.setLatitude(status.getLocation().latitude());
     snappedLocation.setLongitude(status.getLocation().longitude());
     snappedLocation.setBearing(status.getBearing());

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/snap/SnapToRouteTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/snap/SnapToRouteTest.java
@@ -2,16 +2,21 @@ package com.mapbox.services.android.navigation.v5.snap;
 
 import android.location.Location;
 
+import com.mapbox.geojson.Point;
 import com.mapbox.navigator.NavigationStatus;
 
-import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
 
+import java.util.Date;
+
+import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-@Ignore
+@RunWith(RobolectricTestRunner.class)
 public class SnapToRouteTest {
 
   @Test
@@ -22,13 +27,62 @@ public class SnapToRouteTest {
   }
 
   @Test
-  public void getSnappedLocation_returnsProviderNameCorrectly() {
-    // TODO mock final class
-    NavigationStatus status = mock(NavigationStatus.class);
+  public void getSnappedLocationWith_returnsRawLocationProvider() {
+    NavigationStatus status = buildMockStatus();
+    String provider = "location_provider";
+    Location rawLocation = new Location(provider);
     SnapToRoute snap = new SnapToRoute();
 
-    Location snappedLocation = snap.getSnappedLocationWith(status);
+    Location snappedLocation = snap.getSnappedLocationWith(status, rawLocation);
 
-    assertTrue(snappedLocation.getProvider().equals("NavigatorSnappedLocation"));
+    assertEquals(provider, snappedLocation.getProvider());
+  }
+
+  @Test
+  public void getSnappedLocationWith_returnsRawLocationSpeed() {
+    NavigationStatus status = buildMockStatus();
+    Location rawLocation = new Location("location_provider");
+    float speed = 1.4f;
+    rawLocation.setSpeed(speed);
+    SnapToRoute snap = new SnapToRoute();
+
+    Location snappedLocation = snap.getSnappedLocationWith(status, rawLocation);
+
+    assertEquals(speed, snappedLocation.getSpeed());
+  }
+
+  @Test
+  public void getSnappedLocationWith_returnsRawLocationAltitude() {
+    NavigationStatus status = buildMockStatus();
+    Location rawLocation = new Location("location_provider");
+    double altitude = 25d;
+    rawLocation.setAltitude(altitude);
+    SnapToRoute snap = new SnapToRoute();
+
+    Location snappedLocation = snap.getSnappedLocationWith(status, rawLocation);
+
+    assertEquals(altitude, snappedLocation.getAltitude());
+  }
+
+  @Test
+  public void getSnappedLocationWith_returnsRawLocationAccuracy() {
+    NavigationStatus status = buildMockStatus();
+    Location rawLocation = new Location("location_provider");
+    float accuracy = 20f;
+    rawLocation.setAccuracy(accuracy);
+    SnapToRoute snap = new SnapToRoute();
+
+    Location snappedLocation = snap.getSnappedLocationWith(status, rawLocation);
+
+    assertEquals(accuracy, snappedLocation.getAccuracy());
+  }
+
+  private NavigationStatus buildMockStatus() {
+    NavigationStatus status = mock(NavigationStatus.class);
+    Point location = Point.fromLngLat(0.0, 0.0);
+    when(status.getLocation()).thenReturn(location);
+    when(status.getTime()).thenReturn(new Date());
+    when(status.getBearing()).thenReturn(0.0f);
+    return status;
   }
 }


### PR DESCRIPTION
Fixes #1518 

We can use the most recent raw `Location` update to build the snapped `Location`.  With the current creation of the snapped location, we omit a lot of data that a developer may be looking for in the snapped location provided by the `ProgressChangeListener`.  

Eventually, this can be provided by the `NavigationStatus`, but we can use this approach until that is added upstream.

cc @kevinkreiser 