### PR TITLE
vanishRouteLineEnabled off by default

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/NavigationMapboxMap.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/NavigationMapboxMap.java
@@ -91,7 +91,7 @@ public class NavigationMapboxMap {
   private LocationFpsDelegate locationFpsDelegate;
   @Nullable
   private MapboxNavigation navigation;
-  private Boolean vanishRouteLineEnabled;
+  private boolean vanishRouteLineEnabled;
 
   /**
    * Constructor that can be used once {@link OnMapReadyCallback}

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/NavigationMapRoute.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/NavigationMapRoute.java
@@ -54,7 +54,7 @@ public class NavigationMapRoute implements LifecycleObserver {
   private MapboxNavigation navigation;
   private MapRouteLine routeLine;
   private MapRouteArrow routeArrow;
-  private Boolean vanishRouteLineEnabled;
+  private boolean vanishRouteLineEnabled;
 
   /**
    * Construct an instance of {@link NavigationMapRoute}.


### PR DESCRIPTION
## Description
Ensured that the vanishing route line feature is off by default. 

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal
The route line should be off by default and enabled if desired.

### Implementation
The flag for enabling the feature is changed to a primitive which is false be default.

## Screenshots or Gifs

N/A

## Testing


- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->