### PR TITLE
Remove utils dependency on the logger

### DIFF
--- a/libnavigation-util/build.gradle
+++ b/libnavigation-util/build.gradle
@@ -17,7 +17,6 @@ android {
 }
 
 dependencies {
-    implementation project(':liblogger')
     implementation dependenciesList.kotlinStdLib
 
     //ktlint


### PR DESCRIPTION
The logger is unused in the utils module and makes the snapshots artifact fail because the logger artifact is not being distributed yet.