### PR TITLE
Fix release-core-1_0-prod job filter

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -48,7 +48,7 @@ workflows:
       - release-core-1_0-prod:
           filters:
             tags:
-              only: /^prod_release_core_*/
+              only: /^prod_release_core_.*/
             branches:
               ignore: /.*/
 


### PR DESCRIPTION
## Description

Follow up from https://github.com/mapbox/mapbox-navigation-android/pull/2640

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

CI release trigger was not working (`release-core-1_0-prod`)

### Implementation

Bring `.` back to Circle CI job filter tags (`release-core-1_0-prod`)

## Testing

- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR