### PR TITLE
Bump Maps SDK and NN versions and add congestions support to Offboard examples

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/activity/OffboardRouterActivityJava.java
+++ b/examples/src/main/java/com/mapbox/navigation/examples/activity/OffboardRouterActivityJava.java
@@ -8,6 +8,7 @@ import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 
 import com.google.android.material.snackbar.Snackbar;
+import com.mapbox.api.directions.v5.DirectionsCriteria;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.api.directions.v5.models.RouteOptions;
 import com.mapbox.geojson.Point;
@@ -125,9 +126,9 @@ public class OffboardRouterActivityJava extends AppCompatActivity implements
     if (origin != null && destination != null) {
       if (offboardRouter == null) {
         offboardRouter = new MapboxOffboardRouter(
-                Utils.getMapboxAccessToken(this),
-                this,
-                MapboxNavigationAccounts.getInstance(this));
+          Utils.getMapboxAccessToken(this),
+          this,
+          MapboxNavigationAccounts.getInstance(this));
       } else {
         offboardRouter.cancel();
       }
@@ -138,8 +139,14 @@ public class OffboardRouterActivityJava extends AppCompatActivity implements
           waypoints.add(waypoint);
         }
         RouteOptions.Builder optionsBuilder =
-                applyDefaultParams(RouteOptions.builder())
-                .accessToken(Utils.getMapboxAccessToken(this));
+          applyDefaultParams(RouteOptions.builder())
+          .accessToken(Utils.getMapboxAccessToken(this))
+          .profile(DirectionsCriteria.PROFILE_DRIVING_TRAFFIC)
+          .annotations(
+            DirectionsCriteria.ANNOTATION_CONGESTION + ","
+            + DirectionsCriteria.ANNOTATION_DISTANCE
+            + "," + DirectionsCriteria.ANNOTATION_DURATION
+          );
 
         coordinates(optionsBuilder, origin, waypoints, destination);
 

--- a/examples/src/main/java/com/mapbox/navigation/examples/activity/OffboardRouterActivityKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/activity/OffboardRouterActivityKt.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.snackbar.Snackbar
+import com.mapbox.api.directions.v5.DirectionsCriteria
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.RouteOptions
 import com.mapbox.geojson.Point
@@ -88,7 +89,11 @@ class OffboardRouterActivityKt : AppCompatActivity(),
         mapboxMap.setStyle(Style.MAPBOX_STREETS) {
             MapboxLogger.d(Message("Style setting finished"))
             navigationMapRoute = NavigationMapRoute(mapView, mapboxMap)
-            Snackbar.make(findViewById(R.id.container), "Tap map to place waypoint", Snackbar.LENGTH_LONG).show()
+            Snackbar.make(
+                findViewById(R.id.container),
+                "Tap map to place waypoint",
+                Snackbar.LENGTH_LONG
+            ).show()
             newOrigin()
         }
     }
@@ -106,7 +111,11 @@ class OffboardRouterActivityKt : AppCompatActivity(),
                 findRoute()
             }
             else -> {
-                Toast.makeText(this, "Only 2 waypoints supported for this example", Toast.LENGTH_LONG).show()
+                Toast.makeText(
+                    this,
+                    "Only 2 waypoints supported for this example",
+                    Toast.LENGTH_LONG
+                ).show()
                 clearMap()
             }
         }
@@ -131,18 +140,31 @@ class OffboardRouterActivityKt : AppCompatActivity(),
     private fun findRoute() {
         ifNonNull(origin, destination) { originPoint, destinationPoint ->
             if (offboardRouter == null) {
-                offboardRouter = MapboxOffboardRouter(Utils.getMapboxAccessToken(this), this, MapboxNavigationAccounts.getInstance(this))
+                offboardRouter = MapboxOffboardRouter(
+                    Utils.getMapboxAccessToken(this),
+                    this,
+                    MapboxNavigationAccounts.getInstance(this)
+                )
             } else {
                 offboardRouter?.cancel()
             }
 
-            if (TurfMeasurement.distance(originPoint, destinationPoint, TurfConstants.UNIT_METERS) < 50) {
+            if (TurfMeasurement.distance(
+                    originPoint,
+                    destinationPoint,
+                    TurfConstants.UNIT_METERS
+                ) < 50
+            ) {
                 return
             }
             val waypoints = mutableListOf(waypoint).filterNotNull()
             val options = RouteOptions.builder().applyDefaultParams().apply {
                 accessToken(Utils.getMapboxAccessToken(this@OffboardRouterActivityKt))
                 coordinates(originPoint, waypoints, destinationPoint)
+                profile(DirectionsCriteria.PROFILE_DRIVING_TRAFFIC)
+                annotations(
+                    "${DirectionsCriteria.ANNOTATION_CONGESTION},${DirectionsCriteria.ANNOTATION_DISTANCE},${DirectionsCriteria.ANNOTATION_DURATION}"
+                )
             }.build()
 
             offboardRouter?.getRoute(options, this@OffboardRouterActivityKt)

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,12 +8,12 @@ ext {
   ]
 
   version = [
-      mapboxMapSdk              : '8.5.1',
+      mapboxMapSdk              : '8.6.2',
       mapboxSdkServices         : '5.1.0-beta.1',
       mapboxSdkDirectionsModels : '5.1.0-beta.1',
       mapboxEvents              : '4.5.1',
       mapboxCore                : '1.3.0',
-      mapboxNavigator           : '9.0.2',
+      mapboxNavigator           : '9.0.4',
       mapboxCrashMonitor        : '2.0.0',
       mapboxAnnotationPlugin    : '0.7.0',
       mapboxAccounts            : '0.2.0',


### PR DESCRIPTION
## Description

Bumps `mapbox-android-sdk` and `mapbox-navigation-native` versions to `8.6.2` and `9.0.4` respectively and adds `PROFILE_DRIVING_TRAFFIC` and annotations support to `RouteOptions` in `OffboardRouterActivityKt` and `OffboardRouterActivityJava` examples to get congestion data back if available

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

- Getting the latest version from `mapboxNavigator` and `mapboxMapSdk` including the new features and bug fixes
- Showcase congestion support in Offboard `examples`

### Implementation

- Bumping the `mapboxNavigator` and `mapboxMapSdk` versions to `9.0.4` and `8.6.2` respectively in `dependencies.gradle`
- Add `profile` and `annotations` to `RouteOptions.Builder` in `OffboardRouterActivityKt` and `OffboardRouterActivityJava` examples

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
