### PR TITLE
Avoid infinite loop when drawing a route

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationViewModel.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationViewModel.java
@@ -261,18 +261,6 @@ public class NavigationViewModel extends AndroidViewModel {
     }
   }
 
-  void updateRoute(DirectionsRoute route) {
-    this.route.setValue(route);
-    if (!isChangingConfigurations) {
-      routeJunctionModel.setValue(null);
-      startNavigation(route);
-      updateReplayEngine(route);
-      sendEventOnRerouteAlong(route);
-      isOffRoute.setValue(false);
-    }
-    resetConfigurationFlag();
-  }
-
   void updateRouteProgress(RouteProgress routeProgress) {
     this.routeProgress = routeProgress;
     sendEventArrival(routeProgress);
@@ -450,7 +438,7 @@ public class NavigationViewModel extends AndroidViewModel {
     @Override
     public void onRoutesChanged(@NotNull List<? extends DirectionsRoute> routes) {
       if (routes.size() > 0) {
-        updateRoute(routes.get(0));
+        route.setValue(routes.get(0));
       }
     }
   };


### PR DESCRIPTION
As far as I can tell, the `updateRoute` in the `NavigationView` should be unused (is unused in https://github.com/mapbox/mapbox-navigation-android/pull/2527 as well). Otherwise, we're running into an infinite loop.