### PR TITLE
Replay player api feedback

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MultipleStopsActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MultipleStopsActivity.kt
@@ -45,11 +45,11 @@ import com.mapbox.navigation.ui.map.NavigationMapboxMap
 import com.mapbox.navigation.ui.map.NavigationMapboxMapInstanceState
 import java.lang.ref.WeakReference
 import java.util.Collections
-import kotlinx.android.synthetic.main.replay_engine_example_activity_layout.container
-import kotlinx.android.synthetic.main.replay_engine_example_activity_layout.mapView
-import kotlinx.android.synthetic.main.replay_engine_example_activity_layout.seekBar
-import kotlinx.android.synthetic.main.replay_engine_example_activity_layout.seekBarText
-import kotlinx.android.synthetic.main.replay_engine_example_activity_layout.startNavigation
+import kotlinx.android.synthetic.main.multiple_stops_example_activity_layout.container
+import kotlinx.android.synthetic.main.multiple_stops_example_activity_layout.mapView
+import kotlinx.android.synthetic.main.multiple_stops_example_activity_layout.seekBar
+import kotlinx.android.synthetic.main.multiple_stops_example_activity_layout.seekBarText
+import kotlinx.android.synthetic.main.multiple_stops_example_activity_layout.startNavigation
 import timber.log.Timber
 
 /**
@@ -70,7 +70,7 @@ class MultipleStopsActivity : AppCompatActivity(), OnMapReadyCallback {
     @SuppressLint("MissingPermission")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.replay_engine_example_activity_layout)
+        setContentView(R.layout.multiple_stops_example_activity_layout)
         mapView.onCreate(savedInstanceState)
 
         val mapboxNavigationOptions = MapboxNavigation.defaultNavigationOptions(
@@ -166,7 +166,7 @@ class MultipleStopsActivity : AppCompatActivity(), OnMapReadyCallback {
             mapboxNavigation?.registerRouteProgressObserver(replayProgressObserver)
             mapboxNavigation?.startTripSession()
             startNavigation.visibility = View.GONE
-            replayHistoryPlayer.play(this)
+            replayHistoryPlayer.play()
         }
     }
 

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayActivity.kt
@@ -148,7 +148,7 @@ class ReplayActivity : AppCompatActivity(), OnMapReadyCallback {
             }
             mapboxNavigation?.startTripSession()
             startNavigation.visibility = View.GONE
-            replayHistoryPlayer.play(this)
+            replayHistoryPlayer.play()
         }
     }
 

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayHistoryActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayHistoryActivity.kt
@@ -26,6 +26,7 @@ import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesRequestCallback
 import com.mapbox.navigation.core.replay.history.CustomEventMapper
 import com.mapbox.navigation.core.replay.history.ReplayEventBase
+import com.mapbox.navigation.core.replay.history.ReplayEventsObserver
 import com.mapbox.navigation.core.replay.history.ReplayHistoryLocationEngine
 import com.mapbox.navigation.core.replay.history.ReplayHistoryMapper
 import com.mapbox.navigation.core.replay.history.ReplayHistoryPlayer
@@ -144,20 +145,22 @@ class ReplayHistoryActivity : AppCompatActivity() {
             true
         }
 
-        replayHistoryPlayer.observeReplayEvents {
-            it.forEach { event ->
-                when (event) {
-                    is ReplayEventInitialRoute -> {
-                        event.coordinates.lastOrNull()?.let { latLng ->
-                            selectMapLocation(latLng)
+        replayHistoryPlayer.registerObserver(object : ReplayEventsObserver {
+            override fun replayEvents(events: List<ReplayEventBase>) {
+                events.forEach { event ->
+                    when (event) {
+                        is ReplayEventInitialRoute -> {
+                            event.coordinates.lastOrNull()?.let { latLng ->
+                                selectMapLocation(latLng)
+                            }
                         }
                     }
                 }
             }
-        }
+        })
 
         playReplay.setOnClickListener {
-            replayHistoryPlayer.play(this@ReplayHistoryActivity)
+            replayHistoryPlayer.play()
         }
     }
 
@@ -301,18 +304,18 @@ private fun loadHistoryJsonFromAssets(context: Context, fileName: String): Strin
 }
 
 private class ReplayCustomEventMapper : CustomEventMapper {
-    override fun invoke(eventType: String, event: LinkedTreeMap<*, *>): ReplayEventBase? {
+    override fun map(eventType: String, properties: LinkedTreeMap<*, *>): ReplayEventBase? {
         return when (eventType) {
             "start_transit" -> ReplayEventStartTransit(
-                eventTimestamp = event["event_timestamp"] as Double,
-                properties = event["properties"] as Double)
+                eventTimestamp = properties["event_timestamp"] as Double,
+                properties = properties["properties"] as Double)
             "initial_route" -> {
-                val properties = event["properties"] as LinkedTreeMap<*, *>
-                val routeOptions = properties["routeOptions"] as LinkedTreeMap<*, *>
+                val eventProperties = properties["properties"] as LinkedTreeMap<*, *>
+                val routeOptions = eventProperties["routeOptions"] as LinkedTreeMap<*, *>
                 val coordinates = routeOptions["coordinates"] as List<List<Double>>
                 val coordinatesLatLng = coordinates.map { LatLng(it[1], it[0]) }
                 ReplayEventInitialRoute(
-                    eventTimestamp = event["event_timestamp"] as Double,
+                    eventTimestamp = properties["event_timestamp"] as Double,
                     coordinates = coordinatesLatLng
                 )
             }

--- a/examples/src/main/res/layout/multiple_stops_example_activity_layout.xml
+++ b/examples/src/main/res/layout/multiple_stops_example_activity_layout.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".core.SimpleMapboxNavigationKt"
+    app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+    <com.mapbox.mapboxsdk.maps.MapView
+        android:id="@+id/mapView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"/>
+
+    <com.google.android.material.card.MaterialCardView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toTopOf="@id/navigationLayout"
+        app:cardElevation="3dp"
+        app:cardUseCompatPadding="true">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="vertical">
+            <TextView
+                android:id="@+id/seekBarText"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_horizontal"
+                style="@style/TextAppearance.MaterialComponents.Headline6"
+                android:text="Replay speed" />
+
+            <SeekBar
+                android:id="@+id/seekBar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingBottom="6dp"
+                android:paddingTop="6dp" />
+        </LinearLayout>
+
+    </com.google.android.material.card.MaterialCardView>
+
+    <LinearLayout
+        android:id="@+id/navigationLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:weightSum="0"
+        android:orientation="horizontal">
+        <Button
+            android:id="@+id/startNavigation"
+            android:layout_weight="1"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="@string/start_navigation"
+            style="@style/Widget.MaterialComponents.Button"
+            android:visibility="gone"
+            />
+
+        <Button
+            android:id="@+id/navigateNextRouteLeg"
+            android:layout_weight="1"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="@string/navigate_waypoints_next_stop"
+            style="@style/Widget.MaterialComponents.Button"
+            android:visibility="gone"
+            />
+    </LinearLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/examples/src/main/res/layout/replay_engine_example_activity_layout.xml
+++ b/examples/src/main/res/layout/replay_engine_example_activity_layout.xml
@@ -18,72 +18,16 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"/>
 
-    <com.google.android.material.card.MaterialCardView
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:layout_constraintBottom_toTopOf="@id/navigationCard"
-        app:cardElevation="3dp"
-        app:cardUseCompatPadding="true">
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:orientation="vertical">
-            <TextView
-                android:id="@+id/seekBarText"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:gravity="center_horizontal"
-                style="@style/TextAppearance.MaterialComponents.Headline6"
-                android:text="Replay speed" />
-
-            <SeekBar
-                android:id="@+id/seekBar"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:paddingBottom="6dp"
-                android:paddingTop="6dp" />
-        </LinearLayout>
-
-    </com.google.android.material.card.MaterialCardView>
-
-    <com.google.android.material.card.MaterialCardView
-        android:id="@+id/navigationCard"
-        android:layout_width="match_parent"
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/startNavigation"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:cardElevation="3dp"
-        app:cardUseCompatPadding="true">
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:weightSum="0"
-            android:orientation="horizontal">
-            <Button
-                android:id="@+id/startNavigation"
-                android:layout_weight="1"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:text="@string/start_navigation"
-                style="@style/Widget.MaterialComponents.Button"
-                android:visibility="gone"
-                />
-
-            <Button
-                android:id="@+id/navigateNextRouteLeg"
-                android:layout_weight="1"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:text="@string/navigate_waypoints_next_stop"
-                style="@style/Widget.MaterialComponents.Button"
-                android:visibility="gone"
-                />
-        </LinearLayout>
-
-    </com.google.android.material.card.MaterialCardView>
-
+        android:background="@color/colorPrimary"
+        android:text="@string/start_navigation"
+        android:textColor="@android:color/white"
+        android:visibility="gone" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/history/ReplayEventsObserver.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/history/ReplayEventsObserver.kt
@@ -1,0 +1,15 @@
+package com.mapbox.navigation.core.replay.history
+
+/**
+ * Used to observe events replayed by the [ReplayHistoryPlayer]
+ */
+interface ReplayEventsObserver {
+
+    /**
+     * Called with all events that occurred within a time window
+     * during replay
+     *
+     * @param events events in chronological order, index 0 being the oldest
+     */
+    fun replayEvents(events: List<ReplayEventBase>)
+}

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/history/ReplayHistoryLocationEngine.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/history/ReplayHistoryLocationEngine.kt
@@ -16,7 +16,7 @@ private typealias EngineCallback = LocationEngineCallback<LocationEngineResult>
  */
 class ReplayHistoryLocationEngine(
     replayHistoryPlayer: ReplayHistoryPlayer
-) : LocationEngine {
+) : LocationEngine, ReplayEventsObserver {
 
     private val registeredCallbacks: MutableList<EngineCallback> = mutableListOf()
     private val lastLocationCallbacks: MutableList<EngineCallback> = mutableListOf()
@@ -33,9 +33,7 @@ class ReplayHistoryLocationEngine(
 
     init {
         myId = instances
-        replayHistoryPlayer.observeReplayEvents { recordUpdate ->
-            replayEvents(recordUpdate)
-        }
+        replayHistoryPlayer.registerObserver(this)
     }
 
     /**
@@ -85,7 +83,7 @@ class ReplayHistoryLocationEngine(
         throw UnsupportedOperationException("$myId removeLocationUpdates with intents is unsupported")
     }
 
-    private fun replayEvents(replayEvents: List<ReplayEventBase>) {
+    override fun replayEvents(replayEvents: List<ReplayEventBase>) {
         replayEvents.forEach { event ->
             when (event) {
                 is ReplayEventUpdateLocation -> replayLocation(event)

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/history/ReplayHistoryMapper.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/history/ReplayHistoryMapper.kt
@@ -5,7 +5,17 @@ import com.google.gson.internal.LinkedTreeMap
 import com.mapbox.base.common.logger.Logger
 import com.mapbox.base.common.logger.model.Message
 
-typealias CustomEventMapper = (String, LinkedTreeMap<*, *>) -> ReplayEventBase?
+/**
+ * Additional mapper that can be used with [ReplayHistoryMapper].
+ */
+interface CustomEventMapper {
+
+    /**
+     * Override to map your own custom events from history files,
+     * into [ReplayEventBase] for the [ReplayHistoryPlayer]
+     */
+    fun map(eventType: String, properties: LinkedTreeMap<*, *>): ReplayEventBase?
+}
 
 /**
  * This class is responsible for creating [ReplayEvents] from history data.
@@ -15,7 +25,7 @@ typealias CustomEventMapper = (String, LinkedTreeMap<*, *>) -> ReplayEventBase?
  * own [CustomEventMapper] (optional)
  * @param logger interface for logging any events (optional)
  */
-class ReplayHistoryMapper(
+class ReplayHistoryMapper @JvmOverloads constructor(
     private val gson: Gson = Gson(),
     private val customEventMapper: CustomEventMapper? = null,
     private val logger: Logger
@@ -63,7 +73,7 @@ class ReplayHistoryMapper(
                     eventTimestamp = eventTimestamp)
             }
             else -> {
-                val replayEvent = customEventMapper?.invoke(eventType, event)
+                val replayEvent = customEventMapper?.map(eventType, event)
                 if (replayEvent == null) {
                     logger.e(msg = Message("Replay unsupported event $eventType"))
                 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayRouteLocationEngine.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayRouteLocationEngine.kt
@@ -22,9 +22,12 @@ import java.util.ArrayList
  * @param logger [Logger](optional)
  * @param converter ReplayLocationConverter
  */
-class ReplayRouteLocationEngine(
+class ReplayRouteLocationEngine @JvmOverloads constructor(
     val logger: Logger? = null,
-    private val converter: ReplayLocationConverter
+    private val converter: ReplayLocationConverter = ReplayRouteLocationConverter(
+        DEFAULT_SPEED,
+        DEFAULT_DELAY
+    )
 ) : LocationEngine, Runnable {
 
     private var speed = DEFAULT_SPEED
@@ -36,17 +39,6 @@ class ReplayRouteLocationEngine(
     private var lastLocation = Location(REPLAY_ROUTE)
     private var route: DirectionsRoute? = null
     private var point: Point? = null
-
-    /**
-     * @param [Logger](optional)
-     */
-    constructor(logger: Logger? = null) : this(
-        logger,
-        ReplayRouteLocationConverter(
-            DEFAULT_SPEED,
-            DEFAULT_DELAY
-        )
-    )
 
     companion object {
         private const val HEAD = 0

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route2/ReplayProgressObserver.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route2/ReplayProgressObserver.kt
@@ -23,7 +23,7 @@ class ReplayProgressObserver(
     private var currentRouteLeg: RouteLeg? = null
 
     /**
-     * @param options allow you to control the driver and car behavior
+     * @param options allow you to control the driver and car behavior.
      */
     fun updateOptions(options: ReplayRouteOptions): ReplayProgressObserver {
         replayRouteMapper.options = options

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route2/ReplayRouteMapper.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route2/ReplayRouteMapper.kt
@@ -16,7 +16,7 @@ import com.mapbox.navigation.core.replay.history.ReplayHistoryPlayer
  * This class converts a [DirectionsRoute] into events that can be
  * replayed using the [ReplayHistoryPlayer] to navigate a route.
  */
-class ReplayRouteMapper(
+class ReplayRouteMapper @JvmOverloads constructor(
     /**
      * Options that allow you to control the driver and car behavior
      */

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/history/ReplayHistoryMapperTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/history/ReplayHistoryMapperTest.kt
@@ -75,11 +75,11 @@ class ReplayHistoryMapperTest {
     ) : ReplayEventBase
 
     private class ExampleCustomEventMapper : CustomEventMapper {
-        override fun invoke(eventType: String, parameters: LinkedTreeMap<*, *>): ReplayEventBase? {
+        override fun map(eventType: String, properties: LinkedTreeMap<*, *>): ReplayEventBase? {
             return when (eventType) {
                 "end_transit" -> ExampleEndTransitEvent(
-                    eventTimestamp = parameters["event_timestamp"] as Double,
-                    properties = parameters["properties"] as Double
+                    eventTimestamp = properties["event_timestamp"] as Double,
+                    properties = properties["properties"] as Double
                 )
                 else -> null
             }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/history/ReplayHistoryPlayerTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/history/ReplayHistoryPlayerTest.kt
@@ -1,8 +1,6 @@
 package com.mapbox.navigation.core.replay.history
 
 import android.os.SystemClock
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleOwner
 import com.mapbox.base.common.logger.Logger
 import com.mapbox.navigation.testing.MainCoroutineRule
 import io.mockk.Called
@@ -14,7 +12,6 @@ import io.mockk.unmockkObject
 import io.mockk.verify
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.cancelAndJoin
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -28,12 +25,7 @@ class ReplayHistoryPlayerTest {
     @get:Rule
     val coroutineRule = MainCoroutineRule()
 
-    private val lifecycleOwner: LifecycleOwner = mockk {
-        every { lifecycle } returns mockk {
-            every { currentState } returns Lifecycle.State.STARTED
-        }
-    }
-    private val mockLambda: (List<ReplayEventBase>) -> Unit = mockk(relaxed = true)
+    private val replayEventsObserver: ReplayEventsObserver = mockk(relaxed = true)
     private val logger: Logger = mockk(relaxUnitFun = true)
 
     private var deviceElapsedTimeNanos = TimeUnit.HOURS.toNanos(11)
@@ -55,15 +47,14 @@ class ReplayHistoryPlayerTest {
                         speed = 0.5585000514984131)
                 )
             ))
-        replayHistoryPlayer.observeReplayEvents(mockLambda)
+        replayHistoryPlayer.registerObserver(replayEventsObserver)
 
-        val job = replayHistoryPlayer.play(lifecycleOwner)
+        replayHistoryPlayer.play()
         advanceTimeMillis(5000)
         replayHistoryPlayer.finish()
-        job.cancelAndJoin()
 
         val replayUpdates = mutableListOf<List<ReplayEventBase>>()
-        coVerify { mockLambda(capture(replayUpdates)) }
+        coVerify { replayEventsObserver.replayEvents(capture(replayUpdates)) }
         val events = replayUpdates.flatten()
         assertEquals(2, events.size)
         assertEquals(1580777612.853, events[0].eventTimestamp, 0.001)
@@ -105,16 +96,15 @@ class ReplayHistoryPlayerTest {
                         accuracyHorizontal = 3.9000000953674318,
                         provider = "fused"))
             ))
-        replayHistoryPlayer.observeReplayEvents(mockLambda)
+        replayHistoryPlayer.registerObserver(replayEventsObserver)
 
-        val job = replayHistoryPlayer.play(lifecycleOwner)
+        replayHistoryPlayer.play()
         advanceTimeMillis(3000)
         replayHistoryPlayer.finish()
-        job.cancelAndJoin()
 
         // Note that it only played 2 of the 3 locations
         val replayUpdates = mutableListOf<List<ReplayEventBase>>()
-        coVerify { mockLambda(capture(replayUpdates)) }
+        coVerify { replayEventsObserver.replayEvents(capture(replayUpdates)) }
         val events = replayUpdates.flatten()
         assertEquals(2, events.size)
         assertEquals(1580777820.952, events[0].eventTimestamp, 0.001)
@@ -127,17 +117,18 @@ class ReplayHistoryPlayerTest {
         val replayHistoryPlayer = ReplayHistoryPlayer(logger)
             .pushEvents(testEvents)
         val timeCapture = mutableListOf<Pair<ReplayEventBase, Long>>()
-        replayHistoryPlayer.observeReplayEvents { replayEvents ->
-            replayEvents.forEach { timeCapture.add(Pair(it, currentTime)) }
-        }
+        replayHistoryPlayer.registerObserver(object : ReplayEventsObserver {
+            override fun replayEvents(events: List<ReplayEventBase>) {
+                events.forEach { timeCapture.add(Pair(it, currentTime)) }
+            }
+        })
 
-        val job = replayHistoryPlayer.play(lifecycleOwner)
+        replayHistoryPlayer.play()
         advanceTimeMillis(20000)
         val extraEvents = List(7) { ReplayEventGetStatus(it.toDouble()) }
         replayHistoryPlayer.pushEvents(extraEvents)
         advanceTimeMillis(20000)
         replayHistoryPlayer.finish()
-        job.cancelAndJoin()
 
         // 12 events at the beginning
         // 7 events later
@@ -155,19 +146,20 @@ class ReplayHistoryPlayerTest {
                 ReplayEventGetStatus(1003.000)
             ))
         val timeCapture = mutableListOf<Long>()
-        replayHistoryPlayer.observeReplayEvents { replayEvents ->
-            if (replayEvents.isNotEmpty()) {
-                timeCapture.add(currentTime)
-                advanceTimeMillis(75)
+        replayHistoryPlayer.registerObserver(object : ReplayEventsObserver {
+            override fun replayEvents(events: List<ReplayEventBase>) {
+                if (events.isNotEmpty()) {
+                    timeCapture.add(currentTime)
+                    advanceTimeMillis(75)
+                }
             }
-        }
+        })
 
-        val job = replayHistoryPlayer.play(lifecycleOwner)
+        replayHistoryPlayer.play()
         for (i in 0..3000) {
             advanceTimeMillis(1)
         }
         replayHistoryPlayer.finish()
-        job.cancelAndJoin()
 
         assertEquals(3, timeCapture.size)
         assertEquals(0L, timeCapture[0])
@@ -195,15 +187,14 @@ class ReplayHistoryPlayerTest {
                         bearing = null,
                         speed = null))
             ))
-        replayHistoryPlayer.observeReplayEvents(mockLambda)
+        replayHistoryPlayer.registerObserver(replayEventsObserver)
 
-        val job = replayHistoryPlayer.play(lifecycleOwner)
+        replayHistoryPlayer.play()
         advanceTimeMillis(5000)
         replayHistoryPlayer.finish()
-        job.cancelAndJoin()
 
         val replayUpdates = mutableListOf<List<ReplayEventBase>>()
-        coVerify { mockLambda(capture(replayUpdates)) }
+        coVerify { replayEventsObserver.replayEvents(capture(replayUpdates)) }
         val events = replayUpdates.flatten()
         assertEquals(events.size, 2)
         assertTrue(events[0] is CustomReplayEvent)
@@ -211,11 +202,11 @@ class ReplayHistoryPlayerTest {
         assertEquals(1580777613.89, events[1].eventTimestamp, 0.001)
     }
 
-    @Test(expected = Exception::class)
-    fun `should crash if history data is empty`() {
+    @Test
+    fun `should not crash if history data is empty`() {
         val replayHistoryPlayer = ReplayHistoryPlayer(logger)
 
-        replayHistoryPlayer.play(lifecycleOwner)
+        replayHistoryPlayer.play()
         replayHistoryPlayer.finish()
     }
 
@@ -235,12 +226,12 @@ class ReplayHistoryPlayerTest {
                         bearing = 243.31265258789063,
                         speed = 0.5585000514984131))
             ))
-        replayHistoryPlayer.observeReplayEvents(mockLambda)
+        replayHistoryPlayer.registerObserver(replayEventsObserver)
 
         replayHistoryPlayer.playFirstLocation()
 
         val replayUpdates = mutableListOf<List<ReplayEventBase>>()
-        verify { mockLambda(capture(replayUpdates)) }
+        verify { replayEventsObserver.replayEvents(capture(replayUpdates)) }
         val events = replayUpdates.flatten()
         assertEquals(1, events.size)
         assertEquals(1580777612.89, events[0].eventTimestamp, 0.001)
@@ -254,11 +245,11 @@ class ReplayHistoryPlayerTest {
                 ReplayEventGetStatus(1580777613.452),
                 ReplayEventGetStatus(1580777614.085)
             ))
-        replayHistoryPlayer.observeReplayEvents(mockLambda)
+        replayHistoryPlayer.registerObserver(replayEventsObserver)
 
         replayHistoryPlayer.playFirstLocation()
 
-        verify { mockLambda(any()) wasNot Called }
+        verify { replayEventsObserver wasNot Called }
     }
 
     @Test
@@ -270,16 +261,15 @@ class ReplayHistoryPlayerTest {
                 seekToEvent,
                 ReplayEventGetStatus(3.085)
             ))
-        replayHistoryPlayer.observeReplayEvents(mockLambda)
+        replayHistoryPlayer.registerObserver(replayEventsObserver)
         replayHistoryPlayer.seekTo(seekToEvent)
 
-        val job = replayHistoryPlayer.play(lifecycleOwner)
+        replayHistoryPlayer.play()
         advanceTimeMillis(5000)
         replayHistoryPlayer.finish()
-        job.cancelAndJoin()
 
         val replayUpdates = mutableListOf<List<ReplayEventBase>>()
-        coVerify { mockLambda(capture(replayUpdates)) }
+        coVerify { replayEventsObserver.replayEvents(capture(replayUpdates)) }
         val events = replayUpdates.flatten()
         assertEquals(events.size, 2)
         assertEquals(2.452, events[0].eventTimestamp, 0.001)
@@ -294,7 +284,7 @@ class ReplayHistoryPlayerTest {
                 ReplayEventGetStatus(1.853),
                 ReplayEventGetStatus(3.085)
             ))
-        replayHistoryPlayer.observeReplayEvents(mockLambda)
+        replayHistoryPlayer.registerObserver(replayEventsObserver)
         replayHistoryPlayer.seekTo(seekToEvent)
     }
 
@@ -306,16 +296,15 @@ class ReplayHistoryPlayerTest {
                 ReplayEventGetStatus(2.0),
                 ReplayEventGetStatus(4.0)
             ))
-        replayHistoryPlayer.observeReplayEvents(mockLambda)
+        replayHistoryPlayer.registerObserver(replayEventsObserver)
         replayHistoryPlayer.seekTo(1.0)
 
-        val job = replayHistoryPlayer.play(lifecycleOwner)
+        replayHistoryPlayer.play()
         advanceTimeMillis(5000)
         replayHistoryPlayer.finish()
-        job.cancelAndJoin()
 
         val replayUpdates = mutableListOf<List<ReplayEventBase>>()
-        coVerify { mockLambda(capture(replayUpdates)) }
+        coVerify { replayEventsObserver.replayEvents(capture(replayUpdates)) }
         val events = replayUpdates.flatten()
         assertEquals(events.size, 2)
         assertEquals(2.0, events[0].eventTimestamp, 0.001)
@@ -330,16 +319,15 @@ class ReplayHistoryPlayerTest {
                 ReplayEventGetStatus(1580777613.452),
                 ReplayEventGetStatus(1580777614.085)
             ))
