### PR TITLE
Ensure to use valid MapRouteArrow and MapRouteLine Layer references during style change

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/EmbeddedNavigationActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/EmbeddedNavigationActivity.java
@@ -294,7 +294,8 @@ public class EmbeddedNavigationActivity extends AppCompatActivity implements OnN
   }
 
   private void setupStyleFab() {
-    fabStyleToggle.setOnClickListener(view -> navigationView.retrieveNavigationMapboxMap().retrieveMap().setStyle(styleCycle.getNextStyle()));
+    fabStyleToggle.setOnClickListener(view ->
+      navigationView.retrieveNavigationMapboxMap().retrieveMap().setStyle(styleCycle.getNextStyle()));
   }
 
   private static class StyleCycle {

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/EmbeddedNavigationActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/EmbeddedNavigationActivity.java
@@ -28,6 +28,7 @@ import com.mapbox.geojson.Point;
 import com.mapbox.mapboxsdk.Mapbox;
 import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.services.android.navigation.testapp.R;
 import com.mapbox.services.android.navigation.ui.v5.NavigationView;
 import com.mapbox.services.android.navigation.ui.v5.NavigationViewOptions;
@@ -59,9 +60,12 @@ public class EmbeddedNavigationActivity extends AppCompatActivity implements OnN
   private View spacer;
   private TextView speedWidget;
   private FloatingActionButton fabNightModeToggle;
+  private FloatingActionButton fabStyleToggle;
 
   private boolean bottomSheetVisible = true;
   private boolean instructionListShown = false;
+
+  private StyleCycle styleCycle = new StyleCycle();
 
   @Override
   protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -71,6 +75,7 @@ public class EmbeddedNavigationActivity extends AppCompatActivity implements OnN
     setContentView(R.layout.activity_embedded_navigation);
     navigationView = findViewById(R.id.navigationView);
     fabNightModeToggle = findViewById(R.id.fabToggleNightMode);
+    fabStyleToggle = findViewById(R.id.fabToggleStyle);
     speedWidget = findViewById(R.id.speed_limit);
     spacer = findViewById(R.id.spacer);
     setSpeedWidgetAnchor(R.id.summaryBottomSheet);
@@ -203,6 +208,7 @@ public class EmbeddedNavigationActivity extends AppCompatActivity implements OnN
         .offlineRoutingTilesPath(obtainOfflineDirectory())
         .offlineRoutingTilesVersion(obtainOfflineTileVersion());
     setBottomSheetCallback(options);
+    setupStyleFab();
     setupNightModeFab();
 
     navigationView.startNavigation(options.build());
@@ -285,6 +291,34 @@ public class EmbeddedNavigationActivity extends AppCompatActivity implements OnN
 
   private void setupNightModeFab() {
     fabNightModeToggle.setOnClickListener(view -> toggleNightMode());
+  }
+
+  private void setupStyleFab() {
+    fabStyleToggle.setOnClickListener(view -> navigationView.retrieveNavigationMapboxMap().retrieveMap().setStyle(styleCycle.getNextStyle()));
+  }
+
+  private static class StyleCycle {
+    private static final String[] STYLES = new String[]{
+      Style.MAPBOX_STREETS,
+      Style.OUTDOORS,
+      Style.LIGHT,
+      Style.DARK,
+      Style.SATELLITE_STREETS
+    };
+
+    private int index;
+
+    private String getNextStyle() {
+      index++;
+      if (index == STYLES.length) {
+        index = 0;
+      }
+      return getStyle();
+    }
+
+    private String getStyle() {
+      return STYLES[index];
+    }
   }
 
   private void toggleNightMode() {

--- a/app/src/main/res/layout/activity_embedded_navigation.xml
+++ b/app/src/main/res/layout/activity_embedded_navigation.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.coordinatorlayout.widget.CoordinatorLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
@@ -10,19 +9,34 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:navigationDarkTheme="@style/NavigationViewDark"
-        app:navigationLightTheme="@style/CustomNavigationView"/>
+        app:navigationLightTheme="@style/CustomNavigationView" />
 
-    <com.google.android.material.floatingactionbutton.FloatingActionButton
-        android:id="@+id/fabToggleNightMode"
+    <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="top|start"
         android:layout_marginEnd="16dp"
         android:layout_marginRight="16dp"
-        android:tint="@android:color/white"
+        android:orientation="vertical"
         app:layout_anchor="@id/spacer"
-        app:layout_anchorGravity="top|end"
-        app:srcCompat="@drawable/ic_refresh"/>
+        app:layout_anchorGravity="top|end">
+
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/fabToggleStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:tint="@android:color/white"
+            app:srcCompat="@drawable/ic_layers" />
+
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/fabToggleNightMode"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:tint="@android:color/white"
+            app:srcCompat="@drawable/ic_refresh" />
+
+    </LinearLayout>
 
     <TextView
         android:id="@+id/speed_limit"
@@ -38,7 +52,7 @@
         android:textSize="35sp"
         android:visibility="gone"
         app:layout_anchor="@id/spacer"
-        app:layout_anchorGravity="top"/>
+        app:layout_anchorGravity="top" />
 
     <View
         android:id="@+id/spacer"
@@ -46,6 +60,6 @@
         android:layout_height="6dp"
         android:layout_gravity="top"
         android:background="@android:color/transparent"
-        app:layout_anchorGravity="top"/>
+        app:layout_anchorGravity="top" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/MapRouteArrow.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/MapRouteArrow.java
@@ -17,6 +17,7 @@ import com.mapbox.geojson.LineString;
 import com.mapbox.geojson.Point;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.style.layers.Layer;
 import com.mapbox.mapboxsdk.style.layers.LineLayer;
 import com.mapbox.mapboxsdk.style.layers.Property;
@@ -85,7 +86,7 @@ class MapRouteArrow {
   @ColorInt
   private final int arrowBorderColor;
 
-  private List<Layer> arrowLayers;
+  private List<String> arrowLayerIds;
   private GeoJsonSource arrowShaftGeoJsonSource;
   private GeoJsonSource arrowHeadGeoJsonSource;
 
@@ -123,10 +124,16 @@ class MapRouteArrow {
   }
 
   void updateVisibilityTo(boolean visible) {
-    for (Layer layer : arrowLayers) {
-      String targetVisibility = visible ? VISIBLE : NONE;
-      if (!targetVisibility.equals(layer.getVisibility().getValue())) {
-        layer.setProperties(visibility(targetVisibility));
+    Style style = mapboxMap.getStyle();
+    if (style != null) {
+      for (String layerId : arrowLayerIds) {
+        Layer layer = style.getLayer(layerId);
+        if (layer != null) {
+          String targetVisibility = visible ? VISIBLE : NONE;
+          if (!targetVisibility.equals(layer.getVisibility().getValue())) {
+            layer.setProperties(visibility(targetVisibility));
+          }
+        }
       }
     }
   }
@@ -186,7 +193,7 @@ class MapRouteArrow {
   private void initializeArrowShaft() {
     arrowShaftGeoJsonSource = new GeoJsonSource(
       ARROW_SHAFT_SOURCE_ID,
-      FeatureCollection.fromFeatures(new Feature[] {}),
+      FeatureCollection.fromFeatures(new Feature[]{}),
       new GeoJsonOptions().withMaxZoom(16)
     );
     mapboxMap.getStyle().addSource(arrowShaftGeoJsonSource);
@@ -195,7 +202,7 @@ class MapRouteArrow {
   private void initializeArrowHead() {
     arrowHeadGeoJsonSource = new GeoJsonSource(
       ARROW_HEAD_SOURCE_ID,
-      FeatureCollection.fromFeatures(new Feature[] {}),
+      FeatureCollection.fromFeatures(new Feature[]{}),
       new GeoJsonOptions().withMaxZoom(16)
     );
     mapboxMap.getStyle().addSource(arrowHeadGeoJsonSource);
@@ -336,10 +343,10 @@ class MapRouteArrow {
 
   private void createArrowLayerList(LineLayer shaftLayer, LineLayer shaftCasingLayer, SymbolLayer headLayer,
                                     SymbolLayer headCasingLayer) {
-    arrowLayers = new ArrayList<>();
-    arrowLayers.add(shaftCasingLayer);
-    arrowLayers.add(shaftLayer);
-    arrowLayers.add(headCasingLayer);
-    arrowLayers.add(headLayer);
+    arrowLayerIds = new ArrayList<>();
+    arrowLayerIds.add(shaftCasingLayer.getId());
+    arrowLayerIds.add(shaftLayer.getId());
+    arrowLayerIds.add(headCasingLayer.getId());
+    arrowLayerIds.add(headLayer.getId());
   }
 }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/MapRouteLine.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/route/MapRouteLine.java
@@ -3,10 +3,10 @@ package com.mapbox.services.android.navigation.ui.v5.route;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.graphics.drawable.Drawable;
+import android.os.Handler;
 
 import androidx.annotation.ColorInt;
 import androidx.core.content.ContextCompat;
-import android.os.Handler;
 
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.api.directions.v5.models.RouteLeg;
@@ -64,10 +64,12 @@ class MapRouteLine {
   private float alternativeRouteScale;
   private boolean roundedLineCap;
 
+  private Style style;
+
   private final HashMap<LineString, DirectionsRoute> routeLineStrings = new HashMap<>();
   private final List<FeatureCollection> routeFeatureCollections = new ArrayList<>();
   private final List<DirectionsRoute> directionsRoutes = new ArrayList<>();
-  private final List<Layer> routeLayers;
+  private final List<String> routeLayerIds;
 
   private final GeoJsonSource wayPointSource;
   private final GeoJsonSource routeLineSource;
@@ -121,8 +123,9 @@ class MapRouteLine {
                boolean alternativesVisible,
                Handler handler
   ) {
-    this.routeLayers = new ArrayList<>();
+    this.routeLayerIds = new ArrayList<>();
     this.mainHandler = handler;
+    this.style = style;
 
     TypedArray typedArray = context.obtainStyledAttributes(styleRes, R.styleable.NavigationMapRoute);
     // Primary Route attributes
@@ -188,10 +191,10 @@ class MapRouteLine {
   }
 
   // For testing only
-  MapRouteLine(GeoJsonSource routeLineSource, GeoJsonSource wayPointSource, List<Layer> routeLayers) {
+  MapRouteLine(GeoJsonSource routeLineSource, GeoJsonSource wayPointSource, List<String> routeLayerIds) {
     this.routeLineSource = routeLineSource;
     this.wayPointSource = wayPointSource;
-    this.routeLayers = routeLayers;
+    this.routeLayerIds = routeLayerIds;
   }
 
   void draw(DirectionsRoute directionsRoute) {
@@ -390,7 +393,7 @@ class MapRouteLine {
       return primaryRouteUpdateTask;
     }
     return new PrimaryRouteUpdateTask(newPrimaryIndex,
-        routeFeatureCollections, primaryRouteUpdatedCallback, mainHandler);
+      routeFeatureCollections, primaryRouteUpdatedCallback, mainHandler);
   }
 
   private OnPrimaryRouteUpdatedCallback primaryRouteUpdatedCallback = new OnPrimaryRouteUpdatedCallback() {
@@ -427,7 +430,7 @@ class MapRouteLine {
       routeShieldColor, alternativeRouteShieldColor
     );
     MapUtils.addLayerToMap(style, routeShieldLayer, belowLayer);
-    routeLayers.add(routeShieldLayer);
+    routeLayerIds.add(routeShieldLayer.getId());
 
     LineLayer routeLayer = layerProvider.initializeRouteLayer(
       style, roundedLineCap, routeScale, alternativeRouteScale,
@@ -436,25 +439,29 @@ class MapRouteLine {
       alternativeRouteSevereColor
     );
     MapUtils.addLayerToMap(style, routeLayer, belowLayer);
-    routeLayers.add(routeLayer);
+    routeLayerIds.add(routeLayer.getId());
 
     SymbolLayer wayPointLayer = layerProvider.initializeWayPointLayer(
       style, originIcon, destinationIcon
     );
     MapUtils.addLayerToMap(style, wayPointLayer, belowLayer);
-    routeLayers.add(wayPointLayer);
+    routeLayerIds.add(wayPointLayer.getId());
   }
 
   private void updateAlternativeVisibilityTo(boolean isAlternativeVisible) {
     this.alternativesVisible = isAlternativeVisible;
-    for (Layer layer : routeLayers) {
-      String layerId = layer.getId();
-      if (layerId.equals(ROUTE_LAYER_ID) || layerId.equals(ROUTE_SHIELD_LAYER_ID)) {
-        LineLayer route = (LineLayer) layer;
-        if (isAlternativeVisible) {
-          route.setFilter(literal(true));
-        } else {
-          route.setFilter(Expression.eq(Expression.get(PRIMARY_ROUTE_PROPERTY_KEY), true));
+    if (style != null && style.isFullyLoaded()) {
+      for (String layerId : routeLayerIds) {
+        if (layerId.equals(ROUTE_LAYER_ID) || layerId.equals(ROUTE_SHIELD_LAYER_ID)) {
+          Layer layer = style.getLayer(layerId);
+          if (layer != null) {
+            LineLayer route = (LineLayer) layer;
+            if (isAlternativeVisible) {
+              route.setFilter(literal(true));
+            } else {
+              route.setFilter(Expression.eq(Expression.get(PRIMARY_ROUTE_PROPERTY_KEY), true));
+            }
+          }
         }
       }
     }
@@ -462,10 +469,15 @@ class MapRouteLine {
 
   private void updateAllLayersVisibilityTo(boolean isVisible) {
     this.isVisible = isVisible;
-    for (Layer layer : routeLayers) {
-      layer.setProperties(
-        visibility(isVisible ? VISIBLE : NONE)
-      );
+    if (style != null && style.isFullyLoaded()) {
+      for (String layerId : routeLayerIds) {
+        Layer layer = style.getLayer(layerId);
+        if (layer != null) {
+          layer.setProperties(
+            visibility(isVisible ? VISIBLE : NONE)
+          );
+        }
+      }
     }
   }
 

--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/route/MapRouteLineTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/route/MapRouteLineTest.java
@@ -3,15 +3,14 @@ package com.mapbox.services.android.navigation.ui.v5.route;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.graphics.drawable.Drawable;
+import android.os.Handler;
 
 import androidx.annotation.NonNull;
-import android.os.Handler;
 
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.geojson.FeatureCollection;
 import com.mapbox.geojson.LineString;
 import com.mapbox.mapboxsdk.maps.Style;
-import com.mapbox.mapboxsdk.style.layers.Layer;
 import com.mapbox.mapboxsdk.style.layers.LineLayer;
 import com.mapbox.mapboxsdk.style.layers.SymbolLayer;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions;
@@ -66,8 +65,8 @@ public class MapRouteLineTest extends BaseTest {
   public void onDraw_routeLineSourceIsSet() throws Exception {
     GeoJsonSource routeLineSource = mock(GeoJsonSource.class);
     GeoJsonSource wayPointSource = mock(GeoJsonSource.class);
-    List<Layer> routeLayers = buildMockLayers();
-    MapRouteLine routeLine = new MapRouteLine(routeLineSource, wayPointSource, routeLayers);
+    List<String> routeLayerIds = buildMockLayers();
+    MapRouteLine routeLine = new MapRouteLine(routeLineSource, wayPointSource, routeLayerIds);
     List<DirectionsRoute> routes = new ArrayList<>();
     routes.add(buildTestDirectionsRoute());
     ArgumentCaptor<Runnable> runnableFeatures = ArgumentCaptor.forClass(Runnable.class);
@@ -96,8 +95,8 @@ public class MapRouteLineTest extends BaseTest {
   public void onDraw_wayPointSourceIsSet() throws Exception {
     GeoJsonSource routeLineSource = mock(GeoJsonSource.class);
     GeoJsonSource wayPointSource = mock(GeoJsonSource.class);
-    List<Layer> routeLayers = buildMockLayers();
-    MapRouteLine routeLine = new MapRouteLine(routeLineSource, wayPointSource, routeLayers);
+    List<String> routeLayerIds = buildMockLayers();
+    MapRouteLine routeLine = new MapRouteLine(routeLineSource, wayPointSource, routeLayerIds);
     List<DirectionsRoute> routes = new ArrayList<>();
     routes.add(buildTestDirectionsRoute());
     ArgumentCaptor<Runnable> runnableFeatures = ArgumentCaptor.forClass(Runnable.class);
@@ -191,8 +190,8 @@ public class MapRouteLineTest extends BaseTest {
   public void updatePrimaryIndex_routeLineSourceIsSet() throws Exception {
     GeoJsonSource routeLineSource = mock(GeoJsonSource.class);
     GeoJsonSource wayPointSource = mock(GeoJsonSource.class);
-    List<Layer> routeLayers = buildMockLayers();
-    MapRouteLine routeLine = new MapRouteLine(routeLineSource, wayPointSource, routeLayers);
+    List<String> routeLayerIds = buildMockLayers();
+    MapRouteLine routeLine = new MapRouteLine(routeLineSource, wayPointSource, routeLayerIds);
     List<DirectionsRoute> routes = new ArrayList<>();
     routes.add(buildTestDirectionsRoute());
     routes.add(buildTestDirectionsRoute());
@@ -229,8 +228,8 @@ public class MapRouteLineTest extends BaseTest {
   public void updatePrimaryIndex_newPrimaryRouteIndexUpdated() throws Exception {
     GeoJsonSource routeLineSource = mock(GeoJsonSource.class);
     GeoJsonSource wayPointSource = mock(GeoJsonSource.class);
-    List<Layer> routeLayers = buildMockLayers();
-    MapRouteLine routeLine = new MapRouteLine(routeLineSource, wayPointSource, routeLayers);
+    List<String> routeLayerIds = buildMockLayers();
+    MapRouteLine routeLine = new MapRouteLine(routeLineSource, wayPointSource, routeLayerIds);
     List<DirectionsRoute> routes = new ArrayList<>();
     routes.add(buildTestDirectionsRoute());
     routes.add(buildTestDirectionsRoute());
@@ -270,8 +269,8 @@ public class MapRouteLineTest extends BaseTest {
   public void updatePrimaryIndex_newPrimaryRouteIndexIsNotUpdated() throws Exception {
     GeoJsonSource routeLineSource = mock(GeoJsonSource.class);
     GeoJsonSource wayPointSource = mock(GeoJsonSource.class);
-    List<Layer> routeLayers = buildMockLayers();
-    MapRouteLine routeLine = new MapRouteLine(routeLineSource, wayPointSource, routeLayers);
+    List<String> routeLayerIds = buildMockLayers();
+    MapRouteLine routeLine = new MapRouteLine(routeLineSource, wayPointSource, routeLayerIds);
     List<DirectionsRoute> routes = new ArrayList<>();
     routes.add(buildTestDirectionsRoute());
     routes.add(buildTestDirectionsRoute());
@@ -338,14 +337,10 @@ public class MapRouteLineTest extends BaseTest {
   }
 
   @NonNull
-  private List<Layer> buildMockLayers() {
-    List<Layer> routeLayers = new ArrayList<>();
-    LineLayer lineLayerOne = mock(LineLayer.class);
-    when(lineLayerOne.getId()).thenReturn(ROUTE_LAYER_ID);
-    routeLayers.add(lineLayerOne);
-    LineLayer lineLayerTwo = mock(LineLayer.class);
-    when(lineLayerTwo.getId()).thenReturn(ROUTE_LAYER_ID);
-    routeLayers.add(lineLayerTwo);
+  private List<String> buildMockLayers() {
+    List<String> routeLayers = new ArrayList<>();
+    routeLayers.add(ROUTE_LAYER_ID);
+    routeLayers.add(ROUTE_LAYER_ID);
     return routeLayers;
   }
 


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description
Closes https://github.com/mapbox/mapbox-navigation-android/issues/2305.
The `MapRouteArrow` has been misusing the Maps SDK by caching the `Layer`s and trying to access their values after the style has started to change. Previously, Maps SDK was removing the layers when style started to change, but that's not the case anymore to avoid blinking of resources, which exposed the issue.

I also discovered that `MapRouteArrow` is not re-appearing after style change - https://github.com/mapbox/mapbox-navigation-android/issues/2314. This is also reproducible on `master` before any changes from https://github.com/mapbox/mapbox-navigation-android/pull/2262.

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Implementation

Instead of caching layer instances, I'm caching IDs instead. Then, I can safely use those IDs and verify if the layer and style are present.

### Testing
@Guardiola31337 is there an integration test that can be reused? It's surprising that this hasn't been caught before.