### PR TITLE
Add NavigationCamera#update for MapboxMap animations

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/ComponentNavigationActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/ComponentNavigationActivity.java
@@ -9,6 +9,7 @@ import android.os.Bundle;
 import android.os.VibrationEffect;
 import android.os.Vibrator;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.constraint.ConstraintLayout;
 import android.support.design.widget.BaseTransientBottomBar;
 import android.support.design.widget.FloatingActionButton;
@@ -26,6 +27,7 @@ import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.geojson.Point;
 import com.mapbox.mapboxsdk.Mapbox;
 import com.mapbox.mapboxsdk.camera.CameraPosition;
+import com.mapbox.mapboxsdk.camera.CameraUpdate;
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.geometry.LatLngBounds;
@@ -38,6 +40,7 @@ import com.mapbox.services.android.navigation.testapp.R;
 import com.mapbox.services.android.navigation.testapp.activity.HistoryActivity;
 import com.mapbox.services.android.navigation.ui.v5.camera.DynamicCamera;
 import com.mapbox.services.android.navigation.ui.v5.camera.NavigationCamera;
+import com.mapbox.services.android.navigation.ui.v5.camera.NavigationCameraUpdate;
 import com.mapbox.services.android.navigation.ui.v5.instruction.InstructionView;
 import com.mapbox.services.android.navigation.ui.v5.map.NavigationMapboxMap;
 import com.mapbox.services.android.navigation.ui.v5.voice.NavigationSpeechPlayer;
@@ -171,7 +174,6 @@ public class ComponentNavigationActivity extends HistoryActivity implements OnMa
 
   @OnClick(R.id.startNavigationFab)
   public void onStartNavigationClick(FloatingActionButton floatingActionButton) {
-    navigationMap.updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_GPS);
     // Transition to navigation state
     mapState = MapState.NAVIGATION;
 
@@ -188,6 +190,14 @@ public class ComponentNavigationActivity extends HistoryActivity implements OnMa
 
     // Location updates will be received from ProgressChangeListener
     removeLocationEngineListener();
+
+    // TODO remove example usage
+    navigationMap.resetCameraPositionWith(NavigationCamera.NAVIGATION_TRACKING_MODE_GPS);
+    CameraUpdate cameraUpdate = cameraOverheadUpdate();
+    if (cameraUpdate != null) {
+      NavigationCameraUpdate navUpdate = new NavigationCameraUpdate(cameraUpdate);
+      navigationMap.retrieveCamera().update(navUpdate);
+    }
   }
 
   @OnClick(R.id.cancelNavigationFab)
@@ -386,6 +396,15 @@ public class ComponentNavigationActivity extends HistoryActivity implements OnMa
     navigationMap.retrieveMap().animateCamera(
       CameraUpdateFactory.newCameraPosition(cameraPosition), TWO_SECONDS_IN_MILLISECONDS
     );
+  }
+
+  @Nullable
+  private CameraUpdate cameraOverheadUpdate() {
+    if (lastLocation == null) {
+      return null;
+    }
+    CameraPosition cameraPosition = buildCameraPositionFrom(lastLocation, DEFAULT_BEARING);
+    return CameraUpdateFactory.newCameraPosition(cameraPosition);
   }
 
   @NonNull

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationContract.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationContract.java
@@ -5,7 +5,6 @@ import android.support.annotation.NonNull;
 
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.geojson.Point;
-import com.mapbox.services.android.navigation.ui.v5.camera.NavigationCamera;
 
 public interface NavigationContract {
 
@@ -20,8 +19,6 @@ public interface NavigationContract {
     void updateWayNameVisibility(boolean isVisible);
 
     void updateWayNameView(@NonNull String wayName);
-
-    void updateCameraTrackingMode(@NavigationCamera.TrackingMode int trackingMode);
 
     void resetCameraPosition();
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationPresenter.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationPresenter.java
@@ -7,7 +7,6 @@ import android.support.design.widget.BottomSheetBehavior;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.core.utils.TextUtils;
 import com.mapbox.geojson.Point;
-import com.mapbox.services.android.navigation.ui.v5.camera.NavigationCamera;
 
 class NavigationPresenter {
 
@@ -34,7 +33,6 @@ class NavigationPresenter {
     if (!view.isSummaryBottomSheetHidden()) {
       view.setSummaryBehaviorHideable(true);
       view.setSummaryBehaviorState(BottomSheetBehavior.STATE_HIDDEN);
-      view.updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_NONE);
       view.updateWayNameVisibility(false);
     }
   }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
@@ -243,14 +243,6 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
     return summaryBehavior.getState() == BottomSheetBehavior.STATE_HIDDEN;
   }
 
-
-  @Override
-  public void updateCameraTrackingMode(int trackingMode) {
-    if (navigationMap != null) {
-      navigationMap.updateCameraTrackingMode(trackingMode);
-    }
-  }
-
   @Override
   public void resetCameraPosition() {
     if (navigationMap != null) {

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/camera/CameraAnimationDelegate.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/camera/CameraAnimationDelegate.java
@@ -1,0 +1,30 @@
+package com.mapbox.services.android.navigation.ui.v5.camera;
+
+import com.mapbox.mapboxsdk.camera.CameraUpdate;
+import com.mapbox.mapboxsdk.location.modes.CameraMode;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+
+class CameraAnimationDelegate {
+
+  private final MapboxMap mapboxMap;
+
+  CameraAnimationDelegate(MapboxMap mapboxMap) {
+    this.mapboxMap = mapboxMap;
+  }
+
+  void render(NavigationCameraUpdate update, int durationMs, MapboxMap.CancelableCallback callback) {
+    CameraUpdateMode mode = update.getMode();
+    CameraUpdate cameraUpdate = update.getCameraUpdate();
+    if (mode == CameraUpdateMode.OVERRIDE) {
+      mapboxMap.getLocationComponent().setCameraMode(CameraMode.NONE);
+      mapboxMap.animateCamera(cameraUpdate, durationMs, callback);
+    } else if (!isTracking()) {
+      mapboxMap.animateCamera(cameraUpdate, durationMs, callback);
+    }
+  }
+
+  private boolean isTracking() {
+    int cameraMode = mapboxMap.getLocationComponent().getCameraMode();
+    return cameraMode != CameraMode.NONE;
+  }
+}

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/camera/CameraUpdateMode.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/camera/CameraUpdateMode.java
@@ -1,0 +1,24 @@
+package com.mapbox.services.android.navigation.ui.v5.camera;
+
+/**
+ * This class is passed to {@link NavigationCameraUpdate} to
+ * determine the update's behavior when passed to {@link NavigationCamera}.
+ */
+public enum CameraUpdateMode {
+
+  /**
+   * For a given {@link NavigationCameraUpdate}, this default mode means the
+   * {@link NavigationCamera} will ignore the update when tracking is already
+   * enabled.
+   * <p>
+   * If tracking is disabled, the update animation will execute.
+   */
+  DEFAULT,
+
+  /**
+   * For a given {@link NavigationCameraUpdate}, this override mode means the
+   * {@link NavigationCamera} will stop tracking (if tracking) and execute the
+   * given update animation.
+   */
+  OVERRIDE
+}

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/camera/NavigationCameraTrackingChangedListener.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/camera/NavigationCameraTrackingChangedListener.java
@@ -1,0 +1,25 @@
+package com.mapbox.services.android.navigation.ui.v5.camera;
+
+import com.mapbox.mapboxsdk.location.OnCameraTrackingChangedListener;
+
+class NavigationCameraTrackingChangedListener implements OnCameraTrackingChangedListener {
+
+  private final NavigationCamera camera;
+
+  NavigationCameraTrackingChangedListener(NavigationCamera camera) {
+    this.camera = camera;
+  }
+
+  @Override
+  public void onCameraTrackingDismissed() {
+    camera.updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_NONE);
+  }
+
+  @Override
+  public void onCameraTrackingChanged(int currentMode) {
+    Integer trackingMode = camera.findTrackingModeFor(currentMode);
+    if (trackingMode != null) {
+      camera.updateCameraTrackingMode(trackingMode);
+    }
+  }
+}

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/camera/NavigationCameraUpdate.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/camera/NavigationCameraUpdate.java
@@ -1,0 +1,48 @@
+package com.mapbox.services.android.navigation.ui.v5.camera;
+
+import android.support.annotation.NonNull;
+
+import com.mapbox.mapboxsdk.camera.CameraUpdate;
+
+/**
+ * Used with {@link NavigationCamera#update(NavigationCameraUpdate)}.
+ * <p>
+ * This class wraps a Maps SDK {@link CameraUpdate}.  It adds an option
+ * for {@link CameraUpdateMode} that determine how the camera update behaves
+ * with tracking modes.
+ */
+public class NavigationCameraUpdate {
+
+  private final CameraUpdate cameraUpdate;
+  private CameraUpdateMode mode = CameraUpdateMode.DEFAULT;
+
+  /**
+   * Creates and instance of this class, taking a {@link CameraUpdate}
+   * that has already been built.
+   *
+   * @param cameraUpdate with map camera parameters
+   */
+  public NavigationCameraUpdate(@NonNull CameraUpdate cameraUpdate) {
+    this.cameraUpdate = cameraUpdate;
+  }
+
+  /**
+   * Updates the {@link CameraUpdateMode} that will determine this updates
+   * behavior based on the current tracking mode in {@link NavigationCamera}.
+   *
+   * @param mode either default or override
+   */
+  public void setMode(CameraUpdateMode mode) {
+    this.mode = mode;
+  }
+
+  @NonNull
+  CameraUpdate getCameraUpdate() {
+    return cameraUpdate;
+  }
+
+  @NonNull
+  CameraUpdateMode getMode() {
+    return mode;
+  }
+}

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/camera/NavigationCameraTrackingChangedListenerTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/camera/NavigationCameraTrackingChangedListenerTest.java
@@ -1,0 +1,34 @@
+package com.mapbox.services.android.navigation.ui.v5.camera;
+
+import com.mapbox.mapboxsdk.location.modes.CameraMode;
+
+import org.junit.Test;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class NavigationCameraTrackingChangedListenerTest {
+
+  @Test
+  public void onCameraTrackingDismissed_cameraSetToTrackingNone() {
+    NavigationCamera camera = mock(NavigationCamera.class);
+    NavigationCameraTrackingChangedListener listener = new NavigationCameraTrackingChangedListener(camera);
+
+    listener.onCameraTrackingDismissed();
+
+    verify(camera).updateCameraTrackingMode(eq(NavigationCamera.NAVIGATION_TRACKING_MODE_NONE));
+  }
+
+  @Test
+  public void onCameraTrackingChanged_navigationCameraTrackingUpdated() {
+    NavigationCamera camera = mock(NavigationCamera.class);
+    when(camera.findTrackingModeFor(CameraMode.TRACKING_GPS)).thenReturn(NavigationCamera.NAVIGATION_TRACKING_MODE_GPS);
+    NavigationCameraTrackingChangedListener listener = new NavigationCameraTrackingChangedListener(camera);
+
+    listener.onCameraTrackingChanged(CameraMode.TRACKING_GPS);
+
+    verify(camera).updateCameraTrackingMode(eq(NavigationCamera.NAVIGATION_TRACKING_MODE_GPS));
+  }
+}


### PR DESCRIPTION
## Description

The `NavigationCamera` currently has a few tracking modes that make it simple for developers to engage or disengage camera tracking behavior.  Although when tracking is engaged and, simultaneously, a normal `MapboxMap` animation such as `MapboxMap#animateCamera` conflict can occur as the animation fights our current tracking state.  

## What's the goal?

The goal is to better organize this experience for developers.  We should have explicit options that clearly determine / state the behavior for these two APIs interacting.  

## How is it being implemented?

New APIs:
```
NavigationCamera#update(NavigationCameraUpdate)
NavigationCamera#update(NavigationCameraUpdate, int durationMs)
NavigationCamera#update(NavigationCameraUpdate, int durationMs, Callback)
```

##### `new NavigationCameraUpdate(CameraUpdate)`
  - `#setMode(CameraUpdateMode)` - determines behavior with tracking
  
#####  `enum CameraUpdateMode`
  - `DEFAULT` - if tracking or resetting, provided animation will be ignored
  - `OVERRIDE` - if tracking or retting, `LocationComponent` will be set to tracking `NONE` and animation will fire

#### Example usage:
```
NavigationCamera camera = ...;
camera.updateCameraTrackingMode(NAVIGATION_TRACKING_MODE_GPS);

CameraUpdate cameraUpdate = ...;
NavigationCameraUpdate navCameraUpdate = new NavigationCameraUpdate(cameraUpdate);
navCameraUpdate.setMode(CameraUpdateMode.DEFAULT);

camera.update(navCameraUpdate); // Ignored
camera.updateCameraTrackingMode(NAVIGATION_TRACKING_MODE_NONE);
camera.update(navCameraUpdate); // Fires animation

camera.updateCameraTrackingMode(NAVIGATION_TRACKING_MODE_GPS);
navCameraUpdate.setMode(CameraUpdateMode.OVERRIDE);
camera.update(navCameraUpdate); // Fires animation
```

## Screenshots or Gifs

##### Code driving this `.gif` (`DEFAULT` behavior):
```
navigationMap.resetCameraPositionWith(NavigationCamera.NAVIGATION_TRACKING_MODE_GPS);
CameraUpdate cameraUpdate = cameraOverheadUpdate();
if (cameraUpdate != null) {
  NavigationCameraUpdate navUpdate = new NavigationCameraUpdate(cameraUpdate);
  navigationMap.retrieveCamera().update(navUpdate);
}
```

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/8434572/55173341-eb191080-5151-11e9-9234-4d2aafa201b3.gif)

##### Code driving this `.gif` (`OVERRIDE` behavior):
```
navigationMap.resetCameraPositionWith(NavigationCamera.NAVIGATION_TRACKING_MODE_GPS);
CameraUpdate cameraUpdate = cameraOverheadUpdate();
if (cameraUpdate != null) {
  NavigationCameraUpdate navUpdate = new NavigationCameraUpdate(cameraUpdate).setMode(CameraUpdateMode.OVERRIDE);
  navigationMap.retrieveCamera().update(navUpdate);
}
```

![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/8434572/55173319-df2d4e80-5151-11e9-985c-74f968d946d4.gif)

## How has this been tested?

- Tested in `ComponentNavigationActivity`
- Unit testing

## Checklist

- [x] I have made corresponding changes to the documentation (JavaDoc)
- [x] I have tested locally / staging (including `SNAPSHOT` upstream dependencies if needed)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added an `Activity` example in the test app showing the new feature implemented