### PR TITLE
Add DepartEventFactory for handling route departure events

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/DepartEventFactory.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/DepartEventFactory.java
@@ -1,0 +1,55 @@
+package com.mapbox.services.android.navigation.v5.navigation;
+
+import com.mapbox.services.android.navigation.v5.location.MetricsLocation;
+import com.mapbox.services.android.navigation.v5.navigation.metrics.SessionState;
+import com.mapbox.services.android.navigation.v5.routeprogress.MetricsRouteProgress;
+
+import java.util.Date;
+
+class DepartEventFactory {
+
+  private static final int INITIAL_LEG_INDEX = -1;
+  private final DepartEventHandler departEventHandler;
+  private int currentLegIndex = INITIAL_LEG_INDEX;
+
+  DepartEventFactory(DepartEventHandler departEventHandler) {
+    this.departEventHandler = departEventHandler;
+  }
+
+  SessionState send(SessionState sessionState, MetricsRouteProgress routeProgress, MetricsLocation location) {
+    sessionState = checkResetForNewLeg(sessionState, routeProgress);
+    this.currentLegIndex = routeProgress.getLegIndex();
+    if (isValidDeparture(sessionState, routeProgress)) {
+      return sendToHandler(sessionState, routeProgress, location);
+    }
+    return sessionState;
+  }
+
+  void reset() {
+    currentLegIndex = INITIAL_LEG_INDEX;
+  }
+
+  private SessionState checkResetForNewLeg(SessionState sessionState, MetricsRouteProgress routeProgress) {
+    if (shouldResetDepartureDate(routeProgress)) {
+      sessionState = sessionState.toBuilder().startTimestamp(null).build();
+    }
+    return sessionState;
+  }
+
+  private boolean shouldResetDepartureDate(MetricsRouteProgress routeProgress) {
+    return currentLegIndex != routeProgress.getLegIndex();
+  }
+
+  private boolean isValidDeparture(SessionState sessionState, MetricsRouteProgress routeProgress) {
+    return sessionState.startTimestamp() == null && routeProgress.getDistanceTraveled() > 0;
+  }
+
+  private SessionState sendToHandler(SessionState sessionState, MetricsRouteProgress routeProgress,
+                             MetricsLocation location) {
+    SessionState updatedState = sessionState.toBuilder()
+      .startTimestamp(new Date())
+      .build();
+    departEventHandler.send(updatedState, routeProgress, location);
+    return updatedState;
+  }
+}

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/DepartEventHandler.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/DepartEventHandler.java
@@ -1,0 +1,20 @@
+package com.mapbox.services.android.navigation.v5.navigation;
+
+import android.content.Context;
+
+import com.mapbox.services.android.navigation.v5.location.MetricsLocation;
+import com.mapbox.services.android.navigation.v5.navigation.metrics.SessionState;
+import com.mapbox.services.android.navigation.v5.routeprogress.MetricsRouteProgress;
+
+class DepartEventHandler {
+
+  private final Context applicationContext;
+
+  DepartEventHandler(Context applicationContext) {
+    this.applicationContext = applicationContext;
+  }
+
+  void send(SessionState sessionState, MetricsRouteProgress routeProgress, MetricsLocation location) {
+    NavigationMetricsWrapper.departEvent(sessionState, routeProgress, location.getLocation(), applicationContext);
+  }
+}

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
@@ -356,6 +356,7 @@ public class MapboxNavigation implements ServiceConnection {
   public void stopNavigation() {
     Timber.d("MapboxNavigation stopNavigation called");
     if (isServiceAvailable()) {
+      navigationTelemetry.stopSession();
       applicationContext.unbindService(this);
       isBound = false;
       navigationService.endNavigation();

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/DepartEventFactoryTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/DepartEventFactoryTest.java
@@ -1,0 +1,85 @@
+package com.mapbox.services.android.navigation.v5.navigation;
+
+import com.mapbox.services.android.navigation.v5.location.MetricsLocation;
+import com.mapbox.services.android.navigation.v5.navigation.metrics.SessionState;
+import com.mapbox.services.android.navigation.v5.routeprogress.MetricsRouteProgress;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class DepartEventFactoryTest {
+
+  @Test
+  public void send_nullStartTimestampAndValidDistanceSendsEvent() {
+    DepartEventHandler handler = mock(DepartEventHandler.class);
+    SessionState sessionState = SessionState.builder().build();
+    MetricsRouteProgress routeProgress = mock(MetricsRouteProgress.class);
+    when(routeProgress.getLegIndex()).thenReturn(0);
+    when(routeProgress.getDistanceTraveled()).thenReturn(100);
+    MetricsLocation location = mock(MetricsLocation.class);
+    DepartEventFactory factory = new DepartEventFactory(handler);
+
+    SessionState sentState = factory.send(sessionState, routeProgress, location);
+
+    assertNotNull(sentState.startTimestamp());
+  }
+
+  @Test
+  public void send_nullStartTimestampAndInvalidDistanceDoesNotSendEvent() {
+    DepartEventHandler handler = mock(DepartEventHandler.class);
+    SessionState sessionState = SessionState.builder().build();
+    MetricsRouteProgress routeProgress = mock(MetricsRouteProgress.class);
+    when(routeProgress.getLegIndex()).thenReturn(0);
+    when(routeProgress.getDistanceTraveled()).thenReturn(0);
+    MetricsLocation location = mock(MetricsLocation.class);
+    DepartEventFactory factory = new DepartEventFactory(handler);
+
+    SessionState sentState = factory.send(sessionState, routeProgress, location);
+
+    assertNull(sentState.startTimestamp());
+  }
+
+  @Test
+  public void send_nonNullStartTimestampAndValidDistanceDoesNotSendEvent() {
+    DepartEventHandler handler = mock(DepartEventHandler.class);
+    SessionState sessionState = SessionState.builder().build();
+    MetricsRouteProgress routeProgress = mock(MetricsRouteProgress.class);
+    when(routeProgress.getLegIndex()).thenReturn(0);
+    when(routeProgress.getDistanceTraveled()).thenReturn(100);
+    MetricsLocation location = mock(MetricsLocation.class);
+    DepartEventFactory factory = new DepartEventFactory(handler);
+
+    SessionState updatedState = factory.send(sessionState, routeProgress, location);
+    factory.send(updatedState, routeProgress, location);
+
+    verify(handler, times(1)).send(eq(updatedState), eq(routeProgress), eq(location));
+  }
+
+  @Test
+  public void send_resetAllowsNewEventToBeSent() {
+    DepartEventHandler handler = mock(DepartEventHandler.class);
+    SessionState sessionState = SessionState.builder().build();
+    MetricsRouteProgress routeProgress = mock(MetricsRouteProgress.class);
+    when(routeProgress.getLegIndex()).thenReturn(0);
+    when(routeProgress.getDistanceTraveled()).thenReturn(100);
+    MetricsLocation location = mock(MetricsLocation.class);
+    DepartEventFactory factory = new DepartEventFactory(handler);
+
+    SessionState updatedState = factory.send(sessionState, routeProgress, location);
+    factory.send(updatedState, routeProgress, location);
+    factory.reset();
+    factory.send(updatedState, routeProgress, location);
+
+    verify(handler, times(2)).send(
+      any(SessionState.class), any(MetricsRouteProgress.class), any(MetricsLocation.class)
+    );
+  }
+}


### PR DESCRIPTION
Add classes for departure event handling in `NavigationTelemetry`.

## Description

The change is extracting the business logic for departure events out of `NavigationTelemetry` and into its own class `DepartureEventFactory` that is testable.  The factory is able to be "reset" for new routes or if navigation has been stopped.   

## What's the goal?

The goal is to update `NavigationTelemetry` to provide consistent departure events so we can gain better insight into customer usage of the SDK.

## How is it being implemented?

- `NavigationTelemetry`
  - Instantiates a `NavigationEventHandler` and `NavigationEventFactory` (which takes the handler)
  - Updates `NavigationEventFactory` with appropriate data which may or may not trigger the depart event
  - Resets the `NavigationEventFactory` when appropriate (if we need to fire a new departure event after a previous has fired)

## How has this been tested?

- [x] Tested locally with `Timber` logging and `MapboxTelemetry` debug logging
  - [x] Test multi-leg route
  - [x] Test multi-route single navigation session
- [x] @coxchapman can we write a quick mode report to verify 100% consistent depart events?  

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

cc @coxchapman @akitchen 