### PR TITLE
Bump mapbox-navigation-native version to 6.1.2

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -12,7 +12,7 @@ ext {
       mapboxSdkServices      : '4.6.0',
       mapboxEvents           : '4.3.0',
       mapboxCore             : '1.2.0',
-      mapboxNavigator        : '6.1.0',
+      mapboxNavigator        : '6.1.2',
       mapboxCrashMonitor     : '2.0.0',
       mapboxAnnotationPlugin : '0.6.0',
       mapboxSearchSdk        : '0.1.0-SNAPSHOT',


### PR DESCRIPTION
## Description

- Bumps `mapbox-navigation-native` version to `6.1.2`

### Goal

Getting the latest version from `mapboxNavigator` including the new features and bug fixes.

### Implementation

Bumping the `mapboxNavigator` version to `6.1.2` in `dependencies.gradle`

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed)
- [x]  I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
