### PR TITLE
Bump mapbox-navigation-native version to 6.0.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -12,7 +12,7 @@ ext {
       mapboxSdkServices      : '4.5.0',
       mapboxEvents           : '4.2.0',
       mapboxCore             : '1.2.0',
-      mapboxNavigator        : '5.1.0',
+      mapboxNavigator        : '6.0.0',
       mapboxAnnotationPlugin : '0.5.0',
       mapboxSearchSdk        : '0.1.0-SNAPSHOT',
       autoValue              : '1.5.4',

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/ConfigureRouterTask.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/ConfigureRouterTask.java
@@ -5,7 +5,6 @@ import android.os.AsyncTask;
 import com.mapbox.navigator.Navigator;
 
 class ConfigureRouterTask extends AsyncTask<Void, Void, Long> {
-  private static final String EMPTY_TRANSLATIONS_DIR_PATH = "";
   private final Navigator navigator;
   private final String tilePath;
   private final OnOfflineTilesConfiguredCallback callback;
@@ -19,7 +18,7 @@ class ConfigureRouterTask extends AsyncTask<Void, Void, Long> {
   @Override
   protected Long doInBackground(Void... paramsUnused) {
     synchronized (this) {
-      return navigator.configureRouter(tilePath, EMPTY_TRANSLATIONS_DIR_PATH);
+      return navigator.configureRouter(tilePath);
     }
   }
 


### PR DESCRIPTION
## Description

- Bumps `mapbox-navigation-native` version to `6.0.0`

- Fixes https://github.com/mapbox/mapbox-navigation-android/issues/1806

## What's the goal?

Getting the latest version from NN including the new features and bug fixes.

## How is it being implemented?

Bumping the `mapboxNavigator` version to `6.0.0` in `dependencies.gradle`

## How has this been tested?

Tested that all the `Activities` in the test app and didn't 👀 any regressions

## Checklist

- [x] I have tested locally / staging (including `SNAPSHOT` upstream dependencies if needed)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes