### PR TITLE
Fix telemetry access token crash

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -200,7 +200,6 @@ constructor(
             MapboxMetricsReporter.toggleLogging(navigationOptions.isDebugLoggingEnabled)
             MapboxNavigationTelemetry.initialize(
                 context.applicationContext,
-                token,
                 this,
                 MapboxMetricsReporter,
                 locationEngine.javaClass.name,

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetryTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetryTest.kt
@@ -136,7 +136,6 @@ class MapboxNavigationTelemetryTest {
     private fun initTelemetry() {
         MapboxNavigationTelemetry.initialize(
             context,
-            token,
             mapboxNavigation,
             MapboxMetricsReporter,
             "locationEngine",


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Resolves https://github.com/mapbox/mapbox-navigation-android/issues/2841

There are many places we can fail because of a bad access token. But it doesn't look like this is a proper one, because the access token is not used here. 

For telemetry, the access token is needed by the `MapboxTelemetryReporter`. It gets its access token through MapboxNavigation
https://github.com/mapbox/mapbox-navigation-android/blob/5d7113ed6fa65cde72c2d57f2ca558e6c8dc3a8b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt#L197

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->