### PR TITLE
Remove unnecessary Turf dependency from libtrip-notification

### DIFF
--- a/libtrip-notification/build.gradle
+++ b/libtrip-notification/build.gradle
@@ -20,7 +20,6 @@ dependencies {
     kapt dependenciesList.mapboxAnnotationsProcessor
 
     api project(':libnavigation-base')
-    implementation dependenciesList.mapboxSdkTurf
 
     //ktlint
     ktlint dependenciesList.ktlint


### PR DESCRIPTION
## Description

Removes unnecessary Turf dependency from `libtrip-notification`

Tail work from https://github.com/mapbox/mapbox-navigation-android/pull/2355

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Remove unnecessary dependency

### Implementation

Remove `implementation dependenciesList.mapboxSdkTurf` from `libtrip-notification` `build.gradle`'s file

## Testing

- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR