### PR TITLE
issue 2418 clean up of potential resource leaks

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/activity/TripServiceActivityKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/activity/TripServiceActivityKt.kt
@@ -114,7 +114,7 @@ class TripServiceActivityKt : AppCompatActivity(), OnMapReadyCallback {
             when (notificationAction) {
                 NotificationAction.END_NAVIGATION -> stopService()
             }
-        }, {})
+        })
     }
 
     private fun stopService() {

--- a/examples/src/main/java/com/mapbox/navigation/examples/activity/TripServiceActivityKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/activity/TripServiceActivityKt.kt
@@ -110,11 +110,11 @@ class TripServiceActivityKt : AppCompatActivity(), OnMapReadyCallback {
     }
 
     private fun monitorNotificationActionButton(channel: ReceiveChannel<NotificationAction>) {
-        mainJobController.scope.monitorChannelWithException(channel) { notificationAction ->
+        mainJobController.scope.monitorChannelWithException(channel, { notificationAction ->
             when (notificationAction) {
                 NotificationAction.END_NAVIGATION -> stopService()
             }
-        }
+        }, {})
     }
 
     private fun stopService() {

--- a/libdirections-hybrid/src/main/java/com/mapbox/navigation/route/hybrid/MapboxHybridRouter.kt
+++ b/libdirections-hybrid/src/main/java/com/mapbox/navigation/route/hybrid/MapboxHybridRouter.kt
@@ -43,10 +43,8 @@ class MapboxHybridRouter(
      * on that state we use either the off-board or on-board router.
      */
     init {
-        jobControl.scope.monitorChannelWithException(
-            networkStatusService.getNetworkStatusChannel()
-        ) { networkStatus ->
-            when (networkStatus.isNetworkAvailable) {
+        jobControl.scope.monitorChannelWithException(networkStatusService.getNetworkStatusChannel(), { networkStatus ->
+            when(networkStatus.isNetworkAvailable) {
                 true -> {
                     routeDispatchHandler.set(offBoardRouterHandler)
                 }
@@ -54,7 +52,7 @@ class MapboxHybridRouter(
                     routeDispatchHandler.set(onBoardRouterHandler)
                 }
             }
-        }
+        }, networkStatusService::cleanup)
     }
 
     /**

--- a/libdirections-hybrid/src/main/java/com/mapbox/navigation/route/hybrid/MapboxHybridRouter.kt
+++ b/libdirections-hybrid/src/main/java/com/mapbox/navigation/route/hybrid/MapboxHybridRouter.kt
@@ -42,7 +42,7 @@ class MapboxHybridRouter(
      */
     init {
         jobControl.scope.monitorChannelWithException(networkStatusService.getNetworkStatusChannel(), { networkStatus ->
-            when(networkStatus.isNetworkAvailable) {
+            when (networkStatus.isNetworkAvailable) {
                 true -> {
                     routeDispatchHandler.set(offBoardRouterHandler)
                 }

--- a/libdirections-hybrid/src/main/java/com/mapbox/navigation/route/hybrid/MapboxHybridRouter.kt
+++ b/libdirections-hybrid/src/main/java/com/mapbox/navigation/route/hybrid/MapboxHybridRouter.kt
@@ -1,6 +1,5 @@
 package com.mapbox.navigation.route.hybrid
 
-import android.content.Context
 import com.mapbox.annotation.navigation.module.MapboxNavigationModule
 import com.mapbox.annotation.navigation.module.MapboxNavigationModuleType
 import com.mapbox.api.directions.v5.models.DirectionsRoute
@@ -19,10 +18,9 @@ import java.util.concurrent.atomic.AtomicReference
 class MapboxHybridRouter(
     private val onboardRouter: Router,
     private val offboardRouter: Router,
-    context: Context
+    networkStatusService: NetworkStatusService
 ) : Router {
 
-    private val networkStatusService = NetworkStatusService(context)
     private val jobControl = ThreadController.getIOScopeAndRootJob()
     private val offBoardRouterHandler: RouterHandler by lazy {
         RouterHandler(mainRouter = offboardRouter, reserveRouter = onboardRouter)

--- a/libdirections-hybrid/src/test/java/com/mapbox/navigation/route/hybrid/MapboxHybridRouterTest.kt
+++ b/libdirections-hybrid/src/test/java/com/mapbox/navigation/route/hybrid/MapboxHybridRouterTest.kt
@@ -26,7 +26,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import java.lang.Exception
 
 @InternalCoroutinesApi
 @ExperimentalCoroutinesApi

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -403,11 +403,11 @@ class MapboxNavigation(
     }
 
     private fun monitorNotificationActionButton(channel: ReceiveChannel<NotificationAction>) {
-        mainJobController.scope.monitorChannelWithException(channel) { notificationAction ->
+        mainJobController.scope.monitorChannelWithException(channel, { notificationAction ->
             when (notificationAction) {
                 NotificationAction.END_NAVIGATION -> tripSession.stop()
             }
-        }
+        }, {})
     }
 
     /**

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -407,7 +407,7 @@ class MapboxNavigation(
             when (notificationAction) {
                 NotificationAction.END_NAVIGATION -> tripSession.stop()
             }
-        }, {})
+        })
     }
 
     /**

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -186,17 +186,13 @@ class MapboxNavigation(
         ThreadController.cancelAllNonUICoroutines()
         ThreadController.cancelAllUICoroutines()
         directionsSession.shutDownSession()
-
-        directionsSession.unregisterRouteObserver(internalRouteObserver)
-        directionsSession.unregisterRouteObserver(navigationSession)
-
-        tripSession.unregisterOffRouteObserver(internalOffRouteObserver)
-        tripSession.unregisterStateObserver(navigationSession)
-
-        // todo what about observers that are registered via this class's methods?
-        // if onDestroy gets called and there were observers registered from the outside
-        // will that cause resource leaks? Should this class keep track of the observers
-        // registered from the outside and unregister those listeners here?
+        directionsSession.unregisterAllRouteObservers()
+        tripSession.unregisterAllLocationObservers()
+        tripSession.unregisterAllRouteProgressObservers()
+        tripSession.unregisterAllOffRouteObservers()
+        tripSession.unregisterAllStateObservers()
+        tripSession.unregisterAllBannerInstructionsObservers()
+        tripSession.unregisterAllVoiceInstructionsObservers()
     }
 
     /**

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/DirectionsSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/DirectionsSession.kt
@@ -18,4 +18,6 @@ internal interface DirectionsSession {
     fun unregisterRouteObserver(routeObserver: RouteObserver)
 
     fun shutDownSession()
+
+    fun unregisterAllRouteObservers()
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/MapboxDirectionsSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/MapboxDirectionsSession.kt
@@ -92,6 +92,10 @@ class MapboxDirectionsSession(
         routeObservers.remove(routeObserver)
     }
 
+    override fun unregisterAllRouteObservers() {
+        routeObservers.clear()
+    }
+
     override fun shutDownSession() {
         fasterRouteTimer.stop()
     }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/service/NavigationNotificationService.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/service/NavigationNotificationService.kt
@@ -32,6 +32,6 @@ class NavigationNotificationService : Service() {
         ioJobController.scope.monitorChannelWithException(MapboxTripService.getNotificationDataChannel(), { notificationResponse ->
             notificationResponse.notification.flags = Notification.FLAG_FOREGROUND_SERVICE
             startForeground(notificationResponse.notificationId, notificationResponse.notification)
-        }, {})
+        })
     }
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/service/NavigationNotificationService.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/service/NavigationNotificationService.kt
@@ -29,9 +29,9 @@ class NavigationNotificationService : Service() {
     }
 
     private fun startForegroundNotification() {
-        ioJobController.scope.monitorChannelWithException(MapboxTripService.getNotificationDataChannel()) { notificationResponse ->
+        ioJobController.scope.monitorChannelWithException(MapboxTripService.getNotificationDataChannel(), { notificationResponse ->
             notificationResponse.notification.flags = Notification.FLAG_FOREGROUND_SERVICE
             startForeground(notificationResponse.notificationId, notificationResponse.notification)
-        }
+        }, {})
     }
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
@@ -142,6 +142,10 @@ class MapboxTripSession(
         locationObservers.remove(locationObserver)
     }
 
+    override fun unregisterAllLocationObservers() {
+        locationObservers.clear()
+    }
+
     override fun registerRouteProgressObserver(routeProgressObserver: RouteProgressObserver) {
         routeProgressObservers.add(routeProgressObserver)
         routeProgress?.let { routeProgressObserver.onRouteProgressChanged(it) }
@@ -151,6 +155,10 @@ class MapboxTripSession(
         routeProgressObservers.remove(routeProgressObserver)
     }
 
+    override fun unregisterAllRouteProgressObservers() {
+        routeProgressObservers.clear()
+    }
+
     override fun registerOffRouteObserver(offRouteObserver: OffRouteObserver) {
         offRouteObservers.add(offRouteObserver)
         offRouteObserver.onOffRouteStateChanged(isOffRoute)
@@ -158,6 +166,10 @@ class MapboxTripSession(
 
     override fun unregisterOffRouteObserver(offRouteObserver: OffRouteObserver) {
         offRouteObservers.add(offRouteObserver)
+    }
+
+    override fun unregisterAllOffRouteObservers() {
+        offRouteObservers.clear()
     }
 
     override fun registerStateObserver(stateObserver: TripSessionStateObserver) {
@@ -173,6 +185,10 @@ class MapboxTripSession(
         stateObservers.remove(stateObserver)
     }
 
+    override fun unregisterAllStateObservers() {
+        stateObservers.clear()
+    }
+
     override fun registerBannerInstructionsObserver(bannerInstructionsObserver: BannerInstructionsObserver) {
         bannerInstructionsObservers.add(bannerInstructionsObserver)
         routeProgress?.let {
@@ -180,6 +196,10 @@ class MapboxTripSession(
                 bannerInstructionsObserver.onNewBannerInstructions(bannerInstruction)
             }
         }
+    }
+
+    override fun unregisterAllBannerInstructionsObservers() {
+        bannerInstructionsObservers.clear()
     }
 
     override fun unregisterBannerInstructionsObserver(bannerInstructionsObserver: BannerInstructionsObserver) {
@@ -197,6 +217,10 @@ class MapboxTripSession(
 
     override fun unregisterVoiceInstructionsObserver(voiceInstructionsObserver: VoiceInstructionsObserver) {
         voiceInstructionsObservers.remove(voiceInstructionsObserver)
+    }
+
+    override fun unregisterAllVoiceInstructionsObservers() {
+        voiceInstructionsObservers.clear()
     }
 
     private var locationEngineCallback = object : LocationEngineCallback<LocationEngineResult> {
@@ -253,9 +277,7 @@ class MapboxTripSession(
         routeProgress = progress
         tripService.updateNotification(progress)
         routeProgressObservers.forEach { it.onRouteProgressChanged(progress) }
-        checkBannerInstructionEvent(
-            progress
-        ) { bannerInstruction ->
+        checkBannerInstructionEvent(progress) { bannerInstruction ->
             bannerInstructionsObservers.forEach {
                 it.onNewBannerInstructions(bannerInstruction)
             }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/TripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/TripSession.kt
@@ -23,19 +23,25 @@ internal interface TripSession {
 
     fun registerLocationObserver(locationObserver: LocationObserver)
     fun unregisterLocationObserver(locationObserver: LocationObserver)
+    fun unregisterAllLocationObservers()
 
     fun registerRouteProgressObserver(routeProgressObserver: RouteProgressObserver)
     fun unregisterRouteProgressObserver(routeProgressObserver: RouteProgressObserver)
+    fun unregisterAllRouteProgressObservers()
 
     fun registerOffRouteObserver(offRouteObserver: OffRouteObserver)
     fun unregisterOffRouteObserver(offRouteObserver: OffRouteObserver)
+    fun unregisterAllOffRouteObservers()
 
     fun registerStateObserver(stateObserver: TripSessionStateObserver)
     fun unregisterStateObserver(stateObserver: TripSessionStateObserver)
+    fun unregisterAllStateObservers()
 
     fun registerBannerInstructionsObserver(bannerInstructionsObserver: BannerInstructionsObserver)
     fun unregisterBannerInstructionsObserver(bannerInstructionsObserver: BannerInstructionsObserver)
+    fun unregisterAllBannerInstructionsObservers()
 
     fun registerVoiceInstructionsObserver(voiceInstructionsObserver: VoiceInstructionsObserver)
     fun unregisterVoiceInstructionsObserver(voiceInstructionsObserver: VoiceInstructionsObserver)
+    fun unregisterAllVoiceInstructionsObservers()
 }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
@@ -6,11 +6,14 @@ import com.mapbox.android.core.location.LocationEngine
 import com.mapbox.android.core.location.LocationEngineRequest
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.core.directions.session.DirectionsSession
-import com.mapbox.navigation.core.directions.session.RouteObserver
 import com.mapbox.navigation.core.trip.service.TripService
 import com.mapbox.navigation.core.trip.session.TripSession
 import com.mapbox.navigation.utils.extensions.inferDeviceLocale
-import io.mockk.*
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.verify
 import java.util.Locale
 import org.junit.Assert.assertNotNull
 import org.junit.Before

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
@@ -80,20 +80,48 @@ class MapboxNavigationTest {
     fun onDestroy_unregisters_DirectionSession_observers() {
         mapboxNavigation.onDestroy()
 
-        verify(exactly = 2) { directionsSession.unregisterRouteObserver(any()) }
+        verify(exactly = 1) { directionsSession.unregisterAllRouteObservers() }
     }
 
     @Test
-    fun onDestroy_unregistersOffRouteObservers_from_tripSession() {
+    fun onDestroy_unregisters_TripSession_location_observers() {
         mapboxNavigation.onDestroy()
 
-        verify(exactly = 1) { tripSession.unregisterOffRouteObserver(any()) }
+        verify(exactly = 1) { tripSession.unregisterAllLocationObservers() }
     }
 
     @Test
-    fun onDestroy_unregistersStateObservers_from_tripSession() {
+    fun onDestroy_unregisters_TripSession_routeProgress_observers() {
         mapboxNavigation.onDestroy()
 
-        verify(exactly = 1) { tripSession.unregisterStateObserver(any()) }
+        verify(exactly = 1) { tripSession.unregisterAllRouteProgressObservers() }
+    }
+
+    @Test
+    fun onDestroy_unregisters_TripSession_offRoute_observers() {
+        mapboxNavigation.onDestroy()
+
+        verify(exactly = 1) { tripSession.unregisterAllOffRouteObservers() }
+    }
+
+    @Test
+    fun onDestroy_unregisters_TripSession_state_observers() {
+        mapboxNavigation.onDestroy()
+
+        verify(exactly = 1) { tripSession.unregisterAllStateObservers() }
+    }
+
+    @Test
+    fun unregisterAllBannerInstructionsObservers() {
+        mapboxNavigation.onDestroy()
+
+        verify(exactly = 1) { tripSession.unregisterAllBannerInstructionsObservers() }
+    }
+
+    @Test
+    fun unregisterAllVoiceInstructionsObservers() {
+        mapboxNavigation.onDestroy()
+
+        verify(exactly = 1) { tripSession.unregisterAllVoiceInstructionsObservers() }
     }
 }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
@@ -6,13 +6,11 @@ import com.mapbox.android.core.location.LocationEngine
 import com.mapbox.android.core.location.LocationEngineRequest
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.core.directions.session.DirectionsSession
+import com.mapbox.navigation.core.directions.session.RouteObserver
 import com.mapbox.navigation.core.trip.service.TripService
 import com.mapbox.navigation.core.trip.session.TripSession
 import com.mapbox.navigation.utils.extensions.inferDeviceLocale
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.mockkObject
-import io.mockk.mockkStatic
+import io.mockk.*
 import java.util.Locale
 import org.junit.Assert.assertNotNull
 import org.junit.Before
@@ -76,5 +74,26 @@ class MapboxNavigationTest {
     @Test
     fun sanity() {
         assertNotNull(mapboxNavigation)
+    }
+
+    @Test
+    fun onDestroy_unregisters_DirectionSession_observers() {
+        mapboxNavigation.onDestroy()
+
+        verify(exactly = 2) { directionsSession.unregisterRouteObserver(any()) }
+    }
+
+    @Test
+    fun onDestroy_unregistersOffRouteObservers_from_tripSession() {
+        mapboxNavigation.onDestroy()
+
+        verify(exactly = 1) { tripSession.unregisterOffRouteObserver(any()) }
+    }
+
+    @Test
+    fun onDestroy_unregistersStateObservers_from_tripSession() {
+        mapboxNavigation.onDestroy()
+
+        verify(exactly = 1) { tripSession.unregisterStateObserver(any()) }
     }
 }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/directions/session/MapboxDirectionsSessionTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/directions/session/MapboxDirectionsSessionTest.kt
@@ -187,4 +187,18 @@ class MapboxDirectionsSessionTest {
         session.requestRoutes(routeOptions)
         verify(exactly = 2) { router.cancel() }
     }
+
+    @Test
+    fun unregisterAllRouteObservers() {
+        session.registerRouteObserver(observer)
+        session.requestRoutes(routeOptions)
+
+        session.unregisterAllRouteObservers()
+
+        callback.onResponse(routes)
+        delayLambda()
+
+        verify { router.getRoute(routeOptions, callback) }
+        verify(exactly = 0) { observer.onRoutesChanged(any()) }
+    }
 }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
@@ -452,11 +452,11 @@ class MapboxTripSessionTest {
 
         locationCallbackSlot.captured.onSuccess(locationEngineResult)
 
-        //registerOffRouteObserver will call onOffRouteStateChanged() on
-        //the offRouteObserver so that accounts for the verify 1 time
-        //below. However there shouldn't be any additional calls when
-        //the locationCallback.onSuccess() is called because the collection
-        //of offRouteObservers should be empty.
+        // registerOffRouteObserver will call onOffRouteStateChanged() on
+        // the offRouteObserver so that accounts for the verify 1 time
+        // below. However there shouldn't be any additional calls when
+        // the locationCallback.onSuccess() is called because the collection
+        // of offRouteObservers should be empty.
         verify(exactly = 1) { offRouteObserver.onOffRouteStateChanged(any()) }
 
         tripSession.stop()
@@ -473,7 +473,7 @@ class MapboxTripSessionTest {
 
         tripSession.unregisterAllStateObservers()
 
-        //stop() would normally trigger a call to stateObserver.onSessionStopped()
+        // stop() would normally trigger a call to stateObserver.onSessionStopped()
         tripSession.stop()
 
         verify(exactly = 1) { stateObserver.onSessionStarted() }
@@ -508,7 +508,6 @@ class MapboxTripSessionTest {
         locationCallbackSlot.captured.onSuccess(locationEngineResult)
 
         tripSession.stop()
-
 
         tripSession.start()
         tripSession.unregisterAllBannerInstructionsObservers()
@@ -549,7 +548,6 @@ class MapboxTripSessionTest {
         locationCallbackSlot.captured.onSuccess(locationEngineResult)
 
         tripSession.stop()
-
 
         tripSession.start()
         tripSession.unregisterAllVoiceInstructionsObservers()

--- a/libnavigation-util/src/main/java/com/mapbox/navigation/utils/network/NetworkStatusService.kt
+++ b/libnavigation-util/src/main/java/com/mapbox/navigation/utils/network/NetworkStatusService.kt
@@ -64,7 +64,7 @@ class NetworkStatusService(private val applicationContext: Context) {
     }
 
     fun cleanup() {
-        if(receiver != null) {
+        if (receiver != null) {
             applicationContext.unregisterReceiver(receiver)
         }
     }

--- a/libnavigation-util/src/main/java/com/mapbox/navigation/utils/thread/ThreadController.kt
+++ b/libnavigation-util/src/main/java/com/mapbox/navigation/utils/thread/ThreadController.kt
@@ -20,7 +20,7 @@ import kotlinx.coroutines.selects.select
 fun <T> CoroutineScope.monitorChannelWithException(
     channel: ReceiveChannel<T>,
     predicate: suspend (T) -> Unit,
-    onCancellation: () -> Unit
+    onCancellation: (() -> Unit) = {}
 ): Job {
 
     var isChannelValid = true

--- a/libnavigation-util/src/main/java/com/mapbox/navigation/utils/thread/ThreadController.kt
+++ b/libnavigation-util/src/main/java/com/mapbox/navigation/utils/thread/ThreadController.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.cancelChildren
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ClosedReceiveChannelException
 import kotlinx.coroutines.channels.ClosedSendChannelException
 import kotlinx.coroutines.channels.ReceiveChannel

--- a/libnavigation-util/src/main/java/com/mapbox/navigation/utils/thread/ThreadController.kt
+++ b/libnavigation-util/src/main/java/com/mapbox/navigation/utils/thread/ThreadController.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.cancelChildren
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ClosedReceiveChannelException
 import kotlinx.coroutines.channels.ClosedSendChannelException
 import kotlinx.coroutines.channels.ReceiveChannel
@@ -18,7 +19,8 @@ import kotlinx.coroutines.selects.select
 
 fun <T> CoroutineScope.monitorChannelWithException(
     channel: ReceiveChannel<T>,
-    predicate: suspend (T) -> Unit
+    predicate: suspend (T) -> Unit,
+    onCancellation: () -> Unit
 ): Job {
 
     var isChannelValid = true
@@ -33,6 +35,7 @@ fun <T> CoroutineScope.monitorChannelWithException(
             } catch (e: Exception) {
                 e.ifChannelException {
                     isChannelValid = false
+                    onCancellation()
                 }
             }
         }

--- a/libnavigation-util/src/test/java/com/mapbox/navigation/utils/network/NetworkStatusServiceTest.kt
+++ b/libnavigation-util/src/test/java/com/mapbox/navigation/utils/network/NetworkStatusServiceTest.kt
@@ -8,7 +8,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
-import org.junit.Assert.*
 import org.junit.Test
 
 class NetworkStatusServiceTest {

--- a/libnavigation-util/src/test/java/com/mapbox/navigation/utils/network/NetworkStatusServiceTest.kt
+++ b/libnavigation-util/src/test/java/com/mapbox/navigation/utils/network/NetworkStatusServiceTest.kt
@@ -1,0 +1,30 @@
+package com.mapbox.navigation.utils.network
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.net.ConnectivityManager
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.Assert.*
+import org.junit.Test
+
+class NetworkStatusServiceTest {
+
+    @Test
+    fun cleanup() {
+        val ctx = mockk<Context>(relaxUnitFun = true)
+        val connectivityManager = mockk< ConnectivityManager>()
+        val receiverIntent = mockk<Intent>()
+        val receiverSlot = slot<BroadcastReceiver>()
+
+        every { ctx.getSystemService(Context.CONNECTIVITY_SERVICE) } returns connectivityManager
+        every { ctx.registerReceiver(capture(receiverSlot), any()) } returns receiverIntent
+
+        NetworkStatusService(ctx).cleanup()
+
+        verify(exactly = 1) { ctx.unregisterReceiver(receiverSlot.captured) }
+    }
+}

--- a/libnavigation-util/src/test/java/com/mapbox/navigation/utils/thread/ThreadControllerKtTest.kt
+++ b/libnavigation-util/src/test/java/com/mapbox/navigation/utils/thread/ThreadControllerKtTest.kt
@@ -1,0 +1,56 @@
+package com.mapbox.navigation.utils.thread
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ClosedReceiveChannelException
+import org.hamcrest.CoreMatchers.`is`
+import org.junit.Assert.*
+import org.junit.Test
+
+class ThreadControllerKtTest {
+
+    @Test
+    fun monitorChannelWithException_callsOnCancellation_whenChannelClosed() {
+        var flag = false
+        val channel: Channel<String> = Channel()
+
+        runBlocking {
+            monitorChannelWithException(
+                    channel,
+                    {},
+                    { flag = true }
+            )
+
+            channel.send("foobar")
+
+            assertFalse(flag)
+
+            channel.close(ClosedReceiveChannelException(""))
+            try {
+                channel.send("foobar")
+            } catch (ex: Exception) {}
+        }
+        assertTrue(flag)
+    }
+
+    @Test
+    fun monitorChannelWithException() {
+        val channel: Channel<String> = Channel()
+        var msg = "error"
+
+        runBlocking {
+            monitorChannelWithException(
+                    channel,
+                    {
+                        msg = it
+                    },
+                    {}
+            )
+
+            channel.send("success")
+            channel.close()
+        }
+
+        assertThat(msg, `is`("success"))
+    }
+}

--- a/libnavigation-util/src/test/java/com/mapbox/navigation/utils/thread/ThreadControllerKtTest.kt
+++ b/libnavigation-util/src/test/java/com/mapbox/navigation/utils/thread/ThreadControllerKtTest.kt
@@ -1,10 +1,12 @@
 package com.mapbox.navigation.utils.thread
 
-import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ClosedReceiveChannelException
+import kotlinx.coroutines.runBlocking
 import org.hamcrest.CoreMatchers.`is`
-import org.junit.Assert.*
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThat
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ThreadControllerKtTest {


### PR DESCRIPTION
## Description

In response to:   https://github.com/mapbox/mapbox-navigation-android/issues/2418

In MapboxNavigation there were observers registered in the init() that weren't unregistered in onDestroy(). In addition external callers could register observers but in the event onDestroy() was called there was no assurance the caller(s) would unregister their observers. 

I modified the MapboxNavigation.onDestroy to unregister all observers in the MapboxNavigation class as well as the TripSession referenced by MapboxNavigation. I added unRegisterObserver methods for the various types of observers in the TripSession interface and the implementation. MapboxNavigation.onDestroy() calls all of the unRegisterObserver methods in the tripSession in order to release all resources.

NetworkStatusService is registering a service with a context but was not unregistering the service. In the event the channel in the NetworkStatusService was closed there was a need to unregister the service to prevent possible leaking of resources.  

I modified CoroutineScope.monitorChannelWithException to take an (optional) onCancelled function that can be used in the event an exception occurs inside of CoroutineScope.monitorChannelWithException. I added a cleanup() in  NetworkStatusService that gets called in event the channel is closed and/or exception occurs during the execution of the lambda passed to  CoroutineScope.monitorChannelWithException.
 
I replaced the context parameter in the MapboxHybridRouter constructor with NetworkStatusService. The context was only being used to instantiate a NetworkStatusService. The MapboxHybridRouter had no real dependency on a Context. This violated (my interpretation of) the law of demeter. In addition it made it impossible to test that NetworkStatusService.cleanup() was being passed as an onCancelled parameter to monitorChannelWithException(). If NetworkStatusService.cleanup() isn't called, NetworkStatusService doesn't unregister itself with the context potentially resulting in leaked resources.

Unit tests added and adjusted as appropriate. 