### PR TITLE
Example activity demonstrating customization of the route line colors

### DIFF
--- a/examples/src/main/AndroidManifest.xml
+++ b/examples/src/main/AndroidManifest.xml
@@ -271,6 +271,16 @@
                 android:value=".UIActivity" />
         </activity>
 
+        <activity
+            android:name=".core.CustomRouteStylingActivity"
+            android:label="@string/title_custom_route_styling_kotlin"
+            android:screenOrientation="portrait"
+            android:theme="@style/CustomRouteTheme">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".CoreActivity" />
+        </activity>
+
         <meta-data
             android:name="com.mapbox.TestEventsServer"
             android:value="api-events-staging.tilestream.net" />

--- a/examples/src/main/java/com/mapbox/navigation/examples/CoreActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/CoreActivity.kt
@@ -8,6 +8,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.LinearLayoutManager.VERTICAL
 import com.mapbox.navigation.examples.core.BasicNavSdkOnlyActivity
 import com.mapbox.navigation.examples.core.BasicNavigationActivity
+import com.mapbox.navigation.examples.core.CustomRouteStylingActivity
 import com.mapbox.navigation.examples.core.DebugMapboxNavigationKt
 import com.mapbox.navigation.examples.core.FasterRouteActivity
 import com.mapbox.navigation.examples.core.FeedbackButtonActivity
@@ -161,7 +162,12 @@ class CoreActivity : AppCompatActivity() {
                 getString(R.string.title_debug_navigation_kotlin),
                 getString(R.string.description_debug_navigation_kotlin),
                 DebugMapboxNavigationKt::class.java
-            )
+            ),
+            SampleItem(
+                getString(R.string.title_custom_route_styling_kotlin),
+                getString(R.string.description_custom_route_styling_kotlin),
+                CustomRouteStylingActivity::class.java
+        )
         )
     }
 }

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/BasicNavigationActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/BasicNavigationActivity.kt
@@ -44,7 +44,7 @@ import timber.log.Timber
  * navigation experience with the Navigation SDK and
  * Navigation UI SDK.
  */
-class BasicNavigationActivity : AppCompatActivity(), OnMapReadyCallback {
+open class BasicNavigationActivity : AppCompatActivity(), OnMapReadyCallback {
 
     companion object {
         const val MAP_INSTANCE_STATE_KEY = "navgation_mapbox_map_instance_state"

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/CustomRouteStylingActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/CustomRouteStylingActivity.kt
@@ -1,0 +1,16 @@
+package com.mapbox.navigation.examples.core
+
+import android.os.Bundle
+import android.view.View
+import kotlinx.android.synthetic.main.activity_basic_navigation_layout.*
+
+/**
+ * Note: See the AndroidManifest.xml for this activity and notice how the theme is set.
+ */
+class CustomRouteStylingActivity : BasicNavigationActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        fabToggleStyle.visibility = View.GONE
+    }
+}

--- a/examples/src/main/res/values/colors.xml
+++ b/examples/src/main/res/values/colors.xml
@@ -25,4 +25,20 @@
 
     <color name="navigation_maneuver_view_primary">#4164FB</color>
     <color name="navigation_maneuver_view_secondary">@android:color/holo_blue_light</color>
+
+    <!-- Custom Route Colors -->
+    <color name="customRouteShieldColor">#4164FB</color>
+    <color name="customRouteColor">#AD80C2</color>
+    <color name="customRouteUnknownCongestionColor">#a8aaba</color>
+    <color name="customRouteModerateCongestionColor">#CFAC00</color>
+    <color name="customRouteHeavyCongestionColor">#D19500</color>
+    <color name="customRouteSevereCongestionColor">#D16100</color>
+    <color name="customRouteLineTraveledColor">#3300B4D1</color>
+
+    <color name="customAlternativeRouteColor">#7EC8CF</color>
+    <color name="customAlternativeRouteUnknownCongestionColor">#7EC8CF</color>
+    <color name="customAlternativeRouteModerateCongestionColor">#76BCC2</color>
+    <color name="customAlternativeRouteHeavyCongestionColor">#67A3A8</color>
+    <color name="customAlternativeRouteSevereCongestionColor">#4F7E82</color>
+    <color name="customAlternativeRouteShieldColor">#284042</color>
 </resources>

--- a/examples/src/main/res/values/strings.xml
+++ b/examples/src/main/res/values/strings.xml
@@ -96,6 +96,9 @@
     <string name="title_debug_navigation_kotlin" translatable="false">Debug MapboxNavigation Kotlin</string>
     <string name="description_debug_navigation_kotlin" translatable="false">Shows debug points for raw(red) and enhanced(blue) location update.</string>
 
+    <string name="title_custom_route_styling_kotlin" translatable="false">Custom Route Styling Kotlin</string>
+    <string name="description_custom_route_styling_kotlin" translatable="false">Demonstrates applying a custom style for the routes.</string>
+
     <string name="settings" translatable="false">Settings</string>
     <string name="simulate_route" translatable="false">Simulate Route</string>
     <string name="language" translatable="false">Language</string>

--- a/examples/src/main/res/values/styles.xml
+++ b/examples/src/main/res/values/styles.xml
@@ -86,4 +86,34 @@
         <!-- Summary bottom sheet secondary text color (e.g. the remaining distance label) -->
         <item name="summaryBottomSheetSecondaryTextColor">@color/navigation_secondary_text</item>
     </style>
+
+    <style name="CustomRouteTheme" parent="NavigationViewLight">
+        <item name="navigationViewRouteStyle">@style/CustomRouteStyle</item>
+    </style>
+
+    <style name="CustomRouteStyle" parent="@style/NavigationMapRoute">
+        <item name="routeColor">@color/customRouteColor</item>
+        <item name="routeUnknownCongestionColor">@color/customRouteUnknownCongestionColor</item>
+        <item name="routeModerateCongestionColor">@color/customRouteModerateCongestionColor</item>
+        <item name="routeHeavyCongestionColor">@color/customRouteHeavyCongestionColor</item>
+        <item name="routeSevereCongestionColor">@color/customRouteSevereCongestionColor</item>
+        <item name="routeShieldColor">@color/customRouteShieldColor</item>
+        <item name="routeLineTraveledColor">@color/customRouteLineTraveledColor</item>
+        <item name="alternativeRouteColor">@color/customAlternativeRouteColor</item>
+        <item name="alternativeRouteUnknownCongestionColor">
+            @color/customAlternativeRouteUnknownCongestionColor
+        </item>
+        <item name="alternativeRouteModerateCongestionColor">
+            @color/customAlternativeRouteModerateCongestionColor
+        </item>
+        <item name="alternativeRouteHeavyCongestionColor">
+            @color/customAlternativeRouteHeavyCongestionColor
+        </item>
+        <item name="alternativeRouteSevereCongestionColor">
+            @color/customAlternativeRouteSevereCongestionColor
+        </item>
+        <item name="alternativeRouteShieldColor">
+            @color/customAlternativeRouteShieldColor
+        </item>
+    </style>
 </resources>


### PR DESCRIPTION
## Description
An example activity demonstrating the changing of the the route colors through a customized style has been created.

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal

The example activity is a real world example demonstrating the customization described in the documentation. https://docs.mapbox.com/android/navigation/overview/map-styling/#style-the-map-route

### Implementation

A custom theme was added and is used by an activity is available along with the other Mapbox examples.

## Screenshots or Gifs

![20200527_140154](https://user-images.githubusercontent.com/2249818/83076787-0835c180-a02b-11ea-9edc-075ecd9e9fa9.gif)

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [x] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->