### PR TITLE
Add network interceptor connection

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRoute.kt
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRoute.kt
@@ -14,11 +14,12 @@ import com.mapbox.services.android.navigation.v5.internal.accounts.SkuIntercepto
 import com.mapbox.services.android.navigation.v5.utils.extensions.getUnitTypeForLocale
 import com.mapbox.services.android.navigation.v5.utils.extensions.inferDeviceLocale
 import com.mapbox.services.android.navigation.v5.utils.extensions.mapToWalkingOptions
-import java.util.Locale
 import okhttp3.EventListener
 import okhttp3.Interceptor
 import retrofit2.Call
 import retrofit2.Callback
+import java.util.*
+import kotlin.collections.ArrayList
 
 /**
  * The NavigationRoute class wraps the [MapboxDirections] class with parameters which
@@ -568,6 +569,17 @@ internal constructor(
          */
         fun interceptor(interceptor: Interceptor): Builder {
             directionsBuilder.interceptor(interceptor)
+            return this
+        }
+
+        /**
+         * Adds an optional network interceptor to set in the OkHttp client.
+         *
+         * @param interceptor to set for OkHttp
+         * @return this builder for chaining options together
+         */
+        fun networkInterceptor(interceptor: Interceptor): Builder {
+            directionsBuilder.networkInterceptor(interceptor)
             return this
         }
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRoute.kt
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRoute.kt
@@ -19,7 +19,6 @@ import okhttp3.EventListener
 import okhttp3.Interceptor
 import retrofit2.Call
 import retrofit2.Callback
-import kotlin.collections.ArrayList
 
 /**
  * The NavigationRoute class wraps the [MapboxDirections] class with parameters which

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRoute.kt
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRoute.kt
@@ -14,11 +14,11 @@ import com.mapbox.services.android.navigation.v5.internal.accounts.SkuIntercepto
 import com.mapbox.services.android.navigation.v5.utils.extensions.getUnitTypeForLocale
 import com.mapbox.services.android.navigation.v5.utils.extensions.inferDeviceLocale
 import com.mapbox.services.android.navigation.v5.utils.extensions.mapToWalkingOptions
+import java.util.Locale
 import okhttp3.EventListener
 import okhttp3.Interceptor
 import retrofit2.Call
 import retrofit2.Callback
-import java.util.*
 import kotlin.collections.ArrayList
 
 /**

--- a/libdirections-offboard/src/main/java/com/mapbox/navigation/route/offboard/router/NavigationRoute.kt
+++ b/libdirections-offboard/src/main/java/com/mapbox/navigation/route/offboard/router/NavigationRoute.kt
@@ -16,6 +16,7 @@ import okhttp3.EventListener
 import okhttp3.Interceptor
 import retrofit2.Call
 import retrofit2.Callback
+import kotlin.collections.ArrayList
 
 /**
  * The NavigationRoute class wraps the [MapboxDirections] class with parameters which
@@ -218,6 +219,17 @@ constructor(
          */
         fun interceptor(interceptor: Interceptor): Builder {
             directionsBuilder.interceptor(interceptor)
+            return this
+        }
+
+        /**
+         * Adds an optional network interceptor to set in the OkHttp client.
+         *
+         * @param interceptor to set for OkHttp
+         * @return this builder for chaining options together
+         */
+        fun networkInterceptor(interceptor: Interceptor): Builder {
+            directionsBuilder.networkInterceptor(interceptor)
             return this
         }
 

--- a/libdirections-offboard/src/main/java/com/mapbox/navigation/route/offboard/router/NavigationRoute.kt
+++ b/libdirections-offboard/src/main/java/com/mapbox/navigation/route/offboard/router/NavigationRoute.kt
@@ -16,7 +16,6 @@ import okhttp3.EventListener
 import okhttp3.Interceptor
 import retrofit2.Call
 import retrofit2.Callback
-import kotlin.collections.ArrayList
 
 /**
  * The NavigationRoute class wraps the [MapboxDirections] class with parameters which


### PR DESCRIPTION
## Description

In mapbox-java 5.0.0, added the ability to hook up a [network interceptor](https://github.com/mapbox/mapbox-java/pull/1093). This will allow us to debug the directions api without making code changes. http://facebook.github.io/stetho/

- [x] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal

Add the ability to debug the api without new code changes. The immediate need to help debug junction view routes.

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->