### PR TITLE
Fix JSON file names (repo name) in check binary size script

### DIFF
--- a/scripts/check_binary_size.sh
+++ b/scripts/check_binary_size.sh
@@ -16,8 +16,8 @@ sdks_file=$5
 
 source=mobile.binarysize
 scripts_path="scripts"
-json_name="$scripts_path/${platform}-binarysize.json"
-json_gz="$scripts_path/${platform}-binarysize.json.gz"
+json_name="$scripts_path/${repo_name}.json"
+json_gz="$scripts_path/${repo_name}.json.gz"
 
 date=`date '+%Y-%m-%d'`
 utc_iso_date=`date -u +'%Y-%m-%dT%H:%M:%SZ'`


### PR DESCRIPTION
- Fixes JSON file names (`repo_name`) in `check_binary_size` script

More tail work from #1554