### PR TITLE
Fix replay route floating point error

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route2/ReplayRouteInterpolator.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route2/ReplayRouteInterpolator.kt
@@ -54,10 +54,11 @@ internal class ReplayRouteInterpolator {
      */
     fun createBearingProfile(replayRouteLocations: List<ReplayRouteLocation>) {
         var bearing = replayRouteLocations.first().bearing
+        val lookAhead = 2
         replayRouteLocations.forEachIndexed { index, location ->
-            if (index + 1 < replayRouteLocations.lastIndex) {
+            if (index + lookAhead < replayRouteLocations.lastIndex) {
                 val fromPoint = location.point
-                val toPoint = replayRouteLocations[index + 1].point
+                val toPoint = replayRouteLocations[index + lookAhead].point
                 bearing = TurfMeasurement.bearing(fromPoint, toPoint)
             }
             location.bearing = bearing
@@ -149,6 +150,7 @@ internal class ReplayRouteInterpolator {
                 positionMeters = previous.positionMeters + positionSpeed
             ))
         }
+        steps[steps.lastIndex] = ReplayRouteStep(steps.last().acceleration, endSpeed, distance)
     }
 
     private fun distanceToSlowDown(options: ReplayRouteOptions, velocity: Double, acceleration: Double, endVelocity: Double): Double {

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/route2/ReplayRouteDriverTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/route2/ReplayRouteDriverTest.kt
@@ -3,9 +3,8 @@ package com.mapbox.navigation.core.replay.route2
 import com.mapbox.geojson.LineString
 import com.mapbox.turf.TurfConstants
 import com.mapbox.turf.TurfMeasurement
-import junit.framework.Assert.assertEquals
-import junit.framework.Assert.assertTrue
-import org.junit.Ignore
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ReplayRouteDriverTest {
@@ -46,7 +45,6 @@ class ReplayRouteDriverTest {
     }
 
     @Test
-    @Ignore // TODO fix the floating point rounding errors 223.96630390737917 > 223.96630390737914
     fun `should slow down at the end of a route`() {
         val geometry = """qnq_gAxdhmhFuvBlJe@?qC^^`GD|@bBpq@pB~{@om@xCqL\"""
 

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/route2/ReplayRouteInterpolatorTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/route2/ReplayRouteInterpolatorTest.kt
@@ -128,6 +128,22 @@ class ReplayRouteInterpolatorTest {
     }
 
     @Test
+    fun `should handle distances at low precision`() {
+        val startSpeedMps = 0.0
+        val endSpeedMps = 3.0
+        val distanceMeters = 223.96630390737917
+
+        val segment = routeInterpolator.interpolateSpeed(
+            defaultOptions,
+            startSpeedMps,
+            endSpeedMps,
+            distanceMeters)
+
+        assertEquals(223.96630390737917, segment.steps.last().positionMeters, 0.00001)
+        assertEquals(3.0, segment.endSpeedMps, 0.0001)
+    }
+
+    @Test
     fun `should create speed for each point`() {
         val coordinates = listOf(
             Point.fromLngLat(-121.46991, 38.550876),


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Following up from this change https://github.com/mapbox/mapbox-navigation-android/pull/2934

When interpolating slow down speeds, the distance calculation can be extremely close because of accumulated floating point error. 
"223.96630390737917 > 223.96630390737914"

I tried a few things, like converting distances to centimeters, or rounding to 6 digits, but those approaches broke more tests from more error accumulation.

This fix, is to assume the last step is always perfect. The driver will be driving at the exact place, at the exact speed. Looks good!

- [ ] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->