### PR TITLE
Fix NavigationStepData regression from #1890

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Mapbox welcomes participation and contributions from everyone.
 
 ### v0.42.0 - 
 
+* Fix NavigationStepData regression from [#1890](https://github.com/mapbox/mapbox-navigation-android/pull/1890)
 * Bump mapbox-android-sdk version to 8.2.1 [#2013](https://github.com/mapbox/mapbox-navigation-android/pull/2013)
 * Bump Mapbox Annotation Plugin version to v8 0.7.0 [#2014](https://github.com/mapbox/mapbox-navigation-android/pull/2014)
 * Auto generate license for the SDK [#2002](https://github.com/mapbox/mapbox-navigation-android/pull/2002)

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/metrics/NavigationDepartEvent.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/metrics/NavigationDepartEvent.java
@@ -3,7 +3,7 @@ package com.mapbox.services.android.navigation.v5.navigation.metrics;
 import android.annotation.SuppressLint;
 
 @SuppressLint("ParcelCreator")
-public class NavigationDepartEvent extends NavigationEvent {
+class NavigationDepartEvent extends NavigationEvent {
   private static final String NAVIGATION_DEPART = "navigation.depart";
 
   NavigationDepartEvent(PhoneState phoneState) {

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/metrics/NavigationStepData.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/metrics/NavigationStepData.java
@@ -30,8 +30,10 @@ class NavigationStepData {
     this.previousModifier = metricsRouteProgress.getPreviousStepModifier();
     this.previousType = metricsRouteProgress.getPreviousStepType();
     this.previousName = metricsRouteProgress.getPreviousStepName();
-    this.distanceRemaining = metricsRouteProgress.getDistanceRemaining();
-    this.durationRemaining = metricsRouteProgress.getDurationRemaining();
+    this.distance = metricsRouteProgress.getCurrentStepDistance();
+    this.duration = metricsRouteProgress.getCurrentStepDuration();
+    this.distanceRemaining = metricsRouteProgress.getCurrentStepDistanceRemaining();
+    this.durationRemaining = metricsRouteProgress.getCurrentStepDurationRemaining();
   }
 
   String getUpcomingInstruction() {
@@ -70,19 +72,15 @@ class NavigationStepData {
     return distance;
   }
 
+  int getDuration() {
+    return duration;
+  }
+
   public int getDistanceRemaining() {
     return distanceRemaining;
   }
 
   public int getDurationRemaining() {
     return durationRemaining;
-  }
-
-  int getDuration() {
-    return duration;
-  }
-
-  void setDuration(int duration) {
-    this.duration = duration;
   }
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/metrics/audio/BluetoothAudioType.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/metrics/audio/BluetoothAudioType.java
@@ -3,7 +3,7 @@ package com.mapbox.services.android.navigation.v5.navigation.metrics.audio;
 import android.content.Context;
 import android.media.AudioManager;
 
-public class BluetoothAudioType implements AudioTypeResolver {
+class BluetoothAudioType implements AudioTypeResolver {
   private static final String BLUETOOTH = "bluetooth";
   private AudioTypeResolver chain;
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/metrics/audio/HeadphonesAudioType.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/metrics/audio/HeadphonesAudioType.java
@@ -3,7 +3,7 @@ package com.mapbox.services.android.navigation.v5.navigation.metrics.audio;
 import android.content.Context;
 import android.media.AudioManager;
 
-public class HeadphonesAudioType implements AudioTypeResolver {
+class HeadphonesAudioType implements AudioTypeResolver {
   private static final String HEADPHONES = "headphones";
   private AudioTypeResolver chain;
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/metrics/audio/SpeakerAudioType.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/metrics/audio/SpeakerAudioType.java
@@ -3,7 +3,7 @@ package com.mapbox.services.android.navigation.v5.navigation.metrics.audio;
 import android.content.Context;
 import android.media.AudioManager;
 
-public class SpeakerAudioType implements AudioTypeResolver {
+class SpeakerAudioType implements AudioTypeResolver {
   private static final String SPEAKER = "speaker";
   private AudioTypeResolver chain;
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/metrics/audio/UnknownAudioType.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/metrics/audio/UnknownAudioType.java
@@ -2,7 +2,7 @@ package com.mapbox.services.android.navigation.v5.navigation.metrics.audio;
 
 import android.content.Context;
 
-public class UnknownAudioType implements AudioTypeResolver {
+class UnknownAudioType implements AudioTypeResolver {
   private static final String UNKNOWN = "unknown";
 
   @Override

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/metrics/NavigationEventFactoryTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/metrics/NavigationEventFactoryTest.java
@@ -49,6 +49,10 @@ public class NavigationEventFactoryTest {
   private static final int SECOND_SINCE_LAST_REROUTE = 5;
   private static final int DISTANCE_REMAINING = 33;
   private static final int DURATION_REMAINING = 1000;
+  private static final int CURRENT_STEP_DISTANCE = 53;
+  private static final int CURRENT_STEP_DURATION = 7;
+  private static final int CURRENT_STEP_DISTANCE_REMAINING = 13;
+  private static final int CURRENT_STEP_DURATION_REMAINING = 3;
   private static final String DIRECTION_PROFILE = "DIRECTION PROFILE";
   private static final int LEG_INDEX = 5;
   private static final int LEG_COUNT = 15;
@@ -64,8 +68,6 @@ public class NavigationEventFactoryTest {
   private static final String PRE_MODIFIER = "PRE MODIFIER";
   private static final String PRE_TYPE = "PRE TYPE";
   private static final String PRE_NAME = "PRE_NAME";
-  private static final int CURRENT_DISTANCE = 200;
-  private static final int CURRENT_DURATION = 2001;
   private static final String SDK_ID = "SDK ID";
   private static final Boolean BATTER_PLUGGEDIN = Boolean.TRUE;
   private static final boolean IS_MOCK = true;
@@ -131,6 +133,8 @@ public class NavigationEventFactoryTest {
     when(metricsRouteProgress.getDistanceTraveled()).thenReturn(DISTANCE_TRAVELED);
     when(metricsRouteProgress.getDistanceRemaining()).thenReturn(DISTANCE_REMAINING);
     when(metricsRouteProgress.getDurationRemaining()).thenReturn(DURATION_REMAINING);
+    when(metricsRouteProgress.getCurrentStepDistanceRemaining()).thenReturn(CURRENT_STEP_DISTANCE_REMAINING);
+    when(metricsRouteProgress.getCurrentStepDurationRemaining()).thenReturn(CURRENT_STEP_DURATION_REMAINING);
     when(metricsRouteProgress.getDirectionsRouteProfile()).thenReturn(DIRECTION_PROFILE);
     when(metricsRouteProgress.getLegIndex()).thenReturn(LEG_INDEX);
     when(metricsRouteProgress.getLegCount()).thenReturn(LEG_COUNT);
@@ -146,8 +150,8 @@ public class NavigationEventFactoryTest {
     when(metricsRouteProgress.getPreviousStepModifier()).thenReturn(PRE_MODIFIER);
     when(metricsRouteProgress.getPreviousStepType()).thenReturn(PRE_TYPE);
     when(metricsRouteProgress.getPreviousStepName()).thenReturn(PRE_NAME);
-    when(metricsRouteProgress.getCurrentStepDistance()).thenReturn(CURRENT_DISTANCE);
-    when(metricsRouteProgress.getCurrentStepDuration()).thenReturn(CURRENT_DURATION);
+    when(metricsRouteProgress.getCurrentStepDistance()).thenReturn(CURRENT_STEP_DISTANCE);
+    when(metricsRouteProgress.getCurrentStepDuration()).thenReturn(CURRENT_STEP_DURATION);
     when(metricsRouteProgress.getDirectionsRouteDestination())
       .thenReturn(Point.fromLngLat(LONGITUDE_AFTER, LATITUDE_AFTER));
   }
@@ -182,7 +186,8 @@ public class NavigationEventFactoryTest {
     when(rerouteEvent.getNewRouteGeometry()).thenReturn(newRouteGeo);
 
     NavigationRerouteEvent navigationRerouteEvent = NavigationEventFactory
-      .buildNavigationRerouteEvent(phoneState, sessionState, metricsRouteProgress, locationBefore, SDK_ID, rerouteEvent);
+      .buildNavigationRerouteEvent(phoneState, sessionState, metricsRouteProgress, locationBefore, SDK_ID,
+        rerouteEvent);
     checkNavigationEvent(navigationRerouteEvent);
     checkNavigationStepData(navigationRerouteEvent.getStep());
     assertEquals(newDistanceRemaining, navigationRerouteEvent.getNewDistanceRemaining(), 0);
@@ -233,7 +238,7 @@ public class NavigationEventFactoryTest {
     assertNotNull(s);
   }
 
-  private void checkNavigationStepData(NavigationStepData data){
+  private void checkNavigationStepData(NavigationStepData data) {
     assertEquals(PRE_INSTRU, data.getPreviousInstruction());
     assertEquals(PRE_MODIFIER, data.getPreviousModifier());
     assertEquals(PRE_NAME, data.getPreviousName());
@@ -242,9 +247,12 @@ public class NavigationEventFactoryTest {
     assertEquals(UPCOMING_MODIFIER, data.getUpcomingModifier());
     assertEquals(UPCOMING_NAME, data.getUpcomingName());
     assertEquals(UPCOMING_TYPE, data.getUpcomingType());
-    assertEquals(DISTANCE_REMAINING, data.getDistanceRemaining());
-    assertEquals(DURATION_REMAINING, data.getDurationRemaining());
+    assertEquals(CURRENT_STEP_DISTANCE, data.getDistance());
+    assertEquals(CURRENT_STEP_DURATION, data.getDuration());
+    assertEquals(CURRENT_STEP_DISTANCE_REMAINING, data.getDistanceRemaining());
+    assertEquals(CURRENT_STEP_DURATION_REMAINING, data.getDurationRemaining());
   }
+
   private void checkNavigationEvent(NavigationEvent event) {
     assertEquals(APP_STATE, event.getApplicationState());
     assertEquals(AUDIO_TYPE, event.getAudioType());


### PR DESCRIPTION
## Description

Fixes `NavigationStepData` regression from extracting the navigation events out of the Events library and into the Navigation SDK 👀 #1890 and cleanup / make `AudioTypeResolver` implementation classes and `NavigationDepartEvent` package private

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

`distanceRemaining` and `durationRemaining` were wrongly calculated in `NavigationStepData` we were using `metricsRouteProgress.getDistanceRemaining()` and `metricsRouteProgress.getDurationRemaining()` instead of `metricsRouteProgress.getCurrentStepDistanceRemaining()` and `metricsRouteProgress.getCurrentStepDurationRemaining()` respectively.
Also we were missing `distance` and `duration` calculations (`metricsRouteProgress.getCurrentStepDistance()` and `metricsRouteProgress.getCurrentStepDuration()` respectively)

### Implementation

Use the correct methods from `MetricsRouteProgress` which are:

`distanceRemaining` 👉 `metricsRouteProgress.getCurrentStepDistanceRemaining()`
`durationRemaining` 👉 `metricsRouteProgress.getCurrentStepDurationRemaining()` 
`distance` 👉 `metricsRouteProgress.getCurrentStepDistance()`
`duration` 👉 `metricsRouteProgress.getCurrentStepDuration()`

Also now `BluetoothAudioType`, `HeadphonesAudioType`, `SpeakerAudioType`, `UnknownAudioType` (`AudioTypeResolver` implementation classes) and `NavigationDepartEvent` are package-private. We don't believe these classes need to be `public` as they're used only internally.

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have updated the `CHANGELOG` including this PR

cc @Chaoba 