### PR TITLE
Bearing route listener

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/WaypointNavigationActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/WaypointNavigationActivity.java
@@ -130,7 +130,7 @@ public class WaypointNavigationActivity extends AppCompatActivity implements OnN
   }
 
   @Override
-  public boolean allowRerouteFrom(Point offRoutePoint) {
+  public boolean allowRerouteFrom(Point offRoutePoint, float bearing) {
     return true;
   }
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewEventDispatcher.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewEventDispatcher.java
@@ -130,8 +130,8 @@ class NavigationViewEventDispatcher {
     }
   }
 
-  boolean allowRerouteFrom(Point point) {
-    return routeListener == null || routeListener.allowRerouteFrom(point);
+  boolean allowRerouteFrom(Point point, float bearing) {
+    return routeListener == null || routeListener.allowRerouteFrom(point, bearing);
   }
 
   void onOffRoute(Point point) {

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
@@ -399,7 +399,7 @@ public class NavigationViewModel extends AndroidViewModel {
     public void userOffRoute(Location location) {
       speechPlayer.onOffRoute();
       Point newOrigin = Point.fromLngLat(location.getLongitude(), location.getLatitude());
-      handleOffRouteEvent(newOrigin);
+      handleOffRouteEvent(newOrigin, location.getBearing());
     }
   };
 
@@ -513,8 +513,8 @@ public class NavigationViewModel extends AndroidViewModel {
     }
   }
 
-  private void handleOffRouteEvent(Point newOrigin) {
-    if (navigationViewEventDispatcher != null && navigationViewEventDispatcher.allowRerouteFrom(newOrigin)) {
+  private void handleOffRouteEvent(Point newOrigin, float bearing) {
+    if (navigationViewEventDispatcher != null && navigationViewEventDispatcher.allowRerouteFrom(newOrigin, bearing)) {
       navigationViewEventDispatcher.onOffRoute(newOrigin);
       router.findRouteFrom(routeProgress);
       isOffRoute.setValue(true);

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/listeners/RouteListener.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/listeners/RouteListener.java
@@ -21,13 +21,14 @@ public interface RouteListener {
    * new route in the direction they are traveling.
    *
    * @param offRoutePoint the given point the user has gone off route
+   * @param bearing the bearing of the point the user has gone off route
    * @return true if the reroute should be allowed, false if not
    * @since 0.8.0
    */
-  boolean allowRerouteFrom(Point offRoutePoint);
+  boolean allowRerouteFrom(Point offRoutePoint, float bearing);
 
   /**
-   * Will triggered only if {@link RouteListener#allowRerouteFrom(Point)} returns true.
+   * Will triggered only if {@link RouteListener#allowRerouteFrom(Point, float)} returns true.
    * <p>
    * This serves as the official off route event and will continue the process to fetch a new route
    * with the given off route {@link Point}.

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewEventDispatcherTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewEventDispatcherTest.java
@@ -155,11 +155,12 @@ public class NavigationViewEventDispatcherTest {
     NavigationViewEventDispatcher eventDispatcher = new NavigationViewEventDispatcher();
     RouteListener routeListener = mock(RouteListener.class);
     Point point = mock(Point.class);
+    float bearing = 1.0f;
     eventDispatcher.assignRouteListener(routeListener);
 
-    eventDispatcher.allowRerouteFrom(point);
+    eventDispatcher.allowRerouteFrom(point, bearing);
 
-    verify(routeListener, times(1)).allowRerouteFrom(point);
+    verify(routeListener, times(1)).allowRerouteFrom(point, bearing);
   }
 
   @Test
@@ -167,10 +168,11 @@ public class NavigationViewEventDispatcherTest {
     NavigationViewEventDispatcher eventDispatcher = new NavigationViewEventDispatcher();
     RouteListener routeListener = mock(RouteListener.class);
     Point point = mock(Point.class);
+    float bearing = 1.0f;
 
-    boolean shouldAllowReroute = eventDispatcher.allowRerouteFrom(point);
+    boolean shouldAllowReroute = eventDispatcher.allowRerouteFrom(point, bearing);
 
-    verify(routeListener, times(0)).allowRerouteFrom(point);
+    verify(routeListener, times(0)).allowRerouteFrom(point, bearing);
     assertTrue(shouldAllowReroute);
   }
 
@@ -212,10 +214,11 @@ public class NavigationViewEventDispatcherTest {
     NavigationViewEventDispatcher eventDispatcher = new NavigationViewEventDispatcher();
     RouteListener routeListener = mock(RouteListener.class);
     Point point = mock(Point.class);
+    float bearing = 0.0f;
 
-    eventDispatcher.allowRerouteFrom(point);
+    eventDispatcher.allowRerouteFrom(point, bearing);
 
-    verify(routeListener, times(0)).allowRerouteFrom(point);
+    verify(routeListener, times(0)).allowRerouteFrom(point, bearing);
   }
 
   @Test


### PR DESCRIPTION
[Contribution](https://github.com/mapbox/mapbox-navigation-android/pull/1963) from @tomrom95 

## Description
This PR changes the RouteListener to pass the current bearing of the user to `allowRerouteFrom` along with the current location.

### Goal

The intention of this PR is to allow the user to use their bearing to both inform their decision to reroute and in any external routing requests. Currently, we are using a directions API that allows the client to specify the initial bearing. This is useful for deciding what orientation the car should start in and in what direction to move.

This feature became necessary for us because of the following situation. Let's say we're using an external directions API that triggers whenever `allowRerouteFrom` is called. Also say we are in a car that is going North and misses a turn to go East. Since we are off-route, `allowRerouteFrom` is called and we request new directions. However, this directions API returns us a route that initially goes _South_. The car, however, continues to go North. This yet again means we went off route and `allowRerouteFrom` is triggered. What results is an endless loop of going off-route and re-routing.

By using the bearing to inform the re-route, we can correctly route in the same orientation of the car.

### Implementation

- Modified RouteListener.allowRerouteFrom to take in a bearing
- Modified NavigationViewModel to populate the bearing when the vehicle is off route
- Updated relevant tests

## Testing

Updated all tests to use the updated API by providing a bearing.