### PR TITLE
Junit framework is deprecated

### DIFF
--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/summary/list/InstructionListPresenterTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/summary/list/InstructionListPresenterTest.java
@@ -21,7 +21,6 @@ import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertNull;
 import static junit.framework.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/history/ReplayHistoryPlayerTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/history/ReplayHistoryPlayerTest.kt
@@ -12,11 +12,11 @@ import io.mockk.mockkStatic
 import io.mockk.unmockkObject
 import io.mockk.verify
 import java.util.concurrent.TimeUnit
-import junit.framework.Assert.assertEquals
-import junit.framework.Assert.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancelAndJoin
 import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -64,8 +64,8 @@ class ReplayHistoryPlayerTest {
         coVerify { mockLambda(capture(replayUpdates)) }
         val events = replayUpdates.flatten()
         assertEquals(2, events.size)
-        assertEquals(1580777612.853, events[0].eventTimestamp)
-        assertEquals(1580777612.89, events[1].eventTimestamp)
+        assertEquals(1580777612.853, events[0].eventTimestamp, 0.001)
+        assertEquals(1580777612.89, events[1].eventTimestamp, 0.001)
     }
 
     @Test
@@ -115,8 +115,8 @@ class ReplayHistoryPlayerTest {
         coVerify { mockLambda(capture(replayUpdates)) }
         val events = replayUpdates.flatten()
         assertEquals(2, events.size)
-        assertEquals(1580777820.952, events[0].eventTimestamp)
-        assertEquals(1580777822.959, events[1].eventTimestamp)
+        assertEquals(1580777820.952, events[0].eventTimestamp, 0.001)
+        assertEquals(1580777822.959, events[1].eventTimestamp, 0.001)
     }
 
     @Test
@@ -181,7 +181,7 @@ class ReplayHistoryPlayerTest {
         assertEquals(events.size, 2)
         assertTrue(events[0] is CustomReplayEvent)
         assertEquals("custom value", (events[0] as CustomReplayEvent).customValue)
-        assertEquals(1580777613.89, events[1].eventTimestamp)
+        assertEquals(1580777613.89, events[1].eventTimestamp, 0.001)
     }
 
     @Test(expected = Exception::class)
@@ -216,7 +216,7 @@ class ReplayHistoryPlayerTest {
         verify { mockLambda(capture(replayUpdates)) }
         val events = replayUpdates.flatten()
         assertEquals(1, events.size)
-        assertEquals(1580777612.89, events[0].eventTimestamp)
+        assertEquals(1580777612.89, events[0].eventTimestamp, 0.001)
     }
 
     @Test
@@ -255,8 +255,8 @@ class ReplayHistoryPlayerTest {
         coVerify { mockLambda(capture(replayUpdates)) }
         val events = replayUpdates.flatten()
         assertEquals(events.size, 2)
-        assertEquals(2.452, events[0].eventTimestamp)
-        assertEquals(3.085, events[1].eventTimestamp)
+        assertEquals(2.452, events[0].eventTimestamp, 0.001)
+        assertEquals(3.085, events[1].eventTimestamp, 0.001)
     }
 
     @Test(expected = Exception::class)
@@ -291,8 +291,8 @@ class ReplayHistoryPlayerTest {
         coVerify { mockLambda(capture(replayUpdates)) }
         val events = replayUpdates.flatten()
         assertEquals(events.size, 2)
-        assertEquals(2.0, events[0].eventTimestamp)
-        assertEquals(4.0, events[1].eventTimestamp)
+        assertEquals(2.0, events[0].eventTimestamp, 0.001)
+        assertEquals(4.0, events[1].eventTimestamp, 0.001)
     }
 
     @Test
@@ -315,8 +315,8 @@ class ReplayHistoryPlayerTest {
         coVerify { mockLambda(capture(replayUpdates)) }
         val events = replayUpdates.flatten()
         assertEquals(2, events.size)
-        assertEquals(1580777613.452, events[0].eventTimestamp)
-        assertEquals(1580777614.085, events[1].eventTimestamp)
+        assertEquals(1580777613.452, events[0].eventTimestamp, 0.001)
+        assertEquals(1580777614.085, events[1].eventTimestamp, 0.001)
     }
 
     /**

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/sensors/SensorEventEmitterTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/sensors/SensorEventEmitterTest.kt
@@ -6,7 +6,7 @@ import android.hardware.SensorManager
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import junit.framework.Assert.assertEquals
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class SensorEventEmitterTest {

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteProgressChangeListenerTest.kt
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteProgressChangeListenerTest.kt
@@ -6,7 +6,7 @@ import io.mockk.Called
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import junit.framework.Assert.assertEquals
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 
@@ -148,8 +148,8 @@ class MapRouteProgressChangeListenerTest {
         progressChangeListener.onRouteProgressChanged(routeProgress)
 
         verify(exactly = 1) { routeLine.draw(any<DirectionsRoute>()) }
-        assertEquals(drawDirections.size, 1)
-        assertEquals(drawDirections[0].geometry(), "{au|bAqtiiiG|TnI`B\\dEzAl_@hMxGxB")
+        assertEquals(1, drawDirections.size)
+        assertEquals("{au|bAqtiiiG|TnI`B\\dEzAl_@hMxGxB", drawDirections[0].geometry())
     }
 
     @Test
@@ -171,7 +171,7 @@ class MapRouteProgressChangeListenerTest {
         progressChangeListener.onRouteProgressChanged(routeProgress)
 
         verify(exactly = 1) { routeLine.draw(any<DirectionsRoute>()) }
-        assertEquals(drawDirections.size, 1)
-        assertEquals(drawDirections[0].distance(), 100.0)
+        assertEquals(1, drawDirections.size)
+        assertEquals(100.0, drawDirections[0].distance()!!, 0.001)
     }
 }


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Looks like this is suddenly blocking PRs https://github.com/mapbox/mapbox-navigation-android/pull/2774

```
ReplayHistoryMapperTest.kt: (5, 24): 'Assert' is deprecated. Deprecated in Java
```

- [ ] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->