### PR TITLE
Fix Navigator synchronization issue

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1126,6 +1126,12 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 
 ===========================================================================
 
+Mapbox Navigation uses portions of the kotlinx-coroutines-core (Coroutines support libraries for Kotlin).
+URL: [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
+License: [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+===========================================================================
+
 Mapbox Navigation uses portions of the Mapbox Java SDK.
 URL: [https://github.com/mapbox/mapbox-java](https://github.com/mapbox/mapbox-java)
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -53,7 +53,7 @@ ext {
       crashlytics               : '2.9.9',
       multidex                  : '2.0.0',
       json                      : '20180813',
-      coroutinesAndroid         : '1.3.3',
+      coroutinesAndroid         : '1.3.5',
       okhttp                    : '3.12.0',
       okio                      : '2.4.3',
       androidxTestJunit         : '1.1.1',
@@ -87,6 +87,7 @@ ext {
       // Coroutines and Channels
       coroutinesAndroid         : "org.jetbrains.kotlinx:kotlinx-coroutines-android:${version.coroutinesAndroid}",
       coroutinesTestAndroid     : "org.jetbrains.kotlinx:kotlinx-coroutines-test:${version.coroutinesAndroid}",
+      coroutinesCore            : "org.jetbrains.kotlinx:kotlinx-coroutines-core:${version.coroutinesAndroid}",
 
       // code style
       ktlint                    : "com.pinterest:ktlint:${version.ktlint}",

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
@@ -18,6 +18,8 @@ import com.mapbox.navigation.utils.thread.JobControl
 import com.mapbox.navigation.utils.thread.ThreadController
 import com.mapbox.navigator.NavigationStatus
 import io.mockk.clearMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -87,9 +89,9 @@ class MapboxTripSessionTest {
             navigator
         )
 
-        every { navigator.getStatus(any()) } returns tripStatus
+        coEvery { navigator.getStatus(any()) } returns tripStatus
         every { navigator.updateLocation(any()) } returns false
-        every { navigator.setRoute(any()) } returns navigationStatus
+        coEvery { navigator.setRoute(any()) } returns navigationStatus
         every { tripStatus.enhancedLocation } returns enhancedLocation
         every { tripStatus.keyPoints } returns keyPoints
         every { tripStatus.offRoute } returns false
@@ -353,14 +355,14 @@ class MapboxTripSessionTest {
     fun setRoute() {
         tripSession.route = route
 
-        verify { navigator.setRoute(route) }
+        coVerify { navigator.setRoute(route) }
     }
 
     @Test
     fun setRoute_nullable() {
         tripSession.route = null
 
-        verify { navigator.setRoute(null) }
+        coVerify { navigator.setRoute(null) }
     }
 
     @Test

--- a/libnavigator/build.gradle
+++ b/libnavigator/build.gradle
@@ -47,6 +47,8 @@ dependencies {
 
     implementation dependenciesList.mapboxSdkGeoJSON
 
+    implementation dependenciesList.coroutinesCore
+
     apply from: "${rootDir}/gradle/unit-testing-dependencies.gradle"
 }
 

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/MapboxNativeNavigator.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/MapboxNativeNavigator.kt
@@ -61,7 +61,7 @@ interface MapboxNativeNavigator {
      * is earlier than a previous call, the last status will be returned,
      * the function does not support re-winding time.
      */
-    fun getStatus(date: Date): TripStatus
+    suspend fun getStatus(date: Date): TripStatus
 
     // Routing
 
@@ -77,7 +77,7 @@ interface MapboxNativeNavigator {
      * @return a [NavigationStatus] route state if no errors occurred.
      * Otherwise, it returns a invalid route state.
      */
-    fun setRoute(
+    suspend fun setRoute(
         route: DirectionsRoute?,
         routeIndex: Int = INDEX_FIRST_ROUTE,
         legIndex: Int = INDEX_FIRST_LEG


### PR DESCRIPTION
## Description

Fixes `MapboxNativeNavigator` `getStatus` / `setRoute` synchronization issue

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Goal here is fixing NN synchronization issues causing unexpected behaviors (e.g. premature arrive after re-route)

### Implementation

Looks like `mutex.withLock{...}` is the replacement of `@Synchronized` for suspending shared mutable state (@korshaknn thanks for sharing this great post  https://blog.danlew.net/2020/01/28/coroutines-and-java-synchronization-dont-mix/ by @dlew 💯). `getStatus` / `setRoute` are now `suspend`adble and a [`Mutex`](https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.sync/-mutex/) was added to `MapboxNativeNavigatorImpl` locking each APIs.

This wasn't a problem in the past (legacy) because all of the NN APIs were `@Synchronized` https://github.com/mapbox/mapbox-navigation-android/blob/master/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/MapboxNavigator.kt but in `1.0` are not because NN deals with asynchronicity - we thought that `@Synchronized` annotations were not needed anymore. 

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR

cc @mskurydin 