### PR TITLE
The traffic section of the line can be scaled differently

### DIFF
--- a/examples/src/main/res/values/colors.xml
+++ b/examples/src/main/res/values/colors.xml
@@ -27,13 +27,15 @@
     <color name="navigation_maneuver_view_secondary">@android:color/holo_blue_light</color>
 
     <!-- Custom Route Colors -->
-    <color name="customRouteShieldColor">#4164FB</color>
-    <color name="customRouteColor">#AD80C2</color>
+    <color name="customRouteShieldColor">#000000</color>
+    <color name="customRouteColor">#ffffff</color>
+    <color name="customRouteLowCongestionColor">#00ff00</color>
     <color name="customRouteUnknownCongestionColor">#a8aaba</color>
     <color name="customRouteModerateCongestionColor">#CFAC00</color>
-    <color name="customRouteHeavyCongestionColor">#D19500</color>
-    <color name="customRouteSevereCongestionColor">#D16100</color>
-    <color name="customRouteLineTraveledColor">#3300B4D1</color>
+    <color name="customRouteHeavyCongestionColor">#D16100</color>
+    <color name="customRouteSevereCongestionColor">#FF0000</color>
+    <color name="customRouteLineTraveledColor">#a8aaba</color>
+    <color name="customRouteLineShieldTraveledColor">#6E707A</color>
 
     <color name="customAlternativeRouteColor">#7EC8CF</color>
     <color name="customAlternativeRouteUnknownCongestionColor">#7EC8CF</color>

--- a/examples/src/main/res/values/styles.xml
+++ b/examples/src/main/res/values/styles.xml
@@ -93,12 +93,14 @@
 
     <style name="CustomRouteStyle" parent="@style/NavigationMapRoute">
         <item name="routeColor">@color/customRouteColor</item>
+        <item name="routeLowCongestionColor">@color/customRouteLowCongestionColor</item>
         <item name="routeUnknownCongestionColor">@color/customRouteUnknownCongestionColor</item>
         <item name="routeModerateCongestionColor">@color/customRouteModerateCongestionColor</item>
         <item name="routeHeavyCongestionColor">@color/customRouteHeavyCongestionColor</item>
         <item name="routeSevereCongestionColor">@color/customRouteSevereCongestionColor</item>
         <item name="routeShieldColor">@color/customRouteShieldColor</item>
         <item name="routeLineTraveledColor">@color/customRouteLineTraveledColor</item>
+        <item name="routeLineShieldTraveledColor">@color/customRouteLineShieldTraveledColor</item>
         <item name="alternativeRouteColor">@color/customAlternativeRouteColor</item>
         <item name="alternativeRouteUnknownCongestionColor">
             @color/customAlternativeRouteUnknownCongestionColor
@@ -115,5 +117,6 @@
         <item name="alternativeRouteShieldColor">
             @color/customAlternativeRouteShieldColor
         </item>
+        <item name="routeTrafficScale">0.5</item>
     </style>
 </resources>

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/internal/route/MapRouteLayerProvider.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/internal/route/MapRouteLayerProvider.java
@@ -36,6 +36,8 @@ import static com.mapbox.navigation.ui.internal.route.RouteConstants.ORIGIN_MARK
 import static com.mapbox.navigation.ui.internal.route.RouteConstants.PRIMARY_ROUTE_LAYER_ID;
 import static com.mapbox.navigation.ui.internal.route.RouteConstants.PRIMARY_ROUTE_SHIELD_LAYER_ID;
 import static com.mapbox.navigation.ui.internal.route.RouteConstants.PRIMARY_ROUTE_SOURCE_ID;
+import static com.mapbox.navigation.ui.internal.route.RouteConstants.PRIMARY_ROUTE_TRAFFIC_LAYER_ID;
+import static com.mapbox.navigation.ui.internal.route.RouteConstants.PRIMARY_ROUTE_TRAFFIC_SOURCE_ID;
 import static com.mapbox.navigation.ui.internal.route.RouteConstants.WAYPOINT_DESTINATION_VALUE;
 import static com.mapbox.navigation.ui.internal.route.RouteConstants.WAYPOINT_LAYER_ID;
 import static com.mapbox.navigation.ui.internal.route.RouteConstants.WAYPOINT_ORIGIN_VALUE;
