### PR TITLE
Add manifest placeholder for enabling / disabling Crashlytics automatically

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -58,10 +58,12 @@ android {
   buildTypes {
     debug {
       testCoverageEnabled = false
+      manifestPlaceholders = [enableCrashReporting:"false"]
     }
     release {
       minifyEnabled true
       signingConfig signingConfigs.release
+      manifestPlaceholders = [enableCrashReporting:"true"]
     }
   }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,8 @@
     <uses-permission android:name="android.permission.VIBRATE"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 
+    <meta-data android:name="firebase_crashlytics_collection_enabled" android:value="${enableCrashReporting}" />
+
     <application
         android:name=".NavigationApplication"
         android:allowBackup="true"


### PR DESCRIPTION
## Description

Adds `manifestPlaceholders` for enabling / disabling reporting automatically depending on the `buildType` - `RELEASE` / `DEBUG` respectively

## What's the goal?

Avoid unnecessary noise from Crashlytics when testing `DEBUG` APKs

## How is it being implemented?

Using `manifestPlaceholders` is pretty straightforward to change the value automatically to `true` or `false` depending on the `buildType` and use it in the `AndroidManifest` (`<meta-data android:name="firebase_crashlytics_collection_enabled" android:value="${enableCrashReporting}" />` to enable / disable reporting

## How has this been tested?

- 👀 the `value` from the `Merged Manifest` `true` for `RELEASE` builds / `false` for `DEBUG` ones

## Checklist

- [x] I have tested locally / staging (including `SNAPSHOT` upstream dependencies if needed)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes