### PR TITLE
Create NavigationViewRouter timeout to unblock routing state

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/OfflineRouteFoundCallback.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/OfflineRouteFoundCallback.java
@@ -17,10 +17,12 @@ class OfflineRouteFoundCallback implements OnOfflineRouteFoundCallback {
   @Override
   public void onRouteFound(@NonNull DirectionsRoute offlineRoute) {
     router.updateCurrentRoute(offlineRoute);
+    router.updateCallStatusReceived();
   }
 
   @Override
   public void onError(@NonNull OfflineError error) {
     router.onRequestError(error.getMessage());
+    router.updateCallStatusReceived();
   }
 }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/RouteCallStatus.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/RouteCallStatus.java
@@ -1,0 +1,29 @@
+package com.mapbox.services.android.navigation.ui.v5;
+
+import java.util.Date;
+
+class RouteCallStatus {
+
+  private static final int FIVE_SECONDS_IN_MILLISECONDS = 5000;
+  private boolean responseReceived;
+  private final Date callDate;
+
+  RouteCallStatus(Date callDate) {
+    this.callDate = callDate;
+  }
+
+  void setResponseReceived() {
+    this.responseReceived = true;
+  }
+
+  boolean isRouting(Date currentDate) {
+    if (responseReceived) {
+      return false;
+    }
+    return diffInMilliseconds(callDate, currentDate) < FIVE_SECONDS_IN_MILLISECONDS;
+  }
+
+  private long diffInMilliseconds(Date callDate, Date currentDate) {
+    return currentDate.getTime() - callDate.getTime();
+  }
+}

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewRouterTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewRouterTest.java
@@ -103,7 +103,8 @@ public class NavigationViewRouterTest extends BaseTest {
       null, // Null offline (simulate no data)
       status,
       mock(RouteComparator.class),
-      mock(ViewRouteListener.class)
+      mock(ViewRouteListener.class),
+      mock(RouteCallStatus.class)
     );
     router.updateLocation(mock(Location.class));
 
@@ -125,7 +126,8 @@ public class NavigationViewRouterTest extends BaseTest {
       null, // Null offline (simulate no data)
       status,
       mock(RouteComparator.class),
-      mock(ViewRouteListener.class)
+      mock(ViewRouteListener.class),
+      mock(RouteCallStatus.class)
     );
     router.updateLocation(mock(Location.class));
 
@@ -148,7 +150,8 @@ public class NavigationViewRouterTest extends BaseTest {
       offlineRouter,
       status,
       mock(RouteComparator.class),
-      mock(ViewRouteListener.class)
+      mock(ViewRouteListener.class),
+      mock(RouteCallStatus.class)
     );
     router.updateLocation(mock(Location.class));
 
@@ -171,7 +174,8 @@ public class NavigationViewRouterTest extends BaseTest {
       offlineRouter,
       status,
       mock(RouteComparator.class),
-      mock(ViewRouteListener.class)
+      mock(ViewRouteListener.class),
+      mock(RouteCallStatus.class)
     );
     router.updateLocation(mock(Location.class));
 
@@ -189,7 +193,8 @@ public class NavigationViewRouterTest extends BaseTest {
       mock(NavigationViewOfflineRouter.class),
       mock(ConnectivityStatusProvider.class),
       mock(RouteComparator.class),
-      mock(ViewRouteListener.class)
+      mock(ViewRouteListener.class),
+      mock(RouteCallStatus.class)
     );
 
     router.onDestroy();
@@ -205,7 +210,8 @@ public class NavigationViewRouterTest extends BaseTest {
       mock(NavigationViewOfflineRouter.class),
       mock(ConnectivityStatusProvider.class),
       mock(RouteComparator.class),
-      mock(ViewRouteListener.class)
+      mock(ViewRouteListener.class),
+      mock(RouteCallStatus.class)
     );
 
     router.onDestroy();
@@ -227,7 +233,8 @@ public class NavigationViewRouterTest extends BaseTest {
       offlineRouter,
       mock(ConnectivityStatusProvider.class),
       mock(RouteComparator.class),
-      mock(ViewRouteListener.class)
+      mock(ViewRouteListener.class),
+      mock(RouteCallStatus.class)
     );
 
     router.extractRouteOptions(options);
@@ -249,7 +256,8 @@ public class NavigationViewRouterTest extends BaseTest {
       offlineRouter,
       mock(ConnectivityStatusProvider.class),
       mock(RouteComparator.class),
-      mock(ViewRouteListener.class)
+      mock(ViewRouteListener.class),
+      mock(RouteCallStatus.class)
     );
 
     router.extractRouteOptions(options);
@@ -271,7 +279,8 @@ public class NavigationViewRouterTest extends BaseTest {
       offlineRouter,
       mock(ConnectivityStatusProvider.class),
       mock(RouteComparator.class),
-      mock(ViewRouteListener.class)
+      mock(ViewRouteListener.class),
+      mock(RouteCallStatus.class)
     );
 
     router.extractRouteOptions(options);
