### PR TITLE
Move replay route package

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/BasicNavigationActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/BasicNavigationActivity.kt
@@ -27,7 +27,7 @@ import com.mapbox.navigation.base.extensions.coordinates
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesRequestCallback
-import com.mapbox.navigation.core.location.ReplayRouteLocationEngine
+import com.mapbox.navigation.core.replay.route.ReplayRouteLocationEngine
 import com.mapbox.navigation.core.trip.session.LocationObserver
 import com.mapbox.navigation.core.trip.session.RouteProgressObserver
 import com.mapbox.navigation.examples.R

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/GuidanceViewActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/GuidanceViewActivity.kt
@@ -27,7 +27,7 @@ import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesObserver
 import com.mapbox.navigation.core.directions.session.RoutesRequestCallback
-import com.mapbox.navigation.core.location.ReplayRouteLocationEngine
+import com.mapbox.navigation.core.replay.route.ReplayRouteLocationEngine
 import com.mapbox.navigation.core.trip.session.BannerInstructionsObserver
 import com.mapbox.navigation.core.trip.session.LocationObserver
 import com.mapbox.navigation.core.trip.session.RouteProgressObserver

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/InstructionViewActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/InstructionViewActivity.kt
@@ -36,7 +36,7 @@ import com.mapbox.navigation.base.extensions.coordinates
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesRequestCallback
-import com.mapbox.navigation.core.location.ReplayRouteLocationEngine
+import com.mapbox.navigation.core.replay.route.ReplayRouteLocationEngine
 import com.mapbox.navigation.core.trip.session.BannerInstructionsObserver
 import com.mapbox.navigation.core.trip.session.LocationObserver
 import com.mapbox.navigation.core.trip.session.RouteProgressObserver

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayActivity.kt
@@ -26,7 +26,7 @@ import com.mapbox.navigation.base.extensions.applyDefaultParams
 import com.mapbox.navigation.base.extensions.coordinates
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesRequestCallback
-import com.mapbox.navigation.core.location.ReplayRouteLocationEngine
+import com.mapbox.navigation.core.replay.route.ReplayRouteLocationEngine
 import com.mapbox.navigation.core.trip.session.LocationObserver
 import com.mapbox.navigation.examples.R
 import com.mapbox.navigation.examples.utils.Utils

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/SimpleMapboxNavigationKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/SimpleMapboxNavigationKt.kt
@@ -42,7 +42,7 @@ import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesObserver
 import com.mapbox.navigation.core.directions.session.RoutesRequestCallback
 import com.mapbox.navigation.core.fasterroute.FasterRouteObserver
-import com.mapbox.navigation.core.location.ReplayRouteLocationEngine
+import com.mapbox.navigation.core.replay.route.ReplayRouteLocationEngine
 import com.mapbox.navigation.core.telemetry.events.FeedbackEvent
 import com.mapbox.navigation.core.trip.session.LocationObserver
 import com.mapbox.navigation.core.trip.session.RouteProgressObserver

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/SummaryBottomSheetActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/SummaryBottomSheetActivity.kt
@@ -33,7 +33,7 @@ import com.mapbox.navigation.base.extensions.coordinates
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesRequestCallback
-import com.mapbox.navigation.core.location.ReplayRouteLocationEngine
+import com.mapbox.navigation.core.replay.route.ReplayRouteLocationEngine
 import com.mapbox.navigation.core.trip.session.LocationObserver
 import com.mapbox.navigation.core.trip.session.RouteProgressObserver
 import com.mapbox.navigation.core.trip.session.TripSessionState

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayLocationConverter.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayLocationConverter.kt
@@ -1,4 +1,4 @@
-package com.mapbox.navigation.core.location.replay
+package com.mapbox.navigation.core.replay.route
 
 import android.location.Location
 import com.mapbox.api.directions.v5.models.DirectionsRoute

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayLocationDispatcher.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayLocationDispatcher.kt
@@ -1,4 +1,4 @@
-package com.mapbox.navigation.core.location.replay
+package com.mapbox.navigation.core.replay.route
 
 import android.location.Location
 import android.os.Handler

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayLocationDto.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayLocationDto.kt
@@ -1,4 +1,4 @@
-package com.mapbox.navigation.core.location.replay
+package com.mapbox.navigation.core.replay.route
 
 import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayLocationListener.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayLocationListener.kt
