### PR TITLE
Generate unique filenames for archives in check binary size script

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -147,7 +147,7 @@ jobs:
       - run:
           name: Check & Publish Binary Size
           command: |
-            ./scripts/check_binary_size.sh ./scripts/paths_file.txt ./scripts/labels_file.txt 'mapbox-navigation-android' 'android' ./scripts/sdks_file.txt
+            ./scripts/check_binary_size.sh ./scripts/paths_file.txt ./scripts/labels_file.txt 'mapbox-navigation-android' 'android' ./scripts/sdks_file.txt "${CIRCLE_SHA1}"
 # ------------------------------------------------------------------------------
   publish:
     docker:

--- a/scripts/check_binary_size.sh
+++ b/scripts/check_binary_size.sh
@@ -13,11 +13,13 @@ repo_name=$3
 platform=$4
 # Argument 5 is a file including the different SDKs / modules (one per line) - Must match paths_file number of lines / size
 sdks_file=$5
+# Argument 6 is the commit SHA
+commit_sha=$6
 
 source=mobile.binarysize
 scripts_path="scripts"
-json_name="$scripts_path/${repo_name}.json"
-json_gz="$scripts_path/${repo_name}.json.gz"
+json_name="$scripts_path/${repo_name}-${commit_sha}.json"
+json_gz="$scripts_path/${repo_name}-${commit_sha}.json.gz"
 
 date=`date '+%Y-%m-%d'`
 utc_iso_date=`date -u +'%Y-%m-%dT%H:%M:%SZ'`


### PR DESCRIPTION
- Generates unique filenames for archives in `check_binary_size` script appending the SHA1 hash of the last commit of the current build

Tail work from #1554