### PR TITLE
Add connectivity status check to SpeechPlayer provider

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/ConnectivityStatusProvider.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/ConnectivityStatusProvider.java
@@ -9,29 +9,32 @@ import android.net.wifi.WifiManager;
 
 import java.util.HashMap;
 
-class ConnectivityStatusProvider {
+/**
+ * TODO internal package
+ */
+public class ConnectivityStatusProvider {
 
   private final Context context;
   private final WifiNetworkChecker wifiNetworkChecker;
   private final MobileNetworkChecker mobileNetworkChecker;
 
-  ConnectivityStatusProvider(Context applicationContext) {
+  public ConnectivityStatusProvider(Context applicationContext) {
     this.context = applicationContext;
     this.wifiNetworkChecker = new WifiNetworkChecker(new HashMap<Integer, Boolean>());
     this.mobileNetworkChecker = new MobileNetworkChecker(new HashMap<Integer, Boolean>());
   }
 
-  boolean isConnected() {
-    NetworkInfo info = getNetworkInfo(context);
-    return (info != null && info.isConnected());
-  }
-
-  boolean isConnectedFast() {
+  public boolean isConnectedFast() {
     NetworkInfo info = getNetworkInfo(context);
     int wifiLevel = getWifiLevel(context);
     return (info != null
       && info.isConnected()
       && isConnectionFast(info.getType(), info.getSubtype(), wifiLevel));
+  }
+
+  public boolean isConnected() {
+    NetworkInfo info = getNetworkInfo(context);
+    return (info != null && info.isConnected());
   }
 
   @SuppressLint("MissingPermission")

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
@@ -319,7 +319,8 @@ public class NavigationViewModel extends AndroidViewModel {
   }
 
   private void initializeVoiceInstructionCache() {
-    voiceInstructionCache = new VoiceInstructionCache(navigation, voiceInstructionLoader);
+    ConnectivityStatusProvider connectivityStatus = new ConnectivityStatusProvider(getApplication());
+    voiceInstructionCache = new VoiceInstructionCache(navigation, voiceInstructionLoader, connectivityStatus);
   }
 
   @NonNull

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/VoiceInstructionCache.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/VoiceInstructionCache.java
@@ -16,16 +16,23 @@ class VoiceInstructionCache {
   private static final int VOICE_INSTRUCTIONS_TO_CACHE_THRESHOLD = 5;
   private final MapboxNavigation navigation;
   private final VoiceInstructionLoader voiceInstructionLoader;
+  private final ConnectivityStatusProvider connectivityStatus;
   private int totalVoiceInstructions = 0;
   private int currentVoiceInstructionsCachedIndex = 0;
   private boolean isVoiceInstructionsToCacheThresholdReached = false;
 
-  VoiceInstructionCache(MapboxNavigation navigation, VoiceInstructionLoader voiceInstructionLoader) {
+  VoiceInstructionCache(MapboxNavigation navigation, VoiceInstructionLoader voiceInstructionLoader,
+                        ConnectivityStatusProvider connectivityStatus) {
     this.navigation = navigation;
     this.voiceInstructionLoader = voiceInstructionLoader;
+    this.connectivityStatus = connectivityStatus;
   }
 
   void preCache(DirectionsRoute route) {
+    if (!connectivityStatus.isConnected()) {
+      return;
+    }
+
     totalVoiceInstructions = 0;
     currentVoiceInstructionsCachedIndex = 0;
     isVoiceInstructionsToCacheThresholdReached = false;
@@ -50,6 +57,10 @@ class VoiceInstructionCache {
   }
 
   void cache() {
+    if (!connectivityStatus.isConnected()) {
+      return;
+    }
+
     if (isVoiceInstructionsToCacheThresholdReached) {
       isVoiceInstructionsToCacheThresholdReached = false;
       voiceInstructionLoader.evictVoiceInstructions();

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/VoiceInstructionCacheTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/VoiceInstructionCacheTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
 
 public class VoiceInstructionCacheTest extends BaseTest {
 
@@ -25,8 +26,10 @@ public class VoiceInstructionCacheTest extends BaseTest {
   public void checksPreCachingCachesNineInstructions() throws Exception {
     MapboxNavigation aMapboxNavigation = mock(MapboxNavigation.class);
     VoiceInstructionLoader aVoiceInstructionLoader = mock(VoiceInstructionLoader.class);
+    ConnectivityStatusProvider aConnectivityStatus = mock(ConnectivityStatusProvider.class);
+    when(aConnectivityStatus.isConnected()).thenReturn(true);
     VoiceInstructionCache theVoiceInstructionCache = new VoiceInstructionCache(aMapboxNavigation,
-      aVoiceInstructionLoader);
+      aVoiceInstructionLoader, aConnectivityStatus);
     DirectionsRoute aRoute = buildDirectionsRoute();
     ArgumentCaptor<List> voiceInstructionsToCache = ArgumentCaptor.forClass(List.class);
 
@@ -40,8 +43,9 @@ public class VoiceInstructionCacheTest extends BaseTest {
   public void checksCacheIsNotCalledIfIsVoiceInstructionsToCacheThresholdNotReached() {
     MapboxNavigation aMapboxNavigation = mock(MapboxNavigation.class);
     VoiceInstructionLoader aVoiceInstructionLoader = mock(VoiceInstructionLoader.class);
+    ConnectivityStatusProvider aConnectivityStatus = mock(ConnectivityStatusProvider.class);
     VoiceInstructionCache theVoiceInstructionCache = new VoiceInstructionCache(aMapboxNavigation,
-      aVoiceInstructionLoader);
+      aVoiceInstructionLoader, aConnectivityStatus);
 
     theVoiceInstructionCache.cache();
 
@@ -52,8 +56,10 @@ public class VoiceInstructionCacheTest extends BaseTest {
   public void checksCaching() throws Exception {
     MapboxNavigation aMapboxNavigation = mock(MapboxNavigation.class);
     VoiceInstructionLoader aVoiceInstructionLoader = mock(VoiceInstructionLoader.class);
+    ConnectivityStatusProvider aConnectivityStatus = mock(ConnectivityStatusProvider.class);
+    when(aConnectivityStatus.isConnected()).thenReturn(true);
     VoiceInstructionCache theVoiceInstructionCache = new VoiceInstructionCache(aMapboxNavigation,
-      aVoiceInstructionLoader);
+      aVoiceInstructionLoader, aConnectivityStatus);
     DirectionsRoute twentyOneInstructionsRoute = buildDirectionsRoute();
     ArgumentCaptor<List> voiceInstructionsToCache = ArgumentCaptor.forClass(List.class);
 
@@ -74,8 +80,10 @@ public class VoiceInstructionCacheTest extends BaseTest {
   public void checksEvictVoiceInstructionsIsCalledWhenCaching() throws Exception {
     MapboxNavigation aMapboxNavigation = mock(MapboxNavigation.class);
     VoiceInstructionLoader aVoiceInstructionLoader = mock(VoiceInstructionLoader.class);
+    ConnectivityStatusProvider aConnectivityStatus = mock(ConnectivityStatusProvider.class);
+    when(aConnectivityStatus.isConnected()).thenReturn(true);
     VoiceInstructionCache theVoiceInstructionCache = new VoiceInstructionCache(aMapboxNavigation,
-      aVoiceInstructionLoader);
+      aVoiceInstructionLoader, aConnectivityStatus);
     DirectionsRoute aRoute = buildDirectionsRoute();
 
     theVoiceInstructionCache.preCache(aRoute);
@@ -83,6 +91,35 @@ public class VoiceInstructionCacheTest extends BaseTest {
     theVoiceInstructionCache.cache();
 
     verify(aVoiceInstructionLoader, times(1)).evictVoiceInstructions();
+  }
+
+  @Test
+  public void noConnectivityDoesNotAllowPreCaching() throws Exception {
+    MapboxNavigation aMapboxNavigation = mock(MapboxNavigation.class);
+    VoiceInstructionLoader aVoiceInstructionLoader = mock(VoiceInstructionLoader.class);
+    ConnectivityStatusProvider aConnectivityStatus = mock(ConnectivityStatusProvider.class);
+    when(aConnectivityStatus.isConnected()).thenReturn(false);
+    VoiceInstructionCache theVoiceInstructionCache = new VoiceInstructionCache(aMapboxNavigation,
+      aVoiceInstructionLoader, aConnectivityStatus);
+    DirectionsRoute aRoute = buildDirectionsRoute();
+
+    theVoiceInstructionCache.preCache(aRoute);
+
+    verifyZeroInteractions(aVoiceInstructionLoader);
+  }
+
+  @Test
+  public void noConnectivityDoesNotAllowCaching() {
+    MapboxNavigation aMapboxNavigation = mock(MapboxNavigation.class);
+    VoiceInstructionLoader aVoiceInstructionLoader = mock(VoiceInstructionLoader.class);
+    ConnectivityStatusProvider aConnectivityStatus = mock(ConnectivityStatusProvider.class);
+    when(aConnectivityStatus.isConnected()).thenReturn(false);
+    VoiceInstructionCache theVoiceInstructionCache = new VoiceInstructionCache(aMapboxNavigation,
+      aVoiceInstructionLoader, aConnectivityStatus);
+
+    theVoiceInstructionCache.cache();
+
+    verifyZeroInteractions(aVoiceInstructionLoader);
   }
 
   private DirectionsRoute buildDirectionsRoute() throws IOException {

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/voice/SpeechPlayerProviderTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/voice/SpeechPlayerProviderTest.java
@@ -2,6 +2,8 @@ package com.mapbox.services.android.navigation.ui.v5.voice;
 
 import android.content.Context;
 
+import com.mapbox.services.android.navigation.ui.v5.ConnectivityStatusProvider;
+
 import org.junit.Test;
 
 import java.util.Locale;
@@ -9,6 +11,7 @@ import java.util.Locale;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class SpeechPlayerProviderTest {
 
@@ -48,10 +51,59 @@ public class SpeechPlayerProviderTest {
     assertNotNull(speechPlayer);
   }
 
+  @Test
+  public void noConnectivity_alwaysReturnsAndroidSpeechPlayer() {
+    Context context = mock(Context.class);
+    String language = Locale.US.getLanguage();
+    VoiceInstructionLoader voiceInstructionLoader = mock(VoiceInstructionLoader.class);
+    ConnectivityStatusProvider connectivityStatus = mock(ConnectivityStatusProvider.class);
+    when(connectivityStatus.isConnectedFast()).thenReturn(false);
+    SpeechPlayerProvider provider = new SpeechPlayerProvider(context, language, true,
+      voiceInstructionLoader, connectivityStatus);
+
+    SpeechPlayer speechPlayer = provider.retrieveSpeechPlayer();
+
+    assertTrue(speechPlayer instanceof AndroidSpeechPlayer);
+  }
+
+  @Test
+  public void noCache_alwaysReturnsAndroidSpeechPlayer() {
+    Context context = mock(Context.class);
+    String language = Locale.US.getLanguage();
+    VoiceInstructionLoader voiceInstructionLoader = mock(VoiceInstructionLoader.class);
+    when(voiceInstructionLoader.hasCache()).thenReturn(false);
+    ConnectivityStatusProvider connectivityStatus = mock(ConnectivityStatusProvider.class);
+    when(connectivityStatus.isConnectedFast()).thenReturn(false);
+    SpeechPlayerProvider provider = new SpeechPlayerProvider(context, language, true,
+      voiceInstructionLoader, connectivityStatus);
+
+    SpeechPlayer speechPlayer = provider.retrieveSpeechPlayer();
+
+    assertTrue(speechPlayer instanceof AndroidSpeechPlayer);
+  }
+
+  @Test
+  public void hasCache_alwaysReturnsMapboxSpeechPlayer() {
+    Context context = mock(Context.class);
+    String language = Locale.US.getLanguage();
+    VoiceInstructionLoader voiceInstructionLoader = mock(VoiceInstructionLoader.class);
+    when(voiceInstructionLoader.hasCache()).thenReturn(true);
+    ConnectivityStatusProvider connectivityStatus = mock(ConnectivityStatusProvider.class);
+    SpeechPlayerProvider provider = new SpeechPlayerProvider(context, language, true,
+      voiceInstructionLoader, connectivityStatus);
+
+    SpeechPlayer speechPlayer = provider.retrieveSpeechPlayer();
+
+    assertTrue(speechPlayer instanceof MapboxSpeechPlayer);
+  }
+
   private SpeechPlayerProvider buildSpeechPlayerProvider(boolean voiceLanguageSupported) {
     Context context = mock(Context.class);
     String language = Locale.US.getLanguage();
     VoiceInstructionLoader voiceInstructionLoader = mock(VoiceInstructionLoader.class);
-    return new SpeechPlayerProvider(context, language, voiceLanguageSupported, voiceInstructionLoader);
+    when(voiceInstructionLoader.hasCache()).thenReturn(true);
+    ConnectivityStatusProvider connectivityStatus = mock(ConnectivityStatusProvider.class);
+    return new SpeechPlayerProvider(context, language, voiceLanguageSupported,
+      voiceInstructionLoader, connectivityStatus);
   }
 }

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/voice/VoiceInstructionLoaderTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/voice/VoiceInstructionLoaderTest.java
@@ -4,6 +4,7 @@ import android.content.Context;
 
 import com.mapbox.api.speech.v1.MapboxSpeech;
 import com.mapbox.services.android.navigation.ui.v5.BaseTest;
+import com.mapbox.services.android.navigation.ui.v5.ConnectivityStatusProvider;
 
 import org.junit.Test;
 
@@ -44,7 +45,6 @@ public class VoiceInstructionLoaderTest extends BaseTest {
 
   @Test
   public void checksRequestEnqueuedIfCacheIsNotClosedAndMapboxSpeechBuilderIsNotNull() {
-    Context anyContext = mock(Context.class);
     Cache anyCache = mock(Cache.class);
     when(anyCache.isClosed()).thenReturn(false);
     MapboxSpeech.Builder aSpeechBuilder = mock(MapboxSpeech.Builder.class);
@@ -52,8 +52,9 @@ public class VoiceInstructionLoaderTest extends BaseTest {
     when(aSpeechBuilder.textType(anyString())).thenReturn(aSpeechBuilder);
     MapboxSpeech aSpeech = mock(MapboxSpeech.class);
     when(aSpeechBuilder.build()).thenReturn(aSpeech);
-    VoiceInstructionLoader theVoiceInstructionLoader = new VoiceInstructionLoader(anyContext, "any_access_token",
-      anyCache, aSpeechBuilder);
+    ConnectivityStatusProvider connectivityStatus = mock(ConnectivityStatusProvider.class);
+    VoiceInstructionLoader theVoiceInstructionLoader = new VoiceInstructionLoader("any_access_token",
+      anyCache, aSpeechBuilder, connectivityStatus);
     Callback aCallback = mock(Callback.class);
 
     theVoiceInstructionLoader.requestInstruction("anyInstruction", "anyType", aCallback);
@@ -63,13 +64,13 @@ public class VoiceInstructionLoaderTest extends BaseTest {
 
   @Test
   public void checksRequestNotEnqueuedIfCacheIsClosed() {
-    Context anyContext = mock(Context.class);
     Cache anyCache = mock(Cache.class);
     when(anyCache.isClosed()).thenReturn(true);
     MapboxSpeech.Builder anySpeechBuilder = mock(MapboxSpeech.Builder.class);
     MapboxSpeech aSpeech = mock(MapboxSpeech.class);
-    VoiceInstructionLoader theVoiceInstructionLoader = new VoiceInstructionLoader(anyContext, "any_access_token",
-      anyCache, anySpeechBuilder);
+    ConnectivityStatusProvider connectivityStatus = mock(ConnectivityStatusProvider.class);
+    VoiceInstructionLoader theVoiceInstructionLoader = new VoiceInstructionLoader("any_access_token",
+      anyCache, anySpeechBuilder, connectivityStatus);
     Callback aCallback = mock(Callback.class);
 
     theVoiceInstructionLoader.requestInstruction("anyInstruction", "anyType", aCallback);
@@ -79,13 +80,13 @@ public class VoiceInstructionLoaderTest extends BaseTest {
 
   @Test
   public void checksRequestNotEnqueuedIfMapboxSpeechBuilderIsNull() {
-    Context anyContext = mock(Context.class);
     Cache anyCache = mock(Cache.class);
     when(anyCache.isClosed()).thenReturn(false);
     MapboxSpeech.Builder nullSpeechBuilder = null;
     MapboxSpeech aSpeech = mock(MapboxSpeech.class);
-    VoiceInstructionLoader theVoiceInstructionLoader = new VoiceInstructionLoader(anyContext, "any_access_token",
-      anyCache, nullSpeechBuilder);
+    ConnectivityStatusProvider connectivityStatus = mock(ConnectivityStatusProvider.class);
+    VoiceInstructionLoader theVoiceInstructionLoader = new VoiceInstructionLoader("any_access_token",
+      anyCache, nullSpeechBuilder, connectivityStatus);
     Callback aCallback = mock(Callback.class);
 
     theVoiceInstructionLoader.requestInstruction("anyInstruction", "anyType", aCallback);


### PR DESCRIPTION
## Description

Closes #1842 

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

As described in #1842, we rely on failed Voice API requests for our fallback to the `AndroidSpeechPlayer` or "offline voice".  The goal of this PR is to check connection upfront so that we don't worry about the API request or have to deal with the latency of the failed request.  

### Implementation

Make `ConnectivityStatusProvider` `public` so we can share it between the router / voice instruction loader, etc.  We should definitely make this `internal` as soon as the package work lands.  I've added a javadoc note `TODO` as a reminder. 

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed)
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code