### PR TITLE
Refactor NavigationOptions Builder to have optional values

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/TripServiceActivityKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/TripServiceActivityKt.kt
@@ -78,8 +78,8 @@ class TripServiceActivityKt : AppCompatActivity(), OnMapReadyCallback {
 
         mapboxTripNotification = MapboxTripNotification(
             applicationContext,
-            NavigationOptions.Builder(
-                distanceFormatter = MapboxDistanceFormatter(
+            NavigationOptions.Builder()
+                .distanceFormatter(MapboxDistanceFormatter(
                     applicationContext,
                     "en",
                     METRIC,

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/TripSessionActivityKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/TripSessionActivityKt.kt
@@ -94,8 +94,8 @@ class TripSessionActivityKt : AppCompatActivity(), OnMapReadyCallback {
                 applicationContext,
                 MapboxTripNotification(
                     applicationContext,
-                    NavigationOptions.Builder(
-                        distanceFormatter = MapboxDistanceFormatter(
+                    NavigationOptions.Builder()
+                        .distanceFormatter(MapboxDistanceFormatter(
                             applicationContext,
                             "en",
                             METRIC,

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/NavigationOptions.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/NavigationOptions.kt
@@ -29,28 +29,27 @@ data class NavigationOptions constructor(
     val navigatorPollingDelay: Long,
     val distanceFormatter: DistanceFormatter?,
     val onboardRouterConfig: MapboxOnboardRouterConfig?,
-    val isFromNavigationUi: Boolean = false
+    val isFromNavigationUi: Boolean
 ) {
 
     /**
      * Get a builder to customize a subset of current options.
      */
-    fun toBuilder() = Builder(
-        roundingIncrement,
-        timeFormatType,
-        navigatorPollingDelay,
-        distanceFormatter,
-        onboardRouterConfig
-    )
+    fun toBuilder() = Builder()
+        .roundingIncrement(roundingIncrement)
+        .timeFormatType(timeFormatType)
+        .navigatorPollingDelay(navigatorPollingDelay)
+        .distanceFormatter(distanceFormatter)
+        .onboardRouterConfig(onboardRouterConfig)
+        .isFromNavigationUi(isFromNavigationUi)
 
-    data class Builder(
-        private var roundingIncrement: Int = ROUNDING_INCREMENT_FIFTY,
-        private var timeFormatType: Int = NONE_SPECIFIED,
-        private var navigatorPollingDelay: Long = DEFAULT_NAVIGATOR_POLLING_DELAY,
-        private var distanceFormatter: DistanceFormatter? = null,
-        private var onboardRouterConfig: MapboxOnboardRouterConfig? = null,
+    class Builder {
+        private var roundingIncrement: Int = ROUNDING_INCREMENT_FIFTY
+        private var timeFormatType: Int = NONE_SPECIFIED
+        private var navigatorPollingDelay: Long = DEFAULT_NAVIGATOR_POLLING_DELAY
+        private var distanceFormatter: DistanceFormatter? = null
+        private var onboardRouterConfig: MapboxOnboardRouterConfig? = null
         private var isFromNavigationUi: Boolean = false
-    ) {
 
         fun roundingIncrement(roundingIncrement: Int) =
             apply { this.roundingIncrement = roundingIncrement }
@@ -72,12 +71,12 @@ data class NavigationOptions constructor(
 
         fun build(): NavigationOptions {
             return NavigationOptions(
-                roundingIncrement,
-                timeFormatType,
-                navigatorPollingDelay,
-                distanceFormatter,
-                onboardRouterConfig,
-                isFromNavigationUi
+                roundingIncrement = roundingIncrement,
+                timeFormatType = timeFormatType,
+                navigatorPollingDelay = navigatorPollingDelay,
+                distanceFormatter = distanceFormatter,
+                onboardRouterConfig = onboardRouterConfig,
+                isFromNavigationUi = isFromNavigationUi
             )
         }
     }


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Everytime we add a value to the NavigationOptions we will force clients to support the new flags. Put all options into the constructor. But make the Builder have default values. This way we can add new values and they will adopt our defaults without any changes.

- [ ] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->

@Guardiola31337 @LukasPaczos @abhishek1508 