### PR TITLE
Fix ride history mapper for older versions

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/history/ReplayEvents.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/history/ReplayEvents.kt
@@ -13,8 +13,7 @@ interface ReplayEventBase {
 
 data class ReplayEventGetStatus(
     @SerializedName("event_timestamp")
-    override val eventTimestamp: Double,
-    val timestamp: Double
+    override val eventTimestamp: Double
 ) : ReplayEventBase
 
 data class ReplayEventUpdateLocation(

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/history/ReplayHistoryMapper.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/history/ReplayHistoryMapper.kt
@@ -46,9 +46,15 @@ class ReplayHistoryMapper(
     private fun mapToEvent(eventType: String, event: LinkedTreeMap<*, *>): ReplayEventBase? {
         return when (eventType) {
             "updateLocation" -> gson.fromJson(event.toString(), ReplayEventUpdateLocation::class.java)
-            "getStatus" -> ReplayEventGetStatus(
-                eventTimestamp = event["event_timestamp"] as Double,
-                timestamp = event["timestamp"] as Double)
+            "getStatus" -> {
+                val eventTimestamp = if (event.contains("event_timestamp")) {
+                    event["event_timestamp"]
+                } else {
+                    event["timestamp"]
+                } as Double
+                ReplayEventGetStatus(
+                    eventTimestamp = eventTimestamp)
+            }
             else -> {
                 val replayEvent = customEventMapper?.invoke(eventType, event)
                 if (replayEvent == null) {

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/history/ReplayHistoryMapperTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/history/ReplayHistoryMapperTest.kt
@@ -56,6 +56,14 @@ class ReplayHistoryMapperTest {
         assertEquals(historyEvents.events.size, 4)
     }
 
+    @Test
+    fun `old versions of history are missing event_timestamp`() {
+        val historyString = """{"events":[{"type":"getStatus","timestamp":1551460823.922}],"version":"5.0.0","history_version":"1.0.0"}"""
+        val replayHistoryMapper = ReplayHistoryMapper(customEventMapper = ExampleCustomEventMapper())
+        val historyEvents = replayHistoryMapper.mapToReplayEvents(historyString)
+        assertEquals(historyEvents.events.size, 1)
+    }
+
     private data class ExampleEndTransitEvent(
         @SerializedName("event_timestamp")
         override val eventTimestamp: Double,

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/history/ReplayHistoryPlayerTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/history/ReplayHistoryPlayerTest.kt
@@ -39,7 +39,7 @@ class ReplayHistoryPlayerTest {
     fun `should play start transit and location in order`() = coroutineRule.runBlockingTest {
         val replayHistoryData = ReplayEvents(
             listOf(
-                ReplayEventGetStatus(1580777612.853, 1580777612.853),
+                ReplayEventGetStatus(1580777612.853),
                 ReplayEventUpdateLocation(1580777612.89,
                     ReplayEventLocation(
                         lat = 49.2492411,


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

I ran into this issue early on but didn't debug it as I was hacking. I found it again, getStatus won't have the event_timestamp in older versions. https://github.com/mapbox/mapbox-navigation-android/issues/2688

- [x] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->