### PR TITLE
Modify MapboxTimer to be used by FasterRoute and RouteRefresh

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/activity/SimpleMapboxNavigationKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/activity/SimpleMapboxNavigationKt.kt
@@ -157,6 +157,7 @@ class SimpleMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback {
         super.onDestroy()
         mapView.onDestroy()
         mapboxNavigation.stopTripSession()
+        mapboxNavigation.onDestroy()
     }
 
     override fun onSaveInstanceState(outState: Bundle) {

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/MapboxDirectionsSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/MapboxDirectionsSession.kt
@@ -32,10 +32,14 @@ class MapboxDirectionsSession(
                         emptyList()
                     )
                 }
-                is State.RoutesAvailable -> routeObservers.forEach {
-                    it.onRoutesChanged(
-                        currentRoutes
-                    )
+                is State.RoutesAvailable -> {
+                    // start the timer only when the route has been requested at least once
+                    fasterRouteTimer.start()
+                    routeObservers.forEach {
+                        it.onRoutesChanged(
+                            currentRoutes
+                        )
+                    }
                 }
                 is State.UserRoutesRequestInProgress -> routeObservers.forEach { it.onRoutesRequested() }
                 is State.UserRoutesRequestFailed -> {
@@ -65,8 +69,6 @@ class MapboxDirectionsSession(
             override fun onResponse(routes: List<DirectionsRoute>) {
                 currentRoutes = routes
                 state = State.RoutesAvailable
-                // start the timer only when the route has been requested at least once
-                fasterRouteTimer.start()
             }
 
             override fun onFailure(throwable: Throwable) {

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/MapboxDirectionsSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/MapboxDirectionsSession.kt
@@ -95,7 +95,7 @@ class MapboxDirectionsSession(
     }
 
     private fun requestFasterRoute(routeOptions: RouteOptions) {
-        if (state == State.UserRoutesRequestInProgress) {
+        if (state != State.RoutesAvailable) {
             return
         }
         router.getRoute(routeOptions, object : Router.Callback {

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/MapboxDirectionsSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/MapboxDirectionsSession.kt
@@ -18,7 +18,7 @@ class MapboxDirectionsSession(
     private val fasterRouteTimer =
         NavigationComponentProvider.createMapboxTimer(fasterRouteInterval) {
             _routeOptions?.let { requestFasterRoute(it) }
-        }.apply { start() }
+        }
 
     private var state: State = State.NoRoutesAvailable
         set(value) {
@@ -65,6 +65,8 @@ class MapboxDirectionsSession(
             override fun onResponse(routes: List<DirectionsRoute>) {
                 currentRoutes = routes
                 state = State.RoutesAvailable
+                // start the timer only when the route has been requested at least once
+                fasterRouteTimer.start()
             }
 
             override fun onFailure(throwable: Throwable) {
@@ -93,7 +95,7 @@ class MapboxDirectionsSession(
     }
 
     private fun requestFasterRoute(routeOptions: RouteOptions) {
-        if (state != State.RoutesAvailable) {
+        if (state == State.UserRoutesRequestInProgress) {
             return
         }
         router.getRoute(routeOptions, object : Router.Callback {

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/directions/session/MapboxDirectionsSessionTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/directions/session/MapboxDirectionsSessionTest.kt
@@ -158,7 +158,7 @@ class MapboxDirectionsSessionTest {
         val throwable: Throwable = mockk()
         callback.onFailure(throwable)
         delayLambda()
-        verify(exactly = 2) { router.getRoute(any(), any()) }
+        verify(exactly = 1) { router.getRoute(any(), any()) }
     }
 
     @Test

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/directions/session/MapboxDirectionsSessionTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/directions/session/MapboxDirectionsSessionTest.kt
@@ -127,6 +127,7 @@ class MapboxDirectionsSessionTest {
     @Test
     fun fasterRoute_timerStartedOnce() {
         session.requestRoutes(routeOptions)
+        callback.onResponse(routes)
         session.requestRoutes(routeOptions)
         verify(exactly = 1) { mapboxTimer.start() }
     }
@@ -157,7 +158,7 @@ class MapboxDirectionsSessionTest {
         val throwable: Throwable = mockk()
         callback.onFailure(throwable)
         delayLambda()
-        verify(exactly = 1) { router.getRoute(any(), any()) }
+        verify(exactly = 2) { router.getRoute(any(), any()) }
     }
 
     @Test

--- a/libnavigation-util/src/main/java/com/mapbox/navigation/utils/timer/MapboxTimer.kt
+++ b/libnavigation-util/src/main/java/com/mapbox/navigation/utils/timer/MapboxTimer.kt
@@ -1,6 +1,8 @@
 package com.mapbox.navigation.utils.timer
 
 import com.mapbox.navigation.utils.thread.ThreadController
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -9,23 +11,28 @@ import kotlinx.coroutines.launch
  * Schedules a delay of [restartAfter] milliseconds and then restarts.
  *
  * @param restartAfter Time delay until the timer should restart.
- * @param delayLambda lambda function that is to be executed after [restartAfter] milliseconds.
+ * @param executeLambda lambda function that is to be executed after [restartAfter] milliseconds.
  */
-class MapboxTimer(private val restartAfter: Long, private val delayLambda: () -> Unit) {
+class MapboxTimer(private val restartAfter: Long, private val executeLambda: () -> Unit) {
     private val mainControllerJobScope = ThreadController.getMainScopeAndRootJob()
+    private var timerJob: Job = Job()
+    init {
+        timerJob.cancel()
+    }
 
     fun start() {
-        mainControllerJobScope.scope.launch {
+        if (timerJob.isActive) {
+            return
+        }
+        timerJob = mainControllerJobScope.scope.launch {
             while (isActive) {
                 delay(restartAfter)
-                delayLambda()
+                executeLambda()
             }
         }
     }
 
     fun stop() {
-        mainControllerJobScope.job.children.forEach { job ->
-            job.cancel()
-        }
+        mainControllerJobScope.job.cancelChildren()
     }
 }


### PR DESCRIPTION
## Description

Modify MapboxTimer to be used by FasterRoute and RouteRefresh

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Modify MapboxTimer to be used by FasterRoute and RouteRefresh

### Implementation

Modify MapboxTimer to be used by FasterRoute and RouteRefresh

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->