@@ -294,7 +303,8 @@ public class NavigationViewRouterTest extends BaseTest {
       offlineRouter,
       mock(ConnectivityStatusProvider.class),
       mock(RouteComparator.class),
-      mock(ViewRouteListener.class)
+      mock(ViewRouteListener.class),
+      mock(RouteCallStatus.class)
     );
 
     router.extractRouteOptions(options);
@@ -317,7 +327,8 @@ public class NavigationViewRouterTest extends BaseTest {
       offlineRouter,
       mock(ConnectivityStatusProvider.class),
       mock(RouteComparator.class),
-      mock(ViewRouteListener.class)
+      mock(ViewRouteListener.class),
+      mock(RouteCallStatus.class)
     );
 
     router.extractRouteOptions(options);

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/OfflineRouteFoundCallbackTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/OfflineRouteFoundCallbackTest.java
@@ -24,6 +24,17 @@ public class OfflineRouteFoundCallbackTest {
   }
 
   @Test
+  public void onRouteFound_callStatusIsUpdated() {
+    NavigationViewRouter router = mock(NavigationViewRouter.class);
+    DirectionsRoute offlineRoute = mock(DirectionsRoute.class);
+    OfflineRouteFoundCallback callback = new OfflineRouteFoundCallback(router);
+
+    callback.onRouteFound(offlineRoute);
+
+    verify(router).updateCallStatusReceived();
+  }
+
+  @Test
   public void onError_routerReceivesErrorMessage() {
     NavigationViewRouter router = mock(NavigationViewRouter.class);
     OfflineError error = mock(OfflineError.class);
@@ -34,5 +45,18 @@ public class OfflineRouteFoundCallbackTest {
     callback.onError(error);
 
     verify(router).onRequestError(eq(errorMessage));
+  }
+
+  @Test
+  public void onError_callStatusIsUpdated() {
+    NavigationViewRouter router = mock(NavigationViewRouter.class);
+    OfflineError error = mock(OfflineError.class);
+    String errorMessage = "error message";
+    when(error.getMessage()).thenReturn(errorMessage);
+    OfflineRouteFoundCallback callback = new OfflineRouteFoundCallback(router);
+
+    callback.onError(error);
+
+    verify(router).updateCallStatusReceived();
   }
 }

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/RouteCallStatusTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/RouteCallStatusTest.java
@@ -1,0 +1,49 @@
+package com.mapbox.services.android.navigation.ui.v5;
+
+import org.junit.Test;
+
+import java.util.Date;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class RouteCallStatusTest {
+
+  @Test
+  public void setResponseReceived_isNoLongerRouting() {
+    Date callDate = mock(Date.class);
+    RouteCallStatus callStatus = new RouteCallStatus(callDate);
+
+    callStatus.setResponseReceived();
+
+    assertFalse(callStatus.isRouting(mock(Date.class)));
+  }
+
+  @Test
+  public void isRouting_returnsTrueUnderTwoSeconds() {
+    Date callDate = mock(Date.class);
+    when(callDate.getTime()).thenReturn(0L);
+    Date currentDate = mock(Date.class);
+    when((currentDate.getTime())).thenReturn(1000L);
+    RouteCallStatus callStatus = new RouteCallStatus(callDate);
+
+    boolean isRouting = callStatus.isRouting(currentDate);
+
+    assertTrue(isRouting);
+  }
+
+  @Test
+  public void isRouting_returnsFalseOverFiveSeconds() {
+    Date callDate = mock(Date.class);
+    when(callDate.getTime()).thenReturn(0L);
+    Date currentDate = mock(Date.class);
+    when((currentDate.getTime())).thenReturn(5100L);
+    RouteCallStatus callStatus = new RouteCallStatus(callDate);
+
+    boolean isRouting = callStatus.isRouting(currentDate);
+
+    assertFalse(isRouting);
+  }
+}

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/route/RouteFetcher.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/route/RouteFetcher.java
@@ -215,9 +215,6 @@ public class RouteFetcher {
   private Callback<DirectionsResponse> directionsResponseCallback = new Callback<DirectionsResponse>() {
     @Override
     public void onResponse(@NonNull Call<DirectionsResponse> call, @NonNull Response<DirectionsResponse> response) {
-      if (!response.isSuccessful()) {
-        return;
-      }
       updateListeners(response.body(), routeProgress);
     }
 


### PR DESCRIPTION
## Description

While testing #1829, we noticed that we can get "stuck" in a routing state, where subsequent requests are ignored.  I.e. - stuck in constant state of loading after an off-route is detected.

### Goal

The goal of this PR is to create a timeout that accompanies the routing state.  So, even if we haven't received a response, we should try again and cancel the existing call.  The idea is, with the second try, if connectivity has changed, the `ConnectivityStatusProvider` should pick up on that change (and hit offline for example).

### Implementation

Added a new package-private class `RouteCallStatus` that will monitor response received / time since the call to the current time.  This class is used in `NavigationViewRouter`.

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested via a test drive (we should do both for this)
   - [x] Simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code