### PR TITLE
Rename replay core classes

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayActivity.kt
@@ -23,8 +23,8 @@ import com.mapbox.navigation.base.internal.extensions.applyDefaultParams
 import com.mapbox.navigation.base.internal.extensions.coordinates
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesRequestCallback
-import com.mapbox.navigation.core.replay.history.ReplayHistoryLocationEngine
-import com.mapbox.navigation.core.replay.history.ReplayHistoryPlayer
+import com.mapbox.navigation.core.replay.MapboxReplayer
+import com.mapbox.navigation.core.replay.ReplayLocationEngine
 import com.mapbox.navigation.core.replay.route2.ReplayRouteMapper
 import com.mapbox.navigation.core.trip.session.TripSessionState
 import com.mapbox.navigation.core.trip.session.TripSessionStateObserver
@@ -50,7 +50,7 @@ class ReplayActivity : AppCompatActivity(), OnMapReadyCallback {
     private val firstLocationCallback = FirstLocationCallback(this)
 
     private val replayRouteMapper = ReplayRouteMapper()
-    private val replayHistoryPlayer = ReplayHistoryPlayer()
+    private val mapboxReplayer = MapboxReplayer()
 
     @SuppressLint("MissingPermission")
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -66,7 +66,7 @@ class ReplayActivity : AppCompatActivity(), OnMapReadyCallback {
         mapboxNavigation = MapboxNavigation(
             applicationContext,
             mapboxNavigationOptions,
-            locationEngine = ReplayHistoryLocationEngine(replayHistoryPlayer)
+            locationEngine = ReplayLocationEngine(mapboxReplayer)
         ).apply {
             registerTripSessionStateObserver(tripSessionStateObserver)
         }
@@ -117,8 +117,8 @@ class ReplayActivity : AppCompatActivity(), OnMapReadyCallback {
                 navigationMapboxMap?.drawRoute(routes[0])
 
                 val replayEvents = replayRouteMapper.mapGeometry(routes[0].geometry()!!)
-                replayHistoryPlayer.pushEvents(replayEvents)
-                replayHistoryPlayer.seekTo(replayEvents.first())
+                mapboxReplayer.pushEvents(replayEvents)
+                mapboxReplayer.seekTo(replayEvents.first())
 
                 startNavigation.visibility = View.VISIBLE
             } else {
@@ -148,7 +148,7 @@ class ReplayActivity : AppCompatActivity(), OnMapReadyCallback {
             }
             mapboxNavigation?.startTripSession()
             startNavigation.visibility = View.GONE
-            replayHistoryPlayer.play()
+            mapboxReplayer.play()
         }
     }
 
@@ -176,7 +176,7 @@ class ReplayActivity : AppCompatActivity(), OnMapReadyCallback {
 
     override fun onDestroy() {
         super.onDestroy()
-        replayHistoryPlayer.finish()
+        mapboxReplayer.finish()
         mapboxNavigation?.unregisterTripSessionStateObserver(tripSessionStateObserver)
         mapboxNavigation?.stopTripSession()
         mapboxNavigation?.onDestroy()

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayHistoryActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayHistoryActivity.kt
@@ -24,12 +24,12 @@ import com.mapbox.navigation.base.internal.extensions.applyDefaultParams
 import com.mapbox.navigation.base.internal.extensions.coordinates
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesRequestCallback
+import com.mapbox.navigation.core.replay.MapboxReplayer
+import com.mapbox.navigation.core.replay.ReplayLocationEngine
 import com.mapbox.navigation.core.replay.history.CustomEventMapper
 import com.mapbox.navigation.core.replay.history.ReplayEventBase
 import com.mapbox.navigation.core.replay.history.ReplayEventsObserver
-import com.mapbox.navigation.core.replay.history.ReplayHistoryLocationEngine
 import com.mapbox.navigation.core.replay.history.ReplayHistoryMapper
-import com.mapbox.navigation.core.replay.history.ReplayHistoryPlayer
 import com.mapbox.navigation.examples.R
 import com.mapbox.navigation.examples.utils.Utils
 import com.mapbox.navigation.examples.utils.extensions.toPoint
@@ -80,11 +80,11 @@ class ReplayHistoryActivity : AppCompatActivity() {
             // Load and replay history on IO dispatchers
             val deferredEvents = async(Dispatchers.IO) { loadReplayHistory() }
             val replayEvents = deferredEvents.await()
-            val replayHistoryPlayer = ReplayHistoryPlayer()
+            val mapboxReplay = MapboxReplayer()
                 .pushEvents(replayEvents)
             if (!isActive) return@launch
 
-            val locationEngine = ReplayHistoryLocationEngine(replayHistoryPlayer)
+            val locationEngine = ReplayLocationEngine(mapboxReplay)
 
             // Await the map and we're ready for navigation
             val mapboxNavigation = createMapboxNavigation(locationEngine)
@@ -100,7 +100,7 @@ class ReplayHistoryActivity : AppCompatActivity() {
                 style,
                 mapboxNavigation,
                 navigationMapboxMap,
-                replayHistoryPlayer
+                mapboxReplay
             )
             callback(navigationContext)
         }
@@ -141,13 +141,13 @@ class ReplayHistoryActivity : AppCompatActivity() {
 
         navigationMapboxMap.addProgressChangeListener(mapboxNavigation)
 
-        replayHistoryPlayer.playFirstLocation()
+        mapboxReplayer.playFirstLocation()
         mapboxMap.addOnMapLongClickListener { latLng ->
             selectMapLocation(latLng)
             true
         }
 
-        replayHistoryPlayer.registerObserver(object : ReplayEventsObserver {
+        mapboxReplayer.registerObserver(object : ReplayEventsObserver {
             override fun replayEvents(events: List<ReplayEventBase>) {
                 events.forEach { event ->
                     when (event) {
@@ -162,7 +162,7 @@ class ReplayHistoryActivity : AppCompatActivity() {
         })
 
         playReplay.setOnClickListener {
-            replayHistoryPlayer.play()
+            mapboxReplayer.play()
         }
     }
 
@@ -172,7 +172,7 @@ class ReplayHistoryActivity : AppCompatActivity() {
         seekBarText.text = getString(R.string.replay_playback_speed_seekbar, seekBar.progress)
         seekBar.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
             override fun onProgressChanged(seekBar: SeekBar, progress: Int, fromUser: Boolean) {
-                replayHistoryPlayer.playbackSpeed(progress.toDouble())
+                mapboxReplayer.playbackSpeed(progress.toDouble())
                 seekBarText.text = getString(R.string.replay_playback_speed_seekbar, progress)
             }
 
@@ -266,7 +266,7 @@ class ReplayHistoryActivity : AppCompatActivity() {
         super.onDestroy()
         loadNavigationJob?.cancelChildren()
         navigationContext?.apply {
-            replayHistoryPlayer.finish()
+            mapboxReplayer.finish()
             mapboxNavigation.stopTripSession()
             mapboxNavigation.onDestroy()
         }
@@ -285,7 +285,7 @@ private data class ReplayNavigationContext(
     val style: Style,
     val mapboxNavigation: MapboxNavigation,
     val navigationMapboxMap: NavigationMapboxMap,
-    val replayHistoryPlayer: ReplayHistoryPlayer
+    val mapboxReplayer: MapboxReplayer
 )
 
 private fun loadHistoryJsonFromAssets(context: Context, fileName: String): String {

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayWaypointsActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayWaypointsActivity.kt
@@ -27,8 +27,8 @@ import com.mapbox.navigation.base.trip.model.RouteLegProgress
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesRequestCallback
-import com.mapbox.navigation.core.replay.history.ReplayHistoryLocationEngine
-import com.mapbox.navigation.core.replay.history.ReplayHistoryPlayer
+import com.mapbox.navigation.core.replay.MapboxReplayer
+import com.mapbox.navigation.core.replay.ReplayLocationEngine
 import com.mapbox.navigation.core.replay.route2.ReplayProgressObserver
 import com.mapbox.navigation.core.replay.route2.ReplayRouteMapper
 import com.mapbox.navigation.core.stops.ArrivalController
@@ -68,8 +68,8 @@ class ReplayWaypointsActivity : AppCompatActivity(), OnMapReadyCallback {
     private val firstLocationCallback = FirstLocationCallback(this)
     private val stopsController = StopsController()
 
-    private val replayHistoryPlayer = ReplayHistoryPlayer()
-    private val replayProgressObserver = ReplayProgressObserver(replayHistoryPlayer)
+    private val mapboxReplayer = MapboxReplayer()
+    private val replayProgressObserver = ReplayProgressObserver(mapboxReplayer)
 
     @SuppressLint("MissingPermission")
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -85,7 +85,7 @@ class ReplayWaypointsActivity : AppCompatActivity(), OnMapReadyCallback {
         mapboxNavigation = MapboxNavigation(
             applicationContext,
             mapboxNavigationOptions,
-            locationEngine = ReplayHistoryLocationEngine(replayHistoryPlayer)
+            locationEngine = ReplayLocationEngine(mapboxReplayer)
         ).apply {
             registerTripSessionStateObserver(tripSessionStateObserver)
         }
@@ -169,7 +169,7 @@ class ReplayWaypointsActivity : AppCompatActivity(), OnMapReadyCallback {
             mapboxNavigation?.registerRouteProgressObserver(replayProgressObserver)
             mapboxNavigation?.startTripSession()
             startNavigation.visibility = View.GONE
-            replayHistoryPlayer.play()
+            mapboxReplayer.play()
         }
     }
 
@@ -179,7 +179,7 @@ class ReplayWaypointsActivity : AppCompatActivity(), OnMapReadyCallback {
         seekBarText.text = getString(R.string.replay_playback_speed_seekbar, seekBar.progress)
         seekBar.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
             override fun onProgressChanged(seekBar: SeekBar, progress: Int, fromUser: Boolean) {
-                replayHistoryPlayer.playbackSpeed(progress.toDouble())
+                mapboxReplayer.playbackSpeed(progress.toDouble())
                 seekBarText.text = getString(R.string.replay_playback_speed_seekbar, progress)
             }
 
@@ -240,7 +240,7 @@ class ReplayWaypointsActivity : AppCompatActivity(), OnMapReadyCallback {
 
     override fun onDestroy() {
         super.onDestroy()
-        replayHistoryPlayer.finish()
+        mapboxReplayer.finish()
         mapboxNavigation?.unregisterTripSessionStateObserver(tripSessionStateObserver)
         mapboxNavigation?.stopTripSession()
         mapboxNavigation?.onDestroy()
@@ -262,8 +262,8 @@ class ReplayWaypointsActivity : AppCompatActivity(), OnMapReadyCallback {
                 activityRef.get()?.let { activity ->
                     val locationEvent = ReplayRouteMapper.mapToUpdateLocation(0.0, location)
                     val locationEventList = Collections.singletonList(locationEvent)
-                    activity.replayHistoryPlayer.pushEvents(locationEventList)
-                    activity.replayHistoryPlayer.playFirstLocation()
+                    activity.mapboxReplayer.pushEvents(locationEventList)
+                    activity.mapboxReplayer.playFirstLocation()
                     activity.navigationMapboxMap?.updateLocation(result.lastLocation)
                 }
             }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/MapboxReplayer.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/MapboxReplayer.kt
@@ -1,12 +1,17 @@
-package com.mapbox.navigation.core.replay.history
+package com.mapbox.navigation.core.replay
 
 import com.mapbox.android.core.location.LocationEngine
+import com.mapbox.navigation.core.replay.history.ReplayEventBase
+import com.mapbox.navigation.core.replay.history.ReplayEventSimulator
+import com.mapbox.navigation.core.replay.history.ReplayEventUpdateLocation
+import com.mapbox.navigation.core.replay.history.ReplayEvents
+import com.mapbox.navigation.core.replay.history.ReplayEventsObserver
 import java.util.Collections.singletonList
 
 /**
  * This class is similar to a music player. It will include controls like play, pause, seek.
  */
-class ReplayHistoryPlayer {
+class MapboxReplayer {
 
     private val replayEvents = ReplayEvents(mutableListOf())
     private val replayEventSimulator = ReplayEventSimulator(replayEvents)
@@ -19,7 +24,7 @@ class ReplayHistoryPlayer {
      *
      * @param events the events to be replayed.
      */
-    fun pushEvents(events: List<ReplayEventBase>): ReplayHistoryPlayer {
+    fun pushEvents(events: List<ReplayEventBase>): MapboxReplayer {
         this.replayEvents.events.addAll(events)
         return this
     }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/ReplayLocationEngine.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/ReplayLocationEngine.kt
@@ -1,4 +1,4 @@
-package com.mapbox.navigation.core.replay.history
+package com.mapbox.navigation.core.replay
 
 import android.app.PendingIntent
 import android.location.Location
@@ -7,6 +7,9 @@ import com.mapbox.android.core.location.LocationEngine
 import com.mapbox.android.core.location.LocationEngineCallback
 import com.mapbox.android.core.location.LocationEngineRequest
 import com.mapbox.android.core.location.LocationEngineResult
+import com.mapbox.navigation.core.replay.history.ReplayEventBase
+import com.mapbox.navigation.core.replay.history.ReplayEventUpdateLocation
+import com.mapbox.navigation.core.replay.history.ReplayEventsObserver
 import java.util.Date
 
 private typealias EngineCallback = LocationEngineCallback<LocationEngineResult>
@@ -14,8 +17,8 @@ private typealias EngineCallback = LocationEngineCallback<LocationEngineResult>
 /**
  * Location Engine for replaying route history.
  */
-class ReplayHistoryLocationEngine(
-    replayHistoryPlayer: ReplayHistoryPlayer
+class ReplayLocationEngine(
+    mapboxReplayer: MapboxReplayer
 ) : LocationEngine, ReplayEventsObserver {
 
     private val registeredCallbacks: MutableList<EngineCallback> = mutableListOf()
@@ -33,7 +36,7 @@ class ReplayHistoryLocationEngine(
 
     init {
         myId = instances
-        replayHistoryPlayer.registerObserver(this)
+        mapboxReplayer.registerObserver(this)
     }
 
     /**

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/history/ReplayEventSimulator.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/history/ReplayEventSimulator.kt
@@ -1,6 +1,7 @@
 package com.mapbox.navigation.core.replay.history
 
 import android.os.SystemClock
+import com.mapbox.navigation.core.replay.MapboxReplayer
 import com.mapbox.navigation.utils.internal.ThreadController
 import kotlin.math.max
 import kotlin.math.roundToLong
@@ -14,8 +15,7 @@ import kotlinx.coroutines.launch
  * This class keeps track of a forward playing replay. As time moves forward, it captures
  * all events from [ReplayEvents] that happened, and provides them in a [ReplayEvents]
  *
- * @param replayEvents events needed to be replayed by [ReplayHistoryPlayer]
- * @param logger interface for logging any events
+ * @param replayEvents events needed to be replayed by [MapboxReplayer]
  */
 internal class ReplayEventSimulator(
     private val replayEvents: ReplayEvents

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/history/ReplayEvents.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/history/ReplayEvents.kt
@@ -1,12 +1,14 @@
 package com.mapbox.navigation.core.replay.history
 
 import com.google.gson.annotations.SerializedName
+import com.mapbox.navigation.core.replay.MapboxReplayer
+import com.mapbox.navigation.core.replay.ReplayLocationEngine
 
 /**
  * Replay event that mapped from [ReplayHistoryDTO] or created on your own. Override this
- * to support new or custom events. Each event can be replayed by the [ReplayHistoryPlayer]
+ * to support new or custom events. Each event can be replayed by the [MapboxReplayer]
  *
- * @param events Assumes chronological order, index 0 moves to [events.size] over time.
+ * @param events Assumes chronological order, index 0 moves to [List.size] over time.
  */
 data class ReplayEvents(
     val events: MutableList<ReplayEventBase>
@@ -16,7 +18,7 @@ data class ReplayEvents(
  * Base interface event for ReplayEvent
  *
  * @property eventTimestamp timestamp of event milliseconds
- * @see [ReplayHistoryLocationEngine]
+ * @see [ReplayLocationEngine]
  */
 interface ReplayEventBase {
     val eventTimestamp: Double

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/history/ReplayEventsObserver.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/history/ReplayEventsObserver.kt
@@ -1,7 +1,9 @@
 package com.mapbox.navigation.core.replay.history
 
+import com.mapbox.navigation.core.replay.MapboxReplayer
+
 /**
- * Used to observe events replayed by the [ReplayHistoryPlayer]
+ * Used to observe events replayed by the [MapboxReplayer]
  */
 interface ReplayEventsObserver {
 

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/history/ReplayHistoryMapper.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/history/ReplayHistoryMapper.kt
@@ -4,6 +4,7 @@ import com.google.gson.Gson
 import com.google.gson.internal.LinkedTreeMap
 import com.mapbox.base.common.logger.Logger
 import com.mapbox.base.common.logger.model.Message
+import com.mapbox.navigation.core.replay.MapboxReplayer
 
 /**
  * Additional mapper that can be used with [ReplayHistoryMapper].
@@ -12,7 +13,7 @@ interface CustomEventMapper {
 
     /**
      * Override to map your own custom events from history files,
-     * into [ReplayEventBase] for the [ReplayHistoryPlayer]
+     * into [ReplayEventBase] for the [MapboxReplayer]
      */
     fun map(eventType: String, properties: LinkedTreeMap<*, *>): ReplayEventBase?
 }
@@ -28,11 +29,11 @@ interface CustomEventMapper {
 class ReplayHistoryMapper @JvmOverloads constructor(
     private val gson: Gson = Gson(),
     private val customEventMapper: CustomEventMapper? = null,
-    private val logger: Logger
+    private val logger: Logger? = null
 ) {
 
     /**
-     * Given raw json string return [ReplayEvents] that can be given to a [ReplayHistoryPlayer]
+     * Given raw json string return [ReplayEvents] that can be given to a [MapboxReplayer]
      */
     fun mapToReplayEvents(historyData: String): List<ReplayEventBase> {
         val exampleHistoryData = gson.fromJson(historyData, ReplayHistoryDTO::class.java)
@@ -40,7 +41,7 @@ class ReplayHistoryMapper @JvmOverloads constructor(
     }
 
     /**
-     * Given [ReplayHistoryDTO] return [ReplayEvents] that can be given to a [ReplayHistoryPlayer]
+     * Given [ReplayHistoryDTO] return [ReplayEvents] that can be given to a [MapboxReplayer]
      */
     fun mapToReplayEvents(historyDTO: ReplayHistoryDTO): List<ReplayEventBase> {
         return historyDTO.events
@@ -50,7 +51,7 @@ class ReplayHistoryMapper @JvmOverloads constructor(
                     val eventType: String = event["type"] as String
                     mapToEvent(eventType, event)
                 } catch (throwable: Throwable) {
-                    logger.e(
+                    logger?.e(
                         msg = Message("Failed to read index $index: $event"),
                         tr = throwable
                     )
@@ -75,7 +76,7 @@ class ReplayHistoryMapper @JvmOverloads constructor(
             else -> {
                 val replayEvent = customEventMapper?.map(eventType, event)
                 if (replayEvent == null) {
-                    logger.e(msg = Message("Replay unsupported event $eventType"))
+                    logger?.e(msg = Message("Replay unsupported event $eventType"))
                 }
                 replayEvent
             }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route2/ReplayProgressObserver.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route2/ReplayProgressObserver.kt
@@ -3,12 +3,12 @@ package com.mapbox.navigation.core.replay.route2
 import com.mapbox.api.directions.v5.models.RouteLeg
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.MapboxNavigation
-import com.mapbox.navigation.core.replay.history.ReplayHistoryPlayer
+import com.mapbox.navigation.core.replay.MapboxReplayer
 import com.mapbox.navigation.core.trip.session.RouteProgressObserver
 
 /**
  * Register this to [MapboxNavigation.registerRouteProgressObserver].
- * This class will feed locations to your [ReplayHistoryPlayer] and simulate
+ * This class will feed locations to your [MapboxReplayer] and simulate
  * your active route for you.
  */
 class ReplayProgressObserver(
@@ -16,7 +16,7 @@ class ReplayProgressObserver(
      * As navigation receives [RouteProgress], this will push events to your
      * replay history player to be played.
      */
-    private val replayHistoryPlayer: ReplayHistoryPlayer
+    private val mapboxReplayer: MapboxReplayer
 ) : RouteProgressObserver {
 
     private val replayRouteMapper = ReplayRouteMapper()
@@ -48,8 +48,8 @@ class ReplayProgressObserver(
         if (routeProgressRouteLeg != null) {
             val replayEvents = replayRouteMapper.mapRouteLegGeometry(routeProgressRouteLeg)
             if (replayEvents.isNotEmpty()) {
-                replayHistoryPlayer.pushEvents(replayEvents)
-                replayHistoryPlayer.seekTo(replayEvents.first())
+                mapboxReplayer.pushEvents(replayEvents)
+                mapboxReplayer.seekTo(replayEvents.first())
             }
         }
     }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route2/ReplayRouteLocation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route2/ReplayRouteLocation.kt
@@ -2,7 +2,7 @@ package com.mapbox.navigation.core.replay.route2
 
 import android.location.Location
 import com.mapbox.geojson.Point
-import com.mapbox.navigation.core.replay.history.ReplayHistoryPlayer
+import com.mapbox.navigation.core.replay.MapboxReplayer
 
 internal data class ReplayRouteSegment(
     val startSpeedMps: Double,
@@ -23,7 +23,7 @@ internal class ReplayRouteLocation(
 ) {
 
     /**
-     * [ReplayHistoryPlayer] is in Double seconds and [Location] is in milliseconds.
+     * [MapboxReplayer] is in Double seconds and [Location] is in milliseconds.
      * Keep track of the mapping in between
      */
     var timeMillis: Long = 0L

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route2/ReplayRouteMapper.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route2/ReplayRouteMapper.kt
@@ -7,14 +7,14 @@ import com.mapbox.api.directions.v5.models.LegAnnotation
 import com.mapbox.api.directions.v5.models.LegStep
 import com.mapbox.api.directions.v5.models.RouteLeg
 import com.mapbox.geojson.utils.PolylineUtils
+import com.mapbox.navigation.core.replay.MapboxReplayer
 import com.mapbox.navigation.core.replay.history.ReplayEventBase
 import com.mapbox.navigation.core.replay.history.ReplayEventLocation
 import com.mapbox.navigation.core.replay.history.ReplayEventUpdateLocation
-import com.mapbox.navigation.core.replay.history.ReplayHistoryPlayer
 
 /**
  * This class converts a [DirectionsRoute] into events that can be
- * replayed using the [ReplayHistoryPlayer] to navigate a route.
+ * replayed using the [MapboxReplayer] to navigate a route.
  */
 class ReplayRouteMapper @JvmOverloads constructor(
     /**
@@ -26,7 +26,7 @@ class ReplayRouteMapper @JvmOverloads constructor(
     private val replayRouteDriver = ReplayRouteDriver()
 
     /**
-     * Take a [DirectionsRoute] and map it to events that can be replayed by the [ReplayHistoryPlayer].
+     * Take a [DirectionsRoute] and map it to events that can be replayed by the [MapboxReplayer].
      * Uses the Directions API [DirectionsRoute.geometry] to calculate the speed
      * and position estimates for the replay locations.
      *
@@ -72,7 +72,7 @@ class ReplayRouteMapper @JvmOverloads constructor(
     }
 
     /**
-     * Take a [DirectionsRoute] and map it to events that can be replayed by the [ReplayHistoryPlayer].
+     * Take a [DirectionsRoute] and map it to events that can be replayed by the [MapboxReplayer].
      * Uses the Directions API [LegAnnotation] to create the speed and position
      * estimates for the replay locations.
      *


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

> **Naming**: The naming ReplayHistoryLocationEngine suggests that it can only replay history traces, but with the modular design using the mappers, it can also play DirectionsRoute s. Therefore, the name ReplayLocationEngine would fit better here. What do you think?

With the introduction of replay route, the ReplayHistoryLocationEngine and ReplayHistoryPlayer has created confusion.

Renaming these classes to
`ReplayLocationEngine`: capable of replaying history, routes, and more
`MapboxReplayer`: capable of replaying history, routes, and more

- [ ] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->