### PR TITLE
When the progress listener is observed in NavigationMapRoute the obse…

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteLine.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteLine.kt
@@ -365,6 +365,7 @@ internal class MapRouteLine(
             )
             routeFeatureData.addAll(newRouteFeatureData)
             drawRoutes(newRouteFeatureData)
+            hideShieldLineAtOffset(0f)
             drawWayPoints()
             updateAlternativeLayersVisibility(alternativesVisible, routeLayerIds)
             updateAllLayersVisibility(allLayersAreVisible)

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteProgressChangeListener.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteProgressChangeListener.kt
@@ -39,16 +39,9 @@ internal class MapRouteProgressChangeListener(
     ) : this(routeLine, routeArrow, false)
 
     private var job: Job? = null
-    private var isVisible = true
 
     override fun onRouteProgressChanged(routeProgress: RouteProgress) {
-        if (!isVisible) return
-
         onProgressChange(routeProgress)
-    }
-
-    fun updateVisibility(isVisible: Boolean) {
-        this.isVisible = isVisible
     }
 
     private fun onProgressChange(routeProgress: RouteProgress) {

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/NavigationMapRoute.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/NavigationMapRoute.java
@@ -288,7 +288,6 @@ public class NavigationMapRoute implements LifecycleObserver {
    */
   public void updateRouteVisibilityTo(boolean isVisible) {
     routeLine.updateVisibilityTo(isVisible);
-    mapRouteProgressChangeListener.updateVisibility(isVisible);
   }
 
 

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteProgressChangeListenerTest.kt
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteProgressChangeListenerTest.kt
@@ -2,7 +2,6 @@ package com.mapbox.navigation.ui.route
 
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.navigation.base.trip.model.RouteProgress
-import io.mockk.Called
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -28,17 +27,6 @@ class MapRouteProgressChangeListenerTest {
     }
 
     @Test
-    fun `should do nothing when invisible`() {
-        val routeProgress: RouteProgress = mockk()
-
-        progressChangeListener.updateVisibility(false)
-        progressChangeListener.onRouteProgressChanged(routeProgress)
-
-        verify { routeLine wasNot Called }
-        verify { routeArrow wasNot Called }
-    }
-
-    @Test
     fun `should not draw route without geometry`() {
         val newRoute: DirectionsRoute = mockk {
             every { geometry() } returns null
@@ -48,7 +36,6 @@ class MapRouteProgressChangeListenerTest {
         }
         every { routeLine.getPrimaryRoute() } returns newRoute
 
-        progressChangeListener.updateVisibility(true)
         progressChangeListener.onRouteProgressChanged(routeProgress)
 
         verify(exactly = 0) { routeLine.draw(any<DirectionsRoute>()) }
@@ -62,7 +49,6 @@ class MapRouteProgressChangeListenerTest {
             every { route() } returns null
         }
 
-        progressChangeListener.updateVisibility(true)
         progressChangeListener.onRouteProgressChanged(routeProgress)
 
         verify(exactly = 0) { routeLine.draw(any<DirectionsRoute>()) }

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/NavigationMapRouteTest.java
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/NavigationMapRouteTest.java
@@ -326,28 +326,6 @@ public class NavigationMapRouteTest {
   }
 
   @Test
-  public void updateRouteVisibilityTo_progressChangeVisibilityIsUpdated() {
-    MapboxNavigation mockedNavigation = mock(MapboxNavigation.class);
-    MapView mockedMapView = mock(MapView.class);
-    MapboxMap mockedMapboxMap = mock(MapboxMap.class);
-    int mockedStyleRes = 0;
-    MapRouteClickListener mockedMapClickListener = mock(MapRouteClickListener.class);
-    MapView.OnDidFinishLoadingStyleListener mockedDidFinishLoadingStyleListener =
-      mock(MapView.OnDidFinishLoadingStyleListener.class);
-    MapRouteProgressChangeListener mockedProgressChangeListener = mock(MapRouteProgressChangeListener.class);
-    MapRouteLine mockedMapRouteLine = mock(MapRouteLine.class);
-    MapRouteArrow mockedMapRouteArrow = mock(MapRouteArrow.class);
-    NavigationMapRoute theNavigationMapRoute = new NavigationMapRoute(mockedNavigation, mockedMapView, mockedMapboxMap,
-      mockedStyleRes, "", mockedMapClickListener, mockedDidFinishLoadingStyleListener,
-      mockedProgressChangeListener, mockedMapRouteLine, mockedMapRouteArrow);
-    boolean isVisible = false;
-
-    theNavigationMapRoute.updateRouteVisibilityTo(isVisible);
-
-    verify(mockedProgressChangeListener).updateVisibility(isVisible);
-  }
-
-  @Test
   public void updateRouteArrowVisibilityTo_routeArrowReceivesNewVisibility() {
     MapboxNavigation mockedNavigation = mock(MapboxNavigation.class);
     MapView mockedMapView = mock(MapView.class);


### PR DESCRIPTION
##Description
Fix for #3001 when the when a route progress change listener is added it is explicitly activated.

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal
This issue shows up when going from active guidance to free drive and back to active guidance. When resuming active guidance and the vanish route line feature is enabled the line should continue vanishing.

### Implementation
The MapRouteProgressChangeListener has a boolean isVisible flag that when going to free drive can be set to false. When going back to active guidance the flag is set to true so that the listener will continue to process the events.

## Screenshots or Gifs

## Testing


- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->