### PR TITLE
Fix Javadoc Kotlin issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Mapbox welcomes participation and contributions from everyone.
 
 ### v0.43.0 -
 
+* Fix Javadoc Kotlin issues [#2103](https://github.com/mapbox/mapbox-navigation-android/pull/2103)
 * Fix intermittent memory issues in CI [#2096](https://github.com/mapbox/mapbox-navigation-android/pull/2096)
 
 ### v0.42.0 - September 20, 2019

--- a/gradle/mvn-push-android.gradle
+++ b/gradle/mvn-push-android.gradle
@@ -109,6 +109,8 @@ afterEvaluate { project ->
 
   task androidJavadocs(type: Javadoc) {
     source = android.sourceSets.main.java.srcDirs
+    options.addBooleanOption('Xdoclint:none', true)
+    excludes = ['**/*.kt']
     classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
   }
 

--- a/libandroid-navigation-ui/javadoc.gradle
+++ b/libandroid-navigation-ui/javadoc.gradle
@@ -14,6 +14,6 @@ android.libraryVariants.all { variant ->
     options.bottom("&copy; 2019 Mapbox. All rights reserved.")
     options.links("http://docs.oracle.com/javase/7/docs/api/")
     options.linksOffline("http://d.android.com/reference/", "$System.env.ANDROID_HOME/docs/reference")
-    exclude '**/R.java', '**/BuildConfig.java'
+    exclude '**/R.java', '**/BuildConfig.java', '**/*.kt'
   }
 }

--- a/libandroid-navigation/javadoc.gradle
+++ b/libandroid-navigation/javadoc.gradle
@@ -14,6 +14,6 @@ android.libraryVariants.all { variant ->
     options.bottom("&copy; 2019 Mapbox. All rights reserved.")
     options.links("http://docs.oracle.com/javase/7/docs/api/")
     options.linksOffline("http://d.android.com/reference/", "$System.env.ANDROID_HOME/docs/reference")
-    exclude '**/R.java', '**/BuildConfig.java'
+    exclude '**/R.java', '**/BuildConfig.java', '**/*.kt'
   }
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/OnOfflineTilesConfiguredCallback.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/OnOfflineTilesConfiguredCallback.java
@@ -4,15 +4,15 @@ import androidx.annotation.NonNull;
 
 /**
  * Listener that needs to be added to
- * {@link MapboxOfflineRouter#configure(String, OnOfflineTilesConfiguredCallback)} to know when
+ * <tt>MapboxOfflineRouter#configure(String, OnOfflineTilesConfiguredCallback)</tt> to know when
  * offline data is initialized and
- * {@link MapboxOfflineRouter#findRoute(OfflineRoute, OnOfflineRouteFoundCallback)} could be called.
+ * <tt>MapboxOfflineRouter#findRoute(OfflineRoute, OnOfflineRouteFoundCallback)</tt> could be called.
  */
 public interface OnOfflineTilesConfiguredCallback {
 
   /**
    * Called whe the offline data is initialized and
-   * {@link MapboxOfflineRouter#findRoute(OfflineRoute, OnOfflineRouteFoundCallback)}.
+   * <tt>MapboxOfflineRouter#findRoute(OfflineRoute, OnOfflineRouteFoundCallback)</tt>.
    * could be called safely.
    *
    * @param numberOfTiles initialized in the path provided

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/OnOfflineTilesRemovedCallback.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/OnOfflineTilesRemovedCallback.java
@@ -4,7 +4,7 @@ import com.mapbox.geojson.BoundingBox;
 
 /**
  * Listener that needs to be added to
- * {@link MapboxOfflineRouter#removeTiles(String, BoundingBox, OnOfflineTilesRemovedCallback)} to know when the routing
+ * <tt>MapboxOfflineRouter#removeTiles(String, BoundingBox, OnOfflineTilesRemovedCallback)</tt> to know when the routing
  * tiles within the provided {@link BoundingBox} have been removed
  */
 public interface OnOfflineTilesRemovedCallback {

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/OnTileVersionsFoundCallback.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/OnTileVersionsFoundCallback.java
@@ -5,13 +5,13 @@ import androidx.annotation.NonNull;
 import java.util.List;
 
 /**
- * Callback used with {@link MapboxOfflineRouter#fetchAvailableTileVersions(String, OnTileVersionsFoundCallback)}.
+ * Callback used with <tt>MapboxOfflineRouter#fetchAvailableTileVersions(String, OnTileVersionsFoundCallback)</tt>.
  */
 public interface OnTileVersionsFoundCallback {
 
   /**
    * A list of available offline tile versions that can be used
-   * with {@link MapboxOfflineRouter#downloadTiles(OfflineTiles, RouteTileDownloadListener)}.
+   * with <tt>MapboxOfflineRouter#downloadTiles(OfflineTiles, RouteTileDownloadListener)</tt>.
    *
    * @param availableVersions for offline tiles
    */


### PR DESCRIPTION
## Description

Fixes Javadoc Kotlin issues caused by Kotlin conversion

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Currently (after starting the Kotlin migration) is not possible to publish the artifacts in Maven because Javadoc is failing. The goal here is to fix this so that `mvn-push-android` works normally again.

### Implementation

Added `excludes = ['**/*.kt']` to `mvn-push-android.gradle` (and `javadoc.gradle` files) and replaced missing classes `{@link}` (now Kotlin files / classes are excluded) by `<tt></tt>` (code formatting). Also added ` options.addBooleanOption('Xdoclint:none', true)` to `mvn-push-android` solving Java 8 Javadoc issues (`doclint` 👀 https://blog.joda.org/2014/02/turning-off-doclint-in-jdk-8-javadoc.html) 

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->

cc @abhishek1508 