### PR TITLE
Preserve historical total progress in RouteProgress updates 

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -11,7 +11,7 @@ ext {
       mapboxMapSdk           : '7.1.2',
       mapboxSdkServices      : '4.5.0',
       mapboxEvents           : '4.2.0',
-      mapboxNavigator        : '5.0.0',
+      mapboxNavigator        : 'kk_prior_progress-SNAPSHOT-10',
       mapboxAnnotationPlugin : '0.5.0',
       mapboxSearchSdk        : '0.1.0-SNAPSHOT',
       autoValue              : '1.5.4',

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/TestRouteProgressBuilder.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/TestRouteProgressBuilder.java
@@ -52,6 +52,9 @@ class TestRouteProgressBuilder {
     );
 
     return RouteProgress.builder()
+      .totalFractionTraveled(0f)
+      .totalDurationTraveled(0f)
+      .totalDistanceTraveled(0d)
       .stepDistanceRemaining(stepDistanceRemaining)
       .legDistanceRemaining(legDistanceRemaining)
       .legDurationRemaining(legDurationRemaining)

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigator.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigator.java
@@ -7,9 +7,11 @@ import com.mapbox.navigator.BannerInstruction;
 import com.mapbox.navigator.FixLocation;
 import com.mapbox.navigator.NavigationStatus;
 import com.mapbox.navigator.Navigator;
+import com.mapbox.navigator.TrackedRoute;
 import com.mapbox.navigator.VoiceInstruction;
 
 import java.util.Date;
+import java.util.List;
 
 class MapboxNavigator {
 
@@ -32,6 +34,10 @@ class MapboxNavigator {
       date.setTime(date.getTime() + lagInMilliseconds);
     }
     return navigator.getStatus(date);
+  }
+
+  synchronized List<TrackedRoute> retrieveRouteHistory() {
+    return navigator.getTrackedRoutes();
   }
 
   void updateLocation(Location raw) {

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/routeprogress/RouteProgress.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/routeprogress/RouteProgress.java
@@ -78,6 +78,14 @@ public abstract class RouteProgress {
   }
 
   /**
+   * Provides the distance traveled along the total route progress.
+   *
+   * @return {@code double} value representing the distance traveled along the total route progress, in unit
+   * meters
+   */
+  public abstract double totalDistanceTraveled();
+
+  /**
    * Provides the duration remaining in seconds till the user reaches the end of the route.
    *
    * @return {@code long} value representing the duration remaining till end of route, in unit
@@ -88,11 +96,20 @@ public abstract class RouteProgress {
     return (1 - fractionTraveled()) * directionsRoute().duration();
   }
 
+
+  /**
+   * Provides the duration traveled along the total route progress.
+   *
+   * @return {@code long} value representing the duration traveled along the total route progress, in unit
+   * seconds
+   */
+  public abstract float totalDurationTraveled();
+
   /**
    * Get the fraction traveled along the current route, this is a float value between 0 and 1 and
    * isn't guaranteed to reach 1 before the user reaches the end of the route.
    *
-   * @return a float value between 0 and 1 representing the fraction the user has traveled along the
+   * @return a float value between 0 and 1 representing the fraction the user has traveled along the current
    * route
    * @since 0.1.0
    */
@@ -104,6 +121,16 @@ public abstract class RouteProgress {
     }
     return fractionRemaining;
   }
+
+
+  /**
+   * Get the fraction traveled along the total route progress, this is a float value between 0 and 1 and
+   * isn't guaranteed to reach 1 before the user reaches the end of the route.
+   *
+   * @return a float value between 0 and 1 representing the fraction the user has traveled along the
+   * total route
+   */
+  public abstract float totalFractionTraveled();
 
   /**
    * Provides the distance remaining in meters till the user reaches the end of the route.
@@ -215,6 +242,12 @@ public abstract class RouteProgress {
     public abstract Builder directionsRoute(DirectionsRoute directionsRoute);
 
     abstract DirectionsRoute directionsRoute();
+
+    public abstract Builder totalDistanceTraveled(double totalDistanceTraveled);
+
+    public abstract Builder totalDurationTraveled(float totalDurationTraveled);
+
+    public abstract Builder totalFractionTraveled(float totalFractionTraveled);
 
     public abstract Builder legIndex(int legIndex);
 

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/TestRouteProgressBuilder.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/TestRouteProgressBuilder.java
@@ -54,6 +54,9 @@ class TestRouteProgressBuilder {
       currentIntersection);
 
     return RouteProgress.builder()
+      .totalFractionTraveled(0f)
+      .totalDurationTraveled(0f)
+      .totalDistanceTraveled(0d)
       .stepDistanceRemaining(stepDistanceRemaining)
       .legDistanceRemaining(legDistanceRemaining)
       .legDurationRemaining(legDurationRemaining)

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteProcessorTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteProcessorTest.java
@@ -1,10 +1,10 @@
 package com.mapbox.services.android.navigation.v5.navigation;
 
+import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.navigator.NavigationStatus;
 import com.mapbox.services.android.navigation.v5.BaseTest;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -12,15 +12,16 @@ import java.io.IOException;
 import static junit.framework.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 
-@Ignore
 public class NavigationRouteProcessorTest extends BaseTest {
 
   @Test
   public void buildNewRouteProgress_routeProgressReturned() throws IOException {
+    MapboxNavigator navigator = mock(MapboxNavigator.class);
+    NavigationStatus status = mock(NavigationStatus.class);
+    DirectionsRoute route = buildTestDirectionsRoute();
     NavigationRouteProcessor processor = new NavigationRouteProcessor();
 
-    // TODO mock final status
-    RouteProgress progress = processor.buildNewRouteProgress(mock(MapboxNavigator.class), mock(NavigationStatus.class), buildTestDirectionsRoute());
+    RouteProgress progress = processor.buildNewRouteProgress(navigator, status, route);
 
     assertNotNull(progress);
   }


### PR DESCRIPTION
Closes #1595 

This PR adds three new fields to the `RouteProgress`:
* `.totalDistanceTraveled` total distance traveled along all previous routes including the current route’s `RouteProgress.distanceTraveled`.
* `RouteProgress.totalFractionTraveled` the total fraction traveled along all reroutes including the full distance of the current route.
* `RouteProgress.totalDistance` distance traveled along all previous routes including the full distance of the current route.

TODO:
- [x] Update `Navigator`
- [ ] Unit testing 
- [x] Javadoc
- [x] Update `RouteProgress`

cc @akitchen 