### PR TITLE
Add MapboxOfflineRouter constructor that doesn't require an offline path

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/OfflineRegionDownloadActivity.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/OfflineRegionDownloadActivity.kt
@@ -60,7 +60,7 @@ class OfflineRegionDownloadActivity : AppCompatActivity(), RouteTileDownloadList
     }
 
     fun setupSpinner() {
-        MapboxOfflineRouter("")
+        MapboxOfflineRouter()
             .fetchAvailableTileVersions(Mapbox.getAccessToken(),
                 object : OnTileVersionsFoundCallback {
                 override fun onVersionsFound(availableVersions: MutableList<String>) {

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/MapboxOfflineRouterTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/MapboxOfflineRouterTest.java
@@ -2,6 +2,7 @@ package com.mapbox.services.android.navigation.v5.navigation;
 
 import org.junit.Test;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -32,6 +33,28 @@ public class MapboxOfflineRouterTest {
   }
 
   @Test
+  public void configure_errorWithEmptyTilePath() {
+    String emptyTilePath = "";
+    OnOfflineTilesConfiguredCallback callback = mock(OnOfflineTilesConfiguredCallback.class);
+    MapboxOfflineRouter offlineRouter = buildRouter(emptyTilePath);
+
+    offlineRouter.configure("some_version", callback);
+
+    verify(callback).onConfigurationError(any(OfflineError.class));
+  }
+
+  @Test
+  public void downloadTiles_errorWithEmptyTilePath() {
+    String emptyTilePath = "";
+    RouteTileDownloadListener listener = mock(RouteTileDownloadListener.class);
+    MapboxOfflineRouter offlineRouter = buildRouter(emptyTilePath);
+
+    offlineRouter.downloadTiles(mock(OfflineTiles.class), listener);
+
+    verify(listener).onError(any(OfflineError.class));
+  }
+
+  @Test
   public void fetchAvailableTileVersions() {
     String accessToken = "access_token";
     OnTileVersionsFoundCallback callback = mock(OnTileVersionsFoundCallback.class);
@@ -41,6 +64,10 @@ public class MapboxOfflineRouterTest {
     offlineRouter.fetchAvailableTileVersions(accessToken, callback);
 
     verify(offlineTileVersions).fetchRouteTileVersions(accessToken, callback);
+  }
+
+  private MapboxOfflineRouter buildRouter(String tilePath) {
+    return new MapboxOfflineRouter(tilePath, mock(OfflineNavigator.class), mock(OfflineTileVersions.class));
   }
 
   private MapboxOfflineRouter buildRouter(String tilePath, OfflineNavigator offlineNavigator) {


### PR DESCRIPTION
For fetching offline tile versions, I think it makes sense to add a constructor to `MapboxOfflineRouter` that doesn't require `offlinePath`.  

If a developer wants to _only_ request available tile versions (like we do in `OfflineRegionDownloadActivity`), the `offlinePath` goes unused and isn't relevant to the API call. 

