### PR TITLE
The same route object was retained between trip sessions.

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
@@ -167,6 +167,7 @@ class MapboxTripSession(
         enhancedLocation = null
         routeProgress = null
         isOffRoute = false
+        route = null
     }
 
     /**


### PR DESCRIPTION
##Description

Addresses #2782 in which it was noticed that when using a turn by turn navigation example activity and then using the free drive example activity the notification from the previous trip session was displayed. I discovered that route object was retained by the trip session.

