### PR TITLE
Only allow choosing an offline version with valid data

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/NavigationSettingsActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/NavigationSettingsActivity.java
@@ -67,12 +67,15 @@ public class NavigationSettingsActivity extends PreferenceActivity {
         file.mkdirs();
       }
 
+      ListPreference offlineVersions = (ListPreference) findPreference(getString(R.string.offline_version_key));
       List<String> list = buildFileList(file);
       if (!list.isEmpty()) {
-        ListPreference offlineVersions = (ListPreference) findPreference(getString(R.string.offline_version_key));
         String[] entries = list.toArray(new String[list.size() - 1]);
         offlineVersions.setEntries(entries);
         offlineVersions.setEntryValues(entries);
+        offlineVersions.setEnabled(true);
+      } else {
+        offlineVersions.setEnabled(false);
       }
     }
 

--- a/app/src/main/res/xml/fragment_navigation_preferences.xml
+++ b/app/src/main/res/xml/fragment_navigation_preferences.xml
@@ -64,7 +64,8 @@
 
         <ListPreference
             android:key="@string/offline_version_key"
-            android:title="@string/offline_version_title"/>
+            android:title="@string/offline_version_title"
+            android:enabled="false"/>
 
     </PreferenceCategory>
 


### PR DESCRIPTION
🐛 caught in CI for `NavigationSettingsActivity`:

```
java.lang.IllegalStateException: ListPreference requires an entries array and an entryValues array.
FATAL EXCEPTION: ControllerMessenger
Process: com.mapbox.services.android.navigation.testapp, PID: 12222
java.lang.IllegalStateException: ListPreference requires an entries array and an entryValues array.
	at android.preference.ListPreference.onPrepareDialogBuilder(ListPreference.java:248)
	at android.preference.DialogPreference.showDialog(DialogPreference.java:303)
	at android.preference.DialogPreference.onClick(DialogPreference.java:274)
	at android.preference.Preference.performClick(Preference.java:983)
	at android.preference.PreferenceScreen.onItemClick(PreferenceScreen.java:214)
	at android.widget.AdapterView.performItemClick(AdapterView.java:305)
	at android.widget.AbsListView.performItemClick(AbsListView.java:1146)
	at android.widget.AbsListView$PerformClick.run(AbsListView.java:3053)
	at android.widget.AbsListView$3.run(AbsListView.java:3860)
	at android.os.Handler.handleCallback(Handler.java:739)
	at android.os.Handler.dispatchMessage(Handler.java:95)
```

We should enable or disable the list based on the data found in the file system. 