### PR TITLE
Bump mapbox-navigation-native version to 7.0.0

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/ComponentNavigationActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/ComponentNavigationActivity.java
@@ -109,6 +109,9 @@ public class ComponentNavigationActivity extends HistoryActivity implements OnMa
   @BindView(R.id.cancelNavigationFab)
   FloatingActionButton cancelNavigationFab;
 
+  @BindView(R.id.sendAnomalyFab)
+  FloatingActionButton sendAnomalyFab;
+
   private final ComponentActivityLocationCallback callback = new ComponentActivityLocationCallback(this);
   private LocationEngine locationEngine;
   private MapboxNavigation navigation;
@@ -202,6 +205,11 @@ public class ComponentNavigationActivity extends HistoryActivity implements OnMa
     addLocationEngineListener();
   }
 
+  @OnClick(R.id.sendAnomalyFab)
+  public void onSendAnomalyClick(FloatingActionButton floatingActionButton) {
+    addEventToHistoryFile("anomaly");
+  }
+
   /*
    * Navigation listeners
    */
@@ -209,6 +217,8 @@ public class ComponentNavigationActivity extends HistoryActivity implements OnMa
   @Override
   public void onProgressChange(Location location, RouteProgress routeProgress) {
     // Cache "snapped" Locations for re-route Directions API requests
+    // TODO This is for testing / debugging purposes
+    Timber.d("DEBUG snapped %s", location.toString());
     updateLocation(location);
 
     // Update InstructionView data from RouteProgress
@@ -217,6 +227,8 @@ public class ComponentNavigationActivity extends HistoryActivity implements OnMa
 
   @Override
   public void onEnhancedLocationUpdate(Location location) {
+    // TODO This is for testing / debugging purposes
+    Timber.d("DEBUG enhanced %s", location.toString());
     checkFirstUpdate(location);
     updateLocation(location);
   }
@@ -334,6 +346,7 @@ public class ComponentNavigationActivity extends HistoryActivity implements OnMa
       new MapboxNavigationOptions.Builder().build(), locationEngine);
     addNavigationForHistory(navigation);
     addLocationEngineListener();
+    sendAnomalyFab.show();
     navigation.setCameraEngine(new DynamicCamera(mapboxMap));
     navigation.addProgressChangeListener(this);
     navigation.addMilestoneEventListener(this);

--- a/app/src/main/res/layout/activity_component_navigation.xml
+++ b/app/src/main/res/layout/activity_component_navigation.xml
@@ -12,7 +12,9 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"/>
+        app:layout_constraintTop_toTopOf="parent"
+        app:mapbox_uiAttribution="false"
+        app:mapbox_uiLogo="false"/>
 
     <com.mapbox.services.android.navigation.ui.v5.instruction.InstructionView
         android:id="@+id/instructionView"
@@ -22,6 +24,19 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"/>
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/sendAnomalyFab"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginLeft="16dp"
+        android:layout_marginBottom="16dp"
+        android:visibility="invisible"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        android:tint="@android:color/background_light"
+        app:srcCompat="@drawable/ic_car" />
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/startNavigationFab"

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -12,7 +12,7 @@ ext {
       mapboxSdkServices         : '4.9.0',
       mapboxEvents              : '4.5.1',
       mapboxCore                : '1.3.0',
-      mapboxNavigator           : 'ms-update-valhalla-multi-threaded-graphreader-SNAPSHOT-1',
+      mapboxNavigator           : '7.0.0',
       mapboxCrashMonitor        : '2.0.0',
       mapboxAnnotationPlugin    : '0.7.0',
       mapboxSearchSdk           : '0.1.0-SNAPSHOT',

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/FreeDriveLocationUpdater.kt
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/FreeDriveLocationUpdater.kt
@@ -42,7 +42,8 @@ internal class FreeDriveLocationUpdater(
             locationEngine.requestLocationUpdates(locationEngineRequest, callback, null)
             future = executorService.scheduleAtFixedRate({
                 if (rawLocation != null) {
-                    val enhancedLocation = getLocation(Date(), 0, rawLocation)
+                    // Pass the same lag as when in active guidance i.e. 1500 ms
+                    val enhancedLocation = getLocation(Date(), 1500, rawLocation)
                     handler.post {
                         navigationEventDispatcher.onEnhancedLocationUpdate(
                             enhancedLocation

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/ConfigureRouterTask.kt
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/ConfigureRouterTask.kt
@@ -17,6 +17,7 @@ internal class ConfigureRouterTask(
             tilePath,
             null,
             null,
+            2, // Two threads for downloading tiles simultaneously
             tileEndpointConfiguration
         )
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
@@ -1037,7 +1037,7 @@ public class MapboxNavigation implements ServiceConnection {
     locationEngineRequest = obtainLocationEngineRequest();
     OfflineNavigator offlineNavigator = new OfflineNavigator(mapboxNavigator.getNavigator(),
             "2019_04_13-00_00_11", "https://api-routing-tiles-staging.tilestream.net",
-            accessToken);
+            accessToken); // TODO Replace with an api-routing-tiles-staging valid one
     freeDriveLocationUpdater = new FreeDriveLocationUpdater(locationEngine, locationEngineRequest,
         navigationEventDispatcher, mapboxNavigator, offlineNavigator,
         Executors.newSingleThreadScheduledExecutor());


### PR DESCRIPTION
## Description

Bumps `mapbox-navigation-native` version to `7.0.0`

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Getting the latest version from `mapboxNavigator` including the new features and bug fixes

### Implementation

- Adds a button to `ComponentNavigationActivity` so we can add "anomaly" events to the history file and location fixes logs (snapped / enhanced)
- Sets same lag in `FreeDriveLocationUpdater` as when in active guidance i.e. 1500 ms
- Hardcodes 2 threads to download tiles simultaneously when configuring the router (`ConfigureRouterTask`)

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR