### PR TITLE
Github PR template refactor

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,57 +1,42 @@
-### ⚠️ TEMPLATE ⚠️
-**Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your commited changes.**
-
-## Title
-
-Please include some human-understandable summary
+###
+<!-- ⚠️ TEMPLATE ⚠️ -->
+<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your commited changes. -->
 
 ## Description
 
-Please include a brief summary of the change and which issue is fixed
+Please include a brief summary of the change and which issue is fixed (e.g., fixes [#issue](link))
 
-- Fixes [#issue](link)
+- [ ] I have added any issue links
+- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
+- [ ] I have added the appropriate milestone and project boards
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
 
-## What's the goal?
+### Goal
 
 Please describe the PR goals. Just the stuff needed to implement the fix / feature and a simple rationale. It could contain many check points if needed
 
-## How is it being implemented?
+### Implementation
 
 Please include all the relevant things implemented and also rationale, aclarations / disclaimers etc. related to the approach used. It could be as self code companion comments
 
 ## Screenshots or Gifs
 
 Please include all the media files to give some context about what's being implemented or fixed. It's not mandatory to upload screenshots or gifs, but for most of the cases it becomes really handy to get into the scope of the feature / bug being fixed and aslo it's REALLY useful for UI related PRs
-
 ![screenshot gif](link)
 
-## How has this been tested?
+## Testing
 
-Please describe the manual tests that you ran to verify your changes. Test drive if possible, if not use simulation or any mock location app
+Please describe the manual tests that you ran to verify your changes
 
-- Test A
-- Test B
-
-## Type of change
-
-Please add all related Labels `bug`, `feature`, `new API(s)`, `SEMVER`, etc.
-
-## Projects
-
-Please attach the ticket to the appropriate project boards
-
-## Milestone
-
-Please add the appropriate milestone to the ticket
-
-## Checklist
-
-- [ ] I have tested locally / staging (including `SNAPSHOT` upstream dependencies if needed)
-- [ ] My code follows the style guidelines of this project
-- [ ] I have performed a self-review of my own code
-- [ ] I have made corresponding changes to the documentation
+- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed)
+- [ ] I have test driven or tested via simulation/mock location app
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
+
+<!-- ## Checklist - where applicable
+
 - [ ] I have added an `Activity` example in the test app showing the new feature implemented
+- [ ] I have made corresponding changes to the documentation
 - [ ] Any changes to strings have been published to our translation tool
-- [ ] Publish `testapp` in Google Play `internal` test track
+- [ ] Publish `testapp` in Google Play `internal` test track -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,7 +34,7 @@ Please describe the manual tests that you ran to verify your changes
 
 - [ ] My code follows the style guidelines of this project
 - [ ] I have performed a self-review of my own code
-- [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable)
-- [ ] I have made corresponding changes to the documentation (where applicable)
-- [ ] Any changes to strings have been published to our translation tool (where applicable)
-- [ ] Publish `testapp` in Google Play `internal` test track (where applicable)
+<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
+<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
+<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
+<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,5 @@
-###
 <!-- ⚠️ TEMPLATE ⚠️ -->
-<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your commited changes. -->
+<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->
 
 ## Description
 
@@ -9,8 +8,6 @@ Please include a brief summary of the change and which issue is fixed (e.g., fix
 - [ ] I have added any issue links
 - [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
 - [ ] I have added the appropriate milestone and project boards
-- [ ] My code follows the style guidelines of this project
-- [ ] I have performed a self-review of my own code
 
 ### Goal
 
@@ -18,25 +15,26 @@ Please describe the PR goals. Just the stuff needed to implement the fix / featu
 
 ### Implementation
 
-Please include all the relevant things implemented and also rationale, aclarations / disclaimers etc. related to the approach used. It could be as self code companion comments
+Please include all the relevant things implemented and also rationale, clarifications / disclaimers etc. related to the approach used. It could be as self code companion comments
 
 ## Screenshots or Gifs
 
-Please include all the media files to give some context about what's being implemented or fixed. It's not mandatory to upload screenshots or gifs, but for most of the cases it becomes really handy to get into the scope of the feature / bug being fixed and aslo it's REALLY useful for UI related PRs
-![screenshot gif](link)
+Please include all the media files to give some context about what's being implemented or fixed. It's not mandatory to upload screenshots or gifs, but for most of the cases it becomes really handy to get into the scope of the feature / bug being fixed and also it's REALLY useful for UI related PRs ![screenshot gif](link)
 
 ## Testing
 
 Please describe the manual tests that you ran to verify your changes
 
 - [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed)
-- [ ] I have test driven or tested via simulation/mock location app
+- [ ] I have tested via a test drive, or a simulation/mock location app
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 
-<!-- ## Checklist - where applicable
+## Checklist
 
-- [ ] I have added an `Activity` example in the test app showing the new feature implemented
-- [ ] I have made corresponding changes to the documentation
-- [ ] Any changes to strings have been published to our translation tool
-- [ ] Publish `testapp` in Google Play `internal` test track -->
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable)
+- [ ] I have made corresponding changes to the documentation (where applicable)
+- [ ] Any changes to strings have been published to our translation tool (where applicable)
+- [ ] Publish `testapp` in Google Play `internal` test track (where applicable)


### PR DESCRIPTION
## Description

Just a few ideas of what I think makes the template a little easier to use. Any suggestions welcome

## What's the goal?

Make the PR template easier to use

## Screenshots or Gifs

<img width="570" alt="Screen Shot 2019-04-12 at 1 21 52 PM" src="https://user-images.githubusercontent.com/14295757/56054920-2442aa80-5d26-11e9-8870-a5d8638e31c9.png">

## How has this been tested?

Using github preview

## Checklist

- [x] I have tested locally / staging (including `SNAPSHOT` upstream dependencies if needed)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
