### PR TITLE
InstructionView: not return when showSubLayout has been called. 

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/instruction/InstructionView.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/instruction/InstructionView.java
@@ -838,6 +838,7 @@ public class InstructionView extends RelativeLayout implements LifecycleObserver
         instructionLoader.loadInstruction();
       }
       showSubLayout();
+      hideTurnLanes();
       return;
     } else {
       hideSubLayout();


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Ref #3133 

This PR fixes an issue mentioned in #3133 which is a different issue.

- [ ] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Improve UI SDK quality.

### Implementation

In the original implementation #1440, it added the `return` statement. @Guardiola31337 , if you know anything about why it's needed please let me know.

But from my testing, in the route of your comment https://github.com/mapbox/mapbox-navigation-android/issues/3133#issuecomment-640739571

In the route there are two consecutive `bannerInstructions`, both have `sub` node.
The first `sub` node is for turnLanes. The second `sub` node is to show the subText.
The existing implementation will return after it shows the subText. So the `turnLanes` doesn't have chance to hide itself.

## Screenshots or Gifs

![ezgif com-video-to-gif (3)](https://user-images.githubusercontent.com/3918950/84084061-9e58d880-a997-11ea-93f7-725b73f7d4bf.gif)

## Testing

See above gif.

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->