### PR TITLE
Fix notification leak

### DIFF
--- a/libtrip-notification/src/main/java/com/mapbox/navigation/trip/notification/MapboxTripNotification.kt
+++ b/libtrip-notification/src/main/java/com/mapbox/navigation/trip/notification/MapboxTripNotification.kt
@@ -112,6 +112,7 @@ class MapboxTripNotification constructor(
     override fun getNotificationId(): Int = NOTIFICATION_ID
 
     override fun updateNotification(routeProgress: RouteProgress) {
+        buildRemoteViews()
         updateNotificationViews(routeProgress)
         notification = navigationNotificationProvider.buildNotification(getNotificationBuilder())
         notificationManager.notify(NOTIFICATION_ID, notification)

--- a/libtrip-notification/src/main/java/com/mapbox/navigation/trip/notification/MapboxTripNotification.kt
+++ b/libtrip-notification/src/main/java/com/mapbox/navigation/trip/notification/MapboxTripNotification.kt
@@ -112,6 +112,9 @@ class MapboxTripNotification constructor(
     override fun getNotificationId(): Int = NOTIFICATION_ID
 
     override fun updateNotification(routeProgress: RouteProgress) {
+        // RemoteView has an internal mActions, which stores every change and cannot be cleared.
+        // As we set new bitmaps, the mActions parcelable size will grow and eventually cause a crash.
+        // buildRemoteViews() will rebuild the RemoteViews and clear the stored mActions.
         buildRemoteViews()
         updateNotificationViews(routeProgress)
         notification = navigationNotificationProvider.buildNotification(getNotificationBuilder())


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

https://github.com/mapbox/driver/issues/541

The `RemoteView` in Android will grow in size. If you preserve the view, it will eventually become too large and crash. This "fix" is to create a new view every update. 

Understanding that this is essentially wasted memory, it is at least better than a deterministic Notification crash.

- [x] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->