@@ -53,19 +55,19 @@ public class MapRouteLayerProvider {
     // fixme reduce all the duplicate code here
 
     primaryShieldLayer = new LineLayer(PRIMARY_ROUTE_SHIELD_LAYER_ID, PRIMARY_ROUTE_SOURCE_ID).withProperties(
-       lineCap(Property.LINE_CAP_ROUND),
-       lineJoin(Property.LINE_JOIN_ROUND),
-       lineWidth(
-           interpolate(
-               exponential(1.5f), zoom(),
-                   stop(10f, 7f),
-                   stop(14f, product(literal(10.5f), literal(routeScale))),
-                   stop(16.5f, product(literal(15.5f), literal(routeScale))),
-                   stop(19f, product(literal(24f), literal(routeScale))),
-                   stop(22f, product(literal(29f), literal(routeScale)))
-               )
-       ),
-       lineColor(color(routeShieldColor))
+     lineCap(Property.LINE_CAP_ROUND),
+     lineJoin(Property.LINE_JOIN_ROUND),
+     lineWidth(
+       interpolate(
+          exponential(1.5f), zoom(),
+             stop(10f, 7f),
+             stop(14f, product(literal(10.5f), literal(routeScale))),
+             stop(16.5f, product(literal(15.5f), literal(routeScale))),
+             stop(19f, product(literal(24f), literal(routeScale))),
+             stop(22f, product(literal(29f), literal(routeScale)))
+          )
+     ),
+     lineColor(color(routeShieldColor))
    );
     return primaryShieldLayer;
   }
@@ -129,6 +131,41 @@ public class MapRouteLayerProvider {
                    stop(19f, product(literal(14f), literal(routeScale))),
                    stop(22f, product(literal(18f), literal(routeScale)))
            )
+       ),
+       lineColor(color(routeDefaultColor))
+       );
+    return primaryRouteLayer;
+  }
+
+  public LineLayer initializePrimaryRouteTrafficLayer(Style style,
+                                          boolean roundedLineCap,
+                                          float routeScale,
+                                          int routeDefaultColor) {
+    LineLayer primaryRouteLayer = style.getLayerAs(PRIMARY_ROUTE_TRAFFIC_LAYER_ID);
+    if (primaryRouteLayer != null) {
+      style.removeLayer(primaryRouteLayer);
+    }
+
+    String lineCap = Property.LINE_CAP_ROUND;
+    String lineJoin = Property.LINE_JOIN_ROUND;
+    if (!roundedLineCap) {
+      lineCap = Property.LINE_CAP_BUTT;
+      lineJoin = Property.LINE_JOIN_BEVEL;
+    }
+
+    primaryRouteLayer = new LineLayer(PRIMARY_ROUTE_TRAFFIC_LAYER_ID, PRIMARY_ROUTE_TRAFFIC_SOURCE_ID).withProperties(
+        lineCap(lineCap),
+        lineJoin(lineJoin),
+        lineWidth(
+            interpolate(
+                exponential(1.5f), zoom(),
+                    stop(4f, product(literal(3f), literal(routeScale))),
+                    stop(10f, product(literal(4f), literal(routeScale))),
+                    stop(13f, product(literal(6f), literal(routeScale))),
+                    stop(16f, product(literal(10f), literal(routeScale))),
+                    stop(19f, product(literal(14f), literal(routeScale))),
+                    stop(22f, product(literal(18f), literal(routeScale)))
+            )
        ),
        lineColor(color(routeDefaultColor))
        );

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/internal/route/RouteConstants.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/internal/route/RouteConstants.java
@@ -2,7 +2,9 @@ package com.mapbox.navigation.ui.internal.route;
 
 public class RouteConstants {
   public static final String PRIMARY_ROUTE_SOURCE_ID = "mapbox-navigation-route-source";
+  public static final String PRIMARY_ROUTE_TRAFFIC_SOURCE_ID = "mapbox-navigation-route-traffic-source";
   public static final String PRIMARY_ROUTE_LAYER_ID = "mapbox-navigation-route-layer";
+  public static final String PRIMARY_ROUTE_TRAFFIC_LAYER_ID = "mapbox-navigation-route-traffic-layer";
   public static final String PRIMARY_ROUTE_SHIELD_LAYER_ID = "mapbox-navigation-route-shield-layer";
   public static final String ALTERNATIVE_ROUTE_SOURCE_ID = "mapbox-navigation-alt-route-source";
   public static final String ALTERNATIVE_ROUTE_LAYER_ID = "mapbox-navigation-alt-route-layer";

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteProgressChangeListener.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteProgressChangeListener.kt
@@ -32,6 +32,7 @@ internal class MapRouteProgressChangeListener(
         if (animationDistanceValue > MINIMUM_ROUTE_LINE_OFFSET) {
             val expression = routeLine.getExpressionAtOffset(animationDistanceValue)
             routeLine.hideShieldLineAtOffset(animationDistanceValue)
+            routeLine.hideRouteLineAtOffset(animationDistanceValue)
             routeLine.decorateRouteLine(expression)
         }
     }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/RouteLineLayerIds.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/RouteLineLayerIds.kt
@@ -3,7 +3,12 @@ package com.mapbox.navigation.ui.route
 /**
  * Contains the values for the primary and alternative route line layer ID's
  *
+ * @param primaryRouteTrafficLineLayerId the layer ID for the traffic line layer
  * @param primaryRouteLineLayerId the layer ID for the primary route line
  * @param alternativeRouteLineLayerId the layer ID for the alternative route line(s)
  */
-data class RouteLineLayerIds(val primaryRouteLineLayerId: String, val alternativeRouteLineLayerId: String)
+data class RouteLineLayerIds(
+    val primaryRouteTrafficLineLayerId: String,
+    val primaryRouteLineLayerId: String,
+    val alternativeRouteLineLayerId: String
+)

--- a/libnavigation-ui/src/main/res/values/attrs.xml
+++ b/libnavigation-ui/src/main/res/values/attrs.xml
@@ -4,15 +4,18 @@
     <!-- Primary route colors -->
     <attr name="routeColor" format="color"/>
     <attr name="routeUnknownCongestionColor" format="color"/>
+    <attr name="routeLowCongestionColor" format="color"/>
     <attr name="routeModerateCongestionColor" format="color"/>
     <attr name="routeHeavyCongestionColor" format="color"/>
     <attr name="routeSevereCongestionColor" format="color"/>
     <attr name="routeShieldColor" format="color"/>
     <attr name="routeLineTraveledColor" format="color"/>
+    <attr name="routeLineShieldTraveledColor" format="color"/>
 
     <!-- Alternative route colors -->
     <attr name="alternativeRouteColor" format="color"/>
     <attr name="alternativeRouteUnknownCongestionColor" format="color"/>
+    <attr name="alternativeRouteLowCongestionColor" format="color"/>
     <attr name="alternativeRouteModerateCongestionColor" format="color"/>
     <attr name="alternativeRouteHeavyCongestionColor" format="color"/>
     <attr name="alternativeRouteSevereCongestionColor" format="color"/>
@@ -24,6 +27,7 @@
 
     <!-- Route Scales -->
     <attr name="routeScale" format="float"/>
+    <attr name="routeTrafficScale" format="float"/>
     <attr name="alternativeRouteScale" format="float"/>
 
     <attr name="upcomingManeuverArrowColor" format="color"/>

--- a/libnavigation-ui/src/main/res/values/colors.xml
+++ b/libnavigation-ui/src/main/res/values/colors.xml
@@ -2,12 +2,14 @@
 <resources>
   <!-- Primary route colors -->
   <color name="mapbox_navigation_route_layer_blue">#56A8FB</color>
+  <color name="mapbox_navigation_route_traffic_layer_color">#56A8FB</color>
   <color name="mapbox_navigation_route_layer_congestion_unknown">#56A8FB</color>
   <color name="mapbox_navigation_route_layer_congestion_yellow">#F3A64F</color>
   <color name="mapbox_navigation_route_layer_congestion_heavy">#E93340</color>
   <color name="mapbox_navigation_route_layer_congestion_red">#E93340</color>
   <color name="mapbox_navigation_route_shield_layer_color">#2F7AC6</color>
   <color name="mapbox_navigation_route_line_traveled_color">#00000000</color>
+  <color name="mapbox_navigation_route_shield_line_traveled_color">#00000000</color>
 
   <!-- Alternative route colors -->
   <color name="mapbox_navigation_route_alternative_color">#8694A5</color>

--- a/libnavigation-ui/src/main/res/values/styles.xml
+++ b/libnavigation-ui/src/main/res/values/styles.xml
@@ -4,6 +4,7 @@
     <style name="NavigationMapRoute">
         <!-- Colors -->
         <item name="routeColor">@color/mapbox_navigation_route_layer_blue</item>
+        <item name="routeLowCongestionColor">@color/mapbox_navigation_route_layer_blue</item>
         <item name="routeUnknownCongestionColor">
             @color/mapbox_navigation_route_layer_congestion_unknown
         </item>
@@ -23,6 +24,9 @@
         <item name="alternativeRouteUnknownCongestionColor">
             @color/mapbox_navigation_route_alternative_congestion_unknown
         </item>
+        <item name="alternativeRouteLowCongestionColor">
+            @color/mapbox_navigation_route_alternative_color
+        </item>
         <item name="alternativeRouteModerateCongestionColor">
             @color/mapbox_navigation_route_alternative_congestion_yellow
         </item>
@@ -37,6 +41,7 @@
         </item>
         <!-- Scales -->
         <item name="routeScale">1.0</item>
+        <item name="routeTrafficScale">1.0</item>
         <item name="alternativeRouteScale">1.0</item>
         <item name="upcomingManeuverArrowColor">
             @color/mapbox_navigation_route_upcoming_maneuver_arrow_color


### PR DESCRIPTION
## Description
With this PR the traffic line can be scaled differently from the route line. Also the color of the route line as well as the shield line can be colored differently from each other and are customizable.

- [ ] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal

The line representing the traffic can be scaled differently from the route line.
The route line shield color behind the puck can be customized independently of the vanishing route line color. Transparency for both or either is also supported.

### Implementation

An additional layer was added for the route traffic line. 
Styling elements were added.

## Screenshots or Gifs
Note: Colors are unrealistic so they are more noticeable. The colors can be customized.
![Screenshot_20200603-141100](https://user-images.githubusercontent.com/2249818/83691937-e21e9d00-a5a7-11ea-83f9-27d8a031fc6f.png)

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->