### PR TITLE
Adjust NavigationCamera zoom reset behavior

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/camera/ResetCancelableCallback.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/camera/ResetCancelableCallback.java
@@ -1,0 +1,22 @@
+package com.mapbox.services.android.navigation.ui.v5.camera;
+
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+
+class ResetCancelableCallback implements MapboxMap.CancelableCallback {
+
+  private final NavigationCamera camera;
+
+  ResetCancelableCallback(NavigationCamera camera) {
+    this.camera = camera;
+  }
+
+  @Override
+  public void onCancel() {
+    // No-impl
+  }
+
+  @Override
+  public void onFinish() {
+    camera.updateIsResetting(false);
+  }
+}

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/camera/DynamicCameraTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/camera/DynamicCameraTest.java
@@ -51,6 +51,17 @@ public class DynamicCameraTest extends BaseTest {
   }
 
   @Test
+  public void onIsResetting_dynamicCameraReturnsDefault() throws Exception {
+    RouteInformation routeInformation = RouteInformation.create(buildDirectionsRoute(), null, null);
+    DynamicCamera cameraEngine = buildDynamicCamera();
+    cameraEngine.forceResetZoomLevel();
+
+    double zoom = cameraEngine.zoom(routeInformation);
+
+    assertEquals(15d, zoom);
+  }
+
+  @Test
   public void onInformationFromRoute_engineCreatesCorrectTilt() throws Exception {
     DynamicCamera cameraEngine = buildDynamicCamera();
     RouteInformation routeInformation = RouteInformation.create(buildDirectionsRoute(), null, null);

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/camera/NavigationCameraTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/camera/NavigationCameraTest.java
@@ -1,11 +1,13 @@
 package com.mapbox.services.android.navigation.ui.v5.camera;
 
+import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.location.LocationComponent;
 import com.mapbox.mapboxsdk.location.OnLocationCameraTransitionListener;
 import com.mapbox.mapboxsdk.location.modes.CameraMode;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.services.android.navigation.ui.v5.BaseTest;
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation;
+import com.mapbox.services.android.navigation.v5.navigation.camera.RouteInformation;
 import com.mapbox.services.android.navigation.v5.routeprogress.ProgressChangeListener;
 
 import org.junit.Test;
@@ -18,6 +20,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class NavigationCameraTest extends BaseTest {
 
@@ -81,6 +84,21 @@ public class NavigationCameraTest extends BaseTest {
   }
 
   @Test
+  public void onResetCamera_dynamicCameraIsReset() {
+    MapboxMap mapboxMap = mock(MapboxMap.class);
+    when(mapboxMap.getCameraPosition()).thenReturn(mock(CameraPosition.class));
+    MapboxNavigation navigation = mock(MapboxNavigation.class);
+    DynamicCamera dynamicCamera = mock(DynamicCamera.class);
+    when(navigation.getCameraEngine()).thenReturn(dynamicCamera);
+    RouteInformation currentRouteInformation = mock(RouteInformation.class);
+    NavigationCamera camera = buildCamera(mapboxMap, navigation, currentRouteInformation);
+
+    camera.resetCameraPositionWith(NavigationCamera.NAVIGATION_TRACKING_MODE_GPS);
+
+    verify(dynamicCamera).forceResetZoomLevel();
+  }
+
+  @Test
   public void onStartWithNullRoute_progressListenerIsAdded() {
     MapboxNavigation navigation = mock(MapboxNavigation.class);
     ProgressChangeListener listener = mock(ProgressChangeListener.class);
@@ -111,6 +129,13 @@ public class NavigationCameraTest extends BaseTest {
   }
 
   private NavigationCamera buildCamera(MapboxNavigation navigation, ProgressChangeListener listener) {
-    return new NavigationCamera(mock(MapboxMap.class), navigation, listener, mock(LocationComponent.class));
+    return new NavigationCamera(mock(MapboxMap.class), navigation, listener,
+      mock(LocationComponent.class), mock(RouteInformation.class));
+  }
+
+  private NavigationCamera buildCamera(MapboxMap mapboxMap, MapboxNavigation navigation,
+                                       RouteInformation routeInformation) {
+    return new NavigationCamera(mapboxMap, navigation, mock(ProgressChangeListener.class),
+      mock(LocationComponent.class), routeInformation);
   }
 }

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/camera/ResetCancelableCallbackTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/camera/ResetCancelableCallbackTest.java
@@ -1,0 +1,20 @@
+package com.mapbox.services.android.navigation.ui.v5.camera;
+
+import org.junit.Test;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class ResetCancelableCallbackTest {
+
+  @Test
+  public void onFinish_dynamicCameraIsReset() {
+    NavigationCamera camera = mock(NavigationCamera.class);
+    ResetCancelableCallback callback = new ResetCancelableCallback(camera);
+
+    callback.onFinish();
+
+    verify(camera).updateIsResetting(eq(false));
+  }
+}


### PR DESCRIPTION
## Description

This PR adjusts the behavior of `NavigationCamera` and `DynamicCamera` so that the `NavigationCamera` will wait for a reset animation with the `LocationComponent` to finish before allowing another route-following animation.

- Fixes #1801 

## What's the goal?

The goal of the PR is to ensure the reset camera animation finishes before we allow another animation, preventing the interruption.

## How is it being implemented?

We have added a `MapboxMap.CancelableCallback` that will let us know when the reset animation is finished and we may proceed with normal route-following animations.

## Screenshots or Gifs

Old behavior as ticketed in #1801:

![](https://user-images.githubusercontent.com/8434572/54037648-a28eb880-418c-11e9-88b2-53d0c834fe6d.gif) 

Fixed behavior in this PR:

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/8434572/54038171-e2a26b00-418d-11e9-81a5-12dd85792a2c.gif)

## How has this been tested?

- Tested with / without simulation enabled (harder to reproduce with simulation as there are a steady stream of updates to fixup the camera)
- Unit tests were added to verify the reset behavior

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes