### PR TITLE
Added walking options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ Mapbox welcomes participation and contributions from everyone.
 
 ### v0.38.0 - May 15, 2019
 
-* SoundButton clicklistener wasn't set properly [#1937](https://github.com/mapbox/mapbox-navigation-android/pull/1937)
 * Added walking options [#1934](https://github.com/mapbox/mapbox-navigation-android/pull/1934)
+* SoundButton clicklistener wasn't set properly [#1937](https://github.com/mapbox/mapbox-navigation-android/pull/1937)
 
 ### v0.37.0 - May 1, 2019
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Mapbox welcomes participation and contributions from everyone.
 ### v0.38.0 - May 15, 2019
 
 * SoundButton clicklistener wasn't set properly [#1937](https://github.com/mapbox/mapbox-navigation-android/pull/1937)
+* Added walking options [#1934](https://github.com/mapbox/mapbox-navigation-android/pull/1934)
 
 ### v0.37.0 - May 1, 2019
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -9,7 +9,7 @@ ext {
 
   version = [
       mapboxMapSdk           : '7.3.2',
-      mapboxSdkServices      : '4.7.0',
+      mapboxSdkServices      : '4.8.0-alpha.3',
       mapboxEvents           : '4.3.0',
       mapboxCore             : '1.2.0',
       mapboxNavigator        : '6.1.3',

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -9,7 +9,7 @@ ext {
 
   version = [
       mapboxMapSdk           : '7.3.2',
-      mapboxSdkServices      : '4.8.0-alpha.3',
+      mapboxSdkServices      : '4.8.0',
       mapboxEvents           : '4.3.0',
       mapboxCore             : '1.2.0',
       mapboxNavigator        : '6.1.3',

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRoute.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRoute.java
@@ -12,6 +12,7 @@ import com.mapbox.api.directions.v5.DirectionsCriteria.ExcludeCriteria;
 import com.mapbox.api.directions.v5.DirectionsCriteria.ProfileCriteria;
 import com.mapbox.api.directions.v5.DirectionsCriteria.VoiceUnitCriteria;
 import com.mapbox.api.directions.v5.MapboxDirections;
+import com.mapbox.api.directions.v5.WalkingOptions;
 import com.mapbox.api.directions.v5.models.DirectionsResponse;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.api.directions.v5.models.RouteOptions;
@@ -588,6 +589,11 @@ public final class NavigationRoute {
       return this;
     }
 
+    public Builder walkingOptions(NavigationWalkingOptions navigationWalkingOptions) {
+      directionsBuilder.walkingOptions(navigationWalkingOptions.getWalkingOptions());
+      return this;
+    }
+
     /**
      * Optionally create a {@link Builder} based on all variables
      * from given {@link RouteOptions}.
@@ -658,6 +664,11 @@ public final class NavigationRoute {
       if (!TextUtils.isEmpty(waypointTargets)) {
         Point[] splitWaypointTargets = parseWaypointTargets(waypointTargets);
         directionsBuilder.addWaypointTargets(splitWaypointTargets);
+      }
+
+      WalkingOptions walkingOptions = options.walkingOptions();
+      if (walkingOptions != null) {
+        directionsBuilder.walkingOptions(options.walkingOptions());
       }
 
       return this;

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRoute.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRoute.java
@@ -589,6 +589,13 @@ public final class NavigationRoute {
       return this;
     }
 
+    /**
+     * Sets a {@link NavigationWalkingOptions} object which contains options for use with the
+     * walking profile.
+     *
+     * @param navigationWalkingOptions object holding walking options
+     * @return this builder for chaining options together
+     */
     public Builder walkingOptions(NavigationWalkingOptions navigationWalkingOptions) {
       directionsBuilder.walkingOptions(navigationWalkingOptions.getWalkingOptions());
       return this;
@@ -668,7 +675,7 @@ public final class NavigationRoute {
 
       WalkingOptions walkingOptions = options.walkingOptions();
       if (walkingOptions != null) {
-        directionsBuilder.walkingOptions(options.walkingOptions());
+        directionsBuilder.walkingOptions(walkingOptions);
       }
 
       return this;

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationWalkingOptions.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationWalkingOptions.java
@@ -1,0 +1,46 @@
+package com.mapbox.services.android.navigation.v5.navigation;
+
+import com.mapbox.api.directions.v5.WalkingOptions;
+
+public final class NavigationWalkingOptions {
+  private final WalkingOptions walkingOptions;
+
+  NavigationWalkingOptions(WalkingOptions walkingOptions) {
+    this.walkingOptions = walkingOptions;
+  }
+
+  WalkingOptions getWalkingOptions() {
+    return walkingOptions;
+  }
+
+  public static Builder builder() {
+    return new Builder(WalkingOptions.builder());
+  }
+
+  public static final class Builder {
+    private final WalkingOptions.Builder builder;
+
+    Builder(WalkingOptions.Builder builder) {
+      this.builder = builder;
+    }
+
+    public NavigationWalkingOptions build() {
+      return new NavigationWalkingOptions(builder.build());
+    }
+
+    public Builder walkingSpeed(Double walkingSpeed) {
+      builder.walkingSpeed(walkingSpeed);
+      return this;
+    }
+
+    public Builder walkwayBias(Double walkwayBias) {
+      builder.walkwayBias(walkwayBias);
+      return this;
+    }
+
+    public Builder alleyBias(Double alleyBias) {
+      builder.alleyBias(alleyBias);
+      return this;
+    }
+  }
+}

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationWalkingOptions.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationWalkingOptions.java
@@ -59,8 +59,8 @@ public final class NavigationWalkingOptions {
     /**
      * A bias which determines whether the route should prefer or avoid the use of roads or paths
      * that are set aside for pedestrian-only use (walkways). The allowed range of values is from
-     * -1 to 1, where -1 indicates indicates preference to avoid walkways, 1 indicates preference
-     * to favor walkways, and 0 indicates no preference (the default).
+     * -1 to 1, where -1 indicates preference to avoid walkways, 1 indicates preference to favor
+     * walkways, and 0 indicates no preference (the default).
      *
      * @param walkwayBias bias to prefer or avoid walkways
      * @return this builder
@@ -72,8 +72,8 @@ public final class NavigationWalkingOptions {
 
     /**
      * A bias which determines whether the route should prefer or avoid the use of alleys. The
-     * allowed range of values is from -1 to 1, where -1 indicates indicates preference to avoid
-     * alleys, 1 indicates preference to favor alleys, and 0 indicates no preference (the default).
+     * allowed range of values is from -1 to 1, where -1 indicates preference to avoid alleys, 1
+     * indicates preference to favor alleys, and 0 indicates no preference (the default).
      *
      * @param alleyBias bias to prefer or avoid alleys
      * @return this builder

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationWalkingOptions.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationWalkingOptions.java
@@ -2,6 +2,9 @@ package com.mapbox.services.android.navigation.v5.navigation;
 
 import com.mapbox.api.directions.v5.WalkingOptions;
 
+/**
+ * Class for specifying options for use with the walking profile.
+ */
 public final class NavigationWalkingOptions {
   private final WalkingOptions walkingOptions;
 
@@ -13,10 +16,18 @@ public final class NavigationWalkingOptions {
     return walkingOptions;
   }
 
+  /**
+   * Build a new {@link WalkingOptions} object with no defaults.
+   *
+   * @return a {@link Builder} object for creating a {@link NavigationWalkingOptions} object
+   */
   public static Builder builder() {
     return new Builder(WalkingOptions.builder());
   }
 
+  /**
+   * This builder is used to create a new object with specifications relating to walking directions.
+   */
   public static final class Builder {
     private final WalkingOptions.Builder builder;
 
@@ -24,20 +35,49 @@ public final class NavigationWalkingOptions {
       this.builder = builder;
     }
 
+    /**
+     * Builds a {@link NavigationWalkingOptions} object with the specified configurations.
+     *
+     * @return a NavigationWalkingOptions object
+     */
     public NavigationWalkingOptions build() {
       return new NavigationWalkingOptions(builder.build());
     }
 
+    /**
+     * Walking speed in meters per second. Must be between 0.14 and 6.94 meters per second.
+     * Defaults to 1.42 meters per second
+     *
+     * @param walkingSpeed in meters per second
+     * @return this builder
+     */
     public Builder walkingSpeed(Double walkingSpeed) {
       builder.walkingSpeed(walkingSpeed);
       return this;
     }
 
+    /**
+     * A bias which determines whether the route should prefer or avoid the use of roads or paths
+     * that are set aside for pedestrian-only use (walkways). The allowed range of values is from
+     * -1 to 1, where -1 indicates indicates preference to avoid walkways, 1 indicates preference
+     * to favor walkways, and 0 indicates no preference (the default).
+     *
+     * @param walkwayBias bias to prefer or avoid walkways
+     * @return this builder
+     */
     public Builder walkwayBias(Double walkwayBias) {
       builder.walkwayBias(walkwayBias);
       return this;
     }
 
+    /**
+     * A bias which determines whether the route should prefer or avoid the use of alleys. The
+     * allowed range of values is from -1 to 1, where -1 indicates indicates preference to avoid
+     * alleys, 1 indicates preference to favor alleys, and 0 indicates no preference (the default).
+     *
+     * @param alleyBias bias to prefer or avoid alleys
+     * @return this builder
+     */
     public Builder alleyBias(Double alleyBias) {
       builder.alleyBias(alleyBias);
       return this;

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteTest.java
@@ -4,6 +4,7 @@ import android.content.Context;
 
 import com.mapbox.api.directions.v5.DirectionsCriteria;
 import com.mapbox.api.directions.v5.MapboxDirections;
+import com.mapbox.api.directions.v5.WalkingOptions;
 import com.mapbox.api.directions.v5.models.DirectionsResponse;
 import com.mapbox.api.directions.v5.models.RouteOptions;
 import com.mapbox.geojson.Point;
@@ -174,6 +175,7 @@ public class NavigationRouteTest extends BaseTest {
       .waypointNames("Origin;Pickup;Destination")
       .waypointTargets(";;0.99,4.99")
       .waypointIndices("0;2")
+      .walkingOptions(WalkingOptions.builder().alleyBias(0.6).walkwayBias(0.7).walkingSpeed(1.0).build())
       .build();
 
     NavigationRoute navigationRoute = NavigationRoute.builder(context, localeUtils)
@@ -194,6 +196,9 @@ public class NavigationRouteTest extends BaseTest {
     assertThat(request, containsString("curb"));
     assertThat(request, containsString("Origin"));
     assertThat(request, containsString("waypoint_targets"));
+    assertThat(request, containsString("alley_bias"));
+    assertThat(request, containsString("walkway_bias"));
+    assertThat(request, containsString("walking_speed"));
   }
 
   @Test

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationWalkingOptionsTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationWalkingOptionsTest.java
@@ -1,0 +1,44 @@
+package com.mapbox.services.android.navigation.v5.navigation;
+
+import com.mapbox.api.directions.v5.WalkingOptions;
+
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class NavigationWalkingOptionsTest {
+
+  @Test
+  public void alleyBias_walkingOptionSet() {
+    WalkingOptions.Builder walkingOptionsBuilder = mock(WalkingOptions.Builder.class);
+    NavigationWalkingOptions.Builder navigationWalkingOptionsBuilder =
+      new NavigationWalkingOptions.Builder(walkingOptionsBuilder);
+
+    navigationWalkingOptionsBuilder.alleyBias(0.7);
+
+    verify(walkingOptionsBuilder).alleyBias(0.7);
+  }
+
+  @Test
+  public void WalkwayBias_walkingOptionSet() {
+    WalkingOptions.Builder walkingOptionsBuilder = mock(WalkingOptions.Builder.class);
+    NavigationWalkingOptions.Builder navigationWalkingOptionsBuilder =
+      new NavigationWalkingOptions.Builder(walkingOptionsBuilder);
+
+    navigationWalkingOptionsBuilder.walkwayBias(0.8);
+
+    verify(walkingOptionsBuilder).walkwayBias(0.8);
+  }
+
+  @Test
+  public void walkingSpeed_walkingOptionSet() {
+    WalkingOptions.Builder walkingOptionsBuilder = mock(WalkingOptions.Builder.class);
+    NavigationWalkingOptions.Builder navigationWalkingOptionsBuilder =
+      new NavigationWalkingOptions.Builder(walkingOptionsBuilder);
+
+    navigationWalkingOptionsBuilder.walkingSpeed(1.0);
+
+    verify(walkingOptionsBuilder).walkingSpeed(1.0);
+  }
+}

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationWalkingOptionsTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationWalkingOptionsTest.java
@@ -14,7 +14,7 @@ public class NavigationWalkingOptionsTest {
   }
 
   @Test
-  public void WalkwayBias_walkingOptionSet() {
+  public void walkwayBias_walkingOptionSet() {
     NavigationWalkingOptions options = NavigationWalkingOptions.builder().walkwayBias(0.8).build();
 
     assertEquals(Double.valueOf(0.8), options.getWalkingOptions().walkwayBias());

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationWalkingOptionsTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationWalkingOptionsTest.java
@@ -1,44 +1,29 @@
 package com.mapbox.services.android.navigation.v5.navigation;
 
-import com.mapbox.api.directions.v5.WalkingOptions;
-
 import org.junit.Test;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+import static org.junit.Assert.assertEquals;
 
 public class NavigationWalkingOptionsTest {
 
   @Test
   public void alleyBias_walkingOptionSet() {
-    WalkingOptions.Builder walkingOptionsBuilder = mock(WalkingOptions.Builder.class);
-    NavigationWalkingOptions.Builder navigationWalkingOptionsBuilder =
-      new NavigationWalkingOptions.Builder(walkingOptionsBuilder);
+    NavigationWalkingOptions options = NavigationWalkingOptions.builder().alleyBias(0.7).build();
 
-    navigationWalkingOptionsBuilder.alleyBias(0.7);
-
-    verify(walkingOptionsBuilder).alleyBias(0.7);
+    assertEquals(Double.valueOf(0.7), options.getWalkingOptions().alleyBias());
   }
 
   @Test
   public void WalkwayBias_walkingOptionSet() {
-    WalkingOptions.Builder walkingOptionsBuilder = mock(WalkingOptions.Builder.class);
-    NavigationWalkingOptions.Builder navigationWalkingOptionsBuilder =
-      new NavigationWalkingOptions.Builder(walkingOptionsBuilder);
+    NavigationWalkingOptions options = NavigationWalkingOptions.builder().walkwayBias(0.8).build();
 
-    navigationWalkingOptionsBuilder.walkwayBias(0.8);
-
-    verify(walkingOptionsBuilder).walkwayBias(0.8);
+    assertEquals(Double.valueOf(0.8), options.getWalkingOptions().walkwayBias());
   }
 
   @Test
   public void walkingSpeed_walkingOptionSet() {
-    WalkingOptions.Builder walkingOptionsBuilder = mock(WalkingOptions.Builder.class);
-    NavigationWalkingOptions.Builder navigationWalkingOptionsBuilder =
-      new NavigationWalkingOptions.Builder(walkingOptionsBuilder);
+    NavigationWalkingOptions options = NavigationWalkingOptions.builder().walkingSpeed(2.0).build();
 
-    navigationWalkingOptionsBuilder.walkingSpeed(1.0);
-
-    verify(walkingOptionsBuilder).walkingSpeed(1.0);
+    assertEquals(Double.valueOf(2.0), options.getWalkingOptions().walkingSpeed());
   }
 }


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

This adds walking options to `NavigationRoute` for use with the walking profile.

Closes https://github.com/mapbox/mapbox-navigation-android/issues/1824

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

The goal is to add options for use with the walking profile. These options include walking speed, walkway bias and alley bias.

### Implementation

The additional API parameters were added in mapbox-java and in the mapbox-navigation-android repos.

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have updated the `CHANGELOG` including this PR
- [ ] I have added an `Activity` example in the test app showing the new feature implemented
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->