### PR TITLE
Hide alternative routes when navigation begins.

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/DebugMapboxNavigationKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/DebugMapboxNavigationKt.kt
@@ -226,6 +226,7 @@ class DebugMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
             if (routes.isNotEmpty()) {
                 initDynamicCamera(routes[0])
             }
+            navigationMapboxMap.showAlternativeRoutes(false)
         }
     }
 

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/FasterRouteActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/FasterRouteActivity.kt
@@ -236,6 +236,7 @@ class FasterRouteActivity : AppCompatActivity(), OnMapReadyCallback {
                 navigationMapboxMap?.startCamera(mapboxNavigation.getRoutes()[0])
             }
             mapboxNavigation.startTripSession()
+            navigationMapboxMap?.showAlternativeRoutes(false)
             stopLocationUpdates()
         }
         dismissLayout.setOnClickListener {

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/SimpleMapboxNavigationKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/SimpleMapboxNavigationKt.kt
@@ -224,6 +224,7 @@ class SimpleMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
             if (routes.isNotEmpty()) {
                 initDynamicCamera(routes[0])
             }
+            navigationMapboxMap.showAlternativeRoutes(false)
         }
         dismissLayout.setOnClickListener {
             fasterRouteSelectionTimer.onFinish()


### PR DESCRIPTION
## Description

Addresses issue #3120. 

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal
When navigation starts the alternative route lines should disappear.

### Implementation

Added call to hide the alternative routes.

## Screenshots or Gifs


## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->