### PR TITLE
1.0 modules release setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,11 +72,13 @@ navigation-fixtures:
 1.0-build-debug:
 	./gradlew :libdirections-offboard:assembleDebug
 	./gradlew :libdirections-hybrid:assembleDebug
+	./gradlew :libdirections-onboard:assembleDebug
 
 .PHONY: 1.0-build-release
 1.0-build-release:
 	./gradlew :libdirections-offboard:assembleRelease
 	./gradlew :libdirections-hybrid:assembleRelease
+	./gradlew :libdirections-onboard:assembleRelease
 
 .PHONY: 1.0-unit-tests
 1.0-unit-tests:
@@ -98,8 +100,10 @@ navigation-fixtures:
 1.0-publish-to-bintray:
 	./gradlew :libdirections-offboard:bintrayUpload
 	./gradlew :libdirections-hybrid:bintrayUpload
+	./gradlew :libdirections-onboard:bintrayUpload
 
 .PHONY: 1.0-publish-to-artifactory
 1.0-publish-to-artifactory:
 	./gradlew :libdirections-offboard:artifactoryPublish
 	./gradlew :libdirections-hybrid:artifactoryPublish
+	./gradlew :libdirections-onboard:artifactoryPublish

--- a/Makefile
+++ b/Makefile
@@ -73,12 +73,14 @@ navigation-fixtures:
 	./gradlew :libdirections-offboard:assembleDebug
 	./gradlew :libdirections-hybrid:assembleDebug
 	./gradlew :libdirections-onboard:assembleDebug
+	./gradlew :libdirections-base:assembleDebug
 
 .PHONY: 1.0-build-release
 1.0-build-release:
 	./gradlew :libdirections-offboard:assembleRelease
 	./gradlew :libdirections-hybrid:assembleRelease
 	./gradlew :libdirections-onboard:assembleRelease
+	./gradlew :libdirections-base:assembleRelease
 
 .PHONY: 1.0-unit-tests
 1.0-unit-tests:
@@ -101,9 +103,11 @@ navigation-fixtures:
 	./gradlew :libdirections-offboard:bintrayUpload
 	./gradlew :libdirections-hybrid:bintrayUpload
 	./gradlew :libdirections-onboard:bintrayUpload
+	./gradlew :libdirections-base:bintrayUpload
 
 .PHONY: 1.0-publish-to-artifactory
 1.0-publish-to-artifactory:
 	./gradlew :libdirections-offboard:artifactoryPublish
 	./gradlew :libdirections-hybrid:artifactoryPublish
 	./gradlew :libdirections-onboard:artifactoryPublish
+	./gradlew :libdirections-base:artifactoryPublish

--- a/Makefile
+++ b/Makefile
@@ -71,10 +71,12 @@ navigation-fixtures:
 .PHONY: 1.0-build-debug
 1.0-build-debug:
 	./gradlew :libdirections-offboard:assembleDebug
+	./gradlew :libdirections-hybrid:assembleDebug
 
 .PHONY: 1.0-build-release
 1.0-build-release:
 	./gradlew :libdirections-offboard:assembleRelease
+	./gradlew :libdirections-hybrid:assembleRelease
 
 .PHONY: 1.0-unit-tests
 1.0-unit-tests:
@@ -95,7 +97,9 @@ navigation-fixtures:
 .PHONY: 1.0-publish-to-bintray
 1.0-publish-to-bintray:
 	./gradlew :libdirections-offboard:bintrayUpload
+	./gradlew :libdirections-hybrid:bintrayUpload
 
 .PHONY: 1.0-publish-to-artifactory
 1.0-publish-to-artifactory:
 	./gradlew :libdirections-offboard:artifactoryPublish
+	./gradlew :libdirections-hybrid:artifactoryPublish

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ navigation-fixtures:
 	./gradlew :libnavigation-base:assembleDebug
 	./gradlew :libnavigation-metrics:assembleDebug
 	./gradlew :libnavigation-util:assembleDebug
+	./gradlew :libnavigator:assembleDebug
 
 .PHONY: 1.0-build-release
 1.0-build-release:
@@ -85,6 +86,7 @@ navigation-fixtures:
 	./gradlew :libnavigation-base:assembleRelease
 	./gradlew :libnavigation-metrics:assembleRelease
 	./gradlew :libnavigation-util:assembleRelease
+	./gradlew :libnavigator:assembleRelease
 
 .PHONY: 1.0-unit-tests
 1.0-unit-tests:
@@ -110,6 +112,7 @@ navigation-fixtures:
 	./gradlew :libnavigation-base:bintrayUpload
 	./gradlew :libnavigation-metrics:bintrayUpload
 	./gradlew :libnavigation-util:bintrayUpload
+	./gradlew :libnavigator:bintrayUpload
 
 .PHONY: 1.0-publish-to-artifactory
 1.0-publish-to-artifactory:
@@ -119,3 +122,4 @@ navigation-fixtures:
 	./gradlew :libnavigation-base:artifactoryPublish
 	./gradlew :libnavigation-metrics:artifactoryPublish
 	./gradlew :libnavigation-util:artifactoryPublish
+	./gradlew :libnavigator:artifactoryPublish

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,7 @@ navigation-fixtures:
 	./gradlew :libnavigation-metrics:assembleDebug
 	./gradlew :libnavigation-util:assembleDebug
 	./gradlew :libnavigator:assembleDebug
+	./gradlew :libtrip-notification:assembleDebug
 
 .PHONY: 1.0-build-release
 1.0-build-release:
@@ -87,6 +88,7 @@ navigation-fixtures:
 	./gradlew :libnavigation-metrics:assembleRelease
 	./gradlew :libnavigation-util:assembleRelease
 	./gradlew :libnavigator:assembleRelease
+	./gradlew :libtrip-notification:assembleRelease
 
 .PHONY: 1.0-unit-tests
 1.0-unit-tests:
@@ -113,6 +115,7 @@ navigation-fixtures:
 	./gradlew :libnavigation-metrics:bintrayUpload
 	./gradlew :libnavigation-util:bintrayUpload
 	./gradlew :libnavigator:bintrayUpload
+	./gradlew :libtrip-notification:bintrayUpload
 
 .PHONY: 1.0-publish-to-artifactory
 1.0-publish-to-artifactory:
@@ -123,3 +126,4 @@ navigation-fixtures:
 	./gradlew :libnavigation-metrics:artifactoryPublish
 	./gradlew :libnavigation-util:artifactoryPublish
 	./gradlew :libnavigator:artifactoryPublish
+	./gradlew :libtrip-notification:artifactoryPublish

--- a/Makefile
+++ b/Makefile
@@ -12,20 +12,6 @@ test:
 	# See libandroid-navigation/build.gradle for details
 	./gradlew :libandroid-navigation:test
 	./gradlew :libandroid-navigation-ui:test
-	./gradlew :libdirections-hybrid:test
-	./gradlew :libdirections-offboard:test
-	./gradlew :libdirections-onboard:test
-	./gradlew :libdirections-session:test
-	./gradlew :liblogger:test
-	./gradlew :libnavigation-base:test
-	./gradlew :libnavigation-core:test
-	./gradlew :libnavigation-metrics:test
-	./gradlew :libnavigation-util:test
-	./gradlew :libnavigator:test
-	./gradlew :libtrip-notification:test
-	./gradlew :libtrip-service:test
-	./gradlew :libtrip-session:test
-	./gradlew :libnavigation-core:test
 
 build-release:
 	./gradlew :libandroid-navigation:assembleRelease
@@ -81,3 +67,35 @@ navigation-fixtures:
     # No VoiceInstructions
 	curl "https://api.mapbox.com/directions/v5/mapbox/driving/-77.034013,38.899994;-77.033757,38.903311?geometries=polyline6&steps=true&access_token=$(MAPBOX_ACCESS_TOKEN)" \
 		-o libandroid-navigation/src/test/resources/directions_v5_no_voice.json
+
+.PHONY: 1.0-build-debug
+1.0-build-debug:
+	./gradlew :libdirections-offboard:assembleDebug
+
+.PHONY: 1.0-build-release
+1.0-build-release:
+	./gradlew :libdirections-offboard:assembleRelease
+
+.PHONY: 1.0-unit-tests
+1.0-unit-tests:
+	./gradlew :libdirections-hybrid:test
+	./gradlew :libdirections-offboard:test
+	./gradlew :libdirections-onboard:test
+	./gradlew :liblogger:test
+	./gradlew :libnavigation-base:test
+	./gradlew :libnavigation-core:test
+	./gradlew :libnavigation-metrics:test
+	./gradlew :libnavigation-util:test
+	./gradlew :libnavigator:test
+	./gradlew :libtrip-notification:test
+	./gradlew :libtrip-service:test
+	./gradlew :libtrip-session:test
+	./gradlew :libnavigation-core:test
+
+.PHONY: 1.0-publish-to-bintray
+1.0-publish-to-bintray:
+	./gradlew :libdirections-offboard:bintrayUpload
+
+.PHONY: 1.0-publish-to-artifactory
+1.0-publish-to-artifactory:
+	./gradlew :libdirections-offboard:artifactoryPublish

--- a/Makefile
+++ b/Makefile
@@ -73,14 +73,16 @@ navigation-fixtures:
 	./gradlew :libdirections-offboard:assembleDebug
 	./gradlew :libdirections-hybrid:assembleDebug
 	./gradlew :libdirections-onboard:assembleDebug
-	./gradlew :libdirections-base:assembleDebug
+	./gradlew :libnavigation-base:assembleDebug
+	./gradlew :libnavigation-metrics:assembleDebug
 
 .PHONY: 1.0-build-release
 1.0-build-release:
 	./gradlew :libdirections-offboard:assembleRelease
 	./gradlew :libdirections-hybrid:assembleRelease
 	./gradlew :libdirections-onboard:assembleRelease
-	./gradlew :libdirections-base:assembleRelease
+	./gradlew :libnavigation-base:assembleRelease
+	./gradlew :libnavigation-metrics:assembleRelease
 
 .PHONY: 1.0-unit-tests
 1.0-unit-tests:
@@ -103,11 +105,13 @@ navigation-fixtures:
 	./gradlew :libdirections-offboard:bintrayUpload
 	./gradlew :libdirections-hybrid:bintrayUpload
 	./gradlew :libdirections-onboard:bintrayUpload
-	./gradlew :libdirections-base:bintrayUpload
+	./gradlew :libnavigation-base:bintrayUpload
+	./gradlew :libnavigation-metrics:bintrayUpload
 
 .PHONY: 1.0-publish-to-artifactory
 1.0-publish-to-artifactory:
 	./gradlew :libdirections-offboard:artifactoryPublish
 	./gradlew :libdirections-hybrid:artifactoryPublish
 	./gradlew :libdirections-onboard:artifactoryPublish
-	./gradlew :libdirections-base:artifactoryPublish
+	./gradlew :libnavigation-base:artifactoryPublish
+	./gradlew :libnavigation-metrics:artifactoryPublish

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,7 @@ navigation-fixtures:
 	./gradlew :libdirections-onboard:assembleDebug
 	./gradlew :libnavigation-base:assembleDebug
 	./gradlew :libnavigation-metrics:assembleDebug
+	./gradlew :libnavigation-util:assembleDebug
 
 .PHONY: 1.0-build-release
 1.0-build-release:
@@ -83,6 +84,7 @@ navigation-fixtures:
 	./gradlew :libdirections-onboard:assembleRelease
 	./gradlew :libnavigation-base:assembleRelease
 	./gradlew :libnavigation-metrics:assembleRelease
+	./gradlew :libnavigation-util:assembleRelease
 
 .PHONY: 1.0-unit-tests
 1.0-unit-tests:
@@ -107,6 +109,7 @@ navigation-fixtures:
 	./gradlew :libdirections-onboard:bintrayUpload
 	./gradlew :libnavigation-base:bintrayUpload
 	./gradlew :libnavigation-metrics:bintrayUpload
+	./gradlew :libnavigation-util:bintrayUpload
 
 .PHONY: 1.0-publish-to-artifactory
 1.0-publish-to-artifactory:
@@ -115,3 +118,4 @@ navigation-fixtures:
 	./gradlew :libdirections-onboard:artifactoryPublish
 	./gradlew :libnavigation-base:artifactoryPublish
 	./gradlew :libnavigation-metrics:artifactoryPublish
+	./gradlew :libnavigation-util:artifactoryPublish

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,9 @@ buildscript {
     classpath pluginDependencies.crashlytics
     classpath pluginDependencies.license
     classpath pluginDependencies.mapboxSdkVersions
+    classpath pluginDependencies.mavenPublish
+    classpath pluginDependencies.bintray
+    classpath pluginDependencies.artifactory
   }
 }
 

--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,7 @@ workflows:
   default:
     jobs:
       - build
+      - build-1.0
       - release
       - publish:
           filters:
@@ -110,6 +111,33 @@ jobs:
       - store_test_results:
           path: app/build/test-results
 
+  build-1.0:
+    working_directory: ~/code
+    docker:
+      - image: mbgl/61abee1674:android-ndk-r18
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - deps-{{ checksum "build.gradle" }}-{{ checksum  "gradle/dependencies.gradle" }}-{{ checksum  "libdirections-hybrid/build.gradle" }}-{{ checksum  "libdirections-offboard/build.gradle" }}-{{ checksum  "libdirections-onboard/build.gradle" }}-{{ checksum  "liblogger/build.gradle" }}-{{ checksum  "libnavigation-base/build.gradle" }}-{{ checksum  "libnavigation-core/build.gradle" }}-{{ checksum  "libnavigation-metrics/build.gradle" }}-{{ checksum  "libnavigation-util/build.gradle" }}-{{ checksum  "libnavigator/build.gradle" }}-{{ checksum  "libtrip-notification/build.gradle" }}-{{ checksum  "libtrip-service/build.gradle" }}-{{ checksum  "libtrip-session/build.gradle" }}
+            - deps-
+      - run:
+          name: Download Dependencies
+          command: ./gradlew androidDependencies
+      - save_cache:
+          paths:
+            - ~/.gradle
+          key: deps-{{ checksum "build.gradle" }}-{{ checksum  "gradle/dependencies.gradle" }}-{{ checksum  "libdirections-hybrid/build.gradle" }}-{{ checksum  "libdirections-offboard/build.gradle" }}-{{ checksum  "libdirections-onboard/build.gradle" }}-{{ checksum  "liblogger/build.gradle" }}-{{ checksum  "libnavigation-base/build.gradle" }}-{{ checksum  "libnavigation-core/build.gradle" }}-{{ checksum  "libnavigation-metrics/build.gradle" }}-{{ checksum  "libnavigation-util/build.gradle" }}-{{ checksum  "libnavigator/build.gradle" }}-{{ checksum  "libtrip-notification/build.gradle" }}-{{ checksum  "libtrip-service/build.gradle" }}-{{ checksum  "libtrip-session/build.gradle" }}
+      - run:
+          name: Check Kotlin code style
+          command: ./gradlew ktlint
+      - run:
+          name: Build Navigation SDK 1.0 (debug)
+          command: make 1.0-build-debug
+      - run:
+          name: Run unit-test
+          command: make 1.0-unit-tests
+
 # ------------------------------------------------------------------------------
   release:
     branch:
@@ -164,6 +192,35 @@ jobs:
           name: Check & Publish Binary Size
           command: |
             ./scripts/check_binary_size.sh ./scripts/paths_file.txt ./scripts/labels_file.txt 'mapbox-navigation-android' 'android' ./scripts/sdks_file.txt "${CIRCLE_SHA1}"
+
+  release-1.0:
+    working_directory: ~/code
+    docker:
+      - image: mbgl/61abee1674:android-ndk-r18
+    steps:
+      - checkout
+      - run:
+          name: Build Navigation SDK 1.0 (release)
+          command: make 1.0-build-release
+      - run:
+          name: Generate Bintray credentials
+          command: |
+            if [ -n "${BINTRAY_USER}" ]; then
+              echo "BINTRAY_USER=$BINTRAY_USER
+              BINTRAY_API_KEY=$BINTRAY_API_KEY
+              GPG_PASSPHRASE=$GPG_PASSPHRASE"
+            fi
+      - deploy:
+          name: Publish Navigation SDK 1.0 to Bintray
+          command: |
+            if [[ $CIRCLE_BRANCH == master ]]; then
+              version=$(cat gradle/artifact-settings.gradle | grep "versionName")
+              if [[ $version != *"SNAPSHOT"* ]]; then
+                make 1.0-publish-to-bintray
+              else
+                make 1.0-publish-to-artifactory
+              fi
+            fi
 # ------------------------------------------------------------------------------
   publish:
     docker:

