### PR TITLE
Fix NavigationView memory leak

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
@@ -89,6 +89,8 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
   private CameraPosition initialMapCameraPosition;
   private boolean isMapInitialized;
   private boolean isSubscribed;
+  private LifecycleOwner lifecycleOwner;
+  private NavigationViewSubscriber navigationViesSubscriber;
 
   public NavigationView(Context context) {
     this(context, null);
@@ -695,8 +697,9 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
     instructionView.subscribe(navigationViewModel);
     summaryBottomSheet.subscribe(navigationViewModel);
 
-    NavigationViewSubscriber subscriber = new NavigationViewSubscriber(navigationPresenter);
-    subscriber.subscribe(((LifecycleOwner) getContext()), navigationViewModel);
+    navigationViesSubscriber = new NavigationViewSubscriber(navigationPresenter);
+    lifecycleOwner = (LifecycleOwner) getContext();
+    navigationViesSubscriber.subscribe(lifecycleOwner, navigationViewModel);
     isSubscribed = true;
   }
 
@@ -707,7 +710,16 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
     navigationViewEventDispatcher.onDestroy(navigationViewModel.retrieveNavigation());
     mapView.onDestroy();
     navigationViewModel.onDestroy(isChangingConfigurations());
+    unsubscribeViewModels();
     ImageCreator.getInstance().shutdown();
     navigationMap = null;
+  }
+
+  private void unsubscribeViewModels() {
+    if (isSubscribed) {
+      instructionView.unsubscribe(navigationViewModel);
+      summaryBottomSheet.unsubscribe(navigationViewModel);
+      navigationViesSubscriber.unsubscribe(lifecycleOwner, navigationViewModel);
+    }
   }
 }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
