### PR TITLE
Updated SimpleMapboxNavigation to work with DynamicCamera from (1.0) …

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/location/ReplayRouteLocationEngine.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/location/ReplayRouteLocationEngine.kt
@@ -153,6 +153,7 @@ class ReplayRouteLocationEngine(
         callback: LocationEngineCallback<LocationEngineResult>
     ) {
         handler.removeCallbacks(this)
+        converter.setRoute(route)
         converter.initializeTime()
         mockedLocations = converter.toLocations().toMutableList()
         dispatcher = obtainDispatcher(callback)

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/location/replay/ReplayRouteLocationConverter.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/location/replay/ReplayRouteLocationConverter.kt
@@ -17,7 +17,7 @@ internal class ReplayRouteLocationConverter(
     private var currentLeg: Int = 0
     private var currentStep: Int = 0
     private var time: Long = 0
-    private val route: DirectionsRoute? = null
+    private var route: DirectionsRoute? = null
 
     override val isMultiLegRoute: Boolean
         get() = route?.legs()?.let { legs ->
@@ -51,7 +51,7 @@ internal class ReplayRouteLocationConverter(
     }
 
     override fun setRoute(route: DirectionsRoute) {
-        TODO("not implemented") // To change body of created functions use File | Settings | File Templates.
+        this.route = route
     }
 
     override fun initializeTime() {

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/camera/NavigationCamera.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/camera/NavigationCamera.java
@@ -105,6 +105,7 @@ public class NavigationCamera implements LifecycleObserver {
 
     @Override
     public void onRawLocationChanged(@NotNull Location rawLocation) {
+      rawLocation.toString();
     }
 
     @Override
@@ -408,7 +409,7 @@ public class NavigationCamera implements LifecycleObserver {
   }
 
   private void tryToBuildRouteInformationAndAdjustCamera() {
-    if (isTrackingEnabled()) {
+    if (isTrackingEnabled() && currentRouteProgress != null) {
       currentRouteInformation =
         new RouteInformation(currentRouteProgress.route(), currentLocation, currentRouteProgress);
       if (!isCameraResetting) {

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/MapWayName.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/MapWayName.java
@@ -50,7 +50,7 @@ class MapWayName {
   }
 
   void updateProgress(List<Point> currentStepPoints) {
-    if (!this.currentStepPoints.equals(currentStepPoints)) {
+    if (currentStepPoints != null && !this.currentStepPoints.equals(currentStepPoints)) {
       this.currentStepPoints = currentStepPoints;
     }
   }


### PR DESCRIPTION
##Description
Updated SimpleMapboxNavigation to work with DynamicCamera from (1.0) UI SDK along with the ReplayRouteLocationEngine. The Activity will now honor the simulateRoute preference and if true it will use the replay engine else it will use the normal location engine. When navigation starts the camra will now tilt and zoom as the route is being followed.