--- a/gradle/artifact-settings.gradle
+++ b/gradle/artifact-settings.gradle
@@ -1,0 +1,20 @@
+ext {
+    mapboxArtifactGroupId = 'com.mapbox.navigation'
+    mapboxArtifactId = project.property('POM_ARTIFACT_ID')
+    mapboxArtifactTitle = project.property('POM_ARTIFACT_TITLE')
+    mapboxArtifactDescription = project.property('POM_DESCRIPTION')
+    mapboxDeveloperName = 'Mapbox'
+    mapboxDeveloperId = 'mapbox'
+    mapboxArtifactUrl = 'https://github.com/mapbox/mapbox-navigation-android'
+    mapboxArtifactVcsUrl = 'https://github.com/mapbox/mapbox-navigation-android.git'
+    mapboxArtifactScmUrl = 'scm:git@github.com:mapbox/mapbox-navigation-android.git'
+    mapboxArtifactLicenseName = 'BSD'
+    mapboxArtifactLicenseUrl = 'https://opensource.org/licenses/BSD-2-Clause'
+    versionName = '1.0.0-SNAPSHOT'
+
+    mapboxBintrayUserOrg = 'mapbox'
+    mapboxBintrayRepoName = 'mapbox'
+    mapboxBintrayUser = project.hasProperty('BINTRAY_USER') ? project.property('BINTRAY_USER') : System.getenv('BINTRAY_USER')
+    mapboxBintrayApiKey = project.hasProperty('BINTRAY_API_KEY') ? project.property('BINTRAY_API_KEY') : System.getenv('BINTRAY_API_KEY')
+    mapboxGpgPassphrase = project.hasProperty('GPG_PASSPHRASE') ? project.property('GPG_PASSPHRASE') : System.getenv('GPG_PASSPHRASE')
+}

--- a/gradle/bintray-publish.gradle
+++ b/gradle/bintray-publish.gradle
@@ -1,0 +1,89 @@
+apply plugin: 'digital.wup.android-maven-publish'
+apply plugin: 'maven-publish'
+apply plugin: 'com.jfrog.bintray'
+apply plugin: 'com.jfrog.artifactory'
+apply from: file("${rootDir}/gradle/artifact-settings.gradle")
+
+version = project.ext.versionName
+group = project.ext.mapboxArtifactGroupId
+
+publishing {
+    publications {
+        MapboxNavigationPublication(MavenPublication) {
+            afterEvaluate {
+                from components.android
+                artifact(androidSourcesJar)
+            }
+
+            groupId this.group
+            artifactId project.ext.mapboxArtifactId
+            version this.version
+
+            pom.withXml {
+                final mainNode = asNode()
+                mainNode.appendNode('name', project.ext.mapboxArtifactTitle)
+                mainNode.appendNode('description', project.ext.mapboxArtifactDescription)
+                mainNode.appendNode('url', project.ext.mapboxArtifactUrl)
+
+                final licenseNode = mainNode.appendNode('licenses').appendNode('license')
+                licenseNode.appendNode('name', project.ext.mapboxArtifactLicenseName)
+                licenseNode.appendNode('url', project.ext.mapboxArtifactLicenseUrl)
+                licenseNode.appendNode('distribution', "repo")
+
+                final developerNode = mainNode.appendNode('developers').appendNode('developer')
+                developerNode.appendNode('id', project.ext.mapboxDeveloperId)
+                developerNode.appendNode('name', project.ext.mapboxDeveloperName)
+
+                final scmNode = mainNode.appendNode("scm")
+                scmNode.appendNode("connection", project.ext.mapboxArtifactScmUrl)
+                scmNode.appendNode("developerConnection", project.ext.mapboxArtifactScmUrl)
+                scmNode.appendNode("url", project.ext.mapboxArtifactUrl)
+            }
+        }
+    }
+}
+
+bintray {
+    user = mapboxBintrayUser
+    key = mapboxBintrayApiKey
+    publications('MapboxNavigationPublication')
+    pkg {
+        repo = project.ext.mapboxBintrayRepoName
+        name = mapboxArtifactGroupId + ":" + project.ext.mapboxArtifactId
+        userOrg = project.ext.mapboxBintrayUserOrg
+        licenses = [project.ext.mapboxArtifactLicenseName]
+        vcsUrl = project.ext.mapboxArtifactVcsUrl
+        publish = false
+        version {
+            name = project.ext.versionName
+            desc = project.ext.mapboxArtifactDescription
+            released = new Date()
+            gpg {
+                sign = true
+                passphrase = mapboxGpgPassphrase
+            }
+            mavenCentralSync {
+                sync = false
+            }
+        }
+    }
+}
+
+artifactory {
+    contextUrl = 'http://oss.jfrog.org'
+    publish {
+        repository {
+            repoKey = 'oss-snapshot-local'
+            username = mapboxBintrayUser
+            password = mapboxBintrayApiKey
+        }
+        defaults {
+            publications('MapboxNavigationPublication')
+        }
+    }
+}
+
+task androidSourcesJar(type: Jar) {
+    classifier = 'sources'
+    from android.sourceSets.main.kotlin
+}

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -142,7 +142,10 @@ ext {
       playPublisher    : '2.3.0',
       googleServices   : '4.2.0',
       crashlytics      : '1.26.1',
-      mapboxSdkVersions: '1.0.0'
+      mapboxSdkVersions: '1.0.0',
+      mavenPublish     : '3.6.2',
+      bintray          : '1.8.4',
+      artifactory      : '4.9.3'
   ]
 
   pluginDependencies = [
@@ -159,6 +162,9 @@ ext {
       playPublisher    : "com.github.triplet.gradle:play-publisher:${pluginVersion.playPublisher}",
       googleServices   : "com.google.gms:google-services:${pluginVersion.googleServices}",
       crashlytics      : "io.fabric.tools:gradle:${pluginVersion.crashlytics}",
-      mapboxSdkVersions: "com.mapbox.mapboxsdk:mapbox-android-sdk-versions:${pluginVersion.mapboxSdkVersions}"
+      mapboxSdkVersions: "com.mapbox.mapboxsdk:mapbox-android-sdk-versions:${pluginVersion.mapboxSdkVersions}",
+      mavenPublish     : "digital.wup:android-maven-publish:${pluginVersion.mavenPublish}",
+      bintray          : "com.jfrog.bintray.gradle:gradle-bintray-plugin:${pluginVersion.bintray}",
+      artifactory      : "org.jfrog.buildinfo:build-info-extractor-gradle:${pluginVersion.artifactory}"
   ]
 }

--- a/libdirections-hybrid/build.gradle
+++ b/libdirections-hybrid/build.gradle
@@ -33,4 +33,4 @@ dependencies {
     testImplementation dependenciesList.junit
 }
 
-apply from: "${rootDir}/gradle/jacoco.gradle"
+apply from: "${rootDir}/gradle/bintray-publish.gradle"

--- a/libdirections-hybrid/gradle.properties
+++ b/libdirections-hybrid/gradle.properties
@@ -1,0 +1,3 @@
+POM_ARTIFACT_ID=router
+POM_ARTIFACT_TITLE=Mapbox Hybrid Router
+POM_DESCRIPTION=Artifact that provides the default implementation of the routing engine implementation that alternates between offbaord and onboard data (online/offline)

--- a/libdirections-offboard/build.gradle
+++ b/libdirections-offboard/build.gradle
@@ -36,4 +36,4 @@ dependencies {
     testImplementation dependenciesList.mockk
 }
 
-apply from: "${rootDir}/gradle/jacoco.gradle"
+apply from: "${rootDir}/gradle/bintray-publish.gradle"

--- a/libdirections-offboard/gradle.properties
+++ b/libdirections-offboard/gradle.properties
@@ -1,0 +1,3 @@
+POM_ARTIFACT_ID=router-offboard
+POM_ARTIFACT_TITLE=Mapbox Offboard Router
+POM_DESCRIPTION=Artifact that provides the default implementation of the offbaord (online) routing engine implementation

--- a/libdirections-onboard/build.gradle
+++ b/libdirections-onboard/build.gradle
@@ -32,4 +32,4 @@ dependencies {
     testImplementation dependenciesList.junit
 }
 
