### PR TITLE
Fix Navigator.reset regression

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -136,6 +136,7 @@ constructor(
 
     private val mainJobController: JobControl = ThreadController.getMainScopeAndRootJob()
     private val directionsSession: DirectionsSession
+    private val navigator: MapboxNativeNavigator
     private val tripService: TripService
     private val tripSession: TripSession
     private val navigationSession: NavigationSession
@@ -172,6 +173,7 @@ constructor(
                     isAccessible = true
                 }
         }
+        navigator = NavigationComponentProvider.createNativeNavigator()
         tripService = NavigationComponentProvider.createTripService(
             context.applicationContext,
             notification,
@@ -182,7 +184,8 @@ constructor(
             locationEngine,
             locationEngineRequest,
             navigationOptions.navigatorPredictionMillis,
-            logger
+            navigator = navigator,
+            logger = logger
         )
         tripSession.registerOffRouteObserver(internalOffRouteObserver)
         tripSession.registerStateObserver(navigationSession)
@@ -312,6 +315,7 @@ constructor(
         tripSession.unregisterAllBannerInstructionsObservers()
         tripSession.unregisterAllVoiceInstructionsObservers()
         tripSession.route = null
+        navigator.reset()
         navigationSession.unregisterAllNavigationSessionStateObservers()
         fasterRouteController.stop()
         routeRefreshController.stop()
@@ -463,7 +467,8 @@ constructor(
      *
      * @param arrivalController [ArrivalController]
      */
-    @JvmOverloads fun attachArrivalController(arrivalController: ArrivalController = AutoArrivalController()) {
+    @JvmOverloads
+    fun attachArrivalController(arrivalController: ArrivalController = AutoArrivalController()) {
         arrivalProgressObserver.attach(arrivalController)
         tripSession.registerRouteProgressObserver(arrivalProgressObserver)
     }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/NavigationComponentProvider.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/NavigationComponentProvider.kt
@@ -12,12 +12,16 @@ import com.mapbox.navigation.core.internal.trip.service.MapboxTripService
 import com.mapbox.navigation.core.internal.trip.service.TripService
 import com.mapbox.navigation.core.internal.trip.session.MapboxTripSession
 import com.mapbox.navigation.core.trip.session.TripSession
+import com.mapbox.navigation.navigator.internal.MapboxNativeNavigator
+import com.mapbox.navigation.navigator.internal.MapboxNativeNavigatorImpl
 
 internal object NavigationComponentProvider {
     fun createDirectionsSession(
         router: Router
     ): DirectionsSession =
         MapboxDirectionsSession(router)
+
+    fun createNativeNavigator(): MapboxNativeNavigator = MapboxNativeNavigatorImpl
 
     fun createTripService(
         applicationContext: Context,
@@ -34,12 +38,14 @@ internal object NavigationComponentProvider {
         locationEngine: LocationEngine,
         locationEngineRequest: LocationEngineRequest,
         navigatorPredictionMillis: Long,
+        navigator: MapboxNativeNavigator,
         logger: Logger
     ): TripSession = MapboxTripSession(
         tripService,
         locationEngine,
         locationEngineRequest,
         navigatorPredictionMillis,
+        navigator = navigator,
         logger = logger
     )
 

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/trip/session/MapboxTripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/trip/session/MapboxTripSession.kt
@@ -184,7 +184,6 @@ class MapboxTripSession(
         enhancedLocation = null
         routeProgress = null
         isOffRoute = false
-        navigator.reset()
     }
 
     /**

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/internal/trip/session/MapboxTripSessionTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/internal/trip/session/MapboxTripSessionTest.kt
@@ -157,15 +157,6 @@ class MapboxTripSessionTest {
     }
 
     @Test
-    fun stopSessionCallsMapboxNativeNavigatorReset() {
-        tripSession.start()
-
-        tripSession.stop()
-
-        verify { navigator.reset() }
-    }
-
-    @Test
     fun stopSessionDoesNotClearUpRoute() {
         tripSession.route = route
         tripSession.start()


### PR DESCRIPTION
## Description

Fix `Navigator#reset` regression from https://github.com/mapbox/mapbox-navigation-android/pull/2850

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

The `Navigator` was reset when stopping a trip session (e.g. stopping from the `MapboxTripNotification`) removing `MapboxTripSession.route` `Navigator`s state

### Implementation

- Move `navigator.reset` out from `MapboxTripSession` to `MapboxNavigation#onDestroy` only

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR

cc @Lebedinsky 