### PR TITLE
Fix way name truncating too soon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Mapbox welcomes participation and contributions from everyone.
 
 ### v0.39.0 - May 29, 2019
 
+* Fix way name truncating too soon [#1947](https://github.com/mapbox/mapbox-navigation-android/pull/1947)
 * Fix instruction icon mismatch in between banner and notification [#1946](https://github.com/mapbox/mapbox-navigation-android/pull/1946)
 
 ### v0.38.0 - May 16, 2019

--- a/libandroid-navigation-ui/src/main/res/layout/wayname_view_layout.xml
+++ b/libandroid-navigation-ui/src/main/res/layout/wayname_view_layout.xml
@@ -13,7 +13,6 @@
         android:background="@drawable/wayname_text_background"
         android:ellipsize="end"
         android:gravity="center"
-        android:maxWidth="@dimen/wayname_max_width"
         android:maxLines="1"
         android:paddingLeft="@dimen/wayname_padding"
         android:paddingRight="@dimen/wayname_padding"

--- a/libandroid-navigation-ui/src/main/res/values/dimens.xml
+++ b/libandroid-navigation-ui/src/main/res/values/dimens.xml
@@ -5,5 +5,4 @@
     <dimen name="wayname_bottom_padding">8dp</dimen>
     <dimen name="wayname_padding">16dp</dimen>
     <dimen name="wayname_padding_bottom">2dp</dimen>
-    <dimen name="wayname_max_width">200dp</dimen>
 </resources>


### PR DESCRIPTION
## Description

Way name chip cuts off too soon

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

The goal here avoid too soon truncation for long road names

### Implementation

Remove `android:maxWidth` `wayname_max_width` limit from `wayname_view_layout`

## Screenshots or Gifs

**Before**

![way_name_truncated_issue](https://user-images.githubusercontent.com/1668582/58345902-7e578500-7e27-11e9-8cfc-1ef86ffe0b86.png)

**After**

![way_name_truncated_issue_fixed](https://user-images.githubusercontent.com/1668582/58345912-8283a280-7e27-11e9-820d-74a6006c75b2.png)

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->