### PR TITLE
Expose settings option to collect nav native history

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/MainActivity.java
+++ b/examples/src/main/java/com/mapbox/navigation/examples/MainActivity.java
@@ -1,8 +1,10 @@
 package com.mapbox.navigation.examples;
 
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
+import android.preference.PreferenceManager;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -10,6 +12,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
@@ -27,6 +30,7 @@ import com.mapbox.navigation.examples.activity.OnboardRouterActivityKt;
 import com.mapbox.navigation.examples.activity.SimpleMapboxNavigationKt;
 import com.mapbox.navigation.examples.activity.TripServiceActivityKt;
 import com.mapbox.navigation.examples.activity.TripSessionActivityKt;
+import com.mapbox.navigation.navigator.MapboxNativeNavigatorImpl;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -51,6 +55,8 @@ public class MainActivity extends AppCompatActivity implements PermissionsListen
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_main);
     ButterKnife.bind(this);
+
+    updateNavNativeHistoryCollection();
 
     settingsFab.setOnClickListener(v -> startActivityForResult(
             new Intent(MainActivity.this, NavigationSettingsActivity.class),
@@ -159,6 +165,20 @@ public class MainActivity extends AppCompatActivity implements PermissionsListen
       permissionsNeeded.add(permission);
       ActivityCompat.requestPermissions(this, permissionsNeeded.toArray(new String[0]), 10);
     }
+  }
+
+  @Override
+  protected void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
+    super.onActivityResult(requestCode, resultCode, data);
+    if (requestCode == CHANGE_SETTING_REQUEST_CODE) {
+      updateNavNativeHistoryCollection();
+    }
+  }
+
+  private void updateNavNativeHistoryCollection() {
+    SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
+    MapboxNativeNavigatorImpl.INSTANCE.toggleHistory(
+            prefs.getBoolean(getString(R.string.nav_native_history_collect_key), false));
   }
 
   /*

--- a/examples/src/main/res/values/strings.xml
+++ b/examples/src/main/res/values/strings.xml
@@ -40,6 +40,9 @@
     <string name="route_profile_key" translatable="false">route_profile</string>
     <string name="default_route_profile">driving-traffic</string>
     <string name="git_hash_key" translatable="false">git_hash</string>
+    <string name="nav_native_history_retrieve_key" translatable="false">nav_native_history_retrieve</string>
+    <string name="nav_native_history_collect_key" translatable="false">nav_native_history_collect</string>
+    <string name="nav_native_history_collect" translatable="false">Collect Nav Native history</string>
     <string name="offline_version_key" translatable="false">offline_preference_key</string>
     <string name="offline_region_download" translatable="false">offline_region_download</string>
     <string name="offline_enabled" translatable="false">offline_region_download</string>

--- a/examples/src/main/res/xml/fragment_navigation_preferences.xml
+++ b/examples/src/main/res/xml/fragment_navigation_preferences.xml
@@ -13,6 +13,15 @@
 
         <CheckBoxPreference
             android:defaultValue="false"
+            android:key="@string/nav_native_history_collect_key"
+            android:title="@string/nav_native_history_collect"/>
+
+        <Preference
+            android:key="@string/nav_native_history_retrieve_key"
+            android:title="Save Nav Native history"/>
+
+        <CheckBoxPreference
+            android:defaultValue="false"
             android:key="@string/simulate_route_key"
             android:title="@string/simulate_route"/>
 


### PR DESCRIPTION
![ezgif com-video-to-gif (16)](https://user-images.githubusercontent.com/16925074/74540941-f5e2bc80-4f40-11ea-861d-8d781bff920b.gif)

After opting-in, the `examples` module (that contains examples for Nav SDK 1.0) will start collecting Nav Native history. At any point, we can come back to opt-out or export the collected traces.

The traces are saved to the device's public directory under `{public_dir}/navigation_debug/history_{timestamp}`.

/cc @mapbox/navnative @mapbox/navigation-android 