### PR TITLE
[ci] Add trigger to track the binary size of android navigation sdk.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -365,6 +365,14 @@ commands:
                  https://circleci.com/api/v1.1/project/github/mapbox/mobile-metrics/tree/master
               fi
             fi
+      - run:
+          name: Trigger android binary size check
+          command: |
+            if [ -n "${MOBILE_METRICS_TOKEN}" ]; then
+              if [[ $CIRCLE_BRANCH == master ]]; then
+                curl -u ${MOBILE_METRICS_TOKEN}: -d build_parameters[CIRCLE_JOB]=android-navigation-binary-size https://circleci.com/api/v1.1/project/github/mapbox/mobile-metrics/tree/master
+              fi
+            fi
 
 jobs:
   build:


### PR DESCRIPTION
This PR adds trigger for downstream CI job to collect the binary size data of the navigation SDK.