### PR TITLE
Bump mapbox-navigation-native version to 3.4.10

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -11,7 +11,7 @@ ext {
       mapboxMapSdk       : '6.7.2',
       mapboxSdkServices  : '4.2.0',
       mapboxEvents       : '3.5.6',
-      mapboxNavigator    : '3.4.9',
+      mapboxNavigator    : '3.4.10',
       searchSdk          : '0.1.0-SNAPSHOT',
       autoValue          : '1.5.4',
       autoValueParcel    : '0.2.5',


### PR DESCRIPTION
- Bumps `mapbox-navigation-native` version to `3.4.10`