### PR TITLE
Added and adjusted examples test app snackbars

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/BasicNavigationActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/BasicNavigationActivity.kt
@@ -81,7 +81,7 @@ class BasicNavigationActivity : AppCompatActivity(), OnMapReadyCallback {
         )
 
         initListeners()
-        Snackbar.make(container, R.string.msg_long_press_for_destination, Snackbar.LENGTH_LONG)
+        Snackbar.make(container, R.string.msg_long_press_map_for_destination, Snackbar.LENGTH_LONG)
             .show()
     }
 
@@ -110,6 +110,11 @@ class BasicNavigationActivity : AppCompatActivity(), OnMapReadyCallback {
             true
         }
         locationComponent = mapboxMap.locationComponent
+        Snackbar.make(
+                findViewById(R.id.container),
+                getString(R.string.msg_long_press_map_for_destination),
+                Snackbar.LENGTH_SHORT
+        ).show()
     }
 
     @SuppressLint("RestrictedApi")

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/DebugMapboxNavigationKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/DebugMapboxNavigationKt.kt
@@ -11,6 +11,7 @@ import android.widget.Button
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
+import com.google.android.material.snackbar.Snackbar
 import com.mapbox.android.core.location.LocationEngine
 import com.mapbox.android.core.location.LocationEngineCallback
 import com.mapbox.android.core.location.LocationEngineProvider
@@ -208,6 +209,11 @@ class DebugMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
                     add(0, route)
                 })
             }
+            Snackbar.make(
+                    findViewById(R.id.container),
+                    getString(R.string.msg_long_press_map_for_destination),
+                    Snackbar.LENGTH_SHORT
+            ).show()
         }
 
         initializeSpeechPlayer()

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/FasterRouteActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/FasterRouteActivity.kt
@@ -10,7 +10,7 @@ import android.view.View.VISIBLE
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.snackbar.Snackbar
-import com.google.android.material.snackbar.Snackbar.LENGTH_LONG
+import com.google.android.material.snackbar.Snackbar.LENGTH_SHORT
 import com.mapbox.android.core.location.LocationEngineCallback
 import com.mapbox.android.core.location.LocationEngineProvider
 import com.mapbox.android.core.location.LocationEngineRequest
@@ -248,7 +248,7 @@ class FasterRouteActivity : AppCompatActivity(), OnMapReadyCallback {
 
     @SuppressLint("MissingPermission")
     private fun initListeners() {
-        Snackbar.make(container, R.string.msg_long_press_for_destination, LENGTH_LONG).show()
+        Snackbar.make(container, R.string.msg_long_press_map_for_destination, LENGTH_SHORT).show()
         bottomSheetBehavior = BottomSheetBehavior.from(bottomSheetFasterRoute)
         bottomSheetBehavior.peekHeight = 0
         fasterRouteAcceptProgress.max = MAX_PROGRESS.toInt()

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/InstructionViewActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/InstructionViewActivity.kt
@@ -296,7 +296,7 @@ class InstructionViewActivity : AppCompatActivity(), OnMapReadyCallback,
         startNavigation.visibility = VISIBLE
         startNavigation.isEnabled = false
         instructionView.visibility = GONE
-        Snackbar.make(container, R.string.msg_long_press_for_destination, LENGTH_LONG).show()
+        Snackbar.make(container, R.string.msg_long_press_map_for_destination, LENGTH_LONG).show()
         feedbackButton = instructionView.retrieveFeedbackButton().apply {
             hide()
             addOnClickListener {

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/OffboardRouterActivityJava.java
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/OffboardRouterActivityJava.java
@@ -90,7 +90,8 @@ public class OffboardRouterActivityJava extends AppCompatActivity implements
     this.mapboxMap.addOnMapClickListener(this);
     mapboxMap.setStyle(Style.MAPBOX_STREETS, style -> {
       navigationMapRoute = new NavigationMapRoute(mapView, mapboxMap);
-      Snackbar.make(findViewById(R.id.container), "Tap map to place waypoint", Snackbar.LENGTH_LONG).show();
+      Snackbar.make(findViewById(R.id.container),
+          "Tap map to place waypoint", Snackbar.LENGTH_LONG).show();
       newOrigin();
     });
   }
@@ -106,7 +107,9 @@ public class OffboardRouterActivityJava extends AppCompatActivity implements
       mapboxMap.addMarker(new MarkerOptions().position(point));
       findRoute();
     } else {
-      Toast.makeText(this, "Only 2 waypoints supported for this example", Toast.LENGTH_LONG).show();
+      Toast.makeText(this,
+          "Only 2 waypoints supported for this example",
+          Toast.LENGTH_LONG).show();
       clearMap();
     }
     return false;

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/OffboardRouterActivityKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/OffboardRouterActivityKt.kt
@@ -95,6 +95,11 @@ class OffboardRouterActivityKt : AppCompatActivity(),
                 Snackbar.LENGTH_LONG
             ).show()
             newOrigin()
+            Snackbar.make(
+                    findViewById(R.id.container),
+                    getString(R.string.msg_tap_map_for_destination),
+                    Snackbar.LENGTH_SHORT
+            ).show()
         }
     }
 

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/OnboardRouterActivityJava.java
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/OnboardRouterActivityJava.java
@@ -105,7 +105,9 @@ public class OnboardRouterActivityJava extends AppCompatActivity implements OnMa
     this.mapboxMap.addOnMapClickListener(this);
     mapboxMap.setStyle(Style.MAPBOX_STREETS, style -> {
       navigationMapRoute = new NavigationMapRoute(mapView, mapboxMap);
-      Snackbar.make(findViewById(R.id.container), "Tap map to place waypoint", Snackbar.LENGTH_LONG).show();
+      Snackbar.make(findViewById(R.id.container),
+          getString(R.string.msg_tap_map_for_destination),
+          Snackbar.LENGTH_SHORT).show();
       newOrigin();
     });
   }

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/OnboardRouterActivityKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/OnboardRouterActivityKt.kt
@@ -81,11 +81,7 @@ class OnboardRouterActivityKt : AppCompatActivity(), OnMapReadyCallback,
             Style.MAPBOX_STREETS
         ) {
             navigationMapRoute = NavigationMapRoute(mapView, mapboxMap)
-            Snackbar.make(
-                findViewById(R.id.container),
-                "Tap map to place waypoint",
-                Snackbar.LENGTH_LONG
-            ).show()
+            Snackbar.make(findViewById(R.id.container), getString(R.string.msg_tap_map_for_destination), Snackbar.LENGTH_SHORT).show()
             newOrigin()
         }
     }

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/ReRouteActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/ReRouteActivity.kt
@@ -217,7 +217,7 @@ class ReRouteActivity : AppCompatActivity(), OnMapReadyCallback {
 
     @SuppressLint("MissingPermission")
     private fun initListeners() {
-        Snackbar.make(container, R.string.msg_long_press_for_destination, LENGTH_LONG).show()
+        Snackbar.make(container, R.string.msg_long_press_map_for_destination, LENGTH_LONG).show()
         startNavigation.setOnClickListener {
             if (mapboxNavigation.getRoutes().isNotEmpty()) {
                 navigationMapboxMap.updateLocationLayerRenderMode(RenderMode.GPS)

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayActivity.kt
@@ -175,7 +175,7 @@ class ReplayActivity : AppCompatActivity(), OnMapReadyCallback {
         super.onStart()
         mapView.onStart()
         mapboxNavigation?.registerLocationObserver(locationObserver)
-        Snackbar.make(container, R.string.msg_long_press_for_destination, Snackbar.LENGTH_SHORT)
+        Snackbar.make(container, R.string.msg_long_press_map_for_destination, Snackbar.LENGTH_SHORT)
             .show()
     }
 

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/SimpleMapboxNavigationKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/SimpleMapboxNavigationKt.kt
@@ -13,6 +13,7 @@ import android.widget.Button
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.snackbar.Snackbar
 import com.mapbox.android.core.location.LocationEngine
 import com.mapbox.android.core.location.LocationEngineCallback
 import com.mapbox.android.core.location.LocationEngineProvider
@@ -212,6 +213,7 @@ class SimpleMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
                 })
                 replayRouteLocationEngine.assign(route)
             }
+            Snackbar.make(findViewById(R.id.container), getString(R.string.msg_long_press_map_for_destination), Snackbar.LENGTH_SHORT).show()
         }
 
         initializeSpeechPlayer()

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/SummaryBottomSheetActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/SummaryBottomSheetActivity.kt
@@ -10,6 +10,7 @@ import android.widget.ImageButton
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.AppCompatImageButton
 import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.snackbar.Snackbar
 import com.mapbox.android.core.location.LocationEngine
 import com.mapbox.android.core.location.LocationEngineCallback
 import com.mapbox.android.core.location.LocationEngineProvider
@@ -166,6 +167,7 @@ class SummaryBottomSheetActivity : AppCompatActivity(), OnMapReadyCallback {
                 addProgressChangeListener(mapboxNavigation)
                 setCamera(DynamicCamera(mapboxMap))
             }
+            Snackbar.make(findViewById(R.id.container), getString(R.string.msg_long_press_map_for_destination), Snackbar.LENGTH_SHORT).show()
         }
     }
 

--- a/examples/src/main/res/values/strings.xml
+++ b/examples/src/main/res/values/strings.xml
@@ -95,8 +95,9 @@
     <string name="default_unit_type" translatable="false">default_for_device</string>
     <string name="start_navigation" translatable="false">Start Navigation</string>
     <string name="play_history" translatable="false">Play history</string>
-    <string name="offline_region_download_title">Download offline region</string>
-    <string name="msg_long_press_for_destination">Long press a point on the map to indicate a destination.</string>
+    <string name="offline_region_download_title" translatable="false">Download offline region</string>
+    <string name="msg_long_press_map_for_destination" translatable="false">Long press on the map to indicate a destination.</string>
+    <string name="msg_tap_map_for_destination" translatable="false">Tap on the map to indicate a destination.</string>
     <string name="offline_category_title" translatable="false">Offline</string>
     <string name="offline_enabled_title" translatable="false">Offline routing enabled</string>
     <string name="offline_version_title" translatable="false">Choose offline version</string>


### PR DESCRIPTION
The `examples` test app activities needed instructional snackbars. For users who are unfamiliar with the test app examples, it's not obvious when the next action should be after opening the specific example.

<img width="433" alt="Screen Shot 2020-04-06 at 1 01 06 PM" src="https://user-images.githubusercontent.com/4394910/78599855-b5981000-7806-11ea-8e2c-08f41a8023df.png">

<img width="550" alt="Screen Shot 2020-04-06 at 1 00 45 PM" src="https://user-images.githubusercontent.com/4394910/78599852-b466e300-7806-11ea-8a8b-c0ca01343db6.png">
