### PR TITLE
added a color representation for heavy traffic condition

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteLine.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteLine.kt
@@ -36,6 +36,7 @@ import com.mapbox.navigation.ui.route.RouteConstants.MINIMUM_ROUTE_LINE_OFFSET
 import com.mapbox.navigation.ui.route.RouteConstants.MODERATE_CONGESTION_VALUE
 import com.mapbox.navigation.ui.route.RouteConstants.PRIMARY_ROUTE_LAYER_ID
 import com.mapbox.navigation.ui.route.RouteConstants.SEVERE_CONGESTION_VALUE
+import com.mapbox.navigation.ui.route.RouteConstants.UNKNOWN_CONGESTION_VALUE
 import com.mapbox.navigation.ui.route.RouteConstants.WAYPOINT_DESTINATION_VALUE
 import com.mapbox.navigation.ui.route.RouteConstants.WAYPOINT_ORIGIN_VALUE
 import com.mapbox.navigation.ui.route.RouteConstants.WAYPOINT_PROPERTY_KEY
@@ -107,6 +108,15 @@ internal class MapRouteLine(
     var vanishPointOffset: Float = 0f
         private set
 
+    private val routeUnknownColor: Int by lazy {
+        getStyledColor(
+            R.styleable.NavigationMapRoute_routeUnknownCongestionColor,
+            R.color.mapbox_navigation_route_layer_congestion_unknown,
+            context,
+            styleRes
+        )
+    }
+
     private val routeDefaultColor: Int by lazy {
         getStyledColor(
             R.styleable.NavigationMapRoute_routeColor,
@@ -120,6 +130,15 @@ internal class MapRouteLine(
         getStyledColor(
             R.styleable.NavigationMapRoute_routeModerateCongestionColor,
             R.color.mapbox_navigation_route_layer_congestion_yellow,
+            context,
+            styleRes
+        )
+    }
+
+    private val routeHeavyColor: Int by lazy {
+        getStyledColor(
+            R.styleable.NavigationMapRoute_routeHeavyCongestionColor,
+            R.color.mapbox_navigation_route_layer_congestion_heavy,
             context,
             styleRes
         )
@@ -161,6 +180,15 @@ internal class MapRouteLine(
         )
     }
 
+    private val alternativeRouteUnknownColor: Int by lazy {
+        getStyledColor(
+            R.styleable.NavigationMapRoute_alternativeRouteUnknownCongestionColor,
+            R.color.mapbox_navigation_route_alternative_congestion_unknown,
+            context,
+            styleRes
+        )
+    }
+
     private val alternativeRouteDefaultColor: Int by lazy {
         getStyledColor(
             R.styleable.NavigationMapRoute_alternativeRouteColor,
@@ -174,6 +202,15 @@ internal class MapRouteLine(
         getStyledColor(
             R.styleable.NavigationMapRoute_alternativeRouteSevereCongestionColor,
             R.color.mapbox_navigation_route_alternative_congestion_red,
+            context,
+            styleRes
+        )
+    }
+
+    private val alternativeRouteHeavyColor: Int by lazy {
+        getStyledColor(
+            R.styleable.NavigationMapRoute_alternativeRouteHeavyCongestionColor,
+            R.color.mapbox_navigation_route_alternative_congestion_heavy,
             context,
             styleRes
         )
@@ -620,14 +657,16 @@ internal class MapRouteLine(
         return when (isPrimaryRoute) {
             true -> when (congestionValue) {
                 MODERATE_CONGESTION_VALUE -> routeModerateColor
-                HEAVY_CONGESTION_VALUE -> routeSevereColor
+                HEAVY_CONGESTION_VALUE -> routeHeavyColor
                 SEVERE_CONGESTION_VALUE -> routeSevereColor
+                UNKNOWN_CONGESTION_VALUE -> routeUnknownColor
                 else -> routeDefaultColor
             }
             false -> when (congestionValue) {
                 MODERATE_CONGESTION_VALUE -> alternativeRouteModerateColor
-                HEAVY_CONGESTION_VALUE -> alternativeRouteSevereColor
+                HEAVY_CONGESTION_VALUE -> alternativeRouteHeavyColor
                 SEVERE_CONGESTION_VALUE -> alternativeRouteSevereColor
+                UNKNOWN_CONGESTION_VALUE -> alternativeRouteUnknownColor
                 else -> alternativeRouteDefaultColor
             }
         }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/RouteConstants.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/RouteConstants.java
@@ -42,6 +42,7 @@ class RouteConstants {
   static final String MODERATE_CONGESTION_VALUE = "moderate";
   static final String HEAVY_CONGESTION_VALUE = "heavy";
   static final String SEVERE_CONGESTION_VALUE = "severe";
+  static final String UNKNOWN_CONGESTION_VALUE = "unknown";
   static final String ORIGIN_MARKER_NAME = "originMarker";
   static final String DESTINATION_MARKER_NAME = "destinationMarker";
   static final String MAPBOX_LOCATION_ID = "mapbox-location";

--- a/libnavigation-ui/src/main/res/values/attrs.xml
+++ b/libnavigation-ui/src/main/res/values/attrs.xml
@@ -3,13 +3,17 @@
   <declare-styleable name="NavigationMapRoute">
     <!-- Primary route colors -->
     <attr name="routeColor" format="color"/>
+    <attr name="routeUnknownCongestionColor" format="color"/>
     <attr name="routeModerateCongestionColor" format="color"/>
+    <attr name="routeHeavyCongestionColor" format="color"/>
     <attr name="routeSevereCongestionColor" format="color"/>
     <attr name="routeShieldColor" format="color"/>
 
     <!-- Alternative route colors -->
     <attr name="alternativeRouteColor" format="color"/>
+    <attr name="alternativeRouteUnknownCongestionColor" format="color"/>
     <attr name="alternativeRouteModerateCongestionColor" format="color"/>
+    <attr name="alternativeRouteHeavyCongestionColor" format="color"/>
     <attr name="alternativeRouteSevereCongestionColor" format="color"/>
     <attr name="alternativeRouteShieldColor" format="color"/>
 

--- a/libnavigation-ui/src/main/res/values/colors.xml
+++ b/libnavigation-ui/src/main/res/values/colors.xml
@@ -2,13 +2,17 @@
 <resources>
   <!-- Primary route colors -->
   <color name="mapbox_navigation_route_layer_blue">#56A8FB</color>
+  <color name="mapbox_navigation_route_layer_congestion_unknown">#56A8FB</color>
   <color name="mapbox_navigation_route_layer_congestion_yellow">#F3A64F</color>
+  <color name="mapbox_navigation_route_layer_congestion_heavy">#E93340</color>
   <color name="mapbox_navigation_route_layer_congestion_red">#E93340</color>
   <color name="mapbox_navigation_route_shield_layer_color">#2F7AC6</color>
 
   <!-- Alternative route colors -->
   <color name="mapbox_navigation_route_alternative_color">#8694A5</color>
+  <color name="mapbox_navigation_route_alternative_congestion_unknown">#8694A5</color>
   <color name="mapbox_navigation_route_alternative_congestion_yellow">#BEA087</color>
+  <color name="mapbox_navigation_route_alternative_congestion_heavy">#B58281</color>
   <color name="mapbox_navigation_route_alternative_congestion_red">#B58281</color>
   <color name="mapbox_navigation_route_alternative_shield_color">#727E8D</color>
 

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteLineTest.kt
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteLineTest.kt
@@ -700,6 +700,166 @@ class MapRouteLineTest {
         assertEquals("\"origin\"", result!!.properties()!!["wayPoint"].toString())
     }
 
+    @Test
+    fun getRouteColorForCongestionPrimaryRouteCongestionModerate() {
+        every { style.layers } returns listOf(primaryRouteLayer)
+        val mapRouteLine = MapRouteLine(
+            ctx,
+            style,
+            styleRes,
+            null,
+            layerProvider,
+            mapRouteSourceProvider)
+
+        val result = mapRouteLine.getRouteColorForCongestion(RouteConstants.MODERATE_CONGESTION_VALUE, true)
+
+        assertEquals(-809393, result)
+    }
+
+    @Test
+    fun getRouteColorForCongestionPrimaryRouteCongestionHeavy() {
+        every { style.layers } returns listOf(primaryRouteLayer)
+        val mapRouteLine = MapRouteLine(
+            ctx,
+            style,
+            styleRes,
+            null,
+            layerProvider,
+            mapRouteSourceProvider)
+
+        val result = mapRouteLine.getRouteColorForCongestion(RouteConstants.HEAVY_CONGESTION_VALUE, true)
+
+        assertEquals(-1494208, result)
+    }
+
+    @Test
+    fun getRouteColorForCongestionPrimaryRouteCongestionSevere() {
+        every { style.layers } returns listOf(primaryRouteLayer)
+        val mapRouteLine = MapRouteLine(
+            ctx,
+            style,
+            styleRes,
+            null,
+            layerProvider,
+            mapRouteSourceProvider)
+
+        val result = mapRouteLine.getRouteColorForCongestion(RouteConstants.SEVERE_CONGESTION_VALUE, true)
+
+        assertEquals(-1494208, result)
+    }
+
+    @Test
+    fun getRouteColorForCongestionPrimaryRouteCongestionUnknown() {
+        every { style.layers } returns listOf(primaryRouteLayer)
+        val mapRouteLine = MapRouteLine(
+            ctx,
+            style,
+            styleRes,
+            null,
+            layerProvider,
+            mapRouteSourceProvider)
+
+        val result = mapRouteLine.getRouteColorForCongestion(RouteConstants.UNKNOWN_CONGESTION_VALUE, true)
+
+        assertEquals(-11097861, result)
+    }
+
+    @Test
+    fun getRouteColorForCongestionPrimaryRouteCongestionDefault() {
+        every { style.layers } returns listOf(primaryRouteLayer)
+        val mapRouteLine = MapRouteLine(
+            ctx,
+            style,
+            styleRes,
+            null,
+            layerProvider,
+            mapRouteSourceProvider)
+
+        val result = mapRouteLine.getRouteColorForCongestion("foobar", true)
+
+        assertEquals(-11097861, result)
+    }
+
+    @Test
+    fun getRouteColorForCongestionNonPrimaryRouteCongestionModerate() {
+        every { style.layers } returns listOf(primaryRouteLayer)
+        val mapRouteLine = MapRouteLine(
+            ctx,
+            style,
+            styleRes,
+            null,
+            layerProvider,
+            mapRouteSourceProvider)
+
+        val result = mapRouteLine.getRouteColorForCongestion(RouteConstants.MODERATE_CONGESTION_VALUE, false)
+
+        assertEquals(-4881791, result)
+    }
+
+    @Test
+    fun getRouteColorForCongestionNonPrimaryRouteCongestionHeavy() {
+        every { style.layers } returns listOf(primaryRouteLayer)
+        val mapRouteLine = MapRouteLine(
+            ctx,
+            style,
+            styleRes,
+            null,
+            layerProvider,
+            mapRouteSourceProvider)
+
+        val result = mapRouteLine.getRouteColorForCongestion(RouteConstants.HEAVY_CONGESTION_VALUE, false)
+
+        assertEquals(-4881791, result)
+    }
+
+    @Test
+    fun getRouteColorForCongestionNonPrimaryRouteCongestionSevere() {
+        every { style.layers } returns listOf(primaryRouteLayer)
+        val mapRouteLine = MapRouteLine(
+            ctx,
+            style,
+            styleRes,
+            null,
+            layerProvider,
+            mapRouteSourceProvider)
+
+        val result = mapRouteLine.getRouteColorForCongestion(RouteConstants.SEVERE_CONGESTION_VALUE, false)
+
+        assertEquals(-4881791, result)
+    }
+
+    @Test
+    fun getRouteColorForCongestionNonPrimaryRouteCongestionUnknown() {
+        every { style.layers } returns listOf(primaryRouteLayer)
+        val mapRouteLine = MapRouteLine(
+            ctx,
+            style,
+            styleRes,
+            null,
+            layerProvider,
+            mapRouteSourceProvider)
+
+        val result = mapRouteLine.getRouteColorForCongestion(RouteConstants.UNKNOWN_CONGESTION_VALUE, false)
+
+        assertEquals(-7957339, result)
+    }
+
+    @Test
+    fun getRouteColorForCongestionNonPrimaryRouteCongestionDefault() {
+        every { style.layers } returns listOf(primaryRouteLayer)
+        val mapRouteLine = MapRouteLine(
+            ctx,
+            style,
+            styleRes,
+            null,
+            layerProvider,
+            mapRouteSourceProvider)
+
+        val result = mapRouteLine.getRouteColorForCongestion("foobar", false)
+
+        assertEquals(-7957339, result)
+    }
+
     private fun getDirectionsRoute(includeCongestion: Boolean): DirectionsRoute {
         val congestion = when (includeCongestion) {
             true -> "\"unknown\",\"heavy\",\"low\""


### PR DESCRIPTION
## Description
Addresses #2972 by providing color representations for "heavy" and "unknown" traffic congestions. 

- [x] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal

Support color differentiation for  "heavy" and "unknown" traffic conditions.

### Implementation

Using the existing patterns for the color definitions, additional attributes were added to represent "heavy" and "unknown" conditions.

## Screenshots or Gifs

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->