### PR TITLE
Rename ArrivalObserver methods name to be more clearer. Fix #2933

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/FasterRouteActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/FasterRouteActivity.kt
@@ -43,6 +43,10 @@ import kotlinx.android.synthetic.main.content_faster_route_layout.*
 import timber.log.Timber
 
 /**
+ * This example shows how to use the Navigation SDK's [FasterRouteObserver]
+ * and display the observer's faster routes that are returned if the
+ * device goes off of the original [DirectionsRoute].
+ *
  * To ensure proper functioning of this example make sure your Location is turned on.
  */
 class FasterRouteActivity : AppCompatActivity(), OnMapReadyCallback {
@@ -113,7 +117,11 @@ class FasterRouteActivity : AppCompatActivity(), OnMapReadyCallback {
     private val fasterRouteObserver = object : FasterRouteObserver {
         // [Optional] Override the interval to check for faster routes.
         override fun restartAfterMillis() = FasterRouteObserver.DEFAULT_INTERVAL_MILLIS
-        override fun onFasterRoute(currentRoute: DirectionsRoute, alternatives: List<DirectionsRoute>, isAlternativeFaster: Boolean) {
+        override fun onFasterRoute(
+            currentRoute: DirectionsRoute,
+            alternatives: List<DirectionsRoute>,
+            isAlternativeFaster: Boolean
+        ) {
             if (isAlternativeFaster) {
                 this@FasterRouteActivity.fasterRoutes = alternatives
                 fasterRouteSelectionTimer.start()
@@ -127,7 +135,7 @@ class FasterRouteActivity : AppCompatActivity(), OnMapReadyCallback {
             override fun onTick(millisUntilFinished: Long) {
                 Timber.d("FASTER_ROUTE: millisUntilFinished $millisUntilFinished")
                 fasterRouteAcceptProgress.progress =
-                        (MAX_PROGRESS - millisUntilFinished / COUNT_DOWN_INTERVAL).toInt()
+                    (MAX_PROGRESS - millisUntilFinished / COUNT_DOWN_INTERVAL).toInt()
             }
 
             override fun onFinish() {
@@ -144,8 +152,8 @@ class FasterRouteActivity : AppCompatActivity(), OnMapReadyCallback {
         mapView.getMapAsync(this)
 
         val mapboxNavigationOptions = MapboxNavigation.defaultNavigationOptions(
-                this,
-                Mapbox.getAccessToken()
+            this,
+            Mapbox.getAccessToken()
         )
         mapboxNavigationOptions.onboardRouterConfig?.toBuilder()?.tilePath("")
 
@@ -155,7 +163,7 @@ class FasterRouteActivity : AppCompatActivity(), OnMapReadyCallback {
 
         initListeners()
         Snackbar.make(container, R.string.msg_long_press_map_to_place_waypoint, LENGTH_SHORT)
-                .show()
+            .show()
     }
 
     override fun onLowMemory() {
@@ -207,13 +215,13 @@ class FasterRouteActivity : AppCompatActivity(), OnMapReadyCallback {
         mapboxMap.addOnMapLongClickListener { latLng ->
             mapboxMap.locationComponent.lastKnownLocation?.let { originLocation ->
                 mapboxNavigation.requestRoutes(
-                        RouteOptions.builder().applyDefaultParams()
-                                .accessToken(Utils.getMapboxAccessToken(applicationContext))
-                                .coordinates(originLocation.toPoint(), null, latLng.toPoint())
-                                .alternatives(true)
-                                .profile(DirectionsCriteria.PROFILE_DRIVING_TRAFFIC)
-                                .build(),
-                        routesReqCallback
+                    RouteOptions.builder().applyDefaultParams()
+                        .accessToken(Utils.getMapboxAccessToken(applicationContext))
+                        .coordinates(originLocation.toPoint(), null, latLng.toPoint())
+                        .alternatives(true)
+                        .profile(DirectionsCriteria.PROFILE_DRIVING_TRAFFIC)
+                        .build(),
+                    routesReqCallback
                 )
             }
             true
@@ -252,15 +260,15 @@ class FasterRouteActivity : AppCompatActivity(), OnMapReadyCallback {
     @SuppressLint("RestrictedApi")
     private fun startLocationUpdates() {
         val requestLocationUpdateRequest =
-                LocationEngineRequest.Builder(DEFAULT_ENGINE_REQUEST_INTERVAL)
-                        .setFastestInterval(DEFAULT_FASTEST_INTERVAL)
-                        .setPriority(LocationEngineRequest.PRIORITY_HIGH_ACCURACY)
-                        .build()
+            LocationEngineRequest.Builder(DEFAULT_ENGINE_REQUEST_INTERVAL)
+                .setFastestInterval(DEFAULT_FASTEST_INTERVAL)
+                .setPriority(LocationEngineRequest.PRIORITY_HIGH_ACCURACY)
+                .build()
         try {
             mapboxNavigation.locationEngine.requestLocationUpdates(
-                    requestLocationUpdateRequest,
-                    locationListenerCallback,
-                    mainLooper
+                requestLocationUpdateRequest,
+                locationListenerCallback,
+                mainLooper
             )
             mapboxNavigation.locationEngine.getLastLocation(locationListenerCallback)
         } catch (exception: SecurityException) {
@@ -283,7 +291,7 @@ class FasterRouteActivity : AppCompatActivity(), OnMapReadyCallback {
     }
 
     private class MyLocationEngineCallback(activity: FasterRouteActivity) :
-            LocationEngineCallback<LocationEngineResult> {
+        LocationEngineCallback<LocationEngineResult> {
 
         private val activityRef = WeakReference(activity)
 

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayWaypointsActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayWaypointsActivity.kt
@@ -202,11 +202,11 @@ class ReplayWaypointsActivity : AppCompatActivity(), OnMapReadyCallback {
     }
 
     private val arrivalObserver = object : ArrivalObserver {
-        override fun onStopArrival(routeLegProgress: RouteLegProgress) {
+        override fun onNextRouteLegStart(routeLegProgress: RouteLegProgress) {
             findViewById<Button>(R.id.navigateNextRouteLeg).visibility = View.GONE
         }
 
-        override fun onRouteArrival(routeProgress: RouteProgress) {
+        override fun onFinalDestinationArrival(routeProgress: RouteProgress) {
             findViewById<Button>(R.id.navigateNextRouteLeg).visibility = View.GONE
         }
     }

--- a/examples/src/main/java/com/mapbox/navigation/examples/ui/BuildingFootprintHighlightActivityKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/ui/BuildingFootprintHighlightActivityKt.kt
@@ -28,7 +28,7 @@ import kotlinx.android.synthetic.main.activity_final_destination_arrival_buildin
 /**
  * This example shows how to use the Navigation UI SDK's [BuildingFootprintHighlightLayer]
  * class to highlight a building footprint. The final destination arrival callback is from
- * [ArrivalObserver.onRouteArrival].
+ * [ArrivalObserver.onFinalDestinationArrival].
  */
 class BuildingFootprintHighlightActivityKt : AppCompatActivity(), OnNavigationReadyCallback, NavigationListener,
     BannerInstructionsListener, ArrivalObserver {
@@ -139,11 +139,11 @@ class BuildingFootprintHighlightActivityKt : AppCompatActivity(), OnNavigationRe
         return instructions!!
     }
 
-    override fun onStopArrival(routeLegProgress: RouteLegProgress) {
+    override fun onNextRouteLegStart(routeLegProgress: RouteLegProgress) {
         // Not needed in this example
     }
 
-    override fun onRouteArrival(routeProgress: RouteProgress) {
+    override fun onFinalDestinationArrival(routeProgress: RouteProgress) {
         mapboxMap.easeCamera(zoomTo(18.0), 1800)
 
         // Adjust the visibility of the building footprint highlight layer

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/stops/ArrivalObserver.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/stops/ArrivalObserver.kt
@@ -13,13 +13,13 @@ interface ArrivalObserver {
 
     /**
      * Once [MapboxNavigation.navigateNextRouteLeg] has been called and returns true,
-     * this observer will be notified of a stop arrival.
+     * this observer will be notified of the next route leg start.
      */
-    fun onStopArrival(routeLegProgress: RouteLegProgress)
+    fun onNextRouteLegStart(routeLegProgress: RouteLegProgress)
 
     /**
-     * Once the [RouteProgress.currentState] has reached [RouteProgressState.ROUTE_ARRIVED]
-     * for the last stop, this will be called once.
+     * This will be called once the [RouteProgress.currentState] has reached [RouteProgressState.ROUTE_ARRIVED].
+     * This means the device has reached the final destination on the route.
      */
-    fun onRouteArrival(routeProgress: RouteProgress)
+    fun onFinalDestinationArrival(routeProgress: RouteProgress)
 }


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

As we discussed in the #2928 that we want to rename the callbacks to be more clearer in terms of `waypoint` and `final destination`.

Fix #2933

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Implementation

* Rename all the `stop` to `waypoint`
* Rename all the `route` to `finalDestination`

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->