-        replayHistoryPlayer.observeReplayEvents(mockLambda)
+        replayHistoryPlayer.registerObserver(replayEventsObserver)
         replayHistoryPlayer.seekTo(1.0)
 
-        val job = replayHistoryPlayer.play(lifecycleOwner)
+        replayHistoryPlayer.play()
         advanceTimeMillis(5000)
         replayHistoryPlayer.finish()
-        job.cancelAndJoin()
 
         val replayUpdates = mutableListOf<List<ReplayEventBase>>()
-        coVerify { mockLambda(capture(replayUpdates)) }
+        coVerify { replayEventsObserver.replayEvents(capture(replayUpdates)) }
         val events = replayUpdates.flatten()
         assertEquals(2, events.size)
         assertEquals(1580777613.452, events[0].eventTimestamp, 0.001)
@@ -353,14 +341,15 @@ class ReplayHistoryPlayerTest {
             .pushEvents(testEvents)
 
         replayHistoryPlayer.playbackSpeed(1.0)
-        val job = replayHistoryPlayer.play(lifecycleOwner)
+        replayHistoryPlayer.play()
         val timeCapture = mutableListOf<Pair<ReplayEventBase, Long>>()
-        replayHistoryPlayer.observeReplayEvents { replayEvents ->
-            replayEvents.forEach { timeCapture.add(Pair(it, currentTime)) }
-        }
+        replayHistoryPlayer.registerObserver(object : ReplayEventsObserver {
+            override fun replayEvents(events: List<ReplayEventBase>) {
+                events.forEach { timeCapture.add(Pair(it, currentTime)) }
+            }
+        })
         advanceTimeMillis(3000)
         replayHistoryPlayer.finish()
-        job.cancelAndJoin()
 
         assertEquals(3, timeCapture.size)
     }
