### PR TITLE
Remove never used apis causing unnecessary memory issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Mapbox welcomes participation and contributions from everyone.
 
 ### v0.42.0 - 
 
+* Remove never used apis causing unnecessary memory issues [#2052](https://github.com/mapbox/mapbox-navigation-android/pull/2052)
 * Fix backwards instructions in left-side driving scenarios [#2044](https://github.com/mapbox/mapbox-navigation-android/pull/2044)
 * Fix rerouting inside the NavigationUI [#2010](https://github.com/mapbox/mapbox-navigation-android/issues/2010)
 * Fix on route selection change listener being called if route is not visible [#2035](https://github.com/mapbox/mapbox-navigation-android/pull/2035)

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/TestRouteProgressBuilder.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/TestRouteProgressBuilder.java
@@ -1,10 +1,7 @@
 package com.mapbox.services.android.navigation.ui.v5;
 
-import android.support.v4.util.Pair;
-
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.api.directions.v5.models.LegStep;
-import com.mapbox.api.directions.v5.models.StepIntersection;
 import com.mapbox.geojson.Point;
 import com.mapbox.geojson.utils.PolylineUtils;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
@@ -12,10 +9,6 @@ import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 import java.util.List;
 
 import static com.mapbox.core.constants.Constants.PRECISION_6;
-import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.createDistancesToIntersections;
-import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.createIntersectionsList;
-import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.findCurrentIntersection;
-import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.findUpcomingIntersection;
 
 class TestRouteProgressBuilder {
 
@@ -24,7 +17,7 @@ class TestRouteProgressBuilder {
                                        double legDistanceRemaining,
                                        double distanceRemaining,
                                        int stepIndex,
-                                       int legIndex) throws Exception {
+                                       int legIndex) {
     double legDurationRemaining = route.legs().get(0).duration();
     List<LegStep> steps = route.legs().get(legIndex).steps();
     LegStep currentStep = steps.get(stepIndex);
@@ -38,18 +31,6 @@ class TestRouteProgressBuilder {
       String upcomingStepGeometry = upcomingStep.geometry();
       upcomingStepPoints = buildStepPointsFromGeometry(upcomingStepGeometry);
     }
-    List<StepIntersection> intersections = createIntersectionsList(currentStep, upcomingStep);
-    List<Pair<StepIntersection, Double>> intersectionDistances = createDistancesToIntersections(
-      currentStepPoints, intersections
-    );
-
-    double stepDistanceTraveled = currentStep.distance() - stepDistanceRemaining;
-    StepIntersection currentIntersection = findCurrentIntersection(intersections,
-      intersectionDistances, stepDistanceTraveled
-    );
-    StepIntersection upcomingIntersection = findUpcomingIntersection(
-      intersections, upcomingStep, currentIntersection
-    );
 
     return RouteProgress.builder()
       .stepDistanceRemaining(stepDistanceRemaining)
@@ -60,10 +41,6 @@ class TestRouteProgressBuilder {
       .currentStep(currentStep)
       .currentStepPoints(currentStepPoints)
       .upcomingStepPoints(upcomingStepPoints)
-      .intersections(intersections)
-      .currentIntersection(currentIntersection)
-      .upcomingIntersection(upcomingIntersection)
-      .intersectionDistancesAlongStep(intersectionDistances)
       .stepIndex(stepIndex)
       .legIndex(legIndex)
       .inTunnel(false)

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigator.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigator.java
@@ -6,7 +6,6 @@ import android.support.annotation.Nullable;
 
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.geojson.Geometry;
-import com.mapbox.geojson.LineString;
 import com.mapbox.geojson.Point;
 import com.mapbox.geojson.gson.GeometryGeoJson;
 import com.mapbox.navigator.BannerInstruction;
@@ -15,7 +14,6 @@ import com.mapbox.navigator.NavigationStatus;
 import com.mapbox.navigator.Navigator;
 import com.mapbox.navigator.VoiceInstruction;
 
-import java.util.ArrayList;
 import java.util.Date;
 
 class MapboxNavigator {
@@ -94,15 +92,6 @@ class MapboxNavigator {
 
   synchronized BannerInstruction retrieveBannerInstruction(int index) {
     return navigator.getBannerInstruction(index);
-  }
-
-  @Nullable
-  synchronized Geometry retrieveRouteGeometry() {
-    ArrayList<Point> routeGeometry = navigator.getRouteGeometry();
-    if (routeGeometry == null) {
-      return null;
-    }
-    return LineString.fromLngLats(routeGeometry);
   }
 
   @Nullable

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteProcessor.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRouteProcessor.java
@@ -1,12 +1,10 @@
 package com.mapbox.services.android.navigation.v5.navigation;
 
 import android.support.annotation.Nullable;
-import android.support.v4.util.Pair;
 
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.api.directions.v5.models.LegStep;
 import com.mapbox.api.directions.v5.models.RouteLeg;
-import com.mapbox.api.directions.v5.models.StepIntersection;
 import com.mapbox.geojson.Geometry;
 import com.mapbox.geojson.Point;
 import com.mapbox.navigator.BannerInstruction;
@@ -21,11 +19,7 @@ import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgressStat
 import java.util.List;
 
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.createCurrentAnnotation;
-import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.createDistancesToIntersections;
-import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.createIntersectionsList;
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.decodeStepPoints;
-import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.findCurrentIntersection;
-import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.findUpcomingIntersection;
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.routeDistanceRemaining;
 
 class NavigationRouteProcessor {
@@ -40,12 +34,8 @@ class NavigationRouteProcessor {
   private RouteLeg currentLeg;
   private LegStep currentStep;
   private List<Point> currentStepPoints;
-  private LegStep upcomingStep;
   private List<Point> upcomingStepPoints;
-  private List<StepIntersection> currentIntersections;
-  private List<Pair<StepIntersection, Double>> currentIntersectionDistances;
   private CurrentLegAnnotation currentLegAnnotation;
-  private Geometry routeGeometry;
   private Geometry routeGeometryWithBuffer;
 
   RouteProgress buildNewRouteProgress(MapboxNavigator navigator, NavigationStatus status, DirectionsRoute route) {
@@ -71,7 +61,6 @@ class NavigationRouteProcessor {
   private void updateRoute(DirectionsRoute route, MapboxNavigator navigator) {
     if (this.route == null || !this.route.equals(route)) {
       this.route = route;
-      routeGeometry = navigator.retrieveRouteGeometry();
       routeGeometryWithBuffer = navigator.retrieveRouteGeometryWithBuffer();
     }
   }
@@ -80,23 +69,15 @@ class NavigationRouteProcessor {
     int legIndex = status.getLegIndex();
     int stepIndex = status.getStepIndex();
     int upcomingStepIndex = stepIndex + ONE_INDEX;
-    updateSteps(route, legIndex, stepIndex, upcomingStepIndex);
+    updateSteps(route, legIndex, stepIndex);
     updateStepPoints(route, legIndex, stepIndex, upcomingStepIndex);
-    updateIntersections();
 
     double legDistanceRemaining = status.getRemainingLegDistance();
     double routeDistanceRemaining = routeDistanceRemaining(legDistanceRemaining, legIndex, route);
     double stepDistanceRemaining = status.getRemainingStepDistance();
-    double stepDistanceTraveled = currentStep.distance() - stepDistanceRemaining;
     double legDurationRemaining = status.getRemainingLegDuration() / ONE_SECOND_IN_MILLISECONDS;
 
     currentLegAnnotation = createCurrentAnnotation(currentLegAnnotation, currentLeg, legDistanceRemaining);
-    StepIntersection currentIntersection = findCurrentIntersection(
-      currentIntersections, currentIntersectionDistances, stepDistanceTraveled
-    );
-    StepIntersection upcomingIntersection = findUpcomingIntersection(
-      currentIntersections, upcomingStep, currentIntersection
-    );
     RouteState routeState = status.getRouteState();
     RouteProgressState currentRouteState = progressStateMap.get(routeState);
 
@@ -111,11 +92,6 @@ class NavigationRouteProcessor {
       .upcomingStepPoints(upcomingStepPoints)
       .stepIndex(stepIndex)
       .legIndex(legIndex)
-      .intersections(currentIntersections)
-      .currentIntersection(currentIntersection)
-      .upcomingIntersection(upcomingIntersection)
-      .intersectionDistancesAlongStep(currentIntersectionDistances)
-      .currentLegAnnotation(currentLegAnnotation)
       .inTunnel(status.getInTunnel())
       .currentState(currentRouteState);
 
@@ -126,7 +102,7 @@ class NavigationRouteProcessor {
     return progressBuilder.build();
   }
 
-  private void updateSteps(DirectionsRoute route, int legIndex, int stepIndex, int upcomingStepIndex) {
+  private void updateSteps(DirectionsRoute route, int legIndex, int stepIndex) {
     List<RouteLeg> legs = route.legs();
     if (legIndex < legs.size()) {
       currentLeg = legs.get(legIndex);
@@ -135,17 +111,11 @@ class NavigationRouteProcessor {
     if (stepIndex < steps.size()) {
       currentStep = steps.get(stepIndex);
     }
-    upcomingStep = upcomingStepIndex < steps.size() - ONE_INDEX ? steps.get(upcomingStepIndex) : null;
   }
 
   private void updateStepPoints(DirectionsRoute route, int legIndex, int stepIndex, int upcomingStepIndex) {
     currentStepPoints = decodeStepPoints(route, currentStepPoints, legIndex, stepIndex);
     upcomingStepPoints = decodeStepPoints(route, null, legIndex, upcomingStepIndex);
-  }
-
-  private void updateIntersections() {
-    currentIntersections = createIntersectionsList(currentStep, upcomingStep);
-    currentIntersectionDistances = createDistancesToIntersections(currentStepPoints, currentIntersections);
   }
 
   private void addUpcomingStepPoints(RouteProgress.Builder progressBuilder) {
@@ -155,7 +125,6 @@ class NavigationRouteProcessor {
   }
 
   private void addRouteGeometries(RouteProgress.Builder progressBuilder) {
-    progressBuilder.routeGeometry(routeGeometry);
     progressBuilder.routeGeometryWithBuffer(routeGeometryWithBuffer);
   }
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/routeprogress/RouteLegProgress.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/routeprogress/RouteLegProgress.java
@@ -1,16 +1,12 @@
 package com.mapbox.services.android.navigation.v5.routeprogress;
 
-import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.v4.util.Pair;
 
 import com.google.auto.value.AutoValue;
 import com.mapbox.api.directions.v5.models.LegStep;
 import com.mapbox.api.directions.v5.models.RouteLeg;
-import com.mapbox.api.directions.v5.models.StepIntersection;
 import com.mapbox.geojson.Point;
-import com.mapbox.services.android.navigation.v5.navigation.NavigationRoute;
 
 import java.util.List;
 
@@ -172,35 +168,11 @@ public abstract class RouteLegProgress {
   public abstract List<Point> upcomingStepPoints();
 
   /**
-   * Provides the current annotation data for a leg segment determined by
-   * the distance traveled along the route.
-   * <p>
-   * This object will only be present when a {@link com.mapbox.api.directions.v5.models.DirectionsRoute}
-   * requested with {@link com.mapbox.api.directions.v5.DirectionsCriteria#ANNOTATION_DISTANCE}.
-   * <p>
-   * This will be provided by default with {@link NavigationRoute#builder(Context)}.
-   *
-   * @return object current annotation data
-   * @since 0.13.0
-   */
-  @Nullable
-  public abstract CurrentLegAnnotation currentLegAnnotation();
-
-  /**
    * Not public since developer can access same information from {@link RouteProgress}.
    */
   abstract RouteLeg routeLeg();
 
   abstract double stepDistanceRemaining();
-
-  abstract List<StepIntersection> intersections();
-
-  abstract StepIntersection currentIntersection();
-
-  @Nullable
-  abstract StepIntersection upcomingIntersection();
-
-  abstract List<Pair<StepIntersection, Double>> intersectionDistancesAlongStep();
 
   @AutoValue.Builder
   public abstract static class Builder {
@@ -227,36 +199,12 @@ public abstract class RouteLegProgress {
 
     abstract Builder upcomingStepPoints(@Nullable List<Point> upcomingStepPoints);
 
-    abstract Builder intersections(List<StepIntersection> intersections);
-
-    abstract List<StepIntersection> intersections();
-
-    abstract Builder intersectionDistancesAlongStep(
-      List<Pair<StepIntersection, Double>> intersectionDistancesAlongStep
-    );
-
-    abstract List<Pair<StepIntersection, Double>> intersectionDistancesAlongStep();
-
-    abstract Builder currentIntersection(StepIntersection currentIntersection);
-
-    abstract StepIntersection currentIntersection();
-
-    abstract Builder upcomingIntersection(@Nullable StepIntersection upcomingIntersection);
-
-    abstract StepIntersection upcomingIntersection();
-
-    abstract Builder currentLegAnnotation(@Nullable CurrentLegAnnotation currentLegAnnotation);
-
     abstract RouteLegProgress autoBuild(); // not public
 
     public RouteLegProgress build() {
       RouteStepProgress stepProgress = RouteStepProgress.builder()
         .step(currentStep())
         .distanceRemaining(stepDistanceRemaining())
-        .intersections(intersections())
-        .currentIntersection(currentIntersection())
-        .upcomingIntersection(upcomingIntersection())
-        .intersectionDistancesAlongStep(intersectionDistancesAlongStep())
         .build();
       currentStepProgress(stepProgress);
       return autoBuild();

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/routeprogress/RouteProgress.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/routeprogress/RouteProgress.java
@@ -2,13 +2,11 @@ package com.mapbox.services.android.navigation.v5.routeprogress;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.v4.util.Pair;
 
 import com.google.auto.value.AutoValue;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.api.directions.v5.models.LegStep;
 import com.mapbox.api.directions.v5.models.RouteLeg;
-import com.mapbox.api.directions.v5.models.StepIntersection;
 import com.mapbox.geojson.Geometry;
 import com.mapbox.geojson.Point;
 import com.mapbox.navigator.BannerInstruction;
@@ -190,14 +188,6 @@ public abstract class RouteProgress {
   public abstract RouteProgressState currentState();
 
   /**
-   * Returns the current {@link DirectionsRoute} geometry.
-   *
-   * @return current route geometry
-   */
-  @Nullable
-  public abstract Geometry routeGeometry();
-
-  /**
    * Returns the current {@link DirectionsRoute} geometry with a buffer
    * that encompasses visible tile surface are while navigating.
    * <p>
@@ -218,18 +208,6 @@ public abstract class RouteProgress {
   abstract double legDistanceRemaining();
 
   abstract double stepDistanceRemaining();
-
-  abstract List<StepIntersection> intersections();
-
-  abstract StepIntersection currentIntersection();
-
-  @Nullable
-  abstract StepIntersection upcomingIntersection();
-
-  @Nullable
-  abstract CurrentLegAnnotation currentLegAnnotation();
-
-  abstract List<Pair<StepIntersection, Double>> intersectionDistancesAlongStep();
 
   abstract double legDurationRemaining();
 
@@ -274,28 +252,6 @@ public abstract class RouteProgress {
 
     public abstract Builder distanceRemaining(double distanceRemaining);
 
-    public abstract Builder intersections(List<StepIntersection> intersections);
-
-    abstract List<StepIntersection> intersections();
-
-    public abstract Builder currentIntersection(StepIntersection currentIntersection);
-
-    abstract StepIntersection currentIntersection();
-
-    public abstract Builder upcomingIntersection(@Nullable StepIntersection upcomingIntersection);
-
-    abstract StepIntersection upcomingIntersection();
-
-    public abstract Builder intersectionDistancesAlongStep(
-      List<Pair<StepIntersection, Double>> intersectionDistancesAlongStep
-    );
-
-    abstract List<Pair<StepIntersection, Double>> intersectionDistancesAlongStep();
-
-    public abstract Builder currentLegAnnotation(@Nullable CurrentLegAnnotation currentLegAnnotation);
-
-    abstract CurrentLegAnnotation currentLegAnnotation();
-
     abstract Builder currentLegProgress(RouteLegProgress routeLegProgress);
 
     public abstract Builder inTunnel(boolean inTunnel);
@@ -305,8 +261,6 @@ public abstract class RouteProgress {
     public abstract Builder bannerInstruction(@Nullable BannerInstruction bannerInstruction);
 
     public abstract Builder currentState(@Nullable RouteProgressState currentState);
-
-    public abstract Builder routeGeometry(@Nullable Geometry routeGeometry);
 
     public abstract Builder routeGeometryWithBuffer(@Nullable Geometry routeGeometryWithBuffer);
 
@@ -323,11 +277,6 @@ public abstract class RouteProgress {
         .stepDistanceRemaining(stepDistanceRemaining())
         .currentStepPoints(currentStepPoints())
         .upcomingStepPoints(upcomingStepPoints())
-        .intersections(intersections())
-        .currentIntersection(currentIntersection())
-        .upcomingIntersection(upcomingIntersection())
-        .intersectionDistancesAlongStep(intersectionDistancesAlongStep())
-        .currentLegAnnotation(currentLegAnnotation())
         .build();
       currentLegProgress(legProgress);
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/routeprogress/RouteStepProgress.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/routeprogress/RouteStepProgress.java
@@ -1,15 +1,8 @@
 package com.mapbox.services.android.navigation.v5.routeprogress;
 
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.v4.util.Pair;
-
 import com.google.auto.value.AutoValue;
 import com.mapbox.api.directions.v5.models.LegStep;
-import com.mapbox.api.directions.v5.models.StepIntersection;
-
-import java.util.List;
 
 
 /**
@@ -65,49 +58,6 @@ public abstract class RouteStepProgress {
    */
   public abstract double durationRemaining();
 
-  /**
-   * A collection of all the current steps intersections and the next steps maneuver location
-   * (if one exist).
-   *
-   * @return a list of {@link StepIntersection}s which may include the next steps maneuver
-   * intersection if it exist
-   * @since 0.7.0
-   */
-  public abstract List<StepIntersection> intersections();
-
-  /**
-   * The current intersection that has been passed along the route.
-   * <p>
-   * An intersection is considered a current intersection once passed through
-   * and will remain so until a different intersection is passed through.
-   *
-   * @return current intersection the user has passed through
-   * @since 0.13.0
-   */
-  public abstract StepIntersection currentIntersection();
-
-  /**
-   * The intersection being traveled towards on the route.
-   * <p>
-   * Will be null if the upcoming step is null (last step of the leg).
-   *
-   * @return intersection being traveled towards
-   * @since 0.13.0
-   */
-  @Nullable
-  public abstract StepIntersection upcomingIntersection();
-
-  /**
-   * Provides a list of pairs containing two distances, in meters, along the route.
-   * <p>
-   * The first distance in the pair is the tunnel entrance along the step geometry.
-   * The second distance is the tunnel exit along the step geometry.
-   *
-   * @return list of pairs containing tunnnel entrance and exit distances
-   * @since 0.13.0
-   */
-  public abstract List<Pair<StepIntersection, Double>> intersectionDistancesAlongStep();
-
   abstract LegStep step();
 
   @AutoValue.Builder
@@ -126,14 +76,6 @@ public abstract class RouteStepProgress {
     abstract Builder fractionTraveled(float fractionTraveled);
 
     abstract Builder durationRemaining(double durationRemaining);
-
-    abstract Builder intersections(@NonNull List<StepIntersection> intersections);
-
-    abstract Builder currentIntersection(StepIntersection currentIntersection);
-
-    abstract Builder upcomingIntersection(@Nullable StepIntersection upcomingIntersection);
-
-    abstract Builder intersectionDistancesAlongStep(List<Pair<StepIntersection, Double>> intersections);
 
     abstract RouteStepProgress autoBuild();
 

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/TestRouteProgressBuilder.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/TestRouteProgressBuilder.java
@@ -1,11 +1,9 @@
 package com.mapbox.services.android.navigation.v5;
 
 import android.support.annotation.NonNull;
-import android.support.v4.util.Pair;
 
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.api.directions.v5.models.LegStep;
-import com.mapbox.api.directions.v5.models.StepIntersection;
 import com.mapbox.geojson.Point;
 import com.mapbox.geojson.utils.PolylineUtils;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
@@ -13,14 +11,10 @@ import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 import java.util.List;
 
 import static com.mapbox.core.constants.Constants.PRECISION_6;
-import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.createDistancesToIntersections;
-import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.createIntersectionsList;
-import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.findCurrentIntersection;
-import static com.mapbox.services.android.navigation.v5.navigation.NavigationHelper.findUpcomingIntersection;
 
 class TestRouteProgressBuilder {
 
-  RouteProgress buildDefaultTestRouteProgress(DirectionsRoute testRoute) throws Exception {
+  RouteProgress buildDefaultTestRouteProgress(DirectionsRoute testRoute) {
     return buildTestRouteProgress(testRoute, 100, 100,
       100, 0, 0);
   }
@@ -30,7 +24,7 @@ class TestRouteProgressBuilder {
                                        double legDistanceRemaining,
                                        double distanceRemaining,
                                        int stepIndex,
-                                       int legIndex) throws Exception {
+                                       int legIndex) {
     double legDurationRemaining = route.legs().get(0).duration();
     List<LegStep> steps = route.legs().get(legIndex).steps();
     LegStep currentStep = steps.get(stepIndex);
@@ -43,15 +37,6 @@ class TestRouteProgressBuilder {
       String upcomingStepGeometry = upcomingStep.geometry();
       upcomingStepPoints = buildStepPointsFromGeometry(upcomingStepGeometry);
     }
-    List<StepIntersection> intersections = createIntersectionsList(currentStep, upcomingStep);
-    List<Pair<StepIntersection, Double>> intersectionDistances = createDistancesToIntersections(
-      currentStepPoints, intersections
-    );
-
-    StepIntersection currentIntersection = createCurrentIntersection(stepDistanceRemaining, currentStep,
-      intersections, intersectionDistances);
-    StepIntersection upcomingIntersection = createUpcomingIntersection(upcomingStep, intersections,
-      currentIntersection);
 
     return RouteProgress.builder()
       .stepDistanceRemaining(stepDistanceRemaining)
@@ -62,10 +47,6 @@ class TestRouteProgressBuilder {
       .currentStep(currentStep)
       .currentStepPoints(currentStepPoints)
       .upcomingStepPoints(upcomingStepPoints)
-      .intersections(intersections)
-      .currentIntersection(currentIntersection)
-      .upcomingIntersection(upcomingIntersection)
-      .intersectionDistancesAlongStep(intersectionDistances)
       .stepIndex(stepIndex)
       .legIndex(legIndex)
       .inTunnel(false)
@@ -76,22 +57,6 @@ class TestRouteProgressBuilder {
   private List<Point> buildCurrentStepPoints(LegStep currentStep) {
     String currentStepGeometry = currentStep.geometry();
     return buildStepPointsFromGeometry(currentStepGeometry);
-  }
-
-  private StepIntersection createCurrentIntersection(double stepDistanceRemaining, LegStep currentStep,
-                                                     List<StepIntersection> intersections,
-                                                     List<Pair<StepIntersection, Double>> intersectionDistances) {
-    double stepDistanceTraveled = currentStep.distance() - stepDistanceRemaining;
-    return findCurrentIntersection(intersections,
-      intersectionDistances, stepDistanceTraveled
-    );
-  }
-
-  private StepIntersection createUpcomingIntersection(LegStep upcomingStep, List<StepIntersection> intersections,
-                                                      StepIntersection currentIntersection) {
-    return findUpcomingIntersection(
-        intersections, upcomingStep, currentIntersection
-      );
   }
 
   private List<Point> buildStepPointsFromGeometry(String stepGeometry) {

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationHelperTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/navigation/NavigationHelperTest.java
@@ -1,24 +1,15 @@
 package com.mapbox.services.android.navigation.v5.navigation;
 
-import android.support.v4.util.Pair;
-
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.mapbox.api.directions.v5.DirectionsAdapterFactory;
 import com.mapbox.api.directions.v5.models.DirectionsResponse;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.api.directions.v5.models.LegAnnotation;
-import com.mapbox.api.directions.v5.models.LegStep;
 import com.mapbox.api.directions.v5.models.RouteLeg;
-import com.mapbox.api.directions.v5.models.StepIntersection;
-import com.mapbox.core.constants.Constants;
-import com.mapbox.geojson.Point;
-import com.mapbox.geojson.utils.PolylineUtils;
 import com.mapbox.services.android.navigation.v5.BaseTest;
 import com.mapbox.services.android.navigation.v5.routeprogress.CurrentLegAnnotation;
-import com.mapbox.services.android.navigation.v5.routeprogress.RouteLegProgress;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
-import com.mapbox.services.android.navigation.v5.routeprogress.RouteStepProgress;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -26,10 +17,8 @@ import org.robolectric.RobolectricTestRunner;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.List;
 
 import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -37,202 +26,10 @@ import static org.mockito.Mockito.when;
 @RunWith(RobolectricTestRunner.class)
 public class NavigationHelperTest extends BaseTest {
 
-  private static final String MULTI_LEG_ROUTE_FIXTURE = "directions_two_leg_route.json";
   private static final String ANNOTATED_DISTANCE_CONGESTION_ROUTE_FIXTURE = "directions_distance_congestion_annotation.json";
 
   @Test
-  public void createIntersectionList_returnsCompleteIntersectionList() throws Exception {
-    RouteProgress routeProgress = buildMultiLegRouteProgress();
-    LegStep currentStep = routeProgress.currentLegProgress().currentStep();
-    LegStep upcomingStep = routeProgress.currentLegProgress().upComingStep();
-
-    List<StepIntersection> intersections = NavigationHelper.createIntersectionsList(currentStep, upcomingStep);
-    int correctListSize = currentStep.intersections().size() + 1;
-
-    assertTrue(correctListSize == intersections.size());
-  }
-
-  @Test
-  public void createIntersectionList_upcomingStepNull_returnsCurrentStepIntersectionList() throws Exception {
-    RouteProgress routeProgress = buildMultiLegRouteProgress();
-    LegStep currentStep = routeProgress.currentLegProgress().currentStep();
-    LegStep upcomingStep = null;
-
-    List<StepIntersection> intersections = NavigationHelper.createIntersectionsList(currentStep, upcomingStep);
-    int correctListSize = currentStep.intersections().size() + 1;
-
-    assertFalse(correctListSize == intersections.size());
-  }
-
-  @Test
-  public void createIntersectionDistanceList_samePointsForDistanceCalculationsEqualZero() throws Exception {
-    RouteProgress routeProgress = buildMultiLegRouteProgress();
-    LegStep currentStep = routeProgress.currentLegProgress().currentStep();
-    List<Point> currentStepPoints = PolylineUtils.decode(currentStep.geometry(), Constants.PRECISION_6);
-    List<StepIntersection> currentStepIntersections = currentStep.intersections();
-
-    List<Pair<StepIntersection, Double>> intersectionDistances = NavigationHelper.createDistancesToIntersections(
-      currentStepPoints, currentStepIntersections
-    );
-
-    assertTrue(intersectionDistances.get(0).second == 0);
-  }
-
-  @Test
-  public void createIntersectionDistanceList_intersectionListSizeEqualsDistanceListSize() throws Exception {
-    RouteProgress routeProgress = buildMultiLegRouteProgress();
-    LegStep currentStep = routeProgress.currentLegProgress().currentStep();
-    List<Point> currentStepPoints = PolylineUtils.decode(currentStep.geometry(), Constants.PRECISION_6);
-    List<StepIntersection> currentStepIntersections = currentStep.intersections();
-
-    List<Pair<StepIntersection, Double>> intersectionDistances = NavigationHelper.createDistancesToIntersections(
-      currentStepPoints, currentStepIntersections
-    );
-
-    assertTrue(currentStepIntersections.size() == intersectionDistances.size());
-  }
-
-  @Test
-  public void createIntersectionDistanceList_emptyStepPointsReturnsEmptyList() throws Exception {
-    RouteProgress routeProgress = buildMultiLegRouteProgress();
-    LegStep currentStep = routeProgress.currentLegProgress().currentStep();
-    List<Point> currentStepPoints = new ArrayList<>();
-    List<StepIntersection> currentStepIntersections = currentStep.intersections();
-
-    List<Pair<StepIntersection, Double>> intersectionDistances = NavigationHelper.createDistancesToIntersections(
-      currentStepPoints, currentStepIntersections
-    );
-
-    assertTrue(intersectionDistances.isEmpty());
-  }
-
-  @Test
-  public void createIntersectionDistanceList_oneStepPointReturnsEmptyList() throws Exception {
-    RouteProgress routeProgress = buildMultiLegRouteProgress();
-    LegStep currentStep = routeProgress.currentLegProgress().currentStep();
-    List<Point> currentStepPoints = new ArrayList<>();
-    currentStepPoints.add(Point.fromLngLat(1d, 1d));
-    List<StepIntersection> currentStepIntersections = currentStep.intersections();
-
-    List<Pair<StepIntersection, Double>> intersectionDistances = NavigationHelper.createDistancesToIntersections(
-      currentStepPoints, currentStepIntersections
-    );
-
-    assertTrue(intersectionDistances.isEmpty());
-  }
-
-  @Test
-  public void createIntersectionDistanceList_emptyStepIntersectionsReturnsEmptyList() throws Exception {
-    RouteProgress routeProgress = buildMultiLegRouteProgress();
-    LegStep currentStep = routeProgress.currentLegProgress().currentStep();
-    List<Point> currentStepPoints = PolylineUtils.decode(currentStep.geometry(), Constants.PRECISION_6);
-    List<StepIntersection> currentStepIntersections = new ArrayList<>();
-
-    List<Pair<StepIntersection, Double>> intersectionDistances = NavigationHelper.createDistancesToIntersections(
-      currentStepPoints, currentStepIntersections
-    );
-
-    assertTrue(intersectionDistances.isEmpty());
-  }
-
-  @Test
-  public void findCurrentIntersection_beginningOfStepReturnsFirstIntersection() throws Exception {
-    RouteProgress routeProgress = buildMultiLegRouteProgress();
-    RouteLegProgress legProgress = routeProgress.currentLegProgress();
-    RouteStepProgress stepProgress = legProgress.currentStepProgress();
-    List<StepIntersection> intersections = stepProgress.intersections();
-    List<Pair<StepIntersection, Double>> intersectionDistances = stepProgress.intersectionDistancesAlongStep();
-
-    StepIntersection currentIntersection = NavigationHelper.findCurrentIntersection(
-      intersections, intersectionDistances, 0
-    );
-
-    assertTrue(currentIntersection.equals(intersections.get(0)));
-  }
-
-  @Test
-  public void findCurrentIntersection_endOfStepReturnsLastIntersection() throws Exception {
-    RouteProgress routeProgress = buildMultiLegRouteProgress();
-    RouteLegProgress legProgress = routeProgress.currentLegProgress();
-    RouteStepProgress stepProgress = legProgress.currentStepProgress();
-    List<StepIntersection> intersections = stepProgress.intersections();
-    List<Pair<StepIntersection, Double>> intersectionDistances = stepProgress.intersectionDistancesAlongStep();
-
-    StepIntersection currentIntersection = NavigationHelper.findCurrentIntersection(
-      intersections, intersectionDistances, legProgress.currentStep().distance()
-    );
-
-    assertTrue(currentIntersection.equals(intersections.get(intersections.size() - 1)));
-  }
-
-  @Test
-  public void findCurrentIntersection_middleOfStepReturnsCorrectIntersection() throws Exception {
-    RouteProgress routeProgress = buildMultiLegRouteProgress(100, 0, 0, 2, 0);
-    RouteLegProgress legProgress = routeProgress.currentLegProgress();
-    RouteStepProgress stepProgress = legProgress.currentStepProgress();
-    List<StepIntersection> intersections = stepProgress.intersections();
-    List<Pair<StepIntersection, Double>> intersectionDistances = stepProgress.intersectionDistancesAlongStep();
-
-    StepIntersection currentIntersection = NavigationHelper.findCurrentIntersection(
-      intersections, intersectionDistances, 130
-    );
-
-    assertTrue(currentIntersection.equals(intersections.get(1)));
-  }
-
-  @Test
-  public void findUpcomingIntersection_beginningOfStepReturnsSecondIntersection() throws Exception {
-    RouteProgress routeProgress = buildMultiLegRouteProgress();
-    RouteLegProgress legProgress = routeProgress.currentLegProgress();
-    RouteStepProgress stepProgress = legProgress.currentStepProgress();
-    List<StepIntersection> intersections = stepProgress.intersections();
-
-    StepIntersection upcomingIntersection = NavigationHelper.findUpcomingIntersection(
-      intersections, legProgress.upComingStep(), stepProgress.currentIntersection()
-    );
-
-    assertTrue(upcomingIntersection.equals(intersections.get(1)));
-  }
-
-  @Test
-  public void findUpcomingIntersection_endOfStepReturnsUpcomingStepFirstIntersection() throws Exception {
-    RouteProgress routeProgress = buildMultiLegRouteProgress();
-    RouteLegProgress legProgress = routeProgress.currentLegProgress();
-    RouteStepProgress stepProgress = legProgress.currentStepProgress();
-    List<StepIntersection> intersections = stepProgress.intersections();
-    List<Pair<StepIntersection, Double>> intersectionDistances = stepProgress.intersectionDistancesAlongStep();
-    StepIntersection currentIntersection = NavigationHelper.findCurrentIntersection(
-      intersections, intersectionDistances, legProgress.currentStep().distance()
-    );
-
-    StepIntersection upcomingIntersection = NavigationHelper.findUpcomingIntersection(
-      intersections, legProgress.upComingStep(), currentIntersection
-    );
-
-    assertEquals(legProgress.upComingStep().intersections().get(0), upcomingIntersection);
-  }
-
-  @Test
-  public void findUpcomingIntersection_endOfLegReturnsNullIntersection() throws Exception {
-    int stepIndex = buildMultiLegRoute().legs().get(1).steps().size() - 1;
-    RouteProgress routeProgress = buildMultiLegRouteProgress(0, 0, 0, stepIndex, 1);
-    RouteLegProgress legProgress = routeProgress.currentLegProgress();
-    RouteStepProgress stepProgress = legProgress.currentStepProgress();
-    List<StepIntersection> intersections = stepProgress.intersections();
-    List<Pair<StepIntersection, Double>> intersectionDistances = stepProgress.intersectionDistancesAlongStep();
-    StepIntersection currentIntersection = NavigationHelper.findCurrentIntersection(
-      intersections, intersectionDistances, legProgress.currentStep().distance()
-    );
-
-    StepIntersection upcomingIntersection = NavigationHelper.findUpcomingIntersection(
-      intersections, legProgress.upComingStep(), currentIntersection
-    );
-
-    assertEquals(null, upcomingIntersection);
-  }
-
-  @Test
-  public void createCurrentAnnotation_nullAnnotationReturnsNull() throws Exception {
+  public void createCurrentAnnotation_nullAnnotationReturnsNull() {
     CurrentLegAnnotation currentLegAnnotation = NavigationHelper.createCurrentAnnotation(
       null, mock(RouteLeg.class), 0
     );
@@ -241,7 +38,7 @@ public class NavigationHelperTest extends BaseTest {
   }
 
   @Test
-  public void createCurrentAnnotation_emptyDistanceArrayReturnsNull() throws Exception {
+  public void createCurrentAnnotation_emptyDistanceArrayReturnsNull() {
     CurrentLegAnnotation currentLegAnnotation = buildCurrentAnnotation();
     RouteLeg routeLeg = buildRouteLegWithAnnotation();
 
@@ -295,31 +92,11 @@ public class NavigationHelperTest extends BaseTest {
     assertEquals(11, newLegAnnotation.index());
   }
 
-  private RouteProgress buildMultiLegRouteProgress(double stepDistanceRemaining, double legDistanceRemaining,
-                                                   double distanceRemaining, int stepIndex, int legIndex) throws Exception {
-    DirectionsRoute multiLegRoute = buildMultiLegRoute();
-    return buildTestRouteProgress(multiLegRoute, stepDistanceRemaining,
-      legDistanceRemaining, distanceRemaining, stepIndex, legIndex);
-  }
-
   private RouteProgress buildDistanceCongestionAnnotationRouteProgress(double stepDistanceRemaining, double legDistanceRemaining,
                                                                        double distanceRemaining, int stepIndex, int legIndex) throws Exception {
     DirectionsRoute annotatedRoute = buildDistanceCongestionAnnotationRoute();
     return buildTestRouteProgress(annotatedRoute, stepDistanceRemaining,
       legDistanceRemaining, distanceRemaining, stepIndex, legIndex);
-  }
-
-  private RouteProgress buildMultiLegRouteProgress() throws Exception {
-    DirectionsRoute multiLegRoute = buildMultiLegRoute();
-    return buildTestRouteProgress(multiLegRoute, 1000, 1000, 1000, 0, 0);
-  }
-
-  private DirectionsRoute buildMultiLegRoute() throws IOException {
-    Gson gson = new GsonBuilder()
-      .registerTypeAdapterFactory(DirectionsAdapterFactory.create()).create();
-    String body = loadJsonFixture(MULTI_LEG_ROUTE_FIXTURE);
-    DirectionsResponse response = gson.fromJson(body, DirectionsResponse.class);
-    return response.routes().get(0);
   }
 
   private DirectionsRoute buildDistanceCongestionAnnotationRoute() throws IOException {

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/routeprogress/RouteStepProgressTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/routeprogress/RouteStepProgressTest.java
@@ -10,7 +10,6 @@ import com.mapbox.api.directions.v5.models.RouteLeg;
 import com.mapbox.core.constants.Constants;
 import com.mapbox.geojson.LineString;
 import com.mapbox.geojson.Point;
-import com.mapbox.geojson.utils.PolylineUtils;
 import com.mapbox.services.android.navigation.v5.BaseTest;
 import com.mapbox.turf.TurfConstants;
 import com.mapbox.turf.TurfMeasurement;
@@ -314,46 +313,6 @@ public class RouteStepProgressTest extends BaseTest {
     RouteStepProgress routeStepProgress = routeProgress.currentLegProgress().currentStepProgress();
 
     assertEquals(0, routeStepProgress.durationRemaining(), BaseTest.DELTA);
-  }
-
-  @Test
-  public void stepIntersections_includesAllStepIntersectionsAndNextManeuver() throws Exception {
-    DirectionsRoute route = buildTestDirectionsRoute();
-    RouteLeg firstLeg = route.legs().get(0);
-    int stepIndex = 3;
-    int legIndex = 0;
-    double stepDistanceRemaining = 0;
-    double legDistanceRemaining = firstLeg.distance();
-    double distanceRemaining = route.distance();
-    RouteProgress routeProgress = buildTestRouteProgress(route, stepDistanceRemaining,
-      legDistanceRemaining, distanceRemaining, stepIndex, legIndex);
-    RouteStepProgress routeStepProgress = routeProgress.currentLegProgress().currentStepProgress();
-
-    int stepIntersections = route.legs().get(0).steps().get(3).intersections().size();
-    int intersectionSize = stepIntersections + 1;
-
-    assertEquals(intersectionSize, routeStepProgress.intersections().size());
-  }
-
-  @Test
-  public void stepIntersections_handlesNullNextManeuverCorrectly() throws Exception {
-    DirectionsRoute route = buildTestDirectionsRoute();
-    RouteLeg firstLeg = route.legs().get(0);
-    int stepIndex = (route.legs().get(0).steps().size() - 1);
-    int legIndex = 0;
-    double stepDistanceRemaining = 0;
-    double legDistanceRemaining = firstLeg.distance();
-    double distanceRemaining = route.distance();
-    RouteProgress routeProgress = buildTestRouteProgress(route, stepDistanceRemaining,
-      legDistanceRemaining, distanceRemaining, stepIndex, legIndex);
-    RouteStepProgress routeStepProgress = routeProgress.currentLegProgress().currentStepProgress();
-    int currentStepTotal = route.legs().get(0).steps().get(stepIndex).intersections().size();
-    List<Point> lastStepLocation = PolylineUtils.decode(
-      route.legs().get(0).steps().get(stepIndex).geometry(), Constants.PRECISION_6);
-
-    assertEquals(currentStepTotal, routeStepProgress.intersections().size());
-    assertEquals(routeStepProgress.intersections().get(0).location().latitude(), lastStepLocation.get(0).latitude());
-    assertEquals(routeStepProgress.intersections().get(0).location().longitude(), lastStepLocation.get(0).longitude());
   }
 
   private DirectionsRoute loadChipotleTestRoute() throws IOException {


### PR DESCRIPTION
## Description

Removes never used apis causing unnecessary memory issues

- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

We run some profiling sessions and noticed some memory issues (especially around number of allocations / deallocations) 👀 

![Screen Shot 2019-09-16 at 3 06 55 PM](https://user-images.githubusercontent.com/1668582/64999000-38ca3680-d8b4-11e9-9007-94181380b498.png)

### Implementation

As seen above, top runners are:

`NavigationRouteProcessor#buildRouteProgressFrom` and `NavigationRouteProcessor#updateRoute`. Both methods are executed as part of `NavigationRouteProcessor#buildNewRouteProgress` which is executed every second.

After some analysis, noticed that `NavigationRouteProcessor#buildRouteProgressFrom` > `updateIntersections` > `createDistancesToIntersections` is called but never used i.e. operations are useless. This implementation was pre Nav Native and should have been removed as part of the migration PR. Good news is that removing all these never used APIs solves the problem. Following you can see a benchmark report not exercising these methods, allocations / deallocations decreased drastically 👀 

![Screen Shot 2019-09-16 at 6 42 35 PM](https://user-images.githubusercontent.com/1668582/64999799-14bc2480-d8b7-11e9-9810-54899163fbcb.png)

For the second top runner, `NavigationRouteProcessor#updateRoute` > `retrieveRouteGeometry` and `retrieveRouteGeometryWithBuffer` I noticed that `retrieveRouteGeometry` is never used either. This leaked as part of https://github.com/mapbox/mapbox-navigation-android/pull/1895 but the SDK doesn't need to retrieve the route geometry from NN. That API is been there forever and it was implemented for the Core SDK team originally because they didn't want to parse API directions (like the SDK does), they don't have a directions object so they needed this getter. Good news is that we could also fix it removing this API so underneath operations are not executed 👀 

After removing `retrieveRouteGeometry`,  `NavigationRouteProcessor#updateRoute` allocations went from `42055` to `20487` 📉 

![Screen Shot 2019-09-17 at 1 53 33 PM](https://user-images.githubusercontent.com/1668582/65066916-56021200-d953-11e9-89dc-3ee1def1de9b.png)

For the current hybrid offline solution, we're relying on `retrieveRouteGeometryWithBuffer` so some extra thinking is needed on how to avoid these allocations / deallocations. We should think about how to expose `retrieveRouteGeometryWithBuffer` as it's only consumed from the UI SDK.

That being said I want to mention that both allocations / deallocations coming from `updateRoute` don't happen that often because `retrieveRouteGeometry` and `retrieveRouteGeometryWithBuffer` are only called if the route is different - initial set and off-route / faster route scenarios.

In any case, although workarounds implemented in this PR will fix the memory issues in the SDK, we might need to revisit [`MAS`](https://github.com/mapbox/mapbox-java) implementations in the future and make them more performant - especially around time and space computational complexity (Big O notation) and how objects are serialized / deserialized (cost), currently relying on [Gson](https://github.com/google/gson).

Also as part of this PR I did some housekeeping and removed some `public` APIs, as they were only used internally (breaking change / SemVer).

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->