### PR TITLE
Clear navigator's route if the routes list is empty

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/MapboxDirectionsSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/MapboxDirectionsSession.kt
@@ -21,7 +21,7 @@ class MapboxDirectionsSession(
                 return
             }
             field = value
-            if (!routes.isEmpty()) {
+            if (routes.isNotEmpty()) {
                 this.routeOptions = routes[0].routeOptions()
             }
             routesObservers.forEach { it.onRoutesChanged(value) }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
@@ -41,10 +41,8 @@ class MapboxTripSession(
     override var route: DirectionsRoute? = null
         set(value) {
             field = value
-            if (value != null) {
-                ioJobController.scope.launch {
-                    navigator.setRoute(value)
-                }
+            ioJobController.scope.launch {
+                navigator.setRoute(value)
             }
         }
     private val ioJobController: JobControl = threadController.getIOScopeAndRootJob()

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
@@ -16,6 +16,7 @@ import com.mapbox.navigation.base.route.internal.RouteUrl
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.base.typedef.NONE_SPECIFIED
 import com.mapbox.navigation.core.directions.session.DirectionsSession
+import com.mapbox.navigation.core.directions.session.RoutesObserver
 import com.mapbox.navigation.core.directions.session.RoutesRequestCallback
 import com.mapbox.navigation.core.fasterroute.FasterRouteDetector
 import com.mapbox.navigation.core.fasterroute.FasterRouteObserver
@@ -284,6 +285,28 @@ class MapboxNavigationTest {
         offRouteObserverSlot.captured.onOffRouteStateChanged(false)
 
         verify(exactly = 0) { directionsSession.requestRoutes(any(), any()) }
+    }
+
+    @Test
+    fun internalRouteObserver_notEmpty() {
+        val primary: DirectionsRoute = mockk()
+        val secondary: DirectionsRoute = mockk()
+        val routes = listOf(primary, secondary)
+        val routeObserversSlot = mutableListOf<RoutesObserver>()
+        verify { directionsSession.registerRoutesObserver(capture(routeObserversSlot)) }
+        routeObserversSlot[0].onRoutesChanged(routes)
+
+        verify { tripSession.route = primary }
+    }
+
+    @Test
+    fun internalRouteObserver_empty() {
+        val routes = emptyList<DirectionsRoute>()
+        val routeObserversSlot = mutableListOf<RoutesObserver>()
+        verify { directionsSession.registerRoutesObserver(capture(routeObserversSlot)) }
+        routeObserversSlot[0].onRoutesChanged(routes)
+
+        verify { tripSession.route = null }
     }
 
     private fun mockTripService() {

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
@@ -347,6 +347,13 @@ class MapboxTripSessionTest {
     }
 
     @Test
+    fun setRoute_nullable() {
+        tripSession.route = null
+
+        verify { navigator.setRoute(null) }
+    }
+
+    @Test
     fun stateObserverImmediateStop() {
         tripSession.registerStateObserver(stateObserver)
         verify(exactly = 1) { stateObserver.onSessionStateChanged(TripSessionState.STOPPED) }

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/MapboxNativeNavigator.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/MapboxNativeNavigator.kt
@@ -31,7 +31,7 @@ interface MapboxNativeNavigator {
     // Routing
 
     fun setRoute(
-        route: DirectionsRoute,
+        route: DirectionsRoute?,
         routeIndex: Int = INDEX_FIRST_ROUTE,
         legIndex: Int = INDEX_FIRST_LEG
     ): NavigationStatus

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/MapboxNativeNavigatorImpl.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/MapboxNativeNavigatorImpl.kt
@@ -75,12 +75,12 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
     // Routing
 
     override fun setRoute(
-        route: DirectionsRoute,
+        route: DirectionsRoute?,
         routeIndex: Int,
         legIndex: Int
     ): NavigationStatus {
         this.route = route
-        val result = navigator.setRoute(route.toJson(), routeIndex, legIndex)
+        val result = navigator.setRoute(route?.toJson() ?: "{}", routeIndex, legIndex)
         navigator.getRouteBufferGeoJson(GRID_SIZE, BUFFER_DILATION)?.also {
             routeBufferGeoJson = GeometryGeoJson.fromJson(it)
         }


### PR DESCRIPTION
This PR enables us to clear the navigator's route. This is required in a scenario when we finish the active guidance session, but we want to re-enter free drive, so the navigator cannot have a route reference available.

This also fixes a small bug in the examples.