### PR TITLE
fix for formatter returning negative distance values...

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxDistanceFormatter.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxDistanceFormatter.kt
@@ -12,6 +12,7 @@ import com.mapbox.navigation.base.extensions.inferDeviceLocale
 import com.mapbox.navigation.base.formatter.DistanceFormatter
 import com.mapbox.navigation.base.typedef.IMPERIAL
 import com.mapbox.navigation.base.typedef.RoundingIncrement
+import com.mapbox.navigation.base.typedef.UNDEFINED
 import com.mapbox.navigation.base.typedef.VoiceUnit
 import com.mapbox.turf.TurfConstants
 import com.mapbox.turf.TurfConversion
@@ -71,7 +72,11 @@ class MapboxDistanceFormatter private constructor(
 
         fun build(): MapboxDistanceFormatter {
             val localeToUse: Locale = locale ?: context.applicationContext.inferDeviceLocale()
-            val unitTypeToUse: String = unitType ?: localeToUse.getUnitTypeForLocale()
+            val unitTypeToUse: String = when (unitType) {
+                null -> localeToUse.getUnitTypeForLocale()
+                UNDEFINED -> localeToUse.getUnitTypeForLocale()
+                else -> unitType!!
+            }
 
             return MapboxDistanceFormatter(
                 context.applicationContext,
@@ -90,6 +95,9 @@ class MapboxDistanceFormatter private constructor(
      */
     override fun formatDistance(distance: Double): SpannableString {
         val distanceAndSuffix = when (distance) {
+            !in 0.0..Double.MAX_VALUE -> {
+                formatDistanceAndSuffixForSmallUnit(0.0)
+            }
             in 0.0..smallDistanceUpperThresholdInMeters -> {
                 formatDistanceAndSuffixForSmallUnit(distance)
             }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxDistanceFormatterTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxDistanceFormatterTest.kt
@@ -8,6 +8,8 @@ import androidx.test.core.app.ApplicationProvider
 import com.mapbox.navigation.base.typedef.IMPERIAL
 import com.mapbox.navigation.base.typedef.METRIC
 import com.mapbox.navigation.base.typedef.ROUNDING_INCREMENT_FIFTY
+import com.mapbox.navigation.base.typedef.ROUNDING_INCREMENT_FIVE
+import com.mapbox.navigation.base.typedef.UNDEFINED
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -216,5 +218,53 @@ class MapboxDistanceFormatterTest {
         MapboxDistanceFormatter.Builder(mockContext).build()
 
         verify(exactly = 2) { mockContext.applicationContext }
+    }
+
+    @Config(qualifiers = "en")
+    @Test
+    fun formatDistanceBelowZeroDistance() {
+        val result = MapboxDistanceFormatter.Builder(ctx)
+                .withUnitType(IMPERIAL)
+                .withRoundingIncrement(ROUNDING_INCREMENT_FIFTY)
+                .build()
+                .formatDistance(-0.1)
+
+        assertEquals("50 ft", result.toString())
+    }
+
+    @Config(qualifiers = "en")
+    @Test
+    fun formatDistanceBelowZeroDistanceRoundingIncrementFive() {
+        val result = MapboxDistanceFormatter.Builder(ctx)
+                .withUnitType(IMPERIAL)
+                .withRoundingIncrement(ROUNDING_INCREMENT_FIVE)
+                .build()
+                .formatDistance(-0.1)
+
+        assertEquals("5 ft", result.toString())
+    }
+
+    @Config(qualifiers = "en-rUS")
+    @Test
+    fun formatDistanceUnitTypeUndefinedImperial() {
+        val result = MapboxDistanceFormatter.Builder(ctx)
+                .withUnitType(UNDEFINED)
+                .withRoundingIncrement(ROUNDING_INCREMENT_FIFTY)
+                .build()
+                .formatDistance(19312.1)
+
+        assertEquals("12 mi", result.toString())
+    }
+
+    @Config(qualifiers = "jp-rJP")
+    @Test
+    fun formatDistanceUnitTypeUndefinedMetric() {
+        val result = MapboxDistanceFormatter.Builder(ctx)
+                .withUnitType(UNDEFINED)
+                .withRoundingIncrement(ROUNDING_INCREMENT_FIVE)
+                .build()
+                .formatDistance(19312.1)
+
+        assertEquals("19 km", result.toString())
     }
 }


### PR DESCRIPTION
## Description
This is a fix for #2734 handling cases in which the inputted value could be below 0 and for the banner view showing a different unit type than the notification which was caused by the formatter not correctly handling a unit type of UNKNOWN.

Unit tests added for the previously missing use cases.