### PR TITLE
Cancel event can now be sent after arrival

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/events/NavigationCancelEvent.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/events/NavigationCancelEvent.kt
@@ -11,7 +11,7 @@ internal class NavigationCancelEvent(
      * Don't remove any fields, cause they are should match with
      * the schema downloaded from S3. Look at {@link SchemaTest}
      */
-    var arrivalTimestamp: String? = null // Schema null if the user cancelled without arriving (can't happen)
+    var arrivalTimestamp: String? = null
     var rating: Int = 0
     var comment: String = ""
 


### PR DESCRIPTION
## Description
Originally, the Telemetry code prohibited sending a cancel event once an arrival event was received. This behavior is undesirable. The correct behavior as requested by @coxchapman is to send a cancel event regardless of arrival. The new behavior is: 
SDK detects an arrival -> arrival event sent automatically -> SDK detects a cancel request -> cancel request sent automatically

### Goal
Implement requested behavior

### Implementation
Implementation involved removing code that discriminated between an arrival and a non-arrival navigation session

## Testing

Please describe the manual tests that you ran to verify your changes

- [x ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x ] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x ] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->