### PR TITLE
Add write external permission storage to app AndroidManifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
           package="com.mapbox.services.android.navigation.testapp">
 
     <uses-permission android:name="android.permission.VIBRATE"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 
     <application
         android:name=".NavigationApplication"


### PR DESCRIPTION
- Adds `WRITE_EXTERNAL_STORAGE` to app's `AndroidManifest.xml` needed for offline activities