### PR TITLE
Bump Maps SDK dependency version to 9.2.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ allprojects {
     jcenter()
     maven { url 'https://plugins.gradle.org/m2' }
     maven {
-      url 'https://mapbox.bintray.com/mapbox_private'
+      url 'https://mapbox.bintray.com/mapbox_internal'
       credentials {
         username = project.hasProperty('BINTRAY_USER') ? project.property('BINTRAY_USER') : System.getenv('BINTRAY_USER')
         password = project.hasProperty('BINTRAY_API_KEY') ? project.property('BINTRAY_API_KEY') : System.getenv('BINTRAY_API_KEY')
@@ -50,6 +50,13 @@ allprojects {
     }
     maven {
       url 'https://mapbox.bintray.com/mapbox_collab'
+      credentials {
+        username = project.hasProperty('BINTRAY_USER') ? project.property('BINTRAY_USER') : System.getenv('BINTRAY_USER')
+        password = project.hasProperty('BINTRAY_API_KEY') ? project.property('BINTRAY_API_KEY') : System.getenv('BINTRAY_API_KEY')
+      }
+    }
+    maven {
+      url 'https://mapbox.bintray.com/mapbox_private'
       credentials {
         username = project.hasProperty('BINTRAY_USER') ? project.property('BINTRAY_USER') : System.getenv('BINTRAY_USER')
         password = project.hasProperty('BINTRAY_API_KEY') ? project.property('BINTRAY_API_KEY') : System.getenv('BINTRAY_API_KEY')

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -9,7 +9,7 @@ ext {
   ]
 
   version = [
-      mapboxMapSdk              : '9.2.0',
+      mapboxMapSdk              : '9.2.1',
       mapboxSdkServices         : '5.2.1',
       mapboxSdkDirectionsModels : '5.2.1',
       mapboxEvents              : '5.0.1',


### PR DESCRIPTION
## Description

Bumps `mapbox-android-sdk` version to `9.2.1` and adds `mapbox_internal` Bintray repository setup to `build.gradle` (follow up from https://github.com/mapbox/mapbox-navigation-android/pull/2961)

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Getting the latest version from `mapboxMapSdk` including the new features and bug fixes.

### Implementation

- Bump the `mapboxMapSdk` version to `9.2.1` in `dependencies.gradle`
- Add

```
maven {
      url 'https://mapbox.bintray.com/mapbox_internal'
      credentials {
        username = project.hasProperty('BINTRAY_USER') ? project.property('BINTRAY_USER') : System.getenv('BINTRAY_USER')
        password = project.hasProperty('BINTRAY_API_KEY') ? project.property('BINTRAY_API_KEY') : System.getenv('BINTRAY_API_KEY')
      }
}
```

to root's `build.gradle` file.

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR

cc @chloekraw 
