### PR TITLE
Prevent RouteLeg list access for current step creation

### DIFF
--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/TestRouteProgressBuilder.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/TestRouteProgressBuilder.java
@@ -57,6 +57,7 @@ class TestRouteProgressBuilder {
       .legDurationRemaining(legDurationRemaining)
       .distanceRemaining(distanceRemaining)
       .directionsRoute(route)
+      .currentStep(currentStep)
       .currentStepPoints(currentStepPoints)
       .upcomingStepPoints(upcomingStepPoints)
       .intersections(intersections)

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteProcessor.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteProcessor.java
@@ -94,6 +94,7 @@ class NavigationRouteProcessor {
       .legDurationRemaining(legDurationRemaining)
       .stepDistanceRemaining(stepDistanceRemaining)
       .directionsRoute(route)
+      .currentStep(currentStep)
       .currentStepPoints(currentStepPoints)
       .upcomingStepPoints(upcomingStepPoints)
       .stepIndex(stepIndex)

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/routeprogress/RouteLegProgress.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/routeprogress/RouteLegProgress.java
@@ -111,9 +111,7 @@ public abstract class RouteLegProgress {
    * @since 0.1.0
    */
   @NonNull
-  public LegStep currentStep() {
-    return routeLeg().steps().get(stepIndex());
-  }
+  public abstract LegStep currentStep();
 
   /**
    * Get the next/upcoming step immediately after the current step. If the user is on the last step
@@ -209,11 +207,11 @@ public abstract class RouteLegProgress {
 
     abstract Builder routeLeg(RouteLeg routeLeg);
 
-    abstract RouteLeg routeLeg();
+    abstract Builder currentStep(LegStep currentStep);
+
+    abstract LegStep currentStep();
 
     abstract Builder stepIndex(int stepIndex);
-
-    abstract int stepIndex();
 
     abstract Builder durationRemaining(double durationRemaining);
 
@@ -252,9 +250,8 @@ public abstract class RouteLegProgress {
     abstract RouteLegProgress autoBuild(); // not public
 
     public RouteLegProgress build() {
-      LegStep currentStep = routeLeg().steps().get(stepIndex());
       RouteStepProgress stepProgress = RouteStepProgress.builder()
-        .step(currentStep)
+        .step(currentStep())
         .distanceRemaining(stepDistanceRemaining())
         .intersections(intersections())
         .currentIntersection(currentIntersection())
@@ -262,7 +259,6 @@ public abstract class RouteLegProgress {
         .intersectionDistancesAlongStep(intersectionDistancesAlongStep())
         .build();
       currentStepProgress(stepProgress);
-
       return autoBuild();
     }
   }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/routeprogress/RouteProgress.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/routeprogress/RouteProgress.java
@@ -6,6 +6,7 @@ import android.support.v4.util.Pair;
 
 import com.google.auto.value.AutoValue;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
+import com.mapbox.api.directions.v5.models.LegStep;
 import com.mapbox.api.directions.v5.models.RouteLeg;
 import com.mapbox.api.directions.v5.models.StepIntersection;
 import com.mapbox.geojson.Point;
@@ -189,6 +190,8 @@ public abstract class RouteProgress {
 
   public abstract RouteProgress.Builder toBuilder();
 
+  abstract LegStep currentStep();
+
   abstract int stepIndex();
 
   abstract double legDistanceRemaining();
@@ -235,6 +238,10 @@ public abstract class RouteProgress {
     public abstract Builder stepDistanceRemaining(double stepDistanceRemaining);
 
     abstract double stepDistanceRemaining();
+
+    public abstract Builder currentStep(LegStep currentStep);
+
+    abstract LegStep currentStep();
 
     public abstract Builder currentStepPoints(List<Point> currentStepPoints);
 
@@ -284,6 +291,7 @@ public abstract class RouteProgress {
       RouteLeg currentLeg = directionsRoute().legs().get(legIndex());
       RouteLegProgress legProgress = RouteLegProgress.builder()
         .routeLeg(currentLeg)
+        .currentStep(currentStep())
         .stepIndex(stepIndex())
         .distanceRemaining(legDistanceRemaining())
         .durationRemaining(legDurationRemaining())

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/TestRouteProgressBuilder.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/TestRouteProgressBuilder.java
@@ -59,6 +59,7 @@ class TestRouteProgressBuilder {
       .legDurationRemaining(legDurationRemaining)
       .distanceRemaining(distanceRemaining)
       .directionsRoute(route)
+      .currentStep(currentStep)
       .currentStepPoints(currentStepPoints)
       .upcomingStepPoints(upcomingStepPoints)
       .intersections(intersections)

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/routeprogress/RouteLegProgressTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/routeprogress/RouteLegProgressTest.java
@@ -55,13 +55,11 @@ public class RouteLegProgressTest extends BaseTest {
     DirectionsRoute route = buildTestDirectionsRoute();
     RouteLeg firstLeg = route.legs().get(0);
 
-    routeProgress = routeProgress.toBuilder().stepIndex(5).build();
-
     assertEquals(
-      firstLeg.steps().get(5).geometry(), routeProgress.currentLegProgress().currentStep().geometry()
+      firstLeg.steps().get(0).geometry(), routeProgress.currentLegProgress().currentStep().geometry()
     );
     assertNotSame(
-      firstLeg.steps().get(6).geometry(), routeProgress.currentLegProgress().currentStep().geometry()
+      firstLeg.steps().get(1).geometry(), routeProgress.currentLegProgress().currentStep().geometry()
     );
   }
 

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/utils/RouteUtilsTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/utils/RouteUtilsTest.java
@@ -92,7 +92,6 @@ public class RouteUtilsTest extends BaseTest {
   public void findCurrentBannerInstructions_adjustedDistanceRemainingReturnsCorrectInstruction() throws Exception {
     RouteProgress routeProgress = buildDefaultTestRouteProgress();
     routeProgress = routeProgress.toBuilder()
-      .stepIndex(1)
       .stepDistanceRemaining(50)
       .build();
     LegStep currentStep = routeProgress.currentLegProgress().currentStep();
@@ -103,7 +102,7 @@ public class RouteUtilsTest extends BaseTest {
       currentStep, stepDistanceRemaining
     );
 
-    assertEquals(currentStep.bannerInstructions().get(1), currentBannerInstructions);
+    assertEquals(currentStep.bannerInstructions().get(0), currentBannerInstructions);
   }
 
   @Test


### PR DESCRIPTION
## Description

Found while testing:
```
Fatal Exception: java.lang.IndexOutOfBoundsException: Index: 4, Size: 4
       at java.util.ArrayList.get(ArrayList.java:411)
       at com.mapbox.services.android.navigation.v5.routeprogress.RouteLegProgress$Builder.build(RouteLegProgress.java:255)
       at com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress$Builder.build(RouteProgress.java:298)
       at com.mapbox.services.android.navigation.v5.navigation.NavigationRouteProcessor.buildRouteProgressFrom(NavigationRouteProcessor.java:112)
       at com.mapbox.services.android.navigation.v5.navigation.NavigationRouteProcessor.buildNewRouteProgress(NavigationRouteProcessor.java:49)
       at com.mapbox.services.android.navigation.v5.navigation.RouteProcessorRunnable.process(RouteProcessorRunnable.java:61)
       at com.mapbox.services.android.navigation.v5.navigation.RouteProcessorRunnable.run(RouteProcessorRunnable.java:46)
       at android.os.Handler.handleCallback(Handler.java:761)
       at android.os.Handler.dispatchMessage(Handler.java:98)
       at android.os.Looper.loop(Looper.java:156)
       at android.os.HandlerThread.run(HandlerThread.java:61)
```

### Implementation

Pass current `LegStep` to `RouteProgress` builder directly.

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code