### PR TITLE
Apply android-sdk-versions-plugin to Navigation SDK modules

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ buildscript {
     classpath pluginDependencies.googleServices
     classpath pluginDependencies.crashlytics
     classpath pluginDependencies.license
+    classpath pluginDependencies.mapboxSdkVersions
   }
 }
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,158 +1,160 @@
 ext {
 
-  androidVersions = [
-      minSdkVersion    : 14,
-      targetSdkVersion : 28,
-      compileSdkVersion: 28,
-      buildToolsVersion: '28.0.3'
-  ]
+    androidVersions = [
+            minSdkVersion    : 14,
+            targetSdkVersion : 28,
+            compileSdkVersion: 28,
+            buildToolsVersion: '28.0.3'
+    ]
 
-  version = [
-      mapboxMapSdk             : '8.2.1',
-      mapboxSdkServices        : '4.9.0',
-      mapboxEvents             : '4.5.1',
-      mapboxCore               : '1.3.0',
-      mapboxNavigator          : 'ms-update-valhalla-multi-threaded-graphreader-SNAPSHOT-1',
-      mapboxCrashMonitor       : '2.0.0',
-      mapboxAnnotationPlugin   : '0.7.0',
-      mapboxSearchSdk          : '0.1.0-SNAPSHOT',
-      autoValue                : '1.5.4',
-      autoValueParcel          : '0.2.5',
-      junit                    : '4.12',
-      supportLibVersion        : '1.0.0',
-      supportAnnotationsVersion: '1.1.0',
-      constraintLayout         : '1.1.3',
-      mockito                  : '2.23.4',
-      mockkVersion             : '1.9.3',
-      hamcrest                 : '2.0.0.0',
-      errorprone               : '2.3.1',
-      butterknife              : '10.1.0',
-      leakCanaryVersion        : '1.6.3',
-      timber                   : '4.7.1',
-      testRunnerVersion        : '1.1.0',
-      espressoVersion          : '3.1.0',
-      spoonRunner              : '1.6.2',
-      commonsIO                : '2.6',
-      robolectric              : '4.1',
-      lifecycle                : '2.0.0-rc01',
-      picasso                  : '2.71828',
-      gmsLocation              : '16.0.0',
-      ktlint                   : '0.34.2',
-      kotlinStdLib             : '1.3.50',
-      ankoCommon               : '0.10.0',
-      firebaseCore             : '16.0.7',
-      crashlytics              : '2.9.9',
-      multidex                 : '2.0.0',
-      json                     : '20180813'
-  ]
+    version = [
+            mapboxMapSdk             : '8.2.1',
+            mapboxSdkServices        : '4.9.0',
+            mapboxEvents             : '4.5.1',
+            mapboxCore               : '1.3.0',
+            mapboxNavigator          : 'ms-update-valhalla-multi-threaded-graphreader-SNAPSHOT-1',
+            mapboxCrashMonitor       : '2.0.0',
+            mapboxAnnotationPlugin   : '0.7.0',
+            mapboxSearchSdk          : '0.1.0-SNAPSHOT',
+            autoValue                : '1.5.4',
+            autoValueParcel          : '0.2.5',
+            junit                    : '4.12',
+            supportLibVersion        : '1.0.0',
+            supportAnnotationsVersion: '1.1.0',
+            constraintLayout         : '1.1.3',
+            mockito                  : '2.23.4',
+            mockkVersion             : '1.9.3',
+            hamcrest                 : '2.0.0.0',
+            errorprone               : '2.3.1',
+            butterknife              : '10.1.0',
+            leakCanaryVersion        : '1.6.3',
+            timber                   : '4.7.1',
+            testRunnerVersion        : '1.1.0',
+            espressoVersion          : '3.1.0',
+            spoonRunner              : '1.6.2',
+            commonsIO                : '2.6',
+            robolectric              : '4.1',
+            lifecycle                : '2.0.0-rc01',
+            picasso                  : '2.71828',
+            gmsLocation              : '16.0.0',
+            ktlint                   : '0.34.2',
+            kotlinStdLib             : '1.3.50',
+            ankoCommon               : '0.10.0',
+            firebaseCore             : '16.0.7',
+            crashlytics              : '2.9.9',
+            multidex                 : '2.0.0',
+            json                     : '20180813'
+    ]
 
-  dependenciesList = [
-      // mapbox
-      mapboxMapSdk           : "com.mapbox.mapboxsdk:mapbox-android-sdk:${version.mapboxMapSdk}",
-      mapboxSdkServices      : "com.mapbox.mapboxsdk:mapbox-sdk-services:${version.mapboxSdkServices}",
-      mapboxSdkGeoJSON      : "com.mapbox.mapboxsdk:mapbox-sdk-geojson:${version.mapboxSdkServices}",
-      mapboxSdkTurf          : "com.mapbox.mapboxsdk:mapbox-sdk-turf:${version.mapboxSdkServices}",
-      mapboxEvents           : "com.mapbox.mapboxsdk:mapbox-android-telemetry:${version.mapboxEvents}",
-      mapboxCore             : "com.mapbox.mapboxsdk:mapbox-android-core:${version.mapboxCore}",
-      mapboxNavigator        : "com.mapbox.navigator:mapbox-navigation-native:${version.mapboxNavigator}",
-      mapboxAnnotationPlugin : "com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v8:${version.mapboxAnnotationPlugin}",
-      mapboxSearchSdk        : "com.mapbox.mapboxsdk:mapbox-search-android:${version.mapboxSearchSdk}",
-      mapboxCrashMonitor     : "com.mapbox.crashmonitor:mapbox-crash-monitor-native:${version.mapboxCrashMonitor}",
+    dependenciesList = [
+            // mapbox
+            mapboxMapSdk           : "com.mapbox.mapboxsdk:mapbox-android-sdk:${version.mapboxMapSdk}",
+            mapboxSdkServices      : "com.mapbox.mapboxsdk:mapbox-sdk-services:${version.mapboxSdkServices}",
+            mapboxSdkGeoJSON       : "com.mapbox.mapboxsdk:mapbox-sdk-geojson:${version.mapboxSdkServices}",
+            mapboxSdkTurf          : "com.mapbox.mapboxsdk:mapbox-sdk-turf:${version.mapboxSdkServices}",
+            mapboxEvents           : "com.mapbox.mapboxsdk:mapbox-android-telemetry:${version.mapboxEvents}",
+            mapboxCore             : "com.mapbox.mapboxsdk:mapbox-android-core:${version.mapboxCore}",
+            mapboxNavigator        : "com.mapbox.navigator:mapbox-navigation-native:${version.mapboxNavigator}",
+            mapboxAnnotationPlugin : "com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v8:${version.mapboxAnnotationPlugin}",
+            mapboxSearchSdk        : "com.mapbox.mapboxsdk:mapbox-search-android:${version.mapboxSearchSdk}",
+            mapboxCrashMonitor     : "com.mapbox.crashmonitor:mapbox-crash-monitor-native:${version.mapboxCrashMonitor}",
 
-      // Kotlin
-      kotlinStdLib           : "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${version.kotlinStdLib}",
-      ankoCommon             : "org.jetbrains.anko:anko-common:${version.ankoCommon}",
+            // Kotlin
+            kotlinStdLib           : "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${version.kotlinStdLib}",
+            ankoCommon             : "org.jetbrains.anko:anko-common:${version.ankoCommon}",
 
-      // code style
-      ktlint                 : "com.pinterest:ktlint:${version.ktlint}",
+            // code style
+            ktlint                 : "com.pinterest:ktlint:${version.ktlint}",
 
-      // AutoValue
-      autoValue              : "com.google.auto.value:auto-value:${version.autoValue}",
-      autoValuesParcel       : "com.ryanharter.auto.value:auto-value-parcel:${version.autoValueParcel}",
-      autoValuesParcelAdapter: "com.ryanharter.auto.value:auto-value-parcel-adapter:${version.autoValueParcel}",
+            // AutoValue
+            autoValue              : "com.google.auto.value:auto-value:${version.autoValue}",
+            autoValuesParcel       : "com.ryanharter.auto.value:auto-value-parcel:${version.autoValueParcel}",
+            autoValuesParcelAdapter: "com.ryanharter.auto.value:auto-value-parcel-adapter:${version.autoValueParcel}",
 
-      // butterknife
-      butterKnife            : "com.jakewharton:butterknife:${version.butterknife}",
-      butterKnifeProcessor   : "com.jakewharton:butterknife-compiler:${version.butterknife}",
+            // butterknife
+            butterKnife            : "com.jakewharton:butterknife:${version.butterknife}",
+            butterKnifeProcessor   : "com.jakewharton:butterknife-compiler:${version.butterknife}",
 
-      // support
-      supportAnnotation      : "androidx.annotation:annotation:${version.supportAnnotationsVersion}",
-      supportAppcompatV7     : "androidx.appcompat:appcompat:${version.supportLibVersion}",
-      supportV4              : "androidx.legacy:legacy-support-v4:${version.supportLibVersion}",
-      supportDesign          : "com.google.android.material:material:${version.supportLibVersion}",
-      supportRecyclerView    : "androidx.recyclerview:recyclerview:${version.supportLibVersion}",
-      supportCardView        : "androidx.cardview:cardview:${version.supportLibVersion}",
-      supportConstraintLayout: "androidx.constraintlayout:constraintlayout:${version.constraintLayout}",
+            // support
+            supportAnnotation      : "androidx.annotation:annotation:${version.supportAnnotationsVersion}",
+            supportAppcompatV7     : "androidx.appcompat:appcompat:${version.supportLibVersion}",
+            supportV4              : "androidx.legacy:legacy-support-v4:${version.supportLibVersion}",
+            supportDesign          : "com.google.android.material:material:${version.supportLibVersion}",
+            supportRecyclerView    : "androidx.recyclerview:recyclerview:${version.supportLibVersion}",
+            supportCardView        : "androidx.cardview:cardview:${version.supportLibVersion}",
+            supportConstraintLayout: "androidx.constraintlayout:constraintlayout:${version.constraintLayout}",
 
-      // architecture
-      lifecycleExtensions    : "androidx.lifecycle:lifecycle-extensions:${version.lifecycle}",
-      lifecycleCompiler      : "androidx.lifecycle:lifecycle-compiler:${version.lifecycle}",
+            // architecture
+            lifecycleExtensions    : "androidx.lifecycle:lifecycle-extensions:${version.lifecycle}",
+            lifecycleCompiler      : "androidx.lifecycle:lifecycle-compiler:${version.lifecycle}",
 
-      // square crew
-      timber                 : "com.jakewharton.timber:timber:${version.timber}",
-      picasso                : "com.squareup.picasso:picasso:${version.picasso}",
-      leakCanaryDebug        : "com.squareup.leakcanary:leakcanary-android:${version.leakCanaryVersion}",
-      leakCanaryRelease      : "com.squareup.leakcanary:leakcanary-android-no-op:${version.leakCanaryVersion}",
-      leakCanaryTest         : "com.squareup.leakcanary:leakcanary-android-no-op:${version.leakCanaryVersion}",
+            // square crew
+            timber                 : "com.jakewharton.timber:timber:${version.timber}",
+            picasso                : "com.squareup.picasso:picasso:${version.picasso}",
+            leakCanaryDebug        : "com.squareup.leakcanary:leakcanary-android:${version.leakCanaryVersion}",
+            leakCanaryRelease      : "com.squareup.leakcanary:leakcanary-android-no-op:${version.leakCanaryVersion}",
+            leakCanaryTest         : "com.squareup.leakcanary:leakcanary-android-no-op:${version.leakCanaryVersion}",
 
-      // instrumentation test
-      testSpoonRunner        : "com.squareup.spoon:spoon-client:${version.spoonRunner}",
-      testRunner             : "androidx.test:runner:${version.testRunnerVersion}",
-      testRules              : "androidx.test:rules:${version.testRunnerVersion}",
-      testEspressoCore       : "androidx.test.espresso:espresso-core:${version.espressoVersion}",
-      testEspressoContrib    : "androidx.test.espresso:espresso-contrib:${version.espressoVersion}",
-      testEspressoIntents    : "androidx.test.espresso:espresso-intents:${version.espressoVersion}",
+            // instrumentation test
+            testSpoonRunner        : "com.squareup.spoon:spoon-client:${version.spoonRunner}",
+            testRunner             : "androidx.test:runner:${version.testRunnerVersion}",
+            testRules              : "androidx.test:rules:${version.testRunnerVersion}",
+            testEspressoCore       : "androidx.test.espresso:espresso-core:${version.espressoVersion}",
+            testEspressoContrib    : "androidx.test.espresso:espresso-contrib:${version.espressoVersion}",
+            testEspressoIntents    : "androidx.test.espresso:espresso-intents:${version.espressoVersion}",
 
-      // unit test
-      junit                  : "junit:junit:${version.junit}",
-      mockito                : "org.mockito:mockito-core:${version.mockito}",
-      mockk                  : "io.mockk:mockk:${version.mockkVersion}",
-      hamcrest               : "org.hamcrest:hamcrest-junit:${version.hamcrest}",
-      commonsIO              : "commons-io:commons-io:${version.commonsIO}",
-      robolectric            : "org.robolectric:robolectric:${version.robolectric}",
-      json                   : "org.json:json:${version.json}",
+            // unit test
+            junit                  : "junit:junit:${version.junit}",
+            mockito                : "org.mockito:mockito-core:${version.mockito}",
+            mockk                  : "io.mockk:mockk:${version.mockkVersion}",
+            hamcrest               : "org.hamcrest:hamcrest-junit:${version.hamcrest}",
+            commonsIO              : "commons-io:commons-io:${version.commonsIO}",
+            robolectric            : "org.robolectric:robolectric:${version.robolectric}",
+            json                   : "org.json:json:${version.json}",
 
-      // play services
-      gmsLocation            : "com.google.android.gms:play-services-location:${version.gmsLocation}",
+            // play services
+            gmsLocation            : "com.google.android.gms:play-services-location:${version.gmsLocation}",
 
-      firebaseCore           : "com.google.firebase:firebase-core:${version.firebaseCore}",
-      crashlytics            : "com.crashlytics.sdk.android:crashlytics:${version.crashlytics}",
+            firebaseCore           : "com.google.firebase:firebase-core:${version.firebaseCore}",
+            crashlytics            : "com.crashlytics.sdk.android:crashlytics:${version.crashlytics}",
 
-      multidex               : "androidx.multidex:multidex:${version.multidex}",
+            multidex               : "androidx.multidex:multidex:${version.multidex}",
 
-      errorprone             : "com.google.errorprone:error_prone_core:${version.errorprone}"
-  ]
+            errorprone             : "com.google.errorprone:error_prone_core:${version.errorprone}"
+    ]
 
-  pluginVersion = [
-      checkstyle       : '8.2',
-      pmd              : '5.8.1',
-      errorprone       : '0.0.13',
-      coveralls        : '2.8.1',
-      spotbugs         : '1.3',
-      gradle           : '3.5.1',
-      dependencyGraph  : '0.3.0',
-      dependencyUpdates: '0.20.0',
-      kotlin           : '1.3.50',
-      license          : '0.8.5',
-      jacoco           : '0.8.2',
-      playPublisher    : '1.2.2',
-      googleServices   : '4.2.0',
-      crashlytics      : '1.26.1'
-  ]
+    pluginVersion = [
+            checkstyle       : '8.2',
+            pmd              : '5.8.1',
+            errorprone       : '0.0.13',
+            coveralls        : '2.8.1',
+            spotbugs         : '1.3',
+            gradle           : '3.5.1',
+            dependencyGraph  : '0.3.0',
+            dependencyUpdates: '0.20.0',
+            kotlin           : '1.3.50',
+            license          : '0.8.5',
+            jacoco           : '0.8.2',
+            playPublisher    : '1.2.2',
+            googleServices   : '4.2.0',
+            crashlytics      : '1.26.1',
+            mapboxSdkVersions: '0.1.3'
+    ]
 
-  pluginDependencies = [
-      gradle           : "com.android.tools.build:gradle:${pluginVersion.gradle}",
-      kotlin           : "org.jetbrains.kotlin:kotlin-gradle-plugin:${pluginVersion.kotlin}",
-      checkstyle       : "com.puppycrawl.tools:checkstyle:${pluginVersion.checkstyle}",
-      license          : "com.jaredsburrows:gradle-license-plugin:${pluginVersion.license}",
-      spotbugs         : "gradle.plugin.com.github.spotbugs:gradlePlugin:${pluginVersion.spotbugs}",
-      coveralls        : "org.kt3k.gradle.plugin:coveralls-gradle-plugin:${pluginVersion.coveralls}",
-      errorprone       : "net.ltgt.gradle:gradle-errorprone-plugin:${pluginVersion.errorprone}",
-      dependencyGraph  : "com.vanniktech:gradle-dependency-graph-generator-plugin:${pluginVersion.dependencyGraph}",
-      dependencyUpdates: "com.github.ben-manes:gradle-versions-plugin:${pluginVersion.dependencyUpdates}",
-      jacoco           : "com.github.ben-manes:gradle-versions-plugin:${pluginVersion.jacoco}",
-      playPublisher    : "com.github.triplet.gradle:play-publisher:${pluginVersion.playPublisher}",
-      googleServices   : "com.google.gms:google-services:${pluginVersion.googleServices}",
-      crashlytics      : "io.fabric.tools:gradle:${pluginVersion.crashlytics}"
-  ]
+    pluginDependencies = [
+            gradle           : "com.android.tools.build:gradle:${pluginVersion.gradle}",
+            kotlin           : "org.jetbrains.kotlin:kotlin-gradle-plugin:${pluginVersion.kotlin}",
+            checkstyle       : "com.puppycrawl.tools:checkstyle:${pluginVersion.checkstyle}",
+            license          : "com.jaredsburrows:gradle-license-plugin:${pluginVersion.license}",
+            spotbugs         : "gradle.plugin.com.github.spotbugs:gradlePlugin:${pluginVersion.spotbugs}",
+            coveralls        : "org.kt3k.gradle.plugin:coveralls-gradle-plugin:${pluginVersion.coveralls}",
+            errorprone       : "net.ltgt.gradle:gradle-errorprone-plugin:${pluginVersion.errorprone}",
+            dependencyGraph  : "com.vanniktech:gradle-dependency-graph-generator-plugin:${pluginVersion.dependencyGraph}",
+            dependencyUpdates: "com.github.ben-manes:gradle-versions-plugin:${pluginVersion.dependencyUpdates}",
+            jacoco           : "com.github.ben-manes:gradle-versions-plugin:${pluginVersion.jacoco}",
+            playPublisher    : "com.github.triplet.gradle:play-publisher:${pluginVersion.playPublisher}",
+            googleServices   : "com.google.gms:google-services:${pluginVersion.googleServices}",
+            crashlytics      : "io.fabric.tools:gradle:${pluginVersion.crashlytics}",
+            mapboxSdkVersions: "com.mapbox.mapboxsdk:mapbox-android-sdk-versions:${pluginVersion.mapboxSdkVersions}"
+    ]
 }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,160 +1,160 @@
 ext {
 
-    androidVersions = [
-            minSdkVersion    : 14,
-            targetSdkVersion : 28,
-            compileSdkVersion: 28,
-            buildToolsVersion: '28.0.3'
-    ]
+  androidVersions = [
+      minSdkVersion    : 14,
+      targetSdkVersion : 28,
+      compileSdkVersion: 28,
+      buildToolsVersion: '28.0.3'
+  ]
 
-    version = [
-            mapboxMapSdk             : '8.2.1',
-            mapboxSdkServices        : '4.9.0',
-            mapboxEvents             : '4.5.1',
-            mapboxCore               : '1.3.0',
-            mapboxNavigator          : 'ms-update-valhalla-multi-threaded-graphreader-SNAPSHOT-1',
-            mapboxCrashMonitor       : '2.0.0',
-            mapboxAnnotationPlugin   : '0.7.0',
-            mapboxSearchSdk          : '0.1.0-SNAPSHOT',
-            autoValue                : '1.5.4',
-            autoValueParcel          : '0.2.5',
-            junit                    : '4.12',
-            supportLibVersion        : '1.0.0',
-            supportAnnotationsVersion: '1.1.0',
-            constraintLayout         : '1.1.3',
-            mockito                  : '2.23.4',
-            mockkVersion             : '1.9.3',
-            hamcrest                 : '2.0.0.0',
-            errorprone               : '2.3.1',
-            butterknife              : '10.1.0',
-            leakCanaryVersion        : '1.6.3',
-            timber                   : '4.7.1',
-            testRunnerVersion        : '1.1.0',
-            espressoVersion          : '3.1.0',
-            spoonRunner              : '1.6.2',
-            commonsIO                : '2.6',
-            robolectric              : '4.1',
-            lifecycle                : '2.0.0-rc01',
-            picasso                  : '2.71828',
-            gmsLocation              : '16.0.0',
-            ktlint                   : '0.34.2',
-            kotlinStdLib             : '1.3.50',
-            ankoCommon               : '0.10.0',
-            firebaseCore             : '16.0.7',
-            crashlytics              : '2.9.9',
-            multidex                 : '2.0.0',
-            json                     : '20180813'
-    ]
+  version = [
+      mapboxMapSdk             : '8.2.1',
+      mapboxSdkServices        : '4.9.0',
+      mapboxEvents             : '4.5.1',
+      mapboxCore               : '1.3.0',
+      mapboxNavigator          : 'ms-update-valhalla-multi-threaded-graphreader-SNAPSHOT-1',
+      mapboxCrashMonitor       : '2.0.0',
+      mapboxAnnotationPlugin   : '0.7.0',
+      mapboxSearchSdk          : '0.1.0-SNAPSHOT',
+      autoValue                : '1.5.4',
+      autoValueParcel          : '0.2.5',
+      junit                    : '4.12',
+      supportLibVersion        : '1.0.0',
+      supportAnnotationsVersion: '1.1.0',
+      constraintLayout         : '1.1.3',
+      mockito                  : '2.23.4',
+      mockkVersion             : '1.9.3',
+      hamcrest                 : '2.0.0.0',
+      errorprone               : '2.3.1',
+      butterknife              : '10.1.0',
+      leakCanaryVersion        : '1.6.3',
+      timber                   : '4.7.1',
+      testRunnerVersion        : '1.1.0',
+      espressoVersion          : '3.1.0',
+      spoonRunner              : '1.6.2',
+      commonsIO                : '2.6',
+      robolectric              : '4.1',
+      lifecycle                : '2.0.0-rc01',
+      picasso                  : '2.71828',
+      gmsLocation              : '16.0.0',
+      ktlint                   : '0.34.2',
+      kotlinStdLib             : '1.3.50',
+      ankoCommon               : '0.10.0',
+      firebaseCore             : '16.0.7',
+      crashlytics              : '2.9.9',
+      multidex                 : '2.0.0',
+      json                     : '20180813'
+  ]
 
-    dependenciesList = [
-            // mapbox
-            mapboxMapSdk           : "com.mapbox.mapboxsdk:mapbox-android-sdk:${version.mapboxMapSdk}",
-            mapboxSdkServices      : "com.mapbox.mapboxsdk:mapbox-sdk-services:${version.mapboxSdkServices}",
-            mapboxSdkGeoJSON       : "com.mapbox.mapboxsdk:mapbox-sdk-geojson:${version.mapboxSdkServices}",
-            mapboxSdkTurf          : "com.mapbox.mapboxsdk:mapbox-sdk-turf:${version.mapboxSdkServices}",
-            mapboxEvents           : "com.mapbox.mapboxsdk:mapbox-android-telemetry:${version.mapboxEvents}",
-            mapboxCore             : "com.mapbox.mapboxsdk:mapbox-android-core:${version.mapboxCore}",
-            mapboxNavigator        : "com.mapbox.navigator:mapbox-navigation-native:${version.mapboxNavigator}",
-            mapboxAnnotationPlugin : "com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v8:${version.mapboxAnnotationPlugin}",
-            mapboxSearchSdk        : "com.mapbox.mapboxsdk:mapbox-search-android:${version.mapboxSearchSdk}",
-            mapboxCrashMonitor     : "com.mapbox.crashmonitor:mapbox-crash-monitor-native:${version.mapboxCrashMonitor}",
+  dependenciesList = [
+      // mapbox
+      mapboxMapSdk           : "com.mapbox.mapboxsdk:mapbox-android-sdk:${version.mapboxMapSdk}",
+      mapboxSdkServices      : "com.mapbox.mapboxsdk:mapbox-sdk-services:${version.mapboxSdkServices}",
+      mapboxSdkGeoJSON      : "com.mapbox.mapboxsdk:mapbox-sdk-geojson:${version.mapboxSdkServices}",
+      mapboxSdkTurf          : "com.mapbox.mapboxsdk:mapbox-sdk-turf:${version.mapboxSdkServices}",
+      mapboxEvents           : "com.mapbox.mapboxsdk:mapbox-android-telemetry:${version.mapboxEvents}",
+      mapboxCore             : "com.mapbox.mapboxsdk:mapbox-android-core:${version.mapboxCore}",
+      mapboxNavigator        : "com.mapbox.navigator:mapbox-navigation-native:${version.mapboxNavigator}",
+      mapboxAnnotationPlugin : "com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v8:${version.mapboxAnnotationPlugin}",
+      mapboxSearchSdk        : "com.mapbox.mapboxsdk:mapbox-search-android:${version.mapboxSearchSdk}",
+      mapboxCrashMonitor     : "com.mapbox.crashmonitor:mapbox-crash-monitor-native:${version.mapboxCrashMonitor}",
 
-            // Kotlin
-            kotlinStdLib           : "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${version.kotlinStdLib}",
-            ankoCommon             : "org.jetbrains.anko:anko-common:${version.ankoCommon}",
+      // Kotlin
+      kotlinStdLib           : "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${version.kotlinStdLib}",
+      ankoCommon             : "org.jetbrains.anko:anko-common:${version.ankoCommon}",
 
-            // code style
-            ktlint                 : "com.pinterest:ktlint:${version.ktlint}",
+      // code style
+      ktlint                 : "com.pinterest:ktlint:${version.ktlint}",
 
-            // AutoValue
-            autoValue              : "com.google.auto.value:auto-value:${version.autoValue}",
-            autoValuesParcel       : "com.ryanharter.auto.value:auto-value-parcel:${version.autoValueParcel}",
-            autoValuesParcelAdapter: "com.ryanharter.auto.value:auto-value-parcel-adapter:${version.autoValueParcel}",
+      // AutoValue
+      autoValue              : "com.google.auto.value:auto-value:${version.autoValue}",
+      autoValuesParcel       : "com.ryanharter.auto.value:auto-value-parcel:${version.autoValueParcel}",
+      autoValuesParcelAdapter: "com.ryanharter.auto.value:auto-value-parcel-adapter:${version.autoValueParcel}",
 
-            // butterknife
-            butterKnife            : "com.jakewharton:butterknife:${version.butterknife}",
-            butterKnifeProcessor   : "com.jakewharton:butterknife-compiler:${version.butterknife}",
+      // butterknife
+      butterKnife            : "com.jakewharton:butterknife:${version.butterknife}",
+      butterKnifeProcessor   : "com.jakewharton:butterknife-compiler:${version.butterknife}",
 
-            // support
-            supportAnnotation      : "androidx.annotation:annotation:${version.supportAnnotationsVersion}",
-            supportAppcompatV7     : "androidx.appcompat:appcompat:${version.supportLibVersion}",
-            supportV4              : "androidx.legacy:legacy-support-v4:${version.supportLibVersion}",
-            supportDesign          : "com.google.android.material:material:${version.supportLibVersion}",
-            supportRecyclerView    : "androidx.recyclerview:recyclerview:${version.supportLibVersion}",
-            supportCardView        : "androidx.cardview:cardview:${version.supportLibVersion}",
-            supportConstraintLayout: "androidx.constraintlayout:constraintlayout:${version.constraintLayout}",
+      // support
+      supportAnnotation      : "androidx.annotation:annotation:${version.supportAnnotationsVersion}",
+      supportAppcompatV7     : "androidx.appcompat:appcompat:${version.supportLibVersion}",
+      supportV4              : "androidx.legacy:legacy-support-v4:${version.supportLibVersion}",
+      supportDesign          : "com.google.android.material:material:${version.supportLibVersion}",
+      supportRecyclerView    : "androidx.recyclerview:recyclerview:${version.supportLibVersion}",
+      supportCardView        : "androidx.cardview:cardview:${version.supportLibVersion}",
+      supportConstraintLayout: "androidx.constraintlayout:constraintlayout:${version.constraintLayout}",
 
-            // architecture
-            lifecycleExtensions    : "androidx.lifecycle:lifecycle-extensions:${version.lifecycle}",
-            lifecycleCompiler      : "androidx.lifecycle:lifecycle-compiler:${version.lifecycle}",
+      // architecture
+      lifecycleExtensions    : "androidx.lifecycle:lifecycle-extensions:${version.lifecycle}",
+      lifecycleCompiler      : "androidx.lifecycle:lifecycle-compiler:${version.lifecycle}",
 
-            // square crew
-            timber                 : "com.jakewharton.timber:timber:${version.timber}",
-            picasso                : "com.squareup.picasso:picasso:${version.picasso}",
-            leakCanaryDebug        : "com.squareup.leakcanary:leakcanary-android:${version.leakCanaryVersion}",
-            leakCanaryRelease      : "com.squareup.leakcanary:leakcanary-android-no-op:${version.leakCanaryVersion}",
-            leakCanaryTest         : "com.squareup.leakcanary:leakcanary-android-no-op:${version.leakCanaryVersion}",
+      // square crew
+      timber                 : "com.jakewharton.timber:timber:${version.timber}",
+      picasso                : "com.squareup.picasso:picasso:${version.picasso}",
+      leakCanaryDebug        : "com.squareup.leakcanary:leakcanary-android:${version.leakCanaryVersion}",
+      leakCanaryRelease      : "com.squareup.leakcanary:leakcanary-android-no-op:${version.leakCanaryVersion}",
+      leakCanaryTest         : "com.squareup.leakcanary:leakcanary-android-no-op:${version.leakCanaryVersion}",
 
-            // instrumentation test
-            testSpoonRunner        : "com.squareup.spoon:spoon-client:${version.spoonRunner}",
-            testRunner             : "androidx.test:runner:${version.testRunnerVersion}",
-            testRules              : "androidx.test:rules:${version.testRunnerVersion}",
-            testEspressoCore       : "androidx.test.espresso:espresso-core:${version.espressoVersion}",
-            testEspressoContrib    : "androidx.test.espresso:espresso-contrib:${version.espressoVersion}",
-            testEspressoIntents    : "androidx.test.espresso:espresso-intents:${version.espressoVersion}",
+      // instrumentation test
+      testSpoonRunner        : "com.squareup.spoon:spoon-client:${version.spoonRunner}",
+      testRunner             : "androidx.test:runner:${version.testRunnerVersion}",
+      testRules              : "androidx.test:rules:${version.testRunnerVersion}",
+      testEspressoCore       : "androidx.test.espresso:espresso-core:${version.espressoVersion}",
+      testEspressoContrib    : "androidx.test.espresso:espresso-contrib:${version.espressoVersion}",
+      testEspressoIntents    : "androidx.test.espresso:espresso-intents:${version.espressoVersion}",
 
-            // unit test
-            junit                  : "junit:junit:${version.junit}",
-            mockito                : "org.mockito:mockito-core:${version.mockito}",
-            mockk                  : "io.mockk:mockk:${version.mockkVersion}",
-            hamcrest               : "org.hamcrest:hamcrest-junit:${version.hamcrest}",
-            commonsIO              : "commons-io:commons-io:${version.commonsIO}",
-            robolectric            : "org.robolectric:robolectric:${version.robolectric}",
-            json                   : "org.json:json:${version.json}",
+      // unit test
+      junit                  : "junit:junit:${version.junit}",
+      mockito                : "org.mockito:mockito-core:${version.mockito}",
+      mockk                  : "io.mockk:mockk:${version.mockkVersion}",
+      hamcrest               : "org.hamcrest:hamcrest-junit:${version.hamcrest}",
+      commonsIO              : "commons-io:commons-io:${version.commonsIO}",
+      robolectric            : "org.robolectric:robolectric:${version.robolectric}",
+      json                   : "org.json:json:${version.json}",
 
-            // play services
-            gmsLocation            : "com.google.android.gms:play-services-location:${version.gmsLocation}",
+      // play services
+      gmsLocation            : "com.google.android.gms:play-services-location:${version.gmsLocation}",
 
-            firebaseCore           : "com.google.firebase:firebase-core:${version.firebaseCore}",
-            crashlytics            : "com.crashlytics.sdk.android:crashlytics:${version.crashlytics}",
+      firebaseCore           : "com.google.firebase:firebase-core:${version.firebaseCore}",
+      crashlytics            : "com.crashlytics.sdk.android:crashlytics:${version.crashlytics}",
 
-            multidex               : "androidx.multidex:multidex:${version.multidex}",
+      multidex               : "androidx.multidex:multidex:${version.multidex}",
 
-            errorprone             : "com.google.errorprone:error_prone_core:${version.errorprone}"
-    ]
+      errorprone             : "com.google.errorprone:error_prone_core:${version.errorprone}"
+  ]
 
-    pluginVersion = [
-            checkstyle       : '8.2',
-            pmd              : '5.8.1',
-            errorprone       : '0.0.13',
-            coveralls        : '2.8.1',
-            spotbugs         : '1.3',
-            gradle           : '3.5.1',
-            dependencyGraph  : '0.3.0',
-            dependencyUpdates: '0.20.0',
-            kotlin           : '1.3.50',
-            license          : '0.8.5',
-            jacoco           : '0.8.2',
-            playPublisher    : '1.2.2',
-            googleServices   : '4.2.0',
-            crashlytics      : '1.26.1',
-            mapboxSdkVersions: '1.0.0'
-    ]
+  pluginVersion = [
+      checkstyle       : '8.2',
+      pmd              : '5.8.1',
+      errorprone       : '0.0.13',
+      coveralls        : '2.8.1',
+      spotbugs         : '1.3',
+      gradle           : '3.5.1',
+      dependencyGraph  : '0.3.0',
+      dependencyUpdates: '0.20.0',
+      kotlin           : '1.3.50',
+      license          : '0.8.5',
+      jacoco           : '0.8.2',
+      playPublisher    : '1.2.2',
+      googleServices   : '4.2.0',
+      crashlytics      : '1.26.1',
+      mapboxSdkVersions: '1.0.0'
+  ]
 
-    pluginDependencies = [
-            gradle           : "com.android.tools.build:gradle:${pluginVersion.gradle}",
-            kotlin           : "org.jetbrains.kotlin:kotlin-gradle-plugin:${pluginVersion.kotlin}",
-            checkstyle       : "com.puppycrawl.tools:checkstyle:${pluginVersion.checkstyle}",
-            license          : "com.jaredsburrows:gradle-license-plugin:${pluginVersion.license}",
-            spotbugs         : "gradle.plugin.com.github.spotbugs:gradlePlugin:${pluginVersion.spotbugs}",
-            coveralls        : "org.kt3k.gradle.plugin:coveralls-gradle-plugin:${pluginVersion.coveralls}",
-            errorprone       : "net.ltgt.gradle:gradle-errorprone-plugin:${pluginVersion.errorprone}",
-            dependencyGraph  : "com.vanniktech:gradle-dependency-graph-generator-plugin:${pluginVersion.dependencyGraph}",
-            dependencyUpdates: "com.github.ben-manes:gradle-versions-plugin:${pluginVersion.dependencyUpdates}",
-            jacoco           : "com.github.ben-manes:gradle-versions-plugin:${pluginVersion.jacoco}",
-            playPublisher    : "com.github.triplet.gradle:play-publisher:${pluginVersion.playPublisher}",
-            googleServices   : "com.google.gms:google-services:${pluginVersion.googleServices}",
-            crashlytics      : "io.fabric.tools:gradle:${pluginVersion.crashlytics}",
-            mapboxSdkVersions: "com.mapbox.mapboxsdk:mapbox-android-sdk-versions:${pluginVersion.mapboxSdkVersions}"
-    ]
+  pluginDependencies = [
+      gradle           : "com.android.tools.build:gradle:${pluginVersion.gradle}",
+      kotlin           : "org.jetbrains.kotlin:kotlin-gradle-plugin:${pluginVersion.kotlin}",
+      checkstyle       : "com.puppycrawl.tools:checkstyle:${pluginVersion.checkstyle}",
+      license          : "com.jaredsburrows:gradle-license-plugin:${pluginVersion.license}",
+      spotbugs         : "gradle.plugin.com.github.spotbugs:gradlePlugin:${pluginVersion.spotbugs}",
+      coveralls        : "org.kt3k.gradle.plugin:coveralls-gradle-plugin:${pluginVersion.coveralls}",
+      errorprone       : "net.ltgt.gradle:gradle-errorprone-plugin:${pluginVersion.errorprone}",
+      dependencyGraph  : "com.vanniktech:gradle-dependency-graph-generator-plugin:${pluginVersion.dependencyGraph}",
+      dependencyUpdates: "com.github.ben-manes:gradle-versions-plugin:${pluginVersion.dependencyUpdates}",
+      jacoco           : "com.github.ben-manes:gradle-versions-plugin:${pluginVersion.jacoco}",
+      playPublisher    : "com.github.triplet.gradle:play-publisher:${pluginVersion.playPublisher}",
+      googleServices   : "com.google.gms:google-services:${pluginVersion.googleServices}",
+      crashlytics      : "io.fabric.tools:gradle:${pluginVersion.crashlytics}",
+      mapboxSdkVersions: "com.mapbox.mapboxsdk:mapbox-android-sdk-versions:${pluginVersion.mapboxSdkVersions}"
+  ]
 }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -138,7 +138,7 @@ ext {
             playPublisher    : '1.2.2',
             googleServices   : '4.2.0',
             crashlytics      : '1.26.1',
-            mapboxSdkVersions: '0.1.3'
+            mapboxSdkVersions: '1.0.0'
     ]
 
     pluginDependencies = [

--- a/libandroid-navigation-ui/build.gradle
+++ b/libandroid-navigation-ui/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'com.jaredsburrows.license'
+apply plugin: 'com.mapbox.android.sdk.versions'
 apply from: "${rootDir}/gradle/ktlint.gradle"
 
 android {

--- a/libandroid-navigation-ui/src/main/assets/sdk_versions/com.mapbox.services.android.navigation.ui.v5
+++ b/libandroid-navigation-ui/src/main/assets/sdk_versions/com.mapbox.services.android.navigation.ui.v5
@@ -1,0 +1,2 @@
+libandroid-navigation-ui/0.43.0-SNAPSHOT
+v-1

--- a/libandroid-navigation/build.gradle
+++ b/libandroid-navigation/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'com.jaredsburrows.license'
+apply plugin: 'com.mapbox.android.sdk.versions'
 apply from: "${rootDir}/gradle/ktlint.gradle"
 
 android {

--- a/libandroid-navigation/src/main/assets/sdk_versions/com.mapbox.services.android.navigation
+++ b/libandroid-navigation/src/main/assets/sdk_versions/com.mapbox.services.android.navigation
@@ -1,0 +1,2 @@
+libandroid-navigation/0.43.0-SNAPSHOT
+v-1


### PR DESCRIPTION

## Description

This is to apply the plugin that validates and persists SDK version in a file in assets folder.
More context to this is in:
mapbox/mobile-telemetry#452
mapbox/mobile-telemetry#423
https://github.com/mapbox/android-sdk-versions-plugin

- [ ] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal
Validate and Persist SDK Version information as required by the Telemetry SDK.

### Implementation
 Apply preview release version of the plugin to navigation and navigation-ui modules.

## Screenshots or Gifs

Please include all the media files to give some context about what's being implemented or fixed. It's not mandatory to upload screenshots or gifs, but for most of the cases it becomes really handy to get into the scope of the feature / bug being fixed and also it's REALLY useful for UI related PRs ![screenshot gif](link)

## Testing
Verified that the files that are meant to be generated are generated with appropriate information in assets folder

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->