### PR TITLE
Update circle.yml gradle options to fix intermittent unit test failures

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -21,6 +21,7 @@ jobs:
       JVM_OPTS: -Xmx3200m
       BUILDTYPE: Debug
       IS_LOCAL_DEVELOPMENT: false
+      GRADLE_OPTS: -Xmx2048m -Dorg.gradle.daemon=false
     steps:
       - checkout
       - restore_cache:
@@ -38,7 +39,7 @@ jobs:
       - run:
           name: Run unit-test, generate Jacoco test report and Post code coverage report to Codecov.io
           command: |
-            ./gradlew testDebugUnitTestCoverage --no-daemon
+            ./gradlew testDebugUnitTestCoverage
             pip install --user codecov && /root/.local/bin/codecov
       - run:
           name: Build release to test ProGuard rules


### PR DESCRIPTION
## Description

Updating `circle.yml` with gradle options to add more virtual memory when running out unit tests.

- Fixes #1790 

## What's the goal?

It looks like we are running into cases where virtual memory is running short and causing kernel OOM (Out of Memory).  CircleCI is then forcibly failing our unit tests as a result. 

## How is it being implemented?

Updating the `circle.yml` `environment` with `GRADLE_OPTS: -Xmx2048m -Dorg.gradle.daemon=false`

## How has this been tested?

Running CI on this branch trying to reproduce.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes

cc @springmeyer 