### PR TITLE
Bump mapboxMapSdk, mapboxEvents, mapboxCore and mapboxNavigator versions

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -54,12 +54,6 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 
 ===========================================================================
 
-Mapbox Navigation uses portions of the Android DB.
-URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)
-License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-===========================================================================
-
 Mapbox Navigation uses portions of the Android Lifecycle LiveData.
 URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -78,12 +72,6 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 
 ===========================================================================
 
-Mapbox Navigation uses portions of the Android Lifecycle Service.
-URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)
-License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-===========================================================================
-
 Mapbox Navigation uses portions of the Android Lifecycle ViewModel.
 URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -91,18 +79,6 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 ===========================================================================
 
 Mapbox Navigation uses portions of the Android Lifecycle-Common.
-URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)
-License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-===========================================================================
-
-Mapbox Navigation uses portions of the Android Room-Common.
-URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)
-License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-===========================================================================
-
-Mapbox Navigation uses portions of the Android Room-Runtime.
 URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -222,20 +198,8 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 
 ===========================================================================
 
-Mapbox Navigation uses portions of the Android Support SQLite - Framework Implementation (The implementation of Support SQLite library using the framework code.).
-URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)
-License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-===========================================================================
-
 Mapbox Navigation uses portions of the Android Support VectorDrawable.
 URL: [http://developer.android.com/tools/extras/support-library.html](http://developer.android.com/tools/extras/support-library.html)
-License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-===========================================================================
-
-Mapbox Navigation uses portions of the Android WorkManager Runtime (Android WorkManager runtime library).
-URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
@@ -247,27 +211,6 @@ License: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 Mapbox Navigation uses portions of the Gson.
 License: [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-===========================================================================
-
-Mapbox Navigation uses portions of the Guava ListenableFuture only (Contains Guava's com.google.common.util.concurrent.ListenableFuture class,
-    without any of its other classes -- but is also available in a second
-    "version" that omits the class to avoid conflicts with the copy in Guava
-    itself. The idea is:
-
-    - If users want only ListenableFuture, they depend on listenablefuture-1.0.
-
-    - If users want all of Guava, they depend on guava, which, as of Guava
-    27.0, depends on
-    listenablefuture-9999.0-empty-to-avoid-conflict-with-guava. The 9999.0-...
-    version number is enough for some build systems (notably, Gradle) to select
-    that empty artifact over the "real" listenablefuture-1.0 -- avoiding a
-    conflict with the copy of ListenableFuture in guava itself. If users are
-    using an older version of Guava or a build system other than Gradle, they
-    may see class conflicts. If so, they can solve them by manually excluding
-    the listenablefuture artifact or manually forcing their build systems to
-    use 9999.0-....).
-License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
@@ -1083,12 +1026,6 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 
 ===========================================================================
 
-Mapbox Navigation uses portions of the Android DB.
-URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)
-License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-===========================================================================
-
 Mapbox Navigation uses portions of the Android Lifecycle LiveData.
 URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -1107,12 +1044,6 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 
 ===========================================================================
 
-Mapbox Navigation uses portions of the Android Lifecycle Service.
-URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)
-License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-===========================================================================
-
 Mapbox Navigation uses portions of the Android Lifecycle ViewModel.
 URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -1120,18 +1051,6 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 ===========================================================================
 
 Mapbox Navigation uses portions of the Android Lifecycle-Common.
-URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)
-License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-===========================================================================
-
-Mapbox Navigation uses portions of the Android Room-Common.
-URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)
-License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-===========================================================================
-
-Mapbox Navigation uses portions of the Android Room-Runtime.
 URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -1185,41 +1104,8 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 
 ===========================================================================
 
