### PR TITLE
Adjusting activity to correctly handle alternative route selection

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/FasterRouteActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/FasterRouteActivity.kt
@@ -206,6 +206,12 @@ class FasterRouteActivity : AppCompatActivity(), OnMapReadyCallback {
         mapboxMap.setStyle(Style.MAPBOX_STREETS) {
             mapboxMap.moveCamera(CameraUpdateFactory.zoomTo(15.0))
             navigationMapboxMap = NavigationMapboxMap(mapView, mapboxMap, this, true)
+            navigationMapboxMap?.setOnRouteSelectionChangeListener { route ->
+                mapboxNavigation.setRoutes(mapboxNavigation.getRoutes().toMutableList().apply {
+                    remove(route)
+                    add(0, route)
+                })
+            }
         }
 
         mapboxMap.addOnMapLongClickListener { latLng ->


### PR DESCRIPTION
## Description

Fix for #3119. When an alternative route is chosen it remains the primary route when navigation starts.

- [x] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal

When an alternative route is chosen it should remain the primary route when navigation begins.

### Implementation

Added a setOnRouteSelectionChangeListener.

## Screenshots or Gifs

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->