### PR TITLE
Fix #2867: puck icon inconsistent issue in example activities

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/BasicNavigationActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/BasicNavigationActivity.kt
@@ -160,8 +160,7 @@ class BasicNavigationActivity : AppCompatActivity(), OnMapReadyCallback {
     @SuppressLint("MissingPermission")
     fun initListeners() {
         startNavigation.setOnClickListener {
-            navigationMapboxMap?.updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_GPS)
-            navigationMapboxMap?.updateLocationLayerRenderMode(RenderMode.GPS)
+            updateCameraOnNavigationStateChange(true)
             navigationMapboxMap?.addProgressChangeListener(mapboxNavigation!!)
             if (mapboxNavigation?.getRoutes()?.isNotEmpty() == true) {
                 navigationMapboxMap?.startCamera(mapboxNavigation?.getRoutes()!![0])
@@ -237,6 +236,7 @@ class BasicNavigationActivity : AppCompatActivity(), OnMapReadyCallback {
                 TripSessionState.STOPPED -> {
                     startLocationUpdates()
                     navigationMapboxMap?.removeRoute()
+                    updateCameraOnNavigationStateChange(false)
                 }
             }
         }
@@ -256,6 +256,20 @@ class BasicNavigationActivity : AppCompatActivity(), OnMapReadyCallback {
             ReplayRouteLocationEngine()
         } else {
             LocationEngineProvider.getBestLocationEngine(this)
+        }
+    }
+
+    private fun updateCameraOnNavigationStateChange(
+        navigationStarted: Boolean
+    ) {
+        navigationMapboxMap?.apply {
+            if (navigationStarted) {
+                updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_GPS)
+                updateLocationLayerRenderMode(RenderMode.GPS)
+            } else {
+                updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_NONE)
+                updateLocationLayerRenderMode(RenderMode.COMPASS)
+            }
         }
     }
 

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/DebugMapboxNavigationKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/DebugMapboxNavigationKt.kt
@@ -229,6 +229,7 @@ class DebugMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
     @SuppressLint("MissingPermission")
     private fun initViews() {
         startNavigation.setOnClickListener {
+            updateCameraOnNavigationStateChange(true)
             mapboxNavigation.registerVoiceInstructionsObserver(this)
             mapboxNavigation.startTripSession()
             val routes = mapboxNavigation.getRoutes()
@@ -340,14 +341,13 @@ class DebugMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
                 TripSessionState.STOPPED -> {
                     startLocationUpdates()
                     startNavigation.visibility = VISIBLE
+                    updateCameraOnNavigationStateChange(false)
                 }
             }
         }
     }
 
     private fun initDynamicCamera(route: DirectionsRoute) {
-        navigationMapboxMap.updateLocationLayerRenderMode(RenderMode.GPS)
-        navigationMapboxMap.updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_GPS)
         navigationMapboxMap.startCamera(route)
     }
 
@@ -461,5 +461,21 @@ class DebugMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
     private fun shouldSimulateRoute(): Boolean {
         return PreferenceManager.getDefaultSharedPreferences(this.applicationContext)
                 .getBoolean(this.getString(R.string.simulate_route_key), false)
+    }
+
+    private fun updateCameraOnNavigationStateChange(
+        navigationStarted: Boolean
+    ) {
+        if (::navigationMapboxMap.isInitialized) {
+            navigationMapboxMap.apply {
+                if (navigationStarted) {
+                    updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_GPS)
+                    updateLocationLayerRenderMode(RenderMode.GPS)
+                } else {
+                    updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_NONE)
+                    updateLocationLayerRenderMode(RenderMode.COMPASS)
+                }
+            }
+        }
     }
 }

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/FasterRouteActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/FasterRouteActivity.kt
@@ -104,6 +104,8 @@ class FasterRouteActivity : AppCompatActivity(), OnMapReadyCallback {
                     startLocationUpdates()
                     mapboxNavigation.detachFasterRouteObserver()
                     mapboxNavigation.unregisterRouteProgressObserver(routeProgressObserver)
+                    navigationMapboxMap?.removeRoute()
+                    updateCameraOnNavigationStateChange(false)
                 }
             }
         }
@@ -227,8 +229,7 @@ class FasterRouteActivity : AppCompatActivity(), OnMapReadyCallback {
         bottomSheetBehavior.peekHeight = 0
         fasterRouteAcceptProgress.max = MAX_PROGRESS.toInt()
         startNavigation.setOnClickListener {
-            navigationMapboxMap?.updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_GPS)
-            navigationMapboxMap?.updateLocationLayerRenderMode(RenderMode.GPS)
+            updateCameraOnNavigationStateChange(true)
             navigationMapboxMap?.addProgressChangeListener(mapboxNavigation)
             if (mapboxNavigation.getRoutes().isNotEmpty()) {
                 navigationMapboxMap?.startCamera(mapboxNavigation.getRoutes()[0])
@@ -270,6 +271,20 @@ class FasterRouteActivity : AppCompatActivity(), OnMapReadyCallback {
             mapboxNavigation.locationEngine.getLastLocation(locationListenerCallback)
         } catch (exception: SecurityException) {
             Timber.e(exception)
+        }
+    }
+
+    private fun updateCameraOnNavigationStateChange(
+        navigationStarted: Boolean
+    ) {
+        navigationMapboxMap?.apply {
+            if (navigationStarted) {
+                updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_GPS)
+                updateLocationLayerRenderMode(RenderMode.GPS)
+            } else {
+                updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_NONE)
+                updateLocationLayerRenderMode(RenderMode.COMPASS)
+            }
         }
     }
 

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/FeedbackButtonActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/FeedbackButtonActivity.kt
@@ -171,8 +171,7 @@ class FeedbackButtonActivity : AppCompatActivity(), OnMapReadyCallback,
     @SuppressLint("MissingPermission")
     private fun initListeners() {
         startNavigation.setOnClickListener {
-            navigationMapboxMap?.updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_GPS)
-            navigationMapboxMap?.updateLocationLayerRenderMode(RenderMode.GPS)
+            updateCameraOnNavigationStateChange(true)
             navigationMapboxMap?.addProgressChangeListener(mapboxNavigation!!)
             if (mapboxNavigation?.getRoutes()?.isNotEmpty() == true) {
                 navigationMapboxMap?.startCamera(mapboxNavigation?.getRoutes()!![0])
@@ -221,6 +220,7 @@ class FeedbackButtonActivity : AppCompatActivity(), OnMapReadyCallback,
                 TripSessionState.STOPPED -> {
                     updateViews(TripSessionState.STOPPED)
                     navigationMapboxMap?.removeRoute()
+                    updateCameraOnNavigationStateChange(false)
                 }
             }
         }
@@ -290,5 +290,19 @@ class FeedbackButtonActivity : AppCompatActivity(), OnMapReadyCallback,
         )
 
         snackbar.show()
+    }
+
+    private fun updateCameraOnNavigationStateChange(
+        navigationStarted: Boolean
+    ) {
+        navigationMapboxMap?.apply {
+            if (navigationStarted) {
+                updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_GPS)
+                updateLocationLayerRenderMode(RenderMode.GPS)
+            } else {
+                updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_NONE)
+                updateLocationLayerRenderMode(RenderMode.COMPASS)
+            }
+        }
     }
 }

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/FreeDriveNavigationActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/FreeDriveNavigationActivity.kt
@@ -95,8 +95,7 @@ class FreeDriveNavigationActivity : AppCompatActivity(), OnMapReadyCallback {
     @SuppressLint("MissingPermission")
     fun initListeners() {
         startNavigation.setOnClickListener {
-            navigationMapboxMap?.updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_GPS)
-            navigationMapboxMap?.updateLocationLayerRenderMode(RenderMode.GPS)
+            updateCameraOnNavigationStateChange(true)
             navigationMapboxMap?.addProgressChangeListener(mapboxNavigation!!)
             if (mapboxNavigation?.getRoutes()?.isNotEmpty() == true) {
                 navigationMapboxMap?.startCamera(mapboxNavigation?.getRoutes()!![0])
@@ -155,6 +154,20 @@ class FreeDriveNavigationActivity : AppCompatActivity(), OnMapReadyCallback {
         mapInstanceState = savedInstanceState?.getParcelable(MAP_INSTANCE_STATE_KEY)
     }
 
+    private fun updateCameraOnNavigationStateChange(
+        navigationStarted: Boolean
+    ) {
+        navigationMapboxMap?.apply {
+            if (navigationStarted) {
+                updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_GPS)
+                updateLocationLayerRenderMode(RenderMode.GPS)
+            } else {
+                updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_NONE)
+                updateLocationLayerRenderMode(RenderMode.COMPASS)
+            }
+        }
+    }
+
     private val locationListenerCallback = MyLocationEngineCallback(this)
 
     private class MyLocationEngineCallback(activity: FreeDriveNavigationActivity) : LocationEngineCallback<LocationEngineResult> {
@@ -206,7 +219,9 @@ class FreeDriveNavigationActivity : AppCompatActivity(), OnMapReadyCallback {
                     stopLocationUpdates()
                 }
                 TripSessionState.STOPPED -> {
+                    startNavigation.visibility = View.VISIBLE
                     startLocationUpdates()
+                    updateCameraOnNavigationStateChange(false)
                 }
             }
         }

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/GuidanceViewActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/GuidanceViewActivity.kt
@@ -132,6 +132,7 @@ class GuidanceViewActivity : AppCompatActivity(), OnMapReadyCallback {
                 TripSessionState.STOPPED -> {
                     instructionView.visibility = View.GONE
                     startNavigation.visibility = View.VISIBLE
+                    updateCameraOnNavigationStateChange(false)
                 }
             }
         }
