### PR TITLE
Fix gitignore sdk_versions rules

### DIFF
--- a/libandroid-navigation-ui/.gitignore
+++ b/libandroid-navigation-ui/.gitignore
@@ -1,1 +1,2 @@
 dependency-graph-mapbox-libraries.png
+src/main/assets/sdk_versions/*

--- a/libandroid-navigation-ui/src/main/assets/sdk_versions/.gitignore
+++ b/libandroid-navigation-ui/src/main/assets/sdk_versions/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/libandroid-navigation/.gitignore
+++ b/libandroid-navigation/.gitignore
@@ -1,2 +1,3 @@
 dependency-graph-mapbox-libraries.png
 mobile-event-schemas.jsonl.gz
+src/main/assets/sdk_versions/*

--- a/libandroid-navigation/src/main/assets/sdk_versions/.gitignore
+++ b/libandroid-navigation/src/main/assets/sdk_versions/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/libnavigation-core/.gitignore
+++ b/libnavigation-core/.gitignore
@@ -1,1 +1,3 @@
 mobile-event-schemas.jsonl.gz
+src/main/assets/sdk_versions/*
+

--- a/libnavigation-core/src/main/assets/sdk_versions/.gitignore
+++ b/libnavigation-core/src/main/assets/sdk_versions/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/libnavigation-ui/.gitignore
+++ b/libnavigation-ui/.gitignore
@@ -1,1 +1,2 @@
 dependency-graph-mapbox-libraries.png
+src/main/assets/sdk_versions/*

--- a/libnavigation-ui/src/main/assets/sdk_versions/.gitignore
+++ b/libnavigation-ui/src/main/assets/sdk_versions/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
## Description

Fixes `.gitignore` `sdk_versions` rules
Follow up from https://github.com/mapbox/mapbox-navigation-android/pull/2666

Refs. https://github.com/mapbox/mobile-telemetry/issues/564

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Fixes `.gitignore` `sdk_versions` rules as https://github.com/mapbox/mapbox-navigation-android/commit/16231999cb66606dcfe993112aaac68f30005a70 didn't work because the plugin removes `assets/sdk_versions` completely including `.gitignore` files

### Implementation

Remove `assets/sdk_versions` `.gitignore` files and fix module ones

## Testing

- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR

cc @nkukday