### PR TITLE
Improve RoutesRequestCallback#onRoutesReady

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/NavigateWithInstructionViewActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/NavigateWithInstructionViewActivity.kt
@@ -231,8 +231,8 @@ class NavigateWithInstructionViewActivity : AppCompatActivity(), OnMapReadyCallb
     }
 
     private val routesReqCallback = object : RoutesRequestCallback {
-        override fun onRoutesReady(routes: List<DirectionsRoute>): List<DirectionsRoute> {
-            return routes
+        override fun onRoutesReady(routes: List<DirectionsRoute>) {
+            // do nothing
         }
 
         override fun onRoutesRequestFailure(throwable: Throwable, routeOptions: RouteOptions) {

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/SimpleMapboxNavigationKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/SimpleMapboxNavigationKt.kt
@@ -307,10 +307,9 @@ class SimpleMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
     }
 
     private val routesReqCallback = object : RoutesRequestCallback {
-        override fun onRoutesReady(routes: List<DirectionsRoute>): List<DirectionsRoute> {
+        override fun onRoutesReady(routes: List<DirectionsRoute>) {
             Timber.d("route request success %s", routes.toString())
             replayRouteLocationEngine.assign(routes[0])
-            return routes
         }
 
         override fun onRoutesRequestFailure(throwable: Throwable, routeOptions: RouteOptions) {

--- a/examples/src/main/java/com/mapbox/navigation/examples/ui/ArrivalUiBuildingExtrusionLayerActivityKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/ui/ArrivalUiBuildingExtrusionLayerActivityKt.kt
@@ -279,9 +279,8 @@ class ArrivalUiBuildingExtrusionLayerActivityKt : AppCompatActivity(), OnMapRead
     }
 
     private val routesReqCallback = object : RoutesRequestCallback {
-        override fun onRoutesReady(routes: List<DirectionsRoute>): List<DirectionsRoute> {
+        override fun onRoutesReady(routes: List<DirectionsRoute>) {
             Timber.d("route request success %s", routes.toString())
-            return routes
         }
 
         override fun onRoutesRequestFailure(throwable: Throwable, routeOptions: RouteOptions) {

--- a/examples/src/main/java/com/mapbox/navigation/examples/ui/FinalDestinationBuildingFootprintHighlightActivityKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/ui/FinalDestinationBuildingFootprintHighlightActivityKt.kt
@@ -276,9 +276,8 @@ class FinalDestinationBuildingFootprintHighlightActivityKt : AppCompatActivity()
     }
 
     private val routesReqCallback = object : RoutesRequestCallback {
-        override fun onRoutesReady(routes: List<DirectionsRoute>): List<DirectionsRoute> {
+        override fun onRoutesReady(routes: List<DirectionsRoute>) {
             Timber.d("route request success %s", routes.toString())
-            return routes
         }
 
         override fun onRoutesRequestFailure(throwable: Throwable, routeOptions: RouteOptions) {

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/DirectionsSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/DirectionsSession.kt
@@ -10,7 +10,7 @@ internal interface DirectionsSession {
 
     fun getRouteOptions(): RouteOptions?
 
-    fun requestRoutes(routeOptions: RouteOptions, routesRequestCallback: RoutesRequestCallback)
+    fun requestRoutes(routeOptions: RouteOptions, routesRequestCallback: RoutesRequestCallback? = null)
 
     /**
      * Requests a route using the provided [Router] implementation.

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/MapboxDirectionsSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/MapboxDirectionsSession.kt
@@ -35,20 +35,24 @@ class MapboxDirectionsSession(
 
     override fun requestRoutes(
         routeOptions: RouteOptions,
-        routesRequestCallback: RoutesRequestCallback
+        routesRequestCallback: RoutesRequestCallback?
     ) {
         routes = emptyList()
         router.getRoute(routeOptions, object : Router.Callback {
             override fun onResponse(routes: List<DirectionsRoute>) {
-                this@MapboxDirectionsSession.routes = routesRequestCallback.onRoutesReady(routes)
+                this@MapboxDirectionsSession.routes = routes
+                routesRequestCallback?.onRoutesReady(routes)
+                // todo log in the future
             }
 
             override fun onFailure(throwable: Throwable) {
-                routesRequestCallback.onRoutesRequestFailure(throwable, routeOptions)
+                routesRequestCallback?.onRoutesRequestFailure(throwable, routeOptions)
+                // todo log in the future
             }
 
             override fun onCanceled() {
-                routesRequestCallback.onRoutesRequestCanceled(routeOptions)
+                routesRequestCallback?.onRoutesRequestCanceled(routeOptions)
+                // todo log in the future
             }
         })
     }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/RoutesRequestCallback.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/RoutesRequestCallback.kt
@@ -3,6 +3,7 @@ package com.mapbox.navigation.core.directions.session
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.RouteOptions
 import com.mapbox.navigation.base.route.Router
+import com.mapbox.navigation.core.MapboxNavigation
 
 /**
  * Interface definition for a callback associated with a routes request.
@@ -12,15 +13,17 @@ interface RoutesRequestCallback {
     /**
      * Invoked whenever a new set of routes is available.
      *
-     * The return type is a list that's going to be assigned to and maintained by the [DirectionsSession].
-     * The route at index 0, if exist, will be treated as the primary route for 'Active Guidance' and location map-matching.
+     * The provided list is the list of routes created by this request and assigned to be managed by the SDK.
+     * The route at index 0, if exist, is treated as the primary route for 'Active Guidance' and location map-matching.
      *
-     * If an empty list is returned, this request will effectively be ignored by the [DirectionsSession].
+     * The list provided by this callback is not guaranteed to still be the one managed by the SDK at the moment of invocation.
+     * Use [RoutesObserver] and [MapboxNavigation.registerRoutesObserver] to observe whenever the routes list reference managed by the SDK changes, regardless of a source.
+     *
+     * Use [MapboxNavigation.setRoutes] to supply a transformed list of routes, or a list from an external source, to be managed by the SDK.
      *
      * @param routes list of routes returned by a [Router]
-     * @return a list of routes that will be assigned to the session where route at index 0 is the primary one
      */
-    fun onRoutesReady(routes: List<DirectionsRoute>): List<DirectionsRoute>
+    fun onRoutesReady(routes: List<DirectionsRoute>)
 
     /**
      * Called whenever this [Router] request fails.


### PR DESCRIPTION
This PR changes the responsibility of the `RoutesRequestCallback#onRoutesReady`.

After hearing feedback from @langsmith and @kmadsen, as well as @korshaknn who all tried to implement the SDK in various apps, it looks like the method even though provided a lot of flexibility, also caused even more confusion.

The callback is now simplified, `onRoutesReady` does not require a return type anymore, and the provided argument is just the same reference that is set on the `DirectionSessions` and provided by the `RoutesObserver` in parallel, for easy of use.

After the request is successful, the route is first set on the session, only then the `onRoutesReady` which still gives the user an opportunity to invoke `MapboxNavigation#setRoutes` in the `onRoutesReady`, which basically covers the same use-case as the return type did in the past.