### PR TITLE
Provide fully initialized route progress from the navigator

### DIFF
--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/banner/BannerInstruction.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/banner/BannerInstruction.kt
@@ -1,6 +1,0 @@
-package com.mapbox.navigation.base.banner
-
-data class BannerInstruction(private val primary: BannerSection) {
-
-    fun primary(): BannerSection = primary
-}

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/banner/BannerSection.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/banner/BannerSection.kt
@@ -1,6 +1,0 @@
-package com.mapbox.navigation.base.banner
-
-data class BannerSection internal constructor(private val text: String) {
-
-    fun text(): String = text
-}

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteLegProgress.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteLegProgress.kt
@@ -1,0 +1,130 @@
+package com.mapbox.navigation.base.trip.model
+
+import com.mapbox.api.directions.v5.models.LegStep
+import com.mapbox.api.directions.v5.models.RouteLeg
+
+class RouteLegProgress private constructor(
+    private val legIndex: Int = 0,
+    private val routeLeg: RouteLeg? = null,
+    private val distanceTraveled: Float = 0f,
+    private val distanceRemaining: Float = 0f,
+    private val durationRemaining: Long = 0L,
+    private val fractionTraveled: Float = 0f,
+    private val currentStepProgress: RouteStepProgress? = null,
+    private val upcomingStep: LegStep? = null,
+    private val builder: Builder
+) {
+
+    /**
+     * Index representing the current leg the user is on. If the directions route currently in use
+     * contains more then two waypoints, the route is likely to have multiple legs representing the
+     * distance between the two points.
+     *
+     * @return an integer representing the current leg the user is on
+     */
+    fun legIndex(): Int = legIndex
+
+    /**
+     * This [RouteLeg] geometry.
+     *
+     * @return route leg geometry
+     */
+    fun routeLeg(): RouteLeg? = routeLeg
+
+    /**
+     * Total distance traveled in meters along current leg.
+     *
+     * @return a double value representing the total distance the user has traveled along the current
+     * leg, using unit meters.
+     */
+    fun distanceTraveled(): Float = distanceTraveled
+
+    /**
+     * Provides the duration remaining in seconds till the user reaches the end of the route.
+     *
+     * @return long value representing the duration remaining till end of route, in unit seconds
+     */
+    fun distanceRemaining(): Float = distanceRemaining
+
+    /**
+     * Provides the duration remaining in seconds till the user reaches the end of the current step.
+     *
+     * @return long value representing the duration remaining till end of step, in unit seconds.
+     */
+    fun durationRemaining(): Long = durationRemaining
+
+    /**
+     * Get the fraction traveled along the current leg, this is a float value between 0 and 1 and
+     * isn't guaranteed to reach 1 before the user reaches the next waypoint.
+     *
+     * @return a float value between 0 and 1 representing the fraction the user has traveled along the
+     * current leg
+     */
+    fun fractionTraveled(): Float = fractionTraveled
+
+    /**
+     * Gives a [RouteStepProgress] object with information about the particular step the user
+     * is currently on.
+     *
+     * @return a [RouteStepProgress] object
+     */
+    fun currentStepProgress(): RouteStepProgress? = currentStepProgress
+
+    /**
+     * Get the next/upcoming step immediately after the current step. If the user is on the last step
+     * on the last leg, this will return null since a next step doesn't exist.
+     *
+     * @return a [LegStep] representing the next step the user will be on.
+     */
+    fun upcomingStep(): LegStep? = upcomingStep
+
+    fun toBuilder() = builder
+
+    data class Builder(
+        private var legIndex: Int = 0,
+        private var routeLeg: RouteLeg? = null,
+        private var distanceTraveled: Float = 0f,
+        private var distanceRemaining: Float = 0f,
+        private var durationRemaining: Long = 0L,
+        private var fractionTraveled: Float = 0f,
+        private var currentStepProgress: RouteStepProgress? = null,
+        private var upcomingStep: LegStep? = null
+    ) {
+
+        fun legIndex(legIndex: Int) = apply { this.legIndex = legIndex }
+
+        fun routeLeg(routeLeg: RouteLeg) = apply { this.routeLeg = routeLeg }
+
+        fun distanceTraveled(distanceTraveled: Float) =
+            apply { this.distanceTraveled = distanceTraveled }
+
+        fun distanceRemaining(distanceRemaining: Float) =
+            apply { this.distanceRemaining = distanceRemaining }
+
+        fun durationRemaining(durationRemaining: Long) =
+            apply { this.durationRemaining = durationRemaining }
+
+        fun fractionTraveled(fractionTraveled: Float) =
+            apply { this.fractionTraveled = fractionTraveled }
+
+        fun currentStepProgress(currentStepProgress: RouteStepProgress) =
+            apply { this.currentStepProgress = currentStepProgress }
+
+        fun upcomingStep(upcomingStep: LegStep) =
+            apply { this.upcomingStep = upcomingStep }
+
+        fun build(): RouteLegProgress {
+            return RouteLegProgress(
+                legIndex,
+                routeLeg,
+                distanceTraveled,
+                distanceRemaining,
+                durationRemaining,
+                fractionTraveled,
+                currentStepProgress,
+                upcomingStep,
+                this
+            )
+        }
+    }
+}

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteProgress.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteProgress.kt
@@ -1,3 +1,207 @@
 package com.mapbox.navigation.base.trip.model
 
-data class RouteProgress(val progress: String)
+import com.mapbox.api.directions.v5.models.BannerInstructions
+import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.api.directions.v5.models.VoiceInstructions
+import com.mapbox.geojson.Geometry
+import com.mapbox.geojson.Point
+
+class RouteProgress private constructor(
+    private val route: DirectionsRoute? = null,
+    private val routeGeometryWithBuffer: Geometry? = null,
+    private val bannerInstructions: BannerInstructions? = null,
+    private val voiceInstructions: VoiceInstructions? = null,
+    private val currentState: RouteProgressState? = null,
+    private val currentLegProgress: RouteLegProgress? = null,
+    private val upcomingStepPoints: List<Point>? = null,
+    private val inTunnel: Boolean = false,
+    private val distanceRemaining: Float = 0f,
+    private val distanceTraveled: Float = 0f,
+    private val durationRemaining: Long = 0L,
+    private val fractionTraveled: Float = 0f,
+    private val remainingWaypoints: Int = 0,
+    private val builder: Builder
+) {
+
+    /**
+     * Get the route the navigation session is currently using. When a reroute occurs and a new
+     * directions route gets obtained, with the next location update this directions route should
+     * reflect the new route.
+     *
+     * @return a [DirectionsRoute] currently being used for the navigation session
+     */
+    fun route() = route
+
+    /**
+     * Total distance traveled in meters along route.
+     *
+     * @return a Float value representing the total distance the user has traveled along the route,
+     * using unit meters
+     */
+    fun distanceTraveled(): Float = distanceTraveled
+
+    /**
+     * Provides the duration remaining in seconds till the user reaches the end of the route.
+     *
+     * @return `long` value representing the duration remaining till end of route, in unit
+     * seconds
+     */
+    fun durationRemaining(): Long = durationRemaining
+
+    /**
+     * Get the fraction traveled along the current route, this is a float value between 0 and 1 and
+     * isn't guaranteed to reach 1 before the user reaches the end of the route.
+     *
+     * @return a Float value between 0 and 1 representing the fraction the user has traveled along the
+     * route
+     */
+    private fun fractionTraveled(): Float? = fractionTraveled
+
+    /**
+     * Provides the distance remaining in meters till the user reaches the end of the route.
+     *
+     * @return `long` value representing the distance remaining till end of route, in unit meters
+     */
+    fun distanceRemaining(): Float = distanceRemaining
+
+    /**
+     * Number of waypoints remaining on the current route.
+     *
+     * @return integer value representing the number of way points remaining along the route
+     */
+    fun remainingWaypoints(): Int = remainingWaypoints
+
+    /**
+     * Gives a [RouteLegProgress] object with information about the particular leg the user is
+     * currently on.
+     *
+     * @return a [RouteLegProgress] object
+     */
+    fun currentLegProgress() = currentLegProgress
+
+    /**
+     * Provides a list of points that represent the upcoming step
+     * step geometry.
+     *
+     * @return list of points representing the upcoming step
+     */
+    fun upcomingStepPoints() = upcomingStepPoints
+
+    /**
+     * Returns whether or not the location updates are
+     * considered in a tunnel along the route.
+     *
+     * @return true if in a tunnel, false otherwise
+     */
+    fun inTunnel() = inTunnel
+
+    /**
+     * Current banner instruction.
+     *
+     * @return current banner instruction
+     */
+    fun bannerInstructions() = bannerInstructions
+
+    /**
+     * Current voice instruction.
+     *
+     * @return current voice instruction
+     */
+    fun voiceInstructions() = voiceInstructions
+
+    /**
+     * Returns the current state of progress along the route.  Provides route and location tracking
+     * information.
+     *
+     * @return the current state of progress along the route.
+     */
+    fun currentState() = currentState
+
+    /**
+     * Returns the current [DirectionsRoute] geometry with a buffer
+     * that encompasses visible tile surface are while navigating.
+     *
+     *
+     * This [Geometry] is ideal for offline downloads of map or routing tile
+     * data.
+     *
+     * @return current route geometry with buffer
+     */
+    fun routeGeometryWithBuffer() = routeGeometryWithBuffer
+
+    fun toBuilder() = builder
+
+    data class Builder(
+        private var directionsRoute: DirectionsRoute? = null,
+        private var routeGeometryWithBuffer: Geometry? = null,
+        private var bannerInstructions: BannerInstructions? = null,
+        private var voiceInstructions: VoiceInstructions? = null,
+        private var currentState: RouteProgressState? = null,
+        private var currentLegProgress: RouteLegProgress? = null,
+        private var upcomingStepPoints: List<Point>? = null,
+        private var inTunnel: Boolean = false,
+        private var distanceRemaining: Float = 0f,
+        private var distanceTraveled: Float = 0f,
+        private var durationRemaining: Long = 0L,
+        private var fractionTraveled: Float = 0f,
+        private var remainingWaypoints: Int = 0
+    ) {
+
+        fun route(route: DirectionsRoute) =
+            apply { this.directionsRoute = route }
+
+        fun routeGeometryWithBuffer(routeGeometryWithBuffer: Geometry?) =
+            apply { this.routeGeometryWithBuffer = routeGeometryWithBuffer }
+
+        fun bannerInstructions(bannerInstructions: BannerInstructions?) =
+            apply { this.bannerInstructions = bannerInstructions }
+
+        fun voiceInstructions(voiceInstructions: VoiceInstructions?) =
+            apply { this.voiceInstructions = voiceInstructions }
+
+        fun currentState(currentState: RouteProgressState) =
+            apply { this.currentState = currentState }
+
+        fun currentLegProgress(legProgress: RouteLegProgress) =
+            apply { this.currentLegProgress = legProgress }
+
+        fun upcomingStepPoints(upcomingStepPoints: List<Point>?) =
+            apply { this.upcomingStepPoints = upcomingStepPoints }
+
+        fun inTunnel(inTunnel: Boolean) = apply { this.inTunnel = inTunnel }
+
+        fun distanceRemaining(distanceRemaining: Float) =
+            apply { this.distanceRemaining = distanceRemaining }
+
+        fun distanceTraveled(distanceTraveled: Float) =
+            apply { this.distanceTraveled = distanceTraveled }
+
+        fun durationRemaining(durationRemaining: Long) =
+            apply { this.durationRemaining = durationRemaining }
+
+        fun fractionTraveled(fractionTraveled: Float) =
+            apply { this.fractionTraveled = fractionTraveled }
+
+        fun remainingWaypoints(remainingWaypoints: Int) =
+            apply { this.remainingWaypoints = remainingWaypoints }
+
+        fun build(): RouteProgress {
+            return RouteProgress(
+                directionsRoute,
+                routeGeometryWithBuffer,
+                bannerInstructions,
+                voiceInstructions,
+                currentState,
+                currentLegProgress,
+                upcomingStepPoints,
+                inTunnel,
+                distanceRemaining,
+                distanceTraveled,
+                durationRemaining,
+                fractionTraveled,
+                remainingWaypoints,
+                this
+            )
+        }
+    }
+}

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteProgressState.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteProgressState.kt
@@ -1,0 +1,9 @@
+package com.mapbox.navigation.base.trip.model
+
+enum class RouteProgressState {
+    ROUTE_INVALID,
+    ROUTE_INITIALIZED,
+    ROUTE_ARRIVED,
+    LOCATION_TRACKING,
+    LOCATION_STALE
+}

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteStepProgress.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteStepProgress.kt
@@ -1,0 +1,116 @@
+package com.mapbox.navigation.base.trip.model
+
+import com.mapbox.api.directions.v5.models.LegStep
+import com.mapbox.geojson.Point
+
+class RouteStepProgress private constructor(
+    private val stepIndex: Int = 0,
+    private val step: LegStep? = null,
+    private val stepPoints: List<Point>? = null,
+    private val distanceRemaining: Float = 0f,
+    private val distanceTraveled: Float = 0f,
+    private val fractionTraveled: Float = 0f,
+    private val durationRemaining: Long = 0L,
+    private val builder: Builder
+) {
+
+    /**
+     * Index representing the current step the user is on.
+     *
+     * @return an integer representing the current step the user is on
+     */
+    fun stepIndex(): Int = stepIndex
+
+    /**
+     * Returns the current step the user is traversing along.
+     *
+     * @return a [LegStep] representing the step the user is currently on
+     */
+    fun step(): LegStep? = step
+
+    /**
+     * Provides a list of points that represent the current step
+     * step geometry.
+     *
+     * @return list of points representing the current step
+     */
+    fun stepPoints() = stepPoints
+
+    /**
+     * Total distance in meters from user to end of step.
+     *
+     * @return float value representing the distance the user has remaining till they reach the end
+     * of the current step. Uses unit meters.
+     */
+    fun distanceRemaining(): Float = distanceRemaining
+
+    /**
+     * Returns distance user has traveled along current step in unit meters.
+     *
+     * @return double value representing the distance the user has traveled so far along the current
+     * step. Uses unit meters.
+     */
+    fun distanceTraveled(): Float = distanceTraveled
+
+    /**
+     * Get the fraction traveled along the current step, this is a float value between 0 and 1 and
+     * isn't guaranteed to reach 1 before the user reaches the next step (if another step exist in route).
+     *
+     * @return a float value between 0 and 1 representing the fraction the user has traveled along
+     * the current step.
+     */
+    fun fractionTraveled(): Float = fractionTraveled
+
+    /**
+     * Provides the duration remaining in seconds till the user reaches the end of the current step.
+     *
+     * @return `long` value representing the duration remaining till end of step, in unit seconds.
+     */
+    fun durationRemaining(): Long = durationRemaining
+
+    fun toBuilder() = builder
+
+    data class Builder(
+        private var stepIndex: Int = 0,
+        private var step: LegStep? = null,
+        private var stepPoints: List<Point>? = null,
+        private var distanceRemaining: Float = 0f,
+        private var distanceTraveled: Float = 0f,
+        private var fractionTraveled: Float = 0f,
+        private var durationRemaining: Long = 0L
+    ) {
+
+        fun stepIndex(stepIndex: Int) =
+            apply { this.stepIndex = stepIndex }
+
+        fun step(step: LegStep) = apply { this.step = step }
+
+        fun stepPoints(stepPoints: List<Point>) =
+            apply { this.stepPoints = stepPoints }
+
+        fun distanceRemaining(distanceRemaining: Float) =
+            apply { this.distanceRemaining = distanceRemaining }
+
+        fun distanceTraveled(distanceTraveled: Float) =
+            apply { this.distanceTraveled = distanceTraveled }
+
+        fun fractionTraveled(fractionTraveled: Float) =
+            apply { this.fractionTraveled = fractionTraveled }
+
+        fun durationRemaining(durationRemaining: Long) =
+            apply { this.durationRemaining = durationRemaining }
+
+        fun build(): RouteStepProgress {
+            return RouteStepProgress(
+                stepIndex,
+                step,
+                stepPoints,
+                distanceRemaining,
+                distanceTraveled,
+                fractionTraveled,
+                durationRemaining,
+                this
+            )
+        }
+    }
+}

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/MapboxNativeNavigator.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/MapboxNativeNavigator.kt
@@ -1,6 +1,7 @@
 package com.mapbox.navigation.navigator
 
 import android.location.Location
+import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.geojson.Point
 import com.mapbox.navigator.BannerInstruction
 import com.mapbox.navigator.HttpInterface
@@ -28,7 +29,7 @@ interface MapboxNativeNavigator {
     // Routing
 
     fun setRoute(
-        routeJson: String,
+        route: DirectionsRoute,
         routeIndex: Int = INDEX_FIRST_ROUTE,
         legIndex: Int = INDEX_FIRST_LEG
     ): NavigationStatus

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/MapboxNativeNavigatorImpl.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/MapboxNativeNavigatorImpl.kt
@@ -1,18 +1,36 @@
 package com.mapbox.navigation.navigator
 
 import android.location.Location
+import com.mapbox.api.directions.v5.models.BannerComponents
+import com.mapbox.api.directions.v5.models.BannerInstructions
+import com.mapbox.api.directions.v5.models.BannerText
+import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.api.directions.v5.models.LegStep
+import com.mapbox.api.directions.v5.models.RouteLeg
+import com.mapbox.api.directions.v5.models.VoiceInstructions
+import com.mapbox.geojson.Geometry
 import com.mapbox.geojson.Point
+import com.mapbox.geojson.gson.GeometryGeoJson
+import com.mapbox.geojson.utils.PolylineUtils
+import com.mapbox.navigation.base.extensions.ifNonNull
+import com.mapbox.navigation.base.trip.model.RouteLegProgress
 import com.mapbox.navigation.base.trip.model.RouteProgress
+import com.mapbox.navigation.base.trip.model.RouteProgressState
+import com.mapbox.navigation.base.trip.model.RouteStepProgress
+import com.mapbox.navigator.BannerComponent
 import com.mapbox.navigator.BannerInstruction
+import com.mapbox.navigator.BannerSection
 import com.mapbox.navigator.FixLocation
 import com.mapbox.navigator.HttpInterface
 import com.mapbox.navigator.NavigationStatus
 import com.mapbox.navigator.Navigator
 import com.mapbox.navigator.NavigatorConfig
+import com.mapbox.navigator.RouteState
 import com.mapbox.navigator.RouterParams
 import com.mapbox.navigator.RouterResult
 import com.mapbox.navigator.VoiceInstruction
 import java.util.Date
+import kotlin.math.roundToLong
 
 object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
 
@@ -21,7 +39,16 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
         System.loadLibrary("navigator-android")
     }
 
+    private const val ONE_INDEX = 1
+    private const val ONE_SECOND_IN_MILLISECONDS = 1000.0
+    private const val FIRST_BANNER_INSTRUCTION = 0
+    private const val GRID_SIZE = 0.0025f
+    private const val BUFFER_DILATION: Short = 1
+    private const val TWO_LEGS: Short = 2
+
     private val navigator: Navigator = Navigator()
+    private var route: DirectionsRoute? = null
+    private var routeBufferGeoJson: Geometry? = null
 
     // Route following
 
@@ -38,8 +65,18 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
 
     // Routing
 
-    override fun setRoute(routeJson: String, routeIndex: Int, legIndex: Int): NavigationStatus =
-        navigator.setRoute(routeJson, routeIndex, legIndex)
+    override fun setRoute(
+        route: DirectionsRoute,
+        routeIndex: Int,
+        legIndex: Int
+    ): NavigationStatus {
+        this.route = route
+        val result = navigator.setRoute(route.toJson(), routeIndex, legIndex)
+        navigator.getRouteBufferGeoJson(GRID_SIZE, BUFFER_DILATION)?.also {
+            routeBufferGeoJson = GeometryGeoJson.fromJson(it)
+        }
+        return result
+    }
 
     override fun updateAnnotations(
         legAnnotationJson: String,
@@ -120,6 +157,170 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
     }
 
     private fun NavigationStatus.getRouteProgress(): RouteProgress {
-        return RouteProgress("")
+        val upcomingStepIndex = stepIndex + ONE_INDEX
+
+        val routeProgressBuilder = RouteProgress.Builder()
+        val legProgressBuilder = RouteLegProgress.Builder()
+        val stepProgressBuilder = RouteStepProgress.Builder()
+
+        ifNonNull(route?.legs()) { legs ->
+            var currentLeg: RouteLeg? = null
+            if (legIndex < legs.size) {
+                currentLeg = legs[legIndex]
+                legProgressBuilder.legIndex(legIndex)
+                legProgressBuilder.routeLeg(currentLeg)
+
+                // todo mapbox java issue - leg distance is nullable
+                val distanceTraveled =
+                    (currentLeg.distance()?.toFloat() ?: 0f) - remainingLegDistance
+                legProgressBuilder.distanceTraveled(distanceTraveled)
+                legProgressBuilder.fractionTraveled(
+                    distanceTraveled / (currentLeg.distance()?.toFloat() ?: 0f)
+                )
+
+                var routeDistanceRemaining = remainingLegDistance
+                if (legs.size >= TWO_LEGS) {
+                    for (i in legIndex + ONE_INDEX until legs.size) {
+                        routeDistanceRemaining += legs[i].distance()?.toFloat() ?: 0f
+                    }
+                }
+                routeProgressBuilder.distanceRemaining(routeDistanceRemaining)
+
+                var routeDistance = 0f
+                for (leg in legs) {
+                    routeDistance += leg.distance()?.toFloat() ?: 0f
+                }
+                val routeDistanceTraveled = routeDistance - routeDistanceRemaining
+                routeProgressBuilder.distanceTraveled(routeDistanceTraveled)
+                routeProgressBuilder.fractionTraveled(routeDistanceTraveled / routeDistance)
+
+                routeProgressBuilder.remainingWaypoints(legs.size - (legIndex + 1))
+            }
+
+            ifNonNull(currentLeg?.steps()) { steps ->
+                val currentStep: LegStep?
+                if (stepIndex < steps.size) {
+                    currentStep = steps[stepIndex]
+                    stepProgressBuilder.stepIndex(stepIndex)
+                    stepProgressBuilder.step(currentStep)
+
+                    currentStep?.distance()
+                    val stepGeometry = currentStep.geometry()
+                    stepGeometry?.let {
+                        stepProgressBuilder.stepPoints(
+                            PolylineUtils.decode(
+                                stepGeometry, /* todo add core dependency PRECISION_6*/
+                                6
+                            )
+                        )
+                    }
+
+                    val distanceTraveled =
+                        currentStep.distance().toFloat() - remainingStepDistance
+                    stepProgressBuilder.distanceTraveled(distanceTraveled)
+                    stepProgressBuilder.fractionTraveled(distanceTraveled / currentStep.distance().toFloat())
+                }
+
+                if (upcomingStepIndex < steps.size) {
+                    val upcomingStep = steps[upcomingStepIndex]
+                    legProgressBuilder.upcomingStep(upcomingStep)
+
+                    val stepGeometry = upcomingStep.geometry()
+                    stepGeometry?.let {
+                        routeProgressBuilder.upcomingStepPoints(
+                            PolylineUtils.decode(
+                                stepGeometry, /* todo add core dependency PRECISION_6*/
+                                6
+                            )
+                        )
+                    }
+                }
+            }
+        }
+
+        stepProgressBuilder.distanceRemaining(remainingStepDistance)
+        stepProgressBuilder.durationRemaining((remainingStepDuration / ONE_SECOND_IN_MILLISECONDS).roundToLong())
+
+        legProgressBuilder.currentStepProgress(stepProgressBuilder.build())
+        legProgressBuilder.distanceRemaining(remainingLegDistance)
+        legProgressBuilder.durationRemaining((remainingLegDuration / ONE_SECOND_IN_MILLISECONDS).roundToLong())
+
+        routeProgressBuilder.currentLegProgress(legProgressBuilder.build())
+
+        routeState.convertState()?.also {
+            routeProgressBuilder.currentState(it)
+
+            var bannerInstructions = bannerInstruction?.mapToDirectionsApi()
+            if (it == RouteProgressState.ROUTE_INITIALIZED) {
+                bannerInstructions =
+                    getBannerInstruction(FIRST_BANNER_INSTRUCTION)?.mapToDirectionsApi()
+            }
+            routeProgressBuilder.bannerInstructions(bannerInstructions)
+        }
+
+        routeProgressBuilder.inTunnel(inTunnel)
+        routeProgressBuilder.routeGeometryWithBuffer(routeBufferGeoJson)
+
+        routeProgressBuilder.voiceInstructions(voiceInstruction?.mapToDirectionsApi())
+
+        return routeProgressBuilder.build()
+    }
+
+    private fun BannerInstruction.mapToDirectionsApi(): BannerInstructions {
+        return BannerInstructions.builder()
+            .distanceAlongGeometry(this.remainingStepDistance.toDouble())
+            .primary(this.primary.mapToDirectionsApi())
+            .secondary(this.secondary?.mapToDirectionsApi())
+            .sub(this.sub?.mapToDirectionsApi())
+            .view(null)
+            .build()
+    }
+
+    private fun BannerSection.mapToDirectionsApi(): BannerText {
+        return BannerText.builder()
+            .components(this.components?.mapToDirectionsApi())
+            .degrees(this.degrees?.toDouble())
+            .drivingSide(this.drivingSide)
+            .modifier(this.modifier)
+            .text(this.text)
+            .type(this.type)
+            .build()
+    }
+
+    private fun MutableList<BannerComponent>.mapToDirectionsApi(): MutableList<BannerComponents>? {
+        val components = mutableListOf<BannerComponents>()
+        this.forEach {
+            components.add(
+                BannerComponents.builder()
+                    .abbreviation(it.abbr)
+                    .abbreviationPriority(it.abbrPriority)
+                    .active(it.active)
+                    .directions(it.directions)
+                    .imageBaseUrl(it.imageBaseurl)
+                    .text(it.text)
+                    .type(it.type)
+                    .build()
+            )
+        }
+        return components
+    }
+
+    private fun VoiceInstruction.mapToDirectionsApi(): VoiceInstructions? {
+        return VoiceInstructions.builder()
+            .announcement(this.announcement)
+            .distanceAlongGeometry(this.remainingStepDistance.toDouble())
+            .ssmlAnnouncement(this.ssmlAnnouncement)
+            .build()
+    }
+}
+
+private fun RouteState.convertState(): RouteProgressState? {
+    return when (this) {
+        RouteState.INVALID -> RouteProgressState.ROUTE_INVALID
+        RouteState.INITIALIZED -> RouteProgressState.ROUTE_INITIALIZED
+        RouteState.TRACKING -> RouteProgressState.LOCATION_TRACKING
+        RouteState.COMPLETE -> RouteProgressState.ROUTE_ARRIVED
+        RouteState.OFFROUTE -> null // send in a callback instead
+        RouteState.STALE -> RouteProgressState.LOCATION_STALE
     }
 }

--- a/libtrip-notification/src/main/java/com/mapbox/navigation/trip/notification/MapboxTripNotification.kt
+++ b/libtrip-notification/src/main/java/com/mapbox/navigation/trip/notification/MapboxTripNotification.kt
@@ -151,7 +151,7 @@ class MapboxTripNotification(
         buildRemoteViews()
         updateData(routeProgress)
         // TODO:OZ,AK uncomment for full functionality of the NotificationService
-//        updateInstructionText(routeProgress.bannerInstruction())
+//        updateInstructionText(routeProgress.bannerInstructions())
 //        updateDistanceText(routeProgress)
 //        val time = Calendar.getInstance()
 //
@@ -167,11 +167,11 @@ class MapboxTripNotification(
     private fun updateData(routeProgress: RouteProgress) {
         collapsedNotificationRemoteViews?.setTextViewText(
             R.id.notificationDistanceText,
-            routeProgress.progress
+            "" // todo
         )
         expandedNotificationRemoteViews?.setTextViewText(
             R.id.notificationDistanceText,
-            routeProgress.progress
+            "" // todo
         )
     }
 }


### PR DESCRIPTION
Refs https://github.com/mapbox/mapbox-navigation-android/pull/2359 and https://github.com/mapbox/mapbox-navigation-android/pull/2360.

This PR provides a fully initialized route progress object.

Tailwork that we can target here or preferably in a separate PR:
- [ ] Add geojson core dependency to get a polyline precision constant
- [x] Implement `routeGeometryWithBuffer` field
- [x] Check if `CurrentLegAnnotation`s are used and whether we should include them in the progress.
- [ ] Verify if we want to pass `MaxSpeed` in the route progress.