### PR TITLE
Fix turn-by-turn UI voice instructions repeated after a config change

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewRouteEngineListener.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewRouteEngineListener.java
@@ -1,0 +1,35 @@
+package com.mapbox.services.android.navigation.ui.v5;
+
+import com.mapbox.api.directions.v5.models.DirectionsRoute;
+import com.mapbox.geojson.Point;
+import com.mapbox.services.android.navigation.ui.v5.route.ViewRouteListener;
+
+
+class NavigationViewRouteEngineListener implements ViewRouteListener {
+
+  private final NavigationViewModel navigationViewModel;
+
+  NavigationViewRouteEngineListener(NavigationViewModel navigationViewModel) {
+    this.navigationViewModel = navigationViewModel;
+  }
+
+  @Override
+  public void onRouteUpdate(DirectionsRoute directionsRoute) {
+    if (!navigationViewModel.isRunning() || navigationViewModel.isOffRoute()) {
+      navigationViewModel.updateRoute(directionsRoute);
+    }
+  }
+
+  @Override
+  public void onRouteRequestError(Throwable throwable) {
+    if (navigationViewModel.isOffRoute()) {
+      String errorMessage = throwable.getMessage();
+      navigationViewModel.sendEventFailedReroute(errorMessage);
+    }
+  }
+
+  @Override
+  public void onDestinationSet(Point destination) {
+    navigationViewModel.retrieveDestination().setValue(destination);
+  }
+}

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewSubscriber.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewSubscriber.java
@@ -27,7 +27,7 @@ class NavigationViewSubscriber {
       }
     });
 
-    navigationViewModel.destination.observe(owner, new Observer<Point>() {
+    navigationViewModel.retrieveDestination().observe(owner, new Observer<Point>() {
       @Override
       public void onChanged(@Nullable Point point) {
         if (point != null) {

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewRouteEngineListenerTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewRouteEngineListenerTest.java
@@ -1,0 +1,102 @@
+package com.mapbox.services.android.navigation.ui.v5;
+
+import android.arch.lifecycle.MutableLiveData;
+
+import com.mapbox.api.directions.v5.models.DirectionsRoute;
+import com.mapbox.geojson.Point;
+
+import org.junit.Test;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class NavigationViewRouteEngineListenerTest {
+
+  @Test
+  public void checksUpdateRouteCalledIfNavigationIsNotRunning() {
+    NavigationViewModel mockedNavigationViewModel = mock(NavigationViewModel.class);
+    when(mockedNavigationViewModel.isRunning()).thenReturn(false);
+    DirectionsRoute aDirectionsRoute = mock(DirectionsRoute.class);
+    NavigationViewRouteEngineListener theRouteEngineListener
+      = new NavigationViewRouteEngineListener(mockedNavigationViewModel);
+
+    theRouteEngineListener.onRouteUpdate(aDirectionsRoute);
+
+    verify(mockedNavigationViewModel).updateRoute(eq(aDirectionsRoute));
+  }
+
+  @Test
+  public void checksUpdateRouteCalledIfNavigationIsOffRoute() {
+    NavigationViewModel mockedNavigationViewModel = mock(NavigationViewModel.class);
+    when(mockedNavigationViewModel.isRunning()).thenReturn(true);
+    when(mockedNavigationViewModel.isOffRoute()).thenReturn(true);
+    DirectionsRoute aDirectionsRoute = mock(DirectionsRoute.class);
+    NavigationViewRouteEngineListener theRouteEngineListener
+      = new NavigationViewRouteEngineListener(mockedNavigationViewModel);
+
+    theRouteEngineListener.onRouteUpdate(aDirectionsRoute);
+
+    verify(mockedNavigationViewModel).updateRoute(eq(aDirectionsRoute));
+  }
+
+  @Test
+  public void checksUpdateRouteNotCalledIfNavigationIsRunningAndIsNotOffRoute() {
+    NavigationViewModel mockedNavigationViewModel = mock(NavigationViewModel.class);
+    when(mockedNavigationViewModel.isRunning()).thenReturn(true);
+    when(mockedNavigationViewModel.isOffRoute()).thenReturn(false);
+    DirectionsRoute aDirectionsRoute = mock(DirectionsRoute.class);
+    NavigationViewRouteEngineListener theRouteEngineListener
+      = new NavigationViewRouteEngineListener(mockedNavigationViewModel);
+
+    theRouteEngineListener.onRouteUpdate(aDirectionsRoute);
+
+    verify(mockedNavigationViewModel, times(0)).updateRoute(eq(aDirectionsRoute));
+  }
+
+  @Test
+  public void checksSendEventFailedRerouteCalledIfNavigationIsOffRoute() {
+    NavigationViewModel mockedNavigationViewModel = mock(NavigationViewModel.class);
+    when(mockedNavigationViewModel.isOffRoute()).thenReturn(true);
+    Throwable aThrowable = mock(Throwable.class);
+    String anError = "An error occurred!";
+    when(aThrowable.getMessage()).thenReturn(anError);
+    NavigationViewRouteEngineListener theRouteEngineListener
+      = new NavigationViewRouteEngineListener(mockedNavigationViewModel);
+
+    theRouteEngineListener.onRouteRequestError(aThrowable);
+
+    verify(mockedNavigationViewModel).sendEventFailedReroute(eq(anError));
+  }
+
+  @Test
+  public void checksSendEventFailedRerouteNotCalledIfNavigationIsNotOffRoute() {
+    NavigationViewModel mockedNavigationViewModel = mock(NavigationViewModel.class);
+    when(mockedNavigationViewModel.isOffRoute()).thenReturn(false);
+    Throwable aThrowable = mock(Throwable.class);
+    String anError = "An error occurred!";
+    when(aThrowable.getMessage()).thenReturn(anError);
+    NavigationViewRouteEngineListener theRouteEngineListener
+      = new NavigationViewRouteEngineListener(mockedNavigationViewModel);
+
+    theRouteEngineListener.onRouteRequestError(aThrowable);
+
+    verify(mockedNavigationViewModel, times(0)).sendEventFailedReroute(eq(anError));
+  }
+
+  @Test
+  public void checksOnDestinationSet() {
+    NavigationViewModel mockedNavigationViewModel = mock(NavigationViewModel.class);
+    Point mockedPoint = mock(Point.class);
+    MutableLiveData<Point> mockedDestination = mock(MutableLiveData.class);
+    when(mockedNavigationViewModel.retrieveDestination()).thenReturn(mockedDestination);
+    NavigationViewRouteEngineListener theRouteEngineListener
+      = new NavigationViewRouteEngineListener(mockedNavigationViewModel);
+
+    theRouteEngineListener.onDestinationSet(mockedPoint);
+
+    verify(mockedDestination).setValue(eq(mockedPoint));
+  }
+}


### PR DESCRIPTION
- Fixes `updateRoute` in turn-by-turn UI (`NavigationViewModel`) to be called only if navigation is not running (first time / once) or if it is off route - preventing setting new routes unnecessarily which ended up in announcing voice instructions already announced