### PR TITLE
Adjust route overview to account for lifecycle

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationPresenter.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationPresenter.java
@@ -47,7 +47,9 @@ class NavigationPresenter {
 
   void onRouteUpdate(DirectionsRoute directionsRoute) {
     view.drawRoute(directionsRoute);
-    if (!resumeState) {
+    if (resumeState && view.isRecenterButtonVisible()) {
+      view.updateCameraRouteOverview();
+    } else {
       view.startCamera(directionsRoute);
     }
   }

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/NavigationPresenterTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/NavigationPresenterTest.java
@@ -1,5 +1,7 @@
 package com.mapbox.services.android.navigation.ui.v5;
 
+import com.mapbox.api.directions.v5.models.DirectionsRoute;
+
 import org.junit.Test;
 
 import static org.mockito.Mockito.mock;
@@ -118,5 +120,40 @@ public class NavigationPresenterTest {
     presenter.onNavigationStopped();
 
     verify(view).updateWayNameVisibility(false);
+  }
+
+  @Test
+  public void onRouteUpdate_routeIsDrawn() {
+    DirectionsRoute directionsRoute = mock(DirectionsRoute.class);
+    NavigationContract.View view = mock(NavigationContract.View.class);
+    NavigationPresenter presenter = new NavigationPresenter(view);
+
+    presenter.onRouteUpdate(directionsRoute);
+
+    verify(view).drawRoute(directionsRoute);
+  }
+
+  @Test
+  public void onRouteUpdate_overviewIsShownWhenResumeState() {
+    DirectionsRoute directionsRoute = mock(DirectionsRoute.class);
+    NavigationContract.View view = mock(NavigationContract.View.class);
+    when(view.isRecenterButtonVisible()).thenReturn(true);
+    NavigationPresenter presenter = new NavigationPresenter(view);
+    presenter.updateResumeState(true);
+
+    presenter.onRouteUpdate(directionsRoute);
+
+    verify(view).updateCameraRouteOverview();
+  }
+
+  @Test
+  public void onRouteUpdate_cameraIsStartedOnFirstRoute() {
+    DirectionsRoute directionsRoute = mock(DirectionsRoute.class);
+    NavigationContract.View view = mock(NavigationContract.View.class);
+    NavigationPresenter presenter = new NavigationPresenter(view);
+
+    presenter.onRouteUpdate(directionsRoute);
+
+    verify(view).startCamera(directionsRoute);
   }
 }


### PR DESCRIPTION
Closes #1673 

We were not accounting for camera adjustment when rotating the phone in "route overview mode". 
 This PR adjusts the presenter logic to recenter the camera upon rotation.