### PR TITLE
adding legacy method for determining the below layer id

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteLine.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteLine.kt
@@ -19,6 +19,7 @@ import com.mapbox.mapboxsdk.style.layers.LineLayer
 import com.mapbox.mapboxsdk.style.layers.Property
 import com.mapbox.mapboxsdk.style.layers.PropertyFactory
 import com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineGradient
+import com.mapbox.mapboxsdk.style.layers.SymbolLayer
 import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource
 import com.mapbox.navigation.ui.route.MapRouteLine.MapRouteLineSupport.buildRouteLineExpression
@@ -685,8 +686,14 @@ internal class MapRouteLine(
          *
          * @return either the layer ID if found else a default layer ID
          */
-        fun getBelowLayer(layerId: String?, style: Style): String =
-            style.layers.firstOrNull { it.id == layerId }?.id ?: LocationComponentConstants.SHADOW_LAYER
+        fun getBelowLayer(layerId: String?, style: Style): String {
+            return when (layerId.isNullOrEmpty()) {
+                false -> style.layers.firstOrNull { it.id == layerId }?.id
+                true -> style.layers.reversed().filter { it !is SymbolLayer }
+                    .firstOrNull { it.id != RouteConstants.MAPBOX_LOCATION_ID }
+                    ?.id
+            } ?: LocationComponentConstants.SHADOW_LAYER
+        }
 
         /**
          * Generates a FeatureCollection and LineString based on the @param route.

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/RouteConstants.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/RouteConstants.java
@@ -1,7 +1,6 @@
 package com.mapbox.navigation.ui.route;
 
 class RouteConstants {
-  static final String CONGESTION_KEY = "congestion";
   static final String PRIMARY_ROUTE_SOURCE_ID = "mapbox-navigation-route-source";
   static final String PRIMARY_ROUTE_LAYER_ID = "mapbox-navigation-route-layer";
   static final String PRIMARY_ROUTE_SHIELD_LAYER_ID = "mapbox-navigation-route-shield-layer";
@@ -37,15 +36,13 @@ class RouteConstants {
   static final float OPAQUE = 0.0f;
   static final int ARROW_HIDDEN_ZOOM_LEVEL = 14;
   static final float TRANSPARENT = 1.0f;
-  static final String LAYER_ABOVE_UPCOMING_MANEUVER_ARROW = "com.mapbox.annotations.points";
-  static final int FIRST_COLLECTION_INDEX = 0;
   static final String WAYPOINT_PROPERTY_KEY = "wayPoint";
   static final String WAYPOINT_ORIGIN_VALUE = "origin";
   static final String WAYPOINT_DESTINATION_VALUE = "destination";
-  static final String PRIMARY_ROUTE_PROPERTY_KEY = "primary-route";
   static final String MODERATE_CONGESTION_VALUE = "moderate";
   static final String HEAVY_CONGESTION_VALUE = "heavy";
   static final String SEVERE_CONGESTION_VALUE = "severe";
   static final String ORIGIN_MARKER_NAME = "originMarker";
   static final String DESTINATION_MARKER_NAME = "destinationMarker";
+  static final String MAPBOX_LOCATION_ID = "mapbox-location";
 }

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteLineTest.kt
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteLineTest.kt
@@ -367,31 +367,92 @@ class MapRouteLineTest {
     }
 
     @Test
-    fun getBelowLayer() {
+    fun getBelowLayerWithNullLayerId() {
         val style = mockk<Style>()
-        val layer1 = mockk<Layer>()
-        val layer2 = mockk<Layer>()
-        val layers = listOf(layer1, layer2)
+        val layerApple = mockk<Layer>()
+        val layerBanana = mockk<Layer>()
+        val layerCantaloupe = mockk<Layer>()
+        val layerDragonfruit = mockk<SymbolLayer>()
+        val layers = listOf(layerApple, layerBanana, layerCantaloupe, layerDragonfruit)
         every { style.layers } returns layers
-        every { layer1.id } returns "1"
-        every { layer2.id } returns "2"
+        every { layerApple.id } returns "layerApple"
+        every { layerBanana.id } returns RouteConstants.MAPBOX_LOCATION_ID
+        every { layerCantaloupe.id } returns "layerCantaloupe"
+        every { layerDragonfruit.id } returns "layerDragonfruit"
 
-        val result = MapRouteLine.MapRouteLineSupport.getBelowLayer("2", style)
+        val result = MapRouteLine.MapRouteLineSupport.getBelowLayer(null, style)
 
-        assertEquals("2", result)
+        assertEquals("layerCantaloupe", result)
     }
 
     @Test
-    fun getBelowLayerReturnsShadowLayerId() {
+    fun getBelowLayerWithEmptyLayerId() {
         val style = mockk<Style>()
-        val layer1 = mockk<Layer>()
-        val layer2 = mockk<Layer>()
-        val layers = listOf(layer1, layer2)
+        val layerApple = mockk<Layer>()
+        val layerBanana = mockk<Layer>()
+        val layerCantaloupe = mockk<Layer>()
+        val layerDragonfruit = mockk<SymbolLayer>()
+        val layers = listOf(layerApple, layerBanana, layerCantaloupe, layerDragonfruit)
         every { style.layers } returns layers
-        every { layer1.id } returns "1"
-        every { layer2.id } returns "2"
+        every { layerApple.id } returns "layerApple"
+        every { layerBanana.id } returns RouteConstants.MAPBOX_LOCATION_ID
+        every { layerCantaloupe.id } returns "layerCantaloupe"
+        every { layerDragonfruit.id } returns "layerDragonfruit"
 
-        val result = MapRouteLine.MapRouteLineSupport.getBelowLayer("3", style)
+        val result = MapRouteLine.MapRouteLineSupport.getBelowLayer("", style)
+
+        assertEquals("layerCantaloupe", result)
+    }
+
+    @Test
+    fun getBelowLayerReturnsShadowLayerIdAsDefault() {
+        val style = mockk<Style>()
+        val layerApple = mockk<Layer>()
+        val layerBanana = mockk<SymbolLayer>()
+        val layers = listOf(layerApple, layerBanana)
+        every { style.layers } returns layers
+        every { layerApple.id } returns RouteConstants.MAPBOX_LOCATION_ID
+        every { layerBanana.id } returns "layerBanana"
+
+        val result = MapRouteLine.MapRouteLineSupport.getBelowLayer(null, style)
+
+        assertEquals(LocationComponentConstants.SHADOW_LAYER, result)
+    }
+
+    @Test
+    fun getBelowLayerReturnsInputIdIfFound() {
+        val style = mockk<Style>()
+        val layerApple = mockk<Layer>()
+        val layerBanana = mockk<Layer>()
+        val layerCantaloupe = mockk<Layer>()
+        val layerDragonfruit = mockk<Layer>()
+        val layers = listOf(layerApple, layerBanana, layerCantaloupe, layerDragonfruit)
+        every { style.layers } returns layers
+        every { layerApple.id } returns "layerApple"
+        every { layerBanana.id } returns "layerBanana"
+        every { layerCantaloupe.id } returns "layerCantaloupe"
+        every { layerDragonfruit.id } returns "layerDragonfruit"
+
+        val result = MapRouteLine.MapRouteLineSupport.getBelowLayer("layerBanana", style)
+
+        assertEquals("layerBanana", result)
+    }
+
+    @Test
+    fun getBelowLayerReturnsShadowLayerIfInputNotNullOrEmptyAndNotFound() {
+        val style = mockk<Style>()
+        val layerApple = mockk<Layer>()
+        val layerBanana = mockk<Layer>()
+        val layerCantaloupe = mockk<Layer>()
+        val layerDragonfruit = mockk<Layer>()
+        val layers = listOf(layerApple, layerBanana, layerCantaloupe, layerDragonfruit)
+        every { style.layers } returns layers
+        every { layerApple.id } returns "layerApple"
+        every { layerBanana.id } returns "layerBanana"
+        every { layerCantaloupe.id } returns "layerCantaloupe"
+        every { layerDragonfruit.id } returns "layerDragonfruit"
+
+        val result = MapRouteLine.MapRouteLineSupport.getBelowLayer("foobar", style)
 
         assertEquals(LocationComponentConstants.SHADOW_LAYER, result)
     }


### PR DESCRIPTION
## Description

See #2872 for details

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

The route line should appear below the street names.

### Implementation

Method from legacy codebase was used.

## Screenshots or Gifs

![Screenshot_20200505-130633](https://user-images.githubusercontent.com/2249818/81111137-6f030780-8ed1-11ea-8e06-c25203db679e.png)


## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->