### PR TITLE
Remove directionsProfile from NavigationUiOptions

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/NavigationApplication.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/NavigationApplication.kt
@@ -61,7 +61,7 @@ class NavigationApplication : MultiDexApplication() {
       Timber.w("Mapbox access token isn't set!")
     }
 
-    val cachingMode = MapboxSearchOptions().setCachingMode(MapboxSearchOptions.CACHE_EXTERNAL)
+    val cachingMode = MapboxSearchOptions().setCachingEnabled(true)
     MapboxSearch.getInstance(applicationContext, mapboxAccessToken, cachingMode)
     Mapbox.getInstance(applicationContext, mapboxAccessToken)
   }

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/NavigationLauncherActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/NavigationLauncherActivity.java
@@ -258,6 +258,7 @@ public class NavigationLauncherActivity extends AppCompatActivity implements OnM
       .accessToken(Mapbox.getAccessToken())
       .origin(currentLocation)
       .destination(destination)
+      .profile(getRouteProfileFromSharedPreferences())
       .alternatives(true);
     setFieldsFromSharedPreferences(builder);
     builder.build()
@@ -327,8 +328,7 @@ public class NavigationLauncherActivity extends AppCompatActivity implements OnM
     }
 
     NavigationLauncherOptions.Builder optionsBuilder = NavigationLauncherOptions.builder()
-      .shouldSimulateRoute(getShouldSimulateRouteFromSharedPreferences())
-      .directionsProfile(getRouteProfileFromSharedPreferences());
+      .shouldSimulateRoute(getShouldSimulateRouteFromSharedPreferences());
     CameraPosition initialPosition = new CameraPosition.Builder()
       .target(new LatLng(currentLocation.latitude(), currentLocation.longitude()))
       .zoom(INITIAL_ZOOM)

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/MapboxNavigationActivity.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/MapboxNavigationActivity.java
@@ -7,7 +7,6 @@ import android.preference.PreferenceManager;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
 
-import com.mapbox.api.directions.v5.DirectionsCriteria;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.services.android.navigation.ui.v5.listeners.NavigationListener;
@@ -133,8 +132,6 @@ public class MapboxNavigationActivity extends AppCompatActivity implements OnNav
     SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(this);
     options.shouldSimulateRoute(preferences
       .getBoolean(NavigationConstants.NAVIGATION_VIEW_SIMULATE_ROUTE, false));
-    options.directionsProfile(preferences
-      .getString(NavigationConstants.NAVIGATION_VIEW_ROUTE_PROFILE_KEY, DirectionsCriteria.PROFILE_DRIVING_TRAFFIC));
   }
 
   private void finishNavigation() {

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationLauncher.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationLauncher.java
@@ -67,7 +67,6 @@ public class NavigationLauncher {
     editor
       .remove(NavigationConstants.NAVIGATION_VIEW_ROUTE_KEY)
       .remove(NavigationConstants.NAVIGATION_VIEW_SIMULATE_ROUTE)
-      .remove(NavigationConstants.NAVIGATION_VIEW_ROUTE_PROFILE_KEY)
       .remove(NavigationConstants.NAVIGATION_VIEW_PREFERENCE_SET_THEME)
       .remove(NavigationConstants.NAVIGATION_VIEW_PREFERENCE_SET_THEME)
       .remove(NavigationConstants.NAVIGATION_VIEW_LIGHT_THEME)
@@ -81,7 +80,6 @@ public class NavigationLauncher {
 
   private static void storeConfiguration(NavigationLauncherOptions options, SharedPreferences.Editor editor) {
     editor.putBoolean(NavigationConstants.NAVIGATION_VIEW_SIMULATE_ROUTE, options.shouldSimulateRoute());
-    editor.putString(NavigationConstants.NAVIGATION_VIEW_ROUTE_PROFILE_KEY, options.directionsProfile());
   }
 
   private static void storeThemePreferences(NavigationLauncherOptions options, SharedPreferences.Editor editor) {

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationLauncherOptions.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationLauncherOptions.java
@@ -3,7 +3,6 @@ package com.mapbox.services.android.navigation.ui.v5;
 import android.support.annotation.Nullable;
 
 import com.google.auto.value.AutoValue;
-import com.mapbox.api.directions.v5.DirectionsCriteria;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.mapboxsdk.camera.CameraPosition;
 
@@ -17,8 +16,6 @@ public abstract class NavigationLauncherOptions extends NavigationUiOptions {
   public abstract static class Builder {
 
     public abstract Builder directionsRoute(DirectionsRoute directionsRoute);
-
-    public abstract Builder directionsProfile(@DirectionsCriteria.ProfileCriteria String directionsProfile);
 
     public abstract Builder lightThemeResId(Integer lightThemeResId);
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationUiOptions.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationUiOptions.java
@@ -9,9 +9,6 @@ public abstract class NavigationUiOptions {
   public abstract DirectionsRoute directionsRoute();
 
   @Nullable
-  public abstract String directionsProfile();
-
-  @Nullable
   public abstract Integer lightThemeResId();
 
   @Nullable

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewOptions.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewOptions.java
@@ -5,7 +5,6 @@ import android.support.design.widget.BottomSheetBehavior.BottomSheetCallback;
 
 import com.google.auto.value.AutoValue;
 import com.mapbox.android.core.location.LocationEngine;
-import com.mapbox.api.directions.v5.DirectionsCriteria;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.services.android.navigation.ui.v5.listeners.BannerInstructionsListener;
 import com.mapbox.services.android.navigation.ui.v5.listeners.FeedbackListener;
@@ -66,8 +65,6 @@ public abstract class NavigationViewOptions extends NavigationUiOptions {
   public abstract static class Builder {
 
     public abstract Builder directionsRoute(DirectionsRoute directionsRoute);
-
-    public abstract Builder directionsProfile(@DirectionsCriteria.ProfileCriteria String directionsProfile);
 
     public abstract Builder lightThemeResId(Integer lightThemeResId);
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationConstants.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationConstants.java
@@ -145,11 +145,6 @@ public final class NavigationConstants {
 
   static final String NON_NULL_APPLICATION_CONTEXT_REQUIRED = "Non-null application context required.";
 
-  public static final Float[] WAYNAME_OFFSET = {0.0f, 40.0f};
-  public static final String MAPBOX_LOCATION_SOURCE = "mapbox-location-source";
-  public static final String MAPBOX_WAYNAME_LAYER = "mapbox-wayname-layer";
-  public static final String MAPBOX_WAYNAME_ICON = "mapbox-wayname-icon";
-
   // Bundle variable keys
   public static final String NAVIGATION_VIEW_ROUTE_KEY = "route_json";
   public static final String NAVIGATION_VIEW_SIMULATE_ROUTE = "navigation_view_simulate_route";


### PR DESCRIPTION
## Description

The `NavigationUiOptions#directionsProfile` is no longer being used and should be removed to prevent developer confusion.  

- Fixes #1786 

## What's the goal?

The goal is to clean up the `NavigationUiOptions#directionsProfile` field as it's no longer being used.

## How is it being implemented?

Deleting `NavigationUiOptions#directionsProfile` and anywhere it was referenced in our internal code.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code