### PR TITLE
Fix the progressUpdateListener for Tile Pack Unpacking

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/UnpackUpdateTask.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/UnpackUpdateTask.java
@@ -24,14 +24,17 @@ class UnpackUpdateTask extends AsyncTask<File, Long, File> {
 
   @Override
   protected File doInBackground(File... files) {
-    File tar = files[0];
-    long size = tar.length();
+    // As the data is unpacked from the file, the file is truncated
+    // We are finished unpacking the data when the file is fully 0 bytes
+    File tile_pack = files[0];
+    double size = tile_pack.length();
+    long progress = 0;
+    do {
+      progress = (long)(100.0 * (1.0 - (tile_pack.length() / size)));
+      publishProgress(progress);
+    } while (progress < 100L);
 
-    while (tar.length() > 0) {
-      publishProgress((((tar.length() / size)) * 100));
-    }
-
-    return tar;
+    return tile_pack;
   }
 
   @Override

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/UnpackUpdateTask.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/UnpackUpdateTask.java
@@ -26,15 +26,16 @@ class UnpackUpdateTask extends AsyncTask<File, Long, File> {
   protected File doInBackground(File... files) {
     // As the data is unpacked from the file, the file is truncated
     // We are finished unpacking the data when the file is fully 0 bytes
-    File tile_pack = files[0];
-    double size = tile_pack.length();
+    File tilePack = files[0];
+    double size = tilePack.length();
     long progress = 0;
     do {
-      progress = (long)(100.0 * (1.0 - (tile_pack.length() / size)));
+      progress = (long)(100.0 * (1.0 - (tilePack.length() / size)));
       publishProgress(progress);
-    } while (progress < 100L);
+    }
+    while (progress < 100L);
 
-    return tile_pack;
+    return tilePack;
   }
 
   @Override


### PR DESCRIPTION
Not much to describe here, just that we had two small issues. We needed to use floating point division so that when we cast back to long it doesn't truncate to `0` and we also needed to invert the percentage since we are counting down to `0` from the full size of the file as its being truncated.