### PR TITLE
Fix #3077: should setLocale to the cloned context instead of calling it against the current context.

### DIFF
--- a/libtrip-notification/src/main/java/com/mapbox/navigation/trip/notification/internal/TimeFormatter.kt
+++ b/libtrip-notification/src/main/java/com/mapbox/navigation/trip/notification/internal/TimeFormatter.kt
@@ -1,6 +1,7 @@
 package com.mapbox.navigation.trip.notification.internal
 
 import android.content.Context
+import android.content.res.Configuration
 import android.content.res.Resources
 import android.graphics.Typeface
 import android.text.SpannableStringBuilder
@@ -53,7 +54,11 @@ object TimeFormatter {
      * @return SpannableStringBuilder
      */
     @JvmStatic
-    fun formatTimeRemaining(context: Context, routeDuration: Double, locale: Locale?): SpannableStringBuilder {
+    fun formatTimeRemaining(
+        context: Context,
+        routeDuration: Double,
+        locale: Locale?
+    ): SpannableStringBuilder {
         var seconds = routeDuration.toLong()
 
         if (seconds < 0) {
@@ -86,7 +91,11 @@ object TimeFormatter {
         }
     }
 
-    private fun formatHours(resources: Resources, hours: Long, textSpanItems: MutableList<SpanItem>) {
+    private fun formatHours(
+        resources: Resources,
+        hours: Long,
+        textSpanItems: MutableList<SpanItem>
+    ) {
         if (hours != 0L) {
             val hourString = String.format(TIME_STRING_FORMAT, resources.getString(R.string.hr))
             textSpanItems.add(TextSpanItem(StyleSpan(Typeface.BOLD), hours.toString()))
@@ -121,7 +130,7 @@ object TimeFormatter {
     }
 
     private fun Context.resourcesWithLocale(locale: Locale?): Resources {
-        val config = this.resources.configuration.also {
+        val config = Configuration(this.resources.configuration).also {
             it.setLocale(locale)
         }
         return this.createConfigurationContext(config).resources


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Fix #3077: should `setLocale` to the cloned context instead of calling it against the current context.

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Improve the Navigation SDK

### Implementation

The original implementation will change the running application context's locale.
That locale is created in `SummaryModel` and is a temporary variable based on `directionsRoute.voiceLanguage` which doesn't initiated with the `country` attribute. This results in the voice-unit will always be `metric` for next route request, due to the null `country` attribute. 
Refer: [LocaleEx.getUnitTypeForLocale()](https://github.com/mapbox/mapbox-navigation-android/blob/master/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/extensions/LocaleEx.kt#L32): 
```kotlin
    fun Locale.getUnitTypeForLocale(): String =
            when (this.country.toUpperCase(this)) {
                "US", // US
                "LR", // Liberia
                "MM" -> // Burma
                    VoiceUnit.IMPERIAL
                else ->
                    VoiceUnit.METRIC
            }
```

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->