### PR TITLE
fix #3069: restore the subInstructionView visibibility after show/hide the InstructionListView in landscape mode.

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/instruction/InstructionView.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/instruction/InstructionView.java
@@ -1025,6 +1025,7 @@ public class InstructionView extends RelativeLayout implements LifecycleObserver
   private void updateLandscapeConstraintsTo(int layoutRes) {
     final int feedbackButtonVisibility = feedbackButton.getVisibility();
     final int soundButtonVisibility = feedbackButton.getVisibility();
+    final int subInstructionLayoutVisitbility = subStepLayout.getVisibility();
 
     ConstraintSet collapsed = new ConstraintSet();
     collapsed.clone(getContext(), layoutRes);
@@ -1032,6 +1033,7 @@ public class InstructionView extends RelativeLayout implements LifecycleObserver
 
     feedbackButton.setVisibility(feedbackButtonVisibility);
     soundButton.setVisibility(soundButtonVisibility);
+    subStepLayout.setVisibility(subInstructionLayoutVisitbility);
   }
 
   /**


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Fix #3069 

The `subInstructionView` will dismiss in landscape mode after show/hide the InstructionList view.

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal

Make sure the InstructionView works as expected.

### Implementation

Save and restore the `subInstructionView` visibility when hide the InstructionList view.

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->