### PR TITLE
force to use okhttp version 3.12.x to keep compatibility of Android OS 19

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -602,6 +602,11 @@ License: [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
+Mapbox Navigation uses portions of the OkHttp Logging Interceptor.
+License: [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+===========================================================================
+
 Mapbox Navigation uses portions of the Okio.
 License: [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -114,6 +114,14 @@ dependencies {
   // Logging
   implementation dependenciesList.timber
 
+  // Network
+  implementation(dependenciesList.okhttp) {
+    force = true
+  }
+  implementation(dependenciesList.okhttpInterceptor) {
+    force = true
+  }
+
   // Butter Knife
   implementation dependenciesList.butterKnife
   annotationProcessor dependenciesList.butterKnifeProcessor

--- a/examples/src/main/res/drawable/bottom_button_background.xml
+++ b/examples/src/main/res/drawable/bottom_button_background.xml
@@ -2,7 +2,7 @@
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:state_enabled="true">
         <shape android:shape="rectangle">
-            <solid android:color="?attr/colorPrimary" />
+            <solid android:color="@color/colorPrimary" />
         </shape>
     </item>
     <item android:state_enabled="false">

--- a/examples/src/main/res/layout/activity_instruction_view_layout.xml
+++ b/examples/src/main/res/layout/activity_instruction_view_layout.xml
@@ -50,7 +50,6 @@
 
     <com.mapbox.navigation.ui.instruction.InstructionView
         android:id="@+id/instructionView"
-        style="@style/InstructionView"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:gravity="top"

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -55,7 +55,7 @@ ext {
       multidex                  : '2.0.0',
       json                      : '20180813',
       coroutinesAndroid         : '1.3.5',
-      okhttp                    : '3.12.0',
+      okhttp                    : '3.12.10',
       okio                      : '2.4.3',
       androidxTestJunit         : '1.1.1',
       barista                   : '3.2.0',

--- a/libandroid-navigation-ui/build.gradle
+++ b/libandroid-navigation-ui/build.gradle
@@ -73,6 +73,14 @@ dependencies {
   // Timber
   implementation dependenciesList.timber
 
+  // Network
+  implementation(dependenciesList.okhttp) {
+    force = true
+  }
+  implementation(dependenciesList.okhttpInterceptor) {
+    force = true
+  }
+
   // Mapbox Map SDK Javadoc
   javadocDeps dependenciesList.mapboxMapSdk
 

--- a/libandroid-navigation/build.gradle
+++ b/libandroid-navigation/build.gradle
@@ -74,6 +74,14 @@ dependencies {
 
   implementation dependenciesList.timber
 
+  // Network
+  implementation(dependenciesList.okhttp) {
+    force = true
+  }
+  implementation(dependenciesList.okhttpInterceptor) {
+    force = true
+  }
+
   // Unit testing
   testImplementation dependenciesList.junit
   testImplementation dependenciesList.mockito

--- a/libdirections-offboard/build.gradle
+++ b/libdirections-offboard/build.gradle
@@ -43,6 +43,14 @@ dependencies {
 
     implementation dependenciesList.mapboxSdkServices
 
+    // Network
+    implementation(dependenciesList.okhttp) {
+        force = true
+    }
+    implementation(dependenciesList.okhttpInterceptor) {
+        force = true
+    }
+
     apply from: "${rootDir}/gradle/unit-testing-dependencies.gradle"
 }
 

--- a/libnavigation-ui/build.gradle
+++ b/libnavigation-ui/build.gradle
@@ -84,6 +84,14 @@ dependencies {
   // Mapbox Map SDK Javadoc
   javadocDeps dependenciesList.mapboxMapSdk
 
+  // Network
+  implementation(dependenciesList.okhttp) {
+    force = true
+  }
+  implementation(dependenciesList.okhttpInterceptor) {
+    force = true
+  }
+
   // Unit testing
   testImplementation dependenciesList.junit
   testImplementation dependenciesList.mockito


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Fix #2684 

The two test apps, `example` and `app`, will crash on Android OS 19 Emulator.
The stack trace shows:
```
Caused by: java.lang.IllegalStateException: Expected Android API level 21+ but was 19
```
The reason is from `mapbox-java` https://github.com/mapbox/mapbox-java/blob/v5.1.0/gradle/dependencies.gradle#L9 starts using **retrofit 2.7.1** from version 5.0.0 which relies on **okhttp 3.14.4** 
Ref mapbox/mapbox-java#1127

The `okhttp` stops supporting Android OS 19 from its **3.13.X** release. This causes the above crash. 
👀 -> https://medium.com/square-corner-blog/okhttp-3-13-requires-android-5-818bb78d07ce

- [x] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

