### PR TITLE
Fix issue 2732: stop tripSession when MapboxNavigation destroy

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -290,6 +290,7 @@ constructor(
             ThreadController.cancelAllUICoroutines()
             directionsSession.shutDownSession()
             directionsSession.unregisterAllRoutesObservers()
+            tripSession.stop()
             tripSession.unregisterAllLocationObservers()
             tripSession.unregisterAllRouteProgressObservers()
             tripSession.unregisterAllOffRouteObservers()


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Fix #2732 

When NavigationView destroys itself, we need to make sure the Notification goes away.
It's in legacy code, but not in V1.0 SDK.

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

