### PR TITLE
Cancel animator if the coroutine is not active which implies the acti…

### DIFF
--- a/libnavigation-ui/build.gradle
+++ b/libnavigation-ui/build.gradle
@@ -113,6 +113,8 @@ dependencies {
   testImplementation dependenciesList.robolectric
   testImplementation dependenciesList.json
   testImplementation dependenciesList.androidxTestCore
+  testImplementation dependenciesList.coroutinesTestAndroid
+  testImplementation project(':libtesting-utils')
 }
 apply from: "${rootDir}/gradle/jacoco.gradle"
 apply from: "${rootDir}/gradle/checkstyle.gradle"

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteProgressChangeListener.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteProgressChangeListener.kt
@@ -1,15 +1,12 @@
 package com.mapbox.navigation.ui.route
 
+import android.animation.PropertyValuesHolder
 import android.animation.ValueAnimator
-import android.view.animation.LinearInterpolator
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.trip.session.RouteProgressObserver
 import com.mapbox.navigation.ui.route.RouteConstants.MINIMUM_ROUTE_LINE_OFFSET
-import com.mapbox.navigation.ui.route.RouteConstants.ROUTE_LINE_VANISH_ANIMATION_DELAY
-import com.mapbox.navigation.ui.route.RouteConstants.ROUTE_LINE_VANISH_ANIMATION_DURATION
 import com.mapbox.navigation.utils.internal.ThreadController
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 
 /**
@@ -24,23 +21,25 @@ import kotlinx.coroutines.launch
 internal class MapRouteProgressChangeListener(
     private val routeLine: MapRouteLine,
     private val routeArrow: MapRouteArrow,
-    private val vanishRouteLineEnabled: Boolean
+    private val vanishingLineAnimator: ValueAnimator?
 ) : RouteProgressObserver {
 
-    /**
-     * Upon receiving route progress events draws and/or updates the line on the map representing the
-     * route as well as arrow(s) representing the next maneuver.
-     *
-     * @param routeLine the route to represent on the map
-     * @param routeArrow the arrow representing the next maneuver
-     */
-    constructor(
-        routeLine: MapRouteLine,
-        routeArrow: MapRouteArrow
-    ) : this(routeLine, routeArrow, false)
-
-    private var job: Job? = null
+    private val jobControl by lazy { ThreadController.getMainScopeAndRootJob() }
     private var lastDistanceValue = 0f
