### PR TITLE
Bump mapbox-android-telemetry version to 4.3.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -10,7 +10,7 @@ ext {
   version = [
       mapboxMapSdk           : '7.3.0',
       mapboxSdkServices      : '4.5.0',
-      mapboxEvents           : '4.2.0',
+      mapboxEvents           : '4.3.0',
       mapboxCore             : '1.2.0',
       mapboxNavigator        : '6.1.0',
       mapboxCrashMonitor     : '2.0.0',


### PR DESCRIPTION
## Description

- Bumps `mapbox-android-telemetry` version to `4.3.0`

## What's the goal?

Getting the latest version from `mapboxEvents` including the new features and bug fixes.

## How is it being implemented?

Bumping the `mapboxEvents` version to `4.3.0` in `dependencies.gradle`

## How has this been tested?

Tested that all the `Activities` in the test app and didn't 👀 any issues

## Checklist

- [x] I have tested locally / staging (including `SNAPSHOT` upstream dependencies if needed)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes