### PR TITLE
Update / bump various dependency versions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,7 +7,6 @@ apply from: "${rootDir}/gradle/ktlint.gradle"
 
 android {
   compileSdkVersion androidVersions.compileSdkVersion
-  buildToolsVersion androidVersions.buildToolsVersion
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_1_8

--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExampleViewModel.kt
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/example/ui/ExampleViewModel.kt
@@ -169,7 +169,7 @@ class ExampleViewModel(application: Application) : AndroidViewModel(application)
     private fun retrieveOfflineVersionFromPreferences(): String {
         val context = getApplication<Application>()
         return PreferenceManager.getDefaultSharedPreferences(context)
-            .getString(context.getString(R.string.offline_version_key), "")
+            .getString(context.getString(R.string.offline_version_key), "") ?: ""
     }
 
     private fun retrieveProfileFromPreferences(): String {
@@ -181,7 +181,7 @@ class ExampleViewModel(application: Application) : AndroidViewModel(application)
                         R.string
                             .default_route_profile
                     )
-                )
+                ) ?: ""
         )
     }
 

--- a/circle.yml
+++ b/circle.yml
@@ -270,7 +270,7 @@ jobs:
   build:
     working_directory: ~/code
     docker:
-      - image: mbgl/61abee1674:android-ndk-r18
+      - image: mbgl/android-ndk-r21:latest
     environment:
       JVM_OPTS: -Xmx3200m
       BUILDTYPE: Debug
@@ -324,7 +324,7 @@ jobs:
   build-1_0:
     working_directory: ~/code
     docker:
-      - image: mbgl/61abee1674:android-ndk-r18
+      - image: mbgl/android-ndk-r21:latest
     steps:
       - checkout
       - restore-gradle-cache-1_0
@@ -334,7 +334,7 @@ jobs:
 
   ui-tests-1_0:
     docker:
-      - image: mbgl/61abee1674:android-ndk-r18
+      - image: mbgl/android-ndk-r21:latest
     working_directory: ~/code
     environment:
       JVM_OPTS: -Xmx3200m
@@ -355,7 +355,7 @@ jobs:
 # ------------------------------------------------------------------------------
   release:
     docker:
-      - image: mbgl/61abee1674:android-ndk-r18
+      - image: mbgl/android-ndk-r21:latest
     working_directory: ~/code
     environment:
       BUILDTYPE: Release
@@ -394,7 +394,7 @@ jobs:
   release-1_0-snapshot:
     working_directory: ~/code
     docker:
-      - image: mbgl/61abee1674:android-ndk-r18
+      - image: mbgl/android-ndk-r21:latest
     steps:
       - checkout
       - build-release-1_0
@@ -409,7 +409,7 @@ jobs:
   release-1_0:
     working_directory: ~/code
     docker:
-      - image: mbgl/61abee1674:android-ndk-r18
+      - image: mbgl/android-ndk-r21:latest
     environment:
       BINTRAY_REPO: mapbox
     steps:
@@ -426,7 +426,7 @@ jobs:
   release-1_0-qa:
     working_directory: ~/code
     docker:
-      - image: mbgl/61abee1674:android-ndk-r18
+      - image: mbgl/android-ndk-r21:latest
     environment:
       BINTRAY_REPO: mapbox_private
     steps:
@@ -443,7 +443,7 @@ jobs:
   release-1_0-prod:
     working_directory: ~/code
     docker:
-      - image: mbgl/61abee1674:android-ndk-r18
+      - image: mbgl/android-ndk-r21:latest
     environment:
       BINTRAY_REPO: mapbox_collab
     steps:
@@ -459,7 +459,7 @@ jobs:
 # ------------------------------------------------------------------------------
   publish:
     docker:
