### PR TITLE
Allow NavigationView to start navigation during existing session

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewRouteEngineListener.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewRouteEngineListener.java
@@ -15,9 +15,7 @@ class NavigationViewRouteEngineListener implements ViewRouteListener {
 
   @Override
   public void onRouteUpdate(DirectionsRoute directionsRoute) {
-    if (!navigationViewModel.isRunning() || navigationViewModel.isOffRoute()) {
-      navigationViewModel.updateRoute(directionsRoute);
-    }
+    navigationViewModel.updateRoute(directionsRoute);
   }
 
   @Override

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModelTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModelTest.java
@@ -2,6 +2,8 @@ package com.mapbox.services.android.navigation.ui.v5;
 
 import android.app.Application;
 
+import com.mapbox.api.directions.v5.models.DirectionsRoute;
+import com.mapbox.services.android.navigation.ui.v5.location.LocationEngineConductor;
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation;
 
 import org.junit.Test;
@@ -9,6 +11,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @RunWith(RobolectricTestRunner.class)
@@ -34,5 +37,34 @@ public class NavigationViewModelTest {
     viewModel.stopNavigation();
 
     verify(navigation).removeMilestoneEventListener(null);
+  }
+
+  @Test
+  public void updateRoute_navigationIsNotUpdatedWhenChangingConfigurations() {
+    Application application = mock(Application.class);
+    MapboxNavigation navigation = mock(MapboxNavigation.class);
+    DirectionsRoute route = mock(DirectionsRoute.class);
+    NavigationViewModel viewModel = new NavigationViewModel(application, navigation);
+    viewModel.onDestroy(true);
+
+    viewModel.updateRoute(route);
+
+    verify(navigation, times(0)).startNavigation(route);
+  }
+
+  @Test
+  public void updateRoute_navigationIsUpdated() {
+    Application application = mock(Application.class);
+    MapboxNavigation navigation = mock(MapboxNavigation.class);
+    LocationEngineConductor conductor = mock(LocationEngineConductor.class);
+    NavigationViewEventDispatcher dispatcher = mock(NavigationViewEventDispatcher.class);
+    VoiceInstructionCache cache = mock(VoiceInstructionCache.class);
+    DirectionsRoute route = mock(DirectionsRoute.class);
+    NavigationViewModel viewModel = new NavigationViewModel(application, navigation, conductor, dispatcher, cache);
+    viewModel.isOffRoute.postValue(true);
+
+    viewModel.updateRoute(route);
+
+    verify(navigation).startNavigation(route);
   }
 }

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewRouteEngineListenerTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewRouteEngineListenerTest.java
@@ -16,9 +16,8 @@ import static org.mockito.Mockito.when;
 public class NavigationViewRouteEngineListenerTest {
 
   @Test
-  public void checksUpdateRouteCalledIfNavigationIsNotRunning() {
+  public void onRouteUpdate_checksUpdateRouteCalled() {
     NavigationViewModel mockedNavigationViewModel = mock(NavigationViewModel.class);
-    when(mockedNavigationViewModel.isRunning()).thenReturn(false);
     DirectionsRoute aDirectionsRoute = mock(DirectionsRoute.class);
     NavigationViewRouteEngineListener theRouteEngineListener
       = new NavigationViewRouteEngineListener(mockedNavigationViewModel);
@@ -26,34 +25,6 @@ public class NavigationViewRouteEngineListenerTest {
     theRouteEngineListener.onRouteUpdate(aDirectionsRoute);
 
     verify(mockedNavigationViewModel).updateRoute(eq(aDirectionsRoute));
-  }
-
-  @Test
-  public void checksUpdateRouteCalledIfNavigationIsOffRoute() {
-    NavigationViewModel mockedNavigationViewModel = mock(NavigationViewModel.class);
-    when(mockedNavigationViewModel.isRunning()).thenReturn(true);
-    when(mockedNavigationViewModel.isOffRoute()).thenReturn(true);
-    DirectionsRoute aDirectionsRoute = mock(DirectionsRoute.class);
-    NavigationViewRouteEngineListener theRouteEngineListener
-      = new NavigationViewRouteEngineListener(mockedNavigationViewModel);
-
-    theRouteEngineListener.onRouteUpdate(aDirectionsRoute);
-
-    verify(mockedNavigationViewModel).updateRoute(eq(aDirectionsRoute));
-  }
-
-  @Test
-  public void checksUpdateRouteNotCalledIfNavigationIsRunningAndIsNotOffRoute() {
-    NavigationViewModel mockedNavigationViewModel = mock(NavigationViewModel.class);
-    when(mockedNavigationViewModel.isRunning()).thenReturn(true);
-    when(mockedNavigationViewModel.isOffRoute()).thenReturn(false);
-    DirectionsRoute aDirectionsRoute = mock(DirectionsRoute.class);
-    NavigationViewRouteEngineListener theRouteEngineListener
-      = new NavigationViewRouteEngineListener(mockedNavigationViewModel);
-
-    theRouteEngineListener.onRouteUpdate(aDirectionsRoute);
-
-    verify(mockedNavigationViewModel, times(0)).updateRoute(eq(aDirectionsRoute));
   }
 
   @Test


### PR DESCRIPTION
This behavior was introduced in https://github.com/mapbox/mapbox-navigation-android/pull/1622:

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/8434572/50911251-7a3d4480-13fd-11e9-83c6-d814c8a476b2.gif)

#1622 was created to prevent duplicate voice instructions from firing during configuration changes.  

This PR removes the checks in `NavigationViewRouteEngineListener` and rather checks for configuration changes in the `NavigationViewModel`.  This will prevent the duplicate voice instruction but also allow developers to start navigation while a session is running (regardless off off-route or first-route).  