### PR TITLE
Add tests for MapboxTripNotification

### DIFF
--- a/libtrip-notification/src/main/java/com/mapbox/navigation/trip/notification/MapboxTripNotification.kt
+++ b/libtrip-notification/src/main/java/com/mapbox/navigation/trip/notification/MapboxTripNotification.kt
@@ -64,7 +64,6 @@ class MapboxTripNotification constructor(
 
         pendingOpenIntent = createPendingOpenIntent(applicationContext)
         pendingCloseIntent = createPendingCloseIntent(applicationContext)
-        registerReceiver()
         createNotificationChannel()
     }
 


### PR DESCRIPTION
## Description

This PR adds a couple of tests for MapboxTripNotification

- [ ] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

