### PR TITLE
fix which will create an expression for vanishing the routeline when …

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteLine.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteLine.kt
@@ -731,16 +731,22 @@ internal class MapRouteLine(
             val scrubbedRouteLegs = route.legs()
                 ?.filter { it.annotation()?.congestion() != null }
 
-            val stopExpressionsWithTraffic: List<Expression.Stop> = scrubbedRouteLegs?.map {
-                getStopsFromLeg(
-                    it,
+            val stopExpressionsWithTraffic: List<Expression.Stop> = when (scrubbedRouteLegs?.isEmpty()) {
+                false -> scrubbedRouteLegs.map {
+                    getStopsFromLeg(
+                        it,
+                        distFractionToVanish,
+                        routeLineString,
+                        route.distance() ?: 0.0,
+                        isPrimaryRoute,
+                        congestionColorProvider
+                    )
+                }.flatten()
+                else -> listOf(Expression.stop(
                     distFractionToVanish,
-                    routeLineString,
-                    route.distance() ?: 0.0,
-                    isPrimaryRoute,
-                    congestionColorProvider
-                )
-            }?.flatten() ?: listOf()
+                    Expression.color(congestionColorProvider("", isPrimaryRoute)
+                    )))
+            }
 
             return Expression.step(
                 Expression.lineProgress(),

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteLineTest.kt
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteLineTest.kt
@@ -120,7 +120,7 @@ class MapRouteLineTest {
     @Test
     fun getPrimaryRoute() {
         every { style.layers } returns listOf(primaryRouteLayer)
-        val directionsRoute: DirectionsRoute = getDirectionsRoute()
+        val directionsRoute: DirectionsRoute = getDirectionsRoute(true)
         val mrl = MapRouteLine(
             ctx,
             style,
@@ -137,7 +137,7 @@ class MapRouteLineTest {
     @Test
     fun getLineStringForRoute() {
         every { style.layers } returns listOf(primaryRouteLayer)
-        val directionsRoute: DirectionsRoute = getDirectionsRoute()
+        val directionsRoute: DirectionsRoute = getDirectionsRoute(true)
         val mrl = MapRouteLine(
             ctx,
             style,
@@ -154,8 +154,8 @@ class MapRouteLineTest {
     @Test
     fun getLineStringForRouteWhenCalledWithUnknownRoute() {
         every { style.layers } returns listOf(primaryRouteLayer)
-        val directionsRoute: DirectionsRoute = getDirectionsRoute()
-        val directionsRoute2: DirectionsRoute = getDirectionsRoute()
+        val directionsRoute: DirectionsRoute = getDirectionsRoute(true)
+        val directionsRoute2: DirectionsRoute = getDirectionsRoute(true)
         val mrl = MapRouteLine(
             ctx,
             style,
@@ -172,7 +172,7 @@ class MapRouteLineTest {
     @Test
     fun retrieveRouteFeatureData() {
         every { style.layers } returns listOf(primaryRouteLayer)
-        val directionsRoute: DirectionsRoute = getDirectionsRoute()
+        val directionsRoute: DirectionsRoute = getDirectionsRoute(true)
         val mrl = MapRouteLine(
             ctx,
             style,
@@ -190,7 +190,7 @@ class MapRouteLineTest {
     @Test
     fun retrieveRouteLineStrings() {
         every { style.layers } returns listOf(primaryRouteLayer)
-        val directionsRoute: DirectionsRoute = getDirectionsRoute()
+        val directionsRoute: DirectionsRoute = getDirectionsRoute(true)
         val mrl = MapRouteLine(
             ctx,
             style,
@@ -207,7 +207,7 @@ class MapRouteLineTest {
     @Test
     fun retrieveDirectionsRoutes() {
         every { style.layers } returns listOf(primaryRouteLayer)
-        val directionsRoute: DirectionsRoute = getDirectionsRoute()
+        val directionsRoute: DirectionsRoute = getDirectionsRoute(true)
         val mrl = MapRouteLine(
             ctx,
             style,
@@ -240,8 +240,8 @@ class MapRouteLineTest {
     @Test
     fun updatePrimaryRouteIndex() {
         every { style.layers } returns listOf(primaryRouteLayer)
-        val directionsRoute: DirectionsRoute = getDirectionsRoute()
-        val directionsRoute2: DirectionsRoute = getDirectionsRoute()
+        val directionsRoute: DirectionsRoute = getDirectionsRoute(true)
+        val directionsRoute2: DirectionsRoute = getDirectionsRoute(true)
         val mrl = MapRouteLine(
             ctx,
             style,
@@ -398,7 +398,7 @@ class MapRouteLineTest {
 
     @Test
     fun generateFeatureCollectionContainsRoute() {
-        val route = getDirectionsRoute()
+        val route = getDirectionsRoute(true)
 
         val result = MapRouteLine.MapRouteLineSupport.generateFeatureCollection(route)
 
@@ -407,7 +407,7 @@ class MapRouteLineTest {
 
     @Test
     fun generateFeatureLineStringContainsCorrectCoordinates() {
-        val route = getDirectionsRoute()
+        val route = getDirectionsRoute(true)
 
         val result = MapRouteLine.MapRouteLineSupport.generateFeatureCollection(route)
 
@@ -416,7 +416,7 @@ class MapRouteLineTest {
 
     @Test
     fun generateFeatureFeatureCollectionContainsCorrectFeatures() {
-        val route = getDirectionsRoute()
+        val route = getDirectionsRoute(true)
 
         val result = MapRouteLine.MapRouteLineSupport.generateFeatureCollection(route)
 
@@ -426,7 +426,22 @@ class MapRouteLineTest {
     @Test
     fun buildRouteLineExpression() {
         val expectedExpression = "[\"step\", [\"line-progress\"], [\"rgba\", 0.0, 0.0, 0.0, 0.0], 0.2, [\"rgba\", 0.0, 7.0, 255.0, 0.0], 0.31436133, [\"rgba\", 0.0, 7.0, 255.0, 0.0], 0.66388464, [\"rgba\", 0.0, 7.0, 255.0, 0.0], 0.6948727, [\"rgba\", 0.0, 7.0, 255.0, 0.0]]"
-        val route = getDirectionsRoute()
+        val route = getDirectionsRoute(true)
+        val lineString = LineString.fromPolyline(route.geometry()!!, Constants.PRECISION_6)
+
+        val expression = MapRouteLine.MapRouteLineSupport.buildRouteLineExpression(
+            route,
+            lineString,
+            true,
+            .2) { _, _ -> 2047 }
+
+        assertEquals(expectedExpression, expression.toString())
+    }
+
+    @Test
+    fun buildRouteLineExpressionWhenNoTraffic() {
+        val expectedExpression = "[\"step\", [\"line-progress\"], [\"rgba\", 0.0, 0.0, 0.0, 0.0], 0.2, [\"rgba\", 0.0, 7.0, 255.0, 0.0]]"
+        val route = getDirectionsRoute(false)
         val lineString = LineString.fromPolyline(route.geometry()!!, Constants.PRECISION_6)
 
         val expression = MapRouteLine.MapRouteLineSupport.buildRouteLineExpression(
@@ -440,7 +455,7 @@ class MapRouteLineTest {
 
     @Test
     fun getStopsFromLegReturnsCorrectNumStops() {
-        val route = getDirectionsRoute()
+        val route = getDirectionsRoute(true)
         val lineString = LineString.fromPolyline(route.geometry()!!, Constants.PRECISION_6)
 
         val result = MapRouteLine.MapRouteLineSupport.getStopsFromLeg(
@@ -456,7 +471,7 @@ class MapRouteLineTest {
 
     @Test
     fun buildWayPointFeatureCollection() {
-        val route = getDirectionsRoute()
+        val route = getDirectionsRoute(true)
 
         val result = MapRouteLine.MapRouteLineSupport.buildWayPointFeatureCollection(route)
 
@@ -465,7 +480,7 @@ class MapRouteLineTest {
 
     @Test
     fun buildWayPointFeatureCollectionFirstFeatureOrigin() {
-        val route = getDirectionsRoute()
+        val route = getDirectionsRoute(true)
 
         val result = MapRouteLine.MapRouteLineSupport.buildWayPointFeatureCollection(route)
 
@@ -474,7 +489,7 @@ class MapRouteLineTest {
 
     @Test
     fun buildWayPointFeatureCollectionSecondFeatureOrigin() {
-        val route = getDirectionsRoute()
+        val route = getDirectionsRoute(true)
 
         val result = MapRouteLine.MapRouteLineSupport.buildWayPointFeatureCollection(route)
 
@@ -483,7 +498,7 @@ class MapRouteLineTest {
 
     @Test
     fun buildWayPointFeatureFromLeg() {
-        val route = getDirectionsRoute()
+        val route = getDirectionsRoute(true)
 
         val result = MapRouteLine.MapRouteLineSupport.buildWayPointFeatureFromLeg(route.legs()!![0], 0)
 
@@ -493,16 +508,20 @@ class MapRouteLineTest {
 
     @Test
     fun buildWayPointFeatureFromLegContainsOriginWaypoint() {
-        val route = getDirectionsRoute()
+        val route = getDirectionsRoute(true)
 
         val result = MapRouteLine.MapRouteLineSupport.buildWayPointFeatureFromLeg(route.legs()!![0], 0)
 
         assertEquals("\"origin\"", result!!.properties()!!["wayPoint"].toString())
     }
 
-    private fun getDirectionsRoute(): DirectionsRoute {
+    private fun getDirectionsRoute(includeCongestion: Boolean): DirectionsRoute {
+        val congestion = when (includeCongestion) {
+            true -> "\"unknown\",\"heavy\",\"low\""
+            false -> ""
+        }
         val tokenHere = "someToken"
-        val directionsRouteAsJson = "{\"routeIndex\":\"0\",\"distance\":66.9,\"duration\":45.0,\"geometry\":\"urylgArvfuhFjJ`CbC{[pAZ\",\"weight\":96.6,\"weight_name\":\"routability\",\"legs\":[{\"distance\":66.9,\"duration\":45.0,\"summary\":\"Laurel Place, Lincoln Avenue\",\"steps\":[{\"distance\":21.0,\"duration\":16.7,\"geometry\":\"urylgArvfuhFjJ`C\",\"name\":\"\",\"mode\":\"driving\",\"maneuver\":{\"location\":[-122.523514,37.975355],\"bearing_before\":0.0,\"bearing_after\":196.0,\"instruction\":\"Head south\",\"type\":\"depart\",\"modifier\":\"right\"},\"voiceInstructions\":[{\"distanceAlongGeometry\":21.0,\"announcement\":\"Head south, then turn left onto Laurel Place\",\"ssmlAnnouncement\":\"\\u003cspeak\\u003e\\u003camazon:effect name\\u003d\\\"drc\\\"\\u003e\\u003cprosody rate\\u003d\\\"1.08\\\"\\u003eHead south, then turn left onto Laurel Place\\u003c/prosody\\u003e\\u003c/amazon:effect\\u003e\\u003c/speak\\u003e\"},{\"distanceAlongGeometry\":18.9,\"announcement\":\"Turn left onto Laurel Place, then turn right onto Lincoln Avenue\",\"ssmlAnnouncement\":\"\\u003cspeak\\u003e\\u003camazon:effect name\\u003d\\\"drc\\\"\\u003e\\u003cprosody rate\\u003d\\\"1.08\\\"\\u003eTurn left onto Laurel Place, then turn right onto Lincoln Avenue\\u003c/prosody\\u003e\\u003c/amazon:effect\\u003e\\u003c/speak\\u003e\"}],\"bannerInstructions\":[{\"distanceAlongGeometry\":21.0,\"primary\":{\"text\":\"Laurel Place\",\"components\":[{\"text\":\"Laurel Place\",\"type\":\"text\",\"abbr\":\"Laurel Pl\",\"abbr_priority\":0}],\"type\":\"turn\",\"modifier\":\"left\"}},{\"distanceAlongGeometry\":18.9,\"primary\":{\"text\":\"Laurel Place\",\"components\":[{\"text\":\"Laurel Place\",\"type\":\"text\",\"abbr\":\"Laurel Pl\",\"abbr_priority\":0}],\"type\":\"turn\",\"modifier\":\"left\"},\"sub\":{\"text\":\"Lincoln Avenue\",\"components\":[{\"text\":\"Lincoln Avenue\",\"type\":\"text\",\"abbr\":\"Lincoln Ave\",\"abbr_priority\":0}],\"type\":\"turn\",\"modifier\":\"right\"}}],\"driving_side\":\"right\",\"weight\":52.6,\"intersections\":[{\"location\":[-122.523514,37.975355],\"bearings\":[196],\"entry\":[true],\"out\":0}]},{\"distance\":41.2,\"duration\":27.3,\"geometry\":\"igylgAtzfuhFbC{[\",\"name\":\"Laurel Place\",\"mode\":\"driving\",\"maneuver\":{\"location\":[-122.523579,37.975173],\"bearing_before\":195.0,\"bearing_after\":99.0,\"instruction\":\"Turn left onto Laurel Place\",\"type\":\"turn\",\"modifier\":\"left\"},\"voiceInstructions\":[{\"distanceAlongGeometry\":22.6,\"announcement\":\"Turn right onto Lincoln Avenue, then you will arrive at your destination\",\"ssmlAnnouncement\":\"\\u003cspeak\\u003e\\u003camazon:effect name\\u003d\\\"drc\\\"\\u003e\\u003cprosody rate\\u003d\\\"1.08\\\"\\u003eTurn right onto Lincoln Avenue, then you will arrive at your destination\\u003c/prosody\\u003e\\u003c/amazon:effect\\u003e\\u003c/speak\\u003e\"}],\"bannerInstructions\":[{\"distanceAlongGeometry\":41.2,\"primary\":{\"text\":\"Lincoln Avenue\",\"components\":[{\"text\":\"Lincoln Avenue\",\"type\":\"text\",\"abbr\":\"Lincoln Ave\",\"abbr_priority\":0}],\"type\":\"turn\",\"modifier\":\"right\"}}],\"driving_side\":\"right\",\"weight\":43.0,\"intersections\":[{\"location\":[-122.523579,37.975173],\"bearings\":[15,105,285],\"entry\":[false,true,true],\"in\":0,\"out\":1}]},{\"distance\":4.7,\"duration\":1.0,\"geometry\":\"ecylgAx}euhFpAZ\",\"name\":\"Lincoln Avenue\",\"mode\":\"driving\",\"maneuver\":{\"location\":[-122.523117,37.975107],\"bearing_before\":99.0,\"bearing_after\":194.0,\"instruction\":\"Turn right onto Lincoln Avenue\",\"type\":\"turn\",\"modifier\":\"right\"},\"voiceInstructions\":[{\"distanceAlongGeometry\":4.7,\"announcement\":\"You have arrived at your destination\",\"ssmlAnnouncement\":\"\\u003cspeak\\u003e\\u003camazon:effect name\\u003d\\\"drc\\\"\\u003e\\u003cprosody rate\\u003d\\\"1.08\\\"\\u003eYou have arrived at your destination\\u003c/prosody\\u003e\\u003c/amazon:effect\\u003e\\u003c/speak\\u003e\"}],\"bannerInstructions\":[{\"distanceAlongGeometry\":4.7,\"primary\":{\"text\":\"You have arrived\",\"components\":[{\"text\":\"You have arrived\",\"type\":\"text\"}],\"type\":\"arrive\",\"modifier\":\"straight\"}}],\"driving_side\":\"right\",\"weight\":1.0,\"intersections\":[{\"location\":[-122.523117,37.975107],\"bearings\":[15,105,195,285],\"entry\":[true,true,true,false],\"in\":3,\"out\":2}]},{\"distance\":0.0,\"duration\":0.0,\"geometry\":\"s`ylgAt~euhF\",\"name\":\"Lincoln Avenue\",\"mode\":\"driving\",\"maneuver\":{\"location\":[-122.523131,37.975066],\"bearing_before\":195.0,\"bearing_after\":0.0,\"instruction\":\"You have arrived at your destination\",\"type\":\"arrive\"},\"voiceInstructions\":[],\"bannerInstructions\":[],\"driving_side\":\"right\",\"weight\":0.0,\"intersections\":[{\"location\":[-122.523131,37.975066],\"bearings\":[15],\"entry\":[true],\"in\":0}]}],\"annotation\":{\"distance\":[21.030105037432428,41.16669115760234,4.722589365163041],\"congestion\":[\"unknown\",\"heavy\",\"low\"]}}],\"routeOptions\":{\"baseUrl\":\"https://api.mapbox.com\",\"user\":\"mapbox\",\"profile\":\"driving-traffic\",\"coordinates\":[[-122.5237559,37.9754094],[-122.5231475,37.9750697]],\"alternatives\":true,\"language\":\"en\",\"continue_straight\":false,\"roundabout_exits\":false,\"geometries\":\"polyline6\",\"overview\":\"full\",\"steps\":true,\"annotations\":\"congestion,distance\",\"voice_instructions\":true,\"banner_instructions\":true,\"voice_units\":\"imperial\",\"access_token\":\"$tokenHere\",\"uuid\":\"ck9g2sbdk6pod7ynuece0r2yo\"},\"voiceLocale\":\"en-US\"}"
+        val directionsRouteAsJson = "{\"routeIndex\":\"0\",\"distance\":66.9,\"duration\":45.0,\"geometry\":\"urylgArvfuhFjJ`CbC{[pAZ\",\"weight\":96.6,\"weight_name\":\"routability\",\"legs\":[{\"distance\":66.9,\"duration\":45.0,\"summary\":\"Laurel Place, Lincoln Avenue\",\"steps\":[{\"distance\":21.0,\"duration\":16.7,\"geometry\":\"urylgArvfuhFjJ`C\",\"name\":\"\",\"mode\":\"driving\",\"maneuver\":{\"location\":[-122.523514,37.975355],\"bearing_before\":0.0,\"bearing_after\":196.0,\"instruction\":\"Head south\",\"type\":\"depart\",\"modifier\":\"right\"},\"voiceInstructions\":[{\"distanceAlongGeometry\":21.0,\"announcement\":\"Head south, then turn left onto Laurel Place\",\"ssmlAnnouncement\":\"\\u003cspeak\\u003e\\u003camazon:effect name\\u003d\\\"drc\\\"\\u003e\\u003cprosody rate\\u003d\\\"1.08\\\"\\u003eHead south, then turn left onto Laurel Place\\u003c/prosody\\u003e\\u003c/amazon:effect\\u003e\\u003c/speak\\u003e\"},{\"distanceAlongGeometry\":18.9,\"announcement\":\"Turn left onto Laurel Place, then turn right onto Lincoln Avenue\",\"ssmlAnnouncement\":\"\\u003cspeak\\u003e\\u003camazon:effect name\\u003d\\\"drc\\\"\\u003e\\u003cprosody rate\\u003d\\\"1.08\\\"\\u003eTurn left onto Laurel Place, then turn right onto Lincoln Avenue\\u003c/prosody\\u003e\\u003c/amazon:effect\\u003e\\u003c/speak\\u003e\"}],\"bannerInstructions\":[{\"distanceAlongGeometry\":21.0,\"primary\":{\"text\":\"Laurel Place\",\"components\":[{\"text\":\"Laurel Place\",\"type\":\"text\",\"abbr\":\"Laurel Pl\",\"abbr_priority\":0}],\"type\":\"turn\",\"modifier\":\"left\"}},{\"distanceAlongGeometry\":18.9,\"primary\":{\"text\":\"Laurel Place\",\"components\":[{\"text\":\"Laurel Place\",\"type\":\"text\",\"abbr\":\"Laurel Pl\",\"abbr_priority\":0}],\"type\":\"turn\",\"modifier\":\"left\"},\"sub\":{\"text\":\"Lincoln Avenue\",\"components\":[{\"text\":\"Lincoln Avenue\",\"type\":\"text\",\"abbr\":\"Lincoln Ave\",\"abbr_priority\":0}],\"type\":\"turn\",\"modifier\":\"right\"}}],\"driving_side\":\"right\",\"weight\":52.6,\"intersections\":[{\"location\":[-122.523514,37.975355],\"bearings\":[196],\"entry\":[true],\"out\":0}]},{\"distance\":41.2,\"duration\":27.3,\"geometry\":\"igylgAtzfuhFbC{[\",\"name\":\"Laurel Place\",\"mode\":\"driving\",\"maneuver\":{\"location\":[-122.523579,37.975173],\"bearing_before\":195.0,\"bearing_after\":99.0,\"instruction\":\"Turn left onto Laurel Place\",\"type\":\"turn\",\"modifier\":\"left\"},\"voiceInstructions\":[{\"distanceAlongGeometry\":22.6,\"announcement\":\"Turn right onto Lincoln Avenue, then you will arrive at your destination\",\"ssmlAnnouncement\":\"\\u003cspeak\\u003e\\u003camazon:effect name\\u003d\\\"drc\\\"\\u003e\\u003cprosody rate\\u003d\\\"1.08\\\"\\u003eTurn right onto Lincoln Avenue, then you will arrive at your destination\\u003c/prosody\\u003e\\u003c/amazon:effect\\u003e\\u003c/speak\\u003e\"}],\"bannerInstructions\":[{\"distanceAlongGeometry\":41.2,\"primary\":{\"text\":\"Lincoln Avenue\",\"components\":[{\"text\":\"Lincoln Avenue\",\"type\":\"text\",\"abbr\":\"Lincoln Ave\",\"abbr_priority\":0}],\"type\":\"turn\",\"modifier\":\"right\"}}],\"driving_side\":\"right\",\"weight\":43.0,\"intersections\":[{\"location\":[-122.523579,37.975173],\"bearings\":[15,105,285],\"entry\":[false,true,true],\"in\":0,\"out\":1}]},{\"distance\":4.7,\"duration\":1.0,\"geometry\":\"ecylgAx}euhFpAZ\",\"name\":\"Lincoln Avenue\",\"mode\":\"driving\",\"maneuver\":{\"location\":[-122.523117,37.975107],\"bearing_before\":99.0,\"bearing_after\":194.0,\"instruction\":\"Turn right onto Lincoln Avenue\",\"type\":\"turn\",\"modifier\":\"right\"},\"voiceInstructions\":[{\"distanceAlongGeometry\":4.7,\"announcement\":\"You have arrived at your destination\",\"ssmlAnnouncement\":\"\\u003cspeak\\u003e\\u003camazon:effect name\\u003d\\\"drc\\\"\\u003e\\u003cprosody rate\\u003d\\\"1.08\\\"\\u003eYou have arrived at your destination\\u003c/prosody\\u003e\\u003c/amazon:effect\\u003e\\u003c/speak\\u003e\"}],\"bannerInstructions\":[{\"distanceAlongGeometry\":4.7,\"primary\":{\"text\":\"You have arrived\",\"components\":[{\"text\":\"You have arrived\",\"type\":\"text\"}],\"type\":\"arrive\",\"modifier\":\"straight\"}}],\"driving_side\":\"right\",\"weight\":1.0,\"intersections\":[{\"location\":[-122.523117,37.975107],\"bearings\":[15,105,195,285],\"entry\":[true,true,true,false],\"in\":3,\"out\":2}]},{\"distance\":0.0,\"duration\":0.0,\"geometry\":\"s`ylgAt~euhF\",\"name\":\"Lincoln Avenue\",\"mode\":\"driving\",\"maneuver\":{\"location\":[-122.523131,37.975066],\"bearing_before\":195.0,\"bearing_after\":0.0,\"instruction\":\"You have arrived at your destination\",\"type\":\"arrive\"},\"voiceInstructions\":[],\"bannerInstructions\":[],\"driving_side\":\"right\",\"weight\":0.0,\"intersections\":[{\"location\":[-122.523131,37.975066],\"bearings\":[15],\"entry\":[true],\"in\":0}]}],\"annotation\":{\"distance\":[21.030105037432428,41.16669115760234,4.722589365163041],\"congestion\":[$congestion]}}],\"routeOptions\":{\"baseUrl\":\"https://api.mapbox.com\",\"user\":\"mapbox\",\"profile\":\"driving-traffic\",\"coordinates\":[[-122.5237559,37.9754094],[-122.5231475,37.9750697]],\"alternatives\":true,\"language\":\"en\",\"continue_straight\":false,\"roundabout_exits\":false,\"geometries\":\"polyline6\",\"overview\":\"full\",\"steps\":true,\"annotations\":\"congestion,distance\",\"voice_instructions\":true,\"banner_instructions\":true,\"voice_units\":\"imperial\",\"access_token\":\"$tokenHere\",\"uuid\":\"ck9g2sbdk6pod7ynuece0r2yo\"},\"voiceLocale\":\"en-US\"}"
         return DirectionsRoute.fromJson(directionsRouteAsJson)
     }
 }


### PR DESCRIPTION
## Description

addresses the issue described in #2875 

Offline routes don't have traffic indicators which is what the vanishing route line mechanism was depending on.

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal

The route line should vanish with offline routes.

### Implementation

If no traffic indicators are present in the route update a default expression is created that will vanish the line at the appropriate place.


## Testing

Test with offline routes as described in #2875

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->