### PR TITLE
Update nav native location with current timestamp

### DIFF
--- a/libnavigator/build.gradle
+++ b/libnavigator/build.gradle
@@ -12,6 +12,10 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'proguard-consumer.pro'
     }
+
+    testOptions {
+        unitTests.returnDefaultValues = true
+    }
 }
 
 dependencies {
@@ -35,6 +39,7 @@ dependencies {
     // Unit testing
     testImplementation dependenciesList.junit
     testImplementation dependenciesList.mockk
+    testImplementation dependenciesList.robolectric
 }
 
 apply from: "${rootDir}/gradle/bintray-publish.gradle"

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/LocationEx.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/LocationEx.kt
@@ -1,0 +1,26 @@
+package com.mapbox.navigation.navigator
+
+import android.location.Location
+import com.mapbox.geojson.Point
+import com.mapbox.navigator.FixLocation
+import java.util.Date
+
+internal fun FixLocation.toLocation(): Location = Location(this.provider).also {
+    it.latitude = this.coordinate.latitude()
+    it.longitude = this.coordinate.longitude()
+    it.time = this.time.time
+    it.speed = this.speed ?: 0f
+    it.bearing = this.bearing ?: 0f
+    it.altitude = this.altitude?.toDouble() ?: 0.0
+    it.accuracy = this.accuracyHorizontal ?: 0f
+}
+
+internal fun Location.toFixLocation(date: Date) = FixLocation(
+    Point.fromLngLat(this.longitude, this.latitude),
+    date,
+    this.speed,
+    this.bearing,
+    this.altitude.toFloat(),
+    this.accuracy,
+    this.provider
+)

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/MapboxNativeNavigatorImpl.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/MapboxNativeNavigatorImpl.kt
@@ -20,7 +20,6 @@ import com.mapbox.navigation.base.trip.model.RouteStepProgress
 import com.mapbox.navigator.BannerComponent
 import com.mapbox.navigator.BannerInstruction
 import com.mapbox.navigator.BannerSection
-import com.mapbox.navigator.FixLocation
 import com.mapbox.navigator.HttpInterface
 import com.mapbox.navigator.NavigationStatus
 import com.mapbox.navigator.Navigator
@@ -53,7 +52,7 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
     // Route following
 
     override fun updateLocation(rawLocation: Location): Boolean =
-        navigator.updateLocation(rawLocation.toFixLocation())
+        navigator.updateLocation(rawLocation.toFixLocation(Date()))
 
     override fun getStatus(date: Date): TripStatus {
         val status = navigator.getStatus(date)
@@ -136,26 +135,6 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
 
     override fun getVoiceInstruction(index: Int): VoiceInstruction? =
         navigator.getVoiceInstruction(index)
-
-    private fun Location.toFixLocation() = FixLocation(
-        Point.fromLngLat(this.longitude, this.latitude),
-        Date(this.time),
-        this.speed,
-        this.bearing,
-        this.altitude.toFloat(),
-        this.accuracy,
-        this.provider
-    )
-
-    private fun FixLocation.toLocation(): Location = Location(this.provider).also {
-        it.latitude = this.coordinate.latitude()
-        it.longitude = this.coordinate.longitude()
-        it.time = this.time.time
-        it.speed = this.speed ?: 0f
-        it.bearing = this.bearing ?: 0f
-        it.altitude = this.altitude?.toDouble() ?: 0.0
-        it.accuracy = this.accuracyHorizontal ?: 0f
-    }
 
     private fun NavigationStatus.getRouteProgress(): RouteProgress {
         val upcomingStepIndex = stepIndex + ONE_INDEX

--- a/libnavigator/src/test/java/com/mapbox/navigation/navigator/LocationExTest.kt
+++ b/libnavigator/src/test/java/com/mapbox/navigation/navigator/LocationExTest.kt
@@ -1,0 +1,35 @@
+package com.mapbox.navigation.navigator
+
+import android.location.Location
+import java.util.Date
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class LocationExTest {
+
+    @Test
+    fun toFixLocation() {
+        val location = Location("test").apply {
+            latitude = 11.0
+            longitude = 22.0
+            time = 123456789
+            speed = 10f
+            bearing = 20f
+            altitude = 30.0
+            accuracy = 40f
+        }
+
+        val date = Date()
+        val fix = location.toFixLocation(date)
+        assertEquals(11.0, fix.coordinate.latitude(), .00001)
+        assertEquals(22.0, fix.coordinate.longitude(), .00001)
+        assertEquals(date, fix.time)
+        assertEquals(10f, fix.speed!!, .00001f)
+        assertEquals(20f, fix.bearing!!, .00001f)
+        assertEquals(30.0, fix.altitude!!.toDouble(), .00001)
+        assertEquals(40f, fix.accuracyHorizontal!!, .00001f)
+    }
+}


### PR DESCRIPTION
Fixes a regression when transitioning from legacy to 1.0 codebase - we shouldn't use the provided raw location's timestamp, but rather a current one.