### PR TITLE
Add ability to disable auto-increment of RouteLeg index

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationOptions.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationOptions.java
@@ -19,6 +19,8 @@ public abstract class MapboxNavigationOptions {
 
   public abstract boolean enableFasterRouteDetection();
 
+  public abstract boolean enableAutoIncrementLegIndex();
+
   public abstract boolean isFromNavigationUi();
 
   public abstract boolean isDebugLoggingEnabled();
@@ -43,6 +45,8 @@ public abstract class MapboxNavigationOptions {
 
     public abstract Builder enableFasterRouteDetection(boolean enableFasterRouteDetection);
 
+    public abstract Builder enableAutoIncrementLegIndex(boolean enableAutoIncrementLegIndex);
+
     public abstract Builder isFromNavigationUi(boolean isFromNavigationUi);
 
     public abstract Builder isDebugLoggingEnabled(boolean debugLoggingEnabled);
@@ -61,6 +65,7 @@ public abstract class MapboxNavigationOptions {
   public static Builder builder() {
     return new AutoValue_MapboxNavigationOptions.Builder()
       .enableFasterRouteDetection(false)
+      .enableAutoIncrementLegIndex(true)
       .defaultMilestonesEnabled(true)
       .isFromNavigationUi(false)
       .isDebugLoggingEnabled(false)

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/RouteProcessorRunnable.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/RouteProcessorRunnable.java
@@ -59,7 +59,7 @@ class RouteProcessorRunnable implements Runnable {
       options.navigationLocationEngineIntervalLagInMilliseconds());
     RouteProgress routeProgress = routeProcessor.buildNewRouteProgress(status, route);
 
-    status = checkForNewLegIndex(mapboxNavigator, route, status);
+    status = checkForNewLegIndex(mapboxNavigator, route, status, options.enableAutoIncrementLegIndex());
 
     NavigationEngineFactory engineFactory = navigation.retrieveEngineFactory();
     final boolean userOffRoute = isUserOffRoute(options, status, rawLocation, routeProgress, engineFactory);
@@ -74,13 +74,13 @@ class RouteProcessorRunnable implements Runnable {
   }
 
   private NavigationStatus checkForNewLegIndex(MapboxNavigator mapboxNavigator, DirectionsRoute route,
-                                               NavigationStatus currentStatus) {
+                                               NavigationStatus currentStatus, boolean autoIncrementEnabled) {
     RouteState currentState = currentStatus.getRouteState();
     int currentLegIndex = currentStatus.getLegIndex();
     int routeLegsSize = route.legs().size() - 1;
     boolean canUpdateLeg = currentState == RouteState.COMPLETE && currentLegIndex < routeLegsSize;
     boolean isValidDistanceRemaining = currentStatus.getRemainingLegDistance() < ARRIVAL_ZONE_RADIUS;
-    if (canUpdateLeg && isValidDistanceRemaining) {
+    if (autoIncrementEnabled && (canUpdateLeg && isValidDistanceRemaining)) {
       int newLegIndex = currentLegIndex + 1;
       return mapboxNavigator.updateLegIndex(newLegIndex);
     }

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationTest.java
@@ -3,6 +3,7 @@ package com.mapbox.services.android.navigation.v5.navigation;
 import android.content.Context;
 
 import com.mapbox.android.core.location.LocationEngine;
+import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.services.android.navigation.v5.BaseTest;
 import com.mapbox.services.android.navigation.v5.milestone.BannerInstructionMilestone;
 import com.mapbox.services.android.navigation.v5.milestone.Milestone;
@@ -16,12 +17,14 @@ import com.mapbox.services.android.navigation.v5.snap.SnapToRoute;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.BANNER_INSTRUCTION_MILESTONE_ID;
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.VOICE_INSTRUCTION_MILESTONE_ID;
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertNotSame;
 import static junit.framework.Assert.assertTrue;
@@ -268,11 +271,55 @@ public class MapboxNavigationTest extends BaseTest {
     assertTrue(navigation.getCameraEngine() instanceof SimpleCamera);
   }
 
+  @Test
+  public void updateRouteLegIndex_negativeIndexIsIgnored() throws IOException {
+    MapboxNavigator navigator = mock(MapboxNavigator.class);
+    MapboxNavigation navigation = buildMapboxNavigationWith(navigator);
+    DirectionsRoute directionsRoute = buildTestDirectionsRoute();
+    navigation.startNavigation(directionsRoute);
+
+    boolean didUpdate = navigation.updateRouteLegIndex(-1);
+
+    assertFalse(didUpdate);
+  }
+
+  @Test
+  public void updateRouteLegIndex_invalidIndexIsIgnored() throws IOException {
+    MapboxNavigator navigator = mock(MapboxNavigator.class);
+    MapboxNavigation navigation = buildMapboxNavigationWith(navigator);
+    DirectionsRoute directionsRoute = buildTestDirectionsRoute();
+    navigation.startNavigation(directionsRoute);
+
+    boolean didUpdate = navigation.updateRouteLegIndex(100);
+
+    assertFalse(didUpdate);
+  }
+
+  @Test
+  public void updateRouteLegIndex_validIndexIsUpdated() throws IOException {
+    MapboxNavigator navigator = mock(MapboxNavigator.class);
+    MapboxNavigation navigation = buildMapboxNavigationWith(navigator);
+    DirectionsRoute directionsRoute = buildTestDirectionsRoute();
+    navigation.startNavigation(directionsRoute);
+    int legIndex = 0;
+
+    boolean didUpdate = navigation.updateRouteLegIndex(legIndex);
+
+    assertTrue(didUpdate);
+  }
+
+  private MapboxNavigation buildMapboxNavigationWith(MapboxNavigator mapboxNavigator) {
+    Context context = mock(Context.class);
+    when(context.getApplicationContext()).thenReturn(context);
+    return new MapboxNavigation(context, ACCESS_TOKEN, mock(NavigationTelemetry.class),
+      mock(LocationEngine.class), mapboxNavigator);
+  }
+
   private MapboxNavigation buildMapboxNavigation() {
     Context context = mock(Context.class);
     when(context.getApplicationContext()).thenReturn(context);
     return new MapboxNavigation(context, ACCESS_TOKEN, mock(NavigationTelemetry.class),
-      mock(LocationEngine.class));
+      mock(LocationEngine.class), mock(MapboxNavigator.class));
   }
 
   private MapboxNavigation buildMapboxNavigationWithOptions(MapboxNavigationOptions options) {

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEventDispatcherTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEventDispatcherTest.java
@@ -67,7 +67,7 @@ public class NavigationEventDispatcherTest extends BaseTest {
     Context context = mock(Context.class);
     when(context.getApplicationContext()).thenReturn(mock(Context.class));
     navigation = new MapboxNavigation(context, ACCESS_TOKEN, mock(NavigationTelemetry.class),
-      mock(LocationEngine.class));
+      mock(LocationEngine.class), mock(MapboxNavigator.class));
     navigationEventDispatcher = navigation.getEventDispatcher();
 
     Gson gson = new GsonBuilder()


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-navigation-android/issues/1613

This PR gives the ability to disable our "auto-incrementing" of leg index added back in #1604.  It also adds `MapboxNavigation#updateLegIndex` to allow developers to increment on their own.