### PR TITLE
Extract the accounts lib logic to a separate class

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -26,6 +26,7 @@ import com.mapbox.navigation.base.typedef.NONE_SPECIFIED
 import com.mapbox.navigation.base.typedef.ROUNDING_INCREMENT_FIFTY
 import com.mapbox.navigation.base.typedef.UNDEFINED
 import com.mapbox.navigation.core.accounts.MapboxNavigationAccounts
+import com.mapbox.navigation.core.accounts.NavigationAccountsSession
 import com.mapbox.navigation.core.directions.session.AdjustedRouteOptionsProvider
 import com.mapbox.navigation.core.directions.session.DirectionsSession
 import com.mapbox.navigation.core.directions.session.RoutesObserver
@@ -133,7 +134,8 @@ constructor(
     private val directionsSession: DirectionsSession
     private val tripService: TripService
     private val tripSession: TripSession
-    private val navigationSession = NavigationSession(context)
+    private val navigationSession = NavigationSession()
+    private val navigationAccountsSession = NavigationAccountsSession(context)
     private val internalRoutesObserver = createInternalRoutesObserver()
     private val internalOffRouteObserver = createInternalOffRouteObserver()
     private val fasterRouteController: FasterRouteController
@@ -176,6 +178,7 @@ constructor(
         )
         tripSession.registerOffRouteObserver(internalOffRouteObserver)
         tripSession.registerStateObserver(navigationSession)
+        navigationSession.registerNavigationSessionStateObserver(navigationAccountsSession)
         ifNonNull(accessToken) { token ->
             Log.d("MAPBOX_TELEMETRY", "MapboxMetricsReporter.init from MapboxNavigation main")
             MapboxMetricsReporter.init(
@@ -294,6 +297,7 @@ constructor(
             tripSession.unregisterAllStateObservers()
             tripSession.unregisterAllBannerInstructionsObservers()
             tripSession.unregisterAllVoiceInstructionsObservers()
+            navigationSession.unregisterAllNavigationSessionStateObservers()
             fasterRouteController.stop()
             routeRefreshController.stop()
         }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/NavigationSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/NavigationSession.kt
@@ -1,14 +1,12 @@
 package com.mapbox.navigation.core
 
-import android.content.Context
 import com.mapbox.api.directions.v5.models.DirectionsRoute
-import com.mapbox.navigation.core.accounts.MapboxNavigationAccounts
 import com.mapbox.navigation.core.directions.session.RoutesObserver
 import com.mapbox.navigation.core.trip.session.TripSessionState
 import com.mapbox.navigation.core.trip.session.TripSessionStateObserver
 import java.util.concurrent.CopyOnWriteArrayList
 
-internal class NavigationSession(private val context: Context) : RoutesObserver,
+internal class NavigationSession : RoutesObserver,
     TripSessionStateObserver {
 
     private val stateObservers = CopyOnWriteArrayList<NavigationSessionStateObserver>()
@@ -18,19 +16,9 @@ internal class NavigationSession(private val context: Context) : RoutesObserver,
             if (field == value) {
                 return
             }
-            val previousValue = state
             field = value
 
             stateObservers.forEach { it.onNavigationSessionStateChanged(value) }
-
-            when {
-                previousValue == State.ACTIVE_GUIDANCE -> MapboxNavigationAccounts.getInstance(
-                    context.applicationContext
-                ).navigationStopped()
-                value == State.ACTIVE_GUIDANCE -> MapboxNavigationAccounts.getInstance(
-                    context.applicationContext
-                ).navigationStarted()
-            }
         }
 
     private var hasRoutes = false

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/accounts/NavigationAccountsSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/accounts/NavigationAccountsSession.kt
@@ -1,0 +1,30 @@
+package com.mapbox.navigation.core.accounts
+
+import android.content.Context
+import com.mapbox.navigation.core.NavigationSession
+import com.mapbox.navigation.core.NavigationSessionStateObserver
+
+internal class NavigationAccountsSession(private val context: Context) : NavigationSessionStateObserver {
+
+    private var state = NavigationSession.State.IDLE
+        set(value) {
+            if (field == value) {
+                return
+            }
+            val previousValue = state
+            field = value
+
+            when {
+                previousValue == NavigationSession.State.ACTIVE_GUIDANCE -> MapboxNavigationAccounts.getInstance(
+                    context.applicationContext
+                ).navigationStopped()
+                value == NavigationSession.State.ACTIVE_GUIDANCE -> MapboxNavigationAccounts.getInstance(
+                    context.applicationContext
+                ).navigationStarted()
+            }
+        }
+
+    override fun onNavigationSessionStateChanged(navigationSession: NavigationSession.State) {
+        state = navigationSession
+    }
+}

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/accounts/NavigationAccountsSessionTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/accounts/NavigationAccountsSessionTest.kt
@@ -1,0 +1,130 @@
+package com.mapbox.navigation.core.accounts
+
+import android.content.Context
+import com.mapbox.navigation.core.NavigationSession
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Test
+
+class NavigationAccountsSessionTest {
+
+    private val context: Context = mockk()
+    private val appContext: Context = mockk()
+    private val accounts: MapboxNavigationAccounts = mockk(relaxUnitFun = true)
+
+    @Before
+    fun setUp() {
+        every { context.applicationContext } returns appContext
+        mockkObject(MapboxNavigationAccounts)
+        every {
+            MapboxNavigationAccounts.getInstance(
+                appContext
+            )
+        } returns accounts
+    }
+
+    @Test
+    fun previousIdleCurrentIdleNeitherStartedNorStoppedAreCalled() {
+        val navigationAccountsSession = NavigationAccountsSession(context)
+
+        navigationAccountsSession.onNavigationSessionStateChanged(NavigationSession.State.IDLE)
+
+        verify(exactly = 0) { accounts.navigationStarted() }
+        verify(exactly = 0) { accounts.navigationStopped() }
+    }
+
+    @Test
+    fun previousIdleCurrentFreeDriveNeitherStartedNorStoppedAreCalled() {
+        val navigationAccountsSession = NavigationAccountsSession(context)
+
+        navigationAccountsSession.onNavigationSessionStateChanged(NavigationSession.State.FREE_DRIVE)
+
+        verify(exactly = 0) { accounts.navigationStarted() }
+        verify(exactly = 0) { accounts.navigationStopped() }
+    }
+
+    @Test
+    fun previousIdleCurrentActiveGuidanceStartedIsCalled() {
+        val navigationAccountsSession = NavigationAccountsSession(context)
+
+        navigationAccountsSession.onNavigationSessionStateChanged(NavigationSession.State.ACTIVE_GUIDANCE)
+
+        verify(exactly = 1) { accounts.navigationStarted() }
+    }
+
+    @Test
+    fun previousIdleCurrentActiveGuidanceStoppedIsNotCalled() {
+        val navigationAccountsSession = NavigationAccountsSession(context)
+
+        navigationAccountsSession.onNavigationSessionStateChanged(NavigationSession.State.ACTIVE_GUIDANCE)
+
+        verify(exactly = 0) { accounts.navigationStopped() }
+    }
+
+    @Test
+    fun previousActiveGuidanceCurrentIdleStoppedIsCalled() {
+        val navigationAccountsSession = NavigationAccountsSession(context)
+        navigationAccountsSession.onNavigationSessionStateChanged(NavigationSession.State.ACTIVE_GUIDANCE)
+
+        navigationAccountsSession.onNavigationSessionStateChanged(NavigationSession.State.IDLE)
+
+        verify(exactly = 1) { accounts.navigationStopped() }
+    }
+
+    @Test
+    fun previousActiveGuidanceCurrentFreeDriveStoppedIsCalled() {
+        val navigationAccountsSession = NavigationAccountsSession(context)
+        navigationAccountsSession.onNavigationSessionStateChanged(NavigationSession.State.ACTIVE_GUIDANCE)
+
+        navigationAccountsSession.onNavigationSessionStateChanged(NavigationSession.State.FREE_DRIVE)
+
+        verify(exactly = 1) { accounts.navigationStopped() }
+    }
+
+    @Test
+    fun previousActiveGuidanceCurrentActiveGuidanceStartedOnce() {
+        val navigationAccountsSession = NavigationAccountsSession(context)
+        navigationAccountsSession.onNavigationSessionStateChanged(NavigationSession.State.ACTIVE_GUIDANCE)
+
+        navigationAccountsSession.onNavigationSessionStateChanged(NavigationSession.State.ACTIVE_GUIDANCE)
+
+        verify(exactly = 1) { accounts.navigationStarted() }
+        verify(exactly = 0) { accounts.navigationStopped() }
+    }
+
+    @Test
+    fun previousFreeDriveCurrentIdleNeitherStartedNorStoppedAreCalled() {
+        val navigationAccountsSession = NavigationAccountsSession(context)
+        navigationAccountsSession.onNavigationSessionStateChanged(NavigationSession.State.FREE_DRIVE)
+
+        navigationAccountsSession.onNavigationSessionStateChanged(NavigationSession.State.IDLE)
+
+        verify(exactly = 0) { accounts.navigationStarted() }
+        verify(exactly = 0) { accounts.navigationStopped() }
+    }
+
+    @Test
+    fun previousFreeDriveCurrentFreeDriveNeitherStartedNorStoppedAreCalled() {
+        val navigationAccountsSession = NavigationAccountsSession(context)
+        navigationAccountsSession.onNavigationSessionStateChanged(NavigationSession.State.FREE_DRIVE)
+
+        navigationAccountsSession.onNavigationSessionStateChanged(NavigationSession.State.FREE_DRIVE)
+
+        verify(exactly = 0) { accounts.navigationStarted() }
+        verify(exactly = 0) { accounts.navigationStopped() }
+    }
+
+    @Test
+    fun previousFreeDriveCurrentActiveGuidanceNeitherStartedNorStoppedAreCalled() {
+        val navigationAccountsSession = NavigationAccountsSession(context)
+        navigationAccountsSession.onNavigationSessionStateChanged(NavigationSession.State.FREE_DRIVE)
+
+        navigationAccountsSession.onNavigationSessionStateChanged(NavigationSession.State.ACTIVE_GUIDANCE)
+
+        verify(exactly = 1) { accounts.navigationStarted() }
+        verify(exactly = 0) { accounts.navigationStopped() }
+    }
+}


### PR DESCRIPTION
## Description

Extracts the accounts lib logic to a separate class
Follow up from https://github.com/mapbox/mapbox-navigation-android/pull/2637#discussion_r397756896

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Since we do have an observer now https://github.com/mapbox/mapbox-navigation-android/pull/2637, we should extract the accounts lib logic to a separate class

### Implementation

Refactor accounts logic out from `NavigationSession` into `NavigationAccountsSession`

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] Add `MapboxNavigation` `NavigationAccountsSession` integration tests when https://github.com/mapbox/mapbox-navigation-android/pull/2641 lands
- [ ] I have updated the `CHANGELOG` including this PR

cc @abhishek1508 @olegzil @LukasPaczos 