### PR TITLE
Move SummaryBottomSheet above RecenterBtn in navigation_view_layout.xml

### DIFF
--- a/libandroid-navigation-ui/src/main/res/layout-land/navigation_view_layout.xml
+++ b/libandroid-navigation-ui/src/main/res/layout-land/navigation_view_layout.xml
@@ -21,6 +21,12 @@
         android:layout_height="match_parent"
         android:visibility="invisible"/>
 
+    <com.mapbox.services.android.navigation.ui.v5.summary.SummaryBottomSheet
+        android:id="@+id/summaryBottomSheet"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_behavior="android.support.design.widget.BottomSheetBehavior"/>
+
     <com.mapbox.services.android.navigation.ui.v5.RecenterButton
         android:id="@+id/recenterBtn"
         android:layout_width="wrap_content"
@@ -30,12 +36,6 @@
         android:visibility="invisible"
         app:layout_anchor="@id/summaryBottomSheet"
         app:layout_anchorGravity="top|left"/>
-
-    <com.mapbox.services.android.navigation.ui.v5.summary.SummaryBottomSheet
-        android:id="@+id/summaryBottomSheet"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:layout_behavior="android.support.design.widget.BottomSheetBehavior"/>
 
     <com.mapbox.services.android.navigation.ui.v5.instruction.InstructionView
         android:id="@+id/instructionView"

--- a/libandroid-navigation-ui/src/main/res/layout/navigation_view_layout.xml
+++ b/libandroid-navigation-ui/src/main/res/layout/navigation_view_layout.xml
@@ -22,6 +22,12 @@
         android:layout_height="match_parent"
         android:visibility="invisible"/>
 
+    <com.mapbox.services.android.navigation.ui.v5.summary.SummaryBottomSheet
+        android:id="@+id/summaryBottomSheet"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_behavior="android.support.design.widget.BottomSheetBehavior"/>
+
     <com.mapbox.services.android.navigation.ui.v5.RecenterButton
         android:id="@+id/recenterBtn"
         android:layout_width="wrap_content"
@@ -32,11 +38,6 @@
         app:layout_anchor="@id/summaryBottomSheet"
         app:layout_anchorGravity="top|left"/>
 
-    <com.mapbox.services.android.navigation.ui.v5.summary.SummaryBottomSheet
-        android:id="@+id/summaryBottomSheet"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:layout_behavior="android.support.design.widget.BottomSheetBehavior"/>
 
     <com.mapbox.services.android.navigation.ui.v5.instruction.InstructionView
         android:id="@+id/instructionView"


### PR DESCRIPTION
I'm not sure why this reproducible consistently, but I think https://github.com/mapbox/mapbox-navigation-android/issues/1614 and https://github.com/mapbox/mapbox-navigation-android/issues/1424#issuecomment-430375120 are valid.  

It seems this error can occur when a view in the XML is trying to anchor to another view that hasn't been declared yet in the XML.  In our case, the `RecenterBtn` was trying to anchor to the `SummaryBottomSheet` directly below it.  See https://stackoverflow.com/a/11669528/8412108