### PR TITLE
one line fix for the round-about issue

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/maneuver/ManeuverView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/maneuver/ManeuverView.java
@@ -236,6 +236,9 @@ public class ManeuverView extends View {
       maneuverViewUpdate.updateManeuverView(canvas, primaryColor, secondaryColor, size, roundaboutAngle);
     }
     boolean flip = SHOULD_FLIP_MODIFIERS.contains(maneuverModifier);
+    if (ROUNDABOUT_MANEUVER_TYPES.contains(maneuverType)) {
+      flip = STEP_MANEUVER_MODIFIER_LEFT.equals(drivingSide);
+    }
     if (STEP_MANEUVER_MODIFIER_LEFT.equals(drivingSide) && STEP_MANEUVER_MODIFIER_UTURN.contains(maneuverModifier)) {
       setScaleX(flip ? 1 : -1);
     } else {


### PR DESCRIPTION
## Description
Closes #2191 

One line change to handle RoundAbout navigation correctly in righ-side driving countries.
### Implementation

ROUNDABOUT_MANEUVER_TYPES hash table is used to search for the maneuver modifier. If it is found and driving side is  STEP_MANEUVER_MODIFIER_LEFT, then the flip flag is set
## Screenshots or Gifs

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->