### PR TITLE
Showing wordmark and attribution in NavigationView

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/ui/BuildingExtrusionActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/ui/BuildingExtrusionActivity.kt
@@ -105,7 +105,9 @@ class BuildingExtrusionActivity : AppCompatActivity(), OnNavigationReadyCallback
                 optionsBuilder.directionsRoute(route)
                 optionsBuilder.shouldSimulateRoute(true)
                 optionsBuilder.routeProgressObserver(this)
-                optionsBuilder.navigationOptions(NavigationOptions.Builder().build())
+                optionsBuilder.navigationOptions(NavigationOptions.Builder()
+                        .accessToken(Utils.getMapboxAccessToken(this))
+                        .build())
                 navigationView.startNavigation(optionsBuilder.build())
 
                 // Initialize the Navigation UI SDK's BuildingExtrusionLayer class.

--- a/examples/src/main/java/com/mapbox/navigation/examples/ui/BuildingFootprintHighlightActivityKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/ui/BuildingFootprintHighlightActivityKt.kt
@@ -116,7 +116,9 @@ class BuildingFootprintHighlightActivityKt : AppCompatActivity(), OnNavigationRe
                 optionsBuilder.directionsRoute(directionsRoute)
                 optionsBuilder.shouldSimulateRoute(true)
                 optionsBuilder.bannerInstructionsListener(this)
-                optionsBuilder.navigationOptions(NavigationOptions.Builder().build())
+                optionsBuilder.navigationOptions(NavigationOptions.Builder()
+                        .accessToken(Utils.getMapboxAccessToken(this))
+                        .build())
                 navigationView.startNavigation(optionsBuilder.build())
 
                 // Initialize the Nav UI SDK's BuildingFootprintHighlightLayer class.

--- a/examples/src/main/java/com/mapbox/navigation/examples/ui/CustomCameraActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/ui/CustomCameraActivity.kt
@@ -104,7 +104,9 @@ class CustomCameraActivity : AppCompatActivity(), OnNavigationReadyCallback, Nav
                 // Add the custom camera
                 optionsBuilder.camera(CustomCamera())
 
-                optionsBuilder.navigationOptions(NavigationOptions.Builder().build())
+                optionsBuilder.navigationOptions(NavigationOptions.Builder()
+                        .accessToken(Utils.getMapboxAccessToken(this))
+                        .build())
                 navigationView.startNavigation(optionsBuilder.build())
             }
         }

--- a/examples/src/main/java/com/mapbox/navigation/examples/ui/CustomPuckActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/ui/CustomPuckActivity.kt
@@ -95,7 +95,9 @@ class CustomPuckActivity : AppCompatActivity(), OnNavigationReadyCallback, Navig
                 optionsBuilder.directionsRoute(directionsRoute)
                 optionsBuilder.shouldSimulateRoute(true)
                 optionsBuilder.bannerInstructionsListener(this)
-                optionsBuilder.navigationOptions(NavigationOptions.Builder().build())
+                optionsBuilder.navigationOptions(NavigationOptions.Builder()
+                        .accessToken(Utils.getMapboxAccessToken(this))
+                        .build())
                 optionsBuilder.puckDrawableSupplier(CustomPuckDrawableSupplier())
                 navigationView.startNavigation(optionsBuilder.build())
             }

--- a/examples/src/main/java/com/mapbox/navigation/examples/ui/CustomUIComponentStyleActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/ui/CustomUIComponentStyleActivity.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.graphics.Bitmap
 import android.os.Bundle
 import android.view.View
+import android.view.ViewTreeObserver
 import android.widget.ImageButton
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.AppCompatImageButton
@@ -308,6 +309,7 @@ class CustomUIComponentStyleActivity : AppCompatActivity(), OnMapReadyCallback,
                 instructionView.visibility = View.VISIBLE
                 feedbackButton.show()
                 instructionSoundButton.show()
+                showLogoAndAttribution()
             }
             TripSessionState.STOPPED -> {
                 startNavigation.visibility = View.VISIBLE
@@ -322,6 +324,26 @@ class CustomUIComponentStyleActivity : AppCompatActivity(), OnMapReadyCallback,
                 instructionSoundButton.hide()
             }
         }
+    }
+
+    private fun showLogoAndAttribution() {
+        summaryBottomSheet.viewTreeObserver.addOnGlobalLayoutListener(object :
+                ViewTreeObserver.OnGlobalLayoutListener {
+            override fun onGlobalLayout() {
+                navigationMapboxMap?.retrieveMap()?.uiSettings?.apply {
+                    val bottomMargin = summaryBottomSheet.measuredHeight
+                    setLogoMargins(logoMarginLeft,
+                            logoMarginTop,
+                            logoMarginRight,
+                            bottomMargin)
+                    setAttributionMargins(attributionMarginLeft,
+                            attributionMarginTop,
+                            attributionMarginRight,
+                            bottomMargin)
+                }
+                summaryBottomSheet.viewTreeObserver.removeOnGlobalLayoutListener(this)
+            }
+        })
     }
 
     private fun initNavigation() {

--- a/examples/src/main/java/com/mapbox/navigation/examples/ui/NavigationViewActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/ui/NavigationViewActivity.kt
@@ -7,7 +7,6 @@ import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.mapboxsdk.camera.CameraPosition
 import com.mapbox.mapboxsdk.geometry.LatLng
 import com.mapbox.mapboxsdk.location.modes.RenderMode
-import com.mapbox.mapboxsdk.maps.MapboxMap
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.examples.R
@@ -23,7 +22,6 @@ import kotlinx.android.synthetic.main.activity_navigation_view.*
 class NavigationViewActivity : AppCompatActivity(), OnNavigationReadyCallback, NavigationListener,
     BannerInstructionsListener {
 
-    private lateinit var mapboxMap: MapboxMap
     private lateinit var navigationMapboxMap: NavigationMapboxMap
     private lateinit var mapboxNavigation: MapboxNavigation
     private val route by lazy { getDirectionsRoute() }
@@ -59,7 +57,6 @@ class NavigationViewActivity : AppCompatActivity(), OnNavigationReadyCallback, N
     override fun onPause() {
         super.onPause()
         navigationView.onPause()
-        // stopLocationUpdates()
     }
 
     override fun onDestroy() {
@@ -89,7 +86,6 @@ class NavigationViewActivity : AppCompatActivity(), OnNavigationReadyCallback, N
             ifNonNull(navigationView.retrieveNavigationMapboxMap()) { navMapboxMap ->
                 this.navigationMapboxMap = navMapboxMap
                 this.navigationMapboxMap.updateLocationLayerRenderMode(RenderMode.NORMAL)
-                this.mapboxMap = navMapboxMap.retrieveMap()
                 navigationView.retrieveMapboxNavigation()?.let { this.mapboxNavigation = it }
 
                 val optionsBuilder = NavigationViewOptions.builder()
@@ -97,7 +93,9 @@ class NavigationViewActivity : AppCompatActivity(), OnNavigationReadyCallback, N
                 optionsBuilder.directionsRoute(route)
                 optionsBuilder.shouldSimulateRoute(true)
                 optionsBuilder.bannerInstructionsListener(this)
-                optionsBuilder.navigationOptions(NavigationOptions.Builder().build())
+                optionsBuilder.navigationOptions(NavigationOptions.Builder()
+                        .accessToken(Utils.getMapboxAccessToken(this))
+                        .build())
                 navigationView.startNavigation(optionsBuilder.build())
             }
         }

--- a/examples/src/main/res/layout/activity_custom_ui_component_style.xml
+++ b/examples/src/main/res/layout/activity_custom_ui_component_style.xml
@@ -11,9 +11,7 @@
         android:id="@+id/mapView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:mapbox_uiAttribution="false"
-        app:mapbox_uiCompass="false"
-        app:mapbox_uiLogo="false" />
+        app:mapbox_uiCompass="false" />
 
     <ImageView
         android:id="@+id/screenshotView"

--- a/libnavigation-ui/src/main/res/layout/navigation_view_layout.xml
+++ b/libnavigation-ui/src/main/res/layout/navigation_view_layout.xml
@@ -10,9 +10,7 @@
         android:id="@+id/navigationMapView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:mapbox_uiAttribution="false"
-        app:mapbox_uiCompass="false"
-        app:mapbox_uiLogo="false" />
+        app:mapbox_uiCompass="false" />
 
     <ImageView
         android:id="@+id/screenshotView"


### PR DESCRIPTION

## Description

Resolves #2935 by adding a Mapbox logo and attribution button to the 1.0 Nav UI SDK's `NavigationView`. 

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

To have the Mapbox logo and attribution button appear in the default `NavigationView`. By default, they're tied to the visibilty of the `SummaryBottomSheet`'s state/location.

Maps using Mapbox map designs or data must display the Mapbox wordmark and text attribution. The Mapbox wordmark is a small image containing the stylized word "Mapbox". It typically resides on the bottom left corner of a map. While you may move the wordmark to a different corner of the map, we require the Mapbox wordmark to appear on our maps so that Mapbox and its maps get proper credit. If you wish to otherwise move or remove the Mapbox wordmark, contact Mapbox sales via https://www.mapbox.com/contact/sales

See https://docs.mapbox.com/help/how-mapbox-works/attribution for more information.

### Implementation

Two main changes in this pr are:

1. Removed `app:mapbox_uiLogo="false"` and `app:mapbox_uiAttribution="false"` used in the `NavigationView`'s `navigation_view_layout.xml` file.

2. Added private methods in `NavigationView` that run based on the `SummaryBottomSheet`'s state


By default, the logo and attribution button are visible when the camera's tracking the device location in turn-by-turn mode in the `NavigationView`. If the camera is manually adjusted, they appear until it's recentered on the device.

## Screenshots or Gifs

![ezgif com-resize (1)](https://user-images.githubusercontent.com/4394910/81525197-c1488c00-9308-11ea-9a5b-7d2719fa100c.gif)

![ezgif com-resize (2)](https://user-images.githubusercontent.com/4394910/81525288-0a98db80-9309-11ea-85b1-b2d884ebe628.gif)


## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->