### PR TITLE
Add missing MapboxNavigation tests

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -134,7 +134,7 @@ constructor(
     private val directionsSession: DirectionsSession
     private val tripService: TripService
     private val tripSession: TripSession
-    private val navigationSession = NavigationSession()
+    private val navigationSession: NavigationSession
     private val navigationAccountsSession = NavigationAccountsSession(context)
     private val internalRoutesObserver = createInternalRoutesObserver()
     private val internalOffRouteObserver = createInternalOffRouteObserver()
@@ -148,6 +148,7 @@ constructor(
 
     init {
         ThreadController.init()
+        navigationSession = NavigationComponentProvider.createNavigationSession()
         directionsSession = NavigationComponentProvider.createDirectionsSession(
             NavigationModuleProvider.createModule(
                 MapboxNavigationModuleType.HybridRouter,
@@ -472,8 +473,7 @@ constructor(
                 directionsSession,
                 tripSession,
                 location
-            )
-                ?: return
+            ) ?: return
             directionsSession.requestRoutes(
                 optionsRebuilt,
                 null

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/NavigationComponentProvider.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/NavigationComponentProvider.kt
@@ -35,4 +35,6 @@ internal object NavigationComponentProvider {
         locationEngineRequest,
         navigatorPollingDelay
     )
+
+    fun createNavigationSession(): NavigationSession = NavigationSession()
 }


### PR DESCRIPTION
## Description

Adds missing `registering` / `unregistering` observers `MapboxNavigation` behavior verification tests

Follow up from https://github.com/mapbox/mapbox-navigation-android/pull/2650

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Add missing `MapboxNavigationTest`s

### Implementation

Add missing behavior verification tests to `MapboxNavigationTest`

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR

cc @LukasPaczos @olegzil @korshaknn 