### PR TITLE
Fix issue #2603: set default attr programmatically

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/ThemeSwitcher.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/ThemeSwitcher.java
@@ -10,6 +10,7 @@ import android.preference.PreferenceManager;
 import android.util.AttributeSet;
 import android.util.TypedValue;
 
+import androidx.annotation.AnyRes;
 import androidx.annotation.NonNull;
 import androidx.appcompat.content.res.AppCompatResources;
 import androidx.core.content.ContextCompat;
@@ -48,6 +49,14 @@ public class ThemeSwitcher {
   public static Bitmap retrieveThemeMapMarker(Context context) {
     TypedValue destinationMarkerResId = resolveAttributeFromId(context, R.attr.navigationViewDestinationMarker);
     int markerResId = destinationMarkerResId.resourceId;
+    if (!isValid(markerResId)) {
+      if (isNightModeEnabled(context)) {
+        markerResId = R.drawable.map_marker_dark;
+      } else {
+        markerResId = R.drawable.map_marker_light;
+      }
+    }
+
     Drawable markerDrawable = ContextCompat.getDrawable(context, markerResId);
     return BitmapUtils.getBitmapFromDrawable(markerDrawable);
   }
@@ -61,11 +70,18 @@ public class ThemeSwitcher {
   public static Drawable retrieveThemeOverviewDrawable(Context context) {
     TypedValue destinationMarkerResId = resolveAttributeFromId(context, R.attr.navigationViewRouteOverviewDrawable);
     int overviewResId = destinationMarkerResId.resourceId;
+    if (!isValid(overviewResId)) {
+      if (isNightModeEnabled(context)) {
+        overviewResId = R.drawable.ic_route_preview_dark;
+      } else {
+        overviewResId = R.drawable.ic_route_preview;
+      }
+    }
     return AppCompatResources.getDrawable(context, overviewResId);
   }
 
   /**
-   * Looks are current theme and retrieves the style
+   * Looks at current theme and retrieves the style
    * for the given resId set in the theme.
    *
    * @param context    to retrieve the resolved attribute
@@ -75,6 +91,23 @@ public class ThemeSwitcher {
   public static int retrieveNavigationViewStyle(Context context, int styleResId) {
     TypedValue outValue = resolveAttributeFromId(context, styleResId);
     return outValue.resourceId;
+  }
+
+  /**
+   * Looks at current theme and retrieves the resource
+   * for the given attrId set in the theme.
+   *
+   * @param context to retrieve the resolved attribute
+   * @param attrId  for the given attribute Id
+   * @return resolved resource Id
+   */
+  public static int retrieveAttrResourceId(Context context, int attrId, int defaultResId) {
+    TypedValue outValue = resolveAttributeFromId(context, attrId);
+    if (isValid(outValue.resourceId)) {
+      return outValue.resourceId;
+    } else {
+      return defaultResId;
+    }
   }
 
   /**
@@ -139,5 +172,9 @@ public class ThemeSwitcher {
   private static int retrieveThemeResIdFromPreferences(Context context, String key) {
     SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
     return preferences.getInt(key, 0);
+  }
+
+  private static boolean isValid(@AnyRes int resId) {
+    return resId != -1 && (resId & 0xff000000) != 0 && (resId & 0x00ff0000) != 0;
   }
 }

--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/NavigationMapboxMap.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/NavigationMapboxMap.java
@@ -7,7 +7,6 @@ import android.graphics.PointF;
 import android.location.Location;
 import android.os.Bundle;
 
-import androidx.annotation.AnyRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.FragmentActivity;
@@ -64,9 +63,9 @@ public class NavigationMapboxMap {
   private static final double NAVIGATION_MAXIMUM_MAP_ZOOM = 18d;
   private static final double NAVIGATION_INITIAL_MAP_ZOOM = 17d;
   private final CopyOnWriteArrayList<OnWayNameChangedListener> onWayNameChangedListeners
-          = new CopyOnWriteArrayList<>();
+    = new CopyOnWriteArrayList<>();
   private final MapWayNameChangedListener internalWayNameChangedListener
-          = new MapWayNameChangedListener(onWayNameChangedListeners);
+    = new MapWayNameChangedListener(onWayNameChangedListeners);
   private NavigationMapSettings settings = new NavigationMapSettings();
   private MapView mapView;
   private MapboxMap mapboxMap;
@@ -86,8 +85,8 @@ public class NavigationMapboxMap {
    * Constructor that can be used once {@link OnMapReadyCallback}
    * has been called via {@link MapView#getMapAsync(OnMapReadyCallback)}.
    *
-   * @param mapView           for map size and Context
-   * @param mapboxMap         for APIs to interact with the map
+   * @param mapView   for map size and Context
+   * @param mapboxMap for APIs to interact with the map
    */
   public NavigationMapboxMap(@NonNull MapView mapView,
                              @NonNull MapboxMap mapboxMap) {
@@ -637,27 +636,15 @@ public class NavigationMapboxMap {
     map.setMaxZoomPreference(NAVIGATION_MAXIMUM_MAP_ZOOM);
     Context context = mapView.getContext();
     Style style = map.getStyle();
-    int locationLayerStyleRes = findLayerStyleRes(context);
+    int locationLayerStyleRes = ThemeSwitcher.retrieveAttrResourceId(context,
+      R.attr.navigationViewLocationLayerStyle, R.style.NavigationLocationLayerStyle);
     LocationComponentOptions options = LocationComponentOptions.createFromAttributes(context, locationLayerStyleRes);
     LocationComponentActivationOptions activationOptions = LocationComponentActivationOptions.builder(context, style)
-            .locationComponentOptions(options)
-            .useDefaultLocationEngine(false)
-            .build();
+      .locationComponentOptions(options)
+      .useDefaultLocationEngine(false)
+      .build();
     locationComponent.activateLocationComponent(activationOptions);
     locationComponent.setLocationComponentEnabled(true);
-  }
-
-  private int findLayerStyleRes(Context context) {
-    int locationLayerStyleRes = ThemeSwitcher.retrieveNavigationViewStyle(context,
-            R.attr.navigationViewLocationLayerStyle);
-    if (!isValid(locationLayerStyleRes)) {
-      locationLayerStyleRes = R.style.NavigationLocationLayerStyle;
-    }
-    return locationLayerStyleRes;
-  }
-
-  private boolean isValid(@AnyRes int resId) {
-    return resId != -1 && (resId & 0xff000000) != 0 && (resId & 0x00ff0000) != 0;
   }
 
   private void initializeMapPaddingAdjustor(MapView mapView, MapboxMap mapboxMap) {
@@ -679,7 +666,8 @@ public class NavigationMapboxMap {
 
   private void initializeRoute(MapView mapView, MapboxMap map, String routeBelowLayerId) {
     Context context = mapView.getContext();
-    int routeStyleRes = ThemeSwitcher.retrieveNavigationViewStyle(context, R.attr.navigationViewRouteStyle);
+    int routeStyleRes = ThemeSwitcher.retrieveAttrResourceId(context,
+      R.attr.navigationViewRouteStyle, R.style.NavigationMapRoute);
     mapRoute = new NavigationMapRoute(null, mapView, map, routeStyleRes, routeBelowLayerId);
   }
 

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/ThemeSwitcher.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/ThemeSwitcher.java
@@ -10,6 +10,7 @@ import android.preference.PreferenceManager;
 import android.util.AttributeSet;
 import android.util.TypedValue;
 
+import androidx.annotation.AnyRes;
 import androidx.annotation.NonNull;
 import androidx.appcompat.content.res.AppCompatResources;
 import androidx.core.content.ContextCompat;
@@ -49,6 +50,14 @@ public class ThemeSwitcher {
   public static Bitmap retrieveThemeMapMarker(Context context) {
     TypedValue destinationMarkerResId = resolveAttributeFromId(context, R.attr.navigationViewDestinationMarker);
     int markerResId = destinationMarkerResId.resourceId;
+    if (!isValid(markerResId)) {
+      if (isNightModeEnabled(context)) {
+        markerResId = R.drawable.map_marker_dark;
+      } else {
+        markerResId = R.drawable.map_marker_light;
+      }
+    }
+
     Drawable markerDrawable = ContextCompat.getDrawable(context, markerResId);
     return BitmapUtils.getBitmapFromDrawable(markerDrawable);
   }
@@ -62,20 +71,31 @@ public class ThemeSwitcher {
   public static Drawable retrieveThemeOverviewDrawable(Context context) {
     TypedValue destinationMarkerResId = resolveAttributeFromId(context, R.attr.navigationViewRouteOverviewDrawable);
     int overviewResId = destinationMarkerResId.resourceId;
+    if (!isValid(overviewResId)) {
+      if (isNightModeEnabled(context)) {
+        overviewResId = R.drawable.ic_route_preview_dark;
+      } else {
+        overviewResId = R.drawable.ic_route_preview;
+      }
+    }
     return AppCompatResources.getDrawable(context, overviewResId);
   }
 
   /**
-   * Looks are current theme and retrieves the style
-   * for the given resId set in the theme.
+   * Looks at current theme and retrieves the resource
+   * for the given attrId set in the theme.
    *
-   * @param context    to retrieve the resolved attribute
-   * @param styleResId for the given style
-   * @return resolved style resource Id
+   * @param context to retrieve the resolved attribute
+   * @param attrId  for the given attribute Id
+   * @return resolved resource Id
    */
-  public static int retrieveNavigationViewStyle(Context context, int styleResId) {
-    TypedValue outValue = resolveAttributeFromId(context, styleResId);
-    return outValue.resourceId;
+  public static int retrieveAttrResourceId(Context context, int attrId, int defaultResId) {
+    TypedValue outValue = resolveAttributeFromId(context, attrId);
+    if (isValid(outValue.resourceId)) {
+      return outValue.resourceId;
+    } else {
+      return defaultResId;
+    }
   }
 
   /**
@@ -140,5 +160,9 @@ public class ThemeSwitcher {
   private static int retrieveThemeResIdFromPreferences(Context context, String key) {
     SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
     return preferences.getInt(key, 0);
+  }
+
+  private static boolean isValid(@AnyRes int resId) {
+    return resId != -1 && (resId & 0xff000000) != 0 && (resId & 0x00ff0000) != 0;
   }
 }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/NavigationMapboxMap.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/NavigationMapboxMap.java
@@ -7,6 +7,10 @@ import android.graphics.PointF;
 import android.location.Location;
 import android.os.Bundle;
 
+import androidx.annotation.DrawableRes;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.geojson.Point;
 import com.mapbox.libnavigation.ui.R;
@@ -27,9 +31,9 @@ import com.mapbox.navigation.base.trip.model.RouteProgress;
 import com.mapbox.navigation.core.MapboxNavigation;
 import com.mapbox.navigation.ui.NavigationSnapshotReadyCallback;
 import com.mapbox.navigation.ui.ThemeSwitcher;
-import com.mapbox.navigation.ui.camera.Camera;
 import com.mapbox.navigation.ui.arrival.BuildingExtrusionLayer;
 import com.mapbox.navigation.ui.arrival.DestinationBuildingFootprintLayer;
+import com.mapbox.navigation.ui.camera.Camera;
 import com.mapbox.navigation.ui.camera.NavigationCamera;
 import com.mapbox.navigation.ui.puck.NavigationPuckPresenter;
 import com.mapbox.navigation.ui.puck.PuckDrawableSupplier;
@@ -39,11 +43,6 @@ import com.mapbox.navigation.ui.route.OnRouteSelectionChangeListener;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
-
-import androidx.annotation.AnyRes;
-import androidx.annotation.DrawableRes;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import static com.mapbox.navigation.ui.legacy.NavigationConstants.MINIMAL_LOOKAHEAD_LOCATION_TIME_VALUE;
 import static com.mapbox.navigation.ui.legacy.NavigationConstants.NAVIGATION_MINIMUM_MAP_ZOOM;
@@ -71,9 +70,9 @@ public class NavigationMapboxMap {
   private static final double NAVIGATION_MAXIMUM_MAP_ZOOM = 18d;
   private static final double NAVIGATION_INITIAL_MAP_ZOOM = 17d;
   private final CopyOnWriteArrayList<OnWayNameChangedListener> onWayNameChangedListeners
-          = new CopyOnWriteArrayList<>();
+    = new CopyOnWriteArrayList<>();
   private final MapWayNameChangedListener internalWayNameChangedListener
-          = new MapWayNameChangedListener(onWayNameChangedListeners);
+    = new MapWayNameChangedListener(onWayNameChangedListeners);
   private NavigationMapSettings settings = new NavigationMapSettings();
   private MapView mapView;
   private MapboxMap mapboxMap;
@@ -708,27 +707,15 @@ public class NavigationMapboxMap {
     map.setMaxZoomPreference(NAVIGATION_MAXIMUM_MAP_ZOOM);
     Context context = mapView.getContext();
     Style style = map.getStyle();
-    int locationLayerStyleRes = findLayerStyleRes(context);
+    int locationLayerStyleRes = ThemeSwitcher.retrieveAttrResourceId(context,
+      R.attr.navigationViewLocationLayerStyle, R.style.NavigationLocationLayerStyle);
     LocationComponentOptions options = LocationComponentOptions.createFromAttributes(context, locationLayerStyleRes);
     LocationComponentActivationOptions activationOptions = LocationComponentActivationOptions.builder(context, style)
-            .locationComponentOptions(options)
-            .useDefaultLocationEngine(false)
-            .build();
+      .locationComponentOptions(options)
+      .useDefaultLocationEngine(false)
+      .build();
     locationComponent.activateLocationComponent(activationOptions);
     locationComponent.setLocationComponentEnabled(true);
-  }
-
-  private int findLayerStyleRes(Context context) {
-    int locationLayerStyleRes = ThemeSwitcher.retrieveNavigationViewStyle(context,
-            R.attr.navigationViewLocationLayerStyle);
-    if (!isValid(locationLayerStyleRes)) {
-      locationLayerStyleRes = R.style.NavigationLocationLayerStyle;
-    }
-    return locationLayerStyleRes;
-  }
-
-  private boolean isValid(@AnyRes int resId) {
-    return resId != -1 && (resId & 0xff000000) != 0 && (resId & 0x00ff0000) != 0;
   }
 
   private void initializeMapPaddingAdjustor(MapView mapView, MapboxMap mapboxMap) {
@@ -750,7 +737,8 @@ public class NavigationMapboxMap {
 
   private void initializeRoute(MapView mapView, MapboxMap map, String routeBelowLayerId) {
     Context context = mapView.getContext();
-    int routeStyleRes = ThemeSwitcher.retrieveNavigationViewStyle(context, R.attr.navigationViewRouteStyle);
+    int routeStyleRes = ThemeSwitcher.retrieveAttrResourceId(context,
+      R.attr.navigationViewRouteStyle, R.style.NavigationMapRoute);
     mapRoute = new NavigationMapRoute(null, mapView, map, routeStyleRes, routeBelowLayerId);
   }
 


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Fix #2603, this PR only addresses `format=reference` attr crash. If the current Theme doesn't define the attr, set a default one programmatically. With this fix, the NavigationMapboxMap can be used without extending any NavigationTheme.

During testing, not only the `format=reference` attrs but all the attributes in the _attrs.xml_ have the same problem. This PR doesn't handle this case.

- [x] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards



### Implementation

If the resourceId is invalid, then set a default one accordingly.

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->