### PR TITLE
Sb 2495 waypoints with core

### DIFF
--- a/examples/src/main/AndroidManifest.xml
+++ b/examples/src/main/AndroidManifest.xml
@@ -183,6 +183,14 @@
                 android:value=".CoreActivity" />
         </activity>
 
+        <activity android:name=".core.TestWaypointsActivity"
+            android:label="@string/title_summary_bottom_sheet"
+            android:screenOrientation="portrait">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".CoreActivity" />
+        </activity>
+
         <meta-data
             android:name="com.mapbox.TestEventsServer"
             android:value="api-events-staging.tilestream.net" />

--- a/examples/src/main/java/com/mapbox/navigation/examples/CoreActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/CoreActivity.kt
@@ -6,20 +6,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.LinearLayoutManager.VERTICAL
-import com.mapbox.navigation.examples.core.BasicNavigationActivity
-import com.mapbox.navigation.examples.core.FasterRouteActivity
-import com.mapbox.navigation.examples.core.GuidanceViewActivity
-import com.mapbox.navigation.examples.core.InstructionViewActivity
-import com.mapbox.navigation.examples.core.OffboardRouterActivityJava
-import com.mapbox.navigation.examples.core.OffboardRouterActivityKt
-import com.mapbox.navigation.examples.core.OnboardRouterActivityJava
-import com.mapbox.navigation.examples.core.OnboardRouterActivityKt
-import com.mapbox.navigation.examples.core.ReRouteActivity
-import com.mapbox.navigation.examples.core.ReplayActivity
-import com.mapbox.navigation.examples.core.SimpleMapboxNavigationKt
-import com.mapbox.navigation.examples.core.SummaryBottomSheetActivity
-import com.mapbox.navigation.examples.core.TripServiceActivityKt
-import com.mapbox.navigation.examples.core.TripSessionActivityKt
+import com.mapbox.navigation.examples.core.*
 import kotlinx.android.synthetic.main.activity_core.*
 
 class CoreActivity : AppCompatActivity() {
@@ -113,7 +100,12 @@ class CoreActivity : AppCompatActivity() {
                 getString(R.string.title_summary_bottom_sheet),
                 getString(R.string.description_summary_bottom_sheet),
                 SummaryBottomSheetActivity::class.java
-            )
+            ),
+                SampleItem(
+                        getString(R.string.title_test_waypoints),
+                        getString(R.string.description_test_waypoints),
+                        TestWaypointsActivity::class.java
+                )
         )
     }
 }

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/TestWaypointsActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/TestWaypointsActivity.kt
@@ -119,26 +119,43 @@ class TestWaypointsActivity : AppCompatActivity(), OnMapReadyCallback {
                     it.restoreFrom(state)
                 }
             }
+            gotoPredefinedLocation(mapboxMap)
         }
-        mapboxMap.addOnMapLongClickListener { latLng ->
-            //mapboxMap.locationComponent.lastKnownLocation?.let { originLocation ->
-            mapboxMap.moveCamera(CameraUpdateFactory.newLatLng(LatLng(waypoints[0].latitude(), waypoints[0].longitude())))
-            mapboxNavigation?.registerBannerInstructionsObserver(bannerInstructionObserver)
-            mapboxNavigation?.registerVoiceInstructionsObserver(voiceInstructionsObserver)
-                mapboxNavigation?.requestRoutes(
-                        RouteOptions.builder().applyDefaultParams()
-                                .accessToken(Utils.getMapboxAccessToken(applicationContext))
-                                .coordinates(waypoints.first(), waypoints.subList(1, waypoints.lastIndex), waypoints.last())
-                                .alternatives(true)
-                                .waypointNamesList(names)
-                                .profile(DirectionsCriteria.PROFILE_DRIVING)
-                                .build(),
-                        routesReqCallback
-                )
-            //}
-            true
-        }
+//        mapboxMap.addOnMapLongClickListener { latLng ->
+//            //mapboxMap.locationComponent.lastKnownLocation?.let { originLocation ->
+//            mapboxMap.moveCamera(CameraUpdateFactory.newLatLng(LatLng(waypoints[0].latitude(), waypoints[0].longitude())))
+//            mapboxNavigation?.registerBannerInstructionsObserver(bannerInstructionObserver)
+//            mapboxNavigation?.registerVoiceInstructionsObserver(voiceInstructionsObserver)
+//                mapboxNavigation?.requestRoutes(
+//                        RouteOptions.builder().applyDefaultParams()
+//                                .accessToken(Utils.getMapboxAccessToken(applicationContext))
+//                                .coordinates(waypoints.first(), waypoints.subList(1, waypoints.lastIndex), waypoints.last())
+//                                .alternatives(true)
+//                                .waypointNamesList(names)
+//                                .profile(DirectionsCriteria.PROFILE_DRIVING)
+//                                .build(),
+//                        routesReqCallback
+//                )
+//            //}
+//            true
+//        }
         locationComponent = mapboxMap.locationComponent
+    }
+
+    fun gotoPredefinedLocation(mapboxMap: MapboxMap) {
+        mapboxMap.moveCamera(CameraUpdateFactory.newLatLng(LatLng(waypoints[0].latitude(), waypoints[0].longitude())))
+        mapboxNavigation?.registerBannerInstructionsObserver(bannerInstructionObserver)
+        mapboxNavigation?.registerVoiceInstructionsObserver(voiceInstructionsObserver)
+        mapboxNavigation?.requestRoutes(
+                RouteOptions.builder().applyDefaultParams()
+                        .accessToken(Utils.getMapboxAccessToken(applicationContext))
+                        .coordinates(waypoints.first(), waypoints.subList(1, waypoints.lastIndex), waypoints.last())
+                        .alternatives(true)
+                        .waypointNamesList(names)
+                        .profile(DirectionsCriteria.PROFILE_DRIVING)
+                        .build(),
+                routesReqCallback
+        )
     }
 
     @SuppressLint("RestrictedApi")

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/TestWaypointsActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/TestWaypointsActivity.kt
@@ -1,0 +1,341 @@
+package com.mapbox.navigation.examples.core
+
+import android.annotation.SuppressLint
+import android.location.Location
+import android.os.Bundle
+import android.preference.PreferenceManager
+import android.view.View
+import androidx.appcompat.app.AppCompatActivity
+import com.mapbox.android.core.location.*
+import com.mapbox.api.directions.v5.DirectionsCriteria
+import com.mapbox.api.directions.v5.models.BannerInstructions
+import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.api.directions.v5.models.RouteOptions
+import com.mapbox.api.directions.v5.models.VoiceInstructions
+import com.mapbox.geojson.Point
+import com.mapbox.mapboxsdk.Mapbox
+import com.mapbox.mapboxsdk.camera.CameraUpdateFactory
+import com.mapbox.mapboxsdk.geometry.LatLng
+import com.mapbox.mapboxsdk.location.LocationComponent
+import com.mapbox.mapboxsdk.location.LocationComponentActivationOptions
+import com.mapbox.mapboxsdk.location.modes.CameraMode
+import com.mapbox.mapboxsdk.location.modes.RenderMode
+import com.mapbox.mapboxsdk.maps.MapboxMap
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback
+import com.mapbox.mapboxsdk.maps.Style
+import com.mapbox.navigation.base.extensions.applyDefaultParams
+import com.mapbox.navigation.base.extensions.coordinates
+import com.mapbox.navigation.base.trip.model.RouteProgress
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.directions.session.RoutesRequestCallback
+import com.mapbox.navigation.core.location.ReplayRouteLocationEngine
+import com.mapbox.navigation.core.trip.session.*
+import com.mapbox.navigation.examples.R
+import com.mapbox.navigation.examples.utils.Utils
+import com.mapbox.navigation.examples.utils.extensions.toPoint
+import com.mapbox.navigation.ui.camera.NavigationCamera
+import com.mapbox.navigation.ui.map.NavigationMapboxMap
+import com.mapbox.navigation.ui.map.NavigationMapboxMapInstanceState
+import com.mapbox.navigation.ui.voice.NavigationSpeechPlayer
+import com.mapbox.navigation.ui.voice.SpeechPlayerProvider
+import com.mapbox.navigation.ui.voice.VoiceInstructionLoader
+import kotlinx.android.synthetic.main.activity_instruction_view_layout.*
+import kotlinx.android.synthetic.main.test_waypoints_activity_layout.mapView
+import kotlinx.android.synthetic.main.test_waypoints_activity_layout.startNavigation
+import okhttp3.Cache
+import timber.log.Timber
+import java.io.File
+import java.util.*
+
+
+class TestWaypointsActivity : AppCompatActivity(), OnMapReadyCallback {
+
+    companion object {
+        const val MAP_INSTANCE_STATE_KEY = "navgation_mapbox_map_instance_state"
+        const val DEFAULT_INTERVAL_IN_MILLISECONDS = 1000L
+        const val DEFAULT_MAX_WAIT_TIME = DEFAULT_INTERVAL_IN_MILLISECONDS * 5
+        private const val VOICE_INSTRUCTION_CACHE = "voice-instruction-cache"
+    }
+
+    private var mapboxNavigation: MapboxNavigation? = null
+    private var navigationMapboxMap: NavigationMapboxMap? = null
+    private var mapInstanceState: NavigationMapboxMapInstanceState? = null
+    private var locationComponent: LocationComponent? = null
+    private lateinit var speechPlayer: NavigationSpeechPlayer
+
+
+    @SuppressLint("MissingPermission")
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.test_waypoints_activity_layout)
+        mapView.onCreate(savedInstanceState)
+        mapView.getMapAsync(this)
+
+        val mapboxNavigationOptions = MapboxNavigation.defaultNavigationOptions(
+                this,
+                Utils.getMapboxAccessToken(this)
+        )
+
+        mapboxNavigation = MapboxNavigation(
+                applicationContext,
+                Utils.getMapboxAccessToken(this),
+                mapboxNavigationOptions,
+                locationEngine = getLocationEngine()
+        ).also {
+            it.registerRouteProgressObserver(routeProgressObserver)
+        }
+
+        initListeners()
+        initializeSpeechPlayer()
+    }
+
+    val waypoints = listOf(
+            Point.fromLngLat(-77.038294672966, 38.91854721860871),
+            Point.fromLngLat(-77.03662633895874, 38.91920249133305),
+            Point.fromLngLat(-77.03660779663086, 38.9182091456012),
+            Point.fromLngLat(-77.03660052546692, 38.91565476415369),
+            Point.fromLngLat(-77.03664779663086, 38.91398518410977),
+            Point.fromLngLat(-77.03661561012268, 38.913726395687185),
+            Point.fromLngLat(-77.03665852546692, 38.91345925826118),
+            Point.fromLngLat(-77.03665852546692, 38.91270792885979)
+    )
+    val names = listOf(
+            "animal", // origin
+            "ocelot",
+            "bear",
+            "cat",
+            "dog",
+            "elephant",
+            "frog",
+            "goat" // destination
+    )
+
+    override fun onMapReady(mapboxMap: MapboxMap) {
+        mapboxMap.setStyle(Style.MAPBOX_STREETS) { style ->
+            initLocationComponent(style, mapboxMap)
+            navigationMapboxMap = NavigationMapboxMap(mapView, mapboxMap).also {
+                it.addProgressChangeListener(mapboxNavigation!!)
+                mapInstanceState?.let { state ->
+                    it.restoreFrom(state)
+                }
+            }
+        }
+        mapboxMap.addOnMapLongClickListener { latLng ->
+            //mapboxMap.locationComponent.lastKnownLocation?.let { originLocation ->
+            mapboxMap.moveCamera(CameraUpdateFactory.newLatLng(LatLng(waypoints[0].latitude(), waypoints[0].longitude())))
+            mapboxNavigation?.registerBannerInstructionsObserver(bannerInstructionObserver)
+            mapboxNavigation?.registerVoiceInstructionsObserver(voiceInstructionsObserver)
+                mapboxNavigation?.requestRoutes(
+                        RouteOptions.builder().applyDefaultParams()
+                                .accessToken(Utils.getMapboxAccessToken(applicationContext))
+                                .coordinates(waypoints.first(), waypoints.subList(1, waypoints.lastIndex), waypoints.last())
+                                .alternatives(true)
+                                .waypointNamesList(names)
+                                .profile(DirectionsCriteria.PROFILE_DRIVING)
+                                .build(),
+                        routesReqCallback
+                )
+            //}
+            true
+        }
+        locationComponent = mapboxMap.locationComponent
+    }
+
+    @SuppressLint("RestrictedApi")
+    fun initLocationComponent(loadedMapStyle: Style, mapboxMap: MapboxMap) {
+        mapboxMap.moveCamera(CameraUpdateFactory.zoomTo(15.0))
+        mapboxMap.locationComponent.let { locationComponent ->
+            val locationComponentActivationOptions =
+                    LocationComponentActivationOptions.builder(this, loadedMapStyle)
+                            .build()
+
+            locationComponent.activateLocationComponent(locationComponentActivationOptions)
+            locationComponent.isLocationComponentEnabled = true
+            locationComponent.cameraMode = CameraMode.TRACKING
+            locationComponent.renderMode = RenderMode.COMPASS
+
+            initLocationEngine()
+        }
+    }
+
+    fun initLocationEngine() {
+        val requestLocationUpdateRequest =
+                LocationEngineRequest.Builder(BasicNavigationActivity.DEFAULT_INTERVAL_IN_MILLISECONDS)
+                        .setPriority(LocationEngineRequest.PRIORITY_NO_POWER)
+                        .setMaxWaitTime(BasicNavigationActivity.DEFAULT_MAX_WAIT_TIME)
+                        .build()
+
+        mapboxNavigation?.locationEngine?.requestLocationUpdates(
+                requestLocationUpdateRequest,
+                locationListenerCallback,
+                mainLooper
+        )
+        mapboxNavigation?.locationEngine?.getLastLocation(locationListenerCallback)
+    }
+
+    private val routesReqCallback = object : RoutesRequestCallback {
+        override fun onRoutesReady(routes: List<DirectionsRoute>) {
+            if (routes.isNotEmpty()) {
+                navigationMapboxMap?.drawRoute(routes[0])
+                if (shouldSimulateRoute()) {
+                    (mapboxNavigation?.locationEngine as ReplayRouteLocationEngine).assign(routes[0])
+                }
+                startNavigation.visibility = View.VISIBLE
+            } else {
+                startNavigation.visibility = View.GONE
+            }
+        }
+
+        override fun onRoutesRequestFailure(throwable: Throwable, routeOptions: RouteOptions) {
+            Timber.e("route request failure %s", throwable.toString())
+        }
+
+        override fun onRoutesRequestCanceled(routeOptions: RouteOptions) {
+            Timber.d("route request canceled")
+        }
+    }
+
+    @SuppressLint("MissingPermission")
+    fun initListeners() {
+        startNavigation.setOnClickListener {
+            if (mapboxNavigation?.getRoutes()?.isNotEmpty() == true) {
+                navigationMapboxMap?.updateLocationLayerRenderMode(RenderMode.GPS)
+                navigationMapboxMap?.updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_GPS)
+                navigationMapboxMap?.startCamera(mapboxNavigation?.getRoutes()!![0])
+            }
+            mapboxNavigation?.startTripSession()
+            startNavigation.visibility = View.GONE
+        }
+    }
+
+    override fun onStart() {
+        super.onStart()
+        mapView.onStart()
+        mapboxNavigation?.registerLocationObserver(locationObserver)
+    }
+
+    public override fun onResume() {
+        super.onResume()
+        mapView.onResume()
+    }
+
+    public override fun onPause() {
+        super.onPause()
+        mapView.onPause()
+    }
+
+    override fun onStop() {
+        super.onStop()
+        mapboxNavigation?.unregisterLocationObserver(locationObserver)
+        mapboxNavigation?.unregisterRouteProgressObserver(routeProgressObserver)
+        stopLocationUpdates()
+        mapView.onStop()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        mapboxNavigation?.unregisterVoiceInstructionsObserver(voiceInstructionsObserver)
+        mapboxNavigation?.unregisterBannerInstructionsObserver(bannerInstructionObserver)
+        mapboxNavigation?.stopTripSession()
+        mapboxNavigation?.onDestroy()
+        mapView.onDestroy()
+    }
+
+    override fun onLowMemory() {
+        super.onLowMemory()
+        mapView.onLowMemory()
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        navigationMapboxMap?.saveStateWith(BasicNavigationActivity.MAP_INSTANCE_STATE_KEY, outState)
+        mapView.onSaveInstanceState(outState)
+    }
+
+    override fun onRestoreInstanceState(savedInstanceState: Bundle?) {
+        super.onRestoreInstanceState(savedInstanceState)
+        mapInstanceState = savedInstanceState?.getParcelable(BasicNavigationActivity.MAP_INSTANCE_STATE_KEY)
+    }
+
+    private val locationListenerCallback: LocationEngineCallback<LocationEngineResult> =
+            object : LocationEngineCallback<LocationEngineResult> {
+                override fun onSuccess(result: LocationEngineResult) {
+                    // todo
+                }
+
+                override fun onFailure(exception: Exception) {
+                    Timber.i(exception)
+                }
+            }
+
+    private fun stopLocationUpdates() {
+        mapboxNavigation?.locationEngine?.removeLocationUpdates(locationListenerCallback)
+    }
+
+    private val locationObserver = object : LocationObserver {
+        override fun onRawLocationChanged(rawLocation: Location) {
+            Timber.d("raw location %s", rawLocation.toString())
+        }
+
+        override fun onEnhancedLocationChanged(
+                enhancedLocation: Location,
+                keyPoints: List<Location>
+        ) {
+            if (keyPoints.isNotEmpty()) {
+                locationComponent?.forceLocationUpdate(keyPoints, true)
+            } else {
+                locationComponent?.forceLocationUpdate(enhancedLocation)
+            }
+        }
+    }
+
+    private val routeProgressObserver = object : RouteProgressObserver {
+        override fun onRouteProgressChanged(routeProgress: RouteProgress) {
+            // do something with the route progress
+            instructionView.updateDistanceWith(routeProgress)
+            Timber.i("route progress: ${routeProgress.currentState()}")
+        }
+    }
+
+    // Used to determine if the ReplayRouteLocationEngine should be used to simulate the routing.
+    // This is used for testing purposes.
+    private fun shouldSimulateRoute(): Boolean {
+        return true
+//        return PreferenceManager.getDefaultSharedPreferences(this.applicationContext)
+//                .getBoolean(this.getString(R.string.simulate_route_key), false)
+    }
+
+    // If shouldSimulateRoute is true a ReplayRouteLocationEngine will be used which is intended
+    // for testing else a real location engine is used.
+    private fun getLocationEngine(): LocationEngine {
+        return if (shouldSimulateRoute()) {
+            ReplayRouteLocationEngine()
+        } else {
+            LocationEngineProvider.getBestLocationEngine(this)
+        }
+    }
+
+
+    private val bannerInstructionObserver = object : BannerInstructionsObserver {
+        override fun onNewBannerInstructions(bannerInstructions: BannerInstructions) {
+            instructionView.updateBannerInstructionsWith(bannerInstructions)
+        }
+    }
+
+    private val voiceInstructionsObserver = object : VoiceInstructionsObserver {
+        override fun onNewVoiceInstructions(voiceInstructions: VoiceInstructions) {
+            speechPlayer.play(voiceInstructions)
+        }
+    }
+
+    private fun initializeSpeechPlayer() {
+        val cache =
+                Cache(File(application.cacheDir, VOICE_INSTRUCTION_CACHE), 10 * 1024 * 1024)
+        val voiceInstructionLoader =
+                VoiceInstructionLoader(application, Mapbox.getAccessToken(), cache)
+        val speechPlayerProvider =
+                SpeechPlayerProvider(application, Locale.US.language, true, voiceInstructionLoader)
+        speechPlayer = NavigationSpeechPlayer(speechPlayerProvider)
+    }
+
+}

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/TestWaypointsActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/TestWaypointsActivity.kt
@@ -27,6 +27,7 @@ import com.mapbox.navigation.base.extensions.applyDefaultParams
 import com.mapbox.navigation.base.extensions.coordinates
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.directions.session.RoutesObserver
 import com.mapbox.navigation.core.directions.session.RoutesRequestCallback
 import com.mapbox.navigation.core.location.ReplayRouteLocationEngine
 import com.mapbox.navigation.core.trip.session.*
@@ -83,6 +84,7 @@ class TestWaypointsActivity : AppCompatActivity(), OnMapReadyCallback {
                 locationEngine = getLocationEngine()
         ).also {
             it.registerRouteProgressObserver(routeProgressObserver)
+            it.registerRoutesObserver(routeObserver)
         }
 
         initListeners()
@@ -90,14 +92,15 @@ class TestWaypointsActivity : AppCompatActivity(), OnMapReadyCallback {
     }
 
     val waypoints = listOf(
-            Point.fromLngLat(-77.038294672966, 38.91854721860871),
-            Point.fromLngLat(-77.03662633895874, 38.91920249133305),
-            Point.fromLngLat(-77.03660779663086, 38.9182091456012),
-            Point.fromLngLat(-77.03660052546692, 38.91565476415369),
-            Point.fromLngLat(-77.03664779663086, 38.91398518410977),
-            Point.fromLngLat(-77.03661561012268, 38.913726395687185),
-            Point.fromLngLat(-77.03665852546692, 38.91345925826118),
-            Point.fromLngLat(-77.03665852546692, 38.91270792885979)
+            Point.fromLngLat(-122.5243002, 37.9753461),
+            Point.fromLngLat(-122.5282836, 37.9751463),
+            Point.fromLngLat(-122.5283157, 37.9742329),
+            Point.fromLngLat(-122.5319528, 37.9720847),
+            Point.fromLngLat(-122.5298285, 37.9709683),
+            //Point.fromLngLat(-122.5319528, 37.9720847),
+            //Point.fromLngLat(-77.03661561012268, 38.913726395687185),
+            //Point.fromLngLat(-77.03665852546692, 38.91345925826118),
+            Point.fromLngLat(-122.5298285, 37.9709683)
     )
     val names = listOf(
             "animal", // origin
@@ -105,9 +108,9 @@ class TestWaypointsActivity : AppCompatActivity(), OnMapReadyCallback {
             "bear",
             "cat",
             "dog",
-            "elephant",
-            "frog",
-            "goat" // destination
+            "elephant"
+            //"frog",
+            //"goat" // destination
     )
 
     override fun onMapReady(mapboxMap: MapboxMap) {
@@ -253,6 +256,7 @@ class TestWaypointsActivity : AppCompatActivity(), OnMapReadyCallback {
         super.onDestroy()
         mapboxNavigation?.unregisterVoiceInstructionsObserver(voiceInstructionsObserver)
         mapboxNavigation?.unregisterBannerInstructionsObserver(bannerInstructionObserver)
+        mapboxNavigation?.unregisterRoutesObserver(routeObserver)
         mapboxNavigation?.stopTripSession()
         mapboxNavigation?.onDestroy()
         mapView.onDestroy()
@@ -317,9 +321,8 @@ class TestWaypointsActivity : AppCompatActivity(), OnMapReadyCallback {
     // Used to determine if the ReplayRouteLocationEngine should be used to simulate the routing.
     // This is used for testing purposes.
     private fun shouldSimulateRoute(): Boolean {
-        return true
-//        return PreferenceManager.getDefaultSharedPreferences(this.applicationContext)
-//                .getBoolean(this.getString(R.string.simulate_route_key), false)
+        return PreferenceManager.getDefaultSharedPreferences(this.applicationContext)
+                .getBoolean(this.getString(R.string.simulate_route_key), false)
     }
 
     // If shouldSimulateRoute is true a ReplayRouteLocationEngine will be used which is intended
@@ -355,4 +358,11 @@ class TestWaypointsActivity : AppCompatActivity(), OnMapReadyCallback {
         speechPlayer = NavigationSpeechPlayer(speechPlayerProvider)
     }
 
+    private val routeObserver = object : RoutesObserver {
+        override fun onRoutesChanged(routes: List<DirectionsRoute>) {
+            if (routes.isNotEmpty()) {
+                navigationMapboxMap?.drawRoute(routes[0])
+            }
+        }
+    }
 }

--- a/examples/src/main/res/layout/test_waypoints_activity_layout.xml
+++ b/examples/src/main/res/layout/test_waypoints_activity_layout.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".core.SimpleMapboxNavigationKt"
+    app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+    <com.mapbox.mapboxsdk.maps.MapView
+        android:id="@+id/mapView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"/>
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/startNavigation"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:background="@color/colorPrimary"
+        android:text="@string/start_navigation"
+        android:textColor="@android:color/white"
+        android:visibility="gone" />
+
+    <com.mapbox.navigation.ui.instruction.InstructionView
+        android:id="@+id/instructionView"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:gravity="top"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:visibility="visible" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/examples/src/main/res/values/strings.xml
+++ b/examples/src/main/res/values/strings.xml
@@ -56,6 +56,9 @@
     <string name="title_summary_bottom_sheet" translatable="false">SummaryBottomSheet</string>
     <string name="description_summary_bottom_sheet" translatable="false">Shows how to integrate SummaryBottomSheet, Recenter button with core SDK.</string>
 
+    <string name="title_test_waypoints" translatable="false">Waypoints test</string>
+    <string name="description_test_waypoints" translatable="false">Waypoints test</string>
+
     <string name="title_instruction_view" translatable="false">InstructionView</string>
     <string name="description_instruction_view" translatable="false">Shows how to integrate InstructionView, FeedbackButton and SoundButton with core SDK.</string>
 

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/MapboxNativeNavigatorImpl.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/MapboxNativeNavigatorImpl.kt
@@ -67,11 +67,6 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
 
     override fun getStatus(date: Date): TripStatus {
         val status = navigator.getStatus(date)
-//
-//        if(status.bannerInstruction != null) {
-//            status.bannerInstruction
-//        }
-
         return TripStatus(
             status.location.toLocation(),
             status.key_points.map { it.toLocation() },

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/MapboxNativeNavigatorImpl.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/MapboxNativeNavigatorImpl.kt
@@ -67,10 +67,10 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
 
     override fun getStatus(date: Date): TripStatus {
         val status = navigator.getStatus(date)
-
-        if(status.bannerInstruction != null) {
-            status.bannerInstruction
-        }
+//
+//        if(status.bannerInstruction != null) {
+//            status.bannerInstruction
+//        }
 
         return TripStatus(
             status.location.toLocation(),

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/MapboxNativeNavigatorImpl.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/MapboxNativeNavigatorImpl.kt
@@ -67,6 +67,11 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
 
     override fun getStatus(date: Date): TripStatus {
         val status = navigator.getStatus(date)
+
+        if(status.bannerInstruction != null) {
+            status.bannerInstruction
+        }
+
         return TripStatus(
             status.location.toLocation(),
             status.key_points.map { it.toLocation() },


### PR DESCRIPTION
#Description
This sample code tests waypoints with core 1.0. The code is based on user submitted code via issue: #2495 . 

Take note of TestWaypointsActivity. The code in this activity is mostly what was submitted by the user with slight modifications.

I've noticed that after the first waypoint there are no other banner instructions emitted. I set a break point in MapboxNativeNavigatorImpl.getStatus() and I see that status.bannerInstruction is always null after the first waypoint is reached.