### PR TITLE
Return the actual error coming back from NN when fetching an offline route fails

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/OfflineRoute.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/OfflineRoute.java
@@ -4,7 +4,6 @@ import android.support.annotation.FloatRange;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
-import com.google.gson.Gson;
 import com.mapbox.api.directions.v5.models.DirectionsResponse;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.core.exceptions.ServicesException;
@@ -14,7 +13,6 @@ import com.mapbox.navigator.RouterResult;
 import java.util.List;
 
 import okhttp3.HttpUrl;
-import timber.log.Timber;
 
 /**
  * The {@link OfflineRoute} class wraps the {@link NavigationRoute} class with parameters which
@@ -73,10 +71,10 @@ public class OfflineRoute {
   @Nullable
   DirectionsRoute retrieveOfflineRoute(@NonNull RouterResult response) {
     boolean success = response.getSuccess();
-    String jsonResponse = response.getJson();
-    if (checkOfflineRoute(success, jsonResponse)) {
+    if (!checkOfflineRoute(success)) {
       return null;
     }
+    String jsonResponse = response.getJson();
     return obtainRouteFor(jsonResponse);
   }
 
@@ -155,11 +153,8 @@ public class OfflineRoute {
     return offlineUrlBuilder.build().toString();
   }
 
-  private boolean checkOfflineRoute(boolean isSuccess, String json) {
-    if (!isSuccess) {
-      Gson gson = new Gson();
-      OfflineRouteError error = gson.fromJson(json, OfflineRouteError.class);
-      Timber.e("Error occurred fetching offline route: %s - Code: %d", error.getError(), error.getErrorCode());
+  private boolean checkOfflineRoute(boolean isSuccess) {
+    if (isSuccess) {
       return true;
     }
     return false;

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/OfflineRouteRetrievalTask.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/OfflineRouteRetrievalTask.java
@@ -1,24 +1,34 @@
 package com.mapbox.services.android.navigation.v5.navigation;
 
 import android.os.AsyncTask;
+import android.support.annotation.NonNull;
 
+import com.google.gson.Gson;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.navigator.Navigator;
 import com.mapbox.navigator.RouterResult;
+
+import timber.log.Timber;
 
 class OfflineRouteRetrievalTask extends AsyncTask<OfflineRoute, Void, DirectionsRoute> {
   private static final int FIRST_ROUTE = 0;
   private final Navigator navigator;
   private final OnOfflineRouteFoundCallback callback;
+  private RouterResult routerResult;
 
   OfflineRouteRetrievalTask(Navigator navigator, OnOfflineRouteFoundCallback callback) {
     this.navigator = navigator;
     this.callback = callback;
   }
 
+  // For testing only
+  OfflineRouteRetrievalTask(Navigator navigator, OnOfflineRouteFoundCallback callback, RouterResult routerResult) {
+    this(navigator, callback);
+    this.routerResult = routerResult;
+  }
+
   @Override
   protected DirectionsRoute doInBackground(OfflineRoute... offlineRoutes) {
-    RouterResult routerResult;
     String url = offlineRoutes[FIRST_ROUTE].buildUrl();
 
     synchronized (navigator) {
@@ -33,8 +43,20 @@ class OfflineRouteRetrievalTask extends AsyncTask<OfflineRoute, Void, Directions
     if (offlineRoute != null) {
       callback.onRouteFound(offlineRoute);
     } else {
-      OfflineError error = new OfflineError("Offline route was not found");
+      String errorMessage = generateErrorMessage();
+      OfflineError error = new OfflineError(errorMessage);
       callback.onError(error);
     }
+  }
+
+  @NonNull
+  private String generateErrorMessage() {
+    String jsonResponse = routerResult.getJson();
+    Gson gson = new Gson();
+    OfflineRouteError routeError = gson.fromJson(jsonResponse, OfflineRouteError.class);
+    String errorMessage = String.format("Error occurred fetching offline route: %s - Code: %d", routeError.getError(),
+      routeError.getErrorCode());
+    Timber.e(errorMessage);
+    return errorMessage;
   }
 }

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/OfflineRouteRetrievalTaskTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/OfflineRouteRetrievalTaskTest.java
@@ -1,0 +1,66 @@
+package com.mapbox.services.android.navigation.v5.navigation;
+
+import com.mapbox.api.directions.v5.models.DirectionsRoute;
+import com.mapbox.navigator.Navigator;
+import com.mapbox.navigator.RouterResult;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class OfflineRouteRetrievalTaskTest {
+
+  @Test
+  public void checksOnErrorIsCalledIfRouteIsNotFetched() {
+    Navigator mockedNavigator = mock(Navigator.class);
+    OnOfflineRouteFoundCallback mockedCallback = mock(OnOfflineRouteFoundCallback.class);
+    RouterResult mockedResult = mock(RouterResult.class);
+    when(mockedResult.getJson()).thenReturn("{\"status\": \"Bad Request\", \"status_code\": 400, \"error\": \"No " +
+      "suitable edges near location\", \"error_code\": 171}");
+    OfflineRouteRetrievalTask theOfflineRouteRetrievalTask = new OfflineRouteRetrievalTask(mockedNavigator,
+      mockedCallback, mockedResult);
+    DirectionsRoute nullRoute = null;
+
+    theOfflineRouteRetrievalTask.onPostExecute(nullRoute);
+
+    verify(mockedCallback).onError(any(OfflineError.class));
+  }
+
+  @Test
+  public void checksErrorMessageIsWellFormedIfRouteIsNotFetched() {
+    Navigator mockedNavigator = mock(Navigator.class);
+    OnOfflineRouteFoundCallback mockedCallback = mock(OnOfflineRouteFoundCallback.class);
+    RouterResult mockedResult = mock(RouterResult.class);
+    when(mockedResult.getJson()).thenReturn("{\"status\": \"Bad Request\", \"status_code\": 400, \"error\": \"No " +
+      "suitable edges near location\", \"error_code\": 171}");
+    OfflineRouteRetrievalTask theOfflineRouteRetrievalTask = new OfflineRouteRetrievalTask(mockedNavigator,
+      mockedCallback, mockedResult);
+    DirectionsRoute nullRoute = null;
+    ArgumentCaptor<OfflineError> offlineError = ArgumentCaptor.forClass(OfflineError.class);
+
+    theOfflineRouteRetrievalTask.onPostExecute(nullRoute);
+
+    verify(mockedCallback).onError(offlineError.capture());
+    assertEquals("Error occurred fetching offline route: No suitable edges near location - Code: 171",
+      offlineError.getValue().getMessage());
+  }
+
+  @Test
+  public void checksOnRouteFoundIsCalledIfRouteIsFetched() {
+    Navigator mockedNavigator = mock(Navigator.class);
+    OnOfflineRouteFoundCallback mockedCallback = mock(OnOfflineRouteFoundCallback.class);
+    OfflineRouteRetrievalTask theOfflineRouteRetrievalTask = new OfflineRouteRetrievalTask(mockedNavigator,
+      mockedCallback);
+    DirectionsRoute aRoute = mock(DirectionsRoute.class);
+
+    theOfflineRouteRetrievalTask.onPostExecute(aRoute);
+
+    verify(mockedCallback).onRouteFound(eq(aRoute));
+  }
+}


### PR DESCRIPTION
- Returns the actual error coming back from NN when fetching an offline route fails, adding something which has more information to help which will definitely help diagnose potential fetching issues

cc @kevinkreiser 