### PR TITLE
Fix initialize location engine regression from #2154

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
@@ -1032,6 +1032,7 @@ public class MapboxNavigation implements ServiceConnection {
       }
     });
     navigationEngineFactory = new NavigationEngineFactory();
+    locationEngine = obtainLocationEngine();
     locationEngineRequest = obtainLocationEngineRequest();
     OfflineNavigator offlineNavigator = new OfflineNavigator(mapboxNavigator.getNavigator(),
             "2019_04_13-00_00_11", "https://api-routing-tiles-staging.tilestream.net",


### PR DESCRIPTION
## Description

Fixes initialize location engine regression from #2154

https://github.com/mapbox/mapbox-navigation-android/pull/2154/files#diff-667eeafdcc4161cea7ec77c7be674b6fL910

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Prevent unexpected crashes when initializing `MapboxNavigation`.

### Implementation

Bring `locationEngine = obtainLocationEngine();` (that slipped out in #2154) back.

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR