### PR TITLE
Do not require upcoming step data

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/routeprogress/RouteLegProgress.kt
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/routeprogress/RouteLegProgress.kt
@@ -166,7 +166,7 @@ data class RouteLegProgress internal constructor(
 
         fun previousStep(previousStep: LegStep) = apply { this.previousStep = previousStep }
         fun currentStep(currentStep: LegStep) = apply { this.currentStep = currentStep }
-        fun upComingStep(upComingStep: LegStep) = apply { this.upComingStep = upComingStep }
+        fun upComingStep(upComingStep: LegStep?) = apply { this.upComingStep = upComingStep }
         fun followOnStep(followOnStep: LegStep) = apply { this.followOnStep = followOnStep }
         fun currentStepProgress(currentStepProgress: RouteStepProgress) =
             apply { this.currentStepProgress = currentStepProgress }


### PR DESCRIPTION
This makes upcoming step data optional in the legacy route progress builder. This condition is true when the route has only one step.