### PR TITLE
Add custom history events for MapboxNavigation

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/HistoryActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/HistoryActivity.java
@@ -1,12 +1,10 @@
 package com.mapbox.services.android.navigation.testapp.activity;
 
-import android.location.Location;
 import android.support.annotation.NonNull;
 import android.support.v7.app.AppCompatActivity;
 
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation;
 import com.mapbox.services.android.navigation.v5.routeprogress.ProgressChangeListener;
-import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -18,6 +16,7 @@ public class HistoryActivity extends AppCompatActivity {
 
   private MapboxNavigation navigation;
   private String filename;
+  private ProgressChangeListener progressHistoryListener = (location, routeProgress) -> executeStoreHistoryTask();
 
   public void addNavigationForHistory(@NonNull MapboxNavigation navigation) {
     if (navigation == null) {
@@ -27,6 +26,10 @@ public class HistoryActivity extends AppCompatActivity {
     navigation.addProgressChangeListener(progressHistoryListener);
     navigation.toggleHistory(true);
     filename = buildFileName();
+  }
+
+  protected void executeStoreHistoryTask() {
+    new StoreHistoryTask(navigation, filename).execute();
   }
 
   @Override
@@ -47,11 +50,4 @@ public class HistoryActivity extends AppCompatActivity {
     String strDate = DATE_FORMAT.format(now);
     return strDate;
   }
-
-  private ProgressChangeListener progressHistoryListener = new ProgressChangeListener() {
-    @Override
-    public void onProgressChange(Location location, RouteProgress routeProgress) {
-      new StoreHistoryTask(navigation, filename).execute();
-    }
-  };
 }

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/ComponentNavigationActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/ComponentNavigationActivity.java
@@ -58,6 +58,7 @@ import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 
 import java.io.File;
 import java.lang.ref.WeakReference;
+import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 
@@ -187,6 +188,7 @@ public class ComponentNavigationActivity extends HistoryActivity implements OnMa
     // Start navigation
     adjustMapPaddingForNavigation();
     navigation.startNavigation(route);
+    addEventToHistoryFile("start_navigation");
 
     // Location updates will be received from ProgressChangeListener
     removeLocationEngineListener();
@@ -428,6 +430,8 @@ public class ComponentNavigationActivity extends HistoryActivity implements OnMa
   private void resetMapAfterNavigation() {
     navigationMap.removeRoute();
     navigationMap.clearMarkers();
+    addEventToHistoryFile("cancel_navigation");
+    executeStoreHistoryTask();
     navigation.stopNavigation();
     moveCameraOverhead();
   }
@@ -488,6 +492,11 @@ public class ComponentNavigationActivity extends HistoryActivity implements OnMa
     } else {
       vibrator.vibrate(ONE_HUNDRED_MILLISECONDS);
     }
+  }
+
+  private void addEventToHistoryFile(String type) {
+    double secondsFromEpoch = new Date().getTime() / 1000.0;
+    navigation.addHistoryEvent(type, Double.toString(secondsFromEpoch));
   }
 
   @NonNull

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
@@ -794,6 +794,10 @@ public class MapboxNavigation implements ServiceConnection {
     mapboxNavigator.toggleHistory(isEnabled);
   }
 
+  public void addHistoryEvent(String eventType, String eventJsonProperties) {
+    mapboxNavigator.addHistoryEvent(eventType, eventJsonProperties);
+  }
+
   public String retrieveSsmlAnnouncementInstruction(int index) {
     return mapboxNavigator.retrieveVoiceInstruction(index).getSsmlAnnouncement();
   }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigator.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigator.java
@@ -77,6 +77,9 @@ class MapboxNavigator {
     navigator.toggleHistory(isEnabled);
   }
 
