### PR TITLE
Ignore free-drive route progress updates

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/SimpleMapboxNavigationKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/SimpleMapboxNavigationKt.kt
@@ -275,7 +275,9 @@ class SimpleMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
         override fun onRouteProgressChanged(routeProgress: RouteProgress) {
             Timber.d("route progress %s", routeProgress.toString())
             updatePuck(routeProgress)
-            navigationMapboxMap.onNewRouteProgress(routeProgress)
+            if (routeProgress.route() != null) {
+                navigationMapboxMap.onNewRouteProgress(routeProgress)
+            }
         }
     }
 


### PR DESCRIPTION
We shouldn't push `RouteProgress` updates if we're not in active guidance.