### PR TITLE
Fix logger creation

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -555,17 +555,14 @@ constructor(
                     MapboxNativeNavigator::class.java to MapboxNativeNavigatorImpl,
                     MapboxOnboardRouterConfig::class.java to (navigationOptions.onboardRouterConfig
                         ?: throw RuntimeException(MAPBOX_NAVIGATION_TOKEN_EXCEPTION_ONBOARD_ROUTER)),
-                    Logger::class.java to MapboxModuleProvider.createModule(
-                        MapboxModuleType.CommonLogger,
-                        ::paramsProvider
-                    )
+                    Logger::class.java to logger
                 )
             }
             MapboxModuleType.NavigationTripNotification -> arrayOf(
                 Context::class.java to context.applicationContext,
                 NavigationOptions::class.java to navigationOptions
             )
-            MapboxModuleType.CommonLogger -> arrayOf(Logger::class.java to logger)
+            MapboxModuleType.CommonLogger -> arrayOf()
             MapboxModuleType.CommonLibraryLoader -> throw IllegalArgumentException("not supported: $type")
             MapboxModuleType.CommonHttpClient -> throw IllegalArgumentException("not supported: $type")
         }


### PR DESCRIPTION
## Description

Fixes `Logger` creation

Regression from https://github.com/mapbox/mapbox-navigation-android/pull/2820

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

https://github.com/mapbox/mapbox-navigation-android/pull/2820/files#r412584609 `Logger` doesn't need to take `Logger` as parameter (`Logger` is a singleton `object` so the module provider gets the instance this way and doesn't even reach the arguments so it doesn't crash but it's generally incorrect)
https://github.com/mapbox/mapbox-navigation-android/pull/2820/files#r412977448 reuse `logger` as was created before (no need to instantiate twice)


### Implementation

```kotlin
MapboxModuleType.CommonLogger -> arrayOf()
```

```kotlin
Logger::class.java to logger
```

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR