### PR TITLE
fix bug: app can't exit if user don‘t click textbox.

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExampleViewModel.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExampleViewModel.kt
@@ -52,7 +52,7 @@ class ExampleViewModel(application: Application) : AndroidViewModel(application)
   val geocode: MutableLiveData<GeocodingResponse> = MutableLiveData()
 
   var primaryRoute: DirectionsRoute? = null
-  var collapsedBottomSheet: Boolean = false
+  var collapsedBottomSheet: Boolean = true
   var isOffRoute: Boolean = false
 
   private val locationEngine: LocationEngine


### PR DESCRIPTION
## Description

When start test app, if user don't click the textbox on the bottom of screen, app can't exit by clicking android back button.

## What's the goal?

fix bug.

## How has this been tested?

Debugged by my android phone, 4.4.0.

## Checklist

- [x] I have tested locally / staging (including `SNAPSHOT` upstream dependencies if needed)
- [x] I have performed a self-review of my own code