### PR TITLE
Add missing Navigator APIs and implementations

### DIFF
--- a/libdirections-onboard/src/main/java/com/mapbox/navigation/route/onboard/MapboxOnboardRouter.kt
+++ b/libdirections-onboard/src/main/java/com/mapbox/navigation/route/onboard/MapboxOnboardRouter.kt
@@ -11,10 +11,11 @@ import com.mapbox.navigation.navigator.MapboxNativeNavigator
 import com.mapbox.navigation.navigator.MapboxNativeNavigatorImpl
 import com.mapbox.navigation.route.onboard.model.Config
 import com.mapbox.navigation.route.onboard.model.OfflineError
-import com.mapbox.navigation.route.onboard.model.mapToRouteConfig
 import com.mapbox.navigation.route.onboard.network.HttpClient
 import com.mapbox.navigation.route.onboard.task.OfflineRouteRetrievalTask
 import com.mapbox.navigation.utils.exceptions.NavigationException
+import com.mapbox.navigator.RouterParams
+import com.mapbox.navigator.TileEndpointConfiguration
 import java.io.File
 
 @MapboxNavigationModule(MapboxNavigationModuleType.OnboardRouter, skipConfiguration = true)
@@ -44,7 +45,21 @@ class MapboxOnboardRouter : Router {
         this.config = config
         this.logger = logger
         val httpClient = HttpClient()
-        MapboxNativeNavigatorImpl.configureRouter(config.mapToRouteConfig(), httpClient, httpClient.userAgent)
+        val routerParams = RouterParams(
+            config.tilePath,
+            config.inMemoryTileCache,
+            config.mapMatchingSpatialCache,
+            config.threadsCount,
+            config.endpoint?.let {
+                TileEndpointConfiguration(
+                    it.host,
+                    it.version,
+                    it.token,
+                    httpClient.userAgent,
+                    ""
+                )
+            })
+        MapboxNativeNavigatorImpl.configureRouter(routerParams, httpClient)
     }
 
     // Package private for testing purposes

--- a/libdirections-onboard/src/main/java/com/mapbox/navigation/route/onboard/model/Config.kt
+++ b/libdirections-onboard/src/main/java/com/mapbox/navigation/route/onboard/model/Config.kt
@@ -1,7 +1,5 @@
 package com.mapbox.navigation.route.onboard.model
 
