### PR TITLE
Remove unnecessary NN Proguard rules

### DIFF
--- a/libnavigation-core/proguard-rules.pro
+++ b/libnavigation-core/proguard-rules.pro
@@ -6,6 +6,8 @@
 -keep class com.mapbox.navigation.route.onboard.MapboxOnboardRouter {*;}
 -keep class com.mapbox.navigation.route.offboard.MapboxOffboardRouter {*;}
 -keep class com.mapbox.navigation.trip.notification.MapboxTripNotification {*;}
+# TODO Remove this rule when added in com.mapbox.common:logger https://github.com/mapbox/mapbox-base-android/issues/41
+-keep class com.mapbox.common.logger.MapboxLogger {*;}
 
 # --- OkHttp ---
 -dontwarn okhttp3.**

--- a/libnavigator/proguard-rules.pro
+++ b/libnavigator/proguard-rules.pro
@@ -1,3 +1,1 @@
 # --- Navigator ---
--keep class com.mapbox.navigator.** { *; }
--keep class com.mapbox.bindgen.** { *; }


### PR DESCRIPTION
## Description

Fixes https://github.com/mapbox/mapbox-navigation-android/issues/2663

Removes unnecessary NN Proguard rules as they were added downstream
Workarounds `Logger` minification regression from https://github.com/mapbox/mapbox-navigation-android/pull/2774 👀 https://github.com/mapbox/mapbox-base-android/issues/41

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Clean up `libnavigator/proguard-rules.pro` not necessary anymore as NN `11.0.1` already adds them

### Implementation

Remove

```
-keep class com.mapbox.navigator.** { *; }	
-keep class com.mapbox.bindgen.** { *; }
```

from `libnavigator/proguard-rules.pro`

Adds 

```
-keep class com.mapbox.common.logger.MapboxLogger {*;}
```

to `libnavigation-core/proguard-rules.pro`

## Testing

- [x] I have tested the `examples` test app with `minifyEnabled true`
- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR

cc @RingerJK 