### PR TITLE
Use the full host name in the onboard router configuration example

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/SimpleMapboxNavigationKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/SimpleMapboxNavigationKt.kt
@@ -88,7 +88,7 @@ class SimpleMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback {
         val tilesVersion = "2020_02_02-03_00_00"
 
         val endpoint = options.onboardRouterConfig?.endpoint?.toBuilder()
-            ?.host(tilesUri.host)
+            ?.host(tilesUri.toString())
             ?.version(tilesVersion)
             ?.build()
 


### PR DESCRIPTION
Fixes an issue where the `SimpleMapboxNavigationKt` was incorrectly configuring the router which resulted in the
```
E/valhalla: Failed to get URL Failed to connect to api-routing-tiles-staging.tilestream.net port 80: Connection refused
```
because we didn't specify the protocol.

/cc @Lebedinsky