### PR TITLE
Fix replay history LocationComponent locations when navigating

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayHistoryActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayHistoryActivity.kt
@@ -56,6 +56,10 @@ class ReplayHistoryActivity : AppCompatActivity() {
 
     private var navigationContext: ReplayNavigationContext? = null
 
+    // This is needed to update the location component with enhanced location while navigating
+    // TODO replace with a recommended way to deal with the issue
+    private var isNavigating = false
+
     // You choose your loading mechanism. Use Coroutines, ViewModels, RxJava, Threads, etc..
     private var loadNavigationJob: Job? = null
 
@@ -179,6 +183,8 @@ class ReplayHistoryActivity : AppCompatActivity() {
 
     @SuppressLint("MissingPermission")
     private fun ReplayNavigationContext.startNavigation() {
+        isNavigating = true
+
         if (mapboxNavigation.getRoutes().isNotEmpty()) {
             navigationMapboxMap.updateLocationLayerRenderMode(RenderMode.GPS)
             navigationMapboxMap.updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_GPS)
@@ -275,6 +281,8 @@ class ReplayHistoryActivity : AppCompatActivity() {
     private val locationListenerCallback: LocationEngineCallback<LocationEngineResult> =
         object : LocationEngineCallback<LocationEngineResult> {
             override fun onSuccess(result: LocationEngineResult) {
+                if (isNavigating) return
+
                 result.lastLocation?.let {
                     navigationContext?.mapboxMap?.locationComponent?.forceLocationUpdate(it)
                 }
@@ -294,6 +302,8 @@ class ReplayHistoryActivity : AppCompatActivity() {
             enhancedLocation: Location,
             keyPoints: List<Location>
         ) {
+            if (!isNavigating) return
+
             if (keyPoints.isNotEmpty()) {
                 navigationContext?.mapboxMap?.locationComponent?.forceLocationUpdate(keyPoints, true)
             } else {


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

During ride replay. There are competing location updates for the LocationComponent. One from GPS, and the other from enhanced locations. 

- [ ] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->