### PR TITLE
Fix milestone / progress listener leaks from NavigationView

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
@@ -102,6 +102,12 @@ public class NavigationViewModel extends AndroidViewModel {
     localeUtils = new LocaleUtils();
   }
 
+  // Package private (no modifier) for testing purposes
+  NavigationViewModel(Application application, MapboxNavigation navigation) {
+    super(application);
+    this.navigation = navigation;
+  }
+
   public void onCreate() {
     if (!isRunning) {
       locationEngineConductor.onCreate();
@@ -213,6 +219,8 @@ public class NavigationViewModel extends AndroidViewModel {
   }
 
   void stopNavigation() {
+    navigation.removeProgressChangeListener(null);
+    navigation.removeMilestoneEventListener(null);
     navigation.stopNavigation();
   }
 

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModelTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModelTest.java
@@ -1,0 +1,38 @@
+package com.mapbox.services.android.navigation.ui.v5;
+
+import android.app.Application;
+
+import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@RunWith(RobolectricTestRunner.class)
+public class NavigationViewModelTest {
+
+  @Test
+  public void stopNavigation_progressListenersAreRemoved() {
+    Application application = mock(Application.class);
+    MapboxNavigation navigation = mock(MapboxNavigation.class);
+    NavigationViewModel viewModel = new NavigationViewModel(application, navigation);
+
+    viewModel.stopNavigation();
+
+    verify(navigation).removeProgressChangeListener(null);
+  }
+
+  @Test
+  public void stopNavigation_milestoneListenersAreRemoved() {
+    Application application = mock(Application.class);
+    MapboxNavigation navigation = mock(MapboxNavigation.class);
+    NavigationViewModel viewModel = new NavigationViewModel(application, navigation);
+
+    viewModel.stopNavigation();
+
+    verify(navigation).removeMilestoneEventListener(null);
+  }
+}


### PR DESCRIPTION
Fixes #1279 

This leak was caused by a new `ProgressChangeListener` being added each time navigation was started with the `NavigationView` in `EndNavigationActivity`. 

If we stop navigation, we should also remove the listeners if we require them when starting as well.  