### PR TITLE
Remove ArrivalObserver default implementations

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/stops/ArrivalObserver.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/stops/ArrivalObserver.kt
@@ -15,11 +15,11 @@ interface ArrivalObserver {
      * Once [MapboxNavigation.navigateNextRouteLeg] has been called and returns true,
      * this observer will be notified of a stop arrival.
      */
-    fun onStopArrival(routeLegProgress: RouteLegProgress) {}
+    fun onStopArrival(routeLegProgress: RouteLegProgress)
 
     /**
      * Once the [RouteProgress.currentState] has reached [RouteProgressState.ROUTE_ARRIVED]
      * for the last stop, this will be called once.
      */
-    fun onRouteArrival(routeProgress: RouteProgress) {}
+    fun onRouteArrival(routeProgress: RouteProgress)
 }


### PR DESCRIPTION
## Description

Removes `ArrivalObserver` default implementations

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

`ArrivalObserver` is currently an `interface` with default implementations for `onStopArrival` and `onRouteArrival`, so because we're supporting Java 7 (as of now :grin:), it'll be unnecessarily converted to an `abstract` class on the Java side. The idea behind this was that as a client you don't need to override both if you don’t want to e.g.

```kotlin
private val arrivalObserver = object : ArrivalObserver {
    override fun onRouteArrival(routeProgress: RouteProgress) {
        findViewById<Button>(R.id.navigateNextRouteLeg).visibility = View.GONE
    }
}
```

Only in Kolin though because in Java 7 you'd be forced to implement both. [Interface segregation principle](https://en.wikipedia.org/wiki/Interface_segregation_principle) is another option to fix this.

We can revisit and bring this back when we support Java 8 (hopefully soon 😅).

### Implementation

Remove default implementations (`{}`) from `onStopArrival` and `onRouteArrival` (`ArrivalObserver`)

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR

cc @kmadsen @abhishek1508 @LukasPaczos @langsmith 