### PR TITLE
fix to prevent duplicate listener registration

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/NavigationSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/NavigationSession.kt
@@ -4,12 +4,12 @@ import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.navigation.core.directions.session.RoutesObserver
 import com.mapbox.navigation.core.trip.session.TripSessionState
 import com.mapbox.navigation.core.trip.session.TripSessionStateObserver
-import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CopyOnWriteArraySet
 
 internal class NavigationSession : RoutesObserver,
     TripSessionStateObserver {
 
-    private val stateObservers = CopyOnWriteArrayList<NavigationSessionStateObserver>()
+    private val stateObservers = CopyOnWriteArraySet<NavigationSessionStateObserver>()
 
     private var state = State.IDLE
         set(value) {

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/MapboxDirectionsSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/MapboxDirectionsSession.kt
@@ -5,7 +5,7 @@ import com.mapbox.api.directions.v5.models.RouteOptions
 import com.mapbox.navigation.base.route.RouteRefreshCallback
 import com.mapbox.navigation.base.route.Router
 import com.mapbox.navigation.utils.internal.ifNonNull
-import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CopyOnWriteArraySet
 
 // todo make internal
 /**
@@ -18,7 +18,7 @@ class MapboxDirectionsSession(
     private val router: Router
 ) : DirectionsSession {
 
-    private val routesObservers = CopyOnWriteArrayList<RoutesObserver>()
+    private val routesObservers = CopyOnWriteArraySet<RoutesObserver>()
     private var routeOptions: RouteOptions? = null
 
     /**

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
@@ -25,7 +25,7 @@ import com.mapbox.navigation.utils.internal.JobControl
 import com.mapbox.navigation.utils.internal.ThreadController
 import com.mapbox.navigation.utils.internal.ifNonNull
 import java.util.Date
-import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CopyOnWriteArraySet
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.delay
@@ -72,12 +72,12 @@ class MapboxTripSession(
     private val ioJobController: JobControl = threadController.getIOScopeAndRootJob()
     private val mainJobController: JobControl = threadController.getMainScopeAndRootJob()
 
-    private val locationObservers = CopyOnWriteArrayList<LocationObserver>()
-    private val routeProgressObservers = CopyOnWriteArrayList<RouteProgressObserver>()
-    private val offRouteObservers = CopyOnWriteArrayList<OffRouteObserver>()
-    private val stateObservers = CopyOnWriteArrayList<TripSessionStateObserver>()
-    private val bannerInstructionsObservers = CopyOnWriteArrayList<BannerInstructionsObserver>()
-    private val voiceInstructionsObservers = CopyOnWriteArrayList<VoiceInstructionsObserver>()
+    private val locationObservers = CopyOnWriteArraySet<LocationObserver>()
+    private val routeProgressObservers = CopyOnWriteArraySet<RouteProgressObserver>()
+    private val offRouteObservers = CopyOnWriteArraySet<OffRouteObserver>()
+    private val stateObservers = CopyOnWriteArraySet<TripSessionStateObserver>()
+    private val bannerInstructionsObservers = CopyOnWriteArraySet<BannerInstructionsObserver>()
+    private val voiceInstructionsObservers = CopyOnWriteArraySet<VoiceInstructionsObserver>()
 
     private val bannerInstructionEvent = BannerInstructionEvent()
     private val voiceInstructionEvent = VoiceInstructionEvent()

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/camera/NavigationCamera.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/camera/NavigationCamera.java
@@ -36,7 +36,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CopyOnWriteArraySet;
 
 import timber.log.Timber;
 
@@ -73,10 +73,10 @@ public class NavigationCamera implements LifecycleObserver {
    */
   public static final int NAVIGATION_TRACKING_MODE_NONE = 2;
   private static final int ONE_POINT = 1;
-  private final CopyOnWriteArrayList<OnTrackingModeTransitionListener> onTrackingModeTransitionListeners
-          = new CopyOnWriteArrayList<>();
-  private final CopyOnWriteArrayList<OnTrackingModeChangedListener> onTrackingModeChangedListeners
-          = new CopyOnWriteArrayList<>();
+  private final CopyOnWriteArraySet<OnTrackingModeTransitionListener> onTrackingModeTransitionListeners
+          = new CopyOnWriteArraySet<>();
+  private final CopyOnWriteArraySet<OnTrackingModeChangedListener> onTrackingModeChangedListeners
+          = new CopyOnWriteArraySet<>();
   private final OnLocationCameraTransitionListener cameraTransitionListener
           = new NavigationCameraTransitionListener(this);
   private final OnCameraTrackingChangedListener cameraTrackingChangedListener


### PR DESCRIPTION
##Description

I noticed that the routeProgressObservers collection in MapboxTripSession had two references to the same NavigationCamera instance. While some further exploration is needed to determine why it's getting registered twice I added a check to various registration methods to determine if the listener was already registered prior to adding it to the collection.

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Ensure that a listeners is only registered once so that upon event emissions there isn't a duplicate call made to the listener

### Implementation

I check if the listener is already contained in the collection.

## Screenshots or Gifs

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->