### PR TITLE
On rotation the route line will not redraw entire line if vanishing f…

### DIFF
--- a/libnavigation-ui/api/current.txt
+++ b/libnavigation-ui/api/current.txt
@@ -546,6 +546,7 @@ package com.mapbox.navigation.ui.route {
     method public void addProgressChangeListener(com.mapbox.navigation.core.MapboxNavigation!, boolean);
     method public void addRoute(com.mapbox.api.directions.v5.models.DirectionsRoute!);
     method public void addRoutes(@Size(min=1) java.util.List<? extends com.mapbox.api.directions.v5.models.DirectionsRoute>);
+    method public float getPercentDistanceTraveled();
     method public void onNewRouteProgress(com.mapbox.navigation.base.trip.model.RouteProgress!);
     method @androidx.lifecycle.OnLifecycleEvent(androidx.lifecycle.Lifecycle.Event.ON_START) protected void onStart();
     method @androidx.lifecycle.OnLifecycleEvent(androidx.lifecycle.Lifecycle.Event.ON_STOP) protected void onStop();
@@ -553,6 +554,7 @@ package com.mapbox.navigation.ui.route {
     method public void setOnRouteSelectionChangeListener(com.mapbox.navigation.ui.route.OnRouteSelectionChangeListener?);
     method public void showAlternativeRoutes(boolean);
     method public void updateRouteArrowVisibilityTo(boolean);
+    method public void updateRouteLineWithDistanceTraveled(float);
     method public void updateRouteVisibilityTo(boolean);
   }
 

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/NavigationMapSettings.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/NavigationMapSettings.java
@@ -16,6 +16,7 @@ class NavigationMapSettings implements Parcelable {
   private boolean maxFpsEnabled = true;
   private boolean mapWayNameEnabled;
   private boolean locationFpsEnabled = true;
+  private float percentDistanceTraveled;
 
   NavigationMapSettings() {
   }
@@ -73,6 +74,14 @@ class NavigationMapSettings implements Parcelable {
     this.locationFpsEnabled = locationFpsEnabled;
   }
 
+  void updatePercentDistanceTraveled(float distance) {
+    this.percentDistanceTraveled = distance;
+  }
+
+  float retrievePercentDistanceTraveled() {
+    return this.percentDistanceTraveled;
+  }
+
   boolean isLocationFpsEnabled() {
     return locationFpsEnabled;
   }
@@ -85,6 +94,7 @@ class NavigationMapSettings implements Parcelable {
     maxFpsEnabled = in.readByte() != 0;
     mapWayNameEnabled = in.readByte() != 0;
     locationFpsEnabled = in.readByte() != 0;
+    percentDistanceTraveled = in.readFloat();
   }
 
   @Override
@@ -96,6 +106,7 @@ class NavigationMapSettings implements Parcelable {
     dest.writeByte((byte) (maxFpsEnabled ? 1 : 0));
     dest.writeByte((byte) (mapWayNameEnabled ? 1 : 0));
     dest.writeByte((byte) (locationFpsEnabled ? 1 : 0));
+    dest.writeFloat(percentDistanceTraveled);
   }
 
   @Override

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/NavigationMapboxMap.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/NavigationMapboxMap.java
@@ -412,6 +412,7 @@ public class NavigationMapboxMap implements LifecycleObserver {
     settings.updateShouldUseDefaultPadding(mapPaddingAdjustor.isUsingDefault());
     settings.updateCameraTrackingMode(mapCamera.getCameraTrackingMode());
     settings.updateLocationFpsEnabled(locationFpsDelegate.isEnabled());
+    settings.updatePercentDistanceTraveled(mapRoute.getPercentDistanceTraveled());
     NavigationMapboxMapInstanceState instanceState = new NavigationMapboxMapInstanceState(settings);
     outState.putParcelable(key, instanceState);
   }
@@ -430,6 +431,7 @@ public class NavigationMapboxMap implements LifecycleObserver {
   public void restoreFrom(NavigationMapboxMapInstanceState instanceState) {
     settings = instanceState.retrieveSettings();
     restoreMapWith(settings);
+    restoreVanishingRouteLineSection(settings);
   }
 
   /**
@@ -892,6 +894,14 @@ public class NavigationMapboxMap implements LifecycleObserver {
     LatLng latLng = new LatLng(location);
     PointF mapPoint = mapboxMap.getProjection().toScreenLocation(latLng);
     mapWayName.updateWayNameWithPoint(mapPoint);
+  }
+
+  private void restoreVanishingRouteLineSection(NavigationMapSettings settings) {
+    float percentDistanceTraveled = settings.retrievePercentDistanceTraveled();
+    if (percentDistanceTraveled > 0) {
+      mapRoute.updateRouteLineWithDistanceTraveled(percentDistanceTraveled);
+      settings.updatePercentDistanceTraveled(0);
+    }
   }
 
   private void restoreMapWith(NavigationMapSettings settings) {


### PR DESCRIPTION
## Description

An outstanding issue that has been noticed is that upon device rotation when the vanishing route line feature was enabled, was that initially the entire route line would be redrawn and upon the next route progress update the line would vanish from the origin to the puck in an animated fashion. This PR resolves the issue when using NavigationMapboxMap by storing the value representing the section that has been vanished and restoring that value when the map and line are redrawn after rotation.

- [ ] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal

While not effective 100% of the time this is an improvement over the previous behavior.

### Implementation

The NavigationMapboxMap will store the value representing the vanished section in a bundle and upon restoration the value will be used to vanish the map route line up to the appropriate position.

## Screenshots or Gifs

![20200609_102149](https://user-images.githubusercontent.com/2249818/84179679-2e9c2980-aa3b-11ea-901c-68145cf0cba1.gif)


## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->