### PR TITLE
Remove libnavigator unnecessary dependencies

### DIFF
--- a/libnavigator/build.gradle
+++ b/libnavigator/build.gradle
@@ -16,8 +16,6 @@ android {
 
 dependencies {
     implementation(project(':libnavigation-base'))
-    implementation(project(':liblogger'))
-    implementation project(':libnavigation-util')
 
     // Navigator
     api dependenciesList.mapboxNavigator


### PR DESCRIPTION
## Description

Removes `libnavigator` unnecessary `liblogger` and `libnavigation-util` dependencies

Regression from https://github.com/mapbox/mapbox-navigation-android/pull/2300 (probably from rebasing 😬)

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Avoid building issues as `liblogger` is not published already

### Implementation

Remove `implementation(project(':liblogger'))` and `implementation project(':libnavigation-util')` from `libnavigator`'s `build.gradle`

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
