### PR TITLE
Add playbackSpeed to handle replay fast forward and pause

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayHistoryActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayHistoryActivity.kt
@@ -3,6 +3,7 @@ package com.mapbox.navigation.examples.core
 import android.annotation.SuppressLint
 import android.content.Context
 import android.os.Bundle
+import android.widget.SeekBar
 import androidx.appcompat.app.AppCompatActivity
 import com.google.gson.Gson
 import com.google.gson.internal.LinkedTreeMap
@@ -137,6 +138,8 @@ class ReplayHistoryActivity : AppCompatActivity() {
      * After the map, style, and replay history is all loaded. Connect the view.
      */
     private fun ReplayNavigationContext.onNavigationReady() {
+        setupReplayControls()
+
         navigationMapboxMap.addProgressChangeListener(mapboxNavigation)
 
         replayHistoryPlayer.playFirstLocation()
@@ -160,6 +163,21 @@ class ReplayHistoryActivity : AppCompatActivity() {
         playReplay.setOnClickListener {
             replayHistoryPlayer.play(this@ReplayHistoryActivity)
         }
+    }
+
+    private fun ReplayNavigationContext.setupReplayControls() {
+        seekBar.max = 8
+        seekBar.progress = 1
+        seekBarText.text = getString(R.string.replay_history_player_playback_seekbar, seekBar.progress)
+        seekBar.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
+            override fun onProgressChanged(seekBar: SeekBar, progress: Int, fromUser: Boolean) {
+                replayHistoryPlayer.playbackSpeed(progress.toDouble())
+                seekBarText.text = getString(R.string.replay_history_player_playback_seekbar, progress)
+            }
+
+            override fun onStartTrackingTouch(seekBar: SeekBar) { }
+            override fun onStopTrackingTouch(seekBar: SeekBar) { }
+        })
     }
 
     private fun ReplayNavigationContext.selectMapLocation(latLng: LatLng) {

--- a/examples/src/main/res/layout/replay_history_example_activity_layout.xml
+++ b/examples/src/main/res/layout/replay_history_example_activity_layout.xml
@@ -30,4 +30,36 @@
         android:textColor="@android:color/white"
         />
 
+    <com.google.android.material.card.MaterialCardView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toTopOf="@id/playReplay"
+        app:cardElevation="3dp"
+        app:cardUseCompatPadding="true">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/seekBarText"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_horizontal"
+                style="@style/TextAppearance.MaterialComponents.Headline6"
+                />
+
+            <SeekBar
+                android:id="@+id/seekBar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingBottom="6dp"
+                android:paddingTop="6dp"
+                />
+
+        </LinearLayout>
+
+    </com.google.android.material.card.MaterialCardView>
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/examples/src/main/res/values/strings.xml
+++ b/examples/src/main/res/values/strings.xml
@@ -58,6 +58,7 @@
 
     <string name="title_replay_history_kotlin" translatable="false">ReplayHistoryActivity</string>
     <string name="description_replay_history_kotlin" translatable="false">Shows how to use replay ride history in Kotlin code.</string>
+    <string name="replay_history_player_playback_seekbar" translatable="false">Replay speed %d</string>
 
     <string name="title_reroute_view" translatable="false">RerouteActivity</string>
     <string name="description_reroute_view" translatable="false">Shows how to observe reroute events.</string>

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/history/ReplayEventSimulator.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/history/ReplayEventSimulator.kt
@@ -32,14 +32,9 @@ internal class ReplayEventSimulator(
     // The pivot will move forward through the events with time.
     private var historyTimeOffset: Double = 0.0
     private var simulatorTimeOffset: Double = 0.0
+    private var simulatorTimeScale: Double = 1.0
 
     private var pivotIndex = 0
-
-    fun seekTo(indexOfEvent: Int) {
-        historyTimeOffset = replayEvents.events[indexOfEvent].eventTimestamp
-        pivotIndex = indexOfEvent
-        resetSimulatorClock()
-    }
 
     fun launchPlayLoop(lifecycleOwner: LifecycleOwner, replayEventsCallback: (List<ReplayEventBase>) -> Unit): Job {
         logger.i(msg = Message("Replay started"))
@@ -69,6 +64,17 @@ internal class ReplayEventSimulator(
 
     fun stopPlaying() {
         jobControl.job.cancelChildren()
+    }
+
+    fun seekTo(indexOfEvent: Int) {
+        historyTimeOffset = replayEvents.events[indexOfEvent].eventTimestamp
+        pivotIndex = indexOfEvent
+        resetSimulatorClock()
+    }
+
+    fun playbackSpeed(scale: Double) {
+        simulatorTimeScale = scale
+        resetSimulatorClock()
     }
 
     private fun resetSimulatorClock() {
@@ -104,6 +110,11 @@ internal class ReplayEventSimulator(
         return pivotIndex >= replayEvents.events.size
     }
 
+    private fun timeSeconds(): Double {
+        val elapsedNanos = SystemClock.elapsedRealtimeNanos().toDouble() * NANOS_PER_SECOND
+        return elapsedNanos * simulatorTimeScale
+    }
+
     companion object {
 
         // The frequency that replay updates will be broad-casted
@@ -111,6 +122,5 @@ internal class ReplayEventSimulator(
 
         private const val MILLIS_PER_SECOND = 1000
         private const val NANOS_PER_SECOND = 1e-9
-        private fun timeSeconds(): Double = SystemClock.elapsedRealtimeNanos().toDouble() * NANOS_PER_SECOND
     }
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/history/ReplayHistoryPlayer.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/history/ReplayHistoryPlayer.kt
@@ -75,6 +75,20 @@ class ReplayHistoryPlayer(
     }
 
     /**
+     * This determines the speed of event playback. Default is 1.0 for 1x playback speed.
+     *
+     * For faster playback, use values greater than one such as 2x, 3x or even 4x.
+     * For slower playback, use values between 0 and 1; 0.25 will replay at 1/4th speed.
+     * To pause playback, use 0.0
+     *
+     * Negative (going backwards), is not yet supported. Use [seekTo] to go backwards.
+     */
+    fun playbackSpeed(scale: Double) {
+        check(scale >= 0.0) { "Negative playback is not supported: $scale" }
+        replayEventSimulator.playbackSpeed(scale)
+    }
+
+    /**
      * Seek to a time to play from.
      *
      * @param replayTime time in seconds between 0.0 to [replayDurationSeconds]


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

There has been a few asks to be able to change the replay speed. I've been playing with this, and it is reliable so far. 

I'm starting to merge route replay https://github.com/mapbox/mapbox-navigation-android/pull/2802

- [ ] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

## Screenshots or Gifs

![output](https://user-images.githubusercontent.com/3021882/80738029-3fb35b80-8ac9-11ea-9a82-797185a20297.gif)

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->