### PR TITLE
Fix battery charge reporter NPE

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationTelemetry.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationTelemetry.java
@@ -568,6 +568,8 @@ class NavigationTelemetry implements NavigationMetricListener {
   }
 
   private void cancelBatteryScheduler() {
-    batteryChargeReporter.stop();
+    if (batteryChargeReporter != null) {
+      batteryChargeReporter.stop();
+    }
   }
 }


### PR DESCRIPTION
- Fixes `BatteryChargeReporter` `NullPointerException` found while testing

```
Caused by java.lang.NullPointerException: Attempt to invoke virtual method 'void com.mapbox.services.android.navigation.v5.navigation.BatteryChargeReporter.stop()' on a null object reference
       at com.mapbox.services.android.navigation.v5.navigation.NavigationTelemetry.cancelBatteryScheduler(NavigationTelemetry.java:571)
       at com.mapbox.services.android.navigation.v5.navigation.NavigationTelemetry.endSession(NavigationTelemetry.java:209)
       at com.mapbox.services.android.navigation.v5.navigation.NavigationLifecycleMonitor.onActivityDestroyed(NavigationLifecycleMonitor.java:57)
       at android.app.Application.dispatchActivityDestroyed(Application.java:251)
       at android.app.Activity.onDestroy(Activity.java:1699)
       at android.support.v4.app.FragmentActivity.onDestroy(FragmentActivity.java:413)
       at android.support.v7.app.AppCompatActivity.onDestroy(AppCompatActivity.java:210)
       at com.mapbox.logistics.ui.LogisticsActivity.onDestroy(LogisticsActivity.kt:102)
       at android.app.Activity.performDestroy(Activity.java:6463)
       at android.app.Instrumentation.callActivityOnDestroy(Instrumentation.java:1143)
       at android.app.ActivityThread.performDestroyActivity(ActivityThread.java:3818)
       at android.app.ActivityThread.handleDestroyActivity(ActivityThread.java:3849)
       at android.app.ActivityThread.access$1500(ActivityThread.java:150)
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1398)
       at android.os.Handler.dispatchMessage(Handler.java:102)
       at android.os.Looper.loop(Looper.java:148)
       at android.app.ActivityThread.main(ActivityThread.java:5417)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616)
```