### PR TITLE
Added check for legs to route refresh

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/RouteRefreshCallback.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/RouteRefreshCallback.java
@@ -27,7 +27,7 @@ class RouteRefreshCallback implements Callback<DirectionsRefreshResponse> {
 
   @Override
   public void onResponse(Call<DirectionsRefreshResponse> call, Response<DirectionsRefreshResponse> response) {
-    if (response.body() == null || response.body().route() == null) {
+    if (response.body() == null || response.body().route() == null || response.body().route().legs() == null) {
       refreshCallback.onError(new RefreshError(response.message()));
     } else {
       refreshCallback.onRefresh(routeAnnotationUpdater.update(directionsRoute, response.body().route(), legIndex));

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/RouteRefreshCallbackTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/RouteRefreshCallbackTest.java
@@ -1,0 +1,87 @@
+package com.mapbox.services.android.navigation.v5.navigation;
+
+import com.mapbox.api.directions.v5.models.DirectionsRoute;
+import com.mapbox.api.directionsrefresh.v1.models.DirectionsRefreshResponse;
+
+import org.junit.Test;
+
+import retrofit2.Call;
+import retrofit2.Response;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class RouteRefreshCallbackTest {
+  @Test
+  public void onErrorIsCalled_nullLegs() {
+    RefreshCallback refreshCallback = mock(RefreshCallback.class);
+    DirectionsRoute directionsRoute = mock(DirectionsRoute.class);
+    RouteRefreshCallback routeRefreshCallback =
+      new RouteRefreshCallback(directionsRoute, 1, refreshCallback);
+    Call<DirectionsRefreshResponse> call = mock(Call.class);
+    Response<DirectionsRefreshResponse> response = mock(Response.class);
+    DirectionsRefreshResponse directionsRefreshResponse = mock(DirectionsRefreshResponse.class);
+    when(directionsRoute.legs()).thenReturn(null);
+    when(directionsRefreshResponse.route()).thenReturn(directionsRoute);
+    when(response.body()).thenReturn(directionsRefreshResponse);
+
+    routeRefreshCallback.onResponse(call, response);
+
+    verify(refreshCallback).onError(any(RefreshError.class));
+  }
+
+  @Test
+  public void onErrorIsCalled_nullBody() {
+    RefreshCallback refreshCallback = mock(RefreshCallback.class);
+    DirectionsRoute directionsRoute = mock(DirectionsRoute.class);
+    RouteRefreshCallback routeRefreshCallback =
+      new RouteRefreshCallback(directionsRoute, 1, refreshCallback);
+    Call<DirectionsRefreshResponse> call = mock(Call.class);
+    Response<DirectionsRefreshResponse> response = mock(Response.class);
+    when(response.body()).thenReturn(null);
+
+    routeRefreshCallback.onResponse(call, response);
+
+    verify(refreshCallback).onError(any(RefreshError.class));
+  }
+
+  @Test
+  public void onErrorIsCalled_nullRoute() {
+    RefreshCallback refreshCallback = mock(RefreshCallback.class);
+    RouteRefreshCallback routeRefreshCallback =
+      new RouteRefreshCallback(mock(DirectionsRoute.class), 1, refreshCallback);
+    Call<DirectionsRefreshResponse> call = mock(Call.class);
+    Response<DirectionsRefreshResponse> response = mock(Response.class);
+    DirectionsRefreshResponse directionsRefreshResponse = mock(DirectionsRefreshResponse.class);
+    when(directionsRefreshResponse.route()).thenReturn(null);
+    when(response.body()).thenReturn(directionsRefreshResponse);
+
+    routeRefreshCallback.onResponse(call, response);
+
+    verify(refreshCallback).onError(any(RefreshError.class));
+  }
+
+  @Test
+  public void onRefreshIsCalled() {
+    RefreshCallback refreshCallback = mock(RefreshCallback.class);
+    DirectionsRoute directionsRoute1 = mock(DirectionsRoute.class);
+    DirectionsRoute directionsRoute2 = mock(DirectionsRoute.class);
+    DirectionsRoute directionsRoute3 = mock(DirectionsRoute.class);
+    int legIndex = 1;
+    RouteAnnotationUpdater routeAnnotationUpdater = mock(RouteAnnotationUpdater.class);
+    RouteRefreshCallback routeRefreshCallback =
+      new RouteRefreshCallback(routeAnnotationUpdater, directionsRoute1, legIndex, refreshCallback);
+    Call<DirectionsRefreshResponse> call = mock(Call.class);
+    Response<DirectionsRefreshResponse> response = mock(Response.class);
+    DirectionsRefreshResponse directionsRefreshResponse = mock(DirectionsRefreshResponse.class);
+    when(directionsRefreshResponse.route()).thenReturn(directionsRoute2);
+    when(response.body()).thenReturn(directionsRefreshResponse);
+    when(routeAnnotationUpdater.update(directionsRoute1, directionsRoute2, legIndex)).thenReturn(directionsRoute3);
+
+    routeRefreshCallback.onResponse(call, response);
+
+    verify(refreshCallback).onRefresh(any(DirectionsRoute.class));
+  }
+}


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Fixed NPE reported by customer.

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

The directions refresh API now sends no legs when the map matching request fails. This PR accounts for those responses.

### Implementation

This was fixed with a null check.

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed)
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->