### PR TITLE
Prevent from requesting voice instructions if the cache has been closed

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExampleViewModel.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExampleViewModel.kt
@@ -33,7 +33,7 @@ import java.io.File
 import java.util.Locale.US
 
 private const val ONE_SECOND_INTERVAL = 1000
-private const val EXAMPLE_INSTRUCTION_CACHE = "component-navigation-instruction-cache"
+private const val EXAMPLE_INSTRUCTION_CACHE = "example-navigation-instruction-cache"
 private const val TEN_MEGABYTE_CACHE_SIZE: Long = 10 * 1024 * 1024
 
 class ExampleViewModel(application: Application) : AndroidViewModel(application) {

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/voice/VoiceInstructionLoader.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/voice/VoiceInstructionLoader.java
@@ -82,16 +82,20 @@ public class VoiceInstructionLoader {
   }
 
   void requestInstruction(String instruction, String textType, Callback<ResponseBody> callback) {
-    MapboxSpeech mapboxSpeech = mapboxSpeechBuilder
-      .instruction(instruction)
-      .textType(textType)
-      .build();
-    mapboxSpeech.enqueueCall(callback);
+    if (!cache.isClosed()) {
+      MapboxSpeech mapboxSpeech = mapboxSpeechBuilder
+        .instruction(instruction)
+        .textType(textType)
+        .build();
+      mapboxSpeech.enqueueCall(callback);
+    }
   }
 
   void flushCache() {
     try {
-      cache.delete();
+      if (cache.directory().listFiles() != null) {
+        cache.delete();
+      }
     } catch (IOException exception) {
       Timber.e(exception);
     }


### PR DESCRIPTION
Fixes #1537 

- Prevents from requesting voice instructions if the cache has been previously closed
- Adds a check to delete the cache only if there are files (preventing errors for when the cache has not been initialized)

