### PR TITLE
fix: removed unnecessary check for geometry on directionsRoute

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteProgressChangeListener.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteProgressChangeListener.kt
@@ -58,8 +58,7 @@ internal class MapRouteProgressChangeListener(
 
     private fun updateRoute(directionsRoute: DirectionsRoute?, routeProgress: RouteProgress) {
         val currentRoute = routeProgress.route()
-        val hasGeometry = !(directionsRoute?.geometry().isNullOrEmpty() ||
-            currentRoute?.geometry().isNullOrEmpty())
+        val hasGeometry = currentRoute?.geometry()?.isNotEmpty() ?: false
         if (currentRoute != null && hasGeometry && currentRoute != directionsRoute) {
             routeLine.draw(currentRoute)
             routeArrow.addUpcomingManeuverArrow(routeProgress)

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteProgressChangeListenerTest.kt
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteProgressChangeListenerTest.kt
@@ -97,15 +97,15 @@ class MapRouteProgressChangeListenerTest {
     }
 
     @Test
-    fun `should only draw routes with geometry`() {
+    fun `should draw routes when route progress has geometry`() {
         every { routeLine.retrieveDirectionsRoutes() } returns listOf(
             mockk {
-                every { geometry() } returns "y{v|bA{}diiGOuDpBiMhM{k@~Syj@bLuZlEiM"
+                every { geometry() } returns null
             }
         )
         val routeProgress: RouteProgress = mockk {
             every { route() } returns mockk {
-                every { geometry() } returns null
+                every { geometry() } returns "y{v|bA{}diiGOuDpBiMhM{k@~Syj@bLuZlEiM"
             }
         }
         val newRoute: DirectionsRoute = mockk {
@@ -116,8 +116,7 @@ class MapRouteProgressChangeListenerTest {
 
         progressChangeListener.onRouteProgressChanged(routeProgress)
 
-        verify(exactly = 0) { routeLine.draw(any<DirectionsRoute>()) }
-        verify(exactly = 0) { routeLine.draw(any<List<DirectionsRoute>>()) }
+        verify(exactly = 1) { routeLine.draw(any<DirectionsRoute>()) }
     }
 
     @Test


### PR DESCRIPTION
## Description
It was discovered in the driver app that when it went into dark mode the route line wasn't being redrawn. This was due to a check for geometry on the directions route which wasn't necessary as only the route progress's route needed geometry.

- [ ] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal

The route line should redraw when going into dark mode, more specifically if there is a restore of the MapRouteLine.

### Implementation


## Screenshots or Gifs


## Testing


- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->