### PR TITLE
Bump mapbox-android-sdk version to 7.3.1

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,7 +8,7 @@ ext {
   ]
 
   version = [
-      mapboxMapSdk           : '7.3.0',
+      mapboxMapSdk           : '7.3.1',
       mapboxSdkServices      : '4.5.0',
       mapboxEvents           : '4.3.0',
       mapboxCore             : '1.2.0',


### PR DESCRIPTION
## Description

- Bumps `mapbox-android-sdk` version to `7.3.1`
Fixes https://github.com/mapbox/mapbox-navigation-android/issues/1865

## What's the goal?

Getting the latest version from `mapboxMapSdk` including the new features and bug fixes.

## How is it being implemented?

Bumping the `mapboxMapSdk` version to `7.3.1` in `dependencies.gradle`

## How has this been tested?

Tested that all the `Activities` in the test app and didn't 👀 any issues

## Checklist

- [x] I have tested locally / staging (including `SNAPSHOT` upstream dependencies if needed)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes