### PR TITLE
Add dynamic map FPS adjustment for NavigationMapboxMap

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,7 +8,7 @@ ext {
   ]
 
   version = [
-      mapboxMapSdk       : '7.0.0',
+      mapboxMapSdk       : '7.0.1',
       mapboxSdkServices  : '4.3.0',
       mapboxEvents       : '4.2.0',
       mapboxNavigator    : '3.4.12',

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationOnCameraTrackingChangedListener.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationOnCameraTrackingChangedListener.java
@@ -9,7 +9,7 @@ import com.mapbox.mapboxsdk.location.OnCameraTrackingChangedListener;
  * <p>
  * If the camera tracking is dismissed, we notify the presenter to adjust UI accordingly.
  */
-public class NavigationOnCameraTrackingChangedListener implements OnCameraTrackingChangedListener {
+class NavigationOnCameraTrackingChangedListener implements OnCameraTrackingChangedListener {
 
   private final NavigationPresenter navigationPresenter;
   private final BottomSheetBehavior summaryBehavior;

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/camera/NavigationCameraTransitionListener.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/camera/NavigationCameraTransitionListener.java
@@ -1,0 +1,22 @@
+package com.mapbox.services.android.navigation.ui.v5.camera;
+
+import com.mapbox.mapboxsdk.location.OnLocationCameraTransitionListener;
+
+class NavigationCameraTransitionListener implements OnLocationCameraTransitionListener {
+
+  private final NavigationCamera camera;
+
+  NavigationCameraTransitionListener(NavigationCamera camera) {
+    this.camera = camera;
+  }
+
+  @Override
+  public void onLocationCameraTransitionFinished(int cameraMode) {
+    camera.updateTransitionListenersFinished(cameraMode);
+  }
+
+  @Override
+  public void onLocationCameraTransitionCanceled(int cameraMode) {
+    camera.updateTransitionListenersCancelled(cameraMode);
+  }
+}

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/camera/OnTrackingModeChangedListener.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/camera/OnTrackingModeChangedListener.java
@@ -1,0 +1,15 @@
+package com.mapbox.services.android.navigation.ui.v5.camera;
+
+/**
+ * Use this listener to observe changes in the {@link NavigationCamera}
+ * tracking mode.
+ */
+public interface OnTrackingModeChangedListener {
+
+  /**
+   * Invoked when {@link NavigationCamera} tracking mode changes.
+   *
+   * @param trackingMode the current tracking mode
+   */
+  void onTrackingModeChanged(@NavigationCamera.TrackingMode int trackingMode);
+}

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/camera/OnTrackingModeTransitionListener.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/camera/OnTrackingModeTransitionListener.java
@@ -1,0 +1,18 @@
+package com.mapbox.services.android.navigation.ui.v5.camera;
+
+/**
+ * Listener that gets invoked when the navigation camera finishes a transition
+ * to a new tracking mode.
+ */
+public interface OnTrackingModeTransitionListener {
+
+  /**
+   * Invoked when the camera has finished a transition to a new tracking mode.
+   */
+  void onTransitionFinished(@NavigationCamera.TrackingMode int trackingMode);
+
+  /**
+   * Invoked when the transition to a new tracking mode has been cancelled.
+   */
+  void onTransitionCancelled(@NavigationCamera.TrackingMode int trackingMode);
+}

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/FpsDelegateProgressChangeListener.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/FpsDelegateProgressChangeListener.java
@@ -1,0 +1,20 @@
+package com.mapbox.services.android.navigation.ui.v5.map;
+
+import android.location.Location;
+
+import com.mapbox.services.android.navigation.v5.routeprogress.ProgressChangeListener;
+import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
+
+class FpsDelegateProgressChangeListener implements ProgressChangeListener {
+
+  private final MapFpsDelegate fpsDelegate;
+
+  FpsDelegateProgressChangeListener(MapFpsDelegate fpsDelegate) {
+    this.fpsDelegate = fpsDelegate;
+  }
+
+  @Override
+  public void onProgressChange(Location location, RouteProgress routeProgress) {
+    fpsDelegate.adjustFpsFor(routeProgress);
+  }
+}

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/MapBatteryMonitor.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/MapBatteryMonitor.java
@@ -1,0 +1,33 @@
+package com.mapbox.services.android.navigation.ui.v5.map;
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.os.BatteryManager;
+import android.os.Build;
+
+class MapBatteryMonitor {
+
+  private static final int DEFAULT_BATTERY_LEVEL = -1;
+
+  boolean isPluggedIn(Context context) {
+    Intent batteryStatus = registerBatteryUpdates(context);
+    if (batteryStatus == null) {
+      return false;
+    }
+
+    int chargePlug = batteryStatus.getIntExtra(BatteryManager.EXTRA_PLUGGED, DEFAULT_BATTERY_LEVEL);
+    boolean pluggedUsb = chargePlug == BatteryManager.BATTERY_PLUGGED_USB;
+    boolean pluggedAc = chargePlug == BatteryManager.BATTERY_PLUGGED_AC;
+    boolean isPlugged = pluggedUsb || pluggedAc;
+    if (Build.VERSION.SDK_INT > Build.VERSION_CODES.JELLY_BEAN) {
+      isPlugged = isPlugged || chargePlug == BatteryManager.BATTERY_PLUGGED_WIRELESS;
+    }
+    return isPlugged;
+  }
+
+  private static Intent registerBatteryUpdates(Context context) {
+    IntentFilter filter = new IntentFilter(Intent.ACTION_BATTERY_CHANGED);
+    return context.registerReceiver(null, filter);
+  }
+}

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/MapFpsDelegate.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/MapFpsDelegate.java
@@ -1,0 +1,136 @@
+package com.mapbox.services.android.navigation.ui.v5.map;
+
+import android.content.Context;
+
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.services.android.navigation.ui.v5.camera.NavigationCamera;
+import com.mapbox.services.android.navigation.ui.v5.camera.OnTrackingModeChangedListener;
+import com.mapbox.services.android.navigation.ui.v5.camera.OnTrackingModeTransitionListener;
+import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation;
+import com.mapbox.services.android.navigation.v5.navigation.NavigationConstants;
+import com.mapbox.services.android.navigation.v5.routeprogress.ProgressChangeListener;
+import com.mapbox.services.android.navigation.v5.routeprogress.RouteLegProgress;
+import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
+
+class MapFpsDelegate implements OnTrackingModeChangedListener, OnTrackingModeTransitionListener {
+
+  private static final double VALID_DURATION_IN_SECONDS_UNTIL_NEXT_MANEUVER = 7d;
+  private static final double VALID_DURATION_IN_SECONDS_SINCE_PREVIOUS_MANEUVER = 5d;
+  private static final int DEVICE_MAX_FPS = Integer.MAX_VALUE;
+  private static final int LOW_POWER_MAX_FPS = 30;
+  private static final int DEFAULT_MAX_FPS_THRESHOLD = 20;
+
+  private final MapView mapView;
+  private final MapBatteryMonitor batteryMonitor;
+  private final ProgressChangeListener fpsProgressListener = new FpsDelegateProgressChangeListener(this);
+  private MapboxNavigation navigation;
+  private int maxFpsThreshold = DEFAULT_MAX_FPS_THRESHOLD;
+  private boolean isTracking = true;
+  private boolean isEnabled = true;
+
+  MapFpsDelegate(MapView mapView, MapBatteryMonitor batteryMonitor) {
+    this.mapView = mapView;
+    this.batteryMonitor = batteryMonitor;
+  }
+
+  @Override
+  public void onTrackingModeChanged(int trackingMode) {
+    int trackingModeNone = NavigationCamera.NAVIGATION_TRACKING_MODE_NONE;
+    if (trackingMode == trackingModeNone) {
+      updateCameraTracking(trackingModeNone);
+    }
+  }
+
+  @Override
+  public void onTransitionFinished(int trackingMode) {
+    updateCameraTracking(trackingMode);
+  }
+
+  @Override
+  public void onTransitionCancelled(int trackingMode) {
+    updateCameraTracking(trackingMode);
+  }
+
+  void addProgressChangeListener(MapboxNavigation navigation) {
+    this.navigation = navigation;
+    navigation.addProgressChangeListener(fpsProgressListener);
+  }
+
+  void onStart() {
+    if (navigation != null) {
+      navigation.addProgressChangeListener(fpsProgressListener);
+    }
+  }
+
+  void onStop() {
+    if (navigation != null) {
+      navigation.removeProgressChangeListener(fpsProgressListener);
+    }
+  }
+
+  void updateEnabled(boolean isEnabled) {
+    this.isEnabled = isEnabled;
+    resetMaxFps(!isEnabled);
+  }
+
+  boolean isEnabled() {
+    return isEnabled;
+  }
+
+  void updateMaxFpsThreshold(int maxFps) {
+    this.maxFpsThreshold = maxFps;
+  }
+
+  int retrieveMaxFpsThreshold() {
+    return maxFpsThreshold;
+  }
+
+  void adjustFpsFor(RouteProgress routeProgress) {
+    if (!isEnabled || !isTracking) {
+      return;
+    }
+
+    int maxFps = determineMaxFpsFrom(routeProgress, mapView.getContext());
+    mapView.setMaximumFps(maxFps);
+  }
+
+  private void updateCameraTracking(@NavigationCamera.TrackingMode int trackingMode) {
+    isTracking = trackingMode != NavigationCamera.NAVIGATION_TRACKING_MODE_NONE;
+    resetMaxFps(!isTracking);
+  }
+
+  private void resetMaxFps(boolean shouldReset) {
+    if (shouldReset) {
+      mapView.setMaximumFps(DEVICE_MAX_FPS);
+    }
+  }
+
+  private int determineMaxFpsFrom(RouteProgress routeProgress, Context context) {
+    final boolean isPluggedIn = batteryMonitor.isPluggedIn(context);
+    RouteLegProgress routeLegProgress = routeProgress.currentLegProgress();
+
+    if (isPluggedIn) {
+      return LOW_POWER_MAX_FPS;
+    } else if (validLowFpsManeuver(routeLegProgress) || validLowFpsDuration(routeLegProgress)) {
+      return maxFpsThreshold;
+    } else {
+      return LOW_POWER_MAX_FPS;
+    }
+  }
+
+  private boolean validLowFpsManeuver(RouteLegProgress routeLegProgress) {
+    final String maneuverModifier = routeLegProgress.currentStep().maneuver().modifier();
+    return maneuverModifier != null
+      && (maneuverModifier.equals(NavigationConstants.STEP_MANEUVER_MODIFIER_STRAIGHT)
+      || maneuverModifier.equals(NavigationConstants.STEP_MANEUVER_MODIFIER_SLIGHT_LEFT)
+      || maneuverModifier.equals(NavigationConstants.STEP_MANEUVER_MODIFIER_SLIGHT_RIGHT));
+  }
+
+  private boolean validLowFpsDuration(RouteLegProgress routeLegProgress) {
+    final double expectedStepDuration = routeLegProgress.currentStep().duration();
+    final double durationUntilNextManeuver = routeLegProgress.currentStepProgress().durationRemaining();
+    final double durationSincePreviousManeuver = expectedStepDuration - durationUntilNextManeuver;
+    return durationUntilNextManeuver > VALID_DURATION_IN_SECONDS_UNTIL_NEXT_MANEUVER
+      && durationSincePreviousManeuver > VALID_DURATION_IN_SECONDS_SINCE_PREVIOUS_MANEUVER;
+  }
+}

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/MapFpsInstanceState.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/MapFpsInstanceState.java
@@ -1,0 +1,51 @@
+package com.mapbox.services.android.navigation.ui.v5.map;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+class MapFpsInstanceState implements Parcelable {
+
+  private final int maxFps;
+  private final boolean maxFpsEnabled;
+
+  MapFpsInstanceState(int maxFps, boolean maxFpsEnabled) {
+    this.maxFps = maxFps;
+    this.maxFpsEnabled = maxFpsEnabled;
+  }
+
+  int retrieveMaxFps() {
+    return maxFps;
+  }
+
+  boolean isMaxFpsEnabled() {
+    return maxFpsEnabled;
+  }
+
+  private MapFpsInstanceState(Parcel in) {
+    maxFps = in.readInt();
+    maxFpsEnabled = in.readByte() != 0;
+  }
+
+  @Override
+  public void writeToParcel(Parcel dest, int flags) {
+    dest.writeInt(maxFps);
+    dest.writeByte((byte) (maxFpsEnabled ? 1 : 0));
+  }
+
+  @Override
+  public int describeContents() {
+    return 0;
+  }
+
+  public static final Creator<MapFpsInstanceState> CREATOR = new Creator<MapFpsInstanceState>() {
+    @Override
+    public MapFpsInstanceState createFromParcel(Parcel in) {
+      return new MapFpsInstanceState(in);
+    }
+
+    @Override
+    public MapFpsInstanceState[] newArray(int size) {
+      return new MapFpsInstanceState[size];
+    }
+  };
+}

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/NavigationMapboxMapInstanceState.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/NavigationMapboxMapInstanceState.java
@@ -10,13 +10,17 @@ public class NavigationMapboxMapInstanceState implements Parcelable {
   private final MapPaddingInstanceState mapPaddingInstanceState;
   @NavigationCamera.TrackingMode
   private final int cameraTrackingMode;
+  private final MapFpsInstanceState mapFpsInstanceState;
 
   NavigationMapboxMapInstanceState(int[] currentPadding,
                                    boolean shouldUseDefaultPadding,
-                                   @NavigationCamera.TrackingMode int cameraTrackingMode) {
+                                   @NavigationCamera.TrackingMode int cameraTrackingMode,
+                                   int currentMaxFps,
+                                   boolean maxFpsEnabled) {
 
     this.mapPaddingInstanceState = new MapPaddingInstanceState(currentPadding, shouldUseDefaultPadding);
     this.cameraTrackingMode = cameraTrackingMode;
+    this.mapFpsInstanceState = new MapFpsInstanceState(currentMaxFps, maxFpsEnabled);
   }
 
   MapPaddingInstanceState retrieveMapPadding() {
@@ -28,15 +32,21 @@ public class NavigationMapboxMapInstanceState implements Parcelable {
     return cameraTrackingMode;
   }
 
+  MapFpsInstanceState retrieveMapFps() {
+    return mapFpsInstanceState;
+  }
+
   private NavigationMapboxMapInstanceState(Parcel in) {
     mapPaddingInstanceState = in.readParcelable(MapPaddingInstanceState.class.getClassLoader());
     cameraTrackingMode = in.readInt();
+    mapFpsInstanceState = in.readParcelable(MapFpsInstanceState.class.getClassLoader());
   }
 
   @Override
   public void writeToParcel(Parcel dest, int flags) {
     dest.writeParcelable(mapPaddingInstanceState, flags);
     dest.writeInt(cameraTrackingMode);
+    dest.writeParcelable(mapFpsInstanceState, flags);
   }
 
   @Override
@@ -46,15 +56,14 @@ public class NavigationMapboxMapInstanceState implements Parcelable {
 
   public static final Creator<NavigationMapboxMapInstanceState> CREATOR =
     new Creator<NavigationMapboxMapInstanceState>() {
+    @Override
+    public NavigationMapboxMapInstanceState createFromParcel(Parcel in) {
+      return new NavigationMapboxMapInstanceState(in);
+    }
 
-      @Override
-      public NavigationMapboxMapInstanceState createFromParcel(Parcel in) {
-        return new NavigationMapboxMapInstanceState(in);
-      }
-
-      @Override
-      public NavigationMapboxMapInstanceState[] newArray(int size) {
-        return new NavigationMapboxMapInstanceState[size];
-      }
-    };
+    @Override
+    public NavigationMapboxMapInstanceState[] newArray(int size) {
+      return new NavigationMapboxMapInstanceState[size];
+    }
+  };
 }

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/camera/NavigationCameraTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/camera/NavigationCameraTest.java
@@ -1,6 +1,7 @@
 package com.mapbox.services.android.navigation.ui.v5.camera;
 
 import com.mapbox.mapboxsdk.location.LocationComponent;
+import com.mapbox.mapboxsdk.location.OnLocationCameraTransitionListener;
 import com.mapbox.mapboxsdk.location.modes.CameraMode;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.services.android.navigation.ui.v5.BaseTest;
@@ -12,6 +13,8 @@ import org.junit.Test;
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -30,14 +33,18 @@ public class NavigationCameraTest extends BaseTest {
     LocationComponent locationComponent = mock(LocationComponent.class);
     NavigationCamera camera = buildCamera(locationComponent);
 
-    verify(locationComponent, times(1)).setCameraMode(CameraMode.TRACKING_GPS);
-    verify(locationComponent, times(0)).setCameraMode(CameraMode.NONE);
+    verify(locationComponent, times(1)).setCameraMode(eq(CameraMode.TRACKING_GPS),
+      any(OnLocationCameraTransitionListener.class));
+    verify(locationComponent, times(0)).setCameraMode(eq(CameraMode.NONE),
+      any(OnLocationCameraTransitionListener.class));
 
     camera.updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_NONE);
-    verify(locationComponent, times(1)).setCameraMode(CameraMode.NONE);
+    verify(locationComponent, times(1)).setCameraMode(eq(CameraMode.NONE),
+      any(OnLocationCameraTransitionListener.class));
 
     camera.updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_GPS);
-    verify(locationComponent, times(2)).setCameraMode(CameraMode.TRACKING_GPS);
+    verify(locationComponent, times(2)).setCameraMode(eq(CameraMode.TRACKING_GPS),
+      any(OnLocationCameraTransitionListener.class));
 
     assertTrue(camera.isTrackingEnabled());
   }
@@ -47,14 +54,18 @@ public class NavigationCameraTest extends BaseTest {
     LocationComponent locationComponent = mock(LocationComponent.class);
     NavigationCamera camera = buildCamera(locationComponent);
 
-    verify(locationComponent, times(1)).setCameraMode(CameraMode.TRACKING_GPS);
-    verify(locationComponent, times(0)).setCameraMode(CameraMode.NONE);
+    verify(locationComponent, times(1)).setCameraMode(eq(CameraMode.TRACKING_GPS),
+      any(OnLocationCameraTransitionListener.class));
+    verify(locationComponent, times(0)).setCameraMode(eq(CameraMode.NONE),
+      any(OnLocationCameraTransitionListener.class));
 
     camera.updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_GPS);
-    verify(locationComponent, times(2)).setCameraMode(CameraMode.TRACKING_GPS);
+    verify(locationComponent, times(2)).setCameraMode(eq(CameraMode.TRACKING_GPS),
+      any(OnLocationCameraTransitionListener.class));
 
     camera.updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_NONE);
-    verify(locationComponent, times(1)).setCameraMode(CameraMode.NONE);
+    verify(locationComponent, times(1)).setCameraMode(eq(CameraMode.NONE),
+      any(OnLocationCameraTransitionListener.class));
 
     assertFalse(camera.isTrackingEnabled());
   }

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/camera/NavigationCameraTransitionListenerTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/camera/NavigationCameraTransitionListenerTest.java
@@ -1,0 +1,33 @@
+package com.mapbox.services.android.navigation.ui.v5.camera;
+
+import com.mapbox.mapboxsdk.location.modes.CameraMode;
+
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class NavigationCameraTransitionListenerTest {
+
+  @Test
+  public void onLocationCameraTransitionFinished() {
+    NavigationCamera camera = mock(NavigationCamera.class);
+    NavigationCameraTransitionListener listener = new NavigationCameraTransitionListener(camera);
+    int trackingGps = CameraMode.TRACKING_GPS;
+
+    listener.onLocationCameraTransitionFinished(trackingGps);
+
+    verify(camera).updateTransitionListenersFinished(trackingGps);
+  }
+
+  @Test
+  public void onLocationCameraTransitionCanceled() {
+    NavigationCamera camera = mock(NavigationCamera.class);
+    NavigationCameraTransitionListener listener = new NavigationCameraTransitionListener(camera);
+    int trackingGpsNorth = CameraMode.TRACKING_GPS_NORTH;
+
+    listener.onLocationCameraTransitionCanceled(trackingGpsNorth);
+
+    verify(camera).updateTransitionListenersCancelled(trackingGpsNorth);
+  }
+}

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/map/MapFpsDelegateTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/map/MapFpsDelegateTest.java
@@ -1,0 +1,153 @@
+package com.mapbox.services.android.navigation.ui.v5.map;
+
+import android.content.Context;
+
+import com.mapbox.api.directions.v5.models.LegStep;
+import com.mapbox.api.directions.v5.models.StepManeuver;
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.services.android.navigation.ui.v5.camera.NavigationCamera;
+import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation;
+import com.mapbox.services.android.navigation.v5.routeprogress.RouteLegProgress;
+import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
+import com.mapbox.services.android.navigation.v5.routeprogress.RouteStepProgress;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class MapFpsDelegateTest {
+
+  @Test
+  public void addProgressChangeListener_navigationReceivesListener() {
+    MapboxNavigation navigation = mock(MapboxNavigation.class);
+    MapFpsDelegate delegate = new MapFpsDelegate(mock(MapView.class), mock(MapBatteryMonitor.class));
+
+    delegate.addProgressChangeListener(navigation);
+
+    verify(navigation).addProgressChangeListener(any(FpsDelegateProgressChangeListener.class));
+  }
+
+  @Test
+  public void onTransitionFinished_resetFpsWhenNotTracking() {
+    MapView mapView = mock(MapView.class);
+    MapFpsDelegate delegate = new MapFpsDelegate(mapView, mock(MapBatteryMonitor.class));
+
+    delegate.onTransitionFinished(NavigationCamera.NAVIGATION_TRACKING_MODE_NONE);
+
+    verify(mapView).setMaximumFps(eq(Integer.MAX_VALUE));
+  }
+
+  @Test
+  public void onTransitionCancelled_resetFpsWhenNotTracking() {
+    MapView mapView = mock(MapView.class);
+    MapFpsDelegate delegate = new MapFpsDelegate(mapView, mock(MapBatteryMonitor.class));
+
+    delegate.onTransitionCancelled(NavigationCamera.NAVIGATION_TRACKING_MODE_NONE);
+
+    verify(mapView).setMaximumFps(eq(Integer.MAX_VALUE));
+  }
+
+  @Test
+  public void onStop_navigationListenerRemoved() {
+    MapboxNavigation navigation = mock(MapboxNavigation.class);
+    MapFpsDelegate delegate = new MapFpsDelegate(mock(MapView.class), mock(MapBatteryMonitor.class));
+    delegate.addProgressChangeListener(navigation);
+
+    delegate.onStop();
+
+    verify(navigation).removeProgressChangeListener(any(FpsDelegateProgressChangeListener.class));
+  }
+
+  @Test
+  public void updateEnabledFalse_maxFpsReset() {
+    MapView mapView = mock(MapView.class);
+    MapFpsDelegate delegate = new MapFpsDelegate(mapView, mock(MapBatteryMonitor.class));
+
+    delegate.updateEnabled(false);
+
+    mapView.setMaximumFps(eq(Integer.MAX_VALUE));
+  }
+
+  @Test
+  public void isEnabled_returnsCurrentEnabledState() {
+    MapFpsDelegate delegate = new MapFpsDelegate(mock(MapView.class), mock(MapBatteryMonitor.class));
+
+    delegate.updateEnabled(false);
+
+    assertFalse(delegate.isEnabled());
+  }
+
+  @Test
+  public void updateMaxFpsThreshold_isCorrectlySet() {
+    MapFpsDelegate delegate = new MapFpsDelegate(mock(MapView.class), mock(MapBatteryMonitor.class));
+    int maxFpsThreshold = 5;
+
+    delegate.updateMaxFpsThreshold(maxFpsThreshold);
+
+    assertEquals(maxFpsThreshold, delegate.retrieveMaxFpsThreshold());
+  }
+
+  @Test
+  public void adjustFpsFor_thresholdSetWithCorrectManeuver() {
+    MapView mapView = mock(MapView.class);
+    MapBatteryMonitor batteryMonitor = mock(MapBatteryMonitor.class);
+    when(batteryMonitor.isPluggedIn(any(Context.class))).thenReturn(false);
+    MapFpsDelegate delegate = new MapFpsDelegate(mapView, batteryMonitor);
+    RouteProgress routeProgress = buildRouteProgressWith("straight");
+    int maxFps = 5;
+    delegate.updateMaxFpsThreshold(maxFps);
+
+    delegate.adjustFpsFor(routeProgress);
+
+    verify(mapView).setMaximumFps(eq(maxFps));
+  }
+
+  @Test
+  public void adjustFpsFor_thresholdSetWithCorrectDuration() {
+    MapView mapView = mock(MapView.class);
+    MapBatteryMonitor batteryMonitor = mock(MapBatteryMonitor.class);
+    when(batteryMonitor.isPluggedIn(any(Context.class))).thenReturn(false);
+    MapFpsDelegate delegate = new MapFpsDelegate(mapView, batteryMonitor);
+    RouteProgress routeProgress = buildRouteProgressWith(100d, 20d);
+    int maxFps = 5;
+    delegate.updateMaxFpsThreshold(maxFps);
+
+    delegate.adjustFpsFor(routeProgress);
+
+    verify(mapView).setMaximumFps(eq(maxFps));
+  }
+
+  private RouteProgress buildRouteProgressWith(String maneuverModifier) {
+    RouteProgress routeProgress = mock(RouteProgress.class);
+    RouteLegProgress routeLegProgress = mock(RouteLegProgress.class);
+    LegStep currentStep = mock(LegStep.class);
+    StepManeuver currentManeuver = mock(StepManeuver.class);
+    when(currentManeuver.modifier()).thenReturn(maneuverModifier);
+    when(currentStep.maneuver()).thenReturn(currentManeuver);
+    when(routeLegProgress.currentStep()).thenReturn(currentStep);
+    when(routeProgress.currentLegProgress()).thenReturn(routeLegProgress);
+    return routeProgress;
+  }
+
+  private RouteProgress buildRouteProgressWith(double totalDuration, double durationRemaining) {
+    RouteProgress routeProgress = mock(RouteProgress.class);
+    RouteLegProgress routeLegProgress = mock(RouteLegProgress.class);
+    RouteStepProgress routeStepProgress = mock(RouteStepProgress.class);
+    StepManeuver currentManeuver = mock(StepManeuver.class);
+    when(currentManeuver.modifier()).thenReturn("left");
+    LegStep currentStep = mock(LegStep.class);
+    when(currentStep.duration()).thenReturn(totalDuration);
+    when(routeStepProgress.durationRemaining()).thenReturn(durationRemaining);
+    when(routeLegProgress.currentStepProgress()).thenReturn(routeStepProgress);
+    when(routeProgress.currentLegProgress()).thenReturn(routeLegProgress);
+    when(currentStep.maneuver()).thenReturn(currentManeuver);
+    when(routeLegProgress.currentStep()).thenReturn(currentStep);
+    return routeProgress;
+  }
+}

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/map/NavigationMapboxMapTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/map/NavigationMapboxMapTest.java
@@ -124,4 +124,26 @@ public class NavigationMapboxMapTest {
 
     verify(mapWayName).removeOnWayNameChangedListener(listener);
   }
