### PR TITLE
Bump NN version to 9.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,13 @@ allprojects {
         password = project.hasProperty('BINTRAY_API_KEY') ? project.property('BINTRAY_API_KEY') : System.getenv('BINTRAY_API_KEY')
       }
     }
+    maven {
+      url 'https://mapbox.bintray.com/mapbox_collab'
+      credentials {
+        username = project.hasProperty('BINTRAY_USER') ? project.property('BINTRAY_USER') : System.getenv('BINTRAY_USER')
+        password = project.hasProperty('BINTRAY_API_KEY') ? project.property('BINTRAY_API_KEY') : System.getenv('BINTRAY_API_KEY')
+      }
+    }
     maven { url 'https://mapbox.bintray.com/mapbox' }
     maven { url 'https://oss.jfrog.org/artifactory/oss-snapshot-local/' }
   }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -13,7 +13,7 @@ ext {
       mapboxSdkDirectionsModels : '5.1.0-SNAPSHOT',
       mapboxEvents              : '4.7.3',
       mapboxCore                : '1.3.0',
-      mapboxNavigator           : 'km-add-bindings-for-sensor-data-SNAPSHOT-1',
+      mapboxNavigator           : '9.1.0',
       mapboxCrashMonitor        : '2.0.0',
       mapboxAnnotationPlugin    : '0.7.0',
       mapboxAccounts            : '0.3.1',


### PR DESCRIPTION
## Description

Bumps `mapbox-navigation-native` version to ~`9.2.0`~ `9.1.0`

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Getting the latest version from `mapboxNavigator` including the new features and bug fixes.

### Implementation

Bumping the `mapboxNavigator` version to ~`9.2.0`~ `9.1.0` in `dependencies.gradle`

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

Run into a native 💥 when testing `FinalDestinationBuildingFootprintHighlightActivityKt` and `ArrivalUiBuildingExtrusionLayerActivityKt` from `examples` test app:

Steps to reproduce:

1. Bump `mapboxNavigator` version to `9.2.0` in `dependencies.gradle`
2. Build the `examples` test app
3. Click on `Navigation UI SDK` card
4. Click on `Final Destination Building Highlight UI Kotlin`
5. Long press to select a destination
6. Click on `START NAVIGATION`
7. After some location updates 💥 

```
03-09 19:43:54.466 20934-21839/com.mapbox.navigation.examples E/valhalla: Failed to get URL Failed to connect to api-routing-tiles-staging.tilestream.net port 80: Connection refused
    
    --------- beginning of crash
03-09 19:43:54.469 20934-21839/com.mapbox.navigation.examples A/libc: /usr/local/google/buildbot/src/android/ndk-release-r20/external/libcxx/../../external/libcxxabi/src/abort_message.cpp:73: abort_message: assertion "terminating with uncaught exception of type std::runtime_error: Failed to get URL Failed to connect to api-routing-tiles-staging.tilestream.net port 80: Connection refused" failed
03-09 19:43:54.469 20934-21839/com.mapbox.navigation.examples A/libc: Fatal signal 6 (SIGABRT), code -6 in tid 21839 (gation.examples)
03-09 19:43:54.484 20934-20934/com.mapbox.navigation.examples D/FinalDestinationBuildin: enhanced location Location[fused 39.114639,-77.171898 acc=13 et=?!? alt=118.76908111572266 vel=12.567006 bear=218.63884]
03-09 19:43:54.485 20934-20934/com.mapbox.navigation.examples D/FinalDestinationBuildin: enhanced keyPoints []
03-09 19:43:54.499 20934-20934/com.mapbox.navigation.examples D/FinalDestinationBuildin: route progress com.mapbox.navigation.base.trip.model.RouteProgress@da1d1ca
03-09 19:43:54.574 201-201/? A/DEBUG: *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
03-09 19:43:54.574 201-201/? A/DEBUG: Build fingerprint: 'google/hammerhead/hammerhead:6.0.1/M4B30Z/3437181:user/release-keys'
03-09 19:43:54.574 201-201/? A/DEBUG: Revision: '11'
03-09 19:43:54.574 201-201/? A/DEBUG: ABI: 'arm'
03-09 19:43:54.575 201-201/? A/DEBUG: pid: 20934, tid: 21839, name: gation.examples  >>> com.mapbox.navigation.examples <<<
03-09 19:43:54.575 201-201/? A/DEBUG: signal 6 (SIGABRT), code -6 (SI_TKILL), fault addr --------
03-09 19:43:54.631 821-821/? D/GpsNetInitiatedHandler: location enabled :true
03-09 19:43:54.641 821-821/? D/GpsNetInitiatedHandler: location enabled :true
03-09 19:43:54.668 201-201/? A/DEBUG: Abort message: '/usr/local/google/buildbot/src/android/ndk-release-r20/external/libcxx/../../external/libcxxabi/src/abort_message.cpp:73: abort_message: assertion "terminating with uncaught exception of type std::runtime_error: Failed to get URL Failed to connect to api-routing-tiles-staging.tilestream.net port 80: Connection refused" failed'
03-09 19:43:54.668 201-201/? A/DEBUG:     r0 00000000  r1 0000554f  r2 00000006  r3 99b0d978
03-09 19:43:54.668 201-201/? A/DEBUG:     r4 99b0d980  r5 99b0d930  r6 0000006f  r7 0000010c
03-09 19:43:54.668 201-201/? A/DEBUG:     r8 9a332369  r9 99b0d180  sl 99b0d29c  fp b6d09ec0
03-09 19:43:54.668 201-201/? A/DEBUG:     ip 00000006  sp 99b0cbb0  lr b6ccfb61  pc b6cd1f50  cpsr 40000010
03-09 19:43:54.716 201-201/? A/DEBUG: backtrace:
03-09 19:43:54.716 201-201/? A/DEBUG:     #00 pc 00041f50  /system/lib/libc.so (tgkill+12)
03-09 19:43:54.716 201-201/? A/DEBUG:     #01 pc 0003fb5d  /system/lib/libc.so (pthread_kill+32)
03-09 19:43:54.717 201-201/? A/DEBUG:     #02 pc 0001c30f  /system/lib/libc.so (raise+10)
03-09 19:43:54.717 201-201/? A/DEBUG:     #03 pc 000194c1  /system/lib/libc.so (__libc_android_abort+34)
03-09 19:43:54.717 201-201/? A/DEBUG:     #04 pc 000174ac  /system/lib/libc.so (abort+4)
03-09 19:43:54.717 201-201/? A/DEBUG:     #05 pc 0001af23  /system/lib/libc.so (__libc_fatal+16)
03-09 19:43:54.717 201-201/? A/DEBUG:     #06 pc 00019549  /system/lib/libc.so (__assert2+20)
03-09 19:43:54.717 201-201/? A/DEBUG:     #07 pc 0061a4cd  /data/app/com.mapbox.navigation.examples-1/lib/arm/libnavigator-android.so
03-09 19:43:54.717 201-201/? A/DEBUG:     #08 pc 0061a5cd  /data/app/com.mapbox.navigation.examples-1/lib/arm/libnavigator-android.so
03-09 19:43:54.718 201-201/? A/DEBUG:     #09 pc 00618b6d  /data/app/com.mapbox.navigation.examples-1/lib/arm/libnavigator-android.so
03-09 19:43:54.718 201-201/? A/DEBUG:     #10 pc 0061851b  /data/app/com.mapbox.navigation.examples-1/lib/arm/libnavigator-android.so
03-09 19:43:54.718 201-201/? A/DEBUG:     #11 pc 006184e3  /data/app/com.mapbox.navigation.examples-1/lib/arm/libnavigator-android.so (__cxa_throw+74)
03-09 19:43:54.718 201-201/? A/DEBUG:     #12 pc 004b8b8d  /data/app/com.mapbox.navigation.examples-1/lib/arm/libnavigator-android.so (_ZN8valhalla5baldr8curler_t7pimpl_t11assert_curlE8CURLcodeRKNSt6__ndk112basic_stringIcNS4_11char_traitsIcEENS4_9allocatorIcEEEE+144)
03-09 19:43:54.718 201-201/? A/DEBUG:     #13 pc 004b891f  /data/app/com.mapbox.navigation.examples-1/lib/arm/libnavigator-android.so (_ZN8valhalla5baldr8curler_t7pimpl_t5fetchERKNSt6__ndk112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEERlb+314)
03-09 19:43:54.718 201-201/? A/DEBUG:     #14 pc 004b87df  /data/app/com.mapbox.navigation.examples-1/lib/arm/libnavigator-android.so (_ZN8valhalla5baldr8curler_tclERKNSt6__ndk112basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEERlb+14)
03-09 19:43:54.719 201-201/? A/DEBUG:     #15 pc 0045d8ef  /data/app/com.mapbox.navigation.examples-1/lib/arm/libnavigator-android.so (_ZN8valhalla5baldr18curl_tile_getter_t3getERKNSt6__ndk112basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEE+54)
03-09 19:43:54.719 201-201/? A/DEBUG:     #16 pc 0045eeef  /data/app/com.mapbox.navigation.examples-1/lib/arm/libnavigator-android.so (_ZN8valhalla5baldr9GraphTile12CacheTileURLERKNSt6__ndk112basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEERKNS0_7GraphIdEPNS0_13tile_getter_tESA_+134)
03-09 19:43:54.719 201-201/? A/DEBUG:     #17 pc 00457465  /data/app/com.mapbox.navigation.examples-1/lib/arm/libnavigator-android.so (_ZN8valhalla5baldr11GraphReader12GetGraphTileERKNS0_7GraphIdE+260)
03-09 19:43:54.719 201-201/? A/DEBUG:     #18 pc 004312df  /data/app/com.mapbox.navigation.examples-1/lib/arm/libnavigator-android.so
03-09 19:43:54.719 201-201/? A/DEBUG:     #19 pc 004311f9  /data/app/com.mapbox.navigation.examples-1/lib/arm/libnavigator-android.so
03-09 19:43:54.719 201-201/? A/DEBUG:     #20 pc 0042edb9  /data/app/com.mapbox.navigation.examples-1/lib/arm/libnavigator-android.so
03-09 19:43:54.720 201-201/? A/DEBUG:     #21 pc 0042ed37  /data/app/com.mapbox.navigation.examples-1/lib/arm/libnavigator-android.so
03-09 19:43:54.720 201-201/? A/DEBUG:     #22 pc 0042caab  /data/app/com.mapbox.navigation.examples-1/lib/arm/libnavigator-android.so
03-09 19:43:54.720 201-201/? A/DEBUG:     #23 pc 0042c919  /data/app/com.mapbox.navigation.examples-1/lib/arm/libnavigator-android.so
03-09 19:43:54.720 201-201/? A/DEBUG:     #24 pc 0042d891  /data/app/com.mapbox.navigation.examples-1/lib/arm/libnavigator-android.so
03-09 19:43:54.720 201-201/? A/DEBUG:     #25 pc 00426fb7  /data/app/com.mapbox.navigation.examples-1/lib/arm/libnavigator-android.so
03-09 19:43:54.720 201-201/? A/DEBUG:     #26 pc 00426d3d  /data/app/com.mapbox.navigation.examples-1/lib/arm/libnavigator-android.so
03-09 19:43:54.720 201-201/? A/DEBUG:     #27 pc 00427257  /data/app/com.mapbox.navigation.examples-1/lib/arm/libnavigator-android.so
03-09 19:43:54.720 201-201/? A/DEBUG:     #28 pc 0003f45f  /system/lib/libc.so (_ZL15__pthread_startPv+30)
03-09 19:43:54.721 201-201/? A/DEBUG:     #29 pc 00019b43  /system/lib/libc.so (__start_thread+6)
```

👀 

![FinalDestinationBuildingFootprintHighlightActivityKt_nn_crash](https://user-images.githubusercontent.com/1668582/76266063-aa1fec00-623c-11ea-8ad5-23c68608f90e.gif)

It can be also reproduced when running `ArrivalUiBuildingExtrusionLayerActivityKt`

Steps to reproduce:

1. Bump `mapboxNavigator` version to `9.2.0` in `dependencies.gradle`
2. Build the `examples` test app
3. Click on `Navigation UI SDK` card
4. Click on `Arrival UI Building Extrusion Kotlin`
5. Long press to select a destination
6. Click on `START NAVIGATION`
7. After some location updates 💥

```
03-09 18:45:13.373 25634-25820/com.mapbox.navigation.examples E/valhalla: Failed to get URL Failed to connect to api-routing-tiles-staging.tilestream.net port 80: Connection refused
03-09 18:45:13.389 25634-25634/com.mapbox.navigation.examples D/ArrivalUiBuildingExtrus: enhanced location Location[fused 39.114582,-77.176506 acc=14 et=?!? alt=123.5541763305664 vel=0.0 bear=39.1053]
03-09 18:45:13.390 25634-25634/com.mapbox.navigation.examples D/ArrivalUiBuildingExtrus: enhanced keyPoints []
03-09 18:45:13.411 25634-25820/com.mapbox.navigation.examples A/libc: /usr/local/google/buildbot/src/android/ndk-release-r20/external/libcxx/../../external/libcxxabi/src/abort_message.cpp:73: abort_message: assertion "terminating with uncaught exception of type std::runtime_error: Failed to get URL Failed to connect to api-routing-tiles-staging.tilestream.net port 80: Connection refused" failed
03-09 18:45:13.414 25634-25820/com.mapbox.navigation.examples A/libc: Fatal signal 6 (SIGABRT), code -6 in tid 25820 (gation.examples)
03-09 18:45:13.416 25634-25634/com.mapbox.navigation.examples D/ArrivalUiBuildingExtrus: route progress com.mapbox.navigation.base.trip.model.RouteProgress@a48972e
03-09 18:45:13.441 11706-11706/? I/GCoreUlr: Unbound from all signal providers.
03-09 18:45:13.441 11706-11706/? I/GCoreUlr: Stopping handler for UlrDispSvcFast
03-09 18:45:13.442 11706-27530/? I/GCoreUlr: Successfully accounts update
03-09 18:45:13.526 201-201/? A/DEBUG: *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
03-09 18:45:13.526 201-201/? A/DEBUG: Build fingerprint: 'google/hammerhead/hammerhead:6.0.1/M4B30Z/3437181:user/release-keys'
03-09 18:45:13.526 201-201/? A/DEBUG: Revision: '11'
03-09 18:45:13.526 201-201/? A/DEBUG: ABI: 'arm'
03-09 18:45:13.527 201-201/? A/DEBUG: pid: 25634, tid: 25820, name: gation.examples  >>> com.mapbox.navigation.examples <<<
03-09 18:45:13.527 201-201/? A/DEBUG: signal 6 (SIGABRT), code -6 (SI_TKILL), fault addr --------
03-09 18:45:13.592 201-201/? A/DEBUG: Abort message: '/usr/local/google/buildbot/src/android/ndk-release-r20/external/libcxx/../../external/libcxxabi/src/abort_message.cpp:73: abort_message: assertion "terminating with uncaught exception of type std::runtime_error: Failed to get URL Failed to connect to api-routing-tiles-staging.tilestream.net port 80: Connection refused" failed'
03-09 18:45:13.592 201-201/? A/DEBUG:     r0 00000000  r1 000064dc  r2 00000006  r3 99fbf978
03-09 18:45:13.592 201-201/? A/DEBUG:     r4 99fbf980  r5 99fbf930  r6 0000006f  r7 0000010c
03-09 18:45:13.592 201-201/? A/DEBUG:     r8 9c411369  r9 99fbf180  sl 99fbf29c  fp b6d09ec0
03-09 18:45:13.592 201-201/? A/DEBUG:     ip 00000006  sp 99fbebb0  lr b6ccfb61  pc b6cd1f50  cpsr 40000010
03-09 18:45:13.639 201-201/? A/DEBUG: backtrace:
03-09 18:45:13.640 201-201/? A/DEBUG:     #00 pc 00041f50  /system/lib/libc.so (tgkill+12)
03-09 18:45:13.640 201-201/? A/DEBUG:     #01 pc 0003fb5d  /system/lib/libc.so (pthread_kill+32)
03-09 18:45:13.640 201-201/? A/DEBUG:     #02 pc 0001c30f  /system/lib/libc.so (raise+10)
03-09 18:45:13.640 201-201/? A/DEBUG:     #03 pc 000194c1  /system/lib/libc.so (__libc_android_abort+34)
03-09 18:45:13.641 201-201/? A/DEBUG:     #04 pc 000174ac  /system/lib/libc.so (abort+4)
03-09 18:45:13.641 201-201/? A/DEBUG:     #05 pc 0001af23  /system/lib/libc.so (__libc_fatal+16)
03-09 18:45:13.641 201-201/? A/DEBUG:     #06 pc 00019549  /system/lib/libc.so (__assert2+20)
03-09 18:45:13.641 201-201/? A/DEBUG:     #07 pc 0061a4cd  /data/app/com.mapbox.navigation.examples-1/lib/arm/libnavigator-android.so
03-09 18:45:13.641 201-201/? A/DEBUG:     #08 pc 0061a5cd  /data/app/com.mapbox.navigation.examples-1/lib/arm/libnavigator-android.so
03-09 18:45:13.641 201-201/? A/DEBUG:     #09 pc 00618b6d  /data/app/com.mapbox.navigation.examples-1/lib/arm/libnavigator-android.so
03-09 18:45:13.641 201-201/? A/DEBUG:     #10 pc 0061851b  /data/app/com.mapbox.navigation.examples-1/lib/arm/libnavigator-android.so
03-09 18:45:13.641 201-201/? A/DEBUG:     #11 pc 006184e3  /data/app/com.mapbox.navigation.examples-1/lib/arm/libnavigator-android.so (__cxa_throw+74)
03-09 18:45:13.642 201-201/? A/DEBUG:     #12 pc 004b8b8d  /data/app/com.mapbox.navigation.examples-1/lib/arm/libnavigator-android.so (_ZN8valhalla5baldr8curler_t7pimpl_t11assert_curlE8CURLcodeRKNSt6__ndk112basic_stringIcNS4_11char_traitsIcEENS4_9allocatorIcEEEE+144)
03-09 18:45:13.642 201-201/? A/DEBUG:     #13 pc 004b891f  /data/app/com.mapbox.navigation.examples-1/lib/arm/libnavigator-android.so (_ZN8valhalla5baldr8curler_t7pimpl_t5fetchERKNSt6__ndk112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEERlb+314)
03-09 18:45:13.642 201-201/? A/DEBUG:     #14 pc 004b87df  /data/app/com.mapbox.navigation.examples-1/lib/arm/libnavigator-android.so (_ZN8valhalla5baldr8curler_tclERKNSt6__ndk112basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEERlb+14)
03-09 18:45:13.642 201-201/? A/DEBUG:     #15 pc 0045d8ef  /data/app/com.mapbox.navigation.examples-1/lib/arm/libnavigator-android.so (_ZN8valhalla5baldr18curl_tile_getter_t3getERKNSt6__ndk112basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEE+54)
03-09 18:45:13.642 201-201/? A/DEBUG:     #16 pc 0045eeef  /data/app/com.mapbox.navigation.examples-1/lib/arm/libnavigator-android.so (_ZN8valhalla5baldr9GraphTile12CacheTileURLERKNSt6__ndk112basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEERKNS0_7GraphIdEPNS0_13tile_getter_tESA_+134)
03-09 18:45:13.642 201-201/? A/DEBUG:     #17 pc 00457465  /data/app/com.mapbox.navigation.examples-1/lib/arm/libnavigator-android.so (_ZN8valhalla5baldr11GraphReader12GetGraphTileERKNS0_7GraphIdE+260)
03-09 18:45:13.642 201-201/? A/DEBUG:     #18 pc 004312df  /data/app/com.mapbox.navigation.examples-1/lib/arm/libnavigator-android.so
03-09 18:45:13.643 201-201/? A/DEBUG:     #19 pc 004311f9  /data/app/com.mapbox.navigation.examples-1/lib/arm/libnavigator-android.so
03-09 18:45:13.643 201-201/? A/DEBUG:     #20 pc 0042edb9  /data/app/com.mapbox.navigation.examples-1/lib/arm/libnavigator-android.so
03-09 18:45:13.643 201-201/? A/DEBUG:     #21 pc 0042ed37  /data/app/com.mapbox.navigation.examples-1/lib/arm/libnavigator-android.so
03-09 18:45:13.643 201-201/? A/DEBUG:     #22 pc 0042caab  /data/app/com.mapbox.navigation.examples-1/lib/arm/libnavigator-android.so
03-09 18:45:13.643 201-201/? A/DEBUG:     #23 pc 0042c919  /data/app/com.mapbox.navigation.examples-1/lib/arm/libnavigator-android.so
03-09 18:45:13.643 201-201/? A/DEBUG:     #24 pc 0042d891  /data/app/com.mapbox.navigation.examples-1/lib/arm/libnavigator-android.so
03-09 18:45:13.643 201-201/? A/DEBUG:     #25 pc 00426fb7  /data/app/com.mapbox.navigation.examples-1/lib/arm/libnavigator-android.so
03-09 18:45:13.643 201-201/? A/DEBUG:     #26 pc 00426d3d  /data/app/com.mapbox.navigation.examples-1/lib/arm/libnavigator-android.so
03-09 18:45:13.644 201-201/? A/DEBUG:     #27 pc 00427257  /data/app/com.mapbox.navigation.examples-1/lib/arm/libnavigator-android.so
03-09 18:45:13.644 201-201/? A/DEBUG:     #28 pc 0003f45f  /system/lib/libc.so (_ZL15__pthread_startPv+30)
03-09 18:45:13.644 201-201/? A/DEBUG:     #29 pc 00019b43  /system/lib/libc.so (__start_thread+6)
``` 

👀 

![ArrivalUiBuildingExtrusionLayerActivityKt_nn_crash](https://user-images.githubusercontent.com/1668582/76266089-befc7f80-623c-11ea-87ed-be01ea063264.gif)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR

cc @mskurydin @SiarheiFedartsou @Aurora-Boreal @zugaldia  