### PR TITLE
Added attribute to capture event name in performance trace event

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/BatteryEvent.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/BatteryEvent.java
@@ -8,9 +8,10 @@ import android.os.Parcelable;
 class BatteryEvent extends NavigationPerformanceEvent implements Parcelable {
   private static final String BATTERY_PERCENTAGE_KEY = "battery_percentage";
   private static final String IS_PLUGGED_IN_KEY = "is_plugged_in";
+  private static final String BATTERY_EVENT_NAME = "battery_event";
 
   BatteryEvent(String sessionId, float batteryPercentage, boolean isPluggedIn) {
-    super(sessionId);
+    super(sessionId, BATTERY_EVENT_NAME);
 
     addCounter(new FloatCounter(BATTERY_PERCENTAGE_KEY, batteryPercentage));
     addAttribute(new Attribute(IS_PLUGGED_IN_KEY, String.valueOf(isPluggedIn)));

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/InitialGpsEvent.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/InitialGpsEvent.java
@@ -7,9 +7,10 @@ import android.os.Parcelable;
 @SuppressWarnings("ParcelableCreator")
 class InitialGpsEvent extends NavigationPerformanceEvent implements Parcelable {
   private static final String TIME_TO_FIRST_GPS = "time_to_first_gps";
+  private static final String INITIAL_GPS_EVENT_NAME = "initial_gps_event";
 
   InitialGpsEvent(double elapsedTime, String sessionId) {
-    super(sessionId);
+    super(sessionId, INITIAL_GPS_EVENT_NAME);
     addCounter(new DoubleCounter(TIME_TO_FIRST_GPS, elapsedTime));
   }
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationPerformanceEvent.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationPerformanceEvent.java
@@ -18,6 +18,7 @@ class NavigationPerformanceEvent extends Event implements Parcelable {
   private static final String DATE_AND_TIME_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
   private static final SimpleDateFormat dateFormat = new SimpleDateFormat(DATE_AND_TIME_PATTERN, Locale.US);
   private static final String PERFORMANCE_TRACE = "mobile.performance_trace";
+  private static final String EVENT_NAME = "event_name";
 
   private final String event;
   private final String created;
@@ -25,12 +26,13 @@ class NavigationPerformanceEvent extends Event implements Parcelable {
   private final List<Counter> counters;
   private final List<Attribute> attributes;
 
-  NavigationPerformanceEvent(String sessionId) {
+  NavigationPerformanceEvent(String sessionId, String eventName) {
     this.event = PERFORMANCE_TRACE;
     this.created = obtainCurrentDate();
     this.sessionId = sessionId;
     this.counters = new ArrayList<>();
     this.attributes = new ArrayList<>();
+    attributes.add(new Attribute(EVENT_NAME, eventName));
   }
 
   private String obtainCurrentDate() {

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/RouteRetrievalEvent.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/RouteRetrievalEvent.java
@@ -8,9 +8,10 @@ import android.os.Parcelable;
 class RouteRetrievalEvent extends NavigationPerformanceEvent implements Parcelable {
   private static final String ELAPSED_TIME_NAME = "elapsed_time";
   private static final String ROUTE_UUID_NAME = "route_uuid";
+  private static final String ROUTE_RETRIEVAL_EVENT_NAME = "route_retrieval_event";
 
   RouteRetrievalEvent(double elapsedTime, String routeUuid, String sessionId) {
-    super(sessionId);
+    super(sessionId, ROUTE_RETRIEVAL_EVENT_NAME);
 
     addCounter(new DoubleCounter(ELAPSED_TIME_NAME, elapsedTime));
     addAttribute(new Attribute(ROUTE_UUID_NAME, routeUuid));


### PR DESCRIPTION
## Description

Added attribute to capture event name in performance trace event

## What's the goal?

This will make it easier/clearer to query different performance events

## How has this been tested?

- [x]  Test that events show up in mode properly