### PR TITLE
Do not leak NavigationRoute outside of OffboardRouter module

### DIFF
--- a/libdirections-offboard/src/main/java/com/mapbox/navigation/route/offboard/MapboxOffboardRouter.kt
+++ b/libdirections-offboard/src/main/java/com/mapbox/navigation/route/offboard/MapboxOffboardRouter.kt
@@ -1,5 +1,6 @@
 package com.mapbox.navigation.route.offboard
 
+import android.content.Context
 import com.mapbox.annotation.navigation.module.MapboxNavigationModule
 import com.mapbox.annotation.navigation.module.MapboxNavigationModuleType
 import com.mapbox.api.directions.v5.models.DirectionsResponse
@@ -13,9 +14,9 @@ import retrofit2.Callback
 import retrofit2.Response
 
 @MapboxNavigationModule(MapboxNavigationModuleType.OffboardRouter, skipConfiguration = true)
-class MapboxOffboardRouter(
-    private val routeBuilder: NavigationRoute.Builder
-) : Router {
+class MapboxOffboardRouter(private val routeBuilder: NavigationRoute.Builder) : Router {
+
+    constructor(context: Context) : this(NavigationRoute.builder(context))
 
     companion object {
         const val ERROR_FETCHING_ROUTE = "Error fetching route"

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/NavigationController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/NavigationController.kt
@@ -1,5 +1,6 @@
 package com.mapbox.navigation
 
+import android.content.Context
 import android.os.Handler
 import android.os.HandlerThread
 import android.os.Looper
@@ -22,10 +23,9 @@ import com.mapbox.navigation.base.trip.TripService
 import com.mapbox.navigation.base.trip.TripSession
 import com.mapbox.navigation.module.NavigationModuleProvider
 import com.mapbox.navigation.navigator.MapboxNativeNavigator
-import com.mapbox.navigation.route.offboard.router.NavigationRoute
 
 class NavigationController(
-    private val routeBuilderProvider: NavigationRoute.Builder,
+    private val context: Context,
     private val navigator: MapboxNativeNavigator,
     private val locationEngine: LocationEngine,
     private val locationEngineRequest: LocationEngineRequest,
@@ -65,7 +65,7 @@ class NavigationController(
                 )
             )
             OffboardRouter -> arrayOf(
-                NavigationRoute.Builder::class.java to routeBuilderProvider
+                Context::class.java to context
             )
             OnboardRouter -> arrayOf(
                 MapboxNativeNavigator::class.java to navigator

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/NavigationControllerTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/NavigationControllerTest.kt
@@ -1,12 +1,15 @@
 package com.mapbox.navigation
 
+import android.content.Context
 import com.mapbox.android.core.location.LocationEngine
 import com.mapbox.android.core.location.LocationEngineRequest
 import com.mapbox.navigation.base.route.DirectionsSession
 import com.mapbox.navigation.navigator.MapboxNativeNavigator
-import com.mapbox.navigation.route.offboard.router.NavigationRoute
+import com.mapbox.navigation.utils.extensions.inferDeviceLocale
+import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
+import java.util.Locale
 import org.junit.Assert
 import org.junit.Before
 import org.junit.BeforeClass
@@ -15,7 +18,7 @@ import org.junit.Test
 class NavigationControllerTest {
 
     private lateinit var navigationController: NavigationController
-    private val routeBuilderProvider: NavigationRoute.Builder = mockk()
+    private val context: Context = mockk()
     private val navigator: MapboxNativeNavigator = mockk()
     private val locationEngine: LocationEngine = mockk()
     private val locationEngineRequest: LocationEngineRequest = mockk()
@@ -31,9 +34,10 @@ class NavigationControllerTest {
 
     @Before
     fun setUp() {
+        every { context.inferDeviceLocale() } returns Locale.US
         navigationController =
             NavigationController(
-                routeBuilderProvider,
+                context,
                 navigator,
                 locationEngine,
                 locationEngineRequest,


### PR DESCRIPTION
Removes the `NavigationController`'s dependency on the offboard router module.