### PR TITLE
Append SKU token to Route Refresh requests

### DIFF
--- a/libdirections-offboard/src/main/java/com/mapbox/navigation/route/offboard/MapboxOffboardRouter.kt
+++ b/libdirections-offboard/src/main/java/com/mapbox/navigation/route/offboard/MapboxOffboardRouter.kt
@@ -110,6 +110,12 @@ class MapboxOffboardRouter(
                 .accessToken(accessToken)
                 .requestId(route.routeOptions()?.requestUuid())
                 .legIndex(legIndex)
+                .interceptor {
+                    val httpUrl = it.request().url()
+                    val skuUrl =
+                        skuTokenProvider.obtainUrlWithSkuToken(httpUrl.toString(), httpUrl.querySize())
+                    it.proceed(it.request().newBuilder().url(skuUrl).build())
+                }
 
             mapboxDirectionsRefresh = refreshBuilder.build()
             mapboxDirectionsRefresh?.enqueueCall(RouteRefreshCallbackMapper(route, legIndex, callback))


### PR DESCRIPTION
## Description

Appends SKU token to Route Refresh requests

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

All the requests coming from the SDK should append the SKU as part of its URL

### Implementation

Add 👇 

```kotlin
.interceptor {
    val httpUrl = it.request().url()
    val skuUrl = skuTokenProvider.obtainUrlWithSkuToken(httpUrl.toString(), httpUrl.querySize())
    it.proceed(it.request().newBuilder().url(skuUrl).build())
}
```

to `MapboxDirectionsRefresh.builder()` which appends the SKU token to the Route Refresh URL

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR

cc @kmadsen @abhishek1508 