### PR TITLE
Hide wayname if text is empty

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/NavigationView.java
@@ -331,6 +331,9 @@ public class NavigationView extends CoordinatorLayout implements LifecycleOwner,
    */
   @Override
   public void updateWayNameVisibility(boolean isVisible) {
+    if (wayNameView.retrieveWayNameText().isEmpty()) {
+      isVisible = false;
+    }
     wayNameView.updateVisibility(isVisible);
     if (navigationMap != null) {
       navigationMap.updateWaynameQueryMap(isVisible);


### PR DESCRIPTION
## Desctiption

This PR hides wayname if text is empty and fixes #2032 . This should also prevent other scenarios (with empty wayname) that may occur.

## Screenshots
Before:

![device-2020-01-14-135753](https://user-images.githubusercontent.com/15325804/72436230-39aaa080-37a0-11ea-9b8f-90fad9c6c786.png)

After:
![device-2020-01-15-140419](https://user-images.githubusercontent.com/15325804/72436250-4929e980-37a0-11ea-9e11-79d90c089604.png)

## Testing

I have tested it on "NavigationView implemented with Fragment" test app
