### PR TITLE
Fix CHANGELOG for v0.41.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@ Mapbox welcomes participation and contributions from everyone.
 
 ### v0.41.0 - July 11, 2019
 
+* Fix navigation camera tracking the puck [#1995](https://github.com/mapbox/mapbox-navigation-android/pull/1995)
 * Move events from telemetry to nav sdk [#1890](https://github.com/mapbox/mapbox-navigation-android/pull/1890)
 * Fix DynamicCamera#CameraPosition.zoom NPE [#1979](https://github.com/mapbox/mapbox-navigation-android/pull/1979)
 * Update ComponentNavigationActivity example [#1978](https://github.com/mapbox/mapbox-navigation-android/pull/1978)
-* Fix navigation camera tracking the puck [#1995](https://github.com/mapbox/mapbox-navigation-android/pull/1995)
 
 ### v0.40.0 - June 12, 2019
 


### PR DESCRIPTION
- Fixes `CHANGELOG` for `v0.41.0` putting PRs in chronological order