### PR TITLE
Always recreate notification channel when session is restarted

### DIFF
--- a/libtrip-notification/src/main/java/com/mapbox/navigation/trip/notification/MapboxTripNotification.kt
+++ b/libtrip-notification/src/main/java/com/mapbox/navigation/trip/notification/MapboxTripNotification.kt
@@ -86,6 +86,7 @@ class MapboxTripNotification constructor(
 
     override fun onTripSessionStarted() {
         registerReceiver()
+        notificationActionButtonChannel = Channel(1)
     }
 
     override fun onTripSessionStopped() {
@@ -323,10 +324,7 @@ class MapboxTripNotification constructor(
         } catch (e: Exception) {
             when (e) {
                 is ClosedReceiveChannelException,
-                is ClosedSendChannelException -> {
-                    notificationActionButtonChannel = Channel(1)
-                    notificationActionButtonChannel.offer(NotificationAction.END_NAVIGATION)
-                }
+                is ClosedSendChannelException -> { }
                 else -> {
                     throw e
                 }


### PR DESCRIPTION
Looking at the previous flow, if we stopped and restarted the session manually the channel would be invalidated and we wouldn't be able to subscribe to it before it dispatches an event.