### PR TITLE
maneuver arrow updates only if is visible and arrow layer visible by …

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteArrow.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteArrow.java
@@ -93,6 +93,7 @@ class MapRouteArrow {
 
   private final MapView mapView;
   private final MapboxMap mapboxMap;
+  private boolean isVisible = true;
 
   MapRouteArrow(MapView mapView, MapboxMap mapboxMap, @StyleRes int styleRes, String aboveLayer) {
     this.mapView = mapView;
@@ -108,6 +109,7 @@ class MapRouteArrow {
     typedArray.recycle();
 
     initialize(aboveLayer);
+    updateVisibilityTo(isVisible);
   }
 
   void addUpcomingManeuverArrow(RouteProgress routeProgress) {
@@ -133,6 +135,7 @@ class MapRouteArrow {
   }
 
   void updateVisibilityTo(boolean visible) {
+    this.isVisible = visible;
     Style style = mapboxMap.getStyle();
     if (style != null) {
       for (String layerId : arrowLayerIds) {
@@ -145,6 +148,10 @@ class MapRouteArrow {
         }
       }
     }
+  }
+
+  public boolean routeArrowIsVisible() {
+    return isVisible;
   }
 
   private List<Point> obtainArrowPointsFrom(RouteProgress routeProgress) {

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteProgressChangeListener.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteProgressChangeListener.kt
@@ -69,7 +69,9 @@ internal class MapRouteProgressChangeListener(
                 }
             }
         }
-        routeArrow.addUpcomingManeuverArrow(routeProgress)
+        if (routeArrow.routeArrowIsVisible()) {
+            routeArrow.addUpcomingManeuverArrow(routeProgress)
+        }
     }
 
     private fun animateVanishRouteLineUpdate(startingDistanceValue: Float, percentDistanceTraveled: Float) {

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/NavigationMapRoute.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/NavigationMapRoute.java
@@ -349,7 +349,9 @@ public class NavigationMapRoute implements LifecycleObserver {
 
   private void redraw(Style style) {
     recreateRouteLine(style);
+    boolean arrowVisibility = routeArrow.routeArrowIsVisible();
     routeArrow = new MapRouteArrow(mapView, mapboxMap, styleRes, routeLine.getTopLayerId());
+    routeArrow.updateVisibilityTo(arrowVisibility);
     updateProgressChangeListener();
   }
 

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteProgressChangeListenerTest.kt
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteProgressChangeListenerTest.kt
@@ -24,6 +24,7 @@ class MapRouteProgressChangeListenerTest {
         every { routeLine.retrieveDirectionsRoutes() } returns emptyList()
         every { routeLine.draw(capture(drawDirections)) } returns Unit
         every { routeArrow.addUpcomingManeuverArrow(capture(addRouteProgress)) } returns Unit
+        every { routeArrow.routeArrowIsVisible() } returns true
     }
 
     @Test
@@ -79,7 +80,7 @@ class MapRouteProgressChangeListenerTest {
     }
 
     @Test
-    fun `should only add maneuver arrow with geometry`() {
+    fun `should only add maneuver arrow when visible`() {
         val routes = listOf(
             mockk<DirectionsRoute> {
                 every { geometry() } returns "y{v|bA{}diiGOuDpBiMhM{k@~Syj@bLuZlEiM"
@@ -96,6 +97,27 @@ class MapRouteProgressChangeListenerTest {
         progressChangeListener.onRouteProgressChanged(routeProgress)
 
         verify(exactly = 1) { routeArrow.addUpcomingManeuverArrow(routeProgress) }
+    }
+
+    @Test
+    fun `should not add maneuver arrow when not visible`() {
+        every { routeArrow.routeArrowIsVisible() } returns false
+        val routes = listOf(
+            mockk<DirectionsRoute> {
+                every { geometry() } returns "y{v|bA{}diiGOuDpBiMhM{k@~Syj@bLuZlEiM"
+            }
+        )
+        every { routeLine.getPrimaryRoute() } returns routes[0]
+        every { routeLine.retrieveDirectionsRoutes() } returns routes
+        val routeProgress: RouteProgress = mockk {
+            every { route } returns mockk {
+                every { geometry() } returns "{au|bAqtiiiG|TnI`B\\dEzAl_@hMxGxB"
+            }
+        }
+
+        progressChangeListener.onRouteProgressChanged(routeProgress)
+
+        verify(exactly = 0) { routeArrow.addUpcomingManeuverArrow(routeProgress) }
     }
 
     @Test


### PR DESCRIPTION
## Description

Addresses #3052 by updating the maneuver arrow only if it's visible.

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal

The maneuver arrow should only get updated by the route progress change listener when it's in a visible state.

### Implementation

I added a check in the listener to determine if the arrow layer is visible and it does not update the maneuver arrow if the layer is not visible.  Also the layer is visible by default.

## Screenshots or Gifs

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->