### PR TITLE
Add Android P 440 density support to UrlDensityMap

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/ImageCreator.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/ImageCreator.java
@@ -1,6 +1,7 @@
 package com.mapbox.services.android.navigation.ui.v5.instruction;
 
 import android.content.Context;
+import android.os.Build;
 import android.text.Spannable;
 import android.text.SpannableString;
 import android.text.style.ImageSpan;
@@ -10,6 +11,7 @@ import com.mapbox.api.directions.v5.models.BannerComponents;
 import com.mapbox.api.directions.v5.models.BannerInstructions;
 import com.mapbox.api.directions.v5.models.BannerText;
 import com.mapbox.api.directions.v5.models.LegStep;
+import com.mapbox.services.android.navigation.v5.navigation.SdkVersionChecker;
 import com.squareup.picasso.Picasso;
 
 import java.util.ArrayList;
@@ -126,7 +128,9 @@ public class ImageCreator extends NodeCreator<BannerComponentNode, ImageVerifier
   }
 
   private void initializeData(Context context) {
-    urlDensityMap = new UrlDensityMap(context);
+    SdkVersionChecker currentVersionChecker = new SdkVersionChecker(Build.VERSION.SDK_INT);
+    int displayDensity = context.getResources().getDisplayMetrics().densityDpi;
+    urlDensityMap = new UrlDensityMap(displayDensity, currentVersionChecker);
     targets = new ArrayList<>();
     bannerShieldList = new ArrayList<>();
   }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/UrlDensityMap.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/UrlDensityMap.java
@@ -1,9 +1,10 @@
 package com.mapbox.services.android.navigation.ui.v5.instruction;
 
-import android.content.Context;
 import android.os.Build;
 import android.util.DisplayMetrics;
 import android.util.SparseArray;
