### PR TITLE
Fix intermittent memory issues in CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Mapbox welcomes participation and contributions from everyone.
 
+### v0.43.0 -
+
+* Fix intermittent memory issues in CI [#2096](https://github.com/mapbox/mapbox-navigation-android/pull/2096)
+
 ### v0.42.0 - September 20, 2019
 
 Note: This release breaks `SEMVER` / contains API breaking changes. Please consult this [migration guide](https://github.com/mapbox/mapbox-navigation-android/wiki/0.42.0-Migration-Guide) for the necessary updates required.

--- a/libandroid-navigation-ui/build.gradle
+++ b/libandroid-navigation-ui/build.gradle
@@ -36,6 +36,7 @@ android {
     unitTests.returnDefaultValues = true
     unitTests.includeAndroidResources = true
     unitTests.all {
+      maxHeapSize = "1024m"
       jacoco {
         includeNoLocationClasses = true
       }

--- a/libandroid-navigation/build.gradle
+++ b/libandroid-navigation/build.gradle
@@ -39,6 +39,7 @@ android {
     unitTests.returnDefaultValues = true
     unitTests.includeAndroidResources = true
     unitTests.all {
+      maxHeapSize = "1024m"
       jacoco {
         includeNoLocationClasses = true
       }


### PR DESCRIPTION
## Description

Fixes intermittent memory issues in CI - `finished with non-zero exit value 137`

Fixes https://github.com/mapbox/mapbox-navigation-android/issues/1790

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Fixing intermittent memory issues in CI. Noting that this problem has exacerbated when we started the Kotlin conversion effort.

### Implementation

https://github.com/mockito/shipkit/issues/675#issuecomment-515841010

> This is actually a memory issue, Generally, Docker container has a memory limit of 4G so you need to take care that your java heap doesn't cross that limit,

Adding `maxHeapSize = "1024m"` to `build.gradle` files (`libandroid-navigation` and `libandroid-navigation-ui`) should fix the CI flakiness.

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->