### PR TITLE
Add NavigationMapRoute attribute for styling route line cap expression

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/MapRouteDrawableProvider.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/MapRouteDrawableProvider.java
@@ -1,0 +1,20 @@
+package com.mapbox.services.android.navigation.ui.v5.route;
+
+import android.content.Context;
+import android.graphics.drawable.Drawable;
+import android.support.annotation.Nullable;
+import android.support.v7.content.res.AppCompatResources;
+
+class MapRouteDrawableProvider {
+
+  private final Context context;
+
+  MapRouteDrawableProvider(Context context) {
+    this.context = context;
+  }
+
+  @Nullable
+  Drawable retrieveDrawable(int resId) {
+    return AppCompatResources.getDrawable(context, resId);
+  }
+}

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/MapRouteLayerProvider.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/MapRouteLayerProvider.java
@@ -1,0 +1,196 @@
+package com.mapbox.services.android.navigation.ui.v5.route;
+
+import android.graphics.Bitmap;
+import android.graphics.drawable.Drawable;
+import android.support.annotation.NonNull;
+
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.style.expressions.Expression;
+import com.mapbox.mapboxsdk.style.layers.LineLayer;
+import com.mapbox.mapboxsdk.style.layers.Property;
+import com.mapbox.mapboxsdk.style.layers.SymbolLayer;
+import com.mapbox.services.android.navigation.ui.v5.utils.MapImageUtils;
+
+import static com.mapbox.mapboxsdk.style.expressions.Expression.color;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.exponential;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.get;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.interpolate;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.literal;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.match;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.product;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.stop;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.switchCase;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.zoom;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconAllowOverlap;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconIgnorePlacement;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconImage;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconPitchAlignment;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconSize;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineCap;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineColor;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineJoin;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineWidth;
+import static com.mapbox.services.android.navigation.ui.v5.route.RouteConstants.DESTINATION_MARKER_NAME;
+import static com.mapbox.services.android.navigation.ui.v5.route.RouteConstants.HEAVY_CONGESTION_VALUE;
+import static com.mapbox.services.android.navigation.ui.v5.route.RouteConstants.MODERATE_CONGESTION_VALUE;
+import static com.mapbox.services.android.navigation.ui.v5.route.RouteConstants.ORIGIN_MARKER_NAME;
+import static com.mapbox.services.android.navigation.ui.v5.route.RouteConstants.PRIMARY_ROUTE_PROPERTY_KEY;
+import static com.mapbox.services.android.navigation.ui.v5.route.RouteConstants.ROUTE_LAYER_ID;
+import static com.mapbox.services.android.navigation.ui.v5.route.RouteConstants.ROUTE_SHIELD_LAYER_ID;
+import static com.mapbox.services.android.navigation.ui.v5.route.RouteConstants.ROUTE_SOURCE_ID;
+import static com.mapbox.services.android.navigation.ui.v5.route.RouteConstants.SEVERE_CONGESTION_VALUE;
+import static com.mapbox.services.android.navigation.ui.v5.route.RouteConstants.WAYPOINT_DESTINATION_VALUE;
+import static com.mapbox.services.android.navigation.ui.v5.route.RouteConstants.WAYPOINT_LAYER_ID;
+import static com.mapbox.services.android.navigation.ui.v5.route.RouteConstants.WAYPOINT_ORIGIN_VALUE;
+import static com.mapbox.services.android.navigation.ui.v5.route.RouteConstants.WAYPOINT_PROPERTY_KEY;
+import static com.mapbox.services.android.navigation.ui.v5.route.RouteConstants.WAYPOINT_SOURCE_ID;
+
+class MapRouteLayerProvider {
+
+  LineLayer initializeRouteShieldLayer(MapboxMap mapboxMap, float routeScale, float alternativeRouteScale,
+                                       int routeShieldColor, int alternativeRouteShieldColor) {
+    LineLayer shieldLayer = mapboxMap.getStyle().getLayerAs(ROUTE_SHIELD_LAYER_ID);
+    if (shieldLayer != null) {
+      mapboxMap.getStyle().removeLayer(shieldLayer);
+    }
+
+    shieldLayer = new LineLayer(ROUTE_SHIELD_LAYER_ID, ROUTE_SOURCE_ID).withProperties(
+      lineCap(Property.LINE_CAP_ROUND),
+      lineJoin(Property.LINE_JOIN_ROUND),
+      lineWidth(
+        interpolate(
+          exponential(1.5f), zoom(),
+          stop(10f, 7f),
+          stop(14f, product(literal(10.5f),
+            switchCase(
+              get(PRIMARY_ROUTE_PROPERTY_KEY), literal(routeScale),
+              literal(alternativeRouteScale)))),
+          stop(16.5f, product(literal(15.5f),
+            switchCase(
+              get(PRIMARY_ROUTE_PROPERTY_KEY), literal(routeScale),
+              literal(alternativeRouteScale)))),
+          stop(19f, product(literal(24f),
+            switchCase(
+              get(PRIMARY_ROUTE_PROPERTY_KEY), literal(routeScale),
+              literal(alternativeRouteScale)))),
+          stop(22f, product(literal(29f),
+            switchCase(
+              get(PRIMARY_ROUTE_PROPERTY_KEY), literal(routeScale),
+              literal(alternativeRouteScale))))
+        )
+      ),
+      lineColor(
+        switchCase(
+          get(PRIMARY_ROUTE_PROPERTY_KEY), color(routeShieldColor),
+          color(alternativeRouteShieldColor)
+        )
+      )
+    );
+    return shieldLayer;
+  }
+
+  LineLayer initializeRouteLayer(MapboxMap mapboxMap, boolean roundedLineCap, float routeScale,
+                                 float alternativeRouteScale, int routeDefaultColor, int routeModerateColor,
+                                 int routeSevereColor, int alternativeRouteDefaultColor,
+                                 int alternativeRouteModerateColor, int alternativeRouteSevereColor) {
+    LineLayer routeLayer = mapboxMap.getStyle().getLayerAs(ROUTE_LAYER_ID);
+    if (routeLayer != null) {
+      mapboxMap.getStyle().removeLayer(routeLayer);
+    }
+
+    String lineCap = Property.LINE_CAP_ROUND;
+    String lineJoin = Property.LINE_JOIN_ROUND;
+    if (!roundedLineCap) {
+      lineCap = Property.LINE_CAP_BUTT;
+      lineJoin = Property.LINE_JOIN_BEVEL;
+    }
+
+    routeLayer = new LineLayer(ROUTE_LAYER_ID, ROUTE_SOURCE_ID).withProperties(
+      lineCap(lineCap),
+      lineJoin(lineJoin),
+      lineWidth(
+        interpolate(
+          exponential(1.5f), zoom(),
+          stop(4f, product(literal(3f),
+            switchCase(
+              get(PRIMARY_ROUTE_PROPERTY_KEY), literal(routeScale),
+              literal(alternativeRouteScale)))),
+          stop(10f, product(literal(4f),
+            switchCase(
+              get(PRIMARY_ROUTE_PROPERTY_KEY), literal(routeScale),
+              literal(alternativeRouteScale)))),
+          stop(13f, product(literal(6f),
+            switchCase(
+              get(PRIMARY_ROUTE_PROPERTY_KEY), literal(routeScale),
+              literal(alternativeRouteScale)))),
+          stop(16f, product(literal(10f),
+            switchCase(
+              get(PRIMARY_ROUTE_PROPERTY_KEY), literal(routeScale),
+              literal(alternativeRouteScale)))),
+          stop(19f, product(literal(14f),
+            switchCase(
+              get(PRIMARY_ROUTE_PROPERTY_KEY), literal(routeScale),
+              literal(alternativeRouteScale)))),
+          stop(22f, product(literal(18f),
+            switchCase(
+              get(PRIMARY_ROUTE_PROPERTY_KEY), literal(routeScale),
+              literal(alternativeRouteScale))))
+        )
+      ),
+      lineColor(
+        switchCase(
+          get(PRIMARY_ROUTE_PROPERTY_KEY), match(
+            Expression.toString(get(RouteConstants.CONGESTION_KEY)),
+            color(routeDefaultColor),
+            stop(MODERATE_CONGESTION_VALUE, color(routeModerateColor)),
+            stop(HEAVY_CONGESTION_VALUE, color(routeSevereColor)),
+            stop(SEVERE_CONGESTION_VALUE, color(routeSevereColor))
+          ),
+          match(
+            Expression.toString(get(RouteConstants.CONGESTION_KEY)),
+            color(alternativeRouteDefaultColor),
+            stop(MODERATE_CONGESTION_VALUE, color(alternativeRouteModerateColor)),
+            stop(HEAVY_CONGESTION_VALUE, color(alternativeRouteSevereColor)),
+            stop(SEVERE_CONGESTION_VALUE, color(alternativeRouteSevereColor))
+          )
+        )
+      )
+    );
+    return routeLayer;
+  }
+
+  SymbolLayer initializeWayPointLayer(@NonNull MapboxMap mapboxMap, Drawable originIcon,
+                                      Drawable destinationIcon) {
+    SymbolLayer wayPointLayer = mapboxMap.getStyle().getLayerAs(WAYPOINT_LAYER_ID);
+    if (wayPointLayer != null) {
+      mapboxMap.getStyle().removeLayer(wayPointLayer);
+    }
+
+    Bitmap bitmap = MapImageUtils.getBitmapFromDrawable(originIcon);
+    mapboxMap.getStyle().addImage(ORIGIN_MARKER_NAME, bitmap);
+    bitmap = MapImageUtils.getBitmapFromDrawable(destinationIcon);
+    mapboxMap.getStyle().addImage(DESTINATION_MARKER_NAME, bitmap);
+
+    wayPointLayer = new SymbolLayer(WAYPOINT_LAYER_ID, WAYPOINT_SOURCE_ID).withProperties(
+      iconImage(
+        match(
+          Expression.toString(get(WAYPOINT_PROPERTY_KEY)), literal(ORIGIN_MARKER_NAME),
+          stop(WAYPOINT_ORIGIN_VALUE, literal(ORIGIN_MARKER_NAME)),
+          stop(WAYPOINT_DESTINATION_VALUE, literal(DESTINATION_MARKER_NAME))
+        )),
+      iconSize(
+        interpolate(
+          exponential(1.5f), zoom(),
+          stop(0f, 0.6f),
+          stop(10f, 0.8f),
+          stop(12f, 1.3f),
+          stop(22f, 2.8f)
+        )
+      ),
+      iconPitchAlignment(Property.ICON_PITCH_ALIGNMENT_MAP),
+      iconAllowOverlap(true),
+      iconIgnorePlacement(true)
+    );
+    return wayPointLayer;
+  }
+}

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/MapRouteSourceProvider.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/MapRouteSourceProvider.java
@@ -1,0 +1,12 @@
+package com.mapbox.services.android.navigation.ui.v5.route;
+
+import com.mapbox.geojson.FeatureCollection;
+import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions;
+import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
+
+class MapRouteSourceProvider {
+
+  GeoJsonSource build(String id, FeatureCollection featureCollection, GeoJsonOptions options) {
+    return new GeoJsonSource(id, featureCollection, options);
+  }
+}

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/NavigationMapRoute.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/NavigationMapRoute.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.arch.lifecycle.Lifecycle;
 import android.arch.lifecycle.LifecycleObserver;
 import android.arch.lifecycle.OnLifecycleEvent;
