### PR TITLE
Fix NavigationMapRoute ArrayIndexOutOfBoundsException

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/MapboxNavigationActivity.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/MapboxNavigationActivity.java
@@ -102,14 +102,12 @@ public class MapboxNavigationActivity extends AppCompatActivity implements OnNav
 
   @Override
   public void onCancelNavigation() {
-    // Navigation canceled, finish the activity
-    finish();
+    finishNavigation();
   }
 
   @Override
   public void onNavigationFinished() {
-    // Navigation finished, finish the activity
-    finish();
+    finishNavigation();
   }
 
   @Override
@@ -137,5 +135,10 @@ public class MapboxNavigationActivity extends AppCompatActivity implements OnNav
       .getBoolean(NavigationConstants.NAVIGATION_VIEW_SIMULATE_ROUTE, false));
     options.directionsProfile(preferences
       .getString(NavigationConstants.NAVIGATION_VIEW_ROUTE_PROFILE_KEY, DirectionsCriteria.PROFILE_DRIVING_TRAFFIC));
+  }
+
+  private void finishNavigation() {
+    NavigationLauncher.cleanUpPreferences(this);
+    finish();
   }
 }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationLauncher.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationLauncher.java
@@ -7,8 +7,6 @@ import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
 
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.mapbox.api.directions.v5.DirectionsAdapterFactory;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.services.android.navigation.v5.navigation.NavigationConstants;
 
@@ -63,9 +61,22 @@ public class NavigationLauncher {
     return DirectionsRoute.fromJson(directionsRouteJson);
   }
 
+  static void cleanUpPreferences(Context context) {
+    SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
+    SharedPreferences.Editor editor = preferences.edit();
+    editor
+      .remove(NavigationConstants.NAVIGATION_VIEW_ROUTE_KEY)
+      .remove(NavigationConstants.NAVIGATION_VIEW_SIMULATE_ROUTE)
+      .remove(NavigationConstants.NAVIGATION_VIEW_ROUTE_PROFILE_KEY)
+      .remove(NavigationConstants.NAVIGATION_VIEW_PREFERENCE_SET_THEME)
+      .remove(NavigationConstants.NAVIGATION_VIEW_PREFERENCE_SET_THEME)
+      .remove(NavigationConstants.NAVIGATION_VIEW_LIGHT_THEME)
+      .remove(NavigationConstants.NAVIGATION_VIEW_DARK_THEME)
+      .apply();
+  }
+
   private static void storeDirectionsRouteValue(NavigationLauncherOptions options, SharedPreferences.Editor editor) {
-    editor.putString(NavigationConstants.NAVIGATION_VIEW_ROUTE_KEY, new GsonBuilder()
-      .registerTypeAdapterFactory(DirectionsAdapterFactory.create()).create().toJson(options.directionsRoute()));
+    editor.putString(NavigationConstants.NAVIGATION_VIEW_ROUTE_KEY, options.directionsRoute().toJson());
   }
 
   private static void storeConfiguration(NavigationLauncherOptions options, SharedPreferences.Editor editor) {

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/route/NavigationMapRouteTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/route/NavigationMapRouteTest.java
@@ -1,0 +1,174 @@
+package com.mapbox.services.android.navigation.ui.v5.route;
+
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation;
+
+import org.junit.Test;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class NavigationMapRouteTest {
+
+  @Test
+  public void checksMapClickListenerIsAddedAtConstructionTime() {
+    MapboxNavigation mockedNavigation = mock(MapboxNavigation.class);
+    MapView mockedMapView = mock(MapView.class);
+    MapboxMap mockedMapboxMap = mock(MapboxMap.class);
+    int mockedStyleRes = 0;
+    String mockedBelowLayer = "mocked_below_layer";
+    MapboxMap.OnMapClickListener mockedMapClickListener = mock(MapboxMap.OnMapClickListener.class);
+    MapView.OnDidFinishLoadingStyleListener mockedDidFinishLoadingStyleListener =
+      mock(MapView.OnDidFinishLoadingStyleListener.class);
+    MapRouteProgressChangeListener mockedProgressChangeListener = mock(MapRouteProgressChangeListener.class);
+
+    new NavigationMapRoute(mockedNavigation, mockedMapView, mockedMapboxMap, mockedStyleRes, mockedBelowLayer,
+      mockedMapClickListener, mockedDidFinishLoadingStyleListener, mockedProgressChangeListener);
+
+    verify(mockedMapboxMap, times(1)).addOnMapClickListener(eq(mockedMapClickListener));
+  }
+
+  @Test
+  public void checksDidFinishLoadingStyleListenerIsAddedAtConstructionTime() {
+    MapboxNavigation mockedNavigation = mock(MapboxNavigation.class);
+    MapView mockedMapView = mock(MapView.class);
+    MapboxMap mockedMapboxMap = mock(MapboxMap.class);
+    int mockedStyleRes = 0;
+    String mockedBelowLayer = "mocked_below_layer";
+    MapboxMap.OnMapClickListener mockedMapClickListener = mock(MapboxMap.OnMapClickListener.class);
+    MapView.OnDidFinishLoadingStyleListener mockedDidFinishLoadingStyleListener =
+      mock(MapView.OnDidFinishLoadingStyleListener.class);
+    MapRouteProgressChangeListener mockedProgressChangeListener = mock(MapRouteProgressChangeListener.class);
+
+    new NavigationMapRoute(mockedNavigation, mockedMapView, mockedMapboxMap, mockedStyleRes, mockedBelowLayer,
+      mockedMapClickListener, mockedDidFinishLoadingStyleListener, mockedProgressChangeListener);
+
+    verify(mockedMapView, times(1))
+      .addOnDidFinishLoadingStyleListener(eq(mockedDidFinishLoadingStyleListener));
+  }
+
+  @Test
+  public void checksMapRouteProgressChangeListenerIsAddedAtConstructionTime() {
+    MapboxNavigation mockedNavigation = mock(MapboxNavigation.class);
+    MapView mockedMapView = mock(MapView.class);
+    MapboxMap mockedMapboxMap = mock(MapboxMap.class);
+    int mockedStyleRes = 0;
+    String mockedBelowLayer = "mocked_below_layer";
+    MapboxMap.OnMapClickListener mockedMapClickListener = mock(MapboxMap.OnMapClickListener.class);
+    MapView.OnDidFinishLoadingStyleListener mockedDidFinishLoadingStyleListener =
+      mock(MapView.OnDidFinishLoadingStyleListener.class);
+    MapRouteProgressChangeListener mockedProgressChangeListener = mock(MapRouteProgressChangeListener.class);
+
+    new NavigationMapRoute(mockedNavigation, mockedMapView, mockedMapboxMap, mockedStyleRes, mockedBelowLayer,
+      mockedMapClickListener, mockedDidFinishLoadingStyleListener, mockedProgressChangeListener);
+
+    verify(mockedNavigation, times(1))
+      .addProgressChangeListener(eq(mockedProgressChangeListener));
+  }
+
+  @Test
+  public void checksMapClickListenerIsNotAddedIfIsMapClickListenerAdded() {
+    MapboxNavigation mockedNavigation = mock(MapboxNavigation.class);
+    MapView mockedMapView = mock(MapView.class);
+    MapboxMap mockedMapboxMap = mock(MapboxMap.class);
+    int mockedStyleRes = 0;
+    String mockedBelowLayer = "mocked_below_layer";
+    MapboxMap.OnMapClickListener mockedMapClickListener = mock(MapboxMap.OnMapClickListener.class);
+    MapView.OnDidFinishLoadingStyleListener mockedDidFinishLoadingStyleListener =
+      mock(MapView.OnDidFinishLoadingStyleListener.class);
+    MapRouteProgressChangeListener mockedProgressChangeListener = mock(MapRouteProgressChangeListener.class);
+    NavigationMapRoute theNavigationMapRoute = new NavigationMapRoute(mockedNavigation, mockedMapView,
+      mockedMapboxMap, mockedStyleRes, mockedBelowLayer, mockedMapClickListener, mockedDidFinishLoadingStyleListener,
+      mockedProgressChangeListener);
+
+    theNavigationMapRoute.onStart();
+
+    verify(mockedMapboxMap, times(1)).addOnMapClickListener(eq(mockedMapClickListener));
+  }
+
+  @Test
+  public void checksDidFinishLoadingStyleListenerIsNotAddedIfIsDidFinishLoadingStyleListenerAdded() {
+    MapboxNavigation mockedNavigation = mock(MapboxNavigation.class);
+    MapView mockedMapView = mock(MapView.class);
+    MapboxMap mockedMapboxMap = mock(MapboxMap.class);
+    int mockedStyleRes = 0;
+    String mockedBelowLayer = "mocked_below_layer";
+    MapboxMap.OnMapClickListener mockedMapClickListener = mock(MapboxMap.OnMapClickListener.class);
+    MapView.OnDidFinishLoadingStyleListener mockedDidFinishLoadingStyleListener =
+      mock(MapView.OnDidFinishLoadingStyleListener.class);
+    MapRouteProgressChangeListener mockedProgressChangeListener = mock(MapRouteProgressChangeListener.class);
+    NavigationMapRoute theNavigationMapRoute = new NavigationMapRoute(mockedNavigation, mockedMapView,
+      mockedMapboxMap, mockedStyleRes, mockedBelowLayer, mockedMapClickListener, mockedDidFinishLoadingStyleListener,
+      mockedProgressChangeListener);
+
+    theNavigationMapRoute.onStart();
+
+    verify(mockedMapView, times(1))
+      .addOnDidFinishLoadingStyleListener(eq(mockedDidFinishLoadingStyleListener));
+  }
+
+  @Test
+  public void checksMapClickListenerIsRemovedInOnStop() {
+    MapboxNavigation mockedNavigation = mock(MapboxNavigation.class);
+    MapView mockedMapView = mock(MapView.class);
+    MapboxMap mockedMapboxMap = mock(MapboxMap.class);
+    int mockedStyleRes = 0;
+    String mockedBelowLayer = "mocked_below_layer";
+    MapboxMap.OnMapClickListener mockedMapClickListener = mock(MapboxMap.OnMapClickListener.class);
+    MapView.OnDidFinishLoadingStyleListener mockedDidFinishLoadingStyleListener =
+      mock(MapView.OnDidFinishLoadingStyleListener.class);
+    MapRouteProgressChangeListener mockedProgressChangeListener = mock(MapRouteProgressChangeListener.class);
+    NavigationMapRoute theNavigationMapRoute = new NavigationMapRoute(mockedNavigation, mockedMapView,
+      mockedMapboxMap, mockedStyleRes, mockedBelowLayer, mockedMapClickListener, mockedDidFinishLoadingStyleListener,
+      mockedProgressChangeListener);
+
+    theNavigationMapRoute.onStop();
+
+    verify(mockedMapboxMap, times(1)).removeOnMapClickListener(eq(mockedMapClickListener));
+  }
+
+  @Test
+  public void checksDidFinishLoadingStyleListenerIsRemovedInOnStop() {
+    MapboxNavigation mockedNavigation = mock(MapboxNavigation.class);
+    MapView mockedMapView = mock(MapView.class);
+    MapboxMap mockedMapboxMap = mock(MapboxMap.class);
+    int mockedStyleRes = 0;
+    String mockedBelowLayer = "mocked_below_layer";
+    MapboxMap.OnMapClickListener mockedMapClickListener = mock(MapboxMap.OnMapClickListener.class);
+    MapView.OnDidFinishLoadingStyleListener mockedDidFinishLoadingStyleListener =
+      mock(MapView.OnDidFinishLoadingStyleListener.class);
+    MapRouteProgressChangeListener mockedProgressChangeListener = mock(MapRouteProgressChangeListener.class);
+    NavigationMapRoute theNavigationMapRoute = new NavigationMapRoute(mockedNavigation, mockedMapView,
+      mockedMapboxMap, mockedStyleRes, mockedBelowLayer, mockedMapClickListener, mockedDidFinishLoadingStyleListener,
+      mockedProgressChangeListener);
+
+    theNavigationMapRoute.onStop();
+
+    verify(mockedMapView, times(1))
+      .removeOnDidFinishLoadingStyleListener(eq(mockedDidFinishLoadingStyleListener));
+  }
+
+  @Test
+  public void checksMapRouteProgressChangeListenerIsRemovedInOnStop() {
+    MapboxNavigation mockedNavigation = mock(MapboxNavigation.class);
+    MapView mockedMapView = mock(MapView.class);
+    MapboxMap mockedMapboxMap = mock(MapboxMap.class);
+    int mockedStyleRes = 0;
+    String mockedBelowLayer = "mocked_below_layer";
+    MapboxMap.OnMapClickListener mockedMapClickListener = mock(MapboxMap.OnMapClickListener.class);
+    MapView.OnDidFinishLoadingStyleListener mockedDidFinishLoadingStyleListener =
+      mock(MapView.OnDidFinishLoadingStyleListener.class);
+    MapRouteProgressChangeListener mockedProgressChangeListener = mock(MapRouteProgressChangeListener.class);
+    NavigationMapRoute theNavigationMapRoute = new NavigationMapRoute(mockedNavigation, mockedMapView,
+      mockedMapboxMap, mockedStyleRes, mockedBelowLayer, mockedMapClickListener, mockedDidFinishLoadingStyleListener,
+      mockedProgressChangeListener);
+
+    theNavigationMapRoute.onStop();
+
+    verify(mockedNavigation, times(1))
+      .removeProgressChangeListener(eq(mockedProgressChangeListener));
+  }
+}


### PR DESCRIPTION
Fixes #1512 

- Fixes `NavigationMapRoute` `ArrayIndexOutOfBoundsException` + adds clean up `NavigationLauncher` preferences support (until now the preferences that we were storing never got removed, adding some unnecessary disk space to the app's footprint).