### PR TITLE
Add LocationComponent FPS throttle based on map zoom

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/LocationFpsDelegate.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/LocationFpsDelegate.java
@@ -1,0 +1,89 @@
+package com.mapbox.services.android.navigation.ui.v5.map;
+
+import android.support.annotation.NonNull;
+
+import com.mapbox.mapboxsdk.location.LocationComponent;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+
+class LocationFpsDelegate implements MapboxMap.OnCameraIdleListener {
+
+  private static final int ZOOM_LEVEL_FIVE = 5;
+  private static final int ZOOM_LEVEL_TEN = 10;
+  private static final int ZOOM_LEVEL_FOURTEEN = 14;
+  private static final int ZOOM_LEVEL_SIXTEEN = 16;
+  private static final int ZOOM_LEVEL_EIGHTEEN = 18;
+  private static final int MAX_ANIMATION_FPS_THREE = 3;
+  private static final int MAX_ANIMATION_FPS_FIVE = 5;
+  private static final int MAX_ANIMATION_FPS_TEN = 10;
+  private static final int MAX_ANIMATION_FPS_FIFTEEN = 15;
+  private static final int MAX_ANIMATION_FPS_TWENTY_FIVE = 25;
+  private static final int MAX_ANIMATION_FPS = Integer.MAX_VALUE;
+  private final MapboxMap mapboxMap;
+  private final LocationComponent locationComponent;
+  private int currentFps = MAX_ANIMATION_FPS;
+  private boolean isEnabled = true;
+
+  LocationFpsDelegate(@NonNull MapboxMap mapboxMap, @NonNull LocationComponent locationComponent) {
+    this.mapboxMap = mapboxMap;
+    this.locationComponent = locationComponent;
+    mapboxMap.addOnCameraIdleListener(this);
+  }
+
+  @Override
+  public void onCameraIdle() {
+    if (!isEnabled) {
+      return;
+    }
+    updateMaxFps();
+  }
+
+  void onStart() {
+    mapboxMap.addOnCameraIdleListener(this);
+  }
+
+  void onStop() {
+    mapboxMap.removeOnCameraIdleListener(this);
+  }
+
+  void updateEnabled(boolean isEnabled) {
+    this.isEnabled = isEnabled;
+    resetMaxFps();
+  }
+
+  boolean isEnabled() {
+    return isEnabled;
+  }
+
+  private void updateMaxFps() {
+    double zoom = mapboxMap.getCameraPosition().zoom;
+    int maxAnimationFps = buildFpsFrom(zoom);
+    if (currentFps != maxAnimationFps) {
+      locationComponent.setMaxAnimationFps(maxAnimationFps);
+      currentFps = maxAnimationFps;
+    }
+  }
+
+  private int buildFpsFrom(double zoom) {
+    int maxAnimationFps;
+    if (zoom < ZOOM_LEVEL_FIVE) {
+      maxAnimationFps = MAX_ANIMATION_FPS_THREE;
+    } else if (zoom < ZOOM_LEVEL_TEN) {
+      maxAnimationFps = MAX_ANIMATION_FPS_FIVE;
+    } else if (zoom < ZOOM_LEVEL_FOURTEEN) {
+      maxAnimationFps = MAX_ANIMATION_FPS_TEN;
+    } else if (zoom < ZOOM_LEVEL_SIXTEEN) {
+      maxAnimationFps = MAX_ANIMATION_FPS_FIFTEEN;
+    } else if (zoom < ZOOM_LEVEL_EIGHTEEN) {
+      maxAnimationFps = MAX_ANIMATION_FPS_TWENTY_FIVE;
+    } else {
+      maxAnimationFps = MAX_ANIMATION_FPS;
+    }
+    return maxAnimationFps;
+  }
+
+  private void resetMaxFps() {
+    if (!isEnabled) {
+      locationComponent.setMaxAnimationFps(MAX_ANIMATION_FPS);
+    }
+  }
+}

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/NavigationMapSettings.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/NavigationMapSettings.java
@@ -15,6 +15,7 @@ class NavigationMapSettings implements Parcelable {
   private int maxFps = DEFAULT_MAX_FPS_THRESHOLD;
   private boolean maxFpsEnabled = true;
   private boolean mapWayNameEnabled;
+  private boolean locationFpsEnabled = true;
 
   NavigationMapSettings() {
   }
@@ -68,6 +69,14 @@ class NavigationMapSettings implements Parcelable {
     return mapWayNameEnabled;
   }
 
+  void updateLocationFpsEnabled(boolean locationFpsEnabled) {
+    this.locationFpsEnabled = locationFpsEnabled;
+  }
+
+  boolean isLocationFpsEnabled() {
+    return locationFpsEnabled;
+  }
+
   private NavigationMapSettings(Parcel in) {
     cameraTrackingMode = in.readInt();
     currentPadding = in.createIntArray();
@@ -75,6 +84,7 @@ class NavigationMapSettings implements Parcelable {
     maxFps = in.readInt();
     maxFpsEnabled = in.readByte() != 0;
     mapWayNameEnabled = in.readByte() != 0;
+    locationFpsEnabled = in.readByte() != 0;
   }
 
   @Override
@@ -85,6 +95,7 @@ class NavigationMapSettings implements Parcelable {
     dest.writeInt(maxFps);
     dest.writeByte((byte) (maxFpsEnabled ? 1 : 0));
     dest.writeByte((byte) (mapWayNameEnabled ? 1 : 0));
+    dest.writeByte((byte) (locationFpsEnabled ? 1 : 0));
   }
 
   @Override

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/map/LocationFpsDelegateTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/map/LocationFpsDelegateTest.java
@@ -1,0 +1,117 @@
+package com.mapbox.services.android.navigation.ui.v5.map;
+
+import com.mapbox.mapboxsdk.camera.CameraPosition;
+import com.mapbox.mapboxsdk.location.LocationComponent;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class LocationFpsDelegateTest {
+
+  @Test
+  public void onCameraIdle_newFpsIsSetZoom16() {
+    double zoom = 16d;
+    MapboxMap mapboxMap = mock(MapboxMap.class);
+    when(mapboxMap.getCameraPosition()).thenReturn(buildCameraPosition(zoom));
+    LocationComponent locationComponent = mock(LocationComponent.class);
+    LocationFpsDelegate locationFpsDelegate = new LocationFpsDelegate(mapboxMap, locationComponent);
+
+    locationFpsDelegate.onCameraIdle();
+
+    verify(locationComponent).setMaxAnimationFps(eq(25));
+  }
+
+  @Test
+  public void onCameraIdle_newFpsIsSetZoom14() {
+    double zoom = 14d;
+    MapboxMap mapboxMap = mock(MapboxMap.class);
+    when(mapboxMap.getCameraPosition()).thenReturn(buildCameraPosition(zoom));
+    LocationComponent locationComponent = mock(LocationComponent.class);
+    LocationFpsDelegate locationFpsDelegate = new LocationFpsDelegate(mapboxMap, locationComponent);
+
+    locationFpsDelegate.onCameraIdle();
+
+    verify(locationComponent).setMaxAnimationFps(eq(15));
+  }
+
+  @Test
+  public void onCameraIdle_newFpsIsSetZoom10() {
+    double zoom = 10d;
+    MapboxMap mapboxMap = mock(MapboxMap.class);
+    when(mapboxMap.getCameraPosition()).thenReturn(buildCameraPosition(zoom));
+    LocationComponent locationComponent = mock(LocationComponent.class);
+    LocationFpsDelegate locationFpsDelegate = new LocationFpsDelegate(mapboxMap, locationComponent);
+
+    locationFpsDelegate.onCameraIdle();
+
+    verify(locationComponent).setMaxAnimationFps(eq(10));
+  }
+
+  @Test
+  public void onCameraIdle_newFpsIsSet5() {
+    double zoom = 5d;
+    MapboxMap mapboxMap = mock(MapboxMap.class);
+    when(mapboxMap.getCameraPosition()).thenReturn(buildCameraPosition(zoom));
+    LocationComponent locationComponent = mock(LocationComponent.class);
+    LocationFpsDelegate locationFpsDelegate = new LocationFpsDelegate(mapboxMap, locationComponent);
+
+    locationFpsDelegate.onCameraIdle();
+
+    verify(locationComponent).setMaxAnimationFps(eq(5));
+  }
+
+  @Test
+  public void onStart_idleListenerAdded() {
+    MapboxMap mapboxMap = mock(MapboxMap.class);
+    LocationComponent locationComponent = mock(LocationComponent.class);
+    LocationFpsDelegate locationFpsDelegate = new LocationFpsDelegate(mapboxMap, locationComponent);
+
+    locationFpsDelegate.onStart();
+
+    verify(mapboxMap, times(2)).addOnCameraIdleListener(eq(locationFpsDelegate));
+  }
+
+  @Test
+  public void onStop_idleListenerRemoved() {
+    MapboxMap mapboxMap = mock(MapboxMap.class);
+    LocationComponent locationComponent = mock(LocationComponent.class);
+    LocationFpsDelegate locationFpsDelegate = new LocationFpsDelegate(mapboxMap, locationComponent);
+
+    locationFpsDelegate.onStop();
+
+    verify(mapboxMap).removeOnCameraIdleListener(eq(locationFpsDelegate));
+  }
+
+  @Test
+  public void updateEnabled_falseResetsToMax() {
+    MapboxMap mapboxMap = mock(MapboxMap.class);
+    LocationComponent locationComponent = mock(LocationComponent.class);
+    LocationFpsDelegate locationFpsDelegate = new LocationFpsDelegate(mapboxMap, locationComponent);
+
+    locationFpsDelegate.updateEnabled(false);
+
+    verify(locationComponent).setMaxAnimationFps(eq(Integer.MAX_VALUE));
+  }
+
+  @Test
+  public void isEnabled_returnsFalseWhenSet() {
+    MapboxMap mapboxMap = mock(MapboxMap.class);
+    LocationComponent locationComponent = mock(LocationComponent.class);
+    LocationFpsDelegate locationFpsDelegate = new LocationFpsDelegate(mapboxMap, locationComponent);
+
+    locationFpsDelegate.updateEnabled(false);
+
+    assertFalse(locationFpsDelegate.isEnabled());
+  }
+
+  private CameraPosition buildCameraPosition(double zoom) {
+    return new CameraPosition.Builder().zoom(zoom).build();
+  }
+}

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/map/NavigationMapboxMapTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/map/NavigationMapboxMapTest.java
@@ -166,7 +166,9 @@ public class NavigationMapboxMapTest {
     MapFpsDelegate mapFpsDelegate = mock(MapFpsDelegate.class);
     NavigationMapRoute mapRoute = mock(NavigationMapRoute.class);
     NavigationCamera mapCamera = mock(NavigationCamera.class);
-    NavigationMapboxMap theNavigationMap = new NavigationMapboxMap(mapWayName, mapFpsDelegate, mapRoute, mapCamera);
+    LocationFpsDelegate locationFpsDelegate = mock(LocationFpsDelegate.class);
+    NavigationMapboxMap theNavigationMap = new NavigationMapboxMap(mapWayName, mapFpsDelegate,
+      mapRoute, mapCamera, locationFpsDelegate);
 
     theNavigationMap.onStart();
 
@@ -179,7 +181,9 @@ public class NavigationMapboxMapTest {
     MapFpsDelegate mapFpsDelegate = mock(MapFpsDelegate.class);
     NavigationMapRoute mapRoute = mock(NavigationMapRoute.class);
     NavigationCamera mapCamera = mock(NavigationCamera.class);
-    NavigationMapboxMap theNavigationMap = new NavigationMapboxMap(mapWayName, mapFpsDelegate, mapRoute, mapCamera);
+    LocationFpsDelegate locationFpsDelegate = mock(LocationFpsDelegate.class);
+    NavigationMapboxMap theNavigationMap = new NavigationMapboxMap(mapWayName, mapFpsDelegate,
+      mapRoute, mapCamera, locationFpsDelegate);
 
     theNavigationMap.onStop();
 
@@ -192,7 +196,9 @@ public class NavigationMapboxMapTest {
     MapFpsDelegate mapFpsDelegate = mock(MapFpsDelegate.class);
     NavigationMapRoute mapRoute = mock(NavigationMapRoute.class);
     NavigationCamera mapCamera = mock(NavigationCamera.class);
-    NavigationMapboxMap theNavigationMap = new NavigationMapboxMap(mapWayName, mapFpsDelegate, mapRoute, mapCamera);
+    LocationFpsDelegate locationFpsDelegate = mock(LocationFpsDelegate.class);
+    NavigationMapboxMap theNavigationMap = new NavigationMapboxMap(mapWayName, mapFpsDelegate,
+      mapRoute, mapCamera, locationFpsDelegate);
 
     theNavigationMap.onStart();
 
@@ -205,7 +211,9 @@ public class NavigationMapboxMapTest {
     MapFpsDelegate mapFpsDelegate = mock(MapFpsDelegate.class);
     NavigationMapRoute mapRoute = mock(NavigationMapRoute.class);
     NavigationCamera mapCamera = mock(NavigationCamera.class);
-    NavigationMapboxMap theNavigationMap = new NavigationMapboxMap(mapWayName, mapFpsDelegate, mapRoute, mapCamera);
+    LocationFpsDelegate locationFpsDelegate = mock(LocationFpsDelegate.class);
+    NavigationMapboxMap theNavigationMap = new NavigationMapboxMap(mapWayName, mapFpsDelegate,
+      mapRoute, mapCamera, locationFpsDelegate);
 
     theNavigationMap.onStop();
 
@@ -226,6 +234,51 @@ public class NavigationMapboxMapTest {
     new NavigationMapboxMap(mapboxMap, layerInteractor, adjustor);
 
     verify(layerInteractor).addStreetsLayer("composite", "road_label");
+  }
+
+  @Test
+  public void updateLocationFpsThrottleEnabled_locationFpsUpdateEnabledIsSet() {
+    MapWayName mapWayName = mock(MapWayName.class);
+    MapFpsDelegate mapFpsDelegate = mock(MapFpsDelegate.class);
+    NavigationMapRoute mapRoute = mock(NavigationMapRoute.class);
+    NavigationCamera mapCamera = mock(NavigationCamera.class);
+    LocationFpsDelegate locationFpsDelegate = mock(LocationFpsDelegate.class);
+    NavigationMapboxMap theNavigationMap = new NavigationMapboxMap(mapWayName, mapFpsDelegate,
+      mapRoute, mapCamera, locationFpsDelegate);
+
+    theNavigationMap.updateLocationFpsThrottleEnabled(false);
+
+    verify(locationFpsDelegate).updateEnabled(eq(false));
+  }
+
+  @Test
+  public void onStart_locationFpsUpdateOnStartIsCalled() {
+    MapWayName mapWayName = mock(MapWayName.class);
+    MapFpsDelegate mapFpsDelegate = mock(MapFpsDelegate.class);
+    NavigationMapRoute mapRoute = mock(NavigationMapRoute.class);
+    NavigationCamera mapCamera = mock(NavigationCamera.class);
+    LocationFpsDelegate locationFpsDelegate = mock(LocationFpsDelegate.class);
+    NavigationMapboxMap theNavigationMap = new NavigationMapboxMap(mapWayName, mapFpsDelegate,
+      mapRoute, mapCamera, locationFpsDelegate);
+
+    theNavigationMap.onStart();
+
+    verify(locationFpsDelegate).onStart();
+  }
+
+  @Test
+  public void onStop_locationFpsUpdateOnStopIsCalled() {
+    MapWayName mapWayName = mock(MapWayName.class);
+    MapFpsDelegate mapFpsDelegate = mock(MapFpsDelegate.class);
+    NavigationMapRoute mapRoute = mock(NavigationMapRoute.class);
+    NavigationCamera mapCamera = mock(NavigationCamera.class);
+    LocationFpsDelegate locationFpsDelegate = mock(LocationFpsDelegate.class);
+    NavigationMapboxMap theNavigationMap = new NavigationMapboxMap(mapWayName, mapFpsDelegate,
+      mapRoute, mapCamera, locationFpsDelegate);
+
+    theNavigationMap.onStop();
+
+    verify(locationFpsDelegate).onStop();
   }
 
   @Test


### PR DESCRIPTION
## Description

This PR aims to improve the performance of the `LocationComponent` by dynamically adjusting the FPS of the animation with `LocationComponent#setMaxAnimationFps` that landed in Maps SDK `7.2.0`.

## What's the goal?

Improve performance by throttling the `LocationComponent` animation.  

## How is it being implemented?

A new class called `LocationFpsDelegate` that implements `MapboxMap.OnCameraIdleListener`.  When this callback is triggered, we will look at the current zoom level of the map and determine a set FPS constant from the value, setting it to the `LocationComponent` (if it's new).    

## How has this been tested?

- Unit tested 
- Tested on multiple devices in the test app
- [x] Test before and after CPU profiles

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes