### PR TITLE
Fix faster route units

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/fasterroute/FasterRouteDetector.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/fasterroute/FasterRouteDetector.kt
@@ -13,7 +13,8 @@ internal object FasterRouteDetector {
 
     fun isRouteFaster(newRoute: DirectionsRoute, routeProgress: RouteProgress): Boolean {
         val newRouteDuration = newRoute.duration() ?: return false
-        val weightedDuration = routeProgress.durationRemaining().toDouble() * PERCENTAGE_THRESHOLD
-        return newRouteDuration < weightedDuration
+        val newRouteDurationMs = newRouteDuration * 1000.0
+        val weightedDurationMs = routeProgress.durationRemaining() * PERCENTAGE_THRESHOLD
+        return newRouteDurationMs < weightedDurationMs
     }
 }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/fasterroute/FasterRouteDetectorTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/fasterroute/FasterRouteDetectorTest.kt
@@ -5,7 +5,6 @@ import com.mapbox.navigation.base.trip.model.RouteProgress
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.unmockkObject
-import java.util.concurrent.TimeUnit
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -21,9 +20,9 @@ class FasterRouteDetectorTest {
     @Test
     fun shouldDetectWhenRouteIsFaster() {
         val newRoute: DirectionsRoute = mockk()
-        every { newRoute.duration() } returns TimeUnit.MINUTES.toSeconds(5).toDouble()
+        every { newRoute.duration() } returns 402.6
         val routeProgress: RouteProgress = mockk()
-        every { routeProgress.durationRemaining() } returns TimeUnit.MINUTES.toSeconds(10)
+        every { routeProgress.durationRemaining() } returns 797447
 
         val isFasterRoute = FasterRouteDetector.isRouteFaster(newRoute, routeProgress)
 
@@ -31,11 +30,23 @@ class FasterRouteDetectorTest {
     }
 
     @Test
+    fun shouldDetectWhenRouteIsSlower() {
+        val newRoute: DirectionsRoute = mockk()
+        every { newRoute.duration() } returns 512.2
+        val routeProgress: RouteProgress = mockk()
+        every { routeProgress.durationRemaining() } returns 450501
+
+        val isFasterRoute = FasterRouteDetector.isRouteFaster(newRoute, routeProgress)
+
+        assertFalse(isFasterRoute)
+    }
+
+    @Test
     fun shouldDefaultToFalseWhenDurationIsNull() {
         val newRoute: DirectionsRoute = mockk()
         every { newRoute.duration() } returns null
         val routeProgress: RouteProgress = mockk()
-        every { routeProgress.durationRemaining() } returns TimeUnit.MINUTES.toSeconds(10)
+        every { routeProgress.durationRemaining() } returns 727228
 
         val isFasterRoute = FasterRouteDetector.isRouteFaster(newRoute, routeProgress)
 
@@ -45,9 +56,9 @@ class FasterRouteDetectorTest {
     @Test
     fun shouldNotAllowSlightlyFasterRoutes() {
         val newRoute: DirectionsRoute = mockk()
-        every { newRoute.duration() } returns TimeUnit.MINUTES.toSeconds(49).toDouble()
+        every { newRoute.duration() } returns 634.7
         val routeProgress: RouteProgress = mockk()
-        every { routeProgress.durationRemaining() } returns TimeUnit.MINUTES.toSeconds(50)
+        every { routeProgress.durationRemaining() } returns 695811
 
         val isFasterRoute = FasterRouteDetector.isRouteFaster(newRoute, routeProgress)
 


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

The route is always faster because the unit comparison is wrong. Initial pull request here https://github.com/mapbox/mapbox-navigation-android/pull/2538

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->

cc: @abhishek1508 @Guardiola31337 