### PR TITLE
Update / bump various dependency versions

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,7 +8,7 @@ ext {
   ]
 
   version = [
-      mapboxMapSdk              : '9.1.0-SNAPSHOT',
+      mapboxMapSdk              : '9.1.0-alpha.1',
       mapboxSdkServices         : '5.1.0-SNAPSHOT',
       mapboxSdkDirectionsModels : '5.1.0-SNAPSHOT',
       mapboxEvents              : '4.7.3',
@@ -44,7 +44,7 @@ ext {
       picasso                   : '2.71828',
       gmsLocation               : '16.0.0',
       ktlint                    : '0.34.2',
-      kotlinStdLib              : '1.3.61',
+      kotlinStdLib              : '1.3.70',
       ankoCommon                : '0.10.0',
       firebaseCore              : '16.0.7',
       crashlytics               : '2.9.9',
@@ -162,7 +162,7 @@ ext {
       gradle           : '3.5.3',
       dependencyGraph  : '0.3.0',
       dependencyUpdates: '0.20.0',
-      kotlin           : '1.3.61',
+      kotlin           : '1.3.70',
       license          : '0.8.5',
       jacoco           : '0.8.2',
       playPublisher    : '2.3.0',


### PR DESCRIPTION
## Description

Bumps `mapbox-android-sdk` version to `9.1.0-alpha.1` and bumps `kotlin` version to `1.3.70`

Refs. https://github.com/mapbox/mapbox-navigation-android/pull/2557

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Getting the latest versions from `mapboxMapSdk` and `kotlin` including the new features and bug fixes.

### Implementation

Bumping the `mapboxMapSdk` version to `9.1.0-alpha.1` in `dependencies.gradle`
Bumping the `kotlin` version to `1.3.70` in `dependencies.gradle`

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
