### PR TITLE
Add support of the NavigationListener.onNavigationFinished to fix #2931

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/ui/BuildingExtrusionActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/ui/BuildingExtrusionActivity.kt
@@ -140,7 +140,7 @@ class BuildingExtrusionActivity : AppCompatActivity(), OnNavigationReadyCallback
     }
 
     override fun onNavigationFinished() {
-        // todo
+        finish()
     }
 
     override fun onCancelNavigation() {

--- a/examples/src/main/java/com/mapbox/navigation/examples/ui/BuildingFootprintHighlightActivityKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/ui/BuildingFootprintHighlightActivityKt.kt
@@ -165,7 +165,7 @@ class BuildingFootprintHighlightActivityKt : AppCompatActivity(), OnNavigationRe
     }
 
     override fun onNavigationFinished() {
-        // Not needed in this example
+        finish()
     }
 
     override fun onCancelNavigation() {

--- a/examples/src/main/java/com/mapbox/navigation/examples/ui/CustomCameraActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/ui/CustomCameraActivity.kt
@@ -141,7 +141,7 @@ class CustomCameraActivity : AppCompatActivity(), OnNavigationReadyCallback, Nav
     }
 
     override fun onNavigationFinished() {
-    // todo
+        finish()
     }
 
     override fun onCancelNavigation() {

--- a/examples/src/main/java/com/mapbox/navigation/examples/ui/CustomPuckActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/ui/CustomPuckActivity.kt
@@ -111,7 +111,7 @@ class CustomPuckActivity : AppCompatActivity(), OnNavigationReadyCallback, Navig
     }
 
     override fun onNavigationFinished() {
-        // todo
+        finish()
     }
 
     override fun onCancelNavigation() {

--- a/examples/src/main/java/com/mapbox/navigation/examples/ui/NavigationViewActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/ui/NavigationViewActivity.kt
@@ -112,7 +112,7 @@ class NavigationViewActivity : AppCompatActivity(), OnNavigationReadyCallback, N
     }
 
     override fun onNavigationFinished() {
-        // todo
+        finish()
     }
 
     override fun onCancelNavigation() {

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationLauncher.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationLauncher.java
@@ -76,7 +76,6 @@ public class NavigationLauncher {
       .remove(NavigationConstants.NAVIGATION_VIEW_ROUTE_KEY)
       .remove(NavigationConstants.NAVIGATION_VIEW_SIMULATE_ROUTE)
       .remove(NavigationConstants.NAVIGATION_VIEW_PREFERENCE_SET_THEME)
-      .remove(NavigationConstants.NAVIGATION_VIEW_PREFERENCE_SET_THEME)
       .remove(NavigationConstants.NAVIGATION_VIEW_LIGHT_THEME)
       .remove(NavigationConstants.NAVIGATION_VIEW_DARK_THEME)
       .remove(NavigationConstants.OFFLINE_PATH_KEY)


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Add change to support NavigationListener.onNavigationFinished to fix #2931 

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

When trip session ends, NavigationView owner can be notified and responds accordingly.

### Implementation

* Register/unregister the `TripSessionStateObserver` from the `NavigationViewModel`. When tripSessionState changes to `STOPPED` call the `NavigationListener.onNavigationFinished()`
* Update example activities accordingly.

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->