### PR TITLE
Refactored BuildingFootprintHighlightLayer and test app activity

### DIFF
--- a/examples/src/main/AndroidManifest.xml
+++ b/examples/src/main/AndroidManifest.xml
@@ -127,8 +127,8 @@
                 android:value=".UIActivity"/>
         </activity>
 
-        <activity android:name=".ui.ArrivalUiFootprintHighlightActivityKt"
-            android:label="@string/title_final_destination_building_highlight_kotlin"
+        <activity android:name=".ui.BuildingFootprintHighlightActivityKt"
+            android:label="@string/title_building_highlight_kotlin"
             android:screenOrientation="portrait">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"

--- a/examples/src/main/java/com/mapbox/navigation/examples/UIActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/UIActivity.kt
@@ -7,7 +7,7 @@ import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.LinearLayoutManager.VERTICAL
 import com.mapbox.navigation.examples.ui.ArrivalUiBuildingExtrusionActivityKt
-import com.mapbox.navigation.examples.ui.ArrivalUiFootprintHighlightActivityKt
+import com.mapbox.navigation.examples.ui.BuildingFootprintHighlightActivityKt
 import com.mapbox.navigation.examples.ui.CustomCameraActivity
 import com.mapbox.navigation.examples.ui.CustomPuckActivity
 import com.mapbox.navigation.examples.ui.CustomUIComponentStyleActivity
