### PR TITLE
Remove core dependency on the logger

### DIFF
--- a/libnavigation-core/build.gradle
+++ b/libnavigation-core/build.gradle
@@ -25,7 +25,6 @@ dependencies {
 
     api project(':libnavigation-base')
     implementation project(':libnavigation-util')
-    implementation project(':liblogger')
     implementation project(':libnavigator')
     implementation project(':libdirections-hybrid')
     implementation project(':libtrip-notification')

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/NavigationController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/NavigationController.kt
@@ -15,7 +15,6 @@ import com.mapbox.annotation.navigation.module.MapboxNavigationModuleType.Onboar
 import com.mapbox.annotation.navigation.module.MapboxNavigationModuleType.TripNotification as TripNotificationModule
 import com.mapbox.annotation.navigation.module.MapboxNavigationModuleType.TripService as TripServiceModule
 import com.mapbox.annotation.navigation.module.MapboxNavigationModuleType.TripSession as TripSessionModule
-import com.mapbox.navigation.base.logger.Logger
 import com.mapbox.navigation.base.route.Router
 import com.mapbox.navigation.base.route.model.Route
 import com.mapbox.navigation.directions.session.DirectionsSession
@@ -43,7 +42,6 @@ class NavigationController {
         HandlerThread("NavigationController").apply { start() }
     }
 
-    private val logger: Logger
     private val directionsSession: DirectionsSession
     private val tripService: TripService
     private val tripSession: TripSession
@@ -62,7 +60,6 @@ class NavigationController {
         this.locationEngineRequest = locationEngineRequest
         this.navigationNotificationProvider = navigationNotificationProvider
 
-        logger = NavigationModuleProvider.createModule(LoggerModule, ::paramsProvider)
         directionsSession = NavigationComponentProvider.createDirectionsSession(
             NavigationModuleProvider.createModule(HybridRouter, ::paramsProvider),
             routeObserver

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/trip/service/MapboxTripService.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/trip/service/MapboxTripService.kt
@@ -1,10 +1,9 @@
 package com.mapbox.navigation.trip.service
 
-import com.mapbox.navigation.base.logger.model.Message
+import android.util.Log
 import com.mapbox.navigation.base.trip.TripNotification
 import com.mapbox.navigation.base.trip.model.MapboxNotificationData
 import com.mapbox.navigation.base.trip.model.RouteProgress
-import com.mapbox.navigation.logger.MapboxLogger
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.InternalCoroutinesApi
@@ -37,7 +36,7 @@ class MapboxTripService(
                 )
             }
             false -> {
-                MapboxLogger.i(Message("service already started"))
+                Log.i("MapboxTripService", "service already started")
             }
         }
     }


### PR DESCRIPTION
Similarly to https://github.com/mapbox/mapbox-navigation-android/pull/2340, we should not use logger in any module (besides the examples) until it's moved to `mapbox-base-android` and distributed.