+
+  @Test
+  public void updateMapFpsThrottle_mapFpsDelegateIsUpdated() {
+    MapFpsDelegate delegate = mock(MapFpsDelegate.class);
+    NavigationMapboxMap theNavigationMap = new NavigationMapboxMap(delegate);
+    int maxFpsThreshold = 10;
+
+    theNavigationMap.updateMapFpsThrottle(maxFpsThreshold);
+
+    verify(delegate).updateMaxFpsThreshold(maxFpsThreshold);
+  }
+
+  @Test
+  public void updateMapFpsThrottleEnabled_mapFpsDelegateIsEnabled() {
+    MapFpsDelegate delegate = mock(MapFpsDelegate.class);
+    NavigationMapboxMap theNavigationMap = new NavigationMapboxMap(delegate);
+    boolean isEnabled = false;
+
+    theNavigationMap.updateMapFpsThrottleEnabled(isEnabled);
+
+    verify(delegate).updateEnabled(isEnabled);
+  }
 }


### PR DESCRIPTION
This adds dynamic FPS throttling based on `RouteProgress` along the route.  If we are going to execute a maneuver that is "lower risk" (continue straight, slight right, slight left) or we have determined we are far enough along the step (duration thresholds), we can set a lower ceiling for maximum FPS. [iOS logic](https://github.com/mapbox/mapbox-navigation-ios/blob/master/MapboxNavigation/NavigationMapView.swift#L282-L301)

TODO:
- [x] Unit tests
- [x] Field testing 
- [x] Ensure lifecycle is handled correctly 
- [x] Wait for #1661 to land

cc @1ec5 