### PR TITLE
Update RouteRetrievalEvent

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/ElapsedTime.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/ElapsedTime.java
@@ -5,6 +5,9 @@ import android.support.annotation.Nullable;
 import com.mapbox.services.android.navigation.v5.exception.NavigationException;
 
 class ElapsedTime {
+
+  private static final double ELAPSED_TIME_DENOMINATOR = 1e+9;
+  private static final double PRECISION = 100d;
   private Long start = null;
   private Long end = null;
 
@@ -29,10 +32,12 @@ class ElapsedTime {
     return end;
   }
 
-  long getElapsedTime() {
+  double getElapsedTime() {
     if (start == null || end == null) {
       throw new NavigationException("Must call start() and end() before calling getElapsedTime()");
     }
-    return end - start;
+    long elapsedTimeInNanoseconds = end - start;
+    double elapsedTimeInSeconds = elapsedTimeInNanoseconds / ELAPSED_TIME_DENOMINATOR;
+    return Math.round(elapsedTimeInSeconds * PRECISION) / PRECISION;
   }
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/LongCounter.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/LongCounter.java
@@ -1,8 +1,0 @@
-package com.mapbox.services.android.navigation.v5.navigation;
-
-class LongCounter extends Counter<Long> {
-
-  LongCounter(String name, Long value) {
-    super(name, value);
-  }
-}

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationMetricsWrapper.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationMetricsWrapper.java
@@ -371,7 +371,7 @@ final class NavigationMetricsWrapper {
     mapboxTelemetry.push(feedbackEvent);
   }
 
-  static void routeRetrievalEvent(long elapsedTime, String routeUuid, String sessionId) {
+  static void routeRetrievalEvent(double elapsedTime, String routeUuid, String sessionId) {
     push(new RouteRetrievalEvent(elapsedTime, routeUuid, sessionId));
   }
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteCallback.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteCallback.java
@@ -1,0 +1,49 @@
+package com.mapbox.services.android.navigation.v5.navigation;
+
+import android.support.annotation.NonNull;
+
+import com.mapbox.api.directions.v5.models.DirectionsResponse;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+class NavigationRouteCallback implements Callback<DirectionsResponse> {
+
+  private final NavigationTelemetry telemetry;
+  private final NavigationRouteEventListener listener;
+  private final Callback<DirectionsResponse> callback;
+
+  NavigationRouteCallback(NavigationRouteEventListener listener, Callback<DirectionsResponse> callback) {
+    this(NavigationTelemetry.getInstance(), listener, callback);
+  }
+
+  NavigationRouteCallback(NavigationTelemetry telemetry, NavigationRouteEventListener listener,
+                          Callback<DirectionsResponse> callback) {
+    this.telemetry = telemetry;
+    this.listener = listener;
+    this.callback = callback;
+  }
+
+  @Override
+  public void onResponse(@NonNull Call<DirectionsResponse> call, @NonNull Response<DirectionsResponse> response) {
+    callback.onResponse(call, response);
+    if (isValid(response)) {
+      String uuid = response.body().uuid();
+      sendEventWith(listener.getTime(), uuid);
+    }
+  }
+
+  @Override
+  public void onFailure(@NonNull Call<DirectionsResponse> call, @NonNull Throwable throwable) {
+    callback.onFailure(call, throwable);
+  }
+
+  private boolean isValid(Response<DirectionsResponse> response) {
+    return response.body() != null && !response.body().routes().isEmpty();
+  }
+
+  private void sendEventWith(ElapsedTime time, String uuid) {
+    telemetry.routeRetrievalEvent(time, uuid);
+  }
+}

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteEventListener.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteEventListener.java
@@ -1,0 +1,33 @@
+package com.mapbox.services.android.navigation.v5.navigation;
+
+import okhttp3.Call;
+import okhttp3.EventListener;
+
+class NavigationRouteEventListener extends EventListener {
+
+  private final ElapsedTime time;
+
+  NavigationRouteEventListener() {
+    this(new ElapsedTime());
+  }
+
+  NavigationRouteEventListener(ElapsedTime time) {
+    this.time = time;
+  }
+
+  @Override
+  public void callStart(Call call) {
+    super.callStart(call);
+    time.start();
+  }
+
+  @Override
+  public void callEnd(Call call) {
+    super.callEnd(call);
+    time.end();
+  }
+
+  ElapsedTime getTime() {
+    return time;
+  }
+}

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationTelemetry.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationTelemetry.java
@@ -309,7 +309,8 @@ class NavigationTelemetry implements NavigationMetricListener {
 
   void routeRetrievalEvent(ElapsedTime elapsedTime, String routeUuid) {
     if (navigationSessionState != null && !navigationSessionState.sessionIdentifier().isEmpty()) {
-      NavigationMetricsWrapper.routeRetrievalEvent(elapsedTime.getElapsedTime(), routeUuid,
+      double time = elapsedTime.getElapsedTime();
+      NavigationMetricsWrapper.routeRetrievalEvent(time, routeUuid,
         navigationSessionState.sessionIdentifier());
     } else {
       routeRetrievalElapsedTime = elapsedTime;

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/RouteRetrievalEvent.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/RouteRetrievalEvent.java
@@ -9,10 +9,10 @@ class RouteRetrievalEvent extends NavigationPerformanceEvent implements Parcelab
   private static final String ELAPSED_TIME_NAME = "elapsed_time";
   private static final String ROUTE_UUID_NAME = "route_uuid";
 
-  RouteRetrievalEvent(long elapsedTime, String routeUuid, String sessionId) {
+  RouteRetrievalEvent(double elapsedTime, String routeUuid, String sessionId) {
     super(sessionId);
 
-    addCounter(new LongCounter(ELAPSED_TIME_NAME, elapsedTime));
+    addCounter(new DoubleCounter(ELAPSED_TIME_NAME, elapsedTime));
     addAttribute(new Attribute(ROUTE_UUID_NAME, routeUuid));
   }
 }

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/ElapsedTimeTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/ElapsedTimeTest.java
@@ -8,19 +8,34 @@ import static org.junit.Assert.assertEquals;
 
 public class ElapsedTimeTest {
 
+  private static final double DELTA = 1E-2;
+
   @Test(expected = NavigationException.class)
   public void errorThrownIfEndCalledBeforeStart() {
     new ElapsedTime().end();
   }
 
   @Test
-  public void elapsedTime() {
+  public void elapsedTime_returnsCorrectTimeInSeconds() {
     ElapsedTime elapsedTime = new ElapsedTime();
+
     elapsedTime.start();
+    someOperation();
     elapsedTime.end();
+
     long start = elapsedTime.getStart();
     long end = elapsedTime.getEnd();
+    long elapsedTimeInNanoseconds = end - start;
+    double elapsedTimeInSeconds = elapsedTimeInNanoseconds / 1e+9;
+    double roundedTime =  Math.round(elapsedTimeInSeconds * 100d) / 100d;
+    assertEquals(roundedTime, elapsedTime.getElapsedTime(), DELTA);
+  }
 
-    assertEquals(elapsedTime.getElapsedTime(), end - start);
+  private void someOperation() {
+    try {
+      Thread.sleep(1000);
+    } catch (InterruptedException exception) {
+      exception.printStackTrace();
+    }
   }
 }

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteCallbackTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteCallbackTest.java
@@ -1,0 +1,80 @@
+package com.mapbox.services.android.navigation.v5.navigation;
+
+import android.support.annotation.NonNull;
+
+import com.mapbox.api.directions.v5.models.DirectionsResponse;
+import com.mapbox.api.directions.v5.models.DirectionsRoute;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class NavigationRouteCallbackTest {
+
+  @Test
+  public void onResponse_callbackIsCalled() {
+    NavigationTelemetry telemetry = mock(NavigationTelemetry.class);
+    NavigationRouteEventListener listener = mock(NavigationRouteEventListener.class);
+    Callback<DirectionsResponse> callback = mock(Callback.class);
+    Call call = mock(Call.class);
+    String uuid = "some_uuid";
+    Response response = buildMockResponse(uuid);
+    NavigationRouteCallback routeCallback = new NavigationRouteCallback(telemetry, listener, callback);
+
+    routeCallback.onResponse(call, response);
+
+    verify(callback).onResponse(call, response);
+  }
+
+  @Test
+  public void onResponse_validResponseSendsEvent() {
+    NavigationTelemetry telemetry = mock(NavigationTelemetry.class);
+    NavigationRouteEventListener listener = mock(NavigationRouteEventListener.class);
+    ElapsedTime elapsedTime = mock(ElapsedTime.class);
+    when(listener.getTime()).thenReturn(elapsedTime);
+    Callback<DirectionsResponse> callback = mock(Callback.class);
+    Call call = mock(Call.class);
+    String uuid = "some_uuid";
+    Response response = buildMockResponse(uuid);
+    NavigationRouteCallback routeCallback = new NavigationRouteCallback(telemetry, listener, callback);
+
+    routeCallback.onResponse(call, response);
+
+    verify(telemetry).routeRetrievalEvent(eq(elapsedTime), eq(uuid));
+  }
+
+  @Test
+  public void onFailure_callbackIsCalled() {
+    NavigationTelemetry telemetry = mock(NavigationTelemetry.class);
+    NavigationRouteEventListener listener = mock(NavigationRouteEventListener.class);
+    Callback<DirectionsResponse> callback = mock(Callback.class);
+    Call call = mock(Call.class);
+    Throwable throwable = mock(Throwable.class);
+    NavigationRouteCallback routeCallback = new NavigationRouteCallback(telemetry, listener, callback);
+
+    routeCallback.onFailure(call, throwable);
+
+    verify(callback).onFailure(call, throwable);
+  }
+
+  @NonNull
+  private Response buildMockResponse(String uuid) {
+    Response response = mock(Response.class);
+    DirectionsResponse directionsResponse = mock(DirectionsResponse.class);
+    ArrayList<DirectionsRoute> routes = new ArrayList<>();
+    routes.add(mock(DirectionsRoute.class));
+    when(directionsResponse.uuid()).thenReturn(uuid);
+    when(directionsResponse.routes()).thenReturn(routes);
+    when(response.body()).thenReturn(directionsResponse);
+    return response;
+  }
+}

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteEventListenerTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteEventListenerTest.java
@@ -1,0 +1,31 @@
+package com.mapbox.services.android.navigation.v5.navigation;
+
+import org.junit.Test;
+
+import okhttp3.Call;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class NavigationRouteEventListenerTest {
+
+  @Test
+  public void callStart_timeStartIsCalled() {
+    ElapsedTime time = mock(ElapsedTime.class);
+    NavigationRouteEventListener listener = new NavigationRouteEventListener(time);
+
+    listener.callStart(mock(Call.class));
+
+    verify(time).start();
+  }
+
+  @Test
+  public void callEnd_timeEndIsCalled() {
+    ElapsedTime time = mock(ElapsedTime.class);
+    NavigationRouteEventListener listener = new NavigationRouteEventListener(time);
+
+    listener.callEnd(mock(Call.class));
+
+    verify(time).end();
+  }
+}

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteTest.java
@@ -5,7 +5,6 @@ import android.content.Context;
 import com.mapbox.api.directions.v5.DirectionsCriteria;
 import com.mapbox.api.directions.v5.MapboxDirections;
 import com.mapbox.api.directions.v5.models.DirectionsResponse;
-import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.api.directions.v5.models.RouteOptions;
 import com.mapbox.geojson.Point;
 import com.mapbox.services.android.navigation.v5.BaseTest;
@@ -14,8 +13,6 @@ import com.mapbox.services.android.navigation.v5.utils.LocaleUtils;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -23,17 +20,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
-import edu.emory.mathcs.backport.java.util.Collections;
 import okhttp3.EventListener;
 import okhttp3.Interceptor;
 import retrofit2.Call;
-import retrofit2.Callback;
-import retrofit2.Response;
 
 import static junit.framework.Assert.assertNotNull;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -248,36 +241,5 @@ public class NavigationRouteTest extends BaseTest {
     builder.interceptor(interceptor);
 
     verify(mapboxDirectionsBuilder).interceptor(interceptor);
-  }
-
-  @Test
-  public void getRoute_routeRetrievalEventSent() {
-    MapboxDirections mapboxDirections = mock(MapboxDirections.class);
-    NavigationTelemetry navigationTelemetry = mock(NavigationTelemetry.class);
-    ElapsedTime elapsedTime = mock(ElapsedTime.class);
-    NavigationRoute navigationRoute = new NavigationRoute(mapboxDirections, navigationTelemetry,
-      elapsedTime);
-    Callback<DirectionsResponse> callback = mock(Callback.class);
-    ArgumentCaptor<Callback<DirectionsResponse>> argumentCaptor =
-      ArgumentCaptor.forClass(Callback.class);
-    navigationRoute.getRoute(callback);
-    Response<DirectionsResponse> response = mock(Response.class);
-    DirectionsResponse directionsResponse = mock(DirectionsResponse.class);
-    when(response.body()).thenReturn(directionsResponse);
-    DirectionsRoute directionsRoute = mock(DirectionsRoute.class);
-    RouteOptions routeOptions = mock(RouteOptions.class);
-    when(directionsResponse.routes()).thenReturn(Collections.singletonList(directionsRoute));
-    when(directionsRoute.routeOptions()).thenReturn(routeOptions);
-    String uuid = "uuid";
-    when(routeOptions.requestUuid()).thenReturn(uuid);
-
-    verify(mapboxDirections).enqueueCall(argumentCaptor.capture());
-    Callback<DirectionsResponse> innerCallback = argumentCaptor.getValue();
-    innerCallback.onResponse(mock(Call.class), response);
-
-    InOrder inOrder = inOrder(elapsedTime);
-    inOrder.verify(elapsedTime).start();
-    inOrder.verify(elapsedTime).end();
-    verify(navigationTelemetry).routeRetrievalEvent(elapsedTime, uuid);
   }
 }


### PR DESCRIPTION
Fixes #1732 

This PR updates the route retrieval event to send seconds (with `.00` precision) instead of nanoseconds.  It also uses an `EventListener` from OkHttp for monitoring the start and end time of the network request.  

TODO:
- [x] Verify new data in mode 
- [x] Wait for upstream `4.4.0` release of Java library