### PR TITLE
Fix null ResponseBody in VoiceInstructionLoader

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/voice/InstructionCacheCallback.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/voice/InstructionCacheCallback.java
@@ -1,0 +1,41 @@
+package com.mapbox.services.android.navigation.ui.v5.voice;
+
+import android.support.annotation.NonNull;
+
+import okhttp3.ResponseBody;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+import timber.log.Timber;
+
+class InstructionCacheCallback implements Callback<ResponseBody> {
+
+  private final VoiceInstructionLoader loader;
+
+  InstructionCacheCallback(VoiceInstructionLoader loader) {
+    this.loader = loader;
+  }
+
+  @Override
+  public void onResponse(@NonNull Call<ResponseBody> call, @NonNull Response<ResponseBody> response) {
+    if (closeResponseBody(response)) {
+      String url = call.request().url().toString();
+      loader.addCachedUrl(url);
+    }
+  }
+
+  @Override
+  public void onFailure(@NonNull Call<ResponseBody> call, @NonNull Throwable throwable) {
+    Timber.e(throwable, "onFailure cache instruction");
+  }
+
+  private boolean closeResponseBody(@NonNull Response<ResponseBody> response) {
+    ResponseBody body = response.body();
+    if (body != null) {
+      body.byteStream();
+      body.close();
+      return true;
+    }
+    return false;
+  }
+}

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/voice/VoiceInstructionLoader.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/voice/VoiceInstructionLoader.java
@@ -18,7 +18,6 @@ import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
-import retrofit2.Call;
 import retrofit2.Callback;
 import timber.log.Timber;
 
@@ -105,20 +104,12 @@ public class VoiceInstructionLoader {
     }
   }
 
-  private void cacheInstruction(String instruction) {
-    requestInstruction(instruction, SSML_TEXT_TYPE, new Callback<ResponseBody>() {
-      @Override
-      public void onResponse(Call<ResponseBody> call, retrofit2.Response<ResponseBody> response) {
-        response.body().byteStream();
-        response.body().close();
-        urlsCached.add(call.request().url().toString());
-      }
+  void addCachedUrl(String url) {
+    urlsCached.add(url);
+  }
 
-      @Override
-      public void onFailure(Call<ResponseBody> call, Throwable throwable) {
-        Timber.e("onFailure cache instruction");
-      }
-    });
+  private void cacheInstruction(String instruction) {
+    requestInstruction(instruction, SSML_TEXT_TYPE, new InstructionCacheCallback(this));
   }
 
   private Interceptor provideOfflineCacheInterceptor() {

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/voice/InstructionCacheCallbackTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/voice/InstructionCacheCallbackTest.java
@@ -1,0 +1,71 @@
+package com.mapbox.services.android.navigation.ui.v5.voice;
+
+import org.junit.Test;
+
+import okhttp3.HttpUrl;
+import okhttp3.Request;
+import okhttp3.ResponseBody;
+import retrofit2.Call;
+import retrofit2.Response;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+public class InstructionCacheCallbackTest {
+
+  @Test
+  public void onResponse_cachedUrlIsAdded() {
+    VoiceInstructionLoader loader = mock(VoiceInstructionLoader.class);
+    Response<ResponseBody> response = mock(Response.class);
+    ResponseBody body = mock(ResponseBody.class);
+    when(response.body()).thenReturn(body);
+    String url = "http://some.url";
+    Call call = buildMockCall(url);
+    InstructionCacheCallback callback = new InstructionCacheCallback(loader);
+
+    callback.onResponse(call, response);
+
+    verify(loader).addCachedUrl(eq(url));
+  }
+
+  @Test
+  public void onResponse_bodyIsClosed() {
+    VoiceInstructionLoader loader = mock(VoiceInstructionLoader.class);
+    Response<ResponseBody> response = mock(Response.class);
+    ResponseBody body = mock(ResponseBody.class);
+    when(response.body()).thenReturn(body);
+    String url = "http://some.url";
+    Call call = buildMockCall(url);
+    InstructionCacheCallback callback = new InstructionCacheCallback(loader);
+
+    callback.onResponse(call, response);
+
+    verify(body).close();
+  }
+
+  @Test
+  public void onResponse_nullBodyIsIgnored() {
+    VoiceInstructionLoader loader = mock(VoiceInstructionLoader.class);
+    Response<ResponseBody> response = mock(Response.class);
+    String url = "http://some.url";
+    Call call = buildMockCall(url);
+    InstructionCacheCallback callback = new InstructionCacheCallback(loader);
+
+    callback.onResponse(call, response);
+
+    verifyZeroInteractions(loader);
+  }
+
+  private Call buildMockCall(String stringUrl) {
+    Call call = mock(Call.class);
+    Request request = mock(Request.class);
+    HttpUrl url = mock(HttpUrl.class);
+    when(url.toString()).thenReturn(stringUrl);
+    when(request.url()).thenReturn(url);
+    when(call.request()).thenReturn(request);
+    return call;
+  }
+}


### PR DESCRIPTION
## Description

Found in testing:
```
Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'java.io.InputStream okhttp3.ResponseBody.byteStream()' on a null object reference
       at com.mapbox.services.android.navigation.ui.v5.voice.VoiceInstructionLoader$1.onResponse(VoiceInstructionLoader.java:112)
       at retrofit2.ExecutorCallAdapterFactory$ExecutorCallbackCall$1$1.run(ExecutorCallAdapterFactory.java:70)
       at android.os.Handler.handleCallback(Handler.java:873)
       at android.os.Handler.dispatchMessage(Handler.java:99)
       at android.os.Looper.loop(Looper.java:214)
       at android.app.ActivityThread.main(ActivityThread.java:6981)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1445)
```

Looks to have been introduced in https://github.com/mapbox/mapbox-navigation-android/pull/1481

## What's the goal?

We are not checking for a `null` `ResponseBody` when receiving the response for caching the instructions + their URLs.  This PR adds logic to check for this / unit tests.  

## How is it being implemented?

A class implementing the `Retrofit` callback: `InstructionCacheCallback` so we can inject the `List<String>` urls and verify interaction or no interaction.  

## How has this been tested?

- Unit tests added ✅ 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes