### PR TITLE
Add RawLocationListener for direct updates from LocationEngine

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/location/RawLocationListener.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/location/RawLocationListener.java
@@ -1,0 +1,18 @@
+package com.mapbox.services.android.navigation.v5.location;
+
+import android.location.Location;
+
+/**
+ * A listener for getting {@link Location} updates as they are
+ * received directly from the {@link com.mapbox.android.core.location.LocationEngine}
+ * running in {@link com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation}.
+ */
+public interface RawLocationListener {
+
+  /**
+   * Invoked as soon as a new {@link Location} has been received.
+   *
+   * @param rawLocation un-snapped update
+   */
+  void onLocationUpdate(Location rawLocation);
+}

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/LocationUpdater.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/LocationUpdater.java
@@ -17,13 +17,15 @@ class LocationUpdater {
 
   private final LocationEngineCallback<LocationEngineResult> callback = new CurrentLocationEngineCallback(this);
   private final RouteProcessorBackgroundThread thread;
+  private final NavigationEventDispatcher dispatcher;
   private LocationEngine locationEngine;
   private LocationEngineRequest request;
 
   @SuppressLint("MissingPermission")
-  LocationUpdater(RouteProcessorBackgroundThread thread, LocationEngine locationEngine,
-                  LocationEngineRequest request) {
+  LocationUpdater(RouteProcessorBackgroundThread thread, NavigationEventDispatcher dispatcher,
+                  LocationEngine locationEngine, LocationEngineRequest request) {
     this.thread = thread;
+    this.dispatcher = dispatcher;
     this.locationEngine = locationEngine;
     this.request = request;
     requestInitialLocationUpdates(locationEngine, request);
@@ -42,6 +44,7 @@ class LocationUpdater {
   void onLocationChanged(Location location) {
     if (location != null) {
       thread.updateLocation(location);
+      dispatcher.onLocationUpdate(location);
       NavigationTelemetry.getInstance().updateLocation(location);
     }
   }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
@@ -14,6 +14,7 @@ import com.mapbox.android.core.location.LocationEngineProvider;
 import com.mapbox.android.core.location.LocationEngineRequest;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.navigator.Navigator;
+import com.mapbox.services.android.navigation.v5.location.RawLocationListener;
 import com.mapbox.services.android.navigation.v5.milestone.BannerInstructionMilestone;
 import com.mapbox.services.android.navigation.v5.milestone.Milestone;
 import com.mapbox.services.android.navigation.v5.milestone.MilestoneEventListener;
@@ -174,6 +175,8 @@ public class MapboxNavigation implements ServiceConnection {
     removeProgressChangeListener(null);
     removeMilestoneEventListener(null);
     removeNavigationEventListener(null);
+    removeFasterRouteListener(null);
+    removeRawLocationListener(null);
   }
 
   // Public APIs
@@ -551,6 +554,33 @@ public class MapboxNavigation implements ServiceConnection {
   @SuppressWarnings("WeakerAccess") // Public exposed for usage outside SDK
   public void removeFasterRouteListener(@Nullable FasterRouteListener fasterRouteListener) {
     navigationEventDispatcher.removeFasterRouteListener(fasterRouteListener);
+  }
+
+  /**
+   * This adds a new raw location listener which is invoked when a new {@link android.location.Location}
+   * has been pushed by the {@link LocationEngine}.
+   * <p>
+   * It is not possible to add the same listener implementation more then once and a warning will be
+   * printed in the log if attempted.
+   *
+   * @param rawLocationListener an implementation of {@code RawLocationListener}
+   */
+  public void addRawLocationListener(@NonNull RawLocationListener rawLocationListener) {
+    navigationEventDispatcher.addRawLocationListener(rawLocationListener);
+  }
+
+  /**
+   * This removes a specific raw location listener by passing in the instance of it or you can pass in
+   * null to remove all the listeners. When {@link #onDestroy()} is called, all listeners
+   * get removed automatically, removing the requirement for developers to manually handle this.
+   * <p>
+   * If the listener you are trying to remove does not exist in the list, a warning will be printed
+   * in the log.
+   *
+   * @param rawLocationListener an implementation of {@code RawLocationListener}
+   */
+  public void removeRawLocationListener(@Nullable RawLocationListener rawLocationListener) {
+    navigationEventDispatcher.removeRawLocationListener(rawLocationListener);
   }
 
   // Custom engines

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationService.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationService.java
@@ -120,7 +120,8 @@ public class NavigationService extends Service {
   private void initializeLocationUpdater(MapboxNavigation mapboxNavigation) {
     LocationEngine locationEngine = mapboxNavigation.getLocationEngine();
     LocationEngineRequest locationEngineRequest = mapboxNavigation.retrieveLocationEngineRequest();
-    locationUpdater = new LocationUpdater(thread, locationEngine, locationEngineRequest);
+    NavigationEventDispatcher dispatcher = mapboxNavigation.getEventDispatcher();
+    locationUpdater = new LocationUpdater(thread, dispatcher, locationEngine, locationEngineRequest);
   }
 
   private void startForegroundNotification(NavigationNotification navigationNotification) {

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/LocationUpdaterTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/LocationUpdaterTest.java
@@ -24,7 +24,8 @@ public class LocationUpdaterTest {
     RouteProcessorBackgroundThread thread = mock(RouteProcessorBackgroundThread.class);
     LocationEngine locationEngine = mock(LocationEngine.class);
     LocationEngineRequest locationEngineRequest = mock(LocationEngineRequest.class);
-    LocationUpdater locationUpdater = new LocationUpdater(thread, locationEngine, locationEngineRequest);
+    LocationUpdater locationUpdater = new LocationUpdater(thread, mock(NavigationEventDispatcher.class),
+      locationEngine, locationEngineRequest);
 
     locationUpdater.updateLocationEngine(mock(LocationEngine.class));
 
@@ -36,7 +37,8 @@ public class LocationUpdaterTest {
     RouteProcessorBackgroundThread thread = mock(RouteProcessorBackgroundThread.class);
     LocationEngine locationEngine = mock(LocationEngine.class);
     LocationEngineRequest locationEngineRequest = mock(LocationEngineRequest.class);
-    LocationUpdater locationUpdater = new LocationUpdater(thread, locationEngine, locationEngineRequest);
+    LocationUpdater locationUpdater = new LocationUpdater(thread, mock(NavigationEventDispatcher.class),
+      locationEngine, locationEngineRequest);
 
     locationUpdater.updateLocationEngineRequest(mock(LocationEngineRequest.class));
 
@@ -48,7 +50,8 @@ public class LocationUpdaterTest {
     RouteProcessorBackgroundThread thread = mock(RouteProcessorBackgroundThread.class);
     LocationEngine locationEngine = mock(LocationEngine.class);
     LocationEngineRequest locationEngineRequest = mock(LocationEngineRequest.class);
-    LocationUpdater locationUpdater = new LocationUpdater(thread, locationEngine, locationEngineRequest);
+    LocationUpdater locationUpdater = new LocationUpdater(thread, mock(NavigationEventDispatcher.class),
+      locationEngine, locationEngineRequest);
 
     locationUpdater.removeLocationUpdates();
 
@@ -60,7 +63,8 @@ public class LocationUpdaterTest {
     RouteProcessorBackgroundThread thread = mock(RouteProcessorBackgroundThread.class);
     LocationEngine locationEngine = mock(LocationEngine.class);
     LocationEngineRequest locationEngineRequest = mock(LocationEngineRequest.class);
-    LocationUpdater locationUpdater = new LocationUpdater(thread, locationEngine, locationEngineRequest);
+    LocationUpdater locationUpdater = new LocationUpdater(thread, mock(NavigationEventDispatcher.class),
+      locationEngine, locationEngineRequest);
 
     locationUpdater.updateLocationEngine(mock(LocationEngine.class));
 
@@ -73,7 +77,8 @@ public class LocationUpdaterTest {
     RouteProcessorBackgroundThread thread = mock(RouteProcessorBackgroundThread.class);
     LocationEngine locationEngine = mock(LocationEngine.class);
     LocationEngineRequest locationEngineRequest = mock(LocationEngineRequest.class);
-    LocationUpdater locationUpdater = new LocationUpdater(thread, locationEngine, locationEngineRequest);
+    LocationUpdater locationUpdater = new LocationUpdater(thread, mock(NavigationEventDispatcher.class),
+      locationEngine, locationEngineRequest);
 
     locationUpdater.updateLocationEngineRequest(mock(LocationEngineRequest.class));
 
@@ -94,5 +99,19 @@ public class LocationUpdaterTest {
     callback.onSuccess(result);
 
     verify(locationUpdater).onLocationChanged(location);
+  }
+
+  @Test
+  public void onSuccess_dispatcherReceivesLocation() {
+    RouteProcessorBackgroundThread thread = mock(RouteProcessorBackgroundThread.class);
+    NavigationEventDispatcher dispatcher = mock(NavigationEventDispatcher.class);
+    LocationEngine locationEngine = mock(LocationEngine.class);
+    LocationEngineRequest locationEngineRequest = mock(LocationEngineRequest.class);
+    Location location = mock(Location.class);
+    LocationUpdater locationUpdater = new LocationUpdater(thread, dispatcher, locationEngine, locationEngineRequest);
+
+    locationUpdater.onLocationChanged(location);
+
+    verify(dispatcher).onLocationUpdate(eq(location));
   }
 }

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEventDispatcherTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEventDispatcherTest.java
@@ -11,6 +11,7 @@ import com.mapbox.api.directions.v5.DirectionsAdapterFactory;
 import com.mapbox.api.directions.v5.models.DirectionsResponse;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.services.android.navigation.v5.BaseTest;
+import com.mapbox.services.android.navigation.v5.location.RawLocationListener;
 import com.mapbox.services.android.navigation.v5.milestone.BannerInstructionMilestone;
 import com.mapbox.services.android.navigation.v5.milestone.Milestone;
 import com.mapbox.services.android.navigation.v5.milestone.MilestoneEventListener;
@@ -29,6 +30,7 @@ import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
 
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -363,6 +365,31 @@ public class NavigationEventDispatcherTest extends BaseTest {
     dispatcher.onMilestoneEvent(routeProgress, instruction, milestone);
 
     verify(metricEventListener, times(0)).onOffRouteEvent(location);
+  }
+
+  @Test
+  public void onLocationUpdate_rawLocationListenerIsInvoked() {
+    RawLocationListener listener = mock(RawLocationListener.class);
+    Location location = mock(Location.class);
+    NavigationEventDispatcher dispatcher = new NavigationEventDispatcher(mock(RouteUtils.class));
+    dispatcher.addRawLocationListener(listener);
+
+    dispatcher.onLocationUpdate(location);
+
+    verify(listener).onLocationUpdate(eq(location));
+  }
+
+  @Test
+  public void onLocationUpdate_removedRawLocationListenerIsNotInvoked() {
+    RawLocationListener listener = mock(RawLocationListener.class);
+    Location location = mock(Location.class);
+    NavigationEventDispatcher dispatcher = new NavigationEventDispatcher(mock(RouteUtils.class));
+    dispatcher.addRawLocationListener(listener);
+    dispatcher.removeRawLocationListener(listener);
+
+    dispatcher.onLocationUpdate(location);
+
+    verify(listener, times(0)).onLocationUpdate(eq(location));
   }
 
   @NonNull


### PR DESCRIPTION
## Description

This PR adds a `RawLocationListener` that you can add or remove to `MapboxNavigation` to gain access to the raw `Location` updates from the `LocationEngine` prior to them being pushed to our route-following / snapping logic.  

## What's the goal?

Because `ProgressChangeListener` fires every second for the duration of the navigation session / provides modified "snapped" locations, this listener allows actually insight into the GPS behavior. 

## How is it being implemented?

Adding a `RawLocationListener` and using the `NavigationEventDispatcher` to push the `Location` updates in the `LocationUpdater`.  

## Screenshots or Gifs

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/8434572/54046147-847f8300-41a1-11e9-9bb1-75fdd5332f1f.gif)

## How has this been tested?

- Unit tests have been added 
- Test with both `Replay` / actual `LocationEngine`s 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes