### PR TITLE
Fix intermediate way point arrival not triggered

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteProcessor.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteProcessor.java
@@ -34,6 +34,7 @@ class NavigationRouteProcessor {
   private static final int FIRST_BANNER_INSTRUCTION = 0;
   private final RouteProgressStateMap progressStateMap = new RouteProgressStateMap();
   private RouteProgress previousRouteProgress;
+  private NavigationStatus previousStatus;
   private DirectionsRoute route;
   private RouteLeg currentLeg;
   private LegStep currentStep;
@@ -45,6 +46,7 @@ class NavigationRouteProcessor {
   private CurrentLegAnnotation currentLegAnnotation;
 
   RouteProgress buildNewRouteProgress(MapboxNavigator navigator, NavigationStatus status, DirectionsRoute route) {
+    previousStatus = status;
     updateRoute(route);
     return buildRouteProgressFrom(status, navigator);
   }
@@ -56,6 +58,11 @@ class NavigationRouteProcessor {
   @Nullable
   RouteProgress retrievePreviousRouteProgress() {
     return previousRouteProgress;
+  }
+
+  @Nullable
+  NavigationStatus retrievePreviousStatus() {
+    return previousStatus;
   }
 
   private void updateRoute(DirectionsRoute route) {

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteProcessorTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteProcessorTest.java
@@ -4,24 +4,35 @@ import com.mapbox.navigator.NavigationStatus;
 import com.mapbox.services.android.navigation.v5.BaseTest;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
 
+import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 
-@Ignore
 public class NavigationRouteProcessorTest extends BaseTest {
 
   @Test
   public void buildNewRouteProgress_routeProgressReturned() throws IOException {
+    MapboxNavigator navigator = mock(MapboxNavigator.class);
+    NavigationStatus status = mock(NavigationStatus.class);
     NavigationRouteProcessor processor = new NavigationRouteProcessor();
 
-    // TODO mock final status
-    RouteProgress progress = processor.buildNewRouteProgress(mock(MapboxNavigator.class), mock(NavigationStatus.class), buildTestDirectionsRoute());
+    RouteProgress progress = processor.buildNewRouteProgress(navigator, status, buildTestDirectionsRoute());
 
     assertNotNull(progress);
+  }
+
+  @Test
+  public void buildNewRouteProgress_previousStatusIsReturned() throws IOException {
+    MapboxNavigator navigator = mock(MapboxNavigator.class);
+    NavigationStatus status = mock(NavigationStatus.class);
+    NavigationRouteProcessor processor = new NavigationRouteProcessor();
+
+    processor.buildNewRouteProgress(navigator, status, buildTestDirectionsRoute());
+
+    assertEquals(status, processor.retrievePreviousStatus());
   }
 }

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/RouteProcessorRunnableTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/RouteProcessorRunnableTest.java
@@ -96,14 +96,15 @@ public class RouteProcessorRunnableTest {
   public void onRun_legIndexIncrementsOnLegCompletionWithValidDistanceRemaining() {
     SnapToRoute snapToRoute = mock(SnapToRoute.class);
     NavigationEngineFactory factory = buildMockFactory(snapToRoute);
+    NavigationStatus previousStatus = buildMockStatus();
     NavigationStatus status = buildMockStatus();
-    when(status.getRouteState()).thenReturn(RouteState.COMPLETE);
-    when(status.getRemainingLegDistance()).thenReturn(20f);
+    when(previousStatus.getRouteState()).thenReturn(RouteState.COMPLETE);
+    when(previousStatus.getRemainingLegDistance()).thenReturn(20f);
     MapboxNavigator navigator = mock(MapboxNavigator.class);
     DirectionsRoute route = buildTwoLegRoute();
     boolean autoIncrementEnabled = true;
     RouteProcessorRunnable runnable = buildRouteProcessorRunnableWith(
-      navigator, factory, status, route, autoIncrementEnabled
+      navigator, factory, previousStatus, status, route, autoIncrementEnabled
     );
     Location rawLocation = mock(Location.class);
     runnable.updateRawLocation(rawLocation);
@@ -117,14 +118,15 @@ public class RouteProcessorRunnableTest {
   public void onRun_legIndexDoesNotIncrementsOnLegCompletionWithInvalidDistanceRemaining() {
     SnapToRoute snapToRoute = mock(SnapToRoute.class);
     NavigationEngineFactory factory = buildMockFactory(snapToRoute);
+    NavigationStatus previousStatus = buildMockStatus();
     NavigationStatus status = buildMockStatus();
-    when(status.getRouteState()).thenReturn(RouteState.COMPLETE);
-    when(status.getRemainingLegDistance()).thenReturn(50f);
+    when(previousStatus.getRouteState()).thenReturn(RouteState.COMPLETE);
+    when(previousStatus.getRemainingLegDistance()).thenReturn(50f);
     MapboxNavigator navigator = mock(MapboxNavigator.class);
     DirectionsRoute route = buildTwoLegRoute();
     boolean autoIncrementEnabled = true;
     RouteProcessorRunnable runnable = buildRouteProcessorRunnableWith(
-      navigator, factory, status, route, autoIncrementEnabled
+      navigator, factory, previousStatus, status, route, autoIncrementEnabled
     );
     Location rawLocation = mock(Location.class);
     runnable.updateRawLocation(rawLocation);
@@ -138,15 +140,16 @@ public class RouteProcessorRunnableTest {
   public void onRun_legIndexDoesNotIncrementsOnLegCompletionWithInvalidLegsRemaining() {
     SnapToRoute snapToRoute = mock(SnapToRoute.class);
     NavigationEngineFactory factory = buildMockFactory(snapToRoute);
+    NavigationStatus previousStatus = buildMockStatus();
     NavigationStatus status = buildMockStatus();
-    when(status.getRouteState()).thenReturn(RouteState.COMPLETE);
-    when(status.getRemainingLegDistance()).thenReturn(20f);
-    when(status.getLegIndex()).thenReturn(1);
+    when(previousStatus.getRouteState()).thenReturn(RouteState.COMPLETE);
+    when(previousStatus.getRemainingLegDistance()).thenReturn(20f);
+    when(previousStatus.getLegIndex()).thenReturn(1);
     MapboxNavigator navigator = mock(MapboxNavigator.class);
     DirectionsRoute route = buildTwoLegRoute();
     boolean autoIncrementEnabled = true;
     RouteProcessorRunnable runnable = buildRouteProcessorRunnableWith(
-      navigator, factory, status, route, autoIncrementEnabled
+      navigator, factory, previousStatus, status, route, autoIncrementEnabled
     );
     Location rawLocation = mock(Location.class);
     runnable.updateRawLocation(rawLocation);
@@ -160,14 +163,15 @@ public class RouteProcessorRunnableTest {
   public void onRun_legIndexDoesNotIncrementOnLegCompletionWithAutoIncrementDisabled() {
     SnapToRoute snapToRoute = mock(SnapToRoute.class);
     NavigationEngineFactory factory = buildMockFactory(snapToRoute);
+    NavigationStatus previousStatus = buildMockStatus();
     NavigationStatus status = buildMockStatus();
-    when(status.getRouteState()).thenReturn(RouteState.COMPLETE);
-    when(status.getRemainingLegDistance()).thenReturn(20f);
+    when(previousStatus.getRouteState()).thenReturn(RouteState.COMPLETE);
+    when(previousStatus.getRemainingLegDistance()).thenReturn(20f);
     MapboxNavigator navigator = mock(MapboxNavigator.class);
     DirectionsRoute route = buildTwoLegRoute();
     boolean autoIncrementEnabled = false;
     RouteProcessorRunnable runnable = buildRouteProcessorRunnableWith(
-      navigator, factory, status, route, autoIncrementEnabled
+      navigator, factory, previousStatus, status, route, autoIncrementEnabled
     );
     Location rawLocation = mock(Location.class);
     runnable.updateRawLocation(rawLocation);
@@ -218,6 +222,31 @@ public class RouteProcessorRunnableTest {
     );
   }
 
+  private RouteProcessorRunnable buildRouteProcessorRunnableWith(MapboxNavigator navigator,
+                                                                 NavigationEngineFactory factory,
+                                                                 NavigationStatus previousStatus,
+                                                                 NavigationStatus status,
+                                                                 DirectionsRoute route,
+                                                                 boolean autoIncrementEnabled) {
+    MapboxNavigationOptions options = MapboxNavigationOptions.builder()
+      .enableAutoIncrementLegIndex(autoIncrementEnabled)
+      .build();
+    when(navigator.retrieveStatus(any(Date.class), any(Long.class))).thenReturn(status);
+    MapboxNavigation navigation = mock(MapboxNavigation.class);
+    when(navigation.options()).thenReturn(options);
+    when(navigation.getRoute()).thenReturn(route);
+    when(navigation.retrieveMapboxNavigator()).thenReturn(navigator);
+    when(navigation.retrieveEngineFactory()).thenReturn(factory);
+    NavigationRouteProcessor routeProcessor = mock(NavigationRouteProcessor.class);
+    when(routeProcessor.retrievePreviousStatus()).thenReturn(previousStatus);
+    return new RouteProcessorRunnable(
+      routeProcessor,
+      navigation,
+      mock(Handler.class),
+      mock(Handler.class),
+      mock(RouteProcessorBackgroundThread.Listener.class)
+    );
+  }
 
   private RouteProcessorRunnable buildRouteProcessorRunnableWith(NavigationEngineFactory factory,
                                                                  NavigationStatus status) {


### PR DESCRIPTION
## Description

Fixes #1904 

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Arrival state and listeners should be triggered for each way point along the route, not just the last one. 

### Implementation

Add a "previous" `NavigationStatus` to the processor that allows us to look at the route state only after it's been passed to the developer in a listener.  

## Screenshots or Gifs

Modified `NavigationLauncherActivity` to allow way points for the passed `DirectionsRoute`:

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/8434572/56684868-9c05c300-669e-11e9-8005-6fda77b126c8.gif)

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed)
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code