### PR TITLE
Bump mapbox-android-sdk and mapbox-android-telemetry versions

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,9 +8,9 @@ ext {
   ]
 
   version = [
-      mapboxMapSdk       : '6.7.0',
+      mapboxMapSdk       : '6.7.2',
       mapboxSdkServices  : '4.1.0',
-      mapboxEvents       : '3.5.5',
+      mapboxEvents       : '3.5.6',
       mapboxNavigator    : '3.4.5',
       searchSdk          : '0.1.0-SNAPSHOT',
       autoValue          : '1.5.4',


### PR DESCRIPTION
- Bumps `mapbox-android-sdk` and `mapbox-android-telemetry` versions to `6.7.2` and `3.5.6` respectively