### PR TITLE
Fix stopping location updates when location engine callback on failure

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/trip/session/MapboxTripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/trip/session/MapboxTripSession.kt
@@ -391,7 +391,6 @@ class MapboxTripSession(
                 msg = Message("location on failure"),
                 tr = exception
             )
-            stopLocationUpdates()
         }
     }
 

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/internal/trip/session/MapboxTripSessionTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/internal/trip/session/MapboxTripSessionTest.kt
@@ -35,6 +35,7 @@ import io.mockk.mockkObject
 import io.mockk.slot
 import io.mockk.unmockkObject
 import io.mockk.verify
+import java.lang.Exception
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.InternalCoroutinesApi
@@ -176,6 +177,17 @@ class MapboxTripSessionTest {
 
         verify { observer.onRawLocationChanged(location) }
         assertEquals(location, tripSession.getRawLocation())
+
+        tripSession.stop()
+    }
+
+    @Test
+    fun locationObserverOnFailure() {
+        tripSession.start()
+
+        locationCallbackSlot.captured.onFailure(Exception("location failure"))
+
+        verify(exactly = 0) { locationEngine.removeLocationUpdates(locationCallbackSlot.captured) }
 
         tripSession.stop()
     }


### PR DESCRIPTION
## Description

Fixes stopping location updates when location engine callback on failure

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

If the last known location is not available, then it should still be listened for future location updates. `onFailure` callback shall not break the entire localization stack.

### Implementation

Remove `stopLocationUpdates` call from `LocationEngineCallback#onFailure`

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR