### PR TITLE
Fix DownloadTask regression and add is completed check to OfflineRegion.OfflineRegionObserver

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/OfflineRegionDownloadActivity.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/OfflineRegionDownloadActivity.kt
@@ -87,6 +87,7 @@ class OfflineRegionDownloadActivity : AppCompatActivity(), RouteTileDownloadList
         }
     }
 
+    private var isDownloadCompleted: Boolean = false
     private val offlineRegionObserver = object : OfflineRegion.OfflineRegionObserver {
         override fun mapboxTileCountLimitExceeded(limit: Long) {
             Timber.e("Mapbox tile count limit exceeded: %s", limit)
@@ -99,7 +100,8 @@ class OfflineRegionDownloadActivity : AppCompatActivity(), RouteTileDownloadList
                 status?.requiredResourceCount,
                 status?.completedResourceSize
             )
-            if (status?.isComplete!!) {
+            if (status?.isComplete == true && !isDownloadCompleted) {
+                isDownloadCompleted = true
                 downloadSelectedRegion()
             }
         }
@@ -340,7 +342,8 @@ class OfflineRegionDownloadActivity : AppCompatActivity(), RouteTileDownloadList
 
     override fun onError(error: OfflineError) {
         setDownloadButtonEnabled(true)
-        showToast("There was an error with the download. Please try again.")
+        isDownloadCompleted = false
+        showToast("There was an error with the download: ${error.message}. Please try again.")
     }
 
     override fun onProgressUpdate(percent: Int) {
@@ -349,6 +352,7 @@ class OfflineRegionDownloadActivity : AppCompatActivity(), RouteTileDownloadList
 
     override fun onCompletion() {
         setDownloadButtonEnabled(true)
+        isDownloadCompleted = false
         showToast("Download complete")
     }
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/OfflineRegionObserver.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/OfflineRegionObserver.java
@@ -7,6 +7,7 @@ import com.mapbox.mapboxsdk.offline.OfflineRegionStatus;
 class OfflineRegionObserver implements OfflineRegion.OfflineRegionObserver {
 
   private final OfflineRegionDownloadCallback callback;
+  private boolean isCompleted = false;
 
   OfflineRegionObserver(OfflineRegionDownloadCallback callback) {
     this.callback = callback;
@@ -14,7 +15,8 @@ class OfflineRegionObserver implements OfflineRegion.OfflineRegionObserver {
 
   @Override
   public void onStatusChanged(OfflineRegionStatus status) {
-    if (status.isComplete()) {
+    if (status.isComplete() && !isCompleted) {
+      isCompleted = true;
       callback.onComplete();
     }
   }


### PR DESCRIPTION
## Description

Fix `DownloadTask` regression https://github.com/mapbox/mapbox-navigation-android/pull/2181 and add `isCompleted` check to `OfflineRegion.OfflineRegionObserver` `onStatusChanged` in `OfflineRegionObserver` and `OfflineRegionDownloadActivity`

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Fix `DownloadTask` that wasn't working anymore. Kotlin conversion https://github.com/mapbox/mapbox-navigation-android/blob/master/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/DownloadTask.kt is not behaving as Java https://github.com/mapbox/mapbox-navigation-android/blob/base-v0.42.1/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/DownloadTask.java one was. Noticed when testing `OfflineRegionDownloadActivity` 👀 

```
Error occurred downloading tiles: null file found
```

Also, noticed that `status.isComplete()` from `OfflineRegion.OfflineRegionObserver#onStatusChanged` was called multiple times so a check was added to prevent calling downstream operations only once.

### Implementation

Fix file read / write implementation and make it more Kotlin idiomatic and add a `isCompleted` flag to `OfflineRegion.OfflineRegionObserver` `onStatusChanged` in `OfflineRegionObserver` and `OfflineRegionDownloadActivity`

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] Cherry-pick into [`base-v0.42.1`](https://github.com/mapbox/mapbox-navigation-android/tree/base-v0.42.1) branch

cc @RingerJK 