### PR TITLE
Fix cache is closed crash

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
@@ -113,8 +113,8 @@ public class NavigationViewModel extends AndroidViewModel {
     if (!isChangingConfigurations) {
       locationEngineConductor.onDestroy();
       routeFetcher.onDestroy();
-      deactivateInstructionPlayer();
       endNavigation();
+      deactivateInstructionPlayer();
       isRunning = false;
     }
     clearDynamicCameraMap();

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/voice/VoiceInstructionLoader.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/voice/VoiceInstructionLoader.java
@@ -93,9 +93,7 @@ public class VoiceInstructionLoader {
 
   void flushCache() {
     try {
-      if (cache.directory().listFiles() != null) {
-        cache.delete();
-      }
+      cache.evictAll();
     } catch (IOException exception) {
       Timber.e(exception);
     }


### PR DESCRIPTION
Run into 👇 again during CI

```
11-27 05:34:27.307: E/AndroidRuntime(13865): FATAL EXCEPTION: OkHttp Dispatcher
11-27 05:34:27.307: E/AndroidRuntime(13865): Process: com.mapbox.services.android.navigation.testapp, PID: 13865
11-27 05:34:27.307: E/AndroidRuntime(13865): java.lang.IllegalStateException: cache is closed
11-27 05:34:27.307: E/AndroidRuntime(13865): 	at okhttp3.internal.cache.DiskLruCache.checkNotClosed(DiskLruCache.java:651)
11-27 05:34:27.307: E/AndroidRuntime(13865): 	at okhttp3.internal.cache.DiskLruCache.edit(DiskLruCache.java:465)
11-27 05:34:27.307: E/AndroidRuntime(13865): 	at okhttp3.internal.cache.DiskLruCache.edit(DiskLruCache.java:459)
11-27 05:34:27.307: E/AndroidRuntime(13865): 	at okhttp3.Cache.put(Cache.java:246)
11-27 05:34:27.307: E/AndroidRuntime(13865): 	at okhttp3.Cache$1.put(Cache.java:149)
11-27 05:34:27.307: E/AndroidRuntime(13865): 	at okhttp3.internal.cache.CacheInterceptor.intercept(CacheInterceptor.java:131)
11-27 05:34:27.307: E/AndroidRuntime(13865): 	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:147)
11-27 05:34:27.307: E/AndroidRuntime(13865): 	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:121)
11-27 05:34:27.307: E/AndroidRuntime(13865): 	at okhttp3.internal.http.BridgeInterceptor.intercept(BridgeInterceptor.java:93)
11-27 05:34:27.307: E/AndroidRuntime(13865): 	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:147)
11-27 05:34:27.307: E/AndroidRuntime(13865): 	at okhttp3.internal.http.RetryAndFollowUpInterceptor.intercept(RetryAndFollowUpInterceptor.java:126)
11-27 05:34:27.307: E/AndroidRuntime(13865): 	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:147)
11-27 05:34:27.307: E/AndroidRuntime(13865): 	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:121)
11-27 05:34:27.307: E/AndroidRuntime(13865): 	at com.mapbox.services.android.navigation.ui.v5.voice.VoiceInstructionLoader$2.intercept(VoiceInstructionLoader.java:133)
11-27 05:34:27.307: E/AndroidRuntime(13865): 	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:147)
11-27 05:34:27.307: E/AndroidRuntime(13865): 	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:121)
11-27 05:34:27.307: E/AndroidRuntime(13865): 	at okhttp3.RealCall.getResponseWithInterceptorChain(RealCall.java:200)
11-27 05:34:27.307: E/AndroidRuntime(13865): 	at okhttp3.RealCall$AsyncCall.execute(RealCall.java:147)
11-27 05:34:27.307: E/AndroidRuntime(13865): 	at okhttp3.internal.NamedRunnable.run(NamedRunnable.java:32)
11-27 05:34:27.307: E/AndroidRuntime(13865): 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1112)
11-27 05:34:27.307: E/AndroidRuntime(13865): 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:587)
11-27 05:34:27.307: E/AndroidRuntime(13865): 	at java.lang.Thread.run(Thread.java:818)
11-27 05:34:27.313: W/ActivityManager(770): Error in app com.mapbox.services.android.navigation.testapp running instrumentation ComponentInfo{com.mapbox.services.android.navigation.testapp.test/android.support.test.runner.AndroidJUnitRunner}:
11-27 05:34:27.313: W/ActivityManager(770):   java.lang.IllegalStateException
11-27 05:34:27.313: W/ActivityManager(770):   java.lang.IllegalStateException: cache is closed
```

Edited:

- Fixes https://github.com/mapbox/mapbox-navigation-android/issues/1537 ~ensuring that flushing the cache is only called once after navigation is stopped~ evicting cache entries instead of deleting it altogether preventing potential race conditions from in-flight responses 👀 `Cache#evictAll` documentation

```java
/**
   * Deletes all values stored in the cache. In-flight writes to the cache will complete normally,
   * but the corresponding responses will not be stored.
   */
```

