### PR TITLE
Add arrival controller for multiple stops

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/stops/ArrivalController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/stops/ArrivalController.kt
@@ -1,0 +1,108 @@
+package com.mapbox.navigation.core.stops
+
+import com.mapbox.navigation.base.trip.model.RouteLegProgress
+import com.mapbox.navigation.base.trip.model.RouteProgress
+import com.mapbox.navigation.base.trip.model.RouteProgressState
+import com.mapbox.navigation.core.MapboxNavigation
+
+/**
+ * When navigating to points of interest, you may want to control the arrival
+ * experience. This interface gives you options to change arrival via [MapboxNavigation.attachArrivalController]
+ */
+interface ArrivalController {
+
+    /**
+     * Override the options for your arrival callback.
+     */
+    fun arrivalOptions(): ArrivalOptions
+
+    /**
+     * Based on your [ArrivalOptions], this will be called as the next stop is approached.
+     * To manually navigate the next leg, return false and call [MapboxNavigation.navigateNextRouteLeg]
+     *
+     * @return true to automatically move to the next step, false to do it manually
+     */
+    fun onStopArrival(routeLegProgress: RouteLegProgress): Boolean
+
+    /**
+     * Once the [RouteProgress.currentState] has reached [RouteProgressState.ROUTE_ARRIVED]
+     * for the last stop, this will be called once.
+     */
+    fun onRouteArrival(routeProgress: RouteProgress) {}
+}
+
+/**
+ * The default controller for arrival. This will move onto the next leg automatically
+ * if there is one.
+ */
+class AutoArrivalController : ArrivalController {
+
+    /**
+     * Default arrival options
+     */
+    override fun arrivalOptions(): ArrivalOptions = ArrivalOptions.Builder().build()
+
+    /**
+     * By default this will move onto the next step.
+     */
+    override fun onStopArrival(routeLegProgress: RouteLegProgress): Boolean {
+        return true
+    }
+}
+
+/**
+ * Choose when to be notified of arrival.
+ */
+data class ArrivalOptions(
+
+    /**
+     * While the next stop is less than [arrivalInSeconds] away,
+     * [ArrivalController.onStopArrival] will be called
+     */
+    val arrivalInSeconds: Double?,
+
+    /**
+     * While the next stop is less than [arrivalInMeters] away,
+     * [ArrivalController.onStopArrival] will be called
+     */
+    val arrivalInMeters: Double?
+) {
+    /**
+     * Build your arrival options.
+     */
+    class Builder {
+
+        private var arrivalInSeconds: Double? = 5.0
+        private var arrivalInMeters: Double? = 40.0
+
+        /**
+         * (Recommended) Use time estimation for arrival, arrival is influenced by traffic conditions.
+         * Arrive when the estimated time to a stop is less than or equal to this threshold
+         */
+        fun arriveInSeconds(arriveInSeconds: Double?): Builder {
+            this.arrivalInSeconds = arriveInSeconds
+            return this
+        }
+
+        /**
+         * Arrive when the estimated distance to a stop is less than or equal to this threshold
+         */
+        fun arriveInMeters(arriveInMeters: Double?): Builder {
+            this.arrivalInMeters = arriveInMeters
+            return this
+        }
+
+        /**
+         * Build the object. If you want to disable this feature use [MapboxNavigation.removeArrivalController]
+         */
+        fun build(): ArrivalOptions {
+            check(arrivalInSeconds != null || arrivalInSeconds != null) {
+                "Choose a method to be notified of arrival, time and/or distance."
+            }
+            return ArrivalOptions(
+                arrivalInSeconds = arrivalInSeconds,
+                arrivalInMeters = arrivalInMeters
+            )
+        }
+    }
+}

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/stops/ArrivalProgressObserver.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/stops/ArrivalProgressObserver.kt
@@ -1,0 +1,79 @@
+package com.mapbox.navigation.core.stops
+
+import com.mapbox.navigation.base.trip.RouteProgressObserver
+import com.mapbox.navigation.base.trip.model.RouteLegProgress
+import com.mapbox.navigation.base.trip.model.RouteProgress
+import com.mapbox.navigation.base.trip.model.RouteProgressState
+import com.mapbox.navigation.core.trip.session.TripSession
+
+internal class ArrivalProgressObserver(
+    private val tripSession: TripSession
+) : RouteProgressObserver {
+
+    private var arrivalController: ArrivalController = AutoArrivalController()
+    private var arrivedForRoute = false
+
+    fun attach(arrivalController: ArrivalController) {
+        this.arrivalController = arrivalController
+    }
+
+    fun navigateNextRouteLeg(): Boolean {
+        val numberOfLegs = tripSession.getRouteProgress()?.route()?.legs()?.size
+            ?: return false
+        val legIndex = tripSession.getRouteProgress()?.currentLegProgress()?.legIndex()
+            ?: return false
+        val nextLegIndex = legIndex + 1
+        return if (nextLegIndex < numberOfLegs) {
+            val navigationStatus = tripSession.updateLegIndex(nextLegIndex)
+            return nextLegIndex == navigationStatus.legIndex
+        } else {
+            true
+        }
+    }
+
+    override fun onRouteProgressChanged(routeProgress: RouteProgress) {
+        val routeLegProgress = routeProgress.currentLegProgress()
+            ?: return
+
+        val arrivalOptions = arrivalController.arrivalOptions()
+        if (routeProgress.currentState() == RouteProgressState.ROUTE_ARRIVED && !hasMoreLegs(routeProgress)) {
+            doOnRouteArrival(routeProgress)
+        } else if (arrivalOptions.arrivalInSeconds != null) {
+            checkStopArrivalTime(arrivalOptions.arrivalInSeconds, routeLegProgress)
+        } else if (arrivalOptions.arrivalInMeters != null) {
+            checkStopArrivalDistance(arrivalOptions.arrivalInMeters, routeLegProgress)
+        }
+        arrivedForRoute = (routeProgress.currentState() ?: RouteProgressState.ROUTE_UNCERTAIN) == RouteProgressState.ROUTE_ARRIVED
+    }
+
+    private fun hasMoreLegs(routeProgress: RouteProgress): Boolean {
+        val currentLegIndex = routeProgress.currentLegProgress()?.legIndex()
+        val lastLegIndex = routeProgress.route()?.legs()?.lastIndex
+        return (currentLegIndex != null && lastLegIndex != null) && currentLegIndex < lastLegIndex
+    }
+
+    private fun checkStopArrivalTime(arrivalInSeconds: Double, routeLegProgress: RouteLegProgress) {
+        if (routeLegProgress.durationRemaining() <= arrivalInSeconds) {
+            doOnStopArrival(routeLegProgress)
+        }
+    }
+
+    private fun checkStopArrivalDistance(arrivalInMeters: Double, routeLegProgress: RouteLegProgress) {
+        if (routeLegProgress.distanceRemaining() <= arrivalInMeters) {
+            doOnStopArrival(routeLegProgress)
+        }
+    }
+
+    private fun doOnStopArrival(routeLegProgress: RouteLegProgress) {
+        val moveToNextLeg = arrivalController.onStopArrival(routeLegProgress)
+        if (moveToNextLeg) {
+            navigateNextRouteLeg()
+        }
+    }
+
+    private fun doOnRouteArrival(routeProgress: RouteProgress) {
+        if (!arrivedForRoute) {
+            arrivalController.onRouteArrival(routeProgress)
+        }
+    }
+}

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
@@ -24,6 +24,7 @@ import com.mapbox.navigation.navigator.internal.TripStatus
 import com.mapbox.navigation.utils.internal.JobControl
 import com.mapbox.navigation.utils.internal.ThreadController
 import com.mapbox.navigation.utils.internal.ifNonNull
+import com.mapbox.navigator.NavigationStatus
 import java.util.Date
 import java.util.concurrent.CopyOnWriteArraySet
 import java.util.concurrent.TimeUnit
@@ -339,6 +340,19 @@ class MapboxTripSession(
         SensorMapper.toSensorData(sensorEvent, logger)?.let { sensorData ->
             navigator.updateSensorData(sensorData)
         }
+    }
+
+    /**
+     * Follows a new leg of the already loaded directions.
+     * Returns an initialized navigation status if no errors occurred
+     * otherwise, it returns an invalid navigation status state.
+     *
+     * @param legIndex new leg index
+     *
+     * @return an initialized [NavigationStatus] if no errors, invalid otherwise
+     */
+    override fun updateLegIndex(legIndex: Int): NavigationStatus {
+        return navigator.updateLegIndex(legIndex)
     }
 
     /**

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/TripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/TripSession.kt
@@ -8,6 +8,7 @@ import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.navigation.base.trip.RouteProgressObserver
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.trip.service.TripService
+import com.mapbox.navigator.NavigationStatus
 
 internal interface TripSession {
 
@@ -50,4 +51,5 @@ internal interface TripSession {
     fun updateSensorEvent(sensorEvent: SensorEvent)
 
     fun useExtendedKalmanFilter(useEKF: Boolean)
+    fun updateLegIndex(legIndex: Int): NavigationStatus
 }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/stops/ArrivalProgressObserverTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/stops/ArrivalProgressObserverTest.kt
@@ -1,0 +1,327 @@
+package com.mapbox.navigation.core.stops
+
+import com.mapbox.navigation.base.trip.model.RouteLegProgress
+import com.mapbox.navigation.base.trip.model.RouteProgress
+import com.mapbox.navigation.base.trip.model.RouteProgressState
+import com.mapbox.navigation.core.trip.session.TripSession
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+internal class ArrivalProgressObserverTest {
+
+    private val tripSession: TripSession = mockk()
+    private val arrivalProgressObserver = ArrivalProgressObserver(tripSession)
+
+    @Before
+    fun setup() {
+        every { tripSession.getRouteProgress() } returns null
+    }
+
+    @Test
+    fun `should not crash with null route progress values`() {
+        val routeProgress: RouteProgress = mockk {
+            every { currentState() } returns RouteProgressState.LOCATION_TRACKING
+            every { route() } returns mockk {
+                every { legs() } returns listOf(
+                    mockk(), mockk(), mockk() // This route has three legs
+                )
+                every { routeIndex() } returns null
+                every { currentLegProgress() } returns mockk {
+                    every { legIndex() } returns 0
+                    every { durationRemaining() } returns 0.0
+                    every { distanceRemaining() } returns 0.0f
+                }
+            }
+        }
+
+        arrivalProgressObserver.onRouteProgressChanged(routeProgress)
+    }
+
+    @Test
+    fun `should notify stop arrival when arrived at waypoint`() {
+        val onStopArrivalCalls = slot<RouteLegProgress>()
+        val onRouteArrivalCalls = slot<RouteProgress>()
+        val customArrivalController: ArrivalController = mockk {
+            every { onStopArrival(capture(onStopArrivalCalls)) } returns false
+            every { onRouteArrival(capture(onRouteArrivalCalls)) } returns Unit
+            every { arrivalOptions() } returns mockk {
+                every { arrivalInSeconds } returns null
+                every { arrivalInMeters } returns 10.0
+            }
+        }
+
+        arrivalProgressObserver.attach(customArrivalController)
+        arrivalProgressObserver.onRouteProgressChanged(mockk {
+            every { currentState() } returns RouteProgressState.ROUTE_ARRIVED
+            every { route() } returns mockk {
+                every { legs() } returns listOf(mockk(), mockk(), mockk())
+            }
+            every { currentLegProgress() } returns mockk {
+                every { legIndex() } returns 1
+                every { durationRemaining() } returns 2.0
+                every { distanceRemaining() } returns 8.0f
+            }
+        })
+
+        assertTrue(onStopArrivalCalls.isCaptured)
+        assertFalse(onRouteArrivalCalls.isCaptured)
+    }
+
+    @Test
+    fun `should notify route arrival when arrived at last stop`() {
+        val onStopArrivalCalls = slot<RouteLegProgress>()
+        val onRouteArrivalCalls = slot<RouteProgress>()
+        val customArrivalController: ArrivalController = mockk {
+            every { onStopArrival(capture(onStopArrivalCalls)) } returns false
+            every { onRouteArrival(capture(onRouteArrivalCalls)) } returns Unit
+            every { arrivalOptions() } returns mockk {
+                every { arrivalInSeconds } returns null
+                every { arrivalInMeters } returns 10.0
+            }
+        }
+
+        arrivalProgressObserver.attach(customArrivalController)
+        arrivalProgressObserver.onRouteProgressChanged(mockk {
+            every { currentState() } returns RouteProgressState.ROUTE_ARRIVED
+            every { route() } returns mockk {
+                every { legs() } returns listOf(mockk(), mockk(), mockk())
+            }
+            every { currentLegProgress() } returns mockk {
+                every { legIndex() } returns 2
+                every { durationRemaining() } returns 2.0
+                every { distanceRemaining() } returns 8.0f
+            }
+        })
+
+        assertFalse(onStopArrivalCalls.isCaptured)
+        assertTrue(onRouteArrivalCalls.isCaptured)
+    }
+
+    @Test
+    fun `should notify route arrival when arrived at last stop only once`() {
+        val onStopArrivalCalls = slot<RouteLegProgress>()
+        val onRouteArrivalCalls = mutableListOf<RouteProgress>()
+        val customArrivalController: ArrivalController = mockk {
+            every { onStopArrival(capture(onStopArrivalCalls)) } returns false
+            every { onRouteArrival(capture(onRouteArrivalCalls)) } returns Unit
+            every { arrivalOptions() } returns mockk {
+                every { arrivalInSeconds } returns null
+                every { arrivalInMeters } returns 10.0
+            }
+        }
+        val routeProgress: RouteProgress = mockk {
+            every { currentState() } returns RouteProgressState.ROUTE_ARRIVED
+            every { route() } returns mockk {
+                every { legs() } returns listOf(mockk(), mockk(), mockk())
+            }
+            every { currentLegProgress() } returns mockk {
+                every { legIndex() } returns 2
+                every { durationRemaining() } returns 2.0
+                every { distanceRemaining() } returns 8.0f
+            }
+        }
+
+        arrivalProgressObserver.attach(customArrivalController)
+        arrivalProgressObserver.onRouteProgressChanged(routeProgress)
+        arrivalProgressObserver.onRouteProgressChanged(routeProgress)
+        arrivalProgressObserver.onRouteProgressChanged(routeProgress)
+
+        assertEquals(1, onRouteArrivalCalls.size)
+        assertFalse(onStopArrivalCalls.isCaptured)
+    }
+
+    @Test
+    fun `should notify observers with time option`() {
+        val onArrivalCalls = slot<RouteLegProgress>()
+        val customArrivalController: ArrivalController = mockk {
+            every { onStopArrival(capture(onArrivalCalls)) } returns false
+            every { arrivalOptions() } returns mockk {
+                every { arrivalInSeconds } returns 5.0
+                every { arrivalInMeters } returns null
+            }
+        }
+
+        arrivalProgressObserver.attach(customArrivalController)
+        arrivalProgressObserver.onRouteProgressChanged(mockk {
+            every { currentState() } returns RouteProgressState.LOCATION_TRACKING
+            every { currentLegProgress() } returns mockk {
+                every { durationRemaining() } returns 1.0
+                every { distanceRemaining() } returns 15.0f
+            }
+        })
+
+        assertTrue(onArrivalCalls.isCaptured)
+        assertEquals(onArrivalCalls.captured.durationRemaining(), 1.0, 0.001)
+    }
+
+    @Test
+    fun `should notify observers with distance option`() {
+        val onArrivalCalls = slot<RouteLegProgress>()
+        val customArrivalController: ArrivalController = mockk {
+            every { onStopArrival(capture(onArrivalCalls)) } returns false
+            every { arrivalOptions() } returns mockk {
+                every { arrivalInSeconds } returns null
+                every { arrivalInMeters } returns 10.0
+            }
+        }
+
+        arrivalProgressObserver.attach(customArrivalController)
+        arrivalProgressObserver.onRouteProgressChanged(mockk {
+            every { currentState() } returns RouteProgressState.LOCATION_TRACKING
+            every { currentLegProgress() } returns mockk {
+                every { durationRemaining() } returns 2.0
+                every { distanceRemaining() } returns 8.0f
+            }
+        })
+
+        assertEquals(onArrivalCalls.captured.distanceRemaining(), 8.0f, 0.001f)
+    }
+
+    @Test
+    fun `should notify arrival if arrived on attach`() {
+        val onArrivalCalls = slot<RouteLegProgress>()
+        val customArrivalController: ArrivalController = mockk {
+            every { onStopArrival(capture(onArrivalCalls)) } returns false
+            every { arrivalOptions() } returns mockk {
+                every { arrivalInSeconds } returns 5.0
+                every { arrivalInMeters } returns null
+            }
+        }
+        val routeProgress: RouteProgress = mockk {
+            every { currentState() } returns RouteProgressState.LOCATION_TRACKING
+            every { currentLegProgress() } returns mockk {
+                every { durationRemaining() } returns 1.0
+                every { distanceRemaining() } returns 15.0f
+            }
+        }
+        every { tripSession.getRouteProgress() } returns routeProgress
+
+        arrivalProgressObserver.attach(customArrivalController)
+        arrivalProgressObserver.onRouteProgressChanged(routeProgress)
+
+        assertTrue(onArrivalCalls.isCaptured)
+    }
+
+    @Test
+    fun `should not navigate to next stop before arrival`() {
+        val onArrivalCalls = slot<RouteLegProgress>()
+        val customArrivalController: ArrivalController = mockk {
+            every { onStopArrival(capture(onArrivalCalls)) } returns false
+            every { arrivalOptions() } returns mockk {
+                every { arrivalInMeters } returns 10.0
+                every { arrivalInSeconds } returns 5.0
+            }
+        }
+
+        arrivalProgressObserver.attach(customArrivalController)
+        arrivalProgressObserver.onRouteProgressChanged(mockk {
+            every { currentState() } returns RouteProgressState.LOCATION_TRACKING
+            every { currentLegProgress() } returns mockk {
+                every { durationRemaining() } returns 360.0
+                every { distanceRemaining() } returns 80.0f
+            }
+        })
+
+        assertFalse(onArrivalCalls.isCaptured)
+    }
+
+    @Test
+    fun `should navigate to next stop automatically by default`() {
+        every { tripSession.getRouteProgress() } returns mockk {
+            every { route() } returns mockk {
+                every { legs() } returns listOf(
+                    mockk(), mockk(), mockk() // This route has three legs
+                )
+                every { routeIndex() } returns "0"
+                every { currentLegProgress() } returns mockk {
+                    every { legIndex() } returns 1
+                }
+            }
+        }
+        every { tripSession.updateLegIndex(2) } returns mockk {
+            every { legIndex } returns 2
+        }
+
+        arrivalProgressObserver.onRouteProgressChanged(mockk {
+            every { currentState() } returns RouteProgressState.LOCATION_TRACKING
+            every { currentLegProgress() } returns mockk {
+                every { durationRemaining() } returns 0.0
+                every { distanceRemaining() } returns 0.0f
+            }
+        })
+
+        verify { tripSession.updateLegIndex(2) }
+    }
+
+    @Test
+    fun `should navigate to next stop automatically using options`() {
+        val testNavigateNextRouteLeg = true
+        val routeProgress: RouteProgress = mockk {
+            every { currentState() } returns RouteProgressState.LOCATION_TRACKING
+            every { route() } returns mockk {
+                every { legs() } returns listOf(
+                    mockk(), mockk(), mockk() // This route has three legs
+                )
+                every { routeIndex() } returns "0"
+                every { currentLegProgress() } returns mockk {
+                    every { legIndex() } returns 0
+                    every { durationRemaining() } returns 0.0
+                    every { distanceRemaining() } returns 0.0f
+                }
+            }
+        }
+        every { tripSession.getRouteProgress() } returns routeProgress
+        val customArrivalController: ArrivalController = mockk {
+            every { onStopArrival(any()) } returns testNavigateNextRouteLeg
+            every { arrivalOptions() } returns mockk {
+                every { arrivalInSeconds } returns 0.0
+                every { arrivalInMeters } returns null
+            }
+        }
+        every { tripSession.updateLegIndex(any()) } returns mockk {
+            every { legIndex } returns 1
+        }
+
+        arrivalProgressObserver.attach(customArrivalController)
+        arrivalProgressObserver.onRouteProgressChanged(routeProgress)
+
+        verify(exactly = 1) { tripSession.updateLegIndex(1) }
+    }
+
+    @Test
+    fun `should not navigate to next stop automatically using options`() {
+        val testNavigateNextRouteLeg = false
+        every { tripSession.getRouteProgress() } returns mockk {
+            every { currentState() } returns RouteProgressState.LOCATION_TRACKING
+            every { route() } returns mockk {
+                every { legs() } returns listOf(
+                    mockk(), mockk(), mockk() // This route has three legs
+                )
+                every { routeIndex() } returns "0"
+                every { currentLegProgress() } returns mockk {
+                    every { legIndex() } returns 0
+                    every { durationRemaining() } returns 0.0
+                    every { distanceRemaining() } returns 0.0f
+                }
+            }
+        }
+        val customArrivalController: ArrivalController = mockk {
+            every { onStopArrival(any()) } returns testNavigateNextRouteLeg
+            every { arrivalOptions() } returns mockk {
+                every { arrivalInSeconds } returns 0.0
+                every { arrivalInMeters } returns null
+            }
+        }
+
+        arrivalProgressObserver.attach(customArrivalController)
+
+        verify(exactly = 0) { tripSession.updateLegIndex(any()) }
+    }
+}

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigator.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigator.kt
@@ -121,15 +121,14 @@ interface MapboxNativeNavigator {
 
     /**
      * Follows a new route and leg of the already loaded directions.
-     * Returns an initialized route state if no errors occurred
-     * otherwise, it returns an invalid route state.
+     * Returns an initialized navigation status if no errors occurred
+     * otherwise, it returns an invalid navigation status state.
      *
-     * @param routeIndex new route index
      * @param legIndex new leg index
      *
-     * @return an initialized route state as [NavigationStatus]
+     * @return an initialized [NavigationStatus] if no errors, invalid otherwise
      */
-    fun updateLegIndex(routeIndex: Int, legIndex: Int): NavigationStatus
+    fun updateLegIndex(legIndex: Int): NavigationStatus
 
     // Free Drive
 

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigatorImpl.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigatorImpl.kt
@@ -51,6 +51,7 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
     private const val GRID_SIZE = 0.0025f
     private const val BUFFER_DILATION: Short = 1
     private const val TWO_LEGS: Short = 2
+    private const val PRIMARY_ROUTE_INDEX = 0
 
     private val navigator: Navigator = Navigator()
     private var route: DirectionsRoute? = null
@@ -180,16 +181,15 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
 
     /**
      * Follows a new route and leg of the already loaded directions.
-     * Returns an initialized route state if no errors occurred
-     * otherwise, it returns an invalid route state.
+     * Returns an initialized navigation status if no errors occurred
+     * otherwise, it returns an invalid navigation status state.
      *
-     * @param routeIndex new route index
      * @param legIndex new leg index
      *
-     * @return an initialized route state as [NavigationStatus]
+     * @return an initialized [NavigationStatus] if no errors, invalid otherwise
      */
-    override fun updateLegIndex(routeIndex: Int, legIndex: Int): NavigationStatus =
-        navigator.changeRouteLeg(routeIndex, legIndex)
+    override fun updateLegIndex(legIndex: Int): NavigationStatus =
+        navigator.changeRouteLeg(PRIMARY_ROUTE_INDEX, legIndex)
 
     // Free Drive
     /**


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Resolves: https://github.com/mapbox/navigation-sdks/issues/315

The arrival distances can be wildly incorrect so this may need to be fixed to make this interface work properly https://github.com/mapbox/mapbox-navigation-android/issues/2748

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

 - Provide a callback that notifies arrival for each stop https://github.com/mapbox/mapbox-navigation-android/issues/1904
 - Provide an interface to move to next leg
 - Provide an interface to stay at the current stop

### Implementation

Creating an interface with the options to control arrival, as well as moving to the next step.

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->