### PR TITLE
Added and adjusted examples test app snackbars

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/BaseRouterActivityJava.java
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/BaseRouterActivityJava.java
@@ -51,6 +51,7 @@ import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import timber.log.Timber;
 
+import static com.google.android.material.snackbar.Snackbar.LENGTH_SHORT;
 import static com.mapbox.mapboxsdk.log.Logger.DEBUG;
 import static com.mapbox.mapboxsdk.log.Logger.ERROR;
 import static com.mapbox.mapboxsdk.log.Logger.INFO;
@@ -151,7 +152,7 @@ public abstract class BaseRouterActivityJava extends AppCompatActivity
       style.addImage(MARKER_ROUTE, image);
       navigationMapRoute = new NavigationMapRoute(mapView, mapboxMap);
       symbolManager = new SymbolManager(mapView, mapboxMap, style);
-      Snackbar.make(findViewById(R.id.container), "Tap map to place waypoint", Snackbar.LENGTH_LONG)
+      Snackbar.make(findViewById(R.id.container), R.string.msg_tap_map_to_place_waypoint, LENGTH_SHORT)
           .show();
       newOrigin();
     });
@@ -217,7 +218,7 @@ public abstract class BaseRouterActivityJava extends AppCompatActivity
       addMarker(waypoint);
       findRoute();
     } else {
-      Toast.makeText(this, "Only 2 waypoints supported for this example", Toast.LENGTH_LONG).show();
+      Toast.makeText(this, R.string.only_two_waypoints_supported, Toast.LENGTH_LONG).show();
       clearMap();
     }
     return false;

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/BaseRouterActivityKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/BaseRouterActivityKt.kt
@@ -8,6 +8,7 @@ import androidx.annotation.DrawableRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import com.google.android.material.snackbar.Snackbar
+import com.google.android.material.snackbar.Snackbar.LENGTH_SHORT
 import com.mapbox.api.directions.v5.DirectionsCriteria
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.RouteOptions
@@ -99,11 +100,8 @@ abstract class BaseRouterActivityKt :
             style.addImage(MARKER_ROUTE, R.drawable.mapbox_marker_icon_default)
             navigationMapRoute = NavigationMapRoute(mapView, mapboxMap)
             symbolManager = SymbolManager(mapView, mapboxMap, style)
-            Snackbar.make(
-                findViewById(R.id.container),
-                "Tap map to place waypoint",
-                Snackbar.LENGTH_LONG
-            ).show()
+            Snackbar.make(findViewById(R.id.container), R.string.msg_tap_map_to_place_waypoint,
+                LENGTH_SHORT).show()
             newOrigin()
         }
     }

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/BasicNavigationActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/BasicNavigationActivity.kt
@@ -7,6 +7,7 @@ import android.preference.PreferenceManager
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.snackbar.Snackbar
+import com.google.android.material.snackbar.Snackbar.LENGTH_SHORT
 import com.mapbox.android.core.location.LocationEngine
 import com.mapbox.android.core.location.LocationEngineCallback
 import com.mapbox.android.core.location.LocationEngineProvider
@@ -81,7 +82,7 @@ class BasicNavigationActivity : AppCompatActivity(), OnMapReadyCallback {
         )
 
         initListeners()
-        Snackbar.make(container, R.string.msg_long_press_for_destination, Snackbar.LENGTH_LONG)
+        Snackbar.make(container, R.string.msg_long_press_map_to_place_waypoint, LENGTH_SHORT)
             .show()
     }
 

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/DebugMapboxNavigationKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/DebugMapboxNavigationKt.kt
@@ -11,6 +11,8 @@ import android.widget.Button
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
+import com.google.android.material.snackbar.Snackbar
+import com.google.android.material.snackbar.Snackbar.LENGTH_SHORT
 import com.mapbox.android.core.location.LocationEngine
 import com.mapbox.android.core.location.LocationEngineCallback
 import com.mapbox.android.core.location.LocationEngineProvider
@@ -210,7 +212,8 @@ class DebugMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
                 })
             }
         }
-
+        Snackbar.make(findViewById(R.id.container), R.string.msg_long_press_map_to_place_waypoint,
+                LENGTH_SHORT).show()
         initializeSpeechPlayer()
     }
 

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/FasterRouteActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/FasterRouteActivity.kt
@@ -10,7 +10,7 @@ import android.view.View.VISIBLE
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.snackbar.Snackbar
-import com.google.android.material.snackbar.Snackbar.LENGTH_LONG
+import com.google.android.material.snackbar.Snackbar.LENGTH_SHORT
 import com.mapbox.android.core.location.LocationEngineCallback
 import com.mapbox.android.core.location.LocationEngineProvider
 import com.mapbox.android.core.location.LocationEngineRequest
@@ -248,7 +248,7 @@ class FasterRouteActivity : AppCompatActivity(), OnMapReadyCallback {
 
     @SuppressLint("MissingPermission")
     private fun initListeners() {
-        Snackbar.make(container, R.string.msg_long_press_for_destination, LENGTH_LONG).show()
+        Snackbar.make(container, R.string.msg_long_press_map_to_place_waypoint, LENGTH_SHORT).show()
         bottomSheetBehavior = BottomSheetBehavior.from(bottomSheetFasterRoute)
         bottomSheetBehavior.peekHeight = 0
         fasterRouteAcceptProgress.max = MAX_PROGRESS.toInt()

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/InstructionViewActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/InstructionViewActivity.kt
@@ -9,7 +9,7 @@ import android.view.View.GONE
 import android.view.View.VISIBLE
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.snackbar.Snackbar
-import com.google.android.material.snackbar.Snackbar.LENGTH_LONG
+import com.google.android.material.snackbar.Snackbar.LENGTH_SHORT
 import com.mapbox.android.core.location.LocationEngine
 import com.mapbox.android.core.location.LocationEngineCallback
 import com.mapbox.android.core.location.LocationEngineProvider
@@ -301,7 +301,7 @@ class InstructionViewActivity : AppCompatActivity(), OnMapReadyCallback,
         startNavigation.visibility = VISIBLE
         startNavigation.isEnabled = false
         instructionView.visibility = GONE
-        Snackbar.make(container, R.string.msg_long_press_for_destination, LENGTH_LONG).show()
+        Snackbar.make(container, R.string.msg_long_press_map_to_place_waypoint, LENGTH_SHORT).show()
         feedbackButton = instructionView.retrieveFeedbackButton().apply {
             hide()
             addOnClickListener {

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/ReRouteActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/ReRouteActivity.kt
@@ -7,7 +7,7 @@ import android.view.View.GONE
 import android.view.View.VISIBLE
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.snackbar.Snackbar
-import com.google.android.material.snackbar.Snackbar.LENGTH_LONG
+import com.google.android.material.snackbar.Snackbar.LENGTH_SHORT
 import com.mapbox.android.core.location.LocationEngineCallback
 import com.mapbox.android.core.location.LocationEngineProvider
 import com.mapbox.android.core.location.LocationEngineRequest
@@ -217,7 +217,7 @@ class ReRouteActivity : AppCompatActivity(), OnMapReadyCallback {
 
     @SuppressLint("MissingPermission")
     private fun initListeners() {
-        Snackbar.make(container, R.string.msg_long_press_for_destination, LENGTH_LONG).show()
+        Snackbar.make(container, R.string.msg_long_press_map_to_place_waypoint, LENGTH_SHORT).show()
         startNavigation.setOnClickListener {
             if (mapboxNavigation.getRoutes().isNotEmpty()) {
                 navigationMapboxMap.updateLocationLayerRenderMode(RenderMode.GPS)

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayActivity.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.snackbar.Snackbar
+import com.google.android.material.snackbar.Snackbar.LENGTH_SHORT
 import com.mapbox.android.core.location.LocationEngine
 import com.mapbox.android.core.location.LocationEngineCallback
 import com.mapbox.android.core.location.LocationEngineProvider
@@ -175,8 +176,7 @@ class ReplayActivity : AppCompatActivity(), OnMapReadyCallback {
         super.onStart()
         mapView.onStart()
         mapboxNavigation?.registerLocationObserver(locationObserver)
-        Snackbar.make(container, R.string.msg_long_press_for_destination, Snackbar.LENGTH_SHORT)
-            .show()
+        Snackbar.make(container, R.string.msg_long_press_map_to_place_waypoint, LENGTH_SHORT).show()
     }
 
     public override fun onResume() {

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/SimpleMapboxNavigationKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/SimpleMapboxNavigationKt.kt
@@ -11,8 +11,10 @@ import android.view.View.GONE
 import android.view.View.VISIBLE
 import android.widget.Button
 import android.widget.Toast
+import android.widget.Toast.LENGTH_SHORT
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.snackbar.Snackbar
 import com.mapbox.android.core.location.LocationEngine
 import com.mapbox.android.core.location.LocationEngineCallback
 import com.mapbox.android.core.location.LocationEngineProvider
@@ -213,7 +215,8 @@ class SimpleMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
                 replayRouteLocationEngine.assign(route)
             }
         }
-
+        Snackbar.make(findViewById(R.id.container), getString(R.string.msg_long_press_map_to_place_waypoint),
+                LENGTH_SHORT).show()
         initializeSpeechPlayer()
     }
 

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/SummaryBottomSheetActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/SummaryBottomSheetActivity.kt
@@ -10,6 +10,8 @@ import android.widget.ImageButton
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.AppCompatImageButton
 import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.snackbar.Snackbar
+import com.google.android.material.snackbar.Snackbar.LENGTH_SHORT
 import com.mapbox.android.core.location.LocationEngine
 import com.mapbox.android.core.location.LocationEngineCallback
 import com.mapbox.android.core.location.LocationEngineProvider
@@ -166,6 +168,9 @@ class SummaryBottomSheetActivity : AppCompatActivity(), OnMapReadyCallback {
                 addProgressChangeListener(mapboxNavigation)
                 setCamera(DynamicCamera(mapboxMap))
             }
+            Snackbar.make(findViewById(R.id.navigationLayout),
+                    R.string.msg_long_press_map_to_place_waypoint,
+                    LENGTH_SHORT).show()
         }
     }
 

--- a/examples/src/main/java/com/mapbox/navigation/examples/ui/CustomUIComponentStyleActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/ui/CustomUIComponentStyleActivity.kt
@@ -10,6 +10,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.AppCompatImageButton
 import androidx.core.content.ContextCompat
 import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.snackbar.Snackbar
 import com.mapbox.android.core.location.LocationEngine
 import com.mapbox.android.core.location.LocationEngineCallback
 import com.mapbox.android.core.location.LocationEngineProvider
@@ -197,6 +198,9 @@ class CustomUIComponentStyleActivity : AppCompatActivity(), OnMapReadyCallback,
                 addProgressChangeListener(mapboxNavigation)
                 setCamera(DynamicCamera(mapboxMap))
             }
+            Snackbar.make(findViewById(R.id.navigationLayout),
+                    R.string.msg_long_press_map_to_place_waypoint,
+                    Snackbar.LENGTH_SHORT).show()
         }
     }
 

--- a/examples/src/main/res/values/strings.xml
+++ b/examples/src/main/res/values/strings.xml
@@ -104,8 +104,10 @@
     <string name="default_unit_type" translatable="false">default_for_device</string>
     <string name="start_navigation" translatable="false">Start Navigation</string>
     <string name="play_history" translatable="false">Play history</string>
-    <string name="offline_region_download_title">Download offline region</string>
-    <string name="msg_long_press_for_destination">Long press a point on the map to indicate a destination.</string>
+    <string name="offline_region_download_title" translatable="false">Download offline region</string>
+    <string name="msg_long_press_map_to_place_waypoint" translatable="false">Long press on the map to place a waypoint</string>
+    <string name="msg_tap_map_to_place_waypoint" translatable="false">Tap on the map to place a waypoint</string>
+    <string name="only_two_waypoints_supported" translatable="false">Only two waypoints are supported for this example</string>
     <string name="offline_category_title" translatable="false">Offline</string>
     <string name="offline_enabled_title" translatable="false">Offline routing enabled</string>
     <string name="offline_version_title" translatable="false">Choose offline version</string>


### PR DESCRIPTION
## Description

The `examples` test app activities needed instructional snackbars. For users who are unfamiliar with the test app examples, it's not obvious when the next action should be after opening the specific example.

- [ ] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

## Screenshots or Gifs

<img width="381" alt="Screen Shot 2020-04-15 at 1 11 53 PM" src="https://user-images.githubusercontent.com/4394910/79383816-b0c81000-7f1a-11ea-9eb0-3eabfaf2a89b.png">

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->