### PR TITLE
Fix destination marker not drawn on Style reload

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/ComponentNavigationActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/ComponentNavigationActivity.java
@@ -169,23 +169,25 @@ public class ComponentNavigationActivity extends HistoryActivity implements OnMa
 
   @OnClick(R.id.startNavigationFab)
   public void onStartNavigationClick(FloatingActionButton floatingActionButton) {
-    navigationMap.updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_GPS);
-    // Transition to navigation state
-    mapState = MapState.NAVIGATION;
-
-    floatingActionButton.hide();
-    cancelNavigationFab.show();
-
-    // Show the InstructionView
-    TransitionManager.beginDelayedTransition(navigationLayout);
-    instructionView.setVisibility(View.VISIBLE);
-
-    // Start navigation
-    adjustMapPaddingForNavigation();
-    navigation.startNavigation(route);
-
-    // Location updates will be received from ProgressChangeListener
-    removeLocationEngineListener();
+    // TODO reset after testing
+    navigationMap.retrieveMap().setStyle(Style.DARK);
+//    navigationMap.updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_GPS);
+//    // Transition to navigation state
+//    mapState = MapState.NAVIGATION;
+//
+//    floatingActionButton.hide();
+//    cancelNavigationFab.show();
+//
+//    // Show the InstructionView
+//    TransitionManager.beginDelayedTransition(navigationLayout);
+//    instructionView.setVisibility(View.VISIBLE);
+//
+//    // Start navigation
+//    adjustMapPaddingForNavigation();
+//    navigation.startNavigation(route);
+//
+//    // Location updates will be received from ProgressChangeListener
+//    removeLocationEngineListener();
   }
 
   @OnClick(R.id.cancelNavigationFab)

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/ComponentNavigationActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/ComponentNavigationActivity.java
@@ -169,25 +169,23 @@ public class ComponentNavigationActivity extends HistoryActivity implements OnMa
 
   @OnClick(R.id.startNavigationFab)
   public void onStartNavigationClick(FloatingActionButton floatingActionButton) {
-    // TODO reset after testing
-    navigationMap.retrieveMap().setStyle(Style.DARK);
-//    navigationMap.updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_GPS);
-//    // Transition to navigation state
-//    mapState = MapState.NAVIGATION;
-//
-//    floatingActionButton.hide();
-//    cancelNavigationFab.show();
-//
-//    // Show the InstructionView
-//    TransitionManager.beginDelayedTransition(navigationLayout);
-//    instructionView.setVisibility(View.VISIBLE);
-//
-//    // Start navigation
-//    adjustMapPaddingForNavigation();
-//    navigation.startNavigation(route);
-//
-//    // Location updates will be received from ProgressChangeListener
-//    removeLocationEngineListener();
+    navigationMap.updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_GPS);
+    // Transition to navigation state
+    mapState = MapState.NAVIGATION;
+
+    floatingActionButton.hide();
+    cancelNavigationFab.show();
+
+    // Show the InstructionView
+    TransitionManager.beginDelayedTransition(navigationLayout);
+    instructionView.setVisibility(View.VISIBLE);
+
+    // Start navigation
+    adjustMapPaddingForNavigation();
+    navigation.startNavigation(route);
+
+    // Location updates will be received from ProgressChangeListener
+    removeLocationEngineListener();
   }
 
   @OnClick(R.id.cancelNavigationFab)

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/NavigationMapboxMap.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/NavigationMapboxMap.java
@@ -69,7 +69,6 @@ public class NavigationMapboxMap {
   private LocationComponent locationComponent;
   private MapPaddingAdjustor mapPaddingAdjustor;
   private NavigationSymbolManager navigationSymbolManager;
-  private SymbolOnStyleLoadedListener onStyleLoadedListener;
   private MapLayerInteractor layerInteractor;
   private NavigationMapRoute mapRoute;
   private NavigationCamera mapCamera;
@@ -418,7 +417,6 @@ public class NavigationMapboxMap {
     mapRoute.onStart();
     handleWayNameOnStart();
     handleFpsOnStart();
-    mapView.addOnDidFinishLoadingStyleListener(onStyleLoadedListener);
   }
 
   /**
@@ -430,7 +428,6 @@ public class NavigationMapboxMap {
     mapRoute.onStop();
     handleWayNameOnStop();
     handleFpsOnStop();
-    mapView.removeOnDidFinishLoadingStyleListener(onStyleLoadedListener);
   }
 
   /**
@@ -585,7 +582,7 @@ public class NavigationMapboxMap {
     mapboxMap.getStyle().addImage(MAPBOX_NAVIGATION_MARKER_NAME, markerBitmap);
     SymbolManager symbolManager = new SymbolManager(mapView, mapboxMap, mapboxMap.getStyle());
     navigationSymbolManager = new NavigationSymbolManager(symbolManager);
-    onStyleLoadedListener = new SymbolOnStyleLoadedListener(navigationSymbolManager);
+    SymbolOnStyleLoadedListener onStyleLoadedListener = new SymbolOnStyleLoadedListener(mapboxMap, markerBitmap);
     mapView.addOnDidFinishLoadingStyleListener(onStyleLoadedListener);
   }
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/NavigationMapboxMap.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/NavigationMapboxMap.java
@@ -69,6 +69,7 @@ public class NavigationMapboxMap {
   private LocationComponent locationComponent;
   private MapPaddingAdjustor mapPaddingAdjustor;
   private NavigationSymbolManager navigationSymbolManager;
+  private SymbolOnStyleLoadedListener onStyleLoadedListener;
   private MapLayerInteractor layerInteractor;
   private NavigationMapRoute mapRoute;
   private NavigationCamera mapCamera;
@@ -417,6 +418,7 @@ public class NavigationMapboxMap {
     mapRoute.onStart();
     handleWayNameOnStart();
     handleFpsOnStart();
+    mapView.addOnDidFinishLoadingStyleListener(onStyleLoadedListener);
   }
 
   /**
@@ -428,6 +430,7 @@ public class NavigationMapboxMap {
     mapRoute.onStop();
     handleWayNameOnStop();
     handleFpsOnStop();
+    mapView.removeOnDidFinishLoadingStyleListener(onStyleLoadedListener);
   }
 
   /**
@@ -582,6 +585,8 @@ public class NavigationMapboxMap {
     mapboxMap.getStyle().addImage(MAPBOX_NAVIGATION_MARKER_NAME, markerBitmap);
     SymbolManager symbolManager = new SymbolManager(mapView, mapboxMap, mapboxMap.getStyle());
     navigationSymbolManager = new NavigationSymbolManager(symbolManager);
+    onStyleLoadedListener = new SymbolOnStyleLoadedListener(navigationSymbolManager);
+    mapView.addOnDidFinishLoadingStyleListener(onStyleLoadedListener);
   }
 
   private void initializeMapLayerInteractor(MapboxMap mapboxMap) {

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/NavigationSymbolManager.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/NavigationSymbolManager.java
@@ -14,17 +14,17 @@ import java.util.List;
 class NavigationSymbolManager {
 
   static final String MAPBOX_NAVIGATION_MARKER_NAME = "mapbox-navigation-marker";
-  private final List<SymbolOptions> mapMarkersSymbolOptions = new ArrayList<>();
   private final List<Symbol> mapMarkersSymbols = new ArrayList<>();
   private final SymbolManager symbolManager;
 
   NavigationSymbolManager(SymbolManager symbolManager) {
     this.symbolManager = symbolManager;
+    symbolManager.setIconAllowOverlap(true);
+    symbolManager.setIconIgnorePlacement(true);
   }
 
   void addMarkerFor(Point position) {
     SymbolOptions options = createSymbolOptionsFor(position);
-    mapMarkersSymbolOptions.add(options);
     Symbol markerSymbol = symbolManager.create(options);
     mapMarkersSymbols.add(markerSymbol);
   }
@@ -33,14 +33,7 @@ class NavigationSymbolManager {
     for (Symbol markerSymbol : mapMarkersSymbols) {
       symbolManager.delete(markerSymbol);
     }
-    mapMarkersSymbolOptions.clear();
     mapMarkersSymbols.clear();
-  }
-
-  void redrawMarkers() {
-    for (SymbolOptions options : mapMarkersSymbolOptions) {
-      symbolManager.create(options);
-    }
   }
 
   @NonNull

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/NavigationSymbolManager.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/NavigationSymbolManager.java
@@ -14,6 +14,7 @@ import java.util.List;
 class NavigationSymbolManager {
 
   static final String MAPBOX_NAVIGATION_MARKER_NAME = "mapbox-navigation-marker";
+  private final List<SymbolOptions> mapMarkersSymbolOptions = new ArrayList<>();
   private final List<Symbol> mapMarkersSymbols = new ArrayList<>();
   private final SymbolManager symbolManager;
 
@@ -23,6 +24,7 @@ class NavigationSymbolManager {
 
   void addMarkerFor(Point position) {
     SymbolOptions options = createSymbolOptionsFor(position);
+    mapMarkersSymbolOptions.add(options);
     Symbol markerSymbol = symbolManager.create(options);
     mapMarkersSymbols.add(markerSymbol);
   }
@@ -30,6 +32,14 @@ class NavigationSymbolManager {
   void removeAllMarkerSymbols() {
     for (Symbol markerSymbol : mapMarkersSymbols) {
       symbolManager.delete(markerSymbol);
+    }
+    mapMarkersSymbolOptions.clear();
+    mapMarkersSymbols.clear();
+  }
+
+  void redrawMarkers() {
+    for (SymbolOptions options : mapMarkersSymbolOptions) {
+      symbolManager.create(options);
     }
   }
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/SymbolOnStyleLoadedListener.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/SymbolOnStyleLoadedListener.java
@@ -1,17 +1,24 @@
 package com.mapbox.services.android.navigation.ui.v5.map;
 
+import android.graphics.Bitmap;
+
 import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+
+import static com.mapbox.services.android.navigation.ui.v5.map.NavigationSymbolManager.MAPBOX_NAVIGATION_MARKER_NAME;
 
 class SymbolOnStyleLoadedListener implements MapView.OnDidFinishLoadingStyleListener {
 
-  private final NavigationSymbolManager symbolManager;
+  private final MapboxMap mapboxMap;
+  private final Bitmap markerBitmap;
 
-  SymbolOnStyleLoadedListener(NavigationSymbolManager symbolManager) {
-    this.symbolManager = symbolManager;
+  SymbolOnStyleLoadedListener(MapboxMap mapboxMap, Bitmap markerBitmap) {
+    this.mapboxMap = mapboxMap;
+    this.markerBitmap = markerBitmap;
   }
 
   @Override
   public void onDidFinishLoadingStyle() {
-    symbolManager.redrawMarkers();
+    mapboxMap.getStyle().addImage(MAPBOX_NAVIGATION_MARKER_NAME, markerBitmap);
   }
 }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/SymbolOnStyleLoadedListener.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/SymbolOnStyleLoadedListener.java
@@ -1,0 +1,17 @@
+package com.mapbox.services.android.navigation.ui.v5.map;
+
+import com.mapbox.mapboxsdk.maps.MapView;
+
+class SymbolOnStyleLoadedListener implements MapView.OnDidFinishLoadingStyleListener {
+
+  private final NavigationSymbolManager symbolManager;
+
+  SymbolOnStyleLoadedListener(NavigationSymbolManager symbolManager) {
+    this.symbolManager = symbolManager;
+  }
+
+  @Override
+  public void onDidFinishLoadingStyle() {
+    symbolManager.redrawMarkers();
+  }
+}

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/map/SymbolOnStyleLoadedListenerTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/map/SymbolOnStyleLoadedListenerTest.java
@@ -1,0 +1,30 @@
+package com.mapbox.services.android.navigation.ui.v5.map;
+
+import android.graphics.Bitmap;
+
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.Style;
+
+import org.junit.Test;
+
+import static com.mapbox.services.android.navigation.ui.v5.map.NavigationSymbolManager.MAPBOX_NAVIGATION_MARKER_NAME;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class SymbolOnStyleLoadedListenerTest {
+
+  @Test
+  public void onDidFinishLoadingStyle_markerIsAdded() {
+    MapboxMap mapboxMap = mock(MapboxMap.class);
+    Style style = mock(Style.class);
+    when(mapboxMap.getStyle()).thenReturn(style);
+    Bitmap markerBitmap = mock(Bitmap.class);
+    SymbolOnStyleLoadedListener listener = new SymbolOnStyleLoadedListener(mapboxMap, markerBitmap);
+
+    listener.onDidFinishLoadingStyle();
+
+    verify(style).addImage(eq(MAPBOX_NAVIGATION_MARKER_NAME), eq(markerBitmap));
+  }
+}


### PR DESCRIPTION
## Description

The `NavigationMapboxMap` is not redrawing the `Symbol` for the destination marker on Style reload.

- Fixes https://github.com/mapbox/mapbox-navigation-android/issues/1778

## What's the goal?

Ensure we maintain the current state of the `MapboxMap` between style loads. 

## How is it being implemented?

Adding a `SymbolOnStyleLoadedListener` that holds the `NavigationSymbolManager` and redraws based on the current data in the manager.  

## Screenshots or Gifs

**Before**

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/8434572/53652129-59c38680-3c05-11e9-9be4-8d58e842aa18.gif)

**After**

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/8434572/53738813-38a9a280-3e5e-11e9-86dd-425816dd1564.gif)

## How has this been tested?

Can be tested with the changes here in `ComponentNavigationActivity`:
- Long press to load / draw a route
- Hit "start navigation" icon which is currently rigged to reload the `Style` to `DARK`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes