### PR TITLE
hybrid navigation implementation

### DIFF
--- a/libdirections-hybrid/build.gradle
+++ b/libdirections-hybrid/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     ktlint dependenciesList.ktlint
 
     implementation dependenciesList.kotlinStdLib
+    implementation dependenciesList.coroutinesAndroid
 
     testImplementation dependenciesList.mockk
     testImplementation dependenciesList.junit

--- a/libdirections-hybrid/src/main/java/com/mapbox/navigation/route/hybrid/MapboxHybridRouter.kt
+++ b/libdirections-hybrid/src/main/java/com/mapbox/navigation/route/hybrid/MapboxHybridRouter.kt
@@ -6,7 +6,7 @@ import com.mapbox.annotation.navigation.module.MapboxNavigationModuleType
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.RouteOptions
 import com.mapbox.navigation.base.route.Router
-import com.mapbox.navigation.trip.service.NetworkStatusService
+import com.mapbox.navigation.utils.network.NetworkStatusService
 import com.mapbox.navigation.utils.thread.ThreadController
 import com.mapbox.navigation.utils.thread.monitorChannelWithException
 import java.util.concurrent.atomic.AtomicReference
@@ -18,13 +18,31 @@ class MapboxHybridRouter(
     context: Context
 ) : Router {
 
+    private val navigationMonitorStateException = NetworkStatusService(context)
+    private val jobControl = ThreadController.getIOScopeAndRootJob()
+    private var routeDispatchHandler: AtomicReference<RouterDispatchInterface> = AtomicReference(OffBoardRouterHandler(offboardRouter, onboardRouter))
+
+    init {
+        jobControl.scope.monitorChannelWithException(navigationMonitorStateException.getNetworkStatusChannel()) { networkStatus ->
+            when (networkStatus.isNetworkAvailable) {
+                true -> {
+                    routeDispatchHandler.set(OffBoardRouterHandler(offboardRouter, onboardRouter))
+                }
+                false -> {
+                    routeDispatchHandler.set(OnBoardRouterHandler(offboardRouter, onboardRouter))
+                }
+            }
+        }
+    }
+
     private interface RouterDispatchInterface {
         fun execute(routeOptions: RouteOptions, clientCallback: Router.Callback)
     }
 
-    private class OnBoardRouterHandler(private val offRoute: Router, private val onboaredRouter: Router) : RouterDispatchInterface, Router.Callback {
-        private var offrouterCalled = false
-        private var args: RouteOptions? = null
+    //Off board router is used if an internet connection is available
+    private class OffBoardRouterHandler(private val offBoardRouter: Router, private val onBoardRouter: Router) : RouterDispatchInterface, Router.Callback {
+        private var onBoardRouterCalled = false
+        private var options: RouteOptions? = null
         private var callback: Router.Callback? = null
 
         override fun onResponse(routes: List<DirectionsRoute>) {
@@ -32,58 +50,56 @@ class MapboxHybridRouter(
         }
 
         override fun onFailure(throwable: Throwable) {
-            when (offrouterCalled) {
+            when (onBoardRouterCalled) {
                 true -> {
-                    offrouterCalled = false
+                    onBoardRouterCalled = false
                     callback?.onFailure(throwable)
                 }
                 false -> {
-                    offrouterCalled = true
-                    args?.let { options ->
-                        offRoute.getRoute(options, this)
+                    onBoardRouterCalled = true
+                    options?.let { options ->
+                        onBoardRouter.getRoute(options, this)
                     }
                 }
             }
         }
 
         override fun execute(routeOptions: RouteOptions, clientCallback: Router.Callback) {
-            offrouterCalled = false
-            args = routeOptions
+            onBoardRouterCalled = false
+            options = routeOptions
             callback = clientCallback
-            onboaredRouter.getRoute(routeOptions, this)
+            offBoardRouter.getRoute(routeOptions, this)
         }
     }
 
-    private class OffBoardRouterHandler(private val offboaredRouter: Router) : RouterDispatchInterface, Router.Callback {
+    //On Board router used if an internet connection is not available.
+    private class OnBoardRouterHandler(private val offBoardRouter: Router, private val onBoardRouter: Router) : RouterDispatchInterface, Router.Callback {
+        private var isOffboardRouterCalled = false
+        private var options: RouteOptions? = null
         private var callback: Router.Callback? = null
         override fun onResponse(routes: List<DirectionsRoute>) {
             callback?.onResponse(routes)
         }
 
         override fun onFailure(throwable: Throwable) {
-            callback?.onFailure(throwable)
-        }
-
-        override fun execute(routeOptions: RouteOptions, clientCallback: Router.Callback) {
-            callback = clientCallback
-            offboaredRouter.getRoute(routeOptions, this)
-        }
-    }
-
-    private val navigationMonitorStateException = NetworkStatusService(context)
-    private val jobControl = ThreadController.getIOScopeAndRootJob()
-    private var routeDispatchHandler: AtomicReference<RouterDispatchInterface> = AtomicReference(OnBoardRouterHandler(offboardRouter, onboardRouter))
-
-    init {
-        jobControl.scope.monitorChannelWithException(navigationMonitorStateException.getNetworkStatusChannel()) { networkStatus ->
-            when (networkStatus.isNetworkAvailable) {
+            when (isOffboardRouterCalled) {
                 true -> {
-                    routeDispatchHandler.set(OnBoardRouterHandler(offboardRouter, onboardRouter))
+                    isOffboardRouterCalled = false
+                    callback?.onFailure(throwable)
                 }
                 false -> {
-                    routeDispatchHandler.set(OffBoardRouterHandler(offboardRouter))
+                    isOffboardRouterCalled = true
+                    options?.let { options ->
+                        offBoardRouter.getRoute(options, this)
+                    }
                 }
             }
+        }
+        override fun execute(routeOptions: RouteOptions, clientCallback: Router.Callback) {
+            isOffboardRouterCalled = false
+            options = routeOptions
+            callback = clientCallback
+            onBoardRouter.getRoute(routeOptions, this)
         }
     }
 

--- a/libdirections-hybrid/src/main/java/com/mapbox/navigation/route/hybrid/MapboxHybridRouter.kt
+++ b/libdirections-hybrid/src/main/java/com/mapbox/navigation/route/hybrid/MapboxHybridRouter.kt
@@ -1,20 +1,98 @@
 package com.mapbox.navigation.route.hybrid
 
+import android.content.Context
 import com.mapbox.annotation.navigation.module.MapboxNavigationModule
 import com.mapbox.annotation.navigation.module.MapboxNavigationModuleType
+import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.RouteOptions
 import com.mapbox.navigation.base.route.Router
+import com.mapbox.navigation.trip.service.NetworkStatusService
+import com.mapbox.navigation.utils.thread.ThreadController
+import com.mapbox.navigation.utils.thread.monitorChannelWithException
+import java.util.concurrent.atomic.AtomicReference
 
 @MapboxNavigationModule(MapboxNavigationModuleType.HybridRouter, skipConfiguration = true)
 class MapboxHybridRouter(
     private val onboardRouter: Router,
-    private val offboardRouter: Router
+    private val offboardRouter: Router,
+    context: Context
 ) : Router {
 
+    private interface RouterDispatchInterface {
+        fun execute(routeOptions: RouteOptions, clientCallback: Router.Callback)
+    }
+
+    private class OnBoardRouterHandler(private val offRoute: Router, private val onboaredRouter: Router) : RouterDispatchInterface, Router.Callback {
+        private var offrouterCalled = false
+        private var args: RouteOptions? = null
+        private var callback: Router.Callback? = null
+
+        override fun onResponse(routes: List<DirectionsRoute>) {
+            callback?.onResponse(routes)
+        }
+
+        override fun onFailure(throwable: Throwable) {
+            when (offrouterCalled) {
+                true -> {
+                    offrouterCalled = false
+                    callback?.onFailure(throwable)
+                }
+                false -> {
+                    offrouterCalled = true
+                    args?.let { options ->
+                        offRoute.getRoute(options, this)
+                    }
+                }
+            }
+        }
+
+        override fun execute(routeOptions: RouteOptions, clientCallback: Router.Callback) {
+            offrouterCalled = false
+            args = routeOptions
+            callback = clientCallback
+            onboaredRouter.getRoute(routeOptions, this)
+        }
+    }
+
+    private class OffBoardRouterHandler(private val offboaredRouter: Router) : RouterDispatchInterface, Router.Callback {
+        private var callback: Router.Callback? = null
+        override fun onResponse(routes: List<DirectionsRoute>) {
+            callback?.onResponse(routes)
+        }
+
+        override fun onFailure(throwable: Throwable) {
+            callback?.onFailure(throwable)
+        }
+
+        override fun execute(routeOptions: RouteOptions, clientCallback: Router.Callback) {
+            callback = clientCallback
+            offboaredRouter.getRoute(routeOptions, this)
+        }
+    }
+
+    private val navigationMonitorStateException = NetworkStatusService(context)
+    private val jobControl = ThreadController.getIOScopeAndRootJob()
+    private var routeDispatchHandler: AtomicReference<RouterDispatchInterface> = AtomicReference(OnBoardRouterHandler(offboardRouter, onboardRouter))
+
+    init {
+        jobControl.scope.monitorChannelWithException(navigationMonitorStateException.getNetworkStatusChannel()) { networkStatus ->
+            when (networkStatus.isNetworkAvailable) {
+                true -> {
+                    routeDispatchHandler.set(OnBoardRouterHandler(offboardRouter, onboardRouter))
+                }
+                false -> {
+                    routeDispatchHandler.set(OffBoardRouterHandler(offboardRouter))
+                }
+            }
+        }
+    }
+
     override fun getRoute(
-        routeOptions: RouteOptions,
-        callback: Router.Callback
-    ) = Unit
+            routeOptions: RouteOptions,
+            callback: Router.Callback
+    ) {
+        routeDispatchHandler.get().execute(routeOptions, callback)
+    }
 
     override fun cancel() {
         onboardRouter.cancel()

--- a/libdirections-hybrid/src/test/java/com/mapbox/navigation/route/hybrid/MapboxHybridRouterGenerationTest.kt
+++ b/libdirections-hybrid/src/test/java/com/mapbox/navigation/route/hybrid/MapboxHybridRouterGenerationTest.kt
@@ -1,7 +1,11 @@
 package com.mapbox.navigation.route.hybrid
 
+import android.content.Context
+import android.content.Intent
+import android.net.ConnectivityManager
 import com.mapbox.navigation.route.offboard.MapboxOffboardRouter
 import com.mapbox.navigation.route.onboard.MapboxOnboardRouter
+import io.mockk.every
 import io.mockk.mockk
 import org.junit.Assert
 import org.junit.Before
@@ -12,11 +16,16 @@ class MapboxHybridRouterGenerationTest {
     private lateinit var hybridRouter: MapboxHybridRouter
 
     private val onboardRouter: MapboxOnboardRouter = mockk()
-    private val offboardRouter: MapboxOffboardRouter = mockk()
+    private val offboardRouter: MapboxOffboardRouter = mockk(relaxed = true)
+    private val context: Context = mockk()
+    private val connectivityManager: ConnectivityManager = mockk()
+    private val intent: Intent = mockk()
 
     @Before
     fun setUp() {
-        hybridRouter = MapboxHybridRouter(onboardRouter, offboardRouter)
+        every { context.getSystemService(Context.CONNECTIVITY_SERVICE) } answers { connectivityManager }
+        every { context.registerReceiver(any(), any()) } answers { intent }
+        hybridRouter = MapboxHybridRouter(onboardRouter, offboardRouter, context)
     }
 
     @Test

--- a/libnavigation-util/build.gradle
+++ b/libnavigation-util/build.gradle
@@ -18,6 +18,7 @@ android {
 
 dependencies {
     implementation dependenciesList.kotlinStdLib
+    implementation dependenciesList.coroutinesAndroid
 
     //ktlint
     ktlint dependenciesList.ktlint

--- a/libnavigation-util/src/main/AndroidManifest.xml
+++ b/libnavigation-util/src/main/AndroidManifest.xml
@@ -1,2 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.mapbox.navigation.utils" />
+    package="com.mapbox.navigation.utils" >
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+</manifest>

--- a/libnavigation-util/src/main/java/com/mapbox/navigation/utils/network/NetworkStatusService.kt
+++ b/libnavigation-util/src/main/java/com/mapbox/navigation/utils/network/NetworkStatusService.kt
@@ -1,0 +1,64 @@
+package com.mapbox.navigation.trip.service
+
+import android.annotation.TargetApi
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import android.os.Build
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ReceiveChannel
+
+data class NetworkStatus(val isNetworkAvailable: Boolean)
+
+class NetworkStatusService(private val applicationContext: Context) {
+
+    private val connectivityManager: ConnectivityManager = applicationContext
+            .getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+
+    private val networkStatusChannel = Channel<NetworkStatus>(Channel.CONFLATED)
+
+    fun getNetworkStatusChannel(): ReceiveChannel<NetworkStatus> = networkStatusChannel
+
+    init {
+
+        @TargetApi(11)
+        when (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            true -> {
+                val builder = NetworkRequest.Builder()
+                builder.addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                builder.addTransportType(NetworkCapabilities.TRANSPORT_CELLULAR)
+                builder.addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
+                builder.addTransportType(NetworkCapabilities.TRANSPORT_VPN)
+                val callback: ConnectivityManager.NetworkCallback = object : ConnectivityManager.NetworkCallback() {
+                    override fun onAvailable(network: Network?) {
+                        super.onAvailable(network)
+                        networkStatusChannel.offer(NetworkStatus(true))
+                    }
+
+                    override fun onLost(network: Network?) {
+                        super.onLost(network)
+                        networkStatusChannel.offer(NetworkStatus(false))
+                    }
+                }
+                connectivityManager.registerNetworkCallback(builder.build(), callback)
+            }
+            false -> {
+                val filter = IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION)
+                val receiver: BroadcastReceiver = object : BroadcastReceiver() {
+                    override fun onReceive(context: Context, intent: Intent) {
+                        val activeNetwork = connectivityManager.activeNetworkInfo
+                        val isConnected = (activeNetwork != null &&
+                                activeNetwork.isConnectedOrConnecting)
+                        networkStatusChannel.offer(NetworkStatus(isConnected))
+                    }
+                }
+                applicationContext.registerReceiver(receiver, filter)
+            }
+        }
+    }
+}

--- a/libnavigation-util/src/main/java/com/mapbox/navigation/utils/network/NetworkStatusService.kt
+++ b/libnavigation-util/src/main/java/com/mapbox/navigation/utils/network/NetworkStatusService.kt
@@ -1,4 +1,4 @@
-package com.mapbox.navigation.trip.service
+package com.mapbox.navigation.utils.network
 
 import android.annotation.TargetApi
 import android.content.BroadcastReceiver
@@ -15,7 +15,7 @@ import kotlinx.coroutines.channels.ReceiveChannel
 
 data class NetworkStatus(val isNetworkAvailable: Boolean)
 
-class NetworkStatusService(private val applicationContext: Context) {
+class NetworkStatusService(applicationContext: Context) {
 
     private val connectivityManager: ConnectivityManager = applicationContext
             .getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager

--- a/libnavigation-util/src/main/java/com/mapbox/navigation/utils/thread/ThreadController.kt
+++ b/libnavigation-util/src/main/java/com/mapbox/navigation/utils/thread/ThreadController.kt
@@ -1,0 +1,104 @@
+package com.mapbox.navigation.utils.thread
+
+import java.util.concurrent.Executors
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.channels.ClosedReceiveChannelException
+import kotlinx.coroutines.channels.ClosedSendChannelException
+import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.selects.select
+
+fun <T> CoroutineScope.monitorChannelWithException(
+    channel: ReceiveChannel<T>,
+    predicate: suspend (T) -> Unit
+): Job {
+
+    var isChannelValid = true
+    return launch {
+        while (isActive && isChannelValid) {
+            try {
+                select<Unit> {
+                    channel.onReceive { channelData ->
+                        predicate(channelData)
+                    }
+                }
+            } catch (e: Exception) {
+                when (e) {
+                    is ClosedReceiveChannelException,
+                    is ClosedSendChannelException,
+                    is CancellationException -> {
+                        isChannelValid = false
+                    }
+                }
+            }
+        }
+    }
+}
+
+data class JobControl(val job: Job, val scope: CoroutineScope)
+
+const val MAX_THREAD_COUNT = 2
+
+object ThreadController {
+    private val maxCoresUsed = Runtime.getRuntime().availableProcessors().coerceAtMost(
+            MAX_THREAD_COUNT
+    )
+    private val IODispatchContext =
+            Executors.newFixedThreadPool(maxCoresUsed).asCoroutineDispatcher()
+
+    private val ioRootJob = SupervisorJob()
+    private val mainRootJob = SupervisorJob()
+
+    /**
+     * This method cancels all coroutines that are children of this job. The call affects
+     * all coroutines that where started via ThreadController.ioScope.launch(). It is basically
+     * a kill switch for all non-UI scoped coroutines.
+     */
+    fun cancelAllNonUICoroutines() {
+        ioRootJob.cancel()
+    }
+
+    /**
+     * This method cancels all coroutines that are children of this job. The call affects
+     * all coroutines that where started via ThreadController.mainScope.launch(). It is basically
+     * a kill switch for all UI scoped coroutines.
+     */
+    fun cancelAllUICoroutines() {
+        mainRootJob.cancel()
+    }
+
+    /**
+     * This method creates a [Job] object that is a child of the [ioRootJob]. Using
+     * this job a [CoroutineScope] is created. The return object is the [JobControl] data class. This
+     * data class contains both the new [Job] object and the [CoroutineScope] that uses the [Job] object.
+     * This construct allows the caller to cancel all coroutines created from the returned [CoroutineScope].
+     * Example:
+     * val jobController:JobController = ThreadController.getIOScopeAndRootJob()
+     * val job_1 = jobController.ioScope.launch{ doSomethingUsefull_1()}
+     * val job_2 = jobController.ioScope.launch{ doSomethingUsefull_2()}
+     * val job_3 = jobController.ioScope.launch{ doSomethingUsefull_3()}
+     * val job_4 = jobController.ioScope.launch{ doSomethingUsefull_4()}
+     *
+     * The code launches four coroutines. Each one becomes a parent of ThreadController.job
+     * To cancel all coroutines: jobController.job.cancel()
+     * To cancel a specific coroutine: job_1.cancel(), etc.
+     */
+    fun getIOScopeAndRootJob(): JobControl {
+        val parentJob = SupervisorJob(ioRootJob)
+        return JobControl(parentJob, CoroutineScope(parentJob + IODispatchContext))
+    }
+
+    /**
+     * Same as [cancelAllNonUICoroutines], but using the MainThread dispatcher.
+     */
+    fun getMainScopeAndRootJob(): JobControl {
+        val parentJob = SupervisorJob(mainRootJob)
+        return JobControl(parentJob, CoroutineScope(parentJob + Dispatchers.Main))
+    }
+}


### PR DESCRIPTION
## Description
This is the initial implementation of the hybrid router. The branch does not contain tests yet. Tests will be added once PR review comments are received and addressed.

- [ ] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal
The goal of this implementation is to support hybrid navigation such that the off-board router is called if  internet access is available. If the internet connection fails, the on-board router is called. The network is monitored during the lifetime of the app that is using the SDK.

### Implementation

Please include all the relevant things implemented and also rationale, clarifications / disclaimers etc. related to the approach used. It could be as self code companion comments

## Screenshots or Gifs

Please include all the media files to give some context about what's being implemented or fixed. It's not mandatory to upload screenshots or gifs, but for most of the cases it becomes really handy to get into the scope of the feature / bug being fixed and also it's REALLY useful for UI related PRs ![screenshot gif](link)

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->