### PR TITLE
Fix MapboxHybridRouterTest#networkStatusService_cleanup_calledOnChannelClose flaky test

### DIFF
--- a/libdirections-hybrid/src/test/java/com/mapbox/navigation/route/hybrid/MapboxHybridRouterTest.kt
+++ b/libdirections-hybrid/src/test/java/com/mapbox/navigation/route/hybrid/MapboxHybridRouterTest.kt
@@ -191,6 +191,8 @@ class MapboxHybridRouterTest {
         } catch (ex: Exception) {
         }
 
+        every { context.unregisterReceiver(any()) } answers {}
+
         verify { context.unregisterReceiver(any()) }
     }
 


### PR DESCRIPTION
## Description

Fixes `MapboxHybridRouterTest#networkStatusService_cleanup_calledOnChannelClose` flaky test

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

We've recently seen `MapboxHybridRouterTest#networkStatusService_cleanup_calledOnChannelClose` failing sometimes in CI after https://github.com/mapbox/mapbox-navigation-android/pull/2862/files#diff-2599ac88e0bee88044eeca57cf0e8aa6L193

```
com.******.navigation.route.hybrid.MapboxHybridRouterTest > networkStatusService_cleanup_calledOnChannelClose FAILED
    java.lang.AssertionError at MapboxHybridRouterTest.kt:186
```

https://circleci.com/gh/mapbox/mapbox-navigation-android/24284?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link
https://circleci.com/gh/mapbox/mapbox-navigation-android/25081?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

### Implementation

Bring context unregister receiver stub (`every { context.unregisterReceiver(any()) } answers {}`) back in `MapboxHybridRouterTest#networkStatusService_cleanup_calledOnChannelClose`

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR