### PR TITLE
Bump mapboxSdkServices version to 4.2.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -9,7 +9,7 @@ ext {
 
   version = [
       mapboxMapSdk       : '6.7.2',
-      mapboxSdkServices  : '4.1.1',
+      mapboxSdkServices  : '4.2.0',
       mapboxEvents       : '3.5.6',
       mapboxNavigator    : '3.4.7',
       searchSdk          : '0.1.0-SNAPSHOT',


### PR DESCRIPTION
- Bumps `mapboxSdkServices` version to `4.2.0`