### PR TITLE
Fix replay crash and push event issue

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/history/ReplayHistoryPlayer.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/history/ReplayHistoryPlayer.kt
@@ -53,7 +53,7 @@ class ReplayHistoryPlayer(
      * [observeReplayEvents]
      */
     fun play(lifecycleOwner: LifecycleOwner): Job {
-        return replayEventSimulator.launchPlayLoop(lifecycleOwner) { replayEvents ->
+        return replayEventSimulator.launchSimulator(lifecycleOwner) { replayEvents ->
             replayEventsListeners.forEach { it(replayEvents) }
         }
     }


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

I'm still working to support multiple stops with replay https://github.com/mapbox/mapbox-navigation-android/pull/2802#issuecomment-622588985 (good news is it is working!)

But I found a couple issues, which should be described well with the tests. 
1. when you finish playing events, keep the player going so it'll resume playing later
2. when you finish playing events, playbackSpeed will crash

These are both fixed by this pull request

- [ ] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->