### PR TITLE
fix issue: the MapboxSpeech offline cache interceptor is overriden and lost by #2962

### DIFF
--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/voice/VoiceInstructionLoaderTest.java
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/voice/VoiceInstructionLoaderTest.java
@@ -3,7 +3,6 @@ package com.mapbox.navigation.ui.voice;
 import android.content.Context;
 
 import com.mapbox.api.speech.v1.MapboxSpeech;
-import com.mapbox.navigation.base.internal.accounts.UrlSkuTokenProvider;
 import com.mapbox.navigation.ui.BaseTest;
 import com.mapbox.navigation.ui.ConnectivityStatusProvider;
 
@@ -17,7 +16,6 @@ import okhttp3.Cache;
 import retrofit2.Callback;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -35,12 +33,11 @@ public class VoiceInstructionLoaderTest extends BaseTest {
     urlsToBeCached.remove(4);
     Iterator<String> urlsCached = urlsToBeCached.iterator();
     when(aCache.urls()).thenReturn(urlsCached);
-    UrlSkuTokenProvider anySkuTokenProvider = mock(UrlSkuTokenProvider.class);
     MapboxSpeech.Builder anySpeechBuilder = mock(MapboxSpeech.Builder.class);
     ConnectivityStatusProvider anyConnectivityStatus = mock(ConnectivityStatusProvider.class);
 
     VoiceInstructionLoader theVoiceInstructionLoader = new VoiceInstructionLoader(anyContext, "any_access_token",
-      aCache, anySkuTokenProvider, anySpeechBuilder, anyConnectivityStatus);
+      aCache, anySpeechBuilder, anyConnectivityStatus);
     List<String> urlsToCache = buildUrlsToCache();
     theVoiceInstructionLoader.addStubUrlsToCache(urlsToCache);
 
@@ -56,14 +53,12 @@ public class VoiceInstructionLoaderTest extends BaseTest {
     MapboxSpeech.Builder aSpeechBuilder = mock(MapboxSpeech.Builder.class);
     when(aSpeechBuilder.instruction(anyString())).thenReturn(aSpeechBuilder);
     when(aSpeechBuilder.textType(anyString())).thenReturn(aSpeechBuilder);
-    when(aSpeechBuilder.interceptor(any())).thenReturn(aSpeechBuilder);
     MapboxSpeech aSpeech = mock(MapboxSpeech.class);
     when(aSpeechBuilder.build()).thenReturn(aSpeech);
     ConnectivityStatusProvider connectivityStatus = mock(ConnectivityStatusProvider.class);
     Context context = mock(Context.class);
-    UrlSkuTokenProvider anyUrlSkuTokenProvider = mock(UrlSkuTokenProvider.class);
     VoiceInstructionLoader theVoiceInstructionLoader = new VoiceInstructionLoader(context, "any_access_token",
-      anyCache, anyUrlSkuTokenProvider, aSpeechBuilder, connectivityStatus);
+      anyCache, aSpeechBuilder, connectivityStatus);
     Callback aCallback = mock(Callback.class);
 
     theVoiceInstructionLoader.requestInstruction("anyInstruction", "anyType", aCallback);
@@ -79,9 +74,8 @@ public class VoiceInstructionLoaderTest extends BaseTest {
     MapboxSpeech aSpeech = mock(MapboxSpeech.class);
     ConnectivityStatusProvider connectivityStatus = mock(ConnectivityStatusProvider.class);
     Context context = mock(Context.class);
-    UrlSkuTokenProvider anyUrlSkuTokenProvider = mock(UrlSkuTokenProvider.class);
     VoiceInstructionLoader theVoiceInstructionLoader = new VoiceInstructionLoader(context, "any_access_token",
-      anyCache, anyUrlSkuTokenProvider, anySpeechBuilder, connectivityStatus);
+      anyCache, anySpeechBuilder, connectivityStatus);
     Callback aCallback = mock(Callback.class);
 
     theVoiceInstructionLoader.requestInstruction("anyInstruction", "anyType", aCallback);
@@ -97,9 +91,8 @@ public class VoiceInstructionLoaderTest extends BaseTest {
     MapboxSpeech aSpeech = mock(MapboxSpeech.class);
     ConnectivityStatusProvider connectivityStatus = mock(ConnectivityStatusProvider.class);
     Context context = mock(Context.class);
-    UrlSkuTokenProvider anyUrlSkuTokenProvider = mock(UrlSkuTokenProvider.class);
     VoiceInstructionLoader theVoiceInstructionLoader = new VoiceInstructionLoader(context, "any_access_token",
-      anyCache, anyUrlSkuTokenProvider, nullSpeechBuilder, connectivityStatus);
+      anyCache, nullSpeechBuilder, connectivityStatus);
     Callback aCallback = mock(Callback.class);
 
     theVoiceInstructionLoader.requestInstruction("anyInstruction", "anyType", aCallback);


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

the MapboxSpeech only accepts one interceptor.
in PR #2962 a SKU token interceptor was added to MapboxSpeech
which overrides the original offline cache interceptor logic.

- [ ] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Implementation

Add the sku token interceptor logic on top of the original offline cache interceptor code.

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->