### PR TITLE
Fix #1201: the stepPrimaryText doesn't have enough width in landscape mode

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/instruction/InstructionView.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/instruction/InstructionView.java
@@ -92,6 +92,7 @@ public class InstructionView extends RelativeLayout implements LifecycleObserver
   private static final String COMPONENT_TYPE_LANE = "lane";
   private static final long GUIDANCE_VIEW_DISPLAY_TRANSITION_SPEED = 900L;
   private static final long GUIDANCE_VIEW_HIDE_TRANSITION_SPEED = 900L;
+  private static final double MAXIMUM_PRIMARY_INSTRUCTION_TEXT_WIDTH_RATIO_IN_LANDSCAPE = 0.75;
 
   private ManeuverView maneuverView;
   private TextView stepDistanceText;
@@ -976,9 +977,15 @@ public class InstructionView extends RelativeLayout implements LifecycleObserver
   }
 
   private void loadPrimary(BannerText primaryBannerText) {
-    stepPrimaryText.setMaxLines(2);
+    if (!ViewUtils.isLandscape(getContext())) {
+      stepPrimaryText.setMaxLines(2);
+    }
     stepSecondaryText.setVisibility(GONE);
     adjustBannerTextVerticalBias(0.5f);
+
+    if (ViewUtils.isLandscape(getContext())) {
+      stepPrimaryText.setMaxWidth(instructionLayoutText.getWidth());
+    }
     loadTextWith(primaryBannerText, stepPrimaryText);
   }
 
@@ -986,8 +993,18 @@ public class InstructionView extends RelativeLayout implements LifecycleObserver
     stepPrimaryText.setMaxLines(1);
     stepSecondaryText.setVisibility(VISIBLE);
     adjustBannerTextVerticalBias(0.65f);
+
+    if (ViewUtils.isLandscape(getContext())) {
+      int primaryTextMaxWidth = (int) (instructionLayoutText.getWidth()
+        * MAXIMUM_PRIMARY_INSTRUCTION_TEXT_WIDTH_RATIO_IN_LANDSCAPE);
+      stepPrimaryText.setMaxWidth(primaryTextMaxWidth);
+    }
     loadTextWith(primaryBannerText, stepPrimaryText);
 
+    if (ViewUtils.isLandscape(getContext())) {
+      int primaryTextWidth = (int) stepPrimaryText.getPaint().measureText(String.valueOf(stepPrimaryText.getText()));
+      stepSecondaryText.setMaxWidth(instructionLayoutText.getWidth() - primaryTextWidth);
+    }
     loadTextWith(secondaryBannerText, stepSecondaryText);
   }
 

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/instruction/TextViewUtils.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/instruction/TextViewUtils.java
@@ -18,7 +18,12 @@ class TextViewUtils {
   boolean textFits(TextView textView, String text) {
     Paint paint = new Paint(textView.getPaint());
     float width = paint.measureText(text);
-    return width < textView.getWidth();
+
+    if (textView.getMaxWidth() != Integer.MAX_VALUE) {
+      return width < textView.getMaxWidth();
+    } else {
+      return width < textView.getWidth();
+    }
   }
 
   Drawable createDrawable(TextView textView, Bitmap bitmap) {


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Fix #1201: the stepPrimaryText doesn't have enough width in landscape mode

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Better support landscape mode.

### Implementation

Landscape the primary and secondary text are in same line. Both TextView's width is dynamic
and determined during runtime. This PR assigns maxWidth to each TextView and check fit by
using textView.getMaxWidth() instead of use textView.getWidth().

## Testing

1. Use the location in #1201 to verify the same road name is shown correctly.
![Screenshot_1591404065](https://user-images.githubusercontent.com/3918950/83932007-b1c83180-a754-11ea-9c2a-07630cd18efb.png)

2. Use location that will also have `secondaryText` so verify the fix also work in both cases.
![Screenshot_1591404126](https://user-images.githubusercontent.com/3918950/83932009-b5f44f00-a754-11ea-9820-9ee6d31f00b4.png)
![Screenshot_1591404212](https://user-images.githubusercontent.com/3918950/83932023-c9071f00-a754-11ea-8e2e-2d52dc5a782d.png)


- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->