@@ -146,8 +147,7 @@ class GuidanceViewActivity : AppCompatActivity(), OnMapReadyCallback {
     @SuppressLint("MissingPermission")
     private fun initListeners() {
         startNavigation.setOnClickListener {
-            navigationMapboxMap?.updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_GPS)
-            navigationMapboxMap?.updateLocationLayerRenderMode(RenderMode.GPS)
+            updateCameraOnNavigationStateChange(true)
             mapboxNavigation.startTripSession()
             mapboxNavigation.getRoutes().let { routes ->
                 if (routes.isNotEmpty()) {
@@ -198,5 +198,19 @@ class GuidanceViewActivity : AppCompatActivity(), OnMapReadyCallback {
         mapboxNavigation.stopTripSession()
         mapboxNavigation.onDestroy()
         mapView.onDestroy()
+    }
+
+    private fun updateCameraOnNavigationStateChange(
+        navigationStarted: Boolean
+    ) {
+        navigationMapboxMap?.apply {
+            if (navigationStarted) {
+                updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_GPS)
+                updateLocationLayerRenderMode(RenderMode.GPS)
+            } else {
+                updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_NONE)
+                updateLocationLayerRenderMode(RenderMode.COMPASS)
+            }
+        }
     }
 }

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/InstructionViewActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/InstructionViewActivity.kt
@@ -210,8 +210,7 @@ class InstructionViewActivity : AppCompatActivity(), OnMapReadyCallback,
     @SuppressLint("MissingPermission")
     private fun initListeners() {
         startNavigation.setOnClickListener {
-            navigationMapboxMap?.updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_GPS)
-            navigationMapboxMap?.updateLocationLayerRenderMode(RenderMode.GPS)
+            updateCameraOnNavigationStateChange(true)
             navigationMapboxMap?.addProgressChangeListener(mapboxNavigation!!)
             if (mapboxNavigation?.getRoutes()?.isNotEmpty() == true) {
                 navigationMapboxMap?.startCamera(mapboxNavigation?.getRoutes()!![0])
@@ -315,6 +314,20 @@ class InstructionViewActivity : AppCompatActivity(), OnMapReadyCallback,
         }
     }
 
+    private fun updateCameraOnNavigationStateChange(
+        navigationStarted: Boolean
+    ) {
+        navigationMapboxMap?.apply {
+            if (navigationStarted) {
+                updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_GPS)
+                updateLocationLayerRenderMode(RenderMode.GPS)
+            } else {
+                updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_NONE)
+                updateLocationLayerRenderMode(RenderMode.COMPASS)
+            }
+        }
+    }
+
     private val routesReqCallback = object : RoutesRequestCallback {
         override fun onRoutesReady(routes: List<DirectionsRoute>) {
             if (routes.isNotEmpty()) {
@@ -349,6 +362,7 @@ class InstructionViewActivity : AppCompatActivity(), OnMapReadyCallback,
                     updateViews(TripSessionState.STOPPED)
                     startLocationUpdates()
                     navigationMapboxMap?.removeRoute()
+                    updateCameraOnNavigationStateChange(false)
                 }
             }
         }

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/ReRouteActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/ReRouteActivity.kt
@@ -64,6 +64,7 @@ class ReRouteActivity : AppCompatActivity(), OnMapReadyCallback {
                 TripSessionState.STOPPED -> {
                     startLocationUpdates()
                     navigationMapboxMap?.removeRoute()
+                    updateCameraOnNavigationStateChange(false)
                 }
             }
         }
@@ -123,7 +124,7 @@ class ReRouteActivity : AppCompatActivity(), OnMapReadyCallback {
         }
         initListeners()
         Snackbar.make(container, R.string.msg_long_press_map_to_place_waypoint, LENGTH_SHORT)
