### PR TITLE
Add missing RouteOptions to DirectionsBuilder

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRoute.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRoute.java
@@ -631,10 +631,6 @@ public final class NavigationRoute {
         directionsBuilder.profile(options.profile());
       }
 
-      if (options.alternatives() != null) {
-        directionsBuilder.alternatives(options.alternatives());
-      }
-
       if (!TextUtils.isEmpty(options.voiceUnits())) {
         directionsBuilder.voiceUnits(options.voiceUnits());
       }
@@ -676,6 +672,20 @@ public final class NavigationRoute {
       WalkingOptions walkingOptions = options.walkingOptions();
       if (walkingOptions != null) {
         directionsBuilder.walkingOptions(walkingOptions);
+      }
+
+      if (options.continueStraight() != null) {
+        directionsBuilder.continueStraight(options.continueStraight());
+      }
+
+      if (!TextUtils.isEmpty(options.exclude())) {
+        directionsBuilder.exclude(options.exclude());
+      }
+
+      String radiuses = options.radiuses();
+      if (!TextUtils.isEmpty(radiuses)) {
+        double[] splitRadiuses = parseRadiuses(radiuses);
+        directionsBuilder.radiuses(splitRadiuses);
       }
 
       return this;
@@ -731,6 +741,18 @@ public final class NavigationRoute {
         }
       }
       return waypoints;
+    }
+
+    @NonNull
+    private double[] parseRadiuses(String radiuses) {
+      String[] splitRadiuses = radiuses.split(SEMICOLON);
+      double[] radiusesArray = new double[splitRadiuses.length];
+      int index = 0;
+      for (String radiusIndex : splitRadiuses) {
+        double parsedRadius = Double.valueOf(radiusIndex);
+        radiusesArray[index++] = parsedRadius;
+      }
+      return radiusesArray;
     }
 
     private void assembleWaypoints() {


### PR DESCRIPTION
## Description

This PR adds missing `RouteOptions` to `DirectionsBuilder`

Fixes https://github.com/mapbox/mapbox-navigation-android/issues/2026

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

The goal is to add the options not being carried through reroutes

### Implementation

Add missing options to `MapboxDirections.Builder` in `NavigationRoute.Builder#routeOptions`

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] Backport these changes to `master`

cc @EricGeiler @sridharvenkatesan @ericaeckes @tsuz @danpat @zugaldia @Aurora-Boreal 