### PR TITLE
run release-1.0 CI job

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,6 +7,7 @@ workflows:
       - build
       - build-1.0
       - release
+      - release-1.0
       - publish:
           filters:
             tags:


### PR DESCRIPTION
https://github.com/mapbox/mapbox-navigation-android/pull/2325 follow up. The release-1.0 job was not triggered.