### PR TITLE
Return false for OnMapClick listeners

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/MockNavigationActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/MockNavigationActivity.java
@@ -200,7 +200,7 @@ public class MockNavigationActivity extends AppCompatActivity implements OnMapRe
     }
     mapboxMap.addMarker(new MarkerOptions().position(point));
     calculateRoute();
-    return true;
+    return false;
   }
 
   @SuppressLint("MissingPermission")

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/RerouteActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/RerouteActivity.java
@@ -163,7 +163,7 @@ public class RerouteActivity extends HistoryActivity implements OnMapReadyCallba
   @Override
   public boolean onMapClick(@NonNull LatLng point) {
     if (!running || mapboxMap == null || lastLocation == null) {
-      return true;
+      return false;
     }
 
     mapboxMap.addMarker(new MarkerOptions().position(point));
@@ -173,7 +173,7 @@ public class RerouteActivity extends HistoryActivity implements OnMapReadyCallba
     resetLocationEngine(destination);
 
     tracking = false;
-    return true;
+    return false;
   }
 
   @Override

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/ComponentNavigationActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/ComponentNavigationActivity.java
@@ -150,7 +150,7 @@ public class ComponentNavigationActivity extends HistoryActivity implements OnMa
   public boolean onMapLongClick(@NonNull LatLng point) {
     // Only reverse geocode while we are not in navigation
     if (mapState.equals(MapState.NAVIGATION)) {
-      return true;
+      return false;
     }
 
     // Fetch the route with this given point
@@ -164,7 +164,7 @@ public class ComponentNavigationActivity extends HistoryActivity implements OnMa
     // Update camera to new destination
     moveCameraToInclude(destination);
     vibrate();
-    return true;
+    return false;
   }
 
   @OnClick(R.id.startNavigationFab)

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/NavigationLauncherActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/NavigationLauncherActivity.java
@@ -207,7 +207,7 @@ public class NavigationLauncherActivity extends AppCompatActivity implements OnM
     if (currentLocation != null) {
       fetchRoute();
     }
-    return true;
+    return false;
   }
 
   @Override

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/MapRouteClickListener.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/MapRouteClickListener.java
@@ -32,11 +32,11 @@ class MapRouteClickListener implements MapboxMap.OnMapClickListener {
   public boolean onMapClick(@NonNull LatLng point) {
     HashMap<LineString, DirectionsRoute> routeLineStrings = routeLine.retrieveRouteLineStrings();
     if (invalidMapClick(routeLineStrings)) {
-      return true;
+      return false;
     }
     List<DirectionsRoute> directionsRoutes = routeLine.retrieveDirectionsRoutes();
     findClickedRoute(point, routeLineStrings, directionsRoutes);
-    return true;
+    return false;
   }
 
   void setOnRouteSelectionChangeListener(OnRouteSelectionChangeListener listener) {


### PR DESCRIPTION
Our internal `MapRouteClickListener` currently returns `true` when detecting valid or invalid map clicks for alternative routes.  `MapboxMap.OnMapClickListener` javadoc:

> True if this click should be consumed and not passed further to other listeners registered afterwards, false otherwise.

We should return false so we don't cause unexpected behavior for developers adding their own listeners after the `NavigationMapRoute` has been created. 