### PR TITLE
bug fix updating route arrows on update route independent of vanishing route …

### DIFF
--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteProgressChangeListenerTest.kt
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteProgressChangeListenerTest.kt
@@ -70,33 +70,6 @@ class MapRouteProgressChangeListenerTest {
     }
 
     @Test
-    fun `should not update maneuver arrow without directions route`() {
-        every { routeLine.getPrimaryRoute() } returns null
-        val routeProgress: RouteProgress = mockk {
-            every { route() } returns null
-        }
-
-        progressChangeListener.onRouteProgressChanged(routeProgress)
-
-        verify(exactly = 0) { routeArrow.addUpcomingManeuverArrow(routeProgress) }
-    }
-
-    @Test
-    fun `should not add maneuver arrow without geometry`() {
-        val newRoute: DirectionsRoute = mockk {
-            every { geometry() } returns null
-        }
-        val routeProgress: RouteProgress = mockk {
-            every { route() } returns newRoute
-        }
-        every { routeLine.getPrimaryRoute() } returns newRoute
-
-        progressChangeListener.onRouteProgressChanged(routeProgress)
-
-        verify(exactly = 0) { routeArrow.addUpcomingManeuverArrow(routeProgress) }
-    }
-
-    @Test
     fun `should draw routes when route progress has geometry`() {
         every { routeLine.retrieveDirectionsRoutes() } returns listOf(
             mockk {


### PR DESCRIPTION
## Description

Addresses #2845

- [x] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal

The upcoming maneuver arrows should always display.

### Implementation

The feature to make the vanishing route line caused a regression in the maneuver arrows displaying. The call to update the arrows was moved outside of the condition for updating the route line on route progress updates.

## Screenshots or Gifs

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->