### PR TITLE
Fix notification and banner ETAs not in sync

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationNotification.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationNotification.java
@@ -64,6 +64,14 @@ class MapboxNavigationNotification implements NavigationNotification {
     initialize(applicationContext, mapboxNavigation);
   }
 
+  // For testing only
+  MapboxNavigationNotification(Context applicationContext, MapboxNavigation mapboxNavigation,
+                               Notification notification) {
+    this.applicationContext = applicationContext;
+    this.notification = notification;
+    initialize(applicationContext, mapboxNavigation);
+  }
+
   @Override
   public Notification getNotification() {
     return notification;
@@ -77,11 +85,22 @@ class MapboxNavigationNotification implements NavigationNotification {
   @Override
   public void updateNotification(RouteProgress routeProgress) {
     updateNotificationViews(routeProgress);
+    rebuildNotification();
   }
 
   @Override
   public void onNavigationStopped(Context applicationContext) {
     unregisterReceiver(applicationContext);
+  }
+
+  // Package private (no modifier) for testing purposes
+  String generateArrivalTime(RouteProgress routeProgress, Calendar time) {
+    MapboxNavigationOptions options = mapboxNavigation.options();
+    double legDurationRemaining = routeProgress.currentLegProgress().durationRemaining();
+    int timeFormatType = options.timeFormatType();
+    String arrivalTime = formatTime(time, legDurationRemaining, timeFormatType, isTwentyFourHourFormat);
+    String formattedArrivalTime = String.format(etaFormat, arrivalTime);
+    return formattedArrivalTime;
   }
 
   private void initialize(Context applicationContext, MapboxNavigation mapboxNavigation) {
@@ -96,7 +115,9 @@ class MapboxNavigationNotification implements NavigationNotification {
 
     registerReceiver(applicationContext);
     createNotificationChannel(applicationContext);
-    notification = buildNotification(applicationContext);
+    if (notification == null) {
+      notification = buildNotification(applicationContext);
+    }
   }
 
   private void initializeDistanceFormatter(Context applicationContext, MapboxNavigation mapboxNavigation) {
@@ -172,12 +193,16 @@ class MapboxNavigationNotification implements NavigationNotification {
     buildRemoteViews();
     updateInstructionText(routeProgress.currentLegProgress().currentStep());
     updateDistanceText(routeProgress);
-    updateArrivalTime(routeProgress);
+    Calendar time = Calendar.getInstance();
+    String formattedArrivalTime = generateArrivalTime(routeProgress, time);
+    updateViewsWith(formattedArrivalTime);
     LegStep step = routeProgress.currentLegProgress().upComingStep() != null
       ? routeProgress.currentLegProgress().upComingStep()
       : routeProgress.currentLegProgress().currentStep();
     updateManeuverImage(step);
+  }
 
+  private void rebuildNotification() {
     notification = buildNotification(applicationContext);
     notificationManager.notify(NAVIGATION_NOTIFICATION_ID, notification);
   }
@@ -222,13 +247,7 @@ class MapboxNavigationNotification implements NavigationNotification {
       routeProgress.currentLegProgress().currentStepProgress().distanceRemaining()).toString());
   }
 
-  private void updateArrivalTime(RouteProgress routeProgress) {
-    MapboxNavigationOptions options = mapboxNavigation.options();
-    Calendar time = Calendar.getInstance();
-    double durationRemaining = routeProgress.durationRemaining();
-    int timeFormatType = options.timeFormatType();
-    String arrivalTime = formatTime(time, durationRemaining, timeFormatType, isTwentyFourHourFormat);
-    String formattedArrivalTime = String.format(etaFormat, arrivalTime);
+  private void updateViewsWith(String formattedArrivalTime) {
     collapsedNotificationRemoteViews.setTextViewText(R.id.notificationArrivalText, formattedArrivalTime);
     expandedNotificationRemoteViews.setTextViewText(R.id.notificationArrivalText, formattedArrivalTime);
   }


### PR DESCRIPTION
## Description

Fixes notification and banner ETAs not in sync
Fixes #1887 

### Goal

This was a regression from https://github.com/mapbox/mapbox-navigation-android/pull/1412 where we updated the ETAs to consume NN ones but we forgot to change in `MapboxNavigationNotification`. This PR solves this

### Implementation

In `MapboxNavigationNotification` fix the duration remaining from `routeProgress.durationRemaining()` to `routeProgress.currentLegProgress().durationRemaining()` so both the `SummaryModel` and `MapboxNavigationNotification` use the same value. Took the opportunity to refactor `MapboxNavigationNotification` and make it more testable

## Screenshots or Gifs

**Before**

![wrong_etas](https://user-images.githubusercontent.com/1668582/56162951-2d887d00-5f9b-11e9-9c39-64c0c04df370.jpg)

**After**

![wrong_etas_fixed](https://user-images.githubusercontent.com/1668582/56165362-bce45f00-5fa0-11e9-8b3d-4c3bed212679.png)

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed)
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
