### PR TITLE
Fix arrival observer not being notified

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/history/ReplayHistoryMapper.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/history/ReplayHistoryMapper.kt
@@ -40,7 +40,7 @@ class ReplayHistoryMapper(
                     val eventType: String = event["type"] as String
                     mapToEvent(eventType, event)
                 } catch (throwable: Throwable) {
-                    logger?.e(
+                    logger.e(
                         msg = Message("Failed to read index $index: $event"),
                         tr = throwable
                     )
@@ -65,7 +65,7 @@ class ReplayHistoryMapper(
             else -> {
                 val replayEvent = customEventMapper?.invoke(eventType, event)
                 if (replayEvent == null) {
-                    logger?.e(msg = Message("Replay unsupported event $eventType"))
+                    logger.e(msg = Message("Replay unsupported event $eventType"))
                 }
                 replayEvent
             }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/stops/ArrivalProgressObserver.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/stops/ArrivalProgressObserver.kt
@@ -37,7 +37,7 @@ internal class ArrivalProgressObserver(
         val nextLegIndex = legIndex + 1
         val nextLegStarted = if (nextLegIndex < numberOfLegs) {
             val navigationStatus = tripSession.updateLegIndex(nextLegIndex)
-            return nextLegIndex == navigationStatus.legIndex
+            nextLegIndex == navigationStatus.legIndex
         } else {
             false
         }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/history/ReplayHistoryMapperTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/history/ReplayHistoryMapperTest.kt
@@ -4,8 +4,8 @@ import com.google.gson.annotations.SerializedName
 import com.google.gson.internal.LinkedTreeMap
 import com.mapbox.base.common.logger.Logger
 import io.mockk.mockk
-import junit.framework.Assert.assertEquals
-import junit.framework.Assert.assertTrue
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ReplayHistoryMapperTest {
@@ -20,7 +20,7 @@ class ReplayHistoryMapperTest {
 
         val historyEvents = replayHistoryMapper.mapToReplayEvents(historyString)
 
-        assertEquals(historyEvents.size, 2)
+        assertEquals(2, historyEvents.size)
     }
 
     @Test
@@ -29,7 +29,7 @@ class ReplayHistoryMapperTest {
 
         val historyEvents = replayHistoryMapper.mapToReplayEvents(historyString)
 
-        assertEquals(historyEvents[0].eventTimestamp, 1580744198.879556)
+        assertEquals(1580744198.879556, historyEvents[0].eventTimestamp, 0.000001)
         assertTrue(historyEvents[0] is ReplayEventGetStatus)
     }
 
@@ -39,16 +39,16 @@ class ReplayHistoryMapperTest {
 
         val historyEvents = replayHistoryMapper.mapToReplayEvents(historyString)
 
-        assertEquals(historyEvents[1].eventTimestamp, 1580744199.407049)
+        assertEquals(1580744199.407049, historyEvents[1].eventTimestamp, 0.000001)
         (historyEvents[1] as ReplayEventUpdateLocation).location.let {
-            assertEquals(it.lat, 50.1232182)
-            assertEquals(it.lon, 8.6343946)
-            assertEquals(it.time, 1580744199.406)
-            assertEquals(it.speed, 0.02246818132698536)
-            assertEquals(it.bearing, 33.55318069458008)
-            assertEquals(it.altitude, 162.8000030517578)
-            assertEquals(it.accuracyHorizontal, 14.710000038146973)
-            assertEquals(it.provider, "fused")
+            assertEquals(50.1232182, it.lat, 0.00000001)
+            assertEquals(8.6343946, it.lon, 0.00000001)
+            assertEquals(1580744199.406, it.time)
+            assertEquals(0.02246818132698536, it.speed)
+            assertEquals(33.55318069458008, it.bearing)
+            assertEquals(162.8000030517578, it.altitude)
+            assertEquals(14.710000038146973, it.accuracyHorizontal)
+            assertEquals("fused", it.provider)
         }
     }
 
@@ -57,7 +57,7 @@ class ReplayHistoryMapperTest {
         val historyString = """{"events":[{"type":"getStatus","timestamp":1580744200.379,"event_timestamp":1580744198.879556,"delta_ms":0},{"type":"updateLocation","location":{"lat":50.1232182,"lon":8.6343946,"time":1580744199.406,"speed":0.02246818132698536,"bearing":33.55318069458008,"altitude":162.8000030517578,"accuracyHorizontal":14.710000038146973,"provider":"fused"},"event_timestamp":1580744199.407049,"delta_ms":0},{"type":"getStatus","timestamp":1580744213.506,"event_timestamp":1580744212.006626,"delta_ms":0},{"type":"end_transit","properties":1580744212.223,"event_timestamp":1580744212.223644}],"version":"6.2.1","history_version":"1.0.0"}"""
         val replayHistoryMapper = ReplayHistoryMapper(customEventMapper = ExampleCustomEventMapper(), logger = logger)
         val historyEvents = replayHistoryMapper.mapToReplayEvents(historyString)
-        assertEquals(historyEvents.size, 4)
+        assertEquals(4, historyEvents.size)
     }
 
     @Test
@@ -65,7 +65,7 @@ class ReplayHistoryMapperTest {
         val historyString = """{"events":[{"type":"getStatus","timestamp":1551460823.922}],"version":"5.0.0","history_version":"1.0.0"}"""
         val replayHistoryMapper = ReplayHistoryMapper(customEventMapper = ExampleCustomEventMapper(), logger = logger)
         val historyEvents = replayHistoryMapper.mapToReplayEvents(historyString)
-        assertEquals(historyEvents.size, 1)
+        assertEquals(1, historyEvents.size)
     }
 
     private data class ExampleEndTransitEvent(


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

When you manually call `navigateNextRouteLeg`, the `onStopArrival` is never notificed. I'm hooking up view components to the call back in this comment https://github.com/mapbox/mapbox-navigation-android/pull/2802#issuecomment-622588985

Add a test, and fix it

- [ ] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->