### PR TITLE
Update NavigationCamera resetting state if transition cancelled

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/ComponentNavigationActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/ComponentNavigationActivity.java
@@ -29,6 +29,7 @@ import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.geometry.LatLngBounds;
+import com.mapbox.mapboxsdk.location.modes.RenderMode;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
@@ -140,6 +141,7 @@ public class ComponentNavigationActivity extends HistoryActivity implements OnMa
       // For navigation logic / processing
       initializeNavigation(mapboxMap);
       navigationMap.updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_NONE);
+      navigationMap.updateLocationLayerRenderMode(RenderMode.GPS);
 
       // For voice instructions
       initializeSpeechPlayer();

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/camera/NavigationCameraTransitionListener.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/camera/NavigationCameraTransitionListener.java
@@ -18,5 +18,6 @@ class NavigationCameraTransitionListener implements OnLocationCameraTransitionLi
   @Override
   public void onLocationCameraTransitionCanceled(int cameraMode) {
     camera.updateTransitionListenersCancelled(cameraMode);
+    camera.updateIsResetting(false);
   }
 }

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/camera/NavigationCameraTransitionListenerTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/camera/NavigationCameraTransitionListenerTest.java
@@ -4,6 +4,7 @@ import com.mapbox.mapboxsdk.location.modes.CameraMode;
 
 import org.junit.Test;
 
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -29,5 +30,16 @@ public class NavigationCameraTransitionListenerTest {
     listener.onLocationCameraTransitionCanceled(trackingGpsNorth);
 
     verify(camera).updateTransitionListenersCancelled(trackingGpsNorth);
+  }
+
+  @Test
+  public void onLocationCameraTransitionCanceled_cameraStopsResetting() {
+    NavigationCamera camera = mock(NavigationCamera.class);
+    NavigationCameraTransitionListener listener = new NavigationCameraTransitionListener(camera);
+    int trackingGpsNorth = CameraMode.TRACKING_GPS_NORTH;
+
+    listener.onLocationCameraTransitionCanceled(trackingGpsNorth);
+
+    verify(camera).updateIsResetting(eq(false));
   }
 }


### PR DESCRIPTION
## Description

The `NavigationCamera` is currently able to be interrupted by `MapboxMap` animations when trying to reset.  This PR aims to harden the camera against this.

## What's the goal?

Don't allow the `NavigationCamera` to get stuck in a resetting state if interrupted.

## How is it being implemented?

Set `isResetting` to `false` if the camera transition is interrupted. 

## Screenshots or Gifs

#### Incorrect behavior:

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/8434572/54781445-ac83d300-4bf2-11e9-8fed-d2d5608470fe.gif)

#### Correct behavior:

![ezgif com-video-to-gif (2)](https://user-images.githubusercontent.com/8434572/54781462-b9a0c200-4bf2-11e9-9a8f-2983cad85e1d.gif)

## How has this been tested?

- Unit tests added
- Reproduced and confirmed fixed with `ComponentNavigationActivity`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes