### PR TITLE
removed redundant method call identified in PR comment

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/NavigationMapRoute.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/NavigationMapRoute.java
@@ -167,7 +167,6 @@ public class NavigationMapRoute implements LifecycleObserver {
             routeArrow, vanishRouteLineEnabled
     );
     initializeDidFinishLoadingStyleListener();
-    addListeners();
     registerLifecycleObserver();
   }
 


### PR DESCRIPTION
## Description
This is a response to a PR comment here: https://github.com/mapbox/mapbox-navigation-android/pull/2882#discussion_r419342887

It was pointed out that a line of code in the constructor was redundant because the same method was also being called in onStart.

### Goal
Keep the code clean.

### Implementation

Removed the redundant line of code.

## Screenshots or Gifs

## Testing


- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->