### PR TITLE
Fix on route selection change listener being called if route is not visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Mapbox welcomes participation and contributions from everyone.
 
 ### v0.42.0 - 
 
+* Fix on route selection change listener being called if route is not visible [#2035](https://github.com/mapbox/mapbox-navigation-android/pull/2035)
 * Fix NavigationStepData regression from [#1890](https://github.com/mapbox/mapbox-navigation-android/pull/1890)
 * Bump mapbox-android-sdk version to 8.2.1 [#2013](https://github.com/mapbox/mapbox-navigation-android/pull/2013)
 * Bump Mapbox Annotation Plugin version to v8 0.7.0 [#2014](https://github.com/mapbox/mapbox-navigation-android/pull/2014)

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/MapRouteClickListener.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/MapRouteClickListener.java
@@ -30,6 +30,9 @@ class MapRouteClickListener implements MapboxMap.OnMapClickListener {
 
   @Override
   public boolean onMapClick(@NonNull LatLng point) {
+    if (!isRouteVisible()) {
+      return false;
+    }
     HashMap<LineString, DirectionsRoute> routeLineStrings = routeLine.retrieveRouteLineStrings();
     if (invalidMapClick(routeLineStrings)) {
       return false;
@@ -49,6 +52,10 @@ class MapRouteClickListener implements MapboxMap.OnMapClickListener {
 
   private boolean invalidMapClick(HashMap<LineString, DirectionsRoute> routeLineStrings) {
     return routeLineStrings == null || routeLineStrings.isEmpty() || !alternativesVisible;
+  }
+
+  private boolean isRouteVisible() {
+    return routeLine.retrieveVisibility();
   }
 
   private void findClickedRoute(@NonNull LatLng point, HashMap<LineString, DirectionsRoute> routeLineStrings,

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/route/MapRouteClickListenerTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/route/MapRouteClickListenerTest.java
@@ -1,0 +1,91 @@
+package com.mapbox.services.android.navigation.ui.v5.route;
+
+import com.mapbox.api.directions.v5.models.DirectionsRoute;
+import com.mapbox.core.constants.Constants;
+import com.mapbox.geojson.LineString;
+import com.mapbox.mapboxsdk.geometry.LatLng;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class MapRouteClickListenerTest {
+
+  @Test
+  public void checksOnRouteSelectionChangeListenerIsCalledWhenClickedRouteIsFound() {
+    DirectionsRoute anyRoute = buildMockDirectionsRoute();
+    List<DirectionsRoute> anyDirectionsRoutes = buildDirectionsRoutes(anyRoute);
+    LineString anyRouteGeometry = LineString.fromPolyline(anyRoute.geometry(), Constants.PRECISION_6);
+    HashMap<LineString, DirectionsRoute> anyLineStringDirectionsRouteMap =
+      buildLineStringDirectionsRouteHashMap(anyRoute, anyRouteGeometry);
+    MapRouteLine mockedMapRouteLine = buildMockMapRouteLine(true, anyLineStringDirectionsRouteMap);
+    when(mockedMapRouteLine.updatePrimaryRouteIndex(anyInt())).thenReturn(true);
+    when(mockedMapRouteLine.retrieveDirectionsRoutes()).thenReturn(anyDirectionsRoutes);
+    MapRouteClickListener theMapRouteClickListener = new MapRouteClickListener(mockedMapRouteLine);
+    OnRouteSelectionChangeListener mockedOnRouteSelectionChangeListener =
+      buildMockOnRouteSelectionChangeListener(theMapRouteClickListener);
+    LatLng mockedPoint = mock(LatLng.class);
+
+    theMapRouteClickListener.onMapClick(mockedPoint);
+
+    verify(mockedOnRouteSelectionChangeListener).onNewPrimaryRouteSelected(any(DirectionsRoute.class));
+  }
+
+  @Test
+  public void checksOnRouteSelectionChangeListenerIsNotCalledWhenRouteIsNotVisible() {
+    HashMap<LineString, DirectionsRoute> mockedLineStringDirectionsRouteMap = mock(HashMap.class);
+    MapRouteLine mockedMapRouteLine = buildMockMapRouteLine(false, mockedLineStringDirectionsRouteMap);
+    MapRouteClickListener theMapRouteClickListener = new MapRouteClickListener(mockedMapRouteLine);
+    OnRouteSelectionChangeListener mockedOnRouteSelectionChangeListener =
+      buildMockOnRouteSelectionChangeListener(theMapRouteClickListener);
+    LatLng mockedPoint = mock(LatLng.class);
+
+    theMapRouteClickListener.onMapClick(mockedPoint);
+
+    verify(mockedOnRouteSelectionChangeListener, never()).onNewPrimaryRouteSelected(any(DirectionsRoute.class));
+  }
+
+  private DirectionsRoute buildMockDirectionsRoute() {
+    DirectionsRoute anyRoute = mock(DirectionsRoute.class);
+    when(anyRoute.geometry()).thenReturn("awbagAzavnhFp`@~fGr~Ya|BhcBwcYbr\\u{C`tZ~{H~vrBsge@bdo@`kc@dqpAckUbmn" +
+      "@sphAjnDovu@zviDgasDpa^ixsBbmy@{ubBvou@ajy@|}\\y~q@dycAcotGj{v@cdr@lyUwpC");
+    when(anyRoute.routeIndex()).thenReturn("1");
+    return anyRoute;
+  }
+
+  private List<DirectionsRoute> buildDirectionsRoutes(DirectionsRoute anyRoute) {
+    List<DirectionsRoute> anyDirectionsRoutes = new ArrayList<>();
+    anyDirectionsRoutes.add(anyRoute);
+    return anyDirectionsRoutes;
+  }
+
+  private HashMap<LineString, DirectionsRoute> buildLineStringDirectionsRouteHashMap(DirectionsRoute anyRoute,
+                                                                                     LineString anyRouteGeometry) {
+    HashMap<LineString, DirectionsRoute> anyLineStringDirectionsRouteMap = new HashMap<>();
+    anyLineStringDirectionsRouteMap.put(anyRouteGeometry, anyRoute);
+    return anyLineStringDirectionsRouteMap;
+  }
+
+  private MapRouteLine buildMockMapRouteLine(boolean isVisible,
+                                             HashMap<LineString, DirectionsRoute> lineStringDirectionsRouteMap) {
+    MapRouteLine mockedMapRouteLine = mock(MapRouteLine.class);
+    when(mockedMapRouteLine.retrieveVisibility()).thenReturn(isVisible);
+    when(mockedMapRouteLine.retrieveRouteLineStrings()).thenReturn(lineStringDirectionsRouteMap);
+    return mockedMapRouteLine;
+  }
+
+  private OnRouteSelectionChangeListener buildMockOnRouteSelectionChangeListener(MapRouteClickListener theMapRouteClickListener) {
+    OnRouteSelectionChangeListener mockedOnRouteSelectionChangeListener = mock(OnRouteSelectionChangeListener.class);
+    theMapRouteClickListener.setOnRouteSelectionChangeListener(mockedOnRouteSelectionChangeListener);
+    return mockedOnRouteSelectionChangeListener;
+  }
+}


### PR DESCRIPTION
## Description

Fixes `OnRouteSelectionChangeListener` being called from `MapRouteClickListener` if route is not visible

Fixes #2018 

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

The goal here is to prevent calling `OnRouteSelectionChangeListener` from `MapRouteClickListener` if route is not visible

### Implementation

Add a guard clause to `findClickedRoute` around the route visibility

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->

cc @andrlee 