### PR TITLE
Persist routes across style changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ allprojects {
     jcenter()
     maven { url 'https://plugins.gradle.org/m2' }
     maven { url 'https://mapbox.bintray.com/mapbox' }
+//    maven { url 'https://oss.jfrog.org/artifactory/oss-snapshot-local/' }
   }
 
   group = GROUP

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,7 +8,7 @@ ext {
   ]
 
   version = [
-      mapboxMapSdk             : '8.2.1',
+      mapboxMapSdk             : '8.5.1',
       mapboxSdkServices        : '4.9.0',
       mapboxEvents             : '4.5.1',
       mapboxCore               : '1.3.0',

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/MapRouteLayerProvider.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/MapRouteLayerProvider.java
@@ -3,9 +3,7 @@ package com.mapbox.services.android.navigation.ui.v5.route;
 import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
 
-import androidx.annotation.NonNull;
-
-import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.style.expressions.Expression;
 import com.mapbox.mapboxsdk.style.layers.LineLayer;
 import com.mapbox.mapboxsdk.style.layers.Property;
@@ -48,11 +46,11 @@ import static com.mapbox.services.android.navigation.ui.v5.route.RouteConstants.
 
 class MapRouteLayerProvider {
 
-  LineLayer initializeRouteShieldLayer(MapboxMap mapboxMap, float routeScale, float alternativeRouteScale,
+  LineLayer initializeRouteShieldLayer(Style style, float routeScale, float alternativeRouteScale,
                                        int routeShieldColor, int alternativeRouteShieldColor) {
-    LineLayer shieldLayer = mapboxMap.getStyle().getLayerAs(ROUTE_SHIELD_LAYER_ID);
+    LineLayer shieldLayer = style.getLayerAs(ROUTE_SHIELD_LAYER_ID);
     if (shieldLayer != null) {
-      mapboxMap.getStyle().removeLayer(shieldLayer);
+      style.removeLayer(shieldLayer);
     }
 
     shieldLayer = new LineLayer(ROUTE_SHIELD_LAYER_ID, ROUTE_SOURCE_ID).withProperties(
@@ -90,13 +88,13 @@ class MapRouteLayerProvider {
     return shieldLayer;
   }
 
-  LineLayer initializeRouteLayer(MapboxMap mapboxMap, boolean roundedLineCap, float routeScale,
+  LineLayer initializeRouteLayer(Style style, boolean roundedLineCap, float routeScale,
                                  float alternativeRouteScale, int routeDefaultColor, int routeModerateColor,
                                  int routeSevereColor, int alternativeRouteDefaultColor,
                                  int alternativeRouteModerateColor, int alternativeRouteSevereColor) {
-    LineLayer routeLayer = mapboxMap.getStyle().getLayerAs(ROUTE_LAYER_ID);
+    LineLayer routeLayer = style.getLayerAs(ROUTE_LAYER_ID);
     if (routeLayer != null) {
-      mapboxMap.getStyle().removeLayer(routeLayer);
+      style.removeLayer(routeLayer);
     }
 
     String lineCap = Property.LINE_CAP_ROUND;
@@ -160,17 +158,17 @@ class MapRouteLayerProvider {
     return routeLayer;
   }
 
-  SymbolLayer initializeWayPointLayer(@NonNull MapboxMap mapboxMap, Drawable originIcon,
+  SymbolLayer initializeWayPointLayer(Style style, Drawable originIcon,
                                       Drawable destinationIcon) {
-    SymbolLayer wayPointLayer = mapboxMap.getStyle().getLayerAs(WAYPOINT_LAYER_ID);
+    SymbolLayer wayPointLayer = style.getLayerAs(WAYPOINT_LAYER_ID);
     if (wayPointLayer != null) {
-      mapboxMap.getStyle().removeLayer(wayPointLayer);
+      style.removeLayer(wayPointLayer);
     }
 
     Bitmap bitmap = MapImageUtils.getBitmapFromDrawable(originIcon);
-    mapboxMap.getStyle().addImage(ORIGIN_MARKER_NAME, bitmap);
+    style.addImage(ORIGIN_MARKER_NAME, bitmap);
     bitmap = MapImageUtils.getBitmapFromDrawable(destinationIcon);
-    mapboxMap.getStyle().addImage(DESTINATION_MARKER_NAME, bitmap);
+    style.addImage(DESTINATION_MARKER_NAME, bitmap);
 
     wayPointLayer = new SymbolLayer(WAYPOINT_LAYER_ID, WAYPOINT_SOURCE_ID).withProperties(
       iconImage(

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/NavigationMapRoute.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/NavigationMapRoute.java
@@ -15,6 +15,7 @@ import android.os.Handler;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.services.android.navigation.ui.v5.R;
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation;
 
@@ -323,7 +324,7 @@ public class NavigationMapRoute implements LifecycleObserver {
     MapRouteSourceProvider sourceProvider = new MapRouteSourceProvider();
     MapRouteLayerProvider layerProvider = new MapRouteLayerProvider();
     Handler handler = new Handler(context.getMainLooper());
-    return new MapRouteLine(context, mapboxMap, styleRes, belowLayer,
+    return new MapRouteLine(context, mapboxMap.getStyle(), styleRes, belowLayer,
       drawableProvider, sourceProvider, layerProvider, handler
     );
   }
@@ -332,7 +333,12 @@ public class NavigationMapRoute implements LifecycleObserver {
     didFinishLoadingStyleListener = new MapView.OnDidFinishLoadingStyleListener() {
       @Override
       public void onDidFinishLoadingStyle() {
-        redraw();
+        mapboxMap.getStyle(new Style.OnStyleLoaded() {
+          @Override
+          public void onStyleLoaded(@NonNull Style style) {
+            redraw(style);
+          }
+        });
       }
     };
   }
@@ -365,18 +371,36 @@ public class NavigationMapRoute implements LifecycleObserver {
     }
   }
 
-  private void redraw() {
+  private void redraw(Style style) {
     routeArrow = new MapRouteArrow(mapView, mapboxMap, styleRes);
-    List<DirectionsRoute> routes = routeLine.retrieveDirectionsRoutes();
-    boolean alternativesVisible = routeLine.retrieveAlternativesVisible();
-    int primaryRouteIndex = routeLine.retrievePrimaryRouteIndex();
-    boolean isVisible = routeLine.retrieveVisibility();
-    buildNewRouteLine();
-    routeLine.redraw(routes, alternativesVisible, primaryRouteIndex, isVisible);
+    recreateRouteLine(style);
   }
 
-  private void buildNewRouteLine() {
-    routeLine = buildMapRouteLine(mapView, mapboxMap, styleRes, belowLayer);
+  private void recreateRouteLine(Style style) {
+    Context context = mapView.getContext();
+    MapRouteDrawableProvider drawableProvider = new MapRouteDrawableProvider(context);
+    MapRouteSourceProvider sourceProvider = new MapRouteSourceProvider();
+    MapRouteLayerProvider layerProvider = new MapRouteLayerProvider();
+    Handler handler = new Handler(context.getMainLooper());
+
+    routeLine = new MapRouteLine(
+            context,
+            style,
+            styleRes,
+            belowLayer,
+            drawableProvider,
+            sourceProvider,
+            layerProvider,
+            routeLine.retrieveDrawnRouteFeatureCollections(),
+            routeLine.retrieveDrawnWaypointsFeatureCollections(),
+            routeLine.retrieveDirectionsRoutes(),
+            routeLine.retrieveRouteFeatureCollections(),
+            routeLine.retrieveRouteLineStrings(),
+            routeLine.retrievePrimaryRouteIndex(),
+            routeLine.retrieveVisibility(),
+            routeLine.retrieveAlternativesVisible(),
+            handler
+    );
     mapboxMap.removeOnMapClickListener(mapRouteClickListener);
     mapRouteClickListener = new MapRouteClickListener(routeLine);
     mapboxMap.addOnMapClickListener(mapRouteClickListener);

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/utils/MapUtils.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/utils/MapUtils.java
@@ -4,6 +4,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.style.layers.Layer;
 
 /**
@@ -24,7 +25,9 @@ public final class MapUtils {
    * @param layer        a layer that will be added to the map
    * @param idBelowLayer optionally providing the layer which the new layer should be placed below
    * @since 0.8.0
+   * @deprecated use {@link #addLayerToMap(Style, Layer, String)}
    */
+  @Deprecated
   public static void addLayerToMap(@NonNull MapboxMap mapboxMap, @NonNull Layer layer,
                                    @Nullable String idBelowLayer) {
     if (layer != null && mapboxMap.getStyle().getLayer(layer.getId()) != null) {
@@ -34,6 +37,26 @@ public final class MapUtils {
       mapboxMap.getStyle().addLayer(layer);
     } else {
       mapboxMap.getStyle().addLayerBelow(layer, idBelowLayer);
+    }
+  }
+
+  /**
+   * Generic method for adding layers to the map.
+   *
+   * @param style        that the current mapView is using
+   * @param layer        a layer that will be added to the map
+   * @param idBelowLayer optionally providing the layer which the new layer should be placed below
+   * @since 0.8.0
+   */
+  public static void addLayerToMap(@NonNull Style style, @NonNull Layer layer,
+                                   @Nullable String idBelowLayer) {
+    if (layer != null && style.getLayer(layer.getId()) != null) {
+      return;
+    }
+    if (idBelowLayer == null) {
+      style.addLayer(layer);
+    } else {
+      style.addLayerBelow(layer, idBelowLayer);
     }
   }
 }

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/route/MapRouteLineTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/route/MapRouteLineTest.java
@@ -2,27 +2,31 @@ package com.mapbox.services.android.navigation.ui.v5.route;
 
 import android.content.Context;
 import android.content.res.TypedArray;
+import android.graphics.drawable.Drawable;
 
 import androidx.annotation.NonNull;
 import android.os.Handler;
 
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.geojson.FeatureCollection;
-import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.geojson.LineString;
 import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.style.layers.Layer;
 import com.mapbox.mapboxsdk.style.layers.LineLayer;
+import com.mapbox.mapboxsdk.style.layers.SymbolLayer;
+import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
 import com.mapbox.services.android.navigation.ui.v5.BaseTest;
 import com.mapbox.services.android.navigation.ui.v5.R;
 
-import org.jetbrains.annotations.NotNull;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.robolectric.RobolectricTestRunner;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -30,10 +34,13 @@ import java.util.concurrent.TimeUnit;
 import edu.emory.mathcs.backport.java.util.Collections;
 
 import static com.mapbox.services.android.navigation.ui.v5.route.RouteConstants.ROUTE_LAYER_ID;
+import static com.mapbox.services.android.navigation.ui.v5.route.RouteConstants.ROUTE_SHIELD_LAYER_ID;
+import static com.mapbox.services.android.navigation.ui.v5.route.RouteConstants.WAYPOINT_LAYER_ID;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyFloat;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
@@ -46,6 +53,14 @@ import static org.mockito.Mockito.when;
 public class MapRouteLineTest extends BaseTest {
   // TODO explore making tasks as Runnables and create the thread in the call-site.
   //  That way we'll be able to execute the run synchronously, avoiding `CountDownLatch`
+
+  private Style style;
+
+  @Before
+  public void setUp() {
+    style = mock(Style.class);
+    when(style.getLayers()).thenReturn(Collections.emptyList());
+  }
 
   @Test
   public void onDraw_routeLineSourceIsSet() throws Exception {
@@ -108,63 +123,68 @@ public class MapRouteLineTest extends BaseTest {
   }
 
   @Test
-  public void onRedraw_routeLineSourceIsSet() throws Exception {
+  public void onStyleLoaded_recreateRouteLine() {
+    TypedArray typedArray = mock(TypedArray.class);
+    Context context = mock(Context.class);
+    when(context.obtainStyledAttributes(anyInt(), any(int[].class))).thenReturn(typedArray);
+
+    LineLayer routeShieldLayer = mock(LineLayer.class);
+    when(routeShieldLayer.getId()).thenReturn(ROUTE_SHIELD_LAYER_ID);
+    LineLayer routeLayer = mock(LineLayer.class);
+    when(routeLayer.getId()).thenReturn(ROUTE_LAYER_ID);
+    SymbolLayer wayPointLayer = mock(SymbolLayer.class);
+    when(wayPointLayer.getId()).thenReturn(WAYPOINT_LAYER_ID);
+    MapRouteLayerProvider mapRouteLayerProvider = mock(MapRouteLayerProvider.class);
+    when(mapRouteLayerProvider.initializeRouteLayer(
+      eq(style), anyBoolean(), anyFloat(), anyFloat(),
+      anyInt(), anyInt(), anyInt(), anyInt(), anyInt(), anyInt()))
+      .thenReturn(routeLayer);
+    when(mapRouteLayerProvider.initializeRouteShieldLayer(
+      eq(style), anyFloat(), anyFloat(), anyInt(), anyInt()
+    )).thenReturn(routeShieldLayer);
+    when(mapRouteLayerProvider.initializeWayPointLayer(
+      eq(style), any(Drawable.class), any(Drawable.class)
+    )).thenReturn(wayPointLayer);
+
+    FeatureCollection routesFeatureCollection = mock(FeatureCollection.class);
+    FeatureCollection waypointsFeatureCollection = mock(FeatureCollection.class);
     GeoJsonSource routeLineSource = mock(GeoJsonSource.class);
     GeoJsonSource wayPointSource = mock(GeoJsonSource.class);
-    List<Layer> routeLayers = buildMockLayers();
-    MapRouteLine routeLine = new MapRouteLine(routeLineSource, wayPointSource, routeLayers);
-    List<DirectionsRoute> routes = new ArrayList<>();
-    routes.add(buildTestDirectionsRoute());
-    ArgumentCaptor<Runnable> runnableFeatures = ArgumentCaptor.forClass(Runnable.class);
-    ArgumentCaptor<Runnable> runnablePrimary = ArgumentCaptor.forClass(Runnable.class);
-    CountDownLatch latchRunnableFeatures = new CountDownLatch(1);
-    CountDownLatch latchRunnablePrimary = new CountDownLatch(1);
-    CountDownLatch latch = new CountDownLatch(1);
-    Handler handlerFeatures = mock(Handler.class);
-    buildFeatureProcessingTask(routes, routeLine, handlerFeatures);
-    Handler handlerPrimary = mock(Handler.class);
-    buildPrimaryRouteUpdateTask(routeLine, handlerPrimary);
+    MapRouteSourceProvider mapRouteSourceProvider = mock(MapRouteSourceProvider.class);
+    when(mapRouteSourceProvider.build(
+      eq(RouteConstants.ROUTE_SOURCE_ID), eq(routesFeatureCollection), any(GeoJsonOptions.class)
+    )).thenReturn(routeLineSource);
+    when(mapRouteSourceProvider.build(
+      eq(RouteConstants.WAYPOINT_SOURCE_ID), eq(waypointsFeatureCollection), any(GeoJsonOptions.class)
+    )).thenReturn(wayPointSource);
 
-    routeLine.redraw(routes, false, 0, true);
-    latchRunnableFeatures.await(25, TimeUnit.MILLISECONDS);
-    verify(handlerFeatures).post(runnableFeatures.capture());
-    runnableFeatures.getValue().run();
-    latchRunnablePrimary.await(25, TimeUnit.MILLISECONDS);
-    verify(handlerPrimary).post(runnablePrimary.capture());
-    runnablePrimary.getValue().run();
+    new MapRouteLine(
+      context,
+      style,
+      10,
+      null,
+      buildDrawableProvider(),
+      mapRouteSourceProvider,
+      mapRouteLayerProvider,
+      routesFeatureCollection,
+      waypointsFeatureCollection,
+      new ArrayList<DirectionsRoute>(),
+      new ArrayList<FeatureCollection>(),
+      new HashMap<LineString, DirectionsRoute>(),
+      0,
+      true,
+      true,
+      mock(Handler.class)
+    );
 
-    latch.await(25, TimeUnit.MILLISECONDS);
-    verify(routeLineSource, times(3)).setGeoJson(any(FeatureCollection.class));
-  }
+    verify(style).addLayer(routeLayer);
+    verify(style).addLayer(routeShieldLayer);
+    verify(style).addLayer(wayPointLayer);
+    verify(style).addSource(routeLineSource);
+    verify(style).addSource(wayPointSource);
 
-  @Test
-  public void onRedraw_wayPointSourceIsSet() throws Exception {
-    GeoJsonSource routeLineSource = mock(GeoJsonSource.class);
-    GeoJsonSource wayPointSource = mock(GeoJsonSource.class);
-    List<Layer> routeLayers = buildMockLayers();
-    MapRouteLine routeLine = new MapRouteLine(routeLineSource, wayPointSource, routeLayers);
-    List<DirectionsRoute> routes = new ArrayList<>();
-    routes.add(buildTestDirectionsRoute());
-    ArgumentCaptor<Runnable> runnableFeatures = ArgumentCaptor.forClass(Runnable.class);
-    ArgumentCaptor<Runnable> runnablePrimary = ArgumentCaptor.forClass(Runnable.class);
-    CountDownLatch latchRunnableFeatures = new CountDownLatch(1);
-    CountDownLatch latchRunnablePrimary = new CountDownLatch(1);
-    CountDownLatch latch = new CountDownLatch(1);
-    Handler handlerFeatures = mock(Handler.class);
-    buildFeatureProcessingTask(routes, routeLine, handlerFeatures);
-    Handler handlerPrimary = mock(Handler.class);
-    buildPrimaryRouteUpdateTask(routeLine, handlerPrimary);
-
-    routeLine.redraw(routes, false, 0, true);
-    latchRunnableFeatures.await(25, TimeUnit.MILLISECONDS);
-    verify(handlerFeatures).post(runnableFeatures.capture());
-    runnableFeatures.getValue().run();
-    latchRunnablePrimary.await(25, TimeUnit.MILLISECONDS);
-    verify(handlerPrimary).post(runnablePrimary.capture());
-    runnablePrimary.getValue().run();
-
-    latch.await(25, TimeUnit.MILLISECONDS);
-    verify(wayPointSource, times(2)).setGeoJson(any(FeatureCollection.class));
+    verify(routeLineSource, times(0)).setGeoJson(any(FeatureCollection.class));
+    verify(wayPointSource, times(0)).setGeoJson(any(FeatureCollection.class));
   }
 
   @Test
@@ -287,15 +307,14 @@ public class MapRouteLineTest extends BaseTest {
     TypedArray typedArray = mock(TypedArray.class);
     when(context.obtainStyledAttributes(anyInt(), eq(R.styleable.NavigationMapRoute))).thenReturn(typedArray);
     when(typedArray.getBoolean(R.styleable.NavigationMapRoute_roundedLineCap, true)).thenReturn(true);
-    MapboxMap mapboxMap = buildMockMap();
-    MapRouteLayerProvider layerProvider = mock(MapRouteLayerProvider.class);
+    MapRouteLayerProvider layerProvider = buildLayerProvider();
     Handler handler = mock(Handler.class);
 
-    new MapRouteLine(context, mapboxMap, R.style.NavigationMapRoute, "",
-      mock(MapRouteDrawableProvider.class), mock(MapRouteSourceProvider.class), layerProvider, handler
+    new MapRouteLine(context, style, R.style.NavigationMapRoute, "",
+      buildDrawableProvider(), mock(MapRouteSourceProvider.class), layerProvider, handler
     );
 
-    verify(layerProvider).initializeRouteLayer(eq(mapboxMap), eq(true), anyFloat(), anyFloat(),
+    verify(layerProvider).initializeRouteLayer(eq(style), eq(true), anyFloat(), anyFloat(),
       anyInt(), anyInt(), anyInt(), anyInt(), anyInt(), anyInt()
     );
   }
@@ -306,15 +325,14 @@ public class MapRouteLineTest extends BaseTest {
     TypedArray typedArray = mock(TypedArray.class);
     when(context.obtainStyledAttributes(anyInt(), eq(R.styleable.NavigationMapRoute))).thenReturn(typedArray);
     when(typedArray.getBoolean(R.styleable.NavigationMapRoute_roundedLineCap, true)).thenReturn(false);
-    MapboxMap mapboxMap = buildMockMap();
-    MapRouteLayerProvider layerProvider = mock(MapRouteLayerProvider.class);
+    MapRouteLayerProvider layerProvider = buildLayerProvider();
     Handler handler = mock(Handler.class);
 
-    new MapRouteLine(context, mapboxMap, R.style.NavigationMapRoute, "",
-      mock(MapRouteDrawableProvider.class), mock(MapRouteSourceProvider.class), layerProvider, handler
+    new MapRouteLine(context, style, R.style.NavigationMapRoute, "",
+      buildDrawableProvider(), mock(MapRouteSourceProvider.class), layerProvider, handler
     );
 
-    verify(layerProvider).initializeRouteLayer(eq(mapboxMap), eq(false), anyFloat(), anyFloat(),
+    verify(layerProvider).initializeRouteLayer(eq(style), eq(false), anyFloat(), anyFloat(),
       anyInt(), anyInt(), anyInt(), anyInt(), anyInt(), anyInt()
     );
   }
@@ -331,13 +349,33 @@ public class MapRouteLineTest extends BaseTest {
     return routeLayers;
   }
 
-  @NotNull
-  private MapboxMap buildMockMap() {
-    Style style = mock(Style.class);
-    when(style.getLayers()).thenReturn(Collections.emptyList());
-    MapboxMap mapboxMap = mock(MapboxMap.class);
-    when(mapboxMap.getStyle()).thenReturn(style);
-    return mapboxMap;
+  private MapRouteLayerProvider buildLayerProvider() {
+    LineLayer routeShieldLayer = mock(LineLayer.class);
+    when(routeShieldLayer.getId()).thenReturn(ROUTE_SHIELD_LAYER_ID);
+    LineLayer routeLayer = mock(LineLayer.class);
+    when(routeLayer.getId()).thenReturn(ROUTE_LAYER_ID);
+    SymbolLayer wayPointLayer = mock(SymbolLayer.class);
+    when(wayPointLayer.getId()).thenReturn(WAYPOINT_LAYER_ID);
+    MapRouteLayerProvider mapRouteLayerProvider = mock(MapRouteLayerProvider.class);
+    when(mapRouteLayerProvider.initializeRouteLayer(
+      eq(style), anyBoolean(), anyFloat(), anyFloat(),
+      anyInt(), anyInt(), anyInt(), anyInt(), anyInt(), anyInt()))
+      .thenReturn(routeLayer);
+    when(mapRouteLayerProvider.initializeRouteShieldLayer(
+      eq(style), anyFloat(), anyFloat(), anyInt(), anyInt()
+    )).thenReturn(routeShieldLayer);
+    when(mapRouteLayerProvider.initializeWayPointLayer(
+      eq(style), any(Drawable.class), any(Drawable.class)
+    )).thenReturn(wayPointLayer);
+
+    return mapRouteLayerProvider;
+  }
+
+  private MapRouteDrawableProvider buildDrawableProvider() {
+    Drawable drawable = mock(Drawable.class);
+    MapRouteDrawableProvider mapRouteDrawableProvider = mock(MapRouteDrawableProvider.class);
+    when(mapRouteDrawableProvider.retrieveDrawable(anyInt())).thenReturn(drawable);
+    return mapRouteDrawableProvider;
   }
 
   private FeatureProcessingTask buildFeatureProcessingTask(List<DirectionsRoute> routes, MapRouteLine routeLine, Handler handler) {


### PR DESCRIPTION
This PR fixes https://github.com/mapbox/mapbox-navigation-android/issues/2039 by caching the currently drawn routes/waypoints and reusing those same geometries immediately when the new style is loaded.

![ezgif com-video-to-gif (7)](https://user-images.githubusercontent.com/16925074/68878329-cf29a580-0707-11ea-83d1-81a9beb9cceb.gif)

As you can see, the transitions are smooth, **besides the first style change after `NavigationMapRoute` creation**. @pozdnyakov and I are looking into the root cause.