-import com.mapbox.navigation.navigator.model.RouterConfig
-
 data class Config(
     val tilePath: String,
     val inMemoryTileCache: Int? = null,
@@ -9,12 +7,3 @@ data class Config(
     val threadsCount: Int? = null,
     val endpoint: Endpoint? = null
 )
-
-fun Config.mapToRouteConfig(): RouterConfig =
-    RouterConfig(
-        tilePath = tilePath,
-        inMemoryTileCache = inMemoryTileCache,
-        mapMatchingSpatialCache = mapMatchingSpatialCache,
-        threadsCount = threadsCount,
-        endpointConfig = endpoint?.mapToEndpointConfig()
-    )

--- a/libdirections-onboard/src/main/java/com/mapbox/navigation/route/onboard/model/Endpoint.kt
+++ b/libdirections-onboard/src/main/java/com/mapbox/navigation/route/onboard/model/Endpoint.kt
@@ -1,18 +1,8 @@
 package com.mapbox.navigation.route.onboard.model
 
-import com.mapbox.navigation.navigator.model.EndpointConfig
-
 data class Endpoint(
     val host: String,
     val version: String,
     val token: String,
     val userAgent: String
 )
-
-fun Endpoint.mapToEndpointConfig() =
-    EndpointConfig(
-        host = host,
-        version = version,
-        token = token,
-        userAgent = userAgent
-    )

--- a/libdirections-onboard/src/main/java/com/mapbox/navigation/route/onboard/network/HttpClient.kt
+++ b/libdirections-onboard/src/main/java/com/mapbox/navigation/route/onboard/network/HttpClient.kt
@@ -33,10 +33,10 @@ internal class HttpClient(
 
     private val client: OkHttpClient by lazy {
         if (BuildConfig.DEBUG) {
-            val interceptor = HttpLoggingInterceptor(object : HttpLoggingInterceptor.Logger {
-                override fun log(message: String) {
-                    logger?.d(msg = Message(message))
-                }
+            val interceptor = HttpLoggingInterceptor(HttpLoggingInterceptor.Logger { message ->
+                logger?.d(
+                    msg = Message(message)
+                )
             }).setLevel(HttpLoggingInterceptor.Level.BASIC)
 
             clientBuilder.addInterceptor(interceptor)

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/MapboxNativeNavigator.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/MapboxNativeNavigator.kt
@@ -1,17 +1,70 @@
 package com.mapbox.navigation.navigator
 
 import android.location.Location
-import com.mapbox.navigation.base.route.model.Route
-import com.mapbox.navigation.navigator.model.RouterConfig
+import com.mapbox.geojson.Point
+import com.mapbox.navigator.BannerInstruction
 import com.mapbox.navigator.HttpInterface
+import com.mapbox.navigator.NavigationStatus
+import com.mapbox.navigator.NavigatorConfig
+import com.mapbox.navigator.RouterParams
 import com.mapbox.navigator.RouterResult
+import com.mapbox.navigator.VoiceInstruction
 import java.util.Date
 
 interface MapboxNativeNavigator {
 
-    fun configureRouter(routerConfig: RouterConfig, httpClient: HttpInterface, userAgent: String)
-    fun getRoute(url: String): RouterResult
-    fun updateLocation(rawLocation: Location)
+    companion object {
+        private const val INDEX_FIRST_ROUTE = 0
+        private const val INDEX_FIRST_LEG = 0
+        private const val GRID_SIZE = 0.0025f
+        private const val BUFFER_DILATION: Short = 1
+    }
+
+    // Route following
+
+    fun updateLocation(rawLocation: Location): Boolean
     fun getStatus(date: Date): TripStatus
-    fun setRoute(route: Route)
+
+    // Routing
+
+    fun setRoute(
+        routeJson: String,
+        routeIndex: Int = INDEX_FIRST_ROUTE,
+        legIndex: Int = INDEX_FIRST_LEG
+    ): NavigationStatus
+
+    fun updateAnnotations(legAnnotationJson: String, routeIndex: Int, legIndex: Int): Boolean
+    fun getBannerInstruction(index: Int): BannerInstruction?
+    fun getRouteGeometryWithBuffer(
+        gridSize: Float = GRID_SIZE,
+        bufferDilation: Short = BUFFER_DILATION
+    ): String?
+
+    fun updateLegIndex(routeIndex: Int, legIndex: Int): NavigationStatus
+
+    // Free Drive
+
+    fun getElectronicHorizon(request: String): RouterResult
+
+    // Offline
+
+    fun configureRouter(routerParams: RouterParams, httpClient: HttpInterface): Long
+    fun getRoute(url: String): RouterResult
+    fun unpackTiles(tarPath: String, destinationPath: String): Long
+    fun removeTiles(tilePath: String, southwest: Point, northeast: Point): Long
+
+    // History traces
+
+    fun getHistory(): String
+    fun toggleHistory(isEnabled: Boolean)
+    fun addHistoryEvent(eventType: String, eventJsonProperties: String)
+
+    // Configuration
+
+    fun getConfig(): NavigatorConfig
+    fun setConfig(config: NavigatorConfig?)
+
+    // Other
+
+    fun getVoiceInstruction(index: Int): VoiceInstruction?
 }

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/model/EndpointConfig.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/model/EndpointConfig.kt
@@ -1,8 +1,0 @@
-package com.mapbox.navigation.navigator.model
-
-data class EndpointConfig(
-    val host: String,
-    val version: String,
-    val token: String,
-    val userAgent: String
-)

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/model/RouterConfig.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/model/RouterConfig.kt
@@ -1,9 +1,0 @@
-package com.mapbox.navigation.navigator.model
-
-data class RouterConfig(
-    val tilePath: String,
-    val inMemoryTileCache: Int?,
-    val mapMatchingSpatialCache: Int?,
-    val threadsCount: Int?,
-    val endpointConfig: EndpointConfig?
-)


### PR DESCRIPTION
## Description

Adds missing `MapboxNativeNavigator` APIs and `MapboxNativeNavigatorImpl` implementations

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Expose legacy `Navigator` APIs as part of `1.0` `libnavigator`

### Implementation

Expose APIs as part of `MapboxNativeNavigator` `interface` and add respective implementations in `MapboxNativeNavigatorImpl`

## Testing

- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR