### PR TITLE
fix regression when session is in free drive the vanishing route line…

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteProgressChangeListener.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteProgressChangeListener.kt
@@ -40,7 +40,6 @@ internal class MapRouteProgressChangeListener(
     ) : this(routeLine, routeArrow, false)
 
     private var job: Job? = null
-    private var isVisible = true
     private var lastDistanceValue = 0f
 
     override fun onRouteProgressChanged(routeProgress: RouteProgress) {
@@ -58,7 +57,9 @@ internal class MapRouteProgressChangeListener(
         if (hasGeometry && currentRoute != directionsRoute) {
             routeLine.draw(currentRoute!!)
         } else {
-            if (vanishRouteLineEnabled && (job == null || !job!!.isActive)) {
+            // if there is no geometry then the session is in free drive and the vanishing
+            // route line code should not execute.
+            if (vanishRouteLineEnabled && hasGeometry && (job == null || !job!!.isActive)) {
                 job = ThreadController.getMainScopeAndRootJob().scope.launch {
                     val percentDistanceTraveled = getPercentDistanceTraveled(routeProgress)
                     if (percentDistanceTraveled > 0) {


### PR DESCRIPTION
## Description

I realized a previous merge caused a regression. The code to execute vanishing of the route line should not execute when in free drive. The code was checking if the route progress route had geometry. If it was null that indicated the session was in free drive. I mistakenly removed the check for hasGeometry since it was no longer needed for the vanishing route line calculation. It was needed in an earlier iteration of the algorithm. Removing the check for geometry was a mistake.

- [ ] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal

Fix the regression.

### Implementation

Restored the previous condition and added a comment indicating the usage of the hasGeometry variable in order to avoid a future regression.

## Screenshots or Gifs

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->