### PR TITLE
Fix CI job filter tag triggers

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -24,25 +24,25 @@ workflows:
       - release-core-1_0:
           filters:
             tags:
-              only: /^release_core_*/
+              only: /^release_core_.*/
             branches:
               ignore: /.*/
       - release-ui-1_0:
           filters:
             tags:
-              only: /^release_ui_*_core_*/
+              only: /^release_ui_.*_core_.*/
             branches:
               ignore: /.*/
       - release-core-1_0-qa:
           filters:
             tags:
-              only: /^qa_release_core_*/
+              only: /^qa_release_core_.*/
             branches:
               ignore: /.*/
       - release-ui-1_0-qa:
           filters:
             tags:
-              only: /^qa_release_ui_*_core_*/
+              only: /^qa_release_ui_.*_core_.*/
             branches:
               ignore: /.*/
       - release-core-1_0-prod:
@@ -55,7 +55,7 @@ workflows:
       - release-ui-1_0-prod:
           filters:
             tags:
-              only: /^prod_release_ui_*_core_*/
+              only: /^prod_release_ui_.*_core_.*/
             branches:
               ignore: /.*/
       - ui-tests-1_0


### PR DESCRIPTION
## Description

Follow up from https://github.com/mapbox/mapbox-navigation-android/pull/2639

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

CI release trigger was not working

### Implementation

Bring `.` back to Circle CI job filter tags

## Testing

- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR