### PR TITLE
Fix replay state after clearEvents is called

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/MapboxReplayer.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/MapboxReplayer.kt
@@ -36,9 +36,12 @@ class MapboxReplayer {
     }
 
     /**
-     * Clear all replay events.
+     * Stops the player, seeks to the beginning, and clears all replay events. In order
+     * to start playing a new route, [pushEvents] and then [play].
      */
     fun clearEvents() {
+        stop()
+        seekTo(0.0)
         replayEvents.events.clear()
     }
 
@@ -148,7 +151,8 @@ class MapboxReplayer {
      * @return the duration in seconds
      */
     fun durationSeconds(): Double {
-        val firstEvent = replayEvents.events.first()
+        val firstEvent = replayEvents.events.firstOrNull()
+            ?: return 0.0
         val lastEvent = replayEvents.events.last()
         return lastEvent.eventTimestamp - firstEvent.eventTimestamp
     }
@@ -159,7 +163,9 @@ class MapboxReplayer {
      * @param replayTime time in seconds between 0.0 to [durationSeconds]
      */
     fun seekTo(replayTime: Double) {
-        val offsetTime = replayTime + replayEvents.events.first().eventTimestamp
+        val firstEventTime = replayEvents.events.firstOrNull()?.eventTimestamp
+            ?: return
+        val offsetTime = replayTime + firstEventTime
         val indexOfEvent = replayEvents.events
             .indexOfFirst { offsetTime <= it.eventTimestamp }
         check(indexOfEvent >= 0) { "Make sure your replayTime is less than replayDurationSeconds $replayTime > ${durationSeconds()}: " }


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Issue was found where the MapboxReplayer state is incorrect after clearEvents() is called. This adds a test showing that the state was indeed incorrect, the change fixes the test.

clearEvents is not updating the pivotIndex so the simulator is pointing into a non-existing buffer.

I'm updated the clearEvents() function to include stop() and seekTo(0.0) because they will always be required in order to make the player behave correctly. Also the order of events matter
``` kotlin
    fun clearEvents() {
        stop()
        seekTo(0.0)
        replayEvents.events.clear()
    }
```

- [ ] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

**To Reproduce**
Steps to reproduce the behavior:
1. Use the following code to start the Replayer:

```kotlin
mapboxReplayer.pushEvents(routeEvents)
replayLocationEngine.requestLocationUpdates(LOCATION_ENGINE_REQUEST_DUMMY, someCallback, null)
mapboxReplayer.play()
```

Use the following code to stop the replayer and clear the events:
```kotlin
mapboxReplayer.stop()
mapboxReplayer.clearEvents()
replayLocationEngine.removeLocationUpdates(someCallback)
```

2. Start replay of a route. Route is replayed as expected
3. Once replay has finished, start replay of a shorter route. Route is not replayed

**Expected behavior**
Routes should always be replayed no matter if the previous route was longer or shorter or the same.

**Actual behavior**
If the new route is shorter, the route is not replayed. If it is longer, the puck jumps to some part of the route and then continues normally.

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->