### PR TITLE
Update support lib 28.0.0 to fix issue with ViewModel restoration

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/autocomplete/AutocompleteBottomSheetBehavior.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/autocomplete/AutocompleteBottomSheetBehavior.kt
@@ -13,11 +13,11 @@ class AutocompleteBottomSheetBehavior<V : View> : BottomSheetBehavior<V> {
 
   constructor(context: Context, attrs: AttributeSet) : super(context, attrs)
 
-  override fun onInterceptTouchEvent(parent: CoordinatorLayout?, child: V, event: MotionEvent?): Boolean {
+  override fun onInterceptTouchEvent(parent: CoordinatorLayout, child: V, event: MotionEvent): Boolean {
     return false
   }
 
-  override fun onTouchEvent(parent: CoordinatorLayout?, child: V, event: MotionEvent?): Boolean {
+  override fun onTouchEvent(parent: CoordinatorLayout, child: V, event: MotionEvent): Boolean {
     return false
   }
 }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -16,7 +16,7 @@ ext {
       autoValue          : '1.5.4',
       autoValueParcel    : '0.2.5',
       junit              : '4.12',
-      supportLibVersion  : '27.1.1',
+      supportLibVersion  : '28.0.0',
       constraintLayout   : '1.1.3',
       mockito            : '2.23.4',
       hamcrest           : '2.0.0.0',


### PR DESCRIPTION
Closes #1240 

It turns out the issue reported in #1240 was an issue with the `ViewModel` from the support library.  See this [S/O post](https://stackoverflow.com/questions/49999385/android-viewmodel-recreated-on-screen-rotation).  This was causing the `NavigationViewModel` to be recreated when not necessary, instantiating a new `MapboxNavigation`/`NavigationService`.  

With `27.1.1`:

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/8434572/51542963-76acb300-1e2a-11e9-9bbf-479e5b283548.gif)

With `28.0.0`:
 
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/8434572/51543030-980d9f00-1e2a-11e9-8bd5-951ddce2c755.gif)

Also noting from https://developer.android.com/topic/libraries/support-library/revisions: 

> This is the stable release of Support Library 28.0.0 and is suitable for use in production. This will be the last feature release under the android.support packaging, and developers are encouraged to migrate to AndroidX.

We should start thinking about the right time to do this migration.  