### PR TITLE
Actions and Reducers

### DIFF
--- a/libnavui-alert/src/main/java/com/mapbox/navigation/ui/alert/AlertAction.kt
+++ b/libnavui-alert/src/main/java/com/mapbox/navigation/ui/alert/AlertAction.kt
@@ -1,0 +1,9 @@
+package com.mapbox.navigation.ui.alert
+
+/**
+ * Immutable object which contains all the required information for a business logic to process.
+ */
+internal sealed class AlertAction {
+    internal data class SetAlertText(val alertText: String) : AlertAction()
+    internal data class SetDismissDuration(val dismissDuration: Long) : AlertAction()
+}

--- a/libnavui-alert/src/main/java/com/mapbox/navigation/ui/alert/AlertApi.kt
+++ b/libnavui-alert/src/main/java/com/mapbox/navigation/ui/alert/AlertApi.kt
@@ -22,11 +22,7 @@ interface AlertApi {
      * @return AlertState
      */
     fun durationToDismiss(previousState: AlertState, duration: Long): AlertState {
-        return AlertProcessor
-            .Builder(previousState)
-            .durationToDismiss(duration)
-            .build()
-            .getNewState()
+        return reducer(previousState, setDismissDuration(AlertAction.SetDismissDuration(duration)))
     }
 
     /**
@@ -35,11 +31,7 @@ interface AlertApi {
      * @param text String
      * @return AlertState
      */
-    fun showViewWith(previousState: AlertState, text: String): AlertState {
-        return AlertProcessor
-            .Builder(previousState)
-            .showViewWith(text)
-            .build()
-            .getNewState()
+    fun setAlertText(previousState: AlertState, text: String): AlertState {
+        return reducer(previousState, setAlertText(AlertAction.SetAlertText(text)))
     }
 }

--- a/libnavui-alert/src/main/java/com/mapbox/navigation/ui/alert/AlertProcessor.kt
+++ b/libnavui-alert/src/main/java/com/mapbox/navigation/ui/alert/AlertProcessor.kt
@@ -1,63 +1,48 @@
 package com.mapbox.navigation.ui.alert
 
 import com.mapbox.navigation.ui.base.model.AlertState
-import java.lang.IllegalStateException
 
-/**
- * The class performs logical operations on the [State] fed to it and reduces it to a new [State]
- * @property newState AlertState represents a new reduced [State]
- */
-internal class AlertProcessor private constructor(
-    private val newState: AlertState
-) {
+typealias SetAlertText<T1, T2> = (input: T1) -> T2
 
-    /**
-     * Returns the reduced state
-     * @return AlertState reduced state
-     */
-    fun getNewState() = newState
+typealias SetDismissDuration<T1, T2> = (input: T1) -> T2
 
-    data class Builder(private val previousState: AlertState? = null) {
+typealias AlertReducer<T1, T2> = (input1: T1, input2: T2) -> T1
 
-        private var avText: String? = null
-        private var durationToDismiss: Long? = null
+internal val setAlertText: SetAlertText<AlertAction, AlertResult> = { action ->
+    if (action is AlertAction.SetAlertText) {
+        when (action.alertText.isEmpty()) {
+            true -> AlertResult.SetAlertTextResult.Failure(IllegalArgumentException("Text to be shown in alert view cannot be empty"))
+            false -> AlertResult.SetAlertTextResult.Success(action.alertText)
+        }
+    } else {
+        AlertResult.SetAlertTextResult.Failure(IllegalArgumentException("Unknown $action passed as input"))
+    }
+}
 
-        /**
-         * Set the text to be shown in the view
-         * @param avText String text to set
-         * @return Builder
-         */
-        fun showViewWith(avText: String) =
-            apply { this.avText = avText }
+internal val setDismissDuration: SetDismissDuration<AlertAction, AlertResult> = { action ->
+    if (action is AlertAction.SetDismissDuration) {
+        when (action.dismissDuration > 5000L) {
+            true -> AlertResult.SetDismissDurationResult.Failure(IllegalArgumentException("Duration to dismiss the Alert View cannot be greater than 5000 milliseconds"))
+            false -> AlertResult.SetDismissDurationResult.Success(action.dismissDuration)
+        }
+    } else {
+        AlertResult.SetDismissDurationResult.Failure(IllegalArgumentException("Unknown $action passed as input"))
+    }
+}
 
-        /**
-         * Set the duration for the progress bar
-         * @param durationToDismiss Long
-         * @return Builder
-         */
-        fun durationToDismiss(durationToDismiss: Long) =
-            apply {
-                if (durationToDismiss > 5000L) {
-                    throw IllegalArgumentException("durationToDismiss cannot be greater than 5000ms")
-                }
-                this.durationToDismiss = durationToDismiss
-            }
-
-        /**
-         * Function that returns [AlertProcessor]
-         * @return AlertProcessor
-         */
-        fun build(): AlertProcessor {
-            previousState?.let {
-                val newState = it
-                avText?.let { text ->
-                    newState.copy(avText = text)
-                }
-                durationToDismiss?.let { dismissDuration ->
-                    newState.copy(durationToDismiss = dismissDuration)
-                }
-                return AlertProcessor(newState)
-            } ?: throw IllegalStateException("AlertViewProcessor.Builder previousState cannot be null")
+internal val reducer: AlertReducer<AlertState, AlertResult> = { previousState, result ->
+    when (result) {
+        is AlertResult.SetDismissDurationResult.Success -> {
+            previousState.copy(durationToDismiss = result.dismissDuration)
+        }
+        is AlertResult.SetDismissDurationResult.Failure -> {
+            previousState.copy(error = result.error)
+        }
+        is AlertResult.SetAlertTextResult.Success -> {
+            previousState.copy(avText = result.alertText)
+        }
+        is AlertResult.SetAlertTextResult.Failure -> {
+            previousState.copy(error = result.error)
         }
     }
 }

--- a/libnavui-alert/src/main/java/com/mapbox/navigation/ui/alert/AlertResult.kt
+++ b/libnavui-alert/src/main/java/com/mapbox/navigation/ui/alert/AlertResult.kt
@@ -1,0 +1,17 @@
+package com.mapbox.navigation.ui.alert
+
+/**
+ * Immutable object resulting of a processed business logic
+ */
+internal sealed class AlertResult {
+
+    internal sealed class SetAlertTextResult : AlertResult() {
+        internal data class Success(val alertText: String) : SetAlertTextResult()
+        internal data class Failure(val error: Throwable) : SetAlertTextResult()
+    }
+
+    internal sealed class SetDismissDurationResult : AlertResult() {
+        internal data class Success(val dismissDuration: Long) : SetDismissDurationResult()
+        internal data class Failure(val error: Throwable) : SetDismissDurationResult()
+    }
+}

--- a/libnavui-base/src/main/java/com/mapbox/navigation/ui/base/model/AlertState.kt
+++ b/libnavui-base/src/main/java/com/mapbox/navigation/ui/base/model/AlertState.kt
@@ -6,16 +6,18 @@ import com.mapbox.navigation.ui.base.State
  * Immutable object which contains the required [State] to render [AlertView]
  * @property avText String text to show in the alert view
  * @property durationToDismiss Long specifies the time in ms for AlertView to dismiss automatically. It cannot be greater than 5000ms
+ * @property error Holds erroneous throwable messages
  */
 data class AlertState(
     val avText: String,
-    val durationToDismiss: Long
+    val durationToDismiss: Long,
+    val error: Throwable?
 ) : State {
     companion object {
         /**
          * Returns the initial state of [AlertView]
          * @return [AlertState]
          */
-        fun idle(): AlertState = AlertState("", 3000L)
+        fun idle(): AlertState = AlertState("", 3000L, null)
     }
 }


### PR DESCRIPTION
## Description

The PR attempts to make minor modifications to the implementation details mentioned [here](https://github.com/mapbox/mapbox-navigation-android/pull/2824) 
(Fixes [#334](https://github.com/mapbox/navigation-sdks/issues/334))

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Change the implementation detail associated with `Processor` classes responsible to hold the business logic.

### Implementation

The change introduces three new components 

#### Action
`Action` is a `Sealed` classes representing constrained hierarchies. Each widget should have an `Action` which defines the capabilities provided by the particular widget. 
For ex: `AlertView` should allow you to be able to set the text associated with alert. In order to be able to that, the widget should add an `Action` as below
```
sealed class AlertAction {
    data class SetAlertText(val text: String): AlertAction()
}
```

#### Result
`Result` is a `Sealed` classes representing constrained hierarchies. Based on the business logic processed by an `Action` a `Result` is produced. Each `Action` should have a `Success` and `Failure` `Result`. 
For ex: The `Action` -> `AlertAction.SetAlertText` should be associated with `Result` as follows
```
sealed class AlertResult {
    sealed class SetAlertTextResult: AlertResult() {
        data class Success(val alertText: String): SetAlertTextResult()
        data class Failure(val error: Throwable): SetAlertTextResult()
    }
}
```

#### Processor
The `Processor` is a component that performs business logic on the `Action` passed to it. It is achieved by exposing functions which takes <Action, Result> as types. Based on the `Action` passed it emits the appropriate `Result`.
For ex: To set the text associated with `AlertView` we do the following
```
typealias SetAlertText<T1, T2> = (input: T1) -> T2
internal val setAlertText: SetAlertText<AlertAction, AlertResult> = { action ->
    if (action is AlertAction.SetAlertText) {
        when (action.alertText.isEmpty()) {
            true -> AlertResult.SetAlertTextResult.Failure(IllegalArgumentException("Text to be shown in alert view cannot be empty"))
            false -> AlertResult.SetAlertTextResult.Success(action.alertText)
        }
    } else {
        AlertResult.SetAlertTextResult.Failure(IllegalArgumentException("Unknown $action passed as input"))
    }
}
```

#### Reducer
As the name suggests the job of the `Reducer` is to reduce a given state to another. It is achieved by exposing a function that takes <State, Result> and emits a `State`.
For ex: Based on the `Result` obtained above now we need to create a new state 
```
typealias AlertReducer<T1, T2> = (input1 : T1, input2 : T2) -> T1
internal val alertReducer: AlertReducer<AlertState, AlertResult> = { previousState, result ->
    when(result) {
        is AlertResult.SetAlertTextResult.Success -> {
            previousState.copy(avText = result.alertText)
        }
        is AlertResult.SetAlertTextResult.Failure -> {
            previousState.copy(error = result.error)
        }
    }
```

The good thing about this implementation is that now `when` expressions will require us to provide branches for all the possible `Action` and `Result`. If any of the types are left out, `when` would complain and won't compile. This is also great in case we add a new `Action` as will throw compile time error unless the new `Action` is added in the `when`. Associating a `Throwable` with the `State` allows us to set the appropriate message and then it is up to the user to decide how they want to deal with the exceptions rather than the SDK itself throwing the exception and causing the app to crash.  

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->