### PR TITLE
Set ssmlAnouncement when using SpeechAnnouncementListener

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/EmbeddedNavigationActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/EmbeddedNavigationActivity.java
@@ -176,8 +176,8 @@ public class EmbeddedNavigationActivity extends AppCompatActivity implements OnN
   }
 
   @Override
-  public String willVoice(SpeechAnnouncement announcement) {
-    return "All announcements will be the same.";
+  public SpeechAnnouncement willVoice(SpeechAnnouncement announcement) {
+    return SpeechAnnouncement.builder().announcement("All announcements will be the same.").build();
   }
 
   @Override

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewEventDispatcher.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewEventDispatcher.java
@@ -167,9 +167,7 @@ class NavigationViewEventDispatcher {
 
   SpeechAnnouncement onAnnouncement(SpeechAnnouncement announcement) {
     if (speechAnnouncementListener != null) {
-      String textAnnouncement = speechAnnouncementListener.willVoice(announcement);
-      SpeechAnnouncement announcementToBeVoiced = SpeechAnnouncement.builder().announcement(textAnnouncement).build();
-      return announcementToBeVoiced;
+      return speechAnnouncementListener.willVoice(announcement);
     }
     return announcement;
   }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/listeners/SpeechAnnouncementListener.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/listeners/SpeechAnnouncementListener.java
@@ -17,10 +17,13 @@ public interface SpeechAnnouncementListener {
    * <p>
    * To prevent the given announcement from being announced, you can return null
    * and it will be ignored.
+   * <p>
+   * If the {@code SpeechAnnouncement#ssmlAnnouncement} is malformed,
+   * the {@link com.mapbox.services.android.navigation.ui.v5.voice.SpeechPlayer} will fall back to what is
+   * included in the {@code SpeechAnnouncement#announcement} with {@link android.speech.tts.TextToSpeech}.
    *
    * @param announcement about to be announced
-   * @return text announcement to be played; null if should be ignored
-   * @since 0.19.0
+   * @return speech announcement to be played; null if should be ignored
    */
-  String willVoice(SpeechAnnouncement announcement);
+  SpeechAnnouncement willVoice(SpeechAnnouncement announcement);
 }

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewEventDispatcherTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewEventDispatcherTest.java
@@ -378,8 +378,9 @@ public class NavigationViewEventDispatcherTest {
   public void onNewVoiceAnnouncement_instructionListenerIsCalled() {
     SpeechAnnouncement originalAnnouncement = mock(SpeechAnnouncement.class);
     SpeechAnnouncementListener speechAnnouncementListener = mock(SpeechAnnouncementListener.class);
-    String textAnnouncement = "announcement to be voiced";
-    when(speechAnnouncementListener.willVoice(originalAnnouncement)).thenReturn(textAnnouncement);
+    SpeechAnnouncement newAnnouncement = SpeechAnnouncement.builder()
+      .announcement("New announcement").build();
+    when(speechAnnouncementListener.willVoice(originalAnnouncement)).thenReturn(newAnnouncement);
     NavigationViewEventDispatcher eventDispatcher = buildViewEventDispatcher(speechAnnouncementListener);
 
     eventDispatcher.onAnnouncement(originalAnnouncement);
@@ -391,11 +392,29 @@ public class NavigationViewEventDispatcherTest {
   public void onNewVoiceAnnouncement_announcementToBeVoicedIsReturned() {
     SpeechAnnouncement originalAnnouncement = SpeechAnnouncement.builder().announcement("announcement").build();
     SpeechAnnouncementListener speechAnnouncementListener = mock(SpeechAnnouncementListener.class);
-    String textAnnouncement = "announcement to be voiced";
-    when(speechAnnouncementListener.willVoice(originalAnnouncement)).thenReturn(textAnnouncement);
+    SpeechAnnouncement newAnnouncement = SpeechAnnouncement.builder()
+      .announcement("New announcement").build();
+    when(speechAnnouncementListener.willVoice(originalAnnouncement)).thenReturn(newAnnouncement);
     NavigationViewEventDispatcher eventDispatcher = buildViewEventDispatcher(speechAnnouncementListener);
+
     SpeechAnnouncement modifiedAnnouncement = eventDispatcher.onAnnouncement(originalAnnouncement);
-    assertEquals("announcement to be voiced", modifiedAnnouncement.announcement());
+
+    assertEquals("New announcement", modifiedAnnouncement.announcement());
+  }
+
+  @Test
+  public void onNewVoiceAnnouncement_ssmlAnnouncementToBeVoicedIsReturned() {
+    SpeechAnnouncement originalAnnouncement = SpeechAnnouncement.builder().announcement("announcement").build();
+    SpeechAnnouncementListener speechAnnouncementListener = mock(SpeechAnnouncementListener.class);
+    SpeechAnnouncement newAnnouncement = SpeechAnnouncement.builder()
+      .announcement("New announcement")
+      .ssmlAnnouncement("New SSML announcement").build();
+    when(speechAnnouncementListener.willVoice(originalAnnouncement)).thenReturn(newAnnouncement);
+    NavigationViewEventDispatcher eventDispatcher = buildViewEventDispatcher(speechAnnouncementListener);
+
+    SpeechAnnouncement modifiedAnnouncement = eventDispatcher.onAnnouncement(originalAnnouncement);
+
+    assertEquals("New SSML announcement", modifiedAnnouncement.ssmlAnnouncement());
   }
 
   @NonNull


### PR DESCRIPTION
Closes #1577

SSML tags would never be considered with the current implementation.  This PR reverts #1281 to make `SpeechAnnouncementListener#willVoice` return a `SpeechAnnouncement` again.  