### PR TITLE
Fix event simulation flag field wrongly reported

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/location/replay/ReplayRouteLocationConverter.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/location/replay/ReplayRouteLocationConverter.java
@@ -18,7 +18,8 @@ class ReplayRouteLocationConverter {
   private static final int ONE_SECOND_IN_MILLISECONDS = 1000;
   private static final double ONE_KM_IN_METERS = 1000d;
   private static final int ONE_HOUR_IN_SECONDS = 3600;
-  private static final String REPLAY_ROUTE = "ReplayRouteLocation";
+  private static final String REPLAY_ROUTE = "com.mapbox.services.android.navigation.v5.location.replay"
+    + ".ReplayRouteLocationEngine";
   private DirectionsRoute route;
   private int speed;
   private int delay;

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/location/replay/ReplayRouteLocationEngine.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/location/replay/ReplayRouteLocationEngine.java
@@ -34,7 +34,8 @@ public class ReplayRouteLocationEngine implements LocationEngine, Runnable {
   private static final int ZERO = 0;
   private static final String SPEED_MUST_BE_GREATER_THAN_ZERO_KM_H = "Speed must be greater than 0 km/h.";
   private static final String DELAY_MUST_BE_GREATER_THAN_ZERO_SECONDS = "Delay must be greater than 0 seconds.";
-  private static final String REPLAY_ROUTE = "ReplayRouteLocation";
+  private static final String REPLAY_ROUTE = "com.mapbox.services.android.navigation.v5.location.replay"
+    + ".ReplayRouteLocationEngine";
   private ReplayRouteLocationConverter converter;
   private int speed = DEFAULT_SPEED;
   private int delay = DEFAULT_DELAY;

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
@@ -276,7 +276,7 @@ public class MapboxNavigation implements ServiceConnection {
   public void setLocationEngine(@NonNull LocationEngine locationEngine) {
     this.locationEngine = locationEngine;
     // Setup telemetry with new engine
-    navigationTelemetry.updateLocationEngineName(locationEngine);
+    navigationTelemetry.updateLocationEngineNameAndSimulation(locationEngine);
     // Notify service to get new location engine.
     if (isServiceAvailable()) {
       navigationService.updateLocationEngine(locationEngine);
@@ -848,7 +848,7 @@ public class MapboxNavigation implements ServiceConnection {
 
   private void initializeTelemetry() {
     navigationTelemetry = obtainTelemetry();
-    navigationTelemetry.initialize(applicationContext, accessToken, this, locationEngine);
+    navigationTelemetry.initialize(applicationContext, accessToken, this);
   }
 
   private NavigationTelemetry obtainTelemetry() {
@@ -884,7 +884,7 @@ public class MapboxNavigation implements ServiceConnection {
     this.directionsRoute = directionsRoute;
     mapboxNavigator.updateRoute(directionsRoute.toJson());
     if (!isBound) {
-      navigationTelemetry.startSession(directionsRoute);
+      navigationTelemetry.startSession(directionsRoute, locationEngine);
       startNavigationService();
       navigationEventDispatcher.onNavigationEvent(true);
     } else {


### PR DESCRIPTION
## Description

Fixes event `simulation` flag field wrongly reported

Regression from https://github.com/mapbox/mapbox-navigation-android/pull/1039

## What's the goal?

We noticed wrong event "simulation" fields when testing using the test app reporting `false` values when using `ReplayRouteLocationEngine` so the goal is to update `replay` related code / `NavigationTelemetry` to provide consistent data so we can gain better insight into customer usage of the SDK


## How is it being implemented?

Problem is that `simulation` is calculated checking if the location provider equals to https://github.com/mapbox/mapbox-navigation-android/blob/81e9e5ea3d0a9d3c427dd87d5f996777736d0a58/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationTelemetry.java#L47-L48 👉 https://github.com/mapbox/mapbox-navigation-android/blob/81e9e5ea3d0a9d3c427dd87d5f996777736d0a58/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationTelemetry.java#L169 https://github.com/mapbox/mapbox-navigation-android/blob/81e9e5ea3d0a9d3c427dd87d5f996777736d0a58/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationTelemetry.java#L425 and https://github.com/mapbox/mapbox-navigation-android/blob/81e9e5ea3d0a9d3c427dd87d5f996777736d0a58/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationTelemetry.java#L446 in `NavigationTelemetry` when `ReplayRouteLocationEngine` and `ReplayRouteLocationConverter` are using a different string `ReplayRouteLocation` (`"ReplayRouteLocation"`) which doesn't match.

Fixing the provider to `"com.mapbox.services.android.navigation.v5.location.replay".ReplayRouteLocationEngine"` in `ReplayRouteLocationEngine` and `ReplayRouteLocationConverter` solves the issue here.

## How has this been tested?

- [x] 👀 locally with `Timber` logging ensuring that `simulation` is `true` when in simulation mode
- [ ] Mode report to verify that `simulation` field is 100% consistent

## Checklist

- [x] I have tested locally / staging (including `SNAPSHOT` upstream dependencies if needed)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
