### PR TITLE
fix #2994 InstructionListView fade edge color

### DIFF
--- a/libnavigation-ui/src/main/res/values/styles.xml
+++ b/libnavigation-ui/src/main/res/values/styles.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <style name="NavigationMapRoute">
         <!-- Colors -->
@@ -26,6 +26,7 @@
     </style>
 
     <style name="NavigationViewLight" parent="Theme.MaterialComponents.Light.NoActionBar">
+        <item name="android:colorPrimary" tools:targetApi="lollipop">@android:color/white</item>
         <item name="navigationViewPrimary">@color/mapbox_navigation_view_color_primary</item>
         <item name="navigationViewSecondary">@color/mapbox_navigation_view_color_secondary</item>
         <item name="navigationViewAccent">@color/mapbox_navigation_view_color_accent</item>
@@ -72,6 +73,7 @@
     </style>
 
     <style name="NavigationViewDark" parent="Theme.AppCompat.Light.NoActionBar">
+        <item name="android:colorPrimary" tools:targetApi="lollipop">@android:color/white</item>
         <item name="navigationViewPrimary">@color/mapbox_navigation_view_color_primary_dark</item>
         <item name="navigationViewSecondary">@color/mapbox_navigation_view_color_secondary_dark
         </item>


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Fix #2994

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal

Please describe the PR goals. Just the stuff needed to implement the fix / feature and a simple rationale. It could contain many check points if needed

### Implementation

The RecyclerView fading edge color is related to the current theme's `colorPrimary`. If you look at the other sample like: `InstructionViewActivity` and `CustomUIComponentStyleActivity`, they don't have this issue. So to assign a white color as `colorPrimary` for the default NavigationUISDK theme to have this behavior defined. The developer can still override this attribute when they extend from our theme.

## Screenshots or Gifs

![Screenshot_20200518-170138_XRecorder](https://user-images.githubusercontent.com/3918950/82270374-77276200-9929-11ea-96e3-f1937cd5f604.jpg)

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->