### PR TITLE
Bump Mapbox Annotation Plugin version to v8 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 Mapbox welcomes participation and contributions from everyone.
 
-### v0.42.0 - July 24, 2019
+### v0.42.0 - 
 
+* Bump Mapbox Annotation Plugin version to v8 0.7.0 [#2014](https://github.com/mapbox/mapbox-navigation-android/pull/2014)
 * Auto generate license for the SDK [#2002](https://github.com/mapbox/mapbox-navigation-android/pull/2002)
 * Update translations to latest Transifex [#2003](https://github.com/mapbox/mapbox-navigation-android/pull/2003)
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -14,7 +14,7 @@ ext {
       mapboxCore             : '1.3.0',
       mapboxNavigator        : '6.2.1',
       mapboxCrashMonitor     : '2.0.0',
-      mapboxAnnotationPlugin : '0.6.0',
+      mapboxAnnotationPlugin : '0.7.0',
       mapboxSearchSdk        : '0.1.0-SNAPSHOT',
       autoValue              : '1.5.4',
       autoValueParcel        : '0.2.5',

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -51,7 +51,7 @@ ext {
       mapboxEvents           : "com.mapbox.mapboxsdk:mapbox-android-telemetry:${version.mapboxEvents}",
       mapboxCore             : "com.mapbox.mapboxsdk:mapbox-android-core:${version.mapboxCore}",
       mapboxNavigator        : "com.mapbox.navigator:mapbox-navigation-native:${version.mapboxNavigator}",
-      mapboxAnnotationPlugin : "com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v7:${version.mapboxAnnotationPlugin}",
+      mapboxAnnotationPlugin : "com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v8:${version.mapboxAnnotationPlugin}",
       mapboxSearchSdk        : "com.mapbox.mapboxsdk:mapbox-search-android:${version.mapboxSearchSdk}",
       mapboxCrashMonitor     : "com.mapbox.crashmonitor:mapbox-crash-monitor-native:${version.mapboxCrashMonitor}",
 


### PR DESCRIPTION
### Contribution from @william-reed in https://github.com/mapbox/mapbox-navigation-android/pull/2011

## Description

> Upgrade the mapbox annotation plugin to allow for usage with newer versions of that plugin as well as mapbox 8.

Fixes #2008

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Getting the latest version from `mapboxAnnotationPlugin` including the new features and bug fixes.

### Implementation

Bumping the `mapboxAnnotationPlugin` version to `0.7.0` in `dependencies.gradle`
- [x] Bump version number to `v8` (Maps SDK version) 👀 https://github.com/mapbox/mapbox-navigation-android/blob/f42f433109ade3529040a393c27525d25832a284/gradle/dependencies.gradle#L54 @william-reed Could you quickly fix this? Let us know so we can pull the fix into this PR and get CI going 👀 

```
> Could not find com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v7:0.7.0.
```

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->