### PR TITLE
Bump mapboxEvents and mapboxNavigator versions

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -10,8 +10,8 @@ ext {
   version = [
       mapboxMapSdk       : '6.7.0',
       mapboxSdkServices  : '4.1.0',
-      mapboxEvents       : '3.5.2',
-      mapboxNavigator    : '3.4.0',
+      mapboxEvents       : '3.5.5',
+      mapboxNavigator    : '3.4.2',
       searchSdk          : '0.1.0-SNAPSHOT',
       autoValue          : '1.5.4',
       autoValueParcel    : '0.2.5',


### PR DESCRIPTION
- Bumps `mapbox-android-telemetry` and `mapbox-navigation-native` to `3.5.5` and `3.4.2` versions respectively

Fixes https://github.com/mapbox/mapbox-navigation-android/issues/1557