### PR TITLE
Bump Maps SDK dependency version to 9.2.0

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -606,12 +606,6 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 
 ===========================================================================
 
-Mapbox Navigation uses portions of the SoLoader (Reliable native code loader for Android).
-URL: [https://github.com/facebook/soloader](https://github.com/facebook/soloader)
-License: [Apache-2](https://github.com/facebook/soloader/blob/master/LICENSE)
-
-===========================================================================
-
 Mapbox Navigation uses portions of the Timber (No-nonsense injectable logging.).
 URL: [https://github.com/JakeWharton/timber](https://github.com/JakeWharton/timber)
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -9,7 +9,7 @@ ext {
   ]
 
   version = [
-      mapboxMapSdk              : '9.2.0-beta.1',
+      mapboxMapSdk              : '9.2.0',
       mapboxMapCarbon           : '10.0.0-alpha.4',
       mapboxSdkServices         : '5.1.0',
       mapboxSdkDirectionsModels : '5.1.0',


### PR DESCRIPTION
## Description

Bumps `mapbox-android-sdk` version to `9.2.0`

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Getting the latest version from `mapboxMapSdk` including the new features and bug fixes.

### Implementation

Bumping the `mapboxMapSdk` version to `9.2.0` in `dependencies.gradle`

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR

cc @chloekraw 
