### PR TITLE
Logger tailwork

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1137,18 +1137,6 @@ License: [The Apache Software License, Version 2.0](https://www.apache.org/licen
 
 ===========================================================================
 
-Mapbox Navigation uses portions of the Mapbox Annotations (Artifact that provides Mapbox module and plugin annotations).
-URL: [https://github.com/mapbox/mapbox-base-android](https://github.com/mapbox/mapbox-base-android)
-License: [BSD](https://opensource.org/licenses/BSD-2-Clause)
-
-===========================================================================
-
-Mapbox Navigation uses portions of the Mapbox Common (Artifact that provides Mapbox module and plugin contracts).
-URL: [https://github.com/mapbox/mapbox-base-android](https://github.com/mapbox/mapbox-base-android)
-License: [BSD](https://opensource.org/licenses/BSD-2-Clause)
-
-===========================================================================
-
 Mapbox Navigation uses portions of the Mapbox Java SDK.
 URL: [https://github.com/mapbox/mapbox-java](https://github.com/mapbox/mapbox-java)
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)

--- a/libnavigation-core/build.gradle
+++ b/libnavigation-core/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     implementation project(':libnavigator')
     runtimeOnly project(':libdirections-hybrid')
     runtimeOnly project(':libtrip-notification')
+    runtimeOnly dependenciesList.mapboxLogger
     implementation project(':libnavigation-metrics')
     implementation dependenciesList.mapboxAndroidAccounts
     implementation dependenciesList.mapboxSdkTurf

--- a/libnavigator/build.gradle
+++ b/libnavigator/build.gradle
@@ -31,7 +31,6 @@ android {
 
 dependencies {
     implementation(project(':libnavigation-base'))
-    implementation dependenciesList.mapboxCommon
 
     // Navigator
     api dependenciesList.mapboxNavigator


### PR DESCRIPTION
## Description

Add `runtimeOnly` `mapboxLogger` dependency to `libnavigation-core` and remove unnecessary `mapboxCommon` dependency from `libnavigator`

Regression from https://github.com/mapbox/mapbox-navigation-android/pull/2774

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

- Inject the default `mapboxLogger` preventing the app to crash (trying to instantiate `Logger` in `MapboxNavigation` at initialization) if the dependency is not explicitly added
- Cleanup

### Implementation

- Add `runtimeOnly dependenciesList.mapboxLogger` to `libnavigation-core` `build.gradle`'s file
- Remove `implementation dependenciesList.mapboxCommon` from `libnavigator` `build.gradle`'s file

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR

cc @Lebedinsky @LukasPaczos 