-apply from: "${rootDir}/gradle/jacoco.gradle"
+apply from: "${rootDir}/gradle/bintray-publish.gradle"

--- a/libdirections-onboard/gradle.properties
+++ b/libdirections-onboard/gradle.properties
@@ -1,0 +1,3 @@
+POM_ARTIFACT_ID=router-onboard
+POM_ARTIFACT_TITLE=Mapbox Onboard Router
+POM_DESCRIPTION=Artifact that provides the default implementation of the onbaord (offline) routing engine implementation

--- a/libnavigation-base/build.gradle
+++ b/libnavigation-base/build.gradle
@@ -29,3 +29,5 @@ dependencies {
     testImplementation dependenciesList.junit
     testImplementation dependenciesList.mockk
 }
+
+apply from: "${rootDir}/gradle/bintray-publish.gradle"

--- a/libnavigation-base/gradle.properties
+++ b/libnavigation-base/gradle.properties
@@ -1,0 +1,3 @@
+POM_ARTIFACT_ID=base
+POM_ARTIFACT_TITLE=Mapbox Navigation Base
+POM_DESCRIPTION=Artifact that provides the set of interface definitions and DTOs used in the modular Navigation SDK

--- a/libnavigation-metrics/build.gradle
+++ b/libnavigation-metrics/build.gradle
@@ -35,4 +35,4 @@ dependencies {
     testImplementation dependenciesList.mockk
 }
 
-apply from: "${rootDir}/gradle/jacoco.gradle"
+apply from: "${rootDir}/gradle/bintray-publish.gradle"

--- a/libnavigation-metrics/gradle.properties
+++ b/libnavigation-metrics/gradle.properties
@@ -1,0 +1,3 @@
+POM_ARTIFACT_ID=metrics
+POM_ARTIFACT_TITLE=Mapbox Navigation Metrics
+POM_DESCRIPTION=Artifact that provides the default implementation of the metrics integration

--- a/libnavigation-util/build.gradle
+++ b/libnavigation-util/build.gradle
@@ -28,3 +28,5 @@ dependencies {
     testImplementation dependenciesList.mockito // deprecated
     testImplementation dependenciesList.mockk
 }
+
+apply from: "${rootDir}/gradle/bintray-publish.gradle"

--- a/libnavigation-util/gradle.properties
+++ b/libnavigation-util/gradle.properties
@@ -1,0 +1,3 @@
+POM_ARTIFACT_ID=utils
+POM_ARTIFACT_TITLE=Mapbox Navigation Utils
+POM_DESCRIPTION=Artifact that provides basic navigation utilities

--- a/libnavigator/build.gradle
+++ b/libnavigator/build.gradle
@@ -28,3 +28,5 @@ dependencies {
 
     implementation dependenciesList.kotlinStdLib
 }
+
+apply from: "${rootDir}/gradle/bintray-publish.gradle"

--- a/libnavigator/gradle.properties
+++ b/libnavigator/gradle.properties
@@ -1,0 +1,3 @@
+POM_ARTIFACT_ID=navigator
+POM_ARTIFACT_TITLE=Mapbox Navigation Native wrapper
+POM_DESCRIPTION=Artifact that provides the native capabilities of the SDK

--- a/libtrip-notification/build.gradle
+++ b/libtrip-notification/build.gradle
@@ -29,4 +29,4 @@ dependencies {
     testImplementation dependenciesList.junit
 }
 
-apply from: "${rootDir}/gradle/jacoco.gradle"
+apply from: "${rootDir}/gradle/bintray-publish.gradle"

--- a/libtrip-notification/gradle.properties
+++ b/libtrip-notification/gradle.properties
@@ -1,0 +1,3 @@
+POM_ARTIFACT_ID=notification
+POM_ARTIFACT_TITLE=Mapbox Navigation Notification
+POM_DESCRIPTION=Artifact that provides the default implementation of the navigation notification


### PR DESCRIPTION
This PR adds CI integration for the release process of the 1.0 modules. I also separated the legacy and 1.0.0 CI jobs.

With every merge to `master`, the pipeline currently builds all of the modules and pushes a `1.0.0-SNAPSHOT` version of each of them to Artifactory.

The Bintray and Artifactory repositories are not yet set up pending the internal artifact IDs naming discussion.