### PR TITLE
Increment leg index upon way point arrival

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigator.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigator.java
@@ -12,6 +12,8 @@ import java.util.Date;
 
 class MapboxNavigator {
 
+  private static final int INDEX_FIRST_ROUTE = 0;
+  private static final int INDEX_FIRST_LEG = 0;
   private final Navigator navigator;
 
   MapboxNavigator(Navigator navigator) {
@@ -20,7 +22,7 @@ class MapboxNavigator {
 
   synchronized void updateRoute(String routeJson) {
     // TODO route_index (Which route to follow) and leg_index (Which leg to follow) are hardcoded for now
-    navigator.setRoute(routeJson, 0, 0);
+    navigator.setRoute(routeJson, INDEX_FIRST_ROUTE, INDEX_FIRST_LEG);
   }
 
   synchronized NavigationStatus retrieveStatus(Date date, long lagInMilliseconds) {
@@ -36,6 +38,10 @@ class MapboxNavigator {
     synchronized (this) {
       navigator.updateLocation(fixedLocation);
     }
+  }
+
+  synchronized NavigationStatus updateLegIndex(int index) {
+    return navigator.changeRouteLeg(INDEX_FIRST_ROUTE, index);
   }
 
   /**


### PR DESCRIPTION
Fixes #1487 

We currently do not increment the `RouteLeg` upon arrival of each way point along the route.  This essentially means we can only navigate from an origin to a destination with way points in between.  

This PR looks at a few criteria before incrementing the index and reseting the `NavigationStatus` with the new data.  