### PR TITLE
[WIP] Add ability to replace buttons and banners in NavigationView

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/CustomLayoutInflateFinishedListener.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/CustomLayoutInflateFinishedListener.java
@@ -1,0 +1,25 @@
+package com.mapbox.services.android.navigation.ui.v5;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v4.view.AsyncLayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+class CustomLayoutInflateFinishedListener implements AsyncLayoutInflater.OnInflateFinishedListener {
+
+  private final OnLayoutReplacedListener listener;
+
+  CustomLayoutInflateFinishedListener(@NonNull OnLayoutReplacedListener listener) {
+    this.listener = listener;
+  }
+
+  @Override
+  public void onInflateFinished(@NonNull View customView, int resId, @Nullable ViewGroup frame) {
+    if (frame == null) {
+      return;
+    }
+    frame.addView(customView);
+    listener.onLayoutReplaced();
+  }
+}

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/CustomLayoutUpdater.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/CustomLayoutUpdater.java
@@ -1,0 +1,30 @@
+package com.mapbox.services.android.navigation.ui.v5;
+
+import android.support.v4.view.AsyncLayoutInflater;
+import android.view.View;
+import android.widget.FrameLayout;
+
+import timber.log.Timber;
+
+public class CustomLayoutUpdater {
+
+  private final AsyncLayoutInflater inflater;
+
+  public CustomLayoutUpdater(AsyncLayoutInflater inflater) {
+    this.inflater = inflater;
+  }
+
+  public void update(FrameLayout frame, int layoutResId, OnLayoutReplacedListener replacedListener) {
+    frame.removeAllViews();
+    inflater.inflate(layoutResId, frame, new CustomLayoutInflateFinishedListener(replacedListener));
+  }
+
+  public void update(FrameLayout frame, View customView) {
+    if (customView == null) {
+      Timber.e("Custom layout update failed: null View was provided.");
+      return;
+    }
+    frame.removeAllViews();
+    frame.addView(customView);
+  }
+}

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/FeedbackButton.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/FeedbackButton.java
@@ -1,23 +1,31 @@
 package com.mapbox.services.android.navigation.ui.v5;
 
 import android.content.Context;
-import android.support.constraint.ConstraintLayout;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.design.widget.FloatingActionButton;
+import android.support.v4.view.AsyncLayoutInflater;
 import android.util.AttributeSet;
+import android.view.View;
+import android.widget.FrameLayout;
 
