### PR TITLE
Fix displaying notification in free drive mode

### DIFF
--- a/examples/src/androidTest/java/com/mapbox/navigation/examples/activity/TripServiceActivityKtTest.kt
+++ b/examples/src/androidTest/java/com/mapbox/navigation/examples/activity/TripServiceActivityKtTest.kt
@@ -10,7 +10,8 @@ import com.schibsted.spain.barista.assertion.BaristaEnabledAssertions.assertEnab
 import com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertContains
 import com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertDisplayed
 import com.schibsted.spain.barista.interaction.BaristaClickInteractions.clickOn
-import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -70,13 +71,15 @@ class TripServiceActivityKtTest :
 
         uiDevice.run {
             openNotification()
-            awaitForView("notificationDistanceText")
-            val notificationDistance =
-                By.res("com.mapbox.navigation.examples:id/notificationDistanceText")
-            wait(Until.hasObject(notificationDistance), 1000)
-            val message = findObject(notificationDistance).text
+            awaitForView("etaContent")
+            awaitForView("freeDriveText")
+            val etaContent = By.res("com.mapbox.navigation.examples:id/etaContent")
+            val freeDriveText = By.res("com.mapbox.navigation.examples:id/freeDriveText")
+            wait(Until.hasObject(etaContent), 1000)
+            wait(Until.hasObject(freeDriveText), 1000)
 
-            assertEquals("100 m", message)
+            assertFalse(hasObject(etaContent))
+            assertTrue(hasObject(freeDriveText))
             pressBack()
         }
     }

--- a/libtrip-notification/src/main/java/com/mapbox/navigation/trip/notification/MapboxTripNotification.kt
+++ b/libtrip-notification/src/main/java/com/mapbox/navigation/trip/notification/MapboxTripNotification.kt
@@ -16,6 +16,8 @@ import android.os.Build
 import android.text.SpannableString
 import android.text.TextUtils
 import android.text.format.DateFormat