+
+    private val routeLineAnimatorUpdateCallback = ValueAnimator.AnimatorUpdateListener {
+        val animationDistanceValue = it.animatedValue as Float
+        if (animationDistanceValue > MINIMUM_ROUTE_LINE_OFFSET) {
+            val expression = routeLine.getExpressionAtOffset(animationDistanceValue)
+            routeLine.hideShieldLineAtOffset(animationDistanceValue)
+            routeLine.decorateRouteLine(expression)
+        }
+    }
+
+    init {
+        this.lastDistanceValue = routeLine.vanishPointOffset
+        this.vanishingLineAnimator?.addUpdateListener(routeLineAnimatorUpdateCallback)
+    }
 
     override fun onRouteProgressChanged(routeProgress: RouteProgress) {
         onProgressChange(routeProgress)
@@ -59,8 +58,8 @@ internal class MapRouteProgressChangeListener(
         } else {
             // if there is no geometry then the session is in free drive and the vanishing
             // route line code should not execute.
-            if (vanishRouteLineEnabled && hasGeometry && (job == null || !job!!.isActive)) {
-                job = ThreadController.getMainScopeAndRootJob().scope.launch {
+            if (vanishingLineAnimator != null && hasGeometry) {
+                jobControl.scope.launch {
                     val percentDistanceTraveled = getPercentDistanceTraveled(routeProgress)
                     if (percentDistanceTraveled > 0) {
                         animateVanishRouteLineUpdate(lastDistanceValue, percentDistanceTraveled)
@@ -72,21 +71,16 @@ internal class MapRouteProgressChangeListener(
         routeArrow.addUpcomingManeuverArrow(routeProgress)
     }
 
-    private fun animateVanishRouteLineUpdate(startingDistanceValue: Float, percentDistanceTraveled: Float) {
-        ValueAnimator.ofFloat(startingDistanceValue, percentDistanceTraveled).apply {
-            duration = ROUTE_LINE_VANISH_ANIMATION_DURATION
-            interpolator = LinearInterpolator()
-            startDelay = ROUTE_LINE_VANISH_ANIMATION_DELAY
-            addUpdateListener {
-                val animationDistanceValue = it.animatedValue as Float
-                if (animationDistanceValue > MINIMUM_ROUTE_LINE_OFFSET) {
-                    val expression = routeLine.getExpressionAtOffset(animationDistanceValue)
-                    routeLine.hideShieldLineAtOffset(animationDistanceValue)
-                    routeLine.decorateRouteLine(expression)
-                }
-            }
-            start()
-        }
+    private fun animateVanishRouteLineUpdate(
+        startingDistanceValue: Float,
+        percentDistanceTraveled: Float
+    ) {
+        vanishingLineAnimator?.setValues(PropertyValuesHolder.ofFloat(
+            "",
+            startingDistanceValue,
+            percentDistanceTraveled
+        ))
+        vanishingLineAnimator?.start()
     }
 
     private fun getPercentDistanceTraveled(routeProgress: RouteProgress): Float {

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/NavigationMapRoute.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/NavigationMapRoute.java
@@ -1,6 +1,8 @@
 package com.mapbox.navigation.ui.route;
 
+import android.animation.ValueAnimator;
 import android.content.Context;
+import android.view.animation.LinearInterpolator;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -24,6 +26,9 @@ import org.jetbrains.annotations.TestOnly;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import static com.mapbox.navigation.ui.route.RouteConstants.ROUTE_LINE_VANISH_ANIMATION_DELAY;
+import static com.mapbox.navigation.ui.route.RouteConstants.ROUTE_LINE_VANISH_ANIMATION_DURATION;
 
 /**
  * Provide a route using {@link NavigationMapRoute#addRoutes(List)} and a route will be drawn using
@@ -62,6 +67,7 @@ public class NavigationMapRoute implements LifecycleObserver {
   private MapRouteArrow routeArrow;
   private boolean vanishRouteLineEnabled;
   private MapRouteLineInitializedCallback routeLineInitializedCallback;
+  private ValueAnimator vanishingRouteLineAnimator;
 
   /**
    * Construct an instance of {@link NavigationMapRoute}.
@@ -93,10 +99,7 @@ public class NavigationMapRoute implements LifecycleObserver {
     this.routeLine = buildMapRouteLine(mapView, mapboxMap, styleRes, belowLayer);
     this.routeArrow = new MapRouteArrow(mapView, mapboxMap, styleRes, routeLine.getTopLayerId());
     this.mapRouteClickListener = new MapRouteClickListener(this.routeLine);
-    this.mapRouteProgressChangeListener = new MapRouteProgressChangeListener(
-            this.routeLine,
-            routeArrow, vanishRouteLineEnabled
-    );
+    this.mapRouteProgressChangeListener = buildMapRouteProgressChangeListener();
     this.routeLineInitializedCallback = routeLineInitializedCallback;
     this.lifecycleOwner = lifecycleOwner;
     initializeDidFinishLoadingStyleListener();
@@ -269,6 +272,7 @@ public class NavigationMapRoute implements LifecycleObserver {
    * @param navigation to remove the progress change listener
    */
   public void removeProgressChangeListener(MapboxNavigation navigation) {
+    shutdownVanishingRouteLineAnimator();
     if (navigation != null) {
       navigation.unregisterRouteProgressObserver(mapRouteProgressChangeListener);
     }
@@ -287,6 +291,7 @@ public class NavigationMapRoute implements LifecycleObserver {
    */
   @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
   protected void onStop() {
+    shutdownVanishingRouteLineAnimator();
     removeListeners();
   }
 
@@ -347,6 +352,13 @@ public class NavigationMapRoute implements LifecycleObserver {
     }
   }
 
+  private void shutdownVanishingRouteLineAnimator() {
+    if (this.vanishingRouteLineAnimator != null) {
+      this.vanishingRouteLineAnimator.removeAllUpdateListeners();
+      this.vanishingRouteLineAnimator.cancel();
+    }
+  }
+
   private void redraw(Style style) {
     recreateRouteLine(style);
     routeArrow = new MapRouteArrow(mapView, mapboxMap, styleRes, routeLine.getTopLayerId());
@@ -381,7 +393,7 @@ public class NavigationMapRoute implements LifecycleObserver {
     if (navigation != null) {
       navigation.unregisterRouteProgressObserver(mapRouteProgressChangeListener);
     }
-    mapRouteProgressChangeListener = new MapRouteProgressChangeListener(routeLine, routeArrow, vanishRouteLineEnabled);
+    mapRouteProgressChangeListener = buildMapRouteProgressChangeListener();
     if (navigation != null) {
       navigation.registerRouteProgressObserver(mapRouteProgressChangeListener);
     }
@@ -391,6 +403,24 @@ public class NavigationMapRoute implements LifecycleObserver {
     if (mapRouteProgressChangeListener != null) {
       mapRouteProgressChangeListener.onRouteProgressChanged(routeProgress);
     }
+  }
+
+  private MapRouteProgressChangeListener buildMapRouteProgressChangeListener() {
+    shutdownVanishingRouteLineAnimator();
+    if (vanishRouteLineEnabled) {
+      vanishingRouteLineAnimator = ValueAnimator.ofFloat();
+      vanishingRouteLineAnimator.setDuration(ROUTE_LINE_VANISH_ANIMATION_DURATION);
+      vanishingRouteLineAnimator.setInterpolator(new LinearInterpolator());
+      vanishingRouteLineAnimator.setStartDelay(ROUTE_LINE_VANISH_ANIMATION_DELAY);
+    } else {
+      vanishingRouteLineAnimator = null;
+    }
+
+    return new MapRouteProgressChangeListener(
+            this.routeLine,
+            routeArrow,
+            vanishingRouteLineAnimator
+    );
   }
 
   /**

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteProgressChangeListenerTest.kt
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteProgressChangeListenerTest.kt
@@ -1,28 +1,51 @@
 package com.mapbox.navigation.ui.route
 
+import android.animation.ValueAnimator
+import android.os.Build
+import android.view.animation.LinearInterpolator
 import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.mapboxsdk.style.expressions.Expression
 import com.mapbox.navigation.base.trip.model.RouteProgress
+import com.mapbox.navigation.testing.MainCoroutineRule
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.Assert.assertEquals
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [ Build.VERSION_CODES.M])
 class MapRouteProgressChangeListenerTest {
 
-    private val routeLine: MapRouteLine = mockk()
+    @get:Rule
+    var coroutineRule = MainCoroutineRule()
+
+    private val routeLine: MapRouteLine = mockk(relaxUnitFun = true)
     private val routeArrow: MapRouteArrow = mockk()
+    private val animator: ValueAnimator by lazy {
+        ValueAnimator.ofFloat().apply {
+            duration = 0
+            interpolator = LinearInterpolator()
+        }
+    }
 
     private val drawDirections = mutableListOf<DirectionsRoute>()
     private val addRouteProgress = mutableListOf<RouteProgress>()
 
-    private val progressChangeListener = MapRouteProgressChangeListener(routeLine, routeArrow)
+    private val progressChangeListener by lazy {
+        MapRouteProgressChangeListener(routeLine, routeArrow, null)
+    }
 
     @Before
     fun setup() {
         every { routeLine.retrieveDirectionsRoutes() } returns emptyList()
         every { routeLine.draw(capture(drawDirections)) } returns Unit
+        every { routeLine.vanishPointOffset } returns 0f
         every { routeArrow.addUpcomingManeuverArrow(capture(addRouteProgress)) } returns Unit
     }
 
@@ -140,5 +163,138 @@ class MapRouteProgressChangeListenerTest {
         verify(exactly = 1) { routeLine.draw(any<DirectionsRoute>()) }
         assertEquals(1, drawDirections.size)
         assertEquals(100.0, drawDirections[0].distance()!!, 0.001)
+    }
+
+    @Test
+    fun `decorates route line when route progress route has geometry`() {
+        val expression: Expression = mockk()
+        val progressChangeListener = MapRouteProgressChangeListener(routeLine, routeArrow, animator)
+        val routes = listOf(
+            mockk<DirectionsRoute> {
+                every { geometry() } returns "y{v|bA{}diiGOuDpBiMhM{k@~Syj@bLuZlEiM"
+            }
+        )
+        val routeProgress: RouteProgress = mockk {
+            every { route } returns mockk {
+                every { geometry() } returns "{au|bAqtiiiG|TnI`B\\dEzAl_@hMxGxB"
+                every { distanceRemaining } returns 1000f
+                every { distanceTraveled } returns 500f
+            }
+        }
+        every { routeLine.getPrimaryRoute() } returns routeProgress.route
+        every { routeLine.retrieveDirectionsRoutes() } returns routes
+        every { routeLine.getExpressionAtOffset(any()) } returns expression
+
+        coroutineRule.runBlockingTest {
+            progressChangeListener.onRouteProgressChanged(routeProgress)
+        }
+
+        verify { routeLine.decorateRouteLine(expression) }
+    }
+
+    @Test
+    fun `does not decorate route line when route progress route does not have geometry`() {
+        val expression: Expression = mockk()
+        val progressChangeListener = MapRouteProgressChangeListener(routeLine, routeArrow, animator)
+        val routes = listOf(
+            mockk<DirectionsRoute> {
+                every { geometry() } returns "y{v|bA{}diiGOuDpBiMhM{k@~Syj@bLuZlEiM"
+            }
+        )
+        val routeProgress: RouteProgress = mockk {
+            every { route } returns mockk {
+                every { geometry() } returns ""
+                every { distanceRemaining } returns 1000f
+                every { distanceTraveled } returns 500f
+            }
+        }
+        every { routeLine.getPrimaryRoute() } returns routeProgress.route
+        every { routeLine.retrieveDirectionsRoutes() } returns routes
+        every { routeLine.getExpressionAtOffset(any()) } returns expression
+
+        coroutineRule.runBlockingTest {
+            progressChangeListener.onRouteProgressChanged(routeProgress)
+        }
+
+        verify(exactly = 0) { routeLine.decorateRouteLine(expression) }
+    }
+
+    @Test
+    fun `hides shield line at offset when route progress route has geometry`() {
+        val expression: Expression = mockk()
+        val progressChangeListener = MapRouteProgressChangeListener(routeLine, routeArrow, animator)
+        val routes = listOf(
+            mockk<DirectionsRoute> {
+                every { geometry() } returns "y{v|bA{}diiGOuDpBiMhM{k@~Syj@bLuZlEiM"
+            }
+        )
+        val routeProgress: RouteProgress = mockk {
+            every { route } returns mockk {
+                every { geometry() } returns "{au|bAqtiiiG|TnI`B\\dEzAl_@hMxGxB"
+                every { distanceRemaining } returns 1000f
+                every { distanceTraveled } returns 500f
+            }
+        }
+        every { routeLine.getPrimaryRoute() } returns routeProgress.route
+        every { routeLine.retrieveDirectionsRoutes() } returns routes
+        every { routeLine.getExpressionAtOffset(any()) } returns expression
+
+        coroutineRule.runBlockingTest {
+            progressChangeListener.onRouteProgressChanged(routeProgress)
+        }
+
+        verify { routeLine.hideShieldLineAtOffset(any()) }
+    }
+
+    @Test
+    fun `does not hide shield line at offset when route progress route does not have geometry`() {
+        val expression: Expression = mockk()
+        val progressChangeListener = MapRouteProgressChangeListener(routeLine, routeArrow, animator)
+        val routes = listOf(
+            mockk<DirectionsRoute> {
+                every { geometry() } returns "y{v|bA{}diiGOuDpBiMhM{k@~Syj@bLuZlEiM"
+            }
+        )
+        val routeProgress: RouteProgress = mockk {
+            every { route } returns mockk {
+                every { geometry() } returns ""
+                every { distanceRemaining } returns 1000f
+                every { distanceTraveled } returns 500f
+            }
+        }
+        every { routeLine.getPrimaryRoute() } returns routeProgress.route
+        every { routeLine.retrieveDirectionsRoutes() } returns routes
+        every { routeLine.getExpressionAtOffset(any()) } returns expression
+
+        coroutineRule.runBlockingTest {
+            progressChangeListener.onRouteProgressChanged(routeProgress)
+        }
+
+        verify(exactly = 0) { routeLine.hideShieldLineAtOffset(any()) }
+    }
+
+    @Test
+    fun `calls addUpcomingManeuverArrow when on progress update`() {
+        val expression: Expression = mockk()
+        val progressChangeListener = MapRouteProgressChangeListener(routeLine, routeArrow, animator)
+        val routes = listOf(
+            mockk<DirectionsRoute> {
+                every { geometry() } returns "y{v|bA{}diiGOuDpBiMhM{k@~Syj@bLuZlEiM"
+            }
+        )
+        val routeProgress: RouteProgress = mockk {
+            every { route } returns mockk {
+                every { geometry() } returns "{au|bAqtiiiG|TnI`B\\dEzAl_@hMxGxB"
+                every { distanceRemaining } returns 1000f
+                every { distanceTraveled } returns 500f
+            }
+        }
+        every { routeLine.getPrimaryRoute() } returns routeProgress.route
+        every { routeLine.retrieveDirectionsRoutes() } returns routes
+        every { routeLine.getExpressionAtOffset(any()) } returns expression
+
+        progressChangeListener.onRouteProgressChanged(routeProgress)
+
+        verify { routeArrow.addUpcomingManeuverArrow(routeProgress) }
     }
 }


### PR DESCRIPTION
## Description

Addresses the issue called out in #3030. The value animator that is responsible for animating the vanishing route line gets canceled to prevent leaking the route line and related objects.

- [x] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal

The value animator should not retain a reference to the map route line and associated objects and cause a leak.

### Implementation

The code is in a listener which doesn't have any lifecycle knowledge. It does however use the ThreadController in the SDK to obtain a coroutine job. Since the parent job gets cancelled when the activity/fragment are cleaning up resources the implementation in the listener will check if the child job received from the ThreadController is active. If it is not active the animator will get canceled and the listeners removed which should remove any references the value animator is holding on to. 

## Screenshots or Gifs


## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->