### PR TITLE
Remove gson dependency from history mapper

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayHistoryActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayHistoryActivity.kt
@@ -5,8 +5,6 @@ import android.content.Context
 import android.os.Bundle
 import android.widget.SeekBar
 import androidx.appcompat.app.AppCompatActivity
-import com.google.gson.Gson
-import com.google.gson.internal.LinkedTreeMap
 import com.mapbox.android.core.location.LocationEngine
 import com.mapbox.api.directions.v5.DirectionsCriteria
 import com.mapbox.api.directions.v5.models.DirectionsRoute
@@ -115,7 +113,7 @@ class ReplayHistoryActivity : AppCompatActivity() {
     }
 
     private suspend fun loadReplayHistory(): List<ReplayEventBase> = suspendCoroutine { cont ->
-        val replayHistoryMapper = ReplayHistoryMapper(Gson(), ReplayCustomEventMapper(), MapboxLogger)
+        val replayHistoryMapper = ReplayHistoryMapper(ReplayCustomEventMapper(), MapboxLogger)
         val rideHistoryExample = loadHistoryJsonFromAssets(this@ReplayHistoryActivity, "replay-history-activity.json")
         val replayEvents = replayHistoryMapper.mapToReplayEvents(rideHistoryExample)
         cont.resume(replayEvents)
@@ -306,14 +304,14 @@ private fun loadHistoryJsonFromAssets(context: Context, fileName: String): Strin
 }
 
 private class ReplayCustomEventMapper : CustomEventMapper {
-    override fun map(eventType: String, properties: LinkedTreeMap<*, *>): ReplayEventBase? {
+    override fun map(eventType: String, properties: Map<*, *>): ReplayEventBase? {
         return when (eventType) {
             "start_transit" -> ReplayEventStartTransit(
                 eventTimestamp = properties["event_timestamp"] as Double,
                 properties = properties["properties"] as Double)
             "initial_route" -> {
-                val eventProperties = properties["properties"] as LinkedTreeMap<*, *>
-                val routeOptions = eventProperties["routeOptions"] as LinkedTreeMap<*, *>
+                val eventProperties = properties["properties"] as Map<*, *>
+                val routeOptions = eventProperties["routeOptions"] as Map<*, *>
                 val coordinates = routeOptions["coordinates"] as List<List<Double>>
                 val coordinatesLatLng = coordinates.map { LatLng(it[1], it[0]) }
                 ReplayEventInitialRoute(

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/history/ReplayHistoryMapper.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/history/ReplayHistoryMapper.kt
@@ -15,22 +15,21 @@ interface CustomEventMapper {
      * Override to map your own custom events from history files,
      * into [ReplayEventBase] for the [MapboxReplayer]
      */
-    fun map(eventType: String, properties: LinkedTreeMap<*, *>): ReplayEventBase?
+    fun map(eventType: String, properties: Map<*, *>): ReplayEventBase?
 }
 
 /**
  * This class is responsible for creating [ReplayEvents] from history data.
  *
- * @param gson Gson (optional)
  * @param customEventMapper if you have added custom events to the replay history, include your
  * own [CustomEventMapper] (optional)
  * @param logger interface for logging any events (optional)
  */
 class ReplayHistoryMapper @JvmOverloads constructor(
-    private val gson: Gson = Gson(),
     private val customEventMapper: CustomEventMapper? = null,
     private val logger: Logger? = null
 ) {
+    private val gson: Gson = Gson()
 
     /**
      * Given raw json string return [ReplayEvents] that can be given to a [MapboxReplayer]
@@ -74,7 +73,7 @@ class ReplayHistoryMapper @JvmOverloads constructor(
                     eventTimestamp = eventTimestamp)
             }
             else -> {
-                val replayEvent = customEventMapper?.map(eventType, event)
+                val replayEvent = customEventMapper?.map(eventType, event.toMap())
                 if (replayEvent == null) {
                     logger?.e(msg = Message("Replay unsupported event $eventType"))
                 }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/history/ReplayHistoryMapperTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/history/ReplayHistoryMapperTest.kt
@@ -1,7 +1,6 @@
 package com.mapbox.navigation.core.replay.history
 
 import com.google.gson.annotations.SerializedName
-import com.google.gson.internal.LinkedTreeMap
 import com.mapbox.base.common.logger.Logger
 import io.mockk.mockk
 import org.junit.Assert.assertEquals
@@ -75,7 +74,7 @@ class ReplayHistoryMapperTest {
     ) : ReplayEventBase
 
     private class ExampleCustomEventMapper : CustomEventMapper {
-        override fun map(eventType: String, properties: LinkedTreeMap<*, *>): ReplayEventBase? {
+        override fun map(eventType: String, properties: Map<*, *>): ReplayEventBase? {
             return when (eventType) {
                 "end_transit" -> ExampleEndTransitEvent(
                     eventTimestamp = properties["event_timestamp"] as Double,


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Addresses https://github.com/mapbox/mapbox-navigation-android/pull/3138#discussion_r437578813

I never liked this gson.internal.LinkedTreeMap anyways

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards


## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->