@@ -1,4 +1,4 @@
-package com.mapbox.navigation.core.location.replay
+package com.mapbox.navigation.core.replay.route
 
 import android.location.Location
 

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayRouteLocationConverter.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayRouteLocationConverter.kt
@@ -1,4 +1,4 @@
-package com.mapbox.navigation.core.location.replay
+package com.mapbox.navigation.core.replay.route
 
 import android.location.Location
 import com.mapbox.api.directions.v5.models.DirectionsRoute
@@ -27,8 +27,8 @@ internal class ReplayRouteLocationConverter(
         private const val ONE_SECOND_IN_MILLISECONDS = 1000
         private const val ONE_KM_IN_METERS = 1000.0
         private const val ONE_HOUR_IN_SECONDS = 3600
-        private const val REPLAY_ROUTE =
-            "com.mapbox.navigation.core.location.replay.ReplayRouteLocationEngine"
+        private const val LOCATION_PROVIDER_REPLAY_ROUTE =
+            "com.mapbox.navigation.core.replay.route.ReplayRouteLocationEngine"
     }
 
     init {
@@ -138,7 +138,7 @@ internal class ReplayRouteLocationConverter(
     }
 
     private fun createMockLocationFrom(point: Point): Location {
-        val mockedLocation = Location(REPLAY_ROUTE)
+        val mockedLocation = Location(LOCATION_PROVIDER_REPLAY_ROUTE)
         mockedLocation.latitude = point.latitude()
         mockedLocation.longitude = point.longitude()
         val speedInMetersPerSec = (speed * ONE_KM_IN_METERS / ONE_HOUR_IN_SECONDS).toFloat()

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayRouteLocationEngine.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayRouteLocationEngine.kt
@@ -1,4 +1,4 @@
-package com.mapbox.navigation.core.location
+package com.mapbox.navigation.core.replay.route
 
 import android.app.PendingIntent
 import android.location.Location
@@ -13,10 +13,6 @@ import com.mapbox.geojson.LineString
 import com.mapbox.geojson.Point
 import com.mapbox.navigation.base.logger.Logger
 import com.mapbox.navigation.base.logger.model.Message
-import com.mapbox.navigation.core.location.replay.ReplayLocationConverter
-import com.mapbox.navigation.core.location.replay.ReplayLocationDispatcher
-import com.mapbox.navigation.core.location.replay.ReplayRouteLocationConverter
-import com.mapbox.navigation.core.location.replay.ReplayRouteLocationListener
 import java.util.ArrayList
 
 class ReplayRouteLocationEngine(
@@ -57,7 +53,7 @@ class ReplayRouteLocationEngine(
         private const val DELAY_MUST_BE_GREATER_THAN_ZERO_SECONDS =
             "Delay must be greater than 0 seconds."
         private const val REPLAY_ROUTE =
-            "com.mapbox.navigation.core.location.ReplayRouteLocationEngine"
+            "com.mapbox.navigation.core.replay.route.ReplayRouteLocationEngine"
     }
 
     fun assign(route: DirectionsRoute) {

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayRouteLocationListener.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayRouteLocationListener.kt
@@ -1,9 +1,8 @@
-package com.mapbox.navigation.core.location.replay
+package com.mapbox.navigation.core.replay.route
 
 import android.location.Location
 import com.mapbox.android.core.location.LocationEngineCallback
 import com.mapbox.android.core.location.LocationEngineResult
-import com.mapbox.navigation.core.location.ReplayRouteLocationEngine
 
 internal class ReplayRouteLocationListener(
     private val engine: ReplayRouteLocationEngine,

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/TimestampAdapter.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/TimestampAdapter.kt
@@ -1,4 +1,4 @@
-package com.mapbox.navigation.core.location.replay
+package com.mapbox.navigation.core.replay.route
 
 import com.google.gson.TypeAdapter
 import com.google.gson.stream.JsonReader

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetry.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetry.kt
@@ -105,7 +105,7 @@ internal object MapboxNavigationTelemetry : MapboxNavigationTelemetryInterface {
     internal const val LOCATION_BUFFER_MAX_SIZE = 20
     private const val ONE_SECOND = 1000
     private const val MOCK_PROVIDER =
-        "com.mapbox.navigation.core.location.ReplayRouteLocationEngine"
+        "com.mapbox.navigation.core.replay.route.ReplayRouteLocationEngine"
 
     internal const val TAG = "MAPBOX_TELEMETRY"
     private const val EVENT_VERSION = 7

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/LocationEngineConductor.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/LocationEngineConductor.java
@@ -5,7 +5,7 @@ import android.content.Context;
 import com.mapbox.android.core.location.LocationEngine;
 import com.mapbox.android.core.location.LocationEngineProvider;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
-import com.mapbox.navigation.core.location.ReplayRouteLocationEngine;
+import com.mapbox.navigation.core.replay.route.ReplayRouteLocationEngine;
 
 class LocationEngineConductor {
 

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationLauncher.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationLauncher.java
@@ -9,7 +9,7 @@ import android.preference.PreferenceManager;
 import com.google.gson.Gson;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.navigation.ui.legacy.NavigationConstants;
-import com.mapbox.navigation.core.location.ReplayRouteLocationEngine;
+import com.mapbox.navigation.core.replay.route.ReplayRouteLocationEngine;
 import com.mapbox.navigation.base.route.Router;
 
 /**

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationView.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationView.java
@@ -37,7 +37,7 @@ import com.mapbox.navigation.base.route.Router;
 import com.mapbox.navigation.base.typedef.TimeFormatType;
 import com.mapbox.navigation.core.MapboxDistanceFormatter;
 import com.mapbox.navigation.core.MapboxNavigation;
-import com.mapbox.navigation.core.location.ReplayRouteLocationEngine;
+import com.mapbox.navigation.core.replay.route.ReplayRouteLocationEngine;
 import com.mapbox.navigation.ui.camera.DynamicCamera;
 import com.mapbox.navigation.ui.camera.NavigationCamera;
 import com.mapbox.navigation.ui.instruction.ImageCreator;

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationViewModel.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationViewModel.java
@@ -27,7 +27,7 @@ import com.mapbox.navigation.base.typedef.TimeFormatType;
 import com.mapbox.navigation.core.MapboxDistanceFormatter;
 import com.mapbox.navigation.core.MapboxNavigation;
 import com.mapbox.navigation.core.directions.session.RoutesObserver;
-import com.mapbox.navigation.core.location.ReplayRouteLocationEngine;
+import com.mapbox.navigation.core.replay.route.ReplayRouteLocationEngine;
 import com.mapbox.navigation.core.trip.session.BannerInstructionsObserver;
 import com.mapbox.navigation.core.trip.session.OffRouteObserver;
 import com.mapbox.navigation.core.trip.session.VoiceInstructionsObserver;

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/LocationEngineConductorTest.java
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/LocationEngineConductorTest.java
@@ -8,7 +8,7 @@ import androidx.annotation.NonNull;
 
 import com.mapbox.android.core.location.LocationEngine;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
-import com.mapbox.navigation.core.location.ReplayRouteLocationEngine;
+import com.mapbox.navigation.core.replay.route.ReplayRouteLocationEngine;
 
 import org.junit.Test;
 


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Starting to move `Replay History`. First refactor `Replay Route` package structure so replay history will fit in. More details https://github.com/mapbox/mapbox-navigation-android/issues/2688

The current package structure for replay is `location.` and `location.replay.`
This changes it to be `replay.route.` and `replay.history.` 

- [ ] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->