### PR TITLE
Upon device rotation the map is recreated with the route line and nav…

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationViewModel.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationViewModel.java
@@ -316,6 +316,10 @@ public class NavigationViewModel extends AndroidViewModel {
     return summaryModel;
   }
 
+  protected NavigationViewOptions getNavigationViewOptions() {
+    return navigationViewOptions;
+  }
+
   private void initializeLanguage(NavigationUiOptions options) {
     RouteOptions routeOptions = options.directionsRoute().routeOptions();
     language = ContextEx.inferDeviceLanguage(getApplication());


### PR DESCRIPTION
##  Description

A fix for the the NavigationView device rotation issue described in #3102 [#3067](https://github.com/mapbox/mapbox-navigation-android/issues/3067)

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal

The NavigationView should re-establish the navigation experience upon device rotation without any further coding by a developer.

### Implementation

The NavigationView listens for navigation ready callback events and if the navigation system is already running, indicating navigation is active, the view is re-established.

## Screenshots or Gifs

![20200605_111604](https://user-images.githubusercontent.com/2249818/83909839-5da25a80-a71e-11ea-953d-67b07861fb84.gif)

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->