### PR TITLE
Provide default LocationComponent style when not found

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/NavigationMapboxMap.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/NavigationMapboxMap.java
@@ -6,6 +6,7 @@ import android.graphics.PointF;
 import android.location.Location;
 import android.os.Bundle;
 import android.os.PersistableBundle;
+import android.support.annotation.AnyRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.FragmentActivity;
@@ -542,13 +543,24 @@ public class NavigationMapboxMap {
     map.setMinZoomPreference(NAVIGATION_MINIMUM_MAP_ZOOM);
     map.setMaxZoomPreference(NAVIGATION_MAXIMUM_MAP_ZOOM);
     Context context = mapView.getContext();
-    int locationLayerStyleRes = ThemeSwitcher.retrieveNavigationViewStyle(context,
-      R.attr.navigationViewLocationLayerStyle);
-    LocationComponentOptions locationComponentOptions =
-      LocationComponentOptions.createFromAttributes(context, locationLayerStyleRes);
-    locationComponent.activateLocationComponent(context, map.getStyle(), null, locationComponentOptions);
+    int locationLayerStyleRes = findLayerStyleRes(context);
+    LocationComponentOptions options = LocationComponentOptions.createFromAttributes(context, locationLayerStyleRes);
+    locationComponent.activateLocationComponent(context, map.getStyle(), null, options);
     locationComponent.setLocationComponentEnabled(true);
     locationComponent.setRenderMode(RenderMode.GPS);
+  }
+
+  private int findLayerStyleRes(Context context) {
+    int locationLayerStyleRes = ThemeSwitcher.retrieveNavigationViewStyle(context,
+      R.attr.navigationViewLocationLayerStyle);
+    if (!isValid(locationLayerStyleRes)) {
+      locationLayerStyleRes = R.style.NavigationLocationLayerStyle;
+    }
+    return locationLayerStyleRes;
+  }
+
+  private boolean isValid(@AnyRes int resId) {
+    return resId != -1 && (resId & 0xff000000) != 0 && (resId & 0x00ff0000) != 0;
   }
 
   private void initializeMapPaddingAdjustor(MapView mapView, MapboxMap mapboxMap) {


### PR DESCRIPTION
Closes #1692 

We were assuming a style was being provided for the `LocationComponent` when it's possible for developers to use the `NavigationMapboxMap` outside of the `NavigationView` context.  