### PR TITLE
Off-route threshold options (master)

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
@@ -16,6 +16,7 @@ import com.mapbox.android.core.location.LocationEngineProvider;
 import com.mapbox.android.core.location.LocationEngineRequest;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.navigator.Navigator;
+import com.mapbox.navigator.NavigatorConfig;
 import com.mapbox.services.android.navigation.BuildConfig;
 import com.mapbox.services.android.navigation.v5.internal.navigation.FreeDriveLocationUpdater;
 import com.mapbox.services.android.navigation.v5.internal.navigation.MapboxNavigator;
@@ -1022,7 +1023,7 @@ public class MapboxNavigation implements ServiceConnection {
    * to prevent users from removing it.
    */
   private void initialize() {
-    mapboxNavigator = new MapboxNavigator(new Navigator());
+    mapboxNavigator = new MapboxNavigator(configureNavigator());
     // Initialize event dispatcher and add internal listeners
     navigationEventDispatcher = new NavigationEventDispatcher();
     navigationEventDispatcher.addProgressChangeListener(new ProgressChangeListener() {
@@ -1055,6 +1056,17 @@ public class MapboxNavigation implements ServiceConnection {
       throw new IllegalArgumentException(NON_NULL_APPLICATION_CONTEXT_REQUIRED);
     }
     applicationContext = context.getApplicationContext();
+  }
+
+  @NotNull
+  private Navigator configureNavigator() {
+    Navigator navigator = new Navigator();
+    NavigatorConfig navigatorConfig = navigator.getConfig();
+    navigatorConfig.setOffRouteThreshold(options.getOffRouteThreshold());
+    navigatorConfig.setOffRouteThresholdWhenNearIntersection(options.getOffRouteThresholdWhenNearIntersection());
+    navigatorConfig.setIntersectionRadiusForOffRouteDetection(options.getIntersectionRadiusForOffRouteDetection());
+    navigator.setConfig(navigatorConfig);
+    return navigator;
   }
 
   private void initializeTelemetry(Context context) {

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationOptions.kt
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationOptions.kt
@@ -2,7 +2,10 @@ package com.mapbox.services.android.navigation.v5.navigation
 
 import androidx.annotation.ColorRes
 import com.mapbox.services.android.navigation.R
+import com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.NAVIGATION_INTERSECTION_RADIUS_FOR_OFF_ROUTE_DETECTION
 import com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.NAVIGATION_LOCATION_ENGINE_INTERVAL_LAG
+import com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.NAVIGATION_OFF_ROUTE_THRESHOLD
+import com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.NAVIGATION_OFF_ROUTE_THRESHOLD_WHEN_NEAR_INTERSECTION
 import com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.ROUNDING_INCREMENT_FIFTY
 import com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.ROUTE_REFRESH_INTERVAL
 import com.mapbox.services.android.navigation.v5.navigation.notification.NavigationNotification
@@ -23,6 +26,9 @@ data class MapboxNavigationOptions(
     val timeFormatType: Int,
     val navigationLocationEngineIntervalLagInMilliseconds: Int,
     val defaultNotificationColorId: Int,
+    val offRouteThreshold: Float,
+    val offRouteThresholdWhenNearIntersection: Float,
+    val intersectionRadiusForOffRouteDetection: Float,
     var builder: Builder
 
 ) {
@@ -81,6 +87,11 @@ data class MapboxNavigationOptions(
         var navigationLocationEngineIntervalLagInMilliseconds =
             NAVIGATION_LOCATION_ENGINE_INTERVAL_LAG
         var defaultNotificationColorId = R.color.mapboxNotificationBlue
+        var offRouteThreshold = NAVIGATION_OFF_ROUTE_THRESHOLD
+        var offRouteThresholdWhenNearIntersection =
+            NAVIGATION_OFF_ROUTE_THRESHOLD_WHEN_NEAR_INTERSECTION
+        var intersectionRadiusForOffRouteDetection =
+            NAVIGATION_INTERSECTION_RADIUS_FOR_OFF_ROUTE_DETECTION
 
         fun defaultMilestonesEnabled(defaultMilestonesEnabled: Boolean) =
             apply { this.defaultMilestonesEnabled = defaultMilestonesEnabled }
@@ -138,6 +149,34 @@ data class MapboxNavigationOptions(
         fun defaultNotificationColorId(@ColorRes defaultNotificationColorId: Int) =
             apply { this.defaultNotificationColorId = defaultNotificationColorId }
 
+        /**
+         * This sets the off route threshold in meters. If not specified, the threshold is 50 meters.
+         *
+         * @param thresholdInMeters off route threshold in meters to be used
+         * @return this builder for chaining options together
+         */
+        fun offRouteThreshold(thresholdInMeters: Float) =
+            apply { this.offRouteThreshold = thresholdInMeters }
+
+        /**
+         * This sets the off route threshold in meters when near an intersection which is more prone
+         * to inaccurate gps fixes. If not specified, the threshold is 25 meters.
+         *
+         * @param thresholdInMeters off route threshold in meters when near an intersection to be used
+         * @return this builder for chaining options together
+         */
+        fun offRouteThresholdWhenNearIntersection(thresholdInMeters: Float) =
+            apply { this.offRouteThresholdWhenNearIntersection = thresholdInMeters }
+
+        /**
+         * This sets the radius in meters for off route detection near intersection. If not specified, the radius is 40 meters.
+         *
+         * @param radiusInMeters radius in meters for off route detection near intersection to be used
+         * @return this builder for chaining options together
+         */
+        fun intersectionRadiusForOffRouteDetection(radiusInMeters: Float) =
+            apply { this.intersectionRadiusForOffRouteDetection = radiusInMeters }
+
         fun build(): MapboxNavigationOptions {
             return MapboxNavigationOptions(
                 defaultMilestonesEnabled,
@@ -152,6 +191,9 @@ data class MapboxNavigationOptions(
                 timeFormatType,
                 navigationLocationEngineIntervalLagInMilliseconds,
                 defaultNotificationColorId,
+                offRouteThreshold,
+                offRouteThresholdWhenNearIntersection,
+                intersectionRadiusForOffRouteDetection,
                 this
             )
         }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationConstants.kt
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationConstants.kt
@@ -121,6 +121,22 @@ object NavigationConstants {
      */
     internal const val NAVIGATION_LOCATION_ENGINE_INTERVAL_LAG = 1500
 
+    /**
+     * Default off route threshold in meters
+     */
+    internal const val NAVIGATION_OFF_ROUTE_THRESHOLD = 50.0f
+
+    /**
+     * Default off route threshold in meters when near an intersection which is more prone
+     * to inaccurate gps fixes
+     */
+    internal const val NAVIGATION_OFF_ROUTE_THRESHOLD_WHEN_NEAR_INTERSECTION = 25.0f
+
+    /**
+     * Default radius in meters for off route detection near intersection
+     */
+    internal const val NAVIGATION_INTERSECTION_RADIUS_FOR_OFF_ROUTE_DETECTION = 40.0f
+
     internal const val ROUTE_REFRESH_INTERVAL = 5 * 60 * 1000L
 
     /**


### PR DESCRIPTION
## Description

Exposes `Navigator` off-route threshold options in `MapboxNavigationOptions`

Follow up from https://github.com/mapbox/mapbox-navigation-android/pull/2276#issue-344284927

> Have a local branch that adds this changes to `master` (Kotlin). Will cut a separate PR after this gets merged.

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Make off-route threshold options configurable

### Implementation

Expose `Navigator` off-route threshold options in `MapboxNavigationOptions` and consume it from `MapboxNavigation` when initialized

## Testing

- [x] I have tested changing the `MapboxNavigationOptions` in [`ComponentNavigationActivity`](https://github.com/mapbox/mapbox-navigation-android/blob/master/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/ComponentNavigationActivity.java) from the test app
- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
