### PR TITLE
Resets route and routeBufferGeoJson as part of MapboxNativeNavigatorImpl#reset

### DIFF
--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigatorImpl.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigatorImpl.kt
@@ -328,6 +328,8 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
      */
     override fun reset() {
         navigator = Navigator()
+        route = null
+        routeBufferGeoJson = null
     }
     /**
      * Builds [RouteProgress] object based on [NavigationStatus] returned by [Navigator]


### PR DESCRIPTION
## Description

Resets `route` and `routeBufferGeoJson` as part of `MapboxNativeNavigatorImpl#reset`

Follow up from https://github.com/mapbox/mapbox-navigation-android/pull/2850#discussion_r417015244

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Tailwork from https://github.com/mapbox/mapbox-navigation-android/pull/2850

### Implementation

```kotlin
override fun reset() {
    navigator = Navigator()
    route = null
    routeBufferGeoJson = null
}
```

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR

cc @kmadsen 