### PR TITLE
Sb 2782 fix notification not clearing

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -57,7 +57,6 @@ import java.io.File
 import java.lang.reflect.Field
 import java.net.URI
 import kotlinx.coroutines.channels.ReceiveChannel
-import kotlinx.coroutines.launch
 
 private const val MAPBOX_NAVIGATION_USER_AGENT_BASE = "mapbox-navigation-android"
 private const val MAPBOX_NAVIGATION_UI_USER_AGENT_BASE = "mapbox-navigation-ui-android"
@@ -283,24 +282,23 @@ constructor(
      * Call this method whenever this instance of the [MapboxNavigation] is not going to be used anymore and should release all of its resources.
      */
     fun onDestroy() {
-        mainJobController.scope.launch {
-            Log.d(TAG, "onDestroy")
-            MapboxNavigationTelemetry.unregisterListeners(this@MapboxNavigation)
-            ThreadController.cancelAllNonUICoroutines()
-            ThreadController.cancelAllUICoroutines()
-            directionsSession.shutdownSession()
-            directionsSession.unregisterAllRoutesObservers()
-            tripSession.stop()
-            tripSession.unregisterAllLocationObservers()
-            tripSession.unregisterAllRouteProgressObservers()
-            tripSession.unregisterAllOffRouteObservers()
-            tripSession.unregisterAllStateObservers()
-            tripSession.unregisterAllBannerInstructionsObservers()
-            tripSession.unregisterAllVoiceInstructionsObservers()
-            navigationSession.unregisterAllNavigationSessionStateObservers()
-            fasterRouteController.stop()
-            routeRefreshController.stop()
-        }
+        Log.d(TAG, "onDestroy")
+        MapboxNavigationTelemetry.unregisterListeners(this@MapboxNavigation)
+        directionsSession.shutdownSession()
+        directionsSession.unregisterAllRoutesObservers()
+        tripSession.stop()
+        tripSession.unregisterAllLocationObservers()
+        tripSession.unregisterAllRouteProgressObservers()
+        tripSession.unregisterAllOffRouteObservers()
+        tripSession.unregisterAllStateObservers()
+        tripSession.unregisterAllBannerInstructionsObservers()
+        tripSession.unregisterAllVoiceInstructionsObservers()
+        tripSession.route = null
+        navigationSession.unregisterAllNavigationSessionStateObservers()
+        fasterRouteController.stop()
+        routeRefreshController.stop()
+        ThreadController.cancelAllNonUICoroutines()
+        ThreadController.cancelAllUICoroutines()
     }
 
     /**

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
@@ -210,6 +210,13 @@ class MapboxNavigationTest {
     }
 
     @Test
+    fun onDestroySetsRouteToNullInTripSession() {
+        mapboxNavigation.onDestroy()
+
+        verify(exactly = 1) { tripSession.route = null }
+    }
+
+    @Test
     fun unregisterAllBannerInstructionsObservers() {
         mapboxNavigation.onDestroy()
 


### PR DESCRIPTION
##Description
Addresses an issue identified in ticket: #2782

Please include a brief summary of the change and which issue is fixed (e.g., fixes [#issue](link))

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

When going from a turn by turn navigation example activity to the free drive example activity the notification should not display route information from the previous session.

### Implementation

The route in the trip session was not being set to null when onDestroy in MapboxNavigation was called. There was an additional issue uncovered. When the route setter in MapboxTripSession is called there is also a call to set the route in MapboxNativeNavigator which is wrapped in a coroutine. However in MapboxNavigation.onDestroy() there were calls to cancelAllCoroutines as the first calls so any subsequent coroutines would not execute.

I moved the calls to cancel the coroutines to the end of the onDestroy method. In addition all of the cleanup in onDestroy was wrapped in a coroutine. I removed that coroutine because I don't see any necessity in wrapping all the clean up calls in a coroutine. Also there were calls in that coroutine to cancel all the coroutines so while I can't demonstrate explicitly  that's a problem intuitively it seems like an unwise idea.

## Screenshots or Gifs

Please include all the media files to give some context about what's being implemented or fixed. It's not mandatory to upload screenshots or gifs, but for most of the cases it becomes really handy to get into the scope of the feature / bug being fixed and also it's REALLY useful for UI related PRs ![screenshot gif](link)

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->