### PR TITLE
2880 - fix for leak and exception while creating route line

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/camera/NavigationCamera.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/camera/NavigationCamera.java
@@ -6,9 +6,6 @@ import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.FragmentActivity;
-import androidx.lifecycle.Lifecycle;
-import androidx.lifecycle.LifecycleObserver;
-import androidx.lifecycle.OnLifecycleEvent;
 
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.geojson.Point;
@@ -52,7 +49,7 @@ import static com.mapbox.navigation.ui.legacy.NavigationConstants.NAVIGATION_MIN
  *
  * @since 0.6.0
  */
-public class NavigationCamera implements LifecycleObserver {
+public class NavigationCamera {
 
   /**
    * Camera tracks the user location, with bearing provided by the location update.
@@ -304,7 +301,6 @@ public class NavigationCamera implements LifecycleObserver {
    * and {@link LocationObserver}
    * for the camera and prevent any leaks or further updates.
    */
-  @OnLifecycleEvent(Lifecycle.Event.ON_START)
   public void onStart() {
     if (navigation != null) {
       navigation.registerRouteProgressObserver(routeProgressObserver);
@@ -317,7 +313,6 @@ public class NavigationCamera implements LifecycleObserver {
    * {@link RouteProgressObserver} and {@link LocationObserver}
    * for the camera and prevent any leaks or further updates.
    */
-  @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
   public void onStop() {
     if (navigation != null) {
       navigation.unregisterRouteProgressObserver(routeProgressObserver);

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/NavigationMapboxMap.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/NavigationMapboxMap.java
@@ -548,7 +548,6 @@ public class NavigationMapboxMap {
    */
   public void onStart() {
     mapCamera.onStart();
-    mapRoute.onStart();
     handleWayNameOnStart();
     handleFpsOnStart();
     locationFpsDelegate.onStart();
@@ -568,7 +567,6 @@ public class NavigationMapboxMap {
    */
   public void onStop() {
     mapCamera.onStop();
-    mapRoute.onStop();
     handleWayNameOnStop();
     handleFpsOnStop();
     locationFpsDelegate.onStop();

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/NavigationMapRoute.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/NavigationMapRoute.java
@@ -6,9 +6,9 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.Size;
 import androidx.annotation.StyleRes;
-import androidx.appcompat.app.AppCompatActivity;
 import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.LifecycleObserver;
+import androidx.lifecycle.LifecycleOwner;
 import androidx.lifecycle.OnLifecycleEvent;
 
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
@@ -146,6 +146,14 @@ public class NavigationMapRoute implements LifecycleObserver {
     this.mapRouteProgressChangeListener = new MapRouteProgressChangeListener(this.routeLine, routeArrow);
     initializeDidFinishLoadingStyleListener();
     addListeners();
+    registerLifecycleObserver();
+  }
+
+  private void registerLifecycleObserver() {
+    final Context context = mapView.getContext();
+    if (context instanceof LifecycleOwner) {
+      ((LifecycleOwner)context).getLifecycle().addObserver(this);
+    }
   }
 
   // For testing only
@@ -307,9 +315,7 @@ public class NavigationMapRoute implements LifecycleObserver {
   }
 
   /**
-   * This method should be added in your {@link AppCompatActivity#onStart()} or
-   * {@link androidx.fragment.app.Fragment#onStart()} to handle adding and removing of listeners,
-   * preventing memory leaks.
+   * Called during the onStart event of the Lifecycle owner to initialize resources.
    */
   @OnLifecycleEvent(Lifecycle.Event.ON_START)
   public void onStart() {
@@ -317,9 +323,7 @@ public class NavigationMapRoute implements LifecycleObserver {
   }
 
   /**
-   * This method should be added in your {@link AppCompatActivity#onStop()} or
-   * {@link androidx.fragment.app.Fragment#onStop()}
-   * to handle adding and removing of listeners, preventing memory leaks.
+   * Called during the onStop event of the Lifecycle owner to clean up resources.
    */
   @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
   public void onStop() {


### PR DESCRIPTION
## Description
Addresses the issue #2880 a leak and exception while creating a map route line.


- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards


### Implementation

NavigationMapRoute adds itself as a lifecycle observer so that its lifecycle methods get called for resource clean up. NavigationCamera was implementing LifeCycleObserver but wasn't registering itself as an observer and has no way of doing so as it has no reference to a context. The implementation declaration was removed.
## Screenshots or Gifs

## Testing


- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [x] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->