### PR TITLE
Fix cancel button visibility

### DIFF
--- a/libandroid-navigation-ui/src/main/res/layout-land/summary_peek_layout.xml
+++ b/libandroid-navigation-ui/src/main/res/layout-land/summary_peek_layout.xml
@@ -37,7 +37,7 @@
         app:layout_constraintTop_toTopOf="parent"
         tools:src="@drawable/ic_route_preview"/>
 
-    <ImageButton
+    <android.support.v7.widget.AppCompatImageButtonn
         android:id="@+id/cancelBtn"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/libandroid-navigation-ui/src/main/res/layout/summary_peek_layout.xml
+++ b/libandroid-navigation-ui/src/main/res/layout/summary_peek_layout.xml
@@ -48,7 +48,7 @@
         app:layout_constraintEnd_toStartOf="@+id/cancelBtn"
         app:layout_constraintTop_toTopOf="parent"/>
 
-    <ImageButton
+    <android.support.v7.widget.AppCompatImageButton
         android:id="@+id/cancelBtn"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"


### PR DESCRIPTION
## Title
Fix Cancel Button Visibility

## Description
During navigation, while using a device on API 27, the cancel button does not appear. This is because the cancel button was an `ImageButton` that used `srcCompat` to include the `ic_clear` image. When using `srcCompat`, the UI object must be from the `AppCompat` library. 

This PR simply changes `ImageButton` to `AppCompatImageButton` for the cancel button

- Fixes #1765 

## What's the goal?
The goal is to make the cancel button visible on all devices.

## How is it being implemented?
Modified `summary_peak_layout.xml` to use `ImageButton` instead of `AppCompatImageButton` for the cancel button

## Screenshots or Gifs
Before:
<img width="424" alt="screen shot 2019-02-22 at 2 18 38 pm" src="https://user-images.githubusercontent.com/7095894/53531809-2ec42000-3aa9-11e9-8c63-6405009f4de2.png">

After: 
<img width="420" alt="screen shot 2019-02-27 at 4 02 57 pm" src="https://user-images.githubusercontent.com/7095894/53531822-3be10f00-3aa9-11e9-91ae-50d58392608e.png">

## How has this been tested?
I ran my app using my forked version of the navigation library and verified the cancel button appears