### PR TITLE
Remove unused / package-private RouteStepProgress#nextStep

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/routeprogress/RouteLegProgress.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/routeprogress/RouteLegProgress.java
@@ -252,15 +252,9 @@ public abstract class RouteLegProgress {
     abstract RouteLegProgress autoBuild(); // not public
 
     public RouteLegProgress build() {
-      int lastStepIndex = routeLeg().steps().size() - 1;
-      boolean isOnLastStep = stepIndex() == lastStepIndex;
-      int nextStepIndex = stepIndex() + 1;
-      LegStep nextStep = isOnLastStep ? null : routeLeg().steps().get(nextStepIndex);
-
       LegStep currentStep = routeLeg().steps().get(stepIndex());
       RouteStepProgress stepProgress = RouteStepProgress.builder()
         .step(currentStep)
-        .nextStep(nextStep)
         .distanceRemaining(stepDistanceRemaining())
         .intersections(intersections())
         .currentIntersection(currentIntersection())

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/routeprogress/RouteStepProgress.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/routeprogress/RouteStepProgress.java
@@ -110,9 +110,6 @@ public abstract class RouteStepProgress {
 
   abstract LegStep step();
 
-  @Nullable
-  abstract LegStep nextStep();
-
   @AutoValue.Builder
   abstract static class Builder {
 
@@ -123,8 +120,6 @@ public abstract class RouteStepProgress {
     abstract Builder distanceRemaining(double distanceRemaining);
 
     abstract double distanceRemaining();
-
-    abstract Builder nextStep(@Nullable LegStep nextStep);
 
     abstract Builder distanceTraveled(double distanceTraveled);
 


### PR DESCRIPTION
Closes #1665 

This may be residual code / cleanup missed from the `Navigator` integration, but `RouteStepProgress#nextStep` is not used and is package-private.  It's creation in the `RouteLegProgress` is causing the crash.

All tests run fine and it's better to get this "creation logic" out of the object itself.  