### PR TITLE
Bump play-publisher version to 2.3.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,10 +14,9 @@ android {
     targetCompatibility JavaVersion.VERSION_1_8
   }
 
-  playAccountConfigs {
+  playConfigs {
     defaultAccountConfig {
-      serviceAccountEmail = 'navigation-testapp-publisher@android-gl-native.iam.gserviceaccount.com'
-      jsonFile = file("$project.rootDir/android-gl-native-15d95ab30d0f.json")
+      serviceAccountCredentials = file("$project.rootDir/android-gl-native-15d95ab30d0f.json")
     }
   }
 
@@ -41,7 +40,6 @@ android {
     multiDexEnabled true
     versionCode gitVersionCode
     versionName gitVersionName
-    playAccountConfig = playAccountConfigs.defaultAccountConfig
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     vectorDrawables.useSupportLibrary = true
     buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
@@ -79,6 +77,7 @@ android {
   }
 
   play {
+    serviceAccountCredentials = playConfigs.defaultAccountConfig.serviceAccountCredentials
     track = System.getenv("GOOGLE_PLAY_TRACK") ?: "internal"
   }
 }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -139,7 +139,7 @@ ext {
       kotlin           : '1.3.60',
       license          : '0.8.5',
       jacoco           : '0.8.2',
-      playPublisher    : '1.2.2',
+      playPublisher    : '2.3.0',
       googleServices   : '4.2.0',
       crashlytics      : '1.26.1',
       mapboxSdkVersions: '1.0.0'


### PR DESCRIPTION
## Description

Bumps `play-publisher` version to `2.3.0`

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

The version of the Play Developer API used by `com.github.triplet.gradle:play-publisher:1.2.2` is no longer available and we needed to bump it to `2.x` to avoid 👇 error.

![Google Play Developer API versions 1 and 2 deprecated](https://user-images.githubusercontent.com/1668582/70635094-508a3000-1c01-11ea-843d-a9c76a7a14e1.png)

### Implementation

`com.github.triplet.gradle:play-publisher:2.3.0` introduces some breaking changes and our `build.gradle` files was adapted accordingly.

## Testing

- [x] I have tested these changes publishing and app and it was released successfully and is available in Google Play 🎉 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] Cherry-pick into [`base-v0.42.1`](https://github.com/mapbox/mapbox-navigation-android/tree/base-v0.42.1) branch