### PR TITLE
Added MapboxOfflineRouter and removed snapshots

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/OfflineRerouteActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/OfflineRerouteActivity.java
@@ -35,6 +35,7 @@ import com.mapbox.services.android.navigation.v5.milestone.MilestoneEventListene
 import com.mapbox.services.android.navigation.v5.milestone.VoiceInstructionMilestone;
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation;
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigationOptions;
+import com.mapbox.services.android.navigation.v5.navigation.MapboxOfflineNavigator;
 import com.mapbox.services.android.navigation.v5.navigation.NavigationEventListener;
 import com.mapbox.services.android.navigation.v5.navigation.NavigationRoute;
 import com.mapbox.services.android.navigation.v5.navigation.OfflineCriteria;
@@ -68,6 +69,7 @@ public class OfflineRerouteActivity extends AppCompatActivity implements OnMapRe
 
   private ReplayRouteLocationEngine mockLocationEngine;
   private MapboxNavigation navigation;
+  private MapboxOfflineNavigator offlineRouting;
   private MapboxMap mapboxMap;
   private boolean running;
   private boolean tracking;
@@ -141,6 +143,7 @@ public class OfflineRerouteActivity extends AppCompatActivity implements OnMapRe
   public void onMapReady(MapboxMap mapboxMap) {
     this.mapboxMap = mapboxMap;
     mapboxMap.addOnMapClickListener(this);
+    offlineRouting = new MapboxOfflineNavigator();
 
     LocationComponent locationComponent = mapboxMap.getLocationComponent();
     locationComponent.activateLocationComponent(this);
@@ -197,7 +200,7 @@ public class OfflineRerouteActivity extends AppCompatActivity implements OnMapRe
     mapboxMap.addMarker(new MarkerOptions().position(new LatLng(location.getLatitude(), location.getLongitude())));
     Point newOrigin = Point.fromLngLat(location.getLongitude(), location.getLatitude());
     OfflineRoute offlineRoute = obtainOfflineRoute(newOrigin, newDestination);
-    route = navigation.findOfflineRoute(offlineRoute);
+    route = offlineRouting.findOfflineRoute(offlineRoute);
     handleNewRoute(route);
   }
 
@@ -282,9 +285,9 @@ public class OfflineRerouteActivity extends AppCompatActivity implements OnMapRe
     String tilesDirPath = obtainOfflineDirectoryFor("tiles");
     Timber.d("Tiles directory path: %s", tilesDirPath);
 
-    navigation.initializeOfflineData(tilesDirPath, () -> {
+    offlineRouting.initializeOfflineData(tilesDirPath, () -> {
       OfflineRoute offlineRoute = obtainOfflineRoute(origin, destination);
-      route = navigation.findOfflineRoute(offlineRoute);
+      route = offlineRouting.findOfflineRoute(offlineRoute);
       handleNewRoute(route);
     });
   }

--- a/build.gradle
+++ b/build.gradle
@@ -32,8 +32,6 @@ allprojects {
     jcenter()
     maven { url 'https://plugins.gradle.org/m2' }
     maven { url 'https://mapbox.bintray.com/mapbox' }
-    // TODO Remove SNAPSHOT when 4.1.0 gets released
-    maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
   }
 
   group = GROUP

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -9,8 +9,7 @@ ext {
 
   version = [
       mapboxMapSdk       : '6.7.0',
-      // TODO Remove SNAPSHOT when 4.1.0 gets released - See https://github.com/mapbox/mapbox-java/pull/895
-      mapboxSdkServices  : '4.1.0-SNAPSHOT',
+      mapboxSdkServices  : '4.1.0',
       mapboxEvents       : '3.5.2',
       mapboxNavigator    : '3.4.0',
       searchSdk          : '0.1.0-SNAPSHOT',

--- a/libandroid-navigation-ui/build.gradle
+++ b/libandroid-navigation-ui/build.gradle
@@ -37,10 +37,6 @@ dependencies {
 
   // Mapbox Map SDK
   implementation dependenciesList.mapboxMapSdk
-  // TODO Remove SNAPSHOT when 4.1.0 gets released
-  implementation(dependenciesList.mapboxSdkServices) {
-    force true
-  }
 
   // Support libraries
   implementation dependenciesList.supportDesign

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
@@ -14,7 +14,6 @@ import com.mapbox.android.core.location.LocationEnginePriority;
 import com.mapbox.android.core.location.LocationEngineProvider;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.navigator.Navigator;
-import com.mapbox.navigator.RouterResult;
 import com.mapbox.services.android.navigation.v5.milestone.BannerInstructionMilestone;
 import com.mapbox.services.android.navigation.v5.milestone.Milestone;
 import com.mapbox.services.android.navigation.v5.milestone.MilestoneEventListener;
@@ -716,28 +715,6 @@ public class MapboxNavigation implements ServiceConnection {
     mapboxNavigator.toggleHistory(isEnabled);
   }
 
-  /**
-   * Configures the navigator for getting offline routes
-   *
-   * @param tilesDirPath        directory path where the tiles are located
-   * @param callback            a callback that will be fired when the offline data is initialized and
-   *                            {@link MapboxNavigation#findOfflineRoute(OfflineRoute)} could be called safely
-   */
-  public void initializeOfflineData(String tilesDirPath, OnOfflineDataInitialized callback) {
-    mapboxNavigator.configureRouter(tilesDirPath, callback);
-  }
-
-  /**
-   * Uses libvalhalla and local tile data to generate mapbox-directions-api-like JSON
-   *
-   * @param route the {@link OfflineRoute} to get a {@link DirectionsRoute} from
-   * @return the offline {@link DirectionsRoute}
-   */
-  @Nullable
-  public DirectionsRoute findOfflineRoute(@NonNull OfflineRoute route) {
-    return retrieveOfflineRoute(route);
-  }
-
   public String retrieveSsmlAnnouncementInstruction(int index) {
     return mapboxNavigator.retrieveVoiceInstruction(index).getSsmlAnnouncement();
   }
@@ -900,11 +877,5 @@ public class MapboxNavigation implements ServiceConnection {
 
   private boolean isServiceAvailable() {
     return navigationService != null && isBound;
-  }
-
-  @Nullable
-  private DirectionsRoute retrieveOfflineRoute(@NonNull OfflineRoute offlineRoute) {
-    RouterResult response = mapboxNavigator.retrieveRouteFor(offlineRoute);
-    return offlineRoute.retrieveOfflineRoute(response);
   }
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigator.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigator.java
@@ -6,14 +6,12 @@ import com.mapbox.geojson.Point;
 import com.mapbox.navigator.FixLocation;
 import com.mapbox.navigator.NavigationStatus;
 import com.mapbox.navigator.Navigator;
-import com.mapbox.navigator.RouterResult;
 import com.mapbox.navigator.VoiceInstruction;
 
 import java.util.Date;
 
 class MapboxNavigator {
 
-  private static final String EMPTY_TRANSLATIONS_DIR_PATH = "";
   private final Navigator navigator;
 
   MapboxNavigator(Navigator navigator) {
@@ -38,21 +36,6 @@ class MapboxNavigator {
     synchronized (this) {
       navigator.updateLocation(fixedLocation);
     }
-  }
-
-  void configureRouter(String tileFilePath, OnOfflineDataInitialized callback) {
-    new ConfigureRouterTask(navigator, tileFilePath, EMPTY_TRANSLATIONS_DIR_PATH, callback).execute();
-  }
-
-  /**
-   * Uses libvalhalla and local tile data to generate mapbox-directions-api-like json
-   *
-   * @param offlineRoute an offline navigation route
-   * @return a RouterResult object with the json and a success/fail bool
-   */
-  synchronized RouterResult retrieveRouteFor(OfflineRoute offlineRoute) {
-    String offlineUri = offlineRoute.buildUrl();
-    return navigator.getRoute(offlineUri);
   }
 
   /**

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxOfflineNavigator.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxOfflineNavigator.java
@@ -1,0 +1,46 @@
+package com.mapbox.services.android.navigation.v5.navigation;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.mapbox.api.directions.v5.models.DirectionsRoute;
+import com.mapbox.navigator.Navigator;
+import com.mapbox.navigator.RouterResult;
+
+public class MapboxOfflineNavigator {
+  private OfflineNavigator router;
+
+  public MapboxOfflineNavigator() {
+    router = new OfflineNavigator(new Navigator());
+  }
+
+  /**
+   * Configures the navigator for getting offline routes
+   *
+   * @param tilesDirPath        directory path where the tiles are located
+   * @param callback            a callback that will be fired when the offline data is initialized and
+   *                            {@link MapboxOfflineNavigator#findOfflineRoute(OfflineRoute)} could
+   *                            be called
+   *                            safely
+   */
+  public void initializeOfflineData(String tilesDirPath, OnOfflineDataInitialized callback) {
+    router.configure(tilesDirPath, callback);
+  }
+
+  /**
+   * Uses libvalhalla and local tile data to generate mapbox-directions-api-like JSON
+   *
+   * @param route the {@link OfflineRoute} to get a {@link DirectionsRoute} from
+   * @return the offline {@link DirectionsRoute}
+   */
+  @Nullable
+  public DirectionsRoute findOfflineRoute(@NonNull OfflineRoute route) {
+    return retrieveOfflineRoute(route);
+  }
+
+  @Nullable
+  private DirectionsRoute retrieveOfflineRoute(@NonNull OfflineRoute offlineRoute) {
+    RouterResult response = router.retrieveRouteFor(offlineRoute);
+    return offlineRoute.retrieveOfflineRoute(response);
+  }
+}

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/OfflineNavigator.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/OfflineNavigator.java
@@ -1,0 +1,41 @@
+package com.mapbox.services.android.navigation.v5.navigation;
+
+import com.mapbox.navigator.Navigator;
+import com.mapbox.navigator.RouterResult;
+
+class OfflineNavigator {
+  private static final String EMPTY_TRANSLATIONS_DIR_PATH = "";
+  private Navigator navigator;
+
+  static {
+    NavigationLibraryLoader.load();
+  }
+
+  OfflineNavigator(Navigator navigator) {
+    this.navigator = navigator;
+  }
+
+  /**
+   * Configures the navigator for getting offline routes
+   *
+   * @param tilesPath directory path where the tiles are located
+   * @param callback a callback that will be fired when the offline data is initialized and
+   * {@link MapboxOfflineNavigator#findOfflineRoute(OfflineRoute)} could be called safely
+   */
+  void configure(String tilesPath, OnOfflineDataInitialized callback) {
+    new ConfigureRouterTask(navigator, tilesPath, EMPTY_TRANSLATIONS_DIR_PATH, callback).execute();
+  }
+
+  /**
+   * Uses libvalhalla and local tile data to generate mapbox-directions-api-like json
+   *
+   * @param offlineRoute an offline navigation route
+   * @return a RouterResult object with the json and a success/fail bool
+   */
+  RouterResult retrieveRouteFor(OfflineRoute offlineRoute) {
+    String offlineUri = offlineRoute.buildUrl();
+    synchronized (this) {
+      return navigator.getRoute(offlineUri);
+    }
+  }
+}


### PR DESCRIPTION
After this, offline should be ready to be merged into master as far as I know.

This includes breaking out part of the public API of `MapboxNavigation` into a separate class, `MapboxOfflineNavigator`.