### PR TITLE
#2038 - Fix Null Pointer Exception

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
@@ -44,6 +44,8 @@ import com.mapbox.services.android.navigation.v5.navigation.NavigationTimeFormat
 import com.mapbox.services.android.navigation.v5.utils.DistanceFormatter;
 import com.mapbox.services.android.navigation.v5.utils.LocaleUtils;
 
+import timber.log.Timber;
+
 /**
  * View that creates the drop-in UI.
  * <p>
@@ -392,7 +394,11 @@ public class NavigationView extends CoordinatorLayout implements LifecycleOwner,
    * @param options with containing route / coordinate data
    */
   public void startNavigation(NavigationViewOptions options) {
-    initializeNavigation(options);
+    try {
+      initializeNavigation(options);
+    } catch (NullPointerException exception) {
+      Timber.e(exception);
+    }
   }
 
   /**


### PR DESCRIPTION
## Description

Fix app crash due to null pointer exception(https://github.com/mapbox/mapbox-navigation-android/issues/2038)

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

The app should not crash with an exception if the user terminates the app immediately after clicking on start navigation.

### Implementation

The call to start navigation should be placed inside a try catch to handle exceptions where the `NavigationView` is detached from window due to the lifecycle methods while other API's are still being called.

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->