### PR TITLE
Add play first location to history player

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/history/ReplayHistoryPlayer.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/history/ReplayHistoryPlayer.kt
@@ -4,7 +4,9 @@ import android.os.SystemClock
 import android.util.Log
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
+import com.mapbox.android.core.location.LocationEngine
 import com.mapbox.navigation.utils.thread.ThreadController
+import java.util.Collections.singletonList
 import kotlin.math.abs
 import kotlin.math.roundToInt
 import kotlinx.coroutines.Job
@@ -19,7 +21,7 @@ typealias ReplayEventsListener = (ReplayEvents) -> Unit
  * This class is similar to a music player. It will include controls like play, pause, seek.
  */
 class ReplayHistoryPlayer(
-    replayEvents: ReplayEvents
+    private val replayEvents: ReplayEvents
 ) {
     private val replayEventLookup = ReplayEventLookup(replayEvents)
 
@@ -57,6 +59,22 @@ class ReplayHistoryPlayer(
             }
 
             Log.i("ReplayHistory", "Simulator ended")
+        }
+    }
+
+    /**
+     * When initializing or testing an app, it is needed and useful to decide a code location
+     * to play the first location from GPS. When it is early, you may crash. When it
+     * is late, you may start in null island - LatLng(0,0).
+     * Use this function to play the first location received from your [LocationEngine].
+     */
+    fun playFirstLocation() {
+        val firstUpdateLocation = replayEvents.events.firstOrNull { replayEvent ->
+            replayEvent is ReplayEventUpdateLocation
+        }
+        firstUpdateLocation?.let { replayEvent ->
+            val replayEvents = ReplayEvents(singletonList(replayEvent))
+            replayEventsListeners.forEach { it(replayEvents) }
         }
     }
 


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

When initializing an app using the HistoryPlayer, it is needed and useful to decide a code location to play the first location from GPS. When it is too early, you may crash. When it is too late, you may start in null island. 

This is also how I made it so we can initialize the app, and then press buttons to control when to play the history. https://github.com/mapbox/mapbox-navigation-android/pull/2696

- [x] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->