### PR TITLE
Revert polling sync from #2680

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/ui/CustomCameraActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/ui/CustomCameraActivity.kt
@@ -18,7 +18,7 @@ import com.mapbox.navigation.ui.camera.SimpleCamera
 import com.mapbox.navigation.ui.listeners.BannerInstructionsListener
 import com.mapbox.navigation.ui.listeners.NavigationListener
 import com.mapbox.navigation.ui.map.NavigationMapboxMap
-import kotlinx.android.synthetic.main.activity_navigation_view.*
+import kotlinx.android.synthetic.main.activity_navigation_view.navigationView
 
 /**
  * This activity shows how to create a custom class that extends [Camera] and then passing

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
@@ -19,11 +19,11 @@ import com.mapbox.navigation.navigator.TripStatus
 import com.mapbox.navigation.utils.extensions.ifNonNull
 import com.mapbox.navigation.utils.thread.JobControl
 import com.mapbox.navigation.utils.thread.ThreadController
-import com.mapbox.navigation.utils.timer.MapboxTimer
 import java.util.Date
 import java.util.concurrent.CopyOnWriteArrayList
-import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.cancelChildren
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -37,10 +37,7 @@ class MapboxTripSession(
     threadController: ThreadController = ThreadController
 ) : TripSession {
 
-    companion object {
-        private const val STATUS_POLLING_INTERVAL = 1000L
-    }
-
+    private val STATUS_POLLING_INTERVAL = 1000L
     override var route: DirectionsRoute? = null
         set(value) {
             field = value
@@ -60,9 +57,6 @@ class MapboxTripSession(
 
     private val bannerInstructionEvent = BannerInstructionEvent()
     private val voiceInstructionEvent = VoiceInstructionEvent()
-
-    private var lastLocationUpdateTimeMillis: Long = 0
-    private val statusUpdateTimer = MapboxTimer().apply { restartAfterMillis = TimeUnit.SECONDS.toMillis(1) }
 
     private var state: TripSessionState = TripSessionState.STOPPED
         set(value) {
@@ -253,27 +247,27 @@ class MapboxTripSession(
     }
 
     private fun updateRawLocation(rawLocation: Location) {
-        locationObservers.forEach { it.onRawLocationChanged(rawLocation) }
         ioJobController.scope.launch {
-            navigator.updateLocation(rawLocation)
-            lastLocationUpdateTimeMillis = Date().time
-            statusUpdateTimer.stopJobs()
-        }
-        fireOffStatusPolling()
-        statusUpdateTimer.startTimer {
-            if (Date().time - lastLocationUpdateTimeMillis >= STATUS_POLLING_INTERVAL) {
-                fireOffStatusPolling()
+            rawLocation.let {
+                navigator.updateLocation(it)
             }
+        }
+        locationObservers.forEach { it.onRawLocationChanged(rawLocation) }
+        if (this.rawLocation == null) {
+            fireOffStatusPolling()
         }
         this.rawLocation = rawLocation
     }
 
     private fun fireOffStatusPolling() {
         mainJobController.scope.launch {
-            val status = navigatorPolling()
-            updateEnhancedLocation(status.enhancedLocation, status.keyPoints)
-            updateRouteProgress(status.routeProgress)
-            isOffRoute = status.offRoute
+            while (isActive) {
+                val status = navigatorPolling()
+                updateEnhancedLocation(status.enhancedLocation, status.keyPoints)
+                updateRouteProgress(status.routeProgress)
+                isOffRoute = status.offRoute
+                delay(STATUS_POLLING_INTERVAL)
+            }
         }
     }
 


### PR DESCRIPTION
Reverts polling sync logic from https://github.com/mapbox/mapbox-navigation-android/pull/2680/commits/cf8253a58c891b2094bd6c8bab38cf614a00fce1 to unblock metrics collection until https://github.com/mapbox/mapbox-navigation-android/pull/2719 lands.