### PR TITLE
Check for successful tar response in TarFetchedCallback

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/DownloadUpdateListener.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/DownloadUpdateListener.java
@@ -1,0 +1,47 @@
+package com.mapbox.services.android.navigation.v5.navigation;
+
+import android.support.annotation.NonNull;
+
+import com.mapbox.services.android.navigation.v5.utils.DownloadTask;
+
+import java.io.File;
+
+/**
+ * Triggers a {@link TileUnpacker} to unpack the tar file into routing tiles once the FILE_EXTENSION_TAR
+ * download is complete.
+ */
+class DownloadUpdateListener implements DownloadTask.DownloadListener {
+
+  private static final String DOWNLOAD_ERROR_MESSAGE = "Error occurred downloading tiles: null file found";
+  private final RouteTileDownloader downloader;
+  private final TileUnpacker tileUnpacker;
+  private final RouteTileDownloadListener listener;
+  private final String destinationPath;
+
+  DownloadUpdateListener(RouteTileDownloader downloader, TileUnpacker tileUnpacker,
+                         String tilePath, String tileVersion, RouteTileDownloadListener listener) {
+    this.downloader = downloader;
+    this.listener = listener;
+    this.tileUnpacker = tileUnpacker;
+    destinationPath = buildDestinationPath(tilePath, tileVersion);
+  }
+
+  @Override
+  public void onFinishedDownloading(@NonNull File file) {
+    tileUnpacker.unpack(file, destinationPath, new UnpackProgressUpdateListener(listener));
+  }
+
+  @Override
+  public void onErrorDownloading() {
+    OfflineError error = new OfflineError(DOWNLOAD_ERROR_MESSAGE);
+    downloader.onError(error);
+  }
+
+  private String buildDestinationPath(String tilePath, String tileVersion) {
+    File destination = new File(tilePath, tileVersion);
+    if (!destination.exists()) {
+      destination.mkdirs();
+    }
+    return destination.getAbsolutePath();
+  }
+}

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxOfflineRouter.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxOfflineRouter.java
@@ -74,7 +74,7 @@ public class MapboxOfflineRouter {
    * @param listener     which is updated on error, on progress update and on completion
    */
   public void downloadTiles(OfflineTiles offlineTiles, RouteTileDownloadListener listener) {
-    new RouteTileDownloader(tilePath, listener).startDownload(offlineTiles);
+    new RouteTileDownloader(offlineNavigator, tilePath, listener).startDownload(offlineTiles);
   }
 
   /**

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/OfflineNavigator.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/OfflineNavigator.java
@@ -14,7 +14,7 @@ class OfflineNavigator {
    *
    * @param tilePath directory path where the tiles are located
    * @param callback a callback that will be fired when the offline data is initialized and
-   * {@link MapboxOfflineRouter#findRoute(OfflineRoute, OnOfflineRouteFoundCallback)}
+   *                 {@link MapboxOfflineRouter#findRoute(OfflineRoute, OnOfflineRouteFoundCallback)}
    *                 can be called safely
    */
   void configure(String tilePath, OnOfflineTilesConfiguredCallback callback) {
@@ -25,9 +25,20 @@ class OfflineNavigator {
    * Uses libvalhalla and local tile data to generate mapbox-directions-api-like json
    *
    * @param offlineRoute an offline navigation route
-   * @param callback which receives a RouterResult object with the json and a success/fail bool
+   * @param callback     which receives a RouterResult object with the json and a success/fail bool
    */
   void retrieveRouteFor(OfflineRoute offlineRoute, OnOfflineRouteFoundCallback callback) {
     new OfflineRouteRetrievalTask(navigator, callback).execute(offlineRoute);
+  }
+
+
+  /**
+   * Unpacks tar file into a specified destination path.
+   *
+   * @param tarPath         to find file to be unpacked
+   * @param destinationPath where the tar will be unpacked
+   */
+  void unpackTiles(String tarPath, String destinationPath) {
+    navigator.unpackTiles(tarPath, destinationPath);
   }
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/RouteTileDownloader.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/RouteTileDownloader.java
@@ -1,16 +1,8 @@
 package com.mapbox.services.android.navigation.v5.navigation;
 
-import android.os.AsyncTask;
 import android.support.annotation.NonNull;
 
 import com.mapbox.services.android.navigation.v5.utils.DownloadTask;
-
-import java.io.File;
-
-import okhttp3.ResponseBody;
-import retrofit2.Call;
-import retrofit2.Callback;
-import retrofit2.Response;
 
 /**
  * This class serves to contain the complicated chain of events that must happen to download
@@ -18,86 +10,51 @@ import retrofit2.Response;
  * Offline directory, or wherever someone specifies.
  */
 class RouteTileDownloader {
+
+  private static final String FILE_EXTENSION_TAR = "tar";
+  private final OfflineNavigator offlineNavigator;
   private final String tilePath;
   private final RouteTileDownloadListener listener;
-  private String version;
-  private DownloadTask downloadTask;
 
-  RouteTileDownloader(String tilePath, RouteTileDownloadListener listener) {
+  RouteTileDownloader(OfflineNavigator offlineNavigator, String tilePath, RouteTileDownloadListener listener) {
+    this.offlineNavigator = offlineNavigator;
     this.tilePath = tilePath;
     this.listener = listener;
   }
 
   void startDownload(final OfflineTiles offlineTiles) {
-    version = offlineTiles.version();
-    offlineTiles.fetchRouteTiles(new TarFetchedCallback());
+    String version = offlineTiles.version();
+    TarFetchedCallback tarFetchedCallback = buildTarFetchedCallback(version);
+    offlineTiles.fetchRouteTiles(tarFetchedCallback);
   }
 
-  private void onError(OfflineError error) {
+  void onError(OfflineError error) {
     if (listener != null) {
       listener.onError(error);
     }
   }
 
-  /**
-   * Triggers the downloading of the TAR file included in the {@link ResponseBody} onto disk.
-   */
-  private class TarFetchedCallback implements Callback<ResponseBody> {
-
-    @Override
-    public void onResponse(Call<ResponseBody> call, Response<ResponseBody> response) {
-      downloadTask = new DownloadTask(
-        tilePath,
-        version,
-        "tar",
-        new DownloadUpdateListener());
-      downloadTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, response.body());
-    }
-
-    @Override
-    public void onFailure(Call<ResponseBody> call, Throwable throwable) {
-      OfflineError error = new OfflineError(throwable.getMessage());
-      onError(error);
-    }
+  @NonNull
+  private TarFetchedCallback buildTarFetchedCallback(String version) {
+    DownloadTask downloadTask = buildDownloadTask(tilePath, version);
+    return new TarFetchedCallback(this, downloadTask);
   }
 
-  /**
-   * Triggers a {@link TileUnpacker} to unpack the TAR file into routing tiles once the TAR
-   * download is complete.
-   */
-  private class DownloadUpdateListener implements DownloadTask.DownloadListener {
-
-    @Override
-    public void onFinishedDownloading(@NonNull File file) {
-      File destination = new File(tilePath, version);
-      if (!destination.exists()) {
-        destination.mkdirs();
-      }
-      new TileUnpacker().unpack(file, destination.getAbsolutePath(), new UnpackProgressUpdateListener());
-    }
-
-    @Override
-    public void onErrorDownloading() {
-      OfflineError error = new OfflineError("Error occurred downloading tiles: null file");
-      onError(error);
-    }
-  }
-
-  /**
-   * Updates any UI elements on the status of the TAR unpacking.
-   */
-  private class UnpackProgressUpdateListener implements UnpackUpdateTask.ProgressUpdateListener {
-
-    @Override
-    public void onProgressUpdate(Long progress) {
-      if (listener != null) {
-        listener.onProgressUpdate(progress.intValue());
-      }
-    }
-
-    @Override
-    public void onCompletion() {
-      listener.onCompletion();
-    }
+  @NonNull
+  private DownloadTask buildDownloadTask(String tilePath, String tileVersion) {
+    TileUnpacker tileUnpacker = new TileUnpacker(offlineNavigator);
+    DownloadUpdateListener downloadListener = new DownloadUpdateListener(
+      this,
+      tileUnpacker,
+      tilePath,
+      tileVersion,
+      listener
+    );
+    return new DownloadTask(
+      tilePath,
+      tileVersion,
+      FILE_EXTENSION_TAR,
+      downloadListener
+    );
   }
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/TarFetchedCallback.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/TarFetchedCallback.java
@@ -1,0 +1,45 @@
+package com.mapbox.services.android.navigation.v5.navigation;
+
+import android.os.AsyncTask;
+import android.support.annotation.NonNull;
+
+import com.mapbox.services.android.navigation.v5.utils.DownloadTask;
+
+import java.util.HashMap;
+
+import okhttp3.ResponseBody;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+/**
+ * Triggers the downloading of the tar file included in the {@link ResponseBody} onto disk.
+ */
+class TarFetchedCallback implements Callback<ResponseBody> {
+
+  private final RouteTileDownloader downloader;
+  private final DownloadTask downloadTask;
+
+  TarFetchedCallback(RouteTileDownloader downloader, DownloadTask downloadTask) {
+    this.downloader = downloader;
+    this.downloadTask = downloadTask;
+  }
+
+  @Override
+  public void onResponse(@NonNull Call<ResponseBody> call, @NonNull Response<ResponseBody> response) {
+    if (response.isSuccessful()) {
+      downloadTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, response.body());
+    } else {
+      HashMap<Integer, String> errorCodes = new HashMap<>();
+      TarResponseErrorMap errorMap = new TarResponseErrorMap(errorCodes);
+      OfflineError error = new OfflineError(errorMap.buildErrorMessageWith(response));
+      downloader.onError(error);
+    }
+  }
+
+  @Override
+  public void onFailure(@NonNull Call<ResponseBody> call, @NonNull Throwable throwable) {
+    OfflineError error = new OfflineError(throwable.getMessage());
+    downloader.onError(error);
+  }
+}

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/TarResponseErrorMap.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/TarResponseErrorMap.java
@@ -1,0 +1,36 @@
+package com.mapbox.services.android.navigation.v5.navigation;
+
+import android.support.annotation.NonNull;
+
+import java.util.HashMap;
+
+import okhttp3.ResponseBody;
+import retrofit2.Response;
+
+class TarResponseErrorMap {
+
+  private static final int TILES_ACCESS_TOKEN_ERROR_CODE = 402;
+  private static final int BOUNDING_BOX_ERROR_CODE = 422;
+  private static final String TILES_ACCESS_TOKEN_ERROR_MESSAGE = "Unable to fetch tiles: Before you can fetch "
+    + "routing tiles you must obtain an enterprise access token. Please contact us at support@mapbox.com";
+  private static final String BOUNDING_BOX_ERROR_MESSAGE = "Unable to fetch tiles: The bounding box you have "
+    + "specified is too large. Please select a smaller box and try again.";
+  private static final String ERROR_MESSAGE_FORMAT = "Error code %s: %s";
+  private final HashMap<Integer, String> errorCodes;
+
+  TarResponseErrorMap(@NonNull HashMap<Integer, String> errorCodes) {
+    this.errorCodes = errorCodes;
+    errorCodes.put(TILES_ACCESS_TOKEN_ERROR_CODE, TILES_ACCESS_TOKEN_ERROR_MESSAGE);
+    errorCodes.put(BOUNDING_BOX_ERROR_CODE, BOUNDING_BOX_ERROR_MESSAGE);
+  }
+
+  @NonNull
+  String buildErrorMessageWith(@NonNull Response<ResponseBody> response) {
+    String errorMessage = errorCodes.get(response.code());
+    if (errorMessage == null) {
+      errorMessage = String.format(ERROR_MESSAGE_FORMAT, response.code(), response.message());
+      return errorMessage;
+    }
+    return errorMessage;
+  }
+}

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/TileUnpacker.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/TileUnpacker.java
@@ -2,15 +2,13 @@ package com.mapbox.services.android.navigation.v5.navigation;
 
 import android.os.AsyncTask;
 
-import com.mapbox.navigator.Navigator;
-
 import java.io.File;
 
 class TileUnpacker {
-  private final Navigator navigator;
+  private final OfflineNavigator offlineNavigator;
 
-  TileUnpacker() {
-    this.navigator = new Navigator();
+  TileUnpacker(OfflineNavigator offlineNavigator) {
+    this.offlineNavigator = offlineNavigator;
   }
 
   /**
@@ -21,7 +19,7 @@ class TileUnpacker {
    * @param updateListener listener to listen for progress updates
    */
   void unpack(File src, String destPath, UnpackUpdateTask.ProgressUpdateListener updateListener) {
-    new UnpackerTask(navigator).executeOnExecutor(
+    new UnpackerTask(offlineNavigator).executeOnExecutor(
       AsyncTask.THREAD_POOL_EXECUTOR, src.getAbsolutePath(), destPath + File.separator);
     new UnpackUpdateTask(updateListener).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, src);
   }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/UnpackProgressUpdateListener.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/UnpackProgressUpdateListener.java
@@ -1,0 +1,25 @@
+package com.mapbox.services.android.navigation.v5.navigation;
+
+/**
+ * Updates any UI elements on the status of the TAR unpacking.
+ */
+class UnpackProgressUpdateListener implements UnpackUpdateTask.ProgressUpdateListener {
+
+  private final RouteTileDownloadListener listener;
+
+  UnpackProgressUpdateListener(RouteTileDownloadListener listener) {
+    this.listener = listener;
+  }
+
+  @Override
+  public void onProgressUpdate(Long progress) {
+    if (listener != null) {
+      listener.onProgressUpdate(progress.intValue());
+    }
+  }
+
+  @Override
+  public void onCompletion() {
+    listener.onCompletion();
+  }
+}

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/UnpackerTask.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/UnpackerTask.java
@@ -2,8 +2,6 @@ package com.mapbox.services.android.navigation.v5.navigation;
 
 import android.os.AsyncTask;
 
-import com.mapbox.navigator.Navigator;
-
 import java.io.File;
 
 
@@ -15,15 +13,15 @@ import java.io.File;
  * to the destination directory for the resulting tiles.
  */
 class UnpackerTask extends AsyncTask<String, Integer, File> {
-  private final Navigator navigator;
+  private final OfflineNavigator offlineNavigator;
 
-  UnpackerTask(Navigator navigator) {
-    this.navigator = navigator;
+  UnpackerTask(OfflineNavigator offlineNavigator) {
+    this.offlineNavigator = offlineNavigator;
   }
 
   @Override
   protected File doInBackground(String... strings) {
-    navigator.unpackTiles(strings[0], strings[1]);
+    offlineNavigator.unpackTiles(strings[0], strings[1]);
 
     return new File(strings[0]);
   }

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/DownloadUpdateListenerTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/DownloadUpdateListenerTest.java
@@ -1,0 +1,57 @@
+package com.mapbox.services.android.navigation.v5.navigation;
+
+import android.support.annotation.NonNull;
+
+import org.junit.Test;
+
+import java.io.File;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class DownloadUpdateListenerTest {
+
+  @Test
+  public void onFinishedDownloading_tarIsUnpacked() {
+    TileUnpacker tileUnpacker = mock(TileUnpacker.class);
+    File file = mock(File.class);
+    DownloadUpdateListener downloadUpdateListener = buildDownloadUpdateListener(tileUnpacker);
+
+    downloadUpdateListener.onFinishedDownloading(file);
+
+    verify(tileUnpacker).unpack(any(File.class), any(String.class), any(UnpackProgressUpdateListener.class));
+  }
+
+  @Test
+  public void onErrorDownloading_offlineErrorIsSent() {
+    RouteTileDownloader downloader = mock(RouteTileDownloader.class);
+    DownloadUpdateListener downloadUpdateListener = buildDownloadUpdateListener(downloader);
+
+    downloadUpdateListener.onErrorDownloading();
+
+    verify(downloader).onError(any(OfflineError.class));
+  }
+
+  @NonNull
+  private DownloadUpdateListener buildDownloadUpdateListener(TileUnpacker tileUnpacker) {
+    RouteTileDownloader downloader = mock(RouteTileDownloader.class);
+    String tilePath = "some/path/";
+    String tileVersion = "some-version";
+    RouteTileDownloadListener listener = mock(RouteTileDownloadListener.class);
+    return new DownloadUpdateListener(
+      downloader, tileUnpacker, tilePath, tileVersion, listener
+    );
+  }
+
+  @NonNull
+  private DownloadUpdateListener buildDownloadUpdateListener(RouteTileDownloader downloader) {
+    TileUnpacker tileUnpacker = mock(TileUnpacker.class);
+    String tilePath = "some/path/";
+    String tileVersion = "some-version";
+    RouteTileDownloadListener listener = mock(RouteTileDownloadListener.class);
+    return new DownloadUpdateListener(
+      downloader, tileUnpacker, tilePath, tileVersion, listener
+    );
+  }
+}

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/RouteTileDownloaderTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/RouteTileDownloaderTest.java
@@ -1,0 +1,38 @@
+package com.mapbox.services.android.navigation.v5.navigation;
+
+import org.junit.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class RouteTileDownloaderTest {
+
+  @Test
+  public void startDownload_fetchRouteTilesIsCalled() {
+    String tilePath = "some/path/";
+    OfflineNavigator offlineNavigator = mock(OfflineNavigator.class);
+    RouteTileDownloadListener listener = mock(RouteTileDownloadListener.class);
+    OfflineTiles offlineTiles = mock(OfflineTiles.class);
+    when(offlineTiles.version()).thenReturn("some-version");
+    RouteTileDownloader downloader = new RouteTileDownloader(offlineNavigator, tilePath, listener);
+
+    downloader.startDownload(offlineTiles);
+
+    verify(offlineTiles).fetchRouteTiles(any(TarFetchedCallback.class));
+  }
+
+  @Test
+  public void onError_downloadListenerErrorTriggered() {
+    String tilePath = "some/path/";
+    OfflineNavigator offlineNavigator = mock(OfflineNavigator.class);
+    RouteTileDownloadListener listener = mock(RouteTileDownloadListener.class);
+    OfflineError offlineError = mock(OfflineError.class);
+    RouteTileDownloader downloader = new RouteTileDownloader(offlineNavigator, tilePath, listener);
+
+    downloader.onError(offlineError);
+
+    verify(listener).onError(offlineError);
+  }
+}

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/TarFetchedCallbackTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/TarFetchedCallbackTest.java
@@ -1,0 +1,72 @@
+package com.mapbox.services.android.navigation.v5.navigation;
+
+import android.os.AsyncTask;
+
+import com.mapbox.services.android.navigation.v5.utils.DownloadTask;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import okhttp3.ResponseBody;
+import retrofit2.Call;
+import retrofit2.Response;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(RobolectricTestRunner.class)
+public class TarFetchedCallbackTest {
+
+  @Test
+  public void onSuccessfulResponse_downloadTaskIsExecuted() {
+    DownloadTask downloadTask = mock(DownloadTask.class);
+    TarFetchedCallback callback = buildCallback(downloadTask);
+    Call call = mock(Call.class);
+    Response response = mock(Response.class);
+    ResponseBody responseBody = mock(ResponseBody.class);
+    when(response.body()).thenReturn(responseBody);
+    when(response.isSuccessful()).thenReturn(true);
+
+    callback.onResponse(call, response);
+
+    verify(downloadTask).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, responseBody);
+  }
+
+  @Test
+  public void onUnsuccessfulResponse_errorIsProvided() {
+    RouteTileDownloader downloader = mock(RouteTileDownloader.class);
+    TarFetchedCallback callback = buildCallback(downloader);
+    Call call = mock(Call.class);
+    Response response = mock(Response.class);
+    when(response.isSuccessful()).thenReturn(false);
+
+    callback.onResponse(call, response);
+
+    verify(downloader).onError(any(OfflineError.class));
+  }
+
+  @Test
+  public void onFailure_errorIsProvided() {
+    RouteTileDownloader downloader = mock(RouteTileDownloader.class);
+    TarFetchedCallback callback = buildCallback(downloader);
+    Call call = mock(Call.class);
+    Throwable throwable = mock(Throwable.class);
+
+    callback.onFailure(call, throwable);
+
+    verify(downloader).onError(any(OfflineError.class));
+  }
+
+  private TarFetchedCallback buildCallback(RouteTileDownloader downloader) {
+    DownloadTask downloadTask = mock(DownloadTask.class);
+    return new TarFetchedCallback(downloader, downloadTask);
+  }
+
+  private TarFetchedCallback buildCallback(DownloadTask downloadTask) {
+    RouteTileDownloader downloader = mock(RouteTileDownloader.class);
+    return new TarFetchedCallback(downloader, downloadTask);
+  }
+}

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/TarResponseErrorMapTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/TarResponseErrorMapTest.java
@@ -1,0 +1,40 @@
+package com.mapbox.services.android.navigation.v5.navigation;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import okhttp3.ResponseBody;
+import retrofit2.Response;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TarResponseErrorMapTest {
+
+  @Test
+  public void buildErrorMessage_402messageIsCreated() {
+    HashMap<Integer, String> errorCodes = new HashMap<>();
+    Response<ResponseBody> response = mock(Response.class);
+    when(response.code()).thenReturn(402);
+    TarResponseErrorMap errorMap = new TarResponseErrorMap(errorCodes);
+
+    String errorMessage = errorMap.buildErrorMessageWith(response);
+
+    assertTrue(errorMessage.contains("Please contact us at support@mapbox.com"));
+  }
+
+  @Test
+  public void buildErrorMessage_messageIsCreatedForCodeNotFound() {
+    HashMap<Integer, String> errorCodes = new HashMap<>();
+    Response<ResponseBody> response = mock(Response.class);
+    when(response.code()).thenReturn(100);
+    when(response.message()).thenReturn("Some error message");
+    TarResponseErrorMap errorMap = new TarResponseErrorMap(errorCodes);
+
+    String errorMessage = errorMap.buildErrorMessageWith(response);
+
+    assertEquals("Error code 100: Some error message", errorMessage);
+  }
+}

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/UnpackProgressUpdateListenerTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/UnpackProgressUpdateListenerTest.java
@@ -1,0 +1,30 @@
+package com.mapbox.services.android.navigation.v5.navigation;
+
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class UnpackProgressUpdateListenerTest {
+
+  @Test
+  public void onProgressUpdate_downloadListenerIsTriggered() {
+    RouteTileDownloadListener listener = mock(RouteTileDownloadListener.class);
+    Long progress = 58L;
+    UnpackProgressUpdateListener progressUpdateListener = new UnpackProgressUpdateListener(listener);
+
+    progressUpdateListener.onProgressUpdate(progress);
+
+    verify(listener).onProgressUpdate(progress.intValue());
+  }
+
+  @Test
+  public void onCompletion_downloadListenerIsTriggered() {
+    RouteTileDownloadListener listener = mock(RouteTileDownloadListener.class);
+    UnpackProgressUpdateListener progressUpdateListener = new UnpackProgressUpdateListener(listener);
+
+    progressUpdateListener.onCompletion();
+
+    verify(listener).onCompletion();
+  }
+}


### PR DESCRIPTION
We can check for a successful `Response` in the `TarFetchedCallback` to provide more information for situations like #1618, where developers are using tokens are aren't compatible with offline routing. 

The main point of this PR was:
```
  @Override
  public void onResponse(@NonNull Call<ResponseBody> call, @NonNull Response<ResponseBody> response) {
    if (response.isSuccessful()) {
      downloadTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, response.body());
    } else {
      OfflineError error = new OfflineError(response.message());
      downloader.onError(error);
    }
  }
```

But, I also took some time to extract some of the callbacks and listeners that were living in the `RouteTileDownloader`.  By extracting them, we can add tests to verify the business logic being executed in each callback or listener.  I did not change any business logic, this was mainly shuffling classes around / adding constructors for the dependencies they needed.