### PR TITLE
Add waypoint targets support into NavigationRoute

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -9,7 +9,7 @@ ext {
 
   version = [
       mapboxMapSdk       : '6.7.2',
-      mapboxSdkServices  : '4.2.0',
+      mapboxSdkServices  : '4.3.0',
       mapboxEvents       : '3.5.6',
       mapboxNavigator    : '3.4.11',
       searchSdk          : '0.1.0-SNAPSHOT',

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteTest.java
@@ -96,6 +96,19 @@ public class NavigationRouteTest extends BaseTest {
   }
 
   @Test
+  public void addWaypointTargetsIncludedInRequest() {
+    NavigationRoute navigationRoute = NavigationRoute.builder(context, localeUtils)
+      .accessToken(ACCESS_TOKEN)
+      .origin(Point.fromLngLat(1.0, 2.0))
+      .destination(Point.fromLngLat(1.0, 5.0))
+      .addWaypointTargets(null, Point.fromLngLat(0.99, 4.99))
+      .build();
+
+    assertThat(navigationRoute.getCall().request().url().toString(),
+      containsString("waypoint_targets"));
+  }
+
+  @Test
   public void addingPointAndBearingKeepsCorrectOrder() throws Exception {
     NavigationRoute navigationRoute = NavigationRoute.builder(context, localeUtils)
       .accessToken(ACCESS_TOKEN)
@@ -140,6 +153,7 @@ public class NavigationRouteTest extends BaseTest {
       .geometries("mocked_geometries")
       .approaches("curb;unrestricted")
       .waypointNames("Origin;Destination")
+      .waypointTargets(";0.99,4.99")
       .build();
 
     NavigationRoute navigationRoute = NavigationRoute.builder(context, localeUtils)
@@ -158,6 +172,7 @@ public class NavigationRouteTest extends BaseTest {
     assertThat(request, containsString("walking"));
     assertThat(request, containsString("curb"));
     assertThat(request, containsString("Origin"));
+    assertThat(request, containsString("waypoint_targets"));
   }
 
   @Test


### PR DESCRIPTION
- Adds `waypoint_targets` support into `NavigationRoute`

Fixes https://github.com/mapbox/mapbox-navigation-android/issues/1630

Note: current branch is using MAS `SNAPSHOT` - MAS `4.3.0` needs to be released and the `SNAPSHOT` dependency removed before this PR can merge.

cc @osana 