### PR TITLE
Provide production routing tiles endpoint

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/BaseRouterActivityJava.java
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/BaseRouterActivityJava.java
@@ -31,6 +31,7 @@ import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.plugins.annotation.SymbolManager;
 import com.mapbox.mapboxsdk.plugins.annotation.SymbolOptions;
 import com.mapbox.navigation.base.metrics.MetricsObserver;
+import com.mapbox.navigation.base.options.HandheldProfile;
 import com.mapbox.navigation.base.options.MapboxOnboardRouterConfig;
 import com.mapbox.navigation.base.route.Router;
 import com.mapbox.navigation.core.internal.accounts.MapboxNavigationAccounts;
@@ -95,7 +96,7 @@ public abstract class BaseRouterActivityJava extends AppCompatActivity
 
     return new MapboxOnboardRouter(
             Utils.getMapboxAccessToken(context),
-            MapboxNativeNavigatorImpl.INSTANCE,
+            MapboxNativeNavigatorImpl.INSTANCE.create(new HandheldProfile()),
             config,
             MapboxLogger.INSTANCE,
             MapboxNavigationAccounts.getInstance(context)

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/SimpleMapboxNavigationKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/SimpleMapboxNavigationKt.kt
@@ -60,7 +60,6 @@ import com.mapbox.navigation.ui.voice.SpeechPlayerProvider
 import com.mapbox.navigation.ui.voice.VoiceInstructionLoader
 import java.io.File
 import java.lang.ref.WeakReference
-import java.net.URI
 import java.util.Date
 import java.util.Locale
 import kotlinx.android.synthetic.main.activity_trip_service.mapView
@@ -143,30 +142,7 @@ class SimpleMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
         val options =
             MapboxNavigation.defaultNavigationOptions(this, Utils.getMapboxAccessToken(this))
 
-        val tilesUri = URI("https://api-routing-tiles-staging.tilestream.net")
-        val tilesVersion = "2020_02_02-03_00_00"
-
-        val endpoint = options.onboardRouterConfig?.endpoint?.toBuilder()
-            ?.host(tilesUri.toString())
-            ?.version(tilesVersion)
-            ?.build()
-
-        val onboardRouterConfig = options.onboardRouterConfig?.toBuilder()
-            ?.tilePath(
-                File(
-                    filesDir,
-                    "Offline/${tilesUri.host}/$tilesVersion"
-                ).absolutePath
-            )
-            ?.endpoint(endpoint)
-            ?.build()
-
-        val newOptions =
-            options.toBuilder()
-                .onboardRouterConfig(onboardRouterConfig)
-                .build()
-
-        mapboxNavigation = getMapboxNavigation(newOptions)
+        mapboxNavigation = getMapboxNavigation(options)
     }
 
     override fun onMapReady(mapboxMap: MapboxMap) {

--- a/libdirections-onboard/src/main/java/com/mapbox/navigation/route/onboard/MapboxOnboardRouter.kt
+++ b/libdirections-onboard/src/main/java/com/mapbox/navigation/route/onboard/MapboxOnboardRouter.kt
@@ -49,7 +49,6 @@ class MapboxOnboardRouter(
 
     companion object {
         private const val TAG = "MapboxOnboardRouter"
-        private const val TILES_DIR_NAME = "tiles"
     }
 
     private val mainJobControl by lazy {
@@ -59,7 +58,7 @@ class MapboxOnboardRouter(
 
     init {
         if (config.tilePath.isNotEmpty()) {
-            val tileDir = File(config.tilePath, TILES_DIR_NAME)
+            val tileDir = File(config.tilePath)
             if (!tileDir.exists()) {
                 tileDir.mkdirs()
             }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -652,6 +652,8 @@ constructor(
 
     companion object {
 
+        private const val TILES_DIR_NAME = "tiles"
+
         /**
          * Send user feedback about an issue or problem with the Navigation SDK
          *
@@ -694,13 +696,14 @@ constructor(
                 .navigatorPredictionMillis(DEFAULT_NAVIGATOR_PREDICTION_MILLIS)
                 .distanceFormatter(distanceFormatter)
 
-            // TODO provide a production routing tiles endpoint
-            val tilesUri = URI("")
-            val tilesVersion = ""
+            val tilesUri = URI("https://api.mapbox.com")
+            // Latest version available https://api.mapbox.com/route-tiles/v1/versions?access_token=
+            // as of 05/18/2020
+            val tilesVersion = "2020_02_02-03_00_00"
             val tilesDir = if (tilesUri.toString().isNotEmpty() && tilesVersion.isNotEmpty()) {
                 File(
                     context.filesDir,
-                    "Offline/${tilesUri.host}/$tilesVersion"
+                    "Offline/${tilesUri.host}/$tilesVersion/$TILES_DIR_NAME"
                 ).absolutePath
             } else ""
 


### PR DESCRIPTION
## Description

Provides production routing tiles endpoint and fixes `BaseRouterActivityJava` NPE 👇 (`!!` :trollface: @kmadsen)

```
05-18 15:53:13.597 26616-26616/com.mapbox.navigation.examples E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.mapbox.navigation.examples, PID: 26616
    java.lang.RuntimeException: Unable to start activity ComponentInfo{com.mapbox.navigation.examples/com.mapbox.navigation.examples.core.OnboardRouterActivityJava}: kotlin.KotlinNullPointerException
        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2416)
        at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2476)
        at android.app.ActivityThread.-wrap11(ActivityThread.java)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1344)
        at android.os.Handler.dispatchMessage(Handler.java:102)
        at android.os.Looper.loop(Looper.java:148)
        at android.app.ActivityThread.main(ActivityThread.java:5417)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616)
     Caused by: kotlin.KotlinNullPointerException
        at com.mapbox.navigation.navigator.internal.MapboxNativeNavigatorImpl.configureRouter(MapboxNativeNavigatorImpl.kt:220)
        at com.mapbox.navigation.route.onboard.MapboxOnboardRouter.<init>(MapboxOnboardRouter.kt:80)
        at com.mapbox.navigation.examples.core.BaseRouterActivityJava.setupOnboardRouter(BaseRouterActivityJava.java:101)
        at com.mapbox.navigation.examples.core.OnboardRouterActivityJava.setupRouter(OnboardRouterActivityJava.java:14)
        at com.mapbox.navigation.examples.core.BaseRouterActivityJava.onCreate(BaseRouterActivityJava.java:137)
        at android.app.Activity.performCreate(Activity.java:6251)
        at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1107)
        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2369)
        at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2476) 
        at android.app.ActivityThread.-wrap11(ActivityThread.java) 
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1344) 
        at android.os.Handler.dispatchMessage(Handler.java:102) 
        at android.os.Looper.loop(Looper.java:148) 
        at android.app.ActivityThread.main(ActivityThread.java:5417) 
        at java.lang.reflect.Method.invoke(Native Method) 
        at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726) 
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616) 
```

Fixes https://github.com/mapbox/mapbox-navigation-android/issues/2982 and regression from https://github.com/mapbox/mapbox-navigation-android/pull/2974

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Provide a production default `MapboxOnboardRouterConfig` 

### Implementation

- Default to `val tilesUri = URI("https://api.mapbox.com")` in `MapboxNavigation#defaultNavigationOptions`
- Default to `val tilesVersion = "2020_02_02-03_00_00"` in `MapboxNavigation#defaultNavigationOptions` - latest version available https://api.mapbox.com/route-tiles/v1/versions?access_token=
- Add `MapboxNativeNavigatorImpl.INSTANCE.create(new HandheldProfile())` to `MapboxOnboardRouter` creation in `BaseRouterActivityJava`

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR

cc @mskurydin @danpaz @Aurora-Boreal @LukasPaczos 