### PR TITLE
Remove unnecessary libtrip-session and libtrip-service cache checksums from CI config

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -120,7 +120,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - deps-{{ checksum "build.gradle" }}-{{ checksum  "gradle/dependencies.gradle" }}-{{ checksum  "libdirections-hybrid/build.gradle" }}-{{ checksum  "libdirections-offboard/build.gradle" }}-{{ checksum  "libdirections-onboard/build.gradle" }}-{{ checksum  "liblogger/build.gradle" }}-{{ checksum  "libnavigation-base/build.gradle" }}-{{ checksum  "libnavigation-metrics/build.gradle" }}-{{ checksum  "libnavigation-util/build.gradle" }}-{{ checksum  "libnavigator/build.gradle" }}-{{ checksum  "libtrip-notification/build.gradle" }}-{{ checksum  "libtrip-service/build.gradle" }}-{{ checksum  "libtrip-session/build.gradle" }}
+            - deps-{{ checksum "build.gradle" }}-{{ checksum  "gradle/dependencies.gradle" }}-{{ checksum  "libdirections-hybrid/build.gradle" }}-{{ checksum  "libdirections-offboard/build.gradle" }}-{{ checksum  "libdirections-onboard/build.gradle" }}-{{ checksum  "liblogger/build.gradle" }}-{{ checksum  "libnavigation-base/build.gradle" }}-{{ checksum  "libnavigation-metrics/build.gradle" }}-{{ checksum  "libnavigation-util/build.gradle" }}-{{ checksum  "libnavigator/build.gradle" }}-{{ checksum  "libtrip-notification/build.gradle" }}
             - deps-
       - run:
           name: Download Dependencies
@@ -128,7 +128,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.gradle
-          key: deps-{{ checksum "build.gradle" }}-{{ checksum  "gradle/dependencies.gradle" }}-{{ checksum  "libdirections-hybrid/build.gradle" }}-{{ checksum  "libdirections-offboard/build.gradle" }}-{{ checksum  "libdirections-onboard/build.gradle" }}-{{ checksum  "liblogger/build.gradle" }}-{{ checksum  "libnavigation-base/build.gradle" }}-{{ checksum  "libnavigation-metrics/build.gradle" }}-{{ checksum  "libnavigation-util/build.gradle" }}-{{ checksum  "libnavigator/build.gradle" }}-{{ checksum  "libtrip-notification/build.gradle" }}-{{ checksum  "libtrip-service/build.gradle" }}-{{ checksum  "libtrip-session/build.gradle" }}
+          key: deps-{{ checksum "build.gradle" }}-{{ checksum  "gradle/dependencies.gradle" }}-{{ checksum  "libdirections-hybrid/build.gradle" }}-{{ checksum  "libdirections-offboard/build.gradle" }}-{{ checksum  "libdirections-onboard/build.gradle" }}-{{ checksum  "liblogger/build.gradle" }}-{{ checksum  "libnavigation-base/build.gradle" }}-{{ checksum  "libnavigation-metrics/build.gradle" }}-{{ checksum  "libnavigation-util/build.gradle" }}-{{ checksum  "libnavigator/build.gradle" }}-{{ checksum  "libtrip-notification/build.gradle" }}
       - run:
           name: Check Kotlin code style
           command: ./gradlew ktlint


### PR DESCRIPTION
## Description

Removes unnecessary `libtrip-session` and `libtrip-service` cache checksum from CI config causing CI build errors as those modules do not exist anymore

Tailwork from https://github.com/mapbox/mapbox-navigation-android/pull/2345 and https://github.com/mapbox/mapbox-navigation-android/pull/2334

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Fix 👇 CI errors

_Restoring Cache_

```
Error computing cache key: template: cacheKey:1:532: executing "cacheKey" at <checksum "libtrip-service/build.gradle">: error calling checksum: open /root/code/libtrip-service/build.gradle: no such file or directory
```

_Saving Cache_

```
Error computing cache key: template: cacheKey:1:532: executing "cacheKey" at <checksum "libtrip-service/build.gradle">: error calling checksum: open /root/code/libtrip-service/build.gradle: no such file or directory
```

### Implementation

Remove `-{{ checksum  "libtrip-service/build.gradle" }}-{{ checksum  "libtrip-session/build.gradle" }}` from `circle.yml` `restore_cache` and `save_cache` `build-1.0` job steps

## Testing

- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR