### PR TITLE
Update script-git-version.gradle with try/catch

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,12 +21,16 @@ android {
   }
 
   def getGitHash = { ->
-    def stdout = new ByteArrayOutputStream()
-    exec {
-      commandLine 'git', 'rev-parse', '--short', 'HEAD'
-      standardOutput = stdout
+    try {
+      def stdout = new ByteArrayOutputStream()
+      exec {
+        commandLine 'git', 'rev-parse', '--short', 'HEAD'
+        standardOutput = stdout
+      }
+      return stdout.toString().trim()
+    } catch (Exception exception) {
+      return ""
     }
-    return stdout.toString().trim()
   }
 
   defaultConfig {

--- a/gradle/script-git-version.gradle
+++ b/gradle/script-git-version.gradle
@@ -22,6 +22,9 @@ import org.ajoberstar.grgit.Grgit
  */
 
 ext {
+    gitVersionName = "YOUR VERSION NAME GOES HERE"
+    gitVersionCode = -1
+    gitVersionCodeTime = -1
     try {
         git = Grgit.open(currentDir: projectDir)
         gitVersionName = git.describe()
@@ -30,9 +33,9 @@ ext {
         }
         gitVersionCodeTime = git.head().time
     } catch (Exception exception) {
-        gitVersionName = "1.0"
-        gitVersionCode = 2
-        gitVersionCodeTime = 1484407970
+        println("Does your build of mapbox-navigation-android have a Git directory? The try/catch in the script-git-version.gradle file
+        is for the situation when there is no Git setup. Try cloning the mapbox-navigation-android repo, rather than downloading
+        the repo as a .zip file.")
     }
 }
 

--- a/gradle/script-git-version.gradle
+++ b/gradle/script-git-version.gradle
@@ -33,9 +33,10 @@ ext {
         }
         gitVersionCodeTime = git.head().time
     } catch (Exception exception) {
-        println("Does your build of mapbox-navigation-android have a Git directory? The try/catch in the script-git-version.gradle file
-        is for the situation when there is no Git setup. Try cloning the mapbox-navigation-android repo, rather than downloading
-        the repo as a .zip file.")
+        println("Does your build of mapbox-navigation-android have a Git directory?" +
+                "The try/catch in the script-git-version.gradle file is for the situation " +
+                "when there is no Git setup. Try cloning the mapbox-navigation-android repo, " +
+                "rather than downloading the repo as a .zip file.")
     }
 }
 

--- a/gradle/script-git-version.gradle
+++ b/gradle/script-git-version.gradle
@@ -22,12 +22,18 @@ import org.ajoberstar.grgit.Grgit
  */
 
 ext {
-    git = Grgit.open(currentDir: projectDir)
-    gitVersionName = git.describe()
-    gitVersionCode = git.tag.list().count{
-        it.getName().contains("testapp")
+    try {
+        git = Grgit.open(currentDir: projectDir)
+        gitVersionName = git.describe()
+        gitVersionCode = git.tag.list().count {
+            it.getName().contains("testapp")
+        }
+        gitVersionCodeTime = git.head().time
+    } catch (Exception exception) {
+        gitVersionName = "1.0"
+        gitVersionCode = 2
+        gitVersionCodeTime = 1484407970
     }
-    gitVersionCodeTime = git.head().time
 }
 
 task printVersion() {


### PR DESCRIPTION
This pr adds a try/catch to the gradle script for the test app's gradle play store publish plugin. I ran into an error while trying to create API ref docs for the 0.24.1 release. 

![screen shot 2018-12-07 at 10 48 25 am](https://user-images.githubusercontent.com/4394910/49666818-0c70b800-fa0e-11e8-9007-bab08a8a8e4d.png)

Before this pr, the script assumes that there's a git project directory. However, there is none when I'm creating docs via the command line. I ran into this similar problem with the Android demo app when someone was trying to build the app after downloading the repo's `.zip` file. My work/fix in this pr is similar to [what I did for the `/mapbox-android-demo`](https://github.com/mapbox/mapbox-android-demo/commit/e021b53877fe29df6bff32e2e8fdb22b241b912d#diff-f427beead0190b67a2c08ccb7cccee4e). [Original issue](https://github.com/mapbox/mapbox-android-demo/issues/599)