### PR TITLE
Update ComponentNavigationActivity example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Mapbox welcomes participation and contributions from everyone.
 
+### v0.41.0 - June 26, 2019
+
+* Update ComponentNavigationActivity example [#1978](https://github.com/mapbox/mapbox-navigation-android/pull/1978)
+
 ### v0.40.0 - June 12, 2019
 
 * Fix notification instruction not updated for arrive maneuver [#1959](https://github.com/mapbox/mapbox-navigation-android/pull/1959)

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/ComponentNavigationActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/ComponentNavigationActivity.java
@@ -175,31 +175,8 @@ public class ComponentNavigationActivity extends HistoryActivity implements OnMa
 
   @OnClick(R.id.startNavigationFab)
   public void onStartNavigationClick(FloatingActionButton floatingActionButton) {
-    // Transition to navigation state
-    mapState = MapState.NAVIGATION;
-
     floatingActionButton.hide();
-    cancelNavigationFab.show();
-
-    // Show the InstructionView
-    TransitionManager.beginDelayedTransition(navigationLayout);
-    instructionView.setVisibility(View.VISIBLE);
-
-    // Start navigation
-    adjustMapPaddingForNavigation();
-    navigation.startNavigation(route);
-    addEventToHistoryFile("start_navigation");
-
-    // Location updates will be received from ProgressChangeListener
-    removeLocationEngineListener();
-
-    // TODO remove example usage
-    navigationMap.resetCameraPositionWith(NavigationCamera.NAVIGATION_TRACKING_MODE_GPS);
-    CameraUpdate cameraUpdate = cameraOverheadUpdate();
-    if (cameraUpdate != null) {
-      NavigationCameraUpdate navUpdate = new NavigationCameraUpdate(cameraUpdate);
-      navigationMap.retrieveCamera().update(navUpdate);
-    }
+    quickStartNavigation();
   }
 
   @OnClick(R.id.cancelNavigationFab)
@@ -469,6 +446,38 @@ public class ComponentNavigationActivity extends HistoryActivity implements OnMa
           Timber.e(throwable);
         }
       });
+  }
+
+  private void quickStartNavigation() {
+    // Transition to navigation state
+    mapState = MapState.NAVIGATION;
+
+    cancelNavigationFab.show();
+
+    // Show the InstructionView
+    TransitionManager.beginDelayedTransition(navigationLayout);
+    instructionView.setVisibility(View.VISIBLE);
+
+    adjustMapPaddingForNavigation();
+    // Updates camera with last location before starting navigating,
+    // making sure the route information is updated
+    // by the time the initial camera tracking animation is fired off
+    // Alternatively, NavigationMapboxMap#startCamera could be used here,
+    // centering the map camera to the beginning of the provided route
+    navigationMap.resumeCamera(lastLocation);
+    navigation.startNavigation(route);
+    addEventToHistoryFile("start_navigation");
+
+    // Location updates will be received from ProgressChangeListener
+    removeLocationEngineListener();
+
+    // TODO remove example usage
+    navigationMap.resetCameraPositionWith(NavigationCamera.NAVIGATION_TRACKING_MODE_GPS);
+    CameraUpdate cameraUpdate = cameraOverheadUpdate();
+    if (cameraUpdate != null) {
+      NavigationCameraUpdate navUpdate = new NavigationCameraUpdate(cameraUpdate);
+      navigationMap.retrieveCamera().update(navUpdate);
+    }
   }
 
   private void handleRoute(Response<DirectionsResponse> response, boolean isOffRoute) {


### PR DESCRIPTION
## Description

Updates `ComponentNavigationActivity` example so that initial tracking animation is always executed

- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

The goal here is to showcase how to utilize `NavigationMapboxMap` APIs so that initial tracking animation is always fired off

### Implementation

In order to make sure that the initial tracking animation is always executed when using `NavigationMapboxMap` the camera should be updated before `navigation.startNavigation` - this animation is only executed if the route information is not `null` 👀 https://github.com/mapbox/mapbox-navigation-android/blob/d5f3fc1676193f4f5b7bea3bc61919b93a687484/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/camera/NavigationCamera.java#L430-L434

As commented https://github.com/mapbox/mapbox-navigation-android/blob/d5f3fc1676193f4f5b7bea3bc61919b93a687484/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/ComponentNavigationActivity.java#L462-L467 calling either `NavigationMapboxMap#startCamera` (with the `DirectionsRoute`) or `NavigationMapboxMap#resumeCamera` (with the last `Location`) before `navigation.startNavigation` will ensure that the initial zoom in animation always happens.

## Screenshots or Gifs

**Before**

![component_nav_camera_initial_tracking_not_fired_off](https://user-images.githubusercontent.com/1668582/59790034-03a24e00-929d-11e9-8779-e570e893c3ec.gif)

**After**

![component_nav_camera_initial_tracking_fired_off](https://user-images.githubusercontent.com/1668582/59790128-35b3b000-929d-11e9-850a-cf721e59f52a.gif)

## Testing

Please describe the manual tests that you ran to verify your changes

- Tested forcing  a quick start - replacing `startNavigationFab.show();` by `quickStartNavigation();` in https://github.com/mapbox/mapbox-navigation-android/blob/d5f3fc1676193f4f5b7bea3bc61919b93a687484/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/ComponentNavigationActivity.java#L491 and initial animation was always fired off
- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have updated the `CHANGELOG` including this PR

cc @devotaaabel @andrewychen @abhishek1508 