### PR TITLE
Add missing RouteOptions to DirectionsBuilder

### DIFF
--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRoute.kt
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationRoute.kt
@@ -665,10 +665,6 @@ internal constructor(
                 directionsBuilder.profile(options.profile())
             }
 
-            if (options.alternatives() != null) {
-                directionsBuilder.alternatives(options.alternatives())
-            }
-
             if (!TextUtils.isEmpty(options.voiceUnits())) {
                 directionsBuilder.voiceUnits(options.voiceUnits())
             }
@@ -704,6 +700,20 @@ internal constructor(
             val walkingOptions = options.walkingOptions()
             if (walkingOptions != null) {
                 directionsBuilder.walkingOptions(walkingOptions)
+            }
+
+            if (options.continueStraight() != null) {
+                directionsBuilder.continueStraight(options.continueStraight())
+            }
+
+            if (!options.exclude().isNullOrEmpty()) {
+                directionsBuilder.exclude(options.exclude())
+            }
+
+            val radiuses = options.radiuses() ?: ""
+            if (radiuses.isNotEmpty()) {
+                val splitRadiuses = parseRadiuses(radiuses)
+                directionsBuilder.radiuses(splitRadiuses)
             }
 
             return this
@@ -763,6 +773,10 @@ internal constructor(
             }
             return waypoints
         }
+
+        private fun parseRadiuses(radiuses: String): List<Double?> =
+            radiuses.split(SEMICOLON.toRegex()).dropLastWhile { it.isEmpty() }
+                    .map { if (it.isEmpty()) null else it.toDouble() }
 
         private fun assembleWaypoints() {
             origin?.let { origin ->


### PR DESCRIPTION
## Description

This PR adds missing `RouteOptions` to `DirectionsBuilder`

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

The goal is to add the options not being carried through reroutes

### Implementation

Add missing options to `MapboxDirections.Builder` in `NavigationRoute.Builder#routeOptions`

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR