### PR TITLE
added missing style declaration

### DIFF
--- a/libnavigation-ui/src/main/res/values/styles.xml
+++ b/libnavigation-ui/src/main/res/values/styles.xml
@@ -20,6 +20,8 @@
         <item name="routeShieldColor">@color/mapbox_navigation_route_shield_layer_color</item>
         <item name="routeLineTraveledColor">@color/mapbox_navigation_route_line_traveled_color
         </item>
+        <item name="routeLineShieldTraveledColor">@color/mapbox_navigation_route_shield_line_traveled_color
+        </item>
         <item name="alternativeRouteColor">@color/mapbox_navigation_route_alternative_color</item>
         <item name="alternativeRouteUnknownCongestionColor">
             @color/mapbox_navigation_route_alternative_congestion_unknown


### PR DESCRIPTION
## Description

While updating the documentation for route line styling I noticed I missed a style declaration. This is related to https://github.com/mapbox/mapbox-navigation-android/pull/3099

- [ ] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal


### Implementation


## Screenshots or Gifs


## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->