### PR TITLE
Update documentation to be milliseconds

### DIFF
--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteProgress.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteProgress.kt
@@ -41,10 +41,9 @@ class RouteProgress private constructor(
     fun distanceTraveled(): Float = distanceTraveled
 
     /**
-     * Provides the duration remaining in seconds till the user reaches the end of the route.
+     * Provides the duration remaining in milliseconds till the user reaches the end of the route.
      *
-     * @return `long` value representing the duration remaining till end of route, in unit
-     * seconds
+     * @return `long` value representing the duration remaining till end of route, in milliseconds
      */
     fun durationRemaining(): Long = durationRemaining
 


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Update documentation to represent the value. Confusion for our timestamps comes from the different types of representation we have.

Directions gives time in the `second Double form`. e.g., 61.245 is a little over a minute.
Route progress and navigation native is `millisecond Long form`. e.g., 61245L is a little over a minute

Note that the old [RouteProgress is in second Double form](https://github.com/mapbox/mapbox-navigation-android/blob/1065241164ffb936ab59b301ffbfa8a1d594c423/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/routeprogress/RouteProgress.kt#L29)

- [x] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->