### PR TITLE
Add logic to determine faster route

### DIFF
--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/NavigationOptions.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/NavigationOptions.kt
@@ -7,13 +7,15 @@ import com.mapbox.navigation.base.typedef.RoundingIncrement
 import com.mapbox.navigation.base.typedef.TimeFormatType
 
 const val DEFAULT_NAVIGATOR_POLLING_DELAY = 1500L
+const val DEFAULT_FASTER_ROUTE_DETECTOR_INTERVAL = 2 * 60 * 1000L // 2 minutes
 
 class NavigationOptions private constructor(
     @RoundingIncrement private val roundingIncrement: Int,
     @TimeFormatType private val timeFormatType: Int,
     private val navigatorPollingDelay: Long,
     private val distanceFormatter: DistanceFormatter?,
-    private val onboardRouterConfig: MapboxOnboardRouterConfig?
+    private val onboardRouterConfig: MapboxOnboardRouterConfig?,
+    private val fasterRouteDetectorInterval: Long
 ) {
 
     fun roundingIncrement() = roundingIncrement
@@ -26,11 +28,14 @@ class NavigationOptions private constructor(
 
     fun navigatorPollingDelay() = navigatorPollingDelay
 
+    fun fasterRouteDetectorInterval() = fasterRouteDetectorInterval
+
     fun toBuilder(): Builder {
         val builder = Builder()
             .roundingIncrement(roundingIncrement)
             .timeFormatType(timeFormatType)
             .navigatorPollingDelay(navigatorPollingDelay)
+            .fasterRouteDetectorInterval(fasterRouteDetectorInterval)
         distanceFormatter?.let {
             builder.distanceFormatter(it)
         }
@@ -44,6 +49,7 @@ class NavigationOptions private constructor(
         private var timeFormatType: Int = NONE_SPECIFIED,
         private var roundingIncrement: Int = ROUNDING_INCREMENT_FIFTY,
         private var navigatorPollingDelay: Long = DEFAULT_NAVIGATOR_POLLING_DELAY,
+        private var fasterRouteDetectorInterval: Long = DEFAULT_FASTER_ROUTE_DETECTOR_INTERVAL,
         private var distanceFormatter: DistanceFormatter? = null,
         private var onboardRouterConfig: MapboxOnboardRouterConfig? = null
     ) {
@@ -63,13 +69,17 @@ class NavigationOptions private constructor(
         fun navigatorPollingDelay(pollingDelay: Long) =
             apply { navigatorPollingDelay = pollingDelay }
 
+        fun fasterRouteDetectorInterval(interval: Long) =
+                apply { fasterRouteDetectorInterval = interval }
+
         fun build(): NavigationOptions {
             return NavigationOptions(
                 roundingIncrement,
                 timeFormatType,
                 navigatorPollingDelay,
                 distanceFormatter,
-                onboardRouterConfig
+                onboardRouterConfig,
+                fasterRouteDetectorInterval
             )
         }
     }

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/route/options/NavigationOptionsTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/route/options/NavigationOptionsTest.kt
@@ -2,6 +2,7 @@ package com.mapbox.navigation.base.route.options
 
 import android.text.SpannableString
 import com.mapbox.navigation.base.formatter.DistanceFormatter
+import com.mapbox.navigation.base.options.DEFAULT_FASTER_ROUTE_DETECTOR_INTERVAL
 import com.mapbox.navigation.base.options.DEFAULT_NAVIGATOR_POLLING_DELAY
 import com.mapbox.navigation.base.options.MapboxOnboardRouterConfig
 import com.mapbox.navigation.base.options.NavigationOptions
@@ -24,12 +25,14 @@ class NavigationOptionsTest {
         assertEquals(options.navigatorPollingDelay(), DEFAULT_NAVIGATOR_POLLING_DELAY)
         assertEquals(options.distanceFormatter(), null)
         assertEquals(options.onboardRouterConfig(), null)
+        assertEquals(options.fasterRouteDetectorInterval(), DEFAULT_FASTER_ROUTE_DETECTOR_INTERVAL)
     }
 
     @Test
     fun whenBuilderBuildCalledThenProperNavigationOptionsCreated() {
         val timeFormat = TWELVE_HOURS
         val roundingIncrement = ROUNDING_INCREMENT_TEN
+        val fasterRouteInterval = 120000L
         val pollingDelay = 1020L
         val distanceFormatter = object : DistanceFormatter {
             override fun formatDistance(distance: Double): SpannableString {
@@ -44,6 +47,7 @@ class NavigationOptionsTest {
             .navigatorPollingDelay(pollingDelay)
             .distanceFormatter(distanceFormatter)
             .onboardRouterConfig(routerConfig)
+            .fasterRouteDetectorInterval(fasterRouteInterval)
             .build()
 
         assertEquals(options.roundingIncrement(), roundingIncrement)
@@ -51,6 +55,7 @@ class NavigationOptionsTest {
         assertEquals(options.navigatorPollingDelay(), pollingDelay)
         assertEquals(options.distanceFormatter(), distanceFormatter)
         assertEquals(options.onboardRouterConfig(), routerConfig)
+        assertEquals(options.fasterRouteDetectorInterval(), fasterRouteInterval)
     }
 
     @Test
@@ -58,6 +63,7 @@ class NavigationOptionsTest {
         val timeFormat = TWELVE_HOURS
         val roundingIncrement = ROUNDING_INCREMENT_TEN
         val pollingDelay = 1020L
+        val fasterRouteInterval = 120000L
         val distanceFormatter = object : DistanceFormatter {
             override fun formatDistance(distance: Double): SpannableString {
                 throw NotImplementedError()
@@ -71,14 +77,17 @@ class NavigationOptionsTest {
             .navigatorPollingDelay(pollingDelay)
             .distanceFormatter(distanceFormatter)
             .onboardRouterConfig(routerConfig)
+            .fasterRouteDetectorInterval(fasterRouteInterval)
             .build()
 
         val builder = options.toBuilder()
         val newTimeFormat = TWENTY_FOUR_HOURS
         val newPollingDelay = 900L
+        val newFasterRouteInterval = 60000L
         options = builder
             .timeFormatType(newTimeFormat)
             .navigatorPollingDelay(newPollingDelay)
+            .fasterRouteDetectorInterval(newFasterRouteInterval)
             .build()
 
         assertEquals(options.roundingIncrement(), roundingIncrement)
@@ -86,5 +95,6 @@ class NavigationOptionsTest {
         assertEquals(options.navigatorPollingDelay(), newPollingDelay)
         assertEquals(options.distanceFormatter(), distanceFormatter)
         assertEquals(options.onboardRouterConfig(), routerConfig)
+        assertEquals(options.fasterRouteDetectorInterval(), newFasterRouteInterval)
     }
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/DirectionsSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/DirectionsSession.kt
@@ -2,7 +2,7 @@ package com.mapbox.navigation.core.directions.session
 
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.RouteOptions
-import com.mapbox.navigation.core.fasterroute.FasterRouteObserver
+import com.mapbox.navigation.base.route.Router
 
 internal interface DirectionsSession {
 
@@ -12,15 +12,21 @@ internal interface DirectionsSession {
 
     fun requestRoutes(routeOptions: RouteOptions, routesRequestCallback: RoutesRequestCallback)
 
+    /**
+     * Requests a route using the provided [Router] implementation.
+     * Unlike [DirectionsSession.requestRoutes] it ignores the result and it's up to the
+     * consumer to take an action with the route.
+     *
+     * @param adjustedRouteOptions: RouteOptions with adjusted parameters
+     * @param routesRequestCallback listener that gets notified when request state changes
+     */
+    fun requestFasterRoute(adjustedRouteOptions: RouteOptions, routesRequestCallback: RoutesRequestCallback)
+
     fun cancel()
 
     fun registerRoutesObserver(routesObserver: RoutesObserver)
 
     fun unregisterRoutesObserver(routesObserver: RoutesObserver)
-
-    fun registerFasterRouteObserver(fasterRouteObserver: FasterRouteObserver)
-
-    fun unregisterFasterRouteObserver(fasterRouteObserver: FasterRouteObserver)
 
     fun shutDownSession()
 

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/MapboxDirectionsSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/MapboxDirectionsSession.kt
@@ -21,6 +21,9 @@ class MapboxDirectionsSession(
                 return
             }
             field = value
+            if (!routes.isEmpty()) {
+                this.routeOptions = routes[0].routeOptions()
+            }
             routesObservers.forEach { it.onRoutesChanged(value) }
         }
 
@@ -35,7 +38,6 @@ class MapboxDirectionsSession(
         routesRequestCallback: RoutesRequestCallback
     ) {
         routes = emptyList()
-        this.routeOptions = routeOptions
         router.getRoute(routeOptions, object : Router.Callback {
             override fun onResponse(routes: List<DirectionsRoute>) {
                 this@MapboxDirectionsSession.routes = routesRequestCallback.onRoutesReady(routes)
@@ -59,7 +61,6 @@ class MapboxDirectionsSession(
             routesRequestCallback.onRoutesRequestCanceled(adjustedRouteOptions)
             return
         }
-        this.routeOptions = adjustedRouteOptions
         router.getRoute(adjustedRouteOptions, object : Router.Callback {
             override fun onResponse(routes: List<DirectionsRoute>) {
                 routesRequestCallback.onRoutesReady(routes)

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/fasterroute/FasterRouteDetector.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/fasterroute/FasterRouteDetector.kt
@@ -1,0 +1,11 @@
+package com.mapbox.navigation.core.fasterroute
+
+import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.navigation.base.trip.model.RouteProgress
+
+internal object FasterRouteDetector {
+
+    fun isRouteFaster(newRoute: DirectionsRoute, routeProgress: RouteProgress): Boolean {
+        return false
+    }
+}

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
@@ -2,27 +2,42 @@ package com.mapbox.navigation.core
 
 import android.app.NotificationManager
 import android.content.Context
+import android.location.Location
 import com.mapbox.android.core.location.LocationEngine
 import com.mapbox.android.core.location.LocationEngineRequest
+import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.api.directions.v5.models.RouteOptions
+import com.mapbox.navigation.base.options.MapboxOnboardRouterConfig
 import com.mapbox.navigation.base.options.NavigationOptions
+import com.mapbox.navigation.base.route.internal.RouteUrl
+import com.mapbox.navigation.base.trip.model.RouteProgress
+import com.mapbox.navigation.base.typedef.NONE_SPECIFIED
 import com.mapbox.navigation.core.directions.session.DirectionsSession
+import com.mapbox.navigation.core.directions.session.RoutesRequestCallback
+import com.mapbox.navigation.core.fasterroute.FasterRouteDetector
+import com.mapbox.navigation.core.fasterroute.FasterRouteObserver
 import com.mapbox.navigation.core.trip.service.TripService
 import com.mapbox.navigation.core.trip.session.TripSession
 import com.mapbox.navigation.utils.extensions.inferDeviceLocale
+import com.mapbox.navigation.utils.timer.MapboxTimer
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
+import io.mockk.slot
 import io.mockk.verify
 import java.util.Locale
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.InternalCoroutinesApi
 import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
 
+@InternalCoroutinesApi
+@ExperimentalCoroutinesApi
 class MapboxNavigationTest {
 
-    private lateinit var mapboxNavigation: MapboxNavigation
     private val accessToken = "pk.1234"
     private val context: Context = mockk(relaxed = true)
     private val applicationContext: Context = mockk(relaxed = true)
@@ -31,6 +46,18 @@ class MapboxNavigationTest {
     private val directionsSession: DirectionsSession = mockk(relaxUnitFun = true)
     private val tripSession: TripSession = mockk(relaxUnitFun = true)
     private val tripService: TripService = mockk(relaxUnitFun = true)
+    private val location: Location = mockk(relaxUnitFun = true)
+    private val distanceFormatter: MapboxDistanceFormatter = mockk(relaxed = true)
+    private val onBoardRouterConfig: MapboxOnboardRouterConfig = mockk(relaxed = true)
+    private val fasterRouteRequestCallback: RoutesRequestCallback = mockk(relaxed = true)
+    private val routeOptions: RouteOptions = provideDefaultRouteOptionsBuilder().build()
+    private val fasterRouteObserver: FasterRouteObserver = mockk(relaxUnitFun = true)
+    private val mapboxTimer: MapboxTimer = mockk(relaxUnitFun = true)
+    private val routes: List<DirectionsRoute> = listOf(mockk())
+    private val routeProgress: RouteProgress = mockk(relaxed = true)
+
+    private lateinit var delayLambda: () -> Unit
+    private lateinit var mapboxNavigation: MapboxNavigation
 
     companion object {
         @BeforeClass
@@ -42,28 +69,29 @@ class MapboxNavigationTest {
 
     @Before
     fun setUp() {
+        mockkObject(NavigationComponentProvider)
+
         every { context.inferDeviceLocale() } returns Locale.US
         every { context.applicationContext } returns applicationContext
         val notificationManager = mockk<NotificationManager>()
         every { applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) } returns notificationManager
 
-        mockkObject(NavigationComponentProvider)
-        every { NavigationComponentProvider.createDirectionsSession(any()) } returns directionsSession
-        every {
-            NavigationComponentProvider.createTripService(
-                applicationContext,
-                any()
-            )
-        } returns tripService
-        every {
-            NavigationComponentProvider.createTripSession(
-                tripService,
-                locationEngine,
-                locationEngineRequest,
-                any()
-            )
-        } returns tripSession
-        val navigationOptions = mockk<NavigationOptions>(relaxed = true)
+        mockLocation()
+        mockMapboxTimer()
+        mockTripService()
+        mockTripSession()
+        mockDirectionSession()
+
+        val navigationOptions = NavigationOptions
+                .Builder()
+                .distanceFormatter(distanceFormatter)
+                .fasterRouteDetectorInterval(1000L)
+                .navigatorPollingDelay(1500L)
+                .onboardRouterConfig(onBoardRouterConfig)
+                .roundingIncrement(1)
+                .timeFormatType(NONE_SPECIFIED)
+                .build()
+
         mapboxNavigation =
             MapboxNavigation(
                 context,
@@ -127,4 +155,101 @@ class MapboxNavigationTest {
 
         verify(exactly = 1) { tripSession.unregisterAllVoiceInstructionsObservers() }
     }
+
+    @Test
+    fun fasterRoute_timerStarted() {
+        mapboxNavigation.registerFasterRouteObserver(fasterRouteObserver)
+        verify { mapboxTimer.start() }
+    }
+
+    @Test
+    fun fasterRoute_timerStopped() {
+        mapboxNavigation.registerFasterRouteObserver(fasterRouteObserver)
+        mapboxNavigation.unregisterFasterRouteObserver(fasterRouteObserver)
+        verify { mapboxTimer.stop() }
+    }
+
+    @Test
+    fun fasterRoute_noRouteOptions_noRequest() {
+        every { directionsSession.getRouteOptions() } returns null
+        delayLambda()
+        verify(exactly = 0) { directionsSession.requestFasterRoute(any(), any()) }
+    }
+
+    @Test
+    fun fasterRoute_noEnhancedLocation_noRequest() {
+        every { tripSession.getEnhancedLocation() } returns null
+        delayLambda()
+        verify(exactly = 0) { directionsSession.requestFasterRoute(any(), any()) }
+    }
+
+    @Test
+    fun fasterRoute_makeRequest() {
+        delayLambda()
+        verify(exactly = 1) { directionsSession.requestFasterRoute(any(), any()) }
+    }
+
+    @Test
+    fun fasterRoute_fasterRouteNotAvailable() {
+        mockkObject(FasterRouteDetector)
+        every { FasterRouteDetector.isRouteFaster(any(), any()) } returns false
+        mapboxNavigation.registerFasterRouteObserver(fasterRouteObserver)
+        delayLambda()
+        verify(exactly = 0) { fasterRouteObserver.onFasterRouteAvailable(routes[0]) }
+    }
+
+    private fun mockTripService() {
+        every {
+            NavigationComponentProvider.createTripService(
+                    applicationContext,
+                    any()
+            )
+        } returns tripService
+    }
+
+    private fun mockMapboxTimer() {
+        val lambda = slot<() -> Unit>()
+        every { NavigationComponentProvider.createMapboxTimer(1000L, capture(lambda)) } answers {
+            delayLambda = lambda.captured
+            mapboxTimer
+        }
+    }
+
+    private fun mockLocation() {
+        every { location.longitude } returns -122.789876
+        every { location.latitude } returns 37.657483
+    }
+
+    private fun mockDirectionSession() {
+        every { NavigationComponentProvider.createDirectionsSession(any()) } answers {
+            directionsSession
+        }
+        every { directionsSession.getRouteOptions() } returns routeOptions
+        every { directionsSession.requestFasterRoute(any(), any()) } answers {
+            fasterRouteRequestCallback.onRoutesReady(routes)
+        }
+    }
+
+    private fun mockTripSession() {
+        every {
+            NavigationComponentProvider.createTripSession(
+                    tripService,
+                    locationEngine,
+                    locationEngineRequest,
+                    any()
+            )
+        } returns tripSession
+        every { tripSession.getEnhancedLocation() } returns location
+        every { tripSession.getRouteProgress() } returns routeProgress
+    }
+
+    private fun provideDefaultRouteOptionsBuilder() =
+        RouteOptions.builder()
+            .accessToken(accessToken)
+            .baseUrl(RouteUrl.BASE_URL)
+            .user(RouteUrl.PROFILE_DEFAULT_USER)
+            .profile(RouteUrl.PROFILE_DRIVING)
+            .coordinates(emptyList())
+            .geometries("")
+            .requestUuid("")
 }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/directions/session/MapboxDirectionsSessionTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/directions/session/MapboxDirectionsSessionTest.kt
@@ -32,6 +32,7 @@ class MapboxDirectionsSessionTest {
         every { router.getRoute(routeOptions, capture(listener)) } answers {
             callback = listener.captured
         }
+        every { routes[0].routeOptions() } returns routeOptions
         mockkObject(NavigationComponentProvider)
         every { routesRequestCallback.onRoutesReady(any()) } answers {
             this.value
@@ -87,9 +88,8 @@ class MapboxDirectionsSessionTest {
 
     @Test
     fun getRouteOptions() {
-        val routeOptions: RouteOptions = mockk()
         session.requestRoutes(routeOptions, routesRequestCallback)
-
+        callback.onResponse(routes)
         assertEquals(routeOptions, session.getRouteOptions())
     }
 
@@ -120,6 +120,7 @@ class MapboxDirectionsSessionTest {
         session.requestRoutes(routeOptions, routesRequestCallback)
         callback.onResponse(routes)
         val newRoutes: List<DirectionsRoute> = listOf(mockk())
+        every { newRoutes[0].routeOptions() } returns routeOptions
         session.routes = newRoutes
         verify(exactly = 1) { observer.onRoutesChanged(newRoutes) }
     }


### PR DESCRIPTION
## Description

Add logic to use user current location to request for faster route. Compare new route with current route to determine if it is faster [#221](https://github.com/mapbox/navigation-sdks/issues/221)

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Add logic to use user current location to request for faster route. Compare new route with current route to determine if it is faster.

### Implementation

Add logic to use user current location to request for faster route. Compare new route with current route to determine if it is faster.

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->