### PR TITLE
Expose NavigationSession State internally

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/NavigationSessionStateObserver.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/NavigationSessionStateObserver.kt
@@ -1,0 +1,5 @@
+package com.mapbox.navigation.core
+
+internal interface NavigationSessionStateObserver {
+    fun onNavigationSessionStateChanged(navigationSession: NavigationSession.State)
+}


### PR DESCRIPTION
## Description

Expose `NavigationSession` `State` internally for the rest of the lib to hook into

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

The goal here is that the rest of the lib can hook into the `NavigationSession` `State`s (needed for `MapboxNavigationTelmetry` to detect dynamic transitions between _Active Guidance_ and _Free Drive_ and viceversa)

### Implementation

Add `NavigationSessionStateObserver` to `NavigationSession` and `registerNavigationSessionStateObserver`, `unregisterNavigationSessionStateObserver` and `unregisterAllNavigationSessionStateObservers` to hook internally to the `NavigationSession` `STATE` (`IDLE`, `ACTIVE_GUIDANCE` and `FREE_DRIVE`). For now this is `internal` we can revisit the implementation if the UI SDK needs access to it in the future cc @abhishek1508 

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR

cc @LukasPaczos 