### PR TITLE
Pull in the latest translations from Transifex

### DIFF
--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -15,6 +15,7 @@
 
     <string name="title_navigation_launcher">Navigáció indító</string>
     <string name="title_end_navigation">Navigáció befejezése</string>
+    <string name="title_embedded_navigation">Beágyazott navigáció</string>
     <string name="settings">Beállítások</string>
     <string name="simulate_route">Útvonal szimulációja</string>
     <string name="language">Nyelv</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -13,6 +13,7 @@
     <string name="title_navigation_route_ui">Навігація - Маршрут на мапі</string>
     <string name="description_navigation_route_ui">Показує маршрут поверх мапи</string>
 
+    <string name="title_navigation_launcher">Навігація</string>
     <string name="description_navigation_launcher">Інтерфейс для вводу місця призначення.</string>
 
     <string name="title_end_navigation">Завершити навігацію</string>

--- a/libandroid-navigation-ui/src/main/res/values-de/strings.xml
+++ b/libandroid-navigation-ui/src/main/res/values-de/strings.xml
@@ -12,6 +12,13 @@
     <!-- Indicates voice instructions are unmuted -->
     <string name="unmuted">Ton an</string>
 
+    <!-- Feedback -->
+    <string name="report_feedback">Feedback geben</string>
+
+    <!-- Feedback type for Bad Route -->
+    <string name="feedback_bad_route">Ineffiziente oder\n
+schlechte Route</string>
+
     <!-- Feedback type for Confusing Instruction -->
     <string name="feedback_confusing_instruction">Verwirrende
 Anweisung</string>

--- a/libandroid-navigation-ui/src/main/res/values-fr/strings.xml
+++ b/libandroid-navigation-ui/src/main/res/values-fr/strings.xml
@@ -12,6 +12,9 @@
     <!-- Indicates voice instructions are unmuted -->
     <string name="unmuted">Audible</string>
 
+    <!-- Feedback -->
+    <string name="report_feedback">Donner votre avis</string>
+
     <!-- Feedback type for Confusing Instruction -->
     <string name="feedback_confusing_instruction">Instructions\nnon précises</string>
 
@@ -26,6 +29,12 @@
 
     <!-- Feedback type for Road Closed -->
     <string name="feedback_road_closure">Route\nfermée</string>
+
+    <!-- Shown after a feedback type has been submitted -->
+    <string name="feedback_submitted">Votre avis a bien été pris en compte</string>
+
+    <!-- Shown in off-route scenarios to provide feedback -->
+    <string name="report_problem">Signaler un problème</string>
 
     <!-- Test app dialog text -->
     <string name="dropoff_dialog_text">Voulez vous être guidé vers la prochaine destination? </string>

--- a/libandroid-navigation-ui/src/main/res/values-hu/strings.xml
+++ b/libandroid-navigation-ui/src/main/res/values-hu/strings.xml
@@ -12,6 +12,12 @@
     <!-- Indicates voice instructions are unmuted -->
     <string name="unmuted">Visszahangosítva</string>
 
+    <!-- Feedback -->
+    <string name="report_feedback">Visszajelzés küldése</string>
+
+    <!-- Feedback type for Bad Route -->
+    <string name="feedback_bad_route">Lassú vagy\ntéves útvonal</string>
+
     <!-- Feedback type for Confusing Instruction -->
     <string name="feedback_confusing_instruction">Megtévesztő\nutasítás</string>
 

--- a/libandroid-navigation/src/main/res/values-fr/strings.xml
+++ b/libandroid-navigation/src/main/res/values-fr/strings.xml
@@ -7,6 +7,11 @@
     <string name="meters">m</string>
     <string name="miles">mi</string>
     <string name="feet">ft</string>
+    <!-- Time formatting -->
+    <plurals name="numberOfDays">
+        <item quantity="one">jour</item>
+        <item quantity="other">jours</item>
+    </plurals>
     <!-- Hour -->
     <string name="hr">h</string>
     <!-- Minute -->

--- a/libnavigation-util/src/main/res/values-ar/strings.xml
+++ b/libnavigation-util/src/main/res/values-ar/strings.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="kilometers">كم</string>
     <string name="meters">م</string>

--- a/libnavigation-util/src/main/res/values-bg/strings.xml
+++ b/libnavigation-util/src/main/res/values-bg/strings.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="kilometers">км</string>
     <string name="meters">м</string>

--- a/libnavigation-util/src/main/res/values-cs/strings.xml
+++ b/libnavigation-util/src/main/res/values-cs/strings.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="kilometers">km</string>
     <string name="meters">m</string>

--- a/libnavigation-util/src/main/res/values-da/strings.xml
+++ b/libnavigation-util/src/main/res/values-da/strings.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="kilometers">km</string>
     <string name="meters">m</string>

--- a/libnavigation-util/src/main/res/values-de/strings.xml
+++ b/libnavigation-util/src/main/res/values-de/strings.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="kilometers">km</string>
     <string name="meters">m</string>

--- a/libnavigation-util/src/main/res/values-es/strings.xml
+++ b/libnavigation-util/src/main/res/values-es/strings.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="kilometers">km</string>
     <string name="meters">m</string>

--- a/libnavigation-util/src/main/res/values-fa/strings.xml
+++ b/libnavigation-util/src/main/res/values-fa/strings.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="kilometers">کیلومتر</string>
     <string name="meters">متر</string>

--- a/libnavigation-util/src/main/res/values-fr/strings.xml
+++ b/libnavigation-util/src/main/res/values-fr/strings.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="kilometers">km</string>
     <string name="meters">m</string>

--- a/libnavigation-util/src/main/res/values-gl/strings.xml
+++ b/libnavigation-util/src/main/res/values-gl/strings.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="kilometers">km</string>
     <string name="meters">m</string>

--- a/libnavigation-util/src/main/res/values-he/strings.xml
+++ b/libnavigation-util/src/main/res/values-he/strings.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="kilometers">ק״מ</string>
     <string name="meters">מ׳</string>
     <string name="miles">מייל</string>
-</resources>
+    </resources>

--- a/libnavigation-util/src/main/res/values-hu/strings.xml
+++ b/libnavigation-util/src/main/res/values-hu/strings.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="kilometers">km</string>
     <string name="meters">m</string>

--- a/libnavigation-util/src/main/res/values-ja/strings.xml
+++ b/libnavigation-util/src/main/res/values-ja/strings.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="kilometers">km</string>
     <string name="meters">m</string>

--- a/libnavigation-util/src/main/res/values-ko/strings.xml
+++ b/libnavigation-util/src/main/res/values-ko/strings.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="kilometers">km</string>
     <string name="meters">m</string>

--- a/libnavigation-util/src/main/res/values-my/strings.xml
+++ b/libnavigation-util/src/main/res/values-my/strings.xml
@@ -1,7 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="kilometers">ကီလိုမီတာ</string>
     <string name="meters">မီတာ</string>
     <string name="miles">မိုင်</string>
     <string name="feet">ပေ</string>
-    </resources>
+</resources>

--- a/libnavigation-util/src/main/res/values-pt-rBR/strings.xml
+++ b/libnavigation-util/src/main/res/values-pt-rBR/strings.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="kilometers">KM</string>
     <string name="meters">M</string>

--- a/libnavigation-util/src/main/res/values-pt-rPT/strings.xml
+++ b/libnavigation-util/src/main/res/values-pt-rPT/strings.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="kilometers">km</string>
     <string name="meters">m</string>

--- a/libnavigation-util/src/main/res/values-ru/strings.xml
+++ b/libnavigation-util/src/main/res/values-ru/strings.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="kilometers">км</string>
     <string name="meters">м</string>

--- a/libnavigation-util/src/main/res/values-sv/strings.xml
+++ b/libnavigation-util/src/main/res/values-sv/strings.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="kilometers">km</string>
     <string name="meters">m</string>

--- a/libnavigation-util/src/main/res/values-uk/strings.xml
+++ b/libnavigation-util/src/main/res/values-uk/strings.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="kilometers">км</string>
     <string name="meters">м</string>

--- a/libnavigation-util/src/main/res/values-uz/strings.xml
+++ b/libnavigation-util/src/main/res/values-uz/strings.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="kilometers">km</string>
     <string name="meters">m</string>

--- a/libnavigation-util/src/main/res/values-vi/strings.xml
+++ b/libnavigation-util/src/main/res/values-vi/strings.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="kilometers">km</string>
     <string name="meters">m</string>

--- a/libnavigation-util/src/main/res/values-yo/strings.xml
+++ b/libnavigation-util/src/main/res/values-yo/strings.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="kilometers">km</string>
     <string name="meters">m</string>

--- a/libtrip-notification/src/main/res/values-fr/strings.xml
+++ b/libtrip-notification/src/main/res/values-fr/strings.xml
@@ -1,9 +1,17 @@
-<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification Strings -->
     <string name="end_navigation">Fin de navigation</string>
     <string name="channel_name">Notifications de navigation</string>
     <string name="notification_arrival_time_format">Arrivée à %s</string>
+    <string name="kilometers">km</string>
+    <string name="meters">m</string>
+    <string name="miles">mi</string>
+    <string name="feet">ft</string>
+    <!-- Time formatting -->
+    <plurals name="numberOfDays">
+        <item quantity="one">jour</item>
+        <item quantity="other">jours</item>
+    </plurals>
     <!-- Hour -->
     <string name="hr">h</string>
     <!-- Minute -->


### PR DESCRIPTION
### Contribution from @pouzadf in https://github.com/mapbox/mapbox-navigation-android/pull/2756

## Description

Updates translations to latest Transifex

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Get newest and latest translations available in Transifex

### Implementation

Pull translations from Transifex and add them to the SDK and test app

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [x] Any changes to strings have been published to our translation tool
- [ ] Cherry-pick into [`base-v0.42.1`](https://github.com/mapbox/mapbox-navigation-android/tree/base-v0.42.1) branch 