+import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.Size;
@@ -135,7 +136,7 @@ public class NavigationMapRoute implements LifecycleObserver {
     this.mapView = mapView;
     this.mapboxMap = mapboxMap;
     this.navigation = navigation;
-    this.routeLine = new MapRouteLine(mapView.getContext(), mapboxMap, styleRes, belowLayer);
+    this.routeLine = buildMapRouteLine(mapView, mapboxMap, styleRes, belowLayer);
     this.routeArrow = new MapRouteArrow(mapView, mapboxMap, styleRes);
     this.mapRouteClickListener = new MapRouteClickListener(routeLine);
     this.mapRouteProgressChangeListener = new MapRouteProgressChangeListener(routeLine, routeArrow);
@@ -312,6 +313,17 @@ public class NavigationMapRoute implements LifecycleObserver {
     removeListeners();
   }
 
+  private MapRouteLine buildMapRouteLine(@NonNull MapView mapView, @NonNull MapboxMap mapboxMap,
+                                         @StyleRes int styleRes, @Nullable String belowLayer) {
+    Context context = mapView.getContext();
+    MapRouteDrawableProvider drawableProvider = new MapRouteDrawableProvider(context);
+    MapRouteSourceProvider sourceProvider = new MapRouteSourceProvider();
+    MapRouteLayerProvider layerProvider = new MapRouteLayerProvider();
+    return new MapRouteLine(context, mapboxMap, styleRes, belowLayer,
+      drawableProvider, sourceProvider, layerProvider
+    );
+  }
+
   private void initializeDidFinishLoadingStyleListener() {
     didFinishLoadingStyleListener = new MapView.OnDidFinishLoadingStyleListener() {
       @Override
@@ -360,7 +372,7 @@ public class NavigationMapRoute implements LifecycleObserver {
   }
 
   private void buildNewRouteLine() {
-    routeLine = new MapRouteLine(mapView.getContext(), mapboxMap, styleRes, belowLayer);
+    routeLine = buildMapRouteLine(mapView, mapboxMap, styleRes, belowLayer);
     mapboxMap.removeOnMapClickListener(mapRouteClickListener);
     mapRouteClickListener = new MapRouteClickListener(routeLine);
     mapboxMap.addOnMapClickListener(mapRouteClickListener);

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/utils/MapUtils.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/utils/MapUtils.java
@@ -27,7 +27,7 @@ public final class MapUtils {
    */
   public static void addLayerToMap(@NonNull MapboxMap mapboxMap, @NonNull Layer layer,
                                    @Nullable String idBelowLayer) {
-    if (mapboxMap.getStyle().getLayer(layer.getId()) != null) {
+    if (layer != null && mapboxMap.getStyle().getLayer(layer.getId()) != null) {
       return;
     }
     if (idBelowLayer == null) {

--- a/libandroid-navigation-ui/src/main/res/values/attrs.xml
+++ b/libandroid-navigation-ui/src/main/res/values/attrs.xml
@@ -23,6 +23,9 @@
 
     <attr name="upcomingManeuverArrowColor" format="color"/>
     <attr name="upcomingManeuverArrowBorderColor" format="color"/>
+
+    <!-- Rounded route line cap -->
+    <attr name="roundedLineCap" format="boolean"/>
   </declare-styleable>
 
   <declare-styleable name="NavigationView">

--- a/libandroid-navigation-ui/src/main/res/values/styles.xml
+++ b/libandroid-navigation-ui/src/main/res/values/styles.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <style name="NavigationMapRoute">
-
         <!-- Colors -->
         <item name="routeColor">@color/mapbox_navigation_route_layer_blue</item>
         <item name="routeModerateCongestionColor">@color/mapbox_navigation_route_layer_congestion_yellow</item>
@@ -12,6 +11,9 @@
         <item name="routeScale">1.0</item>
         <item name="upcomingManeuverArrowColor">@color/mapbox_navigation_route_upcoming_maneuver_arrow_color</item>
         <item name="upcomingManeuverArrowBorderColor">@color/mapbox_navigation_route_upcoming_maneuver_arrow_border_color</item>
+
+        <!-- Expression styling -->
+        <item name="roundedLineCap">true</item>
     </style>
 
     <style name="NavigationViewLight" parent="Theme.AppCompat.Light.NoActionBar">

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/route/MapRouteLineTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/route/MapRouteLineTest.java
@@ -1,14 +1,20 @@
 package com.mapbox.services.android.navigation.ui.v5.route;
 
+import android.content.Context;
+import android.content.res.TypedArray;
 import android.support.annotation.NonNull;
 
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.geojson.FeatureCollection;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.style.layers.Layer;
 import com.mapbox.mapboxsdk.style.layers.LineLayer;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
 import com.mapbox.services.android.navigation.ui.v5.BaseTest;
+import com.mapbox.services.android.navigation.ui.v5.R;
 
+import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -17,8 +23,13 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import edu.emory.mathcs.backport.java.util.Collections;
+
 import static com.mapbox.services.android.navigation.ui.v5.route.RouteConstants.ROUTE_LAYER_ID;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyFloat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -99,6 +110,42 @@ public class MapRouteLineTest extends BaseTest {
     verify(routeLineSource, times(4)).setGeoJson(any(FeatureCollection.class));
   }
 
+  @Test
+  public void routeLineCap_defaultIsSet() {
+    Context context = mock(Context.class);
+    TypedArray typedArray = mock(TypedArray.class);
+    when(context.obtainStyledAttributes(anyInt(), eq(R.styleable.NavigationMapRoute))).thenReturn(typedArray);
+    when(typedArray.getBoolean(R.styleable.NavigationMapRoute_roundedLineCap, true)).thenReturn(true);
+    MapboxMap mapboxMap = buildMockMap();
+    MapRouteLayerProvider layerProvider = mock(MapRouteLayerProvider.class);
+
+    new MapRouteLine(context, mapboxMap, R.style.NavigationMapRoute, "",
+      mock(MapRouteDrawableProvider.class), mock(MapRouteSourceProvider.class), layerProvider
+    );
+
+    verify(layerProvider).initializeRouteLayer(eq(mapboxMap), eq(true), anyFloat(), anyFloat(),
+      anyInt(), anyInt(), anyInt(), anyInt(), anyInt(), anyInt()
+    );
+  }
+
+  @Test
+  public void routeLineCap_isSetFromAttributes() {
+    Context context = mock(Context.class);
+    TypedArray typedArray = mock(TypedArray.class);
+    when(context.obtainStyledAttributes(anyInt(), eq(R.styleable.NavigationMapRoute))).thenReturn(typedArray);
+    when(typedArray.getBoolean(R.styleable.NavigationMapRoute_roundedLineCap, true)).thenReturn(false);
+    MapboxMap mapboxMap = buildMockMap();
+    MapRouteLayerProvider layerProvider = mock(MapRouteLayerProvider.class);
+
+    new MapRouteLine(context, mapboxMap, R.style.NavigationMapRoute, "",
+      mock(MapRouteDrawableProvider.class), mock(MapRouteSourceProvider.class), layerProvider
+    );
+
+    verify(layerProvider).initializeRouteLayer(eq(mapboxMap), eq(false), anyFloat(), anyFloat(),
+      anyInt(), anyInt(), anyInt(), anyInt(), anyInt(), anyInt()
+    );
+  }
+
   @NonNull
   private List<Layer> buildMockLayers() {
     List<Layer> routeLayers = new ArrayList<>();
@@ -109,5 +156,14 @@ public class MapRouteLineTest extends BaseTest {
     when(lineLayerTwo.getId()).thenReturn(ROUTE_LAYER_ID);
     routeLayers.add(lineLayerTwo);
     return routeLayers;
+  }
+
+  @NotNull
+  private MapboxMap buildMockMap() {
+    Style style = mock(Style.class);
+    when(style.getLayers()).thenReturn(Collections.emptyList());
+    MapboxMap mapboxMap = mock(MapboxMap.class);
+    when(mapboxMap.getStyle()).thenReturn(style);
+    return mapboxMap;
   }
 }


### PR DESCRIPTION
## Description

This PR adds a `NavigationMapRoute` style attribute for styling the route line expression `Property`.

## What's the goal?

Currently the route line is only rendered with rounded line caps.  The goal of this PR is to add the ability to provide rounded or square styling.  

## How is it being implemented?

Adding `routeLineCap` `String` attribute to the `attrs.xml` for `NavigationMapRoute`.  Then looking for this attribute (default to round) at runtime when initializing the `MapRouteLine`.  

## Screenshots or Gifs

Rounded (default):

![device-2019-03-14-134515](https://user-images.githubusercontent.com/8434572/54380183-41ba2100-4661-11e9-95be-6173d517a569.png)

Square:

![device-2019-03-14-134818](https://user-images.githubusercontent.com/8434572/54380200-48e12f00-4661-11e9-9e13-b34053f8d2f6.png)

## How has this been tested?

- Unit tests added (required some refactoring of `MapRouteLine`)
- UI testing via test app and screenshots aboce

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
  - Noting that we will need to update https://docs.mapbox.com/android/navigation/overview/map-styling/#style-the-navigationview
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes