### PR TITLE
Fix navigation view memory leak - some live data objects from navigat…

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
@@ -2,7 +2,6 @@ package com.mapbox.services.android.navigation.ui.v5;
 
 import android.app.Activity;
 import android.arch.lifecycle.Lifecycle;
-import android.arch.lifecycle.LifecycleObserver;
 import android.arch.lifecycle.LifecycleOwner;
 import android.arch.lifecycle.LifecycleRegistry;
 import android.arch.lifecycle.ViewModelProviders;
@@ -605,7 +604,7 @@ public class NavigationView extends CoordinatorLayout implements LifecycleOwner,
     int paddingBuffer = (int) resources.getDimension(R.dimen.route_overview_buffer_padding);
     int instructionHeight = (int) (resources.getDimension(R.dimen.instruction_layout_height) + paddingBuffer);
     int summaryHeight = (int) resources.getDimension(R.dimen.summary_bottomsheet_height);
-    return new int[] {leftRightPadding, instructionHeight, leftRightPadding, summaryHeight};
+    return new int[]{leftRightPadding, instructionHeight, leftRightPadding, summaryHeight};
   }
 
   private boolean isChangingConfigurations() {

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
@@ -1,8 +1,10 @@
 package com.mapbox.services.android.navigation.ui.v5;
 
 import android.app.Activity;
+import android.arch.lifecycle.Lifecycle;
 import android.arch.lifecycle.LifecycleObserver;
 import android.arch.lifecycle.LifecycleOwner;
+import android.arch.lifecycle.LifecycleRegistry;
 import android.arch.lifecycle.ViewModelProviders;
 import android.content.Context;
 import android.content.res.Resources;
@@ -65,7 +67,7 @@ import com.mapbox.services.android.navigation.v5.utils.LocaleUtils;
  *
  * @since 0.7.0
  */
-public class NavigationView extends CoordinatorLayout implements LifecycleObserver, OnMapReadyCallback,
+public class NavigationView extends CoordinatorLayout implements LifecycleOwner, OnMapReadyCallback,
   NavigationContract.View {
 
   private static final String MAP_INSTANCE_STATE_KEY = "navgation_mapbox_map_instance_state";
@@ -90,6 +92,8 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
   private boolean isMapInitialized;
   private boolean isSubscribed;
 
+  private LifecycleRegistry lifecycleRegistry;
+
   public NavigationView(Context context) {
     this(context, null);
   }
@@ -112,6 +116,8 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
   public void onCreate(@Nullable Bundle savedInstanceState) {
     mapView.onCreate(savedInstanceState);
     updatePresenterState(savedInstanceState);
+    lifecycleRegistry = new LifecycleRegistry(this);
+    lifecycleRegistry.markState(Lifecycle.State.CREATED);
   }
 
   /**
@@ -182,6 +188,7 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
    */
   public void onDestroy() {
     shutdown();
+    lifecycleRegistry.markState(Lifecycle.State.DESTROYED);
   }
 
   public void onStart() {
@@ -189,10 +196,12 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
     if (navigationMap != null) {
       navigationMap.onStart();
     }
+    lifecycleRegistry.markState(Lifecycle.State.STARTED);
   }
 
   public void onResume() {
     mapView.onResume();
+    lifecycleRegistry.markState(Lifecycle.State.RESUMED);
   }
 
   public void onPause() {
@@ -204,6 +213,12 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
     if (navigationMap != null) {
       navigationMap.onStop();
     }
+  }
+
+  @NonNull
+  @Override
+  public Lifecycle getLifecycle() {
+    return lifecycleRegistry;
   }
 
   /**
@@ -692,11 +707,10 @@ public class NavigationView extends CoordinatorLayout implements LifecycleObserv
    * method calls based on the {@link android.arch.lifecycle.LiveData} updates.
    */
   private void subscribeViewModels() {
-    instructionView.subscribe(navigationViewModel);
-    summaryBottomSheet.subscribe(navigationViewModel);
+    instructionView.subscribe(this, navigationViewModel);
+    summaryBottomSheet.subscribe(this, navigationViewModel);
 
-    NavigationViewSubscriber subscriber = new NavigationViewSubscriber(navigationPresenter);
-    subscriber.subscribe(((LifecycleOwner) getContext()), navigationViewModel);
+    new NavigationViewSubscriber(this, navigationViewModel, navigationPresenter).subscribe();
     isSubscribed = true;
   }
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
@@ -61,9 +61,9 @@ public class NavigationViewModel extends AndroidViewModel {
   public final MutableLiveData<BannerInstructionModel> bannerInstructionModel = new MutableLiveData<>();
   public final MutableLiveData<SummaryModel> summaryModel = new MutableLiveData<>();
   public final MutableLiveData<Boolean> isOffRoute = new MutableLiveData<>();
-  final MutableLiveData<Location> navigationLocation = new MutableLiveData<>();
-  final MutableLiveData<DirectionsRoute> route = new MutableLiveData<>();
-  final MutableLiveData<Boolean> shouldRecordScreenshot = new MutableLiveData<>();
+  private final MutableLiveData<Location> navigationLocation = new MutableLiveData<>();
+  private final MutableLiveData<DirectionsRoute> route = new MutableLiveData<>();
+  private final MutableLiveData<Boolean> shouldRecordScreenshot = new MutableLiveData<>();
   private final MutableLiveData<Point> destination = new MutableLiveData<>();
 
   private MapboxNavigation navigation;
@@ -285,8 +285,20 @@ public class NavigationViewModel extends AndroidViewModel {
     }
   }
 
+  MutableLiveData<Location> retrieveNavigationLocation() {
+    return navigationLocation;
+  }
+
+  MutableLiveData<DirectionsRoute> retrieveRoute() {
+    return route;
+  }
+
   MutableLiveData<Point> retrieveDestination() {
     return destination;
+  }
+
+  MutableLiveData<Boolean> retrieveShouldRecordScreenshot() {
+    return shouldRecordScreenshot;
   }
 
   private void initializeRouter() {

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewSubscriber.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewSubscriber.java
@@ -13,9 +13,9 @@ import com.mapbox.geojson.Point;
 
 class NavigationViewSubscriber implements LifecycleObserver {
 
-  private NavigationPresenter navigationPresenter;
-  private NavigationViewModel navigationViewModel;
-  private LifecycleOwner lifecycleOwner;
+  private final NavigationPresenter navigationPresenter;
+  private final NavigationViewModel navigationViewModel;
+  private final LifecycleOwner lifecycleOwner;
 
   NavigationViewSubscriber(final LifecycleOwner owner,
                            final NavigationViewModel navigationViewModel,

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewSubscriber.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewSubscriber.java
@@ -1,24 +1,34 @@
 package com.mapbox.services.android.navigation.ui.v5;
 
+import android.arch.lifecycle.Lifecycle;
+import android.arch.lifecycle.LifecycleObserver;
 import android.arch.lifecycle.LifecycleOwner;
 import android.arch.lifecycle.Observer;
+import android.arch.lifecycle.OnLifecycleEvent;
 import android.location.Location;
 import android.support.annotation.Nullable;
 
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.geojson.Point;
 
-class NavigationViewSubscriber {
+class NavigationViewSubscriber implements LifecycleObserver {
 
   private NavigationPresenter navigationPresenter;
+  private NavigationViewModel navigationViewModel;
+  private LifecycleOwner lifecycleOwner;
 
-  NavigationViewSubscriber(NavigationPresenter navigationPresenter) {
+  NavigationViewSubscriber(final LifecycleOwner owner,
+                           final NavigationViewModel navigationViewModel,
+                           final NavigationPresenter navigationPresenter) {
     this.navigationPresenter = navigationPresenter;
+    this.navigationViewModel = navigationViewModel;
+
+    lifecycleOwner = owner;
+    lifecycleOwner.getLifecycle().addObserver(this);
   }
 
-  void subscribe(LifecycleOwner owner, final NavigationViewModel navigationViewModel) {
-
-    navigationViewModel.route.observe(owner, new Observer<DirectionsRoute>() {
+  void subscribe() {
+    navigationViewModel.retrieveRoute().observe(lifecycleOwner, new Observer<DirectionsRoute>() {
       @Override
       public void onChanged(@Nullable DirectionsRoute directionsRoute) {
         if (directionsRoute != null) {
@@ -27,7 +37,7 @@ class NavigationViewSubscriber {
       }
     });
 
-    navigationViewModel.retrieveDestination().observe(owner, new Observer<Point>() {
+    navigationViewModel.retrieveDestination().observe(lifecycleOwner, new Observer<Point>() {
       @Override
       public void onChanged(@Nullable Point point) {
         if (point != null) {
@@ -36,7 +46,7 @@ class NavigationViewSubscriber {
       }
     });
 
-    navigationViewModel.navigationLocation.observe(owner, new Observer<Location>() {
+    navigationViewModel.retrieveNavigationLocation().observe(lifecycleOwner, new Observer<Location>() {
       @Override
       public void onChanged(@Nullable Location location) {
         if (location != null) {
@@ -45,7 +55,7 @@ class NavigationViewSubscriber {
       }
     });
 
-    navigationViewModel.shouldRecordScreenshot.observe(owner, new Observer<Boolean>() {
+    navigationViewModel.retrieveShouldRecordScreenshot().observe(lifecycleOwner, new Observer<Boolean>() {
       @Override
       public void onChanged(@Nullable Boolean shouldRecordScreenshot) {
         if (shouldRecordScreenshot != null && shouldRecordScreenshot) {
@@ -53,5 +63,13 @@ class NavigationViewSubscriber {
         }
       }
     });
+  }
+
+  @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+  void unsubscribe() {
+    navigationViewModel.retrieveRoute().removeObservers(lifecycleOwner);
+    navigationViewModel.retrieveDestination().removeObservers(lifecycleOwner);
+    navigationViewModel.retrieveNavigationLocation().removeObservers(lifecycleOwner);
+    navigationViewModel.retrieveShouldRecordScreenshot().removeObservers(lifecycleOwner);
   }
 }

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewSubscriberTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewSubscriberTest.java
@@ -1,0 +1,79 @@
+package com.mapbox.services.android.navigation.ui.v5;
+
+import android.arch.lifecycle.Lifecycle;
+import android.arch.lifecycle.LifecycleOwner;
+import android.arch.lifecycle.MutableLiveData;
+import android.arch.lifecycle.Observer;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class NavigationViewSubscriberTest {
+
+  @Mock
+  private LifecycleOwner lifecycleOwner;
+  @Mock
+  private Lifecycle lifecycle;
+  @Mock
+  private NavigationPresenter navigationPresenter;
+  @Mock
+  private NavigationViewModel navigationViewModel;
+
+  @Rule
+  public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+  private NavigationViewSubscriber theNavigationViewSubscriber;
+
+  @Before
+  public void setup() {
+    when(lifecycleOwner.getLifecycle()).thenReturn(lifecycle);
+
+    theNavigationViewSubscriber = new NavigationViewSubscriber(lifecycleOwner,
+      navigationViewModel, navigationPresenter);
+  }
+
+  @Test
+  public void checkLifecycleObserverAddedWhenCreateSubscriber() {
+    verify(lifecycleOwner.getLifecycle()).addObserver(theNavigationViewSubscriber);
+  }
+
+  @Test
+  public void checkObserversAreRemovedWhenUnsubscribe() {
+    when(navigationViewModel.retrieveRoute()).thenReturn(mock(MutableLiveData.class));
+    when(navigationViewModel.retrieveNavigationLocation()).thenReturn(mock(MutableLiveData.class));
+    when(navigationViewModel.retrieveDestination()).thenReturn(mock(MutableLiveData.class));
+    when(navigationViewModel.retrieveShouldRecordScreenshot()).thenReturn(mock(MutableLiveData.class));
+
+    theNavigationViewSubscriber.unsubscribe();
+
+    verify(navigationViewModel.retrieveRoute()).removeObservers(eq(lifecycleOwner));
+    verify(navigationViewModel.retrieveNavigationLocation()).removeObservers(eq(lifecycleOwner));
+    verify(navigationViewModel.retrieveDestination()).removeObservers(eq(lifecycleOwner));
+    verify(navigationViewModel.retrieveShouldRecordScreenshot()).removeObservers(eq(lifecycleOwner));
+  }
+
+  @Test
+  public void checkObserversAreAddedWhenSubscribe() {
+    when(navigationViewModel.retrieveRoute()).thenReturn(mock(MutableLiveData.class));
+    when(navigationViewModel.retrieveNavigationLocation()).thenReturn(mock(MutableLiveData.class));
+    when(navigationViewModel.retrieveDestination()).thenReturn(mock(MutableLiveData.class));
+    when(navigationViewModel.retrieveShouldRecordScreenshot()).thenReturn(mock(MutableLiveData.class));
+
+    theNavigationViewSubscriber.subscribe();
+
+    verify(navigationViewModel.retrieveRoute()).observe(eq(lifecycleOwner), any(Observer.class));
+    verify(navigationViewModel.retrieveNavigationLocation()).observe(eq(lifecycleOwner), any(Observer.class));
+    verify(navigationViewModel.retrieveDestination()).observe(eq(lifecycleOwner), any(Observer.class));
+    verify(navigationViewModel.retrieveShouldRecordScreenshot()).observe(eq(lifecycleOwner), any(Observer.class));
+  }
+}


### PR DESCRIPTION
## Description

Fixes NavigationView memory leak.

Fixes [#2012](https://github.com/mapbox/mapbox-navigation-android/issues/2012)

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Some `LiveData` objects from `NavigationViewModel` were never released as part of the view `onDestroy()` causing a memory leak. The goal here is to avoid that leak.

### Implementation

This PR prevents that leak unsubscribing `NavigationViewModel` `LiveData` objects previously added by removing the observers of the `LifecycleOwner` adding unsubscribe methods to `NavigationViewSubscriber`, `InstructionView` and `SummaryBottomSheet` that are called automatically when called `onDestroy()` method for lifecycle owner of this views. Here `Lifecycle` owner is `NavigationView` by adding to it `LifecycleRegistry`.

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] Tested in [https://github.com/william-reed/mapbox-navui-leak](https://github.com/william-reed/mapbox-navui-leak) and the leak is not reported anymore
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR