### PR TITLE
Service crash due to closed channel access.

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/activity/TripServiceActivityKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/activity/TripServiceActivityKt.kt
@@ -1,7 +1,6 @@
 package com.mapbox.navigation.examples.activity
 
 import android.annotation.SuppressLint
-import android.app.ActivityManager
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
@@ -113,6 +112,7 @@ class TripServiceActivityKt : AppCompatActivity(), OnMapReadyCallback {
     override fun onDestroy() {
         super.onDestroy()
         mapView.onDestroy()
+        mapboxTripService.stopService()
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
@@ -137,15 +137,5 @@ class TripServiceActivityKt : AppCompatActivity(), OnMapReadyCallback {
                 delay(1000L)
             }
         }
-    }
-
-    private fun isServiceRunning(serviceClass: Class<*>): Boolean {
-        val manager = getSystemService(ACTIVITY_SERVICE) as ActivityManager
-        for (service in manager.getRunningServices(Integer.MAX_VALUE)) {
-            if (serviceClass.name == service.service.className) {
-                return true
-            }
-        }
-        return false
     }
 }

--- a/examples/src/main/java/com/mapbox/navigation/examples/activity/TripServiceActivityKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/activity/TripServiceActivityKt.kt
@@ -65,13 +65,12 @@ class TripServiceActivityKt : AppCompatActivity(), OnMapReadyCallback {
         mapView.onCreate(savedInstanceState)
         mapView.getMapAsync(this)
 
-        if (!isServiceRunning(NavigationNotificationService::class.java)) {
-            mapboxTripNotification =
+        mapboxTripNotification =
                 MapboxTripNotification(applicationContext, NavigationNotificationProvider())
-            mapboxTripService =
+        mapboxTripService =
                 MapboxTripService(mapboxTripNotification) {
                     val intent =
-                        Intent(applicationContext, NavigationNotificationService::class.java)
+                            Intent(applicationContext, NavigationNotificationService::class.java)
                     try {
                         applicationContext.startService(intent)
                     } catch (e: IllegalStateException) {
@@ -83,8 +82,7 @@ class TripServiceActivityKt : AppCompatActivity(), OnMapReadyCallback {
                     }
                 }
 
-            mapboxTripService.startService()
-        }
+        mapboxTripService.startService()
     }
 
     public override fun onResume() {

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/trip/service/MapboxTripService.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/trip/service/MapboxTripService.kt
@@ -23,7 +23,7 @@ class MapboxTripService(
     @InternalCoroutinesApi
     override fun startService() {
         if (!notificationDataChannel.isClosedForSend) {
-            notificationDataChannel.close()
+            notificationDataChannel.cancel()
             notificationDataChannel = Channel(1)
         }
         when (serviceStarted.compareAndSet(false, true)) {
@@ -47,7 +47,7 @@ class MapboxTripService(
     }
 
     override fun stopService() {
-        notificationDataChannel.close()
+        notificationDataChannel.cancel()
         tripNotification.onTripSessionStopped()
     }
 

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/trip/service/NavigationNotificationService.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/trip/service/NavigationNotificationService.kt
@@ -25,8 +25,9 @@ class NavigationNotificationService : Service() {
     }
 
     override fun onDestroy() {
-        stopForeground(true)
         super.onDestroy()
+        stopForeground(true)
+        job.cancel()
     }
 
     private fun startForegroundNotification() {

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/trip/service/MapboxTripServiceTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/trip/service/MapboxTripServiceTest.kt
@@ -23,8 +23,8 @@ class MapboxTripServiceTest {
     fun setUp() {
         service = MapboxTripService(tripNotification, callback)
         every { tripNotification.getNotificationId() } answers { 1234 }
-        every { tripNotification.getNotification() } answers {notification}
-        every { tripNotification.onTripSessionStopped() } answers { Unit}
+        every { tripNotification.getNotification() } answers { notification }
+        every { tripNotification.onTripSessionStopped() } answers { Unit }
 
     }
 

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/trip/service/MapboxTripServiceTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/trip/service/MapboxTripServiceTest.kt
@@ -25,11 +25,10 @@ class MapboxTripServiceTest {
         every { tripNotification.getNotificationId() } answers { 1234 }
         every { tripNotification.getNotification() } answers { notification }
         every { tripNotification.onTripSessionStopped() } answers { Unit }
-
     }
 
     @Test
-    fun testServiceStartStop() {
+    fun serviceStartStopShouldNotCrash() {
         service.startService()
         service.stopService()
         service.startService()

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/trip/service/MapboxTripServiceTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/trip/service/MapboxTripServiceTest.kt
@@ -1,6 +1,8 @@
 package com.mapbox.navigation.trip.service
 
+import android.app.Notification
 import com.mapbox.navigation.base.trip.TripNotification
+import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.InternalCoroutinesApi
@@ -13,12 +15,25 @@ import org.junit.Test
 class MapboxTripServiceTest {
 
     private lateinit var service: MapboxTripService
-    private val notification: TripNotification = mockk()
+    private val tripNotification: TripNotification = mockk()
+    private val notification: Notification = mockk()
     private val callback: () -> Unit = { }
 
     @Before
     fun setUp() {
-        service = MapboxTripService(notification, callback)
+        service = MapboxTripService(tripNotification, callback)
+        every { tripNotification.getNotificationId() } answers { 1234 }
+        every { tripNotification.getNotification() } answers {notification}
+        every { tripNotification.onTripSessionStopped() } answers { Unit}
+
+    }
+
+    @Test
+    fun testServiceStartStop() {
+        service.startService()
+        service.stopService()
+        service.startService()
+        service.stopService()
     }
 
     @Test


### PR DESCRIPTION

## Description
MapboxTripService.kt function startService() was calling close() on a channel object. It should have been calling cancel(). The call to close(), does not clear the channel of data, so the receiver can still attempt to receive data on a channel that is now closed.

## Testing
Updated test with start/stop calls

Please describe the manual tests that you ran to verify your changes

- [x ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [ x] I have added tests that prove my fix is effective or that my feature works
- [x ] New and existing unit tests pass locally with my changes

## Checklist

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
