### PR TITLE
Fix typo in PULL_REQUEST_TEMPLATE

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,7 +29,6 @@ Please describe the manual tests that you ran to verify your changes
 - [ ] I have tested via a test drive, or a simulation/mock location app
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
-- [ ] 
 
 ## Checklist
 


### PR DESCRIPTION
## Description

Regression from https://github.com/mapbox/mapbox-navigation-android/pull/1915

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

The goal here is to improve our PR process / workflow

### Implementation

Fixes a typo in `PULL_REQUEST_TEMPLATE`