### PR TITLE
Added support for alternative route scaling in the styles and added m…

### DIFF
--- a/libnavigation-ui/src/main/res/values/styles.xml
+++ b/libnavigation-ui/src/main/res/values/styles.xml
@@ -4,16 +4,39 @@
     <style name="NavigationMapRoute">
         <!-- Colors -->
         <item name="routeColor">@color/mapbox_navigation_route_layer_blue</item>
+        <item name="routeUnknownCongestionColor">
+            @color/mapbox_navigation_route_layer_congestion_unknown
+        </item>
         <item name="routeModerateCongestionColor">
             @color/mapbox_navigation_route_layer_congestion_yellow
+        </item>
+        <item name="routeHeavyCongestionColor">
+            @color/mapbox_navigation_route_layer_congestion_heavy
         </item>
         <item name="routeSevereCongestionColor">
             @color/mapbox_navigation_route_layer_congestion_red
         </item>
         <item name="routeShieldColor">@color/mapbox_navigation_route_shield_layer_color</item>
-
+        <item name="routeLineTraveledColor">@color/mapbox_navigation_route_line_traveled_color</item>
+        <item name="alternativeRouteColor">@color/mapbox_navigation_route_alternative_color</item>
+        <item name="alternativeRouteUnknownCongestionColor">
+            @color/mapbox_navigation_route_alternative_congestion_unknown
+        </item>
+        <item name="alternativeRouteModerateCongestionColor">
+            @color/mapbox_navigation_route_alternative_congestion_yellow
+        </item>
+        <item name="alternativeRouteHeavyCongestionColor">
+            @color/mapbox_navigation_route_alternative_congestion_heavy
+        </item>
+        <item name="alternativeRouteSevereCongestionColor">
+            @color/mapbox_navigation_route_alternative_congestion_red
+        </item>
+        <item name="alternativeRouteShieldColor">
+            @color/mapbox_navigation_route_alternative_shield_color
+        </item>
         <!-- Scales -->
         <item name="routeScale">1.0</item>
+        <item name="alternativeRouteScale">1.0</item>
         <item name="upcomingManeuverArrowColor">
             @color/mapbox_navigation_route_upcoming_maneuver_arrow_color
         </item>


### PR DESCRIPTION
## Description

Fixes  #3037 by exposing the alternative route line scaling in the styles for customization and the traffic congestion colors as well for some that were missing.

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal
All the traffic colors and route line scaling should be customizable via the styling.

### Implementation
Added the missing style items to the styles.xml

## Screenshots or Gifs


## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->