### PR TITLE
Request electronic horizon during FreeDrive 

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/ComponentNavigationActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/ComponentNavigationActivity.java
@@ -121,6 +121,7 @@ public class ComponentNavigationActivity extends HistoryActivity implements OnMa
   private DirectionsRoute route;
   private Point destination;
   private MapState mapState;
+  private boolean isFreeDriveCameraConfigured = false;
 
   private enum MapState {
     INFO,
@@ -322,6 +323,20 @@ public class ComponentNavigationActivity extends HistoryActivity implements OnMa
   void updateLocation(Location location) {
     lastLocation = location;
     navigationMap.updateLocation(location);
+
+    if (navigation.isFreeDriveEnabled()) {
+      if (!isFreeDriveCameraConfigured) {
+        navigationMap.retrieveMap().getLocationComponent().zoomWhileTracking(DEFAULT_ZOOM);
+        int currentZoom = (int) Math.round(navigationMap.retrieveMap().getCameraPosition().zoom);
+        if (currentZoom == DEFAULT_ZOOM) {
+          isFreeDriveCameraConfigured = true;
+        }
+      } else {
+        if (!navigationMap.retrieveCamera().isTrackingEnabled()) {
+          navigationMap.updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_GPS);
+        }
+      }
+    }
   }
 
   private void initializeSpeechPlayer() {
@@ -410,12 +425,17 @@ public class ComponentNavigationActivity extends HistoryActivity implements OnMa
 
   @NonNull
   private CameraPosition buildCameraPositionFrom(Location location, double bearing) {
+    return buildCameraPositionFrom(location, bearing, DEFAULT_ZOOM);
+  }
+
+  @NonNull
+  private CameraPosition buildCameraPositionFrom(Location location, double bearing, double zoom) {
     return new CameraPosition.Builder()
-      .zoom(DEFAULT_ZOOM)
-      .target(new LatLng(location.getLatitude(), location.getLongitude()))
-      .bearing(bearing)
-      .tilt(DEFAULT_TILT)
-      .build();
+            .zoom(zoom)
+            .target(new LatLng(location.getLatitude(), location.getLongitude()))
+            .bearing(bearing)
+            .tilt(DEFAULT_TILT)
+            .build();
   }
 
   private void adjustMapPaddingForNavigation() {

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/ComponentNavigationActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/ComponentNavigationActivity.java
@@ -88,7 +88,7 @@ public class ComponentNavigationActivity extends HistoryActivity implements OnMa
   private static final String COMPONENT_NAVIGATION_INSTRUCTION_CACHE = "component-navigation-instruction-cache";
   private static final long TEN_MEGABYTE_CACHE_SIZE = 10 * 1024 * 1024;
   private static final int ZERO_PADDING = 0;
-  private static final double DEFAULT_ZOOM = 12.0;
+  private static final double DEFAULT_ZOOM = 18.0;
   private static final double DEFAULT_TILT = 0d;
   private static final double DEFAULT_BEARING = 0d;
   private static final long UPDATE_INTERVAL_IN_MILLISECONDS = 1000;
@@ -121,6 +121,7 @@ public class ComponentNavigationActivity extends HistoryActivity implements OnMa
   private DirectionsRoute route;
   private Point destination;
   private MapState mapState;
+  private boolean isFreeDriveEnabled = false;
   private boolean isFreeDriveCameraConfigured = false;
 
   private enum MapState {
@@ -324,7 +325,7 @@ public class ComponentNavigationActivity extends HistoryActivity implements OnMa
     lastLocation = location;
     navigationMap.updateLocation(location);
 
-    if (navigation.isFreeDriveEnabled()) {
+    if (isFreeDriveEnabled) {
       if (!isFreeDriveCameraConfigured) {
         navigationMap.retrieveMap().getLocationComponent().zoomWhileTracking(DEFAULT_ZOOM);
         int currentZoom = (int) Math.round(navigationMap.retrieveMap().getCameraPosition().zoom);
@@ -431,11 +432,11 @@ public class ComponentNavigationActivity extends HistoryActivity implements OnMa
   @NonNull
   private CameraPosition buildCameraPositionFrom(Location location, double bearing, double zoom) {
     return new CameraPosition.Builder()
-            .zoom(zoom)
-            .target(new LatLng(location.getLatitude(), location.getLongitude()))
-            .bearing(bearing)
-            .tilt(DEFAULT_TILT)
-            .build();
+      .zoom(zoom)
+      .target(new LatLng(location.getLatitude(), location.getLongitude()))
+      .bearing(bearing)
+      .tilt(DEFAULT_TILT)
+      .build();
   }
 
   private void adjustMapPaddingForNavigation() {
@@ -458,6 +459,7 @@ public class ComponentNavigationActivity extends HistoryActivity implements OnMa
   private void removeLocationEngineListener() {
     if (locationEngine != null) {
       navigation.disableFreeDrive();
+      isFreeDriveEnabled = false;
       navigation.removeEnhancedLocationListener(this);
     }
   }
@@ -467,6 +469,7 @@ public class ComponentNavigationActivity extends HistoryActivity implements OnMa
     if (locationEngine != null) {
       navigation.addEnhancedLocationListener(this);
       navigation.enableFreeDrive();
+      isFreeDriveEnabled = true;
     }
   }
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/ElectronicHorizonParams.kt
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/ElectronicHorizonParams.kt
@@ -1,0 +1,13 @@
+package com.mapbox.services.android.navigation.v5.internal.navigation
+
+data class ElectronicHorizonParams @JvmOverloads constructor(
+    val delay: Long = ELECTRONIC_HORIZON_DELAY,
+    val interval: Long = ELECTRONIC_HORIZON_INTERVAL,
+    val locationsCacheSize: Int = LOCATIONS_CACHE_MAX_SIZE
+) {
+    companion object {
+        private const val ELECTRONIC_HORIZON_DELAY = 20_000L
+        private const val ELECTRONIC_HORIZON_INTERVAL = 20_000L
+        private const val LOCATIONS_CACHE_MAX_SIZE = 5
+    }
+}

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/ElectronicHorizonParams.kt
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/ElectronicHorizonParams.kt
@@ -1,13 +1,47 @@
 package com.mapbox.services.android.navigation.v5.internal.navigation
 
-data class ElectronicHorizonParams @JvmOverloads constructor(
-    val delay: Long = ELECTRONIC_HORIZON_DELAY,
-    val interval: Long = ELECTRONIC_HORIZON_INTERVAL,
-    val locationsCacheSize: Int = LOCATIONS_CACHE_MAX_SIZE
+class ElectronicHorizonParams private constructor(
+    val delay: Long,
+    val interval: Long,
+    val locationsCacheSize: Int
 ) {
-    companion object {
-        private const val ELECTRONIC_HORIZON_DELAY = 20_000L
-        private const val ELECTRONIC_HORIZON_INTERVAL = 20_000L
-        private const val LOCATIONS_CACHE_MAX_SIZE = 5
+    class Builder {
+        companion object {
+            internal const val DEFAULT_ELECTRONIC_HORIZON_DELAY = 20_000L
+            internal const val DEFAULT_ELECTRONIC_HORIZON_INTERVAL = 20_000L
+            internal const val DEFAULT_LOCATIONS_CACHE_SIZE = 5
+            internal const val LOCATIONS_CACHE_MIN_SIZE = 2
+            internal const val LOCATIONS_CACHE_MAX_SIZE = 10
+        }
+
+        private var delay: Long = DEFAULT_ELECTRONIC_HORIZON_DELAY
+        private var interval: Long = DEFAULT_ELECTRONIC_HORIZON_INTERVAL
+        private var locationsCacheSize: Int = DEFAULT_LOCATIONS_CACHE_SIZE
+
+        fun delay(delay: Long) = apply {
+            invokeIf(delay > 0) { this.delay = delay }
+        }
+
+        fun interval(interval: Long) = apply {
+            invokeIf(interval > 0) { this.interval = interval }
+        }
+
+        fun locationsCacheSize(cacheSize: Int) = apply {
+            invokeIf(cacheSize in LOCATIONS_CACHE_MIN_SIZE..LOCATIONS_CACHE_MAX_SIZE) {
+                this.locationsCacheSize = cacheSize
+            }
+        }
+
+        fun build() = ElectronicHorizonParams(
+            delay,
+            interval,
+            locationsCacheSize
+        )
+
+        private inline fun invokeIf(condition: Boolean, block: () -> Unit) {
+            if (condition) {
+                block()
+            }
+        }
     }
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/ElectronicHorizonRequestBuilder.kt
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/ElectronicHorizonRequestBuilder.kt
@@ -1,0 +1,40 @@
+package com.mapbox.services.android.navigation.v5.internal.navigation
+
+import android.location.Location
+import com.google.gson.Gson
+
+internal object ElectronicHorizonRequestBuilder {
+    private val gson = Gson()
+
+    fun build(
+        expansion: Expansion,
+        locations: List<Location>
+    ): String {
+        val positions = locations.map {
+            Position(
+                it.latitude,
+                it.longitude
+            )
+        }
+        val options = mapOf("expansion" to expansion.value)
+        val request = ElectronicHorizonRequest(positions, options)
+
+        return gson.toJson(request)
+    }
+
+    internal enum class Expansion(val value: String) {
+        _1D("1D"),
+        _1_5D("1.5D"),
+        _2D("2D")
+    }
+
+    private data class Position(
+        val lat: Double,
+        val lon: Double
+    )
+
+    private data class ElectronicHorizonRequest(
+        val shape: List<Position>,
+        val eh_options: Map<String, Any>
+    )
+}

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/ElectronicHorizonRequestBuilder.kt
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/ElectronicHorizonRequestBuilder.kt
@@ -2,6 +2,7 @@ package com.mapbox.services.android.navigation.v5.internal.navigation
 
 import android.location.Location
 import com.google.gson.Gson
+import com.google.gson.annotations.SerializedName
 
 internal object ElectronicHorizonRequestBuilder {
     private val gson = Gson()
@@ -35,6 +36,7 @@ internal object ElectronicHorizonRequestBuilder {
 
     private data class ElectronicHorizonRequest(
         val shape: List<Position>,
-        val eh_options: Map<String, Any>
+        @SerializedName("eh_options")
+        val options: Map<String, Any>
     )
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/FreeDriveLocationUpdater.kt
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/FreeDriveLocationUpdater.kt
@@ -12,6 +12,7 @@ import com.mapbox.services.android.navigation.v5.navigation.OfflineNavigator
 import com.mapbox.services.android.navigation.v5.navigation.OnOfflineTilesConfiguredCallback
 import java.lang.ref.WeakReference
 import java.util.Date
+import java.util.LinkedList
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
@@ -32,7 +33,7 @@ internal class FreeDriveLocationUpdater(
     private var electronicHorizonFuture: ScheduledFuture<*>? = null
     private var rawLocation: Location? = null
     private val handler = Handler(Looper.getMainLooper())
-    private val cachedLocations = mutableListOf<Location>()
+    private val cachedLocations = LinkedList<Location>()
 
     fun configure(
         tilePath: String,
@@ -148,7 +149,7 @@ internal class FreeDriveLocationUpdater(
     private fun cacheLocation(location: Location) {
         // remove the oldest location to fit the max cache size
         if (cachedLocations.size == electronicHorizonParams.locationsCacheSize) {
-            cachedLocations.removeAt(0)
+            cachedLocations.removeFirst()
         }
 
         cachedLocations.add(location)

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/MapboxNavigator.kt
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/MapboxNavigator.kt
@@ -9,6 +9,7 @@ import com.mapbox.navigator.BannerInstruction
 import com.mapbox.navigator.FixLocation
 import com.mapbox.navigator.NavigationStatus
 import com.mapbox.navigator.Navigator
+import com.mapbox.navigator.RouterResult
 import com.mapbox.navigator.VoiceInstruction
 import com.mapbox.services.android.navigation.v5.navigation.DirectionsRouteType
 import java.util.Date
@@ -102,6 +103,11 @@ internal class MapboxNavigator(val navigator: Navigator) {
     fun retrieveRouteGeometryWithBuffer(): Geometry? {
         val routeGeometryWithBuffer = navigator.getRouteBufferGeoJson(GRID_SIZE, BUFFER_DILATION) ?: return null
         return GeometryGeoJson.fromJson(routeGeometryWithBuffer)
+    }
+
+    @Synchronized
+    fun retrieveElectronicHorizon(request: String): RouterResult {
+        return navigator.getElectronicHorizon(request)
     }
 
     private fun buildFixLocationFromLocation(location: Location): FixLocation {

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
@@ -1164,4 +1164,8 @@ public class MapboxNavigation implements ServiceConnection {
       return MAPBOX_NAVIGATION_USER_AGENT_BASE + BuildConfig.MAPBOX_NAVIGATION_VERSION_NAME;
     }
   }
+
+  public boolean isFreeDriveEnabled() {
+    return isFreeDriveEnabled.get();
+  }
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
@@ -1015,7 +1015,7 @@ public class MapboxNavigation implements ServiceConnection {
         offlineNavigator,
         Executors.newScheduledThreadPool(2),
         ElectronicHorizonRequestBuilder.INSTANCE,
-        new ElectronicHorizonParams());
+        new ElectronicHorizonParams.Builder().build());
 
     initializeTelemetry(context);
 
@@ -1057,7 +1057,7 @@ public class MapboxNavigation implements ServiceConnection {
         offlineNavigator,
         Executors.newScheduledThreadPool(2),
         ElectronicHorizonRequestBuilder.INSTANCE,
-        new ElectronicHorizonParams());
+        new ElectronicHorizonParams.Builder().build());
     initializeTelemetry(applicationContext);
 
     // Create and add default milestones if enabled.

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
@@ -18,6 +18,7 @@ import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.navigator.Navigator;
 import com.mapbox.navigator.NavigatorConfig;
 import com.mapbox.services.android.navigation.BuildConfig;
+import com.mapbox.services.android.navigation.v5.internal.navigation.ElectronicHorizonRequestBuilder;
 import com.mapbox.services.android.navigation.v5.internal.navigation.FreeDriveLocationUpdater;
 import com.mapbox.services.android.navigation.v5.internal.navigation.MapboxNavigator;
 import com.mapbox.services.android.navigation.v5.internal.navigation.NavigationEngineFactory;
@@ -1006,7 +1007,7 @@ public class MapboxNavigation implements ServiceConnection {
             accessToken);
     freeDriveLocationUpdater = new FreeDriveLocationUpdater(locationEngine, locationEngineRequest,
         navigationEventDispatcher, mapboxNavigator, offlineNavigator,
-        Executors.newSingleThreadScheduledExecutor());
+        Executors.newSingleThreadScheduledExecutor(), ElectronicHorizonRequestBuilder.INSTANCE);
     initializeTelemetry(context);
 
     // Create and add default milestones if enabled.
@@ -1040,7 +1041,7 @@ public class MapboxNavigation implements ServiceConnection {
             accessToken); // TODO Replace with an api-routing-tiles-staging valid one
     freeDriveLocationUpdater = new FreeDriveLocationUpdater(locationEngine, locationEngineRequest,
         navigationEventDispatcher, mapboxNavigator, offlineNavigator,
-        Executors.newSingleThreadScheduledExecutor());
+        Executors.newSingleThreadScheduledExecutor(), ElectronicHorizonRequestBuilder.INSTANCE);
     initializeTelemetry(applicationContext);
 
     // Create and add default milestones if enabled.

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
@@ -18,6 +18,7 @@ import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.navigator.Navigator;
 import com.mapbox.navigator.NavigatorConfig;
 import com.mapbox.services.android.navigation.BuildConfig;
+import com.mapbox.services.android.navigation.v5.internal.navigation.ElectronicHorizonParams;
 import com.mapbox.services.android.navigation.v5.internal.navigation.ElectronicHorizonRequestBuilder;
 import com.mapbox.services.android.navigation.v5.internal.navigation.FreeDriveLocationUpdater;
 import com.mapbox.services.android.navigation.v5.internal.navigation.MapboxNavigator;
@@ -1005,9 +1006,17 @@ public class MapboxNavigation implements ServiceConnection {
     OfflineNavigator offlineNavigator = new OfflineNavigator(mapboxNavigator.getNavigator(),
             "2019_04_13-00_00_11", "https://api-routing-tiles-staging.tilestream.net",
             accessToken);
-    freeDriveLocationUpdater = new FreeDriveLocationUpdater(locationEngine, locationEngineRequest,
-        navigationEventDispatcher, mapboxNavigator, offlineNavigator,
-        Executors.newSingleThreadScheduledExecutor(), ElectronicHorizonRequestBuilder.INSTANCE);
+
+    freeDriveLocationUpdater = new FreeDriveLocationUpdater(
+        locationEngine,
+        locationEngineRequest,
+        navigationEventDispatcher,
+        mapboxNavigator,
+        offlineNavigator,
+        Executors.newScheduledThreadPool(2),
+        ElectronicHorizonRequestBuilder.INSTANCE,
+        new ElectronicHorizonParams());
+
     initializeTelemetry(context);
 
     // Create and add default milestones if enabled.
@@ -1039,9 +1048,16 @@ public class MapboxNavigation implements ServiceConnection {
     OfflineNavigator offlineNavigator = new OfflineNavigator(mapboxNavigator.getNavigator(),
             "2019_04_13-00_00_11", "https://api-routing-tiles-staging.tilestream.net",
             accessToken); // TODO Replace with an api-routing-tiles-staging valid one
-    freeDriveLocationUpdater = new FreeDriveLocationUpdater(locationEngine, locationEngineRequest,
-        navigationEventDispatcher, mapboxNavigator, offlineNavigator,
-        Executors.newSingleThreadScheduledExecutor(), ElectronicHorizonRequestBuilder.INSTANCE);
+
+    freeDriveLocationUpdater = new FreeDriveLocationUpdater(
+        locationEngine,
+        locationEngineRequest,
+        navigationEventDispatcher,
+        mapboxNavigator,
+        offlineNavigator,
+        Executors.newScheduledThreadPool(2),
+        ElectronicHorizonRequestBuilder.INSTANCE,
+        new ElectronicHorizonParams());
     initializeTelemetry(applicationContext);
 
     // Create and add default milestones if enabled.
@@ -1163,9 +1179,5 @@ public class MapboxNavigation implements ServiceConnection {
     } else {
       return MAPBOX_NAVIGATION_USER_AGENT_BASE + BuildConfig.MAPBOX_NAVIGATION_VERSION_NAME;
     }
-  }
-
-  public boolean isFreeDriveEnabled() {
-    return isFreeDriveEnabled.get();
   }
 }

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/internal/navigation/ElectronicHorizonParamsTest.kt
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/internal/navigation/ElectronicHorizonParamsTest.kt
@@ -1,0 +1,127 @@
+package com.mapbox.services.android.navigation.v5.internal.navigation
+
+import com.mapbox.services.android.navigation.v5.internal.navigation.ElectronicHorizonParams.Builder.Companion.DEFAULT_ELECTRONIC_HORIZON_DELAY
+import com.mapbox.services.android.navigation.v5.internal.navigation.ElectronicHorizonParams.Builder.Companion.DEFAULT_ELECTRONIC_HORIZON_INTERVAL
+import com.mapbox.services.android.navigation.v5.internal.navigation.ElectronicHorizonParams.Builder.Companion.DEFAULT_LOCATIONS_CACHE_SIZE
+import com.mapbox.services.android.navigation.v5.internal.navigation.ElectronicHorizonParams.Builder.Companion.LOCATIONS_CACHE_MAX_SIZE
+import com.mapbox.services.android.navigation.v5.internal.navigation.ElectronicHorizonParams.Builder.Companion.LOCATIONS_CACHE_MIN_SIZE
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+internal class ElectronicHorizonParamsTest(
+    private val testData: TestData
+) {
+    @Test
+    fun `checks ElectronicHorizonParamsBuilder`() {
+        val initParams = testData.params
+        val expectedResults = testData.results
+
+        val actualParams = ElectronicHorizonParams.Builder()
+            .delay(initParams.delay)
+            .interval(initParams.interval)
+            .locationsCacheSize(initParams.locationsCacheSize)
+            .build()
+
+        Assert.assertEquals(expectedResults.delay, actualParams.delay)
+        Assert.assertEquals(expectedResults.interval, actualParams.interval)
+        Assert.assertEquals(expectedResults.locationsCacheSize, actualParams.locationsCacheSize)
+    }
+
+    internal data class TestData(
+        val params: TestParams,
+        val results: ExpectedResults
+    )
+
+    internal data class TestParams(
+        val delay: Long = 0,
+        val interval: Long = 0,
+        val locationsCacheSize: Int = 0
+    )
+
+    internal data class ExpectedResults(
+        val delay: Long = DEFAULT_ELECTRONIC_HORIZON_DELAY,
+        val interval: Long = DEFAULT_ELECTRONIC_HORIZON_INTERVAL,
+        val locationsCacheSize: Int = DEFAULT_LOCATIONS_CACHE_SIZE
+    )
+
+    private companion object {
+        @JvmStatic
+        @Parameterized.Parameters(name = "{0}")
+        fun data(): Collection<TestData> {
+            return listOf(
+                TestData(
+                    TestParams(),
+                    ExpectedResults(
+                        delay = DEFAULT_ELECTRONIC_HORIZON_DELAY,
+                        interval = DEFAULT_ELECTRONIC_HORIZON_INTERVAL,
+                        locationsCacheSize = DEFAULT_LOCATIONS_CACHE_SIZE
+                    )
+                ),
+
+                TestData(
+                    TestParams(delay = -1),
+                    ExpectedResults(delay = DEFAULT_ELECTRONIC_HORIZON_DELAY)
+
+                ),
+
+                TestData(
+                    TestParams(delay = 0),
+                    ExpectedResults(delay = DEFAULT_ELECTRONIC_HORIZON_DELAY)
+                ),
+
+                TestData(
+                    TestParams(delay = 1),
+                    ExpectedResults(delay = 1)
+                ),
+
+                TestData(
+                    TestParams(interval = -1),
+                    ExpectedResults(interval = DEFAULT_ELECTRONIC_HORIZON_INTERVAL)
+
+                ),
+
+                TestData(
+                    TestParams(interval = 0),
+                    ExpectedResults(interval = DEFAULT_ELECTRONIC_HORIZON_INTERVAL)
+                ),
+
+                TestData(
+                    TestParams(interval = 1),
+                    ExpectedResults(interval = 1)
+                ),
+
+                TestData(
+                    TestParams(locationsCacheSize = -1),
+                    ExpectedResults(locationsCacheSize = DEFAULT_LOCATIONS_CACHE_SIZE)
+
+                ),
+
+                TestData(
+                    TestParams(locationsCacheSize = 0),
+                    ExpectedResults(locationsCacheSize = DEFAULT_LOCATIONS_CACHE_SIZE)
+                ),
+
+                TestData(
+                    TestParams(locationsCacheSize = LOCATIONS_CACHE_MIN_SIZE - 1),
+                    ExpectedResults(locationsCacheSize = DEFAULT_LOCATIONS_CACHE_SIZE)
+                ),
+
+                TestData(
+                    TestParams(locationsCacheSize = LOCATIONS_CACHE_MIN_SIZE),
+                    ExpectedResults(locationsCacheSize = LOCATIONS_CACHE_MIN_SIZE)
+                ),
+                TestData(
+                    TestParams(locationsCacheSize = DEFAULT_LOCATIONS_CACHE_SIZE),
+                    ExpectedResults(locationsCacheSize = DEFAULT_LOCATIONS_CACHE_SIZE)
+                ),
+                TestData(
+                    TestParams(locationsCacheSize = LOCATIONS_CACHE_MAX_SIZE + 1),
+                    ExpectedResults(locationsCacheSize = DEFAULT_LOCATIONS_CACHE_SIZE)
+                )
+            )
+        }
+    }
+}

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/internal/navigation/ElectronicHorizonRequestBuilderTest.kt
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/internal/navigation/ElectronicHorizonRequestBuilderTest.kt
@@ -1,0 +1,123 @@
+package com.mapbox.services.android.navigation.v5.internal.navigation
+
+import android.location.Location
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+internal class ElectronicHorizonRequestBuilderTest(
+    private val params: TestParams
+) {
+    @Test
+    fun `checks ElectronicHorizonRequestBuilder`() {
+        val actualResult = ElectronicHorizonRequestBuilder.build(params.expansion, params.locations)
+        Assert.assertEquals(params.expectedResult, actualResult)
+    }
+
+    internal data class TestParams(
+        val expansion: ElectronicHorizonRequestBuilder.Expansion,
+        val locations: List<Location>,
+        val expectedResult: String
+    ) {
+        override fun toString(): String {
+            return "Run test with extension = $expansion, locations = ${locations.map { "lat = ${it.latitude}, lon = ${it.longitude}" }}"
+        }
+    }
+
+    private companion object {
+        private const val DEFAULT_LATITUDE_1 = 10.0
+        private const val DEFAULT_LATITUDE_2 = 20.0
+        private const val DEFAULT_LATITUDE_3 = 30.0
+
+        private const val DEFAULT_LONGITUDE_1 = 111.0
+        private const val DEFAULT_LONGITUDE_2 = 222.0
+        private const val DEFAULT_LONGITUDE_3 = 333.0
+
+        private fun mockLocation(latitude: Double, longitude: Double): Location {
+            return mockk<Location>().also {
+                every { it.latitude }.returns(latitude)
+                every { it.longitude }.returns(longitude)
+            }
+        }
+
+        @JvmStatic
+        @Parameterized.Parameters(name = "{0}")
+        fun data(): Collection<TestParams> {
+            return listOf(
+                TestParams(
+                    ElectronicHorizonRequestBuilder.Expansion._1D,
+                    emptyList(),
+                    "{\"shape\":[],\"eh_options\":{\"expansion\":\"1D\"}}"
+                ),
+                TestParams(
+                    ElectronicHorizonRequestBuilder.Expansion._1_5D,
+                    emptyList(),
+                    "{\"shape\":[],\"eh_options\":{\"expansion\":\"1.5D\"}}"
+                ),
+                TestParams(
+                    ElectronicHorizonRequestBuilder.Expansion._2D,
+                    emptyList(),
+                    "{\"shape\":[],\"eh_options\":{\"expansion\":\"2D\"}}"
+                ),
+                TestParams(
+                    ElectronicHorizonRequestBuilder.Expansion._1D,
+                    listOf(
+                        mockLocation(
+                            latitude = DEFAULT_LATITUDE_1,
+                            longitude = DEFAULT_LONGITUDE_1
+                        ),
+                        mockLocation(
+                            latitude = DEFAULT_LATITUDE_2,
+                            longitude = DEFAULT_LONGITUDE_2
+                        ),
+                        mockLocation(
+                            latitude = DEFAULT_LATITUDE_3,
+                            longitude = DEFAULT_LONGITUDE_3
+                        )
+                    ),
+                    "{\"shape\":[{\"lat\":10.0,\"lon\":111.0},{\"lat\":20.0,\"lon\":222.0},{\"lat\":30.0,\"lon\":333.0}],\"eh_options\":{\"expansion\":\"1D\"}}"
+                ),
+                TestParams(
+                    ElectronicHorizonRequestBuilder.Expansion._1_5D,
+                    listOf(
+                        mockLocation(
+                            latitude = DEFAULT_LATITUDE_1,
+                            longitude = DEFAULT_LONGITUDE_1
+                        ),
+                        mockLocation(
+                            latitude = DEFAULT_LATITUDE_2,
+                            longitude = DEFAULT_LONGITUDE_2
+                        ),
+                        mockLocation(
+                            latitude = DEFAULT_LATITUDE_3,
+                            longitude = DEFAULT_LONGITUDE_3
+                        )
+                    ),
+                    "{\"shape\":[{\"lat\":10.0,\"lon\":111.0},{\"lat\":20.0,\"lon\":222.0},{\"lat\":30.0,\"lon\":333.0}],\"eh_options\":{\"expansion\":\"1.5D\"}}"
+                ),
+                TestParams(
+                    ElectronicHorizonRequestBuilder.Expansion._2D,
+                    listOf(
+                        mockLocation(
+                            latitude = DEFAULT_LATITUDE_1,
+                            longitude = DEFAULT_LONGITUDE_1
+                        ),
+                        mockLocation(
+                            latitude = DEFAULT_LATITUDE_2,
+                            longitude = DEFAULT_LONGITUDE_2
+                        ),
+                        mockLocation(
+                            latitude = DEFAULT_LATITUDE_3,
+                            longitude = DEFAULT_LONGITUDE_3
+                        )
+                    ),
+                    "{\"shape\":[{\"lat\":10.0,\"lon\":111.0},{\"lat\":20.0,\"lon\":222.0},{\"lat\":30.0,\"lon\":333.0}],\"eh_options\":{\"expansion\":\"2D\"}}"
+                )
+            )
+        }
+    }
+}

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/internal/navigation/FreeDriveLocationUpdaterTest.kt
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/internal/navigation/FreeDriveLocationUpdaterTest.kt
@@ -61,7 +61,8 @@ class FreeDriveLocationUpdaterTest {
         val mockedScheduledExecutorService = mockk<ScheduledExecutorService>(relaxed = true)
         val theFreeDriveLocationUpdater =
             buildFreeDriveLocationUpdater(
-                executorService = mockedScheduledExecutorService
+                executorService = mockedScheduledExecutorService,
+                electronicHorizonParams = ElectronicHorizonParams()
             )
 
         theFreeDriveLocationUpdater.start()
@@ -113,7 +114,8 @@ class FreeDriveLocationUpdaterTest {
         val mockedScheduledExecutorService = mockk<ScheduledExecutorService>(relaxed = true)
         val theFreeDriveLocationUpdater =
             buildFreeDriveLocationUpdater(
-                executorService = mockedScheduledExecutorService
+                executorService = mockedScheduledExecutorService,
+                electronicHorizonParams = ElectronicHorizonParams()
             )
 
         theFreeDriveLocationUpdater.start()
@@ -371,7 +373,8 @@ class FreeDriveLocationUpdaterTest {
         mapboxNavigator: MapboxNavigator = mockk<MapboxNavigator>(relaxed = true),
         offlineNavigator: OfflineNavigator = mockk<OfflineNavigator>(relaxed = true),
         executorService: ScheduledExecutorService = mockk<ScheduledExecutorService>(relaxed = true),
-        electronicHorizonRequestBuilder: ElectronicHorizonRequestBuilder = mockk(relaxed = true)
+        electronicHorizonRequestBuilder: ElectronicHorizonRequestBuilder = mockk(relaxed = true),
+        electronicHorizonParams: ElectronicHorizonParams = mockk(relaxed = true)
     ): FreeDriveLocationUpdater {
         return FreeDriveLocationUpdater(
             locationEngine,
@@ -380,7 +383,8 @@ class FreeDriveLocationUpdaterTest {
             mapboxNavigator,
             offlineNavigator,
             executorService,
-            electronicHorizonRequestBuilder
+            electronicHorizonRequestBuilder,
+            electronicHorizonParams
         )
     }
 }

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/internal/navigation/FreeDriveLocationUpdaterTest.kt
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/internal/navigation/FreeDriveLocationUpdaterTest.kt
@@ -62,7 +62,7 @@ class FreeDriveLocationUpdaterTest {
         val theFreeDriveLocationUpdater =
             buildFreeDriveLocationUpdater(
                 executorService = mockedScheduledExecutorService,
-                electronicHorizonParams = ElectronicHorizonParams()
+                electronicHorizonParams = ElectronicHorizonParams.Builder().build()
             )
 
         theFreeDriveLocationUpdater.start()
@@ -115,7 +115,7 @@ class FreeDriveLocationUpdaterTest {
         val theFreeDriveLocationUpdater =
             buildFreeDriveLocationUpdater(
                 executorService = mockedScheduledExecutorService,
-                electronicHorizonParams = ElectronicHorizonParams()
+                electronicHorizonParams = ElectronicHorizonParams.Builder().build()
             )
 
         theFreeDriveLocationUpdater.start()

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/internal/navigation/FreeDriveLocationUpdaterTest.kt
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/internal/navigation/FreeDriveLocationUpdaterTest.kt
@@ -57,7 +57,7 @@ class FreeDriveLocationUpdaterTest {
     }
 
     @Test
-    fun `checks scheduleAtFixedRate is called when start`() {
+    fun `checks scheduleAtFixedRate is called twice when start`() {
         val mockedScheduledExecutorService = mockk<ScheduledExecutorService>(relaxed = true)
         val theFreeDriveLocationUpdater =
             buildFreeDriveLocationUpdater(
@@ -71,6 +71,15 @@ class FreeDriveLocationUpdaterTest {
                 any(),
                 eq(1500),
                 eq(1000),
+                eq(TimeUnit.MILLISECONDS)
+            )
+        }
+
+        verify {
+            mockedScheduledExecutorService.scheduleAtFixedRate(
+                any(),
+                eq(20_000),
+                eq(20_000),
                 eq(TimeUnit.MILLISECONDS)
             )
         }
@@ -100,7 +109,7 @@ class FreeDriveLocationUpdaterTest {
     }
 
     @Test
-    fun `checks scheduleAtFixedRate is called only once if start is called multiple times`() {
+    fun `checks scheduleAtFixedRate is called only twice if start is called multiple times`() {
         val mockedScheduledExecutorService = mockk<ScheduledExecutorService>(relaxed = true)
         val theFreeDriveLocationUpdater =
             buildFreeDriveLocationUpdater(
@@ -116,6 +125,15 @@ class FreeDriveLocationUpdaterTest {
                 any(),
                 eq(1500),
                 eq(1000),
+                eq(TimeUnit.MILLISECONDS)
+            )
+        }
+
+        verify(exactly = 1) {
+            mockedScheduledExecutorService.scheduleAtFixedRate(
+                any(),
+                eq(20_000),
+                eq(20_000),
                 eq(TimeUnit.MILLISECONDS)
             )
         }
@@ -352,7 +370,8 @@ class FreeDriveLocationUpdaterTest {
         ),
         mapboxNavigator: MapboxNavigator = mockk<MapboxNavigator>(relaxed = true),
         offlineNavigator: OfflineNavigator = mockk<OfflineNavigator>(relaxed = true),
-        executorService: ScheduledExecutorService = mockk<ScheduledExecutorService>(relaxed = true)
+        executorService: ScheduledExecutorService = mockk<ScheduledExecutorService>(relaxed = true),
+        electronicHorizonRequestBuilder: ElectronicHorizonRequestBuilder = mockk(relaxed = true)
     ): FreeDriveLocationUpdater {
         return FreeDriveLocationUpdater(
             locationEngine,
@@ -360,7 +379,8 @@ class FreeDriveLocationUpdaterTest {
             navigationEventDispatcher,
             mapboxNavigator,
             offlineNavigator,
-            executorService
+            executorService,
+            electronicHorizonRequestBuilder
         )
     }
 }


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Closes [issue](https://github.com/mapbox/navigation-sdks/issues/177)

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

We need to preload tiles during `FreeDrive`. When we call `mapboxNavigator.retrieveElectronicHorizon` core predicts drivers direction and download the needed tile. 
Currently we call core every 20 seconds, it's customizable. Also we pass `Expansion` param which is used by the core to choose prediction algorithm. 

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally through testapp
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->