### PR TITLE
Expose Maps SDK transitively from UI SDK

### DIFF
--- a/libnavigation-ui/build.gradle
+++ b/libnavigation-ui/build.gradle
@@ -67,7 +67,7 @@ dependencies {
   implementation dependenciesList.mapboxSdkTurf
 
   // Mapbox Maps SDK
-  implementation dependenciesList.mapboxMapSdk
+  api dependenciesList.mapboxMapSdk
   implementation dependenciesList.mapboxAnnotationPlugin
 
   // Support libraries


### PR DESCRIPTION
## Description

Exposes `mapbox-android-sdk` transitively (`api`) from `libnavigation-ui`

We should revisit the rest of the dependencies before releasing `1.0` cc @abhishek1508 

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Developers should add Maps SDK dependency explicitly if they're integrating the Navigation UI SDK

### Implementation

Add `api` (instead of `implementation`) to `dependenciesList.mapboxMapSdk` in `libnavigation-ui` `build.gradle`

## Testing

- [x] I have tested locally creating a quick sample app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR