### PR TITLE
Reset Navigator state

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/FreeDriveNavigationActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/FreeDriveNavigationActivity.kt
@@ -165,7 +165,7 @@ class FreeDriveNavigationActivity : AppCompatActivity(), OnMapReadyCallback {
             activityRef.get()?.navigationMapboxMap?.updateLocation(result.lastLocation)
         }
 
-        override fun onFailure(exception: java.lang.Exception) {
+        override fun onFailure(exception: Exception) {
             Timber.i(exception)
         }
     }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -302,7 +302,7 @@ constructor(
             Message("onDestroy")
         )
         MapboxNavigationTelemetry.unregisterListeners(this@MapboxNavigation)
-        directionsSession.shutdownSession()
+        directionsSession.shutdown()
         directionsSession.unregisterAllRoutesObservers()
         tripSession.stop()
         tripSession.unregisterAllLocationObservers()

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/DirectionsSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/DirectionsSession.kt
@@ -70,5 +70,5 @@ internal interface DirectionsSession {
     /**
      * Interrupts the route-fetching request
      */
-    fun shutdownSession()
+    fun shutdown()
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/MapboxDirectionsSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/MapboxDirectionsSession.kt
@@ -150,7 +150,7 @@ internal class MapboxDirectionsSession(
     /**
      * Interrupt route-fetcher request
      */
-    override fun shutdownSession() {
+    override fun shutdown() {
         router.shutdown()
     }
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/trip/session/MapboxTripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/trip/session/MapboxTripSession.kt
@@ -184,6 +184,7 @@ class MapboxTripSession(
         enhancedLocation = null
         routeProgress = null
         isOffRoute = false
+        navigator.reset()
     }
 
     /**

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
@@ -221,6 +221,13 @@ class MapboxNavigationTest {
     }
 
     @Test
+    fun onDestroyCallsTripSessionStop() {
+        mapboxNavigation.onDestroy()
+
+        verify(exactly = 1) { tripSession.stop() }
+    }
+
+    @Test
     fun unregisterAllBannerInstructionsObservers() {
         mapboxNavigation.onDestroy()
 

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/directions/session/MapboxDirectionsSessionTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/directions/session/MapboxDirectionsSessionTest.kt
@@ -102,7 +102,7 @@ class MapboxDirectionsSessionTest {
 
     @Test
     fun shutDown() {
-        session.shutdownSession()
+        session.shutdown()
         verify { router.shutdown() }
     }
 

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/internal/trip/session/MapboxTripSessionTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/internal/trip/session/MapboxTripSessionTest.kt
@@ -138,14 +138,31 @@ class MapboxTripSessionTest {
     }
 
     @Test
-    fun stopSession() {
+    fun stopSessionCallsTripServiceStopService() {
+        tripSession.start()
+
+        tripSession.stop()
+
+        verify { locationEngine.removeLocationUpdates(locationCallbackSlot.captured) }
+    }
+
+    @Test
+    fun stopSessionCallsLocationEngineRemoveLocationUpdates() {
         tripSession.start()
         locationCallbackSlot.captured.onSuccess(locationEngineResult)
 
         tripSession.stop()
 
-        verify { tripService.stopService() }
         verify { locationEngine.removeLocationUpdates(locationCallbackSlot.captured) }
+    }
+
+    @Test
+    fun stopSessionCallsMapboxNativeNavigatorReset() {
+        tripSession.start()
+
+        tripSession.stop()
+
+        verify { navigator.reset() }
     }
 
     @Test

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigator.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigator.kt
@@ -251,4 +251,9 @@ interface MapboxNativeNavigator {
      * @return [VoiceInstruction] for step index you passed
      */
     fun getVoiceInstruction(index: Int): VoiceInstruction?
+
+    /**
+     * Reset resources.
+     */
+    fun reset()
 }

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigatorImpl.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigatorImpl.kt
@@ -53,7 +53,7 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
     private const val TWO_LEGS: Short = 2
     private const val PRIMARY_ROUTE_INDEX = 0
 
-    private val navigator: Navigator = Navigator()
+    private var navigator: Navigator = Navigator()
     private var route: DirectionsRoute? = null
     private var routeBufferGeoJson: Geometry? = null
     private val mutex = Mutex()
@@ -323,6 +323,12 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
     override fun getVoiceInstruction(index: Int): VoiceInstruction? =
         navigator.getVoiceInstruction(index)
 
+    /**
+     * Reset resources.
+     */
+    override fun reset() {
+        navigator = Navigator()
+    }
     /**
      * Builds [RouteProgress] object based on [NavigationStatus] returned by [Navigator]
      */


### PR DESCRIPTION
## Description

Resets `Navigator` when in on `TripSession#stop` and renames `DirectionsSession` `shutdown` API

Fixes https://github.com/mapbox/mapbox-navigation-android/issues/2769

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

As `MapboxNativeNavigatorImpl` is a singleton (`object`) `Navigator` is retained between sessions causing unexpected behaviors as the internal cache is not reset

### Implementation

- Add `reset` API to `MapboxNativeNavigator` and recreate `Navigator` when `MapboxNativeNavigatorImpl#reset`
- Rename `MapboxDirectionsSession` shutdown API from `shutdownSession` to `shutdown`

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR

cc @kmadsen @cafesilencio @SiarheiFedartsou 