### PR TITLE
[WIP] Add network interceptor and listener for tile download progress

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NetworkProgressInterceptor.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NetworkProgressInterceptor.java
@@ -1,0 +1,25 @@
+package com.mapbox.services.android.navigation.v5.navigation;
+
+import android.support.annotation.NonNull;
+
+import java.io.IOException;
+
+import okhttp3.Interceptor;
+import okhttp3.Response;
+
+class NetworkProgressInterceptor implements Interceptor {
+
+  private final NetworkProgressListener listener;
+
+  NetworkProgressInterceptor(NetworkProgressListener listener) {
+    this.listener = listener;
+  }
+
+  @Override
+  public Response intercept(@NonNull Chain chain) throws IOException {
+    Response originalResponse = chain.proceed(chain.request());
+    return originalResponse.newBuilder()
+      .body(new NetworkResponseBody(originalResponse.body(), listener))
+      .build();
+  }
+}

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NetworkProgressListener.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NetworkProgressListener.java
@@ -1,0 +1,5 @@
+package com.mapbox.services.android.navigation.v5.navigation;
+
+interface NetworkProgressListener {
+  void update(long bytesRead, long contentLength, boolean isDone);
+}

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NetworkResponseBody.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NetworkResponseBody.java
@@ -1,0 +1,57 @@
+package com.mapbox.services.android.navigation.v5.navigation;
+
+import android.support.annotation.NonNull;
+
+import java.io.IOException;
+
+import okhttp3.MediaType;
+import okhttp3.ResponseBody;
+import okio.Buffer;
+import okio.BufferedSource;
+import okio.ForwardingSource;
+import okio.Okio;
+import okio.Source;
+
+class NetworkResponseBody extends ResponseBody {
+
+  private final ResponseBody responseBody;
+  private final NetworkProgressListener listener;
+  private BufferedSource bufferedSource;
+
+  NetworkResponseBody(ResponseBody responseBody, NetworkProgressListener listener) {
+    this.responseBody = responseBody;
+    this.listener = listener;
+  }
+
+  @Override
+  public MediaType contentType() {
+    return responseBody.contentType();
+  }
+
+  @Override
+  public long contentLength() {
+    return responseBody.contentLength();
+  }
+
+  @Override
+  public BufferedSource source() {
+    if (bufferedSource == null) {
+      bufferedSource = Okio.buffer(source(responseBody.source()));
+    }
+    return bufferedSource;
+  }
+
+  private Source source(Source source) {
+    return new ForwardingSource(source) {
+      long totalBytesRead = 0L;
+
+      @Override
+      public long read(@NonNull Buffer sink, long byteCount) throws IOException {
+        long bytesRead = super.read(sink, byteCount);
+        totalBytesRead += bytesRead != -1 ? bytesRead : 0;
+        listener.update(totalBytesRead, responseBody.contentLength(), bytesRead == -1);
+        return bytesRead;
+      }
+    };
+  }
+}


### PR DESCRIPTION
Closes #1741 

This PR adds a `NetworkProgressListener` that will allow us to get progress of a TAR (or any) API request.

This is currently blocked upstream by the TAR download API not returning `content-length`, so we aren't able to do the math for current progress of the download.  Once the lands, we will also need to add `Interceptor` support for the `MapboxRouteTiles` so we can add the interceptor itself for the network request. 

TODO: 
- [ ] Add unit tests
- [ ] Bring in new MAS dependency with `Interceptor` support
- [ ] Confirm `content-length` is being provided

cc @kevinkreiser @akitchen 