-                .show()
+            .show()
     }
 
     override fun onStart() {
@@ -176,11 +177,11 @@ class ReRouteActivity : AppCompatActivity(), OnMapReadyCallback {
             mapboxMap.locationComponent.lastKnownLocation?.let { originLocation ->
                 mapboxNavigation?.requestRoutes(
                     RouteOptions.builder().applyDefaultParams()
-                            .accessToken(Utils.getMapboxAccessToken(applicationContext))
-                            .coordinates(originLocation.toPoint(), null, latLng.toPoint())
-                            .alternatives(true)
-                            .profile(DirectionsCriteria.PROFILE_DRIVING_TRAFFIC)
-                            .build(),
+                        .accessToken(Utils.getMapboxAccessToken(applicationContext))
+                        .coordinates(originLocation.toPoint(), null, latLng.toPoint())
+                        .alternatives(true)
+                        .profile(DirectionsCriteria.PROFILE_DRIVING_TRAFFIC)
+                        .build(),
                     routesReqCallback
                 )
             }
@@ -191,8 +192,7 @@ class ReRouteActivity : AppCompatActivity(), OnMapReadyCallback {
     @SuppressLint("MissingPermission")
     private fun initListeners() {
         startNavigation.setOnClickListener {
-            navigationMapboxMap?.updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_GPS)
-            navigationMapboxMap?.updateLocationLayerRenderMode(RenderMode.GPS)
+            updateCameraOnNavigationStateChange(true)
             navigationMapboxMap?.addProgressChangeListener(mapboxNavigation!!)
             if (mapboxNavigation?.getRoutes()?.isNotEmpty() == true) {
                 navigationMapboxMap?.startCamera(mapboxNavigation?.getRoutes()!![0])
@@ -219,6 +219,20 @@ class ReRouteActivity : AppCompatActivity(), OnMapReadyCallback {
 
     private fun stopLocationUpdates() {
         mapboxNavigation?.locationEngine?.removeLocationUpdates(locationListenerCallback)
+    }
+
+    private fun updateCameraOnNavigationStateChange(
+        navigationStarted: Boolean
+    ) {
+        navigationMapboxMap?.apply {
+            if (navigationStarted) {
+                updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_GPS)
+                updateLocationLayerRenderMode(RenderMode.GPS)
+            } else {
+                updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_NONE)
+                updateLocationLayerRenderMode(RenderMode.COMPASS)
+            }
+        }
     }
 
     private class MyLocationEngineCallback(activity: ReRouteActivity) :

--- a/examples/src/main/java/com/mapbox/navigation/examples/ui/CustomUIComponentStyleActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/ui/CustomUIComponentStyleActivity.kt
@@ -230,6 +230,7 @@ class CustomUIComponentStyleActivity : AppCompatActivity(), OnMapReadyCallback,
         }
     }
 
+    @Suppress("DEPRECATION")
     @SuppressLint("MissingPermission")
     private fun initViews() {
         startNavigation.apply {
@@ -240,8 +241,7 @@ class CustomUIComponentStyleActivity : AppCompatActivity(), OnMapReadyCallback,
                 if (mapboxNavigation.getRoutes().isNotEmpty()) {
                     replayRouteLocationEngine.assign(mapboxNavigation.getRoutes()[0])
 
-                    navigationMapboxMap.updateLocationLayerRenderMode(RenderMode.GPS)
-                    navigationMapboxMap.updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_GPS)
+                    updateCameraOnNavigationStateChange(true)
                     navigationMapboxMap.startCamera(mapboxNavigation.getRoutes()[0])
 
                     mapboxNavigation.startTripSession()
@@ -425,6 +425,22 @@ class CustomUIComponentStyleActivity : AppCompatActivity(), OnMapReadyCallback,
             cameraMode == CameraMode.TRACKING_GPS_NORTH
     }
 
+    private fun updateCameraOnNavigationStateChange(
+        navigationStarted: Boolean
+    ) {
+        if (::navigationMapboxMap.isInitialized) {
+            navigationMapboxMap.apply {
+                if (navigationStarted) {
+                    updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_GPS)
+                    updateLocationLayerRenderMode(RenderMode.GPS)
+                } else {
+                    updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_NONE)
+                    updateLocationLayerRenderMode(RenderMode.COMPASS)
+                }
+            }
+        }
+    }
+
     // Callbacks and Observers
     private val routesReqCallback = object : RoutesRequestCallback {
         override fun onRoutesReady(routes: List<DirectionsRoute>) {
@@ -487,6 +503,8 @@ class CustomUIComponentStyleActivity : AppCompatActivity(), OnMapReadyCallback,
                         navigationMapboxMap.removeOnWayNameChangedListener(this@CustomUIComponentStyleActivity)
                         navigationMapboxMap.updateWaynameQueryMap(false)
                     }
+
+                    updateCameraOnNavigationStateChange(false)
                 }
             }
         }


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Fix #2867: puck icon inconsistent issue in example activities

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Keep `example` app behavior consistency across different activities.

### Implementation

* set _camera tracking mode_ and _location layer render mode_ accordingly when navigation starts/stops.
* not only fix the free drive/active guidance mode switching scenario, it also reset the above modes to default when user `End Navigation` from the Notification.

## Screenshots or Gifs

Please include all the media files to give some context about what's being implemented or fixed. It's not mandatory to upload screenshots or gifs, but for most of the cases it becomes really handy to get into the scope of the feature / bug being fixed and also it's REALLY useful for UI related PRs ![screenshot gif](link)

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->