### PR TITLE
Fix issue with mute persistence between navigation sessions / rotation

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
@@ -144,7 +144,7 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
     boolean isWayNameVisible = wayNameView.getVisibility() == VISIBLE;
     NavigationViewInstanceState navigationViewInstanceState = new NavigationViewInstanceState(
       bottomSheetBehaviorState, recenterBtn.getVisibility(), instructionView.isShowingInstructionList(),
-      isWayNameVisible, wayNameView.retrieveWayNameText());
+      isWayNameVisible, wayNameView.retrieveWayNameText(), navigationViewModel.isMuted());
     String instanceKey = getContext().getString(R.string.navigation_view_instance_state);
     outState.putParcelable(instanceKey, navigationViewInstanceState);
     outState.putBoolean(getContext().getString(R.string.navigation_running), navigationViewModel.isRunning());
@@ -167,6 +167,7 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
     wayNameView.updateWayNameText(navigationViewInstanceState.getWayNameText());
     resetBottomSheetState(navigationViewInstanceState.getBottomSheetBehaviorState());
     updateInstructionListState(navigationViewInstanceState.isInstructionViewVisible());
+    updateInstructionMutedState(navigationViewInstanceState.isMuted());
     mapInstanceState = savedInstanceState.getParcelable(MAP_INSTANCE_STATE_KEY);
   }
 
