### PR TITLE
Make sure core is not depending on module's private impl

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/TripServiceActivityKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/TripServiceActivityKt.kt
@@ -13,6 +13,7 @@ import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.trip.model.RouteLegProgress
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.base.trip.model.RouteStepProgress
+import com.mapbox.navigation.base.trip.notification.NotificationAction
 import com.mapbox.navigation.base.typedef.METRIC
 import com.mapbox.navigation.base.typedef.ROUNDING_INCREMENT_FIFTY
 import com.mapbox.navigation.base.typedef.TWENTY_FOUR_HOURS
@@ -20,7 +21,6 @@ import com.mapbox.navigation.core.MapboxDistanceFormatter
 import com.mapbox.navigation.core.trip.service.MapboxTripService
 import com.mapbox.navigation.examples.R
 import com.mapbox.navigation.trip.notification.MapboxTripNotification
-import com.mapbox.navigation.trip.notification.NotificationAction
 import com.mapbox.navigation.ui.route.NavigationMapRoute
 import com.mapbox.navigation.utils.thread.ThreadController
 import com.mapbox.navigation.utils.thread.monitorChannelWithException
@@ -79,13 +79,14 @@ class TripServiceActivityKt : AppCompatActivity(), OnMapReadyCallback {
         mapboxTripNotification = MapboxTripNotification(
             applicationContext,
             NavigationOptions.Builder()
-                .distanceFormatter(MapboxDistanceFormatter(
-                    applicationContext,
-                    "en",
-                    METRIC,
-                    ROUNDING_INCREMENT_FIFTY
-                )
-            ).timeFormatType(TWENTY_FOUR_HOURS).build()
+                .distanceFormatter(
+                    MapboxDistanceFormatter(
+                        applicationContext,
+                        "en",
+                        METRIC,
+                        ROUNDING_INCREMENT_FIFTY
+                    )
+                ).timeFormatType(TWENTY_FOUR_HOURS).build()
         )
 
         // If you want to use Mapbox provided Service do this

--- a/libdirections-hybrid/build.gradle
+++ b/libdirections-hybrid/build.gradle
@@ -30,8 +30,8 @@ dependencies {
     kapt dependenciesList.mapboxAnnotationsProcessor
 
     api project(':libnavigation-base')
-    implementation project(":libdirections-onboard")
-    implementation project(":libdirections-offboard")
+    runtimeOnly project(":libdirections-onboard")
+    runtimeOnly project(":libdirections-offboard")
     implementation project(":libnavigation-util")
 
     //ktlint

--- a/libdirections-hybrid/src/test/java/com/mapbox/navigation/route/hybrid/MapboxHybridRouterTest.kt
+++ b/libdirections-hybrid/src/test/java/com/mapbox/navigation/route/hybrid/MapboxHybridRouterTest.kt
@@ -10,8 +10,6 @@ import com.mapbox.geojson.Point
 import com.mapbox.navigation.base.extensions.applyDefaultParams
 import com.mapbox.navigation.base.extensions.coordinates
 import com.mapbox.navigation.base.route.Router
-import com.mapbox.navigation.route.offboard.MapboxOffboardRouter
-import com.mapbox.navigation.route.onboard.MapboxOnboardRouter
 import com.mapbox.navigation.testing.MainCoroutineRule
 import com.mapbox.navigation.utils.network.NetworkStatusService
 import io.mockk.every
@@ -36,8 +34,8 @@ class MapboxHybridRouterTest {
     var rule = MainCoroutineRule()
 
     private lateinit var hybridRouter: MapboxHybridRouter
-    private val onboardRouter: MapboxOnboardRouter = mockk(relaxUnitFun = true)
-    private val offboardRouter: MapboxOffboardRouter = mockk(relaxUnitFun = true)
+    private val onboardRouter: Router = mockk(relaxUnitFun = true)
+    private val offboardRouter: Router = mockk(relaxUnitFun = true)
     private val context: Context = mockk(relaxUnitFun = true)
     private val connectivityManager: ConnectivityManager = mockk(relaxUnitFun = true)
     private val intent: Intent = mockk(relaxUnitFun = true)

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/extensions/LocaleEx.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/extensions/LocaleEx.kt
@@ -1,6 +1,6 @@
 @file:JvmName("LocaleEx")
 
-package com.mapbox.navigation.trip.notification.utils.extensions
+package com.mapbox.navigation.base.extensions
 
 import com.mapbox.navigation.base.typedef.IMPERIAL
 import com.mapbox.navigation.base.typedef.METRIC

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/notification/NotificationAction.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/notification/NotificationAction.kt
@@ -1,6 +1,4 @@
-package com.mapbox.navigation.trip.notification
-
-import com.mapbox.navigation.base.trip.TripNotification
+package com.mapbox.navigation.base.trip.notification
 
 /**
  * Defines set of actions available for [TripNotification]

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/notification/TripNotification.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/notification/TripNotification.kt
@@ -1,4 +1,4 @@
-package com.mapbox.navigation.base.trip
+package com.mapbox.navigation.base.trip.notification
 
 import android.app.Notification
 import com.mapbox.navigation.base.trip.model.RouteProgress

--- a/libnavigation-core/build.gradle
+++ b/libnavigation-core/build.gradle
@@ -38,8 +38,8 @@ dependencies {
     api project(':libnavigation-base')
     implementation project(':libnavigation-util')
     implementation project(':libnavigator')
-    implementation project(':libdirections-hybrid')
-    implementation project(':libtrip-notification')
+    runtimeOnly project(':libdirections-hybrid')
+    runtimeOnly project(':libtrip-notification')
     implementation project(':libnavigation-metrics')
     implementation dependenciesList.mapboxAndroidAccounts
     implementation dependenciesList.mapboxSdkTurf

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxDistanceFormatter.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxDistanceFormatter.kt
@@ -6,13 +6,12 @@ import android.text.SpannableString
 import android.text.Spanned
 import android.text.style.RelativeSizeSpan
 import android.text.style.StyleSpan
+import com.mapbox.navigation.base.extensions.getUnitTypeForLocale
 import com.mapbox.navigation.base.formatter.DistanceFormatter
 import com.mapbox.navigation.base.typedef.IMPERIAL
 import com.mapbox.navigation.base.typedef.METRIC
 import com.mapbox.navigation.base.typedef.RoundingIncrement
 import com.mapbox.navigation.base.typedef.VoiceUnit
-import com.mapbox.navigation.trip.notification.R
-import com.mapbox.navigation.trip.notification.utils.extensions.getUnitTypeForLocale
 import com.mapbox.navigation.utils.extensions.inferDeviceLocale
 import com.mapbox.turf.TurfConstants.UNIT_FEET
 import com.mapbox.turf.TurfConstants.UNIT_KILOMETERS

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -19,8 +19,9 @@ import com.mapbox.navigation.base.options.Endpoint
 import com.mapbox.navigation.base.options.MapboxOnboardRouterConfig
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.route.Router
-import com.mapbox.navigation.base.trip.TripNotification
 import com.mapbox.navigation.base.trip.model.RouteProgress
+import com.mapbox.navigation.base.trip.notification.NotificationAction
+import com.mapbox.navigation.base.trip.notification.TripNotification
 import com.mapbox.navigation.base.typedef.NONE_SPECIFIED
 import com.mapbox.navigation.base.typedef.ROUNDING_INCREMENT_FIFTY
 import com.mapbox.navigation.base.typedef.UNDEFINED
@@ -46,7 +47,6 @@ import com.mapbox.navigation.core.trip.session.VoiceInstructionsObserver
 import com.mapbox.navigation.metrics.MapboxMetricsReporter
 import com.mapbox.navigation.navigator.MapboxNativeNavigator
 import com.mapbox.navigation.navigator.MapboxNativeNavigatorImpl
-import com.mapbox.navigation.trip.notification.NotificationAction
 import com.mapbox.navigation.utils.network.NetworkStatusService
 import com.mapbox.navigation.utils.thread.JobControl
 import com.mapbox.navigation.utils.thread.ThreadController
@@ -457,7 +457,11 @@ constructor(
 
     private fun reRoute() {
         ifNonNull(tripSession.getEnhancedLocation()) { location ->
-            val optionsRebuilt = AdjustedRouteOptionsProvider.getRouteOptions(directionsSession, tripSession, location)
+            val optionsRebuilt = AdjustedRouteOptionsProvider.getRouteOptions(
+                directionsSession,
+                tripSession,
+                location
+            )
                 ?: return
             directionsSession.requestRoutes(
                 optionsRebuilt,

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/NavigationComponentProvider.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/NavigationComponentProvider.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import com.mapbox.android.core.location.LocationEngine
 import com.mapbox.android.core.location.LocationEngineRequest
 import com.mapbox.navigation.base.route.Router
-import com.mapbox.navigation.base.trip.TripNotification
+import com.mapbox.navigation.base.trip.notification.TripNotification
 import com.mapbox.navigation.core.directions.session.DirectionsSession
 import com.mapbox.navigation.core.directions.session.MapboxDirectionsSession
 import com.mapbox.navigation.core.trip.service.MapboxTripService

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/service/MapboxTripService.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/service/MapboxTripService.kt
@@ -4,9 +4,9 @@ import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.util.Log
-import com.mapbox.navigation.base.trip.TripNotification
 import com.mapbox.navigation.base.trip.model.MapboxNotificationData
 import com.mapbox.navigation.base.trip.model.RouteProgress
+import com.mapbox.navigation.base.trip.notification.TripNotification
 import com.mapbox.navigation.utils.thread.ifChannelException
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlinx.coroutines.channels.Channel
@@ -21,7 +21,8 @@ class MapboxTripService(
 
     companion object {
         private var notificationDataChannel = Channel<MapboxNotificationData>(1)
-        internal fun getNotificationDataChannel(): ReceiveChannel<MapboxNotificationData> = notificationDataChannel
+        internal fun getNotificationDataChannel(): ReceiveChannel<MapboxNotificationData> =
+            notificationDataChannel
     }
 
     private constructor(

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/service/MapboxTripServiceTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/service/MapboxTripServiceTest.kt
@@ -1,8 +1,8 @@
 package com.mapbox.navigation.core.trip.service
 
 import android.app.Notification
-import com.mapbox.navigation.base.trip.TripNotification
 import com.mapbox.navigation.base.trip.model.RouteProgress
+import com.mapbox.navigation.base.trip.notification.TripNotification
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify

--- a/libnavigation-util/src/main/res/values-ar/strings.xml
+++ b/libnavigation-util/src/main/res/values-ar/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="kilometers">كم</string>
+    <string name="meters">م</string>
+    <string name="miles">ميل</string>
+    <string name="feet">قدم</string>
+</resources>

--- a/libnavigation-util/src/main/res/values-bg/strings.xml
+++ b/libnavigation-util/src/main/res/values-bg/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="kilometers">км</string>
+    <string name="meters">м</string>
+    <string name="miles">мили</string>
+    <string name="feet">фута</string>
+</resources>

--- a/libnavigation-util/src/main/res/values-cs/strings.xml
+++ b/libnavigation-util/src/main/res/values-cs/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="kilometers">km</string>
+    <string name="meters">m</string>
+    <string name="miles">míle</string>
+    <string name="feet">stopy</string>
+</resources>

--- a/libnavigation-util/src/main/res/values-da/strings.xml
+++ b/libnavigation-util/src/main/res/values-da/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="kilometers">km</string>
+    <string name="meters">m</string>
+    <string name="miles">mi</string>
+    <string name="feet">ft</string>
+</resources>

--- a/libnavigation-util/src/main/res/values-de/strings.xml
+++ b/libnavigation-util/src/main/res/values-de/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="kilometers">km</string>
+    <string name="meters">m</string>
+    <string name="miles">mile</string>
+    <string name="feet">Fuß</string>
+</resources>

--- a/libnavigation-util/src/main/res/values-es/strings.xml
+++ b/libnavigation-util/src/main/res/values-es/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="kilometers">km</string>
+    <string name="meters">m</string>
+    <string name="miles">mi</string>
+    <string name="feet">pie</string>
+</resources>

--- a/libnavigation-util/src/main/res/values-fa/strings.xml
+++ b/libnavigation-util/src/main/res/values-fa/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="kilometers">کیلومتر</string>
+    <string name="meters">متر</string>
+    <string name="miles">مایل</string>
+    <string name="feet">قدم</string>
+</resources>

--- a/libnavigation-util/src/main/res/values-fr/strings.xml
+++ b/libnavigation-util/src/main/res/values-fr/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="kilometers">km</string>
+    <string name="meters">m</string>
+    <string name="miles">mi</string>
+    <string name="feet">ft</string>
+</resources>

--- a/libnavigation-util/src/main/res/values-gl/strings.xml
+++ b/libnavigation-util/src/main/res/values-gl/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="kilometers">km</string>
+    <string name="meters">m</string>
+    <string name="miles">mi</string>
+    <string name="feet">pé</string>
+</resources>

--- a/libnavigation-util/src/main/res/values-he/strings.xml
+++ b/libnavigation-util/src/main/res/values-he/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="kilometers">ק״מ</string>
+    <string name="meters">מ׳</string>
+    <string name="miles">מייל</string>
+</resources>

--- a/libnavigation-util/src/main/res/values-hu/strings.xml
+++ b/libnavigation-util/src/main/res/values-hu/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="kilometers">km</string>
+    <string name="meters">m</string>
+    <string name="miles">mérföld</string>
+    <string name="feet">láb</string>
+</resources>

--- a/libnavigation-util/src/main/res/values-ja/strings.xml
+++ b/libnavigation-util/src/main/res/values-ja/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="kilometers">km</string>
+    <string name="meters">m</string>
+    <string name="miles">マイル</string>
+    <string name="feet">フィート</string>
+</resources>

--- a/libnavigation-util/src/main/res/values-ko/strings.xml
+++ b/libnavigation-util/src/main/res/values-ko/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="kilometers">km</string>
+    <string name="meters">m</string>
+    <string name="miles">mi</string>
+    <string name="feet">ft</string>
+</resources>

--- a/libnavigation-util/src/main/res/values-my/strings.xml
+++ b/libnavigation-util/src/main/res/values-my/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="kilometers">ကီလိုမီတာ</string>
+    <string name="meters">မီတာ</string>
+    <string name="miles">မိုင်</string>
+    <string name="feet">ပေ</string>
+    </resources>

--- a/libnavigation-util/src/main/res/values-pt-rBR/strings.xml
+++ b/libnavigation-util/src/main/res/values-pt-rBR/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="kilometers">KM</string>
+    <string name="meters">M</string>
+    <string name="miles">MI</string>
+    <string name="feet">FT</string>
+</resources>

--- a/libnavigation-util/src/main/res/values-pt-rPT/strings.xml
+++ b/libnavigation-util/src/main/res/values-pt-rPT/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="kilometers">km</string>
+    <string name="meters">m</string>
+    <string name="miles">mi</string>
+    <string name="feet">ft</string>
+</resources>

--- a/libnavigation-util/src/main/res/values-ru/strings.xml
+++ b/libnavigation-util/src/main/res/values-ru/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="kilometers">км</string>
+    <string name="meters">м</string>
+    <string name="miles">миль</string>
+    <string name="feet">футов</string>
+</resources>

--- a/libnavigation-util/src/main/res/values-sv/strings.xml
+++ b/libnavigation-util/src/main/res/values-sv/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="kilometers">km</string>
+    <string name="meters">m</string>
+    <string name="miles">mi</string>
+    <string name="feet">fot</string>
+</resources>

--- a/libnavigation-util/src/main/res/values-uk/strings.xml
+++ b/libnavigation-util/src/main/res/values-uk/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="kilometers">км</string>
+    <string name="meters">м</string>
+    <string name="miles">mi</string>
+    <string name="feet">фт</string>
+</resources>

--- a/libnavigation-util/src/main/res/values-uz/strings.xml
+++ b/libnavigation-util/src/main/res/values-uz/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="kilometers">km</string>
+    <string name="meters">m</string>
+    <string name="miles">mil</string>
+    <string name="feet">fut</string>
+</resources>

--- a/libnavigation-util/src/main/res/values-vi/strings.xml
+++ b/libnavigation-util/src/main/res/values-vi/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="kilometers">km</string>
+    <string name="meters">m</string>
+    <string name="miles">dặm</string>
+    <string name="feet">foot</string>
+</resources>

--- a/libnavigation-util/src/main/res/values-yo/strings.xml
+++ b/libnavigation-util/src/main/res/values-yo/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="kilometers">km</string>
+    <string name="meters">m</string>
+    <string name="miles">mi</string>
+    <string name="feet">ft</string>
+</resources>

--- a/libnavigation-util/src/main/res/values/strings.xml
+++ b/libnavigation-util/src/main/res/values/strings.xml
@@ -1,0 +1,6 @@
+<resources>
+    <string name="kilometers">km</string>
+    <string name="meters">m</string>
+    <string name="miles">mi</string>
+    <string name="feet">ft</string>
+</resources>

--- a/libtrip-notification/src/main/java/com/mapbox/navigation/trip/notification/MapboxTripNotification.kt
+++ b/libtrip-notification/src/main/java/com/mapbox/navigation/trip/notification/MapboxTripNotification.kt
@@ -27,8 +27,9 @@ import com.mapbox.annotation.navigation.module.MapboxNavigationModuleType
 import com.mapbox.api.directions.v5.models.BannerInstructions
 import com.mapbox.navigation.base.formatter.DistanceFormatter
 import com.mapbox.navigation.base.options.NavigationOptions
-import com.mapbox.navigation.base.trip.TripNotification
 import com.mapbox.navigation.base.trip.model.RouteProgress
+import com.mapbox.navigation.base.trip.notification.NotificationAction
+import com.mapbox.navigation.base.trip.notification.TripNotification
 import com.mapbox.navigation.trip.notification.maneuver.ManeuverIconHelper.DEFAULT_ROUNDABOUT_ANGLE
 import com.mapbox.navigation.trip.notification.maneuver.ManeuverIconHelper.MANEUVER_ICON_DRAWER_MAP
 import com.mapbox.navigation.trip.notification.maneuver.ManeuverIconHelper.MANEUVER_TYPES_WITH_NULL_MODIFIERS

--- a/libtrip-notification/src/main/res/values-ar/strings.xml
+++ b/libtrip-notification/src/main/res/values-ar/strings.xml
@@ -4,10 +4,6 @@
     <string name="end_navigation">انهاء الرحلة</string>
     <string name="channel_name">تنبيهات الرحلة</string>
     <string name="notification_arrival_time_format">الوصول عند %s</string>
-    <string name="kilometers">كم</string>
-    <string name="meters">م</string>
-    <string name="miles">ميل</string>
-    <string name="feet">قدم</string>
     <string name="eta_format">%s الوقت المتوقع للوصول</string>
 
     <!-- Time formatting -->

--- a/libtrip-notification/src/main/res/values-bg/strings.xml
+++ b/libtrip-notification/src/main/res/values-bg/strings.xml
@@ -4,10 +4,6 @@
     <string name="end_navigation">Край на навигация</string>
     <string name="channel_name">Нотификации от навигация</string>
     <string name="notification_arrival_time_format">Пристигнахте на %s</string>
-    <string name="kilometers">км</string>
-    <string name="meters">м</string>
-    <string name="miles">мили</string>
-    <string name="feet">фута</string>
     <string name="eta_format">%s Пристигане</string>
 
     <!-- Time formatting -->

--- a/libtrip-notification/src/main/res/values-cs/strings.xml
+++ b/libtrip-notification/src/main/res/values-cs/strings.xml
@@ -4,10 +4,6 @@
     <string name="end_navigation">Ukončit navigaci</string>
     <string name="channel_name">Navigační upozornění</string>
     <string name="notification_arrival_time_format">Příjezd v %s</string>
-    <string name="kilometers">km</string>
-    <string name="meters">m</string>
-    <string name="miles">míle</string>
-    <string name="feet">stopy</string>
     <string name="eta_format">%s Předpokládaný čas příjezdu</string>
 
     <!-- Time formatting -->

--- a/libtrip-notification/src/main/res/values-da/strings.xml
+++ b/libtrip-notification/src/main/res/values-da/strings.xml
@@ -4,10 +4,6 @@
     <string name="end_navigation">Slut navigation </string>
     <string name="channel_name">Navigationsnotifikationer</string>
     <string name="notification_arrival_time_format">Ankomst om %s</string>
-    <string name="kilometers">km</string>
-    <string name="meters">m</string>
-    <string name="miles">mi</string>
-    <string name="feet">ft</string>
     <string name="eta_format">%s ETA</string>
 
     <!-- Time formatting -->

--- a/libtrip-notification/src/main/res/values-de/strings.xml
+++ b/libtrip-notification/src/main/res/values-de/strings.xml
@@ -4,10 +4,6 @@
     <string name="end_navigation">Navigation beenden</string>
     <string name="channel_name">Navigationsbenachrichtigungen</string>
     <string name="notification_arrival_time_format">Ankunft um %s</string>
-    <string name="kilometers">km</string>
-    <string name="meters">m</string>
-    <string name="miles">mile</string>
-    <string name="feet">Fuß</string>
     <string name="eta_format">%s ETA</string>
 
     <!-- Time formatting -->

--- a/libtrip-notification/src/main/res/values-es/strings.xml
+++ b/libtrip-notification/src/main/res/values-es/strings.xml
@@ -4,10 +4,6 @@
     <string name="end_navigation">Finaliza navegación</string>
     <string name="channel_name">Notificaciones de navegación</string>
     <string name="notification_arrival_time_format">Llegando en %s</string>
-    <string name="kilometers">km</string>
-    <string name="meters">m</string>
-    <string name="miles">mi</string>
-    <string name="feet">pie</string>
     <!-- Time formatting -->
     <plurals name="numberOfDays">
         <item quantity="one">día</item>

--- a/libtrip-notification/src/main/res/values-fa/strings.xml
+++ b/libtrip-notification/src/main/res/values-fa/strings.xml
@@ -4,10 +4,6 @@
     <string name="end_navigation">پایان مسیر یابی</string>
     <string name="channel_name">اعلانات مسیر یابی</string>
     <string name="notification_arrival_time_format">فعال در %s</string>
-    <string name="kilometers">کیلومتر</string>
-    <string name="meters">متر</string>
-    <string name="miles">مایل</string>
-    <string name="feet">قدم</string>
     <string name="eta_format">%s ETA</string>
 
     <!-- Time formatting -->

--- a/libtrip-notification/src/main/res/values-fr/strings.xml
+++ b/libtrip-notification/src/main/res/values-fr/strings.xml
@@ -4,10 +4,6 @@
     <string name="end_navigation">Fin de navigation</string>
     <string name="channel_name">Notifications de navigation</string>
     <string name="notification_arrival_time_format">Arrivée à %s</string>
-    <string name="kilometers">km</string>
-    <string name="meters">m</string>
-    <string name="miles">mi</string>
-    <string name="feet">ft</string>
     <!-- Hour -->
     <string name="hr">h</string>
     <!-- Minute -->

--- a/libtrip-notification/src/main/res/values-gl/strings.xml
+++ b/libtrip-notification/src/main/res/values-gl/strings.xml
@@ -4,10 +4,6 @@
     <string name="end_navigation">Remata a navegación</string>
     <string name="channel_name">Notificacións de navegación</string>
     <string name="notification_arrival_time_format">Chegando en %s</string>
-    <string name="kilometers">km</string>
-    <string name="meters">m</string>
-    <string name="miles">mi</string>
-    <string name="feet">pé</string>
     <string name="eta_format">%s ETA</string>
 
     <!-- Time formatting -->

--- a/libtrip-notification/src/main/res/values-he/strings.xml
+++ b/libtrip-notification/src/main/res/values-he/strings.xml
@@ -4,9 +4,6 @@
     <string name="end_navigation">סיום ניווט</string>
     <string name="channel_name">הודעות ניווט</string>
     <string name="notification_arrival_time_format">הגעה ב%s</string>
-    <string name="kilometers">ק״מ</string>
-    <string name="meters">מ׳</string>
-    <string name="miles">מייל</string>
     <!-- Hour -->
     <string name="hr">שעות</string>
     <!-- Minute -->

--- a/libtrip-notification/src/main/res/values-hu/strings.xml
+++ b/libtrip-notification/src/main/res/values-hu/strings.xml
@@ -4,10 +4,6 @@
     <string name="end_navigation">Navigáció vége</string>
     <string name="channel_name">Navigációs értesítések</string>
     <string name="notification_arrival_time_format">Érkezés: %s</string>
-    <string name="kilometers">km</string>
-    <string name="meters">m</string>
-    <string name="miles">mérföld</string>
-    <string name="feet">láb</string>
     <string name="eta_format">%s érkezés</string>
 
     <!-- Time formatting -->

--- a/libtrip-notification/src/main/res/values-ja/strings.xml
+++ b/libtrip-notification/src/main/res/values-ja/strings.xml
@@ -4,10 +4,6 @@
     <string name="end_navigation">ナビゲーションを終了</string>
     <string name="channel_name">ナビゲーション通知</string>
     <string name="notification_arrival_time_format">%sに到着します</string>
-    <string name="kilometers">km</string>
-    <string name="meters">m</string>
-    <string name="miles">マイル</string>
-    <string name="feet">フィート</string>
     <string name="eta_format">到着予定時刻%s</string>
 
     <!-- Time formatting -->

--- a/libtrip-notification/src/main/res/values-ko/strings.xml
+++ b/libtrip-notification/src/main/res/values-ko/strings.xml
@@ -4,10 +4,6 @@
     <string name="end_navigation">네비게이션 종료</string>
     <string name="channel_name">네비게이션 알림</string>
     <string name="notification_arrival_time_format">%s 에 도착</string>
-    <string name="kilometers">km</string>
-    <string name="meters">m</string>
-    <string name="miles">mi</string>
-    <string name="feet">ft</string>
     <!-- Hour -->
     <string name="hr">시</string>
     <!-- Minute -->

--- a/libtrip-notification/src/main/res/values-my/strings.xml
+++ b/libtrip-notification/src/main/res/values-my/strings.xml
@@ -4,8 +4,4 @@
     <string name="end_navigation">လမ်းညွန်မှုအဆုံးသတ်ပါ</string>
     <string name="channel_name">လမ်းညွန်မှုအသိပေးခြင်းများ</string>
     <string name="notification_arrival_time_format">%sတွင်ရောက်ရှိသည်</string>
-    <string name="kilometers">ကီလိုမီတာ</string>
-    <string name="meters">မီတာ</string>
-    <string name="miles">မိုင်</string>
-    <string name="feet">ပေ</string>
     </resources>

--- a/libtrip-notification/src/main/res/values-pt-rBR/strings.xml
+++ b/libtrip-notification/src/main/res/values-pt-rBR/strings.xml
@@ -4,10 +4,6 @@
     <string name="end_navigation">Finalizar navegação</string>
     <string name="channel_name">Notificações de navegação</string>
     <string name="notification_arrival_time_format">Chegar às %s</string>
-    <string name="kilometers">KM</string>
-    <string name="meters">M</string>
-    <string name="miles">MI</string>
-    <string name="feet">FT</string>
     <string name="eta_format">%s estimado</string>
 
     <!-- Time formatting -->

--- a/libtrip-notification/src/main/res/values-pt-rPT/strings.xml
+++ b/libtrip-notification/src/main/res/values-pt-rPT/strings.xml
@@ -4,10 +4,6 @@
     <string name="end_navigation">Terminar Navegação</string>
     <string name="channel_name">Notificações de Navegação</string>
     <string name="notification_arrival_time_format">Chegada às %s</string>
-    <string name="kilometers">km</string>
-    <string name="meters">m</string>
-    <string name="miles">mi</string>
-    <string name="feet">ft</string>
     <string name="eta_format">%s TEC</string>
 
     <!-- Time formatting -->

--- a/libtrip-notification/src/main/res/values-ru/strings.xml
+++ b/libtrip-notification/src/main/res/values-ru/strings.xml
@@ -4,10 +4,6 @@
     <string name="end_navigation">Завершить</string>
     <string name="channel_name">Оповещения навигации</string>
     <string name="notification_arrival_time_format">Время прибытия %s</string>
-    <string name="kilometers">км</string>
-    <string name="meters">м</string>
-    <string name="miles">миль</string>
-    <string name="feet">футов</string>
     <string name="eta_format">Ожидаемое прибытие %s</string>
 
     <!-- Time formatting -->

--- a/libtrip-notification/src/main/res/values-sv/strings.xml
+++ b/libtrip-notification/src/main/res/values-sv/strings.xml
@@ -4,10 +4,6 @@
     <string name="end_navigation">Avsluta Navigering</string>
     <string name="channel_name">Navigationsmeddelanden</string>
     <string name="notification_arrival_time_format">Anländ till %s</string>
-    <string name="kilometers">km</string>
-    <string name="meters">m</string>
-    <string name="miles">mi</string>
-    <string name="feet">fot</string>
     <string name="eta_format">%s ETA</string>
 
     </resources>

--- a/libtrip-notification/src/main/res/values-uk/strings.xml
+++ b/libtrip-notification/src/main/res/values-uk/strings.xml
@@ -4,10 +4,6 @@
     <string name="end_navigation">Закінчити навігацію</string>
     <string name="channel_name">Навігаційні повідомлення</string>
     <string name="notification_arrival_time_format">Прибуття о %s</string>
-    <string name="kilometers">км</string>
-    <string name="meters">м</string>
-    <string name="miles">mi</string>
-    <string name="feet">фт</string>
     <string name="eta_format">До прибуття %s</string>
 
     <!-- Time formatting -->

--- a/libtrip-notification/src/main/res/values-uz/strings.xml
+++ b/libtrip-notification/src/main/res/values-uz/strings.xml
@@ -3,10 +3,6 @@
     <!-- Notification Strings -->
     <string name="end_navigation">Yo\'nalish tugallandi</string>
     <string name="channel_name">Yo\'nalish xabarlari</string>
-    <string name="kilometers">km</string>
-    <string name="meters">m</string>
-    <string name="miles">mil</string>
-    <string name="feet">fut</string>
     <!-- Time formatting -->
     <plurals name="numberOfDays">
         <item quantity="other">kun</item>

--- a/libtrip-notification/src/main/res/values-vi/strings.xml
+++ b/libtrip-notification/src/main/res/values-vi/strings.xml
@@ -4,10 +4,6 @@
     <string name="end_navigation">Kết thúc Điều hướng</string>
     <string name="channel_name">Thông báo Điều hướng</string>
     <string name="notification_arrival_time_format">Đến nơi %s</string>
-    <string name="kilometers">km</string>
-    <string name="meters">m</string>
-    <string name="miles">dặm</string>
-    <string name="feet">foot</string>
     <string name="eta_format">Đến %s</string>
 
     <!-- Time formatting -->

--- a/libtrip-notification/src/main/res/values-yo/strings.xml
+++ b/libtrip-notification/src/main/res/values-yo/strings.xml
@@ -4,10 +4,6 @@
     <string name="end_navigation">Muu Lilọ kiri</string>
     <string name="channel_name">Awọn iwifunni Lilọ kiri</string>
     <string name="notification_arrival_time_format">Yọọ ni%s</string>
-    <string name="kilometers">km</string>
-    <string name="meters">m</string>
-    <string name="miles">mi</string>
-    <string name="feet">ft</string>
     <string name="eta_format">%s ETA</string>
 
     <!-- Time formatting -->

--- a/libtrip-notification/src/main/res/values/strings.xml
+++ b/libtrip-notification/src/main/res/values/strings.xml
@@ -5,10 +5,6 @@
     <string name="free_drive_notification_text">Free Drive session</string>
     <string name="channel_name">Navigation Notifications</string>
     <string name="notification_arrival_time_format">Arrive at %s</string>
-    <string name="kilometers">km</string>
-    <string name="meters">m</string>
-    <string name="miles">mi</string>
-    <string name="feet">ft</string>
     <string name="eta_format">%s ETA</string>
 
     <!-- Time formatting -->


### PR DESCRIPTION
Using `releaseOnly` makes sure that we attach the module's implementation, but also that we don't actually use any other classes from a module directly. Otherwise, we won't be able to use the build-time modularisation downstream.