### PR TITLE
Add a crash if history player leaks

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/history/ReplayEventSimulator.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/history/ReplayEventSimulator.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import com.mapbox.navigation.utils.thread.ThreadController
+import java.lang.IllegalStateException
 import kotlin.math.max
 import kotlin.math.roundToLong
 import kotlinx.coroutines.Job
@@ -51,6 +52,10 @@ internal class ReplayEventSimulator(
                 val loopElapsedMillis = (loopElapsedSeconds * MILLIS_PER_SECOND).roundToLong()
                 val delayMillis = max(0L, replayUpdateSpeedMillis - loopElapsedMillis)
                 delay(delayMillis)
+            }
+
+            if (lifecycleOwner.lifecycle.currentState == Lifecycle.State.DESTROYED) {
+                throw IllegalStateException("Make sure to call ReplayHistoryPlayer.finish()")
             }
 
             Log.i("ReplayHistory", "Simulator ended")


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

If someone using the history player does not call finish(), and causes a memory leak. Provide a crash with instructions. Adding this because I messed it up when implementing this https://github.com/mapbox/mapbox-navigation-android/pull/2796

"Make sure to call ReplayHistoryPlayer.finish()"
```
2020-04-17 17:26:39.812 23158-23158/com.mapbox.navigation.examples E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.mapbox.navigation.examples, PID: 23158
    java.lang.IllegalStateException: Make sure to call ReplayHistoryPlayer.finish()
        at com.mapbox.navigation.core.replay.history.ReplayEventSimulator$launchPlayLoop$1.invokeSuspend(ReplayEventSimulator.kt:58)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
        at kotlinx.coroutines.DispatchedTaskKt.resume(DispatchedTask.kt:175)
        at kotlinx.coroutines.DispatchedTaskKt.dispatch(DispatchedTask.kt:111)
```

- [ ] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->