### PR TITLE
Check for valid DirectionsRoute in RouteRefresh

### DIFF
--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/RouteRefreshTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/RouteRefreshTest.java
@@ -1,0 +1,50 @@
+package com.mapbox.services.android.navigation.v5.navigation;
+
+import com.mapbox.api.directions.v5.models.DirectionsRoute;
+import com.mapbox.api.directions.v5.models.RouteOptions;
+import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
+
+import org.junit.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class RouteRefreshTest {
+
+  @Test
+  public void refresh_invalidOptionsSendErrorCallback() {
+    RouteOptions options = mock(RouteOptions.class);
+    DirectionsRoute route = mock(DirectionsRoute.class);
+    when(route.routeOptions()).thenReturn(options);
+    RouteProgress routeProgress = mock(RouteProgress.class);
+    when(routeProgress.directionsRoute()).thenReturn(route);
+    RefreshCallback refreshCallback = mock(RefreshCallback.class);
+    String accessToken = "some_access_token";
+    RouteRefresh refresh = new RouteRefresh(accessToken);
+
+    refresh.refresh(routeProgress, refreshCallback);
+
+    verify(refreshCallback).onError(any(RefreshError.class));
+  }
+
+  @Test
+  public void refresh_validOptionsDoNotSendError() {
+    RouteOptions options = mock(RouteOptions.class);
+    when(options.requestUuid()).thenReturn("some_uuid");
+    DirectionsRoute route = mock(DirectionsRoute.class);
+    when(route.routeIndex()).thenReturn("1");
+    when(route.routeOptions()).thenReturn(options);
+    RouteProgress routeProgress = mock(RouteProgress.class);
+    when(routeProgress.directionsRoute()).thenReturn(route);
+    RefreshCallback refreshCallback = mock(RefreshCallback.class);
+    String accessToken = "some_access_token";
+    RouteRefresh refresh = new RouteRefresh(accessToken);
+
+    refresh.refresh(routeProgress, refreshCallback);
+
+    verify(refreshCallback, times(0)).onError(any(RefreshError.class));
+  }
+}


### PR DESCRIPTION
Found while testing:
```
E/AndroidRuntime: FATAL EXCEPTION: mapbox_navigation_thread
    Process: com.mapbox.mapboxsdk.downstream.testapp, PID: 1955
    java.lang.NumberFormatException: Invalid int: "null"
        at java.lang.Integer.invalidInt(Integer.java:138)
        at java.lang.Integer.parseInt(Integer.java:358)
        at java.lang.Integer.parseInt(Integer.java:334)
        at java.lang.Integer.valueOf(Integer.java:525)
        at com.mapbox.services.android.navigation.v5.navigation.RouteRefresh.refresh(RouteRefresh.java:80)
        at com.mapbox.services.android.navigation.v5.navigation.RouteRefresh.refresh(RouteRefresh.java:74)
        at com.mapbox.services.android.navigation.v5.navigation.RouteRefresher.refresh(RouteRefresher.java:33)
        at com.mapbox.services.android.navigation.v5.navigation.RouteProcessorRunnable.process(RouteProcessorRunnable.java:66)
        at com.mapbox.services.android.navigation.v5.navigation.RouteProcessorRunnable.run(RouteProcessorRunnable.java:46)
        at android.os.Handler.handleCallback(Handler.java:739)
        at android.os.Handler.dispatchMessage(Handler.java:95)
        at android.os.Looper.loop(Looper.java:148)
        at android.os.HandlerThread.run(HandlerThread.java:61)
```

## Description

We should protect against this error.  It seems it was produced while sitting in a stale navigation state for a while.

- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Implementation

Validity check that will fire error callback with error message when invalid.

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed)
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code