### PR TITLE
Use enhanced location as origin for reroutes

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -130,7 +130,6 @@ constructor(
 
     private val mainJobController: JobControl = ThreadController.getMainScopeAndRootJob()
     private val directionsSession: DirectionsSession
-    private val adjustedRouteOptionsProvider: AdjustedRouteOptionsProvider
     private val tripService: TripService
     private val tripSession: TripSession
     private val navigationSession = NavigationSession(context)
@@ -192,8 +191,7 @@ constructor(
             )
         }
 
-        adjustedRouteOptionsProvider = AdjustedRouteOptionsProvider(directionsSession, tripSession)
-        fasterRouteController = FasterRouteController(adjustedRouteOptionsProvider, directionsSession, tripSession)
+        fasterRouteController = FasterRouteController(directionsSession, tripSession)
     }
 
     /**
@@ -458,8 +456,8 @@ constructor(
     }
 
     private fun reRoute() {
-        ifNonNull(tripSession.getRawLocation()) { location ->
-            val optionsRebuilt = adjustedRouteOptionsProvider.getRouteOptions(location)
+        ifNonNull(tripSession.getEnhancedLocation()) { location ->
+            val optionsRebuilt = AdjustedRouteOptionsProvider.getRouteOptions(directionsSession, tripSession, location)
                 ?: return
             directionsSession.requestRoutes(
                 optionsRebuilt,

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/AdjustedRouteOptionsProvider.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/AdjustedRouteOptionsProvider.kt
@@ -6,12 +6,11 @@ import com.mapbox.geojson.Point
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.trip.session.TripSession
 
-internal class AdjustedRouteOptionsProvider(
-    private val directionsSession: DirectionsSession,
-    private val tripSession: TripSession
-) {
+internal object AdjustedRouteOptionsProvider {
 
-    fun getRouteOptions(location: Location): RouteOptions? {
+    private const val DEFAULT_REROUTE_BEARING_TOLERANCE = 90.0
+
+    fun getRouteOptions(directionsSession: DirectionsSession, tripSession: TripSession, location: Location): RouteOptions? {
         val routeOptions: RouteOptions = directionsSession.getRouteOptions() ?: return null
         val routeProgress: RouteProgress = tripSession.getRouteProgress() ?: return null
 
@@ -102,9 +101,5 @@ internal class AdjustedRouteOptionsProvider(
         }
 
         return optionsBuilder.build()
-    }
-
-    companion object {
-        private const val DEFAULT_REROUTE_BEARING_TOLERANCE = 90.0
     }
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/fasterroute/FasterRouteController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/fasterroute/FasterRouteController.kt
@@ -10,7 +10,6 @@ import com.mapbox.navigation.core.trip.session.TripSession
 import com.mapbox.navigation.utils.timer.MapboxTimer
 
 internal class FasterRouteController(
-    private val adjustedRouteObjectsProvider: AdjustedRouteOptionsProvider,
     private val directionsSession: DirectionsSession,
     private val tripSession: TripSession
 ) {
@@ -34,7 +33,7 @@ internal class FasterRouteController(
 
     private fun requestFasterRoute() {
         ifNonNull(tripSession.getEnhancedLocation()) { enhancedLocation ->
-            val optionsRebuilt = adjustedRouteObjectsProvider.getRouteOptions(enhancedLocation)
+            val optionsRebuilt = AdjustedRouteOptionsProvider.getRouteOptions(directionsSession, tripSession, enhancedLocation)
                 ?: return
             directionsSession.requestFasterRoute(optionsRebuilt, fasterRouteRequestCallback)
         }


### PR DESCRIPTION
## Description

This PR replaces origin location for reroutes from raw to enhanced

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Raw location was a source of bad reroutes and snappings to the opposite side of the route

### Implementation

Pass `tripSession.getEnhancedLocation()` as `origin` for reroutes

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR

cc @mskurydin @SiarheiFedartsou @zugaldia @LukasPaczos 