### PR TITLE
Add offline options to Navigation Launcher

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/NavigationLauncherActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/NavigationLauncherActivity.java
@@ -26,6 +26,7 @@ import com.mapbox.api.directions.v5.DirectionsCriteria;
 import com.mapbox.api.directions.v5.models.DirectionsResponse;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.core.constants.Constants;
+import com.mapbox.core.utils.TextUtils;
 import com.mapbox.geojson.LineString;
 import com.mapbox.geojson.Point;
 import com.mapbox.mapboxsdk.Mapbox;
@@ -51,6 +52,7 @@ import com.mapbox.services.android.navigation.ui.v5.route.OnRouteSelectionChange
 import com.mapbox.services.android.navigation.v5.navigation.NavigationRoute;
 import com.mapbox.services.android.navigation.v5.utils.LocaleUtils;
 
+import java.io.File;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
@@ -62,6 +64,8 @@ import butterknife.OnClick;
 import retrofit2.Call;
 import retrofit2.Response;
 import timber.log.Timber;
+
+import static android.os.Environment.getExternalStoragePublicDirectory;
 
 public class NavigationLauncherActivity extends AppCompatActivity implements OnMapReadyCallback,
   MapboxMap.OnMapLongClickListener, OnRouteSelectionChangeListener {
@@ -321,6 +325,16 @@ public class NavigationLauncherActivity extends AppCompatActivity implements OnM
     );
   }
 
+  private String obtainOfflinePath() {
+    File offline = getExternalStoragePublicDirectory("Offline");
+    return offline.getAbsolutePath();
+  }
+
+  private String retrieveOfflineVersionFromPreferences() {
+    SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
+    return sharedPreferences.getString(getString(R.string.offline_version_key), "");
+  }
+
   private void launchNavigationWithRoute() {
     if (route == null) {
       Snackbar.make(mapView, R.string.error_route_not_available, Snackbar.LENGTH_SHORT).show();
@@ -335,6 +349,14 @@ public class NavigationLauncherActivity extends AppCompatActivity implements OnM
       .build();
     optionsBuilder.initialMapCameraPosition(initialPosition);
     optionsBuilder.directionsRoute(route);
+    String offlinePath = obtainOfflinePath();
+    if (!TextUtils.isEmpty(offlinePath)) {
+      optionsBuilder.offlineRoutingTilesPath(offlinePath);
+    }
+    String offlineVersion = retrieveOfflineVersionFromPreferences();
+    if (!offlineVersion.isEmpty()) {
+      optionsBuilder.offlineRoutingTilesVersion(offlineVersion);
+    }
     NavigationLauncher.startNavigation(this, optionsBuilder.build());
   }
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/MapboxNavigationActivity.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/MapboxNavigationActivity.java
@@ -130,8 +130,15 @@ public class MapboxNavigationActivity extends AppCompatActivity implements OnNav
 
   private void extractConfiguration(NavigationViewOptions.Builder options) {
     SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(this);
-    options.shouldSimulateRoute(preferences
-      .getBoolean(NavigationConstants.NAVIGATION_VIEW_SIMULATE_ROUTE, false));
+    options.shouldSimulateRoute(preferences.getBoolean(NavigationConstants.NAVIGATION_VIEW_SIMULATE_ROUTE, false));
+    String offlinePath = preferences.getString(NavigationConstants.OFFLINE_PATH_KEY, "");
+    if (!offlinePath.isEmpty()) {
+      options.offlineRoutingTilesPath(offlinePath);
+    }
+    String offlineVersion = preferences.getString(NavigationConstants.OFFLINE_VERSION_KEY, "");
+    if (!offlineVersion.isEmpty()) {
+      options.offlineRoutingTilesVersion(offlineVersion);
+    }
   }
 
   private void finishNavigation() {

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationLauncher.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationLauncher.java
@@ -38,6 +38,8 @@ public class NavigationLauncher {
     storeConfiguration(options, editor);
 
     storeThemePreferences(options, editor);
+    storeOfflinePath(options, editor);
+    storeOfflineVersion(options, editor);
 
     editor.apply();
 
@@ -71,6 +73,8 @@ public class NavigationLauncher {
       .remove(NavigationConstants.NAVIGATION_VIEW_PREFERENCE_SET_THEME)
       .remove(NavigationConstants.NAVIGATION_VIEW_LIGHT_THEME)
       .remove(NavigationConstants.NAVIGATION_VIEW_DARK_THEME)
+      .remove(NavigationConstants.OFFLINE_PATH_KEY)
+      .remove(NavigationConstants.OFFLINE_VERSION_KEY)
       .apply();
   }
 
@@ -103,4 +107,13 @@ public class NavigationLauncher {
       );
     }
   }
+
+  private static void storeOfflinePath(NavigationLauncherOptions options, SharedPreferences.Editor editor) {
+    editor.putString(NavigationConstants.OFFLINE_PATH_KEY, options.offlineRoutingTilesPath());
+  }
+
+  private static void storeOfflineVersion(NavigationLauncherOptions options, SharedPreferences.Editor editor) {
+    editor.putString(NavigationConstants.OFFLINE_VERSION_KEY, options.offlineRoutingTilesVersion());
+  }
+
 }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationLauncherOptions.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationLauncherOptions.java
@@ -27,6 +27,28 @@ public abstract class NavigationLauncherOptions extends NavigationUiOptions {
 
     public abstract Builder initialMapCameraPosition(@Nullable CameraPosition initialMapCameraPosition);
 
+    /**
+     * Add an offline path for loading offline routing data.
+     * <p>
+     * When added, the {@link NavigationView} will try to initialize and use this data
+     * for offline routing when no or poor internet connection is found.
+     *
+     * @param offlinePath to offline data on device
+     * @return this builder
+     */
+    public abstract Builder offlineRoutingTilesPath(String offlinePath);
+
+    /**
+     * Add an offline tile version.  When providing a routing tile path, this version
+     * is also required for configuration.
+     * <p>
+     * This version should directly correspond to the data in the offline path also provided.
+     *
+     * @param offlineVersion of data in tile path
+     * @return this builder
+     */
+    public abstract Builder offlineRoutingTilesVersion(String offlineVersion);
+
     public abstract NavigationLauncherOptions build();
   }
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationUiOptions.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationUiOptions.java
@@ -17,4 +17,10 @@ public abstract class NavigationUiOptions {
   public abstract boolean shouldSimulateRoute();
 
   public abstract boolean waynameChipEnabled();
+
+  @Nullable
+  public abstract String offlineRoutingTilesPath();
+
+  @Nullable
+  public abstract String offlineRoutingTilesVersion();
 }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewOptions.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewOptions.java
@@ -61,12 +61,6 @@ public abstract class NavigationViewOptions extends NavigationUiOptions {
   @Nullable
   public abstract LocationEngine locationEngine();
 
-  @Nullable
-  public abstract String offlineRoutingTilesPath();
-
-  @Nullable
-  public abstract String offlineRoutingTilesVersion();
-
   @AutoValue.Builder
   public abstract static class Builder {
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationConstants.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationConstants.java
@@ -151,6 +151,8 @@ public final class NavigationConstants {
   public static final String NAVIGATION_VIEW_ROUTE_KEY = "route_json";
   public static final String NAVIGATION_VIEW_SIMULATE_ROUTE = "navigation_view_simulate_route";
   public static final String NAVIGATION_VIEW_ROUTE_PROFILE_KEY = "navigation_view_route_profile";
+  public static final String OFFLINE_PATH_KEY = "offline_path_key";
+  public static final String OFFLINE_VERSION_KEY = "offline_version_key";
 
   // Step Maneuver Types
   public static final String STEP_MANEUVER_TYPE_TURN = "turn";


### PR DESCRIPTION
## Description

Adds offline options (path and version) to navigation launcher

## What's the goal?

Test https://github.com/mapbox/mapbox-navigation-android/pull/1829 within the drop-in UI > `NavigationLauncherActivity` > `NavigationLauncher` > `MapboxNavigationActivity` > `NavigationView`

## How is it being implemented?

Add support to `NavigationLauncherActivity` / `NavigationLauncher` to retrieve / store `offlinePath` and `offlineVersion` options

## How has this been tested?

- Test `NavigationLauncherActivity` on the field 👀 https://github.com/mapbox/mapbox-navigation-android/pull/1829 - downloading an offline region previously from where the test drive is going to happen

## Checklist

- [x] I have tested locally / staging (including `SNAPSHOT` upstream dependencies if needed)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [ ] Publish `testapp` in Google Play `internal` test track