### PR TITLE
fix issue #3031: the feedback button and sound button visibility changes in landscape mode

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/instruction/InstructionView.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/instruction/InstructionView.java
@@ -1023,9 +1023,15 @@ public class InstructionView extends RelativeLayout implements LifecycleObserver
   }
 
   private void updateLandscapeConstraintsTo(int layoutRes) {
+    final int feedbackButtonVisibility = feedbackButton.getVisibility();
+    final int soundButtonVisibility = feedbackButton.getVisibility();
+
     ConstraintSet collapsed = new ConstraintSet();
     collapsed.clone(getContext(), layoutRes);
     collapsed.applyTo(instructionLayout);
+
+    feedbackButton.setVisibility(feedbackButtonVisibility);
+    soundButton.setVisibility(soundButtonVisibility);
   }
 
   /**

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/voice/UtteranceListener.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/voice/UtteranceListener.java
@@ -1,11 +1,7 @@
 package com.mapbox.navigation.ui.voice;
 
-import android.os.Build;
 import android.speech.tts.UtteranceProgressListener;
 
-import androidx.annotation.RequiresApi;
-
-@RequiresApi(api = Build.VERSION_CODES.ICE_CREAM_SANDWICH_MR1)
 class UtteranceListener extends UtteranceProgressListener {
   private VoiceListener voiceListener;
 


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Fix #3031 

There is a user case that the developer integrates the `InstructionView` without using the `feedbackButton` and `soundButton` in it. Like how the 1Tap does. Then in landscape mode, the `feedbackButton` and `soundButton` will show up after user show and hide the `InstructionListView` by clicking the top banner area.
This is because we simply clone the ConstraintSet from layout and apply to the current view. And the visibility might change.

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Make the `InstructionView`'s behavior correct.

### Implementation

Simply save the visibility before clone the ConstraintSet and restore it after the constraintSet applied.

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->