### PR TITLE
Fix Navigation Launcher test app Activity incorrect profile regression

### DIFF
--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -30,9 +30,9 @@
     </string-array>
 
     <string-array name="route_profile_array">
-        <item>@string/route_profile_driving</item>
-        <item>@string/route_profile_cycling</item>
-        <item>@string/route_profile_walking</item>
+        <item>Driving</item>
+        <item>Cycling</item>
+        <item>Walking</item>
     </string-array>
 
     <string-array name="route_profile_values_array">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,10 +50,7 @@
     <string name="simulate_route_key" translatable="false">simulate_route</string>
     <string name="language_key" translatable="false">language</string>
     <string name="route_profile_key" translatable="false">route_profile</string>
-    <string name="route_profile_driving">Driving</string>
-    <string name="route_profile_cycling">Cycling</string>
-    <string name="route_profile_walking">Walking</string>
-    <string name="default_route_profile">@string/route_profile_driving</string>
+    <string name="default_route_profile">driving-traffic</string>
     <string name="view_examples_key" translatable="false">view_examples</string>
     <string name="git_hash_key" translatable="false">git_hash</string>
     <string name="offline_version_key" translatable="false">offline_preference_key</string>


### PR DESCRIPTION
## Description

Fixes `NavigationLauncherActivity` incorrect profile regression from https://github.com/mapbox/mapbox-navigation-android/pull/1884 

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

The goal here is that `NavigationLauncherActivity` test app example works as expected. It wasn't working because the profile from preferences was incorrect from some changes introduced in a previous PR

### Implementation

The `profile` is case sensitive so passing for example `Driving` ends up in a `{"message":"Not Found"}` from the Directions API which left `NavigationLauncherActivity` in a spinning state

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed)
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->