### PR TITLE
Off-route threshold options

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
@@ -14,6 +14,7 @@ import com.mapbox.android.core.location.LocationEngineProvider;
 import com.mapbox.android.core.location.LocationEngineRequest;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.navigator.Navigator;
+import com.mapbox.navigator.NavigatorConfig;
 import com.mapbox.services.android.navigation.v5.location.RawLocationListener;
 import com.mapbox.services.android.navigation.v5.milestone.BannerInstructionMilestone;
 import com.mapbox.services.android.navigation.v5.milestone.Milestone;
@@ -29,6 +30,8 @@ import com.mapbox.services.android.navigation.v5.route.FasterRouteListener;
 import com.mapbox.services.android.navigation.v5.routeprogress.ProgressChangeListener;
 import com.mapbox.services.android.navigation.v5.snap.Snap;
 import com.mapbox.services.android.navigation.v5.utils.ValidationUtils;
+
+import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -879,7 +882,8 @@ public class MapboxNavigation implements ServiceConnection {
    */
   private void initialize() {
     // Initialize event dispatcher and add internal listeners
-    mapboxNavigator = new MapboxNavigator(new Navigator());
+    Navigator navigator = configureNavigator();
+    mapboxNavigator = new MapboxNavigator(navigator);
     navigationEventDispatcher = new NavigationEventDispatcher();
     navigationEngineFactory = new NavigationEngineFactory();
     locationEngine = obtainLocationEngine();
@@ -899,6 +903,17 @@ public class MapboxNavigation implements ServiceConnection {
       throw new IllegalArgumentException(NON_NULL_APPLICATION_CONTEXT_REQUIRED);
     }
     applicationContext = context.getApplicationContext();
+  }
+
+  @NotNull
+  private Navigator configureNavigator() {
+    Navigator navigator = new Navigator();
+    NavigatorConfig navigatorConfig = navigator.getConfig();
+    navigatorConfig.setOffRouteThreshold(options.offRouteThreshold());
+    navigatorConfig.setOffRouteThresholdWhenNearIntersection(options.offRouteThresholdWhenNearIntersection());
+    navigatorConfig.setIntersectionRadiusForOffRouteDetection(options.intersectionRadiusForOffRouteDetection());
+    navigator.setConfig(navigatorConfig);
+    return navigator;
   }
 
   private void initializeTelemetry() {

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationOptions.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationOptions.java
@@ -7,7 +7,10 @@ import com.google.auto.value.AutoValue;
 import com.mapbox.services.android.navigation.R;
 import com.mapbox.services.android.navigation.v5.navigation.notification.NavigationNotification;
 
+import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.NAVIGATION_INTERSECTION_RADIUS_FOR_OFF_ROUTE_DETECTION;
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.NAVIGATION_LOCATION_ENGINE_INTERVAL_LAG;
+import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.NAVIGATION_OFF_ROUTE_THRESHOLD;
+import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.NAVIGATION_OFF_ROUTE_THRESHOLD_WHEN_NEAR_INTERSECTION;
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.ROUNDING_INCREMENT_FIFTY;
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.ROUTE_REFRESH_INTERVAL;
 
@@ -61,6 +64,27 @@ public abstract class MapboxNavigationOptions {
   @ColorRes
   public abstract int defaultNotificationColorId();
 
+  /**
+   * This value indicates the off route threshold.
+   *
+   * @return off route threshold in meters
+   */
+  public abstract float offRouteThreshold();
+
+  /**
+   * This value indicates the off route threshold in meters when near an intersection.
+   *
+   * @return off route threshold in meters when near an intersection
+   */
+  public abstract float offRouteThresholdWhenNearIntersection();
+
+  /**
+   * This value indicates the radius in meters for off route detection near intersection.
+   *
+   * @return radius in meters for off route detection near intersection
+   */
+  public abstract float intersectionRadiusForOffRouteDetection();
+
   public abstract Builder toBuilder();
 
   @AutoValue.Builder
@@ -108,6 +132,32 @@ public abstract class MapboxNavigationOptions {
      */
     public abstract Builder defaultNotificationColorId(@ColorRes int defaultNotificationColorId);
 
+    /**
+     * This sets the off route threshold in meters. If not specified, the threshold is 50 meters by default.
+     *
+     * @param thresholdInMeters the off route threshold in meters to be used
+     * @return this builder for chaining options together
+     */
+    public abstract Builder offRouteThreshold(float thresholdInMeters);
+
+    /**
+     * This sets the off route threshold in meters when near an intersection which is more prone
+     * to inaccurate gps fixes. If not specified, the threshold is 25 meters by default.
+     *
+     * @param thresholdInMeters the off route threshold in meters when near an intersection to be used
+     * @return this builder for chaining options together
+     */
+    public abstract Builder offRouteThresholdWhenNearIntersection(float thresholdInMeters);
+
+    /**
+     * This sets the radius in meters for off route detection near intersection. If not specified,
+     * the radius is 40 meters by default.
+     *
+     * @param radiusInMeters the radius in meters for off route detection near intersection to be used
+     * @return this builder for chaining options together
+     */
+    public abstract Builder intersectionRadiusForOffRouteDetection(float radiusInMeters);
+
     public abstract MapboxNavigationOptions build();
   }
 
@@ -123,6 +173,9 @@ public abstract class MapboxNavigationOptions {
       .roundingIncrement(ROUNDING_INCREMENT_FIFTY)
       .timeFormatType(NavigationTimeFormat.NONE_SPECIFIED)
       .navigationLocationEngineIntervalLagInMilliseconds(NAVIGATION_LOCATION_ENGINE_INTERVAL_LAG)
-      .defaultNotificationColorId(R.color.mapboxNotificationBlue);
+      .defaultNotificationColorId(R.color.mapboxNotificationBlue)
+      .offRouteThreshold(NAVIGATION_OFF_ROUTE_THRESHOLD)
+      .offRouteThresholdWhenNearIntersection(NAVIGATION_OFF_ROUTE_THRESHOLD_WHEN_NEAR_INTERSECTION)
+      .intersectionRadiusForOffRouteDetection(NAVIGATION_INTERSECTION_RADIUS_FOR_OFF_ROUTE_DETECTION);
   }
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationConstants.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationConstants.java
@@ -123,6 +123,12 @@ public final class NavigationConstants {
    */
   static final int NAVIGATION_LOCATION_ENGINE_INTERVAL_LAG = 1500;
 
+  static final float NAVIGATION_OFF_ROUTE_THRESHOLD = 50.0f;
+
+  static final float NAVIGATION_OFF_ROUTE_THRESHOLD_WHEN_NEAR_INTERSECTION = 25.0f;
+
+  static final float NAVIGATION_INTERSECTION_RADIUS_FOR_OFF_ROUTE_DETECTION = 40.0f;
+
   static final long ROUTE_REFRESH_INTERVAL = 5 * 60 * 1000L;
 
   /**


### PR DESCRIPTION
## Description

Exposes `Navigator` off-route threshold options in `MapboxNavigationOptions`

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Make off-route threshold options configurable

### Implementation

Expose `Navigator` off-route threshold options in `MapboxNavigationOptions` and consume it from `MapboxNavigation` when initialized

Have a local branch that adds this changes to `master` (Kotlin). Will cut a separate PR after this gets merged.

## Screenshots or Gifs

_Default values_

```
50.f,                       // offRouteThreshold
25.f,                       // offRouteThresholdWhenNearIntersection
40.f,                       // intersectionRadiusForOffrouteDetection
```

![off_route_threshold_default](https://user-images.githubusercontent.com/1668582/69385469-6ef9ad00-0c8d-11ea-8d83-dd502ebf41ab.gif)

_Custom values_

```
25.f,                       // offRouteThreshold
10.f,                       // offRouteThresholdWhenNearIntersection
20.f,                       // intersectionRadiusForOffrouteDetection
```

![off_route_threshold_25_10_20](https://user-images.githubusercontent.com/1668582/69385492-8b95e500-0c8d-11ea-9be5-ccfe0f28860c.gif)

## Testing

Tested changing the `MapboxNavigationOptions` in [`ComponentNavigationActivity`](https://github.com/mapbox/mapbox-navigation-android/blob/master/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/ComponentNavigationActivity.java) from the test app:

```diff
diff --git a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/ComponentNavigationActivity.java b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/ComponentNavigationActivity.java
index 3bf57178..6e6b7011 100644
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/ComponentNavigationActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/ComponentNavigationActivity.java
@@ -51,6 +51,7 @@ import com.mapbox.services.android.navigation.v5.milestone.Milestone;
 import com.mapbox.services.android.navigation.v5.milestone.MilestoneEventListener;
 import com.mapbox.services.android.navigation.v5.milestone.VoiceInstructionMilestone;
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation;
+import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigationOptions;
 import com.mapbox.services.android.navigation.v5.navigation.NavigationRoute;
 import com.mapbox.services.android.navigation.v5.offroute.OffRouteListener;
 import com.mapbox.services.android.navigation.v5.routeprogress.ProgressChangeListener;
@@ -322,7 +323,12 @@ public class ComponentNavigationActivity extends HistoryActivity implements OnMa
   }
 
   private void initializeNavigation(MapboxMap mapboxMap) {
-    navigation = new MapboxNavigation(this, Mapbox.getAccessToken());
+    MapboxNavigationOptions options = MapboxNavigationOptions.builder()
+        .offRouteThreshold(25.0f)
+        .offRouteThresholdWhenNearIntersection(10.0f)
+        .intersectionRadiusForOffRouteDetection(20.0f)
+        .build();
+    navigation = new MapboxNavigation(this, Mapbox.getAccessToken(), options);
     navigation.setLocationEngine(locationEngine);
     navigation.setCameraEngine(new DynamicCamera(mapboxMap));
     navigation.addProgressChangeListener(this);
```

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR

cc @andrewychen @kevinkreiser @mskurydin 