### PR TITLE
#1965-introduce functions to allow speech to be muted without tapping button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Mapbox welcomes participation and contributions from everyone.
 
+### v0.41.0 - June 26, 2019
+
+* Allow the ability to mute/unmute speech engine without tapping sound button [#1965](https://github.com/mapbox/mapbox-navigation-android/pull/1970)
+
 ### v0.40.0 - June 12, 2019
 
 * Fix notification instruction not updated for arrive maneuver [#1959](https://github.com/mapbox/mapbox-navigation-android/pull/1959)

--- a/app/src/androidTest/java/testapp/NavigationViewTest.java
+++ b/app/src/androidTest/java/testapp/NavigationViewTest.java
@@ -3,54 +3,100 @@ package testapp;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.services.android.navigation.testapp.test.TestNavigationActivity;
 import com.mapbox.services.android.navigation.ui.v5.NavigationViewOptions;
+import com.mapbox.services.android.navigation.ui.v5.listeners.SpeechAnnouncementListener;
 import com.mapbox.services.android.navigation.ui.v5.map.NavigationMapboxMap;
+import com.mapbox.services.android.navigation.ui.v5.voice.SpeechAnnouncement;
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation;
-
 import org.junit.Test;
-
 import testapp.activity.BaseNavigationActivityTest;
 
-import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.*;
 import static testapp.action.NavigationViewAction.invoke;
 
-public class NavigationViewTest extends BaseNavigationActivityTest {
+public class NavigationViewTest extends BaseNavigationActivityTest implements SpeechAnnouncementListener {
 
-  @Override
-  protected Class getActivityClass() {
-    return TestNavigationActivity.class;
-  }
+    @Override
+    protected Class getActivityClass() {
+        return TestNavigationActivity.class;
+    }
 
-  @Test
-  public void onInitialization_navigationMapboxMapIsNotNull() {
-    validateTestSetup();
+    @Override
+    public SpeechAnnouncement willVoice(SpeechAnnouncement announcement) {
+        return SpeechAnnouncement.builder().announcement("All announcements will be the same.").build();
+    }
 
-    invoke(getNavigationView(), (uiController, navigationView) -> {
-      DirectionsRoute testRoute = DirectionsRoute.fromJson(loadJsonFromAsset("lancaster-1.json"));
-      NavigationViewOptions options = NavigationViewOptions.builder()
-        .directionsRoute(testRoute)
-        .build();
+    @Test
+    public void onInitialization_navigationMapboxMapIsNotNull() {
+        validateTestSetup();
 
-      navigationView.startNavigation(options);
-    });
-    NavigationMapboxMap navigationMapboxMap = getNavigationView().retrieveNavigationMapboxMap();
+        invoke(getNavigationView(), (uiController, navigationView) -> {
+            DirectionsRoute testRoute = DirectionsRoute.fromJson(loadJsonFromAsset("lancaster-1.json"));
+            NavigationViewOptions options = NavigationViewOptions.builder()
+                    .directionsRoute(testRoute)
+                    .build();
 
-    assertNotNull(navigationMapboxMap);
-  }
+            navigationView.startNavigation(options);
+        });
+        NavigationMapboxMap navigationMapboxMap = getNavigationView().retrieveNavigationMapboxMap();
 
-  @Test
-  public void onNavigationStart_mapboxNavigationIsNotNull() {
-    validateTestSetup();
+        assertNotNull(navigationMapboxMap);
+    }
 
-    invoke(getNavigationView(), (uiController, navigationView) -> {
-      DirectionsRoute testRoute = DirectionsRoute.fromJson(loadJsonFromAsset("lancaster-1.json"));
-      NavigationViewOptions options = NavigationViewOptions.builder()
-        .directionsRoute(testRoute)
-        .build();
+    @Test
+    public void onNavigationStart_mapboxNavigationIsNotNull() {
+        validateTestSetup();
 
-      navigationView.startNavigation(options);
-    });
-    MapboxNavigation mapboxNavigation = getNavigationView().retrieveMapboxNavigation();
+        invoke(getNavigationView(), (uiController, navigationView) -> {
+            DirectionsRoute testRoute = DirectionsRoute.fromJson(loadJsonFromAsset("lancaster-1.json"));
+            NavigationViewOptions options = NavigationViewOptions.builder()
+                    .directionsRoute(testRoute)
+                    .build();
 
-    assertNotNull(mapboxNavigation);
-  }
+            navigationView.startNavigation(options);
+        });
+        MapboxNavigation mapboxNavigation = getNavigationView().retrieveMapboxNavigation();
+
+        assertNotNull(mapboxNavigation);
+    }
+
+    @Test
+    public void onNavigationStart_toggleToMute() {
+        validateTestSetup();
+
+        invoke(getNavigationView(), (uiController, navigationView) -> {
+            DirectionsRoute testRoute = DirectionsRoute.fromJson(loadJsonFromAsset("lancaster-1.json"));
+            NavigationViewOptions options = NavigationViewOptions.builder()
+                    .directionsRoute(testRoute)
+                    .speechAnnouncementListener(this)
+                    .build();
+
+            navigationView.startNavigation(options);
+            navigationView.toggleMute();
+        });
+        boolean isMute = getNavigationView().isMuted();
+
+        assertTrue(isMute);
+    }
+
+    @Test
+    public void muteSpeechPlayer_withoutStartingNavigation() {
+        boolean thrown = false;
+        try {
+            validateTestSetup();
+
+            invoke(getNavigationView(), (uiController, navigationView) -> {
+                DirectionsRoute testRoute = DirectionsRoute.fromJson(loadJsonFromAsset("lancaster-1.json"));
+                NavigationViewOptions options = NavigationViewOptions.builder()
+                        .directionsRoute(testRoute)
+                        .speechAnnouncementListener(this)
+                        .build();
+                navigationView.toggleMute();
+                navigationView.startNavigation(options);
+            });
+        } catch (IllegalStateException exception) {
+            thrown = true;
+            assertEquals("Navigation needs to start before being able to mute/unmute speech player", exception.getMessage());
+        }
+        assertTrue(thrown);
+    }
 }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
@@ -492,13 +492,13 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
   public NavigationAlertView retrieveAlertView() {
     return instructionView.retrieveAlertView();
   }
-  
+
 
   public boolean isMuted() {
     return navigationViewModel.isMuted();
   }
 
-  public void setMuted() {
+  public void toggleMute() {
     navigationViewModel.setMuted(((SoundButton)retrieveSoundButton()).toggleMute());
   }
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
@@ -493,12 +493,25 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
     return instructionView.retrieveAlertView();
   }
 
-
+  /**
+   * Returns the state of speech player whether it is muted or unmuted
+   * @return true if speech player is mute else false
+   */
   public boolean isMuted() {
     return navigationViewModel.isMuted();
   }
 
+  /**
+   * Should be called after {@link NavigationView#startNavigation}.
+   * <p>
+   * This method toggles the mute state of speech player. It also updates the UI
+   * to reflect the new state of speech player.
+   * <p>
+   */
   public void toggleMute() {
+    if (navigationViewModel.getSpeechPlayer() == null) {
+      throw new IllegalStateException("Navigation needs to start before being able to mute/unmute speech player");
+    }
     navigationViewModel.setMuted(((SoundButton)retrieveSoundButton()).toggleMute());
   }
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
@@ -492,6 +492,15 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
   public NavigationAlertView retrieveAlertView() {
     return instructionView.retrieveAlertView();
   }
+  
+
+  public boolean isMuted() {
+    return navigationViewModel.isMuted();
+  }
+
+  public void setMuted() {
+    navigationViewModel.setMuted(((SoundButton)retrieveSoundButton()).toggleMute());
+  }
 
   private void initializeView() {
     inflate(getContext(), R.layout.navigation_view_layout, this);

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
@@ -220,6 +220,10 @@ public class NavigationViewModel extends AndroidViewModel {
     shouldRecordScreenshot.setValue(false);
   }
 
+  SpeechPlayer getSpeechPlayer() {
+    return speechPlayer;
+  }
+
   boolean isRunning() {
     return isRunning;
   }


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

**Feature:**
To allow the user to start the navigation in muted state without tapping the toggle mute button.

### Goal

Add a new function that allows user to use the speech player to mute/unmute the navigation instructions.

### Implementation

I see that there is a function `toggleMute` in `SoundButton` class. I think this should not be publicly available, as it just toggles the UI of the mute/unmute button if accessed by code. It's only when the user taps on the button, that the mute/unmute effect takes place. Look at lines 517-521 of `InstructionView`. 

## Screenshots or Gifs

Please include all the media files to give some context about what's being implemented or fixed. It's not mandatory to upload screenshots or gifs, but for most of the cases it becomes really handy to get into the scope of the feature / bug being fixed and also it's REALLY useful for UI related PRs ![screenshot gif](link)

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->