### PR TITLE
Add ability to observe arrival independently

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MultipleStopsActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MultipleStopsActivity.kt
@@ -171,7 +171,7 @@ class MultipleStopsActivity : AppCompatActivity(), OnMapReadyCallback {
             .build()
         override fun arrivalOptions(): ArrivalOptions = arrivalOptions
 
-        override fun onStopArrival(routeLegProgress: RouteLegProgress): Boolean {
+        override fun navigateNextRouteLeg(routeLegProgress: RouteLegProgress): Boolean {
             // This example shows you can use both time and distance.
             // Move to the next step when the distance is small
             Timber.i("arrival_debug legIndex=${routeLegProgress.legIndex()} distanceRemaining=${routeLegProgress.distanceRemaining()}")

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -38,6 +38,7 @@ import com.mapbox.navigation.core.internal.accounts.MapboxNavigationAccounts
 import com.mapbox.navigation.core.internal.trip.service.TripService
 import com.mapbox.navigation.core.routerefresh.RouteRefreshController
 import com.mapbox.navigation.core.stops.ArrivalController
+import com.mapbox.navigation.core.stops.ArrivalObserver
 import com.mapbox.navigation.core.stops.ArrivalProgressObserver
 import com.mapbox.navigation.core.stops.AutoArrivalController
 import com.mapbox.navigation.core.telemetry.MapboxNavigationTelemetry
@@ -459,9 +460,9 @@ constructor(
     /**
      * Attach your own controller to determine when drivers arrived at stops via [ArrivalController]
      * Use [navigateNextRouteLeg] to manually move navigator to the next stop. To reset to the
-     * automatic arrival controller, call attachArrivalController()
+     * automatic arrival controller, call [attachArrivalController].
      *
-     * @param arrivalController ArrivalObserver
+     * @param arrivalController [ArrivalController]
      */
     @JvmOverloads fun attachArrivalController(arrivalController: ArrivalController = AutoArrivalController()) {
         arrivalProgressObserver.attach(arrivalController)
@@ -477,9 +478,28 @@ constructor(
     }
 
     /**
+     * Registers [ArrivalObserver]. Monitor arrival at stops and destinations. For more control
+     * of arrival at stops, see [attachArrivalController].
+     *
+     * @see [unregisterArrivalObserver]
+     */
+    fun registerArrivalObserver(arrivalObserver: ArrivalObserver) {
+        arrivalProgressObserver.registerObserver(arrivalObserver)
+    }
+
+    /**
+     * Unregisters [ArrivalObserver].
+     *
+     * @see [registerArrivalObserver]
+     */
+    fun unregisterArrivalObserver(arrivalObserver: ArrivalObserver) {
+        arrivalProgressObserver.unregisterObserver(arrivalObserver)
+    }
+
+    /**
      * After arriving at a stop, this can be used to manually decide when to start
      * navigating to the next stop. Use the [ArrivalController] to control when to
-     * call navigateNextRouteLeg.
+     * call [navigateNextRouteLeg].
      *
      * @return true if navigation to next stop could be started, false otherwise
      */

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/stops/ArrivalController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/stops/ArrivalController.kt
@@ -1,13 +1,13 @@
 package com.mapbox.navigation.core.stops
 
 import com.mapbox.navigation.base.trip.model.RouteLegProgress
-import com.mapbox.navigation.base.trip.model.RouteProgress
-import com.mapbox.navigation.base.trip.model.RouteProgressState
 import com.mapbox.navigation.core.MapboxNavigation
 
 /**
- * When navigating to points of interest, you may want to control the arrival
- * experience. This interface gives you options to change arrival via [MapboxNavigation.attachArrivalController]
+ * When navigating to points of interest, you may want to control the arrival experience.
+ * This interface gives you options to control arrival via [MapboxNavigation.attachArrivalController].
+ *
+ * To observe arrival, see [ArrivalObserver]
  */
 interface ArrivalController {
 
@@ -18,17 +18,11 @@ interface ArrivalController {
 
     /**
      * Based on your [ArrivalOptions], this will be called as the next stop is approached.
-     * To manually navigate the next leg, return false and call [MapboxNavigation.navigateNextRouteLeg]
+     * To manually navigate to the next leg, return false and call [MapboxNavigation.navigateNextRouteLeg].
      *
-     * @return true to automatically move to the next step, false to do it manually
+     * @return true to automatically call [MapboxNavigation.navigateNextRouteLeg], false to do it manually
      */
-    fun onStopArrival(routeLegProgress: RouteLegProgress): Boolean
-
-    /**
-     * Once the [RouteProgress.currentState] has reached [RouteProgressState.ROUTE_ARRIVED]
-     * for the last stop, this will be called once.
-     */
-    fun onRouteArrival(routeProgress: RouteProgress) {}
+    fun navigateNextRouteLeg(routeLegProgress: RouteLegProgress): Boolean
 }
 
 /**
@@ -38,14 +32,14 @@ interface ArrivalController {
 class AutoArrivalController : ArrivalController {
 
     /**
-     * Default arrival options
+     * Default arrival options.
      */
     override fun arrivalOptions(): ArrivalOptions = ArrivalOptions.Builder().build()
 
     /**
      * By default this will move onto the next step.
      */
-    override fun onStopArrival(routeLegProgress: RouteLegProgress): Boolean {
+    override fun navigateNextRouteLeg(routeLegProgress: RouteLegProgress): Boolean {
         return true
     }
 }
@@ -57,13 +51,13 @@ data class ArrivalOptions(
 
     /**
      * While the next stop is less than [arrivalInSeconds] away,
-     * [ArrivalController.onStopArrival] will be called
+     * [ArrivalController.navigateNextRouteLeg] will be called.
      */
     val arrivalInSeconds: Double?,
 
     /**
      * While the next stop is less than [arrivalInMeters] away,
-     * [ArrivalController.onStopArrival] will be called
+     * [ArrivalController.navigateNextRouteLeg] will be called.
      */
     val arrivalInMeters: Double?
 ) {
@@ -77,7 +71,7 @@ data class ArrivalOptions(
 
         /**
          * (Recommended) Use time estimation for arrival, arrival is influenced by traffic conditions.
-         * Arrive when the estimated time to a stop is less than or equal to this threshold
+         * Arrive when the estimated time to a stop is less than or equal to this threshold.
          */
         fun arriveInSeconds(arriveInSeconds: Double?): Builder {
             this.arrivalInSeconds = arriveInSeconds
@@ -85,7 +79,7 @@ data class ArrivalOptions(
         }
 
         /**
-         * Arrive when the estimated distance to a stop is less than or equal to this threshold
+         * Arrive when the estimated distance to a stop is less than or equal to this threshold.
          */
         fun arriveInMeters(arriveInMeters: Double?): Builder {
             this.arrivalInMeters = arriveInMeters
@@ -93,7 +87,7 @@ data class ArrivalOptions(
         }
 
         /**
-         * Build the object. If you want to disable this feature use [MapboxNavigation.removeArrivalController]
+         * Build the object. If you want to disable this feature use [MapboxNavigation.removeArrivalController].
          */
         fun build(): ArrivalOptions {
             check(arrivalInSeconds != null || arrivalInSeconds != null) {

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/stops/ArrivalObserver.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/stops/ArrivalObserver.kt
@@ -1,0 +1,25 @@
+package com.mapbox.navigation.core.stops
+
+import com.mapbox.navigation.base.trip.model.RouteLegProgress
+import com.mapbox.navigation.base.trip.model.RouteProgress
+import com.mapbox.navigation.base.trip.model.RouteProgressState
+import com.mapbox.navigation.core.MapboxNavigation
+
+/**
+ * This gives many observers the ability to monitor the progress of arrival.
+ * To control the behavior of arrival, see [ArrivalController]
+ */
+interface ArrivalObserver {
+
+    /**
+     * Once [MapboxNavigation.navigateNextRouteLeg] has been called and returns true,
+     * this observer will be notified of a stop arrival.
+     */
+    fun onStopArrival(routeLegProgress: RouteLegProgress) {}
+
+    /**
+     * Once the [RouteProgress.currentState] has reached [RouteProgressState.ROUTE_ARRIVED]
+     * for the last stop, this will be called once.
+     */
+    fun onRouteArrival(routeProgress: RouteProgress) {}
+}

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigator.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigator.kt
@@ -120,7 +120,7 @@ interface MapboxNativeNavigator {
     ): String?
 
     /**
-     * Follows a new route and leg of the already loaded directions.
+     * Follows a new leg of the already loaded directions.
      * Returns an initialized navigation status if no errors occurred
      * otherwise, it returns an invalid navigation status state.
      *

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigatorImpl.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigatorImpl.kt
@@ -180,7 +180,7 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
         navigator.getRouteBufferGeoJson(gridSize, bufferDilation)
 
     /**
-     * Follows a new route and leg of the already loaded directions.
+     * Follows a new leg of the already loaded directions.
      * Returns an initialized navigation status if no errors occurred
      * otherwise, it returns an invalid navigation status state.
      *


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

We recently finished controlling arrival https://github.com/mapbox/mapbox-navigation-android/pull/2787

But have noticed that we still want the ability to "observe" arrival, without needing to change the behavior. This pull request adds the ability to add/remove arrival observers. 

- [ ] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->