### PR TITLE
Fix memory leak when set observers in MapboxLogger and MapboxMetricsReporter

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/MockNavigationActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/MockNavigationActivity.java
@@ -342,6 +342,7 @@ public class MockNavigationActivity extends AppCompatActivity implements OnMapRe
   @Override
   protected void onDestroy() {
     super.onDestroy();
+    MapboxMetricsReporter.INSTANCE.removeObserver();
     navigation.onDestroy();
     if (mapboxMap != null) {
       mapboxMap.removeOnMapClickListener(this);

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExampleActivity.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExampleActivity.kt
@@ -97,6 +97,7 @@ class ExampleActivity : HistoryActivity(), ExampleView, MetricsObserver {
     override fun onDestroy() {
         super.onDestroy()
         mapView.onDestroy()
+        MapboxMetricsReporter.removeObserver()
     }
 
     override fun onBackPressed() {

--- a/examples/src/main/java/com/mapbox/navigation/examples/activity/MockNavigationActivity.java
+++ b/examples/src/main/java/com/mapbox/navigation/examples/activity/MockNavigationActivity.java
@@ -351,6 +351,8 @@ public class MockNavigationActivity extends AppCompatActivity implements OnMapRe
   @Override
   protected void onDestroy() {
     super.onDestroy();
+    MapboxMetricsReporter.INSTANCE.removeObserver();
+    MapboxLogger.INSTANCE.removeObserver();
     navigation.onDestroy();
     if (mapboxMap != null) {
       mapboxMap.removeOnMapClickListener(this);

--- a/examples/src/main/java/com/mapbox/navigation/examples/activity/OffboardRouterActivityKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/activity/OffboardRouterActivityKt.kt
@@ -197,6 +197,8 @@ class OffboardRouterActivityKt : AppCompatActivity(),
 
     override fun onDestroy() {
         super.onDestroy()
+        MapboxMetricsReporter.removeObserver()
+        MapboxLogger.removeObserver()
         offboardRouter?.cancel()
         mapboxMap?.removeOnMapClickListener(this)
         mapView.onDestroy()

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/metrics/MetricsReporter.kt
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/metrics/MetricsReporter.kt
@@ -25,4 +25,11 @@ interface MetricsReporter {
      * @since 0.43.0
      */
     fun setMetricsObserver(metricsObserver: MetricsObserver)
+
+    /**
+     * Remove metrics observer
+     *
+     * @since 0.43.0
+     */
+    fun removeObserver()
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/metrics/MapboxMetricsReporter.kt
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/metrics/MapboxMetricsReporter.kt
@@ -87,7 +87,7 @@ object MapboxMetricsReporter : MetricsReporter {
         this.metricsObserver = metricsObserver
     }
 
-    fun removeObserver() {
+    override fun removeObserver() {
         this.metricsObserver = null
     }
 }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/metrics/MapboxMetricsReporter.kt
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/metrics/MapboxMetricsReporter.kt
@@ -68,6 +68,7 @@ object MapboxMetricsReporter : MetricsReporter {
      */
     @JvmStatic
     fun disable() {
+        removeObserver()
         mapboxTelemetry.disable()
         threadWorker.stop()
     }
@@ -84,5 +85,9 @@ object MapboxMetricsReporter : MetricsReporter {
 
     override fun setMetricsObserver(metricsObserver: MetricsObserver) {
         this.metricsObserver = metricsObserver
+    }
+
+    fun removeObserver() {
+        this.metricsObserver = null
     }
 }

--- a/liblogger/src/main/java/com/mapbox/navigation/logger/MapboxLogger.kt
+++ b/liblogger/src/main/java/com/mapbox/navigation/logger/MapboxLogger.kt
@@ -22,6 +22,10 @@ object MapboxLogger : Logger {
         this.observer.set(observer)
     }
 
+    fun removeObserver() {
+        observer.set(null)
+    }
+
     fun v(msg: Message) {
         v(null, msg, null)
     }

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/metrics/MetricsReporter.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/metrics/MetricsReporter.kt
@@ -22,4 +22,11 @@ interface MetricsReporter {
      * @since 1.0.0
      */
     fun setMetricsObserver(metricsObserver: MetricsObserver)
+
+    /**
+     * Remove metrics observer
+     *
+     * @since 1.0.0
+     */
+    fun removeObserver()
 }

--- a/libnavigation-metrics/src/main/java/com/mapbox/navigation/metrics/MapboxMetricsReporter.kt
+++ b/libnavigation-metrics/src/main/java/com/mapbox/navigation/metrics/MapboxMetricsReporter.kt
@@ -70,6 +70,7 @@ object MapboxMetricsReporter : MetricsReporter {
      */
     @JvmStatic
     fun disable() {
+        removeObserver()
         mapboxTelemetry.disable()
         threadWorker.stop()
     }
@@ -86,5 +87,9 @@ object MapboxMetricsReporter : MetricsReporter {
 
     override fun setMetricsObserver(metricsObserver: MetricsObserver) {
         this.metricsObserver = metricsObserver
+    }
+
+    fun removeObserver() {
+        this.metricsObserver = null
     }
 }

--- a/libnavigation-metrics/src/main/java/com/mapbox/navigation/metrics/MapboxMetricsReporter.kt
+++ b/libnavigation-metrics/src/main/java/com/mapbox/navigation/metrics/MapboxMetricsReporter.kt
@@ -89,7 +89,7 @@ object MapboxMetricsReporter : MetricsReporter {
         this.metricsObserver = metricsObserver
     }
 
-    fun removeObserver() {
+    override fun removeObserver() {
         this.metricsObserver = null
     }
 }


### PR DESCRIPTION
## Description

Fix memory leak when set observers in `MapboxLogger` and `MapboxMetricsReporter` [issue comment](https://github.com/mapbox/mapbox-navigation-android/pull/2330#pullrequestreview-336183666)

- [ ] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal

When we add observers (for example some Activity) to `MapboxLogger` and `MapboxMetricsReporter` and then we destroy this activity (leave them), memory leak happens. This PR is about fix this issue.

### Implementation

Added removeObserver() methods in `MapboxLogger` and `MapboxMetricsReporter` and call them in `onDestroy()` method of activity

## Testing

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR