### PR TITLE
Fix missing cancel event / not sent

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationLifecycleMonitor.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationLifecycleMonitor.java
@@ -54,7 +54,6 @@ public class NavigationLifecycleMonitor implements Application.ActivityLifecycle
 
   @Override
   public void onActivityDestroyed(Activity activity) {
-    NavigationTelemetry.getInstance().endSession(activity.isChangingConfigurations());
     if (activity.isFinishing()) {
       activity.getApplication().unregisterActivityLifecycleCallbacks(this);
     }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationService.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationService.java
@@ -71,6 +71,7 @@ public class NavigationService extends Service {
    * Removes the location / route listeners and  quits the thread.
    */
   void endNavigation() {
+    NavigationTelemetry.getInstance().endSession();
     routeFetcher.clearListeners();
     locationUpdater.removeLocationUpdates();
     notificationProvider.shutdown(getApplication());


### PR DESCRIPTION
## Description

Fixes missing cancel event / not sent when a session is stopped

Regression from https://github.com/mapbox/mapbox-navigation-android/pull/1772

## What's the goal?

We noticed missing "cancel" events when testing [`NavigationLauncherActivity`](https://github.com/mapbox/mapbox-navigation-android/blob/master/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/NavigationLauncherActivity.java) from the test app so the goal is to update `NavigationTelemetry` to provide consistent cancel events so we can gain better insight into customer usage of the SDK

## How is it being implemented?

Problem was that we were disabling telemetry https://github.com/mapbox/mapbox-navigation-android/blob/81e9e5ea3d0a9d3c427dd87d5f996777736d0a58/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationTelemetry.java#L194 via https://github.com/mapbox/mapbox-navigation-android/blob/81e9e5ea3d0a9d3c427dd87d5f996777736d0a58/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationLifecycleMonitor.java#L57 before adding the cancel event to the queue which happened when stopping navigation https://github.com/mapbox/mapbox-navigation-android/blob/81e9e5ea3d0a9d3c427dd87d5f996777736d0a58/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java#L359 https://github.com/mapbox/mapbox-navigation-android/blob/81e9e5ea3d0a9d3c427dd87d5f996777736d0a58/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationTelemetry.java#L180-L184 and at that point that doesn't have any effect. This is: `endSession` which stops telemetry because of `NavigationTelemetry.getInstance().endSession(activity.isChangingConfigurations());` when the `Activity` is destroyed and then `stopSession` which tries to add the cancel event without luck because telemetry was stopped when calling `MapboxNavigation#stopNavigation` i.e. the lifecycle monitor is hit before the `Activity#onDestroy`.

~~Sending the cancel event within `endSession` ensures that the event is always sent properly because telemetry is still available / accepting events.~~

Per @danesfeder's comment

> Rather than move the cancel event back into `endSession`, I think we should adjust where `endSession` itself is invoked (currently `Activity#onDestroy`).  Maybe it makes more sense to do it in `Service#onDestroy`?  As this should be guaranteed to occur after `stopNavigation` > `stopSession`

Approach finally taken is to keep sending the cancel event within `NavigationTelemetry#stopSession` but move the `NavigationTelemetry#endSession` call from `NavigationLifecycleMonitor#onActivityDestroyed` to `NavigationService#endNavigation`. We should test thoroughly that this change doesn't introduce any other issues. 

## How has this been tested?

- [x] 👀 locally with `Timber` logging ensuring `cancel` events were added to the payload
- [ ] Mode report to verify 100% consistent `cancel` events

## Checklist

- [x] I have tested locally / staging (including `SNAPSHOT` upstream dependencies if needed)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes