### PR TITLE
Null safety for stopping navigation in NavigationViewModel

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
@@ -232,9 +232,12 @@ public class NavigationViewModel extends AndroidViewModel {
   }
 
   void stopNavigation() {
-    navigation.removeProgressChangeListener(null);
-    navigation.removeMilestoneEventListener(null);
-    navigation.stopNavigation();
+    MapboxNavigation navigation = this.navigation;
+    if (navigation != null) {
+      navigation.removeProgressChangeListener(null);
+      navigation.removeMilestoneEventListener(null);
+      navigation.stopNavigation();
+    }
   }
 
   boolean isOffRoute() {


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

I have noticed app crashes in production around 
https://github.com/mapbox/mapbox-navigation-android/blob/29a7217bcdee91b8f5e6d8ecb5332cc1ffdba1c7/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java#L234-L238

I am not sure why `navigation` is null but I would like to prevent it all together.