+  synchronized void addHistoryEvent(String eventType, String eventJsonProperties) {
+    navigator.pushHistory(eventType, eventJsonProperties);
+  }
 
   synchronized VoiceInstruction retrieveVoiceInstruction(int index) {
     return navigator.getVoiceInstruction(index);
@@ -86,7 +89,7 @@ class MapboxNavigator {
     return navigator.getBannerInstruction(index);
   }
 
-  FixLocation buildFixLocationFromLocation(Location location) {
+  private FixLocation buildFixLocationFromLocation(Location location) {
     Date time = new Date();
     Point rawPoint = Point.fromLngLat(location.getLongitude(), location.getLatitude());
     Float speed = checkFor(location.getSpeed());


### PR DESCRIPTION
## Description

- Adds custom history events support in `MapboxNavigation`

## What's the goal?

Being able to include custom events in a history file. This can be useful to log things that happen during navigation that are specific to your application

## How is it being implemented?

Exposing `addHistoryEvent` in `MapboxNavigation` that delegates the call to `MapboxNavigator#addHistoryEvent` which also delegates into `Navigator#pushHistory`

## How has this been tested?

Added `start_navigation` and `cancel_navigation` custom events in `ComponentNavigationActivity` and checked that both events were included in the generated history file

```json
{
	"events": [{
		"type": "setRoute",
		"route": "{\"routeIndex\":\"0\",\"distance\":1211.6,\"duration\":215.6,\"geometry\":\"snmriApo`erCiNlWgu@st@dyAawCrEkJ~BmEcEyAqBc@}DeE{MoNqGqGoBqBiCgCuBuBuGsGsOmOaXyWag@{j@aRa\\\\iT{i@ou@emBnMoIpHaIcJ_NaBx@}LoY\",\"weight\":396.7,\"weight_name\":\"routability\",\"legs\":[{\"distance\":1211.6,\"duration\":215.6,\"summary\":\"Frederick Road, Redland Road\",\"steps\":[{\"distance\":43.4,\"duration\":10.6,\"geometry\":\"snmriApo`erCiNlW\",\"name\":\"Elmcroft Boulevard\",\"mode\":\"driving\",\"maneuver\":{\"location\":[-77.169417,39.116026],\"bearing_before\":0.0,\"bearing_after\":309.0,\"instruction\":\"Head northwest on Elmcroft Boulevard\",\"type\":\"depart\",\"modifier\":\"right\"},\"voiceInstructions\":[{\"distanceAlongGeometry\":43.4,\"announcement\":\"Head northwest on Elmcroft Boulevard, then turn right onto King Farm Boulevard\",\"ssmlAnnouncement\":\"\\u003cspeak\\u003e\\u003camazon:effect name\\u003d\\\"drc\\\"\\u003e\\u003cprosody rate\\u003d\\\"1.08\\\"\\u003eHead northwest on Elmcroft Boulevard, then turn right onto King Farm Boulevard\\u003c/prosody\\u003e\\u003c/amazon:effect\\u003e\\u003c/speak\\u003e\"}],\"bannerInstructions\":[{\"distanceAlongGeometry\":43.4,\"primary\":{\"text\":\"King Farm Boulevard\",\"components\":[{\"text\":\"King Farm Boulevard\",\"type\":\"text\",\"abbr\":\"King Farm Blvd\",\"abbr_priority\":0}],\"type\":\"turn\",\"modifier\":\"right\"},\"sub\":{\"text\":\"Frederick Road\",\"components\":[{\"text\":\"Frederick Road\",\"type\":\"text\",\"abbr\":\"Frederick Rd\",\"abbr_priority\":0}],\"type\":\"turn\",\"modifier\":\"right\"}}],\"driving_side\":\"right\",\"weight\":22.4,\"intersections\":[{\"location\":[-77.169417,39.116026],\"bearings\":[309],\"entry\":[true],\"out\":0}]},{\"distance\":121.7,\"duration\":31.4,\"geometry\":\"}}mriA~gaerCgu@st@\",\"name\":\"King Farm Boulevard\",\"mode\":\"driving\",\"maneuver\":{\"location\":[-77.169808,39.116271],\"bearing_before\":307.0,\"bearing_after\":36.0,\"instruction\":\"Turn right onto King Farm Boulevard\",\"type\":\"turn\",\"modifier\":\"right\"},\"voiceInstructions\":[{\"distanceAlongGeometry\":58.1,\"announcement\":\"Turn right onto Frederick Road (MD 355 South)\",\"ssmlAnnouncement\":\"\\u003cspeak\\u003e\\u003camazon:effect name\\u003d\\\"drc\\\"\\u003e\\u003cprosody rate\\u003d\\\"1.08\\\"\\u003eTurn right onto Frederick Road (MD \\u003csay-as interpret-as\\u003d\\\"address\\\"\\u003e355\\u003c/say-as\\u003e South)\\u003c/prosody\\u003e\\u003c/amazon:effect\\u003e\\u003c/speak\\u003e\"}],\"bannerInstructions\":[{\"distanceAlongGeometry\":121.7,\"primary\":{\"text\":\"Frederick Road\",\"components\":[{\"text\":\"Frederick Road\",\"type\":\"text\",\"abbr\":\"Frederick Rd\",\"abbr_priority\":0}],\"type\":\"turn\",\"modifier\":\"right\"},\"secondary\":{\"text\":\"MD 355 South\",\"components\":[{\"text\":\"MD 355\",\"type\":\"icon\",\"imageBaseURL\":\"https://s3.amazonaws.com/mapbox/shields/v3/md-355\"},{\"text\":\"South\",\"type\":\"text\",\"abbr\":\"S\",\"abbr_priority\":0}],\"type\":\"turn\",\"modifier\":\"right\"}}],\"driving_side\":\"right\",\"weight\":56.0,\"intersections\":[{\"location\":[-77.169808,39.116271],\"bearings\":[30,135,225,315],\"entry\":[true,false,false,true],\"in\":1,\"out\":0}]},{\"distance\":283.9,\"duration\":48.4,\"geometry\":\"etoriAjr_erCdyAawCrEkJ\",\"name\":\"Frederick Road (MD 355 South)\",\"ref\":\"MD 355 South\",\"mode\":\"driving\",\"maneuver\":{\"location\":[-77.16895,39.117139],\"bearing_before\":36.0,\"bearing_after\":126.0,\"instruction\":\"Turn right onto Frederick Road (MD 355 South)\",\"type\":\"turn\",\"modifier\":\"right\"},\"voiceInstructions\":[{\"distanceAlongGeometry\":263.9,\"announcement\":\"In 900 feet, turn left onto Redland Road\",\"ssmlAnnouncement\":\"\\u003cspeak\\u003e\\u003camazon:effect name\\u003d\\\"drc\\\"\\u003e\\u003cprosody rate\\u003d\\\"1.08\\\"\\u003eIn 900 feet, turn left onto Redland Road\\u003c/prosody\\u003e\\u003c/amazon:effect\\u003e\\u003c/speak\\u003e\"},{\"distanceAlongGeometry\":88.0,\"announcement\":\"Turn left onto Redland Road\",\"ssmlAnnouncement\":\"\\u003cspeak\\u003e\\u003camazon:effect name\\u003d\\\"drc\\\"\\u003e\\u003cprosody rate\\u003d\\\"1.08\\\"\\u003eTurn left onto Redland Road\\u003c/prosody\\u003e\\u003c/amazon:effect\\u003e\\u003c/speak\\u003e\"}],\"bannerInstructions\":[{\"distanceAlongGeometry\":283.9,\"primary\":{\"text\":\"Redland Road\",\"components\":[{\"text\":\"Redland Road\",\"type\":\"text\",\"abbr\":\"Redland Rd\",\"abbr_priority\":0}],\"type\":\"turn\",\"modifier\":\"left\"}}],\"driving_side\":\"right\",\"weight\":60.4,\"intersections\":[{\"location\":[-77.16895,39.117139],\"bearings\":[15,120,210,315],\"entry\":[true,true,false,false],\"in\":2,\"out\":1}]},{\"distance\":632.2,\"duration\":60.7,\"geometry\":\"kslriA|nzdrC~BmEcEyAqBc@}DeE{MoNqGqGoBqBiCgCuBuBuGsGsOmOaXyWag@{j@aRa\\\\iT{i@ou@emB\",\"name\":\"Redland Road\",\"mode\":\"driving\",\"maneuver\":{\"location\":[-77.166335,39.11559],\"bearing_before\":126.0,\"bearing_after\":127.0,\"instruction\":\"Turn left onto Redland Road\",\"type\":\"turn\",\"modifier\":\"left\"},\"voiceInstructions\":[{\"distanceAlongGeometry\":612.2,\"announcement\":\"In a half mile, turn right onto Berwook\",\"ssmlAnnouncement\":\"\\u003cspeak\\u003e\\u003camazon:effect name\\u003d\\\"drc\\\"\\u003e\\u003cprosody rate\\u003d\\\"1.08\\\"\\u003eIn a half mile, turn right onto Berwook\\u003c/prosody\\u003e\\u003c/amazon:effect\\u003e\\u003c/speak\\u003e\"},{\"distanceAlongGeometry\":156.2,\"announcement\":\"Turn right onto Berwook, then turn left\",\"ssmlAnnouncement\":\"\\u003cspeak\\u003e\\u003camazon:effect name\\u003d\\\"drc\\\"\\u003e\\u003cprosody rate\\u003d\\\"1.08\\\"\\u003eTurn right onto Berwook, then turn left\\u003c/prosody\\u003e\\u003c/amazon:effect\\u003e\\u003c/speak\\u003e\"}],\"bannerInstructions\":[{\"distanceAlongGeometry\":632.2,\"primary\":{\"text\":\"Berwook\",\"components\":[{\"text\":\"Berwook\",\"type\":\"text\"}],\"type\":\"turn\",\"modifier\":\"right\"}},{\"distanceAlongGeometry\":156.2,\"primary\":{\"text\":\"Berwook\",\"components\":[{\"text\":\"Berwook\",\"type\":\"text\"}],\"type\":\"turn\",\"modifier\":\"right\"},\"sub\":{\"text\":\"Turn left\",\"components\":[{\"text\":\"Turn left\",\"type\":\"text\"}],\"type\":\"turn\",\"modifier\":\"left\"}}],\"driving_side\":\"right\",\"weight\":133.8,\"intersections\":[{\"location\":[-77.166335,39.11559],\"bearings\":[30,135,225,300],\"entry\":[false,true,true,false],\"in\":3,\"out\":1},{\"location\":[-77.166232,39.115526],\"bearings\":[30,120,210,315],\"entry\":[true,true,false,false],\"in\":3,\"out\":0},{\"location\":[-77.166169,39.115681],\"bearings\":[45,120,210,300],\"entry\":[true,false,true,true],\"in\":2,\"out\":0},{\"location\":[-77.164703,39.117141],\"bearings\":[45,120,225,300],\"entry\":[true,true,false,true],\"in\":2,\"out\":0}]},{\"distance\":51.6,\"duration\":12.2,\"geometry\":\"g{sriA|fpdrCnMoIpHaI\",\"name\":\"Berwook\",\"mode\":\"driving\",\"maneuver\":{\"location\":[-77.161087,39.1193],\"bearing_before\":56.0,\"bearing_after\":150.0,\"instruction\":\"Turn right onto Berwook\",\"type\":\"turn\",\"modifier\":\"right\"},\"voiceInstructions\":[{\"distanceAlongGeometry\":51.6,\"announcement\":\"Turn left, then turn left\",\"ssmlAnnouncement\":\"\\u003cspeak\\u003e\\u003camazon:effect name\\u003d\\\"drc\\\"\\u003e\\u003cprosody rate\\u003d\\\"1.08\\\"\\u003eTurn left, then turn left\\u003c/prosody\\u003e\\u003c/amazon:effect\\u003e\\u003c/speak\\u003e\"}],\"bannerInstructions\":[{\"distanceAlongGeometry\":51.6,\"primary\":{\"text\":\"Turn left\",\"components\":[{\"text\":\"Turn left\",\"type\":\"text\"}],\"type\":\"turn\",\"modifier\":\"left\"},\"sub\":{\"text\":\"Turn left\",\"components\":[{\"text\":\"Turn left\",\"type\":\"text\"}],\"type\":\"turn\",\"modifier\":\"left\"}}],\"driving_side\":\"right\",\"weight\":47.5,\"intersections\":[{\"location\":[-77.161087,39.1193],\"bearings\":[60,150,240],\"entry\":[true,true,false],\"in\":2,\"out\":1}]},{\"distance\":28.7,\"duration\":28.5,\"geometry\":\"ecsriAjrodrCcJ_N\",\"name\":\"\",\"mode\":\"driving\",\"maneuver\":{\"location\":[-77.160758,39.118915],\"bearing_before\":140.0,\"bearing_after\":45.0,\"instruction\":\"Turn left\",\"type\":\"turn\",\"modifier\":\"left\"},\"voiceInstructions\":[{\"distanceAlongGeometry\":15.1,\"announcement\":\"Turn left, then turn right\",\"ssmlAnnouncement\":\"\\u003cspeak\\u003e\\u003camazon:effect name\\u003d\\\"drc\\\"\\u003e\\u003cprosody rate\\u003d\\\"1.08\\\"\\u003eTurn left, then turn right\\u003c/prosody\\u003e\\u003c/amazon:effect\\u003e\\u003c/speak\\u003e\"}],\"bannerInstructions\":[{\"distanceAlongGeometry\":28.7,\"primary\":{\"text\":\"Turn left\",\"components\":[{\"text\":\"Turn left\",\"type\":\"text\"}],\"type\":\"turn\",\"modifier\":\"left\"}},{\"distanceAlongGeometry\":15.1,\"primary\":{\"text\":\"Turn left\",\"components\":[{\"text\":\"Turn left\",\"type\":\"text\"}],\"type\":\"turn\",\"modifier\":\"left\"},\"sub\":{\"text\":\"Turn right\",\"components\":[{\"text\":\"Turn right\",\"type\":\"text\"}],\"type\":\"turn\",\"modifier\":\"right\"}}],\"driving_side\":\"right\",\"weight\":45.1,\"intersections\":[{\"location\":[-77.160758,39.118915],\"bearings\":[45,135,315],\"entry\":[true,true,false],\"in\":2,\"out\":0}]},{\"distance\":6.0,\"duration\":3.9,\"geometry\":\"insriAjcodrCaBx@\",\"name\":\"\",\"mode\":\"driving\",\"maneuver\":{\"location\":[-77.160518,39.119093],\"bearing_before\":45.0,\"bearing_after\":334.0,\"instruction\":\"Turn left\",\"type\":\"turn\",\"modifier\":\"left\"},\"voiceInstructions\":[{\"distanceAlongGeometry\":6.0,\"announcement\":\"Turn right, then you will arrive at your destination\",\"ssmlAnnouncement\":\"\\u003cspeak\\u003e\\u003camazon:effect name\\u003d\\\"drc\\\"\\u003e\\u003cprosody rate\\u003d\\\"1.08\\\"\\u003eTurn right, then you will arrive at your destination\\u003c/prosody\\u003e\\u003c/amazon:effect\\u003e\\u003c/speak\\u003e\"}],\"bannerInstructions\":[{\"distanceAlongGeometry\":6.0,\"primary\":{\"text\":\"Turn right\",\"components\":[{\"text\":\"Turn right\",\"type\":\"text\"}],\"type\":\"turn\",\"modifier\":\"right\"}}],\"driving_side\":\"right\",\"weight\":11.6,\"intersections\":[{\"location\":[-77.160518,39.119093],\"bearings\":[120,225,330],\"entry\":[true,false,true],\"in\":1,\"out\":2}]},{\"distance\":44.2,\"duration\":19.9,\"geometry\":\"kqsriAdeodrC}LoY\",\"name\":\"\",\"mode\":\"driving\",\"maneuver\":{\"location\":[-77.160547,39.119142],\"bearing_before\":334.0,\"bearing_after\":54.0,\"instruction\":\"Turn right\",\"type\":\"turn\",\"modifier\":\"right\"},\"voiceInstructions\":[{\"distanceAlongGeometry\":11.1,\"announcement\":\"You have arrived at your destination, on the right\",\"ssmlAnnouncement\":\"\\u003cspeak\\u003e\\u003camazon:effect name\\u003d\\\"drc\\\"\\u003e\\u003cprosody rate\\u003d\\\"1.08\\\"\\u003eYou have arrived at your destination, on the right\\u003c/prosody\\u003e\\u003c/amazon:effect\\u003e\\u003c/speak\\u003e\"}],\"bannerInstructions\":[{\"distanceAlongGeometry\":44.2,\"primary\":{\"text\":\"You will arrive\",\"components\":[{\"text\":\"You will arrive\",\"type\":\"text\"}],\"type\":\"arrive\",\"modifier\":\"right\"}},{\"distanceAlongGeometry\":11.1,\"primary\":{\"text\":\"You have arrived\",\"components\":[{\"text\":\"You have arrived\",\"type\":\"text\"}],\"type\":\"arrive\",\"modifier\":\"right\"}}],\"driving_side\":\"right\",\"weight\":19.9,\"intersections\":[{\"location\":[-77.160547,39.119142],\"bearings\":[60,150,330],\"entry\":[true,false,true],\"in\":1,\"out\":0}]},{\"distance\":0.0,\"duration\":0.0,\"geometry\":\"i_triAtjndrC\",\"name\":\"\",\"mode\":\"driving\",\"maneuver\":{\"location\":[-77.160123,39.119365],\"bearing_before\":56.0,\"bearing_after\":0.0,\"instruction\":\"You have arrived at your destination, on the right\",\"type\":\"arrive\",\"modifier\":\"right\"},\"voiceInstructions\":[],\"bannerInstructions\":[],\"driving_side\":\"right\",\"weight\":0.0,\"intersections\":[{\"location\":[-77.160123,39.119365],\"bearings\":[236],\"entry\":[true],\"in\":0}]}],\"annotation\":{\"distance\":[43.371853867856295,121.66790731116258,264.2786775998085,19.63892723281784,11.387764069262014,11.571284943830324,6.527422015507397,13.588284999808462,34.041055743240804,19.28660062230622,7.936762837689454,9.661021748637797,8.305898419142162,19.51534256158374,37.288734070891415,56.24082726100347,93.557399988198,52.54543059433288,70.30608300882636,180.4223226707274,29.59802633845618,21.968661313548886,28.65125234915611,5.9971668573179375,44.203128757526464],\"congestion\":[\"unknown\",\"low\",\"heavy\",\"heavy\",\"low\",\"low\",\"low\",\"moderate\",\"moderate\",\"low\",\"low\",\"low\",\"low\",\"moderate\",\"moderate\",\"low\",\"low\",\"low\",\"low\",\"low\",\"low\",\"low\",\"unknown\",\"unknown\",\"unknown\"]}}],\"routeOptions\":{\"baseUrl\":\"https://api.mapbox.com\",\"user\":\"mapbox\",\"profile\":\"driving-traffic\",\"coordinates\":[[-77.1691838,39.1162495],[-77.1600355,39.1192992]],\"language\":\"en\",\"bearings\":\"0,90;\",\"continue_straight\":true,\"roundabout_exits\":true,\"geometries\":\"polyline6\",\"overview\":\"full\",\"steps\":true,\"annotations\":\"congestion,distance\",\"voice_instructions\":true,\"banner_instructions\":true,\"voice_units\":\"imperial\",\"access_token\":\"pk.eyJ1IjoiZ3VhcmRpb2xhMzEzMzciLCJhIjoiY2lzdnc2OXJuMDAxZDJvcGR5dnFrdnkxcyJ9.-EmQHaAPQKzhCwFqfw8lyA\",\"uuid\":\"cjuef6cz402dr6lmj1011uua1\"},\"voiceLocale\":\"en-US\"}",
		"route_index": 0,
		"leg_index": 0,
		"delta_ms": 24
	}, {
		"type": "start_navigation",
		"properties": 1555094604.432
	}, {
		"type": "updateLocation",
		"location": {
			"lat": 39.1162531,
			"lon": -77.1691849,
			"time": 1555094604.567,
			"altitude": 124.4000015258789,
			"accuracyHorizontal": 13.230999946594239,
			"provider": "fused"
		},
		"delta_ms": 0
	}, {
		"type": "getStatus",
		"timestamp": 1555094606.086,
		"delta_ms": 0
	}, {
		"type": "getStatus",
		"timestamp": 1555094607.163,
		"delta_ms": 0
	}, {
		"type": "getStatus",
		"timestamp": 1555094608.206,
		"delta_ms": 0
	}, {
		"type": "getStatus",
		"timestamp": 1555094609.252,
		"delta_ms": 0
	}, {
		"type": "updateLocation",
		"location": {
			"lat": 39.1162586,
			"lon": -77.1691864,
			"time": 1555094608.554,
			"altitude": 124.30000305175781,
			"accuracyHorizontal": 12.307000160217286,
			"provider": "fused"
		},
		"delta_ms": 0
	}, {
		"type": "getStatus",
		"timestamp": 1555094610.27,
		"delta_ms": 0
	}, {
		"type": "getStatus",
		"timestamp": 1555094611.306,
		"delta_ms": 0
	}, {
		"type": "getStatus",
		"timestamp": 1555094612.34,
		"delta_ms": 0
	}, {
		"type": "getStatus",
		"timestamp": 1555094613.381,
		"delta_ms": 0
	}, {
		"type": "cancel_navigation",
		"properties": 1555094611.946
	}],
	"version": "6.0.0",
	"history_version": "1.0.0"
}
```

## Checklist

- [x] I have tested locally / staging (including `SNAPSHOT` upstream dependencies if needed)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] I have added support to `ComponentNavigationActivity` example in the test app showing the new feature implemented

cc @danesfeder 