### PR TITLE
fix typo which will cause a problem that the observer is not registered.

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/NavigationMapRoute.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/NavigationMapRoute.java
@@ -291,7 +291,7 @@ public class NavigationMapRoute implements LifecycleObserver {
    */
   public void addProgressChangeListener(MapboxNavigation navigation) {
     this.navigation = navigation;
-    navigation.unregisterRouteProgressObserver(mapRouteProgressChangeListener);
+    navigation.registerRouteProgressObserver(mapRouteProgressChangeListener);
   }
 
 


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

I think it's a typo when we created the compatible UI SDK. base on the legacy code, it's just add the listener. We should do the register here instead of unregister.