+import android.view.View.GONE
+import android.view.View.VISIBLE
 import android.widget.RemoteViews
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
@@ -233,18 +235,71 @@ class MapboxTripNotification constructor(
     }
 
     private fun updateNotificationViews(routeProgress: RouteProgress) {
-        updateInstructionText(routeProgress.bannerInstructions())
-        updateDistanceText(routeProgress)
-        generateArrivalTime(routeProgress)?.let { formattedTime ->
-            updateViewsWithArrival(formattedTime)
-        }
-        routeProgress.bannerInstructions()?.let { bannerInstructions ->
-            if (updateManeuverState(bannerInstructions)) {
-                updateManeuverImage(
-                    routeProgress.currentLegProgress()?.currentStepProgress()?.step()?.drivingSide()
-                        ?: STEP_MANEUVER_MODIFIER_RIGHT
-                )
+        routeProgress.route()?.let {
+            setFreeDriveMode(false)
+            updateInstructionText(routeProgress.bannerInstructions())
+            updateDistanceText(routeProgress)
+            generateArrivalTime(routeProgress)?.let { formattedTime ->
+                updateViewsWithArrival(formattedTime)
             }
+            routeProgress.bannerInstructions()?.let { bannerInstructions ->
+                if (isManeuverStateChanged(bannerInstructions)) {
+                    updateManeuverImage(
+                            routeProgress.currentLegProgress()?.currentStepProgress()?.step()?.drivingSide()
+                                    ?: STEP_MANEUVER_MODIFIER_RIGHT
+                    )
+                }
+            }
+        } ?: setFreeDriveMode(true)
+    }
+
+    private fun setFreeDriveMode(isFreeDriveMode: Boolean) {
+        updateEtaContentVisibility(isFreeDriveMode)
+        updateFreeDriveTextVisibility(isFreeDriveMode)
+        updateManeuverImageResource(isFreeDriveMode)
+        updateEndNavigationBtnText(isFreeDriveMode)
+        updateCurrentManeuverToDefault(isFreeDriveMode)
+    }
+
+    private fun updateEtaContentVisibility(isFreeDriveMode: Boolean) {
+        collapsedNotificationRemoteViews?.setViewVisibility(
+                R.id.etaContent,
+                if (isFreeDriveMode) GONE else VISIBLE
+        )
+        expandedNotificationRemoteViews?.setViewVisibility(
+                R.id.etaContent,
+                if (isFreeDriveMode) GONE else VISIBLE
+        )
+    }
+
+    private fun updateFreeDriveTextVisibility(isFreeDriveMode: Boolean) {
+        collapsedNotificationRemoteViews?.setViewVisibility(
+                R.id.freeDriveText,
+                if (isFreeDriveMode) VISIBLE else GONE
+        )
+        expandedNotificationRemoteViews?.setViewVisibility(
+                R.id.freeDriveText,
+                if (isFreeDriveMode) VISIBLE else GONE
+        )
+    }
+
+    private fun updateEndNavigationBtnText(isFreeDriveMode: Boolean) {
+        expandedNotificationRemoteViews?.setTextViewText(
+                R.id.endNavigationBtnText,
+                applicationContext.getString(if (isFreeDriveMode) R.string.stop_session else R.string.end_navigation)
+        )
+    }
+
+    private fun updateManeuverImageResource(isFreeDriveMode: Boolean) {
+        if (isFreeDriveMode) {
+            collapsedNotificationRemoteViews?.setImageViewResource(
+                    R.id.maneuverImage,
+                    R.drawable.ic_navigation
+            )
+            expandedNotificationRemoteViews?.setImageViewResource(
+                    R.id.maneuverImage,
+                    R.drawable.ic_navigation
+            )
         }
     }
 
@@ -253,10 +308,12 @@ class MapboxTripNotification constructor(
             val primaryText = bannerIns.primary().text()
             if (currentInstructionText.isNullOrEmpty() || currentInstructionText != primaryText) {
                 collapsedNotificationRemoteViews?.setTextViewText(
-                    R.id.notificationInstructionText, primaryText
+                    R.id.notificationInstructionText,
+                        primaryText
                 )
                 expandedNotificationRemoteViews?.setTextViewText(
-                    R.id.notificationInstructionText, primaryText
+                    R.id.notificationInstructionText,
+                        primaryText
                 )
                 currentInstructionText = primaryText
             }
@@ -305,6 +362,14 @@ class MapboxTripNotification constructor(
         expandedNotificationRemoteViews?.setTextViewText(R.id.notificationArrivalText, time)
     }
 
+    private fun updateCurrentManeuverToDefault(isFreeDriveMode: Boolean) {
+        if (isFreeDriveMode) {
+            currentManeuverType = null
+            currentManeuverModifier = null
+            currentRoundaboutAngle = DEFAULT_ROUNDABOUT_ANGLE
+        }
+    }
+
     private fun newDistanceText(routeProgress: RouteProgress) =
         ifNonNull(
             distanceFormatter,
@@ -333,22 +398,27 @@ class MapboxTripNotification constructor(
         }
     }
 
-    private fun updateManeuverState(bannerInstruction: BannerInstructions): Boolean {
+    private fun isManeuverStateChanged(bannerInstruction: BannerInstructions): Boolean {
         val previousManeuverType = currentManeuverType
         val previousManeuverModifier = currentManeuverModifier
         val previousRoundaboutAngle = currentRoundaboutAngle
 
-        currentManeuverType = bannerInstruction.primary().type()
-        currentManeuverModifier = bannerInstruction.primary().modifier()
-
-        currentRoundaboutAngle = if (ROUNDABOUT_MANEUVER_TYPES.contains(currentManeuverType))
-            adjustRoundaboutAngle(bannerInstruction.primary().degrees()?.toFloat() ?: 0f)
-        else
-            DEFAULT_ROUNDABOUT_ANGLE
+        updateManeuverState(bannerInstruction)
 
         return !TextUtils.equals(currentManeuverType, previousManeuverType) ||
             !TextUtils.equals(currentManeuverModifier, previousManeuverModifier) ||
             currentRoundaboutAngle != previousRoundaboutAngle
+    }
+
+    private fun updateManeuverState(bannerInstruction: BannerInstructions) {
+        currentManeuverType = bannerInstruction.primary().type()
+        currentManeuverModifier = bannerInstruction.primary().modifier()
+
+        currentRoundaboutAngle = if (ROUNDABOUT_MANEUVER_TYPES.contains(currentManeuverType)) {
+            adjustRoundaboutAngle(bannerInstruction.primary().degrees()?.toFloat() ?: 0f)
+        } else {
+            DEFAULT_ROUNDABOUT_ANGLE
+        }
     }
 
     private fun getManeuverBitmap(

--- a/libtrip-notification/src/main/res/layout/collapsed_navigation_notification_layout.xml
+++ b/libtrip-notification/src/main/res/layout/collapsed_navigation_notification_layout.xml
@@ -4,7 +4,8 @@
     android:id="@+id/navigationCollapsedNotificationLayout"
     style="@android:style/TextAppearance.StatusBar.EventContent"
     android:layout_width="match_parent"
-    android:layout_height="64dp">
+    android:layout_height="64dp"
+    android:background="@color/mapboxNotificationBlue">
 
     <ImageView
         android:id="@+id/maneuverImage"
@@ -20,8 +21,48 @@
         android:padding="8dp"
         android:tint="@android:color/white" />
 
+    <LinearLayout
+        android:id="@+id/etaContent"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignTop="@id/maneuverImage"
+        android:layout_marginTop="4dp"
+        android:layout_toEndOf="@id/maneuverImage"
+        android:layout_toRightOf="@id/maneuverImage"
+        android:orientation="horizontal">
+
+        <TextView
+            android:id="@+id/notificationDistanceText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:lines="1"
+            android:textColor="@android:color/white"
+            tools:text="250 ft" />
+
+        <ImageView
+            android:id="@+id/dot"
+            android:layout_width="4dp"
+            android:layout_height="4dp"
+            android:layout_gravity="center_vertical"
+            android:layout_marginStart="8dp"
+            android:layout_marginLeft="8dp"
+            android:src="@drawable/ic_circle"
+            android:tint="@android:color/white" />
+
+        <TextView
+            android:id="@+id/notificationArrivalText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginLeft="8dp"
+            android:lines="1"
+            android:textColor="@android:color/white"
+            tools:text="11:13 AM ETA" />
+
+    </LinearLayout>
+
     <TextView
-        android:id="@+id/notificationDistanceText"
+        android:id="@+id/freeDriveText"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_alignTop="@id/maneuverImage"
@@ -29,35 +70,9 @@
         android:layout_toEndOf="@id/maneuverImage"
         android:layout_toRightOf="@id/maneuverImage"
         android:lines="1"
+        android:text="@string/free_drive_notification_text"
         android:textColor="@android:color/white"
-        tools:text="250 ft" />
-
-    <ImageView
-        android:id="@+id/dot"
-        android:layout_width="4dp"
-        android:layout_height="4dp"
-        android:layout_alignTop="@id/notificationDistanceText"
-        android:layout_alignBottom="@id/notificationDistanceText"
-        android:layout_marginStart="8dp"
-        android:layout_marginLeft="8dp"
-        android:layout_toEndOf="@id/notificationDistanceText"
-        android:layout_toRightOf="@id/notificationDistanceText"
-        android:src="@drawable/ic_circle"
-        android:tint="@android:color/white" />
-
-    <TextView
-        android:id="@+id/notificationArrivalText"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignTop="@id/notificationDistanceText"
-        android:layout_alignBottom="@id/notificationDistanceText"
-        android:layout_marginStart="8dp"
-        android:layout_marginLeft="8dp"
-        android:layout_toEndOf="@+id/dot"
-        android:layout_toRightOf="@+id/dot"
-        android:lines="1"
-        android:textColor="@android:color/white"
-        tools:text="11:13 AM ETA" />
+        android:visibility="gone" />
 
     <TextView
         android:id="@+id/notificationInstructionText"

--- a/libtrip-notification/src/main/res/layout/expanded_navigation_notification_layout.xml
+++ b/libtrip-notification/src/main/res/layout/expanded_navigation_notification_layout.xml
@@ -30,6 +30,7 @@
             android:tint="@android:color/white" />
 
         <TextView
+            android:id="@+id/endNavigationBtnText"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="@android:color/transparent"

--- a/libtrip-notification/src/main/res/values/strings.xml
+++ b/libtrip-notification/src/main/res/values/strings.xml
@@ -1,6 +1,8 @@
 <resources>
     <!-- Notification Strings -->
     <string name="end_navigation">End Navigation</string>
+    <string name="stop_session">Stop session</string>
+    <string name="free_drive_notification_text">Free Drive session</string>
     <string name="channel_name">Navigation Notifications</string>
     <string name="notification_arrival_time_format">Arrive at %s</string>
     <string name="kilometers">km</string>


### PR DESCRIPTION
## Description

Fix displaying notification when user in free-drive mode. Added stub text instead of estimation distance and time block. [issue](https://github.com/mapbox/mapbox-navigation-android/issues/2412)

- [ ] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Implementation

Added stub text instead of estimation distance and time block. Changed "End navigation" button to "Stop session" in free drive mode. Changed maneuver image to default forward arrow for free drive mode.

## Screenshots or Gifs

Collapsed:
![device-2020-02-06-153942](https://user-images.githubusercontent.com/1431259/73937829-fb178a00-48f6-11ea-8689-d33a22632f35.png)

Expanded:
![device-2020-02-06-153743](https://user-images.githubusercontent.com/1431259/73937706-b68bee80-48f6-11ea-8634-d116430abe18.png)

## Testing

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR