### PR TITLE
Update NavigationView NavigationListener to triggered when initialized

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
@@ -629,8 +629,8 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
 
   private void initializeNavigation(NavigationViewOptions options) {
     establish(options);
-    MapboxNavigation navigation = navigationViewModel.initialize(options);
-    initializeNavigationListeners(options, navigation);
+    navigationViewModel.initialize(options);
+    initializeNavigationListeners(options, navigationViewModel);
     setupNavigationMapboxMap(options);
 
     if (!isSubscribed) {
@@ -688,9 +688,9 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
     summaryBottomSheet.setTimeFormat(timeFormatType);
   }
 
-  private void initializeNavigationListeners(NavigationViewOptions options, MapboxNavigation navigation) {
-    navigationMap.addProgressChangeListener(navigation);
-    navigationViewEventDispatcher.initializeListeners(options, navigation);
+  private void initializeNavigationListeners(NavigationViewOptions options, NavigationViewModel navigationViewModel) {
+    navigationMap.addProgressChangeListener(navigationViewModel.retrieveNavigation());
+    navigationViewEventDispatcher.initializeListeners(options, navigationViewModel);
   }
 
   private void setupNavigationMapboxMap(NavigationViewOptions options) {

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewEventDispatcher.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewEventDispatcher.java
@@ -42,11 +42,12 @@ class NavigationViewEventDispatcher {
    *
    * @param navigationViewOptions that contains all listeners to attach
    */
-  void initializeListeners(NavigationViewOptions navigationViewOptions, MapboxNavigation navigation) {
+  void initializeListeners(NavigationViewOptions navigationViewOptions, NavigationViewModel navigationViewModel) {
     assignFeedbackListener(navigationViewOptions.feedbackListener());
-    assignNavigationListener(navigationViewOptions.navigationListener());
+    assignNavigationListener(navigationViewOptions.navigationListener(), navigationViewModel);
     assignRouteListener(navigationViewOptions.routeListener());
     assignBottomSheetCallback(navigationViewOptions.bottomSheetCallback());
+    MapboxNavigation navigation = navigationViewModel.retrieveNavigation();
     assignProgressChangeListener(navigationViewOptions, navigation);
     assignMilestoneEventListener(navigationViewOptions, navigation);
     assignInstructionListListener(navigationViewOptions.instructionListListener());
@@ -65,8 +66,12 @@ class NavigationViewEventDispatcher {
     this.feedbackListener = feedbackListener;
   }
 
-  void assignNavigationListener(@Nullable NavigationListener navigationListener) {
+  void assignNavigationListener(@Nullable NavigationListener navigationListener,
+                                NavigationViewModel navigationViewModel) {
     this.navigationListener = navigationListener;
+    if (navigationListener != null && navigationViewModel.isRunning()) {
+      navigationListener.onNavigationRunning();
+    }
   }
 
   void assignRouteListener(@Nullable RouteListener routeListener) {

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
@@ -194,7 +194,7 @@ public class NavigationViewModel extends AndroidViewModel {
    *
    * @param options to init MapboxNavigation
    */
-  MapboxNavigation initialize(NavigationViewOptions options) {
+  void initialize(NavigationViewOptions options) {
     MapboxNavigationOptions navigationOptions = options.navigationOptions();
     navigationOptions = navigationOptions.toBuilder().isFromNavigationUi(true).build();
     initializeLanguage(options);
@@ -209,7 +209,6 @@ public class NavigationViewModel extends AndroidViewModel {
       initializeNavigationSpeechPlayer(options);
     }
     routeFetcher.extractRouteOptions(options);
-    return navigation;
   }
 
   void updateFeedbackScreenshot(String screenshot) {

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewEventDispatcherTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewEventDispatcherTest.java
@@ -40,7 +40,8 @@ public class NavigationViewEventDispatcherTest {
   public void setNavigationListener_cancelListenerIsCalled() throws Exception {
     NavigationViewEventDispatcher eventDispatcher = new NavigationViewEventDispatcher();
     NavigationListener navigationListener = mock(NavigationListener.class);
-    eventDispatcher.assignNavigationListener(navigationListener);
+    NavigationViewModel viewModel = mock(NavigationViewModel.class);
+    eventDispatcher.assignNavigationListener(navigationListener, viewModel);
 
     eventDispatcher.onCancelNavigation();
 
@@ -48,10 +49,23 @@ public class NavigationViewEventDispatcherTest {
   }
 
   @Test
+  public void setNavigationListener_runningListenerCalledIfRunning() throws Exception {
+    NavigationViewEventDispatcher eventDispatcher = new NavigationViewEventDispatcher();
+    NavigationListener navigationListener = mock(NavigationListener.class);
+    NavigationViewModel viewModel = mock(NavigationViewModel.class);
+    when(viewModel.isRunning()).thenReturn(true);
+
+    eventDispatcher.assignNavigationListener(navigationListener, viewModel);
+
+    verify(navigationListener, times(1)).onNavigationRunning();
+  }
+
+  @Test
   public void setNavigationListener_finishedListenerIsCalled() throws Exception {
     NavigationViewEventDispatcher eventDispatcher = new NavigationViewEventDispatcher();
     NavigationListener navigationListener = mock(NavigationListener.class);
-    eventDispatcher.assignNavigationListener(navigationListener);
+    NavigationViewModel viewModel = mock(NavigationViewModel.class);
+    eventDispatcher.assignNavigationListener(navigationListener, viewModel);
 
     eventDispatcher.onNavigationFinished();
 
@@ -62,7 +76,8 @@ public class NavigationViewEventDispatcherTest {
   public void setNavigationListener_runningListenerIsCalled() throws Exception {
     NavigationViewEventDispatcher eventDispatcher = new NavigationViewEventDispatcher();
     NavigationListener navigationListener = mock(NavigationListener.class);
-    eventDispatcher.assignNavigationListener(navigationListener);
+    NavigationViewModel viewModel = mock(NavigationViewModel.class);
+    eventDispatcher.assignNavigationListener(navigationListener, viewModel);
 
     eventDispatcher.onNavigationRunning();
 
@@ -316,9 +331,11 @@ public class NavigationViewEventDispatcherTest {
     NavigationViewEventDispatcher eventDispatcher = new NavigationViewEventDispatcher();
     NavigationViewOptions options = mock(NavigationViewOptions.class);
     ProgressChangeListener progressChangeListener = setupProgressChangeListener(options);
+    NavigationViewModel navigationViewModel = mock(NavigationViewModel.class);
     MapboxNavigation navigation = mock(MapboxNavigation.class);
+    when(navigationViewModel.retrieveNavigation()).thenReturn(navigation);
 
-    eventDispatcher.initializeListeners(options, navigation);
+    eventDispatcher.initializeListeners(options, navigationViewModel);
 
     verify(navigation, times(1)).addProgressChangeListener(progressChangeListener);
   }
@@ -328,8 +345,10 @@ public class NavigationViewEventDispatcherTest {
     NavigationViewEventDispatcher eventDispatcher = new NavigationViewEventDispatcher();
     NavigationViewOptions options = mock(NavigationViewOptions.class);
     ProgressChangeListener progressChangeListener = setupProgressChangeListener(options);
+    NavigationViewModel navigationViewModel = mock(NavigationViewModel.class);
     MapboxNavigation navigation = mock(MapboxNavigation.class);
-    eventDispatcher.initializeListeners(options, navigation);
+    when(navigationViewModel.retrieveNavigation()).thenReturn(navigation);
+    eventDispatcher.initializeListeners(options, navigationViewModel);
 
     eventDispatcher.onDestroy(navigation);
 
@@ -341,9 +360,11 @@ public class NavigationViewEventDispatcherTest {
     NavigationViewEventDispatcher eventDispatcher = new NavigationViewEventDispatcher();
     NavigationViewOptions options = mock(NavigationViewOptions.class);
     MilestoneEventListener milestoneEventListener = setupMilestoneEventListener(options);
+    NavigationViewModel navigationViewModel = mock(NavigationViewModel.class);
     MapboxNavigation navigation = mock(MapboxNavigation.class);
+    when(navigationViewModel.retrieveNavigation()).thenReturn(navigation);
 
-    eventDispatcher.initializeListeners(options, navigation);
+    eventDispatcher.initializeListeners(options, navigationViewModel);
 
     verify(navigation, times(1)).addMilestoneEventListener(milestoneEventListener);
   }
@@ -353,8 +374,10 @@ public class NavigationViewEventDispatcherTest {
     NavigationViewEventDispatcher eventDispatcher = new NavigationViewEventDispatcher();
     NavigationViewOptions options = mock(NavigationViewOptions.class);
     MilestoneEventListener milestoneEventListener = setupMilestoneEventListener(options);
+    NavigationViewModel navigationViewModel = mock(NavigationViewModel.class);
     MapboxNavigation navigation = mock(MapboxNavigation.class);
-    eventDispatcher.initializeListeners(options, navigation);
+    when(navigationViewModel.retrieveNavigation()).thenReturn(navigation);
+    eventDispatcher.initializeListeners(options, navigationViewModel);
 
     eventDispatcher.onDestroy(navigation);
 


### PR DESCRIPTION
## Description

If the `NavigationViewModel` is already running, we should send the running event in the `NavigationListener`.

- Fixes #1762 

## What's the goal?

Send a `NavigationListener#onRunning` event if the view model is already running when we are initializing the listener.  

## How is it being implemented?

Added logic to the `NavigationViewEventDispatcher` to check for this during assignment / initialization.

## How has this been tested?

- Tested with `EmbeddedNavigationActivity` - first with bug, then confirming the updated logic fixes this.
- Unit test for `NavigationViewEventDispatcher`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
