### PR TITLE
changed the default below layer for drawing route lines and manuever …

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteLine.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteLine.kt
@@ -686,7 +686,7 @@ internal class MapRouteLine(
          * @return either the layer ID if found else a default layer ID
          */
         fun getBelowLayer(layerId: String?, style: Style): String =
-            style.layers.firstOrNull { it.id == layerId }?.id ?: LocationComponentConstants.SHADOW_LAYER
+            style.layers.firstOrNull { it.id == layerId }?.id ?: RouteConstants.DEFAULT_ROUTE_LINE_LAYER_BELOW_ID
 
         /**
          * Generates a FeatureCollection and LineString based on the @param route.

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/RouteConstants.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/RouteConstants.java
@@ -1,6 +1,7 @@
 package com.mapbox.navigation.ui.route;
 
 class RouteConstants {
+  static final String DEFAULT_ROUTE_LINE_LAYER_BELOW_ID = "road-label";
   static final String CONGESTION_KEY = "congestion";
   static final String PRIMARY_ROUTE_SOURCE_ID = "mapbox-navigation-route-source";
   static final String PRIMARY_ROUTE_LAYER_ID = "mapbox-navigation-route-layer";

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteLineTest.kt
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteLineTest.kt
@@ -9,7 +9,6 @@ import com.mapbox.core.constants.Constants
 import com.mapbox.geojson.LineString
 import com.mapbox.geojson.Point
 import com.mapbox.libnavigation.ui.R
-import com.mapbox.mapboxsdk.location.LocationComponentConstants
 import com.mapbox.mapboxsdk.maps.Style
 import com.mapbox.mapboxsdk.style.layers.Layer
 import com.mapbox.mapboxsdk.style.layers.LineLayer
@@ -393,7 +392,7 @@ class MapRouteLineTest {
 
         val result = MapRouteLine.MapRouteLineSupport.getBelowLayer("3", style)
 
-        assertEquals(LocationComponentConstants.SHADOW_LAYER, result)
+        assertEquals(RouteConstants.DEFAULT_ROUTE_LINE_LAYER_BELOW_ID, result)
     }
 
     @Test


### PR DESCRIPTION
## Description

#2872 street names beneath route lines

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

The street names should appear above the route lines and turning arrows.

### Implementation

Looking at the 0.42.4 source code the layer ID below which the route line was being drawn was mapbox-location however I don't see that layer when I list all of the layers in the style. I'm going to instead use the layer "road-label" as the default so that the street names will appear above the route line.

## Screenshots or Gifs

![Screenshot_20200430-164528](https://user-images.githubusercontent.com/2249818/80769459-211d8680-8b02-11ea-9caf-17c7c3333380.png)


## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->