### PR TITLE
Fix navigator prediction naming

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/DebugMapboxNavigationKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/DebugMapboxNavigationKt.kt
@@ -155,7 +155,7 @@ class DebugMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
         val newOptions =
                 options.toBuilder()
                         .onboardRouterConfig(onboardRouterConfig)
-                        .navigatorPollingDelay(1000L)
+                        .navigatorPredictionMillis(1000L)
                         .build()
 
         mapboxNavigation = getMapboxNavigation(newOptions)

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/NavigationOptions.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/NavigationOptions.kt
@@ -7,22 +7,25 @@ import com.mapbox.navigation.base.typedef.RoundingIncrement
 import com.mapbox.navigation.base.typedef.TimeFormatType
 
 /**
- * Default navigation pooling delay
+ * Default navigator approximate prediction in milliseconds
+ *
+ * This value will be used to offset the time at which the current location was calculated
+ * in such a way as to project the location forward along the current trajectory so as to
+ * appear more in sync with the users ground-truth location
  */
-const val DEFAULT_NAVIGATOR_POLLING_DELAY = 1500L
+const val DEFAULT_NAVIGATOR_PREDICTION_MILLIS = 1500L
 
 /**
  * Defines navigation options
  *
  * @param roundingIncrement defines the increment displayed on the instruction view
  * @param timeFormatType defines time format for calculation remaining trip time
- * @param navigatorPollingDelay defines approximate location engine interval lag in milliseconds
+ * @param navigatorPredictionMillis defines approximate navigator prediction in milliseconds
  *
  * This value will be used to offset the time at which the current location was calculated
  * in such a way as to project the location forward along the current trajectory so as to
  * appear more in sync with the users ground-truth location
  *
- * @param fasterRouteDetectorInterval defines time interval in milliseconds for detection is faster route available
  * @param distanceFormatter [DistanceFormatter] for format distances showing in notification during navigation
  * @param onboardRouterConfig [MapboxOnboardRouterConfig] defines configuration for the default on-board router
  * @param isFromNavigationUi Boolean *true* if is called from UI, otherwise *false*
@@ -31,7 +34,7 @@ const val DEFAULT_NAVIGATOR_POLLING_DELAY = 1500L
 data class NavigationOptions constructor(
     @RoundingIncrement val roundingIncrement: Int,
     @TimeFormatType val timeFormatType: Int,
-    val navigatorPollingDelay: Long,
+    val navigatorPredictionMillis: Long,
     val distanceFormatter: DistanceFormatter?,
     val onboardRouterConfig: MapboxOnboardRouterConfig?,
     val isFromNavigationUi: Boolean = false,
@@ -44,7 +47,7 @@ data class NavigationOptions constructor(
     fun toBuilder() = Builder()
         .roundingIncrement(roundingIncrement)
         .timeFormatType(timeFormatType)
-        .navigatorPollingDelay(navigatorPollingDelay)
+        .navigatorPredictionMillis(navigatorPredictionMillis)
         .distanceFormatter(distanceFormatter)
         .onboardRouterConfig(onboardRouterConfig)
         .isFromNavigationUi(isFromNavigationUi)
@@ -55,7 +58,7 @@ data class NavigationOptions constructor(
     class Builder {
         private var roundingIncrement: Int = ROUNDING_INCREMENT_FIFTY
         private var timeFormatType: Int = NONE_SPECIFIED
-        private var navigatorPollingDelay: Long = DEFAULT_NAVIGATOR_POLLING_DELAY
+        private var navigatorPredictionMillis: Long = DEFAULT_NAVIGATOR_PREDICTION_MILLIS
         private var distanceFormatter: DistanceFormatter? = null
         private var onboardRouterConfig: MapboxOnboardRouterConfig? = null
         private var isFromNavigationUi: Boolean = false
@@ -74,10 +77,10 @@ data class NavigationOptions constructor(
             apply { this.timeFormatType = type }
 
         /**
-         * Defines approximate location engine interval lag in milliseconds
+         * Defines approximate navigator prediction in milliseconds
          */
-        fun navigatorPollingDelay(pollingDelay: Long) =
-            apply { navigatorPollingDelay = pollingDelay }
+        fun navigatorPredictionMillis(predictionMillis: Long) =
+            apply { navigatorPredictionMillis = predictionMillis }
 
         /**
          *  Defines format distances showing in notification during navigation
@@ -111,7 +114,7 @@ data class NavigationOptions constructor(
             return NavigationOptions(
                 roundingIncrement = roundingIncrement,
                 timeFormatType = timeFormatType,
-                navigatorPollingDelay = navigatorPollingDelay,
+                navigatorPredictionMillis = navigatorPredictionMillis,
                 distanceFormatter = distanceFormatter,
                 onboardRouterConfig = onboardRouterConfig,
                 isFromNavigationUi = isFromNavigationUi,

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/route/options/NavigationOptionsTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/route/options/NavigationOptionsTest.kt
@@ -2,7 +2,7 @@ package com.mapbox.navigation.base.route.options
 
 import android.text.SpannableString
 import com.mapbox.navigation.base.formatter.DistanceFormatter
-import com.mapbox.navigation.base.options.DEFAULT_NAVIGATOR_POLLING_DELAY
+import com.mapbox.navigation.base.options.DEFAULT_NAVIGATOR_PREDICTION_MILLIS
 import com.mapbox.navigation.base.options.MapboxOnboardRouterConfig
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.typedef.NONE_SPECIFIED
@@ -21,7 +21,7 @@ class NavigationOptionsTest {
 
         assertEquals(options.roundingIncrement, ROUNDING_INCREMENT_FIFTY)
         assertEquals(options.timeFormatType, NONE_SPECIFIED)
-        assertEquals(options.navigatorPollingDelay, DEFAULT_NAVIGATOR_POLLING_DELAY)
+        assertEquals(options.navigatorPredictionMillis, DEFAULT_NAVIGATOR_PREDICTION_MILLIS)
         assertEquals(options.distanceFormatter, null)
         assertEquals(options.onboardRouterConfig, null)
     }
@@ -30,7 +30,7 @@ class NavigationOptionsTest {
     fun whenBuilderBuildCalledThenProperNavigationOptionsCreated() {
         val timeFormat = TWELVE_HOURS
         val roundingIncrement = ROUNDING_INCREMENT_TEN
-        val pollingDelay = 1020L
+        val navigatorPredictionMillis = 1020L
         val distanceFormatter = object : DistanceFormatter {
             override fun formatDistance(distance: Double): SpannableString {
                 throw NotImplementedError()
@@ -41,14 +41,14 @@ class NavigationOptionsTest {
         val options = NavigationOptions.Builder()
             .timeFormatType(timeFormat)
             .roundingIncrement(roundingIncrement)
-            .navigatorPollingDelay(pollingDelay)
+            .navigatorPredictionMillis(navigatorPredictionMillis)
             .distanceFormatter(distanceFormatter)
             .onboardRouterConfig(routerConfig)
             .build()
 
         assertEquals(options.roundingIncrement, roundingIncrement)
         assertEquals(options.timeFormatType, timeFormat)
-        assertEquals(options.navigatorPollingDelay, pollingDelay)
+        assertEquals(options.navigatorPredictionMillis, navigatorPredictionMillis)
         assertEquals(options.distanceFormatter, distanceFormatter)
         assertEquals(options.onboardRouterConfig, routerConfig)
     }
@@ -57,7 +57,7 @@ class NavigationOptionsTest {
     fun whenOptionsValuesChangedThenAllOtherValuesSaved() {
         val timeFormat = TWELVE_HOURS
         val roundingIncrement = ROUNDING_INCREMENT_TEN
-        val pollingDelay = 1020L
+        val navigatorPredictionMillis = 1020L
         val distanceFormatter = object : DistanceFormatter {
             override fun formatDistance(distance: Double): SpannableString {
                 throw NotImplementedError()
@@ -68,22 +68,22 @@ class NavigationOptionsTest {
         var options = NavigationOptions.Builder()
             .timeFormatType(timeFormat)
             .roundingIncrement(roundingIncrement)
-            .navigatorPollingDelay(pollingDelay)
+            .navigatorPredictionMillis(navigatorPredictionMillis)
             .distanceFormatter(distanceFormatter)
             .onboardRouterConfig(routerConfig)
             .build()
 
         val builder = options.toBuilder()
         val newTimeFormat = TWENTY_FOUR_HOURS
-        val newPollingDelay = 900L
+        val newNavigatorPredictionMillis = 900L
         options = builder
             .timeFormatType(newTimeFormat)
-            .navigatorPollingDelay(newPollingDelay)
+            .navigatorPredictionMillis(newNavigatorPredictionMillis)
             .build()
 
         assertEquals(options.roundingIncrement, roundingIncrement)
         assertEquals(options.timeFormatType, newTimeFormat)
-        assertEquals(options.navigatorPollingDelay, newPollingDelay)
+        assertEquals(options.navigatorPredictionMillis, newNavigatorPredictionMillis)
         assertEquals(options.distanceFormatter, distanceFormatter)
         assertEquals(options.onboardRouterConfig, routerConfig)
     }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -14,7 +14,7 @@ import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.RouteOptions
 import com.mapbox.common.module.provider.MapboxModuleProvider
 import com.mapbox.navigation.base.accounts.SkuTokenProvider
-import com.mapbox.navigation.base.options.DEFAULT_NAVIGATOR_POLLING_DELAY
+import com.mapbox.navigation.base.options.DEFAULT_NAVIGATOR_PREDICTION_MILLIS
 import com.mapbox.navigation.base.options.Endpoint
 import com.mapbox.navigation.base.options.MapboxOnboardRouterConfig
 import com.mapbox.navigation.base.options.NavigationOptions
@@ -173,7 +173,7 @@ constructor(
             tripService,
             locationEngine,
             locationEngineRequest,
-            navigationOptions.navigatorPollingDelay
+            navigationOptions.navigatorPredictionMillis
         )
         tripSession.registerOffRouteObserver(internalOffRouteObserver)
         tripSession.registerStateObserver(navigationSession)
@@ -615,7 +615,7 @@ constructor(
             val builder = NavigationOptions.Builder()
                 .timeFormatType(NONE_SPECIFIED)
                 .roundingIncrement(ROUNDING_INCREMENT_FIFTY)
-                .navigatorPollingDelay(DEFAULT_NAVIGATOR_POLLING_DELAY)
+                .navigatorPredictionMillis(DEFAULT_NAVIGATOR_PREDICTION_MILLIS)
                 .distanceFormatter(distanceFormatter)
 
             // TODO provide a production routing tiles endpoint

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/NavigationComponentProvider.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/NavigationComponentProvider.kt
@@ -28,12 +28,12 @@ internal object NavigationComponentProvider {
         tripService: TripService,
         locationEngine: LocationEngine,
         locationEngineRequest: LocationEngineRequest,
-        navigatorPollingDelay: Long
+        navigatorPredictionMillis: Long
     ): TripSession = MapboxTripSession(
         tripService,
         locationEngine,
         locationEngineRequest,
-        navigatorPollingDelay
+        navigatorPredictionMillis
     )
 
     fun createNavigationSession(): NavigationSession = NavigationSession()

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
@@ -38,7 +38,7 @@ import kotlinx.coroutines.withContext
  * @param tripService TripService
  * @param locationEngine LocationEngine
  * @param locationEngineRequest LocationEngineRequest
- * @param navigatorPollingDelay delay fon navigation status predictions.
+ * @param navigatorPredictionMillis millis for navigation status predictions
  * For more information see [MapboxNativeNavigator.getStatus]. Unit is milliseconds
  * @param navigator Native navigator
  *
@@ -48,7 +48,7 @@ class MapboxTripSession(
     override val tripService: TripService,
     override val locationEngine: LocationEngine,
     override val locationEngineRequest: LocationEngineRequest,
-    private val navigatorPollingDelay: Long,
+    private val navigatorPredictionMillis: Long,
     private val navigator: MapboxNativeNavigator = MapboxNativeNavigatorImpl,
     threadController: ThreadController = ThreadController
 ) : TripSession {
@@ -407,7 +407,7 @@ class MapboxTripSession(
 
     private suspend fun getNavigatorStatus(date: Date): TripStatus =
         withContext(ioJobController.scope.coroutineContext) {
-            date.time = date.time + navigatorPollingDelay
+            date.time = date.time + navigatorPredictionMillis
             navigator.getStatus(date)
         }
 

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
@@ -125,7 +125,7 @@ class MapboxNavigationTest {
         val navigationOptions = NavigationOptions
             .Builder()
             .distanceFormatter(distanceFormatter)
-            .navigatorPollingDelay(1500L)
+            .navigatorPredictionMillis(1500L)
             .onboardRouterConfig(onBoardRouterConfig)
             .roundingIncrement(1)
             .timeFormatType(NONE_SPECIFIED)

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
@@ -68,7 +68,7 @@ class MapboxTripSessionTest {
     private val tripStatus: TripStatus = mockk(relaxUnitFun = true)
 
     private val routeProgress: RouteProgress = mockk()
-    private val navigatorPollingDelay = 1500L
+    private val navigatorPredictionMillis = 1500L
 
     private val parentJob = SupervisorJob()
     private val testScope = CoroutineScope(parentJob + coroutineRule.testDispatcher)
@@ -86,7 +86,7 @@ class MapboxTripSessionTest {
             tripService,
             locationEngine,
             locationEngineRequest,
-            navigatorPollingDelay,
+            navigatorPredictionMillis,
             navigator
         )
 
@@ -224,7 +224,7 @@ class MapboxTripSessionTest {
             tripService,
             locationEngine,
             locationEngineRequest,
-            navigatorPollingDelay,
+            navigatorPredictionMillis,
             navigator,
             ThreadController
         )
@@ -244,7 +244,7 @@ class MapboxTripSessionTest {
             tripService,
             locationEngine,
             locationEngineRequest,
-            navigatorPollingDelay,
+            navigatorPredictionMillis,
             navigator,
             ThreadController
         )
@@ -264,7 +264,7 @@ class MapboxTripSessionTest {
             tripService,
             locationEngine,
             locationEngineRequest,
-            navigatorPollingDelay,
+            navigatorPredictionMillis,
             navigator,
             ThreadController
         )
@@ -284,7 +284,7 @@ class MapboxTripSessionTest {
             tripService,
             locationEngine,
             locationEngineRequest,
-            navigatorPollingDelay,
+            navigatorPredictionMillis,
             navigator,
             ThreadController
         )
@@ -305,7 +305,7 @@ class MapboxTripSessionTest {
             tripService,
             locationEngine,
             locationEngineRequest,
-            navigatorPollingDelay,
+            navigatorPredictionMillis,
             navigator,
             ThreadController
         )
@@ -325,7 +325,7 @@ class MapboxTripSessionTest {
             tripService,
             locationEngine,
             locationEngineRequest,
-            navigatorPollingDelay,
+            navigatorPredictionMillis,
             navigator,
             ThreadController
         )
@@ -345,7 +345,7 @@ class MapboxTripSessionTest {
             tripService,
             locationEngine,
             locationEngineRequest,
-            navigatorPollingDelay,
+            navigatorPredictionMillis,
             navigator,
             ThreadController
         )
@@ -468,7 +468,7 @@ class MapboxTripSessionTest {
             tripService,
             locationEngine,
             locationEngineRequest,
-            navigatorPollingDelay,
+            navigatorPredictionMillis,
             navigator,
             ThreadController
         )
@@ -489,7 +489,7 @@ class MapboxTripSessionTest {
             tripService,
             locationEngine,
             locationEngineRequest,
-            navigatorPollingDelay,
+            navigatorPredictionMillis,
             navigator,
             ThreadController
         )
@@ -535,7 +535,7 @@ class MapboxTripSessionTest {
             tripService,
             locationEngine,
             locationEngineRequest,
-            navigatorPollingDelay,
+            navigatorPredictionMillis,
             navigator,
             ThreadController
         )
@@ -568,7 +568,7 @@ class MapboxTripSessionTest {
             tripService,
             locationEngine,
             locationEngineRequest,
-            navigatorPollingDelay,
+            navigatorPredictionMillis,
             navigator,
             ThreadController
         )


### PR DESCRIPTION
## Description

Fixes navigator prediction naming from navigator polling delay to navigator prediction ~interval lag~ millis (https://github.com/mapbox/mapbox-navigation-android/pull/2785#discussion_r409880569)

Refs. https://github.com/mapbox/mapbox-navigation-android/pull/2719#discussion_r406421661

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Improve naming that better reflects the purpose

### Implementation

Replaced `navigatorPollingDelay` by ~`navigatorPredictionIntervalLag`~ `navigatorPredictionMillis` and `DEFAULT_NAVIGATOR_POLLING_DELAY` by ~`DEFAULT_NAVIGATOR_PREDICTION_INTERVAL_LAG`~ `DEFAULT_NAVIGATOR_PREDICTION_MILLIS`. Fixed docs too.

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR

cc @mskurydin 