### PR TITLE
Clean up MapboxNativeNavigator

### DIFF
--- a/libdirections-hybrid/src/test/java/com/mapbox/navigation/route/hybrid/MapboxHybridRouterTest.kt
+++ b/libdirections-hybrid/src/test/java/com/mapbox/navigation/route/hybrid/MapboxHybridRouterTest.kt
@@ -190,8 +190,6 @@ class MapboxHybridRouterTest {
         } catch (ex: Exception) {
         }
 
-        every { context.unregisterReceiver(any()) } answers {}
-
         verify { context.unregisterReceiver(any()) }
     }
 

--- a/libnavigation-util/src/test/java/com/mapbox/navigation/utils/internal/ThreadControllerTest.kt
+++ b/libnavigation-util/src/test/java/com/mapbox/navigation/utils/internal/ThreadControllerTest.kt
@@ -1,6 +1,5 @@
 package com.mapbox.navigation.utils.internal
 
-import com.mapbox.navigation.testing.MainCoroutineRule
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ClosedReceiveChannelException
 import kotlinx.coroutines.delay
@@ -10,16 +9,12 @@ import org.hamcrest.CoreMatchers.`is`
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertThat
 import org.junit.Assert.assertTrue
-import org.junit.Rule
 import org.junit.Test
 
 class ThreadControllerTest {
 
-    @get:Rule
-    val coroutineRule = MainCoroutineRule()
-
     @Test
-    fun jobCountValidationNonUIScope() = coroutineRule.runBlockingTest {
+    fun jobCountValidationNonUIScope() {
         val maxCoroutines = 10
         val maxDelay = 100L
         val jobControl = ThreadController.getIOScopeAndRootJob()

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigator.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigator.kt
@@ -19,7 +19,6 @@ import java.util.Date
 interface MapboxNativeNavigator {
 
     companion object {
-        private const val INDEX_FIRST_ROUTE = 0
         private const val INDEX_FIRST_LEG = 0
         private const val GRID_SIZE = 0.0025f
         private const val BUFFER_DILATION: Short = 1
@@ -69,7 +68,6 @@ interface MapboxNativeNavigator {
      * Otherwise, it returns a invalid route state.
      *
      * @param route [DirectionsRoute] to follow.
-     * @param routeIndex Which route to follow
      * @param legIndex Which leg to follow
      *
      * @return a [NavigationStatus] route state if no errors occurred.
@@ -77,7 +75,6 @@ interface MapboxNativeNavigator {
      */
     suspend fun setRoute(
         route: DirectionsRoute?,
-        routeIndex: Int = INDEX_FIRST_ROUTE,
         legIndex: Int = INDEX_FIRST_LEG
     ): NavigationStatus
 

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigatorImpl.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigatorImpl.kt
@@ -117,7 +117,6 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
      * Otherwise, it returns a invalid route state.
      *
      * @param route [DirectionsRoute] to follow.
-     * @param routeIndex Which route to follow
      * @param legIndex Which leg to follow
      *
      * @return a [NavigationStatus] route state if no errors occurred.
@@ -125,12 +124,11 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
      */
     override suspend fun setRoute(
         route: DirectionsRoute?,
-        routeIndex: Int,
         legIndex: Int
     ): NavigationStatus {
         mutex.withLock {
             MapboxNativeNavigatorImpl.route = route
-            val result = navigator.setRoute(route?.toJson() ?: "{}", routeIndex, legIndex)
+            val result = navigator.setRoute(route?.toJson() ?: "{}", PRIMARY_ROUTE_INDEX, legIndex)
             navigator.getRouteBufferGeoJson(GRID_SIZE, BUFFER_DILATION)?.also {
                 routeBufferGeoJson = GeometryGeoJson.fromJson(it)
             }


### PR DESCRIPTION
## Description

Cleans up `MapboxNativeNavigator`

Follow up from https://github.com/mapbox/mapbox-navigation-android/pull/2839#discussion_r417496474 and https://github.com/mapbox/mapbox-navigation-android/pull/2852

Refs. https://github.com/mapbox/mapbox-navigation-android/pull/2855 and https://github.com/mapbox/mapbox-navigation-android/pull/2787

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

General cleanup

### Implementation

- Remove `coroutineRule.runBlockingTest` in `ThreadControllerTest` not needed (was increasing the test execution time unnecessarily)
- Remove `routeIndex` from `MapboxNativeNavigator#setRoute` as multiple routes is not supported
- Remove unnecessary `every { context.unregisterReceiver(any()) } answers {}` from `MapboxHybridRouterTest`

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR

cc @kmadsen @cafesilencio 