### PR TITLE
Run new modules unit tests on CI

### DIFF
--- a/libdirections-hybrid/build.gradle
+++ b/libdirections-hybrid/build.gradle
@@ -32,3 +32,5 @@ dependencies {
     testImplementation dependenciesList.mockk
     testImplementation dependenciesList.junit
 }
+
+apply from: "${rootDir}/gradle/jacoco.gradle"

--- a/libdirections-offboard/build.gradle
+++ b/libdirections-offboard/build.gradle
@@ -30,3 +30,5 @@ dependencies {
 
     testImplementation dependenciesList.junit
 }
+
+apply from: "${rootDir}/gradle/jacoco.gradle"

--- a/libdirections-onboard/build.gradle
+++ b/libdirections-onboard/build.gradle
@@ -31,3 +31,5 @@ dependencies {
     testImplementation dependenciesList.mockk
     testImplementation dependenciesList.junit
 }
+
+apply from: "${rootDir}/gradle/jacoco.gradle"

--- a/libdirections-session/build.gradle
+++ b/libdirections-session/build.gradle
@@ -31,3 +31,5 @@ dependencies {
     testImplementation dependenciesList.junit
     testImplementation dependenciesList.mockk
 }
+
+apply from: "${rootDir}/gradle/jacoco.gradle"

--- a/libdirections-session/src/test/java/com/mapbox/navigation/directions/session/MapboxDirectionsSessionTest.kt
+++ b/libdirections-session/src/test/java/com/mapbox/navigation/directions/session/MapboxDirectionsSessionTest.kt
@@ -4,7 +4,9 @@ import com.mapbox.geojson.Point
 import com.mapbox.navigation.base.route.DirectionsSession
 import com.mapbox.navigation.base.route.Route
 import com.mapbox.navigation.base.route.Router
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -19,11 +21,15 @@ class MapboxDirectionsSessionTest {
     private val origin: Point = mockk(relaxUnitFun = true)
     private val waypoints: List<Point> = mockk(relaxUnitFun = true)
     private val observer: DirectionsSession.RouteObserver = mockk(relaxUnitFun = true)
+    private val routeCallbackSlot = slot<((route: Route) -> Unit)>()
     private lateinit var routeCallback: ((route: Route) -> Unit)
     private val route: Route = mockk(relaxUnitFun = true)
 
     @Before
     fun setUp() {
+        every { router.getRoute(origin, waypoints, capture(routeCallbackSlot)) } answers {
+            routeCallback = routeCallbackSlot.captured
+        }
         session = MapboxDirectionsSession(router)
         session.setOrigin(origin)
         session.setWaypoints(waypoints)

--- a/liblogger/build.gradle
+++ b/liblogger/build.gradle
@@ -28,3 +28,5 @@ dependencies {
 
     testImplementation dependenciesList.junit
 }
+
+apply from: "${rootDir}/gradle/jacoco.gradle"

--- a/libnavigation-core/build.gradle
+++ b/libnavigation-core/build.gradle
@@ -20,7 +20,7 @@ android {
 }
 
 dependencies {
-    compileOnly(project(':annotations'))
+    implementation(project(':annotations'))
     kapt(project(':annotations-processor'))
 
     api(project(':libnavigation-base'))
@@ -39,3 +39,5 @@ dependencies {
     testImplementation dependenciesList.mockk
     testImplementation dependenciesList.robolectric
 }
+
+apply from: "${rootDir}/gradle/jacoco.gradle"

--- a/libnavigation-metrics/build.gradle
+++ b/libnavigation-metrics/build.gradle
@@ -36,3 +36,5 @@ dependencies {
     testImplementation dependenciesList.junit
     testImplementation dependenciesList.mockk
 }
+
+apply from: "${rootDir}/gradle/jacoco.gradle"

--- a/libtrip-notification/build.gradle
+++ b/libtrip-notification/build.gradle
@@ -28,3 +28,5 @@ dependencies {
 
     testImplementation dependenciesList.junit
 }
+
+apply from: "${rootDir}/gradle/jacoco.gradle"

--- a/libtrip-service/build.gradle
+++ b/libtrip-service/build.gradle
@@ -30,3 +30,5 @@ dependencies {
     testImplementation dependenciesList.junit
     testImplementation dependenciesList.mockk
 }
+
+apply from: "${rootDir}/gradle/jacoco.gradle"

--- a/libtrip-session/build.gradle
+++ b/libtrip-session/build.gradle
@@ -37,3 +37,5 @@ dependencies {
     testImplementation dependenciesList.mockk
     testImplementation dependenciesList.robolectric
 }
+
+apply from: "${rootDir}/gradle/jacoco.gradle"


### PR DESCRIPTION
We should start running unit tests for new modules on CI early to catch regression while we move forward with implementations.