### PR TITLE
Bump NN version to 10.0.3

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -294,6 +294,11 @@ License: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
+Mapbox Navigation uses portions of the support.
+License: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+===========================================================================
+
 Mapbox Navigation uses portions of the Timber (No-nonsense injectable logging.).
 URL: [https://github.com/JakeWharton/timber](https://github.com/JakeWharton/timber)
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -14,7 +14,7 @@ ext {
       mapboxSdkDirectionsModels : '5.1.0',
       mapboxEvents              : '5.0.0',
       mapboxCore                : '2.0.0',
-      mapboxNavigator           : '10.0.2',
+      mapboxNavigator           : '10.0.3',
       mapboxCrashMonitor        : '2.0.0',
       mapboxAnnotationPlugin    : '0.8.0',
       mapboxAccounts            : '0.3.1',

--- a/libnavigator/build.gradle
+++ b/libnavigator/build.gradle
@@ -34,9 +34,6 @@ dependencies {
     // Navigator
     api dependenciesList.mapboxNavigator
 
-    // TODO Adding this temporarily until NN includes bindgen dep downstream
-    implementation "com.mapbox.bindgen:support:0.5.0"
-
     // mapbox-java GeoJSON
     api dependenciesList.mapboxSdkGeoJSON
 


### PR DESCRIPTION
## Description

Bumps NN version to `10.0.3`

Follow up from https://github.com/mapbox/mapbox-navigation-android/pull/2690

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Getting the latest versions from `mapboxNavigator` including the new features and bug fixes.

### Implementation

Bumping `mapboxNavigator` versions to `10.0.3` in `dependencies.gradle`

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR

cc @mskurydin @SiarheiFedartsou @DzmitryFomchyn @LukasPaczos 