-      - image: mbgl/61abee1674:android-ndk-r18
+      - image: mbgl/android-ndk-r21:latest
     working_directory: ~/code
     environment:
       JVM_OPTS: -Xmx3200m

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -7,7 +7,6 @@ apply from: "${rootDir}/gradle/ktlint.gradle"
 
 android {
     compileSdkVersion androidVersions.compileSdkVersion
-    buildToolsVersion androidVersions.buildToolsVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -2,13 +2,12 @@ ext {
 
   androidVersions = [
       minSdkVersion    : 14,
-      targetSdkVersion : 28,
-      compileSdkVersion: 28,
-      buildToolsVersion: '28.0.3'
+      targetSdkVersion : 29,
+      compileSdkVersion: 29
   ]
 
   version = [
-      mapboxMapSdk              : '9.1.0-SNAPSHOT',
+      mapboxMapSdk              : '9.1.0-alpha.1',
       mapboxSdkServices         : '5.1.0-SNAPSHOT',
       mapboxSdkDirectionsModels : '5.1.0-SNAPSHOT',
       mapboxEvents              : '4.7.3',
@@ -38,13 +37,13 @@ ext {
       espressoVersion           : '3.1.0',
       spoonRunner               : '1.6.2',
       commonsIO                 : '2.6',
-      robolectric               : '4.1',
+      robolectric               : '4.3.1',
       mockwebserver             : '3.12.0',
       lifecycle                 : '2.0.0-rc01',
       picasso                   : '2.71828',
       gmsLocation               : '16.0.0',
       ktlint                    : '0.34.2',
-      kotlinStdLib              : '1.3.61',
+      kotlinStdLib              : '1.3.70',
       ankoCommon                : '0.10.0',
       firebaseCore              : '16.0.7',
       crashlytics               : '2.9.9',
@@ -162,7 +161,7 @@ ext {
       gradle           : '3.5.3',
       dependencyGraph  : '0.3.0',
       dependencyUpdates: '0.20.0',
-      kotlin           : '1.3.61',
+      kotlin           : '1.3.70',
       license          : '0.8.5',
       jacoco           : '0.8.2',
       playPublisher    : '2.3.0',

--- a/libandroid-navigation-ui/build.gradle
+++ b/libandroid-navigation-ui/build.gradle
@@ -5,7 +5,6 @@ apply from: "${rootDir}/gradle/ktlint.gradle"
 
 android {
   compileSdkVersion androidVersions.compileSdkVersion
-  buildToolsVersion androidVersions.buildToolsVersion
 
   defaultConfig {
     minSdkVersion androidVersions.minSdkVersion

--- a/libandroid-navigation/build.gradle
+++ b/libandroid-navigation/build.gradle
@@ -6,7 +6,6 @@ apply from: "${rootDir}/gradle/ktlint.gradle"
 
 android {
   compileSdkVersion androidVersions.compileSdkVersion
-  buildToolsVersion androidVersions.buildToolsVersion
 
   defaultConfig {
     minSdkVersion androidVersions.minSdkVersion

--- a/libdirections-hybrid/build.gradle
+++ b/libdirections-hybrid/build.gradle
@@ -15,7 +15,6 @@ dokka {
 
 android {
     compileSdkVersion androidVersions.compileSdkVersion
-    buildToolsVersion androidVersions.buildToolsVersion
 
     defaultConfig {
         minSdkVersion androidVersions.minSdkVersion

--- a/libdirections-offboard/build.gradle
+++ b/libdirections-offboard/build.gradle
@@ -15,7 +15,6 @@ dokka {
 
 android {
     compileSdkVersion androidVersions.compileSdkVersion
-    buildToolsVersion androidVersions.buildToolsVersion
 
     defaultConfig {
         minSdkVersion androidVersions.minSdkVersion

--- a/libdirections-onboard/build.gradle
+++ b/libdirections-onboard/build.gradle
@@ -15,7 +15,6 @@ dokka {
 
 android {
     compileSdkVersion androidVersions.compileSdkVersion
-    buildToolsVersion androidVersions.buildToolsVersion
 
     defaultConfig {
         minSdkVersion androidVersions.minSdkVersion

--- a/liblogger/build.gradle
+++ b/liblogger/build.gradle
@@ -6,7 +6,6 @@ apply from: "${rootDir}/gradle/ktlint.gradle"
 
 android {
     compileSdkVersion androidVersions.compileSdkVersion
-    buildToolsVersion androidVersions.buildToolsVersion
 
     defaultConfig {
         minSdkVersion androidVersions.minSdkVersion

--- a/libnavigation-base/build.gradle
+++ b/libnavigation-base/build.gradle
@@ -19,7 +19,6 @@ dokka {
 
 android {
     compileSdkVersion androidVersions.compileSdkVersion
-    buildToolsVersion androidVersions.buildToolsVersion
 
     defaultConfig {
         minSdkVersion androidVersions.minSdkVersion

--- a/libnavigation-core/build.gradle
+++ b/libnavigation-core/build.gradle
@@ -15,7 +15,6 @@ dokka {
 
 android {
     compileSdkVersion androidVersions.compileSdkVersion
-    buildToolsVersion androidVersions.buildToolsVersion
 
     defaultConfig {
         minSdkVersion androidVersions.minSdkVersion

--- a/libnavigation-metrics/build.gradle
+++ b/libnavigation-metrics/build.gradle
@@ -14,7 +14,6 @@ dokka {
 
 android {
     compileSdkVersion androidVersions.compileSdkVersion
-    buildToolsVersion androidVersions.buildToolsVersion
 
     defaultConfig {
         minSdkVersion androidVersions.minSdkVersion

--- a/libnavigation-ui/build.gradle
+++ b/libnavigation-ui/build.gradle
@@ -7,7 +7,6 @@ apply from: "${rootDir}/gradle/ktlint.gradle"
 
 android {
   compileSdkVersion androidVersions.compileSdkVersion
-  buildToolsVersion androidVersions.buildToolsVersion
 
   defaultConfig {
     minSdkVersion androidVersions.minSdkVersion

--- a/libnavigation-util/build.gradle
+++ b/libnavigation-util/build.gradle
@@ -19,7 +19,6 @@ dokka {
 
 android {
     compileSdkVersion androidVersions.compileSdkVersion
-    buildToolsVersion androidVersions.buildToolsVersion
 
     defaultConfig {
         minSdkVersion androidVersions.minSdkVersion

--- a/libnavigator/build.gradle
+++ b/libnavigator/build.gradle
@@ -14,7 +14,6 @@ dokka {
 
 android {
     compileSdkVersion androidVersions.compileSdkVersion
-    buildToolsVersion androidVersions.buildToolsVersion
 
     defaultConfig {
         minSdkVersion androidVersions.minSdkVersion

--- a/libtesting-ui/build.gradle
+++ b/libtesting-ui/build.gradle
@@ -3,7 +3,6 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 android {
     compileSdkVersion androidVersions.compileSdkVersion
-    buildToolsVersion androidVersions.buildToolsVersion
 
     defaultConfig {
         minSdkVersion androidVersions.minSdkVersion

--- a/libtesting-utils/build.gradle
+++ b/libtesting-utils/build.gradle
@@ -3,7 +3,6 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion androidVersions.compileSdkVersion
-    buildToolsVersion androidVersions.buildToolsVersion
 
     defaultConfig {
         minSdkVersion androidVersions.minSdkVersion

--- a/libtrip-notification/build.gradle
+++ b/libtrip-notification/build.gradle
@@ -15,7 +15,6 @@ dokka {
 
 android {
     compileSdkVersion androidVersions.compileSdkVersion
-    buildToolsVersion androidVersions.buildToolsVersion
 
     defaultConfig {
         minSdkVersion androidVersions.minSdkVersion


### PR DESCRIPTION
## Description

Bumps `mapbox-android-sdk` version to `9.1.0-alpha.1`, bumps `kotlin` version to `1.3.70`, bumps `targetSdkVersion` and `compileSdkVersion` to `29` and updates Docker image to `android-ndk-r21:latest`

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Getting the latest versions from `mapboxMapSdk`, `kotlin` including the new features and bug fixes and bump `targetSdkVersion` and `compileSdkVersion` to `29` and update Docker image to `android-ndk-r21:latest`

### Implementation

Bumping the `mapboxMapSdk` version to `9.1.0-alpha.1` in `dependencies.gradle`
Bumping the `kotlin` version to `1.3.70` in `dependencies.gradle`
Bumping the `targetSdkVersion` and `compileSdkVersion` to `29` in `dependencies.gradle`
Updating Docker image to `android-ndk-r21:latest` in `circle.yml`
Fixing `ExampleViewModel`

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR

cc @harvsu @nkukday 