### PR TITLE
Include 'exit roundabout' in Navigation Constants

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/maneuver/ManeuverView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/maneuver/ManeuverView.java
@@ -27,6 +27,7 @@ import static com.mapbox.services.android.navigation.v5.navigation.NavigationCon
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.STEP_MANEUVER_MODIFIER_UTURN;
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.STEP_MANEUVER_TYPE_ARRIVE;
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.STEP_MANEUVER_TYPE_EXIT_ROTARY;
+import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.STEP_MANEUVER_TYPE_EXIT_ROUNDABOUT;
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.STEP_MANEUVER_TYPE_FORK;
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.STEP_MANEUVER_TYPE_OFF_RAMP;
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.STEP_MANEUVER_TYPE_ROTARY;
@@ -59,6 +60,8 @@ public class ManeuverView extends View {
       add(STEP_MANEUVER_TYPE_ROTARY);
       add(STEP_MANEUVER_TYPE_ROUNDABOUT);
       add(STEP_MANEUVER_TYPE_ROUNDABOUT_TURN);
+      add(STEP_MANEUVER_TYPE_EXIT_ROUNDABOUT);
+      add(STEP_MANEUVER_TYPE_EXIT_ROTARY);
     }
   };
   private static final Set<String> MANEUVER_TYPES_WITH_NULL_MODIFIERS = new HashSet<String>() {
@@ -67,6 +70,7 @@ public class ManeuverView extends View {
       add(STEP_MANEUVER_TYPE_FORK);
       add(STEP_MANEUVER_TYPE_ROUNDABOUT);
       add(STEP_MANEUVER_TYPE_ROUNDABOUT_TURN);
+      add(STEP_MANEUVER_TYPE_EXIT_ROUNDABOUT);
       add(STEP_MANEUVER_TYPE_ROTARY);
       add(STEP_MANEUVER_TYPE_EXIT_ROTARY);
     }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/maneuver/ManeuverViewMap.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/maneuver/ManeuverViewMap.java
@@ -16,6 +16,7 @@ import static com.mapbox.services.android.navigation.v5.navigation.NavigationCon
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.STEP_MANEUVER_MODIFIER_UTURN;
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.STEP_MANEUVER_TYPE_ARRIVE;
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.STEP_MANEUVER_TYPE_EXIT_ROTARY;
+import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.STEP_MANEUVER_TYPE_EXIT_ROUNDABOUT;
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.STEP_MANEUVER_TYPE_FORK;
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.STEP_MANEUVER_TYPE_MERGE;
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.STEP_MANEUVER_TYPE_OFF_RAMP;
@@ -55,6 +56,13 @@ class ManeuverViewMap extends HashMap<Pair<String, String>, ManeuverViewUpdate> 
       }
     });
     put(new Pair<String, String>(STEP_MANEUVER_TYPE_ROUNDABOUT_TURN, null), new ManeuverViewUpdate() {
+      @Override
+      public void updateManeuverView(Canvas canvas, int primaryColor, int secondaryColor,
+                                     PointF size, float roundaboutAngle) {
+        ManeuversStyleKit.drawRoundabout(canvas, primaryColor, secondaryColor, size, roundaboutAngle);
+      }
+    });
+    put(new Pair<String, String>(STEP_MANEUVER_TYPE_EXIT_ROUNDABOUT, null), new ManeuverViewUpdate() {
       @Override
       public void updateManeuverView(Canvas canvas, int primaryColor, int secondaryColor,
                                      PointF size, float roundaboutAngle) {

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationConstants.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationConstants.java
@@ -168,9 +168,10 @@ public final class NavigationConstants {
   public static final String STEP_MANEUVER_TYPE_CONTINUE = "continue";
   public static final String STEP_MANEUVER_TYPE_ROUNDABOUT = "roundabout";
   public static final String STEP_MANEUVER_TYPE_ROTARY = "rotary";
-  public static final String STEP_MANEUVER_TYPE_EXIT_ROTARY = "exit rotary";
   public static final String STEP_MANEUVER_TYPE_ROUNDABOUT_TURN = "roundabout turn";
   public static final String STEP_MANEUVER_TYPE_NOTIFICATION = "notification";
+  public static final String STEP_MANEUVER_TYPE_EXIT_ROUNDABOUT = "exit roundabout";
+  public static final String STEP_MANEUVER_TYPE_EXIT_ROTARY = "exit rotary";
 
   @StringDef( {
     STEP_MANEUVER_TYPE_TURN,
@@ -186,7 +187,9 @@ public final class NavigationConstants {
     STEP_MANEUVER_TYPE_ROUNDABOUT,
     STEP_MANEUVER_TYPE_ROTARY,
     STEP_MANEUVER_TYPE_ROUNDABOUT_TURN,
-    STEP_MANEUVER_TYPE_NOTIFICATION
+    STEP_MANEUVER_TYPE_NOTIFICATION,
+    STEP_MANEUVER_TYPE_EXIT_ROUNDABOUT,
+    STEP_MANEUVER_TYPE_EXIT_ROTARY
   })
   public @interface ManeuverType {
   }


### PR DESCRIPTION
Update maneuver types based on latest values and order documented.
* Adds `exit roundabout`
* Adds `STEP_MANEUVER_TYPE_EXIT_ROUNDABOUT` and `STEP_MANEUVER_TYPE_EXIT_ROTARY` to maneuver type string definition.
* Orders maneuver types to match documentation.