@@ -372,14 +361,15 @@ class ReplayHistoryPlayerTest {
             .pushEvents(testEvents)
 
         replayHistoryPlayer.playbackSpeed(4.0)
-        val job = replayHistoryPlayer.play(lifecycleOwner)
+        replayHistoryPlayer.play()
         val timeCapture = mutableListOf<Pair<ReplayEventBase, Long>>()
-        replayHistoryPlayer.observeReplayEvents { replayEvents ->
-            replayEvents.forEach { timeCapture.add(Pair(it, currentTime)) }
-        }
+        replayHistoryPlayer.registerObserver(object : ReplayEventsObserver {
+            override fun replayEvents(events: List<ReplayEventBase>) {
+                events.forEach { timeCapture.add(Pair(it, currentTime)) }
+            }
+        })
         advanceTimeMillis(4000)
         replayHistoryPlayer.finish()
-        job.cancelAndJoin()
 
         assertEquals(16, timeCapture.size)
     }
@@ -391,14 +381,15 @@ class ReplayHistoryPlayerTest {
             .pushEvents(testEvents)
 
         replayHistoryPlayer.playbackSpeed(0.25)
-        val job = replayHistoryPlayer.play(lifecycleOwner)
+        replayHistoryPlayer.play()
         val timeCapture = mutableListOf<Pair<ReplayEventBase, Long>>()
-        replayHistoryPlayer.observeReplayEvents { replayEvents ->
-            replayEvents.forEach { timeCapture.add(Pair(it, currentTime)) }
-        }
+        replayHistoryPlayer.registerObserver(object : ReplayEventsObserver {
+            override fun replayEvents(events: List<ReplayEventBase>) {
+                events.forEach { timeCapture.add(Pair(it, currentTime)) }
+            }
+        })
         advanceTimeMillis(40000)
         replayHistoryPlayer.finish()
-        job.cancelAndJoin()
 
         assertEquals(10, timeCapture.size)
     }
