### PR TITLE
Add router tile configurations

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/tiles/NavigationRouterParamsProvider.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/tiles/NavigationRouterParamsProvider.kt
@@ -1,0 +1,44 @@
+package com.mapbox.navigation.core.tiles
+
+import com.mapbox.navigator.RouterParams
+import com.mapbox.navigator.TileEndpointConfiguration
+
+class NavigationRouterParamsProvider {
+
+    fun provideRouterParams(tilePath: String, routerTilesParams: RouterTilesParams, accessToken: String): RouterParams {
+        val endPointConfig = TileEndpointConfiguration(
+                routerTilesParams.endpointHost,
+                routerTilesParams.endpointVersion,
+                accessToken,
+                DEFAULT_USER_AGENT,
+                "" // will be removed in the next nav-native release
+        )
+
+        return RouterParams(
+                tilePath,
+                null,
+                null,
+                2,
+                endPointConfig
+        )
+    }
+
+    companion object {
+        const val DEFAULT_USER_AGENT = "MapboxNavigationNative"
+
+        val OSM_2020_02_02 = RouterTilesParams(
+                "https://api-routing-tiles-staging.tilestream.net",
+                "2020_02_02-00_00_11"
+        )
+
+        val OSM_2019_04_13 = RouterTilesParams(
+                "https://api-routing-tiles-staging.tilestream.net",
+                "2019_04_13-00_00_11"
+        )
+
+        val ZENRIN_2020_01_14 = RouterTilesParams(
+                "https://api-routing-tiles-zenrin-staging.tilestream.net",
+                "2020_01_14-03_00_00"
+        )
+    }
+}

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/tiles/NavigationRouterParamsProvider.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/tiles/NavigationRouterParamsProvider.kt
@@ -25,20 +25,5 @@ class NavigationRouterParamsProvider {
 
     companion object {
         const val DEFAULT_USER_AGENT = "MapboxNavigationNative"
-
-        val OSM_2020_02_02 = RouterTilesParams(
-                "https://api-routing-tiles-staging.tilestream.net",
-                "2020_02_02-00_00_11"
-        )
-
-        val OSM_2019_04_13 = RouterTilesParams(
-                "https://api-routing-tiles-staging.tilestream.net",
-                "2019_04_13-00_00_11"
-        )
-
-        val ZENRIN_2020_01_14 = RouterTilesParams(
-                "https://api-routing-tiles-zenrin-staging.tilestream.net",
-                "2020_01_14-03_00_00"
-        )
     }
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/tiles/RouterTilesParams.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/tiles/RouterTilesParams.kt
@@ -1,0 +1,6 @@
+package com.mapbox.navigation.core.tiles
+
+data class RouterTilesParams(
+    val endpointHost: String,
+    val endpointVersion: String
+)


### PR DESCRIPTION
## Description

We are testing onboard router configurations. https://github.com/mapbox/driver/issues/424

References for when they were added to the driver app https://github.com/mapbox/driver/pull/418, https://github.com/mapbox/driver/pull/428

- [x] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal

Currently there are only a few router configurations available. But this unblocks development for improving onboard router configurations. Allow us to develop test new features on a master branch https://github.com/mapbox/driver/pull/435

### Implementation

Included in the comment. But configuring onboard routing tiles is gathering requirements. We need to manage on board files, have the ability to know if they're loaded, and possibly more. 

## Testing

The current test environment for this feature is poor. 

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->

cc: @Guardiola31337 @LukasPaczos @mskurydin 