### PR TITLE
Fix memory leak due to builder with Context in constructor

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/TripServiceActivityKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/TripServiceActivityKt.kt
@@ -84,11 +84,11 @@ class TripServiceActivityKt : AppCompatActivity(), OnMapReadyCallback {
         mapView.onCreate(savedInstanceState)
         mapView.getMapAsync(this)
 
-        val formatter = MapboxDistanceFormatter.builder(this)
+        val formatter = MapboxDistanceFormatter.builder()
             .withRoundingIncrement(Rounding.INCREMENT_FIFTY)
             .withUnitType(METRIC)
             .withLocale(this.inferDeviceLocale())
-            .build()
+            .build(this)
 
         mapboxTripNotification = MapboxTripNotification(
             applicationContext,

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/TripSessionActivityKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/TripSessionActivityKt.kt
@@ -94,11 +94,11 @@ class TripSessionActivityKt : AppCompatActivity(), OnMapReadyCallback {
         mapView.onCreate(savedInstanceState)
         mapView.getMapAsync(this)
 
-        val formatter = MapboxDistanceFormatter.builder(this)
+        val formatter = MapboxDistanceFormatter.builder()
             .withUnitType(METRIC)
             .withRoundingIncrement(Rounding.INCREMENT_FIFTY)
             .withLocale(this.inferDeviceLocale())
-            .build()
+            .build(this)
 
         tripSession = MapboxTripSession(
             MapboxTripService(

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -686,10 +686,10 @@ constructor(
          */
         @JvmStatic
         fun defaultNavigationOptions(context: Context, accessToken: String?): NavigationOptions {
-            val distanceFormatter = MapboxDistanceFormatter.builder(context)
+            val distanceFormatter = MapboxDistanceFormatter.builder()
                 .withUnitType(VoiceUnit.UNDEFINED)
                 .withRoundingIncrement(Rounding.INCREMENT_FIFTY)
-                .build()
+                .build(context)
             val builder = NavigationOptions.Builder()
                 .accessToken(accessToken)
                 .timeFormatType(TimeFormat.NONE_SPECIFIED)

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/internal/MapboxDistanceFormatterTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/internal/MapboxDistanceFormatterTest.kt
@@ -35,10 +35,10 @@ class MapboxDistanceFormatterTest {
     @Config(qualifiers = "en")
     @Test
     fun formatDistanceLargeDistanceImperialWithDefaultLocale() {
-        val result = MapboxDistanceFormatter.Builder(ctx)
+        val result = MapboxDistanceFormatter.Builder()
             .withUnitType(IMPERIAL)
             .withRoundingIncrement(INCREMENT_FIFTY)
-            .build()
+            .build(ctx)
             .formatDistance(19312.1)
 
         assertEquals("12 mi", result.toString())
@@ -47,9 +47,9 @@ class MapboxDistanceFormatterTest {
     @Config(qualifiers = "en")
     @Test
     fun formatDistanceLargeDistanceUnitTypeNull() {
-        val result = MapboxDistanceFormatter.Builder(ctx)
+        val result = MapboxDistanceFormatter.Builder()
             .withRoundingIncrement(INCREMENT_FIFTY)
-            .build()
+            .build(ctx)
             .formatDistance(19312.1)
 
         assertEquals("19 km", result.toString())
@@ -58,10 +58,10 @@ class MapboxDistanceFormatterTest {
     @Config(qualifiers = "en")
     @Test
     fun formatDistanceLargeDistanceUnitTypeEmptyString() {
-        val result = MapboxDistanceFormatter.Builder(ctx)
+        val result = MapboxDistanceFormatter.Builder()
             .withUnitType("")
             .withRoundingIncrement(INCREMENT_FIFTY)
-            .build()
+            .build(ctx)
             .formatDistance(19312.1)
 
         assertEquals("19 km", result.toString())
@@ -70,10 +70,10 @@ class MapboxDistanceFormatterTest {
     @Config(qualifiers = "en")
     @Test
     fun formatDistanceLargeDistanceMetric() {
-        val result = MapboxDistanceFormatter.Builder(ctx)
+        val result = MapboxDistanceFormatter.Builder()
             .withUnitType(METRIC)
             .withRoundingIncrement(INCREMENT_FIFTY)
-            .build()
+            .build(ctx)
             .formatDistance(19312.1)
 
         assertEquals("19 km", result.toString())
@@ -82,10 +82,10 @@ class MapboxDistanceFormatterTest {
     @Config(qualifiers = "en")
     @Test
     fun formatDistanceSmallDistanceMetric() {
-        val result = MapboxDistanceFormatter.Builder(ctx)
+        val result = MapboxDistanceFormatter.Builder()
             .withUnitType(METRIC)
             .withRoundingIncrement(INCREMENT_FIFTY)
-            .build()
+            .build(ctx)
             .formatDistance(10.0)
 
         assertEquals("50 m", result.toString())
@@ -94,10 +94,10 @@ class MapboxDistanceFormatterTest {
     @Config(qualifiers = "en")
     @Test
     fun formatDistanceSmallDistanceImperial() {
-        val result = MapboxDistanceFormatter.Builder(ctx)
+        val result = MapboxDistanceFormatter.Builder()
             .withUnitType(IMPERIAL)
             .withRoundingIncrement(INCREMENT_FIFTY)
-            .build()
+            .build(ctx)
             .formatDistance(10.0)
 
         assertEquals("50 ft", result.toString())
@@ -106,10 +106,10 @@ class MapboxDistanceFormatterTest {
     @Config(qualifiers = "ja")
     @Test
     fun formatDistanceJapaneseLocale() {
-        val result = MapboxDistanceFormatter.Builder(ctx)
+        val result = MapboxDistanceFormatter.Builder()
             .withUnitType(IMPERIAL)
             .withRoundingIncrement(INCREMENT_FIFTY)
-            .build()
+            .build(ctx)
             .formatDistance(10.0)
 
         assertEquals("50 フィート", result.toString())
@@ -118,10 +118,10 @@ class MapboxDistanceFormatterTest {
     @Config(qualifiers = "en")
     @Test
     fun formatDistanceMediumMetric() {
-        val result = MapboxDistanceFormatter.Builder(ctx)
+        val result = MapboxDistanceFormatter.Builder()
             .withUnitType(METRIC)
             .withRoundingIncrement(INCREMENT_FIFTY)
-            .build()
+            .build(ctx)
             .formatDistance(1000.0)
 
         assertEquals("1 km", result.toString())
@@ -130,10 +130,10 @@ class MapboxDistanceFormatterTest {
     @Config(qualifiers = "en")
     @Test
     fun formatDistanceMediumMetricFractionalValue() {
-        val result = MapboxDistanceFormatter.Builder(ctx)
+        val result = MapboxDistanceFormatter.Builder()
             .withUnitType(METRIC)
             .withRoundingIncrement(INCREMENT_FIFTY)
-            .build()
+            .build(ctx)
             .formatDistance(400.5)
 
         assertEquals("0.4 km", result.toString())
@@ -142,10 +142,10 @@ class MapboxDistanceFormatterTest {
     @Config(qualifiers = "en")
     @Test
     fun formatDistanceMediumImperial() {
-        val result = MapboxDistanceFormatter.Builder(ctx)
+        val result = MapboxDistanceFormatter.Builder()
             .withUnitType(IMPERIAL)
             .withRoundingIncrement(INCREMENT_FIFTY)
-            .build()
+            .build(ctx)
             .formatDistance(1000.0)
 
         assertEquals("0.6 mi", result.toString())
@@ -155,8 +155,8 @@ class MapboxDistanceFormatterTest {
     fun getSpannableDistanceStringFormatsString() {
         val input = Pair("12", "mi")
 
-        val result = MapboxDistanceFormatter.Builder(ctx)
-            .build()
+        val result = MapboxDistanceFormatter.Builder()
+            .build(ctx)
             .getSpannableDistanceString(input)
 
         assertEquals("12 mi", result.toString())
@@ -166,8 +166,8 @@ class MapboxDistanceFormatterTest {
     fun getSpannableDistanceStringHasCorrectNumberOfSpans() {
         val input = Pair("12", "mi")
 
-        val result = MapboxDistanceFormatter.Builder(ctx)
-            .build()
+        val result = MapboxDistanceFormatter.Builder()
+            .build(ctx)
             .getSpannableDistanceString(input)
 
         assertEquals(2, result.getSpans(0, result.count(), Object::class.java).size)
@@ -177,8 +177,8 @@ class MapboxDistanceFormatterTest {
     fun getSpannableDistanceStringTypeFace() {
         val input = Pair("12", "mi")
 
-        val result = MapboxDistanceFormatter.Builder(ctx)
-            .build()
+        val result = MapboxDistanceFormatter.Builder()
+            .build(ctx)
             .getSpannableDistanceString(input)
 
         assertEquals(Typeface.BOLD, (result.getSpans(0, result.count(), Object::class.java)[0] as StyleSpan).style)
@@ -188,10 +188,10 @@ class MapboxDistanceFormatterTest {
     fun getSpannableDistanceStringRelativeSizeSpan() {
         val input = Pair("12", "mi")
 
-        val result = MapboxDistanceFormatter.Builder(ctx)
+        val result = MapboxDistanceFormatter.Builder()
             .withUnitType(IMPERIAL)
             .withRoundingIncrement(INCREMENT_FIFTY)
-            .build()
+            .build(ctx)
             .getSpannableDistanceString(input)
 
         assertEquals(0.65f, (result.getSpans(0, result.count(), Object::class.java)[1] as RelativeSizeSpan).sizeChange)
@@ -200,11 +200,11 @@ class MapboxDistanceFormatterTest {
     @Config(qualifiers = "en")
     @Test
     fun formatDistanceImperialWithNonDefaultLocale() {
-        val result = MapboxDistanceFormatter.Builder(ctx)
+        val result = MapboxDistanceFormatter.Builder()
             .withUnitType(IMPERIAL)
             .withRoundingIncrement(INCREMENT_FIFTY)
             .withLocale(Locale("hu"))
-            .build()
+            .build(ctx)
             .formatDistance(19312.1)
 
         assertEquals("12 mérföld", result.toString())
@@ -215,7 +215,7 @@ class MapboxDistanceFormatterTest {
         val mockContext = mockk<Context>()
         every { mockContext.applicationContext } returns ctx
 
-        MapboxDistanceFormatter.Builder(mockContext).build()
+        MapboxDistanceFormatter.Builder().build(mockContext)
 
         verify(exactly = 2) { mockContext.applicationContext }
     }
@@ -223,10 +223,10 @@ class MapboxDistanceFormatterTest {
     @Config(qualifiers = "en")
     @Test
     fun formatDistanceBelowZeroDistance() {
-        val result = MapboxDistanceFormatter.Builder(ctx)
+        val result = MapboxDistanceFormatter.Builder()
                 .withUnitType(IMPERIAL)
                 .withRoundingIncrement(INCREMENT_FIFTY)
-                .build()
+                .build(ctx)
                 .formatDistance(-0.1)
 
         assertEquals("50 ft", result.toString())
@@ -235,10 +235,10 @@ class MapboxDistanceFormatterTest {
     @Config(qualifiers = "en")
     @Test
     fun formatDistanceBelowZeroDistanceRoundingIncrementFive() {
-        val result = MapboxDistanceFormatter.Builder(ctx)
+        val result = MapboxDistanceFormatter.Builder()
                 .withUnitType(IMPERIAL)
                 .withRoundingIncrement(INCREMENT_FIVE)
-                .build()
+                .build(ctx)
                 .formatDistance(-0.1)
 
         assertEquals("5 ft", result.toString())
@@ -247,10 +247,10 @@ class MapboxDistanceFormatterTest {
     @Config(qualifiers = "en-rUS")
     @Test
     fun formatDistanceUnitTypeUndefinedImperial() {
-        val result = MapboxDistanceFormatter.Builder(ctx)
+        val result = MapboxDistanceFormatter.Builder()
                 .withUnitType(UNDEFINED)
                 .withRoundingIncrement(INCREMENT_FIFTY)
-                .build()
+                .build(ctx)
                 .formatDistance(19312.1)
 
         assertEquals("12 mi", result.toString())
@@ -259,10 +259,10 @@ class MapboxDistanceFormatterTest {
     @Config(qualifiers = "jp-rJP")
     @Test
     fun formatDistanceUnitTypeUndefinedMetric() {
-        val result = MapboxDistanceFormatter.Builder(ctx)
+        val result = MapboxDistanceFormatter.Builder()
                 .withUnitType(UNDEFINED)
                 .withRoundingIncrement(INCREMENT_FIFTY)
-                .build()
+                .build(ctx)
                 .formatDistance(19312.1)
 
         assertEquals("19 km", result.toString())

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationView.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationView.java
@@ -843,11 +843,11 @@ public class NavigationView extends CoordinatorLayout implements LifecycleOwner,
     final String unitType = establishUnitType(options);
     final Locale language = getLocaleDirectionsRoute(options.directionsRoute(), getContext());
     final int roundingIncrement = options.roundingIncrement();
-    final DistanceFormatter distanceFormatter = MapboxDistanceFormatter.builder(getContext())
+    final DistanceFormatter distanceFormatter = MapboxDistanceFormatter.builder()
       .withRoundingIncrement(roundingIncrement)
       .withUnitType(unitType)
       .withLocale(language)
-      .build();
+      .build(getContext());
     instructionView.setDistanceFormatter(distanceFormatter);
     summaryBottomSheet.setDistanceFormatter(distanceFormatter);
   }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationViewModel.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationViewModel.java
@@ -338,11 +338,11 @@ public class NavigationViewModel extends AndroidViewModel {
     final String unitType = initializeUnitType(options);
     final int roundingIncrement = options.roundingIncrement();
     final Locale locale = getLocaleDirectionsRoute(options.directionsRoute(), getApplication());
-    return new MapboxDistanceFormatter.Builder(getApplication())
+    return new MapboxDistanceFormatter.Builder()
             .withUnitType(unitType)
             .withRoundingIncrement(roundingIncrement)
             .withLocale(locale)
-            .build();
+            .build(getApplication());
   }
 
   private void initializeNavigationSpeechPlayer(NavigationViewOptions options) {

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/instruction/InstructionView.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/instruction/InstructionView.java
@@ -552,11 +552,11 @@ public class InstructionView extends RelativeLayout implements LifecycleObserver
     final String unitType = getUnitTypeForLocale(ContextEx.inferDeviceLocale(getContext()));
     final int roundingIncrement = Rounding.INCREMENT_FIFTY;
     final Locale locale = ContextEx.inferDeviceLocale(getContext());
-    distanceFormatter = new MapboxDistanceFormatter.Builder(getContext())
+    distanceFormatter = new MapboxDistanceFormatter.Builder()
       .withUnitType(unitType)
       .withRoundingIncrement(roundingIncrement)
       .withLocale(locale)
-      .build();
+      .build(getContext());
     inflate(getContext(), R.layout.instruction_view_layout, this);
   }
 

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/summary/SummaryBottomSheet.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/summary/SummaryBottomSheet.java
@@ -249,11 +249,11 @@ public class SummaryBottomSheet extends FrameLayout implements LifecycleObserver
   private void initializeDistanceFormatter() {
     final Locale locale = ContextEx.inferDeviceLocale(getContext());
     final String unitType = getUnitTypeForLocale(locale);
-    distanceFormatter = new MapboxDistanceFormatter.Builder(getContext())
+    distanceFormatter = new MapboxDistanceFormatter.Builder()
             .withUnitType(unitType)
             .withRoundingIncrement(Rounding.INCREMENT_FIFTY)
             .withLocale(locale)
-            .build();
+            .build(getContext());
   }
 
   /**

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/summary/SummaryModelTest.kt
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/summary/SummaryModelTest.kt
@@ -31,10 +31,10 @@ class SummaryModelTest : BaseTest() {
     @Test
     fun getDistanceRemaining() {
         val routeProgress = buildRouteProgress()
-        val distanceFormatter = MapboxDistanceFormatter.Builder(ctx)
+        val distanceFormatter = MapboxDistanceFormatter.Builder()
             .withUnitType(METRIC)
             .withRoundingIncrement(INCREMENT_FIFTY)
-            .build()
+            .build(ctx)
 
         val result = SummaryModel(
             ctx,
@@ -48,10 +48,10 @@ class SummaryModelTest : BaseTest() {
     @Test
     fun getTimeRemaining() {
         val routeProgress = buildRouteProgress()
-        val distanceFormatter = MapboxDistanceFormatter.Builder(ctx)
+        val distanceFormatter = MapboxDistanceFormatter.Builder()
             .withUnitType(METRIC)
             .withRoundingIncrement(INCREMENT_FIFTY)
-            .build()
+            .build(ctx)
 
         val result = SummaryModel(
             ctx,
@@ -65,10 +65,10 @@ class SummaryModelTest : BaseTest() {
     @Test
     fun getArrivalTime() {
         val routeProgress = buildRouteProgress()
-        val distanceFormatter = MapboxDistanceFormatter.Builder(ctx)
+        val distanceFormatter = MapboxDistanceFormatter.Builder()
             .withUnitType(METRIC)
             .withRoundingIncrement(INCREMENT_FIFTY)
-            .build()
+            .build(ctx)
         val time = Calendar.getInstance()
         val legDurationRemaining: Double = routeProgress!!
             .currentLegProgress!!


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

~Removing the builder from the constructor. It's not a good idea to add the Context to the builder because it creates memory leaks.~ Taking @Guardiola31337 suggestion to throw it in the build(..) function. That function converts the context to an applicationContext to save memory leaks.

This issue was introduced here https://github.com/mapbox/mapbox-navigation-android/pull/3015

There is an outstanding issue for refactoring the MapboxDistanceFormatter https://github.com/mapbox/mapbox-navigation-android/issues/3016

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->