### PR TITLE
Finish camera reset during MapboxMap cancel events

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/camera/ResetCancelableCallback.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/camera/ResetCancelableCallback.java
@@ -12,7 +12,7 @@ class ResetCancelableCallback implements MapboxMap.CancelableCallback {
 
   @Override
   public void onCancel() {
-    // No-impl
+    camera.updateIsResetting(false);
   }
 
   @Override

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/camera/ResetCancelableCallbackTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/camera/ResetCancelableCallbackTest.java
@@ -17,4 +17,14 @@ public class ResetCancelableCallbackTest {
 
     verify(camera).updateIsResetting(eq(false));
   }
+
+  @Test
+  public void onCancel_dynamicCameraIsReset() {
+    NavigationCamera camera = mock(NavigationCamera.class);
+    ResetCancelableCallback callback = new ResetCancelableCallback(camera);
+
+    callback.onCancel();
+
+    verify(camera).updateIsResetting(eq(false));
+  }
 }


### PR DESCRIPTION
## Description

Regression from #1802.  It _is_ possible for the reset zoom animation to be cancelled.  It is not guaranteed to finish.  This PR will tell the `NavigationCamera` the reset zoom animation has finished in the event of a cancel scenario as well.  Currently, if the animation is cancelled, we get stuck ignoring subsequent updates because the camera thinks it is still resetting.

## What's the goal?

The goal is to notify the camera in both cancel and finish events.

## How is it being implemented?

Adding the `NavigationCamera` call in `MapboxMap.CancelableCallback#onCancel` as well.  

## How has this been tested?

- Unit tests

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes