### PR TITLE
Bump mapboxEvents, mapboxCore and NN dependency versions to 5.0.1, 2.0.1 and 11.0.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -12,9 +12,9 @@ ext {
       mapboxMapSdk              : '9.1.0',
       mapboxSdkServices         : '5.1.0',
       mapboxSdkDirectionsModels : '5.1.0',
-      mapboxEvents              : '5.0.0',
-      mapboxCore                : '2.0.0',
-      mapboxNavigator           : 'ak-sensor-history-2-SNAPSHOT-1',
+      mapboxEvents              : '5.0.1',
+      mapboxCore                : '2.0.1',
+      mapboxNavigator           : '11.0.0',
       mapboxCrashMonitor        : '2.0.0',
       mapboxAnnotationPlugin    : '0.8.0',
       mapboxAccounts            : '0.3.1',
@@ -59,7 +59,6 @@ ext {
       okio                      : '2.4.3',
       androidxTestJunit         : '1.1.1',
       barista                   : '3.2.0',
-      workTesting               : '2.2.0',
       androidxTestCore          : '1.2.0'
   ]
   dependenciesList = [
@@ -139,7 +138,6 @@ ext {
       testEspressoIntents       : "androidx.test.espresso:espresso-intents:${version.espressoVersion}",
       androidxTestJunit         : "androidx.test.ext:junit:${version.androidxTestJunit}",
       barista                   : "com.schibsted.spain:barista:${version.barista}",
-      workTesting               : "androidx.work:work-testing:${version.workTesting}",
 
       // unit test
       junit                     : "junit:junit:${version.junit}",

--- a/gradle/unit-testing-dependencies.gradle
+++ b/gradle/unit-testing-dependencies.gradle
@@ -4,5 +4,4 @@ dependencies {
     testImplementation dependenciesList.coroutinesTestAndroid
     testImplementation dependenciesList.mockk
     testImplementation dependenciesList.robolectric
-    testImplementation dependenciesList.workTesting
 }

--- a/libandroid-navigation/build.gradle
+++ b/libandroid-navigation/build.gradle
@@ -90,7 +90,6 @@ dependencies {
   testImplementation dependenciesList.commonsIO
   testImplementation dependenciesList.robolectric
   testImplementation dependenciesList.mockwebserver
-  testImplementation dependenciesList.workTesting
 }
 
 apply from: 'javadoc.gradle'

--- a/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/internal/navigation/NavigationEventDispatcherTest.java
+++ b/libandroid-navigation/src/test/java/com/mapbox/services/android/navigation/v5/internal/navigation/NavigationEventDispatcherTest.java
@@ -4,8 +4,6 @@ import android.content.Context;
 import android.location.Location;
 
 import androidx.annotation.NonNull;
-import androidx.work.Configuration;
-import androidx.work.testing.WorkManagerTestInitHelper;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -75,8 +73,6 @@ public class NavigationEventDispatcherTest extends BaseTest {
   public void setup() throws Exception {
     MockitoAnnotations.initMocks(this);
     Context context = RuntimeEnvironment.application;
-    Configuration config = new Configuration.Builder().build();
-    WorkManagerTestInitHelper.initializeTestWorkManager(context, config);
     navigation = new MapboxNavigation(
             context,
             ACCESS_TOKEN,

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
@@ -5,8 +5,6 @@ import android.app.NotificationManager
 import android.content.Context
 import android.content.SharedPreferences
 import android.location.Location
-import androidx.work.Configuration
-import androidx.work.testing.WorkManagerTestInitHelper
 import com.mapbox.android.core.location.LocationEngine
 import com.mapbox.android.core.location.LocationEngineRequest
 import com.mapbox.android.telemetry.MapboxTelemetryConstants.MAPBOX_SHARED_PREFERENCES
@@ -88,8 +86,6 @@ class MapboxNavigationTest {
 
     @Before
     fun setUp() {
-        val config = Configuration.Builder().build()
-        WorkManagerTestInitHelper.initializeTestWorkManager(context, config)
         mockkObject(MapboxModuleProvider)
         val hybridRouter: Router = mockk(relaxUnitFun = true)
         every {


### PR DESCRIPTION
## Description

Bumps `mapbox-android-telemetry`, `mapbox-android-core` and `mapbox-navigation-native` versions to `5.0.1`, `2.0.1` and `11.0.0` respectively

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Getting the latest versions from `mapboxEvents`, `mapboxCore` and NN including the new features and bug fixes.

### Implementation

Bumping `mapboxEvents`, `mapboxCore`, NN versions to `5.0.1`, `2.0.1` and `11.0.0` respectively in `dependencies.gradle`
Remove `work-testing` dependency not needed anymore

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR

cc @mskurydin @nkukday 