### PR TITLE
Fix AlertView animation leak

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/alert/AlertView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/alert/AlertView.java
@@ -1,6 +1,5 @@
 package com.mapbox.services.android.navigation.ui.v5.alert;
 
-import android.animation.Animator;
 import android.animation.ObjectAnimator;
 import android.content.Context;
 import android.graphics.PorterDuff;
@@ -30,12 +29,12 @@ import com.mapbox.services.android.navigation.ui.v5.ThemeSwitcher;
  */
 public class AlertView extends CardView {
 
+  private static final String ALERT_VIEW_PROGRESS = "progress";
   private TextView alertText;
   private ProgressBar alertProgressBar;
 
   private Animation fadeOut;
   private Animation slideDownTop;
-  private ObjectAnimator countdownAnimation;
 
   public AlertView(Context context) {
     this(context, null);
@@ -56,14 +55,6 @@ public class AlertView extends CardView {
     bind();
     initAnimations();
     initBackground();
-  }
-
-  @Override
-  protected void onDetachedFromWindow() {
-    super.onDetachedFromWindow();
-    if (countdownAnimation != null) {
-      countdownAnimation.cancel();
-    }
   }
 
   /**
@@ -157,31 +148,10 @@ public class AlertView extends CardView {
   }
 
   private void startCountdown(long duration) {
-    countdownAnimation = ObjectAnimator.ofInt(alertProgressBar,
-      "progress", 0);
+    ObjectAnimator countdownAnimation = ObjectAnimator.ofInt(alertProgressBar, ALERT_VIEW_PROGRESS, 0);
     countdownAnimation.setInterpolator(new LinearInterpolator());
     countdownAnimation.setDuration(duration);
-    countdownAnimation.addListener(new Animator.AnimatorListener() {
-      @Override
-      public void onAnimationStart(Animator animation) {
-
-      }
-
-      @Override
-      public void onAnimationEnd(Animator animation) {
-        hide();
-      }
-
-      @Override
-      public void onAnimationCancel(Animator animation) {
-
-      }
-
-      @Override
-      public void onAnimationRepeat(Animator animation) {
-
-      }
-    });
+    countdownAnimation.addListener(new AlertViewAnimatorListener(this));
     countdownAnimation.start();
   }
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/alert/AlertViewAnimatorListener.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/alert/AlertViewAnimatorListener.java
@@ -1,0 +1,38 @@
+package com.mapbox.services.android.navigation.ui.v5.alert;
+
+import android.animation.Animator;
+
+import java.lang.ref.WeakReference;
+
+class AlertViewAnimatorListener implements Animator.AnimatorListener {
+
+  private final WeakReference<AlertView> alertViewWeakReference;
+
+  AlertViewAnimatorListener(AlertView alertView) {
+    this.alertViewWeakReference = new WeakReference<>(alertView);
+  }
+
+  @Override
+  public void onAnimationStart(Animator animation) {
+  }
+
+  @Override
+  public void onAnimationEnd(Animator animation) {
+    hideAlertView();
+  }
+
+  @Override
+  public void onAnimationCancel(Animator animation) {
+  }
+
+  @Override
+  public void onAnimationRepeat(Animator animation) {
+  }
+
+  private void hideAlertView() {
+    AlertView alertView = alertViewWeakReference.get();
+    if (alertView != null) {
+      alertView.hide();
+    }
+  }
+}

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/alert/AlertViewAnimatorListenerTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/alert/AlertViewAnimatorListenerTest.java
@@ -1,0 +1,21 @@
+package com.mapbox.services.android.navigation.ui.v5.alert;
+
+import android.animation.Animator;
+
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class AlertViewAnimatorListenerTest {
+
+  @Test
+  public void onAnimationEnd_alertViewIsHidden() {
+    AlertView alertView = mock(AlertView.class);
+    AlertViewAnimatorListener listener = new AlertViewAnimatorListener(alertView);
+
+    listener.onAnimationEnd(mock(Animator.class));
+
+    verify(alertView).hide();
+  }
+}


### PR DESCRIPTION
@Guardiola31337 spotted this leak when testing 👁:

![screenshot_20190111-215316](https://user-images.githubusercontent.com/8434572/51118330-1c827100-17de-11e9-8f9a-23955f128eae.png)

It seems this is reproducible when closing the `NavigationView` while the `AlertView` is still showing / animating.  I wasn't able to reproduce with thew new `WeakReference`.

We also have an existing check to cancel the animation when the `AlertView` is detached from the window. 
