### PR TITLE
Setup native crash monitor for test application

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -91,6 +91,7 @@ dependencies {
   implementation project(':libandroid-navigation-ui')
   implementation dependenciesList.mapboxMapSdk
   implementation dependenciesList.mapboxSearchSdk
+  implementation dependenciesList.mapboxCrashMonitor
 
   // Support libraries
   implementation dependenciesList.supportAppcompatV7

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/NavigationApplication.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/NavigationApplication.kt
@@ -5,6 +5,7 @@ import android.support.multidex.MultiDexApplication
 import android.text.TextUtils
 import com.mapbox.android.search.MapboxSearch
 import com.mapbox.android.search.MapboxSearchOptions
+import com.mapbox.crashmonitor.CrashMonitor
 import com.mapbox.mapboxsdk.Mapbox
 import com.mapbox.services.android.navigation.testapp.example.utils.DelegatesExt
 import com.squareup.leakcanary.LeakCanary
@@ -25,6 +26,7 @@ class NavigationApplication : MultiDexApplication() {
     setupStrictMode()
     setupCanary()
     setupMapbox()
+    setupCrashMonitor()
   }
 
   private fun setupTimber() {
@@ -64,5 +66,16 @@ class NavigationApplication : MultiDexApplication() {
     val cachingMode = MapboxSearchOptions().setCachingEnabled(true)
     MapboxSearch.getInstance(applicationContext, mapboxAccessToken, cachingMode)
     Mapbox.getInstance(applicationContext, mapboxAccessToken)
+  }
+
+  private fun setupCrashMonitor() {
+    val crashMonitor = CrashMonitor { crashDetails ->
+      throw Exception(crashDetails)
+    }
+    try {
+      crashMonitor.monitor(applicationInfo.dataDir)
+    } catch (e: Exception) {
+      Timber.e("Couldn't monitor for crashes: ${e.message}")
+    }
   }
 }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -13,6 +13,7 @@ ext {
       mapboxEvents           : '4.2.0',
       mapboxCore             : '1.2.0',
       mapboxNavigator        : '6.0.0',
+      mapboxCrashMonitor     : '2.0.0',
       mapboxAnnotationPlugin : '0.5.0',
       mapboxSearchSdk        : '0.1.0-SNAPSHOT',
       autoValue              : '1.5.4',
@@ -51,6 +52,7 @@ ext {
       mapboxNavigator        : "com.mapbox.navigator:mapbox-navigation-native:${version.mapboxNavigator}",
       mapboxAnnotationPlugin : "com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v7:${version.mapboxAnnotationPlugin}",
       mapboxSearchSdk        : "com.mapbox.mapboxsdk:mapbox-search-android:${version.mapboxSearchSdk}",
+      mapboxCrashMonitor     : "com.mapbox.crashmonitor:mapbox-crash-monitor-native:${version.mapboxCrashMonitor}",
 
       // Kotlin
       kotlinStdLib           : "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${version.kotlinStdLib}",


### PR DESCRIPTION
## Description

Sets up an instance of `CrashMonitor` during `NavigationApplication` creation. 

## What's the goal?

Receive crash logs for native maps and navigation code that are more easily understandable. 

## How is it being implemented?

Sets up an instance of `CrashMonitor` during `NavigationApplication` creation. 

## How has this been tested?

Tested with `CrashMonitor#sendSIGSEGV()` static test method. 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] New and existing unit tests pass locally with my changes