### PR TITLE
Add ability to enable/disable the extended kalman filter (EKF)

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -529,6 +529,15 @@ constructor(
         tripSession.updateSensorEvent(sensorEvent)
     }
 
+    /**
+     * Updates the configuration to enable or disable the extended kalman filter (EKF).
+     *
+     * @param useEKF the new value for EKF
+     */
+    fun useExtendedKalmanFilter(useEKF: Boolean) {
+        tripSession.useExtendedKalmanFilter(useEKF)
+    }
+
     companion object {
 
         @JvmStatic

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
@@ -221,6 +221,19 @@ class MapboxTripSession(
         navigator.updateSensorEvent(sensorEvent)
     }
 
+    /**
+     * Updates the configuration to enable or disable the extended kalman filter (EKF).
+     *
+     * @param useEKF the new value for EKF
+     */
+    override fun useExtendedKalmanFilter(useEKF: Boolean) {
+        val config = navigator.getConfig()
+        if (config.useEKF != useEKF) {
+            config.useEKF = useEKF
+            navigator.setConfig(config)
+        }
+    }
+
     private var locationEngineCallback = object : LocationEngineCallback<LocationEngineResult> {
         override fun onSuccess(result: LocationEngineResult?) {
             result?.locations?.firstOrNull()?.let {

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/TripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/TripSession.kt
@@ -47,4 +47,6 @@ internal interface TripSession {
     fun unregisterVoiceInstructionsObserver(voiceInstructionsObserver: VoiceInstructionsObserver)
     fun unregisterAllVoiceInstructionsObservers()
     fun updateSensorEvent(sensorEvent: SensorEvent)
+
+    fun useExtendedKalmanFilter(useEKF: Boolean)
 }


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Add ability to toggle the extended kalman filter in navigation native.

- [ ] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal

We want to be able to able to toggle the extended kalman filter path.

### Implementation

Mapbox location native has a [simple boolean check](https://github.com/mapbox/mapbox-location-native/blob/64b59dee47b47066535815b43517d01a078ec437/src/mblc/mapbox_location.cpp#L209-L220) to see if the configuration supports EKF. 

This will make it so we can enable/disable EKF at any point in the app lifecycle.

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->

cc: @Guardiola31337 @mskurydin @LukasPaczos 