### PR TITLE
Bump NN dependency version to 11.0.1

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -14,7 +14,7 @@ ext {
       mapboxSdkDirectionsModels : '5.1.0',
       mapboxEvents              : '5.0.1',
       mapboxCore                : '2.0.1',
-      mapboxNavigator           : '11.0.0',
+      mapboxNavigator           : '11.0.1',
       mapboxCrashMonitor        : '2.0.0',
       mapboxAnnotationPlugin    : '0.8.0',
       mapboxAccounts            : '0.3.1',

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/NavigationOptions.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/NavigationOptions.kt
@@ -13,7 +13,7 @@ import com.mapbox.navigation.base.typedef.TimeFormatType
  * in such a way as to project the location forward along the current trajectory so as to
  * appear more in sync with the users ground-truth location
  */
-const val DEFAULT_NAVIGATOR_PREDICTION_MILLIS = 1500L
+const val DEFAULT_NAVIGATOR_PREDICTION_MILLIS = 1100L
 
 /**
  * Defines navigation options


### PR DESCRIPTION
## Description

Bump `mapbox-navigation-native` dependency version to `11.0.1` and make 1.1 seconds the navigator default prediction time

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Getting the latest versions from NN including the new features and bug fixes.

### Implementation

Bumping NN version to `11.0.1` in `dependencies.gradle`
Change `DEFAULT_NAVIGATOR_PREDICTION_MILLIS` from 1.5 seconds to 1.1

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR

cc @Aurora-Boreal @mskurydin 