### PR TITLE
Move NavigationService (and dependent classes) into the internal package

### DIFF
--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/TestRouteProgressBuilder.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/TestRouteProgressBuilder.java
@@ -12,10 +12,10 @@ import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 import java.util.List;
 
 import static com.mapbox.core.constants.Constants.PRECISION_6;
-import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.createDistancesToIntersections;
-import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.createIntersectionsList;
-import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.findCurrentIntersection;
-import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.findUpcomingIntersection;
+import static com.mapbox.services.android.navigation.v5.internal.navigation.NavigationHelper.createDistancesToIntersections;
+import static com.mapbox.services.android.navigation.v5.internal.navigation.NavigationHelper.createIntersectionsList;
+import static com.mapbox.services.android.navigation.v5.internal.navigation.NavigationHelper.findCurrentIntersection;
+import static com.mapbox.services.android.navigation.v5.internal.navigation.NavigationHelper.findUpcomingIntersection;
 
 class TestRouteProgressBuilder {
 

--- a/libandroid-navigation/src/main/AndroidManifest.xml
+++ b/libandroid-navigation/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
 
     <application>
-        <service android:name="com.mapbox.services.android.navigation.v5.navigation.NavigationService"/>
+        <service android:name="com.mapbox.services.android.navigation.v5.internal.navigation.NavigationService"/>
         <!-- Include the telemetry service to simplify set up (https://www.mapbox.com/telemetry) -->
         <service android:name="com.mapbox.services.android.telemetry.service.TelemetryService"/>
     </application>

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/IntCounter.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/IntCounter.java
@@ -1,8 +1,0 @@
-package com.mapbox.services.android.navigation.v5.internal.navigation;
-
-class IntCounter extends Counter<Integer> {
-
-  IntCounter(String name, Integer value) {
-    super(name, value);
-  }
-}

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/LocationUpdater.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/LocationUpdater.java
@@ -1,4 +1,4 @@
-package com.mapbox.services.android.navigation.v5.navigation;
+package com.mapbox.services.android.navigation.v5.internal.navigation;
 
 import android.annotation.SuppressLint;
 import android.location.Location;
@@ -8,8 +8,6 @@ import com.mapbox.android.core.location.LocationEngine;
 import com.mapbox.android.core.location.LocationEngineCallback;
 import com.mapbox.android.core.location.LocationEngineRequest;
 import com.mapbox.android.core.location.LocationEngineResult;
-import com.mapbox.services.android.navigation.v5.internal.navigation.NavigationEventDispatcher;
-import com.mapbox.services.android.navigation.v5.internal.navigation.NavigationTelemetry;
 
 import java.lang.ref.WeakReference;
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/MapboxNavigationNotification.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/MapboxNavigationNotification.java
@@ -1,4 +1,4 @@
-package com.mapbox.services.android.navigation.v5.navigation;
+package com.mapbox.services.android.navigation.v5.internal.navigation;
 
 import android.app.Notification;
 import android.app.NotificationChannel;
@@ -20,6 +20,8 @@ import android.widget.RemoteViews;
 import com.mapbox.api.directions.v5.models.LegStep;
 import com.mapbox.api.directions.v5.models.RouteOptions;
 import com.mapbox.services.android.navigation.R;
+import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation;
+import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigationOptions;
 import com.mapbox.services.android.navigation.v5.navigation.notification.NavigationNotification;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 import com.mapbox.services.android.navigation.v5.utils.DistanceFormatter;

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/MapboxNavigator.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/MapboxNavigator.java
@@ -1,4 +1,4 @@
-package com.mapbox.services.android.navigation.v5.navigation;
+package com.mapbox.services.android.navigation.v5.internal.navigation;
 
 import android.location.Location;
 import android.support.annotation.NonNull;
@@ -10,23 +10,57 @@ import com.mapbox.navigator.FixLocation;
 import com.mapbox.navigator.NavigationStatus;
 import com.mapbox.navigator.Navigator;
 import com.mapbox.navigator.VoiceInstruction;
+import com.mapbox.services.android.navigation.v5.navigation.DirectionsRouteType;
 
 import java.util.Date;
 
-// TODO internal
 public class MapboxNavigator {
 
   private static final int INDEX_FIRST_ROUTE = 0;
   private final Navigator navigator;
   private final RouteHandler routeHandler;
 
-  MapboxNavigator(Navigator navigator) {
+  public MapboxNavigator(Navigator navigator) {
     this.navigator = navigator;
     this.routeHandler = new RouteHandler(this);
   }
 
-  void updateRoute(DirectionsRoute route, DirectionsRouteType routeType) {
+  public void updateRoute(DirectionsRoute route, DirectionsRouteType routeType) {
     routeHandler.updateRoute(route, routeType);
+  }
+
+  public synchronized NavigationStatus updateLegIndex(int index) {
+    return navigator.changeRouteLeg(INDEX_FIRST_ROUTE, index);
+  }
+
+  /**
+   * Gets the history of state changing calls to the navigator this can be used to
+   * replay a sequence of events for the purpose of bug fixing.
+   *
+   * @return a json representing the series of events that happened since the last time
+   * history was toggled on
+   */
+  public synchronized String retrieveHistory() {
+    return navigator.getHistory();
+  }
+
+  /**
+   * Toggles the recording of history on or off.
+   *
+   * @param isEnabled set this to true to turn on history recording and false to turn it off
+   *                  toggling will reset all history call getHistory first before toggling
+   *                  to retain a copy
+   */
+  public synchronized void toggleHistory(boolean isEnabled) {
+    navigator.toggleHistory(isEnabled);
+  }
+
+  public synchronized void addHistoryEvent(String eventType, String eventJsonProperties) {
+    navigator.pushHistory(eventType, eventJsonProperties);
+  }
+
+  public synchronized VoiceInstruction retrieveVoiceInstruction(int index) {
+    return navigator.getVoiceInstruction(index);
   }
 
   synchronized NavigationStatus setRoute(@NonNull String routeJson, int routeIndex, int legIndex) {
@@ -50,40 +84,6 @@ public class MapboxNavigator {
     synchronized (this) {
       navigator.updateLocation(fixedLocation);
     }
-  }
-
-  synchronized NavigationStatus updateLegIndex(int index) {
-    return navigator.changeRouteLeg(INDEX_FIRST_ROUTE, index);
-  }
-
-  /**
-   * Gets the history of state changing calls to the navigator this can be used to
-   * replay a sequence of events for the purpose of bug fixing.
-   *
-   * @return a json representing the series of events that happened since the last time
-   * history was toggled on
-   */
-  synchronized String retrieveHistory() {
-    return navigator.getHistory();
-  }
-
-  /**
-   * Toggles the recording of history on or off.
-   *
-   * @param isEnabled set this to true to turn on history recording and false to turn it off
-   *                  toggling will reset all history call getHistory first before toggling
-   *                  to retain a copy
-   */
-  synchronized void toggleHistory(boolean isEnabled) {
-    navigator.toggleHistory(isEnabled);
-  }
-
-  synchronized void addHistoryEvent(String eventType, String eventJsonProperties) {
-    navigator.pushHistory(eventType, eventJsonProperties);
-  }
-
-  synchronized VoiceInstruction retrieveVoiceInstruction(int index) {
-    return navigator.getVoiceInstruction(index);
   }
 
   synchronized BannerInstruction retrieveBannerInstruction(int index) {

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/NavigationEngineFactory.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/NavigationEngineFactory.java
@@ -1,4 +1,4 @@
-package com.mapbox.services.android.navigation.v5.navigation;
+package com.mapbox.services.android.navigation.v5.internal.navigation;
 
 import com.mapbox.services.android.navigation.v5.navigation.camera.Camera;
 import com.mapbox.services.android.navigation.v5.navigation.camera.SimpleCamera;
@@ -9,55 +9,55 @@ import com.mapbox.services.android.navigation.v5.route.FasterRouteDetector;
 import com.mapbox.services.android.navigation.v5.snap.Snap;
 import com.mapbox.services.android.navigation.v5.snap.SnapToRoute;
 
-class NavigationEngineFactory {
+public class NavigationEngineFactory {
 
   private OffRoute offRouteEngine;
   private FasterRoute fasterRouteEngine;
   private Snap snapEngine;
   private Camera cameraEngine;
 
-  NavigationEngineFactory() {
+  public NavigationEngineFactory() {
     initializeDefaultEngines();
   }
 
-  OffRoute retrieveOffRouteEngine() {
+  public OffRoute retrieveOffRouteEngine() {
     return offRouteEngine;
   }
 
-  void updateOffRouteEngine(OffRoute offRouteEngine) {
+  public void updateOffRouteEngine(OffRoute offRouteEngine) {
     if (offRouteEngine == null) {
       return;
     }
     this.offRouteEngine = offRouteEngine;
   }
 
-  FasterRoute retrieveFasterRouteEngine() {
+  public FasterRoute retrieveFasterRouteEngine() {
     return fasterRouteEngine;
   }
 
-  void updateFasterRouteEngine(FasterRoute fasterRouteEngine) {
+  public void updateFasterRouteEngine(FasterRoute fasterRouteEngine) {
     if (fasterRouteEngine == null) {
       return;
     }
     this.fasterRouteEngine = fasterRouteEngine;
   }
 
-  Snap retrieveSnapEngine() {
+  public Snap retrieveSnapEngine() {
     return snapEngine;
   }
 
-  void updateSnapEngine(Snap snapEngine) {
+  public void updateSnapEngine(Snap snapEngine) {
     if (snapEngine == null) {
       return;
     }
     this.snapEngine = snapEngine;
   }
 
-  Camera retrieveCameraEngine() {
+  public Camera retrieveCameraEngine() {
     return cameraEngine;
   }
 
-  void updateCameraEngine(Camera cameraEngine) {
+  public void updateCameraEngine(Camera cameraEngine) {
     if (cameraEngine == null) {
       return;
     }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/NavigationFasterRouteListener.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/NavigationFasterRouteListener.java
@@ -1,9 +1,8 @@
-package com.mapbox.services.android.navigation.v5.navigation;
+package com.mapbox.services.android.navigation.v5.internal.navigation;
 
 import android.support.annotation.Nullable;
 
 import com.mapbox.api.directions.v5.models.DirectionsResponse;
-import com.mapbox.services.android.navigation.v5.internal.navigation.NavigationEventDispatcher;
 import com.mapbox.services.android.navigation.v5.route.FasterRoute;
 import com.mapbox.services.android.navigation.v5.route.RouteListener;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/NavigationHelper.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/NavigationHelper.java
@@ -1,4 +1,4 @@
-package com.mapbox.services.android.navigation.v5.navigation;
+package com.mapbox.services.android.navigation.v5.internal.navigation;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -42,75 +42,6 @@ public class NavigationHelper {
 
   private NavigationHelper() {
     // Empty private constructor to prevent users creating an instance of this class.
-  }
-
-  /**
-   * When a milestones triggered, it's instruction needs to be built either using the provided
-   * string or an empty string.
-   */
-  static String buildInstructionString(RouteProgress routeProgress, Milestone milestone) {
-    if (milestone.getInstruction() != null) {
-      // Create a new custom instruction based on the Instruction packaged with the Milestone
-      return milestone.getInstruction().buildInstruction(routeProgress);
-    }
-    return EMPTY_STRING;
-  }
-
-  /**
-   * Takes in the leg distance remaining value already calculated and if additional legs need to be
-   * traversed along after the current one, adds those distances and returns the new distance.
-   * Otherwise, if the route only contains one leg or the users on the last leg, this value will
-   * equal the leg distance remaining.
-   */
-  static double routeDistanceRemaining(double legDistanceRemaining, int legIndex,
-                                       DirectionsRoute directionsRoute) {
-    if (directionsRoute.legs().size() < 2) {
-      return legDistanceRemaining;
-    }
-
-    for (int i = legIndex + 1; i < directionsRoute.legs().size(); i++) {
-      legDistanceRemaining += directionsRoute.legs().get(i).distance();
-    }
-    return legDistanceRemaining;
-  }
-
-  /**
-   * Given the current {@link DirectionsRoute} and leg / step index,
-   * return a list of {@link Point} representing the current step.
-   * <p>
-   * This method is only used on a per-step basis as {@link PolylineUtils#decode(String, int)}
-   * can be a heavy operation based on the length of the step.
-   * <p>
-   * Returns null if index is invalid.
-   *
-   * @param directionsRoute for list of steps
-   * @param legIndex        to get current step list
-   * @param stepIndex       to get current step
-   * @return list of {@link Point} representing the current step
-   */
-  static List<Point> decodeStepPoints(DirectionsRoute directionsRoute, List<Point> currentPoints,
-                                      int legIndex, int stepIndex) {
-    List<RouteLeg> legs = directionsRoute.legs();
-    if (hasInvalidLegs(legs)) {
-      return currentPoints;
-    }
-    List<LegStep> steps = legs.get(legIndex).steps();
-    if (hasInvalidSteps(steps)) {
-      return currentPoints;
-    }
-    boolean invalidStepIndex = stepIndex < 0 || stepIndex > steps.size() - 1;
-    if (invalidStepIndex) {
-      return currentPoints;
-    }
-    LegStep step = steps.get(stepIndex);
-    if (step == null) {
-      return currentPoints;
-    }
-    String stepGeometry = step.geometry();
-    if (stepGeometry != null) {
-      return PolylineUtils.decode(stepGeometry, PRECISION_6);
-    }
-    return currentPoints;
   }
 
   /**
@@ -219,8 +150,8 @@ public class NavigationHelper {
    * @since 0.13.0
    */
   public static StepIntersection findUpcomingIntersection(@NonNull List<StepIntersection> intersections,
-                                                   @Nullable LegStep upcomingStep,
-                                                   StepIntersection currentIntersection) {
+                                                          @Nullable LegStep upcomingStep,
+                                                          StepIntersection currentIntersection) {
     int intersectionIndex = intersections.indexOf(currentIntersection);
     int nextIntersectionIndex = intersectionIndex + ONE_INDEX;
     int intersectionSize = intersections.size();
@@ -247,7 +178,7 @@ public class NavigationHelper {
    */
   @Nullable
   public static CurrentLegAnnotation createCurrentAnnotation(CurrentLegAnnotation currentLegAnnotation,
-                                                      RouteLeg leg, double legDistanceRemaining) {
+                                                             RouteLeg leg, double legDistanceRemaining) {
     LegAnnotation legAnnotation = leg.annotation();
     if (legAnnotation == null) {
       return null;
@@ -281,6 +212,75 @@ public class NavigationHelper {
     }
     annotationBuilder.index(annotationIndex);
     return annotationBuilder.build();
+  }
+
+  /**
+   * When a milestones triggered, it's instruction needs to be built either using the provided
+   * string or an empty string.
+   */
+  static String buildInstructionString(RouteProgress routeProgress, Milestone milestone) {
+    if (milestone.getInstruction() != null) {
+      // Create a new custom instruction based on the Instruction packaged with the Milestone
+      return milestone.getInstruction().buildInstruction(routeProgress);
+    }
+    return EMPTY_STRING;
+  }
+
+  /**
+   * Takes in the leg distance remaining value already calculated and if additional legs need to be
+   * traversed along after the current one, adds those distances and returns the new distance.
+   * Otherwise, if the route only contains one leg or the users on the last leg, this value will
+   * equal the leg distance remaining.
+   */
+  static double routeDistanceRemaining(double legDistanceRemaining, int legIndex,
+                                       DirectionsRoute directionsRoute) {
+    if (directionsRoute.legs().size() < 2) {
+      return legDistanceRemaining;
+    }
+
+    for (int i = legIndex + 1; i < directionsRoute.legs().size(); i++) {
+      legDistanceRemaining += directionsRoute.legs().get(i).distance();
+    }
+    return legDistanceRemaining;
+  }
+
+  /**
+   * Given the current {@link DirectionsRoute} and leg / step index,
+   * return a list of {@link Point} representing the current step.
+   * <p>
+   * This method is only used on a per-step basis as {@link PolylineUtils#decode(String, int)}
+   * can be a heavy operation based on the length of the step.
+   * <p>
+   * Returns null if index is invalid.
+   *
+   * @param directionsRoute for list of steps
+   * @param legIndex        to get current step list
+   * @param stepIndex       to get current step
+   * @return list of {@link Point} representing the current step
+   */
+  static List<Point> decodeStepPoints(DirectionsRoute directionsRoute, List<Point> currentPoints,
+                                      int legIndex, int stepIndex) {
+    List<RouteLeg> legs = directionsRoute.legs();
+    if (hasInvalidLegs(legs)) {
+      return currentPoints;
+    }
+    List<LegStep> steps = legs.get(legIndex).steps();
+    if (hasInvalidSteps(steps)) {
+      return currentPoints;
+    }
+    boolean invalidStepIndex = stepIndex < 0 || stepIndex > steps.size() - 1;
+    if (invalidStepIndex) {
+      return currentPoints;
+    }
+    LegStep step = steps.get(stepIndex);
+    if (step == null) {
+      return currentPoints;
+    }
+    String stepGeometry = step.geometry();
+    if (stepGeometry != null) {
+      return PolylineUtils.decode(stepGeometry, PRECISION_6);
+    }
+    return currentPoints;
   }
 
   private static int findAnnotationIndex(CurrentLegAnnotation currentLegAnnotation,

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/NavigationLifecycleMonitor.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/NavigationLifecycleMonitor.java
@@ -7,7 +7,7 @@ import android.os.Bundle;
 
 import java.util.ArrayList;
 
-public class NavigationLifecycleMonitor implements Application.ActivityLifecycleCallbacks {
+class NavigationLifecycleMonitor implements Application.ActivityLifecycleCallbacks {
 
   private static final int ONE_HUNDRED_PERCENT = 100;
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/NavigationNotificationProvider.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/NavigationNotificationProvider.java
@@ -1,7 +1,9 @@
-package com.mapbox.services.android.navigation.v5.navigation;
+package com.mapbox.services.android.navigation.v5.internal.navigation;
 
 import android.content.Context;
 
+import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation;
+import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigationOptions;
 import com.mapbox.services.android.navigation.v5.navigation.notification.NavigationNotification;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/NavigationRouteProcessor.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/NavigationRouteProcessor.java
@@ -1,4 +1,4 @@
-package com.mapbox.services.android.navigation.v5.navigation;
+package com.mapbox.services.android.navigation.v5.internal.navigation;
 
 import android.support.annotation.Nullable;
 import android.support.v4.util.Pair;
@@ -19,13 +19,13 @@ import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgressStat
 
 import java.util.List;
 
-import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.createCurrentAnnotation;
-import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.createDistancesToIntersections;
-import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.createIntersectionsList;
-import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.decodeStepPoints;
-import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.findCurrentIntersection;
-import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.findUpcomingIntersection;
-import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.routeDistanceRemaining;
+import static com.mapbox.services.android.navigation.v5.internal.navigation.NavigationHelper.createCurrentAnnotation;
+import static com.mapbox.services.android.navigation.v5.internal.navigation.NavigationHelper.createDistancesToIntersections;
+import static com.mapbox.services.android.navigation.v5.internal.navigation.NavigationHelper.createIntersectionsList;
+import static com.mapbox.services.android.navigation.v5.internal.navigation.NavigationHelper.decodeStepPoints;
+import static com.mapbox.services.android.navigation.v5.internal.navigation.NavigationHelper.findCurrentIntersection;
+import static com.mapbox.services.android.navigation.v5.internal.navigation.NavigationHelper.findUpcomingIntersection;
+import static com.mapbox.services.android.navigation.v5.internal.navigation.NavigationHelper.routeDistanceRemaining;
 
 class NavigationRouteProcessor {
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/NavigationService.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/NavigationService.java
@@ -1,4 +1,4 @@
-package com.mapbox.services.android.navigation.v5.navigation;
+package com.mapbox.services.android.navigation.v5.internal.navigation;
 
 import android.app.Notification;
 import android.app.Service;
@@ -11,8 +11,7 @@ import android.support.annotation.Nullable;
 import com.mapbox.android.core.location.LocationEngine;
 import com.mapbox.android.core.location.LocationEngineRequest;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
-import com.mapbox.services.android.navigation.v5.internal.navigation.NavigationEventDispatcher;
-import com.mapbox.services.android.navigation.v5.internal.navigation.NavigationTelemetry;
+import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation;
 import com.mapbox.services.android.navigation.v5.navigation.notification.NavigationNotification;
 import com.mapbox.services.android.navigation.v5.route.FasterRoute;
 import com.mapbox.services.android.navigation.v5.route.RouteFetcher;
@@ -64,7 +63,7 @@ public class NavigationService extends Service {
    * This gets called when {@link MapboxNavigation#startNavigation(DirectionsRoute)} is called and
    * setups variables among other things on the Navigation Service side.
    */
-  void startNavigation(MapboxNavigation mapboxNavigation) {
+  public void startNavigation(MapboxNavigation mapboxNavigation) {
     initialize(mapboxNavigation);
     startForegroundNotification(notificationProvider.retrieveNotification());
   }
@@ -72,7 +71,7 @@ public class NavigationService extends Service {
   /**
    * Removes the location / route listeners and  quits the thread.
    */
-  void endNavigation() {
+  public void endNavigation() {
     NavigationTelemetry.getInstance().endSession();
     routeFetcher.clearListeners();
     locationUpdater.removeLocationUpdates();
@@ -80,11 +79,11 @@ public class NavigationService extends Service {
     thread.quit();
   }
 
-  void updateLocationEngine(LocationEngine locationEngine) {
+  public void updateLocationEngine(LocationEngine locationEngine) {
     locationUpdater.updateLocationEngine(locationEngine);
   }
 
-  void updateLocationEngineRequest(LocationEngineRequest request) {
+  public void updateLocationEngineRequest(LocationEngineRequest request) {
     locationUpdater.updateLocationEngineRequest(request);
   }
 
@@ -133,8 +132,8 @@ public class NavigationService extends Service {
     startForeground(notificationId, notification);
   }
 
-  class LocalBinder extends Binder {
-    NavigationService getService() {
+  public class LocalBinder extends Binder {
+    public NavigationService getService() {
       Timber.d("Local binder called.");
       return NavigationService.this;
     }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/NavigationTelemetry.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/NavigationTelemetry.java
@@ -19,7 +19,6 @@ import com.mapbox.services.android.navigation.v5.internal.exception.NavigationEx
 import com.mapbox.services.android.navigation.v5.internal.location.MetricsLocation;
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation;
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigationOptions;
-import com.mapbox.services.android.navigation.v5.navigation.NavigationService;
 import com.mapbox.services.android.navigation.v5.navigation.metrics.FeedbackEvent;
 import com.mapbox.services.android.navigation.v5.navigation.metrics.NavigationMetricListener;
 import com.mapbox.services.android.navigation.v5.navigation.metrics.RerouteEvent;
@@ -70,7 +69,7 @@ public class NavigationTelemetry implements NavigationMetricListener {
   private InitialGpsEventFactory gpsEventFactory = new InitialGpsEventFactory();
   private NavigationPerformanceMetadata performanceMetadata;
 
-  NavigationTelemetry() {
+  private NavigationTelemetry() {
     locationBuffer = new RingBuffer<>(40);
     metricLocation = new MetricsLocation(null);
     metricProgress = new MetricsRouteProgress(null);
@@ -140,18 +139,6 @@ public class NavigationTelemetry implements NavigationMetricListener {
   }
 
   /**
-   * Added once created in the {@link NavigationService}, this class
-   * provides data regarding the {@link android.app.Activity} lifecycle.
-   *
-   * @param application to register the callbacks
-   */
-  public void initializeLifecycleMonitor(Application application) {
-    if (lifecycleMonitor == null) {
-      lifecycleMonitor = new NavigationLifecycleMonitor(application);
-    }
-  }
-
-  /**
    * Called when navigation is starting for the first time.
    * Initializes the {@link SessionState}.
    *
@@ -178,14 +165,6 @@ public class NavigationTelemetry implements NavigationMetricListener {
     sendCancelEvent();
     gpsEventFactory.reset();
     resetDepartFactory();
-  }
-
-  public void endSession() {
-    flushEventQueues();
-    lifecycleMonitor = null;
-    NavigationMetricsWrapper.disable();
-    isInitialized = false;
-    cancelBatteryScheduler();
   }
 
   /**
@@ -251,7 +230,7 @@ public class NavigationTelemetry implements NavigationMetricListener {
    * @return String feedbackId to identify the event created if needed
    */
   public String recordFeedbackEvent(@FeedbackEvent.FeedbackType String feedbackType, String description,
-                             @FeedbackEvent.FeedbackSource String feedbackSource) {
+                                    @FeedbackEvent.FeedbackSource String feedbackSource) {
     FeedbackEvent feedbackEvent = queueFeedbackEvent(feedbackType, description, feedbackSource);
     return feedbackEvent.getEventId();
   }
@@ -267,7 +246,7 @@ public class NavigationTelemetry implements NavigationMetricListener {
    * @param screenshot   an optional encoded screenshot to provide more detail about the feedback
    */
   public void updateFeedbackEvent(String feedbackId, @FeedbackEvent.FeedbackType String feedbackType,
-                           String description, String screenshot) {
+                                  String description, String screenshot) {
     // Find the event and send
     FeedbackEvent feedbackEvent = (FeedbackEvent) findQueuedTelemetryEvent(feedbackId);
     if (feedbackEvent != null) {
@@ -288,6 +267,26 @@ public class NavigationTelemetry implements NavigationMetricListener {
     // Find the event and remove it from the queue
     FeedbackEvent feedbackEvent = (FeedbackEvent) findQueuedTelemetryEvent(feedbackId);
     queuedFeedbackEvents.remove(feedbackEvent);
+  }
+
+  /**
+   * Added once created in the {@link NavigationService}, this class
+   * provides data regarding the {@link android.app.Activity} lifecycle.
+   *
+   * @param application to register the callbacks
+   */
+  void initializeLifecycleMonitor(Application application) {
+    if (lifecycleMonitor == null) {
+      lifecycleMonitor = new NavigationLifecycleMonitor(application);
+    }
+  }
+
+  void endSession() {
+    flushEventQueues();
+    lifecycleMonitor = null;
+    NavigationMetricsWrapper.disable();
+    isInitialized = false;
+    cancelBatteryScheduler();
   }
 
   void routeRetrievalEvent(ElapsedTime elapsedTime, String routeUuid) {

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/RouteHandler.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/RouteHandler.java
@@ -1,7 +1,8 @@
-package com.mapbox.services.android.navigation.v5.navigation;
+package com.mapbox.services.android.navigation.v5.internal.navigation;
 
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.api.directions.v5.models.RouteLeg;
+import com.mapbox.services.android.navigation.v5.navigation.DirectionsRouteType;
 
 import java.util.List;
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/RouteProcessorBackgroundThread.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/RouteProcessorBackgroundThread.java
@@ -1,4 +1,4 @@
-package com.mapbox.services.android.navigation.v5.navigation;
+package com.mapbox.services.android.navigation.v5.internal.navigation;
 
 import android.location.Location;
 import android.os.Handler;
@@ -6,15 +6,17 @@ import android.os.HandlerThread;
 import android.os.Process;
 
 import com.mapbox.services.android.navigation.v5.milestone.Milestone;
+import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 
 import java.util.List;
 
+// TODO public for NavigationConstants?
 /**
  * This class extends handler thread to run most of the navigation calculations on a separate
  * background thread.
  */
-class RouteProcessorBackgroundThread extends HandlerThread {
+public class RouteProcessorBackgroundThread extends HandlerThread {
 
   private static final String MAPBOX_NAVIGATION_THREAD_NAME = "mapbox_navigation_thread";
   private final MapboxNavigation navigation;

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/RouteProcessorRunnable.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/RouteProcessorRunnable.java
@@ -1,4 +1,4 @@
-package com.mapbox.services.android.navigation.v5.navigation;
+package com.mapbox.services.android.navigation.v5.internal.navigation;
 
 import android.location.Location;
 import android.os.Handler;
@@ -7,6 +7,8 @@ import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.navigator.NavigationStatus;
 import com.mapbox.navigator.RouteState;
 import com.mapbox.services.android.navigation.v5.milestone.Milestone;
+import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation;
+import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigationOptions;
 import com.mapbox.services.android.navigation.v5.offroute.OffRoute;
 import com.mapbox.services.android.navigation.v5.offroute.OffRouteDetector;
 import com.mapbox.services.android.navigation.v5.route.FasterRoute;

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/RouteProcessorThreadListener.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/RouteProcessorThreadListener.java
@@ -1,16 +1,15 @@
-package com.mapbox.services.android.navigation.v5.navigation;
+package com.mapbox.services.android.navigation.v5.internal.navigation;
 
 import android.location.Location;
 
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
-import com.mapbox.services.android.navigation.v5.internal.navigation.NavigationEventDispatcher;
 import com.mapbox.services.android.navigation.v5.milestone.Milestone;
 import com.mapbox.services.android.navigation.v5.route.RouteFetcher;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 
 import java.util.List;
 
-import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.buildInstructionString;
+import static com.mapbox.services.android.navigation.v5.internal.navigation.NavigationHelper.buildInstructionString;
 
 class RouteProcessorThreadListener implements RouteProcessorBackgroundThread.Listener {
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/RouteRefresher.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/RouteRefresher.java
@@ -1,10 +1,12 @@
-package com.mapbox.services.android.navigation.v5.navigation;
+package com.mapbox.services.android.navigation.v5.internal.navigation;
 
+import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation;
+import com.mapbox.services.android.navigation.v5.navigation.RouteRefresh;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 
 import java.util.Date;
 
-class RouteRefresher {
+public class RouteRefresher {
   private final MapboxNavigation mapboxNavigation;
   private final RouteRefresh routeRefresh;
   private final long refreshIntervalInMilliseconds;
@@ -12,7 +14,7 @@ class RouteRefresher {
   private boolean isChecking;
   private boolean isRefreshRouteEnabled;
 
-  RouteRefresher(MapboxNavigation mapboxNavigation, RouteRefresh routeRefresh) {
+  public RouteRefresher(MapboxNavigation mapboxNavigation, RouteRefresh routeRefresh) {
     this.mapboxNavigation = mapboxNavigation;
     this.routeRefresh = routeRefresh;
     this.refreshIntervalInMilliseconds = mapboxNavigation.options().refreshIntervalInMilliseconds();

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/RouteRefresherCallback.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/RouteRefresherCallback.java
@@ -1,6 +1,10 @@
-package com.mapbox.services.android.navigation.v5.navigation;
+package com.mapbox.services.android.navigation.v5.internal.navigation;
 
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
+import com.mapbox.services.android.navigation.v5.navigation.DirectionsRouteType;
+import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation;
+import com.mapbox.services.android.navigation.v5.navigation.RefreshCallback;
+import com.mapbox.services.android.navigation.v5.navigation.RefreshError;
 
 import java.util.Date;
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
@@ -14,9 +14,13 @@ import com.mapbox.android.core.location.LocationEngineProvider;
 import com.mapbox.android.core.location.LocationEngineRequest;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.navigator.Navigator;
-import com.mapbox.services.android.navigation.v5.location.RawLocationListener;
+import com.mapbox.services.android.navigation.v5.internal.navigation.MapboxNavigator;
+import com.mapbox.services.android.navigation.v5.internal.navigation.NavigationEngineFactory;
 import com.mapbox.services.android.navigation.v5.internal.navigation.NavigationEventDispatcher;
+import com.mapbox.services.android.navigation.v5.internal.navigation.NavigationService;
 import com.mapbox.services.android.navigation.v5.internal.navigation.NavigationTelemetry;
+import com.mapbox.services.android.navigation.v5.internal.navigation.RouteRefresher;
+import com.mapbox.services.android.navigation.v5.location.RawLocationListener;
 import com.mapbox.services.android.navigation.v5.milestone.BannerInstructionMilestone;
 import com.mapbox.services.android.navigation.v5.milestone.Milestone;
 import com.mapbox.services.android.navigation.v5.milestone.MilestoneEventListener;
@@ -41,8 +45,7 @@ import retrofit2.Callback;
 import timber.log.Timber;
 
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.BANNER_INSTRUCTION_MILESTONE_ID;
-import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants
-  .NON_NULL_APPLICATION_CONTEXT_REQUIRED;
+import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.NON_NULL_APPLICATION_CONTEXT_REQUIRED;
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.VOICE_INSTRUCTION_MILESTONE_ID;
 
 /**
@@ -142,18 +145,6 @@ public class MapboxNavigation implements ServiceConnection {
     initialize();
   }
 
-  // Package private (no modifier) for testing purposes
-  MapboxNavigation(@NonNull Context context, @NonNull String accessToken,
-                   @NonNull MapboxNavigationOptions options, NavigationTelemetry navigationTelemetry,
-                   LocationEngine locationEngine) {
-    initializeContext(context);
-    this.accessToken = accessToken;
-    this.options = options;
-    this.navigationTelemetry = navigationTelemetry;
-    this.locationEngine = locationEngine;
-    initializeForTest();
-  }
-
   // TODO public?
   // Package private (no modifier) for testing purposes
   public MapboxNavigation(@NonNull Context context, @NonNull String accessToken,
@@ -165,6 +156,18 @@ public class MapboxNavigation implements ServiceConnection {
     this.navigationTelemetry = navigationTelemetry;
     this.locationEngine = locationEngine;
     this.mapboxNavigator = mapboxNavigator;
+    initializeForTest();
+  }
+
+  // Package private (no modifier) for testing purposes
+  MapboxNavigation(@NonNull Context context, @NonNull String accessToken,
+                   @NonNull MapboxNavigationOptions options, NavigationTelemetry navigationTelemetry,
+                   LocationEngine locationEngine) {
+    initializeContext(context);
+    this.accessToken = accessToken;
+    this.options = options;
+    this.navigationTelemetry = navigationTelemetry;
+    this.locationEngine = locationEngine;
     initializeForTest();
   }
 
@@ -822,15 +825,18 @@ public class MapboxNavigation implements ServiceConnection {
     isBound = false;
   }
 
-  String obtainAccessToken() {
+  // TODO public?
+  public String obtainAccessToken() {
     return accessToken;
   }
 
-  DirectionsRoute getRoute() {
+  // TODO public?
+  public DirectionsRoute getRoute() {
     return directionsRoute;
   }
 
-  List<Milestone> getMilestones() {
+  // TODO public?
+  public List<Milestone> getMilestones() {
     return new ArrayList<>(milestones);
   }
 
@@ -844,21 +850,25 @@ public class MapboxNavigation implements ServiceConnection {
     return navigationEventDispatcher;
   }
 
-  NavigationEngineFactory retrieveEngineFactory() {
+  // TODO public?
+  public NavigationEngineFactory retrieveEngineFactory() {
     return navigationEngineFactory;
   }
 
-  MapboxNavigator retrieveMapboxNavigator() {
+  // TODO public?
+  public MapboxNavigator retrieveMapboxNavigator() {
     return mapboxNavigator;
   }
 
+  // TODO public?
   @NonNull
-  LocationEngineRequest retrieveLocationEngineRequest() {
+  public LocationEngineRequest retrieveLocationEngineRequest() {
     return locationEngineRequest;
   }
 
+  // TODO public?
   @Nullable
-  RouteRefresher retrieveRouteRefresher() {
+  public RouteRefresher retrieveRouteRefresher() {
     return routeRefresher;
   }
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationConstants.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationConstants.java
@@ -3,6 +3,8 @@ package com.mapbox.services.android.navigation.v5.navigation;
 import android.support.annotation.IntDef;
 import android.support.annotation.StringDef;
 
+import com.mapbox.services.android.navigation.v5.internal.navigation.RouteProcessorBackgroundThread;
+
 /**
  * Navigation constants
  *
@@ -150,7 +152,6 @@ public final class NavigationConstants {
   // Bundle variable keys
   public static final String NAVIGATION_VIEW_ROUTE_KEY = "route_json";
   public static final String NAVIGATION_VIEW_SIMULATE_ROUTE = "navigation_view_simulate_route";
-  public static final String NAVIGATION_VIEW_ROUTE_PROFILE_KEY = "navigation_view_route_profile";
   public static final String OFFLINE_PATH_KEY = "offline_path_key";
   public static final String OFFLINE_VERSION_KEY = "offline_version_key";
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/notification/NavigationNotification.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/notification/NavigationNotification.java
@@ -3,6 +3,7 @@ package com.mapbox.services.android.navigation.v5.navigation.notification;
 import android.app.Notification;
 import android.content.Context;
 
+import com.mapbox.services.android.navigation.v5.internal.navigation.NavigationService;
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 
@@ -14,7 +15,7 @@ public interface NavigationNotification {
 
   /**
    * Provides a custom {@link Notification} to launch
-   * with the {@link com.mapbox.services.android.navigation.v5.navigation.NavigationService}, specifically
+   * with the {@link NavigationService}, specifically
    * {@link android.app.Service#startForeground(int, Notification)}.
    *
    * @return a custom notification
@@ -23,7 +24,7 @@ public interface NavigationNotification {
 
   /**
    * An integer id that will be used to start this notification
-   * from {@link com.mapbox.services.android.navigation.v5.navigation.NavigationService} with
+   * from {@link NavigationService} with
    * {@link android.app.Service#startForeground(int, Notification)}.
    *
    * @return an int id specific to the notification

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/TestRouteProgressBuilder.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/TestRouteProgressBuilder.java
@@ -13,10 +13,10 @@ import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 import java.util.List;
 
 import static com.mapbox.core.constants.Constants.PRECISION_6;
-import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.createDistancesToIntersections;
-import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.createIntersectionsList;
-import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.findCurrentIntersection;
-import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.findUpcomingIntersection;
+import static com.mapbox.services.android.navigation.v5.internal.navigation.NavigationHelper.createDistancesToIntersections;
+import static com.mapbox.services.android.navigation.v5.internal.navigation.NavigationHelper.createIntersectionsList;
+import static com.mapbox.services.android.navigation.v5.internal.navigation.NavigationHelper.findCurrentIntersection;
+import static com.mapbox.services.android.navigation.v5.internal.navigation.NavigationHelper.findUpcomingIntersection;
 
 class TestRouteProgressBuilder {
 
@@ -90,8 +90,8 @@ class TestRouteProgressBuilder {
   private StepIntersection createUpcomingIntersection(LegStep upcomingStep, List<StepIntersection> intersections,
                                                       StepIntersection currentIntersection) {
     return findUpcomingIntersection(
-        intersections, upcomingStep, currentIntersection
-      );
+      intersections, upcomingStep, currentIntersection
+    );
   }
 
   private List<Point> buildStepPointsFromGeometry(String stepGeometry) {

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/internal/navigation/LocationUpdaterTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/internal/navigation/LocationUpdaterTest.java
@@ -1,4 +1,4 @@
-package com.mapbox.services.android.navigation.v5.navigation;
+package com.mapbox.services.android.navigation.v5.internal.navigation;
 
 import android.location.Location;
 import android.os.Looper;
@@ -7,7 +7,6 @@ import com.mapbox.android.core.location.LocationEngine;
 import com.mapbox.android.core.location.LocationEngineCallback;
 import com.mapbox.android.core.location.LocationEngineRequest;
 import com.mapbox.android.core.location.LocationEngineResult;
-import com.mapbox.services.android.navigation.v5.internal.navigation.NavigationEventDispatcher;
 
 import org.junit.Test;
 

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/internal/navigation/MapboxNavigationNotificationTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/internal/navigation/MapboxNavigationNotificationTest.java
@@ -1,4 +1,4 @@
-package com.mapbox.services.android.navigation.v5.navigation;
+package com.mapbox.services.android.navigation.v5.internal.navigation;
 
 import android.app.Notification;
 import android.content.Context;
@@ -12,6 +12,9 @@ import com.mapbox.api.directions.v5.DirectionsAdapterFactory;
 import com.mapbox.api.directions.v5.models.DirectionsResponse;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.services.android.navigation.v5.BaseTest;
+import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation;
+import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigationOptions;
+import com.mapbox.services.android.navigation.v5.navigation.NavigationConstants;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 
 import org.junit.Before;

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/internal/navigation/NavigationEventDispatcherTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/internal/navigation/NavigationEventDispatcherTest.java
@@ -16,7 +16,6 @@ import com.mapbox.services.android.navigation.v5.milestone.BannerInstructionMile
 import com.mapbox.services.android.navigation.v5.milestone.Milestone;
 import com.mapbox.services.android.navigation.v5.milestone.MilestoneEventListener;
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation;
-import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigator;
 import com.mapbox.services.android.navigation.v5.navigation.NavigationEventListener;
 import com.mapbox.services.android.navigation.v5.navigation.metrics.NavigationMetricListener;
 import com.mapbox.services.android.navigation.v5.offroute.OffRouteListener;

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/internal/navigation/NavigationFasterRouteListenerTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/internal/navigation/NavigationFasterRouteListenerTest.java
@@ -1,10 +1,9 @@
-package com.mapbox.services.android.navigation.v5.navigation;
+package com.mapbox.services.android.navigation.v5.internal.navigation;
 
 import android.support.annotation.NonNull;
 
 import com.mapbox.api.directions.v5.models.DirectionsResponse;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
-import com.mapbox.services.android.navigation.v5.internal.navigation.NavigationEventDispatcher;
 import com.mapbox.services.android.navigation.v5.route.FasterRoute;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/internal/navigation/NavigationNotificationProviderTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/internal/navigation/NavigationNotificationProviderTest.java
@@ -1,8 +1,10 @@
-package com.mapbox.services.android.navigation.v5.navigation;
+package com.mapbox.services.android.navigation.v5.internal.navigation;
 
 import android.content.Context;
 import android.support.annotation.NonNull;
 
+import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation;
+import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigationOptions;
 import com.mapbox.services.android.navigation.v5.navigation.notification.NavigationNotification;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/internal/navigation/NavigationRouteProcessorTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/internal/navigation/NavigationRouteProcessorTest.java
@@ -1,4 +1,4 @@
-package com.mapbox.services.android.navigation.v5.navigation;
+package com.mapbox.services.android.navigation.v5.internal.navigation;
 
 import com.mapbox.navigator.NavigationStatus;
 import com.mapbox.services.android.navigation.v5.BaseTest;

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/internal/navigation/RouteHandlerTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/internal/navigation/RouteHandlerTest.java
@@ -1,7 +1,8 @@
-package com.mapbox.services.android.navigation.v5.navigation;
+package com.mapbox.services.android.navigation.v5.internal.navigation;
 
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.services.android.navigation.v5.BaseTest;
+import com.mapbox.services.android.navigation.v5.navigation.DirectionsRouteType;
 
 import org.junit.Test;
 

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/internal/navigation/RouteProcessorRunnableTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/internal/navigation/RouteProcessorRunnableTest.java
@@ -1,4 +1,4 @@
-package com.mapbox.services.android.navigation.v5.navigation;
+package com.mapbox.services.android.navigation.v5.internal.navigation;
 
 import android.location.Location;
 import android.os.Handler;
@@ -9,6 +9,8 @@ import com.mapbox.api.directions.v5.models.RouteLeg;
 import com.mapbox.geojson.Point;
 import com.mapbox.navigator.NavigationStatus;
 import com.mapbox.navigator.RouteState;
+import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation;
+import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigationOptions;
 import com.mapbox.services.android.navigation.v5.navigation.camera.SimpleCamera;
 import com.mapbox.services.android.navigation.v5.offroute.OffRouteDetector;
 import com.mapbox.services.android.navigation.v5.route.FasterRouteDetector;
@@ -40,7 +42,7 @@ public class RouteProcessorRunnableTest {
     MapboxNavigator navigator = mock(MapboxNavigator.class);
     NavigationStatus status = buildMockStatus();
     DirectionsRoute route = mock(DirectionsRoute.class);
-    RouteProcessorRunnable runnable = buildRouteProcessorRunnableWith(navigator,processor, status, route);
+    RouteProcessorRunnable runnable = buildRouteProcessorRunnableWith(navigator, processor, status, route);
     runnable.updateRawLocation(mock(Location.class));
 
     runnable.run();
@@ -181,7 +183,8 @@ public class RouteProcessorRunnableTest {
     verify(navigator, times(0)).updateLegIndex(anyInt());
   }
 
-  private RouteProcessorRunnable buildRouteProcessorRunnableWith(MapboxNavigator navigator, NavigationRouteProcessor processor,
+  private RouteProcessorRunnable buildRouteProcessorRunnableWith(MapboxNavigator navigator,
+                                                                 NavigationRouteProcessor processor,
                                                                  NavigationStatus status, DirectionsRoute route) {
     MapboxNavigationOptions options = MapboxNavigationOptions.builder().build();
     when(navigator.retrieveStatus(any(Date.class), any(Long.class))).thenReturn(status);

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/internal/navigation/RouteProcessorThreadListenerTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/internal/navigation/RouteProcessorThreadListenerTest.java
@@ -1,10 +1,9 @@
-package com.mapbox.services.android.navigation.v5.navigation;
+package com.mapbox.services.android.navigation.v5.internal.navigation;
 
 import android.location.Location;
 import android.support.annotation.NonNull;
 
 import com.mapbox.services.android.navigation.v5.instruction.Instruction;
-import com.mapbox.services.android.navigation.v5.internal.navigation.NavigationEventDispatcher;
 import com.mapbox.services.android.navigation.v5.milestone.Milestone;
 import com.mapbox.services.android.navigation.v5.milestone.StepMilestone;
 import com.mapbox.services.android.navigation.v5.route.RouteFetcher;

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/internal/navigation/RouteRefresherCallbackTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/internal/navigation/RouteRefresherCallbackTest.java
@@ -1,8 +1,12 @@
-package com.mapbox.services.android.navigation.v5.navigation;
+package com.mapbox.services.android.navigation.v5.internal.navigation;
 
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
+import com.mapbox.services.android.navigation.v5.navigation.DirectionsRouteType;
+import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation;
+import com.mapbox.services.android.navigation.v5.navigation.RefreshError;
 
 import org.junit.Test;
+import org.mockito.ArgumentMatchers;
 
 import java.util.Date;
 
@@ -23,7 +27,7 @@ public class RouteRefresherCallbackTest {
 
     theRouteRefresherCallback.onRefresh(anyRoute);
 
-    verify(mockedMapboxNavigation).startNavigation(eq(anyRoute), eq(DirectionsRouteType.FRESH_ROUTE));
+    verify(mockedMapboxNavigation).startNavigation(eq(anyRoute), ArgumentMatchers.eq(DirectionsRouteType.FRESH_ROUTE));
   }
 
   @Test

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/internal/navigation/RouteRefresherTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/internal/navigation/RouteRefresherTest.java
@@ -1,5 +1,8 @@
-package com.mapbox.services.android.navigation.v5.navigation;
+package com.mapbox.services.android.navigation.v5.internal.navigation;
 
+import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation;
+import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigationOptions;
+import com.mapbox.services.android.navigation.v5.navigation.RouteRefresh;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 
 import org.junit.Test;

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationTest.java
@@ -6,6 +6,7 @@ import com.mapbox.android.core.location.LocationEngine;
 import com.mapbox.android.core.location.LocationEngineRequest;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.services.android.navigation.v5.BaseTest;
+import com.mapbox.services.android.navigation.v5.internal.navigation.MapboxNavigator;
 import com.mapbox.services.android.navigation.v5.internal.navigation.NavigationTelemetry;
 import com.mapbox.services.android.navigation.v5.milestone.BannerInstructionMilestone;
 import com.mapbox.services.android.navigation.v5.milestone.Milestone;

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEngineFactoryTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationEngineFactoryTest.java
@@ -1,5 +1,7 @@
 package com.mapbox.services.android.navigation.v5.navigation;
 
+import com.mapbox.services.android.navigation.v5.internal.navigation.NavigationEngineFactory;
+
 import org.junit.Test;
 
 import static junit.framework.Assert.assertNotNull;

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationHelperTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationHelperTest.java
@@ -15,6 +15,7 @@ import com.mapbox.core.constants.Constants;
 import com.mapbox.geojson.Point;
 import com.mapbox.geojson.utils.PolylineUtils;
 import com.mapbox.services.android.navigation.v5.BaseTest;
+import com.mapbox.services.android.navigation.v5.internal.navigation.NavigationHelper;
 import com.mapbox.services.android.navigation.v5.routeprogress.CurrentLegAnnotation;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteLegProgress;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
@@ -38,7 +39,8 @@ import static org.mockito.Mockito.when;
 public class NavigationHelperTest extends BaseTest {
 
   private static final String MULTI_LEG_ROUTE_FIXTURE = "directions_two_leg_route.json";
-  private static final String ANNOTATED_DISTANCE_CONGESTION_ROUTE_FIXTURE = "directions_distance_congestion_annotation.json";
+  private static final String ANNOTATED_DISTANCE_CONGESTION_ROUTE_FIXTURE =
+    "directions_distance_congestion_annotation.json";
 
   @Test
   public void createIntersectionList_returnsCompleteIntersectionList() throws Exception {
@@ -302,8 +304,10 @@ public class NavigationHelperTest extends BaseTest {
       legDistanceRemaining, distanceRemaining, stepIndex, legIndex);
   }
 
-  private RouteProgress buildDistanceCongestionAnnotationRouteProgress(double stepDistanceRemaining, double legDistanceRemaining,
-                                                                       double distanceRemaining, int stepIndex, int legIndex) throws Exception {
+  private RouteProgress buildDistanceCongestionAnnotationRouteProgress(double stepDistanceRemaining,
+                                                                       double legDistanceRemaining,
+                                                                       double distanceRemaining, int stepIndex,
+                                                                       int legIndex) throws Exception {
     DirectionsRoute annotatedRoute = buildDistanceCongestionAnnotationRoute();
     return buildTestRouteProgress(annotatedRoute, stepDistanceRemaining,
       legDistanceRemaining, distanceRemaining, stepIndex, legIndex);


### PR DESCRIPTION
## Description

This is a follow up from https://github.com/mapbox/mapbox-navigation-android/pull/1767

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

As discussed, the idea is to move this work in baby steps i.e. creating _small_ PRs against `libandroid-navigation` branch moving stuff incrementally and making the review easier.

### Implementation

This PR moves `NavigationService` (and dependent classes) into the `internal` package.

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

cc @akitchen 