### PR TITLE
Add tests for updateNotification in MapboxTripNotification

### DIFF
--- a/libtrip-notification/src/main/java/com/mapbox/navigation/trip/notification/MapboxTripNotification.kt
+++ b/libtrip-notification/src/main/java/com/mapbox/navigation/trip/notification/MapboxTripNotification.kt
@@ -10,7 +10,6 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.os.Build
 import android.text.SpannableString
-import android.text.TextUtils
 import android.text.format.DateFormat
 import android.widget.RemoteViews
 import androidx.core.app.NotificationCompat
@@ -196,7 +195,6 @@ class MapboxTripNotification constructor(
         generateArrivalTime(routeProgress, Calendar.getInstance())?.let { formattedTime ->
             updateViewsWithArrival(formattedTime)
             val step = routeProgress.currentLegProgress()?.upcomingStep()
-                ?: routeProgress.currentLegProgress()?.currentStepProgress()?.step()
             step?.let { updateManeuverImage(it) }
         }
     }
@@ -295,18 +293,16 @@ class MapboxTripNotification constructor(
         val stepManeuver = step.maneuver()
         val maneuverType = stepManeuver.type()
         val maneuverModifier = stepManeuver.modifier()
-        val isModifierNotEmpty = TextUtils.isEmpty(maneuverModifier).not()
-        val maneuverResourceString = if (isModifierNotEmpty) {
+        val maneuverResourceString = if (maneuverModifier.isNullOrEmpty().not()) {
             val drivingSide = step.drivingSide()
             val isLeftSideDriving = isLeftDrivingSideAndRoundaboutOrRotaryOrUturn(
                 maneuverType,
                 maneuverModifier,
                 drivingSide
             )
-            if (isLeftSideDriving) {
-                maneuverType + maneuverModifier + drivingSide
-            } else {
-                maneuverType + maneuverModifier
+            when (isLeftSideDriving) {
+                true -> maneuverType + maneuverModifier + drivingSide
+                false -> maneuverType + maneuverModifier
             }
         } else {
             maneuverType

--- a/libtrip-notification/src/main/java/com/mapbox/navigation/trip/notification/RemoteViewsProvider.kt
+++ b/libtrip-notification/src/main/java/com/mapbox/navigation/trip/notification/RemoteViewsProvider.kt
@@ -1,0 +1,11 @@
+package com.mapbox.navigation.trip.notification
+
+import android.widget.RemoteViews
+import androidx.annotation.LayoutRes
+
+object RemoteViewsProvider {
+
+    fun createRemoteViews(packageName: String, @LayoutRes layoutId: Int): RemoteViews {
+        return RemoteViews(packageName, layoutId)
+    }
+}

--- a/libtrip-notification/src/test/java/com/mapbox/navigation/trip/notification/MapboxTripNotificationTest.kt
+++ b/libtrip-notification/src/test/java/com/mapbox/navigation/trip/notification/MapboxTripNotificationTest.kt
@@ -50,9 +50,6 @@ class MapboxTripNotificationTest {
         val distanceSlot = slot<Double>()
         distanceFormatter = mockk()
         every { distanceFormatter.formatDistance(capture(distanceSlot)) } returns distanceSpannable
-        // every { distanceSpannable.toString() } answers {
-        //     distanceSlot.captured.toString()
-        // }
         every { navigationOptions.distanceFormatter() } returns distanceFormatter
     }
 
@@ -345,8 +342,6 @@ class MapboxTripNotificationTest {
     ): RouteLegProgress {
         val currentLegProgress = mockk<RouteLegProgress>(relaxed = true)
         every { routeProgress.currentLegProgress() } returns currentLegProgress
-        // val currentStepProgress = mockk<RouteStepProgress>()
-        // every { currentLegProgress.currentStepProgress() } returns currentStepProgress
         every { currentLegProgress.currentStepProgress()?.distanceRemaining() } returns distance
         every { currentLegProgress.durationRemaining() } returns duration
         return currentLegProgress

--- a/libtrip-notification/src/test/java/com/mapbox/navigation/trip/notification/MapboxTripNotificationTest.kt
+++ b/libtrip-notification/src/test/java/com/mapbox/navigation/trip/notification/MapboxTripNotificationTest.kt
@@ -8,12 +8,19 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.content.res.Configuration
 import android.content.res.Resources
+import android.text.TextUtils
 import android.text.format.DateFormat
+import android.widget.RemoteViews
+import com.mapbox.api.directions.v5.models.BannerInstructions
+import com.mapbox.api.directions.v5.models.BannerText
 import com.mapbox.navigation.base.options.NavigationOptions
+import com.mapbox.navigation.base.trip.model.RouteProgress
+import com.mapbox.navigation.utils.NOTIFICATION_ID
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkConstructor
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.verify
@@ -34,10 +41,17 @@ class MapboxTripNotificationTest {
         mockkStatic(DateFormat::class)
         mockkStatic(PendingIntent::class)
         mockedContext = createContext()
+        mockRemoteViews()
         notification = MapboxTripNotification(
             mockedContext,
             navigationOptions
         )
+    }
+
+    private fun mockRemoteViews() {
+        mockkConstructor(RemoteViews::class)
+        every { anyConstructed<RemoteViews>().setInt(any(), any(), any()) } just Runs
+        every { anyConstructed<RemoteViews>().setOnClickPendingIntent(any(), any()) } just Runs
     }
 
     @Test
@@ -101,7 +115,7 @@ class MapboxTripNotificationTest {
         notification.onTripSessionStopped()
 
         verify(exactly = 1) { mockedContext.unregisterReceiver(any()) }
-        verify(exactly = 1) { notificationManager.cancel(any()) }
+        verify(exactly = 1) { notificationManager.cancel(NOTIFICATION_ID) }
         assertEquals(
             true,
             MapboxTripNotification.notificationActionButtonChannel.isClosedForReceive
@@ -111,17 +125,156 @@ class MapboxTripNotificationTest {
 
     @Test
     fun whenGetNotificationCalledThenNavigationNotificationProviderInteractedOnlyOnce() {
+        mockNotificationCreation()
+
+        notification.getNotification()
+
+        verify(exactly = 1) { NavigationNotificationProvider.buildNotification(any()) }
+
+        notification.getNotification()
+        notification.getNotification()
+
+        verify(exactly = 1) { NavigationNotificationProvider.buildNotification(any()) }
+    }
+
+    @Test
+    fun whenUpdateNotificationCalledThenBannerInstructionsPrimaryTextInteracted() {
+        val routeProgress = mockk<RouteProgress>(relaxed = true)
+        val primaryText = { "Primary Text" }
+        val bannerText = mockBannerText(routeProgress, primaryText)
+        mockUpdateNotificationAndroidInteractions()
+
+        notification.updateNotification(routeProgress)
+
+        verify(exactly = 1) { bannerText.text() }
+        verify(exactly = 2) { anyConstructed<RemoteViews>().setTextViewText(any(), primaryText()) }
+    }
+
+    @Test
+    fun whenUpdateNotificationCalledTwiceWithSameDataThenRemoteViewAreNotUpdatedTwice() {
+        val routeProgress = mockk<RouteProgress>(relaxed = true)
+        val primaryText = { "Primary Text" }
+        val bannerText = mockBannerText(routeProgress, primaryText)
+        mockUpdateNotificationAndroidInteractions()
+
+        notification.updateNotification(routeProgress)
+
+        verify(exactly = 1) { bannerText.text() }
+        verify(exactly = 2) { anyConstructed<RemoteViews>().setTextViewText(any(), primaryText()) }
+
+        notification.updateNotification(routeProgress)
+
+        verify(exactly = 2) { bannerText.text() }
+        verify(exactly = 2) { anyConstructed<RemoteViews>().setTextViewText(any(), primaryText()) }
+    }
+
+    @Test
+    fun whenUpdateNotificationCalledTwiceWithDifferentDataThenRemoteViewUpdatedTwice() {
+        val routeProgress = mockk<RouteProgress>(relaxed = true)
+        var primaryText = "Primary Text"
+        val primaryTextLambda = { primaryText }
+        val bannerText = mockBannerText(routeProgress, primaryTextLambda)
+        mockUpdateNotificationAndroidInteractions()
+
+        notification.updateNotification(routeProgress)
+
+        verify(exactly = 1) { bannerText.text() }
+        verify(exactly = 2) {
+            anyConstructed<RemoteViews>().setTextViewText(any(), primaryTextLambda())
+        }
+
+        primaryText = "Changed Primary Text"
+        notification.updateNotification(routeProgress)
+
+        verify(exactly = 2) { bannerText.text() }
+        verify(exactly = 2) {
+            anyConstructed<RemoteViews>().setTextViewText(any(), primaryTextLambda())
+        }
+    }
+
+    @Test
+    fun whenGoThroughStartUpdateStopCycleThenNotificationCacheDropped() {
+        val routeProgress = mockk<RouteProgress>(relaxed = true)
+        val primaryText = { "Primary Text" }
+        val bannerText = mockBannerText(routeProgress, primaryText)
+        mockUpdateNotificationAndroidInteractions()
+
+        notification.onTripSessionStarted()
+        notification.updateNotification(routeProgress)
+
+        verify(exactly = 1) { bannerText.text() }
+        verify(exactly = 2) { anyConstructed<RemoteViews>().setTextViewText(any(), primaryText()) }
+
+        notification.updateNotification(routeProgress)
+
+        verify(exactly = 2) { bannerText.text() }
+        verify(exactly = 2) { anyConstructed<RemoteViews>().setTextViewText(any(), primaryText()) }
+
+        notification.onTripSessionStopped()
+        notification.onTripSessionStarted()
+
+        verify(exactly = 2) { bannerText.text() }
+        verify(exactly = 2) { anyConstructed<RemoteViews>().setTextViewText(any(), primaryText()) }
+
+        notification.updateNotification(routeProgress)
+
+        verify(exactly = 3) { bannerText.text() }
+        verify(exactly = 4) { anyConstructed<RemoteViews>().setTextViewText(any(), primaryText()) }
+    }
+
+    @Test
+    fun whenGoThroughStartUpdateStopCycleThenStartStopSessionDontAffectRemoveViews() {
+        val routeProgress = mockk<RouteProgress>(relaxed = true)
+        val primaryText = { "Primary Text" }
+        val bannerText = mockBannerText(routeProgress, primaryText)
+        mockUpdateNotificationAndroidInteractions()
+
+        notification.onTripSessionStarted()
+        notification.updateNotification(routeProgress)
+
+        verify(exactly = 1) { bannerText.text() }
+        verify(exactly = 2) { anyConstructed<RemoteViews>().setTextViewText(any(), primaryText()) }
+
+        notification.onTripSessionStopped()
+        notification.onTripSessionStarted()
+
+        verify(exactly = 1) { bannerText.text() }
+        verify(exactly = 2) { anyConstructed<RemoteViews>().setTextViewText(any(), primaryText()) }
+
+        notification.onTripSessionStopped()
+
+        verify(exactly = 1) { bannerText.text() }
+        verify(exactly = 2) { anyConstructed<RemoteViews>().setTextViewText(any(), primaryText()) }
+
+        notification.onTripSessionStarted()
+
+        verify(exactly = 1) { bannerText.text() }
+        verify(exactly = 2) { anyConstructed<RemoteViews>().setTextViewText(any(), primaryText()) }
+    }
+
+    private fun mockUpdateNotificationAndroidInteractions() {
+        every { anyConstructed<RemoteViews>().setImageViewResource(any(), any()) } just Runs
+        every { anyConstructed<RemoteViews>().setTextViewText(any(), any()) } just Runs
+        mockkStatic(TextUtils::class)
+        every { TextUtils.isEmpty(any()) } returns false
+        mockNotificationCreation()
+    }
+
+    private fun mockNotificationCreation() {
         mockkObject(NavigationNotificationProvider)
         val notificationMock = mockk<Notification>()
         every { NavigationNotificationProvider.buildNotification(any()) } returns notificationMock
+    }
 
-        notification.getNotification()
-
-        verify(exactly = 1) { NavigationNotificationProvider.buildNotification(any()) }
-
-        notification.getNotification()
-        notification.getNotification()
-
-        verify(exactly = 1) { NavigationNotificationProvider.buildNotification(any()) }
+    private fun mockBannerText(
+        routeProgress: RouteProgress,
+        primaryText: () -> String
+    ): BannerText {
+        val bannerText = mockk<BannerText>()
+        val bannerInstructions = mockk<BannerInstructions>()
+        every { routeProgress.bannerInstructions() } returns bannerInstructions
+        every { bannerInstructions.primary() } returns bannerText
+        every { bannerText.text() } answers { primaryText() }
+        return bannerText
     }
 }


### PR DESCRIPTION
## Description

Add a couple of tests to check that RemoteViews are interacted during `updateNotification` called in `MapboxTripNotification`

- [ ] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
