### PR TITLE
Ignore primary route update tasks with empty collections

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/MapRouteLine.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/MapRouteLine.java
@@ -304,8 +304,7 @@ class MapRouteLine {
   }
 
   private void updateRoutesFor(int newPrimaryIndex) {
-    boolean isRouteFeatureCollectionsEmpty = routeFeatureCollections.isEmpty();
-    if (newPrimaryIndex < 0 || isRouteFeatureCollectionsEmpty || newPrimaryIndex > routeFeatureCollections.size() - 1) {
+    if (newPrimaryIndex < 0 || newPrimaryIndex > routeFeatureCollections.size() - 1) {
       return;
     }
     new PrimaryRouteUpdateTask(newPrimaryIndex, routeFeatureCollections, primaryRouteUpdatedCallback).execute();

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/PrimaryRouteUpdateTask.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/PrimaryRouteUpdateTask.java
@@ -28,6 +28,10 @@ class PrimaryRouteUpdateTask extends AsyncTask<Void, Void, List<FeatureCollectio
   @Override
   protected List<FeatureCollection> doInBackground(Void... voids) {
     List<FeatureCollection> updatedRouteCollections = new ArrayList<>(routeFeatureCollections);
+    if (updatedRouteCollections.isEmpty()) {
+      return routeFeatureCollections;
+    }
+
     // Update the primary new collection
     FeatureCollection primaryCollection = updatedRouteCollections.remove(newPrimaryIndex);
     List<Feature> primaryFeatures = primaryCollection.features();

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/route/PrimaryRouteUpdateTaskTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/route/PrimaryRouteUpdateTaskTest.java
@@ -1,0 +1,27 @@
+package com.mapbox.services.android.navigation.ui.v5.route;
+
+import com.mapbox.geojson.FeatureCollection;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import edu.emory.mathcs.backport.java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+public class PrimaryRouteUpdateTaskTest {
+
+  @Test
+  public void doInBackground_returnsEmptyCollection() {
+    int primaryRouteIndex = 0;
+    List<FeatureCollection> routeFeatureCollections = Collections.emptyList();
+    OnPrimaryRouteUpdatedCallback callback = mock(OnPrimaryRouteUpdatedCallback.class);
+    PrimaryRouteUpdateTask task = new PrimaryRouteUpdateTask(primaryRouteIndex, routeFeatureCollections, callback);
+
+    List<FeatureCollection> updatedCollection = task.doInBackground(mock(Void.class));
+
+    assertEquals(routeFeatureCollections, updatedCollection);
+  }
+}


### PR DESCRIPTION
Closes #1740 