### PR TITLE
Bump mapbox-android-sdk version to 7.3.2

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,7 +8,7 @@ ext {
   ]
 
   version = [
-      mapboxMapSdk           : '7.3.1',
+      mapboxMapSdk           : '7.3.2',
       mapboxSdkServices      : '4.6.0',
       mapboxEvents           : '4.3.0',
       mapboxCore             : '1.2.0',


### PR DESCRIPTION
## Description

- Bumps `mapbox-android-sdk` version to `7.3.2`
Fixes https://github.com/mapbox/mapbox-navigation-android/issues/1886

### Goal

Getting the latest version from `mapboxMapSdk` including the new features and bug fixes

### Implementation

Bumping the `mapboxMapSdk` version to `7.3.2` in `dependencies.gradle`

## Testing

Tested that all the `Activities` in the test app and didn't 👀 any issues

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed)
- [x]  I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
