### PR TITLE
Bump mapboxSdkServices and mapboxSdkDirectionsModels versions to 5.1.0-beta.2

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -10,8 +10,8 @@ ext {
 
   version = [
       mapboxMapSdk              : '9.1.0-beta.1',
-      mapboxSdkServices         : '5.1.0-SNAPSHOT',
-      mapboxSdkDirectionsModels : '5.1.0-SNAPSHOT',
+      mapboxSdkServices         : '5.1.0-beta.2',
+      mapboxSdkDirectionsModels : '5.1.0-beta.2',
       mapboxEvents              : '4.7.4',
       mapboxCore                : '1.4.2',
       mapboxNavigator           : '10.0.1',


### PR DESCRIPTION
## Description

Bumps `mapbox-sdk-services` and `mapbox-sdk-directions-models` versions to `5.1.0-beta.2`

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Getting the latest versions from `mapboxSdkServices` and `mapboxSdkDirectionsModels` including the new features and bug fixes.

### Implementation

Bumping `mapboxSdkServices` and `mapboxSdkDirectionsModels` versions to `5.1.0-beta.2` in `dependencies.gradle`

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR