### PR TITLE
Expose android ui library which is required by Nav UI SDK API transitively from UI SDK

### DIFF
--- a/libnavigation-ui/build.gradle
+++ b/libnavigation-ui/build.gradle
@@ -76,10 +76,8 @@ dependencies {
   implementation dependenciesList.mapboxAnnotationPlugin
 
   // Support libraries
-  implementation dependenciesList.materialDesign
-  implementation dependenciesList.androidXRecyclerView
-  implementation dependenciesList.androidXConstraintLayout
-  implementation dependenciesList.androidXCardView
+  api dependenciesList.materialDesign
+  api dependenciesList.androidXConstraintLayout
 
   // Architecture libraries
   implementation dependenciesList.lifecycleExtensions


### PR DESCRIPTION
## Description

Fix #2682 

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal

The developer can integrates Nav UI SDK without explicitly add new dependency.

### Implementation

We have 
* **`RecenterButton`** extends from CardView
* **`FeedbackButton`** extends from ConstraintLayout
* **`FeedbackBottomSheet`** extends from BottomSheetDialogFragment
So we need to expose the corresponding dependency transitively.
The `materialDesign` dependency includes the _cardview_ and _recyclerview_ dependency, we can safely remove the redundant one from our gradle file.

<img width="652" alt="Screen Shot 2020-05-18 at 14 57 00" src="https://user-images.githubusercontent.com/3918950/82265357-a20ab980-991b-11ea-98ff-a2edecc91d24.png">

## Testing

I have verified the `example` app that the examples are working as before.

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->