### PR TITLE
Add silent waypoints support into NavigationRoute

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/EndNavigationActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/EndNavigationActivity.java
@@ -44,6 +44,7 @@ public class EndNavigationActivity extends AppCompatActivity implements OnNaviga
   private FloatingActionButton launchNavigationFab;
   private Point origin = Point.fromLngLat(-122.423579, 37.761689);
   private Point pickup = Point.fromLngLat(-122.424467, 37.761027);
+  private Point middlePickup = Point.fromLngLat(-122.428604, 37.763559);
   private Point destination = Point.fromLngLat(-122.426183, 37.760872);
   private DirectionsRoute route;
   private boolean paellaPickedUp = false;
@@ -115,7 +116,9 @@ public class EndNavigationActivity extends AppCompatActivity implements OnNaviga
       .accessToken(getString(R.string.mapbox_access_token))
       .origin(origin)
       .addWaypoint(pickup)
+      .addWaypoint(middlePickup)
       .destination(destination)
+      .addWaypointIndices(0, 2, 3)
       .alternatives(true)
       .build();
     builder.getRoute(this);

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -9,7 +9,7 @@ ext {
 
   version = [
       mapboxMapSdk           : '7.1.2',
-      mapboxSdkServices      : '4.3.0',
+      mapboxSdkServices      : '4.4.0',
       mapboxEvents           : '4.2.0',
       mapboxNavigator        : '4.0.0',
       mapboxAnnotationPlugin : '0.5.0',

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteTest.java
@@ -89,6 +89,21 @@ public class NavigationRouteTest extends BaseTest {
   }
 
   @Test
+  public void checksWaypointIndicesIncludedInRequest() {
+    NavigationRoute navigationRoute = NavigationRoute.builder(context, localeUtils)
+      .accessToken(ACCESS_TOKEN)
+      .origin(Point.fromLngLat(1.0, 2.0))
+      .addWaypoint(Point.fromLngLat(1.0, 3.0))
+      .addWaypoint(Point.fromLngLat(1.0, 3.0))
+      .destination(Point.fromLngLat(1.0, 5.0))
+      .addWaypointIndices(0, 2, 3)
+      .build();
+
+    assertThat(navigationRoute.getCall().request().url().toString(),
+      containsString("waypoints"));
+  }
+
+  @Test
   public void addWaypointNamesIncludedInRequest() {
     NavigationRoute navigationRoute = NavigationRoute.builder(context, localeUtils)
       .accessToken(ACCESS_TOKEN)
@@ -142,9 +157,10 @@ public class NavigationRouteTest extends BaseTest {
   }
 
   @Test
-  public void addRouteOptionsIncludedInRequest() throws Exception {
+  public void addRouteOptionsIncludedInRequest() {
     List<Point> coordinates = new ArrayList<>();
     coordinates.add(Point.fromLngLat(1.0, 2.0));
+    coordinates.add(Point.fromLngLat(1.0, 3.0));
     coordinates.add(Point.fromLngLat(1.0, 5.0));
 
     RouteOptions routeOptions = RouteOptions.builder()
@@ -158,14 +174,16 @@ public class NavigationRouteTest extends BaseTest {
       .voiceUnits(DirectionsCriteria.METRIC)
       .user("example_user")
       .geometries("mocked_geometries")
-      .approaches("curb;unrestricted")
-      .waypointNames("Origin;Destination")
-      .waypointTargets(";0.99,4.99")
+      .approaches("curb;;unrestricted")
+      .waypointNames("Origin;Pickup;Destination")
+      .waypointTargets(";;0.99,4.99")
+      .waypointIndices("0;2")
       .build();
 
     NavigationRoute navigationRoute = NavigationRoute.builder(context, localeUtils)
       .origin(coordinates.get(0))
-      .destination(coordinates.get(1))
+      .addWaypoint(coordinates.get(1))
+      .destination(coordinates.get(2))
       .routeOptions(routeOptions)
       .build();
 


### PR DESCRIPTION
Edited:
- Adds ~via~ silent waypoints support into `NavigationRoute`

Fixes #1730 

Note: current branch is using MAS `SNAPSHOT` - MAS `4.4.0` needs to be released and the `SNAPSHOT` dependency removed before this PR can merge.

cc @osana 