@@ -43,9 +43,9 @@ class UIActivity : AppCompatActivity() {
                     NavigationViewActivity::class.java
             ),
             SampleItem(
-                    getString(R.string.title_final_destination_building_highlight_kotlin),
-                    getString(R.string.description_final_destination_building_highlight_kotlin),
-                    ArrivalUiFootprintHighlightActivityKt::class.java
+                    getString(R.string.title_building_highlight_kotlin),
+                    getString(R.string.description_building_highlight_kotlin),
+                    BuildingFootprintHighlightActivityKt::class.java
             ),
             SampleItem(
                     getString(R.string.title_arrival_ui_building_extrusions_kotlin),

--- a/examples/src/main/res/layout/activity_final_destination_arrival_building_highlight.xml
+++ b/examples/src/main/res/layout/activity_final_destination_arrival_building_highlight.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".ui.ArrivalUiFootprintHighlightActivityKt">
+    tools:context=".ui.BuildingFootprintHighlightActivityKt">
 
     <com.mapbox.navigation.ui.NavigationView
         android:id="@+id/navigationView"

--- a/examples/src/main/res/values/strings.xml
+++ b/examples/src/main/res/values/strings.xml
@@ -47,8 +47,8 @@
     <string name="title_custom_ui_component_style" translatable="false">Custom UI Component Style Example</string>
     <string name="description_custom_ui_component_style" translatable="false">Shows how to use your own colors to style the UI SDK Components: InstructionView, SummaryBottomSheet ans so on</string>
 
-    <string name="title_final_destination_building_highlight_kotlin" translatable="false">Final Destination Building Highlight UI Kotlin</string>
-    <string name="description_final_destination_building_highlight_kotlin" translatable="false">Show how the final destination building footprint can be highlighted when the device has arrived. Example\'s in Kotlin.</string>
+    <string name="title_building_highlight_kotlin" translatable="false">Building Footprint Highlight</string>
+    <string name="description_building_highlight_kotlin" translatable="false">Use the Nav UI SDK\'s BuildingFootprintHighlightLayer to show and customize a highlighted building footprint. Great to show the final destination building location. Example\'s in Kotlin.</string>
 
     <string name="title_arrival_ui_building_extrusions_kotlin" translatable="false">Arrival UI Building Extrusions Kotlin</string>
     <string name="description_arrival_ui_building_extrusions_kotlin" translatable="false">Show building extrusions once the device is close enough to the final destination. Example\'s in Kotlin.</string>

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/BuildingFootprintHighlightLayer.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/BuildingFootprintHighlightLayer.java
@@ -1,4 +1,4 @@
-package com.mapbox.navigation.ui.arrival;
+package com.mapbox.navigation.ui.map;
 
 import android.graphics.Color;
 import android.graphics.PointF;
@@ -22,10 +22,10 @@ import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillColor;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillOpacity;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.visibility;
 
-public class DestinationBuildingFootprintLayer {
+public class BuildingFootprintHighlightLayer {
 
-  private static final String DESTINATION_BUILDING_FOOTPRINT_SOURCE_ID = "destination-building-source-id";
-  private static final String DESTINATION_BUILDING_FOOTPRINT_LAYER_ID = "destination-building-footprint-layer-id";
+  private static final String BUILDING_FOOTPRINT_SOURCE_ID = "building-source-id";
+  private static final String BUILDING_FOOTPRINT_LAYER_ID = "building-footprint-layer-id";
   private static final String BUILDING_LAYER_ID = "building";
   private static final String BUILDING_STATION_LAYER_ID = "building station";
   private static final Integer DEFAULT_FOOTPRINT_COLOR = Color.RED;
@@ -37,13 +37,13 @@ public class DestinationBuildingFootprintLayer {
   private Integer color;
   private Float opacity;
 
-  public DestinationBuildingFootprintLayer(MapboxMap mapboxMap, MapView mapView) {
+  public BuildingFootprintHighlightLayer(MapboxMap mapboxMap, MapView mapView) {
     this.mapboxMap = mapboxMap;
     this.mapView = mapView;
   }
 
   /**
-   * Toggles the visibility of the destination building highlight layer.
+   * Toggles the visibility of the building footprint highlight layer.
    *
    * @param visible true if the layer should be placed/displayed. False if it should be hidden.
    */
@@ -54,7 +54,7 @@ public class DestinationBuildingFootprintLayer {
     mapboxMap.getStyle(new Style.OnStyleLoaded() {
       @Override
       public void onStyleLoaded(@NonNull Style style) {
-        FillLayer buildingFootprintFillLayer = style.getLayerAs(DESTINATION_BUILDING_FOOTPRINT_LAYER_ID);
+        FillLayer buildingFootprintFillLayer = style.getLayerAs(BUILDING_FOOTPRINT_LAYER_ID);
         if (buildingFootprintFillLayer == null) {
           addFootprintHighlightFillLayerToMap();
         } else if ((buildingFootprintFillLayer.getVisibility().value.equals(VISIBLE)) != visible) {
@@ -65,17 +65,17 @@ public class DestinationBuildingFootprintLayer {
   }
 
   /**
-   * Set the location of the destination building highlight layer.
+   * Set the location of the building footprint highlight layer.
    *
-   * @param destinationLatLng the new coordinates to use in querying the building layer
+   * @param targetLatLng the new coordinates to use in querying the building layer
    *                          to get the associated {@link Polygon} to eventually highlight.
    */
-  public void setDestinationBuildingLocation(final LatLng destinationLatLng) {
+  public void setBuildingFootprintLocation(final LatLng targetLatLng) {
     mapboxMap.getStyle(new Style.OnStyleLoaded() {
       @Override
       public void onStyleLoaded(@NonNull Style style) {
-        GeoJsonSource geoJsonSource = style.getSourceAs(DESTINATION_BUILDING_FOOTPRINT_SOURCE_ID);
-        Polygon polygon = getFootprintPolygonAssociatedWithDestinationBuilding(destinationLatLng);
+        GeoJsonSource geoJsonSource = style.getSourceAs(BUILDING_FOOTPRINT_SOURCE_ID);
+        Polygon polygon = getFootprintPolygonAssociatedWithBuilding(targetLatLng);
         if (polygon != null && geoJsonSource != null) {
           geoJsonSource.setGeoJson(polygon);
         }
@@ -84,7 +84,7 @@ public class DestinationBuildingFootprintLayer {
   }
 
   /**
-   * Set the color of the destination building highlight layer.
+   * Set the color of the building footprint highlight layer.
    *
    * @param newFootprintColor the new color value
    */
@@ -92,10 +92,9 @@ public class DestinationBuildingFootprintLayer {
     mapboxMap.getStyle(new Style.OnStyleLoaded() {
       @Override
       public void onStyleLoaded(@NonNull Style style) {
-        FillLayer buildingFootprintFillLayer = style.getLayerAs(DESTINATION_BUILDING_FOOTPRINT_LAYER_ID);
+        FillLayer buildingFootprintFillLayer = style.getLayerAs(BUILDING_FOOTPRINT_LAYER_ID);
         if (buildingFootprintFillLayer != null) {
-          buildingFootprintFillLayer.setProperties(
-            fillColor(newFootprintColor));
+          buildingFootprintFillLayer.setProperties(fillColor(newFootprintColor));
           color = newFootprintColor;
         }
       }
@@ -103,7 +102,7 @@ public class DestinationBuildingFootprintLayer {
   }
 
   /**
-   * Set the opacity of the destination building highlight layer.
+   * Set the opacity of the building footprint highlight layer.
    *
    * @param newFootprintOpacity the new opacity value
    */
@@ -111,10 +110,9 @@ public class DestinationBuildingFootprintLayer {
     mapboxMap.getStyle(new Style.OnStyleLoaded() {
       @Override
       public void onStyleLoaded(@NonNull Style style) {
-        FillLayer buildingFootprintFillLayer = style.getLayerAs(DESTINATION_BUILDING_FOOTPRINT_LAYER_ID);
+        FillLayer buildingFootprintFillLayer = style.getLayerAs(BUILDING_FOOTPRINT_LAYER_ID);
         if (buildingFootprintFillLayer != null) {
-          buildingFootprintFillLayer.setProperties(
-            fillOpacity(opacity));
+          buildingFootprintFillLayer.setProperties(fillOpacity(newFootprintOpacity));
           opacity = newFootprintOpacity;
         }
       }
@@ -122,10 +120,10 @@ public class DestinationBuildingFootprintLayer {
   }
 
   /**
-   * Retrieve the {@link Polygon} geometry of the building that the route's final destination
-   * coordinates correspond to.
+   * Retrieve the {@link Polygon} geometry of the footprint of the building that's associated with
+   * the latest targetLatLng.
    *
-   * @return The {@link Polygon}
+   * @return the {@link Polygon}
    */
   public Polygon getBuildingPolygon() {
     return buildingPolygon;
@@ -133,8 +131,8 @@ public class DestinationBuildingFootprintLayer {
 
   /**
    *
-   * Retrieve the building {@link Feature} that the route's final destination
-   * coordinates correspond to.
+   * Retrieve the {@link Feature} the polygonal footprint of the building that's associated with
+   * the latest targetLatLng.
    *
    * @return the {@link Feature}
    */
@@ -143,7 +141,7 @@ public class DestinationBuildingFootprintLayer {
   }
 
   /**
-   * Retrieve the latest set color of the destination building highlight layer.
+   * Retrieve the latest set color of the building footprint highlight layer.
    *
    * @return the color Integer
    */
@@ -152,7 +150,7 @@ public class DestinationBuildingFootprintLayer {
   }
 
   /**
-   * Retrieve the latest set opacity of the destination building highlight layer.
+   * Retrieve the latest set opacity of the building footprint highlight layer.
    *
    * @return the opacity Float
    */
@@ -160,25 +158,22 @@ public class DestinationBuildingFootprintLayer {
     return opacity;
   }
 
-  private Polygon getFootprintPolygonAssociatedWithDestinationBuilding(final LatLng destinationLatLng) {
+  private Polygon getFootprintPolygonAssociatedWithBuilding(final LatLng targetLatLng) {
     mapboxMap.getStyle(new Style.OnStyleLoaded() {
       @Override
       public void onStyleLoaded(@NonNull Style style) {
         PointF pixel = mapboxMap.getProjection().toScreenLocation(new LatLng(
-          destinationLatLng.getLatitude(),
-          destinationLatLng.getLongitude()
+            targetLatLng.getLatitude(), targetLatLng.getLongitude()
         ));
 
         // Check whether the map style has a building layer
         if (style.getLayer(BUILDING_LAYER_ID) != null) {
 
-          // Retrieve the building Feature that is displayed in the middle of the map
+          // Retrieve the building Feature that is associated with the target LatLng
           List<Feature> features = mapboxMap.queryRenderedFeatures(pixel, BUILDING_LAYER_ID, BUILDING_STATION_LAYER_ID);
-          if (features.size() > 0) {
-            if (features.get(0).geometry() instanceof Polygon) {
+          if (features.size() > 0 && features.get(0).geometry() instanceof Polygon) {
               buildingPolygonFeature = features.get(0);
-              buildingPolygon = (Polygon) features.get(0).geometry();
-            }
+              buildingPolygon = (Polygon) buildingPolygonFeature.geometry();
           }
         }
       }
@@ -192,17 +187,17 @@ public class DestinationBuildingFootprintLayer {
       public void onStyleLoaded(@NonNull Style style) {
         FillLayer existingBuildingLayerId = style.getLayerAs(BUILDING_LAYER_ID);
         if (existingBuildingLayerId != null) {
-          GeoJsonSource buildingFootprintGeojsonSource = new GeoJsonSource(DESTINATION_BUILDING_FOOTPRINT_SOURCE_ID);
-          style.addSource(buildingFootprintGeojsonSource);
-          FillLayer finalDestinationBuildingFillLayer = new FillLayer(DESTINATION_BUILDING_FOOTPRINT_LAYER_ID,
-            DESTINATION_BUILDING_FOOTPRINT_SOURCE_ID);
-          finalDestinationBuildingFillLayer.setProperties(
+          GeoJsonSource buildingFootprintGeoJsonSource = new GeoJsonSource(BUILDING_FOOTPRINT_SOURCE_ID);
+          style.addSource(buildingFootprintGeoJsonSource);
+          FillLayer buildingFillLayer = new FillLayer(BUILDING_FOOTPRINT_LAYER_ID,
+              BUILDING_FOOTPRINT_SOURCE_ID);
+          buildingFillLayer.setProperties(
             fillColor(color == null ? DEFAULT_FOOTPRINT_COLOR :
               color),
             fillOpacity(opacity == null ? DEFAULT_BUILDING_FOOTPRINT_OPACITY :
               opacity)
           );
-          style.addLayerAbove(finalDestinationBuildingFillLayer, BUILDING_LAYER_ID);
+          style.addLayerAbove(buildingFillLayer, BUILDING_LAYER_ID);
         }
       }
     });

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/NavigationMapboxMap.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/NavigationMapboxMap.java
@@ -32,8 +32,6 @@ import com.mapbox.navigation.core.MapboxNavigation;
 import com.mapbox.navigation.core.trip.session.LocationObserver;
 import com.mapbox.navigation.ui.NavigationSnapshotReadyCallback;
 import com.mapbox.navigation.ui.ThemeSwitcher;
-import com.mapbox.navigation.ui.arrival.BuildingExtrusionLayer;
-import com.mapbox.navigation.ui.arrival.DestinationBuildingFootprintLayer;
 import com.mapbox.navigation.ui.camera.Camera;
 import com.mapbox.navigation.ui.camera.NavigationCamera;
 import com.mapbox.navigation.ui.puck.NavigationPuckPresenter;
@@ -91,8 +89,6 @@ public class NavigationMapboxMap {
   @Nullable
   private MapFpsDelegate mapFpsDelegate;
   private LocationFpsDelegate locationFpsDelegate;
-  private BuildingExtrusionLayer buildingExtrusionLayer;
-  private DestinationBuildingFootprintLayer destinationBuildingFootprintLayer;
   @Nullable
   private MapboxNavigation navigation;
   private Boolean vanishRouteLineEnabled;
@@ -157,7 +153,6 @@ public class NavigationMapboxMap {
     initializeNavigationSymbolManager(mapView, mapboxMap);
     initializeMapLayerInteractor(mapboxMap);
     initializeRoute(mapView, mapboxMap, routeBelowLayerId);
-    initializeArrivalExperience(mapboxMap, mapView);
     initializeCamera(mapboxMap);
     initializeLocationComponent();
   }
@@ -671,26 +666,6 @@ public class NavigationMapboxMap {
   }
 
   /**
-   * Updates the visibility of the building extrusion layer. Extrusions are added during the arrival experience.
-   *
-   * @param isVisible true if the building extrusions should be visible, false otherwise
-   */
-  public void updateBuildingExtrusionVisibility(boolean isVisible) {
-    buildingExtrusionLayer.updateVisibility(isVisible);
-  }
-
-  /**
-   * Updates the visibility of the destination building footprint highlight
-   * {@link com.mapbox.mapboxsdk.style.layers.FillLayer}. This layer is added during the arrival
-   * experience so that the final destination can be seen more easily.
-   *
-   * @param isVisible true if the building extrusions should be visible, false otherwise
-   */
-  public void updateDestinationFootprintHighlightVisibility(boolean isVisible) {
-    destinationBuildingFootprintLayer.updateVisibility(isVisible);
-  }
-
-  /**
    * Add a {@link OnCameraTrackingChangedListener} to the {@link LocationComponent} that is
    * wrapped within this class.
    * <p>
@@ -799,11 +774,6 @@ public class NavigationMapboxMap {
 
   private void initializeLocationFpsDelegate(MapboxMap map, LocationComponent locationComponent) {
     locationFpsDelegate = new LocationFpsDelegate(map, locationComponent);
-  }
-
-  private void initializeArrivalExperience(MapboxMap map, MapView mapView) {
-    buildingExtrusionLayer = new BuildingExtrusionLayer(map, mapView);
-    destinationBuildingFootprintLayer = new DestinationBuildingFootprintLayer(map, mapView);
   }
 
   private void initializeWayName(MapboxMap mapboxMap, MapPaddingAdjustor paddingAdjustor) {


### PR DESCRIPTION

## Description

This pr refactors the `BuildingFootprintHighlightLayer` and the Nav UI test app example that shows how to use `BuildingFootprintHighlightLayer`.

I didn't want to assume that this layer would **only** be used when the device is near the final arrival location. So some of the refactoring is to remove the `arrival` word from various places. The layer adds/customizes a `FillLayer` that highlights a specific building footprint. The building might or might not be the final building destination. It's up to the developer to decide when to set up this layer. 

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards


## Screenshots or Gifs
![ezgif com-resize](https://user-images.githubusercontent.com/4394910/80998912-98039980-8df8-11ea-92f6-4133cec4e23a.gif)


## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added an `Activity` example in the test app showing the new feature implemented (where applicable)