### PR TITLE
Try using the location timestamp provided by Nav Native for animation

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/legacy/NavigationConstants.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/legacy/NavigationConstants.kt
@@ -158,6 +158,11 @@ object NavigationConstants {
      */
     const val NAVIGATION_MIN_CAMERA_TILT_ADJUSTMENT_ANIMATION_DURATION = 750L
 
+    /**
+     * The minimal lookahead value in milliseconds required to perform a lookahead animation.
+     */
+    const val MINIMAL_LOOKAHEAD_LOCATION_TIME_VALUE = 250L
+
     internal const val NON_NULL_APPLICATION_CONTEXT_REQUIRED =
         "Non-null application context required."
 


### PR DESCRIPTION
This minimizes the visual difference between the pucks position on the map and the real position of the device, because we're using the "in the future" location timestamp generated by Navigation Native. This relies on the assumption that the location sample's timestamp actually is in the future (arbitrary decider value), if it's not, the regular delayed animation is used. This also decreases the speed-up/slow-down visual behavior of the puck near the intersections. It's not removed completely, because keypoints do require us to animate over a longer distance than in reality though.