### PR TITLE
Bumped Java SDK dependency to 4.9.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -9,7 +9,7 @@ ext {
 
   version = [
       mapboxMapSdk           : '8.2.1',
-      mapboxSdkServices      : '4.8.0',
+      mapboxSdkServices      : '4.9.0',
       mapboxEvents           : '4.5.1',
       mapboxCore             : '1.3.0',
       mapboxNavigator        : '6.2.1',

--- a/libandroid-navigation-ui/proguard-consumer.pro
+++ b/libandroid-navigation-ui/proguard-consumer.pro
@@ -10,6 +10,7 @@
 
 # --- Java ---
 -dontwarn java.awt.Color
+-dontwarn com.sun.istack.internal.NotNull
 
 # --- com.mapbox.api.directions.v5.MapboxDirections ---
 -dontwarn com.sun.xml.internal.ws.spi.db.BindingContextFactory

--- a/libandroid-navigation-ui/proguard-consumer.pro
+++ b/libandroid-navigation-ui/proguard-consumer.pro
@@ -1,16 +1,7 @@
 # Consumer proguard rules for libandroid-navigation-ui
 
-# --- OkHttp ---
--dontwarn okhttp3.**
-# A resource is loaded with a relative path so the package of this class must be preserved.
--keepnames class okhttp3.internal.publicsuffix.PublicSuffixDatabase
-
 # --- Picasso ---
 -dontwarn com.squareup.okhttp.**
-
-# --- Java ---
--dontwarn java.awt.Color
--dontwarn com.sun.istack.internal.NotNull
 
 # --- com.mapbox.api.directions.v5.MapboxDirections ---
 -dontwarn com.sun.xml.internal.ws.spi.db.BindingContextFactory

--- a/libandroid-navigation/proguard-consumer.pro
+++ b/libandroid-navigation/proguard-consumer.pro
@@ -8,6 +8,7 @@
 
 # --- Java ---
 -dontwarn java.awt.Color
+-dontwarn com.sun.istack.internal.NotNull
 
 # --- AutoValue ---
 # AutoValue annotations are retained but dependency is compileOnly.


### PR DESCRIPTION
This pr bumps the Navigation SDK for Android's Java SDK dependency to `4.9.0` as part of [the `4.9.0` release](https://github.com/mapbox/mapbox-java/issues/1070).