@@ -410,16 +401,17 @@ class ReplayHistoryPlayerTest {
             .pushEvents(testEvents)
 
         replayHistoryPlayer.playbackSpeed(1.0)
-        val job = replayHistoryPlayer.play(lifecycleOwner)
+        replayHistoryPlayer.play()
         val timeCapture = mutableListOf<Pair<ReplayEventBase, Long>>()
-        replayHistoryPlayer.observeReplayEvents { replayEvents ->
-            replayEvents.forEach { timeCapture.add(Pair(it, currentTime)) }
-        }
+        replayHistoryPlayer.registerObserver(object : ReplayEventsObserver {
+            override fun replayEvents(events: List<ReplayEventBase>) {
+                events.forEach { timeCapture.add(Pair(it, currentTime)) }
+            }
+        })
         advanceTimeMillis(2000)
         replayHistoryPlayer.playbackSpeed(3.0)
         advanceTimeMillis(1999) // advance a fraction to remove the equal events
         replayHistoryPlayer.finish()
-        job.cancelAndJoin()
 
         // 2 events over 2 seconds at 1x speed.
         // 6 events over 2 seconds at 3x speed.
@@ -434,19 +426,74 @@ class ReplayHistoryPlayerTest {
         val replayHistoryPlayer = ReplayHistoryPlayer(logger)
             .pushEvents(testEvents)
         val timeCapture = mutableListOf<Pair<ReplayEventBase, Long>>()
-        replayHistoryPlayer.observeReplayEvents { replayEvents ->
-            replayEvents.forEach { timeCapture.add(Pair(it, currentTime)) }
-        }
+        replayHistoryPlayer.registerObserver(object : ReplayEventsObserver {
+            override fun replayEvents(events: List<ReplayEventBase>) {
+                events.forEach { timeCapture.add(Pair(it, currentTime)) }
+            }
+        })
 
-        val job = replayHistoryPlayer.play(lifecycleOwner)
+        replayHistoryPlayer.play()
         advanceTimeMillis(20000)
         replayHistoryPlayer.playbackSpeed(3.0)
         advanceTimeMillis(20000)
         replayHistoryPlayer.finish()
-        job.cancelAndJoin()
 
         // 12 events at the beginning
         assertEquals(12, timeCapture.size)
+    }
+
+    @Test
+    fun `should register multiple observers`() = coroutineRule.runBlockingTest {
+        val replayHistoryPlayer = ReplayHistoryPlayer(logger)
+            .pushEvents(listOf(
+                ReplayEventGetStatus(1.0),
+                ReplayEventGetStatus(2.0),
+                ReplayEventGetStatus(3.0)
+            ))
+        val firstObserver: ReplayEventsObserver = mockk(relaxed = true)
+        val secondObserver: ReplayEventsObserver = mockk(relaxed = true)
+        replayHistoryPlayer.registerObserver(firstObserver)
+        replayHistoryPlayer.registerObserver(secondObserver)
+
+        replayHistoryPlayer.play()
+        advanceTimeMillis(5000)
+        replayHistoryPlayer.finish()
+
+        val firstObserverEvents = mutableListOf<List<ReplayEventBase>>()
+        coVerify { firstObserver.replayEvents(capture(firstObserverEvents)) }
+        val secondObserverEvents = mutableListOf<List<ReplayEventBase>>()
+        coVerify { secondObserver.replayEvents(capture(secondObserverEvents)) }
+        val firstEvents = firstObserverEvents.flatten()
+        val secondEvents = secondObserverEvents.flatten()
+        assertEquals(3, firstEvents.size)
+        assertEquals(firstEvents, secondEvents)
+    }
+
+    @Test
+    fun `should unregister single observers`() = coroutineRule.runBlockingTest {
+        val replayHistoryPlayer = ReplayHistoryPlayer(logger)
+            .pushEvents(listOf(
+                ReplayEventGetStatus(1.0),
+                ReplayEventGetStatus(2.0),
+                ReplayEventGetStatus(3.0)
+            ))
+        val firstObserver: ReplayEventsObserver = mockk(relaxed = true)
+        val secondObserver: ReplayEventsObserver = mockk(relaxed = true)
+        replayHistoryPlayer.registerObserver(firstObserver)
+        replayHistoryPlayer.registerObserver(secondObserver)
+
+        replayHistoryPlayer.play()
+        advanceTimeMillis(1000)
+        replayHistoryPlayer.unregisterObserver(firstObserver)
+        advanceTimeMillis(2000)
+        replayHistoryPlayer.finish()
+
+        val firstObserverEvents = mutableListOf<List<ReplayEventBase>>()
+        coVerify { firstObserver.replayEvents(capture(firstObserverEvents)) }
+        val secondObserverEvents = mutableListOf<List<ReplayEventBase>>()
+        coVerify { secondObserver.replayEvents(capture(secondObserverEvents)) }
+        assertEquals(2, firstObserverEvents.flatten().size)
+        assertEquals(3, secondObserverEvents.flatten().size)
     }
 
     /**


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Addressing feedback for the replay history player api

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Implementation

> **LifecycleOwner**: the `ReplayHistoryPlayer::play` function requires a `LifecycleOwner` as an argument. The `LifecycleOwner` is used to stop replay once the view is in destroyed state. Since positioning is running independent of UI in our app, the `ReplayHistoryLocationEngine` is used deep down in the business layer and we would have to artificially drag a `lifecycleOwner` all the way down to our `*LocationEngines`. I think the assumption that the `ReplayHistoryLocationEngine` is used in the view layer does not hold generally.

LifecycleOwner is now removed from the play function. Also the coroutine Job has been removed. There are a couple ways to stop the player after calling play().
 1. call `stop()`, keeps observers, and keeps the events
 1. call `finish()`, stops player, removes observers, clears events

> 1. **Re-instantiation**: The `ReplayHistoryPlayer` clears all listeners on stopping via a call to `finish` (it may not be the right one, but there's no other method available). This also removes the listeners registered in the `ReplayHistoryLocationEngine`-constructor, so the pair `ReplayHistoryPlayer`/`ReplayHistoryLocationEngine` has to be re-instantiated on every restart of the route replay (at least when it was stopped). While being awkward to work with this re-instantiation, this goes against the fact that the `LocationEngine` of the `MapboxNavigation`-object cannot be replaced any more from navSDK version 1.0 onwards. => we have to use a wrapper component around the `ReplayHistoryLocationEngine` to be able to provide a `LocationEngine` we don't have to reinstantiate: `ComponentUsingLocationEngine` => `WrapperReplayHistoryLocationEngine` => `ReplayHistoryLocationEngine`

Two new additional functions are being added.
1.  `unregisterObserver(yourObserver)`, which allows you to unregister an individual observer
1. `unregisterObservers()`, removes all observers 
1. `clearEvents()`, which stops the player and clears all events that have been pushed

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->