### PR TITLE
Bump Maps SDK version to 9.1.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -9,7 +9,7 @@ ext {
   ]
 
   version = [
-      mapboxMapSdk              : '9.1.0-beta.2',
+      mapboxMapSdk              : '9.1.0',
       mapboxSdkServices         : '5.1.0',
       mapboxSdkDirectionsModels : '5.1.0',
       mapboxEvents              : '5.0.0',


### PR DESCRIPTION
## Description

Bumps `mapboxMapSdk` version to [`9.1.0`](https://github.com/mapbox/mapbox-gl-native-android/releases/tag/android-v9.1.0)

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Getting the latest versions from `mapboxMapSdk` including the new features and bug fixes.

### Implementation

Bumping `mapboxMapSdk` version to `9.1.0` in `dependencies.gradle`

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR