### PR TITLE
Add onTripSessionStarted API to TripNotification

### DIFF
--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/TripNotification.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/TripNotification.kt
@@ -36,12 +36,20 @@ interface TripNotification {
     fun updateNotification(routeProgress: RouteProgress)
 
     /**
+     * Callback for when trip session is started via [TripSession.start].
+     *
+     *
+     * This callback may be used to perform post start initialization
+     *
+     */
+    fun onTripSessionStarted()
+
+    /**
      * Callback for when trip session is stopped via [TripSession.stop].
      *
      *
      * This callback may be used to clean up any listeners or receivers, preventing leaks.
      *
-     * @param context to be used if needed for Android-related work
      */
     fun onTripSessionStopped()
 }

--- a/libtrip-notification/src/main/java/com/mapbox/navigation/trip/notification/MapboxTripNotification.kt
+++ b/libtrip-notification/src/main/java/com/mapbox/navigation/trip/notification/MapboxTripNotification.kt
@@ -74,6 +74,10 @@ class MapboxTripNotification(
         notificationManager.notify(NOTIFICATION_ID, notification)
     }
 
+    override fun onTripSessionStarted() {
+        registerReceiver()
+    }
+
     override fun onTripSessionStopped() {
         unregisterReceiver()
     }


### PR DESCRIPTION
## Description

Adds `onTripSessionStarted` API to `TripNotification` and `MapboxTripNotification` implementation - brings changes from https://github.com/mapbox/mapbox-navigation-android/commit/1ffedb58043f07a2408784a02b1033a079742d4f ([pg-trip-session-location-updates](https://github.com/mapbox/mapbox-navigation-android/tree/pg-trip-session-location-updates))

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Expose `onTripSessionStopped` counterpart API

### Implementation

Add `onTripSessionStarted` API to `TripNotification` and `MapboxTripNotification` implementation

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR

cc @olegzil @abhishek1508 