### PR TITLE
 MainCoroutineRule update.

### DIFF
--- a/libdirections-onboard/src/test/java/com/mapbox/navigation/route/onboard/MainCoroutineRule.kt
+++ b/libdirections-onboard/src/test/java/com/mapbox/navigation/route/onboard/MainCoroutineRule.kt
@@ -3,31 +3,37 @@ package com.mapbox.navigation.route.onboard
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runBlockingTest
 import kotlinx.coroutines.test.setMain
-import org.junit.rules.TestWatcher
+import org.junit.rules.TestRule
 import org.junit.runner.Description
+import org.junit.runners.model.Statement
 
 @ExperimentalCoroutinesApi
-class MainCoroutineRule(
-    val testDispatcher: TestCoroutineDispatcher = TestCoroutineDispatcher()
-) : TestWatcher() {
+class MainCoroutineRule : TestRule {
+    val coroutineDispatcher = TestCoroutineDispatcher()
+    val coroutineScope = TestCoroutineScope(coroutineDispatcher)
 
-    override fun starting(description: Description?) {
-        super.starting(description)
-        Dispatchers.setMain(testDispatcher)
+    override fun apply(base: Statement, description: Description?) = object : Statement() {
+        @Throws(Throwable::class)
+        override fun evaluate() {
+            Dispatchers.setMain(coroutineDispatcher)
+
+            base.evaluate()
+
+            Dispatchers.resetMain() // Restore original main dispatcher
+            coroutineScope.cleanupTestCoroutines()
+        }
     }
 
-    override fun finished(description: Description?) {
-        super.finished(description)
-        Dispatchers.resetMain()
-        testDispatcher.cleanupTestCoroutines()
-    }
+    fun runBlockingTest(block: suspend TestCoroutineScope.() -> Unit) =
+            coroutineScope.runBlockingTest { block() }
 }
 
 @ExperimentalCoroutinesApi
 fun MainCoroutineRule.runBlockingTest(block: suspend () -> Unit) =
-    this.testDispatcher.runBlockingTest {
-        block()
-    }
+        this.coroutineDispatcher.runBlockingTest {
+            block()
+        }


### PR DESCRIPTION

## Description
The original MainCoroutineRule class did not override apply() which did not wait for the coroutine under test to finish. With this change code under test is executed via apply() using the test dispatcher. Once the test completes the main dispatcher is restored to it's former glory.

### Goal
The goal is to be able to test coroutines without adding wait states.

## Testing
This affects testing of the on-board router only. All coroutine tests should succeed for this class.

- [ x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->