### PR TITLE
Backport voice instruction cache

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationViewModelProgressObserver.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationViewModelProgressObserver.java
@@ -10,11 +10,11 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
-class NavigationViewModelProgressChangeListener implements RouteProgressObserver, LocationObserver {
+class NavigationViewModelProgressObserver implements RouteProgressObserver, LocationObserver {
 
   private final NavigationViewModel viewModel;
 
-  NavigationViewModelProgressChangeListener(NavigationViewModel viewModel) {
+  NavigationViewModelProgressObserver(NavigationViewModel viewModel) {
     this.viewModel = viewModel;
   }
 

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/VoiceInstructionCache.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/VoiceInstructionCache.java
@@ -7,6 +7,8 @@ import com.mapbox.api.directions.v5.models.VoiceInstructions;
 import com.mapbox.navigation.core.MapboxNavigation;
 import com.mapbox.navigation.ui.voice.VoiceInstructionLoader;
 
+import org.jetbrains.annotations.TestOnly;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -85,5 +87,10 @@ class VoiceInstructionCache {
     if (voiceInstructionsToAnnounce % VOICE_INSTRUCTIONS_TO_CACHE_THRESHOLD == 0) {
       isVoiceInstructionsToCacheThresholdReached = true;
     }
+  }
+
+  @TestOnly
+  int getTotalVoiceInstructionNumber() {
+    return totalVoiceInstructions;
   }
 }

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/NavigationViewModelProgressObserverTest.java
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/NavigationViewModelProgressObserverTest.java
@@ -1,8 +1,12 @@
 package com.mapbox.navigation.ui;
 
+import android.location.Location;
+
 import com.mapbox.navigation.base.trip.model.RouteProgress;
 
 import org.junit.Test;
+
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -14,7 +18,7 @@ public class NavigationViewModelProgressObserverTest {
   public void checksNavigationViewModelRouteProgressIsUpdatedWhenOnProgressChange() {
     NavigationViewModel mockedNavigationViewModel = mock(NavigationViewModel.class);
     NavigationViewModelProgressObserver theNavigationViewModelProgressObserver =
-            new NavigationViewModelProgressObserver(mockedNavigationViewModel);
+      new NavigationViewModelProgressObserver(mockedNavigationViewModel);
     RouteProgress theRouteProgress = mock(RouteProgress.class);
 
     theNavigationViewModelProgressObserver.onRouteProgressChanged(theRouteProgress);
@@ -22,15 +26,17 @@ public class NavigationViewModelProgressObserverTest {
     verify(mockedNavigationViewModel).updateRouteProgress(eq(theRouteProgress));
   }
 
-  /*@Test
+  @Test
+  @SuppressWarnings("unchecked assignment")
   public void checksNavigationViewModelLocationIsUpdatedWhenOnProgressChange() {
     NavigationViewModel mockedNavigationViewModel = mock(NavigationViewModel.class);
     NavigationViewModelProgressObserver theNavigationViewModelProgressChangeListener =
-            new NavigationViewModelProgressObserver(mockedNavigationViewModel);
+      new NavigationViewModelProgressObserver(mockedNavigationViewModel);
     Location theLocation = mock(Location.class);
+    List<? extends Location> keyPoints = mock(List.class);
 
-    theNavigationViewModelProgressChangeListener.onRawLocationChanged(theLocation);
+    theNavigationViewModelProgressChangeListener.onEnhancedLocationChanged(theLocation, keyPoints);
 
     verify(mockedNavigationViewModel).updateLocation(eq(theLocation));
-  }*/
+  }
 }

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/NavigationViewModelProgressObserverTest.java
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/NavigationViewModelProgressObserverTest.java
@@ -1,7 +1,5 @@
 package com.mapbox.navigation.ui;
 
-import android.location.Location;
-
 import com.mapbox.navigation.base.trip.model.RouteProgress;
 
 import org.junit.Test;
@@ -10,16 +8,16 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-public class NavigationViewModelProgressChangeListenerTest {
+public class NavigationViewModelProgressObserverTest {
 
   @Test
   public void checksNavigationViewModelRouteProgressIsUpdatedWhenOnProgressChange() {
     NavigationViewModel mockedNavigationViewModel = mock(NavigationViewModel.class);
-    NavigationViewModelProgressChangeListener theNavigationViewModelProgressChangeListener =
-            new NavigationViewModelProgressChangeListener(mockedNavigationViewModel);
+    NavigationViewModelProgressObserver theNavigationViewModelProgressObserver =
+            new NavigationViewModelProgressObserver(mockedNavigationViewModel);
     RouteProgress theRouteProgress = mock(RouteProgress.class);
 
-    theNavigationViewModelProgressChangeListener.onRouteProgressChanged(theRouteProgress);
+    theNavigationViewModelProgressObserver.onRouteProgressChanged(theRouteProgress);
 
     verify(mockedNavigationViewModel).updateRouteProgress(eq(theRouteProgress));
   }
@@ -27,8 +25,8 @@ public class NavigationViewModelProgressChangeListenerTest {
   /*@Test
   public void checksNavigationViewModelLocationIsUpdatedWhenOnProgressChange() {
     NavigationViewModel mockedNavigationViewModel = mock(NavigationViewModel.class);
-    NavigationViewModelProgressChangeListener theNavigationViewModelProgressChangeListener =
-            new NavigationViewModelProgressChangeListener(mockedNavigationViewModel);
+    NavigationViewModelProgressObserver theNavigationViewModelProgressChangeListener =
+            new NavigationViewModelProgressObserver(mockedNavigationViewModel);
     Location theLocation = mock(Location.class);
 
     theNavigationViewModelProgressChangeListener.onRawLocationChanged(theLocation);

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/VoiceInstructionCacheTest.java
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/VoiceInstructionCacheTest.java
@@ -18,59 +18,63 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
+@SuppressWarnings("unchecked assignment")
 public class VoiceInstructionCacheTest extends BaseTest {
 
   private static final String DIRECTIONS_PRECISION_6 = "directions_v5_precision_6.json";
 
   @Test
   public void checksPreCachingCachesNineInstructions() throws Exception {
-    MapboxNavigation aMapboxNavigation = mock(MapboxNavigation.class);
-    VoiceInstructionLoader aVoiceInstructionLoader = mock(VoiceInstructionLoader.class);
-    ConnectivityStatusProvider aConnectivityStatus = mock(ConnectivityStatusProvider.class);
-    when(aConnectivityStatus.isConnected()).thenReturn(true);
-    VoiceInstructionCache theVoiceInstructionCache = new VoiceInstructionCache(aMapboxNavigation,
-      aVoiceInstructionLoader, aConnectivityStatus);
-    DirectionsRoute aRoute = buildDirectionsRoute();
+    MapboxNavigation mockedMapboxNavigation = mock(MapboxNavigation.class);
+    VoiceInstructionLoader mockedVoiceInstructionLoader = mock(VoiceInstructionLoader.class);
+    ConnectivityStatusProvider mockedConnectivityStatus = mock(ConnectivityStatusProvider.class);
+    when(mockedConnectivityStatus.isConnected()).thenReturn(true);
+    VoiceInstructionCache theVoiceInstructionCache = new VoiceInstructionCache(mockedMapboxNavigation,
+      mockedVoiceInstructionLoader, mockedConnectivityStatus);
+    DirectionsRoute twentyOneInstructionsRoute = buildDirectionsRoute();
     ArgumentCaptor<List> voiceInstructionsToCache = ArgumentCaptor.forClass(List.class);
 
-    theVoiceInstructionCache.initCache(aRoute);
+    theVoiceInstructionCache.initCache(twentyOneInstructionsRoute);
 
-    verify(aVoiceInstructionLoader, times(1))
+    verify(mockedVoiceInstructionLoader, times(0))
       .cacheInstructions(voiceInstructionsToCache.capture());
-    assertEquals(9, voiceInstructionsToCache.getValue().size());
+
+    assertEquals(21, theVoiceInstructionCache.getTotalVoiceInstructionNumber());
   }
 
   @Test
   public void checksCacheIsNotCalledIfIsVoiceInstructionsToCacheThresholdNotReached() {
-    MapboxNavigation aMapboxNavigation = mock(MapboxNavigation.class);
-    VoiceInstructionLoader aVoiceInstructionLoader = mock(VoiceInstructionLoader.class);
-    ConnectivityStatusProvider aConnectivityStatus = mock(ConnectivityStatusProvider.class);
-    VoiceInstructionCache theVoiceInstructionCache = new VoiceInstructionCache(aMapboxNavigation,
-      aVoiceInstructionLoader, aConnectivityStatus);
+    MapboxNavigation mockedMapboxNavigation = mock(MapboxNavigation.class);
+    VoiceInstructionLoader mockedVoiceInstructionLoader = mock(VoiceInstructionLoader.class);
+    ConnectivityStatusProvider mockedConnectivityStatus = mock(ConnectivityStatusProvider.class);
+    VoiceInstructionCache theVoiceInstructionCache = new VoiceInstructionCache(mockedMapboxNavigation,
+      mockedVoiceInstructionLoader, mockedConnectivityStatus);
 
     theVoiceInstructionCache.cache();
 
-    verifyZeroInteractions(aVoiceInstructionLoader);
+    verifyZeroInteractions(mockedVoiceInstructionLoader);
   }
 
   @Test
   public void checksCaching() throws Exception {
-    MapboxNavigation aMapboxNavigation = mock(MapboxNavigation.class);
-    VoiceInstructionLoader aVoiceInstructionLoader = mock(VoiceInstructionLoader.class);
-    ConnectivityStatusProvider aConnectivityStatus = mock(ConnectivityStatusProvider.class);
-    when(aConnectivityStatus.isConnected()).thenReturn(true);
-    VoiceInstructionCache theVoiceInstructionCache = new VoiceInstructionCache(aMapboxNavigation,
-      aVoiceInstructionLoader, aConnectivityStatus);
+    MapboxNavigation mockedMapboxNavigation = mock(MapboxNavigation.class);
+    VoiceInstructionLoader mockedVoiceInstructionLoader = mock(VoiceInstructionLoader.class);
+    ConnectivityStatusProvider mockedConnectivityStatus = mock(ConnectivityStatusProvider.class);
+    when(mockedConnectivityStatus.isConnected()).thenReturn(true);
+    VoiceInstructionCache theVoiceInstructionCache = new VoiceInstructionCache(mockedMapboxNavigation,
+      mockedVoiceInstructionLoader, mockedConnectivityStatus);
     DirectionsRoute twentyOneInstructionsRoute = buildDirectionsRoute();
-    ArgumentCaptor<List> voiceInstructionsToCache = ArgumentCaptor.forClass(List.class);
 
     theVoiceInstructionCache.initCache(twentyOneInstructionsRoute);
     theVoiceInstructionCache.update(5);
     theVoiceInstructionCache.cache();
     theVoiceInstructionCache.update(10);
     theVoiceInstructionCache.cache();
+    theVoiceInstructionCache.update(15);
+    theVoiceInstructionCache.cache();
 
-    verify(aVoiceInstructionLoader, times(3))
+    ArgumentCaptor<List> voiceInstructionsToCache = ArgumentCaptor.forClass(List.class);
+    verify(mockedVoiceInstructionLoader, times(3))
       .cacheInstructions(voiceInstructionsToCache.capture());
     List<List> capturedVoiceInstructionsToCache = voiceInstructionsToCache.getAllValues();
     assertEquals(9, capturedVoiceInstructionsToCache.get(0).size());
@@ -80,48 +84,33 @@ public class VoiceInstructionCacheTest extends BaseTest {
 
   @Test
   public void checksEvictVoiceInstructionsIsCalledWhenCaching() throws Exception {
-    MapboxNavigation aMapboxNavigation = mock(MapboxNavigation.class);
-    VoiceInstructionLoader aVoiceInstructionLoader = mock(VoiceInstructionLoader.class);
-    ConnectivityStatusProvider aConnectivityStatus = mock(ConnectivityStatusProvider.class);
-    when(aConnectivityStatus.isConnected()).thenReturn(true);
-    VoiceInstructionCache theVoiceInstructionCache = new VoiceInstructionCache(aMapboxNavigation,
-      aVoiceInstructionLoader, aConnectivityStatus);
-    DirectionsRoute aRoute = buildDirectionsRoute();
+    MapboxNavigation mockedMapboxNavigation = mock(MapboxNavigation.class);
+    VoiceInstructionLoader mockedVoiceInstructionLoader = mock(VoiceInstructionLoader.class);
+    ConnectivityStatusProvider mockedConnectivityStatus = mock(ConnectivityStatusProvider.class);
+    when(mockedConnectivityStatus.isConnected()).thenReturn(true);
+    VoiceInstructionCache theVoiceInstructionCache = new VoiceInstructionCache(mockedMapboxNavigation,
+      mockedVoiceInstructionLoader, mockedConnectivityStatus);
+    DirectionsRoute theDirectionsRoute = buildDirectionsRoute();
 
-    theVoiceInstructionCache.initCache(aRoute);
+    theVoiceInstructionCache.initCache(theDirectionsRoute);
     theVoiceInstructionCache.update(5);
     theVoiceInstructionCache.cache();
 
-    verify(aVoiceInstructionLoader, times(1)).evictVoiceInstructions();
-  }
-
-  @Test
-  public void noConnectivityDoesNotAllowPreCaching() throws Exception {
-    MapboxNavigation aMapboxNavigation = mock(MapboxNavigation.class);
-    VoiceInstructionLoader aVoiceInstructionLoader = mock(VoiceInstructionLoader.class);
-    ConnectivityStatusProvider aConnectivityStatus = mock(ConnectivityStatusProvider.class);
-    when(aConnectivityStatus.isConnected()).thenReturn(false);
-    VoiceInstructionCache theVoiceInstructionCache = new VoiceInstructionCache(aMapboxNavigation,
-      aVoiceInstructionLoader, aConnectivityStatus);
-    DirectionsRoute aRoute = buildDirectionsRoute();
-
-    theVoiceInstructionCache.initCache(aRoute);
-
-    verifyZeroInteractions(aVoiceInstructionLoader);
+    verify(mockedVoiceInstructionLoader, times(1)).evictVoiceInstructions();
   }
 
   @Test
   public void noConnectivityDoesNotAllowCaching() {
-    MapboxNavigation aMapboxNavigation = mock(MapboxNavigation.class);
-    VoiceInstructionLoader aVoiceInstructionLoader = mock(VoiceInstructionLoader.class);
-    ConnectivityStatusProvider aConnectivityStatus = mock(ConnectivityStatusProvider.class);
-    when(aConnectivityStatus.isConnected()).thenReturn(false);
-    VoiceInstructionCache theVoiceInstructionCache = new VoiceInstructionCache(aMapboxNavigation,
-      aVoiceInstructionLoader, aConnectivityStatus);
+    MapboxNavigation mockedMapboxNavigation = mock(MapboxNavigation.class);
+    VoiceInstructionLoader mockedVoiceInstructionLoader = mock(VoiceInstructionLoader.class);
+    ConnectivityStatusProvider mockedConnectivityStatus = mock(ConnectivityStatusProvider.class);
+    when(mockedConnectivityStatus.isConnected()).thenReturn(false);
+    VoiceInstructionCache theVoiceInstructionCache = new VoiceInstructionCache(mockedMapboxNavigation,
+      mockedVoiceInstructionLoader, mockedConnectivityStatus);
 
     theVoiceInstructionCache.cache();
 
-    verifyZeroInteractions(aVoiceInstructionLoader);
+    verifyZeroInteractions(mockedVoiceInstructionLoader);
   }
 
   private DirectionsRoute buildDirectionsRoute() throws IOException {

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/VoiceInstructionCacheTest.java
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/VoiceInstructionCacheTest.java
@@ -33,7 +33,7 @@ public class VoiceInstructionCacheTest extends BaseTest {
     DirectionsRoute aRoute = buildDirectionsRoute();
     ArgumentCaptor<List> voiceInstructionsToCache = ArgumentCaptor.forClass(List.class);
 
-    theVoiceInstructionCache.preCache(aRoute);
+    theVoiceInstructionCache.initCache(aRoute);
 
     verify(aVoiceInstructionLoader, times(1))
       .cacheInstructions(voiceInstructionsToCache.capture());
@@ -64,7 +64,7 @@ public class VoiceInstructionCacheTest extends BaseTest {
     DirectionsRoute twentyOneInstructionsRoute = buildDirectionsRoute();
     ArgumentCaptor<List> voiceInstructionsToCache = ArgumentCaptor.forClass(List.class);
 
-    theVoiceInstructionCache.preCache(twentyOneInstructionsRoute);
+    theVoiceInstructionCache.initCache(twentyOneInstructionsRoute);
     theVoiceInstructionCache.update(5);
     theVoiceInstructionCache.cache();
     theVoiceInstructionCache.update(10);
@@ -88,7 +88,7 @@ public class VoiceInstructionCacheTest extends BaseTest {
       aVoiceInstructionLoader, aConnectivityStatus);
     DirectionsRoute aRoute = buildDirectionsRoute();
 
-    theVoiceInstructionCache.preCache(aRoute);
+    theVoiceInstructionCache.initCache(aRoute);
     theVoiceInstructionCache.update(5);
     theVoiceInstructionCache.cache();
 
@@ -105,7 +105,7 @@ public class VoiceInstructionCacheTest extends BaseTest {
       aVoiceInstructionLoader, aConnectivityStatus);
     DirectionsRoute aRoute = buildDirectionsRoute();
 
-    theVoiceInstructionCache.preCache(aRoute);
+    theVoiceInstructionCache.initCache(aRoute);
 
     verifyZeroInteractions(aVoiceInstructionLoader);
   }


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

 a follow up change of #2540 
1. add voiceInstruction cache handle before play the announcement so user could customize the announcement.
2. add voice instruction cache back.

- [x] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards