### PR TITLE
Add proguard rule for MapboxTelemetry

### DIFF
--- a/libandroid-navigation/proguard-consumer.pro
+++ b/libandroid-navigation/proguard-consumer.pro
@@ -15,3 +15,6 @@
 
 # --- Navigator ---
 -keep class com.mapbox.navigator.** { *; }
+
+# --- Telemetry ---
+-keep class com.mapbox.android.telemetry.** { *; }


### PR DESCRIPTION
Found a telemetry related crash in our release builds, adding this rule seemed to have resolved it.  

cc @electrostat @andrlee 