### PR TITLE
Sb 2859 fix for route line discoloration

### DIFF
--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteLineTest.kt
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteLineTest.kt
@@ -425,7 +425,7 @@ class MapRouteLineTest {
 
     @Test
     fun buildRouteLineExpression() {
-        val expectedExpression = "[\"interpolate\", [\"linear\"], [\"line-progress\"], 0.2, [\"rgba\", 0.0, 0.0, 0.0, 0.0], 0.31436133, [\"rgba\", 0.0, 7.0, 255.0, 0.0], 0.66388464, [\"rgba\", 0.0, 7.0, 255.0, 0.0], 0.6948727, [\"rgba\", 0.0, 7.0, 255.0, 0.0]]"
+        val expectedExpression = "[\"step\", [\"line-progress\"], [\"rgba\", 0.0, 0.0, 0.0, 0.0], 0.2, [\"rgba\", 0.0, 7.0, 255.0, 0.0], 0.31436133, [\"rgba\", 0.0, 7.0, 255.0, 0.0], 0.66388464, [\"rgba\", 0.0, 7.0, 255.0, 0.0], 0.6948727, [\"rgba\", 0.0, 7.0, 255.0, 0.0]]"
         val route = getDirectionsRoute()
         val lineString = LineString.fromPolyline(route.geometry()!!, Constants.PRECISION_6)
 
@@ -451,7 +451,7 @@ class MapRouteLineTest {
             true
         ) { _, _ -> 1 }
 
-        assertEquals(3, result.size)
+        assertEquals(4, result.size)
     }
 
     @Test


### PR DESCRIPTION
## Description

Addresses several issues with the initial vanishing route line feature. 
One such issue is described in #2859

- [ ] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal

This PR should resolve issue of the route line changing to a darker blue color when reaching destination.

The gradient should be less apparent displaying a route line with traffic congestion markers closer to the appearance of the line before the vanishing route line feature was implemented.

### Implementation

A refinement of the layer style expressions generated.

## Screenshots or Gifs

![20200429_185222](https://user-images.githubusercontent.com/2249818/80664105-ba896180-8a4a-11ea-833a-dd5c0ed52f2f.gif)


## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->