### PR TITLE
Add context to router params

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -415,7 +415,8 @@ class MapboxNavigation(
                 Router::class.java to NavigationModuleProvider.createModule(
                     MapboxNavigationModuleType.OffboardRouter,
                     ::paramsProvider
-                )
+                ),
+                Context::class.java to context.applicationContext
             )
             MapboxNavigationModuleType.OffboardRouter -> arrayOf(
                 String::class.java to (accessToken
@@ -423,6 +424,7 @@ class MapboxNavigation(
                 Context::class.java to context,
                 SkuTokenProvider::class.java to MapboxNavigationAccounts.getInstance(context)
             )
+            // TODO replace with config + logger implementation OR add empty default constructor
             MapboxNavigationModuleType.OnboardRouter -> arrayOf()
             MapboxNavigationModuleType.DirectionsSession -> throw NotImplementedError() // going to be removed when next base version
             MapboxNavigationModuleType.TripNotification -> arrayOf(


### PR DESCRIPTION
## Description

Add context as a param during HybridRouter creation

- [ ] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

## Testing

- [x] New and existing unit tests pass locally with my changes
