### PR TITLE
interchange the navigation sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 Mapbox welcomes participation and contributions from everyone.
 
-### v0.41.0
+### v0.41.0 - July 11, 2019
 
 * Move events from telemetry to nav sdk [#1890](https://github.com/mapbox/mapbox-navigation-android/pull/1890)
 * Fix DynamicCamera#CameraPosition.zoom NPE [#1979](https://github.com/mapbox/mapbox-navigation-android/pull/1979)
 * Update ComponentNavigationActivity example [#1978](https://github.com/mapbox/mapbox-navigation-android/pull/1978)
+* Fix navigation camera tracking the puck [#1995](https://github.com/mapbox/mapbox-navigation-android/pull/1995)
 
 ### v0.40.0 - June 12, 2019
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
@@ -540,14 +540,14 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
   }
 
   private void initializeNavigationMap(MapView mapView, MapboxMap map) {
+    if (initialMapCameraPosition != null) {
+      map.setCameraPosition(initialMapCameraPosition);
+    }
     navigationMap = new NavigationMapboxMap(mapView, map);
     navigationMap.updateLocationLayerRenderMode(RenderMode.GPS);
     if (mapInstanceState != null) {
       navigationMap.restoreFrom(mapInstanceState);
       return;
-    }
-    if (initialMapCameraPosition != null) {
-      map.setCameraPosition(initialMapCameraPosition);
     }
   }
 


### PR DESCRIPTION
## Description

Allow the navigation camera to track the puck when in active navigation.

Fixes https://github.com/mapbox/mapbox-navigation-android/issues/1992

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

The goal of the PR is to interchange the animation sequence between setting the initial camera position and navigation tracking

### Implementation

The issue is inside `NavigationView`. Inside the `initializeNavigationMap`, the animation sequence to set the initial camera position has to happen before setting the camera tracking mode.

## Screenshots or Gifs

### Before

![](https://user-images.githubusercontent.com/1668582/60824868-73a74400-a178-11e9-8e6a-854bfe3e72f4.gif)

### After

![](https://user-images.githubusercontent.com/9770186/60997378-88681100-a30b-11e9-8014-139f28df20c8.gif)

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->