### PR TITLE
Define location and service permissions

### DIFF
--- a/libnavigation-core/src/main/AndroidManifest.xml
+++ b/libnavigation-core/src/main/AndroidManifest.xml
@@ -2,6 +2,10 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.mapbox.navigation.core">
 
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+
     <application>
         <provider
             android:name="com.mapbox.navigation.core.accounts.MapboxNavigationAccountsProvider"


### PR DESCRIPTION
The permission declarations are required for the consumers to run the app. We haven't noticed that the declarations were missing because we were providing them directly in the examples, or transitively.