### PR TITLE
Replaces the old Timber usage with the new Logger library

### DIFF
--- a/app/src/androidTest/java/testapp/activity/BaseNavigationActivityTest.java
+++ b/app/src/androidTest/java/testapp/activity/BaseNavigationActivityTest.java
@@ -10,6 +10,8 @@ import androidx.test.espresso.IdlingRegistry;
 import androidx.test.espresso.IdlingResourceTimeoutException;
 import androidx.test.rule.ActivityTestRule;
 
+import com.mapbox.navigation.base.logger.model.Message;
+import com.mapbox.navigation.logger.MapboxLogger;
 import com.mapbox.services.android.navigation.testapp.R;
 import com.mapbox.services.android.navigation.ui.v5.NavigationView;
 
@@ -23,13 +25,11 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import testapp.utils.OnNavigationReadyIdlingResource;
-import timber.log.Timber;
 
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.Espresso.onView;
-
 
 public abstract class BaseNavigationActivityTest {
 
@@ -50,7 +50,7 @@ public abstract class BaseNavigationActivityTest {
       navigationView = idlingResource.getNavigationView();
       assetManager = activity.getAssets();
     } catch (IdlingResourceTimeoutException idlingResourceTimeoutException) {
-      Timber.e("Idling resource timed out. Could not validate if navigation is ready.");
+      MapboxLogger.INSTANCE.e(new Message("Idling resource timed out. Could not validate if navigation is ready."));
       throw new RuntimeException("Could not start test for " + getActivityClass().getSimpleName() + ".\n"
         + "The ViewHierarchy doesn't contain a view with resource id = R.id.navigationView");
     }

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/NavigationApplication.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/NavigationApplication.kt
@@ -7,6 +7,8 @@ import com.mapbox.android.search.MapboxSearch
 import com.mapbox.android.search.MapboxSearchOptions
 import com.mapbox.crashmonitor.CrashMonitor
 import com.mapbox.mapboxsdk.Mapbox
+import com.mapbox.navigation.base.logger.model.Message
+import com.mapbox.navigation.logger.MapboxLogger
 import com.mapbox.services.android.navigation.testapp.example.utils.DelegatesExt
 import com.mapbox.services.android.navigation.testapp.utils.Utils
 import com.squareup.leakcanary.LeakCanary
@@ -65,7 +67,7 @@ class NavigationApplication : MultiDexApplication() {
     private fun setupMapbox() {
         val mapboxAccessToken = Utils.getMapboxAccessToken(applicationContext)
         if (TextUtils.isEmpty(mapboxAccessToken) || mapboxAccessToken == DEFAULT_MAPBOX_ACCESS_TOKEN) {
-            Timber.w("Mapbox access token isn't set!")
+            MapboxLogger.w(Message("Mapbox access token isn't set!"))
         }
 
         val cachingMode = MapboxSearchOptions().setCachingEnabled(true)
@@ -80,7 +82,7 @@ class NavigationApplication : MultiDexApplication() {
         try {
             crashMonitor.monitor(applicationInfo.dataDir)
         } catch (e: Exception) {
-            Timber.e("Couldn't monitor for crashes: ${e.message}")
+            MapboxLogger.e(Message("Couldn't monitor for crashes: ${e.message}"))
         }
     }
 }

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/MockNavigationActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/MockNavigationActivity.java
@@ -122,7 +122,7 @@ public class MockNavigationActivity extends AppCompatActivity implements OnMapRe
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_mock_navigation);
     ButterKnife.bind(this);
-    MapboxLogger.INSTANCE.setLogLevel(LogPriority.DEBUG);
+    MapboxLogger.INSTANCE.setLogLevel(LogPriority.VERBOSE);
     MapboxLogger.INSTANCE.setObserver(this);
     routeRefresh = new RouteRefresh(Mapbox.getAccessToken());
 

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/OffboardRouterActivityJava.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/OffboardRouterActivityJava.java
@@ -17,11 +17,13 @@ import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.maps.Style;
+import com.mapbox.navigation.base.logger.model.Message;
 import com.mapbox.navigation.base.route.DirectionsSession;
 import com.mapbox.navigation.base.route.Router;
 import com.mapbox.navigation.base.route.model.Route;
 import com.mapbox.navigation.base.route.model.RouteOptionsNavigation;
 import com.mapbox.navigation.directions.session.MapboxDirectionsSession;
+import com.mapbox.navigation.logger.MapboxLogger;
 import com.mapbox.navigation.route.offboard.MapboxOffboardRouter;
 import com.mapbox.navigation.route.offboard.router.NavigationRoute;
 import com.mapbox.services.android.navigation.testapp.R;
@@ -39,7 +41,6 @@ import java.util.List;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
-import timber.log.Timber;
 
 public class OffboardRouterActivityJava extends AppCompatActivity implements
         OnMapReadyCallback,
@@ -163,12 +164,12 @@ public class OffboardRouterActivityJava extends AppCompatActivity implements
 
   @Override
   public void onRoutesRequested() {
-    Timber.d("onRoutesRequested: navigation.getRoute()");
+    MapboxLogger.INSTANCE.d(new Message("onRoutesRequested: navigation.getRoute()"));
   }
 
   @Override
   public void onRoutesRequestFailure(@NotNull Throwable throwable) {
-    Timber.e(throwable, "onRoutesRequestFailure: navigation.getRoute()");
+    MapboxLogger.INSTANCE.e(new Message("onRoutesRequestFailure: navigation.getRoute()"), throwable);
   }
 
   /*

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/OffboardRouterActivityKt.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/OffboardRouterActivityKt.kt
@@ -13,10 +13,12 @@ import com.mapbox.mapboxsdk.geometry.LatLng
 import com.mapbox.mapboxsdk.maps.MapboxMap
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback
 import com.mapbox.mapboxsdk.maps.Style
+import com.mapbox.navigation.base.logger.model.Message
 import com.mapbox.navigation.base.route.DirectionsSession
 import com.mapbox.navigation.base.route.model.Route
 import com.mapbox.navigation.base.route.model.RouteOptionsNavigation
 import com.mapbox.navigation.directions.session.MapboxDirectionsSession
+import com.mapbox.navigation.logger.MapboxLogger
 import com.mapbox.navigation.route.offboard.MapboxOffboardRouter
 import com.mapbox.navigation.route.offboard.router.NavigationRoute
 import com.mapbox.navigation.utils.extensions.ifNonNull
@@ -27,7 +29,6 @@ import com.mapbox.services.android.navigation.v5.utils.extensions.mapToDirection
 import com.mapbox.turf.TurfConstants
 import com.mapbox.turf.TurfMeasurement
 import kotlinx.android.synthetic.main.activity_mock_navigation.*
-import timber.log.Timber
 
 class OffboardRouterActivityKt : AppCompatActivity(),
     OnMapReadyCallback,
@@ -144,11 +145,11 @@ class OffboardRouterActivityKt : AppCompatActivity(),
     }
 
     override fun onRoutesRequested() {
-        Timber.d("onRoutesRequested: navigation.getRoute()")
+        MapboxLogger.d(Message("onRoutesRequested: navigation.getRoute()"))
     }
 
     override fun onRoutesRequestFailure(throwable: Throwable) {
-        Timber.e(throwable, "onRoutesRequestFailure: navigation.getRoute()")
+        MapboxLogger.e(Message("onRoutesRequestFailure: navigation.getRoute()"), throwable)
     }
 
     /*

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/OfflineRegionDownloadActivity.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/OfflineRegionDownloadActivity.kt
@@ -32,6 +32,8 @@ import com.mapbox.mapboxsdk.offline.OfflineTilePyramidRegionDefinition
 import com.mapbox.mapboxsdk.style.layers.FillLayer
 import com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillColor
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource
+import com.mapbox.navigation.base.logger.model.Message
+import com.mapbox.navigation.logger.MapboxLogger
 import com.mapbox.services.android.navigation.testapp.R
 import com.mapbox.services.android.navigation.v5.navigation.MapboxOfflineRouter
 import com.mapbox.services.android.navigation.v5.navigation.OfflineError
@@ -41,7 +43,6 @@ import com.mapbox.services.android.navigation.v5.navigation.OnTileVersionsFoundC
 import com.mapbox.services.android.navigation.v5.navigation.RouteTileDownloadListener
 import kotlinx.android.synthetic.main.activity_offline_region_download.*
 import org.json.JSONObject
-import timber.log.Timber
 
 class OfflineRegionDownloadActivity : AppCompatActivity(), RouteTileDownloadListener,
     OnOfflineTilesRemovedCallback {
@@ -77,30 +78,26 @@ class OfflineRegionDownloadActivity : AppCompatActivity(), RouteTileDownloadList
     private var offlineRegion: OfflineRegion? = null
     private val offlineRegionCallback = object : OfflineManager.CreateOfflineRegionCallback {
         override fun onCreate(offlineRegion: OfflineRegion?) {
-            Timber.d("Offline region created: %s", "NavigationOfflineMapsRegion")
+            MapboxLogger.d(Message("Offline region created: NavigationOfflineMapsRegion"))
             this@OfflineRegionDownloadActivity.offlineRegion = offlineRegion
             launchMapsDownload()
         }
 
         override fun onError(error: String?) {
-            Timber.e("Error: %s", error)
+            MapboxLogger.d(Message("Error: $error"))
         }
     }
 
     private var isDownloadCompleted: Boolean = false
     private val offlineRegionObserver = object : OfflineRegion.OfflineRegionObserver {
         override fun mapboxTileCountLimitExceeded(limit: Long) {
-            Timber.e("Mapbox tile count limit exceeded: %s", limit)
+            MapboxLogger.e(Message("Mapbox tile count limit exceeded: $limit"))
         }
 
         override fun onStatusChanged(offlineRegionStatus: OfflineRegionStatus?) {
             offlineRegionStatus?.let { status ->
-                Timber.d(
-                        "%s/%s resources; %s bytes downloaded.",
-                        status.completedResourceCount,
-                        status.requiredResourceCount,
-                        status.completedResourceSize
-                )
+                MapboxLogger.d(Message("${status.completedResourceCount}/${status.requiredResourceCount} resources; " +
+                    "${status.completedResourceSize} bytes downloaded."))
                 if (status.isComplete && !isDownloadCompleted) {
                     isDownloadCompleted = true
                     downloadSelectedRegion()
@@ -109,8 +106,8 @@ class OfflineRegionDownloadActivity : AppCompatActivity(), RouteTileDownloadList
         }
 
         override fun onError(error: OfflineRegionError?) {
-            Timber.e("onError reason: %s", error?.reason)
-            Timber.e("onError message: %s", error?.message)
+            MapboxLogger.e(Message("onError reason: ${error?.reason}"))
+            MapboxLogger.e(Message("onError message: ${error?.message}"))
         }
     }
 
@@ -307,7 +304,7 @@ class OfflineRegionDownloadActivity : AppCompatActivity(), RouteTileDownloadList
     private fun obtainOfflineDirectory(): String {
         val offline = Environment.getExternalStoragePublicDirectory("Offline")
         if (!offline.exists()) {
-            Timber.d("Offline directory does not exist")
+            MapboxLogger.d(Message("Offline directory does not exist"))
             offline.mkdirs()
         }
         return offline.absolutePath

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/RerouteActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/RerouteActivity.java
@@ -30,6 +30,8 @@ import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.maps.Style;
+import com.mapbox.navigation.base.logger.model.Message;
+import com.mapbox.navigation.logger.MapboxLogger;
 import com.mapbox.services.android.navigation.testapp.R;
 import com.mapbox.services.android.navigation.ui.v5.instruction.InstructionView;
 import com.mapbox.services.android.navigation.v5.location.replay.ReplayRouteLocationEngine;
@@ -53,7 +55,6 @@ import butterknife.ButterKnife;
 import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
-import timber.log.Timber;
 
 public class RerouteActivity extends HistoryActivity implements OnMapReadyCallback,
   Callback<DirectionsResponse>, MapboxMap.OnMapClickListener, NavigationEventListener,
@@ -224,12 +225,12 @@ public class RerouteActivity extends HistoryActivity implements OnMapReadyCallba
       Snackbar.make(contentLayout, instruction, Snackbar.LENGTH_SHORT).show();
     }
     instructionView.updateBannerInstructionsWith(milestone);
-    Timber.d("onMilestoneEvent - Current Instruction: %s", instruction);
+    MapboxLogger.INSTANCE.d(new Message("onMilestoneEvent - Current Instruction: " + instruction));
   }
 
   @Override
   public void onResponse(@NonNull Call<DirectionsResponse> call, @NonNull Response<DirectionsResponse> response) {
-    Timber.d(call.request().url().toString());
+    MapboxLogger.INSTANCE.d(new Message(call.request().url().toString()));
     if (response.body() != null) {
       if (!response.body().routes().isEmpty()) {
         DirectionsRoute route = response.body().routes().get(0);
@@ -244,7 +245,7 @@ public class RerouteActivity extends HistoryActivity implements OnMapReadyCallba
 
   @Override
   public void onFailure(@NonNull Call<DirectionsResponse> call, @NonNull Throwable throwable) {
-    Timber.e(throwable);
+    MapboxLogger.INSTANCE.e(new Message(throwable.getLocalizedMessage()), throwable);
   }
 
   void updateLocation(Location location) {
@@ -324,7 +325,7 @@ public class RerouteActivity extends HistoryActivity implements OnMapReadyCallba
 
     @Override
     public void onFailure(@NonNull Exception exception) {
-      Timber.e(exception);
+      MapboxLogger.INSTANCE.e(new Message(exception.getLocalizedMessage()), exception);
     }
   }
 }

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/StoreHistoryTask.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/StoreHistoryTask.java
@@ -3,13 +3,13 @@ package com.mapbox.services.android.navigation.testapp.activity;
 import android.os.AsyncTask;
 import android.os.Environment;
 
+import com.mapbox.navigation.base.logger.model.Message;
+import com.mapbox.navigation.logger.MapboxLogger;
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStreamWriter;
-
-import timber.log.Timber;
 
 class StoreHistoryTask extends AsyncTask<Void, Void, Void> {
   private static final String EMPTY_HISTORY = "{}";
@@ -54,7 +54,7 @@ class StoreHistoryTask extends AsyncTask<Void, Void, Void> {
       fos.flush();
       fos.close();
     } catch (Exception exception) {
-      Timber.e(exception);
+      MapboxLogger.INSTANCE.e(new Message(exception.getLocalizedMessage()), exception);
     }
   }
 }

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/ComponentNavigationActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/ComponentNavigationActivity.java
@@ -37,6 +37,8 @@ import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.maps.Style;
+import com.mapbox.navigation.base.logger.model.Message;
+import com.mapbox.navigation.logger.MapboxLogger;
 import com.mapbox.services.android.navigation.testapp.R;
 import com.mapbox.services.android.navigation.testapp.activity.HistoryActivity;
 import com.mapbox.services.android.navigation.ui.v5.camera.DynamicCamera;
@@ -72,7 +74,6 @@ import okhttp3.Cache;
 import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
-import timber.log.Timber;
 
 public class ComponentNavigationActivity extends HistoryActivity implements OnMapReadyCallback,
   MapboxMap.OnMapLongClickListener, ProgressChangeListener, MilestoneEventListener,
@@ -218,7 +219,7 @@ public class ComponentNavigationActivity extends HistoryActivity implements OnMa
   public void onProgressChange(Location location, RouteProgress routeProgress) {
     // Cache "snapped" Locations for re-route Directions API requests
     // TODO This is for testing / debugging purposes
-    Timber.d("DEBUG snapped %s", location.toString());
+    MapboxLogger.INSTANCE.d(new Message("DEBUG snapped " + location.toString()));
     updateLocation(location);
 
     // Update InstructionView data from RouteProgress
@@ -228,7 +229,7 @@ public class ComponentNavigationActivity extends HistoryActivity implements OnMa
   @Override
   public void onEnhancedLocationUpdate(Location location) {
     // TODO This is for testing / debugging purposes
-    Timber.d("DEBUG enhanced %s", location.toString());
+    MapboxLogger.INSTANCE.d(new Message("DEBUG enhanced " + location.toString()));
     checkFirstUpdate(location);
     updateLocation(location);
   }
@@ -466,7 +467,7 @@ public class ComponentNavigationActivity extends HistoryActivity implements OnMa
 
         @Override
         public void onFailure(@NonNull Call<DirectionsResponse> call, @NonNull Throwable throwable) {
-          Timber.e(throwable);
+          MapboxLogger.INSTANCE.e(new Message(throwable.getLocalizedMessage()), throwable);
         }
       });
   }
@@ -566,7 +567,7 @@ public class ComponentNavigationActivity extends HistoryActivity implements OnMa
 
     @Override
     public void onFailure(@NonNull Exception exception) {
-      Timber.e(exception);
+      MapboxLogger.INSTANCE.e(new Message(exception.getLocalizedMessage()), exception);
     }
   }
 }

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/DualNavigationMapActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/DualNavigationMapActivity.java
@@ -32,6 +32,8 @@ import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.maps.Style;
+import com.mapbox.navigation.base.logger.model.Message;
+import com.mapbox.navigation.logger.MapboxLogger;
 import com.mapbox.services.android.navigation.testapp.R;
 import com.mapbox.services.android.navigation.ui.v5.NavigationView;
 import com.mapbox.services.android.navigation.ui.v5.NavigationViewOptions;
@@ -46,7 +48,6 @@ import java.lang.ref.WeakReference;
 import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
-import timber.log.Timber;
 
 public class DualNavigationMapActivity extends AppCompatActivity implements OnNavigationReadyCallback,
   NavigationListener, Callback<DirectionsResponse>, OnMapReadyCallback, MapboxMap.OnMapLongClickListener,
@@ -356,7 +357,7 @@ public class DualNavigationMapActivity extends AppCompatActivity implements OnNa
 
     @Override
     public void onFailure(@NonNull Exception exception) {
-      Timber.e(exception);
+      MapboxLogger.INSTANCE.e(new Message(exception.getLocalizedMessage()), exception);
     }
   }
 }

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/EmbeddedNavigationActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/EmbeddedNavigationActivity.java
@@ -29,6 +29,8 @@ import com.mapbox.mapboxsdk.Mapbox;
 import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.maps.Style;
+import com.mapbox.navigation.base.logger.model.Message;
+import com.mapbox.navigation.logger.MapboxLogger;
 import com.mapbox.services.android.navigation.testapp.R;
 import com.mapbox.services.android.navigation.ui.v5.NavigationView;
 import com.mapbox.services.android.navigation.ui.v5.NavigationViewOptions;
@@ -46,7 +48,6 @@ import java.io.File;
 
 import retrofit2.Call;
 import retrofit2.Response;
-import timber.log.Timber;
 
 public class EmbeddedNavigationActivity extends AppCompatActivity implements OnNavigationReadyCallback,
   NavigationListener, ProgressChangeListener, InstructionListListener, SpeechAnnouncementListener,
@@ -217,7 +218,7 @@ public class EmbeddedNavigationActivity extends AppCompatActivity implements OnN
   private String obtainOfflineDirectory() {
     File offline = Environment.getExternalStoragePublicDirectory("Offline");
     if (!offline.exists()) {
-      Timber.d("Offline directory does not exist");
+      MapboxLogger.INSTANCE.d(new Message("Offline directory does not exist"));
       offline.mkdirs();
     }
     return offline.getAbsolutePath();

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/NavigationLauncherActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/NavigationLauncherActivity.java
@@ -42,6 +42,8 @@ import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.maps.Style;
+import com.mapbox.navigation.base.logger.model.Message;
+import com.mapbox.navigation.logger.MapboxLogger;
 import com.mapbox.services.android.navigation.testapp.NavigationSettingsActivity;
 import com.mapbox.services.android.navigation.testapp.R;
 import com.mapbox.services.android.navigation.ui.v5.NavigationLauncher;
@@ -67,7 +69,6 @@ import butterknife.ButterKnife;
 import butterknife.OnClick;
 import retrofit2.Call;
 import retrofit2.Response;
-import timber.log.Timber;
 
 import static android.os.Environment.getExternalStoragePublicDirectory;
 
@@ -448,7 +449,7 @@ public class NavigationLauncherActivity extends AppCompatActivity implements OnM
 
     @Override
     public void onFailure(@NonNull Exception exception) {
-      Timber.e(exception);
+      MapboxLogger.INSTANCE.e(new Message(exception.getLocalizedMessage()), exception);
     }
   }
 }

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/NavigationMapRouteActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/NavigationMapRouteActivity.java
@@ -28,6 +28,8 @@ import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.maps.Style;
+import com.mapbox.navigation.base.logger.model.Message;
+import com.mapbox.navigation.logger.MapboxLogger;
 import com.mapbox.services.android.navigation.testapp.R;
 import com.mapbox.services.android.navigation.ui.v5.route.NavigationMapRoute;
 import com.mapbox.services.android.navigation.v5.navigation.NavigationRoute;
@@ -40,7 +42,6 @@ import butterknife.OnClick;
 import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
-import timber.log.Timber;
 
 public class NavigationMapRouteActivity extends AppCompatActivity implements OnMapReadyCallback,
   MapboxMap.OnMapLongClickListener, Callback<DirectionsResponse> {
@@ -115,7 +116,7 @@ public class NavigationMapRouteActivity extends AppCompatActivity implements OnM
 
   @Override
   public void onFailure(@NonNull Call<DirectionsResponse> call, @NonNull Throwable throwable) {
-    Timber.e(throwable);
+    MapboxLogger.INSTANCE.e(new Message(throwable.getLocalizedMessage()), throwable);
   }
 
   @Override

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/SimplifiedCallback.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/navigationui/SimplifiedCallback.java
@@ -1,10 +1,11 @@
 package com.mapbox.services.android.navigation.testapp.activity.navigationui;
 
 import com.mapbox.api.directions.v5.models.DirectionsResponse;
+import com.mapbox.navigation.base.logger.model.Message;
+import com.mapbox.navigation.logger.MapboxLogger;
 
 import retrofit2.Call;
 import retrofit2.Callback;
-import timber.log.Timber;
 
 /**
  * Helper class to reduce redundant logging code when no other action is taken in onFailure
@@ -12,6 +13,6 @@ import timber.log.Timber;
 public abstract class SimplifiedCallback implements Callback<DirectionsResponse> {
   @Override
   public void onFailure(Call<DirectionsResponse> call, Throwable throwable) {
-    Timber.e(throwable, throwable.getMessage());
+    MapboxLogger.INSTANCE.e(new Message(throwable.getMessage()), throwable);
   }
 }

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExampleActivity.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExampleActivity.kt
@@ -66,7 +66,7 @@ class ExampleActivity : HistoryActivity(), ExampleView, LoggerObserver, MetricsO
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_example)
-        MapboxLogger.logLevel = DEBUG
+        MapboxLogger.logLevel = VERBOSE
         MapboxLogger.setObserver(this)
         setupWith(savedInstanceState)
         addNavigationForHistory(viewModel.retrieveNavigation())

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExampleLocationEngineCallback.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExampleLocationEngineCallback.kt
@@ -4,7 +4,8 @@ import android.location.Location
 import androidx.lifecycle.MutableLiveData
 import com.mapbox.android.core.location.LocationEngineCallback
 import com.mapbox.android.core.location.LocationEngineResult
-import timber.log.Timber
+import com.mapbox.navigation.base.logger.model.Message
+import com.mapbox.navigation.logger.MapboxLogger
 
 class ExampleLocationEngineCallback(private val location: MutableLiveData<Location>) :
     LocationEngineCallback<LocationEngineResult> {
@@ -14,6 +15,6 @@ class ExampleLocationEngineCallback(private val location: MutableLiveData<Locati
     }
 
     override fun onFailure(exception: Exception) {
-        Timber.e(exception)
+        MapboxLogger.e(Message(exception.localizedMessage), exception)
     }
 }

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/navigation/ExampleRouteFinder.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/navigation/ExampleRouteFinder.kt
@@ -3,12 +3,13 @@ package com.mapbox.services.android.navigation.testapp.example.ui.navigation
 import android.location.Location
 import com.mapbox.api.directions.v5.models.DirectionsResponse
 import com.mapbox.geojson.Point
+import com.mapbox.navigation.base.logger.model.Message
+import com.mapbox.navigation.logger.MapboxLogger
 import com.mapbox.services.android.navigation.testapp.NavigationApplication
 import com.mapbox.services.android.navigation.v5.navigation.NavigationRoute
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
-import timber.log.Timber
 
 private const val BEARING_TOLERANCE = 90.0
 
@@ -30,7 +31,7 @@ class ExampleRouteFinder(
     }
 
     override fun onFailure(call: Call<DirectionsResponse>, throwable: Throwable) {
-        Timber.e(throwable)
+        MapboxLogger.e(Message(throwable.localizedMessage), throwable)
     }
 
     private fun find(location: Location, destination: Point) {

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/navigation/OfflineRouteFinder.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/navigation/OfflineRouteFinder.kt
@@ -6,6 +6,8 @@ import android.widget.Toast
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.geojson.Point
 import com.mapbox.mapboxsdk.Mapbox
+import com.mapbox.navigation.base.logger.model.Message
+import com.mapbox.navigation.logger.MapboxLogger
 import com.mapbox.services.android.navigation.testapp.NavigationApplication
 import com.mapbox.services.android.navigation.testapp.R
 import com.mapbox.services.android.navigation.v5.navigation.MapboxOfflineRouter
@@ -14,7 +16,6 @@ import com.mapbox.services.android.navigation.v5.navigation.OfflineError
 import com.mapbox.services.android.navigation.v5.navigation.OfflineRoute
 import com.mapbox.services.android.navigation.v5.navigation.OnOfflineRouteFoundCallback
 import com.mapbox.services.android.navigation.v5.navigation.OnOfflineTilesConfiguredCallback
-import timber.log.Timber
 
 private const val BEARING_TOLERANCE = 90.0
 
@@ -40,12 +41,12 @@ class OfflineRouteFinder(
 
         offlineRouter.configure(version, object : OnOfflineTilesConfiguredCallback {
             override fun onConfigured(numberOfTiles: Int) {
-                Timber.d("Offline tiles configured: $numberOfTiles")
+                MapboxLogger.d(Message("Offline tiles configured: $numberOfTiles"))
                 isConfigured = true
             }
 
             override fun onConfigurationError(error: OfflineError) {
-                Timber.d("Offline tiles configuration error: {${error.message}}")
+                MapboxLogger.d(Message("Offline tiles configuration error: {${error.message}}"))
                 isConfigured = false
             }
         })

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/navigation/RouteFinder.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/navigation/RouteFinder.kt
@@ -6,10 +6,11 @@ import android.preference.PreferenceManager
 import androidx.lifecycle.MutableLiveData
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.geojson.Point
+import com.mapbox.navigation.base.logger.model.Message
+import com.mapbox.navigation.logger.MapboxLogger
 import com.mapbox.services.android.navigation.testapp.NavigationApplication
 import com.mapbox.services.android.navigation.testapp.R
 import com.mapbox.services.android.navigation.testapp.example.ui.ExampleViewModel
-import timber.log.Timber
 
 class RouteFinder(
     private val viewModel: ExampleViewModel,
@@ -46,13 +47,13 @@ class RouteFinder(
     }
 
     override fun onError(error: String) {
-        Timber.d(error)
+        MapboxLogger.d(Message(error))
     }
 
     private fun obtainOfflineDirectory(): String {
         val offline = Environment.getExternalStoragePublicDirectory("Offline")
         if (!offline.exists()) {
-            Timber.d("Offline directory does not exist")
+            MapboxLogger.d(Message("Offline directory does not exist"))
             offline.mkdirs()
         }
         return offline.absolutePath

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/utils/Utils.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/utils/Utils.java
@@ -13,10 +13,10 @@ import com.mapbox.mapboxsdk.Mapbox;
 import com.mapbox.mapboxsdk.annotations.Icon;
 import com.mapbox.mapboxsdk.annotations.IconFactory;
 import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.navigation.base.logger.model.Message;
+import com.mapbox.navigation.logger.MapboxLogger;
 
 import java.util.Random;
-
-import timber.log.Timber;
 
 public class Utils {
 
@@ -67,7 +67,7 @@ public class Utils {
     double randomLon = bbox[0] + (bbox[2] - bbox[0]) * random.nextDouble();
 
     LatLng latLng = new LatLng(randomLat, randomLon);
-    Timber.d("getRandomLatLng: %s", latLng.toString());
+    MapboxLogger.INSTANCE.d(new Message("getRandomLatLng: " + latLng.toString()));
     return latLng;
   }
 }

--- a/libandroid-navigation-ui/build.gradle
+++ b/libandroid-navigation-ui/build.gradle
@@ -59,6 +59,7 @@ dependencies {
   // Navigation SDK
   api project(':libandroid-navigation')
   implementation project(':libnavigation-util')
+  implementation project(':liblogger')
 
   // Mapbox Maps SDK
   implementation dependenciesList.mapboxMapSdk
@@ -80,9 +81,6 @@ dependencies {
 
   // Picasso
   implementation dependenciesList.picasso
-
-  // Timber
-  implementation dependenciesList.timber
 
   // Mapbox Map SDK Javadoc
   javadocDeps dependenciesList.mapboxMapSdk

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationOfflineDatabaseCallback.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationOfflineDatabaseCallback.java
@@ -1,8 +1,8 @@
 package com.mapbox.services.android.navigation.ui.v5;
 
+import com.mapbox.navigation.base.logger.model.Message;
+import com.mapbox.navigation.logger.MapboxLogger;
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation;
-
-import timber.log.Timber;
 
 class NavigationOfflineDatabaseCallback implements OfflineDatabaseLoadedCallback {
 
@@ -21,7 +21,7 @@ class NavigationOfflineDatabaseCallback implements OfflineDatabaseLoadedCallback
 
   @Override
   public void onError(String error) {
-    Timber.e(error);
+    MapboxLogger.INSTANCE.e(new Message(error));
   }
 
   void onDestroy() {

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewModel.java
@@ -46,8 +46,6 @@ import com.mapbox.services.android.navigation.v5.utils.RouteUtils;
 import com.mapbox.navigation.utils.extensions.ContextEx;
 import com.mapbox.services.android.navigation.v5.utils.extensions.LocaleEx;
 
-import org.jetbrains.annotations.TestOnly;
-
 import java.io.File;
 import java.util.List;
 
@@ -99,7 +97,6 @@ public class NavigationViewModel extends AndroidViewModel {
     this.connectivityController = new MapConnectivityController();
   }
 
-  @TestOnly
   // Package private (no modifier) for testing purposes
   NavigationViewModel(Application application, MapboxNavigation navigation,
                       MapConnectivityController connectivityController, MapOfflineManager mapOfflineManager,
@@ -111,7 +108,6 @@ public class NavigationViewModel extends AndroidViewModel {
     this.mapOfflineManager = mapOfflineManager;
   }
 
-  @TestOnly
   // Package private (no modifier) for testing purposes
   NavigationViewModel(Application application, MapboxNavigation navigation,
                       LocationEngineConductor conductor, NavigationViewEventDispatcher dispatcher,

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewOfflineRouter.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationViewOfflineRouter.java
@@ -1,10 +1,10 @@
 package com.mapbox.services.android.navigation.ui.v5;
 
+import com.mapbox.navigation.base.logger.model.Message;
+import com.mapbox.navigation.logger.MapboxLogger;
 import com.mapbox.services.android.navigation.v5.navigation.MapboxOfflineRouter;
 import com.mapbox.services.android.navigation.v5.navigation.NavigationRoute;
 import com.mapbox.services.android.navigation.v5.navigation.OfflineRoute;
-
-import timber.log.Timber;
 
 class NavigationViewOfflineRouter {
 
@@ -35,7 +35,7 @@ class NavigationViewOfflineRouter {
 
   void findRouteWith(NavigationRoute.Builder builder) {
     if (!isConfigured) {
-      Timber.e("Cannot find route - offline router is not configured");
+      MapboxLogger.INSTANCE.e(new Message("Cannot find route - offline router is not configured"));
       return;
     }
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/OfflineRouterConfiguredCallback.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/OfflineRouterConfiguredCallback.java
@@ -3,10 +3,10 @@ package com.mapbox.services.android.navigation.ui.v5;
 
 import androidx.annotation.NonNull;
 
+import com.mapbox.navigation.base.logger.model.Message;
+import com.mapbox.navigation.logger.MapboxLogger;
 import com.mapbox.services.android.navigation.v5.navigation.OfflineError;
 import com.mapbox.services.android.navigation.v5.navigation.OnOfflineTilesConfiguredCallback;
-
-import timber.log.Timber;
 
 class OfflineRouterConfiguredCallback implements OnOfflineTilesConfiguredCallback {
 
@@ -23,6 +23,6 @@ class OfflineRouterConfiguredCallback implements OnOfflineTilesConfiguredCallbac
 
   @Override
   public void onConfigurationError(@NonNull OfflineError error) {
-    Timber.e(error.getMessage());
+    MapboxLogger.INSTANCE.e(new Message(error.getMessage()));
   }
 }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/camera/NavigationCamera.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/camera/NavigationCamera.java
@@ -23,6 +23,8 @@ import com.mapbox.mapboxsdk.location.OnLocationCameraTransitionListener;
 import com.mapbox.mapboxsdk.location.modes.CameraMode;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.utils.MathUtils;
+import com.mapbox.navigation.base.logger.model.Message;
+import com.mapbox.navigation.logger.MapboxLogger;
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation;
 import com.mapbox.services.android.navigation.v5.navigation.camera.Camera;
 import com.mapbox.services.android.navigation.v5.navigation.camera.RouteInformation;
@@ -34,8 +36,6 @@ import java.lang.annotation.RetentionPolicy;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
-
-import timber.log.Timber;
 
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.NAVIGATION_MAX_CAMERA_ADJUSTMENT_ANIMATION_DURATION;
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.NAVIGATION_MIN_CAMERA_TILT_ADJUSTMENT_ANIMATION_DURATION;
@@ -486,7 +486,7 @@ public class NavigationCamera implements LifecycleObserver {
         locationComponent.setCameraMode(cameraMode, cameraTransitionListener);
       }
     } else {
-      Timber.e("Using unsupported camera tracking mode - %d.", trackingCameraMode);
+      MapboxLogger.INSTANCE.e(new Message("Using unsupported camera tracking mode - " + trackingCameraMode + "."));
     }
   }
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionTarget.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionTarget.java
@@ -8,12 +8,12 @@ import android.text.TextUtils;
 import android.text.style.ImageSpan;
 import android.widget.TextView;
 
+import com.mapbox.navigation.base.logger.model.Message;
+import com.mapbox.navigation.logger.MapboxLogger;
 import com.squareup.picasso.Picasso;
 import com.squareup.picasso.Target;
 
 import java.util.List;
-
-import timber.log.Timber;
 
 public class InstructionTarget implements Target {
 
@@ -55,7 +55,7 @@ public class InstructionTarget implements Target {
   public void onBitmapFailed(Exception exception, Drawable errorDrawable) {
     setBackupText();
     sendInstructionLoadedCallback();
-    Timber.e(exception);
+    MapboxLogger.INSTANCE.e(new Message(exception.getLocalizedMessage()), exception);
   }
 
   @Override

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/InstructionView.java
@@ -35,6 +35,8 @@ import com.mapbox.api.directions.v5.models.BannerComponents;
 import com.mapbox.api.directions.v5.models.BannerInstructions;
 import com.mapbox.api.directions.v5.models.BannerText;
 import com.mapbox.api.directions.v5.models.LegStep;
+import com.mapbox.navigation.base.logger.model.Message;
+import com.mapbox.navigation.logger.MapboxLogger;
 import com.mapbox.services.android.navigation.ui.v5.FeedbackButton;
 import com.mapbox.services.android.navigation.ui.v5.NavigationButton;
 import com.mapbox.services.android.navigation.ui.v5.NavigationViewModel;
@@ -58,8 +60,6 @@ import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 import com.mapbox.services.android.navigation.v5.utils.DistanceFormatter;
 import com.mapbox.navigation.utils.extensions.ContextEx;
 import com.mapbox.services.android.navigation.v5.utils.extensions.LocaleEx;
-
-import timber.log.Timber;
 
 /**
  * A view that can be used to display upcoming maneuver information and control
@@ -721,7 +721,7 @@ public class InstructionView extends RelativeLayout implements LifecycleObserver
     try {
       return ((FragmentActivity) getContext()).getSupportFragmentManager();
     } catch (ClassCastException exception) {
-      Timber.e(exception);
+      MapboxLogger.INSTANCE.e(new Message(exception.getLocalizedMessage()), exception);
       return null;
     }
   }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/NavigationAlertView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/instruction/NavigationAlertView.java
@@ -9,6 +9,8 @@ import androidx.annotation.Nullable;
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
 
+import com.mapbox.navigation.base.logger.model.Message;
+import com.mapbox.navigation.logger.MapboxLogger;
 import com.mapbox.services.android.navigation.ui.v5.NavigationViewModel;
 import com.mapbox.services.android.navigation.ui.v5.R;
 import com.mapbox.services.android.navigation.ui.v5.alert.AlertView;
@@ -17,8 +19,6 @@ import com.mapbox.services.android.navigation.ui.v5.feedback.FeedbackBottomSheet
 import com.mapbox.services.android.navigation.ui.v5.feedback.FeedbackItem;
 import com.mapbox.services.android.navigation.v5.internal.navigation.metrics.FeedbackEvent;
 import com.mapbox.services.android.navigation.v5.navigation.NavigationConstants;
-
-import timber.log.Timber;
 
 public class NavigationAlertView extends AlertView implements FeedbackBottomSheetListener {
 
@@ -140,7 +140,7 @@ public class NavigationAlertView extends AlertView implements FeedbackBottomShee
     try {
       return ((FragmentActivity) getContext()).getSupportFragmentManager();
     } catch (ClassCastException exception) {
-      Timber.e(exception);
+      MapboxLogger.INSTANCE.e(new Message(exception.getLocalizedMessage()), exception);
       return null;
     }
   }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/voice/AndroidSpeechPlayer.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/voice/AndroidSpeechPlayer.java
@@ -5,10 +5,11 @@ import android.os.Build;
 import android.speech.tts.TextToSpeech;
 import android.text.TextUtils;
 
+import com.mapbox.navigation.base.logger.model.Message;
+import com.mapbox.navigation.logger.MapboxLogger;
+
 import java.util.HashMap;
 import java.util.Locale;
-
-import timber.log.Timber;
 
 /**
  * Default player used to play voice instructions when a connection to Polly is unable to be established.
@@ -40,7 +41,7 @@ class AndroidSpeechPlayer implements SpeechPlayer {
       public void onInit(int status) {
         boolean ableToInitialize = status == TextToSpeech.SUCCESS && language != null;
         if (!ableToInitialize) {
-          Timber.e("There was an error initializing native TTS");
+          MapboxLogger.INSTANCE.e(new Message("There was an error initializing native TTS"));
           return;
         }
         setSpeechListener(speechListener);
@@ -122,7 +123,7 @@ class AndroidSpeechPlayer implements SpeechPlayer {
   private void initializeWithLanguage(Locale language) {
     boolean isLanguageAvailable = textToSpeech.isLanguageAvailable(language) == TextToSpeech.LANG_AVAILABLE;
     if (!isLanguageAvailable) {
-      Timber.w("The specified language is not supported by TTS");
+      MapboxLogger.INSTANCE.w(new Message("The specified language is not supported by TTS"));
       return;
     }
     languageSupported = true;

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/voice/InstructionCacheCallback.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/voice/InstructionCacheCallback.java
@@ -3,11 +3,13 @@ package com.mapbox.services.android.navigation.ui.v5.voice;
 
 import androidx.annotation.NonNull;
 
+import com.mapbox.navigation.base.logger.model.Message;
+import com.mapbox.navigation.logger.MapboxLogger;
+
 import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
-import timber.log.Timber;
 
 class InstructionCacheCallback implements Callback<ResponseBody> {
 
@@ -27,7 +29,7 @@ class InstructionCacheCallback implements Callback<ResponseBody> {
 
   @Override
   public void onFailure(@NonNull Call<ResponseBody> call, @NonNull Throwable throwable) {
-    Timber.e(throwable, "onFailure cache instruction");
+    MapboxLogger.INSTANCE.e(new Message("onFailure cache instruction"), throwable);
   }
 
   private boolean closeResponseBody(@NonNull Response<ResponseBody> response) {

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/voice/MapboxSpeechPlayer.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/voice/MapboxSpeechPlayer.java
@@ -8,6 +8,8 @@ import android.text.TextUtils;
 import androidx.annotation.NonNull;
 import androidx.core.util.Pair;
 
+import com.mapbox.navigation.base.logger.model.Message;
+import com.mapbox.navigation.logger.MapboxLogger;
 import com.mapbox.services.android.navigation.v5.utils.DownloadTask;
 
 import java.io.File;
@@ -19,7 +21,6 @@ import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
-import timber.log.Timber;
 
 /**
  * <p>
@@ -29,7 +30,6 @@ import timber.log.Timber;
 class MapboxSpeechPlayer implements SpeechPlayer {
 
   private static final String MAPBOX_INSTRUCTION_CACHE = "mapbox_instruction_cache";
-  private static final String ERROR_TEXT = "Unable to set data source for the media mediaPlayer! %s";
   private static final SpeechAnnouncementMap SPEECH_ANNOUNCEMENT_MAP = new SpeechAnnouncementMap();
   private static final String MP3_POSTFIX = "mp3";
 
@@ -182,7 +182,9 @@ class MapboxSpeechPlayer implements SpeechPlayer {
     try {
       mediaPlayer.setDataSource(instruction);
     } catch (IOException ioException) {
-      Timber.e(ERROR_TEXT, ioException.getMessage());
+      MapboxLogger.INSTANCE.e(
+              new Message("Unable to set data source for the media mediaPlayer! " + ioException.getMessage())
+      );
     }
   }
 

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/voice/NavigationSpeechListener.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/voice/NavigationSpeechListener.java
@@ -1,6 +1,7 @@
 package com.mapbox.services.android.navigation.ui.v5.voice;
 
-import timber.log.Timber;
+import com.mapbox.navigation.base.logger.model.Message;
+import com.mapbox.navigation.logger.MapboxLogger;
 
 class NavigationSpeechListener implements SpeechListener {
 
@@ -25,7 +26,7 @@ class NavigationSpeechListener implements SpeechListener {
 
   @Override
   public void onError(String errorText, SpeechAnnouncement speechAnnouncement) {
-    Timber.e(errorText);
+    MapboxLogger.INSTANCE.e(new Message(errorText));
     speechPlayerProvider.retrieveAndroidSpeechPlayer().play(speechAnnouncement);
   }
 }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/voice/VoiceInstructionLoader.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/voice/VoiceInstructionLoader.java
@@ -3,6 +3,8 @@ package com.mapbox.services.android.navigation.ui.v5.voice;
 import android.content.Context;
 
 import com.mapbox.api.speech.v1.MapboxSpeech;
+import com.mapbox.navigation.base.logger.model.Message;
+import com.mapbox.navigation.logger.MapboxLogger;
 import com.mapbox.services.android.navigation.ui.v5.ConnectivityStatusProvider;
 
 import java.io.IOException;
@@ -18,7 +20,6 @@ import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 import retrofit2.Callback;
-import timber.log.Timber;
 
 public class VoiceInstructionLoader {
   private static final int VOICE_INSTRUCTIONS_TO_EVICT_THRESHOLD = 4;
@@ -107,7 +108,7 @@ public class VoiceInstructionLoader {
     try {
       cache.evictAll();
     } catch (IOException exception) {
-      Timber.e(exception);
+      MapboxLogger.INSTANCE.e(new Message(exception.getLocalizedMessage()), exception);
     }
   }
 

--- a/libandroid-navigation/build.gradle
+++ b/libandroid-navigation/build.gradle
@@ -59,6 +59,7 @@ dependencies {
   api project(':libnavigation-base')
   implementation project(':libnavigator')
   implementation project(':libnavigation-util')
+  implementation project(':liblogger')
   api dependenciesList.mapboxSdkServices
   api dependenciesList.mapboxSdkTurf
   api dependenciesList.mapboxCore
@@ -76,9 +77,6 @@ dependencies {
 
   // Support
   implementation dependenciesList.supportAppcompatV7
-
-  // Logging
-  implementation dependenciesList.timber
 
   // AutoValues
   annotationProcessor dependenciesList.autoValue

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/FreeDriveLocationUpdater.kt
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/FreeDriveLocationUpdater.kt
@@ -7,6 +7,8 @@ import com.mapbox.android.core.location.LocationEngine
 import com.mapbox.android.core.location.LocationEngineCallback
 import com.mapbox.android.core.location.LocationEngineRequest
 import com.mapbox.android.core.location.LocationEngineResult
+import com.mapbox.navigation.base.logger.model.Message
+import com.mapbox.navigation.logger.MapboxLogger
 import com.mapbox.navigator.NavigationStatus
 import com.mapbox.services.android.navigation.v5.navigation.OfflineNavigator
 import com.mapbox.services.android.navigation.v5.navigation.OnOfflineTilesConfiguredCallback
@@ -15,7 +17,6 @@ import java.util.Date
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
-import timber.log.Timber
 
 internal class FreeDriveLocationUpdater(
     private var locationEngine: LocationEngine,
@@ -132,7 +133,7 @@ internal class FreeDriveLocationUpdater(
         }
 
         override fun onFailure(exception: Exception) {
-            Timber.e(exception)
+            MapboxLogger.e(Message(exception.localizedMessage), exception)
         }
     }
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/LocationUpdater.kt
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/LocationUpdater.kt
@@ -7,8 +7,9 @@ import com.mapbox.android.core.location.LocationEngine
 import com.mapbox.android.core.location.LocationEngineCallback
 import com.mapbox.android.core.location.LocationEngineRequest
 import com.mapbox.android.core.location.LocationEngineResult
+import com.mapbox.navigation.base.logger.model.Message
+import com.mapbox.navigation.logger.MapboxLogger
 import java.lang.ref.WeakReference
-import timber.log.Timber
 
 @SuppressLint("MissingPermission")
 internal class LocationUpdater(
@@ -81,7 +82,7 @@ internal class LocationUpdater(
         }
 
         override fun onFailure(exception: Exception) {
-            Timber.e(exception)
+            MapboxLogger.e(Message(exception.localizedMessage), exception)
         }
     }
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/MetadataBuilder.kt
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/MetadataBuilder.kt
@@ -4,10 +4,11 @@ import android.app.ActivityManager
 import android.content.Context
 import android.os.Build
 import androidx.core.os.ConfigurationCompat
+import com.mapbox.navigation.base.logger.model.Message
+import com.mapbox.navigation.logger.MapboxLogger
 import java.io.IOException
 import java.io.RandomAccessFile
 import java.util.regex.Pattern
-import timber.log.Timber
 
 internal object MetadataBuilder {
 
@@ -80,7 +81,7 @@ internal object MetadataBuilder {
             reader.close()
             (value.toLong() / 1024).toString()
         } catch (ex: IOException) {
-            Timber.e("Failing to access RandomAccessFile $RANDOM_ACCESS_FILE_NAME")
+            MapboxLogger.e(Message("Failing to access RandomAccessFile $RANDOM_ACCESS_FILE_NAME"))
             ""
         }
     }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/NavigationEventDispatcher.kt
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/NavigationEventDispatcher.kt
@@ -2,6 +2,8 @@ package com.mapbox.services.android.navigation.v5.internal.navigation
 
 import android.location.Location
 import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.navigation.base.logger.model.Message
+import com.mapbox.navigation.logger.MapboxLogger
 import com.mapbox.services.android.navigation.v5.internal.navigation.metrics.NavigationMetricListener
 import com.mapbox.services.android.navigation.v5.location.RawLocationListener
 import com.mapbox.services.android.navigation.v5.milestone.Milestone
@@ -14,7 +16,6 @@ import com.mapbox.services.android.navigation.v5.routeprogress.ProgressChangeLis
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress
 import com.mapbox.services.android.navigation.v5.utils.RouteUtils
 import java.util.concurrent.CopyOnWriteArrayList
-import timber.log.Timber
 
 internal class NavigationEventDispatcher {
 
@@ -43,7 +44,7 @@ internal class NavigationEventDispatcher {
 
     fun addMilestoneEventListener(milestoneEventListener: MilestoneEventListener) {
         if (milestoneEventListeners.contains(milestoneEventListener)) {
-            Timber.w("The specified MilestoneEventListener has already been added to the stack.")
+            MapboxLogger.w(Message("The specified MilestoneEventListener has already been added to the stack."))
             return
         }
         milestoneEventListeners.add(milestoneEventListener)
@@ -53,7 +54,7 @@ internal class NavigationEventDispatcher {
         if (milestoneEventListener == null) {
             milestoneEventListeners.clear()
         } else if (!milestoneEventListeners.contains(milestoneEventListener)) {
-            Timber.w("The specified MilestoneEventListener isn't found in stack, therefore, cannot be removed.")
+            MapboxLogger.w(Message("The specified MilestoneEventListener isn't found in stack, therefore, cannot be removed."))
         } else {
             milestoneEventListeners.remove(milestoneEventListener)
         }
@@ -61,7 +62,7 @@ internal class NavigationEventDispatcher {
 
     fun addProgressChangeListener(progressChangeListener: ProgressChangeListener) {
         if (progressChangeListeners.contains(progressChangeListener)) {
-            Timber.w("The specified ProgressChangeListener has already been added to the stack.")
+            MapboxLogger.w(Message("The specified ProgressChangeListener has already been added to the stack."))
             return
         }
         progressChangeListeners.add(progressChangeListener)
@@ -71,7 +72,7 @@ internal class NavigationEventDispatcher {
         if (progressChangeListener == null) {
             progressChangeListeners.clear()
         } else if (!progressChangeListeners.contains(progressChangeListener)) {
-            Timber.w("The specified ProgressChangeListener isn't found in stack, therefore, cannot be removed.")
+            MapboxLogger.w(Message("The specified ProgressChangeListener isn't found in stack, therefore, cannot be removed."))
         } else {
             progressChangeListeners.remove(progressChangeListener)
         }
@@ -79,7 +80,7 @@ internal class NavigationEventDispatcher {
 
     fun addOffRouteListener(offRouteListener: OffRouteListener) {
         if (offRouteListeners.contains(offRouteListener)) {
-            Timber.w("The specified OffRouteListener has already been added to the stack.")
+            MapboxLogger.w(Message("The specified OffRouteListener has already been added to the stack."))
             return
         }
         offRouteListeners.add(offRouteListener)
@@ -89,7 +90,7 @@ internal class NavigationEventDispatcher {
         if (offRouteListener == null) {
             offRouteListeners.clear()
         } else if (!offRouteListeners.contains(offRouteListener)) {
-            Timber.w("The specified OffRouteListener isn't found in stack, therefore, cannot be removed.")
+            MapboxLogger.w(Message("The specified OffRouteListener isn't found in stack, therefore, cannot be removed."))
         } else {
             offRouteListeners.remove(offRouteListener)
         }
@@ -97,7 +98,7 @@ internal class NavigationEventDispatcher {
 
     fun addNavigationEventListener(navigationEventListener: NavigationEventListener) {
         if (navigationEventListeners.contains(navigationEventListener)) {
-            Timber.w("The specified NavigationEventListener has already been added to the stack.")
+            MapboxLogger.w(Message("The specified NavigationEventListener has already been added to the stack."))
             return
         }
         this.navigationEventListeners.add(navigationEventListener)
@@ -107,7 +108,7 @@ internal class NavigationEventDispatcher {
         if (navigationEventListener == null) {
             navigationEventListeners.clear()
         } else if (!navigationEventListeners.contains(navigationEventListener)) {
-            Timber.w("The specified NavigationEventListener isn't found in stack, therefore, cannot be removed.")
+            MapboxLogger.w(Message("The specified NavigationEventListener isn't found in stack, therefore, cannot be removed."))
         } else {
             navigationEventListeners.remove(navigationEventListener)
         }
@@ -115,7 +116,7 @@ internal class NavigationEventDispatcher {
 
     fun addFasterRouteListener(fasterRouteListener: FasterRouteListener) {
         if (fasterRouteListeners.contains(fasterRouteListener)) {
-            Timber.w("The specified FasterRouteListener has already been added to the stack.")
+            MapboxLogger.w(Message("The specified FasterRouteListener has already been added to the stack."))
             return
         }
         fasterRouteListeners.add(fasterRouteListener)
@@ -125,7 +126,7 @@ internal class NavigationEventDispatcher {
         if (fasterRouteListener == null) {
             fasterRouteListeners.clear()
         } else if (!fasterRouteListeners.contains(fasterRouteListener)) {
-            Timber.w("The specified FasterRouteListener isn't found in stack, therefore, cannot be removed.")
+            MapboxLogger.w(Message("The specified FasterRouteListener isn't found in stack, therefore, cannot be removed."))
         } else {
             fasterRouteListeners.remove(fasterRouteListener)
         }
@@ -133,7 +134,7 @@ internal class NavigationEventDispatcher {
 
     fun addRawLocationListener(rawLocationListener: RawLocationListener) {
         if (rawLocationListeners.contains(rawLocationListener)) {
-            Timber.w("The specified RawLocationListener has already been added to the stack.")
+            MapboxLogger.w(Message("The specified RawLocationListener has already been added to the stack."))
             return
         }
         rawLocationListeners.add(rawLocationListener)
@@ -143,7 +144,7 @@ internal class NavigationEventDispatcher {
         if (rawLocationListener == null) {
             rawLocationListeners.clear()
         } else if (!rawLocationListeners.contains(rawLocationListener)) {
-            Timber.w("The specified RawLocationListener isn't found in stack, therefore, cannot be removed.")
+            MapboxLogger.w(Message("The specified RawLocationListener isn't found in stack, therefore, cannot be removed."))
         } else {
             rawLocationListeners.remove(rawLocationListener)
         }
@@ -151,7 +152,7 @@ internal class NavigationEventDispatcher {
 
     fun addEnhancedLocationListener(enhancedLocationListener: EnhancedLocationListener) {
         if (enhancedLocationListeners.contains(enhancedLocationListener)) {
-            Timber.w("The specified EnhancedLocationListener has already been added to the stack.")
+            MapboxLogger.w(Message("The specified EnhancedLocationListener has already been added to the stack."))
             return
         }
         enhancedLocationListeners.add(enhancedLocationListener)
@@ -161,7 +162,7 @@ internal class NavigationEventDispatcher {
         if (enhancedLocationListener == null) {
             enhancedLocationListeners.clear()
         } else if (!enhancedLocationListeners.contains(enhancedLocationListener)) {
-            Timber.w("The specified EnhancedLocationListener isn't found in stack, therefore, cannot be removed.")
+            MapboxLogger.w(Message("The specified EnhancedLocationListener isn't found in stack, therefore, cannot be removed."))
         } else {
             enhancedLocationListeners.remove(enhancedLocationListener)
         }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/NavigationFasterRouteListener.kt
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/NavigationFasterRouteListener.kt
@@ -1,11 +1,12 @@
 package com.mapbox.services.android.navigation.v5.internal.navigation
 
 import com.mapbox.api.directions.v5.models.DirectionsResponse
+import com.mapbox.navigation.base.logger.model.Message
+import com.mapbox.navigation.logger.MapboxLogger
 import com.mapbox.navigation.utils.extensions.ifNonNull
 import com.mapbox.services.android.navigation.v5.route.FasterRoute
 import com.mapbox.services.android.navigation.v5.route.RouteListener
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress
-import timber.log.Timber
 
 internal class NavigationFasterRouteListener(
     private val navigationEventDispatcher: NavigationEventDispatcher,
@@ -25,6 +26,6 @@ internal class NavigationFasterRouteListener(
     }
 
     override fun onErrorReceived(throwable: Throwable) {
-        Timber.e(throwable)
+        MapboxLogger.e(Message(throwable.localizedMessage), throwable)
     }
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/NavigationService.kt
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/NavigationService.kt
@@ -7,11 +7,12 @@ import android.os.Binder
 import android.os.Handler
 import com.mapbox.android.core.location.LocationEngine
 import com.mapbox.android.core.location.LocationEngineRequest
+import com.mapbox.navigation.base.logger.model.Message
+import com.mapbox.navigation.logger.MapboxLogger
 import com.mapbox.services.android.navigation.v5.internal.navigation.metrics.NavigationNotificationProvider
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation
 import com.mapbox.services.android.navigation.v5.navigation.notification.NavigationNotification
 import com.mapbox.services.android.navigation.v5.route.RouteFetcher
-import timber.log.Timber
 
 /**
  * Internal usage only, use navigation by initializing a new instance of {@link MapboxNavigation}
@@ -144,7 +145,7 @@ internal class NavigationService : Service() {
 
     inner class LocalBinder : Binder() {
         fun getService(): NavigationService {
-            Timber.d("Local binder called.")
+            MapboxLogger.d(Message("Local binder called."))
             return this@NavigationService
         }
     }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/RouteRefresherCallback.kt
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/RouteRefresherCallback.kt
@@ -1,12 +1,13 @@
 package com.mapbox.services.android.navigation.v5.internal.navigation
 
 import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.navigation.base.logger.model.Message
+import com.mapbox.navigation.logger.MapboxLogger
 import com.mapbox.services.android.navigation.v5.navigation.DirectionsRouteType
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation
 import com.mapbox.services.android.navigation.v5.navigation.RefreshCallback
 import com.mapbox.services.android.navigation.v5.navigation.RefreshError
 import java.util.Date
-import timber.log.Timber
 
 internal class RouteRefresherCallback(
     private val mapboxNavigation: MapboxNavigation,
@@ -20,7 +21,9 @@ internal class RouteRefresherCallback(
     }
 
     override fun onError(error: RefreshError) {
-        Timber.w(error.message)
+        error.message?.let {
+            MapboxLogger.w(Message(it))
+        }
         routeRefresher.updateIsChecking(false)
     }
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/location/replay/ReplayRouteLocationEngine.kt
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/location/replay/ReplayRouteLocationEngine.kt
@@ -11,11 +11,12 @@ import com.mapbox.android.core.location.LocationEngineResult
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.geojson.LineString
 import com.mapbox.geojson.Point
+import com.mapbox.navigation.base.logger.model.Message
+import com.mapbox.navigation.logger.MapboxLogger
 import com.mapbox.services.android.navigation.v5.internal.location.replay.ReplayLocationDispatcher
 import com.mapbox.services.android.navigation.v5.internal.location.replay.ReplayRouteLocationConverter
 import com.mapbox.services.android.navigation.v5.internal.location.replay.ReplayRouteLocationListener
 import java.util.ArrayList
-import timber.log.Timber
 
 class ReplayRouteLocationEngine : LocationEngine, Runnable {
     private lateinit var converter: ReplayRouteLocationConverter
@@ -107,7 +108,7 @@ class ReplayRouteLocationEngine : LocationEngine, Runnable {
         request: LocationEngineRequest,
         pendingIntent: PendingIntent
     ) {
-        Timber.e("ReplayEngine does not support PendingIntent.")
+        MapboxLogger.e(Message("ReplayEngine does not support PendingIntent."))
     }
 
     override fun removeLocationUpdates(callback: LocationEngineCallback<LocationEngineResult>) {
@@ -115,7 +116,7 @@ class ReplayRouteLocationEngine : LocationEngine, Runnable {
     }
 
     override fun removeLocationUpdates(pendingIntent: PendingIntent) {
-        Timber.e("ReplayEngine does not support PendingIntent.")
+        MapboxLogger.e(Message("ReplayEngine does not support PendingIntent."))
     }
 
     internal fun updateLastLocation(lastLocation: Location) {

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
@@ -15,6 +15,8 @@ import com.mapbox.android.core.location.LocationEngine;
 import com.mapbox.android.core.location.LocationEngineProvider;
 import com.mapbox.android.core.location.LocationEngineRequest;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
+import com.mapbox.navigation.base.logger.model.Message;
+import com.mapbox.navigation.logger.MapboxLogger;
 import com.mapbox.navigator.Navigator;
 import com.mapbox.navigator.NavigatorConfig;
 import com.mapbox.services.android.navigation.BuildConfig;
@@ -54,7 +56,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import retrofit2.Callback;
-import timber.log.Timber;
 
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.BANNER_INSTRUCTION_MILESTONE_ID;
 import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.NON_NULL_APPLICATION_CONTEXT_REQUIRED;
@@ -230,7 +231,7 @@ public class MapboxNavigation implements ServiceConnection {
   public void addMilestone(@NonNull Milestone milestone) {
     boolean milestoneAdded = milestones.add(milestone);
     if (!milestoneAdded) {
-      Timber.w("Milestone has already been added to the stack.");
+      MapboxLogger.INSTANCE.w(new Message("Milestone has already been added to the stack."));
     }
   }
 
@@ -247,7 +248,7 @@ public class MapboxNavigation implements ServiceConnection {
   public void addMilestones(@NonNull List<Milestone> milestones) {
     boolean milestonesAdded = this.milestones.addAll(milestones);
     if (!milestonesAdded) {
-      Timber.w("These milestones have already been added to the stack.");
+      MapboxLogger.INSTANCE.w(new Message("These milestones have already been added to the stack."));
     }
   }
 
@@ -265,7 +266,7 @@ public class MapboxNavigation implements ServiceConnection {
       milestones.clear();
       return;
     } else if (!milestones.contains(milestone)) {
-      Timber.w("Milestone attempting to remove does not exist in stack.");
+      MapboxLogger.INSTANCE.w(new Message("Milestone attempting to remove does not exist in stack."));
       return;
     }
     milestones.remove(milestone);
@@ -287,7 +288,7 @@ public class MapboxNavigation implements ServiceConnection {
         return;
       }
     }
-    Timber.w("No milestone found with the specified identifier.");
+    MapboxLogger.INSTANCE.w(new Message("No milestone found with the specified identifier."));
   }
 
   /**
@@ -423,7 +424,7 @@ public class MapboxNavigation implements ServiceConnection {
   }
 
   private void stopNavigationService() {
-    Timber.d("MapboxNavigation stopped");
+    MapboxLogger.INSTANCE.d(new Message("MapboxNavigation stopped"));
     if (isServiceAvailable()) {
       navigationTelemetry.stopSession();
       applicationContext.unbindService(this);
@@ -697,7 +698,7 @@ public class MapboxNavigation implements ServiceConnection {
       freeDriveLocationUpdater.configure(tilePath, new OnOfflineTilesConfiguredCallback() {
         @Override
         public void onConfigured(int numberOfTiles) {
-          Timber.d("DEBUG: onConfigured %d", numberOfTiles);
+          MapboxLogger.INSTANCE.d(new Message("DEBUG: onConfigured " + numberOfTiles));
           isFreeDriveConfigured.set(true);
           if (!isActiveGuidanceOnGoing.get() && isFreeDriveEnabled.get()) {
             freeDriveLocationUpdater.start();
@@ -706,7 +707,7 @@ public class MapboxNavigation implements ServiceConnection {
 
         @Override
         public void onConfigurationError(@NotNull OfflineError error) {
-          Timber.e("Free drive: onConfigurationError %s", error.getMessage());
+          MapboxLogger.INSTANCE.e(new Message("Free drive: onConfigurationError " + error.getMessage()));
           isFreeDriveConfigured.set(false);
         }
       });
@@ -932,7 +933,7 @@ public class MapboxNavigation implements ServiceConnection {
 
   @Override
   public void onServiceConnected(ComponentName name, IBinder service) {
-    Timber.d("Connected to service.");
+    MapboxLogger.INSTANCE.d(new Message("Connected to service."));
     NavigationService.LocalBinder binder = (NavigationService.LocalBinder) service;
     if (binder != null) {
       navigationService = binder.getService();
@@ -943,7 +944,7 @@ public class MapboxNavigation implements ServiceConnection {
 
   @Override
   public void onServiceDisconnected(ComponentName name) {
-    Timber.d("Disconnected from service.");
+    MapboxLogger.INSTANCE.d(new Message("Disconnected from service."));
     navigationService = null;
     isBound = false;
   }
@@ -1150,7 +1151,9 @@ public class MapboxNavigation implements ServiceConnection {
   private boolean checkInvalidLegIndex(int legIndex) {
     int legSize = directionsRoute.legs().size();
     if (legIndex < 0 || legIndex > legSize - 1) {
-      Timber.e("Invalid leg index update: %s Current leg index size: %s", legIndex, legSize);
+      MapboxLogger.INSTANCE.e(
+              new Message("Invalid leg index update: " + legIndex + " Current leg index size: " + legSize)
+      );
       return true;
     }
     return false;

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationLibraryLoader.kt
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationLibraryLoader.kt
@@ -1,6 +1,7 @@
 package com.mapbox.services.android.navigation.v5.navigation
 
-import timber.log.Timber
+import com.mapbox.navigation.base.logger.model.Message
+import com.mapbox.navigation.logger.MapboxLogger
 
 abstract class NavigationLibraryLoader {
 
@@ -29,7 +30,7 @@ abstract class NavigationLibraryLoader {
             try {
                 loader.load(NAVIGATION_NATIVE)
             } catch (error: UnsatisfiedLinkError) {
-                Timber.e(error, "Failed to load native shared library.")
+                MapboxLogger.e(Message("Failed to load native shared library."), error)
             }
         }
     }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/OfflineRouteRetrievalTask.kt
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/OfflineRouteRetrievalTask.kt
@@ -3,9 +3,10 @@ package com.mapbox.services.android.navigation.v5.navigation
 import android.os.AsyncTask
 import com.google.gson.Gson
 import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.navigation.base.logger.model.Message
+import com.mapbox.navigation.logger.MapboxLogger
 import com.mapbox.navigator.Navigator
 import com.mapbox.navigator.RouterResult
-import timber.log.Timber
 
 internal class OfflineRouteRetrievalTask(
     private val navigator: Navigator,
@@ -50,7 +51,7 @@ internal class OfflineRouteRetrievalTask(
 
         val errorMessage = "Error occurred fetching offline route: $error - Code: $errorCode"
 
-        Timber.e(errorMessage)
+        MapboxLogger.e(Message(errorMessage))
         return errorMessage
     }
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/route/RouteFetcher.kt
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/route/RouteFetcher.kt
@@ -5,6 +5,8 @@ import android.location.Location
 import com.mapbox.api.directions.v5.models.DirectionsResponse
 import com.mapbox.api.directions.v5.models.RouteOptions
 import com.mapbox.geojson.Point
+import com.mapbox.navigation.base.logger.model.Message
+import com.mapbox.navigation.logger.MapboxLogger
 import com.mapbox.navigation.utils.extensions.ifNonNull
 import com.mapbox.services.android.navigation.v5.navigation.NavigationRoute
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress
@@ -14,7 +16,6 @@ import java.util.concurrent.CopyOnWriteArrayList
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
-import timber.log.Timber
 
 /**
  * This class can be used to fetch new routes given a [Location] origin and
@@ -114,7 +115,7 @@ class RouteFetcher
         }
         val remainingWaypoints = routeUtils.calculateRemainingWaypoints(routeProgress)?.toMutableList()
         if (remainingWaypoints == null) {
-            Timber.e("An error occurred fetching a new route")
+            MapboxLogger.e(Message("An error occurred fetching a new route"))
             return null
         }
         addDestination(remainingWaypoints, navigationRouteBuilder)

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/RouteUtils.kt
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/RouteUtils.kt
@@ -3,10 +3,11 @@ package com.mapbox.services.android.navigation.v5.utils
 import com.mapbox.api.directions.v5.models.BannerInstructions
 import com.mapbox.api.directions.v5.models.LegStep
 import com.mapbox.geojson.Point
+import com.mapbox.navigation.base.logger.model.Message
+import com.mapbox.navigation.logger.MapboxLogger
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgressState
 import kotlin.collections.ArrayList
-import timber.log.Timber
 
 class RouteUtils {
 
@@ -84,7 +85,7 @@ class RouteUtils {
             val firstRemainingWaypointIndex = remainingWaypointIndices[FIRST_POSITION].toInt()
             coordinates.subList(firstRemainingWaypointIndex, coordinatesSize)
         } catch (ex: NumberFormatException) {
-            Timber.e("Fail to convert waypoint index to integer")
+            MapboxLogger.e(Message("Fail to convert waypoint index to integer"))
             null
         }
     }
@@ -126,7 +127,7 @@ class RouteUtils {
             }
             resultWaypointIndices
         } catch (ex: NumberFormatException) {
-            Timber.e("Fail to convert waypoint index to integer")
+            MapboxLogger.e(Message("Fail to convert waypoint index to integer"))
             null
         }
     }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/time/TimeFormatter.kt
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/utils/time/TimeFormatter.kt
@@ -6,6 +6,8 @@ import android.graphics.Typeface
 import android.text.SpannableStringBuilder
 import android.text.style.RelativeSizeSpan
 import android.text.style.StyleSpan
+import com.mapbox.navigation.base.logger.model.Message
+import com.mapbox.navigation.logger.MapboxLogger
 import com.mapbox.navigation.utils.extensions.combineSpan
 import com.mapbox.navigation.utils.span.SpanItem
 import com.mapbox.navigation.utils.span.TextSpanItem
@@ -14,7 +16,6 @@ import com.mapbox.services.android.navigation.v5.navigation.TimeFormatType
 import java.util.ArrayList
 import java.util.Calendar
 import java.util.concurrent.TimeUnit
-import timber.log.Timber
 
 object TimeFormatter {
 
@@ -37,7 +38,7 @@ object TimeFormatter {
         var seconds = routeDuration.toLong()
 
         if (seconds < 0) {
-            Timber.e("Duration must be greater than zero. Invalid duration %s", seconds)
+            MapboxLogger.e(Message("Duration must be greater than zero. Invalid duration $seconds"))
             seconds = 0L
         }
 

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/logger/Logger.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/logger/Logger.kt
@@ -7,7 +7,7 @@ interface Logger {
     /**
      * Send a verbose log message and log the exception.
      *
-     * @param tag is [Tag] used to identify the source of a log message.  It usually identifies
+     * @param tag is [Tag] used to identify the source of a log message. It usually identifies
      * the class or activity where the log call occurs.
      * @param msg is [Message] you would like logged.
      * @param tr An exception to log
@@ -17,7 +17,7 @@ interface Logger {
     /**
      * Send a debug log message and log the exception.
      *
-     * @param tag is [Tag] used to identify the source of a log message.  It usually identifies
+     * @param tag is [Tag] used to identify the source of a log message. It usually identifies
      * the class or activity where the log call occurs.
      * @param msg is [Message] you would like logged.
      * @param tr An exception to log
@@ -27,7 +27,7 @@ interface Logger {
     /**
      * Send an info log message and log the exception.
      *
-     * @param tag is [Tag] used to identify the source of a log message.  It usually identifies
+     * @param tag is [Tag] used to identify the source of a log message. It usually identifies
      * the class or activity where the log call occurs.
      * @param msg is [Message] you would like logged.
      * @param tr An exception to log
@@ -37,7 +37,7 @@ interface Logger {
     /**
      * Send a warning log message and log the exception.
      *
-     * @param tag is [Tag] used to identify the source of a log message.  It usually identifies
+     * @param tag is [Tag] used to identify the source of a log message. It usually identifies
      * the class or activity where the log call occurs.
      * @param msg is [Message] you would like logged.
      * @param tr An exception to log
@@ -47,7 +47,7 @@ interface Logger {
     /**
      * Send an error log message and log the exception.
      *
-     * @param tag is [Tag] used to identify the source of a log message.  It usually identifies
+     * @param tag is [Tag] used to identify the source of a log message. It usually identifies
      * the class or activity where the log call occurs.
      * @param msg is [Message] you would like logged.
      * @param tr An exception to log

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/logger/model/Tag.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/logger/model/Tag.kt
@@ -3,7 +3,7 @@ package com.mapbox.navigation.base.logger.model
 /**
  * Wrapper class for loggers tag.
  *
- * @param tag used to identify the source of a log message.  It usually identifies
+ * @param tag used to identify the source of a log message. It usually identifies
  * the class or activity where the log call occurs.
  */
 data class Tag(val tag: String)


### PR DESCRIPTION
## Description

This PR is about replace Timber logger with new `MapboxLogger` in all modules of SDK, including example screens. [(issue)](https://github.com/mapbox/navigation-sdks/issues/186)

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Replace Timber with `MapboxLogger` in all modules.

### Implementation

All mentions of `Timber` removed, as well as `Timber` dependencies. Instead of `Timber` now we log all events via `MapboxLogger`. Timber is still used in next parts of our codebase: 
- `MapboxLogger` (Implementation based on `Timber`)
- `ExampleActivity` (`Timber` used for example of using `LoggerObserver` to log events caught by this hook)
- `MockNavigationActivity` (`Timber` used for example of using `LoggerObserver` to log events caught by this hook)
- `NavigationApplication` (`Timber` initialization for screens mentioned above ⬆️)

Also updated [doc](https://docs.google.com/document/d/1Jaz66SDIzpy2NVQ1ZpFGT_68EK8qjN0RPxi1tJxejSQ/edit?folder=0AMmVnZpKFujrUk9PVA#) with finalized `Logger` interface and examples of usage

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR