### PR TITLE
the vanishing route line color and transparency can be customized

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteLine.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteLine.kt
@@ -125,6 +125,15 @@ internal class MapRouteLine(
     var vanishPointOffset: Float = 0f
         private set
 
+    private val routeLineTraveledColor: Int by lazy {
+        getStyledColor(
+            R.styleable.NavigationMapRoute_routeLineTraveledColor,
+            R.color.mapbox_navigation_route_line_traveled_color,
+            context,
+            styleRes
+        )
+    }
+
     private val routeUnknownColor: Int by lazy {
         getStyledColor(
             R.styleable.NavigationMapRoute_routeUnknownCongestionColor,
@@ -617,7 +626,7 @@ internal class MapRouteLine(
 
         return Expression.step(
             Expression.lineProgress(),
-            Expression.rgba(0, 0, 0, 0),
+            Expression.color(routeLineTraveledColor),
             *trafficExpressions.toTypedArray()
         )
     }

--- a/libnavigation-ui/src/main/res/values/attrs.xml
+++ b/libnavigation-ui/src/main/res/values/attrs.xml
@@ -8,6 +8,7 @@
     <attr name="routeHeavyCongestionColor" format="color"/>
     <attr name="routeSevereCongestionColor" format="color"/>
     <attr name="routeShieldColor" format="color"/>
+    <attr name="routeLineTraveledColor" format="color"/>
 
     <!-- Alternative route colors -->
     <attr name="alternativeRouteColor" format="color"/>

--- a/libnavigation-ui/src/main/res/values/colors.xml
+++ b/libnavigation-ui/src/main/res/values/colors.xml
@@ -7,6 +7,7 @@
   <color name="mapbox_navigation_route_layer_congestion_heavy">#E93340</color>
   <color name="mapbox_navigation_route_layer_congestion_red">#E93340</color>
   <color name="mapbox_navigation_route_shield_layer_color">#2F7AC6</color>
+  <color name="mapbox_navigation_route_line_traveled_color">#00000000</color>
 
   <!-- Alternative route colors -->
   <color name="mapbox_navigation_route_alternative_color">#8694A5</color>


### PR DESCRIPTION
## Description
Implements the feature described in #3021. The color/transparency of the section of the route line behind the puck can be customized in the same way as the traffic congestion colors.

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal

The color of the route line behind the puck should be customizable. The default will be transparent with a value of #00000000 but the color is style-able the same as the traffic congestion colors.

### Implementation

The implementation matches the traffic congestion colors.

## Screenshots or Gifs

![20200522_114923](https://user-images.githubusercontent.com/2249818/82701353-e1d7e680-9c24-11ea-9027-fb8a36c4730e.gif)


## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->