### PR TITLE
Allow default notification color setting via MapboxNavigationOptions

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationNotification.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationNotification.java
@@ -12,6 +12,7 @@ import android.content.pm.PackageManager;
 import android.os.Build;
 import android.support.annotation.Nullable;
 import android.support.v4.app.NotificationCompat;
+import android.support.v4.content.ContextCompat;
 import android.text.SpannableString;
 import android.text.format.DateFormat;
 import android.widget.RemoteViews;
@@ -37,6 +38,7 @@ import static com.mapbox.services.android.navigation.v5.utils.time.TimeFormatter
 class MapboxNavigationNotification implements NavigationNotification {
 
   private static final String END_NAVIGATION_ACTION = "com.mapbox.intent.action.END_NAVIGATION";
+  private static final String SET_BACKGROUND_COLOR = "setBackgroundColor";
   private NotificationManager notificationManager;
   private Notification notification;
   private RemoteViews collapsedNotificationRemoteViews;
@@ -160,11 +162,19 @@ class MapboxNavigationNotification implements NavigationNotification {
   }
 
   private void buildRemoteViews() {
-    collapsedNotificationRemoteViews = new RemoteViews(applicationContext.getPackageName(),
-      R.layout.collapsed_navigation_notification_layout);
-    expandedNotificationRemoteViews = new RemoteViews(applicationContext.getPackageName(),
-      R.layout.expanded_navigation_notification_layout);
+    int colorResId = mapboxNavigation.options().defaultNotificationColorId();
+    int backgroundColor = ContextCompat.getColor(applicationContext, colorResId);
+
+    int collapsedLayout = R.layout.collapsed_navigation_notification_layout;
+    int collapsedLayoutId = R.id.navigationCollapsedNotificationLayout;
+    collapsedNotificationRemoteViews = new RemoteViews(applicationContext.getPackageName(), collapsedLayout);
+    collapsedNotificationRemoteViews.setInt(collapsedLayoutId, SET_BACKGROUND_COLOR, backgroundColor);
+
+    int expandedLayout = R.layout.expanded_navigation_notification_layout;
+    int expandedLayoutId = R.id.navigationExpandedNotificationLayout;
+    expandedNotificationRemoteViews = new RemoteViews(applicationContext.getPackageName(), expandedLayout);
     expandedNotificationRemoteViews.setOnClickPendingIntent(R.id.endNavigationBtn, pendingCloseIntent);
+    expandedNotificationRemoteViews.setInt(expandedLayoutId, SET_BACKGROUND_COLOR, backgroundColor);
   }
 
   @Nullable

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationOptions.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationOptions.java
@@ -1,12 +1,13 @@
 package com.mapbox.services.android.navigation.v5.navigation;
 
+import android.support.annotation.ColorRes;
 import android.support.annotation.Nullable;
 
 import com.google.auto.value.AutoValue;
+import com.mapbox.services.android.navigation.R;
 import com.mapbox.services.android.navigation.v5.navigation.notification.NavigationNotification;
 
-import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants
-  .NAVIGATION_LOCATION_ENGINE_INTERVAL_LAG;
+import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.NAVIGATION_LOCATION_ENGINE_INTERVAL_LAG;
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.ROUNDING_INCREMENT_FIFTY;
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.ROUTE_REFRESH_INTERVAL;
 
@@ -51,6 +52,15 @@ public abstract class MapboxNavigationOptions {
 
   public abstract int navigationLocationEngineIntervalLagInMilliseconds();
 
+  /**
+   * The color resource id for the default notification.  This will be ignored
+   * if a {@link NavigationNotification} is set.
+   *
+   * @return color resource id for notification
+   */
+  @ColorRes
+  public abstract int defaultNotificationColorId();
+
   public abstract Builder toBuilder();
 
   @AutoValue.Builder
@@ -90,6 +100,14 @@ public abstract class MapboxNavigationOptions {
 
     public abstract Builder navigationLocationEngineIntervalLagInMilliseconds(int lagInMilliseconds);
 
+    /**
+     * Optionally, set the background color of the default notification.
+     *
+     * @param defaultNotificationColorId the color resource to be used
+     * @return this builder for chaining operations together
+     */
+    public abstract Builder defaultNotificationColorId(@ColorRes int defaultNotificationColorId);
+
     public abstract MapboxNavigationOptions build();
   }
 
@@ -104,6 +122,7 @@ public abstract class MapboxNavigationOptions {
       .isDebugLoggingEnabled(false)
       .roundingIncrement(ROUNDING_INCREMENT_FIFTY)
       .timeFormatType(NavigationTimeFormat.NONE_SPECIFIED)
-      .navigationLocationEngineIntervalLagInMilliseconds(NAVIGATION_LOCATION_ENGINE_INTERVAL_LAG);
+      .navigationLocationEngineIntervalLagInMilliseconds(NAVIGATION_LOCATION_ENGINE_INTERVAL_LAG)
+      .defaultNotificationColorId(R.color.mapboxNotificationBlue);
   }
 }

--- a/libandroid-navigation/src/main/res/layout/collapsed_navigation_notification_layout.xml
+++ b/libandroid-navigation/src/main/res/layout/collapsed_navigation_notification_layout.xml
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/navigationCollapsedNotificationLayout"
     style="@android:style/TextAppearance.StatusBar.EventContent"
     android:layout_width="match_parent"
-    android:layout_height="64dp"
-    android:background="@android:color/holo_blue_dark"
-    android:id="@+id/relativeLayout">
+    android:layout_height="64dp">
 
     <ImageView
         android:id="@+id/maneuverImage"
         android:layout_width="48dp"
         android:layout_height="48dp"
-        android:layout_marginRight="8dp"
-        android:layout_marginEnd="8dp"
-        android:layout_marginStart="8dp"
         android:layout_alignParentStart="true"
         android:layout_alignParentLeft="true"
         android:layout_centerVertical="true"
+        android:layout_marginStart="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginRight="8dp"
         android:src="@drawable/ic_maneuver_arrive"
         android:tint="@android:color/white"/>
 
@@ -24,10 +24,10 @@
         android:id="@+id/notificationDistanceText"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="4dp"
-        android:layout_toRightOf="@id/maneuverImage"
-        android:layout_toEndOf="@id/maneuverImage"
         android:layout_alignTop="@id/maneuverImage"
+        android:layout_marginTop="4dp"
+        android:layout_toEndOf="@id/maneuverImage"
+        android:layout_toRightOf="@id/maneuverImage"
         android:lines="1"
         android:textColor="@android:color/white"
         tools:text="250 ft"/>
@@ -36,12 +36,12 @@
         android:id="@+id/dot"
         android:layout_width="4dp"
         android:layout_height="4dp"
-        android:layout_toRightOf="@id/notificationDistanceText"
-        android:layout_toEndOf="@id/notificationDistanceText"
         android:layout_alignTop="@id/notificationDistanceText"
         android:layout_alignBottom="@id/notificationDistanceText"
-        android:layout_marginLeft="8dp"
         android:layout_marginStart="8dp"
+        android:layout_marginLeft="8dp"
+        android:layout_toEndOf="@id/notificationDistanceText"
+        android:layout_toRightOf="@id/notificationDistanceText"
         android:src="@drawable/ic_circle"
         android:tint="@android:color/white"/>
 
@@ -49,12 +49,12 @@
         android:id="@+id/notificationArrivalText"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginLeft="8dp"
-        android:layout_marginStart="8dp"
-        android:layout_toRightOf="@+id/dot"
-        android:layout_toEndOf="@+id/dot"
         android:layout_alignTop="@id/notificationDistanceText"
         android:layout_alignBottom="@id/notificationDistanceText"
+        android:layout_marginStart="8dp"
+        android:layout_marginLeft="8dp"
+        android:layout_toEndOf="@+id/dot"
+        android:layout_toRightOf="@+id/dot"
         android:lines="1"
         android:textColor="@android:color/white"
         tools:text="11:13 AM ETA"/>
@@ -63,12 +63,13 @@
         android:id="@+id/notificationInstructionText"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="4dp"
-        android:layout_toRightOf="@id/maneuverImage"
-        android:layout_toEndOf="@id/maneuverImage"
         android:layout_alignBottom="@id/maneuverImage"
+        android:layout_marginBottom="4dp"
+        android:layout_toEndOf="@id/maneuverImage"
+        android:layout_toRightOf="@id/maneuverImage"
         android:ellipsize="end"
         android:lines="1"
         android:textColor="@android:color/white"
         tools:text="Sherman Ave NW"/>
+
 </RelativeLayout>

--- a/libandroid-navigation/src/main/res/layout/expanded_navigation_notification_layout.xml
+++ b/libandroid-navigation/src/main/res/layout/expanded_navigation_notification_layout.xml
@@ -1,22 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/navigationExpandedNotificationLayout"
     style="@android:style/TextAppearance.StatusBar.EventContent"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="@android:color/holo_blue_dark"
+    android:orientation="vertical"
     android:paddingTop="8dp"
-    android:paddingBottom="8dp"
-    android:orientation="vertical">
+    android:paddingBottom="8dp">
 
-    <include layout="@layout/collapsed_navigation_notification_layout" />
+    <include layout="@layout/collapsed_navigation_notification_layout"/>
 
     <LinearLayout
+        android:id="@+id/endNavigationBtn"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:id="@+id/endNavigationBtn"
-        android:gravity="center_vertical"
+        android:layout_marginStart="56dp"
         android:layout_marginLeft="56dp"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
         android:padding="8dp">
 
         <ImageView
@@ -35,5 +37,7 @@
             android:text="@string/end_navigation"
             android:textAllCaps="true"
             android:textColor="@android:color/white"/>
+
     </LinearLayout>
+
 </LinearLayout>

--- a/libandroid-navigation/src/main/res/values/colors.xml
+++ b/libandroid-navigation/src/main/res/values/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="mapboxNotificationBlue">#2D4E73</color>
+</resources>

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationNotificationTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationNotificationTest.java
@@ -18,7 +18,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Calendar;
-import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
 


### PR DESCRIPTION
## Description

Closes #1527 

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Allow developers to still utilize our default `MapboxNavigationNotification`, but adjust the color to the theme of their application.

### Implementation

A `@ColorRes int` added to the `MapboxNavigationOptions` that is then consumed by the notification.  

## Screenshots or Gifs

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/8434572/56367724-e204e780-61c3-11e9-98bf-0f140028073b.gif)

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code