### PR TITLE
bug fix redrawing route line on map style change

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/BasicNavigationActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/BasicNavigationActivity.kt
@@ -54,6 +54,14 @@ class BasicNavigationActivity : AppCompatActivity(), OnMapReadyCallback {
     private var navigationMapboxMap: NavigationMapboxMap? = null
     private var mapInstanceState: NavigationMapboxMapInstanceState? = null
 
+    private val mapStyles = listOf(
+        Style.MAPBOX_STREETS,
+        Style.OUTDOORS,
+        Style.LIGHT,
+        Style.DARK,
+        Style.SATELLITE_STREETS
+    )
+
     @SuppressLint("MissingPermission")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -168,6 +176,10 @@ class BasicNavigationActivity : AppCompatActivity(), OnMapReadyCallback {
             mapboxNavigation?.startTripSession()
             startNavigation.visibility = View.GONE
             stopLocationUpdates()
+        }
+
+        fabToggleStyle.setOnClickListener {
+            navigationMapboxMap?.retrieveMap()?.setStyle(mapStyles.shuffled().first())
         }
     }
 

--- a/examples/src/main/res/drawable/ic_layers_24dp.xml
+++ b/examples/src/main/res/drawable/ic_layers_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M11.99,18.54l-7.37,-5.73L3,14.07l9,7 9,-7 -1.63,-1.27 -7.38,5.74zM12,16l7.36,-5.73L21,9l-9,-7 -9,7 1.63,1.27L12,16z"/>
+</vector>

--- a/examples/src/main/res/layout/activity_basic_navigation_layout.xml
+++ b/examples/src/main/res/layout/activity_basic_navigation_layout.xml
@@ -30,4 +30,15 @@
         android:textColor="@android:color/white"
         android:visibility="gone" />
 
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/fabToggleStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="24dp"
+        android:layout_marginBottom="24dp"
+        android:tint="@android:color/white"
+        app:layout_constraintBottom_toTopOf="@+id/startNavigation"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:srcCompat="@drawable/ic_layers_24dp"/>
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteLine.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteLine.kt
@@ -325,7 +325,12 @@ internal class MapRouteLine(
      * Returns the DirectionsRoutes being used.
      */
     fun retrieveDirectionsRoutes(): List<DirectionsRoute> {
-        return routeFeatureData.map { it.route }
+        val itemsToReturn: MutableList<DirectionsRoute> = when (primaryRoute) {
+            null -> mutableListOf()
+            else -> mutableListOf(primaryRoute!!)
+        }
+        val filteredItems = routeFeatureData.map { it.route }.filter { it != primaryRoute }
+        return itemsToReturn.plus(filteredItems)
     }
 
     /**
@@ -473,7 +478,6 @@ internal class MapRouteLine(
 
     private fun drawRoutes(routeData: List<RouteFeatureData>) {
         val partitionedRoutes = routeData.partition { it.route == primaryRoute }
-
         partitionedRoutes.first.firstOrNull()?.let {
             setPrimaryRoutesSource(it.featureCollection)
             val lineString: LineString = getLineStringForRoute(it.route)
@@ -578,8 +582,10 @@ internal class MapRouteLine(
                 Expression.color(routeShieldColor)
             )
         )
-
-        style.getLayerAs<LineLayer>(RouteConstants.PRIMARY_ROUTE_SHIELD_LAYER_ID)?.setProperties(lineGradient(expression))
+        if (style.isFullyLoaded) {
+            style.getLayerAs<LineLayer>(RouteConstants.PRIMARY_ROUTE_SHIELD_LAYER_ID)
+                ?.setProperties(lineGradient(expression))
+        }
     }
 
     /**

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/NavigationMapRoute.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/NavigationMapRoute.java
@@ -414,9 +414,10 @@ public class NavigationMapRoute implements LifecycleObserver {
   }
 
   private void recreateRouteLine(Style style) {
-    Context context = mapView.getContext();
-    MapRouteLayerProvider layerProvider = new MapRouteLayerProvider();
+    final Context context = mapView.getContext();
+    final MapRouteLayerProvider layerProvider = new MapRouteLayerProvider();
 
+    final List<DirectionsRoute> preExistingRoutes = routeLine.retrieveDirectionsRoutes();
     routeLine = new MapRouteLine(
             context,
             style,
@@ -428,7 +429,7 @@ public class NavigationMapRoute implements LifecycleObserver {
             routeLine.retrieveAlternativesVisible(),
             new MapRouteSourceProvider()
     );
-
+    routeLine.draw(preExistingRoutes);
     mapboxMap.removeOnMapClickListener(mapRouteClickListener);
     mapRouteClickListener = new MapRouteClickListener(routeLine);
     mapboxMap.addOnMapClickListener(mapRouteClickListener);


### PR DESCRIPTION
## Description

It was discovered  that when changing the map style dynamically the route line was not getting redrawn. It was a regression from the legacy code which would do the redraw in the constructor. 

- [ ] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal

When the map style changes dynamically and there's a route line on the map the line should be redrawn.

### Implementation

The NavigationMapRoute in the recreateRouteLine method should call draw after creating a new instance of the MapRouteLine class.

## Screenshots or Gifs

![20200506_150812](https://user-images.githubusercontent.com/2249818/81233468-91695380-8fab-11ea-966b-858f9030bce5.gif)

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->