### PR TITLE
Adjust continueStraight to default for NavigationRoute

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRoute.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRoute.java
@@ -70,7 +70,8 @@ public final class NavigationRoute {
       .annotations(DirectionsCriteria.ANNOTATION_CONGESTION, DirectionsCriteria.ANNOTATION_DISTANCE)
       .language(context, localeUtils)
       .voiceUnits(context, localeUtils)
-      .profile(DirectionsCriteria.PROFILE_DRIVING_TRAFFIC);
+      .profile(DirectionsCriteria.PROFILE_DRIVING_TRAFFIC)
+      .continueStraight(true);
   }
 
   /**
@@ -564,6 +565,21 @@ public final class NavigationRoute {
     }
 
     /**
+     * Sets allowed direction of travel when departing intermediate waypoints. If true the route
+     * will continue in the same direction of travel. If false the route may continue in the
+     * opposite direction of travel. API defaults to true for
+     * {@link DirectionsCriteria#PROFILE_DRIVING} and false for
+     * {@link DirectionsCriteria#PROFILE_WALKING} and {@link DirectionsCriteria#PROFILE_CYCLING}.
+     *
+     * @param continueStraight boolean true if you want to always continue straight, else false.
+     * @return this builder for chaining options together
+     */
+    public Builder continueStraight(boolean continueStraight) {
+      directionsBuilder.continueStraight(continueStraight);
+      return this;
+    }
+
+    /**
      * Optionally create a {@link Builder} based on all variables
      * from given {@link RouteOptions}.
      * <p>
@@ -649,7 +665,6 @@ public final class NavigationRoute {
       // Set the default values which the user cannot alter.
       directionsBuilder
         .steps(true)
-        .continueStraight(true)
         .geometries(DirectionsCriteria.GEOMETRY_POLYLINE6)
         .overview(DirectionsCriteria.OVERVIEW_FULL)
         .voiceInstructions(true)

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteTest.java
@@ -242,4 +242,15 @@ public class NavigationRouteTest extends BaseTest {
 
     verify(mapboxDirectionsBuilder).interceptor(interceptor);
   }
+
+  @Test
+  public void builderContinueStraight_setsMapboxDirections() {
+    MapboxDirections.Builder mapboxDirectionsBuilder = mock(MapboxDirections.Builder.class);
+    NavigationRoute.Builder builder = new NavigationRoute.Builder(mapboxDirectionsBuilder);
+    boolean continueStraight = false;
+
+    builder.continueStraight(continueStraight);
+
+    verify(mapboxDirectionsBuilder).continueStraight(continueStraight);
+  }
 }


### PR DESCRIPTION
Closes #1747 

We currently strictly enforce the `continueStraight` parameter in `NavigationRoute` - we can update this as a default (`true`) that can be overridden.  