### PR TITLE
Add ManeuverView APIs for adjusting primary and secondary color

### DIFF
--- a/libandroid-navigation-ui/src/main/res/layout-land/instruction_content_layout.xml
+++ b/libandroid-navigation-ui/src/main/res/layout-land/instruction_content_layout.xml
@@ -27,7 +27,9 @@
             android:id="@+id/maneuverView"
             android:layout_width="40dp"
             android:layout_height="40dp"
-            android:layout_margin="8dp"/>
+            android:layout_margin="8dp"
+            app:maneuverViewPrimaryColor="?attr/navigationViewBannerManeuverPrimary"
+            app:maneuverViewSecondaryColor="?attr/navigationViewBannerManeuverSecondary"/>
 
         <TextView
             android:id="@+id/stepDistanceText"

--- a/libandroid-navigation-ui/src/main/res/layout-land/instruction_layout.xml
+++ b/libandroid-navigation-ui/src/main/res/layout-land/instruction_layout.xml
@@ -32,7 +32,9 @@
             android:layout_margin="8dp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"/>
+            app:layout_constraintTop_toTopOf="parent"
+            app:maneuverViewPrimaryColor="?attr/navigationViewBannerManeuverPrimary"
+            app:maneuverViewSecondaryColor="?attr/navigationViewBannerManeuverSecondary"/>
 
         <TextView
             android:id="@+id/stepDistanceText"

--- a/libandroid-navigation-ui/src/main/res/layout-land/instruction_layout_alt.xml
+++ b/libandroid-navigation-ui/src/main/res/layout-land/instruction_layout_alt.xml
@@ -29,7 +29,9 @@
             android:id="@+id/maneuverView"
             android:layout_width="40dp"
             android:layout_height="40dp"
-            android:layout_margin="8dp"/>
+            android:layout_margin="8dp"
+            app:maneuverViewPrimaryColor="?attr/navigationViewBannerManeuverPrimary"
+            app:maneuverViewSecondaryColor="?attr/navigationViewBannerManeuverSecondary"/>
 
         <TextView
             android:id="@+id/stepDistanceText"

--- a/libandroid-navigation-ui/src/main/res/layout-land/sub_instruction_layout.xml
+++ b/libandroid-navigation-ui/src/main/res/layout-land/sub_instruction_layout.xml
@@ -12,12 +12,14 @@
         android:id="@+id/subManeuverView"
         android:layout_width="24dp"
         android:layout_height="24dp"
-        android:layout_marginBottom="8dp"
         android:layout_marginTop="8dp"
+        android:layout_marginBottom="8dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/guideline"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"/>
+        app:layout_constraintTop_toTopOf="parent"
+        app:maneuverViewPrimaryColor="?attr/navigationViewBannerManeuverPrimary"
+        app:maneuverViewSecondaryColor="?attr/navigationViewBannerManeuverSecondary"/>
 
     <TextView
         android:id="@+id/subStepText"

--- a/libandroid-navigation-ui/src/main/res/layout/instruction_content_layout.xml
+++ b/libandroid-navigation-ui/src/main/res/layout/instruction_content_layout.xml
@@ -30,7 +30,9 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintVertical_bias="0.75"/>
+            app:layout_constraintVertical_bias="0.75"
+            app:maneuverViewPrimaryColor="?attr/navigationViewBannerManeuverPrimary"
+            app:maneuverViewSecondaryColor="?attr/navigationViewBannerManeuverSecondary"/>
 
         <TextView
             android:id="@+id/stepDistanceText"

--- a/libandroid-navigation-ui/src/main/res/layout/sub_instruction_layout.xml
+++ b/libandroid-navigation-ui/src/main/res/layout/sub_instruction_layout.xml
@@ -16,7 +16,9 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/guideline"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"/>
+        app:layout_constraintTop_toTopOf="parent"
+        app:maneuverViewPrimaryColor="?attr/navigationViewBannerManeuverPrimary"
+        app:maneuverViewSecondaryColor="?attr/navigationViewBannerManeuverSecondary"/>
 
     <TextView
         android:id="@+id/subStepText"

--- a/libandroid-navigation-ui/src/main/res/values/attrs.xml
+++ b/libandroid-navigation-ui/src/main/res/values/attrs.xml
@@ -66,6 +66,10 @@
     <!-- For setting the styles in XML -->
     <attr name="navigationLightTheme" format="reference"/>
     <attr name="navigationDarkTheme" format="reference"/>
+  </declare-styleable>
 
+  <declare-styleable name="ManeuverView">
+    <attr name="maneuverViewPrimaryColor" format="color"/>
+    <attr name="maneuverViewSecondaryColor" format="color"/>
   </declare-styleable>
 </resources>


### PR DESCRIPTION
The `ManeuverView` does not allow color customization outside of looking at the current theme attributes.  This PR adds two APIs to allow for updating the color of the view post-inflation.

Example usage:

```
    maneuverView.setPrimaryColor(ContextCompat.getColor(this, R.color.mapbox_blue));
    maneuverView.setSecondaryColor(ContextCompat.getColor(this, R.color.md_grey_500));
```

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/8434572/51867098-a1aa7180-2318-11e9-92bb-b4ec8bf6e955.gif)