### PR TITLE
Bump mapbox-sdk-services and mapbox-sdk-directions-models version to 5.1.0-beta.1

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -9,8 +9,8 @@ ext {
 
   version = [
       mapboxMapSdk              : '8.5.1',
-      mapboxSdkServices         : '5.1.0-SNAPSHOT',
-      mapboxSdkDirectionsModels : '5.1.0-20200123.133519-5',
+      mapboxSdkServices         : '5.1.0-beta.1',
+      mapboxSdkDirectionsModels : '5.1.0-beta.1',
       mapboxEvents              : '4.5.1',
       mapboxCore                : '1.3.0',
       mapboxNavigator           : '9.0.2',


### PR DESCRIPTION
## Description

Bumps `mapbox-sdk-services` and `mapbox-sdk-directions-models` version to `5.1.0-beta.1`

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Getting the latest version from `mapbox-sdk-services` and `mapbox-sdk-directions-models` in preparation for https://github.com/mapbox/mapbox-navigation-android/issues/2428.

### Implementation

Bumping the `mapboxSdkServices` and `mapboxSdkDirectionsModels` version to `5.1.0-beta.1` in `dependencies.gradle`

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR