### PR TITLE
Remove CHANGELOG incorrect date of v0.41.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Mapbox welcomes participation and contributions from everyone.
 
-### v0.41.0
+### v0.41.0 - 
 
 * Fix DynamicCamera#CameraPosition.zoom NPE [#1979](https://github.com/mapbox/mapbox-navigation-android/pull/1979)
 * Update ComponentNavigationActivity example [#1978](https://github.com/mapbox/mapbox-navigation-android/pull/1978)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Mapbox welcomes participation and contributions from everyone.
 
-### v0.41.0 - 
+### v0.41.0
 
 * Fix DynamicCamera#CameraPosition.zoom NPE [#1979](https://github.com/mapbox/mapbox-navigation-android/pull/1979)
 * Update ComponentNavigationActivity example [#1978](https://github.com/mapbox/mapbox-navigation-android/pull/1978)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Mapbox welcomes participation and contributions from everyone.
 
-### v0.41.0 - June 26, 2019
+### v0.41.0 - 
 
 * Fix DynamicCamera#CameraPosition.zoom NPE [#1979](https://github.com/mapbox/mapbox-navigation-android/pull/1979)
 * Update ComponentNavigationActivity example [#1978](https://github.com/mapbox/mapbox-navigation-android/pull/1978)


### PR DESCRIPTION
## Description

Removes `CHANGELOG` incorrect date of `v0.41.0` release
Tests GitHub CI status checks integration

- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Fix `CHANGELOG` so it's up to date
Test GitHub CI status checks integration

### Implementation

Remove `CHANGELOG` incorrect date of `v0.41.0` release

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] New and existing unit tests pass locally with my changes
- [x] GitHub CI status checks are fired off and show up in any PR

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR

cc @andrlee @Chaoba 