### PR TITLE
Add check to avoid ArrayIndexOutOfBoundsExceptions from MapRouteLine#drawWayPoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Mapbox welcomes participation and contributions from everyone.
 
 ### v0.39.0 - May 29, 2019
 
+* Add check to avoid ArrayIndexOutOfBoundsExceptions from MapRouteLine#drawWayPoints [#1951](https://github.com/mapbox/mapbox-navigation-android/pull/1951)
 * Fix way name truncating too soon [#1947](https://github.com/mapbox/mapbox-navigation-android/pull/1947)
 * Fix instruction icon mismatch in between banner and notification [#1946](https://github.com/mapbox/mapbox-navigation-android/pull/1946)
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/MapRouteClickListener.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/MapRouteClickListener.java
@@ -70,7 +70,7 @@ class MapRouteClickListener implements MapboxMap.OnMapClickListener {
   }
 
   private void calculateClickDistances(HashMap<Double, DirectionsRoute> routeDistancesAwayFromClick,
-                                          Point clickPoint, HashMap<LineString, DirectionsRoute> routeLineStrings) {
+                                       Point clickPoint, HashMap<LineString, DirectionsRoute> routeLineStrings) {
     for (LineString lineString : routeLineStrings.keySet()) {
       Point pointOnLine = findPointOnLine(clickPoint, lineString);
       if (pointOnLine == null) {

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/MapRouteLine.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/MapRouteLine.java
@@ -202,7 +202,7 @@ class MapRouteLine {
 
   boolean updatePrimaryRouteIndex(int primaryRouteIndex) {
     boolean isNewIndex = this.primaryRouteIndex != primaryRouteIndex
-      && primaryRouteIndex < directionsRoutes.size();
+      && primaryRouteIndex < directionsRoutes.size() && primaryRouteIndex >= 0;
     if (isNewIndex) {
       this.primaryRouteIndex = primaryRouteIndex;
       updateRoutesFor(primaryRouteIndex);

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/route/MapRouteLineTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/route/MapRouteLineTest.java
@@ -26,6 +26,9 @@ import java.util.List;
 import edu.emory.mathcs.backport.java.util.Collections;
 
 import static com.mapbox.services.android.navigation.ui.v5.route.RouteConstants.ROUTE_LAYER_ID;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyFloat;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -108,6 +111,44 @@ public class MapRouteLineTest extends BaseTest {
     routeLine.updatePrimaryRouteIndex(1);
 
     verify(routeLineSource, times(4)).setGeoJson(any(FeatureCollection.class));
+  }
+
+  @Test
+  public void updatePrimaryIndex_newPrimaryRouteIndexUpdated() throws IOException {
+    GeoJsonSource mockedRouteLineSource = mock(GeoJsonSource.class);
+    GeoJsonSource mockedWayPointSource = mock(GeoJsonSource.class);
+    List<Layer> anyRouteLayers = buildMockLayers();
+    List<DirectionsRoute> routes = new ArrayList<>();
+    routes.add(buildTestDirectionsRoute());
+    routes.add(buildTestDirectionsRoute());
+    routes.add(buildTestDirectionsRoute());
+    routes.add(buildTestDirectionsRoute());
+    MapRouteLine routeLine = new MapRouteLine(mockedRouteLineSource, mockedWayPointSource, anyRouteLayers);
+    routeLine.draw(routes);
+
+    boolean isNewIndex = routeLine.updatePrimaryRouteIndex(3);
+
+    assertTrue(isNewIndex);
+    assertEquals(3, routeLine.retrievePrimaryRouteIndex());
+  }
+
+  @Test
+  public void updatePrimaryIndex_newPrimaryRouteIndexIsNotUpdated() throws IOException {
+    GeoJsonSource mockedRouteLineSource = mock(GeoJsonSource.class);
+    GeoJsonSource mockedWayPointSource = mock(GeoJsonSource.class);
+    List<Layer> anyRouteLayers = buildMockLayers();
+    List<DirectionsRoute> routes = new ArrayList<>();
+    routes.add(buildTestDirectionsRoute());
+    routes.add(buildTestDirectionsRoute());
+    routes.add(buildTestDirectionsRoute());
+    routes.add(buildTestDirectionsRoute());
+    MapRouteLine routeLine = new MapRouteLine(mockedRouteLineSource, mockedWayPointSource, anyRouteLayers);
+    routeLine.draw(routes);
+
+    boolean isNewIndex = routeLine.updatePrimaryRouteIndex(-1);
+
+    assertFalse(isNewIndex);
+    assertEquals(0, routeLine.retrievePrimaryRouteIndex());
   }
 
   @Test


### PR DESCRIPTION
## Description

Fixes #1948 
Regression from https://github.com/mapbox/mapbox-navigation-android/pull/1387

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Adds a check to avoid `ArrayIndexOutOfBoundsException`s from MapRouteLine#drawWayPoints

### Implementation

Adds a check into `MapRouteLine#updatePrimaryRouteIndex` to cover the scenario for when `newPrimaryIndex` is not valid - could be `-1` if not found 👀 https://github.com/mapbox/mapbox-navigation-android/blob/92ab4ebeeed4728385f200be226ea87b0c080e5b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/MapRouteClickListener.java#L65

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->