### PR TITLE
Fix issue 2722

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/NavigationMapboxMap.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/NavigationMapboxMap.java
@@ -894,7 +894,6 @@ public class NavigationMapboxMap {
       if (options.gpsDrawable() != gpsDrawable) {
         LocationComponentOptions newOptions = options.toBuilder()
           .gpsDrawable(gpsDrawable)
-          .padding(mapboxMap.getPadding())
           .build();
         mapboxMap.getLocationComponent().applyStyle(newOptions);
       }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/puck/NavigationPuckPresenter.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/puck/NavigationPuckPresenter.kt
@@ -4,7 +4,6 @@ import androidx.annotation.DrawableRes
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.OnLifecycleEvent
-import com.mapbox.mapboxsdk.camera.CameraUpdateFactory
 import com.mapbox.mapboxsdk.location.LocationComponentOptions
 import com.mapbox.mapboxsdk.maps.MapboxMap
 import com.mapbox.navigation.base.trip.model.RouteProgress
@@ -57,12 +56,10 @@ class NavigationPuckPresenter(private val mapboxMap: MapboxMap, puckDrawableSupp
     }
 
     private fun updateCurrentLocationDrawable(@DrawableRes gpsDrawable: Int) {
-        val cameraUpdateWithPadding = CameraUpdateFactory.paddingTo(mapboxMap.cameraPosition.padding)
         val options: LocationComponentOptions = mapboxMap.locationComponent.locationComponentOptions
         if (options.gpsDrawable() != gpsDrawable) {
             val newOptions = options.toBuilder().gpsDrawable(gpsDrawable).build()
             mapboxMap.locationComponent.applyStyle(newOptions)
-            mapboxMap.moveCamera(cameraUpdateWithPadding)
         }
     }
 }

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/map/NavigationMapboxMapTest.java
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/map/NavigationMapboxMapTest.java
@@ -372,36 +372,6 @@ public class NavigationMapboxMapTest {
   }
 
   @Test
-  public void updateCurrentLocationDrawable_setsPadding() {
-    Style style = mock(Style.class);
-    String urlV7 = "mapbox://mapbox.mapbox-streets-v7";
-    List<Source> sources = buildMockSourcesWith(urlV7);
-    MapboxMap mapboxMap = mock(MapboxMap.class);
-    MapLayerInteractor layerInteractor = mock(MapLayerInteractor.class);
-    MapPaddingAdjustor adjustor = mock(MapPaddingAdjustor.class);
-    LocationComponent locationComponent = mock(LocationComponent.class);
-    LocationComponentOptions existingOptions = mock(LocationComponentOptions.class);
-    LocationComponentOptions newOptions = mock(LocationComponentOptions.class);
-    LocationComponentOptions.Builder builder = mock(LocationComponentOptions.Builder.class);
-    int[] mapboxPadding = new int[0];
-    when(mapboxMap.getStyle()).thenReturn(style);
-    when(style.getSources()).thenReturn(sources);
-    NavigationMapboxMap theNavigationMap = new NavigationMapboxMap(mapboxMap,layerInteractor, adjustor);
-    when(mapboxMap.getLocationComponent()).thenReturn(locationComponent);
-    when(mapboxMap.getPadding()).thenReturn(mapboxPadding);
-    when(locationComponent.getLocationComponentOptions()).thenReturn(existingOptions);
-    when(builder.gpsDrawable(7)).thenReturn(builder);
-    when(builder.padding(any(int[].class))).thenReturn(builder);
-    when(existingOptions.toBuilder()).thenReturn(builder);
-    when(existingOptions.gpsDrawable()).thenReturn(0);
-    when(builder.build()).thenReturn(newOptions);
-
-    theNavigationMap.updateCurrentLocationDrawable(7);
-
-    verify(builder).padding(mapboxPadding);
-  }
-
-  @Test
   public void updateCurrentLocationDrawable_appliesStyle() {
     Style style = mock(Style.class);
     String urlV7 = "mapbox://mapbox.mapbox-streets-v7";


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Fix issue #2722 

From testing, the padding doesn't have impact here. But the later call of _moveCamera_ will trigger `LocationComponent.java` to `setCameraMode(CameraMode.NONE);` which will reset the camera tracking mode to `CameraMode.NONE` and thus we will see the **RE-CENTER** button and the camera doesn't follow the puck as we see in #2722 and also what @Guardiola31337 noticed [here](https://github.com/mapbox/mobile-metrics/pull/330#issuecomment-607448926)

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

## Testing

I have manually tested the `NavigationViewActivity` in the example app and the `mobile-metrics` test case. Both are passed locally.

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->