+
+import com.mapbox.services.android.navigation.v5.navigation.SdkVersionChecker;
 
 class UrlDensityMap extends SparseArray<String> {
 
@@ -13,38 +14,41 @@ class UrlDensityMap extends SparseArray<String> {
   private static final String FOUR_X = "@4x";
   private static final String DOT_PNG = ".png";
 
-  private int displayDensity;
+  private final int displayDensity;
 
-  UrlDensityMap(Context context) {
+  UrlDensityMap(int displayDensity, SdkVersionChecker sdkVersionChecker) {
     super(4);
-    displayDensity = context.getResources().getDisplayMetrics().densityDpi;
+    this.displayDensity = displayDensity;
     put(DisplayMetrics.DENSITY_LOW, ONE_X + DOT_PNG);
     put(DisplayMetrics.DENSITY_MEDIUM, ONE_X + DOT_PNG);
     put(DisplayMetrics.DENSITY_HIGH, TWO_X + DOT_PNG);
     put(DisplayMetrics.DENSITY_XHIGH, THREE_X + DOT_PNG);
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+    if (sdkVersionChecker.isEqualOrGreaterThan(Build.VERSION_CODES.JELLY_BEAN)) {
       put(DisplayMetrics.DENSITY_XXHIGH, THREE_X + DOT_PNG);
     }
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+    if (sdkVersionChecker.isEqualOrGreaterThan(Build.VERSION_CODES.JELLY_BEAN_MR2)) {
       put(DisplayMetrics.DENSITY_XXXHIGH, FOUR_X + DOT_PNG);
     }
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+    if (sdkVersionChecker.isEqualOrGreaterThan(Build.VERSION_CODES.KITKAT)) {
       put(DisplayMetrics.DENSITY_400, THREE_X + DOT_PNG);
     }
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+    if (sdkVersionChecker.isEqualOrGreaterThan(Build.VERSION_CODES.LOLLIPOP)) {
       put(DisplayMetrics.DENSITY_560, FOUR_X + DOT_PNG);
     }
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
+    if (sdkVersionChecker.isEqualOrGreaterThan(Build.VERSION_CODES.LOLLIPOP_MR1)) {
       put(DisplayMetrics.DENSITY_280, TWO_X + DOT_PNG);
     }
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+    if (sdkVersionChecker.isEqualOrGreaterThan(Build.VERSION_CODES.M)) {
       put(DisplayMetrics.DENSITY_360, THREE_X + DOT_PNG);
       put(DisplayMetrics.DENSITY_420, THREE_X + DOT_PNG);
     }
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
+    if (sdkVersionChecker.isEqualOrGreaterThan(Build.VERSION_CODES.N_MR1)) {
       put(DisplayMetrics.DENSITY_260, TWO_X + DOT_PNG);
       put(DisplayMetrics.DENSITY_300, TWO_X + DOT_PNG);
       put(DisplayMetrics.DENSITY_340, THREE_X + DOT_PNG);
+    }
+    if (sdkVersionChecker.isEqualOrGreaterThan(Build.VERSION_CODES.P)) {
+      put(DisplayMetrics.DENSITY_440, THREE_X + DOT_PNG);
     }
   }
 

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/instruction/UrlDensityMapTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/instruction/UrlDensityMapTest.java
@@ -1,0 +1,199 @@
+package com.mapbox.services.android.navigation.ui.v5.instruction;
+
+import android.content.Context;
+import android.util.DisplayMetrics;
+
+import com.mapbox.services.android.navigation.v5.navigation.SdkVersionChecker;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(RobolectricTestRunner.class)
+public class UrlDensityMapTest {
+
+  @Test
+  public void checksDensityLowReturnsOneXPngUrl() {
+    int lowDensityDpi = 120;
+    SdkVersionChecker anySdkVersionChecker = new SdkVersionChecker(18);
+    UrlDensityMap urlDensityMap = new UrlDensityMap(lowDensityDpi, anySdkVersionChecker);
+    String anyUrl = "any.url";
+
+    String threeXPng = urlDensityMap.get(anyUrl);
+
+    assertEquals(anyUrl + "@1x.png", threeXPng);
+  }
+
+  @Test
+  public void checksDensityMediumReturnsOneXPngUrl() {
+    int mediumDensityDpi = 160;
+    SdkVersionChecker anySdkVersionChecker = new SdkVersionChecker(14);
+    UrlDensityMap urlDensityMap = new UrlDensityMap(mediumDensityDpi, anySdkVersionChecker);
+    String anyUrl = "any.url";
+
+    String threeXPng = urlDensityMap.get(anyUrl);
+
+    assertEquals(anyUrl + "@1x.png", threeXPng);
+  }
+
+  @Test
+  public void checksDensityHighReturnsTwoXPngUrl() {
+    int highDensityDpi = 240;
+    SdkVersionChecker anySdkVersionChecker = new SdkVersionChecker(15);
+    UrlDensityMap urlDensityMap = new UrlDensityMap(highDensityDpi, anySdkVersionChecker);
+    String anyUrl = "any.url";
+
+    String threeXPng = urlDensityMap.get(anyUrl);
+
+    assertEquals(anyUrl + "@2x.png", threeXPng);
+  }
+
+  @Test
+  public void checksDensityXHighReturnsThreeXPngUrl() {
+    int xhighDensityDpi = 320;
+    SdkVersionChecker anySdkVersionChecker = new SdkVersionChecker(21);
+    UrlDensityMap urlDensityMap = new UrlDensityMap(xhighDensityDpi, anySdkVersionChecker);
+    String anyUrl = "any.url";
+
+    String threeXPng = urlDensityMap.get(anyUrl);
+
+    assertEquals(anyUrl + "@3x.png", threeXPng);
+  }
+
+  @Test
+  public void checksAndroidJellyBeanAndDensityXxhighReturnsThreeXPngUrl() {
+    int xxhighDensityDpi = 480;
+    SdkVersionChecker jellyBeanChecker = new SdkVersionChecker(16);
+    UrlDensityMap urlDensityMap = new UrlDensityMap(xxhighDensityDpi, jellyBeanChecker);
+    String anyUrl = "any.url";
+
+    String threeXPng = urlDensityMap.get(anyUrl);
+
+    assertEquals(anyUrl + "@3x.png", threeXPng);
+  }
+
+  @Test
+  public void checksAndroidJellyBeanMr2AndDensityXxxhighReturnsFourXPngUrl() {
+    int xxxhighDensityDpi = 640;
+    SdkVersionChecker jellyBeanMr2Checker = new SdkVersionChecker(18);
+    UrlDensityMap urlDensityMap = new UrlDensityMap(xxxhighDensityDpi, jellyBeanMr2Checker);
+    String anyUrl = "any.url";
+
+    String threeXPng = urlDensityMap.get(anyUrl);
+
+    assertEquals(anyUrl + "@4x.png", threeXPng);
+  }
+
+  @Test
+  public void checksAndroidKitkatAndFourHundredDensityReturnsThreeXPngUrl() {
+    int fourHundredDensityDpi = 400;
+    SdkVersionChecker kitkatChecker = new SdkVersionChecker(19);
+    UrlDensityMap urlDensityMap = new UrlDensityMap(fourHundredDensityDpi, kitkatChecker);
+    String anyUrl = "any.url";
+
+    String threeXPng = urlDensityMap.get(anyUrl);
+
+    assertEquals(anyUrl + "@3x.png", threeXPng);
+  }
+
+  @Test
+  public void checksAndroidLollipopAndFiveHundredAndSixtyDensityReturnsFourXPngUrl() {
+    int fiveHundredAndSixtyDensityDpi = 560;
+    SdkVersionChecker lollipopChecker = new SdkVersionChecker(21);
+    UrlDensityMap urlDensityMap = new UrlDensityMap(fiveHundredAndSixtyDensityDpi, lollipopChecker);
+    String anyUrl = "any.url";
+
+    String threeXPng = urlDensityMap.get(anyUrl);
+
+    assertEquals(anyUrl + "@4x.png", threeXPng);
+  }
+
+  @Test
+  public void checksAndroidLollipopMr1AndTwoHundredAndEightyDensityReturnsTwoXPngUrl() {
+    int twoHundredAndEightyDensityDpi = 280;
+    SdkVersionChecker lollipopMr1Checker = new SdkVersionChecker(22);
+    UrlDensityMap urlDensityMap = new UrlDensityMap(twoHundredAndEightyDensityDpi, lollipopMr1Checker);
+    String anyUrl = "any.url";
+
+    String threeXPng = urlDensityMap.get(anyUrl);
+
+    assertEquals(anyUrl + "@2x.png", threeXPng);
+  }
+
+  @Test
+  public void checksAndroidMAndThreeHundredAndSixtyDensityReturnsThreeXPngUrl() {
+    int threeHundredAndSixtyDensityDpi = 360;
+    SdkVersionChecker mChecker = new SdkVersionChecker(23);
+    UrlDensityMap urlDensityMap = new UrlDensityMap(threeHundredAndSixtyDensityDpi, mChecker);
+    String anyUrl = "any.url";
+
+    String threeXPng = urlDensityMap.get(anyUrl);
+
+    assertEquals(anyUrl + "@3x.png", threeXPng);
+  }
+
+  @Test
+  public void checksAndroidMAndFourHundredAndTwentyDensityReturnsThreeXPngUrl() {
+    int fourHundredAndTwentyDensityDpi = 420;
+    SdkVersionChecker mChecker = new SdkVersionChecker(23);
+    UrlDensityMap urlDensityMap = new UrlDensityMap(fourHundredAndTwentyDensityDpi, mChecker);
+    String anyUrl = "any.url";
+
+    String threeXPng = urlDensityMap.get(anyUrl);
+
+    assertEquals(anyUrl + "@3x.png", threeXPng);
+  }
+
+  @Test
+  public void checksAndroidNMr1AndTwoHundredAndSixtyDensityReturnsTwoXPngUrl() {
+    int twoHundredAndSixtyDensityDpi = 260;
+    SdkVersionChecker nMr1Checker = new SdkVersionChecker(25);
+    UrlDensityMap urlDensityMap = new UrlDensityMap(twoHundredAndSixtyDensityDpi, nMr1Checker);
+    String anyUrl = "any.url";
+
+    String threeXPng = urlDensityMap.get(anyUrl);
+
+    assertEquals(anyUrl + "@2x.png", threeXPng);
+  }
+
+  @Test
+  public void checksAndroidNMr1AndThreeHundredDensityReturnsTwoXPngUrl() {
+    int threeHundredDensityDpi = 300;
+    SdkVersionChecker nMr1Checker = new SdkVersionChecker(25);
+    UrlDensityMap urlDensityMap = new UrlDensityMap(threeHundredDensityDpi, nMr1Checker);
+    String anyUrl = "any.url";
+
+    String threeXPng = urlDensityMap.get(anyUrl);
+
+    assertEquals(anyUrl + "@2x.png", threeXPng);
+  }
+
+  @Test
+  public void checksAndroidNMr1AndThreeHundredAndFortyDensityReturnsThreeXPngUrl() {
+    int threeHundredAndFortyDensityDpi = 340;
+    SdkVersionChecker nMr1Checker = new SdkVersionChecker(25);
+    UrlDensityMap urlDensityMap = new UrlDensityMap(threeHundredAndFortyDensityDpi, nMr1Checker);
+    String anyUrl = "any.url";
+
+    String threeXPng = urlDensityMap.get(anyUrl);
+
+    assertEquals(anyUrl + "@3x.png", threeXPng);
+  }
+
+  @Test
+  public void checksAndroidPAndFourHundredAndFortyDensityReturnsThreeXPngUrl() {
+    int fourHundredAndFortyDensityDpi = 440;
+    SdkVersionChecker androidPChecker = new SdkVersionChecker(28);
+    UrlDensityMap urlDensityMap = new UrlDensityMap(fourHundredAndFortyDensityDpi, androidPChecker);
+    String anyUrl = "any.url";
+
+    String threeXPng = urlDensityMap.get(anyUrl);
+
+    assertEquals(anyUrl + "@3x.png", threeXPng);
+  }
+}

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/SdkVersionChecker.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/SdkVersionChecker.java
@@ -1,14 +1,18 @@
 package com.mapbox.services.android.navigation.v5.navigation;
 
-class SdkVersionChecker {
+public class SdkVersionChecker {
 
   private final int currentSdkVersion;
 
-  SdkVersionChecker(int currentSdkVersion) {
+  public SdkVersionChecker(int currentSdkVersion) {
     this.currentSdkVersion = currentSdkVersion;
   }
 
-  boolean isGreaterThan(int sdkCode) {
+  public boolean isGreaterThan(int sdkCode) {
     return currentSdkVersion > sdkCode;
+  }
+
+  public boolean isEqualOrGreaterThan(int sdkCode) {
+    return currentSdkVersion >= sdkCode;
   }
 }


### PR DESCRIPTION
## Description

- Adds Android P `DisplayMetrics.DENSITY_440` support to `UrlDensityMap`

## What's the goal?

Banner shields were not loaded in Android P devices with `440 dpi` because `UrlDensityMap` wasn't taking into account this new density introduced in Android P and the URL wasn't generated causing the shields to not load at all

## How is it being implemented?

Adding a new check for when the current SDK version is equal or greater than Android P `sdkVersionChecker.isEqualOrGreaterThan(Build.VERSION_CODES.P)` and adding the new density `DisplayMetrics.DENSITY_440` to the `UrlDensityMap` which returns a `@3x.png` URL. Had to make `SdkVersionChecker` `public` so we could use it in `libandroid-navigation-ui` module / `UrlDensityMap` but I want to note that eventually this will be under the `internal` package 👀 https://github.com/mapbox/mapbox-navigation-android/pull/1767

## Screenshots or Gifs

**Before**

![p_440_density_shield](https://user-images.githubusercontent.com/1668582/53820485-d9b95b80-3f39-11e9-8ff5-cbb67bbf7e03.jpeg)

**After**

![fix_p_440_density_shield](https://user-images.githubusercontent.com/1668582/53820500-e1790000-3f39-11e9-8741-7737d511e71e.jpeg)


## How has this been tested?

- Tested on Pixel 3 running Android P (See screenshots above)
- Added Unit tests to `UrlDensityMap`

## Checklist

- [x] I have tested locally / staging (including `SNAPSHOT` upstream dependencies if needed)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

---

In the future, it'd be great to add _Screenshot_ tests ([`screenshot-tests-for-android`](http://facebook.github.io/screenshot-tests-for-android/)) to detect automatically if a shield is not loaded when a new non-supported density is added. 