### PR TITLE
update the route arrow on route progress updates redrawing only if th…

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteArrow.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteArrow.java
@@ -77,6 +77,7 @@ import static com.mapbox.navigation.ui.route.RouteConstants.OPAQUE;
 import static com.mapbox.navigation.ui.route.RouteConstants.THIRTY;
 import static com.mapbox.navigation.ui.route.RouteConstants.TRANSPARENT;
 import static com.mapbox.navigation.ui.route.RouteConstants.TWO_POINTS;
+import static com.mapbox.navigation.ui.utils.CompareUtils.areEqualContentsIgnoreOrder;
 
 class MapRouteArrow {
 
@@ -85,6 +86,7 @@ class MapRouteArrow {
   @ColorInt
   private final int arrowBorderColor;
 
+  private List<Point> maneuverPoints;
   private List<String> arrowLayerIds;
   private GeoJsonSource arrowShaftGeoJsonSource;
   private GeoJsonSource arrowHeadGeoJsonSource;
@@ -95,6 +97,7 @@ class MapRouteArrow {
   MapRouteArrow(MapView mapView, MapboxMap mapboxMap, @StyleRes int styleRes, String aboveLayer) {
     this.mapView = mapView;
     this.mapboxMap = mapboxMap;
+    this.maneuverPoints = new ArrayList<>();
 
     Context context = mapView.getContext();
     TypedArray typedArray = context.obtainStyledAttributes(styleRes, R.styleable.NavigationMapRoute);
@@ -120,9 +123,13 @@ class MapRouteArrow {
     }
     updateVisibilityTo(true);
 
-    List<Point> maneuverPoints = obtainArrowPointsFrom(routeProgress);
-    updateArrowShaftWith(maneuverPoints);
-    updateArrowHeadWith(maneuverPoints);
+    List<Point> newManeuverPoints = obtainArrowPointsFrom(routeProgress);
+    if (!areEqualContentsIgnoreOrder(maneuverPoints, newManeuverPoints)) {
+      maneuverPoints.clear();
+      maneuverPoints.addAll(newManeuverPoints);
+      updateArrowShaftWith(maneuverPoints);
+      updateArrowHeadWith(maneuverPoints);
+    }
   }
 
   void updateVisibilityTo(boolean visible) {

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteProgressChangeListener.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteProgressChangeListener.kt
@@ -42,23 +42,23 @@ internal class MapRouteProgressChangeListener(
             routeLine.draw(currentRoute)
             routeArrow.addUpcomingManeuverArrow(routeProgress)
         } else {
-            if (job == null || !job!!.isActive && directionsRoute != null) {
+            if (job == null || !job!!.isActive && currentRoute != null && hasGeometry) {
                 job = ThreadController.getMainScopeAndRootJob().scope.launch {
                     val totalDist =
                         (routeProgress.distanceRemaining() + routeProgress.distanceTraveled())
                     val dist = routeProgress.distanceTraveled() / totalDist
                     if (dist > 0) {
                         val deferredExpression = async(Dispatchers.Default) {
-                            val lineString: LineString =
-                                routeLine.getLineStringForRoute(directionsRoute!!)
+                            val lineString: LineString = routeLine.getLineStringForRoute(currentRoute!!)
                             buildRouteLineExpression(
-                                    directionsRoute,
+                                currentRoute,
                                 lineString,
                                 true,
                                 dist.toDouble(),
                                 routeLine::getRouteColorForCongestion
                             )
                         }
+                        routeArrow.addUpcomingManeuverArrow(routeProgress)
                         routeLine.hideShieldLineAtOffset(dist)
                         routeLine.decorateRouteLine(deferredExpression.await())
                     }


### PR DESCRIPTION
## Description 
bug fix for the issue #2847 by updating the route arrows on route progress updates. Since route progress events occur often the code checks if the arrows have changed before updating the map so that the map is only updated when the arrows have changed and must be redrawn.

Please include a brief summary of the change and which issue is fixed (e.g., fixes [#issue](link))

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal

The next maneuver arrows should update as the progress changes but should not redraw on the map unless they have changed.

### Implementation

Call addUpcomingManeuverArrow on route progress updates but only redraws if maneuver points have changed.

## Screenshots or Gifs



## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->