### PR TITLE
Attach javadoc to 1.0 artifacts

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -107,10 +107,6 @@ jobs:
             else
               echo "Skipping push to Transifex"
             fi
-#      Uncomment when API' docs will be ready
-#      - run:
-#          name: Check public documentation
-#          command: sh scripts/dokka-validate.sh
       - store_artifacts:
           path: app/build/reports
           destination: reports
@@ -261,6 +257,13 @@ jobs:
       - run:
           name: Build Navigation SDK 1.0 (release)
           command: make 1.0-build-release
+      - run:
+          name: Generate documentation
+          command: make javadoc-dokka
+#     Uncomment when API' docs will be ready
+#     - run:
+#         name: Check public documentation
+#         command: sh scripts/dokka-validate.sh
       - run:
           name: Generate Bintray credentials
           command: |

--- a/gradle/bintray-publish.gradle
+++ b/gradle/bintray-publish.gradle
@@ -10,14 +10,15 @@ group = project.ext.mapboxArtifactGroupId
 publishing {
     publications {
         MapboxNavigationPublication(MavenPublication) {
-            afterEvaluate {
-                from components.android
-                artifact(androidSourcesJar)
-            }
-
+            from components.android
             groupId this.group
             artifactId project.ext.mapboxArtifactId
             version this.version
+
+            afterEvaluate {
+                artifact(androidSourcesJar)
+                artifact(androidJavadocsJar)
+            }
 
             pom.withXml {
                 final mainNode = asNode()
@@ -86,4 +87,9 @@ artifactory {
 task androidSourcesJar(type: Jar) {
     classifier = 'sources'
     from android.sourceSets.main.kotlin
+}
+
+task androidJavadocsJar(type: Jar, dependsOn: dokka) {
+    classifier = 'javadoc'
+    from dokka.outputDirectory
 }

--- a/libnavigation-util/build.gradle
+++ b/libnavigation-util/build.gradle
@@ -1,7 +1,21 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
+apply plugin: 'org.jetbrains.dokka'
 apply from: "${rootDir}/gradle/ktlint.gradle"
+
+dokka {
+    outputDirectory = "$buildDir/javadoc"
+    outputFormat = 'javadoc'
+    configuration {
+        moduleName = 'libnavigation-utils'
+
+        perPackageOption {
+            prefix = "utils"
+            suppress = true
+        }
+    }
+}
 
 android {
     compileSdkVersion androidVersions.compileSdkVersion


### PR DESCRIPTION
This PR attaches all the documentation generated with `dokka` to 1.0 artifacts.