### PR TITLE
ReplayRouteLocationEngine: default init `lastLocation` by own provider

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/location/ReplayRouteLocationEngine.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/location/ReplayRouteLocationEngine.kt
@@ -30,7 +30,7 @@ class ReplayRouteLocationEngine(
     private lateinit var mockedLocations: MutableList<Location>
     private lateinit var dispatcher: ReplayLocationDispatcher
     private lateinit var replayLocationListener: ReplayRouteLocationListener
-    private lateinit var lastLocation: Location
+    private var lastLocation = Location(REPLAY_ROUTE)
     private var route: DirectionsRoute? = null
     private var point: Point? = null
 
@@ -57,7 +57,7 @@ class ReplayRouteLocationEngine(
         private const val DELAY_MUST_BE_GREATER_THAN_ZERO_SECONDS =
             "Delay must be greater than 0 seconds."
         private const val REPLAY_ROUTE =
-            "com.mapbox.services.android.navigation.v5.location.replay.ReplayRouteLocationEngine"
+            "com.mapbox.navigation.core.location.ReplayRouteLocationEngine"
     }
 
     fun assign(route: DirectionsRoute) {
@@ -71,7 +71,6 @@ class ReplayRouteLocationEngine(
     }
 
     fun assignLastLocation(currentPosition: Point) {
-        initializeLastLocation()
         lastLocation.longitude = currentPosition.longitude()
         lastLocation.latitude = currentPosition.latitude()
     }
@@ -223,11 +222,5 @@ class ReplayRouteLocationEngine(
         } ?: point?.let {
             startRoute(it, lastLocation, callback)
         } ?: callback.onFailure(Exception("No route found to replay."))
-    }
-
-    private fun initializeLastLocation() {
-        if (!::lastLocation.isInitialized) {
-            lastLocation = Location(REPLAY_ROUTE)
-        }
     }
 }


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

_ReplayRouteLocationEngine_ crashes on `lastLocation` is not initialized

Closes #2514 

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->