### PR TITLE
Add initial GPS event

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -133,5 +133,12 @@
 
         <!-- Testing -->
         <activity android:name=".test.TestNavigationActivity"/>
+
+        <meta-data
+            android:name="com.mapbox.TestEventsServer"
+            android:value="api-events-staging.tilestream.net" />
+        <meta-data
+            android:name="com.mapbox.TestEventsAccessToken"
+            android:value="pk.eyJ1IjoiYmxzdGFnaW5nIiwiYSI6ImNpdDF3OHpoaTAwMDcyeXA5Y3Z0Nmk2dzEifQ.0IfB7v5Qbm2MGVYt8Kb8fg" />
     </application>
 </manifest>

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/InitialGpsEvent.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/InitialGpsEvent.java
@@ -6,10 +6,10 @@ import android.os.Parcelable;
 @SuppressLint("ParcelCreator")
 @SuppressWarnings("ParcelableCreator")
 class InitialGpsEvent extends NavigationPerformanceEvent implements Parcelable {
-  private static final String ELAPSED_TIME_NAME = "elapsed_time";
+  private static final String TIME_TO_FIRST_GPS = "time_to_first_gps";
 
   InitialGpsEvent(double elapsedTime, String sessionId) {
     super(sessionId);
-    addCounter(new DoubleCounter(ELAPSED_TIME_NAME, elapsedTime));
+    addCounter(new DoubleCounter(TIME_TO_FIRST_GPS, elapsedTime));
   }
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/InitialGpsEvent.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/InitialGpsEvent.java
@@ -1,0 +1,15 @@
+package com.mapbox.services.android.navigation.v5.navigation;
+
+import android.annotation.SuppressLint;
+import android.os.Parcelable;
+
+@SuppressLint("ParcelCreator")
+@SuppressWarnings("ParcelableCreator")
+class InitialGpsEvent extends NavigationPerformanceEvent implements Parcelable {
+  private static final String ELAPSED_TIME_NAME = "elapsed_time";
+
+  InitialGpsEvent(double elapsedTime, String sessionId) {
+    super(sessionId);
+    addCounter(new DoubleCounter(ELAPSED_TIME_NAME, elapsedTime));
+  }
+}

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/InitialGpsEventFactory.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/InitialGpsEventFactory.java
@@ -1,0 +1,47 @@
+package com.mapbox.services.android.navigation.v5.navigation;
+
+import com.mapbox.core.utils.TextUtils;
+
+class InitialGpsEventFactory {
+
+  private static final String EMPTY_STRING = "";
+  private String sessionId = EMPTY_STRING;
+  private ElapsedTime time;
+  private InitialGpsEventHandler handler;
+  private boolean hasSent;
+
+  InitialGpsEventFactory() {
+    this(new ElapsedTime(), new InitialGpsEventHandler());
+  }
+
+  InitialGpsEventFactory(ElapsedTime time, InitialGpsEventHandler handler) {
+    this.time = time;
+    this.handler = handler;
+  }
+
+  void navigationStarted(String sessionId) {
+    this.sessionId = sessionId;
+    time.start();
+  }
+
+  void gpsReceived() {
+    if (time.getStart() == null) {
+      return;
+    }
+    time.end();
+    send(time);
+  }
+
+  void reset() {
+    time = new ElapsedTime();
+    hasSent = false;
+  }
+
+  private void send(ElapsedTime time) {
+    if (!hasSent && !TextUtils.isEmpty(sessionId)) {
+      double elapsedTime = time.getElapsedTime();
+      handler.send(elapsedTime, sessionId);
+      hasSent = true;
+    }
+  }
+}

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/InitialGpsEventHandler.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/InitialGpsEventHandler.java
@@ -1,0 +1,10 @@
+package com.mapbox.services.android.navigation.v5.navigation;
+
+import static com.mapbox.services.android.navigation.v5.navigation.NavigationMetricsWrapper.sendInitialGpsEvent;
+
+class InitialGpsEventHandler {
+
+  void send(double elapsedTime, String sessionId) {
+    sendInitialGpsEvent(elapsedTime, sessionId);
+  }
+}

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationMetricsWrapper.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationMetricsWrapper.java
@@ -375,6 +375,10 @@ final class NavigationMetricsWrapper {
     push(new RouteRetrievalEvent(elapsedTime, routeUuid, sessionId));
   }
 
+  static void sendInitialGpsEvent(double elapsedTime, String sessionId) {
+    push(new InitialGpsEvent(elapsedTime, sessionId));
+  }
+
   static Event turnstileEvent() {
     Event navTurnstileEvent = new AppUserTurnstile(sdkIdentifier,
       BuildConfig.MAPBOX_NAVIGATION_VERSION_NAME);

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/InitialGpsEventFactoryTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/InitialGpsEventFactoryTest.java
@@ -95,10 +95,6 @@ public class InitialGpsEventFactoryTest {
   }
 
   private void waitingForGps() {
-    try {
-      Thread.sleep(1500);
-    } catch (InterruptedException exception) {
-      exception.printStackTrace();
-    }
+    // Empty operation to simulate waiting for GPS
   }
 }

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/InitialGpsEventFactoryTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/InitialGpsEventFactoryTest.java
@@ -1,0 +1,104 @@
+package com.mapbox.services.android.navigation.v5.navigation;
+
+import org.junit.Test;
+
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+public class InitialGpsEventFactoryTest {
+
+  @Test
+  public void navigationStarted_elapsedTimeStarts() {
+    ElapsedTime time = mock(ElapsedTime.class);
+    InitialGpsEventHandler handler = mock(InitialGpsEventHandler.class);
+    InitialGpsEventFactory factory = new InitialGpsEventFactory(time, handler);
+
+    factory.navigationStarted("some_session");
+
+    verify(time).start();
+  }
+
+  @Test
+  public void gpsReceived_elapsedTimeEnds() {
+    ElapsedTime time = mock(ElapsedTime.class);
+    InitialGpsEventHandler handler = mock(InitialGpsEventHandler.class);
+    InitialGpsEventFactory factory = new InitialGpsEventFactory(time, handler);
+
+    factory.gpsReceived();
+
+    verify(time).end();
+  }
+
+  @Test
+  public void validData_sendsCorrectEvent() {
+    ElapsedTime time = mock(ElapsedTime.class);
+    InitialGpsEventHandler handler = mock(InitialGpsEventHandler.class);
+    String sessionId = "some_session";
+    InitialGpsEventFactory factory = new InitialGpsEventFactory(time, handler);
+
+    factory.navigationStarted(sessionId);
+    waitingForGps();
+    factory.gpsReceived();
+
+    verify(handler).send(anyDouble(), eq(sessionId));
+  }
+
+  @Test
+  public void validData_doesNotSendEventTwice() {
+    ElapsedTime time = mock(ElapsedTime.class);
+    InitialGpsEventHandler handler = mock(InitialGpsEventHandler.class);
+    String sessionId = "some_session";
+    InitialGpsEventFactory factory = new InitialGpsEventFactory(time, handler);
+
+    factory.navigationStarted(sessionId);
+    waitingForGps();
+    factory.gpsReceived();
+    factory.gpsReceived();
+
+    verify(handler, times(1)).send(anyDouble(), eq(sessionId));
+  }
+
+  @Test
+  public void invalidStart_doesNotSend() {
+    ElapsedTime time = mock(ElapsedTime.class);
+    InitialGpsEventHandler handler = mock(InitialGpsEventHandler.class);
+    InitialGpsEventFactory factory = new InitialGpsEventFactory(time, handler);
+
+    factory.gpsReceived();
+
+    verifyZeroInteractions(handler);
+  }
+
+  @Test
+  public void reset_allowsNewEventToBeSent() {
+    ElapsedTime time = mock(ElapsedTime.class);
+    InitialGpsEventHandler handler = mock(InitialGpsEventHandler.class);
+    String firstSessionId = "first_session";
+    String secondSessionId = "second_session";
+    InitialGpsEventFactory factory = new InitialGpsEventFactory(time, handler);
+
+    factory.navigationStarted(firstSessionId);
+    waitingForGps();
+    factory.gpsReceived();
+    factory.gpsReceived();
+    factory.reset();
+    factory.navigationStarted(secondSessionId);
+    waitingForGps();
+    factory.gpsReceived();
+
+    verify(handler, times(1)).send(anyDouble(), eq(firstSessionId));
+    verify(handler, times(1)).send(anyDouble(), eq(secondSessionId));
+  }
+
+  private void waitingForGps() {
+    try {
+      Thread.sleep(1500);
+    } catch (InterruptedException exception) {
+      exception.printStackTrace();
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR adds a performance event for tracking time from `MapboxNavigation#startNavigation` to the first GPS update from the `LocationEngine`.  

## What's the goal?

We've seen behavior where the GPS takes time to fire up and begin a steady stream of updates that we can reliably navigate with.  The goal of this PR is to gain signal into how the GPS 

## How is it being implemented?

With a `InitialGpsEventFactory` that holds the business logic for creating and resetting state for the `Event` - called by `NavigationTelemetry`.  `InitialGpsEventHandler` wraps `NavigationMetricsWrapper` for sending the `Event` itself, ensuring we can test it properly.  

## How has this been tested?

- [x] Unit tests added
- [x] Route testing in event staging

## Checklist

- [x] I have tested locally / staging (including `SNAPSHOT` upstream dependencies if needed)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes