### PR TITLE
Remove unused default from old replay

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayLocationConverter.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayLocationConverter.kt
@@ -1,4 +1,4 @@
-package com.mapbox.navigation.core.internal.replay.route
+package com.mapbox.navigation.core.replay.route
 
 import android.location.Location
 import com.mapbox.api.directions.v5.models.DirectionsRoute
@@ -9,7 +9,7 @@ import com.mapbox.geojson.Point
  * The [ReplayLocationConverter] interface is for the [ReplayRouteLocationEngine] to interpolate
  * speed and time on the route.
  */
-interface ReplayLocationConverter {
+internal interface ReplayLocationConverter {
 
     /**
      * *true* if route has more than one leg, *false* otherwise

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayRouteLocationConverter.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayRouteLocationConverter.kt
@@ -4,7 +4,6 @@ import android.location.Location
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.geojson.LineString
 import com.mapbox.geojson.Point
-import com.mapbox.navigation.core.internal.replay.route.ReplayLocationConverter
 import com.mapbox.turf.TurfConstants
 import com.mapbox.turf.TurfMeasurement
 

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayRouteLocationEngine.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayRouteLocationEngine.kt
@@ -13,26 +13,24 @@ import com.mapbox.base.common.logger.Logger
 import com.mapbox.base.common.logger.model.Message
 import com.mapbox.geojson.LineString
 import com.mapbox.geojson.Point
-import com.mapbox.navigation.core.internal.replay.route.ReplayLocationConverter
 import java.util.ArrayList
 
 /**
  * Mock [LocationEngine] for replaying route movement through [DirectionsRoute]
  *
- * @param logger [Logger](optional)
- * @param converter ReplayLocationConverter
+ * @param logger [Logger] (optional)
  */
 class ReplayRouteLocationEngine @JvmOverloads constructor(
-    val logger: Logger? = null,
-    private val converter: ReplayLocationConverter = ReplayRouteLocationConverter(
-        DEFAULT_SPEED,
-        DEFAULT_DELAY
-    )
+    val logger: Logger? = null
 ) : LocationEngine, Runnable {
 
     private var speed = DEFAULT_SPEED
     private var delay = DEFAULT_DELAY
     private val handler: Handler = Handler()
+    private val converter: ReplayLocationConverter = ReplayRouteLocationConverter(
+        DEFAULT_SPEED,
+        DEFAULT_DELAY
+    )
     private lateinit var mockedLocations: MutableList<Location>
     private lateinit var dispatcher: ReplayLocationDispatcher
     private lateinit var replayLocationListener: ReplayRouteLocationListener


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

No need to expose `ReplayRouteLocationConverter` because it is internal. Thanks @Guardiola31337.

Also note that these classes are being replaced by the new replay.

- [ ] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->