### PR TITLE
Update leg and step durationRemaining to Double

### DIFF
--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteLegProgress.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteLegProgress.kt
@@ -8,7 +8,7 @@ class RouteLegProgress private constructor(
     private val routeLeg: RouteLeg? = null,
     private val distanceTraveled: Float = 0f,
     private val distanceRemaining: Float = 0f,
-    private val durationRemaining: Long = 0L,
+    private val durationRemaining: Double = 0.0,
     private val fractionTraveled: Float = 0f,
     private val currentStepProgress: RouteStepProgress? = null,
     private val upcomingStep: LegStep? = null,
@@ -40,18 +40,18 @@ class RouteLegProgress private constructor(
     fun distanceTraveled(): Float = distanceTraveled
 
     /**
-     * Provides the duration remaining in seconds till the user reaches the end of the route.
+     * Provides the distance remaining in meters till the user reaches the end of the leg.
      *
-     * @return long value representing the duration remaining till end of route, in unit seconds
+     * @return distance remaining till end of leg, in unit meters.
      */
     fun distanceRemaining(): Float = distanceRemaining
 
     /**
      * Provides the duration remaining in seconds till the user reaches the end of the current step.
      *
-     * @return long value representing the duration remaining till end of step, in unit seconds.
+     * @return duration remaining till end of leg, in unit seconds.
      */
-    fun durationRemaining(): Long = durationRemaining
+    fun durationRemaining(): Double = durationRemaining
 
     /**
      * Get the fraction traveled along the current leg, this is a float value between 0 and 1 and
@@ -85,7 +85,7 @@ class RouteLegProgress private constructor(
         private var routeLeg: RouteLeg? = null,
         private var distanceTraveled: Float = 0f,
         private var distanceRemaining: Float = 0f,
-        private var durationRemaining: Long = 0L,
+        private var durationRemaining: Double = 0.0,
         private var fractionTraveled: Float = 0f,
         private var currentStepProgress: RouteStepProgress? = null,
         private var upcomingStep: LegStep? = null
@@ -101,7 +101,7 @@ class RouteLegProgress private constructor(
         fun distanceRemaining(distanceRemaining: Float) =
             apply { this.distanceRemaining = distanceRemaining }
 
-        fun durationRemaining(durationRemaining: Long) =
+        fun durationRemaining(durationRemaining: Double) =
             apply { this.durationRemaining = durationRemaining }
 
         fun fractionTraveled(fractionTraveled: Float) =

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteStepProgress.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteStepProgress.kt
@@ -10,7 +10,7 @@ class RouteStepProgress private constructor(
     private val distanceRemaining: Float = 0f,
     private val distanceTraveled: Float = 0f,
     private val fractionTraveled: Float = 0f,
-    private val durationRemaining: Long = 0L,
+    private val durationRemaining: Double = 0.0,
     private val guidanceViewURL: String? = null,
     private val builder: Builder
 ) {
@@ -65,9 +65,9 @@ class RouteStepProgress private constructor(
     /**
      * Provides the duration remaining in seconds till the user reaches the end of the current step.
      *
-     * @return `long` value representing the duration remaining till end of step, in unit seconds.
+     * @return duration remaining till end of step, in unit seconds.
      */
-    fun durationRemaining(): Long = durationRemaining
+    fun durationRemaining(): Double = durationRemaining
 
     /**
      * Provides the duration remaining in seconds till the user reaches the end of the current step.
@@ -85,7 +85,7 @@ class RouteStepProgress private constructor(
         private var distanceRemaining: Float = 0f,
         private var distanceTraveled: Float = 0f,
         private var fractionTraveled: Float = 0f,
-        private var durationRemaining: Long = 0L,
+        private var durationRemaining: Double = 0.0,
         private var guidanceViewURL: String? = null
     ) {
 
@@ -106,7 +106,7 @@ class RouteStepProgress private constructor(
         fun fractionTraveled(fractionTraveled: Float) =
             apply { this.fractionTraveled = fractionTraveled }
 
-        fun durationRemaining(durationRemaining: Long) =
+        fun durationRemaining(durationRemaining: Double) =
             apply { this.durationRemaining = durationRemaining }
 
         fun guidanceViewURL(guidanceURL: String?) =

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/MapboxNativeNavigatorImpl.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/MapboxNativeNavigatorImpl.kt
@@ -30,7 +30,6 @@ import com.mapbox.navigator.RouterParams
 import com.mapbox.navigator.RouterResult
 import com.mapbox.navigator.VoiceInstruction
 import java.util.Date
-import kotlin.math.roundToLong
 
 /**
  * Default implementation of [MapboxNativeNavigator] interface.
@@ -178,7 +177,7 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
                 )
 
                 var routeDistanceRemaining = remainingLegDistance
-                var routeDurationRemaining = remainingLegDuration.toDouble() * 1e-4
+                var routeDurationRemaining = remainingLegDuration / ONE_SECOND_IN_MILLISECONDS
                 if (legs.size >= TWO_LEGS) {
                     for (i in legIndex + ONE_INDEX until legs.size) {
                         routeDistanceRemaining += legs[i].distance()?.toFloat() ?: 0f
@@ -257,11 +256,11 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
         }
 
         stepProgressBuilder.distanceRemaining(remainingStepDistance)
-        stepProgressBuilder.durationRemaining((remainingStepDuration / ONE_SECOND_IN_MILLISECONDS).roundToLong())
+        stepProgressBuilder.durationRemaining(remainingStepDuration / ONE_SECOND_IN_MILLISECONDS)
 
         legProgressBuilder.currentStepProgress(stepProgressBuilder.build())
         legProgressBuilder.distanceRemaining(remainingLegDistance)
-        legProgressBuilder.durationRemaining((remainingLegDuration / ONE_SECOND_IN_MILLISECONDS).roundToLong())
+        legProgressBuilder.durationRemaining(remainingLegDuration / ONE_SECOND_IN_MILLISECONDS)
 
         routeProgressBuilder.currentLegProgress(legProgressBuilder.build())
 

--- a/libtrip-notification/src/test/java/com/mapbox/navigation/trip/notification/MapboxTripNotificationTest.kt
+++ b/libtrip-notification/src/test/java/com/mapbox/navigation/trip/notification/MapboxTripNotificationTest.kt
@@ -195,7 +195,7 @@ class MapboxTripNotificationTest {
     fun whenUpdateNotificationCalledThenDistanceTextIsSetToRemoteViews() {
         val routeProgress = mockk<RouteProgress>(relaxed = true)
         val distance = 30f
-        val duration = 112L
+        val duration = 112.4
         val distanceText = distanceSpannable.toString()
         mockLegProgress(routeProgress, distance, duration)
         mockUpdateNotificationAndroidInteractions()
@@ -210,7 +210,7 @@ class MapboxTripNotificationTest {
     fun whenUpdateNotificationCalledThenArrivalTimeIsSetToRemoteViews() {
         val routeProgress = mockk<RouteProgress>(relaxed = true)
         val distance = 30f
-        val duration = 112L
+        val duration = 112.4
         mockLegProgress(routeProgress, distance, duration)
         mockUpdateNotificationAndroidInteractions()
         val suffix = "this is nice formatting"
@@ -374,7 +374,7 @@ class MapboxTripNotificationTest {
     private fun mockLegProgress(
         routeProgress: RouteProgress,
         distance: Float,
-        duration: Long
+        duration: Double
     ): RouteLegProgress {
         val currentLegProgress = mockk<RouteLegProgress>(relaxed = true)
         every { routeProgress.currentLegProgress() } returns currentLegProgress


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Resolves: https://github.com/mapbox/mapbox-navigation-android/issues/2667
Everywhere we have durationRemaining is in the form of a Double seconds. 

The one place we don't, is where we want to support an atomic value and AtomicDouble is not available.
https://github.com/mapbox/mapbox-navigation-android/pull/2669#discussion_r400507344 

- [x] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Implementation

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->