### PR TITLE
Remove MapboxTripSession route clearing from reset

### DIFF
--- a/examples/src/main/res/layout/content_simple_mapbox_navigation.xml
+++ b/examples/src/main/res/layout/content_simple_mapbox_navigation.xml
@@ -19,11 +19,33 @@
         app:layout_constraintBottom_toBottomOf="parent">
 
         <Button
-            android:id="@+id/btn_send_user_feadback"
+            android:id="@+id/btn_send_user_feedback"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/send_user_feeedback" />
+            android:text="@string/send_user_feedback" />
     </com.mapbox.mapboxsdk.maps.MapView>
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/btn_clear_routes"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/btn_add_original_route"
+        android:background="@color/colorPrimary"
+        android:text="@string/simple_mapbox_navigation_clear_routes"
+        android:textColor="@android:color/white"/>
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/btn_add_original_route"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/startNavigation"
+        android:background="@color/colorPrimary"
+        android:text="@string/simple_mapbox_navigation_add_original_route"
+        android:textColor="@android:color/white"/>
 
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/startNavigation"

--- a/examples/src/main/res/values/strings.xml
+++ b/examples/src/main/res/values/strings.xml
@@ -75,6 +75,8 @@
     <string name="offline_enabled_title" translatable="false">Offline routing enabled</string>
     <string name="offline_version_title" translatable="false">Choose offline version</string>
     <string name="general_category_title" translatable="false">General</string>
-    <string name="send_user_feeedback" translatable="false">Send User Feedback</string>
+    <string name="send_user_feedback" translatable="false">Send User Feedback</string>
+    <string name="simple_mapbox_navigation_clear_routes" translatable="false">CLEAR ROUTES</string>
+    <string name="simple_mapbox_navigation_add_original_route" translatable="false">ADD ORIGINAL ROUTE</string>
 
 </resources>

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
@@ -123,7 +123,6 @@ class MapboxTripSession(
     }
 
     private fun reset() {
-        route = null
         rawLocation = null
         enhancedLocation = null
         routeProgress = null

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
@@ -136,6 +136,16 @@ class MapboxTripSessionTest {
     }
 
     @Test
+    fun stopSessionDoesNotClearUpRoute() {
+        tripSession.route = route
+        tripSession.start()
+
+        tripSession.stop()
+
+        assertEquals(route, tripSession.route)
+    }
+
+    @Test
     fun locationObserverSuccess() = coroutineRule.runBlockingTest {
         tripSession.start()
         val observer: LocationObserver = mockk(relaxUnitFun = true)


### PR DESCRIPTION
## Description

Removes `MapboxTripSession` `route` clearing from `reset` - we should keep the most recent one from directions session if the trip session is ended

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

In order to detect if you're in _Active guidance_ vs _Free Drive_ you need to observe the `STARTED` `TripSessionState` event and check if there are routes or not from `MapboxNavigation#getRoutes`. As currently implemented, this is not working as expected because if you request a route and then start > stop > start the session we're assuming that you're in _Free Drive_ because `MapboxTripSession` `routes` was cleared up as part of `MapboxNavigation#stopTripSession` / `MapboxTripSession#stop` when we should not because `MapboxDirectionsSession` `routes` (and therefore `MapboxNavigation#getRoutes`) is not empty so the goal here is to fix this.

### Implementation

- Removes `MapboxTripSession` `route` clearing from `reset`
- Adds _Clear routes_ and _Add original route_ buttons to `SimpleMapboxNavigationKt` examples to test states (_Active Guidance_ / _Free Drive_) transitions

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR

cc @LukasPaczos @olegzil 