### PR TITLE
Add functions to ReplayHistoryPlayer to replay a route

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/history/ReplayEvents.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/history/ReplayEvents.kt
@@ -4,7 +4,7 @@ import com.google.gson.annotations.SerializedName
 
 data class ReplayEvents(
     // Assumes chronological order, index 0 moves to events.size over time.
-    val events: List<ReplayEventBase>
+    val events: MutableList<ReplayEventBase>
 )
 
 interface ReplayEventBase {

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/history/ReplayHistoryLocationEngine.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/history/ReplayHistoryLocationEngine.kt
@@ -56,8 +56,8 @@ class ReplayHistoryLocationEngine(
         throw UnsupportedOperationException("$myId removeLocationUpdates with intents is unsupported")
     }
 
-    private fun replayEvents(replayEvents: ReplayEvents) {
-        replayEvents.events.forEach { event ->
+    private fun replayEvents(replayEvents: List<ReplayEventBase>) {
+        replayEvents.forEach { event ->
             when (event) {
                 is ReplayEventUpdateLocation -> replayLocation(event)
             }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/history/ReplayHistoryMapper.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/history/ReplayHistoryMapper.kt
@@ -19,7 +19,7 @@ class ReplayHistoryMapper(
     /**
      * Given raw json string return [ReplayEvents] that can be given to a [ReplayHistoryPlayer]
      */
-    fun mapToReplayEvents(historyData: String): ReplayEvents {
+    fun mapToReplayEvents(historyData: String): List<ReplayEventBase> {
         val exampleHistoryData = gson.fromJson(historyData, ReplayHistoryDTO::class.java)
         return mapToReplayEvents(exampleHistoryData)
     }
@@ -27,8 +27,8 @@ class ReplayHistoryMapper(
     /**
      * Given [ReplayHistoryDTO] return [ReplayEvents] that can be given to a [ReplayHistoryPlayer]
      */
-    fun mapToReplayEvents(historyDTO: ReplayHistoryDTO): ReplayEvents {
-        val eventList = historyDTO.events
+    fun mapToReplayEvents(historyDTO: ReplayHistoryDTO): List<ReplayEventBase> {
+        return historyDTO.events
             .mapIndexed { index, _ ->
                 val event = historyDTO.events[index] as LinkedTreeMap<*, *>
                 return@mapIndexed try {
@@ -40,7 +40,6 @@ class ReplayHistoryMapper(
                 }
             }
             .filterNotNull()
-        return ReplayEvents(eventList)
     }
 
     private fun mapToEvent(eventType: String, event: LinkedTreeMap<*, *>): ReplayEventBase? {

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/history/ReplayHistoryMapperTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/history/ReplayHistoryMapperTest.kt
@@ -16,7 +16,7 @@ class ReplayHistoryMapperTest {
 
         val historyEvents = replayHistoryMapper.mapToReplayEvents(historyString)
 
-        assertEquals(historyEvents.events.size, 2)
+        assertEquals(historyEvents.size, 2)
     }
 
     @Test
@@ -25,8 +25,8 @@ class ReplayHistoryMapperTest {
 
         val historyEvents = replayHistoryMapper.mapToReplayEvents(historyString)
 
-        assertEquals(historyEvents.events[0].eventTimestamp, 1580744198.879556)
-        assertTrue(historyEvents.events[0] is ReplayEventGetStatus)
+        assertEquals(historyEvents[0].eventTimestamp, 1580744198.879556)
+        assertTrue(historyEvents[0] is ReplayEventGetStatus)
     }
 
     @Test
@@ -35,8 +35,8 @@ class ReplayHistoryMapperTest {
 
         val historyEvents = replayHistoryMapper.mapToReplayEvents(historyString)
 
-        assertEquals(historyEvents.events[1].eventTimestamp, 1580744199.407049)
-        (historyEvents.events[1] as ReplayEventUpdateLocation).location.let {
+        assertEquals(historyEvents[1].eventTimestamp, 1580744199.407049)
+        (historyEvents[1] as ReplayEventUpdateLocation).location.let {
             assertEquals(it.lat, 50.1232182)
             assertEquals(it.lon, 8.6343946)
             assertEquals(it.time, 1580744199.406)
@@ -53,7 +53,7 @@ class ReplayHistoryMapperTest {
         val historyString = """{"events":[{"type":"getStatus","timestamp":1580744200.379,"event_timestamp":1580744198.879556,"delta_ms":0},{"type":"updateLocation","location":{"lat":50.1232182,"lon":8.6343946,"time":1580744199.406,"speed":0.02246818132698536,"bearing":33.55318069458008,"altitude":162.8000030517578,"accuracyHorizontal":14.710000038146973,"provider":"fused"},"event_timestamp":1580744199.407049,"delta_ms":0},{"type":"getStatus","timestamp":1580744213.506,"event_timestamp":1580744212.006626,"delta_ms":0},{"type":"end_transit","properties":1580744212.223,"event_timestamp":1580744212.223644}],"version":"6.2.1","history_version":"1.0.0"}"""
         val replayHistoryMapper = ReplayHistoryMapper(customEventMapper = ExampleCustomEventMapper())
         val historyEvents = replayHistoryMapper.mapToReplayEvents(historyString)
-        assertEquals(historyEvents.events.size, 4)
+        assertEquals(historyEvents.size, 4)
     }
 
     @Test
@@ -61,7 +61,7 @@ class ReplayHistoryMapperTest {
         val historyString = """{"events":[{"type":"getStatus","timestamp":1551460823.922}],"version":"5.0.0","history_version":"1.0.0"}"""
         val replayHistoryMapper = ReplayHistoryMapper(customEventMapper = ExampleCustomEventMapper())
         val historyEvents = replayHistoryMapper.mapToReplayEvents(historyString)
-        assertEquals(historyEvents.events.size, 1)
+        assertEquals(historyEvents.size, 1)
     }
 
     private data class ExampleEndTransitEvent(


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Replaying a route requires us to be able to `pushEvents` and `seekTo` positions with the `ReplayHistoryPlayer`. This pull request adds these.

- [ ] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->