-public class FeedbackButton extends ConstraintLayout implements NavigationButton {
-  private FloatingActionButton feedbackFab;
+public class FeedbackButton extends FrameLayout implements NavigationButton {
+
   private MultiOnClickListener multiOnClickListener = new MultiOnClickListener();
+  private FloatingActionButton feedbackFab;
+  private CustomLayoutUpdater layoutUpdater;
 
-  public FeedbackButton(Context context) {
-    this(context, null);
+  public FeedbackButton(@NonNull Context context) {
+    super(context);
+    initialize(context);
   }
 
-  public FeedbackButton(Context context, AttributeSet attrs) {
-    this(context, attrs, -1);
+  public FeedbackButton(@NonNull Context context, @Nullable AttributeSet attrs) {
+    super(context, attrs);
+    initialize(context);
   }
 
-  public FeedbackButton(Context context, AttributeSet attrs, int defStyleAttr) {
+  public FeedbackButton(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
     super(context, attrs, defStyleAttr);
     initialize(context);
   }
@@ -58,6 +66,30 @@ public class FeedbackButton extends ConstraintLayout implements NavigationButton
     setVisibility(VISIBLE);
   }
 
+  /**
+   * Replace this component with a pre-built {@link View}.
+   *
+   * @param view to be used in place of the component.
+   */
+  @Override
+  public void replaceWith(View view) {
+    CustomLayoutUpdater layoutUpdater = retrieveLayoutUpdater();
+    layoutUpdater.update(this, view);
+  }
+
+  /**
+   * Replace this component with a layout resource ID.  The component
+   * will inflate and add the layout once it is ready.
+   *
+   * @param layoutResId to be inflated and added
+   * @param listener    to notify when the replacement is finished
+   */
+  @Override
+  public void replaceWith(int layoutResId, OnLayoutReplacedListener listener) {
+    CustomLayoutUpdater layoutUpdater = retrieveLayoutUpdater();
+    layoutUpdater.update(this, layoutResId, listener);
+  }
+
   @Override
   protected void onFinishInflate() {
     super.onFinishInflate();
@@ -76,6 +108,13 @@ public class FeedbackButton extends ConstraintLayout implements NavigationButton
     clearListeners();
   }
 
+  private void initialize(Context context) {
+    inflate(context, R.layout.feedback_button_layout, this);
+  }
+
+  private void bind() {
+    feedbackFab = findViewById(R.id.feedbackFab);
+  }
 
   private void setupOnClickListeners() {
     feedbackFab.setOnClickListener(multiOnClickListener);
@@ -87,11 +126,12 @@ public class FeedbackButton extends ConstraintLayout implements NavigationButton
     setOnClickListener(null);
   }
 
-  private void initialize(Context context) {
-    inflate(context, R.layout.feedback_button_layout, this);
-  }
-
-  private void bind() {
-    feedbackFab = findViewById(R.id.feedbackFab);
+  private CustomLayoutUpdater retrieveLayoutUpdater() {
+    if (layoutUpdater != null) {
+      return layoutUpdater;
+    }
+    AsyncLayoutInflater layoutInflater = new AsyncLayoutInflater(getContext());
+    layoutUpdater = new CustomLayoutUpdater(layoutInflater);
+    return layoutUpdater;
   }
 }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationBottomSheet.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationBottomSheet.java
@@ -1,0 +1,17 @@
+package com.mapbox.services.android.navigation.ui.v5;
+
+/**
+ * Used to display summary information in the {@link NavigationView}.
+ */
+public interface NavigationBottomSheet extends ReplaceableNavigationComponent {
+
+  /**
+   * When invoked, hides the bottom sheet view (INVISIBLE).
+   */
+  void hide();
+
+  /**
+   * When invoked, shows the bottom sheet view (VISIBLE).
+   */
+  void show();
+}

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationButton.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationButton.java
@@ -2,7 +2,7 @@ package com.mapbox.services.android.navigation.ui.v5;
 
 import android.view.View;
 
-public interface NavigationButton {
+public interface NavigationButton extends ReplaceableNavigationComponent {
 
   /**
    * Adds an onClickListener to the button

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
@@ -481,6 +481,16 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
     return instructionView.retrieveAlertView();
   }
 
+  /**
+   * Returns the bottom sheet that is used to display summary information
+   * for the {@link NavigationView}.
+   *
+   * @return the current bottom sheet
+   */
+  public NavigationBottomSheet retrieveBottomSheet() {
+    return summaryBottomSheet;
+  }
+
   private void initializeView() {
     inflate(getContext(), R.layout.navigation_view_layout, this);
     bind();

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/OnLayoutReplacedListener.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/OnLayoutReplacedListener.java
@@ -1,0 +1,14 @@
+package com.mapbox.services.android.navigation.ui.v5;
+
+import android.widget.FrameLayout;
+
+/**
+ * Listener used with {@link CustomLayoutUpdater#update(FrameLayout, int, OnLayoutReplacedListener)}.
+ */
+public interface OnLayoutReplacedListener {
+
+  /**
+   * Invoked when the layout resource ID has been inflated and added to the parent.
+   */
+  void onLayoutReplaced();
+}

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/RecenterButton.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/RecenterButton.java
@@ -1,12 +1,15 @@
 package com.mapbox.services.android.navigation.ui.v5;
 
 import android.content.Context;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.v7.widget.CardView;
+import android.support.v4.view.AsyncLayoutInflater;
 import android.util.AttributeSet;
+import android.view.View;
 import android.view.animation.Animation;
 import android.view.animation.OvershootInterpolator;
 import android.view.animation.TranslateAnimation;
+import android.widget.FrameLayout;
 
 /**
  * Button used to re-activate following user location during navigation.
@@ -20,21 +23,25 @@ import android.view.animation.TranslateAnimation;
  *
  * @since 0.6.0
  */
-public class RecenterButton extends CardView implements NavigationButton {
+public class RecenterButton extends FrameLayout implements NavigationButton {
+
   private MultiOnClickListener multiOnClickListener = new MultiOnClickListener();
+  private CustomLayoutUpdater layoutUpdater;
   private Animation slideUpBottom;
 
-  public RecenterButton(Context context) {
-    this(context, null);
+  public RecenterButton(@NonNull Context context) {
+    super(context);
+    initialize();
   }
 
-  public RecenterButton(Context context, @Nullable AttributeSet attrs) {
-    this(context, attrs, -1);
+  public RecenterButton(@NonNull Context context, @Nullable AttributeSet attrs) {
+    super(context, attrs);
+    initialize();
   }
 
-  public RecenterButton(Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+  public RecenterButton(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
     super(context, attrs, defStyleAttr);
-    init();
+    initialize();
   }
 
   /**
@@ -83,13 +90,37 @@ public class RecenterButton extends CardView implements NavigationButton {
   }
 
   /**
+   * Replace this component with a pre-built {@link View}.
+   *
+   * @param view to be used in place of the component.
+   */
+  @Override
+  public void replaceWith(View view) {
+    CustomLayoutUpdater layoutUpdater = retrieveLayoutUpdater();
+    layoutUpdater.update(this, view);
+  }
+
+  /**
+   * Replace this component with a layout resource ID.  The component
+   * will inflate and add the layout once it is ready.
+   *
+   * @param layoutResId to be inflated and added
+   * @param listener    to notify when the replacement is finished
+   */
+  @Override
+  public void replaceWith(int layoutResId, OnLayoutReplacedListener listener) {
+    CustomLayoutUpdater layoutUpdater = retrieveLayoutUpdater();
+    layoutUpdater.update(this, layoutResId, listener);
+  }
+
+  /**
    * Once inflation of the view has finished,
    * create the custom animation.
    */
   @Override
   protected void onFinishInflate() {
     super.onFinishInflate();
-    initAnimation();
+    initializeAnimation();
   }
 
   @Override
@@ -117,16 +148,25 @@ public class RecenterButton extends CardView implements NavigationButton {
   /**
    * Inflates the layout.
    */
-  private void init() {
+  private void initialize() {
     inflate(getContext(), R.layout.recenter_btn_layout, this);
   }
 
   /**
    * Creates the custom animation used to show this button.
    */
-  private void initAnimation() {
+  private void initializeAnimation() {
     slideUpBottom = new TranslateAnimation(0f, 0f, 125f, 0f);
     slideUpBottom.setDuration(300);
     slideUpBottom.setInterpolator(new OvershootInterpolator(2.0f));
+  }
+
+  private CustomLayoutUpdater retrieveLayoutUpdater() {
+    if (layoutUpdater != null) {
+      return layoutUpdater;
+    }
+    AsyncLayoutInflater layoutInflater = new AsyncLayoutInflater(getContext());
+    layoutUpdater = new CustomLayoutUpdater(layoutInflater);
+    return layoutUpdater;
   }
 }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/ReplaceableNavigationComponent.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/ReplaceableNavigationComponent.java
@@ -1,0 +1,27 @@
+package com.mapbox.services.android.navigation.ui.v5;
+
+import android.support.annotation.LayoutRes;
+import android.view.View;
+
+/**
+ * This interface defines the methods that allow you to
+ * replace the {@link NavigationView} UI components that implement it.
+ */
+public interface ReplaceableNavigationComponent {
+
+  /**
+   * Replace this component with a pre-built {@link View}.
+   *
+   * @param view to be used in place of the component.
+   */
+  void replaceWith(View view);
+
+  /**
+   * Replace this component with a layout resource ID.  The component
+   * will inflate and add the layout once it is ready.
+   *
+   * @param layoutResId to be inflated and added
+   * @param listener    to notify when the replacement is finished
+   */
+  void replaceWith(@LayoutRes int layoutResId, OnLayoutReplacedListener listener);
+}

--- a/libandroid-navigation-ui/src/main/res/layout/feedback_button_layout.xml
+++ b/libandroid-navigation-ui/src/main/res/layout/feedback_button_layout.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<merge
+<FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="wrap_content"
@@ -25,4 +25,4 @@
         app:layout_constraintTop_toTopOf="parent"
         app:srcCompat="@drawable/ic_message"/>
 
-</merge>
+</FrameLayout>

--- a/libandroid-navigation-ui/src/main/res/layout/recenter_btn_layout.xml
+++ b/libandroid-navigation-ui/src/main/res/layout/recenter_btn_layout.xml
@@ -1,33 +1,39 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.v7.widget.CardView
+<FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    app:cardBackgroundColor="?attr/navigationViewPrimary"
-    app:cardElevation="2dp">
+    android:layout_height="wrap_content">
 
-    <LinearLayout
+    <android.support.v7.widget.CardView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:padding="8dp">
+        app:cardBackgroundColor="?attr/navigationViewPrimary"
+        app:cardElevation="2dp">
 
-        <ImageView
+        <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            app:srcCompat="@drawable/ic_navigation"
-            android:tint="?attr/navigationViewAccent"/>
+            android:padding="8dp">
 
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_vertical"
-            android:textAllCaps="true"
-            android:textColor="?attr/navigationViewAccent"
-            android:layout_marginLeft="8dp"
-            android:layout_marginStart="8dp"
-            android:text="@string/re_center"/>
+            <ImageView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:tint="?attr/navigationViewAccent"
+                app:srcCompat="@drawable/ic_navigation"/>
 
-    </LinearLayout>
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:layout_marginStart="8dp"
+                android:layout_marginLeft="8dp"
+                android:text="@string/re_center"
+                android:textAllCaps="true"
+                android:textColor="?attr/navigationViewAccent"/>
 
-</android.support.v7.widget.CardView>
+        </LinearLayout>
+
+    </android.support.v7.widget.CardView>
+
+</FrameLayout>

--- a/libandroid-navigation-ui/src/main/res/layout/sound_layout.xml
+++ b/libandroid-navigation-ui/src/main/res/layout/sound_layout.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<merge
+<FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="wrap_content"
@@ -44,4 +44,4 @@
         app:layout_constraintTop_toTopOf="parent"
         app:srcCompat="@drawable/ic_sound_on"/>
 
-</merge>
+</FrameLayout>

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/CustomLayoutInflateFinishedListenerTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/CustomLayoutInflateFinishedListenerTest.java
@@ -1,0 +1,52 @@
+package com.mapbox.services.android.navigation.ui.v5;
+
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.FrameLayout;
+
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+public class CustomLayoutInflateFinishedListenerTest {
+
+  @Test
+  public void onInflateFinished_nullFrameIgnored() {
+    OnLayoutReplacedListener replacedListener = mock(OnLayoutReplacedListener.class);
+    int someResId = 1234;
+    ViewGroup nullFrame = null;
+    CustomLayoutInflateFinishedListener listener = new CustomLayoutInflateFinishedListener(replacedListener);
+
+    listener.onInflateFinished(mock(View.class), someResId, nullFrame);
+
+    verifyZeroInteractions(replacedListener);
+  }
+
+  @Test
+  public void onInflateFinished_customViewAdded() {
+    OnLayoutReplacedListener replacedListener = mock(OnLayoutReplacedListener.class);
+    View customView = mock(View.class);
+    int someResId = 1234;
+    FrameLayout frame = mock(FrameLayout.class);
+    CustomLayoutInflateFinishedListener listener = new CustomLayoutInflateFinishedListener(replacedListener);
+
+    listener.onInflateFinished(customView, someResId, frame);
+
+    verify(frame).addView(customView);
+  }
+
+  @Test
+  public void onInflateFinished_listenerIsTriggered() {
+    OnLayoutReplacedListener replacedListener = mock(OnLayoutReplacedListener.class);
+    View customView = mock(View.class);
+    int someResId = 1234;
+    FrameLayout frame = mock(FrameLayout.class);
+    CustomLayoutInflateFinishedListener listener = new CustomLayoutInflateFinishedListener(replacedListener);
+
+    listener.onInflateFinished(customView, someResId, frame);
+
+    verify(replacedListener).onLayoutReplaced();
+  }
+}

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/CustomLayoutUpdaterTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/CustomLayoutUpdaterTest.java
@@ -1,0 +1,80 @@
+package com.mapbox.services.android.navigation.ui.v5;
+
+import android.support.v4.view.AsyncLayoutInflater;
+import android.view.View;
+import android.widget.FrameLayout;
+
+import org.junit.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+public class CustomLayoutUpdaterTest {
+
+  @Test
+  public void updateWithView_frameChildrenAreRemoved() {
+    AsyncLayoutInflater inflater = mock(AsyncLayoutInflater.class);
+    FrameLayout frame = mock(FrameLayout.class);
+    View customView = mock(View.class);
+    CustomLayoutUpdater layoutUpdater = new CustomLayoutUpdater(inflater);
+
+    layoutUpdater.update(frame, customView);
+
+    verify(frame).removeAllViews();
+  }
+
+  @Test
+  public void updateWithView_nullCustomViewIgnored() {
+    AsyncLayoutInflater inflater = mock(AsyncLayoutInflater.class);
+    FrameLayout frame = mock(FrameLayout.class);
+    View customView = null;
+    CustomLayoutUpdater layoutUpdater = new CustomLayoutUpdater(inflater);
+
+    layoutUpdater.update(frame, customView);
+
+    verifyZeroInteractions(frame);
+  }
+
+  @Test
+  public void updateWithView_customViewAddedToFrame() {
+    AsyncLayoutInflater inflater = mock(AsyncLayoutInflater.class);
+    FrameLayout frame = mock(FrameLayout.class);
+    View customView = mock(View.class);
+    CustomLayoutUpdater layoutUpdater = new CustomLayoutUpdater(inflater);
+
+    layoutUpdater.update(frame, customView);
+
+    verify(frame).addView(customView);
+  }
+
+  @Test
+  public void updateWithResId_frameChildrenAreRemoved() {
+    AsyncLayoutInflater inflater = mock(AsyncLayoutInflater.class);
+    OnLayoutReplacedListener listener = mock(OnLayoutReplacedListener.class);
+    FrameLayout frame = mock(FrameLayout.class);
+    int layoutResId = 1234;
+    CustomLayoutUpdater layoutUpdater = new CustomLayoutUpdater(inflater);
+
+    layoutUpdater.update(frame, layoutResId, listener);
+
+    verify(frame).removeAllViews();
+  }
+
+  @Test
+  public void updateWithResId_inflaterReceivesResId() {
+    AsyncLayoutInflater inflater = mock(AsyncLayoutInflater.class);
+    OnLayoutReplacedListener listener = mock(OnLayoutReplacedListener.class);
+    FrameLayout frame = mock(FrameLayout.class);
+    int layoutResId = 1234;
+    CustomLayoutUpdater layoutUpdater = new CustomLayoutUpdater(inflater);
+
+    layoutUpdater.update(frame, layoutResId, listener);
+
+    verify(inflater).inflate(
+      eq(layoutResId), any(FrameLayout.class), any(AsyncLayoutInflater.OnInflateFinishedListener.class)
+    );
+  }
+}


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-navigation-android/issues/1468

This PR adds the ability to replace the `NavigationButton`'s,  `NavigationAlertView`, and `SummaryBottomSheet` with either a `View` or an `int` layout resource ID (we will inflate in the background and add the resulting `View` once ready).

TODO:
- [x] Tests
- [x] `NavigationButton`s replacement logic
- [x] `SummaryBottomSheet` replacement logic 