### PR TITLE
ExampleActivity refactor for simplicity/stability

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExampleActivity.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExampleActivity.kt
@@ -1,6 +1,7 @@
 package com.mapbox.services.android.navigation.testapp.example.ui
 
 import android.Manifest
+import android.app.Activity
 import android.arch.lifecycle.ViewModelProviders
 import android.content.Intent
 import android.content.pm.PackageManager
@@ -34,9 +35,12 @@ import com.mapbox.services.android.navigation.v5.milestone.Milestone
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress
 import kotlinx.android.synthetic.main.activity_example.*
+import org.jetbrains.anko.startActivityForResult
 
 private const val ZERO_PADDING = 0
 private const val BOTTOMSHEET_MULTIPLIER = 4
+private const val CHANGE_SETTING_REQUEST_CODE = 1
+
 
 class ExampleActivity : HistoryActivity(), ExampleView {
   private var map: NavigationMapboxMap? = null
@@ -237,7 +241,14 @@ class ExampleActivity : HistoryActivity(), ExampleView {
   }
 
   override fun showSettings() {
-    startActivity(Intent(this, NavigationSettingsActivity::class.java))
+    startActivityForResult(Intent(this, NavigationSettingsActivity::class.java), CHANGE_SETTING_REQUEST_CODE)
+  }
+
+  override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+    super.onActivityResult(requestCode, resultCode, data)
+    if (requestCode == CHANGE_SETTING_REQUEST_CODE && resultCode == Activity.RESULT_OK) {
+      viewModel.updateProfile()
+    }
   }
 
   override fun adjustMapPaddingForNavigation() {

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExampleActivity.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExampleActivity.kt
@@ -39,7 +39,6 @@ private const val ZERO_PADDING = 0
 private const val BOTTOMSHEET_MULTIPLIER = 4
 
 class ExampleActivity : HistoryActivity(), ExampleView {
-
   private var map: NavigationMapboxMap? = null
   private val viewModel by lazy(mode = LazyThreadSafetyMode.NONE) {
     ViewModelProviders.of(this).get(ExampleViewModel::class.java)
@@ -193,10 +192,6 @@ class ExampleActivity : HistoryActivity(), ExampleView {
     locationFab.visibility = visibility
   }
 
-  override fun updateDirectionsFabVisibility(visibility: Int) {
-    directionsFab.visibility = visibility
-  }
-
   override fun updateNavigationFabVisibility(visibility: Int) {
     navigationFab.visibility = visibility
   }
@@ -293,7 +288,6 @@ class ExampleActivity : HistoryActivity(), ExampleView {
 
     settingsFab.setOnClickListener { presenter.onSettingsFabClick() }
     locationFab.setOnClickListener { presenter.onLocationFabClick() }
-    directionsFab.setOnClickListener { presenter.onDirectionsFabClick() }
     navigationFab.setOnClickListener { presenter.onNavigationFabClick() }
     cancelFab.setOnClickListener { presenter.onCancelFabClick() }
     attribution.setOnClickListener { presenter.onAttributionsClick(it) }

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExampleActivity.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExampleActivity.kt
@@ -35,12 +35,10 @@ import com.mapbox.services.android.navigation.v5.milestone.Milestone
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress
 import kotlinx.android.synthetic.main.activity_example.*
-import org.jetbrains.anko.startActivityForResult
 
 private const val ZERO_PADDING = 0
 private const val BOTTOMSHEET_MULTIPLIER = 4
 private const val CHANGE_SETTING_REQUEST_CODE = 1
-
 
 class ExampleActivity : HistoryActivity(), ExampleView {
   private var map: NavigationMapboxMap? = null

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExamplePresenter.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExamplePresenter.kt
@@ -103,6 +103,7 @@ class ExamplePresenter(private val view: ExampleView, private val viewModel: Exa
     view.updateLocationRenderMode(RenderMode.NORMAL)
     view.updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_NONE)
     view.updateLocationFabVisibility(VISIBLE)
+    view.updateNavigationFabVisibility(INVISIBLE)
     view.updateSettingsFabVisibility(VISIBLE)
     view.updateCancelFabVisibility(INVISIBLE)
     view.updateInstructionViewVisibility(INVISIBLE)
@@ -114,9 +115,6 @@ class ExamplePresenter(private val view: ExampleView, private val viewModel: Exa
       BottomSheetBehavior.STATE_COLLAPSED -> {
         view.hideSoftKeyboard()
         presenterState = PresenterState.SHOW_LOCATION
-
-        view.updateLocationFabVisibility(VISIBLE)
-        view.updateSettingsFabVisibility(VISIBLE)
       }
       BottomSheetBehavior.STATE_EXPANDED -> {
         presenterState = PresenterState.SEARCH
@@ -165,7 +163,6 @@ class ExamplePresenter(private val view: ExampleView, private val viewModel: Exa
         }
         presenterState = PresenterState.SHOW_ROUTE
       }
-
       view.updateRoutes(directionsRoutes)
     }
   }

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExamplePresenter.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExamplePresenter.kt
@@ -10,7 +10,6 @@ import android.view.View.INVISIBLE
 import android.view.View.VISIBLE
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.geocoding.v5.models.CarmenFeature
-import com.mapbox.api.geocoding.v5.models.GeocodingResponse
 import com.mapbox.geojson.Point
 import com.mapbox.mapboxsdk.camera.CameraPosition
 import com.mapbox.mapboxsdk.camera.CameraUpdate
@@ -162,6 +161,7 @@ class ExamplePresenter(private val view: ExampleView, private val viewModel: Exa
           moveCameraToInclude(destination)
         }
         presenterState = PresenterState.SHOW_ROUTE
+        view.updateSettingsFabVisibility(INVISIBLE)
       }
       view.updateRoutes(directionsRoutes)
     }
@@ -184,7 +184,6 @@ class ExamplePresenter(private val view: ExampleView, private val viewModel: Exa
   }
 
   fun onMapLongClick(point: LatLng): Boolean {
-    viewModel.reverseGeocode(point)
     viewModel.destination.value = Point.fromLngLat(point.longitude, point.latitude)
     viewModel.findRouteToDestination()
     return true
@@ -215,7 +214,6 @@ class ExamplePresenter(private val view: ExampleView, private val viewModel: Exa
     viewModel.routes.observe(owner, Observer { onRouteFound(it) })
     viewModel.progress.observe(owner, Observer { onProgressUpdate(it) })
     viewModel.milestone.observe(owner, Observer { onMilestoneUpdate(it) })
-    viewModel.geocode.observe(owner, Observer { onGeocodingResponse(it) })
     viewModel.activateLocationEngine()
   }
 
@@ -256,16 +254,6 @@ class ExamplePresenter(private val view: ExampleView, private val viewModel: Exa
       val bottom = resources.getDimension(R.dimen.route_overview_padding_bottom).toInt()
       val padding = intArrayOf(left, top, right, bottom)
       view.updateMapCameraFor(bounds, padding, TWO_SECONDS)
-    }
-  }
-
-  private fun onGeocodingResponse(it: GeocodingResponse?) {
-    val features = it?.features()
-    val isValidFeatureList = features?.isNotEmpty() ?: false
-    if (isValidFeatureList) {
-      features?.first()?.let { firstFeature ->
-        onDestinationFound(firstFeature)
-      }
     }
   }
 }

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExamplePresenter.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExamplePresenter.kt
@@ -55,7 +55,6 @@ class ExamplePresenter(private val view: ExampleView, private val viewModel: Exa
 
   fun onAutocompleteClick() {
     view.selectAllAutocompleteText()
-    view.updateLocationFabVisibility(INVISIBLE)
     view.updateAutocompleteBottomSheetState(BottomSheetBehavior.STATE_EXPANDED)
   }
 
@@ -123,19 +122,9 @@ class ExamplePresenter(private val view: ExampleView, private val viewModel: Exa
 
   fun onDestinationFound(feature: CarmenFeature) {
     feature.center()?.let {
-      if (presenterState == PresenterState.SHOW_ROUTE) {
-        view.removeRoute()
-        viewModel.primaryRoute = null
-        view.updateNavigationFabVisibility(INVISIBLE)
-      }
       viewModel.destination.value = it
-      view.clearMarkers()
       view.hideSoftKeyboard()
       view.updateAutocompleteBottomSheetState(BottomSheetBehavior.STATE_COLLAPSED)
-      view.updateDestinationMarker(it)
-      view.updateLocationFabVisibility(INVISIBLE)
-      view.updateSettingsFabVisibility(INVISIBLE)
-      view.updateNavigationFabVisibility(VISIBLE)
       viewModel.findRouteToDestination()
     }
   }
@@ -153,14 +142,17 @@ class ExamplePresenter(private val view: ExampleView, private val viewModel: Exa
   fun onRouteFound(routes: List<DirectionsRoute>?) {
     routes?.let { directionsRoutes ->
       if (presenterState != PresenterState.NAVIGATE) {
+        view.clearMarkers()
         view.transition()
         view.showAlternativeRoutes(true)
+        view.updateLocationFabVisibility(INVISIBLE)
+        view.updateSettingsFabVisibility(INVISIBLE)
         view.updateNavigationFabVisibility(VISIBLE)
         viewModel.destination.value?.let { destination ->
+          view.updateDestinationMarker(destination)
           moveCameraToInclude(destination)
         }
         presenterState = PresenterState.SHOW_ROUTE
-        view.updateSettingsFabVisibility(INVISIBLE)
       }
       view.updateRoutes(directionsRoutes)
     }

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExamplePresenter.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExamplePresenter.kt
@@ -133,7 +133,6 @@ class ExamplePresenter(private val view: ExampleView, private val viewModel: Exa
       view.hideSoftKeyboard()
       view.updateAutocompleteBottomSheetState(BottomSheetBehavior.STATE_COLLAPSED)
       view.updateDestinationMarker(it)
-      view.updateMapCamera(buildCameraUpdateFrom(it), TWO_SECONDS)
       view.updateLocationFabVisibility(INVISIBLE)
       view.updateSettingsFabVisibility(INVISIBLE)
       view.updateNavigationFabVisibility(VISIBLE)

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExampleView.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExampleView.kt
@@ -45,8 +45,6 @@ interface ExampleView: PermissionsListener, OnMapReadyCallback,
 
   fun updateLocationFabVisibility(visibility: Int)
 
-  fun updateDirectionsFabVisibility(visibility: Int)
-
   fun updateNavigationFabVisibility(visibility: Int)
 
   fun updateCancelFabVisibility(visibility: Int)

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExampleViewModel.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExampleViewModel.kt
@@ -10,12 +10,7 @@ import com.mapbox.android.core.location.LocationEngine
 import com.mapbox.android.core.location.LocationEngineProvider
 import com.mapbox.android.core.location.LocationEngineRequest
 import com.mapbox.api.directions.v5.models.DirectionsRoute
-import com.mapbox.api.geocoding.v5.GeocodingCriteria
-import com.mapbox.api.geocoding.v5.MapboxGeocoding
-import com.mapbox.api.geocoding.v5.models.GeocodingResponse
 import com.mapbox.geojson.Point
-import com.mapbox.mapboxsdk.Mapbox
-import com.mapbox.mapboxsdk.geometry.LatLng
 import com.mapbox.services.android.navigation.testapp.NavigationApplication.Companion.instance
 import com.mapbox.services.android.navigation.testapp.R
 import com.mapbox.services.android.navigation.testapp.example.ui.navigation.ExampleMilestoneEventListener
@@ -31,10 +26,6 @@ import com.mapbox.services.android.navigation.v5.milestone.Milestone
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress
 import okhttp3.Cache
-import retrofit2.Call
-import retrofit2.Callback
-import retrofit2.Response
-import timber.log.Timber
 import java.io.File
 import java.util.Locale.US
 
@@ -50,7 +41,6 @@ class ExampleViewModel(application: Application) : AndroidViewModel(application)
   val progress: MutableLiveData<RouteProgress> = MutableLiveData()
   val milestone: MutableLiveData<Milestone> = MutableLiveData()
   val destination: MutableLiveData<Point> = MutableLiveData()
-  val geocode: MutableLiveData<GeocodingResponse> = MutableLiveData()
 
   var primaryRoute: DirectionsRoute? = null
   var isOffRoute: Boolean = false
@@ -142,23 +132,6 @@ class ExampleViewModel(application: Application) : AndroidViewModel(application)
 
   fun retrieveNavigation(): MapboxNavigation {
     return navigation
-  }
-
-  fun reverseGeocode(point: LatLng) {
-    val reverseGeocode = MapboxGeocoding.builder()
-        .accessToken(Mapbox.getAccessToken()!!)
-        .query(Point.fromLngLat(point.longitude, point.latitude))
-        .geocodingTypes(GeocodingCriteria.TYPE_ADDRESS)
-        .build()
-    reverseGeocode.enqueueCall(object : Callback<GeocodingResponse> {
-      override fun onResponse(call: Call<GeocodingResponse>, response: Response<GeocodingResponse>) {
-        geocode.value = response.body()
-      }
-
-      override fun onFailure(call: Call<GeocodingResponse>, throwable: Throwable) {
-        Timber.e(throwable, "Geocoding request failed")
-      }
-    })
   }
 
   fun refreshOfflineVersionFromPreferences() {

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExampleViewModel.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExampleViewModel.kt
@@ -61,7 +61,7 @@ class ExampleViewModel(application: Application) : AndroidViewModel(application)
   private val navigation: MapboxNavigation
 
   private val accessToken: String = instance.resources.getString(R.string.mapbox_access_token)
-  private val routeFinder: RouteFinder
+  val routeFinder: RouteFinder
 
   init {
     routeFinder = RouteFinder(this, routes, accessToken, retrieveOfflineVersionFromPreferences(),
@@ -84,6 +84,10 @@ class ExampleViewModel(application: Application) : AndroidViewModel(application)
     navigation.addMilestoneEventListener(ExampleMilestoneEventListener(milestone, speechPlayer))
     navigation.addProgressChangeListener(ExampleProgressChangeListener(location, progress))
     navigation.addOffRouteListener(ExampleOffRouteListener(this))
+  }
+
+  internal fun updateProfile() {
+    routeFinder.updateProfile(retrieveProfileFromPreferences())
   }
 
   override fun onCleared() {
@@ -190,9 +194,18 @@ class ExampleViewModel(application: Application) : AndroidViewModel(application)
 
   private fun retrieveProfileFromPreferences(): String {
     val context = getApplication<Application>()
-    return PreferenceManager.getDefaultSharedPreferences(context)
+    return normalizeForTraffic(PreferenceManager.getDefaultSharedPreferences(context)
             .getString(context.getString(R.string.route_profile_key), context.getString(R.string
-                    .default_route_profile))
+                    .default_route_profile)))
+  }
+
+  private fun normalizeForTraffic(string: String): String {
+    var normalizedString = string.toLowerCase()
+    if (string.equals("driving")) {
+      return "driving-traffic"
+    } else {
+      return normalizedString
+    }
   }
 
   private fun buildEngineRequest(): LocationEngineRequest {

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/PresenterState.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/PresenterState.kt
@@ -2,8 +2,7 @@ package com.mapbox.services.android.navigation.testapp.example.ui
 
 enum class PresenterState {
   SHOW_LOCATION,
-  SELECTED_DESTINATION,
-  FIND_ROUTE,
-  ROUTE_FOUND,
+  SEARCH,
+  SHOW_ROUTE,
   NAVIGATE
 }

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/navigation/ExampleRouteFinder.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/navigation/ExampleRouteFinder.kt
@@ -13,7 +13,7 @@ import timber.log.Timber
 private const val BEARING_TOLERANCE = 90.0
 
 class ExampleRouteFinder(private val accessToken: String,
-                         private val profile: String,
+                         var profile: String,
                          private val callback: OnRoutesFoundCallback): Callback<DirectionsResponse> {
 
   fun findRoute(location: Location, destination: Point) {

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/navigation/ExampleRouteFinder.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/navigation/ExampleRouteFinder.kt
@@ -13,6 +13,7 @@ import timber.log.Timber
 private const val BEARING_TOLERANCE = 90.0
 
 class ExampleRouteFinder(private val accessToken: String,
+                         private val profile: String,
                          private val callback: OnRoutesFoundCallback): Callback<DirectionsResponse> {
 
   fun findRoute(location: Location, destination: Point) {
@@ -33,6 +34,7 @@ class ExampleRouteFinder(private val accessToken: String,
     NavigationRoute.builder(NavigationApplication.instance)
             .accessToken(accessToken)
             .origin(origin, bearing, BEARING_TOLERANCE)
+            .profile(profile)
             .destination(destination)
             .alternatives(true)
             .build()

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/navigation/RouteFinder.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/navigation/RouteFinder.kt
@@ -15,7 +15,7 @@ class RouteFinder(private val viewModel: ExampleViewModel,
                   private val routes: MutableLiveData<List<DirectionsRoute>>,
                   accessToken: String,
                   private var tileVersion: String,
-                  private var profile: String) : OnRoutesFoundCallback {
+                  profile: String) : OnRoutesFoundCallback {
 
   private val routeFinder: ExampleRouteFinder = ExampleRouteFinder(accessToken, profile, this)
   private val offlineRouteFinder = OfflineRouteFinder(obtainOfflineDirectory(), tileVersion, this)
@@ -33,6 +33,10 @@ class RouteFinder(private val viewModel: ExampleViewModel,
       offlineRouteFinder.configureWith(tileVersion)
       this.tileVersion = tileVersion
     }
+  }
+
+  internal fun updateProfile(profile: String) {
+    routeFinder.profile = profile
   }
 
   override fun onRoutesFound(routes: List<DirectionsRoute>) {

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/navigation/RouteFinder.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/navigation/RouteFinder.kt
@@ -14,9 +14,10 @@ import timber.log.Timber
 class RouteFinder(private val viewModel: ExampleViewModel,
                   private val routes: MutableLiveData<List<DirectionsRoute>>,
                   accessToken: String,
-                  private var tileVersion: String) : OnRoutesFoundCallback {
+                  private var tileVersion: String,
+                  private var profile: String) : OnRoutesFoundCallback {
 
-  private val routeFinder: ExampleRouteFinder = ExampleRouteFinder(accessToken, this)
+  private val routeFinder: ExampleRouteFinder = ExampleRouteFinder(accessToken, profile, this)
   private val offlineRouteFinder = OfflineRouteFinder(obtainOfflineDirectory(), tileVersion, this)
 
   internal fun findRoute(location: Location, destination: Point) {

--- a/app/src/main/res/layout/activity_example.xml
+++ b/app/src/main/res/layout/activity_example.xml
@@ -76,13 +76,6 @@
                 app:srcCompat="@drawable/ic_my_location"/>
 
             <android.support.design.widget.FloatingActionButton
-                android:id="@+id/directionsFab"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:visibility="invisible"
-                app:srcCompat="@drawable/ic_directions"/>
-
-            <android.support.design.widget.FloatingActionButton
                 android:id="@+id/navigationFab"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -30,9 +30,9 @@
     </string-array>
 
     <string-array name="route_profile_array">
-        <item>Driving</item>
-        <item>Cycling</item>
-        <item>Walking</item>
+        <item>@string/route_profile_driving</item>
+        <item>@string/route_profile_cycling</item>
+        <item>@string/route_profile_walking</item>
     </string-array>
 
     <string-array name="route_profile_values_array">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,6 +50,10 @@
     <string name="simulate_route_key" translatable="false">simulate_route</string>
     <string name="language_key" translatable="false">language</string>
     <string name="route_profile_key" translatable="false">route_profile</string>
+    <string name="route_profile_driving">Driving</string>
+    <string name="route_profile_cycling">Cycling</string>
+    <string name="route_profile_walking">Walking</string>
+    <string name="default_route_profile">@string/route_profile_driving</string>
     <string name="view_examples_key" translatable="false">view_examples</string>
     <string name="git_hash_key" translatable="false">git_hash</string>
     <string name="offline_version_key" translatable="false">offline_preference_key</string>

--- a/app/src/main/res/xml/fragment_navigation_preferences.xml
+++ b/app/src/main/res/xml/fragment_navigation_preferences.xml
@@ -40,6 +40,7 @@
             android:title="@string/unit_type"/>
 
         <ListPreference
+            android:defaultValue="@string/default_route_profile"
             android:entries="@array/route_profile_array"
             android:entryValues="@array/route_profile_values_array"
             android:key="@string/route_profile_key"


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

This addresses multiple issues with the `ExampleActivity`:
- It simplifies the possible states while adding `SEARCH` state. Previously, there were `SHOW_LOCATION`, `FIND_ROUTE`, `ROUTE_FOUND` and `NAVIGATE` states. Now, there's `SHOW_LOCATION` (just showing users location on the map), `SHOW_ROUTE` (showing a route either from a destination long clicked on the map, or found via search), `SEARCH` (search view is open), and `NAVIGATE`. The directions fab is removed because the intermediary step is no longer needed.
- Fixes some backstack issues, including pulling in the fix from [here](https://github.com/mapbox/mapbox-navigation-android/pull/1817) and also addressing some of the issues listed in #1874 
- Retrieved profile and simulate route values from shared preferences as set in settings activity (still have to add `onActivityResult`)

- Also added some extra visibility for the settings fab

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

The goal is to make this activity simpler, more useful for testing, and less buggy, while also allowing the ability to try different settings.

### Implementation

Disclaimer: I'm still having some crazy issues with the camera. These issues exist on master so I don't believe they have anything to do with my changes.

## Screenshots or Gifs

Let me know if there's any screenshots/gifs that would help this PR.

## Testing

Tested the different settings, profiles/simulate route, and tested that the profiles were translating into the urls. UI tested the example flow, including the search, to try to catch edge cases.

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed)
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->