### PR TITLE
Update LocationComponent to use LocationComponentActivationOptions

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/NavigationMapboxMap.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/NavigationMapboxMap.java
@@ -16,12 +16,14 @@ import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.geojson.Point;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.location.LocationComponent;
+import com.mapbox.mapboxsdk.location.LocationComponentActivationOptions;
 import com.mapbox.mapboxsdk.location.LocationComponentOptions;
 import com.mapbox.mapboxsdk.location.OnCameraTrackingChangedListener;
 import com.mapbox.mapboxsdk.location.modes.RenderMode;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.plugins.annotation.SymbolManager;
 import com.mapbox.mapboxsdk.style.sources.Source;
 import com.mapbox.mapboxsdk.style.sources.VectorSource;
@@ -571,9 +573,14 @@ public class NavigationMapboxMap {
     map.setMinZoomPreference(NAVIGATION_MINIMUM_MAP_ZOOM);
     map.setMaxZoomPreference(NAVIGATION_MAXIMUM_MAP_ZOOM);
     Context context = mapView.getContext();
+    Style style = map.getStyle();
     int locationLayerStyleRes = findLayerStyleRes(context);
     LocationComponentOptions options = LocationComponentOptions.createFromAttributes(context, locationLayerStyleRes);
-    locationComponent.activateLocationComponent(context, map.getStyle(), null, options);
+    LocationComponentActivationOptions activationOptions = LocationComponentActivationOptions.builder(context, style)
+      .locationComponentOptions(options)
+      .useDefaultLocationEngine(false)
+      .build();
+    locationComponent.activateLocationComponent(activationOptions);
     locationComponent.setLocationComponentEnabled(true);
   }
 


### PR DESCRIPTION
## Description

Maps SDK `7.3.0` introduces a new `LocationComponentActivationOptions` and deprecated the old `activateLocationComponent` methods.  

## What's the goal?

Remove deprecated use of `LocationComponent#activateLocationComponent` in the `NavigationMapboxMap`.

## How is it being implemented?

Updating `NavigationMapboxMap` `LocationComponent` initialization to use `LocationComponentActivationOptions`.
## Checklist

- [x] I have tested locally / staging (including `SNAPSHOT` upstream dependencies if needed)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes