### PR TITLE
Fix plugged wireless battery monitor check

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/BatteryMonitor.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/BatteryMonitor.java
@@ -12,14 +12,10 @@ class BatteryMonitor {
   private static final int DEFAULT_BATTERY_LEVEL = -1;
   private static final int DEFAULT_SCALE = 100;
   private static final float PERCENT_SCALE = 100.0f;
-  private final SdkVersionChecker jellyBeanVersionChecker;
+  private final SdkVersionChecker currentVersionChecker;
 
-  BatteryMonitor() {
-    this.jellyBeanVersionChecker = new SdkVersionChecker(Build.VERSION_CODES.JELLY_BEAN);
-  }
-
-  BatteryMonitor(SdkVersionChecker jellyBeanVersionChecker) {
-    this.jellyBeanVersionChecker = jellyBeanVersionChecker;
+  BatteryMonitor(SdkVersionChecker currentVersionChecker) {
+    this.currentVersionChecker = currentVersionChecker;
   }
 
   float obtainPercentage(Context context) {
@@ -42,7 +38,7 @@ class BatteryMonitor {
     boolean pluggedUsb = chargePlug == BatteryManager.BATTERY_PLUGGED_USB;
     boolean pluggedAc = chargePlug == BatteryManager.BATTERY_PLUGGED_AC;
     boolean pluggedWireless = false;
-    if (jellyBeanVersionChecker.isGreaterThan(Build.VERSION.SDK_INT)) {
+    if (currentVersionChecker.isGreaterThan(Build.VERSION_CODES.JELLY_BEAN)) {
       pluggedWireless = chargePlug == BatteryManager.BATTERY_PLUGGED_WIRELESS;
     }
     boolean isPlugged = pluggedUsb || pluggedAc || pluggedWireless;

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationTelemetry.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationTelemetry.java
@@ -3,6 +3,7 @@ package com.mapbox.services.android.navigation.v5.navigation;
 import android.app.Application;
 import android.content.Context;
 import android.location.Location;
+import android.os.Build;
 import android.support.annotation.NonNull;
 
 import com.mapbox.android.core.location.LocationEngine;
@@ -561,7 +562,8 @@ class NavigationTelemetry implements NavigationMetricListener {
   }
 
   private BatteryEvent buildBatteryEvent() {
-    BatteryMonitor batteryMonitor = new BatteryMonitor();
+    SdkVersionChecker currentSdkVersionChecker = new SdkVersionChecker(Build.VERSION.SDK_INT);
+    BatteryMonitor batteryMonitor = new BatteryMonitor(currentSdkVersionChecker);
     float batteryPercentage = batteryMonitor.obtainPercentage(context);
     boolean isPluggedIn = batteryMonitor.isPluggedIn(context);
     return new BatteryEvent(navigationSessionState.sessionIdentifier(), batteryPercentage, isPluggedIn);

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/BatteryMonitorTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/BatteryMonitorTest.java
@@ -20,7 +20,9 @@ public class BatteryMonitorTest {
 
   @Test
   public void checksBatteryPercentageIsReturned() {
-    BatteryMonitor theBatteryMonitor = new BatteryMonitor();
+    int anySdkVersion = 21;
+    SdkVersionChecker anySdkVersionChecker = new SdkVersionChecker(anySdkVersion);
+    BatteryMonitor theBatteryMonitor = new BatteryMonitor(anySdkVersionChecker);
     Context mockedContext = mock(Context.class);
     Intent mockedIntent = mock(Intent.class);
     BroadcastReceiver mockedBroadcastReceiver = null;
@@ -35,7 +37,9 @@ public class BatteryMonitorTest {
 
   @Test
   public void checksBatteryPercentageUnavailable() {
-    BatteryMonitor theBatteryMonitor = new BatteryMonitor();
+    int anySdkVersion = 19;
+    SdkVersionChecker anySdkVersionChecker = new SdkVersionChecker(anySdkVersion);
+    BatteryMonitor theBatteryMonitor = new BatteryMonitor(anySdkVersionChecker);
     Context mockedContext = mock(Context.class);
     Intent nullIntent = null;
     BroadcastReceiver mockedBroadcastReceiver = null;
@@ -48,7 +52,9 @@ public class BatteryMonitorTest {
 
   @Test
   public void checksBatteryIsUsbPlugged() {
-    BatteryMonitor theBatteryMonitor = new BatteryMonitor();
+    int anySdkVersion = 14;
+    SdkVersionChecker anySdkVersionChecker = new SdkVersionChecker(anySdkVersion);
+    BatteryMonitor theBatteryMonitor = new BatteryMonitor(anySdkVersionChecker);
     Context mockedContext = mock(Context.class);
     Intent mockedIntent = mock(Intent.class);
     BroadcastReceiver mockedBroadcastReceiver = null;
@@ -62,7 +68,9 @@ public class BatteryMonitorTest {
 
   @Test
   public void checksBatteryIsAcPlugged() {
-    BatteryMonitor theBatteryMonitor = new BatteryMonitor();
+    int anySdkVersion = 5;
+    SdkVersionChecker anySdkVersionChecker = new SdkVersionChecker(anySdkVersion);
+    BatteryMonitor theBatteryMonitor = new BatteryMonitor(anySdkVersionChecker);
     Context mockedContext = mock(Context.class);
     Intent mockedIntent = mock(Intent.class);
     BroadcastReceiver mockedBroadcastReceiver = null;
@@ -92,7 +100,9 @@ public class BatteryMonitorTest {
 
   @Test
   public void checksBatteryPluggedUnavailable() {
-    BatteryMonitor theBatteryMonitor = new BatteryMonitor();
+    int anySdkVersion = 3;
+    SdkVersionChecker anySdkVersionChecker = new SdkVersionChecker(anySdkVersion);
+    BatteryMonitor theBatteryMonitor = new BatteryMonitor(anySdkVersionChecker);
     Context mockedContext = mock(Context.class);
     Intent nullIntent = null;
     BroadcastReceiver mockedBroadcastReceiver = null;


### PR DESCRIPTION
## Description

- Fixes `pluggedWireless` check in `BatteryMonitor`

## What's the goal?

`BatteryManager.BATTERY_PLUGGED_WIRELESS` requires API level 17 (greater than `Build.VERSION_CODES.JELLY_BEAN`) and it was reversed by using `currentSdkVersion` (`Build.VERSION.SDK_INT`). Unit tests didn't spot this because `Build.VERSION.SDK_INT` is `0` making the previous implementation check always `true` - `jellyBeanVersionChecker.isGreaterThan(Build.VERSION.SDK_INT)` `16 > 0` 👉 `true`

## How is it being implemented?

This was an implementation error which was solved reversing the order of the check in `BatteryMonitor` and making sure that when creating a new `SdkVersionChecker` the `sdkVersion` passed in is the current one `Build.VERSION.SDK_INT`. Also the default constructor was removed to make this explicit / "force" the developer to look at what you're passing in

## How has this been tested?

- Unit tests were fixed
- Debugged using a Pixel 3 running Android P (`28` greater than Jeylly Bean `16`) and wireless charger and 👀 that `pluggedWireless` was returning `true`

## Checklist

- [x] I have tested locally / staging (including `SNAPSHOT` upstream dependencies if needed)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes