### PR TITLE
Bump mapbox-android-plugin-annotation-v7 version to 0.6.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -14,7 +14,7 @@ ext {
       mapboxCore             : '1.2.0',
       mapboxNavigator        : '6.1.0',
       mapboxCrashMonitor     : '2.0.0',
-      mapboxAnnotationPlugin : '0.5.0',
+      mapboxAnnotationPlugin : '0.6.0',
       mapboxSearchSdk        : '0.1.0-SNAPSHOT',
       autoValue              : '1.5.4',
       autoValueParcel        : '0.2.5',


### PR DESCRIPTION
## Description

- Bumps `mapbox-android-plugin-annotation-v7` version to `0.6.0`

## What's the goal?

Getting the latest version from `mapboxAnnotationPlugin` including the new features and bug fixes.

## How is it being implemented?

Bumping the `mapboxAnnotationPlugin` version to `0.6.0` in `dependencies.gradle`

## How has this been tested?

Tested that all the `Activities` in the test app and didn't 👀 any issues

## Checklist

- [x] I have tested locally / staging (including `SNAPSHOT` upstream dependencies if needed)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes