### PR TITLE
Add check to only start Route Processor Background Thread once

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/RouteProcessorBackgroundThread.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/RouteProcessorBackgroundThread.java
@@ -34,12 +34,14 @@ class RouteProcessorBackgroundThread extends HandlerThread {
 
   @Override
   public synchronized void start() {
-    super.start();
-    if (workerHandler == null) {
-      workerHandler = new Handler(getLooper());
+    if (super.getState() == Thread.State.NEW) {
+      super.start();
+      if (workerHandler == null) {
+        workerHandler = new Handler(getLooper());
+      }
+      runnable = new RouteProcessorRunnable(routeProcessor, navigation, workerHandler, responseHandler, listener);
+      workerHandler.post(runnable);
     }
-    runnable = new RouteProcessorRunnable(routeProcessor, navigation, workerHandler, responseHandler, listener);
-    workerHandler.post(runnable);
   }
 
   @Override


### PR DESCRIPTION
## Description

Adds a check to only start `RouteProcessorBackgroundThread` only if new / not already started

- Fixes 👇 found during testing

```
Fatal Exception: java.lang.IllegalThreadStateException
       at java.lang.Thread.start(Thread.java:724)
       at com.mapbox.services.android.navigation.v5.navigation.RouteProcessorBackgroundThread.start(RouteProcessorBackgroundThread.java:1)
       at com.mapbox.services.android.navigation.v5.navigation.RouteProcessorBackgroundThread.updateLocation(RouteProcessorBackgroundThread.java:15)
       at com.mapbox.services.android.navigation.v5.navigation.LocationUpdater.updateLocationEngine(LocationUpdater.java:4)
       at com.mapbox.services.android.navigation.v5.navigation.LocationUpdater$CurrentLocationEngineCallback.onSuccess(LocationUpdater.java:14)
       at com.mapbox.services.android.navigation.v5.navigation.LocationUpdater$CurrentLocationEngineCallback.onSuccess(LocationUpdater.java:14)
       at com.mapbox.services.android.navigation.v5.navigation.LocationUpdater$CurrentLocationEngineCallback.onSuccess(LocationUpdater.java:2)
       at com.mapbox.services.android.navigation.v5.navigation.LocationUpdater$CurrentLocationEngineCallback.onSuccess(LocationUpdater.java:2)
       at com.mapbox.android.core.location.MapboxFusedLocationEngineImpl$MapboxLocationEngineCallbackTransport.onLocationChanged(MapboxFusedLocationEngineImpl.java:22)
       at android.location.LocationManager$ListenerTransport._handleMessage(LocationManager.java:371)
       at android.location.LocationManager$ListenerTransport.access$000(LocationManager.java:300)
       at android.location.LocationManager$ListenerTransport$2.handleMessage(LocationManager.java:323)
       at android.os.Handler.dispatchMessage(Handler.java:106)
       at android.os.Looper.loop(Looper.java:193)
       at android.app.ActivityThread.main(ActivityThread.java:6718)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)
```

## What's the goal?

The goal is to only start `RouteProcessorBackgroundThread` once preventing those kind of crashes to happen again. We should investigate deeper though why we haven't seen this crash before, wondering if it's a device / system specific issue 🤔 The crash happened in a Pixel 3 running Android version 9

## How is it being implemented?

Checking state of the thread (`Thread.State.NEW`) before starting it

## How has this been tested?

Tested test app examples without seeing any issues / crashes

## Checklist

- [x] I have tested locally / staging (including `SNAPSHOT` upstream dependencies if needed)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [ ] Publish `testapp` in Google Play `internal` test track