### PR TITLE
Remove min zoom level constraint when initializing the Nav SDK

### DIFF
--- a/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/NavigationMapboxMap.java
+++ b/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/map/NavigationMapboxMap.java
@@ -40,7 +40,6 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import static com.mapbox.services.android.navigation.ui.v5.map.NavigationSymbolManager.MAPBOX_NAVIGATION_MARKER_NAME;
-import static com.mapbox.services.android.navigation.v5.navigation.NavigationConstants.NAVIGATION_MINIMUM_MAP_ZOOM;
 
 /**
  * Wrapper class for {@link MapboxMap}.
@@ -62,7 +61,6 @@ public class NavigationMapboxMap {
   private static final String TRAFFIC_LAYER_ID = "traffic";
   private static final int[] ZERO_MAP_PADDING = {0, 0, 0, 0};
   private static final double NAVIGATION_MAXIMUM_MAP_ZOOM = 18d;
-  private static final double NAVIGATION_INITIAL_MAP_ZOOM = 17d;
   private final CopyOnWriteArrayList<OnWayNameChangedListener> onWayNameChangedListeners
           = new CopyOnWriteArrayList<>();
   private final MapWayNameChangedListener internalWayNameChangedListener
@@ -633,7 +631,6 @@ public class NavigationMapboxMap {
   @SuppressLint("MissingPermission")
   private void initializeLocationComponent(MapView mapView, MapboxMap map) {
     locationComponent = map.getLocationComponent();
-    map.setMinZoomPreference(NAVIGATION_MINIMUM_MAP_ZOOM);
     map.setMaxZoomPreference(NAVIGATION_MAXIMUM_MAP_ZOOM);
     Context context = mapView.getContext();
     Style style = map.getStyle();

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationConstants.kt
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/navigation/NavigationConstants.kt
@@ -124,11 +124,6 @@ object NavigationConstants {
     internal const val ROUTE_REFRESH_INTERVAL = 5 * 60 * 1000L
 
     /**
-     * Defines the minimum zoom level of the displayed map.
-     */
-    const val NAVIGATION_MINIMUM_MAP_ZOOM = 7.0
-
-    /**
      * Maximum duration of the zoom/tilt adjustment animation while tracking.
      */
     const val NAVIGATION_MAX_CAMERA_ADJUSTMENT_ANIMATION_DURATION = 1500L

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/legacy/NavigationConstants.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/legacy/NavigationConstants.kt
@@ -139,11 +139,6 @@ object NavigationConstants {
     internal const val ROUTE_REFRESH_INTERVAL = 5 * 60 * 1000L
 
     /**
-     * Defines the minimum zoom level of the displayed map.
-     */
-    const val NAVIGATION_MINIMUM_MAP_ZOOM = 7.0
-
-    /**
      * Maximum duration of the zoom/tilt adjustment animation while tracking.
      */
     const val NAVIGATION_MAX_CAMERA_ADJUSTMENT_ANIMATION_DURATION = 1500L

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/NavigationMapboxMap.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/NavigationMapboxMap.java
@@ -46,7 +46,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import static com.mapbox.navigation.ui.legacy.NavigationConstants.MINIMAL_LOOKAHEAD_LOCATION_TIME_VALUE;
-import static com.mapbox.navigation.ui.legacy.NavigationConstants.NAVIGATION_MINIMUM_MAP_ZOOM;
 import static com.mapbox.navigation.ui.map.NavigationSymbolManager.MAPBOX_NAVIGATION_MARKER_NAME;
 
 /**
@@ -69,7 +68,6 @@ public class NavigationMapboxMap {
   private static final String TRAFFIC_LAYER_ID = "traffic";
   private static final int[] ZERO_MAP_PADDING = {0, 0, 0, 0};
   private static final double NAVIGATION_MAXIMUM_MAP_ZOOM = 18d;
-  private static final double NAVIGATION_INITIAL_MAP_ZOOM = 17d;
   private final CopyOnWriteArrayList<OnWayNameChangedListener> onWayNameChangedListeners
           = new CopyOnWriteArrayList<>();
   private final MapWayNameChangedListener internalWayNameChangedListener
@@ -704,7 +702,6 @@ public class NavigationMapboxMap {
   @SuppressLint("MissingPermission")
   private void initializeLocationComponent(MapView mapView, MapboxMap map) {
     locationComponent = map.getLocationComponent();
-    map.setMinZoomPreference(NAVIGATION_MINIMUM_MAP_ZOOM);
     map.setMaxZoomPreference(NAVIGATION_MAXIMUM_MAP_ZOOM);
     Context context = mapView.getContext();
     Style style = map.getStyle();


### PR DESCRIPTION
Currently, whenever the `NavigationMapboxMap` is created, it will force the minimum zoom level to `7` which feels a little bit too clamped. Since there doesn't seem to be a strong argument for keeping this constraint, I'm proposing to remove it.

/cc @DzmitryFomchyn 