### PR TITLE
Fix for #2473 - routes blinking when selecting alternate routes as primary.

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/SimpleMapboxNavigationKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/SimpleMapboxNavigationKt.kt
@@ -120,6 +120,7 @@ class SimpleMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
                     } else {
                         mapboxNavigation.setRoutes(listOf(originalRoute))
                     }
+                    replayRouteLocationEngine.assign(originalRoute)
                 }
             }
         }
@@ -209,6 +210,7 @@ class SimpleMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
                     remove(route)
                     add(0, route)
                 })
+                replayRouteLocationEngine.assign(route)
             }
         }
 
@@ -341,6 +343,7 @@ class SimpleMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
     private val routesReqCallback = object : RoutesRequestCallback {
         override fun onRoutesReady(routes: List<DirectionsRoute>) {
             originalRoute = routes[0]
+            navigationMapboxMap.drawRoutes(routes)
             Timber.d("route request success %s", routes.toString())
             replayRouteLocationEngine.assign(originalRoute)
         }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/NavigationMapRoute.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/NavigationMapRoute.java
@@ -19,6 +19,7 @@ import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.navigation.base.trip.model.RouteProgress;
 import com.mapbox.navigation.core.MapboxNavigation;
+import com.mapbox.navigation.ui.utils.CompareUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -208,7 +209,14 @@ public class NavigationMapRoute implements LifecycleObserver {
    * @since 0.8.0
    */
   public void addRoutes(@NonNull @Size(min = 1) List<? extends DirectionsRoute> directionsRoutes) {
-    routeLine.draw(directionsRoutes);
+    if (directionsRoutes.isEmpty()) {
+      routeLine.draw(directionsRoutes);
+    } else if (!CompareUtils.INSTANCE.areEqualContentsIgnoreOrder(
+            routeLine.retrieveDirectionsRoutes(),
+            directionsRoutes)
+    ) {
+      routeLine.draw(directionsRoutes);
+    }
   }
 
   /**

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/utils/CompareUtils.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/utils/CompareUtils.kt
@@ -1,0 +1,14 @@
+package com.mapbox.navigation.ui.utils
+
+object CompareUtils {
+    fun <T> areEqualContentsIgnoreOrder(first: Collection<T>, second: Collection<T>): Boolean {
+        if (first !== second) {
+            if (first.size != second.size) return false
+            val areNotEqual = first.asSequence()
+                .map { it in second }
+                .contains(false)
+            if (areNotEqual) return false
+        }
+        return true
+    }
+}

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/NavigationMapRouteTest.java
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/NavigationMapRouteTest.java
@@ -7,14 +7,17 @@ import com.mapbox.navigation.core.MapboxNavigation;
 
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.List;
 
 import edu.emory.mathcs.backport.java.util.Collections;
 
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class NavigationMapRouteTest {
 
@@ -233,6 +236,30 @@ public class NavigationMapRouteTest {
     theNavigationMapRoute.addRoutes(routes);
 
     verify(mockedMapRouteLine).draw(eq(routes));
+  }
+
+  @Test
+  public void addRoutesDrawNotCalled() {
+    DirectionsRoute mockRoute = mock(DirectionsRoute.class);
+    MapboxNavigation mockedNavigation = mock(MapboxNavigation.class);
+    MapView mockedMapView = mock(MapView.class);
+    MapboxMap mockedMapboxMap = mock(MapboxMap.class);
+    int mockedStyleRes = 0;
+    MapRouteClickListener mockedMapClickListener = mock(MapRouteClickListener.class);
+    MapView.OnDidFinishLoadingStyleListener mockedDidFinishLoadingStyleListener =
+            mock(MapView.OnDidFinishLoadingStyleListener.class);
+    MapRouteProgressChangeListener mockedProgressChangeListener = mock(MapRouteProgressChangeListener.class);
+    MapRouteLine mockedMapRouteLine = mock(MapRouteLine.class);
+    MapRouteArrow mockedMapRouteArrow = mock(MapRouteArrow.class);
+    List<DirectionsRoute> routes = Collections.singletonList(mockRoute);
+    NavigationMapRoute theNavigationMapRoute = new NavigationMapRoute(mockedNavigation, mockedMapView, mockedMapboxMap,
+            mockedStyleRes, "", mockedMapClickListener, mockedDidFinishLoadingStyleListener,
+            mockedProgressChangeListener, mockedMapRouteLine, mockedMapRouteArrow);
+    when(mockedMapRouteLine.retrieveDirectionsRoutes()).thenReturn(Collections.singletonList(mockRoute));
+
+    theNavigationMapRoute.addRoutes(routes);
+
+    verify(mockedMapRouteLine, never()).draw(eq(routes));
   }
 
   @Test

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/utils/CompareUtilsTest.kt
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/utils/CompareUtilsTest.kt
@@ -1,0 +1,28 @@
+package com.mapbox.navigation.ui.utils
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CompareUtilsTest {
+
+    @Test
+    fun areEqualContentsIgnoreOrderWhenContentsAreSame() {
+        val listA = listOf("a", "b", "c")
+        val listB = listOf("b", "a", "c")
+
+        val result = CompareUtils.areEqualContentsIgnoreOrder(listA, listB)
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun areEqualContentsIgnoreOrderWhenContentsAreNotSame() {
+        val listA = listOf("a", "b", "c")
+        val listB = listOf("b", "a", "x")
+
+        val result = CompareUtils.areEqualContentsIgnoreOrder(listA, listB)
+
+        assertFalse(result)
+    }
+}


### PR DESCRIPTION
##Description
#2473 Fix for routes blinking when selecting alternate routes as primary.

Changed when drawRoutes() was called so that selecting an alternate route didn't redraw the routes causing the blinking observed in the bug report.