### PR TITLE
fix #3080: the FAB behavior slightly changed in supportLib 1.1.0

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/SoundButton.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/SoundButton.java
@@ -170,7 +170,7 @@ public class SoundButton extends ConstraintLayout implements NavigationButton {
     soundChipText.setTextColor(secondaryColor);
 
     soundFab.setBackgroundTintList(ColorStateList.valueOf(primaryColor));
-    soundFab.setColorFilter(secondaryColor);
+    soundFab.setSupportImageTintList(ColorStateList.valueOf(secondaryColor));
   }
 
   /**


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Fix #3080
the FAB behavior slightly changed in supportLib 1.1.0

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal

Improve UI SDK 

### Implementation

The original `setColorFilter` method behavior seems changed in lib 1.1.0
The tint color isn't kept after switching icons. The `setSupportImageTintList` is the right call in this scenario.

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->