@@ -59,9 +59,9 @@ public class NavigationViewModel extends AndroidViewModel {
   public final MutableLiveData<BannerInstructionModel> bannerInstructionModel = new MutableLiveData<>();
   public final MutableLiveData<SummaryModel> summaryModel = new MutableLiveData<>();
   public final MutableLiveData<Boolean> isOffRoute = new MutableLiveData<>();
-  final MutableLiveData<Location> navigationLocation = new MutableLiveData<>();
-  final MutableLiveData<DirectionsRoute> route = new MutableLiveData<>();
-  final MutableLiveData<Boolean> shouldRecordScreenshot = new MutableLiveData<>();
+  private final MutableLiveData<Location> navigationLocation = new MutableLiveData<>();
+  private final MutableLiveData<DirectionsRoute> route = new MutableLiveData<>();
+  private final MutableLiveData<Boolean> shouldRecordScreenshot = new MutableLiveData<>();
   private final MutableLiveData<Point> destination = new MutableLiveData<>();
 
   private MapboxNavigation navigation;
@@ -272,6 +272,18 @@ public class NavigationViewModel extends AndroidViewModel {
     if (navigationViewEventDispatcher != null) {
       navigationViewEventDispatcher.onFailedReroute(errorMessage);
     }
+  }
+
+  MutableLiveData<Location> retrieveNavigationLocation() {
+    return navigationLocation;
+  }
+
+  MutableLiveData<DirectionsRoute> retrieveRoute() {
+    return route;
+  }
+
+  MutableLiveData<Boolean> retrieveShouldRecordScreenshot() {
+    return shouldRecordScreenshot;
   }
 
   MutableLiveData<Point> retrieveDestination() {

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewSubscriber.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewSubscriber.java
@@ -3,6 +3,7 @@ package com.mapbox.services.android.navigation.ui.v5;
 import android.arch.lifecycle.LifecycleOwner;
 import android.arch.lifecycle.Observer;
 import android.location.Location;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
@@ -18,7 +19,7 @@ class NavigationViewSubscriber {
 
   void subscribe(LifecycleOwner owner, final NavigationViewModel navigationViewModel) {
 
-    navigationViewModel.route.observe(owner, new Observer<DirectionsRoute>() {
+    navigationViewModel.retrieveRoute().observe(owner, new Observer<DirectionsRoute>() {
       @Override
       public void onChanged(@Nullable DirectionsRoute directionsRoute) {
         if (directionsRoute != null) {
@@ -36,7 +37,7 @@ class NavigationViewSubscriber {
       }
     });
 
-    navigationViewModel.navigationLocation.observe(owner, new Observer<Location>() {
+    navigationViewModel.retrieveNavigationLocation().observe(owner, new Observer<Location>() {
       @Override
       public void onChanged(@Nullable Location location) {
         if (location != null) {
@@ -45,7 +46,7 @@ class NavigationViewSubscriber {
       }
     });
 
-    navigationViewModel.shouldRecordScreenshot.observe(owner, new Observer<Boolean>() {
+    navigationViewModel.retrieveShouldRecordScreenshot().observe(owner, new Observer<Boolean>() {
       @Override
       public void onChanged(@Nullable Boolean shouldRecordScreenshot) {
         if (shouldRecordScreenshot != null && shouldRecordScreenshot) {
@@ -53,5 +54,12 @@ class NavigationViewSubscriber {
         }
       }
     });
+  }
+
+  void unsubscribe(@NonNull LifecycleOwner owner, @NonNull NavigationViewModel navigationViewModel) {
+    navigationViewModel.retrieveRoute().removeObservers(owner);
+    navigationViewModel.retrieveDestination().removeObservers(owner);
+    navigationViewModel.retrieveNavigationLocation().removeObservers(owner);
+    navigationViewModel.retrieveShouldRecordScreenshot().removeObservers(owner);
   }
 }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionView.java
@@ -218,6 +218,20 @@ public class InstructionView extends RelativeLayout implements FeedbackBottomShe
   }
 
   /**
+   * Unsubscribes {@link NavigationViewModel} {@link android.arch.lifecycle.LiveData} objects
+   * previously added in {@link InstructionView#subscribe(NavigationViewModel)}
+   * by removing the observers of the {@link LifecycleOwner}
+   *
+   * @param navigationViewModel to which this View is unsubscribing
+   */
+  public void unsubscribe(@NonNull NavigationViewModel navigationViewModel) {
+    LifecycleOwner owner = (LifecycleOwner) getContext();
+    navigationViewModel.instructionModel.removeObservers(owner);
+    navigationViewModel.bannerInstructionModel.removeObservers(owner);
+    navigationViewModel.isOffRoute.removeObservers(owner);
+  }
+
+  /**
    * Use this method inside a {@link ProgressChangeListener} to update this view with all other information
    * that is not updated by the {@link InstructionView#updateBannerInstructionsWith(Milestone)}.
    * <p>

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/SummaryBottomSheet.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/summary/SummaryBottomSheet.java
@@ -3,6 +3,7 @@ package com.mapbox.services.android.navigation.ui.v5.summary;
 import android.arch.lifecycle.LifecycleOwner;
 import android.arch.lifecycle.Observer;
 import android.content.Context;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v7.widget.RecyclerView;
 import android.util.AttributeSet;
@@ -93,6 +94,19 @@ public class SummaryBottomSheet extends FrameLayout {
         }
       }
     });
+  }
+
+  /**
+   * Unsubscribes {@link NavigationViewModel} {@link android.arch.lifecycle.LiveData} objects
+   * previously added in {@link SummaryBottomSheet#subscribe(NavigationViewModel)}
+   * by removing the observers of the {@link LifecycleOwner}
+   *
+   * @param navigationViewModel to which this View is unsubscribing
+   */
+  public void unsubscribe(@NonNull NavigationViewModel navigationViewModel) {
+    LifecycleOwner owner = (LifecycleOwner) getContext();
+    navigationViewModel.summaryModel.removeObservers(owner);
+    navigationViewModel.isOffRoute.removeObservers(owner);
   }
 
   /**

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewSubscriberTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewSubscriberTest.java
@@ -1,0 +1,61 @@
+package com.mapbox.services.android.navigation.ui.v5;
+
+import android.arch.lifecycle.LifecycleOwner;
+
+import org.junit.Test;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class NavigationViewSubscriberTest {
+
+  @Test
+  public void checksRouteObserversAreRemovedWhenUnsubscribe() {
+    NavigationPresenter mockedNavigationPresenter = mock(NavigationPresenter.class);
+    NavigationViewSubscriber theNavigationViewSubscriber = new NavigationViewSubscriber(mockedNavigationPresenter);
+    LifecycleOwner mockedLifecycleOwner = mock(LifecycleOwner.class);
+    NavigationViewModel mockedNavigationViewModel = mock(NavigationViewModel.class, RETURNS_DEEP_STUBS);
+
+    theNavigationViewSubscriber.unsubscribe(mockedLifecycleOwner, mockedNavigationViewModel);
+
+    verify(mockedNavigationViewModel.retrieveRoute()).removeObservers(eq(mockedLifecycleOwner));
+  }
+
+  @Test
+  public void checksDestinationObserversAreRemovedWhenUnsubscribe() {
+    NavigationPresenter mockedNavigationPresenter = mock(NavigationPresenter.class);
+    NavigationViewSubscriber theNavigationViewSubscriber = new NavigationViewSubscriber(mockedNavigationPresenter);
+    LifecycleOwner mockedLifecycleOwner = mock(LifecycleOwner.class);
+    NavigationViewModel mockedNavigationViewModel = mock(NavigationViewModel.class, RETURNS_DEEP_STUBS);
+
+    theNavigationViewSubscriber.unsubscribe(mockedLifecycleOwner, mockedNavigationViewModel);
+
+    verify(mockedNavigationViewModel.retrieveDestination()).removeObservers(eq(mockedLifecycleOwner));
+  }
+
+  @Test
+  public void checksNavigationLocationObserversAreRemovedWhenUnsubscribe() {
+    NavigationPresenter mockedNavigationPresenter = mock(NavigationPresenter.class);
+    NavigationViewSubscriber theNavigationViewSubscriber = new NavigationViewSubscriber(mockedNavigationPresenter);
+    LifecycleOwner mockedLifecycleOwner = mock(LifecycleOwner.class);
+    NavigationViewModel mockedNavigationViewModel = mock(NavigationViewModel.class, RETURNS_DEEP_STUBS);
+
+    theNavigationViewSubscriber.unsubscribe(mockedLifecycleOwner, mockedNavigationViewModel);
+
+    verify(mockedNavigationViewModel.retrieveNavigationLocation()).removeObservers(eq(mockedLifecycleOwner));
+  }
+
+  @Test
+  public void checksShouldRecordScreenshotObserversAreRemovedWhenUnsubscribe() {
+    NavigationPresenter mockedNavigationPresenter = mock(NavigationPresenter.class);
+    NavigationViewSubscriber theNavigationViewSubscriber = new NavigationViewSubscriber(mockedNavigationPresenter);
+    LifecycleOwner mockedLifecycleOwner = mock(LifecycleOwner.class);
+    NavigationViewModel mockedNavigationViewModel = mock(NavigationViewModel.class, RETURNS_DEEP_STUBS);
+
+    theNavigationViewSubscriber.unsubscribe(mockedLifecycleOwner, mockedNavigationViewModel);
+
+    verify(mockedNavigationViewModel.retrieveShouldRecordScreenshot()).removeObservers(eq(mockedLifecycleOwner));
+  }
+}


### PR DESCRIPTION
## Description

Fixes `NavigationView` memory leak.

Fixes #2012 

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Some `LiveData` objects from `NavigationViewModel` were never released as part of the view `onDestroy` causing a memory leak. The goal here is to avoid that leak.

### Implementation

This PR prevents that leak unsubscribing `NavigationViewModel` `LiveData` objects previously added by removing the observers of the `LifecycleOwner` adding `unsubscribe` methods to `NavigationViewSubscriber`, `InstructionView` and `SummaryBottomSheet` that are called as part of the `NavigationView#shutdown` method.

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] Tested in https://github.com/william-reed/mapbox-navui-leak and the leak is not reported anymore
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR

Thanks again @william-reed for debugging this. Could you take a look at the changes and share what you think 🙏?