### PR TITLE
Add remove offline routing tiles by bounding box functionality

### DIFF
--- a/app/src/main/res/layout/activity_offline_region_download.xml
+++ b/app/src/main/res/layout/activity_offline_region_download.xml
@@ -90,14 +90,31 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:id="@+id/downloadButton"
+            android:layout_above="@id/removeButton"
             android:padding="16dp"
-            android:layout_margin="16dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginLeft="16dp"
+            android:layout_marginRight="16dp"
+            android:layout_marginBottom="8dp"
             android:gravity="center"
             android:text="Download Region"
             android:background="@color/md_grey_700"
-            android:textColor="@color/white"
+            android:textColor="@color/white"/>
+
+        <TextView
+            android:id="@+id/removeButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
             android:layout_alignParentBottom="true"
-            android:layout_centerHorizontal="true"/>
+            android:layout_centerHorizontal="true"
+            android:layout_marginLeft="16dp"
+            android:layout_marginRight="16dp"
+            android:layout_marginBottom="8dp"
+            android:background="@color/mapbox_blue"
+            android:gravity="center"
+            android:padding="16dp"
+            android:text="Remove Region"
+            android:textColor="@color/white"/>
 
     </RelativeLayout>
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -12,7 +12,7 @@ ext {
       mapboxSdkServices      : '4.5.0',
       mapboxEvents           : '4.2.0',
       mapboxCore             : '1.2.0',
-      mapboxNavigator        : '6.0.0',
+      mapboxNavigator        : '6.1.0',
       mapboxCrashMonitor     : '2.0.0',
       mapboxAnnotationPlugin : '0.5.0',
       mapboxSearchSdk        : '0.1.0-SNAPSHOT',

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxOfflineRouter.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxOfflineRouter.java
@@ -3,6 +3,7 @@ package com.mapbox.services.android.navigation.v5.navigation;
 import android.support.annotation.NonNull;
 
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
+import com.mapbox.geojson.BoundingBox;
 import com.mapbox.navigator.Navigator;
 
 import java.io.File;
@@ -86,5 +87,22 @@ public class MapboxOfflineRouter {
    */
   public void fetchAvailableTileVersions(String accessToken, OnTileVersionsFoundCallback callback) {
     offlineTileVersions.fetchRouteTileVersions(accessToken, callback);
+  }
+
+  /**
+   * Removes tiles within / intersected by a bounding box
+   * <p>
+   * Note that calling {@link MapboxOfflineRouter#findRoute(OfflineRoute, OnOfflineRouteFoundCallback)} while
+   * {@link MapboxOfflineRouter#removeTiles(String, BoundingBox, OnOfflineTilesRemovedCallback)} could lead
+   * to undefine behavior
+   * </p>
+   *
+   * @param version     version of offline tiles to use
+   * @param boundingBox bounding box within which routing tiles should be removed
+   * @param callback    a callback that will be fired when the routing tiles have been removed completely
+   */
+  public void removeTiles(String version, BoundingBox boundingBox, OnOfflineTilesRemovedCallback callback) {
+    offlineNavigator.removeTiles(new File(tilePath, version).getAbsolutePath(), boundingBox.southwest(),
+      boundingBox.northeast(), callback);
   }
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/OfflineNavigator.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/OfflineNavigator.java
@@ -1,5 +1,6 @@
 package com.mapbox.services.android.navigation.v5.navigation;
 
+import com.mapbox.geojson.Point;
 import com.mapbox.navigator.Navigator;
 
 class OfflineNavigator {
@@ -40,5 +41,17 @@ class OfflineNavigator {
    */
   void unpackTiles(String tarPath, String destinationPath) {
     navigator.unpackTiles(tarPath, destinationPath);
+  }
+
+  /**
+   * Removes tiles within / intersected by a bounding box
+   *
+   * @param tilePath  directory path where the tiles are located
+   * @param southwest lower left {@link Point} of the bounding box
+   * @param northeast upper right {@link Point} of the bounding box
+   * @param callback  a callback that will be fired when the routing tiles have been removed completely
+   */
+  void removeTiles(String tilePath, Point southwest, Point northeast, OnOfflineTilesRemovedCallback callback) {
+    new RemoveTilesTask(navigator, tilePath, southwest, northeast, callback).execute();
   }
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/OnOfflineTilesRemovedCallback.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/OnOfflineTilesRemovedCallback.java
@@ -1,0 +1,18 @@
+package com.mapbox.services.android.navigation.v5.navigation;
+
+import com.mapbox.geojson.BoundingBox;
+
+/**
+ * Listener that needs to be added to
+ * {@link MapboxOfflineRouter#removeTiles(BoundingBox, OnOfflineTilesRemovedCallback)} to know when the routing
+ * tiles within the provided {@link BoundingBox} have been removed
+ */
+public interface OnOfflineTilesRemovedCallback {
+
+  /**
+   * Called when the routing tiles within the provided {@link BoundingBox} have been removed completely.
+   *
+   * @param numberOfTiles removed within the {@link BoundingBox} provided
+   */
+  void onRemoved(long numberOfTiles);
+}

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/RemoveTilesTask.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/RemoveTilesTask.java
@@ -1,0 +1,33 @@
+package com.mapbox.services.android.navigation.v5.navigation;
+
+import android.os.AsyncTask;
+
+import com.mapbox.geojson.Point;
+import com.mapbox.navigator.Navigator;
+
+class RemoveTilesTask extends AsyncTask<Void, Void, Long> {
+  private final Navigator navigator;
+  private final String tilePath;
+  private final Point southwest;
+  private final Point northeast;
+  private final OnOfflineTilesRemovedCallback callback;
+
+  RemoveTilesTask(Navigator navigator, String tilePath, Point southwest, Point northeast,
+                  OnOfflineTilesRemovedCallback callback) {
+    this.navigator = navigator;
+    this.tilePath = tilePath;
+    this.southwest = southwest;
+    this.northeast = northeast;
+    this.callback = callback;
+  }
+
+  @Override
+  protected Long doInBackground(Void... paramsUnused) {
+    return navigator.removeTiles(tilePath, southwest, northeast);
+  }
+
+  @Override
+  protected void onPostExecute(Long numberOfTiles) {
+    callback.onRemoved(numberOfTiles);
+  }
+}

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/MapboxOfflineRouterTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/MapboxOfflineRouterTest.java
@@ -1,7 +1,11 @@
 package com.mapbox.services.android.navigation.v5.navigation;
 
+import com.mapbox.geojson.BoundingBox;
+import com.mapbox.geojson.Point;
+
 import org.junit.Test;
 
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -41,6 +45,22 @@ public class MapboxOfflineRouterTest {
     offlineRouter.fetchAvailableTileVersions(accessToken, callback);
 
     verify(offlineTileVersions).fetchRouteTileVersions(accessToken, callback);
+  }
+
+  @Test
+  public void checksRemoveTiles() {
+    String aTilePath = "/some/path/";
+    OfflineNavigator anOfflineNavigator = mock(OfflineNavigator.class);
+    MapboxOfflineRouter theOfflineRouter = buildRouter(aTilePath, anOfflineNavigator);
+    Point southwest = Point.fromLngLat(1.0, 2.0);
+    Point northeast = Point.fromLngLat(3.0, 4.0);
+    BoundingBox aBoundingBox = BoundingBox.fromPoints(southwest, northeast);
+    OnOfflineTilesRemovedCallback aCallback = mock(OnOfflineTilesRemovedCallback.class);
+
+    theOfflineRouter.removeTiles("a_version", aBoundingBox, aCallback);
+
+    verify(anOfflineNavigator).removeTiles(eq("/some/path/a_version"), eq(southwest), eq(northeast),
+      eq(aCallback));
   }
 
   private MapboxOfflineRouter buildRouter(String tilePath, OfflineNavigator offlineNavigator) {

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/RemoveTilesTaskTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/RemoveTilesTaskTest.java
@@ -1,0 +1,28 @@
+package com.mapbox.services.android.navigation.v5.navigation;
+
+import com.mapbox.geojson.Point;
+import com.mapbox.navigator.Navigator;
+
+import org.junit.Test;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class RemoveTilesTaskTest {
+
+  @Test
+  public void checksOnRemoveIsCalledWhenTilesAreRemoved() {
+    Navigator mockedNavigator = mock(Navigator.class);
+    String aTilePath = "/some/path/version";
+    Point southwest = Point.fromLngLat(1.0, 2.0);
+    Point northeast = Point.fromLngLat(3.0, 4.0);
+    OnOfflineTilesRemovedCallback mockedCallback = mock(OnOfflineTilesRemovedCallback.class);
+    RemoveTilesTask theRemoveTilesTask = new RemoveTilesTask(mockedNavigator, aTilePath, southwest,
+      northeast, mockedCallback);
+
+    theRemoveTilesTask.onPostExecute(9L);
+
+    verify(mockedCallback).onRemoved(eq(9L));
+  }
+}


### PR DESCRIPTION
## Description

This adds a new API to `MapboxOfflineRouter` which adds the possibility to remove offline routing tiles by bounding box.

## What's the goal?

Add a way to clean up routing tiles by bounding box once tiles are downloaded. Currently clients can wipe out the entire `Offline` directory but that's not ideal because clients cannot keep around tiles from other areas that users would like to keep.

## How is it being implemented?

This adds a new `public` method called `removeTiles` to `MapboxOfflineRouter` which takes a tiles version string, a bounding box and a callback to be notified for when all the tiles are completely removed.

## How has this been tested?

- `OnOfflineTilesRemovedCallback#onRemoved` tells you the number deleted tiles
  - Added `Remove Region` to `OfflineRegionDownloadActivity`
  - Downloaded a bounding box which included DC and some parts of Maryland and Virginia
  - Removed a bounding box which included DC
  - `9 routing tiles were removed`
  - Checked that files in the file system were removed

## Checklist

- [x] I have tested locally / staging (including `SNAPSHOT` upstream dependencies if needed)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added an `Activity` example in the test app showing the new feature implemented
- [x] Bump `mapboxNavigator` version when NN stable release is available

cc @kevinkreiser @ksummerill 