### PR TITLE
Migrate progress classes to data objects

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/BasicNavigationActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/BasicNavigationActivity.kt
@@ -124,7 +124,7 @@ class BasicNavigationActivity : AppCompatActivity(), OnMapReadyCallback {
     private val routeProgressObserver = object : RouteProgressObserver {
         override fun onRouteProgressChanged(routeProgress: RouteProgress) {
             // do something with the route progress
-            Timber.i("route progress: ${routeProgress.currentState()}")
+            Timber.i("route progress: ${routeProgress.currentState}")
         }
     }
 

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/DebugMapboxNavigationKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/DebugMapboxNavigationKt.kt
@@ -265,7 +265,7 @@ class DebugMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
     private val routeProgressObserver = object : RouteProgressObserver {
         override fun onRouteProgressChanged(routeProgress: RouteProgress) {
             Timber.d("route progress %s", routeProgress.toString())
-            if (routeProgress.route() != null) {
+            if (routeProgress.route != null) {
                 navigationMapboxMap.onNewRouteProgress(routeProgress)
             }
         }

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/SimpleMapboxNavigationKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/SimpleMapboxNavigationKt.kt
@@ -260,7 +260,7 @@ class SimpleMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
     private val routeProgressObserver = object : RouteProgressObserver {
         override fun onRouteProgressChanged(routeProgress: RouteProgress) {
             Timber.d("route progress %s", routeProgress.toString())
-            if (routeProgress.route() != null) {
+            if (routeProgress.route != null) {
                 navigationMapboxMap.onNewRouteProgress(routeProgress)
             }
         }

--- a/examples/src/main/java/com/mapbox/navigation/examples/ui/BuildingExtrusionActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/ui/BuildingExtrusionActivity.kt
@@ -133,7 +133,7 @@ class BuildingExtrusionActivity : AppCompatActivity(), OnNavigationReadyCallback
     }
 
     override fun onRouteProgressChanged(routeProgress: RouteProgress) {
-        routeProgress.distanceRemaining()
+        // todo
     }
 
     override fun onNavigationRunning() {

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/NavigationOptions.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/NavigationOptions.kt
@@ -15,7 +15,6 @@ const val DEFAULT_NAVIGATOR_PREDICTION_MILLIS = 1100L
 /**
  * Defines navigation options
  *
- * @param roundingIncrement defines the increment displayed on the instruction view
  * @param timeFormatType defines time format for calculation remaining trip time
  * @param navigatorPredictionMillis defines approximate navigator prediction in milliseconds
  *
@@ -37,8 +36,8 @@ data class NavigationOptions(
     val navigatorPredictionMillis: Long,
     val distanceFormatter: DistanceFormatter?,
     val onboardRouterConfig: MapboxOnboardRouterConfig?,
-    val isFromNavigationUi: Boolean = false,
-    val isDebugLoggingEnabled: Boolean = false,
+    val isFromNavigationUi: Boolean,
+    val isDebugLoggingEnabled: Boolean,
     val deviceProfile: DeviceProfile,
     val builder: Builder
 ) {

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteLegProgress.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteLegProgress.kt
@@ -8,116 +8,45 @@ import com.mapbox.api.directions.v5.models.RouteLeg
  * in the directions route, much of this information will be identical to the parent
  * [RouteProgress].
  *
- * The latest route leg progress object can be obtained through the [com.mapbox.navigation.base.trip.RouteProgressObserver].
+ * The latest route leg progress object can be obtained through the [com.mapbox.navigation.core.trip.session.RouteProgressObserver].
  * Note that the route leg progress object's immutable.
+ *
+ * @param legIndex Index representing the current leg the user is on. If the directions route currently in use
+ * contains more then two waypoints, the route is likely to have multiple legs representing the
+ * distance between the two points.
+ * @param routeLeg [RouteLeg] geometry
+ * @param distanceTraveled Total distance traveled in meters along current leg
+ * @param distanceRemaining The distance remaining in meters until the user reaches the end of the leg
+ * @param durationRemaining The duration remaining in seconds until the user reaches the end of the current step
+ * @param fractionTraveled The fraction traveled along the current leg, this is a float value between 0 and 1 and
+ * isn't guaranteed to reach 1 before the user reaches the next waypoint
+ * @param currentStepProgress [RouteStepProgress] object with information about the particular step the user
+ * is currently on
+ * @param upcomingStep Next/upcoming step immediately after the current step. If the user is on the last step
+ * on the last leg, this will return null since a next step doesn't exist
  */
-class RouteLegProgress private constructor(
-    private val legIndex: Int = 0,
-    private val routeLeg: RouteLeg? = null,
-    private val distanceTraveled: Float = 0f,
-    private val distanceRemaining: Float = 0f,
-    private val durationRemaining: Double = 0.0,
-    private val fractionTraveled: Float = 0f,
-    private val currentStepProgress: RouteStepProgress? = null,
-    private val upcomingStep: LegStep? = null,
-    private val builder: Builder
+data class RouteLegProgress(
+    val legIndex: Int,
+    val routeLeg: RouteLeg?,
+    val distanceTraveled: Float,
+    val distanceRemaining: Float,
+    val durationRemaining: Double,
+    val fractionTraveled: Float,
+    val currentStepProgress: RouteStepProgress?,
+    val upcomingStep: LegStep?
 ) {
-
     /**
-     * Index representing the current leg the user is on. If the directions route currently in use
-     * contains more then two waypoints, the route is likely to have multiple legs representing the
-     * distance between the two points.
-     *
-     * @return an integer representing the current leg the user is on
+     * Builder of [RouteLegProgress].
      */
-    fun legIndex(): Int = legIndex
-
-    /**
-     * This [RouteLeg] geometry.
-     *
-     * @return route leg geometry
-     */
-    fun routeLeg(): RouteLeg? = routeLeg
-
-    /**
-     * Total distance traveled in meters along current leg.
-     *
-     * @return a double value representing the total distance the user has traveled along the current
-     * leg, using unit meters.
-     */
-    fun distanceTraveled(): Float = distanceTraveled
-
-    /**
-     * Provides the distance remaining in meters until the user reaches the end of the leg.
-     *
-     * @return distance remaining till end of leg, in unit meters.
-     */
-    fun distanceRemaining(): Float = distanceRemaining
-
-    /**
-     * Provides the duration remaining in seconds until the user reaches the end of the current step.
-     *
-     * @return duration remaining till end of leg, in unit seconds.
-     */
-    fun durationRemaining(): Double = durationRemaining
-
-    /**
-     * Get the fraction traveled along the current leg, this is a float value between 0 and 1 and
-     * isn't guaranteed to reach 1 before the user reaches the next waypoint.
-     *
-     * @return a float value between 0 and 1 representing the fraction the user has traveled along the
-     * current leg
-     */
-    fun fractionTraveled(): Float = fractionTraveled
-
-    /**
-     * Gives a [RouteStepProgress] object with information about the particular step the user
-     * is currently on.
-     *
-     * @return a [RouteStepProgress] object
-     */
-    fun currentStepProgress(): RouteStepProgress? = currentStepProgress
-
-    /**
-     * Get the next/upcoming step immediately after the current step. If the user is on the last step
-     * on the last leg, this will return null since a next step doesn't exist.
-     *
-     * @return a [LegStep] representing the next step the user will be on.
-     */
-    fun upcomingStep(): LegStep? = upcomingStep
-
-    /**
-     * Get a builder to customize a subset of current options.
-     */
-    fun toBuilder() = builder
-
-    /**
-     * Builder of [RouteLegProgress]
-     *
-     * @param legIndex Index representing the current leg the user is on. If the directions route currently in use
-     * contains more then two waypoints, the route is likely to have multiple legs representing the
-     * distance between the two points.
-     * @param routeLeg [RouteLeg] geometry
-     * @param distanceTraveled Total distance traveled in meters along current leg
-     * @param distanceRemaining The distance remaining in meters until the user reaches the end of the leg
-     * @param durationRemaining The duration remaining in seconds until the user reaches the end of the current step
-     * @param fractionTraveled The fraction traveled along the current leg, this is a float value between 0 and 1 and
-     * isn't guaranteed to reach 1 before the user reaches the next waypoint
-     * @param currentStepProgress [RouteStepProgress] object with information about the particular step the user
-     * is currently on
-     * @param upcomingStep Next/upcoming step immediately after the current step. If the user is on the last step
-     * on the last leg, this will return null since a next step doesn't exist
-     */
-    data class Builder(
-        private var legIndex: Int = 0,
-        private var routeLeg: RouteLeg? = null,
-        private var distanceTraveled: Float = 0f,
-        private var distanceRemaining: Float = 0f,
-        private var durationRemaining: Double = 0.0,
-        private var fractionTraveled: Float = 0f,
-        private var currentStepProgress: RouteStepProgress? = null,
+    class Builder {
+        private var legIndex: Int = 0
+        private var routeLeg: RouteLeg? = null
+        private var distanceTraveled: Float = 0f
+        private var distanceRemaining: Float = 0f
+        private var durationRemaining: Double = 0.0
+        private var fractionTraveled: Float = 0f
+        private var currentStepProgress: RouteStepProgress? = null
         private var upcomingStep: LegStep? = null
-    ) {
 
         /**
          * Index representing the current leg the user is on. If the directions route currently in use
@@ -200,8 +129,7 @@ class RouteLegProgress private constructor(
                 durationRemaining,
                 fractionTraveled,
                 currentStepProgress,
-                upcomingStep,
-                this
+                upcomingStep
             )
         }
     }

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteProgress.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteProgress.kt
@@ -12,174 +12,63 @@ import com.mapbox.geojson.Point
  * With every new valid location update, a new route progress will be generated using the latest
  * information.
  *
- * The latest route progress object can be obtained through the [com.mapbox.navigation.base.trip.RouteProgressObserver].
+ * The latest route progress object can be obtained through the [com.mapbox.navigation.core.trip.session.RouteProgressObserver].
  * Note that the route progress object's immutable.
+ *
+ * @param route [DirectionsRoute] the navigation session is currently using. When a reroute occurs and a new
+ * directions route gets obtained, with the next location update this directions route should
+ * reflect the new route.
+ * @param routeGeometryWithBuffer [Geometry] of the current [DirectionsRoute] with a buffer
+ * that encompasses visible tile surface are while navigating. This [Geometry] is ideal
+ * for offline downloads of map or routing tile data.
+ * @param bannerInstructions [BannerInstructions] current instructions for visual guidance.
+ * @param voiceInstructions [VoiceInstructions] current instruction for audio guidance.
+ * @param currentState [RouteProgressState] the current state of progress along the route.
+ * Provides route and location tracking information.
+ * @param currentLegProgress [RouteLegProgress] current progress of the active leg, includes
+ * time and distance estimations.
+ * @param upcomingStepPoints [List][Point] location coordinates describing the upcoming step.
+ * @param inTunnel [Boolean] value indicating whether the current location is in a tunnel.
+ * @param distanceRemaining [Float] provides the distance remaining in meters until the user
+ * reaches the end of the route.
+ * @param distanceTraveled [Float] representing the distance traveled along the route in meters.
+ * @param durationRemaining [Double] seconds time remaining until the route destination is reached.
+ * @param fractionTraveled [Float] fraction traveled along the current route. This value is
+ * between 0 and 1 and isn't guaranteed to reach 1 before the user reaches the end of the route.
+ * @param remainingWaypoints [Int] number of waypoints remaining on the current route.
  */
-class RouteProgress private constructor(
-    private val route: DirectionsRoute? = null,
-    private val routeGeometryWithBuffer: Geometry? = null,
-    private val bannerInstructions: BannerInstructions? = null,
-    private val voiceInstructions: VoiceInstructions? = null,
-    private val currentState: RouteProgressState? = null,
-    private val currentLegProgress: RouteLegProgress? = null,
-    private val upcomingStepPoints: List<Point>? = null,
-    private val inTunnel: Boolean = false,
-    private val distanceRemaining: Float = 0f,
-    private val distanceTraveled: Float = 0f,
-    private val durationRemaining: Double = 0.0,
-    private val fractionTraveled: Float = 0f,
-    private val remainingWaypoints: Int = 0,
-    private val builder: Builder
+data class RouteProgress(
+    val route: DirectionsRoute?,
+    val routeGeometryWithBuffer: Geometry?,
+    val bannerInstructions: BannerInstructions?,
+    val voiceInstructions: VoiceInstructions?,
+    val currentState: RouteProgressState?,
+    val currentLegProgress: RouteLegProgress?,
+    val upcomingStepPoints: List<Point>?,
+    val inTunnel: Boolean,
+    val distanceRemaining: Float,
+    val distanceTraveled: Float,
+    val durationRemaining: Double,
+    val fractionTraveled: Float,
+    val remainingWaypoints: Int
 ) {
-
-    /**
-     * Get the route the navigation session is currently using. When a reroute occurs and a new
-     * directions route gets obtained, with the next location update this directions route should
-     * reflect the new route.
-     *
-     * @return a [DirectionsRoute] currently being used for the navigation session
-     */
-    fun route() = route
-
-    /**
-     * Total distance traveled in meters along route.
-     *
-     * @return a Float value representing the total distance the user has traveled along the route,
-     * using unit meters
-     */
-    fun distanceTraveled(): Float = distanceTraveled
-
-    /**
-     * Provides the duration remaining in seconds until the user reaches the end of the route.
-     *
-     * @return Double value representing the duration remaining till end of route, in seconds
-     */
-    fun durationRemaining(): Double = durationRemaining
-
-    /**
-     * Get the fraction traveled along the current route, this is a float value between 0 and 1 and
-     * isn't guaranteed to reach 1 before the user reaches the end of the route.
-     *
-     * @return a Float value between 0 and 1 representing the fraction the user has traveled along the
-     * route
-     */
-    private fun fractionTraveled(): Float? = fractionTraveled
-
-    /**
-     * Provides the distance remaining in meters until the user reaches the end of the route.
-     *
-     * @return `long` value representing the distance remaining till end of route, in unit meters
-     */
-    fun distanceRemaining(): Float = distanceRemaining
-
-    /**
-     * Number of waypoints remaining on the current route.
-     *
-     * @return integer value representing the number of way points remaining along the route
-     */
-    fun remainingWaypoints(): Int = remainingWaypoints
-
-    /**
-     * Gives a [RouteLegProgress] object with information about the particular leg the user is
-     * currently on.
-     *
-     * @return a [RouteLegProgress] object
-     */
-    fun currentLegProgress() = currentLegProgress
-
-    /**
-     * Provides a list of points that represent the upcoming step
-     * step geometry.
-     *
-     * @return list of points representing the upcoming step
-     */
-    fun upcomingStepPoints() = upcomingStepPoints
-
-    /**
-     * Returns whether or not the location updates are
-     * considered in a tunnel along the route.
-     *
-     * @return *true* if in a tunnel, *false* otherwise
-     */
-    fun inTunnel() = inTunnel
-
-    /**
-     * Current banner instruction.
-     *
-     * @return current banner instruction
-     */
-    fun bannerInstructions() = bannerInstructions
-
-    /**
-     * Current voice instruction.
-     *
-     * @return current voice instruction
-     */
-    fun voiceInstructions() = voiceInstructions
-
-    /**
-     * Returns the current state of progress along the route.  Provides route and location tracking
-     * information.
-     *
-     * @return the current state of progress along the route.
-     */
-    fun currentState() = currentState
-
-    /**
-     * Returns the current [DirectionsRoute] geometry with a buffer
-     * that encompasses visible tile surface are while navigating.
-     *
-     * This [Geometry] is ideal for offline downloads of map or routing tile
-     * data.
-     *
-     * @return current route geometry with buffer
-     */
-    fun routeGeometryWithBuffer() = routeGeometryWithBuffer
-
-    /**
-     * Get a builder to customize a subset of current options.
-     */
-    fun toBuilder() = builder
-
     /**
      * Builder for [RouteProgress]
-     *
-     * @param directionsRoute [DirectionsRoute] currently is used for the navigation session
-     * @param routeGeometryWithBuffer Current [DirectionsRoute] geometry with a buffer
-     * that encompasses visible tile surface are while navigating.
-     *
-     * This [Geometry] is ideal for offline downloads of map or routing tile
-     * data.
-     *
-     * @param bannerInstructions Current banner instruction.
-     * @param voiceInstructions Current voice instruction.
-     * @param currentState The current state of progress along the route.  Provides route and location
-     * tracking information.
-     * @param currentLegProgress [RouteLegProgress] object with information about the particular
-     * leg the user is currently on.
-     * @param upcomingStepPoints The list of points that represent the upcoming step geometry.
-     * @param inTunnel *true* if in a tunnel, *false* otherwise
-     * @param distanceRemaining The distance remaining in meters until the user reaches the end of the route
-     * @param distanceTraveled Total distance traveled in meters along route
-     * @param durationRemaining The duration remaining in seconds until the user reaches the end of the route
-     * @param fractionTraveled Float
-     * @param remainingWaypoints Number of waypoints remaining on the current route
      */
-    data class Builder(
-        private var directionsRoute: DirectionsRoute? = null,
-        private var routeGeometryWithBuffer: Geometry? = null,
-        private var bannerInstructions: BannerInstructions? = null,
-        private var voiceInstructions: VoiceInstructions? = null,
-        private var currentState: RouteProgressState? = null,
-        private var currentLegProgress: RouteLegProgress? = null,
-        private var upcomingStepPoints: List<Point>? = null,
-        private var inTunnel: Boolean = false,
-        private var distanceRemaining: Float = 0f,
-        private var distanceTraveled: Float = 0f,
-        private var durationRemaining: Double = 0.0,
-        private var fractionTraveled: Float = 0f,
+    class Builder {
+        private var directionsRoute: DirectionsRoute? = null
+        private var routeGeometryWithBuffer: Geometry? = null
+        private var bannerInstructions: BannerInstructions? = null
+        private var voiceInstructions: VoiceInstructions? = null
+        private var currentState: RouteProgressState? = null
+        private var currentLegProgress: RouteLegProgress? = null
+        private var upcomingStepPoints: List<Point>? = null
+        private var inTunnel: Boolean = false
+        private var distanceRemaining: Float = 0f
+        private var distanceTraveled: Float = 0f
+        private var durationRemaining: Double = 0.0
+        private var fractionTraveled: Float = 0f
         private var remainingWaypoints: Int = 0
-    ) {
 
         /**
          * [DirectionsRoute] currently is used for the navigation session
@@ -310,8 +199,7 @@ class RouteProgress private constructor(
                 distanceTraveled,
                 durationRemaining,
                 fractionTraveled,
-                remainingWaypoints,
-                this
+                remainingWaypoints
             )
         }
     }

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteStepProgress.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteStepProgress.kt
@@ -6,110 +6,42 @@ import com.mapbox.geojson.Point
 /**
  * This is a progress object specific to the current step the user is on.
  *
- * The latest route step progress object can be obtained through the [com.mapbox.navigation.base.trip.RouteProgressObserver].
+ * The latest route step progress object can be obtained through the [com.mapbox.navigation.core.trip.session.RouteProgressObserver].
  * Note that the route step progress object's immutable.
+ *
+ * @param stepIndex [Int] Index representing the current step the user is on
+ * @param step [LegStep] Returns the current step the user is traversing along
+ * @param stepPoints [List][Point] that represent the current step geometry
+ * @param distanceRemaining [Float] Total distance in meters from user to end of step
+ * @param distanceTraveled [Float] Distance user has traveled along current step in unit meters
+ * @param fractionTraveled [Float] The fraction traveled along the current step, this is a
+ * float value between 0 and 1 and isn't guaranteed to reach 1 before the user reaches the
+ * next step (if another step exist in route)
+ * @param durationRemaining [Double] The duration remaining in seconds until the user reaches the end of the current step
+ * @param guidanceViewURL [String] Guidance image URL
  */
-class RouteStepProgress private constructor(
-    private val stepIndex: Int = 0,
-    private val step: LegStep? = null,
-    private val stepPoints: List<Point>? = null,
-    private val distanceRemaining: Float = 0f,
-    private val distanceTraveled: Float = 0f,
-    private val fractionTraveled: Float = 0f,
-    private val durationRemaining: Double = 0.0,
-    private val guidanceViewURL: String? = null,
-    private val builder: Builder
+data class RouteStepProgress(
+    val stepIndex: Int,
+    val step: LegStep?,
+    val stepPoints: List<Point>?,
+    val distanceRemaining: Float,
+    val distanceTraveled: Float,
+    val fractionTraveled: Float,
+    val durationRemaining: Double,
+    val guidanceViewURL: String?
 ) {
-
-    /**
-     * Index representing the current step the user is on.
-     *
-     * @return an integer representing the current step the user is on
-     */
-    fun stepIndex(): Int = stepIndex
-
-    /**
-     * Returns the current step the user is traversing along.
-     *
-     * @return a [LegStep] representing the step the user is currently on
-     */
-    fun step(): LegStep? = step
-
-    /**
-     * Provides a list of points that represent the current step
-     * step geometry.
-     *
-     * @return list of points representing the current step
-     */
-    fun stepPoints() = stepPoints
-
-    /**
-     * Total distance in meters from user to end of step.
-     *
-     * @return float value representing the distance the user has remaining till they reach the end
-     * of the current step. Uses unit meters.
-     */
-    fun distanceRemaining(): Float = distanceRemaining
-
-    /**
-     * Returns distance user has traveled along current step in unit meters.
-     *
-     * @return double value representing the distance the user has traveled so far along the current
-     * step. Uses unit meters.
-     */
-    fun distanceTraveled(): Float = distanceTraveled
-
-    /**
-     * Get the fraction traveled along the current step, this is a float value between 0 and 1 and
-     * isn't guaranteed to reach 1 before the user reaches the next step (if another step exist in route).
-     *
-     * @return a float value between 0 and 1 representing the fraction the user has traveled along
-     * the current step.
-     */
-    fun fractionTraveled(): Float = fractionTraveled
-
-    /**
-     * Provides the duration remaining in seconds till the user reaches the end of the current step.
-     *
-     * @return duration remaining till end of step, in unit seconds.
-     */
-    fun durationRemaining(): Double = durationRemaining
-
-    /**
-     * Provides guidance image URL
-     *
-     * @return `long` value representing the duration remaining till end of step, in unit seconds.
-     */
-    fun guidanceViewURL(): String? = guidanceViewURL
-
-    /**
-     * Get a builder to customize a subset of current options.
-     */
-    fun toBuilder() = builder
-
     /**
      * Builder of [RouteStepProgress]
-     *
-     * @param stepIndex Index representing the current step the user is on
-     * @param step Returns the current step the user is traversing along
-     * @param stepPoints A list of points that represent the current step geometry
-     * @param distanceRemaining Total distance in meters from user to end of step
-     * @param distanceTraveled Distance user has traveled along current step in unit meters
-     * @param fractionTraveled The fraction traveled along the current step, this is a float value between 0 and 1 and
-     * isn't guaranteed to reach 1 before the user reaches the next step (if another step exist in route)
-     * @param durationRemaining The duration remaining in seconds until the user reaches the end of the current step
-     * @param guidanceViewURL Guidance image URL
      */
-    data class Builder(
-        private var stepIndex: Int = 0,
-        private var step: LegStep? = null,
-        private var stepPoints: List<Point>? = null,
-        private var distanceRemaining: Float = 0f,
-        private var distanceTraveled: Float = 0f,
-        private var fractionTraveled: Float = 0f,
-        private var durationRemaining: Double = 0.0,
+    class Builder {
+        private var stepIndex: Int = 0
+        private var step: LegStep? = null
+        private var stepPoints: List<Point>? = null
+        private var distanceRemaining: Float = 0f
+        private var distanceTraveled: Float = 0f
+        private var fractionTraveled: Float = 0f
+        private var durationRemaining: Double = 0.0
         private var guidanceViewURL: String? = null
-    ) {
 
         /**
          * Index representing the current step the user is on
@@ -124,7 +56,8 @@ class RouteStepProgress private constructor(
          *
          * @return Builder
          */
-        fun step(step: LegStep) = apply { this.step = step }
+        fun step(step: LegStep) =
+            apply { this.step = step }
 
         /**
          * A list of points that represent the current step geometry
@@ -189,8 +122,7 @@ class RouteStepProgress private constructor(
                 distanceTraveled,
                 fractionTraveled,
                 durationRemaining,
-                guidanceViewURL,
-                this
+                guidanceViewURL
             )
         }
     }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/AdjustedRouteOptionsProvider.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/AdjustedRouteOptionsProvider.kt
@@ -16,7 +16,7 @@ internal object AdjustedRouteOptionsProvider {
 
         val optionsBuilder = routeOptions.toBuilder()
         val coordinates = routeOptions.coordinates()
-        routeProgress.currentLegProgress()?.legIndex()?.let { index ->
+        routeProgress.currentLegProgress?.legIndex?.let { index ->
             optionsBuilder
                 .coordinates(
                     coordinates.drop(index + 1).toMutableList().apply {

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/fasterroute/FasterRouteDetector.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/fasterroute/FasterRouteDetector.kt
@@ -6,7 +6,7 @@ import com.mapbox.navigation.base.trip.model.RouteProgress
 internal class FasterRouteDetector {
     fun isRouteFaster(newRoute: DirectionsRoute, routeProgress: RouteProgress): Boolean {
         val newRouteDuration = newRoute.duration() ?: return false
-        val weightedDuration = routeProgress.durationRemaining() * PERCENTAGE_THRESHOLD
+        val weightedDuration = routeProgress.durationRemaining * PERCENTAGE_THRESHOLD
         return newRouteDuration < weightedDuration
     }
 

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/MapboxDistanceFormatter.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/MapboxDistanceFormatter.kt
@@ -35,7 +35,8 @@ class MapboxDistanceFormatter private constructor(
     private val context: Context,
     private val locale: Locale,
     @VoiceUnit.Type unitType: String,
-    @Rounding.Increment private val roundingIncrement: Int
+    @Rounding.Increment private val roundingIncrement: Int,
+    private val builder: Builder
 ) : DistanceFormatter {
 
     private val smallUnit = when (unitType) {
@@ -62,11 +63,15 @@ class MapboxDistanceFormatter private constructor(
         fun builder(context: Context): Builder = Builder(context)
     }
 
+    fun toBuilder() = builder
+
     /**
      * Builder of [MapboxDistanceFormatter]
      * @param context is application's [Context]
      */
-    class Builder(private val context: Context) {
+    class Builder(
+        private val context: Context
+    ) {
         private var unitType: String? = null
         private var locale: Locale? = null
         private var roundingIncrement = 0
@@ -82,7 +87,7 @@ class MapboxDistanceFormatter private constructor(
         /**
          * Minimal value that distance might be stripped
          *
-         * @see [RoundingIncrement]
+         * @see [Rounding.Increment]
          * @return Builder
          */
         fun withRoundingIncrement(@Rounding.Increment roundingIncrement: Int) =
@@ -111,7 +116,8 @@ class MapboxDistanceFormatter private constructor(
                 context.applicationContext,
                 localeToUse,
                 unitTypeToUse,
-                roundingIncrement)
+                roundingIncrement,
+                this)
         }
     }
 

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route2/ReplayProgressObserver.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route2/ReplayProgressObserver.kt
@@ -37,7 +37,7 @@ class ReplayProgressObserver(
      * @param routeProgress from the navigation session
      */
     override fun onRouteProgressChanged(routeProgress: RouteProgress) {
-        val routeProgressRouteLeg = routeProgress.currentLegProgress()?.routeLeg()
+        val routeProgressRouteLeg = routeProgress.currentLegProgress?.routeLeg
         if (routeProgressRouteLeg != currentRouteLeg) {
             this.currentRouteLeg = routeProgressRouteLeg
             onRouteLegChanged(routeProgressRouteLeg)

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/routerefresh/RouteRefreshController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/routerefresh/RouteRefreshController.kt
@@ -38,7 +38,7 @@ internal class RouteRefreshController(
         return routerRefreshTimer.startTimer {
             val route = tripSession.route?.takeIf { supportsRefresh(it) }
             route?.let {
-                val legIndex = tripSession.getRouteProgress()?.currentLegProgress()?.legIndex() ?: 0
+                val legIndex = tripSession.getRouteProgress()?.currentLegProgress?.legIndex ?: 0
                 directionsSession.requestRouteRefresh(
                     route,
                     legIndex,

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/stops/ArrivalProgressObserver.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/stops/ArrivalProgressObserver.kt
@@ -29,10 +29,10 @@ internal class ArrivalProgressObserver(
 
     fun navigateNextRouteLeg(): Boolean {
         val routeProgress = tripSession.getRouteProgress()
-        val numberOfLegs = routeProgress?.route()?.legs()?.size
+        val numberOfLegs = routeProgress?.route?.legs()?.size
             ?: return false
-        val legProgress = routeProgress.currentLegProgress()
-        val legIndex = legProgress?.legIndex()
+        val legProgress = routeProgress.currentLegProgress
+        val legIndex = legProgress?.legIndex
             ?: return false
         val nextLegIndex = legIndex + 1
         val nextLegStarted = if (nextLegIndex < numberOfLegs) {
@@ -48,34 +48,34 @@ internal class ArrivalProgressObserver(
     }
 
     override fun onRouteProgressChanged(routeProgress: RouteProgress) {
-        val routeLegProgress = routeProgress.currentLegProgress()
+        val routeLegProgress = routeProgress.currentLegProgress
             ?: return
 
         val arrivalOptions = arrivalController.arrivalOptions()
-        if (routeProgress.currentState() == RouteProgressState.ROUTE_ARRIVED && !hasMoreLegs(routeProgress)) {
+        if (routeProgress.currentState == RouteProgressState.ROUTE_ARRIVED && !hasMoreLegs(routeProgress)) {
             doOnFinalDestinationArrival(routeProgress)
         } else if (arrivalOptions.arrivalInSeconds != null) {
             checkWaypointArrivalTime(arrivalOptions.arrivalInSeconds, routeLegProgress)
         } else if (arrivalOptions.arrivalInMeters != null) {
             checkWaypointArrivalDistance(arrivalOptions.arrivalInMeters, routeLegProgress)
         }
-        finalDestinationArrived = (routeProgress.currentState() ?: RouteProgressState.ROUTE_UNCERTAIN) == RouteProgressState.ROUTE_ARRIVED
+        finalDestinationArrived = (routeProgress.currentState ?: RouteProgressState.ROUTE_UNCERTAIN) == RouteProgressState.ROUTE_ARRIVED
     }
 
     private fun hasMoreLegs(routeProgress: RouteProgress): Boolean {
-        val currentLegIndex = routeProgress.currentLegProgress()?.legIndex()
-        val lastLegIndex = routeProgress.route()?.legs()?.lastIndex
+        val currentLegIndex = routeProgress.currentLegProgress?.legIndex
+        val lastLegIndex = routeProgress.route?.legs()?.lastIndex
         return (currentLegIndex != null && lastLegIndex != null) && currentLegIndex < lastLegIndex
     }
 
     private fun checkWaypointArrivalTime(arrivalInSeconds: Double, routeLegProgress: RouteLegProgress) {
-        if (routeLegProgress.durationRemaining() <= arrivalInSeconds) {
+        if (routeLegProgress.durationRemaining <= arrivalInSeconds) {
             doOnWaypointArrival(routeLegProgress)
         }
     }
 
     private fun checkWaypointArrivalDistance(arrivalInMeters: Double, routeLegProgress: RouteLegProgress) {
-        if (routeLegProgress.distanceRemaining() <= arrivalInMeters) {
+        if (routeLegProgress.distanceRemaining <= arrivalInMeters) {
             doOnWaypointArrival(routeLegProgress)
         }
     }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetry.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetry.kt
@@ -564,10 +564,10 @@ internal object MapboxNavigationTelemetry : MapboxNavigationTelemetryInterface {
         while (coroutineContext.isActive && continueRunning) {
             try {
                 val routeData = callbackDispatcher.getRouteProgressChannel().receive()
-                dynamicValues.distanceCompleted.set(dynamicValues.distanceCompleted.get() + routeData.routeProgress.distanceTraveled())
-                dynamicValues.distanceRemaining.set(routeData.routeProgress.distanceRemaining().toLong())
-                dynamicValues.durationRemaining.set(routeData.routeProgress.durationRemaining().toInt())
-                when (routeData.routeProgress.currentState()) {
+                dynamicValues.distanceCompleted.set(dynamicValues.distanceCompleted.get() + routeData.routeProgress.distanceTraveled)
+                dynamicValues.distanceRemaining.set(routeData.routeProgress.distanceRemaining.toLong())
+                dynamicValues.durationRemaining.set(routeData.routeProgress.durationRemaining.toInt())
+                when (routeData.routeProgress.currentState) {
                     RouteProgressState.ROUTE_ARRIVED -> {
                         when (dynamicValues.sessionStarted.get()) {
                             true -> {
@@ -581,8 +581,8 @@ internal object MapboxNavigationTelemetry : MapboxNavigationTelemetryInterface {
                         }
                     } // END
                     RouteProgressState.LOCATION_TRACKING -> {
-                        dynamicValues.timeRemaining.set(callbackDispatcher.getRouteProgress().routeProgress.durationRemaining().toInt())
-                        dynamicValues.distanceRemaining.set(callbackDispatcher.getRouteProgress().routeProgress.distanceRemaining().toLong())
+                        dynamicValues.timeRemaining.set(callbackDispatcher.getRouteProgress().routeProgress.durationRemaining.toInt())
+                        dynamicValues.distanceRemaining.set(callbackDispatcher.getRouteProgress().routeProgress.distanceRemaining.toLong())
                         when (trackingEvent > 20) {
                             true -> {
                                 Log.i(TAG, "LOCATION_TRACKING received $trackingEvent")
@@ -644,13 +644,13 @@ internal object MapboxNavigationTelemetry : MapboxNavigationTelemetryInterface {
             eventLocation = newLocation ?: callbackDispatcher.getLastLocation() ?: Location("unknown")
 
             eventDate = Date()
-            eventRouteDistanceCompleted = callbackDispatcher.getRouteProgress().routeProgress.distanceTraveled().toDouble()
+            eventRouteDistanceCompleted = callbackDispatcher.getRouteProgress().routeProgress.distanceTraveled.toDouble()
             originalDirectionRoute = callbackDispatcher.getOriginalRouteReadOnly()?.route
-            currentDirectionRoute = callbackDispatcher.getRouteProgress().routeProgress.route()
+            currentDirectionRoute = callbackDispatcher.getRouteProgress().routeProgress.route
             sessionIdentifier = dynamicValues.sessionId
             tripIdentifier = dynamicValues.tripIdentifier.get()
             originalRequestIdentifier = callbackDispatcher.getOriginalRouteReadOnly()?.route?.routeOptions()?.requestUuid()
-            requestIdentifier = callbackDispatcher.getRouteProgress().routeProgress.route()?.routeOptions()?.requestUuid()
+            requestIdentifier = callbackDispatcher.getRouteProgress().routeProgress.route?.routeOptions()?.requestUuid()
             mockLocation = locationEngineName == MOCK_PROVIDER
             rerouteCount = dynamicValues.rerouteCount.get()
             startTimestamp = dynamicValues.sessionStartTime
@@ -662,15 +662,15 @@ internal object MapboxNavigationTelemetry : MapboxNavigationTelemetryInterface {
     }
 
     private fun populateNavigationEvent(navigationEvent: NavigationEvent, route: DirectionsRoute? = null, newLocation: Location? = null) {
-        val directionsRoute = route ?: callbackDispatcher.getRouteProgress().routeProgress.route()
+        val directionsRoute = route ?: callbackDispatcher.getRouteProgress().routeProgress.route
         val location = newLocation ?: callbackDispatcher.getLastLocation()
         navigationEvent.startTimestamp = TelemetryUtils.generateCreateDateFormatted(dynamicValues.sessionStartTime)
         navigationEvent.sdkIdentifier = generateSdkIdentifier()
         navigationEvent.sessionIdentifier = dynamicValues.sessionId
-        navigationEvent.geometry = callbackDispatcher.getRouteProgress().routeProgress.route()?.geometry()
-        navigationEvent.profile = callbackDispatcher.getRouteProgress().routeProgress.route()?.routeOptions()?.profile()
+        navigationEvent.geometry = callbackDispatcher.getRouteProgress().routeProgress.route?.geometry()
+        navigationEvent.profile = callbackDispatcher.getRouteProgress().routeProgress.route?.routeOptions()?.profile()
         navigationEvent.originalRequestIdentifier = callbackDispatcher.getOriginalRouteReadOnly()?.route?.routeOptions()?.requestUuid()
-        navigationEvent.requestIdentifier = callbackDispatcher.getRouteProgress().routeProgress.route()?.routeOptions()?.requestUuid()
+        navigationEvent.requestIdentifier = callbackDispatcher.getRouteProgress().routeProgress.route?.routeOptions()?.requestUuid()
         navigationEvent.originalGeometry = callbackDispatcher.getOriginalRouteReadOnly()?.route?.geometry()
         navigationEvent.locationEngine = locationEngineNameExternal
         navigationEvent.tripIdentifier = TelemetryUtils.obtainUniversalUniqueIdentifier()
@@ -689,11 +689,11 @@ internal object MapboxNavigationTelemetry : MapboxNavigationTelemetryInterface {
         navigationEvent.rerouteCount = dynamicValues.rerouteCount.get()
         navigationEvent.originalEstimatedDistance = callbackDispatcher.getOriginalRouteReadOnly()?.route?.distance()?.toInt() ?: 0
         navigationEvent.originalEstimatedDuration = callbackDispatcher.getOriginalRouteReadOnly()?.route?.duration()?.toInt() ?: 0
-        navigationEvent.stepCount = obtainStepCount(callbackDispatcher.getRouteProgress().routeProgress.route())
+        navigationEvent.stepCount = obtainStepCount(callbackDispatcher.getRouteProgress().routeProgress.route)
         navigationEvent.originalStepCount = obtainStepCount(callbackDispatcher.getOriginalRouteReadOnly()?.route)
-        navigationEvent.legIndex = callbackDispatcher.getRouteProgress().routeProgress.route()?.routeIndex()?.toInt() ?: 0
-        navigationEvent.legCount = callbackDispatcher.getRouteProgress().routeProgress.route()?.legs()?.size ?: 0
-        navigationEvent.stepIndex = callbackDispatcher.getRouteProgress().routeProgress.currentLegProgress()?.currentStepProgress()?.stepIndex() ?: 0
+        navigationEvent.legIndex = callbackDispatcher.getRouteProgress().routeProgress.route?.routeIndex()?.toInt() ?: 0
+        navigationEvent.legCount = callbackDispatcher.getRouteProgress().routeProgress.route?.legs()?.size ?: 0
+        navigationEvent.stepIndex = callbackDispatcher.getRouteProgress().routeProgress.currentLegProgress?.currentStepProgress?.stepIndex ?: 0
 
         // TODO:OZ voiceIndex is not available in SDK 1.0 and was not set in the legacy telemetry        navigationEvent.voiceIndex
         // TODO:OZ bannerIndex is not available in SDK 1.0 and was not set in the legacy telemetry        navigationEvent.bannerIndex

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/TelemetryLocationAndProgressDispatcher.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/TelemetryLocationAndProgressDispatcher.kt
@@ -215,7 +215,7 @@ internal class TelemetryLocationAndProgressDispatcher(scope: CoroutineScope) :
         val data = RouteProgressWithTimestamp(Time.SystemImpl.millis(), routeProgress)
         this.routeProgress.set(data)
         channelOnRouteProgress.offer(data)
-        if (routeProgress.currentState() == RouteProgressState.ROUTE_ARRIVED) {
+        if (routeProgress.currentState == RouteProgressState.ROUTE_ARRIVED) {
             routeProgressPredicate.set { progress -> afterArrival(progress) }
         }
     }
@@ -225,12 +225,12 @@ internal class TelemetryLocationAndProgressDispatcher(scope: CoroutineScope) :
      * It stores the route progress data without notifying listeners.
      */
     private fun afterArrival(routeProgress: RouteProgress) {
-        when (routeProgress.currentState()) {
+        when (routeProgress.currentState) {
             priorState -> {
             }
             else -> {
-                priorState = routeProgress.currentState() ?: priorState
-                Log.d(TAG, "route progress state = ${routeProgress.currentState()}")
+                priorState = routeProgress.currentState ?: priorState
+                Log.d(TAG, "route progress state = ${routeProgress.currentState}")
             }
         }
         val data = RouteProgressWithTimestamp(Time.SystemImpl.millis(), routeProgress)

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/events/MetricsRouteProgress.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/events/MetricsRouteProgress.kt
@@ -67,21 +67,21 @@ internal class MetricsRouteProgress(routeProgress: RouteProgress?) {
     init {
         ifNonNull(
             routeProgress,
-            routeProgress?.route(),
-            routeProgress?.currentLegProgress(),
-            routeProgress?.distanceRemaining(),
-            routeProgress?.durationRemaining()
+            routeProgress?.route,
+            routeProgress?.currentLegProgress,
+            routeProgress?.distanceRemaining,
+            routeProgress?.durationRemaining
         ) { _routeProgress, _directionsRoute, _currentLegProgress, _distanceRemaining, _durationRemaining ->
             obtainRouteData(_directionsRoute)
             obtainLegData(_currentLegProgress)
             obtainStepData(_routeProgress)
             distanceRemaining = _distanceRemaining.toInt()
             durationRemaining = _durationRemaining.toInt()
-            distanceTraveled = _routeProgress.distanceTraveled().toInt()
-            legIndex = _routeProgress.currentLegProgress()?.legIndex() ?: 0
+            distanceTraveled = _routeProgress.distanceTraveled.toInt()
+            legIndex = _routeProgress.currentLegProgress?.legIndex ?: 0
             legCount = _directionsRoute.legs()?.size ?: 0
-            stepIndex = _currentLegProgress.currentStepProgress()?.stepIndex() ?: 0
-            stepCount = _routeProgress.currentLegProgress()?.routeLeg()?.steps()?.size ?: 0
+            stepIndex = _currentLegProgress.currentStepProgress?.stepIndex ?: 0
+            stepCount = _routeProgress.currentLegProgress?.routeLeg?.steps()?.size ?: 0
         } ?: initDefaultValues()
     }
 
@@ -107,16 +107,16 @@ internal class MetricsRouteProgress(routeProgress: RouteProgress?) {
     }
 
     private fun obtainLegData(legProgress: RouteLegProgress) {
-        currentStepDistance = legProgress.currentStepProgress()?.step()?.distance()?.toInt() ?: 0
-        currentStepDuration = legProgress.currentStepProgress()?.step()?.duration()?.toInt() ?: 0
-        currentStepDistanceRemaining = legProgress.currentStepProgress()?.distanceRemaining()?.toInt() ?: 0
-        currentStepDurationRemaining = legProgress.currentStepProgress()?.durationRemaining()?.toInt() ?: 0
-        currentStepName = legProgress.currentStepProgress()?.step()?.name() ?: ""
+        currentStepDistance = legProgress.currentStepProgress?.step?.distance()?.toInt() ?: 0
+        currentStepDuration = legProgress.currentStepProgress?.step?.duration()?.toInt() ?: 0
+        currentStepDistanceRemaining = legProgress.currentStepProgress?.distanceRemaining?.toInt() ?: 0
+        currentStepDurationRemaining = legProgress.currentStepProgress?.durationRemaining?.toInt() ?: 0
+        currentStepName = legProgress.currentStepProgress?.step?.name() ?: ""
     }
 
     private fun obtainStepData(routeProgress: RouteProgress) {
-        val legProgress = routeProgress.currentLegProgress()
-        legProgress?.upcomingStep()?.let { upcomingStep ->
+        val legProgress = routeProgress.currentLegProgress
+        legProgress?.upcomingStep?.let { upcomingStep ->
             upcomingStepName = upcomingStep.name()
             upcomingStep.maneuver().let {
                 upcomingStepInstruction = it.instruction()
@@ -124,7 +124,7 @@ internal class MetricsRouteProgress(routeProgress: RouteProgress?) {
                 upcomingStepModifier = it.modifier()
             }
         }
-        legProgress?.currentStepProgress()?.step()?.maneuver().let { stepManeuver ->
+        legProgress?.currentStepProgress?.step?.maneuver().let { stepManeuver ->
             previousStepInstruction = stepManeuver?.instruction()
             previousStepType = stepManeuver?.type()
             previousStepModifier = stepManeuver?.modifier()

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/BannerInstructionEvent.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/BannerInstructionEvent.kt
@@ -12,7 +12,7 @@ internal class BannerInstructionEvent {
     fun isOccurring(routeProgress: RouteProgress): Boolean = updateCurrentBanner(routeProgress)
 
     private fun updateCurrentBanner(routeProgress: RouteProgress): Boolean =
-        ifNonNull(routeProgress.bannerInstructions()) {
+        ifNonNull(routeProgress.bannerInstructions) {
             bannerInstructions = it
             true
         } ?: false

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/VoiceInstructionEvent.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/VoiceInstructionEvent.kt
@@ -13,7 +13,7 @@ internal class VoiceInstructionEvent {
         updateCurrentAnnouncement(routeProgress)
 
     private fun updateCurrentAnnouncement(routeProgress: RouteProgress): Boolean =
-        ifNonNull(routeProgress.voiceInstructions()) {
+        ifNonNull(routeProgress.voiceInstructions) {
             voiceInstructions = it
             true
         } ?: false

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/fasterroute/FasterRouteControllerTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/fasterroute/FasterRouteControllerTest.kt
@@ -121,7 +121,7 @@ class FasterRouteControllerTest {
             every { longitude } returns 151.206087
         }
         every { tripSession.getRouteProgress() } returns mockk {
-            every { durationRemaining() } returns 601.334
+            every { durationRemaining } returns 601.334
         }
         every { directionsSession.requestFasterRoute(any(), capture(routesRequestCallbacks)) } returns mockk()
 
@@ -151,7 +151,7 @@ class FasterRouteControllerTest {
             every { longitude } returns 151.206087
         }
         every { tripSession.getRouteProgress() } returns mockk {
-            every { durationRemaining() } returns 751.334
+            every { durationRemaining } returns 751.334
         }
         every { directionsSession.requestFasterRoute(any(), capture(routesRequestCallbacks)) } returns mockk()
 

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/fasterroute/FasterRouteDetectorTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/fasterroute/FasterRouteDetectorTest.kt
@@ -17,7 +17,7 @@ class FasterRouteDetectorTest {
         val newRoute: DirectionsRoute = mockk()
         every { newRoute.duration() } returns 402.6
         val routeProgress: RouteProgress = mockk()
-        every { routeProgress.durationRemaining() } returns 797.447
+        every { routeProgress.durationRemaining } returns 797.447
 
         val isFasterRoute = fasterRouteDetector.isRouteFaster(newRoute, routeProgress)
 
@@ -29,7 +29,7 @@ class FasterRouteDetectorTest {
         val newRoute: DirectionsRoute = mockk()
         every { newRoute.duration() } returns 512.2
         val routeProgress: RouteProgress = mockk()
-        every { routeProgress.durationRemaining() } returns 450.501
+        every { routeProgress.durationRemaining } returns 450.501
 
         val isFasterRoute = fasterRouteDetector.isRouteFaster(newRoute, routeProgress)
 
@@ -41,7 +41,7 @@ class FasterRouteDetectorTest {
         val newRoute: DirectionsRoute = mockk()
         every { newRoute.duration() } returns null
         val routeProgress: RouteProgress = mockk()
-        every { routeProgress.durationRemaining() } returns 727.228
+        every { routeProgress.durationRemaining } returns 727.228
 
         val isFasterRoute = fasterRouteDetector.isRouteFaster(newRoute, routeProgress)
 
@@ -53,7 +53,7 @@ class FasterRouteDetectorTest {
         val newRoute: DirectionsRoute = mockk()
         every { newRoute.duration() } returns 634.7
         val routeProgress: RouteProgress = mockk()
-        every { routeProgress.durationRemaining() } returns 695.811
+        every { routeProgress.durationRemaining } returns 695.811
 
         val isFasterRoute = fasterRouteDetector.isRouteFaster(newRoute, routeProgress)
 

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/internal/trip/session/MapboxTripSessionTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/internal/trip/session/MapboxTripSessionTest.kt
@@ -106,8 +106,8 @@ class MapboxTripSessionTest {
         every { tripStatus.enhancedLocation } returns enhancedLocation
         every { tripStatus.keyPoints } returns keyPoints
         every { tripStatus.offRoute } returns false
-        every { routeProgress.bannerInstructions() } returns null
-        every { routeProgress.voiceInstructions() } returns null
+        every { routeProgress.bannerInstructions } returns null
+        every { routeProgress.voiceInstructions } returns null
 
         every {
             locationEngine.requestLocationUpdates(
@@ -471,8 +471,8 @@ class MapboxTripSessionTest {
 
     @Test
     fun unregisterAllLocationObservers() = coroutineRule.runBlockingTest {
-        every { routeProgress.bannerInstructions() } returns null
-        every { routeProgress.voiceInstructions() } returns null
+        every { routeProgress.bannerInstructions } returns null
+        every { routeProgress.voiceInstructions } returns null
 
         tripSession.start()
         val observer: LocationObserver = mockk(relaxUnitFun = true)
@@ -554,8 +554,8 @@ class MapboxTripSessionTest {
         val bannerInstructionsObserver: BannerInstructionsObserver = mockk(relaxUnitFun = true)
         val bannerInstructions: BannerInstructions = mockk()
 
-        every { routeProgress.bannerInstructions() } returns bannerInstructions
-        every { routeProgress.voiceInstructions() } returns null
+        every { routeProgress.bannerInstructions } returns bannerInstructions
+        every { routeProgress.voiceInstructions } returns null
         every { tripStatus.offRoute } returns true
 
         tripSession = MapboxTripSession(
@@ -588,8 +588,8 @@ class MapboxTripSessionTest {
     fun unregisterAllVoiceInstructionsObservers() = coroutineRule.runBlockingTest {
         val voiceInstructionsObserver: VoiceInstructionsObserver = mockk(relaxUnitFun = true)
         val voiceInstructions: VoiceInstructions = mockk()
-        every { routeProgress.bannerInstructions() } returns null
-        every { routeProgress.voiceInstructions() } returns voiceInstructions
+        every { routeProgress.bannerInstructions } returns null
+        every { routeProgress.voiceInstructions } returns voiceInstructions
         every { tripStatus.offRoute } returns true
 
         tripSession = MapboxTripSession(

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/stops/ArrivalProgressObserverTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/stops/ArrivalProgressObserverTest.kt
@@ -32,16 +32,16 @@ internal class ArrivalProgressObserverTest {
     @Test
     fun `should not crash with null route progress values`() {
         val routeProgress: RouteProgress = mockk {
-            every { currentState() } returns RouteProgressState.LOCATION_TRACKING
-            every { route() } returns mockk {
+            every { currentState } returns RouteProgressState.LOCATION_TRACKING
+            every { route } returns mockk {
                 every { legs() } returns listOf(
                     mockk(), mockk(), mockk() // This route has three legs
                 )
                 every { routeIndex() } returns null
-                every { currentLegProgress() } returns mockk {
-                    every { legIndex() } returns 0
-                    every { durationRemaining() } returns 0.0
-                    every { distanceRemaining() } returns 0.0f
+                every { currentLegProgress } returns mockk {
+                    every { legIndex } returns 0
+                    every { durationRemaining } returns 0.0
+                    every { distanceRemaining } returns 0.0f
                 }
             }
         }
@@ -63,14 +63,14 @@ internal class ArrivalProgressObserverTest {
 
         arrivalProgressObserver.attach(customArrivalController)
         arrivalProgressObserver.onRouteProgressChanged(mockk {
-            every { currentState() } returns RouteProgressState.ROUTE_ARRIVED
-            every { route() } returns mockk {
+            every { currentState } returns RouteProgressState.ROUTE_ARRIVED
+            every { route } returns mockk {
                 every { legs() } returns listOf(mockk(), mockk(), mockk())
             }
-            every { currentLegProgress() } returns mockk {
-                every { legIndex() } returns 1
-                every { durationRemaining() } returns 2.0
-                every { distanceRemaining() } returns 8.0f
+            every { currentLegProgress } returns mockk {
+                every { legIndex } returns 1
+                every { durationRemaining } returns 2.0
+                every { distanceRemaining } returns 8.0f
             }
         })
 
@@ -93,14 +93,14 @@ internal class ArrivalProgressObserverTest {
 
         arrivalProgressObserver.attach(customArrivalController)
         arrivalProgressObserver.onRouteProgressChanged(mockk {
-            every { currentState() } returns RouteProgressState.ROUTE_ARRIVED
-            every { route() } returns mockk {
+            every { currentState } returns RouteProgressState.ROUTE_ARRIVED
+            every { route } returns mockk {
                 every { legs() } returns listOf(mockk(), mockk(), mockk())
             }
-            every { currentLegProgress() } returns mockk {
-                every { legIndex() } returns 2
-                every { durationRemaining() } returns 2.0
-                every { distanceRemaining() } returns 8.0f
+            every { currentLegProgress } returns mockk {
+                every { legIndex } returns 2
+                every { durationRemaining } returns 2.0
+                every { distanceRemaining } returns 8.0f
             }
         })
 
@@ -121,14 +121,14 @@ internal class ArrivalProgressObserverTest {
         }
         every { arrivalObserver.onFinalDestinationArrival(capture(onFinalDestinationArrivalCalls)) } returns Unit
         val routeProgress: RouteProgress = mockk {
-            every { currentState() } returns RouteProgressState.ROUTE_ARRIVED
-            every { route() } returns mockk {
+            every { currentState } returns RouteProgressState.ROUTE_ARRIVED
+            every { route } returns mockk {
                 every { legs() } returns listOf(mockk(), mockk(), mockk())
             }
-            every { currentLegProgress() } returns mockk {
-                every { legIndex() } returns 2
-                every { durationRemaining() } returns 2.0
-                every { distanceRemaining() } returns 8.0f
+            every { currentLegProgress } returns mockk {
+                every { legIndex } returns 2
+                every { durationRemaining } returns 2.0
+                every { distanceRemaining } returns 8.0f
             }
         }
 
@@ -155,15 +155,15 @@ internal class ArrivalProgressObserverTest {
 
         arrivalProgressObserver.attach(customArrivalController)
         arrivalProgressObserver.onRouteProgressChanged(mockk {
-            every { currentState() } returns RouteProgressState.LOCATION_TRACKING
-            every { currentLegProgress() } returns mockk {
-                every { durationRemaining() } returns 1.0
-                every { distanceRemaining() } returns 15.0f
+            every { currentState } returns RouteProgressState.LOCATION_TRACKING
+            every { currentLegProgress } returns mockk {
+                every { durationRemaining } returns 1.0
+                every { distanceRemaining } returns 15.0f
             }
         })
 
         assertTrue(onArrivalCalls.isCaptured)
-        assertEquals(onArrivalCalls.captured.durationRemaining(), 1.0, 0.001)
+        assertEquals(onArrivalCalls.captured.durationRemaining, 1.0, 0.001)
     }
 
     @Test
@@ -179,14 +179,14 @@ internal class ArrivalProgressObserverTest {
 
         arrivalProgressObserver.attach(customArrivalController)
         arrivalProgressObserver.onRouteProgressChanged(mockk {
-            every { currentState() } returns RouteProgressState.LOCATION_TRACKING
-            every { currentLegProgress() } returns mockk {
-                every { durationRemaining() } returns 2.0
-                every { distanceRemaining() } returns 8.0f
+            every { currentState } returns RouteProgressState.LOCATION_TRACKING
+            every { currentLegProgress } returns mockk {
+                every { durationRemaining } returns 2.0
+                every { distanceRemaining } returns 8.0f
             }
         })
 
-        assertEquals(onArrivalCalls.captured.distanceRemaining(), 8.0f, 0.001f)
+        assertEquals(onArrivalCalls.captured.distanceRemaining, 8.0f, 0.001f)
         verify(exactly = 0) { arrivalObserver.onFinalDestinationArrival(any()) }
     }
 
@@ -201,10 +201,10 @@ internal class ArrivalProgressObserverTest {
             }
         }
         val routeProgress: RouteProgress = mockk {
-            every { currentState() } returns RouteProgressState.LOCATION_TRACKING
-            every { currentLegProgress() } returns mockk {
-                every { durationRemaining() } returns 1.0
-                every { distanceRemaining() } returns 15.0f
+            every { currentState } returns RouteProgressState.LOCATION_TRACKING
+            every { currentLegProgress } returns mockk {
+                every { durationRemaining } returns 1.0
+                every { distanceRemaining } returns 15.0f
             }
         }
         every { tripSession.getRouteProgress() } returns routeProgress
@@ -228,10 +228,10 @@ internal class ArrivalProgressObserverTest {
 
         arrivalProgressObserver.attach(customArrivalController)
         arrivalProgressObserver.onRouteProgressChanged(mockk {
-            every { currentState() } returns RouteProgressState.LOCATION_TRACKING
-            every { currentLegProgress() } returns mockk {
-                every { durationRemaining() } returns 360.0
-                every { distanceRemaining() } returns 80.0f
+            every { currentState } returns RouteProgressState.LOCATION_TRACKING
+            every { currentLegProgress } returns mockk {
+                every { durationRemaining } returns 360.0
+                every { distanceRemaining } returns 80.0f
             }
         })
 
@@ -241,13 +241,13 @@ internal class ArrivalProgressObserverTest {
     @Test
     fun `should navigate to next waypoint automatically by default`() {
         every { tripSession.getRouteProgress() } returns mockk {
-            every { route() } returns mockk {
+            every { route } returns mockk {
                 every { legs() } returns listOf(
                     mockk(), mockk(), mockk() // This route has three legs
                 )
                 every { routeIndex() } returns "0"
-                every { currentLegProgress() } returns mockk {
-                    every { legIndex() } returns 1
+                every { currentLegProgress } returns mockk {
+                    every { legIndex } returns 1
                 }
             }
         }
@@ -256,10 +256,10 @@ internal class ArrivalProgressObserverTest {
         }
 
         arrivalProgressObserver.onRouteProgressChanged(mockk {
-            every { currentState() } returns RouteProgressState.LOCATION_TRACKING
-            every { currentLegProgress() } returns mockk {
-                every { durationRemaining() } returns 0.0
-                every { distanceRemaining() } returns 0.0f
+            every { currentState } returns RouteProgressState.LOCATION_TRACKING
+            every { currentLegProgress } returns mockk {
+                every { durationRemaining } returns 0.0
+                every { distanceRemaining } returns 0.0f
             }
         })
 
@@ -270,16 +270,16 @@ internal class ArrivalProgressObserverTest {
     fun `should navigate to next waypoint automatically using options`() {
         val testNavigateNextRouteLeg = true
         val routeProgress: RouteProgress = mockk {
-            every { currentState() } returns RouteProgressState.LOCATION_TRACKING
-            every { route() } returns mockk {
+            every { currentState } returns RouteProgressState.LOCATION_TRACKING
+            every { route } returns mockk {
                 every { legs() } returns listOf(
                     mockk(), mockk(), mockk() // This route has three legs
                 )
                 every { routeIndex() } returns "0"
-                every { currentLegProgress() } returns mockk {
-                    every { legIndex() } returns 0
-                    every { durationRemaining() } returns 0.0
-                    every { distanceRemaining() } returns 0.0f
+                every { currentLegProgress } returns mockk {
+                    every { legIndex } returns 0
+                    every { durationRemaining } returns 0.0
+                    every { distanceRemaining } returns 0.0f
                 }
             }
         }
@@ -305,16 +305,16 @@ internal class ArrivalProgressObserverTest {
     fun `should not navigate to next waypoint automatically using options`() {
         val testNavigateNextRouteLeg = false
         every { tripSession.getRouteProgress() } returns mockk {
-            every { currentState() } returns RouteProgressState.LOCATION_TRACKING
-            every { route() } returns mockk {
+            every { currentState } returns RouteProgressState.LOCATION_TRACKING
+            every { route } returns mockk {
                 every { legs() } returns listOf(
                     mockk(), mockk(), mockk() // This route has three legs
                 )
                 every { routeIndex() } returns "0"
-                every { currentLegProgress() } returns mockk {
-                    every { legIndex() } returns 0
-                    every { durationRemaining() } returns 0.0
-                    every { distanceRemaining() } returns 0.0f
+                every { currentLegProgress } returns mockk {
+                    every { legIndex } returns 0
+                    every { durationRemaining } returns 0.0
+                    every { distanceRemaining } returns 0.0f
                 }
             }
         }
@@ -334,14 +334,14 @@ internal class ArrivalProgressObserverTest {
     @Test
     fun `navigateNextRouteLeg should return true when route leg is updated`() {
         every { tripSession.getRouteProgress() } returns mockk {
-            every { currentState() } returns RouteProgressState.LOCATION_TRACKING
-            every { route() } returns mockk {
+            every { currentState } returns RouteProgressState.LOCATION_TRACKING
+            every { route } returns mockk {
                 every { legs() } returns listOf(
                     mockk(), mockk(), mockk() // This route has three legs
                 )
                 every { routeIndex() } returns "0"
-                every { currentLegProgress() } returns mockk {
-                    every { legIndex() } returns 1
+                every { currentLegProgress } returns mockk {
+                    every { legIndex } returns 1
                 }
             }
         }
@@ -357,14 +357,14 @@ internal class ArrivalProgressObserverTest {
     @Test
     fun `navigateNextRouteLeg should return false when route leg is not updated`() {
         every { tripSession.getRouteProgress() } returns mockk {
-            every { currentState() } returns RouteProgressState.LOCATION_TRACKING
-            every { route() } returns mockk {
+            every { currentState } returns RouteProgressState.LOCATION_TRACKING
+            every { route } returns mockk {
                 every { legs() } returns listOf(
                     mockk(), mockk(), mockk() // This route has three legs
                 )
                 every { routeIndex() } returns "0"
-                every { currentLegProgress() } returns mockk {
-                    every { legIndex() } returns 2
+                every { currentLegProgress } returns mockk {
+                    every { legIndex } returns 2
                 }
             }
         }
@@ -384,14 +384,14 @@ internal class ArrivalProgressObserverTest {
         every { arrivalObserver.onNextRouteLegStart(capture(onNavigateNextRouteLegCalls)) } returns Unit
         every { arrivalObserver.onFinalDestinationArrival(capture(onFinalDestinationArrivalCalls)) } returns Unit
         every { tripSession.getRouteProgress() } returns mockk {
-            every { currentState() } returns RouteProgressState.LOCATION_TRACKING
-            every { route() } returns mockk {
+            every { currentState } returns RouteProgressState.LOCATION_TRACKING
+            every { route } returns mockk {
                 every { legs() } returns listOf(
                     mockk(), mockk(), mockk() // This route has three legs
                 )
                 every { routeIndex() } returns "0"
-                every { currentLegProgress() } returns mockk {
-                    every { legIndex() } returns 1
+                every { currentLegProgress } returns mockk {
+                    every { legIndex } returns 1
                 }
             }
         }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/MapOfflineManager.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/MapOfflineManager.java
@@ -45,10 +45,10 @@ class MapOfflineManager implements RouteProgressObserver {
 
   @Override
   public void onRouteProgressChanged(@NotNull RouteProgress routeProgress) {
-    Geometry currentRouteGeometry = routeProgress.routeGeometryWithBuffer();
+    Geometry currentRouteGeometry = routeProgress.getRouteGeometryWithBuffer();
     if (previousRouteGeometry == null || !previousRouteGeometry.equals(currentRouteGeometry)) {
       previousRouteGeometry = currentRouteGeometry;
-      String routeSummary = routeProgress.route().routeOptions().requestUuid();
+      String routeSummary = routeProgress.getRoute().routeOptions().requestUuid();
       download(routeSummary, previousRouteGeometry, regionDownloadCallback);
     }
   }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/camera/DynamicCamera.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/camera/DynamicCamera.java
@@ -44,7 +44,7 @@ public class DynamicCamera extends SimpleCamera {
 
     RouteProgress progress = routeInformation.getRouteProgress();
     if (progress != null) {
-      double distanceRemaining = progress.currentLegProgress().currentStepProgress().distanceRemaining();
+      double distanceRemaining = progress.getCurrentLegProgress().getCurrentStepProgress().getDistanceRemaining();
       return createTilt(distanceRemaining);
     }
     return super.tilt(routeInformation);
@@ -111,7 +111,7 @@ public class DynamicCamera extends SimpleCamera {
       return DEFAULT_ZOOM;
     }
     boolean routeProgressIsUncertain = routeInformation.getRouteProgress() != null
-            && routeInformation.getRouteProgress().currentState() == RouteProgressState.ROUTE_UNCERTAIN;
+            && routeInformation.getRouteProgress().getCurrentState() == RouteProgressState.ROUTE_UNCERTAIN;
 
     if (routeProgressIsUncertain) {
       return DEFAULT_ZOOM;
@@ -134,7 +134,7 @@ public class DynamicCamera extends SimpleCamera {
    * @return camera position that encompasses both locations
    */
   private CameraPosition createCameraPosition(Location location, RouteProgress routeProgress) {
-    LegStep upComingStep = routeProgress.currentLegProgress().upcomingStep();
+    LegStep upComingStep = routeProgress.getCurrentLegProgress().getUpcomingStep();
     if (upComingStep != null) {
       Point stepManeuverPoint = upComingStep.maneuver().location();
 
@@ -174,8 +174,8 @@ public class DynamicCamera extends SimpleCamera {
    */
   private boolean isNewStep(RouteProgress routeProgress) {
     boolean isNewStep = currentStep == null
-      || !currentStep.equals(routeProgress.currentLegProgress().currentStepProgress().step());
-    currentStep = routeProgress.currentLegProgress().currentStepProgress().step();
+      || !currentStep.equals(routeProgress.getCurrentLegProgress().getCurrentStepProgress().getStep());
+    currentStep = routeProgress.getCurrentLegProgress().getCurrentStepProgress().getStep();
     resetAlertLevels(isNewStep);
     return isNewStep;
   }
@@ -199,13 +199,13 @@ public class DynamicCamera extends SimpleCamera {
       || isLowAlert(progress)
       || isMediumAlert(progress)
       || isHighAlert(progress)
-      || progress.currentState() == RouteProgressState.ROUTE_UNCERTAIN;
+      || progress.getCurrentState() == RouteProgressState.ROUTE_UNCERTAIN;
   }
 
   private boolean isLowAlert(RouteProgress progress) {
     if (!hasPassedLowAlertLevel) {
-      double durationRemaining = progress.currentLegProgress().currentStepProgress().durationRemaining();
-      double stepDuration = progress.currentLegProgress().currentStepProgress().step().duration();
+      double durationRemaining = progress.getCurrentLegProgress().getCurrentStepProgress().getDurationRemaining();
+      double stepDuration = progress.getCurrentLegProgress().getCurrentStepProgress().getStep().duration();
       boolean isLowAlert = durationRemaining < NavigationConstants.NAVIGATION_LOW_ALERT_DURATION;
       boolean hasValidStepDuration = stepDuration > NavigationConstants.NAVIGATION_LOW_ALERT_DURATION;
       if (hasValidStepDuration && isLowAlert) {
@@ -218,8 +218,8 @@ public class DynamicCamera extends SimpleCamera {
 
   private boolean isMediumAlert(RouteProgress progress) {
     if (!hasPassedMediumAlertLevel) {
-      double durationRemaining = progress.currentLegProgress().currentStepProgress().durationRemaining();
-      double stepDuration = progress.currentLegProgress().currentStepProgress().step().duration();
+      double durationRemaining = progress.getCurrentLegProgress().getCurrentStepProgress().getDurationRemaining();
+      double stepDuration = progress.getCurrentLegProgress().getCurrentStepProgress().getStep().duration();
       boolean isMediumAlert = durationRemaining < NavigationConstants.NAVIGATION_MEDIUM_ALERT_DURATION;
       boolean hasValidStepDuration = stepDuration > NavigationConstants.NAVIGATION_MEDIUM_ALERT_DURATION;
       if (hasValidStepDuration && isMediumAlert) {
@@ -232,8 +232,8 @@ public class DynamicCamera extends SimpleCamera {
 
   private boolean isHighAlert(RouteProgress progress) {
     if (!hasPassedHighAlertLevel) {
-      double durationRemaining = progress.currentLegProgress().currentStepProgress().durationRemaining();
-      double stepDuration = progress.currentLegProgress().currentStepProgress().step().duration();
+      double durationRemaining = progress.getCurrentLegProgress().getCurrentStepProgress().getDurationRemaining();
+      double stepDuration = progress.getCurrentLegProgress().getCurrentStepProgress().getStep().duration();
       boolean isHighAlert = durationRemaining < NavigationConstants.NAVIGATION_HIGH_ALERT_DURATION;
       boolean hasValidStepDuration = stepDuration > NavigationConstants.NAVIGATION_HIGH_ALERT_DURATION;
       if (hasValidStepDuration && isHighAlert) {

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/camera/NavigationCamera.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/camera/NavigationCamera.java
@@ -241,7 +241,7 @@ public class NavigationCamera {
   public void showRouteOverview(int[] padding) {
     updateCameraTrackingMode(NAVIGATION_TRACKING_MODE_NONE);
     RouteInformation routeInformation =
-      new RouteInformation(currentRouteProgress.route(), null, null);
+      new RouteInformation(currentRouteProgress.getRoute(), null, null);
     animateCameraForRouteOverview(routeInformation, padding);
   }
 

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/camera/SimpleCamera.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/camera/SimpleCamera.kt
@@ -46,7 +46,7 @@ open class SimpleCamera : Camera() {
         ifNonNull(routeInformation.route) { route ->
             setupLineStringAndBearing(route)
         }
-            ?: ifNonNull(routeInformation.routeProgress?.route()) { directionsRoute ->
+            ?: ifNonNull(routeInformation.routeProgress?.route) { directionsRoute ->
                 setupLineStringAndBearing(directionsRoute)
             }
     }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/instruction/InstructionModel.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/instruction/InstructionModel.java
@@ -20,13 +20,13 @@ public class InstructionModel {
   public InstructionModel(@NonNull DistanceFormatter distanceFormatter, @Nullable RouteProgress progress) {
     if (progress != null) {
       this.progress = progress;
-      RouteLegProgress legProgress = progress.currentLegProgress();
+      RouteLegProgress legProgress = progress.getCurrentLegProgress();
       if (legProgress != null) {
-        RouteStepProgress stepProgress = legProgress.currentStepProgress();
+        RouteStepProgress stepProgress = legProgress.getCurrentStepProgress();
         if (stepProgress != null) {
-          double distanceRemaining = stepProgress.distanceRemaining();
+          double distanceRemaining = stepProgress.getDistanceRemaining();
           stepDistanceRemaining = distanceFormatter.formatDistance(distanceRemaining);
-          LegStep step = stepProgress.step();
+          LegStep step = stepProgress.getStep();
           if (step != null) {
             this.drivingSide = step.drivingSide();
           }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/instruction/InstructionView.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/instruction/InstructionView.java
@@ -288,12 +288,12 @@ public class InstructionView extends RelativeLayout implements LifecycleObserver
       float currentStepDistanceTraveled = 0f;
       String guidanceUrl = null;
 
-      RouteLegProgress legProgress = routeProgress.currentLegProgress();
-      if (legProgress != null && legProgress.currentStepProgress() != null) {
-        guidanceUrl = legProgress.currentStepProgress().guidanceViewURL();
-        if (legProgress.currentStepProgress().step() != null) {
-          currentStepTotalDistance = legProgress.currentStepProgress().step().distance();
-          currentStepDistanceTraveled = legProgress.currentStepProgress().distanceTraveled();
+      RouteLegProgress legProgress = routeProgress.getCurrentLegProgress();
+      if (legProgress != null && legProgress.getCurrentStepProgress() != null) {
+        guidanceUrl = legProgress.getCurrentStepProgress().getGuidanceViewURL();
+        if (legProgress.getCurrentStepProgress().getStep() != null) {
+          currentStepTotalDistance = legProgress.getCurrentStepProgress().getStep().distance();
+          currentStepDistanceTraveled = legProgress.getCurrentStepProgress().getDistanceTraveled();
         }
       }
       if (guidanceUrl != null && !this.guidanceImageUrl.equals(guidanceUrl)) {
@@ -813,8 +813,8 @@ public class InstructionView extends RelativeLayout implements LifecycleObserver
    */
   private boolean newStep(RouteProgress routeProgress) {
     boolean newStep = currentStep == null
-      || !currentStep.equals(routeProgress.currentLegProgress().currentStepProgress().step());
-    currentStep = routeProgress.currentLegProgress().currentStepProgress().step();
+      || !currentStep.equals(routeProgress.getCurrentLegProgress().getCurrentStepProgress().getStep());
+    currentStep = routeProgress.getCurrentLegProgress().getCurrentStepProgress().getStep();
     return newStep;
   }
 
@@ -955,7 +955,7 @@ public class InstructionView extends RelativeLayout implements LifecycleObserver
     updateDistanceText(model);
     updateInstructionList(model);
     if (newStep(model.retrieveProgress())) {
-      LegStep upComingStep = model.retrieveProgress().currentLegProgress().upcomingStep();
+      LegStep upComingStep = model.retrieveProgress().getCurrentLegProgress().getUpcomingStep();
       ImageCreator.getInstance().prefetchImageCache(upComingStep);
     }
   }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/MapFpsDelegate.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/MapFpsDelegate.java
@@ -6,6 +6,7 @@ import com.mapbox.api.directions.v5.models.ManeuverModifier;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.navigation.base.trip.model.RouteLegProgress;
 import com.mapbox.navigation.base.trip.model.RouteProgress;
+import com.mapbox.navigation.base.trip.model.RouteStepProgress;
 import com.mapbox.navigation.core.MapboxNavigation;
 import com.mapbox.navigation.core.trip.session.RouteProgressObserver;
 import com.mapbox.navigation.ui.camera.NavigationCamera;
@@ -99,7 +100,7 @@ class MapFpsDelegate implements OnTrackingModeChangedListener, OnTrackingModeTra
 
   private int determineMaxFpsFrom(RouteProgress routeProgress, Context context) {
     final boolean isPluggedIn = batteryMonitor.isPluggedIn(context);
-    RouteLegProgress routeLegProgress = routeProgress.currentLegProgress();
+    RouteLegProgress routeLegProgress = routeProgress.getCurrentLegProgress();
 
     if (isPluggedIn) {
       return LOW_POWER_MAX_FPS;
@@ -111,9 +112,9 @@ class MapFpsDelegate implements OnTrackingModeChangedListener, OnTrackingModeTra
   }
 
   private boolean validLowFpsManeuver(RouteLegProgress routeLegProgress) {
-    if (routeLegProgress.currentStepProgress() != null
-        && routeLegProgress.currentStepProgress().step() != null) {
-      final String maneuverModifier = routeLegProgress.currentStepProgress().step().maneuver().modifier();
+    if (routeLegProgress.getCurrentStepProgress() != null
+        && routeLegProgress.getCurrentStepProgress().getStep() != null) {
+      final String maneuverModifier = routeLegProgress.getCurrentStepProgress().getStep().maneuver().modifier();
       return maneuverModifier != null
           && (maneuverModifier.equals(ManeuverModifier.STRAIGHT)
           || maneuverModifier.equals(ManeuverModifier.SLIGHT_LEFT)
@@ -123,9 +124,10 @@ class MapFpsDelegate implements OnTrackingModeChangedListener, OnTrackingModeTra
   }
 
   private boolean validLowFpsDuration(RouteLegProgress routeLegProgress) {
-    if (routeLegProgress.currentStepProgress() != null && routeLegProgress.currentStepProgress().step() != null) {
-      final double expectedStepDuration = routeLegProgress.currentStepProgress().step().duration();
-      final double durationUntilNextManeuver = routeLegProgress.currentStepProgress().durationRemaining();
+    RouteStepProgress currentStepProgress = routeLegProgress.getCurrentStepProgress();
+    if (currentStepProgress != null && currentStepProgress.getStep() != null) {
+      final double expectedStepDuration = routeLegProgress.getCurrentStepProgress().getStep().duration();
+      final double durationUntilNextManeuver = routeLegProgress.getCurrentStepProgress().getDurationRemaining();
       final double durationSincePreviousManeuver = expectedStepDuration - durationUntilNextManeuver;
       return durationUntilNextManeuver > VALID_DURATION_IN_SECONDS_UNTIL_NEXT_MANEUVER
           && durationSincePreviousManeuver > VALID_DURATION_IN_SECONDS_SINCE_PREVIOUS_MANEUVER;

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/MapWayNameChangeObserver.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/MapWayNameChangeObserver.java
@@ -32,6 +32,6 @@ class MapWayNameChangeObserver implements RouteProgressObserver, LocationObserve
 
   @Override
   public void onRouteProgressChanged(@NotNull RouteProgress routeProgress) {
-    mapWayName.updateProgress(routeProgress.currentLegProgress().currentStepProgress().stepPoints());
+    mapWayName.updateProgress(routeProgress.getCurrentLegProgress().getCurrentStepProgress().getStepPoints());
   }
 }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/puck/NavigationPuckPresenter.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/puck/NavigationPuckPresenter.kt
@@ -25,7 +25,7 @@ class NavigationPuckPresenter(private val mapboxMap: MapboxMap, puckDrawableSupp
 
     private val routeProgressObserver = object : RouteProgressObserver {
         override fun onRouteProgressChanged(routeProgress: RouteProgress) {
-            routeProgress.currentState()?.let {
+            routeProgress.currentState?.let {
                 val drawable = puckDrawableSupplier.getPuckDrawable(it)
                 updateCurrentLocationDrawable(drawable)
             }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteArrow.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteArrow.java
@@ -111,12 +111,12 @@ class MapRouteArrow {
   }
 
   void addUpcomingManeuverArrow(RouteProgress routeProgress) {
-    boolean invalidUpcomingStepPoints = routeProgress.upcomingStepPoints() == null
-            || routeProgress.upcomingStepPoints().size() < TWO_POINTS;
-    boolean invalidCurrentStepPoints = routeProgress.currentLegProgress() == null
-            || routeProgress.currentLegProgress().currentStepProgress() == null
-            || routeProgress.currentLegProgress().currentStepProgress().stepPoints() == null
-            || routeProgress.currentLegProgress().currentStepProgress().stepPoints().size() < TWO_POINTS;
+    boolean invalidUpcomingStepPoints = routeProgress.getUpcomingStepPoints() == null
+            || routeProgress.getUpcomingStepPoints().size() < TWO_POINTS;
+    boolean invalidCurrentStepPoints = routeProgress.getCurrentLegProgress() == null
+            || routeProgress.getCurrentLegProgress().getCurrentStepProgress() == null
+            || routeProgress.getCurrentLegProgress().getCurrentStepProgress().getStepPoints() == null
+            || routeProgress.getCurrentLegProgress().getCurrentStepProgress().getStepPoints().size() < TWO_POINTS;
     if (invalidUpcomingStepPoints || invalidCurrentStepPoints) {
       updateVisibilityTo(false);
       return;
@@ -149,11 +149,11 @@ class MapRouteArrow {
 
   private List<Point> obtainArrowPointsFrom(RouteProgress routeProgress) {
     List<Point> reversedCurrent =
-      new ArrayList<>(routeProgress.currentLegProgress().currentStepProgress().stepPoints());
+      new ArrayList<>(routeProgress.getCurrentLegProgress().getCurrentStepProgress().getStepPoints());
     Collections.reverse(reversedCurrent);
 
     LineString arrowLineCurrent = LineString.fromLngLats(reversedCurrent);
-    LineString arrowLineUpcoming = LineString.fromLngLats(routeProgress.upcomingStepPoints());
+    LineString arrowLineUpcoming = LineString.fromLngLats(routeProgress.getUpcomingStepPoints());
 
     LineString arrowCurrentSliced =
       TurfMisc.lineSliceAlong(arrowLineCurrent, 0, THIRTY, TurfConstants.UNIT_METERS);

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteProgressChangeListener.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteProgressChangeListener.kt
@@ -57,7 +57,7 @@ internal class MapRouteProgressChangeListener(
     }
 
     private fun updateRoute(directionsRoute: DirectionsRoute?, routeProgress: RouteProgress) {
-        val currentRoute = routeProgress.route()
+        val currentRoute = routeProgress.route
         val hasGeometry = currentRoute?.geometry()?.isNotEmpty() ?: false
         if (hasGeometry && currentRoute != directionsRoute) {
             routeLine.draw(currentRoute!!)
@@ -65,8 +65,8 @@ internal class MapRouteProgressChangeListener(
             if (vanishRouteLineEnabled && hasGeometry && (job == null || !job!!.isActive)) {
                 job = ThreadController.getMainScopeAndRootJob().scope.launch {
                     val totalDist =
-                        (routeProgress.distanceRemaining() + routeProgress.distanceTraveled())
-                    val dist = routeProgress.distanceTraveled() / totalDist
+                        (routeProgress.distanceRemaining + routeProgress.distanceTraveled)
+                    val dist = routeProgress.distanceTraveled / totalDist
                     if (dist > 0) {
                         val deferredExpression = async(Dispatchers.Default) {
                             routeLine.getExpressionAtOffset(dist)

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/summary/SummaryModel.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/summary/SummaryModel.java
@@ -23,10 +23,10 @@ public class SummaryModel {
 
   public SummaryModel(final Context context, final DistanceFormatter distanceFormatter, final RouteProgress progress,
                       final @TimeFormat.Type int timeFormatType) {
-    final Locale locale = progress.route() == null ? null :
-      LocaleEx.getLocaleDirectionsRoute(progress.route(), context);
-    distanceRemaining = distanceFormatter.formatDistance(progress.distanceRemaining()).toString();
-    final double legDurationRemaining = progress.currentLegProgress().durationRemaining();
+    final Locale locale = progress.getRoute() == null ? null :
+      LocaleEx.getLocaleDirectionsRoute(progress.getRoute(), context);
+    distanceRemaining = distanceFormatter.formatDistance(progress.getDistanceRemaining()).toString();
+    final double legDurationRemaining = progress.getCurrentLegProgress().getDurationRemaining();
     timeRemaining = TimeFormatter.formatTimeRemaining(context, legDurationRemaining, locale);
     final Calendar time = Calendar.getInstance();
 

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/summary/list/InstructionListPresenter.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/summary/list/InstructionListPresenter.java
@@ -114,10 +114,10 @@ class InstructionListPresenter {
   private void addBannerInstructions(RouteProgress routeProgress) {
     if (isNewLeg(routeProgress)) {
       instructions = new ArrayList<>();
-      currentLeg = routeProgress.currentLegProgress().routeLeg();
-      if (routeProgress.currentLegProgress().currentStepProgress() != null
-          && routeProgress.currentLegProgress().currentStepProgress().step() != null) {
-        drivingSide = routeProgress.currentLegProgress().currentStepProgress().step().drivingSide();
+      currentLeg = routeProgress.getCurrentLegProgress().getRouteLeg();
+      if (routeProgress.getCurrentLegProgress().getCurrentStepProgress() != null
+          && routeProgress.getCurrentLegProgress().getCurrentStepProgress().getStep() != null) {
+        drivingSide = routeProgress.getCurrentLegProgress().getCurrentStepProgress().getStep().drivingSide();
       }
       if (currentLeg != null) {
         List<LegStep> steps = currentLeg.steps();
@@ -132,16 +132,16 @@ class InstructionListPresenter {
   }
 
   private boolean isNewLeg(RouteProgress routeProgress) {
-    return currentLeg == null || !currentLeg.equals(routeProgress.currentLegProgress());
+    return currentLeg == null || !currentLeg.equals(routeProgress.getCurrentLegProgress());
   }
 
   private boolean updateInstructionList(RouteProgress routeProgress) {
     if (instructions.isEmpty()) {
       return false;
     }
-    RouteLegProgress legProgress = routeProgress.currentLegProgress();
-    LegStep currentStep = legProgress.currentStepProgress().step();
-    double stepDistanceRemaining = legProgress.currentStepProgress().distanceRemaining();
+    RouteLegProgress legProgress = routeProgress.getCurrentLegProgress();
+    LegStep currentStep = legProgress.getCurrentStepProgress().getStep();
+    double stepDistanceRemaining = legProgress.getCurrentStepProgress().getDistanceRemaining();
     BannerInstructions currentBannerInstructions = findCurrentBannerInstructions(
         currentStep, stepDistanceRemaining
     );

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/MapOfflineManagerTest.java
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/MapOfflineManagerTest.java
@@ -157,12 +157,12 @@ public class MapOfflineManagerTest {
 
   private RouteProgress buildMockRouteProgress(String routeSummary, Geometry routeBufferGeometry) {
     RouteProgress mockedRouteProgress = mock(RouteProgress.class);
-    when(mockedRouteProgress.routeGeometryWithBuffer()).thenReturn(routeBufferGeometry);
+    when(mockedRouteProgress.getRouteGeometryWithBuffer()).thenReturn(routeBufferGeometry);
     DirectionsRoute mockedRoute = mock(DirectionsRoute.class);
     RouteOptions mockedRouteOptions = mock(RouteOptions.class);
     when(mockedRouteOptions.requestUuid()).thenReturn(routeSummary);
     when(mockedRoute.routeOptions()).thenReturn(mockedRouteOptions);
-    when(mockedRouteProgress.route()).thenReturn(mockedRoute);
+    when(mockedRouteProgress.getRoute()).thenReturn(mockedRoute);
     return mockedRouteProgress;
   }
 

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/OfflineMetadataProviderTest.java
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/OfflineMetadataProviderTest.java
@@ -1,7 +1,5 @@
 package com.mapbox.navigation.ui;
 
-import com.mapbox.navigation.ui.OfflineMetadataProvider;
-
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/camera/DynamicCameraTest.java
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/camera/DynamicCameraTest.java
@@ -202,8 +202,7 @@ public class DynamicCameraTest extends BaseTest {
 
   @Nullable
   private List<Point> buildRouteCoordinatesFrom(RouteProgress routeProgress) {
-    DirectionsRoute route = routeProgress.route();
-    return generateRouteCoordinates(route);
+    return generateRouteCoordinates(routeProgress.getRoute());
   }
 
   @NonNull

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/puck/NavigationPuckPresenterTest.kt
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/puck/NavigationPuckPresenterTest.kt
@@ -32,7 +32,7 @@ class NavigationPuckPresenterTest {
         val drawableSlot = slot<Int>()
         every { mapboxMap.locationComponent } returns locationComponent
         every { locationComponent.locationComponentOptions } returns locationComponentOptions
-        every { routeProgress.currentState() } returns RouteProgressState.LOCATION_TRACKING
+        every { routeProgress.currentState } returns RouteProgressState.LOCATION_TRACKING
         every { locationComponentOptions.gpsDrawable() } returns 0
         every { locationComponentOptions.toBuilder() } returns builder
         every { builder.gpsDrawable(capture(drawableSlot)) } returns builder

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteProgressChangeListenerTest.kt
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteProgressChangeListenerTest.kt
@@ -44,7 +44,7 @@ class MapRouteProgressChangeListenerTest {
             every { geometry() } returns null
         }
         val routeProgress: RouteProgress = mockk {
-            every { route() } returns newRoute
+            every { route } returns newRoute
         }
         every { routeLine.getPrimaryRoute() } returns newRoute
 
@@ -59,7 +59,7 @@ class MapRouteProgressChangeListenerTest {
     fun `should not draw route without directions route`() {
         every { routeLine.getPrimaryRoute() } returns null
         val routeProgress: RouteProgress = mockk {
-            every { route() } returns null
+            every { route } returns null
         }
 
         progressChangeListener.updateVisibility(true)
@@ -77,7 +77,7 @@ class MapRouteProgressChangeListenerTest {
             }
         )
         val routeProgress: RouteProgress = mockk {
-            every { route() } returns mockk {
+            every { route } returns mockk {
                 every { geometry() } returns "y{v|bA{}diiGOuDpBiMhM{k@~Syj@bLuZlEiM"
             }
         }
@@ -102,7 +102,7 @@ class MapRouteProgressChangeListenerTest {
         every { routeLine.getPrimaryRoute() } returns routes[0]
         every { routeLine.retrieveDirectionsRoutes() } returns routes
         val routeProgress: RouteProgress = mockk {
-            every { route() } returns mockk {
+            every { route } returns mockk {
                 every { geometry() } returns "{au|bAqtiiiG|TnI`B\\dEzAl_@hMxGxB"
             }
         }
@@ -120,7 +120,7 @@ class MapRouteProgressChangeListenerTest {
             }
         )
         val routeProgress: RouteProgress = mockk {
-            every { route() } returns mockk {
+            every { route } returns mockk {
                 every { geometry() } returns "{au|bAqtiiiG|TnI`B\\dEzAl_@hMxGxB"
             }
         }
@@ -142,7 +142,7 @@ class MapRouteProgressChangeListenerTest {
             }
         )
         val routeProgress: RouteProgress = mockk {
-            every { route() } returns mockk {
+            every { route } returns mockk {
                 every { geometry() } returns "y{v|bA{}diiGOuDpBiMhM{k@~Syj@bLuZlEiM"
                 every { distance() } returns 100.0
             }

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/summary/SummaryModelTest.kt
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/summary/SummaryModelTest.kt
@@ -71,9 +71,8 @@ class SummaryModelTest : BaseTest() {
             .build()
         val time = Calendar.getInstance()
         val legDurationRemaining: Double = routeProgress!!
-            .currentLegProgress()!!
-            .durationRemaining()
-            .toDouble()
+            .currentLegProgress!!
+            .durationRemaining
         val expectedResult =
             formatTime(
                 time,

--- a/libtrip-notification/src/main/java/com/mapbox/navigation/trip/notification/MapboxTripNotification.kt
+++ b/libtrip-notification/src/main/java/com/mapbox/navigation/trip/notification/MapboxTripNotification.kt
@@ -293,16 +293,16 @@ class MapboxTripNotification constructor(
     }
 
     private fun updateNotificationViews(routeProgress: RouteProgress) {
-        routeProgress.route()?.let {
-            updateInstructionText(routeProgress.bannerInstructions())
+        routeProgress.route?.let {
+            updateInstructionText(routeProgress.bannerInstructions)
             updateDistanceText(routeProgress)
             generateArrivalTime(routeProgress)?.let { formattedTime ->
                 updateViewsWithArrival(formattedTime)
             }
-            routeProgress.bannerInstructions()?.let { bannerInstructions ->
+            routeProgress.bannerInstructions?.let { bannerInstructions ->
                 if (isManeuverStateChanged(bannerInstructions)) {
                     updateManeuverImage(
-                        routeProgress.currentLegProgress()?.currentStepProgress()?.step()?.drivingSide()
+                        routeProgress.currentLegProgress?.currentStepProgress?.step?.drivingSide()
                             ?: ManeuverModifier.RIGHT
                     )
                 }
@@ -394,9 +394,9 @@ class MapboxTripNotification constructor(
         if (currentDistanceText == null || newDistanceText(routeProgress)) {
             currentDistanceText = ifNonNull(
                 distanceFormatter,
-                routeProgress.currentLegProgress()
+                routeProgress.currentLegProgress
             ) { distanceFormatter, routeLegProgress ->
-                routeLegProgress.currentStepProgress()?.distanceRemaining()?.let {
+                routeLegProgress.currentStepProgress?.distanceRemaining?.let {
                     distanceFormatter.formatDistance(it.toDouble())
                 }
             }
@@ -415,8 +415,8 @@ class MapboxTripNotification constructor(
         routeProgress: RouteProgress,
         time: Calendar = Calendar.getInstance()
     ): String? =
-        ifNonNull(routeProgress.currentLegProgress()) { currentLegProgress ->
-            val legDurationRemaining = currentLegProgress.durationRemaining()
+        ifNonNull(routeProgress.currentLegProgress) { currentLegProgress ->
+            val legDurationRemaining = currentLegProgress.durationRemaining
             val timeFormatType = navigationOptions.timeFormatType
             val arrivalTime = formatTime(
                 time,
@@ -443,10 +443,10 @@ class MapboxTripNotification constructor(
     private fun newDistanceText(routeProgress: RouteProgress) =
         ifNonNull(
             distanceFormatter,
-            routeProgress.currentLegProgress(),
+            routeProgress.currentLegProgress,
             currentDistanceText
         ) { distanceFormatter, currentLegProgress, currentDistanceText ->
-            val item = currentLegProgress.currentStepProgress()?.distanceRemaining()
+            val item = currentLegProgress.currentStepProgress?.distanceRemaining
             // The call below can return an empty spannable string. toString() will cause a NPE and ?. will not catch it.
             val str = item?.let {
                 distanceFormatter.formatDistance(it.toDouble())

--- a/libtrip-notification/src/test/java/com/mapbox/navigation/trip/notification/MapboxTripNotificationTest.kt
+++ b/libtrip-notification/src/test/java/com/mapbox/navigation/trip/notification/MapboxTripNotificationTest.kt
@@ -330,7 +330,7 @@ class MapboxTripNotificationTest {
     @Test
     fun whenFreeDrive() {
         val routeProgress = mockk<RouteProgress>(relaxed = true)
-        every { routeProgress.route() } returns null
+        every { routeProgress.route } returns null
         mockUpdateNotificationAndroidInteractions()
 
         notification.onTripSessionStarted()
@@ -362,7 +362,7 @@ class MapboxTripNotificationTest {
     ): BannerText {
         val bannerText = mockk<BannerText>()
         val bannerInstructions = mockk<BannerInstructions>()
-        every { routeProgress.bannerInstructions() } returns bannerInstructions
+        every { routeProgress.bannerInstructions } returns bannerInstructions
         every { bannerInstructions.primary() } returns bannerText
         every { bannerText.text() } answers { primaryText() }
         every { bannerText.type() } answers { primaryType() }
@@ -377,9 +377,9 @@ class MapboxTripNotificationTest {
         duration: Double
     ): RouteLegProgress {
         val currentLegProgress = mockk<RouteLegProgress>(relaxed = true)
-        every { routeProgress.currentLegProgress() } returns currentLegProgress
-        every { currentLegProgress.currentStepProgress()?.distanceRemaining() } returns distance
-        every { currentLegProgress.durationRemaining() } returns duration
+        every { routeProgress.currentLegProgress } returns currentLegProgress
+        every { currentLegProgress.currentStepProgress?.distanceRemaining } returns distance
+        every { currentLegProgress.durationRemaining } returns duration
         return currentLegProgress
     }
 


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Addresses https://github.com/mapbox/mapbox-navigation-android/issues/2709

[Document recording design decisions](https://docs.google.com/document/d/16CpedUXG0yPxt0QPoWZrROA9UJVJ9Iwm6qCH2aEoS6c/edit?usp=sharing)

This pull request is starting to address our inconsistent builders. Considering this is a significant SEMVER, talking offline if we still want to do it.

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal
Create a consistent builder pattern for our public [domain entity types](https://martinfowler.com/bliki/EvansClassification.html) with `Builders`

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->