### PR TITLE
Sb 246 migrate to updated dynamic camera

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationView.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationView.java
@@ -31,12 +31,13 @@ import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.navigation.base.formatter.DistanceFormatter;
-import com.mapbox.navigation.core.location.ReplayRouteLocationEngine;
 import com.mapbox.navigation.base.options.NavigationOptions;
 import com.mapbox.navigation.base.route.Router;
 import com.mapbox.navigation.base.typedef.TimeFormatType;
 import com.mapbox.navigation.core.MapboxDistanceFormatter;
 import com.mapbox.navigation.core.MapboxNavigation;
+import com.mapbox.navigation.core.location.ReplayRouteLocationEngine;
+import com.mapbox.navigation.ui.camera.DynamicCamera;
 import com.mapbox.navigation.ui.camera.NavigationCamera;
 import com.mapbox.navigation.ui.instruction.ImageCreator;
 import com.mapbox.navigation.ui.instruction.InstructionView;
@@ -635,6 +636,12 @@ public class NavigationView extends CoordinatorLayout implements LifecycleOwner,
     navigationViewModel.initialize(options);
     initializeNavigationListeners(options, navigationViewModel);
     setupNavigationMapboxMap(options);
+
+    if (options.camera() == null) {
+      navigationMap.setCamera(new DynamicCamera(navigationMap.retrieveMap()));
+    } else {
+      navigationMap.setCamera(options.camera());
+    }
 
     if (!isSubscribed) {
       initializeClickListeners();

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/camera/NavigationCamera.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/camera/NavigationCamera.java
@@ -91,6 +91,7 @@ public class NavigationCamera implements LifecycleObserver {
   private int trackingCameraMode = NAVIGATION_TRACKING_MODE_GPS;
   private boolean isCameraResetting;
   private CameraAnimationDelegate animationDelegate;
+  private Camera camera;
 
   private RouteProgressObserver routeProgressObserver = new RouteProgressObserver() {
     @Override
@@ -130,7 +131,7 @@ public class NavigationCamera implements LifecycleObserver {
     this.locationComponent = locationComponent;
     this.animationDelegate = new CameraAnimationDelegate(mapboxMap);
     this.locationComponent.addOnCameraTrackingChangedListener(cameraTrackingChangedListener);
-    initializeWith(navigation);
+    updateCameraTrackingMode(trackingCameraMode);
   }
 
   /**
@@ -325,7 +326,6 @@ public class NavigationCamera implements LifecycleObserver {
    */
   public void addProgressChangeListener(MapboxNavigation navigation) {
     this.navigation = navigation;
-    /*navigation.setCameraEngine(new DynamicCamera(mapboxMap));*/
     navigation.registerRouteProgressObserver(routeProgressObserver);
   }
 
@@ -407,11 +407,6 @@ public class NavigationCamera implements LifecycleObserver {
     this.isCameraResetting = isResetting;
   }
 
-  private void initializeWith(MapboxNavigation navigation) {
-    /*navigation.setCameraEngine(new DynamicCamera(mapboxMap));*/
-    updateCameraTrackingMode(trackingCameraMode);
-  }
-
   private void tryToBuildRouteInformationAndAdjustCamera() {
     if (isTrackingEnabled()) {
       currentRouteInformation =
@@ -460,11 +455,10 @@ public class NavigationCamera implements LifecycleObserver {
   }
 
   private void animateCameraForRouteOverview(RouteInformation routeInformation, int[] padding) {
-    /*Camera cameraEngine = navigation.getCameraEngine();
-    List<Point> routePoints = cameraEngine.overview(routeInformation);
+    List<Point> routePoints = camera.overview(routeInformation);
     if (!routePoints.isEmpty()) {
       animateMapboxMapForRouteOverview(padding, routePoints);
-    }*/
+    }
   }
 
   private void animateMapboxMapForRouteOverview(int[] padding, List<Point> routePoints) {
@@ -536,7 +530,7 @@ public class NavigationCamera implements LifecycleObserver {
 
   private void resetWith(@TrackingMode int trackingMode) {
     updateIsResetting(true);
-    /*resetDynamicCamera(navigation.getCameraEngine());*/
+    resetDynamicCamera(camera);
     updateCameraTrackingMode(trackingMode);
   }
 
@@ -547,19 +541,17 @@ public class NavigationCamera implements LifecycleObserver {
   }
 
   private void adjustCameraForReset(RouteInformation routeInformation) {
-    /*Camera camera = navigation.getCameraEngine();
     float tilt = (float) camera.tilt(routeInformation);
     double zoom = camera.zoom(routeInformation);
     locationComponent.zoomWhileTracking(zoom, getZoomAnimationDuration(zoom), new ResetCancelableCallback(this));
-    locationComponent.tiltWhileTracking(tilt, getTiltAnimationDuration(tilt));*/
+    locationComponent.tiltWhileTracking(tilt, getTiltAnimationDuration(tilt));
   }
 
   private void adjustCameraFromLocation(RouteInformation routeInformation) {
-    /*Camera camera = navigation.getCameraEngine();
     float tilt = (float) camera.tilt(routeInformation);
     double zoom = camera.zoom(routeInformation);
     locationComponent.zoomWhileTracking(zoom, getZoomAnimationDuration(zoom));
-    locationComponent.tiltWhileTracking(tilt, getTiltAnimationDuration(tilt));*/
+    locationComponent.tiltWhileTracking(tilt, getTiltAnimationDuration(tilt));
   }
 
   private long getZoomAnimationDuration(double zoom) {
@@ -584,5 +576,9 @@ public class NavigationCamera implements LifecycleObserver {
           NAVIGATION_TRACKING_MODE_NONE
   })
   public @interface TrackingMode {
+  }
+
+  public void setCamera(Camera camera) {
+    this.camera = camera;
   }
 }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/NavigationMapboxMap.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/NavigationMapboxMap.java
@@ -32,6 +32,7 @@ import com.mapbox.mapboxsdk.style.sources.VectorSource;
 import com.mapbox.navigation.core.MapboxNavigation;
 import com.mapbox.navigation.ui.NavigationSnapshotReadyCallback;
 import com.mapbox.navigation.ui.ThemeSwitcher;
+import com.mapbox.navigation.ui.camera.Camera;
 import com.mapbox.navigation.ui.camera.NavigationCamera;
 import com.mapbox.navigation.ui.route.NavigationMapRoute;
 import com.mapbox.navigation.ui.route.OnRouteSelectionChangeListener;
@@ -805,5 +806,9 @@ public class NavigationMapboxMap {
       mapFpsDelegate.onStop();
       removeFpsListenersFromCamera();
     }
+  }
+
+  public void setCamera(Camera camera) {
+    mapCamera.setCamera(camera);
   }
 }

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/camera/NavigationCameraTest.java
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/camera/NavigationCameraTest.java
@@ -1,11 +1,13 @@
 package com.mapbox.navigation.ui.camera;
 
+import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.camera.CameraUpdate;
 import com.mapbox.mapboxsdk.location.LocationComponent;
 import com.mapbox.mapboxsdk.location.OnLocationCameraTransitionListener;
 import com.mapbox.mapboxsdk.location.modes.CameraMode;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.navigation.core.MapboxNavigation;
+import com.mapbox.navigation.core.trip.session.RouteProgressObserver;
 import com.mapbox.navigation.ui.BaseTest;
 
 import org.junit.Test;
@@ -81,15 +83,13 @@ public class NavigationCameraTest extends BaseTest {
     assertTrue(camera.isTrackingEnabled());
   }
 
-  /*@Test
+  @Test
   public void onResetCamera_dynamicCameraIsReset() {
     MapboxMap mapboxMap = mock(MapboxMap.class);
     when(mapboxMap.getCameraPosition()).thenReturn(mock(CameraPosition.class));
-    MapboxNavigation navigation = mock(MapboxNavigation.class);
     DynamicCamera dynamicCamera = mock(DynamicCamera.class);
-    when(navigation.getCameraEngine()).thenReturn(dynamicCamera);
-    RouteInformation currentRouteInformation = mock(RouteInformation.class);
-    NavigationCamera camera = buildCamera(mapboxMap, navigation, currentRouteInformation);
+    NavigationCamera camera = buildCamera(mapboxMap);
+    camera.setCamera(dynamicCamera);
 
     camera.resetCameraPositionWith(NavigationCamera.NAVIGATION_TRACKING_MODE_GPS);
 
@@ -98,25 +98,25 @@ public class NavigationCameraTest extends BaseTest {
 
   @Test
   public void onStartWithNullRoute_progressListenerIsAdded() {
+    MapboxMap mapboxMap = mock(MapboxMap.class);
     MapboxNavigation navigation = mock(MapboxNavigation.class);
-    ProgressChangeListener listener = mock(ProgressChangeListener.class);
-    NavigationCamera camera = buildCamera(navigation, listener);
+    NavigationCamera camera = buildCamera(mapboxMap, navigation);
 
     camera.start(null);
 
-    verify(navigation, times(1)).addProgressChangeListener(listener);
+    verify(navigation, times(1)).registerRouteProgressObserver(any(RouteProgressObserver.class));
   }
 
   @Test
   public void onResumeWithNullLocation_progressListenerIsAdded() {
+    MapboxMap mapboxMap = mock(MapboxMap.class);
     MapboxNavigation navigation = mock(MapboxNavigation.class);
-    ProgressChangeListener listener = mock(ProgressChangeListener.class);
-    NavigationCamera camera = buildCamera(navigation, listener);
+    NavigationCamera camera = buildCamera(mapboxMap, navigation);
 
     camera.resume(null);
 
-    verify(navigation, times(1)).addProgressChangeListener(listener);
-  }*/
+    verify(navigation, times(1)).registerRouteProgressObserver(any(RouteProgressObserver.class));
+  }
 
   @Test
   public void update_defaultIsIgnoredWhileTracking() {
@@ -196,14 +196,7 @@ public class NavigationCameraTest extends BaseTest {
     return new NavigationCamera(mock(MapboxMap.class), mock(MapboxNavigation.class), locationComponent);
   }
 
-  /*private NavigationCamera buildCamera(MapboxNavigation navigation, ProgressChangeListener listener) {
-    return new NavigationCamera(mock(MapboxMap.class), navigation, listener,
-      mock(LocationComponent.class), mock(RouteInformation.class));
+  private NavigationCamera buildCamera(MapboxMap mapboxMap, MapboxNavigation mapboxNavigation) {
+    return new NavigationCamera(mapboxMap, mapboxNavigation, mock(LocationComponent.class));
   }
-
-  private NavigationCamera buildCamera(MapboxMap mapboxMap, MapboxNavigation navigation,
-                                       RouteInformation routeInformation) {
-    return new NavigationCamera(mapboxMap, navigation, mock(ProgressChangeListener.class),
-      mock(LocationComponent.class), routeInformation);
-  }*/
 }

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/map/NavigationMapboxMapTest.java
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/map/NavigationMapboxMapTest.java
@@ -11,6 +11,7 @@ import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
 import com.mapbox.mapboxsdk.style.sources.Source;
 import com.mapbox.mapboxsdk.style.sources.VectorSource;
 import com.mapbox.navigation.ui.camera.NavigationCamera;
+import com.mapbox.navigation.ui.camera.SimpleCamera;
 import com.mapbox.navigation.ui.route.NavigationMapRoute;
 import com.mapbox.navigation.ui.route.OnRouteSelectionChangeListener;
 
@@ -319,6 +320,22 @@ public class NavigationMapboxMapTest {
     map.addCustomMarker(options);
 
     verify(navigationSymbolManager).addCustomSymbolFor(options);
+  }
+
+  @Test
+  public void setCamera_setsCameraOnMapCamera() {
+    MapWayName mapWayName = mock(MapWayName.class);
+    MapFpsDelegate mapFpsDelegate = mock(MapFpsDelegate.class);
+    NavigationMapRoute mapRoute = mock(NavigationMapRoute.class);
+    NavigationCamera mapCamera = mock(NavigationCamera.class);
+    LocationFpsDelegate locationFpsDelegate = mock(LocationFpsDelegate.class);
+    NavigationMapboxMap theNavigationMap = new NavigationMapboxMap(mapWayName, mapFpsDelegate,
+            mapRoute, mapCamera, locationFpsDelegate);
+    SimpleCamera simpleCamera = new SimpleCamera();
+
+    theNavigationMap.setCamera(simpleCamera);
+
+    verify(mapCamera).setCamera(simpleCamera);
   }
 
   private List<Source> buildMockSourcesWith(String url) {


### PR DESCRIPTION
## Description
In response to: https://github.com/mapbox/navigation-sdks/issues/246

This work was to get the DynamicCamera working with the 1.0 SDK code base. There was a need to set the camera in the UI code without exposing it to core. I think this is needed to ensure others are not blocked in working on other UI compatibility tickets. More work may need to be done on this but I think this is a step forward allowing others to  continue with the compatibility effort.