### PR TITLE
fix for memory leak, enforcing the usage of application context

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxDistanceFormatter.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxDistanceFormatter.kt
@@ -70,11 +70,11 @@ class MapboxDistanceFormatter private constructor(
             apply { this.locale = locale }
 
         fun build(): MapboxDistanceFormatter {
-            val localeToUse: Locale = locale ?: context.inferDeviceLocale()
+            val localeToUse: Locale = locale ?: context.applicationContext.inferDeviceLocale()
             val unitTypeToUse: String = unitType ?: localeToUse.getUnitTypeForLocale()
 
             return MapboxDistanceFormatter(
-                context,
+                context.applicationContext,
                 localeToUse,
                 unitTypeToUse,
                 roundingIncrement)

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxDistanceFormatterTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxDistanceFormatterTest.kt
@@ -8,6 +8,9 @@ import androidx.test.core.app.ApplicationProvider
 import com.mapbox.navigation.base.typedef.IMPERIAL
 import com.mapbox.navigation.base.typedef.METRIC
 import com.mapbox.navigation.base.typedef.ROUNDING_INCREMENT_FIFTY
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
 import java.util.Locale
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -203,5 +206,15 @@ class MapboxDistanceFormatterTest {
             .formatDistance(19312.1)
 
         assertEquals("12 mérföld", result.toString())
+    }
+
+    @Test
+    fun builderUsesApplicationContext() {
+        val mockContext = mockk<Context>()
+        every { mockContext.applicationContext } returns ctx
+
+        MapboxDistanceFormatter.Builder(mockContext).build()
+
+        verify(exactly = 2) { mockContext.applicationContext }
     }
 }


### PR DESCRIPTION
##Description
fix for #2714 

Added explicit call to use the application context and added unit test.