### PR TITLE
Fix #2604: wrong notification that shows a free-drive notification

### DIFF
--- a/libtrip-notification/src/main/java/com/mapbox/navigation/trip/notification/MapboxTripNotification.kt
+++ b/libtrip-notification/src/main/java/com/mapbox/navigation/trip/notification/MapboxTripNotification.kt
@@ -236,7 +236,6 @@ class MapboxTripNotification constructor(
 
     private fun updateNotificationViews(routeProgress: RouteProgress) {
         routeProgress.route()?.let {
-            setFreeDriveMode(false)
             updateInstructionText(routeProgress.bannerInstructions())
             updateDistanceText(routeProgress)
             generateArrivalTime(routeProgress)?.let { formattedTime ->
@@ -245,11 +244,12 @@ class MapboxTripNotification constructor(
             routeProgress.bannerInstructions()?.let { bannerInstructions ->
                 if (isManeuverStateChanged(bannerInstructions)) {
                     updateManeuverImage(
-                            routeProgress.currentLegProgress()?.currentStepProgress()?.step()?.drivingSide()
-                                    ?: STEP_MANEUVER_MODIFIER_RIGHT
+                        routeProgress.currentLegProgress()?.currentStepProgress()?.step()?.drivingSide()
+                            ?: STEP_MANEUVER_MODIFIER_RIGHT
                     )
                 }
             }
+            setFreeDriveMode(false)
         } ?: setFreeDriveMode(true)
     }
 
@@ -263,42 +263,42 @@ class MapboxTripNotification constructor(
 
     private fun updateEtaContentVisibility(isFreeDriveMode: Boolean) {
         collapsedNotificationRemoteViews?.setViewVisibility(
-                R.id.etaContent,
-                if (isFreeDriveMode) GONE else VISIBLE
+            R.id.etaContent,
+            if (isFreeDriveMode) GONE else VISIBLE
         )
         expandedNotificationRemoteViews?.setViewVisibility(
-                R.id.etaContent,
-                if (isFreeDriveMode) GONE else VISIBLE
+            R.id.etaContent,
+            if (isFreeDriveMode) GONE else VISIBLE
         )
     }
 
     private fun updateFreeDriveTextVisibility(isFreeDriveMode: Boolean) {
         collapsedNotificationRemoteViews?.setViewVisibility(
-                R.id.freeDriveText,
-                if (isFreeDriveMode) VISIBLE else GONE
+            R.id.freeDriveText,
+            if (isFreeDriveMode) VISIBLE else GONE
         )
         expandedNotificationRemoteViews?.setViewVisibility(
-                R.id.freeDriveText,
-                if (isFreeDriveMode) VISIBLE else GONE
+            R.id.freeDriveText,
+            if (isFreeDriveMode) VISIBLE else GONE
         )
     }
 
     private fun updateEndNavigationBtnText(isFreeDriveMode: Boolean) {
         expandedNotificationRemoteViews?.setTextViewText(
-                R.id.endNavigationBtnText,
-                applicationContext.getString(if (isFreeDriveMode) R.string.stop_session else R.string.end_navigation)
+            R.id.endNavigationBtnText,
+            applicationContext.getString(if (isFreeDriveMode) R.string.stop_session else R.string.end_navigation)
         )
     }
 
     private fun updateManeuverImageResource(isFreeDriveMode: Boolean) {
         if (isFreeDriveMode) {
             collapsedNotificationRemoteViews?.setImageViewResource(
-                    R.id.maneuverImage,
-                    R.drawable.ic_navigation
+                R.id.maneuverImage,
+                R.drawable.ic_navigation
             )
             expandedNotificationRemoteViews?.setImageViewResource(
-                    R.id.maneuverImage,
-                    R.drawable.ic_navigation
+                R.id.maneuverImage,
+                R.drawable.ic_navigation
             )
         }
     }
@@ -309,11 +309,11 @@ class MapboxTripNotification constructor(
             if (currentInstructionText.isNullOrEmpty() || currentInstructionText != primaryText) {
                 collapsedNotificationRemoteViews?.setTextViewText(
                     R.id.notificationInstructionText,
-                        primaryText
+                    primaryText
                 )
                 expandedNotificationRemoteViews?.setTextViewText(
                     R.id.notificationInstructionText,
-                        primaryText
+                    primaryText
                 )
                 currentInstructionText = primaryText
             }


### PR DESCRIPTION

<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Fix #2604 : wrong notification that shows a free-drive notification

The kotlin let will use the last sentence in the block as its return value. Before this fix, the `let` block will return `routeProgress.bannerInstructions()?.let` as its result. So in any cases that the routeProgress has a valid `route` but doesn't have a bannerInstruction then it will execute the right-hand side expression
of the elvis operator which is `setFreeDriveMode(true)` in this issue.

To fix this issue, just move a non-null expression to the last of the let block.

- [X] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

