### PR TITLE
Disable faster route when there are no routes

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/MapboxDirectionsSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/MapboxDirectionsSession.kt
@@ -65,15 +65,6 @@ class MapboxDirectionsSession(
         adjustedRouteOptions: RouteOptions,
         routesRequestCallback: RoutesRequestCallback
     ) {
-        // TODO What happens if NavigationSession.State transitions from Active Guidance
-        //  to Free Drive and Faster Route is enabled? We're not cleaning up RouteOptions when
-        //  cleaning up routes here and this call can be done because the only thing that we're
-        //  checking is the route options and the route progress but not if there's a route or not
-        //  See AdjustedRouteOptionsProvider#getRouteOptions
-        if (routes.isEmpty()) {
-            routesRequestCallback.onRoutesRequestCanceled(adjustedRouteOptions)
-            return
-        }
         router.getRoute(adjustedRouteOptions, object : Router.Callback {
             override fun onResponse(routes: List<DirectionsRoute>) {
                 routesRequestCallback.onRoutesReady(routes)

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/fasterroute/FasterRouteDetector.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/fasterroute/FasterRouteDetector.kt
@@ -3,17 +3,18 @@ package com.mapbox.navigation.core.fasterroute
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.navigation.base.trip.model.RouteProgress
 
-internal object FasterRouteDetector {
-
-    /**
-     * This threshold optimizes for the current route. For example, if you're 40 minutes
-     * away and there is an alternative that is 1 minute faster, it will be ignored.
-     */
-    private const val PERCENTAGE_THRESHOLD = 0.90
-
+internal class FasterRouteDetector {
     fun isRouteFaster(newRoute: DirectionsRoute, routeProgress: RouteProgress): Boolean {
         val newRouteDuration = newRoute.duration() ?: return false
         val weightedDuration = routeProgress.durationRemaining() * PERCENTAGE_THRESHOLD
         return newRouteDuration < weightedDuration
+    }
+
+    companion object {
+        /**
+         * This threshold optimizes for the current route. For example, if you're 40 minutes
+         * away and there is an alternative that is 1 minute faster, it will be ignored.
+         */
+        private const val PERCENTAGE_THRESHOLD = 0.90
     }
 }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/fasterroute/FasterRouteControllerTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/fasterroute/FasterRouteControllerTest.kt
@@ -1,0 +1,150 @@
+package com.mapbox.navigation.core.fasterroute
+
+import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.navigation.core.directions.session.AdjustedRouteOptionsProvider
+import com.mapbox.navigation.core.directions.session.DirectionsSession
+import com.mapbox.navigation.core.directions.session.RoutesRequestCallback
+import com.mapbox.navigation.core.trip.session.TripSession
+import com.mapbox.navigation.testing.MainCoroutineRule
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.slot
+import io.mockk.unmockkObject
+import io.mockk.verify
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class FasterRouteControllerTest {
+
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
+
+    private val directionsSession: DirectionsSession = mockk()
+    private val tripSession: TripSession = mockk()
+    private val fasterRouteObserver: FasterRouteObserver = mockk {
+        every { onFasterRouteAvailable(any()) } returns Unit
+    }
+    private val routesRequestCallbacks = slot<RoutesRequestCallback>()
+
+    private val fasterRouteController = FasterRouteController(directionsSession, tripSession)
+
+    @Before
+    fun setup() {
+        mockkObject(AdjustedRouteOptionsProvider)
+        every { AdjustedRouteOptionsProvider.getRouteOptions(any(), any(), any()) } returns mockk()
+
+        every { directionsSession.getRouteOptions() } returns mockk()
+        every { directionsSession.requestFasterRoute(any(), capture(routesRequestCallbacks)) } returns mockk()
+        every { tripSession.getRouteProgress() } returns mockk()
+    }
+
+    @After
+    fun teardown() {
+        unmockkObject(AdjustedRouteOptionsProvider)
+    }
+
+    @Test
+    fun `should request every minute`() = coroutineRule.runBlockingTest {
+        every { directionsSession.routes } returns listOf(
+            mockk {
+                every { routeIndex() } returns "0"
+                every { duration() } returns 727.228
+            }
+        )
+        every { tripSession.getEnhancedLocation() } returns mockk {
+            every { latitude } returns -33.874308
+            every { longitude } returns 151.206087
+        }
+
+        fasterRouteController.attach(fasterRouteObserver)
+        coroutineRule.testDispatcher.advanceTimeBy(TimeUnit.MINUTES.toMillis(4))
+        fasterRouteController.stop()
+
+        coroutineRule.testDispatcher.cleanupTestCoroutines()
+        verify(exactly = 4) { directionsSession.requestFasterRoute(any(), any()) }
+    }
+
+    @Test
+    fun `should only request with a route`() = coroutineRule.runBlockingTest {
+        every { directionsSession.routes } returns emptyList()
+        every { tripSession.getEnhancedLocation() } returns mockk {
+            every { latitude } returns -33.874308
+            every { longitude } returns 151.206087
+        }
+
+        fasterRouteController.attach(fasterRouteObserver)
+        coroutineRule.testDispatcher.advanceTimeBy(TimeUnit.MINUTES.toMillis(4))
+        fasterRouteController.stop()
+
+        coroutineRule.testDispatcher.cleanupTestCoroutines()
+        verify(exactly = 0) { directionsSession.requestFasterRoute(any(), any()) }
+    }
+
+    @Test
+    fun `should notify observer of a faster route`() = coroutineRule.runBlockingTest {
+        every { directionsSession.routes } returns listOf(
+            mockk {
+                every { routeIndex() } returns "0"
+                every { duration() } returns 801.332
+            }
+        )
+        every { tripSession.getEnhancedLocation() } returns mockk {
+            every { latitude } returns -33.874308
+            every { longitude } returns 151.206087
+        }
+        every { tripSession.getRouteProgress() } returns mockk {
+            every { durationRemaining() } returns 601.334
+        }
+        every { directionsSession.requestFasterRoute(any(), capture(routesRequestCallbacks)) } returns mockk()
+
+        fasterRouteController.attach(fasterRouteObserver)
+        coroutineRule.testDispatcher.advanceTimeBy(TimeUnit.MINUTES.toMillis(2))
+        val routes = listOf<DirectionsRoute>(mockk {
+                every { routeIndex() } returns "0"
+                every { duration() } returns 351.013
+            })
+        routesRequestCallbacks.captured.onRoutesReady(routes)
+
+        verify(exactly = 1) { fasterRouteObserver.onFasterRouteAvailable(routes[0]) }
+
+        fasterRouteController.stop()
+        coroutineRule.testDispatcher.cleanupTestCoroutines()
+    }
+
+    @Test
+    fun `should not notify observer if route is slower`() = coroutineRule.runBlockingTest {
+        every { directionsSession.routes } returns listOf(
+            mockk {
+                every { routeIndex() } returns "0"
+                every { duration() } returns 801.332
+            }
+        )
+        every { tripSession.getEnhancedLocation() } returns mockk {
+            every { latitude } returns -33.874308
+            every { longitude } returns 151.206087
+        }
+        every { tripSession.getRouteProgress() } returns mockk {
+            every { durationRemaining() } returns 751.334
+        }
+        every { directionsSession.requestFasterRoute(any(), capture(routesRequestCallbacks)) } returns mockk()
+
+        fasterRouteController.attach(fasterRouteObserver)
+        coroutineRule.testDispatcher.advanceTimeBy(TimeUnit.MINUTES.toMillis(2))
+        val routes = listOf<DirectionsRoute>(mockk {
+            every { routeIndex() } returns "0"
+            every { duration() } returns 951.013
+        })
+        routesRequestCallbacks.captured.onRoutesReady(routes)
+
+        verify(exactly = 0) { fasterRouteObserver.onFasterRouteAvailable(routes[0]) }
+
+        fasterRouteController.stop()
+        coroutineRule.testDispatcher.cleanupTestCoroutines()
+    }
+}

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/fasterroute/FasterRouteDetectorTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/fasterroute/FasterRouteDetectorTest.kt
@@ -4,18 +4,13 @@ import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.unmockkObject
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
-import org.junit.Before
 import org.junit.Test
 
 class FasterRouteDetectorTest {
 
-    @Before
-    fun setup() {
-        unmockkObject(FasterRouteDetector)
-    }
+    private val fasterRouteDetector = FasterRouteDetector()
 
     @Test
     fun shouldDetectWhenRouteIsFaster() {
@@ -24,7 +19,7 @@ class FasterRouteDetectorTest {
         val routeProgress: RouteProgress = mockk()
         every { routeProgress.durationRemaining() } returns 797.447
 
-        val isFasterRoute = FasterRouteDetector.isRouteFaster(newRoute, routeProgress)
+        val isFasterRoute = fasterRouteDetector.isRouteFaster(newRoute, routeProgress)
 
         assertTrue(isFasterRoute)
     }
@@ -36,7 +31,7 @@ class FasterRouteDetectorTest {
         val routeProgress: RouteProgress = mockk()
         every { routeProgress.durationRemaining() } returns 450.501
 
-        val isFasterRoute = FasterRouteDetector.isRouteFaster(newRoute, routeProgress)
+        val isFasterRoute = fasterRouteDetector.isRouteFaster(newRoute, routeProgress)
 
         assertFalse(isFasterRoute)
     }
@@ -48,7 +43,7 @@ class FasterRouteDetectorTest {
         val routeProgress: RouteProgress = mockk()
         every { routeProgress.durationRemaining() } returns 727.228
 
-        val isFasterRoute = FasterRouteDetector.isRouteFaster(newRoute, routeProgress)
+        val isFasterRoute = fasterRouteDetector.isRouteFaster(newRoute, routeProgress)
 
         assertFalse(isFasterRoute)
     }
@@ -60,7 +55,7 @@ class FasterRouteDetectorTest {
         val routeProgress: RouteProgress = mockk()
         every { routeProgress.durationRemaining() } returns 695.811
 
-        val isFasterRoute = FasterRouteDetector.isRouteFaster(newRoute, routeProgress)
+        val isFasterRoute = fasterRouteDetector.isRouteFaster(newRoute, routeProgress)
 
         assertFalse(isFasterRoute)
     }


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

resolves: https://github.com/mapbox/mapbox-navigation-android/issues/2710

Discussion in the issue. When moving in and out of free-drive, faster route could get out of sync. 

cc: @abhishek1508 @Guardiola31337 

- [x] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->