### PR TITLE
Fix notification instruction not updated for arrive maneuver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Mapbox welcomes participation and contributions from everyone.
 
 ### v0.40.0 - June 12, 2019
 
+* Fix notification instruction not updated for arrive maneuver [#1959](https://github.com/mapbox/mapbox-navigation-android/pull/1959)
 * Bump mapbox-navigation-native version to 6.2.1 [#1955](https://github.com/mapbox/mapbox-navigation-android/pull/1955)
 
 ### v0.39.0 - May 29, 2019


### PR DESCRIPTION
## Description

Fixes #1956 

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Goal here is to ensure that both banner and notification instructions show the correct text 

### Implementation

Refactor `MapboxNavigationNotification` to use the current `BannerInstruction` (NN) from the `RouteProgress` instead of 👀 `LegStep` (`RouteProgress#currentLegProgress()#currentStep()`) which may be not properly updated / refreshed 

## Screenshots or Gifs

**Before**

![you_have_arrive_maneuver_banner](https://user-images.githubusercontent.com/1668582/58713519-bc592980-8390-11e9-9544-1d13afa2d871.png)

![you_have_arrived_maneuver_notification_not_updated](https://user-images.githubusercontent.com/1668582/58713526-bf541a00-8390-11e9-9e3c-c979b13dc690.png)

**After**

![you_have_arrive_maneuver_banner_fixed](https://user-images.githubusercontent.com/1668582/58917132-94045e80-86f3-11e9-87b5-210189df923c.png)

![you_have_arrived_maneuver_notification_updated](https://user-images.githubusercontent.com/1668582/58917135-98307c00-86f3-11e9-8b0e-3d0bc2035f92.png)

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have updated the `CHANGELOG` including this PR

cc @danesfeder 