### PR TITLE
Bump mapbox-navigation-native version to 8.2.1

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -12,7 +12,7 @@ ext {
       mapboxSdkServices      : '4.9.0',
       mapboxEvents           : '4.5.1',
       mapboxCore             : '1.3.0',
-      mapboxNavigator        : '7.0.0',
+      mapboxNavigator        : '8.2.1',
       mapboxCrashMonitor     : '2.0.0',
       mapboxAnnotationPlugin : '0.7.0',
       mapboxSearchSdk        : '0.1.0-SNAPSHOT',

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/ConfigureRouterTask.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/ConfigureRouterTask.java
@@ -3,6 +3,7 @@ package com.mapbox.services.android.navigation.v5.navigation;
 import android.os.AsyncTask;
 
 import com.mapbox.navigator.Navigator;
+import com.mapbox.navigator.RouterParams;
 
 class ConfigureRouterTask extends AsyncTask<Void, Void, Long> {
   private final Navigator navigator;
@@ -18,7 +19,8 @@ class ConfigureRouterTask extends AsyncTask<Void, Void, Long> {
   @Override
   protected Long doInBackground(Void... paramsUnused) {
     synchronized (this) {
-      return navigator.configureRouter(tilePath, null, null, null, null);
+      RouterParams routerParams = new RouterParams(tilePath, null, null, null, null);
+      return navigator.configureRouter(routerParams, null);
     }
   }
 


### PR DESCRIPTION
## Description

Bumps `mapbox-navigation-native` version to `8.2.1`

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Getting the latest version from `mapboxNavigator` including the new features and bug fixes.

### Implementation

Bumping the `mapboxNavigator` version to `8.2.1` in `dependencies.gradle`

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
