### PR TITLE
Fix CI release filter pattern triggers

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -24,38 +24,38 @@ workflows:
       - release-core-1_0:
           filters:
             tags:
-              only: /^release-core-*/
+              only: /^release-core-.*/
             branches:
               ignore: /.*/
       - release-ui-1_0:
           filters:
             tags:
-              only: /^release-ui-*/
+              only: /^release-ui-.*/
             branches:
               ignore: /.*/
       - release-core-1_0-qa:
           filters:
             tags:
-              only: /^qa-release-core-*/
+              only: /^qa-release-core-.*/
             branches:
               ignore: /.*/
       - release-ui-1_0-qa:
           filters:
             tags:
-              only: /^qa-release-ui-*/
+              only: /^qa-release-ui-.*/
             branches:
               ignore: /.*/
       - release-core-1_0-prod:
           filters:
             tags:
-              only: /^prod-release-core-*/
+              only: /^prod-release-core-.*/
             branches:
               ignore: /.*/
 
       - release-ui-1_0-prod:
           filters:
             tags:
-              only: /^prod-release-ui-*/
+              only: /^prod-release-ui-.*/
             branches:
               ignore: /.*/
       - ui-tests-1_0


### PR DESCRIPTION
## Description

This PR fixes the CI release filter pattern triggers

Regression from https://github.com/mapbox/mapbox-navigation-android/pull/2568

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Bring the CI release triggers back

### Implementation

Accidentally we removed the `.` from the jobs filters patterns in https://github.com/mapbox/mapbox-navigation-android/pull/2568 required by CircleCI syntax 

## Testing

- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR