### PR TITLE
Showcase hiding notification in free-drive. Refactor TripSession state.

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -38,6 +38,7 @@ import com.mapbox.navigation.core.trip.session.LocationObserver
 import com.mapbox.navigation.core.trip.session.OffRouteObserver
 import com.mapbox.navigation.core.trip.session.RouteProgressObserver
 import com.mapbox.navigation.core.trip.session.TripSession
+import com.mapbox.navigation.core.trip.session.TripSessionState
 import com.mapbox.navigation.core.trip.session.TripSessionStateObserver
 import com.mapbox.navigation.core.trip.session.VoiceInstructionsObserver
 import com.mapbox.navigation.navigator.MapboxNativeNavigator
@@ -192,6 +193,11 @@ constructor(
     fun stopTripSession() {
         tripSession.stop()
     }
+
+    /**
+     * Return the current [TripSessionState].
+     */
+    fun getTripSessionState() = tripSession.getState()
 
     /**
      * Requests a route using the provided [Router] implementation.

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/NavigationSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/NavigationSession.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.navigation.core.accounts.MapboxNavigationAccounts
 import com.mapbox.navigation.core.directions.session.RoutesObserver
+import com.mapbox.navigation.core.trip.session.TripSessionState
 import com.mapbox.navigation.core.trip.session.TripSessionStateObserver
 
 internal class NavigationSession(private val context: Context) : RoutesObserver,
@@ -57,12 +58,11 @@ internal class NavigationSession(private val context: Context) : RoutesObserver,
         hasRoutes = routes.isNotEmpty()
     }
 
-    override fun onSessionStarted() {
-        isDriving = true
-    }
-
-    override fun onSessionStopped() {
-        isDriving = false
+    override fun onSessionStateChanged(tripSessionState: TripSessionState) {
+        isDriving = when (tripSessionState) {
+            TripSessionState.STARTED -> true
+            TripSessionState.STOPPED -> false
+        }
     }
 
     private enum class State {

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/TripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/TripSession.kt
@@ -17,6 +17,7 @@ internal interface TripSession {
     fun getRawLocation(): Location?
     fun getEnhancedLocation(): Location?
     fun getRouteProgress(): RouteProgress?
+    fun getState(): TripSessionState
 
     fun start()
     fun stop()

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/TripSessionState.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/TripSessionState.kt
@@ -1,0 +1,16 @@
+package com.mapbox.navigation.core.trip.session
+
+/**
+ * Describes the [TripSession]'s state.
+ */
+enum class TripSessionState {
+    /**
+     * State when the session is active, running a foreground service and requesting and returning location updates.
+     */
+    STARTED,
+
+    /**
+     * State when the session is inactive.
+     */
+    STOPPED
+}

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/TripSessionStateObserver.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/TripSessionStateObserver.kt
@@ -1,6 +1,5 @@
 package com.mapbox.navigation.core.trip.session
 
 interface TripSessionStateObserver {
-    fun onSessionStarted()
-    fun onSessionStopped()
+    fun onSessionStateChanged(tripSessionState: TripSessionState)
 }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/NavigationSessionTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/NavigationSessionTest.kt
@@ -3,6 +3,7 @@ package com.mapbox.navigation.core
 import android.content.Context
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.navigation.core.accounts.MapboxNavigationAccounts
+import com.mapbox.navigation.core.trip.session.TripSessionState
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -34,7 +35,7 @@ class NavigationSessionTest {
 
     @Test
     fun drive_only() {
-        navigationSession.onSessionStarted()
+        navigationSession.onSessionStateChanged(TripSessionState.STARTED)
         verify(exactly = 0) { accounts.navigationStarted() }
         verify(exactly = 0) { accounts.navigationStopped() }
     }
@@ -49,7 +50,7 @@ class NavigationSessionTest {
 
     @Test
     fun drive_route() {
-        navigationSession.onSessionStarted()
+        navigationSession.onSessionStateChanged(TripSessionState.STARTED)
         routes.add(route)
         navigationSession.onRoutesChanged(routes)
         verify(exactly = 1) { accounts.navigationStarted() }
@@ -59,13 +60,13 @@ class NavigationSessionTest {
     fun route_drive() {
         routes.add(route)
         navigationSession.onRoutesChanged(routes)
-        navigationSession.onSessionStarted()
+        navigationSession.onSessionStateChanged(TripSessionState.STARTED)
         verify(exactly = 1) { accounts.navigationStarted() }
     }
 
     @Test
     fun drive_route_noRoute() {
-        navigationSession.onSessionStarted()
+        navigationSession.onSessionStateChanged(TripSessionState.STARTED)
         routes.add(route)
         navigationSession.onRoutesChanged(routes)
         navigationSession.onRoutesChanged(emptyList())
@@ -74,10 +75,10 @@ class NavigationSessionTest {
 
     @Test
     fun drive_route_noDrive() {
-        navigationSession.onSessionStarted()
+        navigationSession.onSessionStateChanged(TripSessionState.STARTED)
         routes.add(route)
         navigationSession.onRoutesChanged(routes)
-        navigationSession.onSessionStopped()
+        navigationSession.onSessionStateChanged(TripSessionState.STOPPED)
         verify(exactly = 1) { accounts.navigationStopped() }
     }
 
@@ -85,7 +86,7 @@ class NavigationSessionTest {
     fun route_drive_noRoute() {
         routes.add(route)
         navigationSession.onRoutesChanged(routes)
-        navigationSession.onSessionStarted()
+        navigationSession.onSessionStateChanged(TripSessionState.STARTED)
         navigationSession.onRoutesChanged(emptyList())
         verify(exactly = 1) { accounts.navigationStopped() }
     }
@@ -94,8 +95,8 @@ class NavigationSessionTest {
     fun route_drive_noDrive() {
         routes.add(route)
         navigationSession.onRoutesChanged(routes)
-        navigationSession.onSessionStarted()
-        navigationSession.onSessionStopped()
+        navigationSession.onSessionStateChanged(TripSessionState.STARTED)
+        navigationSession.onSessionStateChanged(TripSessionState.STOPPED)
         verify(exactly = 1) { accounts.navigationStopped() }
     }
 
@@ -103,9 +104,9 @@ class NavigationSessionTest {
     fun route_drive_noRoute_noDrive() {
         routes.add(route)
         navigationSession.onRoutesChanged(routes)
-        navigationSession.onSessionStarted()
+        navigationSession.onSessionStateChanged(TripSessionState.STARTED)
         navigationSession.onRoutesChanged(emptyList())
-        navigationSession.onSessionStopped()
+        navigationSession.onSessionStateChanged(TripSessionState.STOPPED)
         verify(exactly = 1) { accounts.navigationStopped() }
     }
 
@@ -113,8 +114,8 @@ class NavigationSessionTest {
     fun route_drive_noDrive_noRoute() {
         routes.add(route)
         navigationSession.onRoutesChanged(routes)
-        navigationSession.onSessionStarted()
-        navigationSession.onSessionStopped()
+        navigationSession.onSessionStateChanged(TripSessionState.STARTED)
+        navigationSession.onSessionStateChanged(TripSessionState.STOPPED)
         navigationSession.onRoutesChanged(emptyList())
         verify(exactly = 1) { accounts.navigationStopped() }
     }
@@ -123,9 +124,9 @@ class NavigationSessionTest {
     fun restart_drive() {
         routes.add(route)
         navigationSession.onRoutesChanged(routes)
-        navigationSession.onSessionStarted()
-        navigationSession.onSessionStopped()
-        navigationSession.onSessionStarted()
+        navigationSession.onSessionStateChanged(TripSessionState.STARTED)
+        navigationSession.onSessionStateChanged(TripSessionState.STOPPED)
+        navigationSession.onSessionStateChanged(TripSessionState.STARTED)
         verify(exactly = 2) { accounts.navigationStarted() }
     }
 
@@ -133,7 +134,7 @@ class NavigationSessionTest {
     fun restart_route() {
         routes.add(route)
         navigationSession.onRoutesChanged(routes)
-        navigationSession.onSessionStarted()
+        navigationSession.onSessionStateChanged(TripSessionState.STARTED)
         navigationSession.onRoutesChanged(emptyList())
         navigationSession.onRoutesChanged(routes)
         verify(exactly = 2) { accounts.navigationStarted() }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
@@ -17,6 +17,7 @@ import com.mapbox.navigation.testing.MainCoroutineRule
 import com.mapbox.navigation.utils.thread.JobControl
 import com.mapbox.navigation.utils.thread.ThreadController
 import com.mapbox.navigator.NavigationStatus
+import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -68,6 +69,8 @@ class MapboxTripSessionTest {
 
     private val parentJob = SupervisorJob()
     private val testScope = CoroutineScope(parentJob + coroutineRule.testDispatcher)
+
+    private val stateObserver: TripSessionStateObserver = mockk(relaxUnitFun = true)
 
     @Before
     fun setUp() {
@@ -344,6 +347,61 @@ class MapboxTripSessionTest {
     }
 
     @Test
+    fun stateObserverImmediateStop() {
+        tripSession.registerStateObserver(stateObserver)
+        verify(exactly = 1) { stateObserver.onSessionStateChanged(TripSessionState.STOPPED) }
+    }
+
+    @Test
+    fun stateObserverImmediateStart() {
+        tripSession.start()
+        tripSession.registerStateObserver(stateObserver)
+        verify(exactly = 1) { stateObserver.onSessionStateChanged(TripSessionState.STARTED) }
+    }
+
+    @Test
+    fun stateObserverStart() {
+        tripSession.registerStateObserver(stateObserver)
+        tripSession.start()
+        verify(exactly = 1) { stateObserver.onSessionStateChanged(TripSessionState.STARTED) }
+    }
+
+    @Test
+    fun stateObserverStop() {
+        tripSession.start()
+        tripSession.registerStateObserver(stateObserver)
+        tripSession.stop()
+        verify(exactly = 1) { stateObserver.onSessionStateChanged(TripSessionState.STOPPED) }
+    }
+
+    @Test
+    fun stateObserverDoubleStart() {
+        tripSession.registerStateObserver(stateObserver)
+        tripSession.start()
+        tripSession.start()
+        verify(exactly = 1) { stateObserver.onSessionStateChanged(TripSessionState.STARTED) }
+    }
+
+    @Test
+    fun stateObserverDoubleStop() {
+        tripSession.start()
+        tripSession.registerStateObserver(stateObserver)
+        tripSession.stop()
+        tripSession.stop()
+        verify(exactly = 1) { stateObserver.onSessionStateChanged(TripSessionState.STOPPED) }
+    }
+
+    @Test
+    fun stateObserverUnregister() {
+        tripSession.registerStateObserver(stateObserver)
+        clearMocks(stateObserver)
+        tripSession.unregisterStateObserver(stateObserver)
+        tripSession.start()
+        tripSession.stop()
+        verify(exactly = 0) { stateObserver.onSessionStateChanged(any()) }
+    }
+
+    @Test
     fun unregisterAllLocationObservers() = coroutineRule.runBlockingTest {
         every { routeProgress.bannerInstructions() } returns null
         every { routeProgress.voiceInstructions() } returns null
@@ -412,19 +470,13 @@ class MapboxTripSessionTest {
 
     @Test
     fun unregisterAllStateObservers() = coroutineRule.runBlockingTest {
-        val stateObserver: TripSessionStateObserver = mockk(relaxUnitFun = true)
-
         tripSession.registerStateObserver(stateObserver)
-
-        tripSession.start()
-
+        clearMocks(stateObserver)
         tripSession.unregisterAllStateObservers()
 
-        // stop() would normally trigger a call to stateObserver.onSessionStopped()
         tripSession.stop()
 
-        verify(exactly = 1) { stateObserver.onSessionStarted() }
-        verify(exactly = 1) { stateObserver.onSessionStopped() }
+        verify(exactly = 0) { stateObserver.onSessionStateChanged(any()) }
     }
 
     @Test


### PR DESCRIPTION
Changes in `SimpleMapboxActivityKt` try to showcase how to manage the state of the `TripSession` to hide the notification when going into the background in Free Drive state, but keeping the notification and service alive when in Active Guidance.

Additionally, this PR refactors `TripSessionState` to be more friendly to use.