### PR TITLE
Bump NN, mapboxSdkServices and mapboxSdkDirectionsModels versions

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1168,6 +1168,11 @@ License: [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENS
 
 ===========================================================================
 
+Mapbox Navigation uses portions of the support.
+License: [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+===========================================================================
+
 
 
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -10,11 +10,11 @@ ext {
 
   version = [
       mapboxMapSdk              : '9.1.0-beta.2',
-      mapboxSdkServices         : '5.1.0-beta.2',
-      mapboxSdkDirectionsModels : '5.1.0-beta.2',
+      mapboxSdkServices         : '5.1.0',
+      mapboxSdkDirectionsModels : '5.1.0',
       mapboxEvents              : '5.0.0',
       mapboxCore                : '2.0.0',
-      mapboxNavigator           : '10.0.1',
+      mapboxNavigator           : '10.0.2',
       mapboxCrashMonitor        : '2.0.0',
       mapboxAnnotationPlugin    : '0.8.0',
       mapboxAccounts            : '0.3.1',

--- a/libnavigator/build.gradle
+++ b/libnavigator/build.gradle
@@ -34,6 +34,9 @@ dependencies {
     // Navigator
     api dependenciesList.mapboxNavigator
 
+    // TODO Adding this temporarily until NN includes bindgen dep downstream
+    implementation "com.mapbox.bindgen:support:0.5.0"
+
     // mapbox-java GeoJSON
     api dependenciesList.mapboxSdkGeoJSON
 


### PR DESCRIPTION
## Description

Bumps `mapbox-navigation-native`, `mapbox-sdk-services` and `mapbox-sdk-directions-models` versions to `10.0.2` and `5.1.0` respectively

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Getting the latest versions from `mapboxNavigator`, `mapboxSdkServices` and `mapboxSdkDirectionsModels` including the new features and bug fixes.

### Implementation

Bumping `mapboxNavigator`, `mapboxSdkServices` and `mapboxSdkDirectionsModels` versions to `10.0.2` and `5.1.0` respectively in `dependencies.gradle`

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR

cc @mskurydin @SiarheiFedartsou @DzmitryFomchyn 