@@ -588,6 +589,12 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
       instructionView.showInstructionList();
     } else {
       instructionView.hideInstructionList();
+    }
+  }
+
+  private void updateInstructionMutedState(boolean isMuted) {
+    if (isMuted) {
+      ((SoundButton) instructionView.retrieveSoundButton()).soundFabOff();
     }
   }
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewInstanceState.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewInstanceState.java
@@ -9,15 +9,18 @@ class NavigationViewInstanceState implements Parcelable {
   private int recenterButtonVisibility;
   private boolean instructionViewVisible;
   private boolean isWayNameVisible;
+  private boolean isMuted;
   private String wayNameText;
 
   NavigationViewInstanceState(int bottomSheetBehaviorState, int recenterButtonVisibility,
-                              boolean instructionViewVisible, boolean isWayNameVisible, String wayNameText) {
+                              boolean instructionViewVisible, boolean isWayNameVisible, String wayNameText,
+                              boolean isMuted) {
     this.bottomSheetBehaviorState = bottomSheetBehaviorState;
     this.recenterButtonVisibility = recenterButtonVisibility;
     this.instructionViewVisible = instructionViewVisible;
     this.isWayNameVisible = isWayNameVisible;
     this.wayNameText = wayNameText;
+    this.isMuted = isMuted;
   }
 
   int getBottomSheetBehaviorState() {
@@ -40,11 +43,16 @@ class NavigationViewInstanceState implements Parcelable {
     return wayNameText;
   }
 
+  boolean isMuted() {
+    return isMuted;
+  }
+
   private NavigationViewInstanceState(Parcel in) {
     bottomSheetBehaviorState = in.readInt();
     recenterButtonVisibility = in.readInt();
     instructionViewVisible = in.readByte() != 0;
     isWayNameVisible = in.readByte() != 0;
+    isMuted = in.readByte() != 0;
     wayNameText = in.readString();
   }
 
@@ -54,6 +62,7 @@ class NavigationViewInstanceState implements Parcelable {
     dest.writeInt(recenterButtonVisibility);
     dest.writeByte((byte) (instructionViewVisible ? 1 : 0));
     dest.writeByte((byte) (isWayNameVisible ? 1 : 0));
+    dest.writeByte((byte) (isMuted ? 1 : 0));
     dest.writeString(wayNameText);
   }
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
@@ -109,12 +109,13 @@ public class NavigationViewModel extends AndroidViewModel {
   // Package private (no modifier) for testing purposes
   NavigationViewModel(Application application, MapboxNavigation navigation,
                       LocationEngineConductor conductor, NavigationViewEventDispatcher dispatcher,
-                      VoiceInstructionCache cache) {
+                      VoiceInstructionCache cache, SpeechPlayer speechPlayer) {
     super(application);
     this.navigation = navigation;
     this.locationEngineConductor = conductor;
     this.navigationViewEventDispatcher = dispatcher;
     this.voiceInstructionCache = cache;
+    this.speechPlayer = speechPlayer;
   }
 
   public void onDestroy(boolean isChangingConfigurations) {
@@ -203,10 +204,10 @@ public class NavigationViewModel extends AndroidViewModel {
       LocationEngine locationEngine = initializeLocationEngineFrom(options);
       initializeNavigation(getApplication(), navigationOptions, locationEngine);
       addMilestones(options);
+      initializeVoiceInstructionLoader();
+      initializeVoiceInstructionCache();
+      initializeNavigationSpeechPlayer(options);
     }
-    initializeVoiceInstructionLoader();
-    initializeVoiceInstructionCache();
-    initializeNavigationSpeechPlayer(options);
     routeFetcher.extractRouteOptions(options);
     return navigation;
   }
@@ -220,6 +221,13 @@ public class NavigationViewModel extends AndroidViewModel {
 
   boolean isRunning() {
     return isRunning;
+  }
+
+  boolean isMuted() {
+    if (speechPlayer == null) {
+      return false;
+    }
+    return speechPlayer.isMuted();
   }
 
   void stopNavigation() {

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/SoundButton.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/SoundButton.java
@@ -104,6 +104,14 @@ public class SoundButton extends ConstraintLayout implements NavigationButton {
     clearListeners();
   }
 
+  /**
+   * Changes sound {@link FloatingActionButton}
+   * {@link android.graphics.drawable.Drawable} to denote sound is off.
+   */
+  void soundFabOff() {
+    soundFab.setImageResource(R.drawable.ic_sound_off);
+  }
+
   private void setupOnClickListeners() {
     setOnClickListener(multiOnClickListener);
   }
@@ -199,14 +207,6 @@ public class SoundButton extends ConstraintLayout implements NavigationButton {
 
   private void initialize(Context context) {
     inflate(context, R.layout.sound_layout, this);
-  }
-
-  /**
-   * Changes sound {@link FloatingActionButton}
-   * {@link android.graphics.drawable.Drawable} to denote sound is off.
-   */
-  private void soundFabOff() {
-    soundFab.setImageResource(R.drawable.ic_sound_off);
   }
 
   /**

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModelTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModelTest.java
@@ -3,15 +3,19 @@ package com.mapbox.services.android.navigation.ui.v5;
 import android.app.Application;
 
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
+import com.mapbox.services.android.navigation.ui.v5.voice.SpeechPlayer;
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricTestRunner.class)
 public class NavigationViewModelTest {
@@ -58,12 +62,50 @@ public class NavigationViewModelTest {
     LocationEngineConductor conductor = mock(LocationEngineConductor.class);
     NavigationViewEventDispatcher dispatcher = mock(NavigationViewEventDispatcher.class);
     VoiceInstructionCache cache = mock(VoiceInstructionCache.class);
+    SpeechPlayer speechPlayer = mock(SpeechPlayer.class);
     DirectionsRoute route = mock(DirectionsRoute.class);
-    NavigationViewModel viewModel = new NavigationViewModel(application, navigation, conductor, dispatcher, cache);
+    NavigationViewModel viewModel = new NavigationViewModel(
+      application, navigation, conductor, dispatcher, cache, speechPlayer
+    );
     viewModel.isOffRoute.postValue(true);
 
     viewModel.updateRoute(route);
 
     verify(navigation).startNavigation(route);
+  }
+
+  @Test
+  public void isMuted_falseWithNullSpeechPlayer() {
+    Application application = mock(Application.class);
+    MapboxNavigation navigation = mock(MapboxNavigation.class);
+    LocationEngineConductor conductor = mock(LocationEngineConductor.class);
+    NavigationViewEventDispatcher dispatcher = mock(NavigationViewEventDispatcher.class);
+    VoiceInstructionCache cache = mock(VoiceInstructionCache.class);
+    SpeechPlayer speechPlayer = null;
+    NavigationViewModel viewModel = new NavigationViewModel(
+      application, navigation, conductor, dispatcher, cache, speechPlayer
+    );
+
+    boolean isMuted = viewModel.isMuted();
+
+    assertFalse(isMuted);
+  }
+
+  @Test
+  public void isMuted_trueWithMutedSpeechPlayer() {
+    Application application = mock(Application.class);
+    MapboxNavigation navigation = mock(MapboxNavigation.class);
+    LocationEngineConductor conductor = mock(LocationEngineConductor.class);
+    NavigationViewEventDispatcher dispatcher = mock(NavigationViewEventDispatcher.class);
+    VoiceInstructionCache cache = mock(VoiceInstructionCache.class);
+    SpeechPlayer speechPlayer = mock(SpeechPlayer.class);
+    when(speechPlayer.isMuted()).thenReturn(true);
+    NavigationViewModel viewModel = new NavigationViewModel(
+      application, navigation, conductor, dispatcher, cache, speechPlayer
+    );
+
+    boolean isMuted = viewModel.isMuted();
+
+    assertTrue(isMuted);
   }
 }


### PR DESCRIPTION
This PR fixes two issues:
- When calling `NavigationView#startNavigation(NavigationViewOptions)`, we were creating a new instance of `NavigationSpeechPlayer`
- When rotating, we were resetting the sound button icon to always "unmuted"

TODO:
- [x] Unit testing for `NavigationViewModel`