### PR TITLE
Fixes incorrect capitalization of word in feedback reported thank you message

### DIFF
--- a/libnavigation-ui/src/main/res/values/strings.xml
+++ b/libnavigation-ui/src/main/res/values/strings.xml
@@ -37,7 +37,7 @@
     <string name="feedback_type_road_closure">Road\nClosure</string>
 
     <!-- Shown after a feedback type has been submitted -->
-    <string name="feedback_reported">Thank you! Issue Reported.</string>
+    <string name="feedback_reported">Thank you! Issue reported.</string>
 
     <!-- Feedback type for Bad Route -->
     <string name="feedback_bad_route">Inefficient or\nBad Route</string>


### PR DESCRIPTION

## Description

This pr fixes the capitalization of `Reported` in the thank you message that's shown after feedback is submitted via the Nav UI SDK feedback flow. Grammatically, there's no reason for `Reported` to be capitalized.

- [ ] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Implementation

Adjusted the string resource in the `strings.xml` file

## Screenshots or Gifs

Before:
<img width="372" alt="Screen Shot 2020-05-12 at 4 40 38 PM" src="https://user-images.githubusercontent.com/4394910/81756321-44382680-9470-11ea-9874-df7755a46ff8.png">

After:

<img width="379" alt="Screen Shot 2020-05-12 at 4 44 16 PM" src="https://user-images.githubusercontent.com/4394910/81756337-4c906180-9470-11ea-9798-351954d97b93.png">

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->