### PR TITLE
Bring latest changes from mapbox-events-android (android-base) submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "vendor/mapbox-events-android"]
 	path = vendor/mapbox-events-android
 	url = git@github.com:mapbox/mapbox-events-android.git
+	branch = android-base

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ We welcome feedback, translations, and code contributions! Please see [CONTRIBUT
 After cloning the repo, make sure to initialize vendor submodules:
 
 ```bash
-git submodule update --init --recursive
+git submodule update --init --recursive --remote
 ```
 
 ## License of Dependencies


### PR DESCRIPTION
This PR adds `android-base` branch to `.gitmodules` config, brings latest changes from `mapbox-events-android` submodule (added build `.gitignore` to `annotations` and `annotations-processor` modules so `build` folders are not tracked and  don't showed up as changes in the submodule when building `master`) and fixes `## Contributing` `git` submodule command in `README` (add `--remote`) so submodule always brings latest changes from `android-base` branch.