### PR TITLE
replacing all calls to job.cancel() with job.cancleChildren()

### DIFF
--- a/libdirections-onboard/src/main/java/com/mapbox/navigation/route/onboard/MapboxOnboardRouter.kt
+++ b/libdirections-onboard/src/main/java/com/mapbox/navigation/route/onboard/MapboxOnboardRouter.kt
@@ -21,7 +21,7 @@ import com.mapbox.navigation.utils.thread.ThreadController
 import com.mapbox.navigator.RouterParams
 import com.mapbox.navigator.TileEndpointConfiguration
 import java.io.File
-import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -41,7 +41,9 @@ class MapboxOnboardRouter : Router {
     private val navigatorNative: MapboxNativeNavigator
     private val config: MapboxOnboardRouterConfig
     private val logger: Logger?
-    private val mainJobControl = ThreadController.getMainScopeAndRootJob()
+    private val mainJobControl by lazy {
+        ThreadController.getMainScopeAndRootJob()
+    }
     private val gson = Gson()
 
     /**
@@ -114,7 +116,7 @@ class MapboxOnboardRouter : Router {
     }
 
     override fun cancel() {
-        mainJobControl.scope.cancel()
+        mainJobControl.job.cancelChildren()
     }
 
     private fun retrieveRoute(url: String, callback: Router.Callback) {

--- a/libdirections-onboard/src/main/java/com/mapbox/navigation/route/onboard/task/RemoveTilesTask.kt
+++ b/libdirections-onboard/src/main/java/com/mapbox/navigation/route/onboard/task/RemoveTilesTask.kt
@@ -4,7 +4,7 @@ import com.mapbox.geojson.Point
 import com.mapbox.navigation.navigator.MapboxNativeNavigator
 import com.mapbox.navigation.route.onboard.OnOfflineTilesRemovedCallback
 import com.mapbox.navigation.utils.thread.ThreadController
-import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -29,6 +29,6 @@ internal class RemoveTilesTask(
     }
 
     fun cancel() {
-        mainJobControl.scope.cancel()
+        mainJobControl.job.cancelChildren()
     }
 }

--- a/libnavigation-util/src/main/java/com/mapbox/navigation/utils/thread/ThreadController.kt
+++ b/libnavigation-util/src/main/java/com/mapbox/navigation/utils/thread/ThreadController.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.channels.ClosedReceiveChannelException
 import kotlinx.coroutines.channels.ClosedSendChannelException
 import kotlinx.coroutines.channels.ReceiveChannel
@@ -72,7 +73,7 @@ object ThreadController {
      * a kill switch for all non-UI scoped coroutines.
      */
     fun cancelAllNonUICoroutines() {
-        ioRootJob.cancel()
+        ioRootJob.cancelChildren()
     }
 
     /**
@@ -81,7 +82,7 @@ object ThreadController {
      * a kill switch for all UI scoped coroutines.
      */
     fun cancelAllUICoroutines() {
-        mainRootJob.cancel()
+        mainRootJob.cancelChildren()
     }
 
     /**

--- a/libtrip-notification/src/main/java/com/mapbox/navigation/trip/notification/MapboxTripNotification.kt
+++ b/libtrip-notification/src/main/java/com/mapbox/navigation/trip/notification/MapboxTripNotification.kt
@@ -29,6 +29,7 @@ import com.mapbox.navigation.utils.NOTIFICATION_CHANNEL
 import com.mapbox.navigation.utils.NOTIFICATION_ID
 import com.mapbox.navigation.utils.SET_BACKGROUND_COLOR
 import com.mapbox.navigation.utils.extensions.ifNonNull
+import com.mapbox.navigation.utils.thread.ifChannelException
 import java.util.Calendar
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ClosedReceiveChannelException
@@ -109,13 +110,8 @@ class MapboxTripNotification constructor(
         try {
             notificationActionButtonChannel.cancel()
         } catch (e: Exception) {
-            when (e) {
-                is ClosedReceiveChannelException,
-                is ClosedSendChannelException -> {
-                }
-                else -> {
-                    throw e
-                }
+            e.ifChannelException {
+                // Do nothing
             }
         }
     }


### PR DESCRIPTION

## Description
This PR updates the codebase so that all coroutine jobs are canceled via call to cancelChidlren()

### Goal
The goal here is to make sure that if the job is canceled it can be used to start new coroutines. This can only be accomplished if job.cancelChildren(() is called instead of job.cancel(). Refer to this [link](https://proandroiddev.com/kotlin-coroutines-patterns-anti-patterns-f9d12984c68e)

Please describe the PR goals. Just the stuff needed to implement the fix / feature and a simple rationale. It could contain many check points if needed


## Testing

Please describe the manual tests that you ran to verify your changes

- [ x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x ] New and existing unit tests pass locally with my changes

## Checklist

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->