### PR TITLE
Allow multiple route simulations with NavigationView

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/LocationEngineConductor.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/LocationEngineConductor.java
@@ -1,4 +1,4 @@
-package com.mapbox.services.android.navigation.ui.v5.location;
+package com.mapbox.services.android.navigation.ui.v5;
 
 import android.content.Context;
 
@@ -7,21 +7,23 @@ import com.mapbox.android.core.location.LocationEngineProvider;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.services.android.navigation.v5.location.replay.ReplayRouteLocationEngine;
 
-public class LocationEngineConductor {
+class LocationEngineConductor {
 
   private LocationEngine locationEngine;
 
-  public void initializeLocationEngine(Context context, LocationEngine locationEngine, boolean shouldReplayRoute) {
+  void initializeLocationEngine(Context context, LocationEngine locationEngine, boolean shouldReplayRoute) {
     initialize(context, locationEngine, shouldReplayRoute);
   }
 
-  public void updateSimulatedRoute(DirectionsRoute route) {
+  boolean updateSimulatedRoute(DirectionsRoute route) {
     if (locationEngine instanceof ReplayRouteLocationEngine) {
       ((ReplayRouteLocationEngine) locationEngine).assign(route);
+      return true;
     }
+    return false;
   }
 
-  public LocationEngine obtainLocationEngine() {
+  LocationEngine obtainLocationEngine() {
     return locationEngine;
   }
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
@@ -21,7 +21,6 @@ import com.mapbox.services.android.navigation.ui.v5.camera.DynamicCamera;
 import com.mapbox.services.android.navigation.ui.v5.feedback.FeedbackItem;
 import com.mapbox.services.android.navigation.ui.v5.instruction.BannerInstructionModel;
 import com.mapbox.services.android.navigation.ui.v5.instruction.InstructionModel;
-import com.mapbox.services.android.navigation.ui.v5.location.LocationEngineConductor;
 import com.mapbox.services.android.navigation.ui.v5.route.OffRouteEvent;
 import com.mapbox.services.android.navigation.ui.v5.route.ViewRouteFetcher;
 import com.mapbox.services.android.navigation.ui.v5.route.ViewRouteListener;
@@ -241,7 +240,7 @@ public class NavigationViewModel extends AndroidViewModel {
     this.route.setValue(route);
     if (!isChangingConfigurations) {
       startNavigation(route);
-      locationEngineConductor.updateSimulatedRoute(route);
+      updateReplayEngine(route);
       sendEventOnRerouteAlong(route);
       isOffRoute.setValue(false);
     }
@@ -409,6 +408,13 @@ public class NavigationViewModel extends AndroidViewModel {
       navigation.startNavigation(route);
       voiceInstructionsToAnnounce = 0;
       voiceInstructionCache.preCache(route);
+    }
+  }
+
+  private void updateReplayEngine(DirectionsRoute route) {
+    if (locationEngineConductor.updateSimulatedRoute(route)) {
+      LocationEngine replayEngine = locationEngineConductor.obtainLocationEngine();
+      navigation.setLocationEngine(replayEngine);
     }
   }
 

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/LocationEngineConductorTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/LocationEngineConductorTest.java
@@ -6,7 +6,7 @@ import android.location.LocationManager;
 import android.support.annotation.NonNull;
 
 import com.mapbox.android.core.location.LocationEngine;
-import com.mapbox.services.android.navigation.ui.v5.location.LocationEngineConductor;
+import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.services.android.navigation.v5.location.replay.ReplayRouteLocationEngine;
 
 import org.junit.Test;
@@ -35,6 +35,17 @@ public class LocationEngineConductorTest extends BaseTest {
     LocationEngine locationEngine = locationEngineConductor.obtainLocationEngine();
 
     assertTrue(locationEngine instanceof ReplayRouteLocationEngine);
+  }
+
+  @Test
+  public void onInitWithSimulation_replayEngineIsUpdated() {
+    LocationEngineConductor locationEngineConductor = new LocationEngineConductor();
+    boolean simulateRouteEnabled = true;
+    locationEngineConductor.initializeLocationEngine(createMockContext(), null, simulateRouteEnabled);
+
+    boolean didUpdate = locationEngineConductor.updateSimulatedRoute(mock(DirectionsRoute.class));
+
+    assertTrue(didUpdate);
   }
 
   @Test

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModelTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModelTest.java
@@ -3,7 +3,6 @@ package com.mapbox.services.android.navigation.ui.v5;
 import android.app.Application;
 
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
-import com.mapbox.services.android.navigation.ui.v5.location.LocationEngineConductor;
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation;
 
 import org.junit.Test;


### PR DESCRIPTION
Fixes #1721 

We were only allowing simulation of the first route with the `NavigationView`.  This was because with the new location APIs, we need to re-request updates in order for the simulation to begin.  

I took this opportunity to make `LocationEngineConductor` package-private as well.  I don't believe this class needs to be `public` as it's used internally in the `NavigationView`. 