### PR TITLE
Fix NavigationRoute bearing order

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteWaypoint.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteWaypoint.java
@@ -1,0 +1,35 @@
+package com.mapbox.services.android.navigation.v5.navigation;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.mapbox.geojson.Point;
+
+class NavigationRouteWaypoint {
+
+  private final Point waypoint;
+  private final Double bearingAngle;
+  private final Double tolerance;
+
+  NavigationRouteWaypoint(@NonNull Point waypoint, @Nullable Double bearingAngle,
+                          @Nullable Double tolerance) {
+    this.waypoint = waypoint;
+    this.bearingAngle = bearingAngle;
+    this.tolerance = tolerance;
+  }
+
+  @NonNull
+  Point getWaypoint() {
+    return waypoint;
+  }
+
+  @Nullable
+  Double getBearingAngle() {
+    return bearingAngle;
+  }
+
+  @Nullable
+  Double getTolerance() {
+    return tolerance;
+  }
+}

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteTest.java
@@ -11,7 +11,6 @@ import com.mapbox.services.android.navigation.v5.BaseTest;
 import com.mapbox.services.android.navigation.v5.utils.LocaleUtils;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -126,29 +125,31 @@ public class NavigationRouteTest extends BaseTest {
   }
 
   @Test
-  public void addingPointAndBearingKeepsCorrectOrder() throws Exception {
-    NavigationRoute navigationRoute = NavigationRoute.builder(context, localeUtils)
-      .accessToken(ACCESS_TOKEN)
-      .origin(Point.fromLngLat(1.0, 2.0), 90d, 90d)
-      .addBearing(2.0, 3.0)
-      .destination(Point.fromLngLat(1.0, 5.0))
-      .build();
-
-    String requestUrl = navigationRoute.getCall().request().url().toString();
-    assertThat(requestUrl, containsString("bearings=90%2C90%3B2%2C3%3B"));
-  }
-
-  @Test
-  @Ignore
-  public void reverseOriginDestinationDoesntMessUpBearings() throws Exception {
+  public void reverseOriginDestination_bearingsAreFormattedCorrectly() {
     NavigationRoute navigationRoute = NavigationRoute.builder(context, localeUtils)
       .accessToken(ACCESS_TOKEN)
       .destination(Point.fromLngLat(1.0, 5.0), 1d, 5d)
       .origin(Point.fromLngLat(1.0, 2.0), 90d, 90d)
       .build();
 
-    assertThat(navigationRoute.getCall().request().url().toString(),
-      containsString("bearings=90,90;1,5"));
+    String requestUrl = navigationRoute.getCall().request().url().toString();
+
+    assertThat(requestUrl, containsString("bearings=90%2C90%3B1%2C5"));
+  }
+
+  @Test
+  public void addWaypointsThenOriginDestination_bearingsAreFormattedCorrectly() {
+    NavigationRoute navigationRoute = NavigationRoute.builder(context, localeUtils)
+      .accessToken(ACCESS_TOKEN)
+      .addWaypoint(Point.fromLngLat(3.0, 4.0), 20d, 20d)
+      .addWaypoint(Point.fromLngLat(5.0, 6.0), 30d, 30d)
+      .destination(Point.fromLngLat(7.0, 8.0), 40d, 40d)
+      .origin(Point.fromLngLat(1.0, 2.0), 10d, 10d)
+      .build();
+
+    String requestUrl = navigationRoute.getCall().request().url().toString();
+
+    assertThat(requestUrl, containsString("bearings=10%2C10%3B20%2C20%3B30%2C30%3B40%2C40"));
   }
 
   @Test


### PR DESCRIPTION
## Description

This PR fixes `NavigationRoute` so that it adds waypoint bearings in the correct order (with each corresponding waypoint).

- Fixes #1774 

## What's the goal?

The goal is to ensure waypoints with bearings can be added to the `NavigationRoute` builder in whatever order the developer chooses. 

## How is it being implemented?

A package-private `NavigationRouteWaypoint` class is introduced in this PR so we store a `NavigationRouteWaypoint origin`, `NavigationRouteWaypoint destination`, and `List< NavigationRouteWaypoint> waypoints`.  These are each set by the builder and then assembled in the correct order when `Builder#build()` is called. 

This PR also deprecates `NavigationRoute` `Builder#addBearing`.  Developers are able to add bearing with origin, destination, and waypoints as explained above.  Having a completely separate API that can mess up the order further is not needed and should eventually be removed. 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes