### PR TITLE
kdoc fixes to RouteListener onFinalDestinationArrival() method

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/listeners/RouteListener.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/listeners/RouteListener.java
@@ -68,10 +68,8 @@ public interface RouteListener {
 
   /**
    * Will trigger when a user has arrived at the final destination on
-   * the {@link DirectionsRoute}. The final destination is considered final
-   * {@link com.mapbox.api.directions.v5.models.DirectionsWaypoint} on the route.
-   *
-   * @since 0.42.5
+   * the {@link DirectionsRoute}. The final destination is the same as the final
+   * {@link com.mapbox.api.directions.v5.models.DirectionsWaypoint} along the route.
    */
   void onFinalDestinationArrival();
 }


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Kdocs at https://github.com/mapbox/mapbox-navigation-android/blob/master/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/listeners/RouteListener.java#L74 needed to be adjusted. The `@since` was incorrect and `@since` tags are not being used by the nav team moving forward anyways.

- [ ] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

N/A

### Implementation

N/A

## Screenshots or Gifs

N/A

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->