### PR TITLE
Fix proguard

### DIFF
--- a/libandroid-navigation-ui/proguard-consumer.pro
+++ b/libandroid-navigation-ui/proguard-consumer.pro
@@ -16,3 +16,6 @@
 
 # --- com.amazonaws.util.json.JacksonFactory ---
 -dontwarn com.fasterxml.jackson.core.**
+
+# --- Mapbox ---
+-dontwarn com.mapbox.services.android.navigation.ui.v5.**


### PR DESCRIPTION
### Originally opened by @ben-j69 in https://github.com/mapbox/mapbox-navigation-android/pull/1814

## Title

Fix proguard file

## Description

Without this line when a project is built it produce this error 

com.mapbox.services.android.navigation.ui.v5.MapboxNavigationActivity: can't find referenced field 'int navigationView' in program class com.mapbox.services.android.navigation.ui.v5.R$id

## What's the goal?

The goal is to be able to build a project using this sdk and proguard.

## How is it being implemented?

Please include all the relevant things implemented and also rationale, aclarations / disclaimers etc. related to the approach used. It could be as self code companion comments

## How has this been tested?

- With the fix the apk is done
- Without the fix an error is thrown
