### PR TITLE
Device rotation for some example activities

### DIFF
--- a/examples/src/main/AndroidManifest.xml
+++ b/examples/src/main/AndroidManifest.xml
@@ -56,7 +56,8 @@
 
         <activity
             android:name=".core.OffboardRouterActivityKt"
-            android:label="@string/title_offboard_router_kotlin">
+            android:label="@string/title_offboard_router_kotlin"
+            android:screenOrientation="portrait">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".CoreActivity" />
@@ -64,7 +65,8 @@
 
         <activity
             android:name=".core.OffboardRouterActivityJava"
-            android:label="@string/title_offboard_router_java">
+            android:label="@string/title_offboard_router_java"
+            android:screenOrientation="portrait">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".CoreActivity" />
@@ -72,7 +74,8 @@
 
         <activity
             android:name=".core.OnboardRouterActivityKt"
-            android:label="@string/title_onboard_router_kotlin">
+            android:label="@string/title_onboard_router_kotlin"
+            android:screenOrientation="portrait">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".CoreActivity" />
@@ -80,7 +83,8 @@
 
         <activity
             android:name=".core.OnboardRouterActivityJava"
-            android:label="@string/title_onboard_router_java">
+            android:label="@string/title_onboard_router_java"
+            android:screenOrientation="portrait">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".CoreActivity" />
@@ -88,7 +92,8 @@
 
         <activity
             android:name=".core.HybridRouterActivityKt"
-            android:label="@string/title_hybrid_router_kotlin">
+            android:label="@string/title_hybrid_router_kotlin"
+            android:screenOrientation="portrait">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".CoreActivity" />
@@ -96,7 +101,8 @@
 
         <activity
             android:name=".core.HybridRouterActivityJava"
-            android:label="@string/title_hybrid_router_java">
+            android:label="@string/title_hybrid_router_java"
+            android:screenOrientation="portrait">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".CoreActivity" />
@@ -104,7 +110,8 @@
 
         <activity
             android:name=".core.TripServiceActivityKt"
-            android:label="@string/title_trip_service_kotlin">
+            android:label="@string/title_trip_service_kotlin"
+            android:screenOrientation="portrait">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".CoreActivity" />
@@ -112,7 +119,8 @@
 
         <activity
             android:name=".core.TripSessionActivityKt"
-            android:label="@string/title_trip_session_kotlin">
+            android:label="@string/title_trip_session_kotlin"
+            android:screenOrientation="portrait">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".CoreActivity" />
@@ -128,7 +136,8 @@
 
         <activity
             android:name=".ui.BuildingFootprintHighlightActivityKt"
-            android:label="@string/title_building_highlight_kotlin">
+            android:label="@string/title_building_highlight_kotlin"
+            android:screenOrientation="portrait">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".UIActivity" />
@@ -136,7 +145,8 @@
 
         <activity
             android:name=".ui.BuildingExtrusionActivity"
-            android:label="@string/title_ui_building_extrusions_kotlin">
+            android:label="@string/title_ui_building_extrusions_kotlin"
+            android:screenOrientation="portrait">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".UIActivity" />
@@ -144,7 +154,8 @@
 
         <activity
             android:name=".core.GuidanceViewActivity"
-            android:label="@string/title_guidance_view">
+            android:label="@string/title_guidance_view"
+            android:screenOrientation="portrait">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".UIActivity" />
@@ -152,7 +163,8 @@
 
         <activity
             android:name=".core.ReplayWaypointsActivity"
-            android:label="@string/title_replay_route">
+            android:label="@string/title_replay_route"
+            android:screenOrientation="portrait">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".CoreActivity" />
@@ -160,7 +172,8 @@
 
         <activity
             android:name=".core.ReplayActivity"
-            android:label="@string/title_replay_route">
+            android:label="@string/title_replay_route"
+            android:screenOrientation="portrait">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".CoreActivity" />
@@ -168,7 +181,8 @@
 
         <activity
             android:name=".core.ReplayHistoryActivity"
-            android:label="@string/title_replay_route">
+            android:label="@string/title_replay_route"
+            android:screenOrientation="portrait">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".CoreActivity" />
@@ -184,7 +198,8 @@
 
         <activity
             android:name=".core.BasicNavigationFragmentActivity"
-            android:label="@string/title_basic_navigation_fragment">
+            android:label="@string/title_basic_navigation_fragment"
+            android:screenOrientation="portrait">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".CoreActivity" />
@@ -192,7 +207,8 @@
 
         <activity
             android:name=".core.BasicNavSdkOnlyActivity"
-            android:label="@string/title_basic_navigation_sdk_only_kotlin">
+            android:label="@string/title_basic_navigation_sdk_only_kotlin"
+            android:screenOrientation="portrait">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".CoreActivity" />
@@ -200,7 +216,8 @@
 
         <activity
             android:name=".core.FreeDriveNavigationActivity"
-            android:label="@string/title_free_drive_kotlin">
+            android:label="@string/title_free_drive_kotlin"
+            android:screenOrientation="portrait">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".CoreActivity" />
@@ -224,7 +241,8 @@
 
         <activity
             android:name=".core.ReRouteActivity"
-            android:label="@string/title_reroute_view">
+            android:label="@string/title_reroute_view"
+            android:screenOrientation="portrait">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".CoreActivity" />
@@ -232,7 +250,8 @@
 
         <activity
             android:name=".core.SummaryBottomSheetActivity"
-            android:label="@string/title_summary_bottom_sheet">
+            android:label="@string/title_summary_bottom_sheet"
+            android:screenOrientation="portrait">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".CoreActivity" />
@@ -240,7 +259,8 @@
 
         <activity
             android:name=".core.FeedbackButtonActivity"
-            android:label="@string/title_feedback_button">
+            android:label="@string/title_feedback_button"
+            android:screenOrientation="portrait">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".CoreActivity" />
@@ -248,7 +268,8 @@
 
         <activity
             android:name=".ui.CustomPuckActivity"
-            android:label="@string/title_custom_puck_example">
+            android:label="@string/title_custom_puck_example"
+            android:screenOrientation="portrait">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".UIActivity" />
@@ -256,7 +277,8 @@
 
         <activity
             android:name=".core.DebugMapboxNavigationKt"
-            android:label="@string/title_debug_navigation_kotlin">
+            android:label="@string/title_debug_navigation_kotlin"
+            android:screenOrientation="portrait">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".CoreActivity" />
@@ -264,7 +286,8 @@
 
         <activity
             android:name=".ui.CustomCameraActivity"
-            android:label="@string/title_custom_camera_example">
+            android:label="@string/title_custom_camera_example"
+            android:screenOrientation="portrait">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".UIActivity" />
@@ -272,7 +295,8 @@
 
         <activity
             android:name=".ui.CustomUIComponentStyleActivity"
-            android:label="@string/title_custom_ui_component_style">
+            android:label="@string/title_custom_ui_component_style"
+            android:screenOrientation="portrait">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".UIActivity" />
@@ -281,8 +305,8 @@
         <activity
             android:name=".core.CustomRouteStylingActivity"
             android:label="@string/title_custom_route_styling_kotlin"
-
-            android:theme="@style/CustomRouteTheme">
+            android:theme="@style/CustomRouteTheme"
+            android:screenOrientation="portrait">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".CoreActivity" />
@@ -290,7 +314,8 @@
 
         <activity
             android:name=".core.NavigationMapRouteActivity"
-            android:label="@string/title_navigation_route_ui">
+            android:label="@string/title_navigation_route_ui"
+            android:screenOrientation="portrait">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".CoreActivity" />

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/FasterRouteActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/FasterRouteActivity.kt
@@ -66,10 +66,12 @@ class FasterRouteActivity : AppCompatActivity(), OnMapReadyCallback {
     private var navigationMapboxMap: NavigationMapboxMap? = null
     private lateinit var bottomSheetBehavior: BottomSheetBehavior<View>
     private val locationListenerCallback = MyLocationEngineCallback(this)
+    private var directionRoute: DirectionsRoute? = null
 
     private val routesReqCallback = object : RoutesRequestCallback {
         override fun onRoutesReady(routes: List<DirectionsRoute>) {
             if (routes.isNotEmpty()) {
+                directionRoute = routes[0]
                 startNavigation.visibility = VISIBLE
             } else {
                 startNavigation.visibility = GONE
@@ -160,8 +162,6 @@ class FasterRouteActivity : AppCompatActivity(), OnMapReadyCallback {
         }
 
         initListeners()
-        Snackbar.make(container, R.string.msg_long_press_map_to_place_waypoint, LENGTH_SHORT)
-            .show()
     }
 
     override fun onLowMemory() {
@@ -211,6 +211,14 @@ class FasterRouteActivity : AppCompatActivity(), OnMapReadyCallback {
                     remove(route)
                     add(0, route)
                 })
+            }
+
+            when (directionRoute) {
+                null -> {
+                    Snackbar.make(container, R.string.msg_long_press_map_to_place_waypoint, LENGTH_SHORT)
+                        .show()
+                }
+                else -> restoreNavigation()
             }
         }
 
@@ -307,6 +315,33 @@ class FasterRouteActivity : AppCompatActivity(), OnMapReadyCallback {
         }
 
         override fun onFailure(exception: Exception) {
+        }
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        mapView.onSaveInstanceState(outState)
+        // This is not the most efficient way to preserve the route on a device rotation.
+        // This is here to demonstrate that this event needs to be handled in order to
+        // redraw the route line after a rotation.
+        directionRoute?.let {
+            outState.putString(Utils.PRIMARY_ROUTE_BUNDLE_KEY, it.toJson())
+        }
+    }
+
+    override fun onRestoreInstanceState(savedInstanceState: Bundle?) {
+        super.onRestoreInstanceState(savedInstanceState)
+        directionRoute = Utils.getRouteFromBundle(savedInstanceState)
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun restoreNavigation() {
+        directionRoute?.let {
+            mapboxNavigation?.setRoutes(listOf(it))
+            navigationMapboxMap?.addProgressChangeListener(mapboxNavigation!!)
+            navigationMapboxMap?.startCamera(mapboxNavigation?.getRoutes()!![0])
+            updateCameraOnNavigationStateChange(true)
+            mapboxNavigation?.startTripSession()
         }
     }
 }

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/NavigationMapRouteActivity.java
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/NavigationMapRouteActivity.java
@@ -54,6 +54,8 @@ import butterknife.ButterKnife;
 import butterknife.OnClick;
 import timber.log.Timber;
 
+import static com.mapbox.navigation.examples.utils.Utils.PRIMARY_ROUTE_BUNDLE_KEY;
+import static com.mapbox.navigation.examples.utils.Utils.getRouteFromBundle;
 import static com.mapbox.navigation.ui.NavigationConstants.MINIMAL_LOOKAHEAD_LOCATION_TIME_VALUE;
 
 /**
@@ -126,7 +128,15 @@ public class NavigationMapRouteActivity extends AppCompatActivity implements OnM
 
       mapboxNavigation.getLocationEngine().getLastLocation(locationEngineCallback);
       mapboxMap.addOnMapLongClickListener(this);
-      Snackbar.make(mapView, R.string.msg_long_press_map_to_place_waypoint, Snackbar.LENGTH_SHORT).show();
+
+      if (activeRoute != null) {
+        final List<DirectionsRoute> routes = Arrays.asList(activeRoute);
+        navigationMapRoute.addRoutes(routes);
+        mapboxNavigation.setRoutes(routes);
+        startNavigationButton.setVisibility(View.VISIBLE);
+      } else {
+        Snackbar.make(mapView, R.string.msg_long_press_map_to_place_waypoint, Snackbar.LENGTH_SHORT).show();
+      }
     });
   }
 
@@ -188,6 +198,19 @@ public class NavigationMapRouteActivity extends AppCompatActivity implements OnM
   protected void onSaveInstanceState(Bundle outState) {
     super.onSaveInstanceState(outState);
     mapView.onSaveInstanceState(outState);
+
+    // This is not the most efficient way to preserve the route on a device rotation.
+    // This is here to demonstrate that this event needs to be handled in order to
+    // redraw the route line after a rotation.
+    if (activeRoute != null) {
+      outState.putString(PRIMARY_ROUTE_BUNDLE_KEY, activeRoute.toJson());
+    }
+  }
+
+  @Override
+  protected void onRestoreInstanceState(Bundle savedInstanceState) {
+    super.onRestoreInstanceState(savedInstanceState);
+    activeRoute = getRouteFromBundle(savedInstanceState);
   }
 
   @SuppressWarnings("MissingPermission")

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/SummaryBottomSheetActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/SummaryBottomSheetActivity.kt
@@ -63,6 +63,7 @@ class SummaryBottomSheetActivity : AppCompatActivity(), OnMapReadyCallback {
     private lateinit var routeOverviewButton: ImageButton
     private lateinit var cancelBtn: AppCompatImageButton
     private val mapboxReplayer = MapboxReplayer()
+    private var directionRoute: DirectionsRoute? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -87,8 +88,6 @@ class SummaryBottomSheetActivity : AppCompatActivity(), OnMapReadyCallback {
         }
 
         initListeners()
-        Snackbar.make(navigationLayout, R.string.msg_long_press_map_to_place_waypoint, LENGTH_SHORT)
-            .show()
     }
 
     override fun onStart() {
@@ -129,6 +128,18 @@ class SummaryBottomSheetActivity : AppCompatActivity(), OnMapReadyCallback {
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
         mapView.onSaveInstanceState(outState)
+
+        // This is not the most efficient way to preserve the route on a device rotation.
+        // This is here to demonstrate that this event needs to be handled in order to
+        // redraw the route line after a rotation.
+        directionRoute?.let {
+            outState.putString(Utils.PRIMARY_ROUTE_BUNDLE_KEY, it.toJson())
+        }
+    }
+
+    override fun onRestoreInstanceState(savedInstanceState: Bundle?) {
+        super.onRestoreInstanceState(savedInstanceState)
+        directionRoute = Utils.getRouteFromBundle(savedInstanceState)
     }
 
     override fun onMapReady(mapboxMap: MapboxMap) {
@@ -136,12 +147,19 @@ class SummaryBottomSheetActivity : AppCompatActivity(), OnMapReadyCallback {
             mapboxMap.moveCamera(CameraUpdateFactory.zoomTo(15.0))
             navigationMapboxMap = NavigationMapboxMap(mapView, mapboxMap, this, true)
 
-            if (shouldSimulateRoute()) {
-                mapboxNavigation?.registerRouteProgressObserver(ReplayProgressObserver(mapboxReplayer))
-                mapboxReplayer.pushRealLocation(this, 0.0)
-                mapboxReplayer.play()
+            when (directionRoute) {
+                null -> {
+                    if (shouldSimulateRoute()) {
+                        mapboxNavigation?.registerRouteProgressObserver(ReplayProgressObserver(mapboxReplayer))
+                        mapboxReplayer.pushRealLocation(this, 0.0)
+                        mapboxReplayer.play()
+                    }
+                    mapboxNavigation?.locationEngine?.getLastLocation(locationListenerCallback)
+                    Snackbar.make(mapView, R.string.msg_long_press_map_to_place_waypoint, LENGTH_SHORT)
+                        .show()
+                }
+                else -> restoreNavigation()
             }
-            mapboxNavigation?.locationEngine?.getLastLocation(locationListenerCallback)
         }
 
         mapboxMap.addOnMapLongClickListener { latLng ->
@@ -270,6 +288,7 @@ class SummaryBottomSheetActivity : AppCompatActivity(), OnMapReadyCallback {
     private val routesReqCallback = object : RoutesRequestCallback {
         override fun onRoutesReady(routes: List<DirectionsRoute>) {
             if (routes.isNotEmpty()) {
+                directionRoute = routes[0]
                 navigationMapboxMap?.drawRoute(routes[0])
                 startNavigation.visibility = VISIBLE
                 startNavigation.isEnabled = true
@@ -351,5 +370,16 @@ class SummaryBottomSheetActivity : AppCompatActivity(), OnMapReadyCallback {
     private fun shouldSimulateRoute(): Boolean {
         return PreferenceManager.getDefaultSharedPreferences(this.applicationContext)
             .getBoolean(this.getString(R.string.simulate_route_key), false)
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun restoreNavigation() {
+        directionRoute?.let {
+            mapboxNavigation?.setRoutes(listOf(it))
+            navigationMapboxMap?.addProgressChangeListener(mapboxNavigation!!)
+            navigationMapboxMap?.startCamera(mapboxNavigation?.getRoutes()!![0])
+            updateCameraOnNavigationStateChange(true)
+            mapboxNavigation?.startTripSession()
+        }
     }
 }

--- a/examples/src/main/java/com/mapbox/navigation/examples/utils/Utils.java
+++ b/examples/src/main/java/com/mapbox/navigation/examples/utils/Utils.java
@@ -4,11 +4,13 @@ import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.drawable.Drawable;
+import android.os.Bundle;
 
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.core.content.res.ResourcesCompat;
 
+import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.base.common.logger.model.Message;
 import com.mapbox.common.logger.MapboxLogger;
 import com.mapbox.mapboxsdk.Mapbox;
@@ -17,6 +19,8 @@ import com.mapbox.mapboxsdk.annotations.IconFactory;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 
 import java.util.Random;
+
+import timber.log.Timber;
 
 public class Utils {
 
@@ -69,5 +73,25 @@ public class Utils {
     LatLng latLng = new LatLng(randomLat, randomLon);
     MapboxLogger.INSTANCE.d(new Message("getRandomLatLng: " + latLng.toString()));
     return latLng;
+  }
+
+  public static final String PRIMARY_ROUTE_BUNDLE_KEY = "myPrimaryRouteBundleKey";
+
+  /**
+   * Used by the example activities to get a DirectionsRoute from a bundle.
+   *
+   * @param bundle to get the DirectionsRoute from
+   * @return a DirectionsRoute or null
+   */
+  public static DirectionsRoute getRouteFromBundle(Bundle bundle) {
+    try {
+      if (bundle.containsKey(PRIMARY_ROUTE_BUNDLE_KEY)) {
+        String routeAsJson = bundle.getString(PRIMARY_ROUTE_BUNDLE_KEY);
+        return DirectionsRoute.fromJson(routeAsJson);
+      }
+    } catch (Exception ex) {
+      Timber.i(ex);
+    }
+    return null;
   }
 }


### PR DESCRIPTION
## Description
Some example activities updated to support device rotation. Other activities updated to redraw the route line on device rotation.

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

The route line redraws after device rotation and/or navigation continues.

### Implementation

## Screenshots or Gifs

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->