### PR TITLE
Bump NN dependency version to 13.1.1

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,7 +1,6 @@
 ext {
 
   androidVersions = [
-      legacyMinSdkVersion     : 14,
       minSdkVersion           : 19,
       targetSdkVersion        : 28,
       compileSdkVersion       : 28,
@@ -14,7 +13,7 @@ ext {
       mapboxSdkDirectionsModels : '5.2.1',
       mapboxEvents              : '5.0.1',
       mapboxCore                : '2.0.1',
-      mapboxNavigator           : '13.0.2',
+      mapboxNavigator           : '13.1.1',
       mapboxCrashMonitor        : '2.0.0',
       mapboxAnnotationPlugin    : '0.8.0',
       mapboxAccounts            : '0.4.0',

--- a/libandroid-navigation-ui/build.gradle
+++ b/libandroid-navigation-ui/build.gradle
@@ -8,7 +8,7 @@ android {
   buildToolsVersion androidVersions.buildToolsVersion
 
   defaultConfig {
-    minSdkVersion androidVersions.legacyMinSdkVersion
+    minSdkVersion androidVersions.minSdkVersion
     targetSdkVersion androidVersions.targetSdkVersion
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     vectorDrawables.useSupportLibrary = true

--- a/libandroid-navigation/build.gradle
+++ b/libandroid-navigation/build.gradle
@@ -9,7 +9,7 @@ android {
   buildToolsVersion androidVersions.buildToolsVersion
 
   defaultConfig {
-    minSdkVersion androidVersions.legacyMinSdkVersion
+    minSdkVersion androidVersions.minSdkVersion
     targetSdkVersion androidVersions.targetSdkVersion
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
## Description

Bumps `mapbox-navigation-native` version to ~`13.1.0`~ `13.1.1`

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Getting the latest version from `mapboxNavigator` including the new features and bug fixes.

### Implementation

Bumping the `mapboxNavigator` version to ~`13.1.0`~ `13.1.1` in `dependencies.gradle`

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

At the moment running into the following crash 💥 

```
06-09 19:02:58.659 27502-27511/com.mapbox.navigation.examples E/AndroidRuntime: FATAL EXCEPTION: FinalizerWatchdogDaemon
    Process: com.mapbox.navigation.examples, PID: 27502
    java.util.concurrent.TimeoutException: com.mapbox.navigator.Navigator.finalize() timed out after 10 seconds
        at com.mapbox.navigator.Navigator.finalize(Native Method)
        at java.lang.Daemons$FinalizerDaemon.doFinalize(Daemons.java:202)
        at java.lang.Daemons$FinalizerDaemon.run(Daemons.java:185)
        at java.lang.Thread.run(Thread.java:818)
```

#### Steps to reproduce

1. Run `examples` test app
2. Run `Simple MapboxNavigation Kotlin` example
3. Click on `START NAVIGATION` button (with or without a route _Active Guidance_ / _Free Drive_)
4. Close example
5. Open `Offboard router` example
6. Tap on the map to place a waypoint
7. Repeat a couple of times
8. Close example
9. 💥 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR

cc @mskurydin @SiarheiFedartsou @vmihaylenko 