### PR TITLE
Create RouteProgress after leg index check in RouteProcessorRunnable

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/RouteProcessorBackgroundThread.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/RouteProcessorBackgroundThread.java
@@ -38,9 +38,7 @@ class RouteProcessorBackgroundThread extends HandlerThread {
     if (workerHandler == null) {
       workerHandler = new Handler(getLooper());
     }
-    runnable = new RouteProcessorRunnable(
-      routeProcessor, navigation, workerHandler, responseHandler, listener
-    );
+    runnable = new RouteProcessorRunnable(routeProcessor, navigation, workerHandler, responseHandler, listener);
     workerHandler.post(runnable);
   }
 
@@ -53,11 +51,11 @@ class RouteProcessorBackgroundThread extends HandlerThread {
   }
 
   void updateRawLocation(Location rawLocation) {
+    navigation.retrieveMapboxNavigator().updateLocation(rawLocation);
     if (!isAlive()) {
       start();
     }
     runnable.updateRawLocation(rawLocation);
-    navigation.retrieveMapboxNavigator().updateLocation(rawLocation);
   }
 
   /**

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/RouteProcessorRunnable.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/RouteProcessorRunnable.java
@@ -57,9 +57,8 @@ class RouteProcessorRunnable implements Runnable {
 
     NavigationStatus status = mapboxNavigator.retrieveStatus(new Date(),
       options.navigationLocationEngineIntervalLagInMilliseconds());
-    RouteProgress routeProgress = routeProcessor.buildNewRouteProgress(status, route);
-
     status = checkForNewLegIndex(mapboxNavigator, route, status, options.enableAutoIncrementLegIndex());
+    RouteProgress routeProgress = routeProcessor.buildNewRouteProgress(status, route);
 
     NavigationEngineFactory engineFactory = navigation.retrieveEngineFactory();
     final boolean userOffRoute = isUserOffRoute(options, status, rawLocation, routeProgress, engineFactory);


### PR DESCRIPTION
We were creating the `RouteProgress` object prior to checking for a leg index bump in the `RouteProcessorRunnable`.  If the index updates, the `RouteProgress` needs to be updated too.  This PR updates the order, so the progress is created _after_ we check for a leg index update. 

Also, we update the `Navigator` `Location` prior to starting the background thread, in an effort to pass that data earlier to the route following APIs.  

cc @kevinkreiser 