-Mapbox Navigation uses portions of the Android Support SQLite - Framework Implementation (The implementation of Support SQLite library using the framework code.).
-URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)
-License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-===========================================================================
-
-Mapbox Navigation uses portions of the Android WorkManager Runtime (Android WorkManager runtime library).
-URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)
-License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-===========================================================================
-
 Mapbox Navigation uses portions of the Gson.
 License: [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-===========================================================================
-
-Mapbox Navigation uses portions of the Guava ListenableFuture only (Contains Guava's com.google.common.util.concurrent.ListenableFuture class,
-    without any of its other classes -- but is also available in a second
-    "version" that omits the class to avoid conflicts with the copy in Guava
-    itself. The idea is:
-
-    - If users want only ListenableFuture, they depend on listenablefuture-1.0.
-
-    - If users want all of Guava, they depend on guava, which, as of Guava
-    27.0, depends on
-    listenablefuture-9999.0-empty-to-avoid-conflict-with-guava. The 9999.0-...
-    version number is enough for some build systems (notably, Gradle) to select
-    that empty artifact over the "real" listenablefuture-1.0 -- avoiding a
-    conflict with the copy of ListenableFuture in guava itself. If users are
-    using an older version of Guava or a build system other than Gradle, they
-    may see class conflicts. If so, they can solve them by manually excluding
-    the listenablefuture artifact or manually forcing their build systems to
-    use 9999.0-....).
-License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -9,12 +9,12 @@ ext {
   ]
 
   version = [
-      mapboxMapSdk              : '9.1.0-alpha.1',
+      mapboxMapSdk              : '9.1.0-beta.1',
       mapboxSdkServices         : '5.1.0-SNAPSHOT',
       mapboxSdkDirectionsModels : '5.1.0-SNAPSHOT',
-      mapboxEvents              : '4.7.3',
-      mapboxCore                : '1.4.1',
-      mapboxNavigator           : '9.2.1',
+      mapboxEvents              : '4.7.4',
+      mapboxCore                : '1.4.2',
+      mapboxNavigator           : '10.0.1',
       mapboxCrashMonitor        : '2.0.0',
       mapboxAnnotationPlugin    : '0.8.0',
       mapboxAccounts            : '0.3.1',

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigation.java
@@ -1077,9 +1077,6 @@ public class MapboxNavigation implements ServiceConnection {
   private Navigator configureNavigator() {
     Navigator navigator = new Navigator();
     NavigatorConfig navigatorConfig = navigator.getConfig();
-    navigatorConfig.setOffRouteThreshold(options.getOffRouteThreshold());
-    navigatorConfig.setOffRouteThresholdWhenNearIntersection(options.getOffRouteThresholdWhenNearIntersection());
-    navigatorConfig.setIntersectionRadiusForOffRouteDetection(options.getIntersectionRadiusForOffRouteDetection());
     navigator.setConfig(navigatorConfig);
     return navigator;
   }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationOptions.kt
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/MapboxNavigationOptions.kt
@@ -2,10 +2,7 @@ package com.mapbox.services.android.navigation.v5.navigation
 
 import androidx.annotation.ColorRes
 import com.mapbox.services.android.navigation.R
-import com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.NAVIGATION_INTERSECTION_RADIUS_FOR_OFF_ROUTE_DETECTION
 import com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.NAVIGATION_LOCATION_ENGINE_INTERVAL_LAG
-import com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.NAVIGATION_OFF_ROUTE_THRESHOLD
-import com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.NAVIGATION_OFF_ROUTE_THRESHOLD_WHEN_NEAR_INTERSECTION
 import com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.ROUNDING_INCREMENT_FIFTY
 import com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.ROUTE_REFRESH_INTERVAL
 import com.mapbox.services.android.navigation.v5.navigation.notification.NavigationNotification
@@ -26,9 +23,6 @@ data class MapboxNavigationOptions(
     val timeFormatType: Int,
     val navigationLocationEngineIntervalLagInMilliseconds: Int,
     val defaultNotificationColorId: Int,
-    val offRouteThreshold: Float,
-    val offRouteThresholdWhenNearIntersection: Float,
-    val intersectionRadiusForOffRouteDetection: Float,
     var builder: Builder
 
 ) {
@@ -87,11 +81,6 @@ data class MapboxNavigationOptions(
         var navigationLocationEngineIntervalLagInMilliseconds =
             NAVIGATION_LOCATION_ENGINE_INTERVAL_LAG
         var defaultNotificationColorId = R.color.mapboxNotificationBlue
-        var offRouteThreshold = NAVIGATION_OFF_ROUTE_THRESHOLD
-        var offRouteThresholdWhenNearIntersection =
-            NAVIGATION_OFF_ROUTE_THRESHOLD_WHEN_NEAR_INTERSECTION
-        var intersectionRadiusForOffRouteDetection =
-            NAVIGATION_INTERSECTION_RADIUS_FOR_OFF_ROUTE_DETECTION
 
         fun defaultMilestonesEnabled(defaultMilestonesEnabled: Boolean) =
             apply { this.defaultMilestonesEnabled = defaultMilestonesEnabled }
@@ -149,34 +138,6 @@ data class MapboxNavigationOptions(
         fun defaultNotificationColorId(@ColorRes defaultNotificationColorId: Int) =
             apply { this.defaultNotificationColorId = defaultNotificationColorId }
 
-        /**
-         * This sets the off route threshold in meters. If not specified, the threshold is 50 meters.
-         *
-         * @param thresholdInMeters off route threshold in meters to be used
-         * @return this builder for chaining options together
-         */
-        fun offRouteThreshold(thresholdInMeters: Float) =
-            apply { this.offRouteThreshold = thresholdInMeters }
-
-        /**
-         * This sets the off route threshold in meters when near an intersection which is more prone
-         * to inaccurate gps fixes. If not specified, the threshold is 25 meters.
-         *
-         * @param thresholdInMeters off route threshold in meters when near an intersection to be used
-         * @return this builder for chaining options together
-         */
-        fun offRouteThresholdWhenNearIntersection(thresholdInMeters: Float) =
-            apply { this.offRouteThresholdWhenNearIntersection = thresholdInMeters }
-
-        /**
-         * This sets the radius in meters for off route detection near intersection. If not specified, the radius is 40 meters.
-         *
-         * @param radiusInMeters radius in meters for off route detection near intersection to be used
-         * @return this builder for chaining options together
-         */
-        fun intersectionRadiusForOffRouteDetection(radiusInMeters: Float) =
-            apply { this.intersectionRadiusForOffRouteDetection = radiusInMeters }
-
         fun build(): MapboxNavigationOptions {
             return MapboxNavigationOptions(
                 defaultMilestonesEnabled,
@@ -191,9 +152,6 @@ data class MapboxNavigationOptions(
                 timeFormatType,
                 navigationLocationEngineIntervalLagInMilliseconds,
                 defaultNotificationColorId,
-                offRouteThreshold,
-                offRouteThresholdWhenNearIntersection,
-                intersectionRadiusForOffRouteDetection,
                 this
             )
         }

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationConstants.kt
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationConstants.kt
@@ -121,22 +121,6 @@ object NavigationConstants {
      */
     internal const val NAVIGATION_LOCATION_ENGINE_INTERVAL_LAG = 1500
 
-    /**
-     * Default off route threshold in meters
-     */
-    internal const val NAVIGATION_OFF_ROUTE_THRESHOLD = 50.0f
-
-    /**
-     * Default off route threshold in meters when near an intersection which is more prone
-     * to inaccurate gps fixes
-     */
-    internal const val NAVIGATION_OFF_ROUTE_THRESHOLD_WHEN_NEAR_INTERSECTION = 25.0f
-
-    /**
-     * Default radius in meters for off route detection near intersection
-     */
-    internal const val NAVIGATION_INTERSECTION_RADIUS_FOR_OFF_ROUTE_DETECTION = 40.0f
-
     internal const val ROUTE_REFRESH_INTERVAL = 5 * 60 * 1000L
 
     /**


### PR DESCRIPTION
## Description

Bumps `mapbox-android-sdk`, `mapbox-android-telemetry`, `mapbox-android-core` and `mapbox-navigation-native` versions to `9.1.0-beta.1`, `4.7.4`, `1.4.2` and `10.0.1` respectively

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Getting the latest versions from `mapboxMapSdk`, `mapboxEvents`, `mapboxCore` and `mapboxNavigator` including the new features and bug fixes.

### Implementation

Bumping `mapboxMapSdk`, `mapboxEvents`, `mapboxCore` and `mapboxNavigator` versions to `9.1.0-beta.1`, `4.7.4`, `1.4.2` and `10.0.1` respectively in `dependencies.gradle`

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR

cc @harvsu @Maksim-Bakanau @SiarheiFedartsou @vmihaylenko @zugaldia @nkukday 