### PR TITLE
Replace NN banner and voice instruction leaked models by Directions ones

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/MapboxNavigationNotification.kt
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/MapboxNavigationNotification.kt
@@ -16,8 +16,8 @@ import android.widget.RemoteViews
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import com.mapbox.api.directions.v5.DirectionsCriteria.IMPERIAL
+import com.mapbox.api.directions.v5.models.BannerInstructions
 import com.mapbox.api.directions.v5.models.LegStep
-import com.mapbox.navigator.BannerInstruction
 import com.mapbox.services.android.navigation.R
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation
 import com.mapbox.services.android.navigation.v5.navigation.NavigationConstants
@@ -247,13 +247,13 @@ internal class MapboxNavigationNotification : NavigationNotification {
         notificationManager?.cancel(NavigationConstants.NAVIGATION_NOTIFICATION_ID)
     }
 
-    private fun updateInstructionText(bannerInstruction: BannerInstruction?) {
+    private fun updateInstructionText(bannerInstruction: BannerInstructions?) {
         if (bannerInstruction != null && (instructionText == null || newInstructionText(
                 bannerInstruction
             ))
         ) {
-            updateViewsWithInstruction(bannerInstruction.primary.text)
-            instructionText = bannerInstruction.primary.text
+            updateViewsWithInstruction(bannerInstruction.primary().text())
+            instructionText = bannerInstruction.primary().text()
         }
     }
 
@@ -262,8 +262,8 @@ internal class MapboxNavigationNotification : NavigationNotification {
         expandedNotificationRemoteViews?.setTextViewText(R.id.notificationInstructionText, text)
     }
 
-    private fun newInstructionText(bannerInstruction: BannerInstruction): Boolean {
-        return instructionText != bannerInstruction.primary.text
+    private fun newInstructionText(bannerInstruction: BannerInstructions): Boolean {
+        return instructionText != bannerInstruction.primary().text()
     }
 
     private fun updateDistanceText(routeProgress: RouteProgress) {

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/milestone/BannerInstructionMilestone.kt
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/milestone/BannerInstructionMilestone.kt
@@ -34,7 +34,7 @@ private constructor(
         ifNonNull(
             routeProgress.bannerInstruction()
         ) {
-            this.bannerInstructions = routeProgress.bannerInstruction()
+            this.bannerInstructions = it
             true
         } ?: false
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/milestone/BannerInstructionMilestone.kt
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/milestone/BannerInstructionMilestone.kt
@@ -1,12 +1,8 @@
 package com.mapbox.services.android.navigation.v5.milestone
 
-import com.mapbox.api.directions.v5.models.BannerComponents
 import com.mapbox.api.directions.v5.models.BannerInstructions
-import com.mapbox.api.directions.v5.models.BannerText
-import com.mapbox.navigator.BannerSection
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress
 import com.mapbox.services.android.navigation.v5.utils.extensions.ifNonNull
-import java.util.ArrayList
 
 /**
  * A default milestone that is added to [com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation]
@@ -36,45 +32,11 @@ private constructor(
 
     private fun updateCurrentBanner(routeProgress: RouteProgress): Boolean =
         ifNonNull(
-            routeProgress.bannerInstruction(),
-            retrieveBannerFrom(routeProgress.bannerInstruction()?.primary)
-        ) { currentBannerInstruction, primaryBannerText ->
-            val secondaryBannerText: BannerText? = retrieveBannerFrom(currentBannerInstruction.secondary)
-            val subBannerText: BannerText? = retrieveBannerFrom(currentBannerInstruction.sub)
-            this.bannerInstructions = BannerInstructions.builder()
-                .primary(primaryBannerText)
-                .secondary(secondaryBannerText)
-                .sub(subBannerText)
-                .distanceAlongGeometry(currentBannerInstruction.remainingStepDistance.toDouble())
-                .build()
+            routeProgress.bannerInstruction()
+        ) {
+            this.bannerInstructions = routeProgress.bannerInstruction()
             true
         } ?: false
-
-    private fun retrieveBannerFrom(bannerSection: BannerSection?): BannerText? =
-        bannerSection?.components?.let { currentComponents ->
-            val primaryComponents = ArrayList<BannerComponents>()
-            currentComponents.forEach {
-                primaryComponents.add(
-                    BannerComponents.builder()
-                        .text(it.text)
-                        .type(it.type)
-                        .abbreviation(it.abbr)
-                        .abbreviationPriority(it.abbrPriority)
-                        .imageBaseUrl(it.imageBaseurl)
-                        .directions(it.directions)
-                        .active(it.active)
-                        .build()
-                )
-            }
-            BannerText.builder()
-                .type(bannerSection.type)
-                .modifier(bannerSection.modifier)
-                .degrees(bannerSection.degrees?.toDouble())
-                .drivingSide(bannerSection.drivingSide)
-                .text(bannerSection.text)
-                ?.components(primaryComponents)
-                ?.build()
-        }
 
     class Builder : Milestone.Builder() {
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/milestone/VoiceInstructionMilestone.kt
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/milestone/VoiceInstructionMilestone.kt
@@ -52,8 +52,8 @@ class VoiceInstructionMilestone(builder: Builder) : Milestone(builder) {
 
     private fun updateCurrentAnnouncement(routeProgress: RouteProgress): Boolean =
         routeProgress.voiceInstruction()?.let {
-            announcement = it.announcement
-            ssmlAnnouncement = it.ssmlAnnouncement
+            announcement = it.announcement() ?: EMPTY_STRING
+            ssmlAnnouncement = it.ssmlAnnouncement() ?: EMPTY_STRING
             true
         } ?: false
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/routeprogress/RouteProgress.kt
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/routeprogress/RouteProgress.kt
@@ -1,12 +1,12 @@
 package com.mapbox.services.android.navigation.v5.routeprogress
 
+import com.mapbox.api.directions.v5.models.BannerInstructions
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.LegStep
 import com.mapbox.api.directions.v5.models.RouteLeg
+import com.mapbox.api.directions.v5.models.VoiceInstructions
 import com.mapbox.geojson.Geometry
 import com.mapbox.geojson.Point
-import com.mapbox.navigator.BannerInstruction
-import com.mapbox.navigator.VoiceInstruction
 import com.mapbox.services.android.navigation.v5.utils.extensions.ifNonNull
 
 /**
@@ -31,8 +31,8 @@ data class RouteProgress internal constructor(
     var currentStepPoints: List<Point>? = null,
     var upcomingStepPoints: List<Point>? = null,
     var inTunnel: Boolean? = null,
-    var voiceInstruction: VoiceInstruction? = null,
-    var bannerInstruction: BannerInstruction? = null,
+    var voiceInstruction: VoiceInstructions? = null,
+    var bannerInstruction: BannerInstructions? = null,
     var currentState: RouteProgressState? = null,
     var routeGeometryWithBuffer: Geometry? = null,
     var currentStep: LegStep? = null,
@@ -233,8 +233,8 @@ data class RouteProgress internal constructor(
         private var currentStepPoints: List<Point>? = null
         private var upcomingStepPoints: List<Point>? = null
         private var inTunnel: Boolean? = null
-        private var voiceInstruction: VoiceInstruction? = null
-        private var bannerInstruction: BannerInstruction? = null
+        private var voiceInstruction: VoiceInstructions? = null
+        private var bannerInstruction: BannerInstructions? = null
         private var currentState: RouteProgressState? = null
         private var routeGeometryWithBuffer: Geometry? = null
         private var currentStep: LegStep? = null
@@ -260,10 +260,10 @@ data class RouteProgress internal constructor(
             apply { this.upcomingStepPoints = upcomingStepPoints }
 
         fun inTunnel(inTunnel: Boolean) = apply { this.inTunnel = inTunnel }
-        fun voiceInstruction(voiceInstruction: VoiceInstruction?) =
+        fun voiceInstruction(voiceInstruction: VoiceInstructions?) =
             apply { this.voiceInstruction = voiceInstruction }
 
-        fun bannerInstruction(bannerInstruction: BannerInstruction?) =
+        fun bannerInstruction(bannerInstruction: BannerInstructions?) =
             apply { this.bannerInstruction = bannerInstruction }
 
         fun currentState(currentState: RouteProgressState?) =

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/internal/navigation/MapboxNavigationNotificationTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/internal/navigation/MapboxNavigationNotificationTest.java
@@ -9,10 +9,10 @@ import android.content.res.Resources;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.mapbox.api.directions.v5.DirectionsAdapterFactory;
+import com.mapbox.api.directions.v5.models.BannerInstructions;
+import com.mapbox.api.directions.v5.models.BannerText;
 import com.mapbox.api.directions.v5.models.DirectionsResponse;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
-import com.mapbox.navigator.BannerInstruction;
-import com.mapbox.navigator.BannerSection;
 import com.mapbox.services.android.navigation.v5.BaseTest;
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigation;
 import com.mapbox.services.android.navigation.v5.navigation.MapboxNavigationOptions;
@@ -86,8 +86,13 @@ public class MapboxNavigationNotificationTest extends BaseTest {
     MapboxNavigationNotification mapboxNavigationNotification = new MapboxNavigationNotification(mockedContext,
       mockedMapboxNavigation, mockedNotification);
     RouteProgress routeProgress = buildDefaultTestRouteProgress();
-    BannerSection aBannerSection = new BannerSection("You have arrived", null, null, null, null, null);
-    BannerInstruction aBannerInstruction = new BannerInstruction(aBannerSection, null, null, 0.1f, 3);
+    BannerText aBannerSection = BannerText.builder()
+            .text("You have arrived")
+            .build();
+    BannerInstructions aBannerInstruction = BannerInstructions.builder()
+            .primary(aBannerSection)
+            .distanceAlongGeometry(0.1f)
+            .build();
     routeProgress = routeProgress.toBuilder().bannerInstruction(aBannerInstruction).build();
 
     mapboxNavigationNotification.updateNotificationViews(routeProgress);
@@ -103,13 +108,23 @@ public class MapboxNavigationNotificationTest extends BaseTest {
     MapboxNavigationNotification mapboxNavigationNotification = new MapboxNavigationNotification(mockedContext,
       mockedMapboxNavigation, mockedNotification);
     RouteProgress routeProgress = buildDefaultTestRouteProgress();
-    BannerSection willArriveBannerSection = new BannerSection("You will arrive", null, null, null, null, null);
-    BannerInstruction willArriveBannerInstruction = new BannerInstruction(willArriveBannerSection, null, null, 0.1f, 3);
+    BannerText willArriveBannerSection = BannerText.builder()
+            .text("You will arrive")
+            .build();
+    BannerInstructions willArriveBannerInstruction = BannerInstructions.builder()
+            .primary(willArriveBannerSection)
+            .distanceAlongGeometry(0.1f)
+            .build();
     routeProgress = routeProgress.toBuilder().bannerInstruction(willArriveBannerInstruction).build();
     mapboxNavigationNotification.updateNotificationViews(routeProgress);
     assertEquals("You will arrive", mapboxNavigationNotification.retrieveInstructionText());
-    BannerSection haveArrivedBannerSection = new BannerSection("You have arrived", null, null, null, null, null);
-    BannerInstruction haveArrivedBannerInstruction = new BannerInstruction(haveArrivedBannerSection, null, null, 0.1f, 3);
+    BannerText haveArrivedBannerSection = BannerText.builder()
+            .text("You have arrived")
+            .build();
+    BannerInstructions haveArrivedBannerInstruction = BannerInstructions.builder()
+            .primary(haveArrivedBannerSection)
+            .distanceAlongGeometry(0.1f)
+            .build();
     routeProgress = routeProgress.toBuilder().bannerInstruction(haveArrivedBannerInstruction).build();
 
     mapboxNavigationNotification.updateNotificationViews(routeProgress);

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/milestone/BannerInstructionMilestoneTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/milestone/BannerInstructionMilestoneTest.java
@@ -1,5 +1,8 @@
 package com.mapbox.services.android.navigation.v5.milestone;
 
+import com.mapbox.api.directions.v5.models.BannerComponents;
+import com.mapbox.api.directions.v5.models.BannerInstructions;
+import com.mapbox.api.directions.v5.models.BannerText;
 import com.mapbox.navigator.BannerComponent;
 import com.mapbox.navigator.BannerInstruction;
 import com.mapbox.navigator.BannerSection;
@@ -21,7 +24,7 @@ public class BannerInstructionMilestoneTest extends BaseTest {
   @Test
   public void checksNotBannerShownIfBannerInstructionIsNull() throws Exception {
     RouteProgress routeProgress = buildDefaultTestRouteProgress();
-    BannerInstruction nullBannerInstruction = null;
+    BannerInstructions nullBannerInstruction = null;
     routeProgress = add(nullBannerInstruction, routeProgress);
     BannerInstructionMilestone milestone = buildBannerInstructionMilestone();
 
@@ -33,10 +36,10 @@ public class BannerInstructionMilestoneTest extends BaseTest {
   @Test
   public void checksBannerShownIfBannerInstructionIsNotNull() throws Exception {
     RouteProgress routeProgress = buildDefaultTestRouteProgress();
-    BannerSection bannerSection = mock(BannerSection.class);
-    when(bannerSection.getText()).thenReturn("mock text");
-    BannerInstruction bannerInstruction =
-      buildEmptyBannerInstructionWithPrimary(bannerSection);
+    BannerText bannerText = mock(BannerText.class);
+    when(bannerText.text()).thenReturn("mock text");
+    BannerInstructions bannerInstruction =
+      buildEmptyBannerInstructionWithPrimary(bannerText);
     routeProgress = add(bannerInstruction, routeProgress);
     BannerInstructionMilestone milestone = buildBannerInstructionMilestone();
 
@@ -52,30 +55,46 @@ public class BannerInstructionMilestoneTest extends BaseTest {
     boolean isActive = true;
     ArrayList<String> anyDirections = new ArrayList<>();
     anyDirections.add("a direction");
-    BannerComponent aComponent = new BannerComponent("a type", "a text", "an abbr", anAbbrPriority,
-      "an image base url", isActive, anyDirections);
-    ArrayList<BannerComponent> components = new ArrayList<>();
+    BannerComponents aComponent = BannerComponents.builder()
+            .type("a type")
+            .text("a text")
+            .abbreviation("an abbr")
+            .abbreviationPriority(anAbbrPriority)
+            .imageBaseUrl("an image base url")
+            .active(isActive)
+            .directions(anyDirections)
+            .build();
+    ArrayList<BannerComponents> components = new ArrayList<>();
     components.add(aComponent);
-    BannerSection sectionWithComponents = new BannerSection("a text", "a type", "a modifier", 60, "a driving side",
-      components);
-    BannerInstruction emptyBannerInstruction = buildEmptyBannerInstructionWithPrimary(sectionWithComponents);
-    routeProgress = add(emptyBannerInstruction, routeProgress);
+    BannerText sectionWithComponents = BannerText.builder()
+            .text("a text")
+            .type("a type")
+            .modifier("a modifier")
+            .degrees(60.0)
+            .drivingSide("a driving side")
+            .components(components)
+            .build();
+    BannerInstructions emptyBannerInstructions = buildEmptyBannerInstructionWithPrimary(sectionWithComponents);
+    routeProgress = add(emptyBannerInstructions, routeProgress);
     BannerInstructionMilestone milestone = buildBannerInstructionMilestone();
 
     boolean isOccurring = milestone.isOccurring(routeProgress, routeProgress);
 
     assertTrue(isOccurring);
-    assertEquals(1, routeProgress.bannerInstruction().getPrimary().getComponents().size());
+    assertEquals(1, routeProgress.bannerInstruction().primary().components().size());
   }
 
-  private RouteProgress add(BannerInstruction bannerInstruction, RouteProgress routeProgress) {
+  private RouteProgress add(BannerInstructions bannerInstructions, RouteProgress routeProgress) {
     return routeProgress.toBuilder()
-      .bannerInstruction(bannerInstruction)
+      .bannerInstruction(bannerInstructions)
       .build();
   }
 
-  private BannerInstruction buildEmptyBannerInstructionWithPrimary(BannerSection section) {
-    return new BannerInstruction(section, null, null, -1, -1);
+  private BannerInstructions buildEmptyBannerInstructionWithPrimary(BannerText text) {
+    return BannerInstructions.builder()
+            .primary(text)
+            .distanceAlongGeometry(0.3f)
+            .build();
   }
 
   private BannerInstructionMilestone buildBannerInstructionMilestone() {

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/milestone/VoiceInstructionMilestoneTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/milestone/VoiceInstructionMilestoneTest.java
@@ -1,6 +1,7 @@
 package com.mapbox.services.android.navigation.v5.milestone;
 
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
+import com.mapbox.api.directions.v5.models.VoiceInstructions;
 import com.mapbox.navigator.VoiceInstruction;
 import com.mapbox.services.android.navigation.v5.routeprogress.RouteProgress;
 
@@ -25,10 +26,10 @@ public class VoiceInstructionMilestoneTest {
   @Test
   public void onSameInstructionOccurring_milestoneDoesNotTriggerTwice() {
     RouteProgress firstProgress = mock(RouteProgress.class);
-    VoiceInstruction voiceInstruction = mock(VoiceInstruction.class);
-    when(voiceInstruction.getSsmlAnnouncement()).thenReturn("current SSML announcement");
-    when(firstProgress.voiceInstruction()).thenReturn(voiceInstruction, null);
-    when(voiceInstruction.getAnnouncement()).thenReturn("instruction");
+    VoiceInstructions voiceInstructions = mock(VoiceInstructions.class);
+    when(voiceInstructions.ssmlAnnouncement()).thenReturn("current SSML announcement");
+    when(firstProgress.voiceInstruction()).thenReturn(voiceInstructions, null);
+    when(voiceInstructions.announcement()).thenReturn("instruction");
     when(firstProgress.directionsRoute()).thenReturn(mock(DirectionsRoute.class));
     VoiceInstructionMilestone milestone = buildVoiceInstructionMilestone();
 
@@ -42,9 +43,9 @@ public class VoiceInstructionMilestoneTest {
   public void onOccurringMilestone_voiceSsmlInstructionsAreReturned() {
     RouteProgress routeProgress = mock(RouteProgress.class, RETURNS_DEEP_STUBS);
     when(routeProgress.directionsRoute()).thenReturn(mock(DirectionsRoute.class));
-    when(routeProgress.voiceInstruction().getAnnouncement()).thenReturn("current announcement");
+    when(routeProgress.voiceInstruction().announcement()).thenReturn("current announcement");
     String currentSsmlAnnouncement = "current SSML announcement";
-    when(routeProgress.voiceInstruction().getSsmlAnnouncement()).thenReturn(currentSsmlAnnouncement);
+    when(routeProgress.voiceInstruction().ssmlAnnouncement()).thenReturn(currentSsmlAnnouncement);
     VoiceInstructionMilestone milestone = buildVoiceInstructionMilestone();
 
     milestone.isOccurring(routeProgress, routeProgress);
@@ -57,9 +58,9 @@ public class VoiceInstructionMilestoneTest {
     RouteProgress routeProgress = mock(RouteProgress.class, RETURNS_DEEP_STUBS);
     when(routeProgress.directionsRoute()).thenReturn(mock(DirectionsRoute.class));
     String currentAnnouncement = "current announcement";
-    when(routeProgress.voiceInstruction().getAnnouncement()).thenReturn(currentAnnouncement);
+    when(routeProgress.voiceInstruction().announcement()).thenReturn(currentAnnouncement);
     String currentSsmlAnnouncement = "current SSML announcement";
-    when(routeProgress.voiceInstruction().getSsmlAnnouncement()).thenReturn(currentSsmlAnnouncement);
+    when(routeProgress.voiceInstruction().ssmlAnnouncement()).thenReturn(currentSsmlAnnouncement);
     VoiceInstructionMilestone milestone = buildVoiceInstructionMilestone();
 
     milestone.isOccurring(routeProgress, routeProgress);
@@ -72,9 +73,9 @@ public class VoiceInstructionMilestoneTest {
     RouteProgress routeProgress = mock(RouteProgress.class, RETURNS_DEEP_STUBS);
     when(routeProgress.directionsRoute()).thenReturn(mock(DirectionsRoute.class));
     String currentAnnouncement = "current announcement";
-    when(routeProgress.voiceInstruction().getAnnouncement()).thenReturn(currentAnnouncement);
+    when(routeProgress.voiceInstruction().announcement()).thenReturn(currentAnnouncement);
     String currentSsmlAnnouncement = "current SSML announcement";
-    when(routeProgress.voiceInstruction().getSsmlAnnouncement()).thenReturn(currentSsmlAnnouncement);
+    when(routeProgress.voiceInstruction().ssmlAnnouncement()).thenReturn(currentSsmlAnnouncement);
     VoiceInstructionMilestone milestone = buildVoiceInstructionMilestone();
 
     milestone.isOccurring(routeProgress, routeProgress);


### PR DESCRIPTION
## Description

Replaces NN banner and voice instruction leaked models by Directions ones

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Not leak NN models into `RouteProgress`

### Implementation

Replace models and add respective mappers

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
