### PR TITLE
Fix DynamicCamera#CameraPosition.zoom NPE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Mapbox welcomes participation and contributions from everyone.
 
 ### v0.41.0 - June 26, 2019
 
+* Fix DynamicCamera#CameraPosition.zoom NPE [#1979](https://github.com/mapbox/mapbox-navigation-android/pull/1979)
 * Update ComponentNavigationActivity example [#1978](https://github.com/mapbox/mapbox-navigation-android/pull/1978)
 
 ### v0.40.0 - June 12, 2019

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/camera/DynamicCamera.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/camera/DynamicCamera.java
@@ -107,6 +107,9 @@ public class DynamicCamera extends SimpleCamera {
    */
   private double createZoom(RouteInformation routeInformation) {
     CameraPosition position = createCameraPosition(routeInformation.location(), routeInformation.routeProgress());
+    if (position == null) {
+      return DEFAULT_ZOOM;
+    }
     if (position.zoom > MAX_CAMERA_ZOOM) {
       return MAX_CAMERA_ZOOM;
     } else if (position.zoom < MIN_CAMERA_ZOOM) {

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/camera/DynamicCameraTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/camera/DynamicCameraTest.java
@@ -12,6 +12,8 @@ import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.core.constants.Constants;
 import com.mapbox.geojson.LineString;
 import com.mapbox.geojson.Point;
+import com.mapbox.mapboxsdk.camera.CameraPosition;
+import com.mapbox.mapboxsdk.geometry.LatLngBounds;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.services.android.navigation.ui.v5.BaseTest;
 import com.mapbox.services.android.navigation.v5.navigation.camera.RouteInformation;
@@ -26,6 +28,7 @@ import java.util.List;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -48,6 +51,65 @@ public class DynamicCameraTest extends BaseTest {
     double zoom = cameraEngine.zoom(routeInformation);
 
     assertEquals(15d, zoom);
+  }
+
+  @Test
+  public void onCameraPositionNull_engineReturnsDefaultZoom() throws Exception {
+    DynamicCamera theCameraEngine = buildDynamicCamera();
+    RouteInformation anyRouteInformation = RouteInformation.create(null,
+      buildDefaultLocationUpdate(-77.0339782574523, 38.89993519985637), buildDefaultRouteProgress(1000d));
+
+    double defaultZoom = theCameraEngine.zoom(anyRouteInformation);
+
+    assertEquals(15d, defaultZoom);
+  }
+
+  @Test
+  public void onCameraPositionZoomGreaterThanMax_engineReturnsMaxCameraZoom() throws Exception {
+    MapboxMap mapboxMap = mock(MapboxMap.class);
+    CameraPosition cameraPositionWithZoomGreaterThanMax = new CameraPosition.Builder()
+      .zoom(20d)
+      .build();
+    when(mapboxMap.getCameraForLatLngBounds(any(LatLngBounds.class), any(int[].class))).thenReturn(cameraPositionWithZoomGreaterThanMax);
+    DynamicCamera theCameraEngine = new DynamicCamera(mapboxMap);
+    RouteInformation anyRouteInformation = RouteInformation.create(null,
+      buildDefaultLocationUpdate(-77.0339782574523, 38.89993519985637), buildDefaultRouteProgress(1000d));
+
+    double maxCameraZoom = theCameraEngine.zoom(anyRouteInformation);
+
+    assertEquals(16d, maxCameraZoom);
+  }
+
+  @Test
+  public void onCameraPositionZoomLessThanMin_engineReturnsMinCameraZoom() throws Exception {
+    MapboxMap mapboxMap = mock(MapboxMap.class);
+    CameraPosition cameraPositionWithZoomLessThanMin = new CameraPosition.Builder()
+      .zoom(10d)
+      .build();
+    when(mapboxMap.getCameraForLatLngBounds(any(LatLngBounds.class), any(int[].class))).thenReturn(cameraPositionWithZoomLessThanMin);
+    DynamicCamera theCameraEngine = new DynamicCamera(mapboxMap);
+    RouteInformation anyRouteInformation = RouteInformation.create(null,
+      buildDefaultLocationUpdate(-77.0339782574523, 38.89993519985637), buildDefaultRouteProgress(1000d));
+
+    double maxCameraZoom = theCameraEngine.zoom(anyRouteInformation);
+
+    assertEquals(12d, maxCameraZoom);
+  }
+
+  @Test
+  public void onCameraPositionZoomGreaterThanMinAndLessThanMax_engineReturnsCameraPositionZoom() throws Exception {
+    MapboxMap mapboxMap = mock(MapboxMap.class);
+    CameraPosition cameraPositionWithZoomGreaterThanMinAndLessThanMax = new CameraPosition.Builder()
+      .zoom(14d)
+      .build();
+    when(mapboxMap.getCameraForLatLngBounds(any(LatLngBounds.class), any(int[].class))).thenReturn(cameraPositionWithZoomGreaterThanMinAndLessThanMax);
+    DynamicCamera theCameraEngine = new DynamicCamera(mapboxMap);
+    RouteInformation anyRouteInformation = RouteInformation.create(null,
+      buildDefaultLocationUpdate(-77.0339782574523, 38.89993519985637), buildDefaultRouteProgress(1000d));
+
+    double maxCameraZoom = theCameraEngine.zoom(anyRouteInformation);
+
+    assertEquals(14d, maxCameraZoom);
   }
 
   @Test


### PR DESCRIPTION
## Description

Fixes `DynamicCamera#CameraPosition.zoom` `NullPointerException`

Fixes #1969 

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

The goal here is to prevent any potential NPEs when using `MapboxNavigationMap` and `NavigationCamera` / `DynamicCamera` objects

### Implementation

Add a `position` `null` check returning `DEFAULT_ZOOM` if the `CameraPosition` created is `null` preventing `position.zoom` to happen and therefore NPEs 👀 https://github.com/mapbox/mapbox-navigation-android/blob/4b95b77203725119117e94ffe5b280fc43724a5a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/camera/DynamicCamera.java#L110-L112

⚠️ DISCLAIMER ⚠️ This NPE isn't reproducible if lifecycle methods from `NavigationCamera` https://github.com/mapbox/mapbox-navigation-android/blob/410672dfc69cfa95296b08c4f8bdf2c14bcfde88/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/camera/NavigationCamera.java#L275-L295 or `NavigationMapboxMap` https://github.com/mapbox/mapbox-navigation-android/blob/410672dfc69cfa95296b08c4f8bdf2c14bcfde88/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/NavigationMapboxMap.java#L461-L483 are called as part of the `Activity` / `Fragment` lifecycle 👀 [`ComponentNavigationActivity`](https://github.com/mapbox/mapbox-navigation-android/blob/master/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/ComponentNavigationActivity.java) for further details on how to use these UI components

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->

cc @hrach 