### PR TITLE
Adjustments to NavigationMapRoute builder to make it clear that in or…

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/NavigationMapboxMap.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/NavigationMapboxMap.java
@@ -384,7 +384,7 @@ public class NavigationMapboxMap implements LifecycleObserver {
     this.navigation = navigation;
     initializeWayName(mapboxMap, mapPaddingAdjustor);
     initializeFpsDelegate(mapView);
-    mapRoute.addProgressChangeListener(navigation);
+    mapRoute.addProgressChangeListener(navigation, vanishRouteLineEnabled);
     mapCamera.addProgressChangeListener(navigation);
     mapWayName.addProgressChangeListener(navigation);
     mapFpsDelegate.addProgressChangeListener(navigation);
@@ -788,7 +788,6 @@ public class NavigationMapboxMap implements LifecycleObserver {
     mapRoute = new NavigationMapRoute.Builder(mapView, map, lifecycleOwner)
             .withStyle(routeStyleRes)
             .withBelowLayer(routeBelowLayerId)
-            .withVanishRouteLineEnabled(vanishRouteLineEnabled)
             .build();
   }
 

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/NavigationMapRoute.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/NavigationMapRoute.java
@@ -264,6 +264,22 @@ public class NavigationMapRoute implements LifecycleObserver {
     navigation.registerRouteProgressObserver(mapRouteProgressChangeListener);
   }
 
+  /**
+   * This method will allow this class to listen to new routes based on
+   * the progress updates from {@link MapboxNavigation}.
+   * <p>
+   * If a new route is given to {@link MapboxNavigation#startTripSession()}, this
+   * class will automatically draw the new route.
+   *
+   * @param navigation to add the progress change listener
+   * @param vanishRouteLineEnabled determines if the route line should vanish behind the puck.
+   */
+  public void addProgressChangeListener(MapboxNavigation navigation, boolean vanishRouteLineEnabled) {
+    this.navigation = navigation;
+    this.vanishRouteLineEnabled = vanishRouteLineEnabled;
+    navigation.registerRouteProgressObserver(mapRouteProgressChangeListener);
+  }
+
 
   /**
    * Should be called if {@link NavigationMapRoute#addProgressChangeListener(MapboxNavigation)} was
@@ -454,10 +470,14 @@ public class NavigationMapRoute implements LifecycleObserver {
     /**
      * An instance of the {@link MapboxNavigation} object. Default is null that means
      * your route won't consider rerouting during a navigation session.
+     *
+     * @param vanishRouteLineEnabled determines if the route line should vanish behind the puck
+     *                               during navigation. By default is `false`
      * @return the builder
      */
-    public Builder withMapboxNavigation(@Nullable MapboxNavigation navigation) {
+    public Builder withMapboxNavigation(@Nullable MapboxNavigation navigation, boolean vanishRouteLineEnabled) {
       this.navigation = navigation;
+      this.vanishRouteLineEnabled = vanishRouteLineEnabled;
       return this;
     }
 
@@ -476,15 +496,6 @@ public class NavigationMapRoute implements LifecycleObserver {
      */
     public Builder withBelowLayer(@Nullable String belowLayer) {
       this.belowLayer = belowLayer;
-      return this;
-    }
-
-    /**
-     * Determines if the route line should vanish behind the puck during navigation. By default is `false`
-     * @return the builder
-     */
-    public Builder withVanishRouteLineEnabled(boolean vanishRouteLineEnabled) {
-      this.vanishRouteLineEnabled = vanishRouteLineEnabled;
       return this;
     }
 


### PR DESCRIPTION
## Description

A customer remarked that it wasn't clear that in order to turn on the vanishing route line feature the NavigationMapRoute class needed a reference to MapboxNavigation in order to attach a MapRouteProgressChangeListener which NavigationMapRoute does behind the scenes. In addition there was no documentation regarding this detail.

Recently a builder was added to NavigationMapRoute which had a clause to indicate if the vanishing route line feature was enabled. However the reference to MapboxNavigation is optional in the builder since it's optional in the  MapboxNavigation class. This could lead to a confusing experience for a developer if the builder is used with a null reference to the MapboxNavigation and a true value for vanishing the route line. The developer wouldn't understand the MapboxNavigation reference would be required. 

- [ ] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal

The goal of this PR is to have a builder that doesn't allow for an invalid or unclear state. 

### Implementation

The builder was modified so that the only way to pass a value for the vanishing route line feature is to also provide a reference to MapboxNavigation as it is necessary for the feature to work correctly. An additional addProgressChangeListener method was added which takes a parameter for the vanishing route line enablement so that the feature can be activated at the same time the progress listener is added.

## Screenshots or Gifs

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->