### PR TITLE
Add missing libnavigation-util Dokka to Makefile javadoc-dokka

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ javadoc-dokka:
 	./gradlew :libdirections-offboard:dokka
 	./gradlew :libdirections-hybrid:dokka
 	./gradlew :libnavigation-metrics:dokka
+	./gradlew :libnavigation-util:dokka
 	./gradlew :libtrip-notification:dokka
 	./gradlew :libnavigation-core:dokka
 	./gradlew :libnavigation-ui:dokka


### PR DESCRIPTION
## Description

Adds missing `libnavigation-util` `dokka` doc generation Gradle command to Makefile `javadoc-dokka` script

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

When running `make javadoc-dokka` generate the documentation for all the modules

### Implementation

Add missing `./gradlew :libnavigation-util:dokka` to Makefile `javadoc-dokka`

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR