### PR TITLE
Add offline version check to Navigation View Router

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewRouter.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewRouter.java
@@ -117,10 +117,13 @@ class NavigationViewRouter implements RouteListener {
 
   private void initializeOfflineFrom(NavigationViewOptions options) {
     String offlinePath = options.offlineRoutingTilesPath();
-    if (!TextUtils.isEmpty(offlinePath)) {
-      MapboxOfflineRouter offlineRouter = new MapboxOfflineRouter(offlinePath);
-      this.offlineRouter = new NavigationViewOfflineRouter(offlineRouter, this);
-      this.offlineRouter.configure(options.offlineRoutingTilesVersion());
+    String offlineTilesVersion = options.offlineRoutingTilesVersion();
+    if (!TextUtils.isEmpty(offlinePath) && !TextUtils.isEmpty(offlineTilesVersion)) {
+      if (this.offlineRouter == null) {
+        MapboxOfflineRouter offlineRouter = new MapboxOfflineRouter(offlinePath);
+        this.offlineRouter = new NavigationViewOfflineRouter(offlineRouter, this);
+      }
+      this.offlineRouter.configure(offlineTilesVersion);
     }
   }
 

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewRouterTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewRouterTest.java
@@ -213,6 +213,118 @@ public class NavigationViewRouterTest extends BaseTest {
     verify(onlineRouter).clearListeners();
   }
 
+  @Test
+  public void checksOfflineRouterIsConfiguredIfPathAndTilesVersionArePresent() throws Exception {
+    NavigationViewOfflineRouter offlineRouter = mock(NavigationViewOfflineRouter.class);
+    String anOfflineRoutingTilesVersion = "offline_routing_tiles_version";
+    NavigationViewOptions options = NavigationViewOptions.builder()
+      .directionsRoute(buildDirectionsRoute())
+      .offlineRoutingTilesPath("offline/routing/tiles/path")
+      .offlineRoutingTilesVersion(anOfflineRoutingTilesVersion)
+      .build();
+    NavigationViewRouter router = new NavigationViewRouter(
+      mock(RouteFetcher.class),
+      offlineRouter,
+      mock(ConnectivityStatusProvider.class),
+      mock(RouteComparator.class),
+      mock(ViewRouteListener.class)
+    );
+
+    router.extractRouteOptions(options);
+
+    verify(offlineRouter).configure(eq(anOfflineRoutingTilesVersion));
+  }
+
+  @Test
+  public void checksOfflineRouterIsNotConfiguredIfPathIsNull() throws Exception {
+    NavigationViewOfflineRouter offlineRouter = mock(NavigationViewOfflineRouter.class);
+    String anyOfflineRoutingTilesVersion = "any_offline_routing_tiles_version";
+    NavigationViewOptions options = NavigationViewOptions.builder()
+      .directionsRoute(buildDirectionsRoute())
+      .offlineRoutingTilesPath(null)
+      .offlineRoutingTilesVersion(anyOfflineRoutingTilesVersion)
+      .build();
+    NavigationViewRouter router = new NavigationViewRouter(
+      mock(RouteFetcher.class),
+      offlineRouter,
+      mock(ConnectivityStatusProvider.class),
+      mock(RouteComparator.class),
+      mock(ViewRouteListener.class)
+    );
+
+    router.extractRouteOptions(options);
+
+    verify(offlineRouter, times(0)).configure(eq(anyOfflineRoutingTilesVersion));
+  }
+
+  @Test
+  public void checksOfflineRouterIsNotConfiguredIfPathIsEmpty() throws Exception {
+    NavigationViewOfflineRouter offlineRouter = mock(NavigationViewOfflineRouter.class);
+    String anyOfflineRoutingTilesVersion = "any_offline_routing_tiles_version";
+    NavigationViewOptions options = NavigationViewOptions.builder()
+      .directionsRoute(buildDirectionsRoute())
+      .offlineRoutingTilesPath("")
+      .offlineRoutingTilesVersion(anyOfflineRoutingTilesVersion)
+      .build();
+    NavigationViewRouter router = new NavigationViewRouter(
+      mock(RouteFetcher.class),
+      offlineRouter,
+      mock(ConnectivityStatusProvider.class),
+      mock(RouteComparator.class),
+      mock(ViewRouteListener.class)
+    );
+
+    router.extractRouteOptions(options);
+
+    verify(offlineRouter, times(0)).configure(eq(anyOfflineRoutingTilesVersion));
+  }
+
+  @Test
+  public void checksOfflineRouterIsNotConfiguredIfTilesVersionIsNull() throws Exception {
+    NavigationViewOfflineRouter offlineRouter = mock(NavigationViewOfflineRouter.class);
+    String anyOfflinePath = "any/offline/routing/tiles/path";
+    String nullOfflineRoutingTilesVersion = null;
+    NavigationViewOptions options = NavigationViewOptions.builder()
+      .directionsRoute(buildDirectionsRoute())
+      .offlineRoutingTilesPath(null)
+      .offlineRoutingTilesVersion(anyOfflinePath)
+      .build();
+    NavigationViewRouter router = new NavigationViewRouter(
+      mock(RouteFetcher.class),
+      offlineRouter,
+      mock(ConnectivityStatusProvider.class),
+      mock(RouteComparator.class),
+      mock(ViewRouteListener.class)
+    );
+
+    router.extractRouteOptions(options);
+
+    verify(offlineRouter, times(0)).configure(eq(nullOfflineRoutingTilesVersion));
+  }
+
+  @Test
+  public void checksOfflineRouterIsNotConfiguredIfTilesVersionIsEmpty() throws Exception {
+    NavigationViewOfflineRouter offlineRouter = mock(NavigationViewOfflineRouter.class);
+    String anyOfflinePath = "any/offline/routing/tiles/path";
+    String emptyOfflineRoutingTilesVersion = "";
+    NavigationViewOptions options = NavigationViewOptions.builder()
+      .directionsRoute(buildDirectionsRoute())
+      .offlineRoutingTilesPath(anyOfflinePath)
+      .offlineRoutingTilesVersion(emptyOfflineRoutingTilesVersion)
+      .build();
+    NavigationViewRouter router = new NavigationViewRouter(
+      mock(RouteFetcher.class),
+      offlineRouter,
+      mock(ConnectivityStatusProvider.class),
+      mock(RouteComparator.class),
+      mock(ViewRouteListener.class)
+    );
+
+    router.extractRouteOptions(options);
+
+    verify(offlineRouter, times(0)).configure(eq(emptyOfflineRoutingTilesVersion));
+  }
+
   @NonNull
   private NavigationViewRouter buildRouteEngine(ViewRouteListener routeEngineListener) {
     return new NavigationViewRouter(mock(RouteFetcher.class), mock(ConnectivityStatusProvider.class),


### PR DESCRIPTION
## Description

Adds offline version check to `NavigationViewRouter` needed for configuring the offline router

- Fixes 

```
04-04 11:48:43.276 1983-1983/com.mapbox.services.android.navigation.app E/Mbgl-MapChangeReceiver: Exception in onDidFinishLoadingStyle
    java.lang.NullPointerException: name == null
        at java.io.File.<init>(File.java:146)
        at com.mapbox.services.android.navigation.v5.navigation.MapboxOfflineRouter.configure(MapboxOfflineRouter.java:58)
        at com.mapbox.services.android.navigation.ui.v5.NavigationViewOfflineRouter.configure(NavigationViewOfflineRouter.java:23)
        at com.mapbox.services.android.navigation.ui.v5.NavigationViewRouter.initializeOfflineFrom(NavigationViewRouter.java:123)
        at com.mapbox.services.android.navigation.ui.v5.NavigationViewRouter.extractRouteOptions(NavigationViewRouter.java:69)
        at com.mapbox.services.android.navigation.ui.v5.NavigationViewModel.initialize(NavigationViewModel.java:205)
        at com.mapbox.services.android.navigation.ui.v5.NavigationView.initializeNavigation(NavigationView.java:624)
        at com.mapbox.services.android.navigation.ui.v5.NavigationView.startNavigation(NavigationView.java:387)
        at com.mapbox.services.android.navigation.ui.v5.MapboxNavigationActivity.onNavigationReady(MapboxNavigationActivity.java:99)
        at com.mapbox.services.android.navigation.ui.v5.NavigationView$1.onStyleLoaded(NavigationView.java:225)
        at com.mapbox.mapboxsdk.maps.MapboxMap.notifyStyleLoaded(MapboxMap.java:846)
        at com.mapbox.mapboxsdk.maps.MapboxMap.onFinishLoadingStyle(MapboxMap.java:206)
        at com.mapbox.mapboxsdk.maps.MapView$MapCallback.onDidFinishLoadingStyle(MapView.java:1178)
        at com.mapbox.mapboxsdk.maps.MapChangeReceiver.onDidFinishLoadingStyle(MapChangeReceiver.java:194)
        at com.mapbox.mapboxsdk.maps.NativeMapView.onDidFinishLoadingStyle(NativeMapView.java:1040)
        at android.os.MessageQueue.nativePollOnce(Native Method)
        at android.os.MessageQueue.next(MessageQueue.java:323)
        at android.os.Looper.loop(Looper.java:135)
        at android.app.ActivityThread.main(ActivityThread.java:5417)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616)
```

## What's the goal?

https://github.com/mapbox/mapbox-navigation-android/pull/1862 added offline options and `NavigationViewOfflineRouter` wasn't 👀 if the offline tiles version was empty or `null` causing above crash and leading to an ANR. The goal here is to account for this case / prevent any issues in this scenario

## How is it being implemented?

Only `configure` `NavigationViewRouter` if both the `offlinePath` and `offlineTilesVersion` are not empty nor `null`

## How has this been tested?

Tested `NavigationLauncherActivity` without previously selecting an offline tiles version and not 👀 the crash / ANR anymore

## Checklist

- [x] I have tested locally / staging (including `SNAPSHOT` upstream dependencies if needed)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Publish `testapp` in Google Play `internal` test track