### PR TITLE
performance improvements for calculating the vanishing route line and…

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteProgressChangeListener.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteProgressChangeListener.kt
@@ -1,14 +1,14 @@
 package com.mapbox.navigation.ui.route
 
 import com.mapbox.api.directions.v5.models.DirectionsRoute
-import com.mapbox.geojson.LineString
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.trip.session.RouteProgressObserver
-import com.mapbox.navigation.ui.route.MapRouteLine.MapRouteLineSupport.buildRouteLineExpression
+import com.mapbox.navigation.ui.route.RouteConstants.VANISHING_ROUTE_LINE_UPDATE_DELAY
 import com.mapbox.navigation.utils.internal.ThreadController
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 /**
@@ -69,16 +69,9 @@ internal class MapRouteProgressChangeListener(
                     val dist = routeProgress.distanceTraveled() / totalDist
                     if (dist > 0) {
                         val deferredExpression = async(Dispatchers.Default) {
-                            val lineString: LineString =
-                                routeLine.getLineStringForRoute(currentRoute!!)
-                            buildRouteLineExpression(
-                                currentRoute,
-                                lineString,
-                                true,
-                                dist.toDouble(),
-                                routeLine::getRouteColorForCongestion
-                            )
+                            routeLine.getExpressionAtOffset(dist)
                         }
+                        delay(VANISHING_ROUTE_LINE_UPDATE_DELAY)
                         routeLine.hideShieldLineAtOffset(dist)
                         routeLine.decorateRouteLine(deferredExpression.await())
                     }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/RouteConstants.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/RouteConstants.java
@@ -45,4 +45,5 @@ class RouteConstants {
   static final String ORIGIN_MARKER_NAME = "originMarker";
   static final String DESTINATION_MARKER_NAME = "destinationMarker";
   static final String MAPBOX_LOCATION_ID = "mapbox-location";
+  static final long VANISHING_ROUTE_LINE_UPDATE_DELAY = 600;
 }

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteLineTest.kt
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteLineTest.kt
@@ -532,30 +532,54 @@ class MapRouteLineTest {
 
     @Test
     fun buildRouteLineExpression() {
-        val expectedExpression = "[\"step\", [\"line-progress\"], [\"rgba\", 0.0, 0.0, 0.0, 0.0], 0.2, [\"rgba\", 0.0, 7.0, 255.0, 0.0], 0.31436133, [\"rgba\", 0.0, 7.0, 255.0, 0.0], 0.66388464, [\"rgba\", 0.0, 7.0, 255.0, 0.0], 0.6948727, [\"rgba\", 0.0, 7.0, 255.0, 0.0]]"
+        every { style.layers } returns listOf(primaryRouteLayer)
+        val expectedExpression = "[\"step\", [\"line-progress\"], [\"rgba\", 0.0, 0.0, 0.0, 0.0], 0.2, [\"rgba\", 86.0, 168.0, 251.0, 1.0], 0.31436133, [\"rgba\", 86.0, 168.0, 251.0, 1.0], 0.66388464, [\"rgba\", 233.0, 51.0, 64.0, 1.0], 0.6948727, [\"rgba\", 86.0, 168.0, 251.0, 1.0]]"
         val route = getDirectionsRoute(true)
-        val lineString = LineString.fromPolyline(route.geometry()!!, Constants.PRECISION_6)
+        val mapRouteLine = MapRouteLine(
+            ctx,
+            style,
+            styleRes,
+            null,
+            layerProvider,
+            mapRouteSourceProvider).also { it.draw(listOf(route)) }
 
-        val expression = MapRouteLine.MapRouteLineSupport.buildRouteLineExpression(
-            route,
-            lineString,
-            true,
-            .2) { _, _ -> 2047 }
+        val expression = mapRouteLine.getExpressionAtOffset(.2f)
 
         assertEquals(expectedExpression, expression.toString())
     }
 
     @Test
     fun buildRouteLineExpressionWhenNoTraffic() {
-        val expectedExpression = "[\"step\", [\"line-progress\"], [\"rgba\", 0.0, 0.0, 0.0, 0.0], 0.2, [\"rgba\", 0.0, 7.0, 255.0, 0.0]]"
+        every { style.layers } returns listOf(primaryRouteLayer)
+        val expectedExpression = "[\"step\", [\"line-progress\"], [\"rgba\", 0.0, 0.0, 0.0, 0.0], 0.2, [\"rgba\", 86.0, 168.0, 251.0, 1.0]]"
         val route = getDirectionsRoute(false)
-        val lineString = LineString.fromPolyline(route.geometry()!!, Constants.PRECISION_6)
+        val mapRouteLine = MapRouteLine(
+            ctx,
+            style,
+            styleRes,
+            null,
+            layerProvider,
+            mapRouteSourceProvider).also { it.draw(listOf(route)) }
 
-        val expression = MapRouteLine.MapRouteLineSupport.buildRouteLineExpression(
-            route,
-            lineString,
-            true,
-            .2) { _, _ -> 2047 }
+        val expression = mapRouteLine.getExpressionAtOffset(.2f)
+
+        assertEquals(expectedExpression, expression.toString())
+    }
+
+    @Test
+    fun buildRouteLineExpressionOffsetAfterLastLeg() {
+        every { style.layers } returns listOf(primaryRouteLayer)
+        val expectedExpression = "[\"step\", [\"line-progress\"], [\"rgba\", 0.0, 0.0, 0.0, 0.0], 0.9, [\"rgba\", 86.0, 168.0, 251.0, 1.0]]"
+        val route = getDirectionsRoute(false)
+        val mapRouteLine = MapRouteLine(
+            ctx,
+            style,
+            styleRes,
+            null,
+            layerProvider,
+            mapRouteSourceProvider).also { it.draw(listOf(route)) }
+
+        val expression = mapRouteLine.getExpressionAtOffset(.9f)
 
         assertEquals(expectedExpression, expression.toString())
     }
@@ -565,9 +589,8 @@ class MapRouteLineTest {
         val route = getDirectionsRoute(true)
         val lineString = LineString.fromPolyline(route.geometry()!!, Constants.PRECISION_6)
 
-        val result = MapRouteLine.MapRouteLineSupport.getStopsFromLeg(
+        val result = MapRouteLine.MapRouteLineSupport.calculateRouteLineSegmentFromLeg(
             route.legs()!![0],
-            0.0,
             lineString,
             route.distance()!!,
             true


### PR DESCRIPTION
… attempted fix for the vanishing point jumping in front of the puck

## Description
Addresses the issue #2868 which describes the vanishing of the route line jumping ahead of the puck. 

- [x] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal

The work done here attempts to reduce the noticeability of the gap between the front of the puck and the vanishing portion of the route line.

### Implementation

A minor performance improvement was included to reduce the calculation that need to be done on each route progress update. Also a strategy of delaying the updating of the route line was employed. Given the puck is animated across the map there is a time for the puck to move between route progress updates. I thought that animating the updates to the route line would negatively impact performance give that the puck's movement is already causing may map updates per second. I chose to delay the route line's update in each route progress update in order to allow time for the puck to advance its position.

## Screenshots or Gifs

![20200507_172523](https://user-images.githubusercontent.com/2249818/81426004-6c8cf180-910d-11ea-9343-5512669a02e1.gif)


## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->