### PR TITLE
Bump the Android Common to v1.4.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -21,7 +21,7 @@ ext {
       mapboxAnnotations         : '0.1.0',
       mapboxAnnotationsProcessor: '0.1.0',
       mapboxAndroidCommon       : '0.1.0',
-      mapboxCoreCommon          : '1.3.1',
+      mapboxCoreCommon          : '1.4.0',
       mapboxBindgenSupport      : '1.0.0',
       mapboxLogger              : '0.1.0',
       androidXCoreVersion       : '1.2.0',

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/NavigationOkHttpService.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/NavigationOkHttpService.kt
@@ -5,6 +5,7 @@ import com.mapbox.base.common.logger.model.Message
 import com.mapbox.base.common.logger.model.Tag
 import com.mapbox.bindgen.Expected
 import com.mapbox.bindgen.ExpectedFactory
+import com.mapbox.common.CancelRequestCallback
 import com.mapbox.common.HttpRequest
 import com.mapbox.common.HttpRequestError
 import com.mapbox.common.HttpRequestErrorType
@@ -95,9 +96,15 @@ internal class NavigationOkHttpService(
         return id
     }
 
-    override fun cancelRequest(id: Long) {
+    override fun cancelRequest(id: Long, callback: CancelRequestCallback) {
         lock.lock()
-        callMap.remove(id)?.cancel()
+        val call = callMap.remove(id)
+        if (call != null) {
+            call.cancel()
+            callback.run(false)
+        } else {
+            callback.run(true)
+        }
         lock.unlock()
     }
 

--- a/libnavigator/src/test/java/com/mapbox/navigation/navigator/NavigationOkHttpServiceTest.kt
+++ b/libnavigator/src/test/java/com/mapbox/navigation/navigator/NavigationOkHttpServiceTest.kt
@@ -1,6 +1,7 @@
 package com.mapbox.navigation.navigator
 
 import com.mapbox.base.common.logger.Logger
+import com.mapbox.common.CancelRequestCallback
 import com.mapbox.common.HttpMethod
 import com.mapbox.common.HttpRequest
 import com.mapbox.common.HttpResponse
@@ -98,9 +99,11 @@ class NavigationOkHttpServiceTest {
         every { httpClient.newCall(any()) } returns call
 
         val id = httpService.request(nativeRequest, nativeCallback)
-        httpService.cancelRequest(id)
+        val cancelRequestCallback: CancelRequestCallback = mockk(relaxUnitFun = true)
+        httpService.cancelRequest(id, cancelRequestCallback)
 
         verify { call.cancel() }
+        verify(exactly = 1) { cancelRequestCallback.run(false) }
     }
 
     @Test
@@ -209,9 +212,11 @@ class NavigationOkHttpServiceTest {
 
         val id = httpService.request(nativeRequest, nativeCallback)
         callbackSlot.captured.onFailure(call, IOException("exceptionMessage"))
-        httpService.cancelRequest(id)
+        val cancelRequestCallback: CancelRequestCallback = mockk(relaxUnitFun = true)
+        httpService.cancelRequest(id, cancelRequestCallback)
 
         verify(exactly = 0) { call.cancel() }
+        verify(exactly = 1) { cancelRequestCallback.run(true) }
     }
 
     @Test
@@ -223,9 +228,11 @@ class NavigationOkHttpServiceTest {
         every { httpClient.newCall(capture(requestSlot)) } returns call
 
         val id = httpService.request(nativeRequest, nativeCallback)
-        httpService.cancelRequest(id)
+        val cancelRequestCallback: CancelRequestCallback = mockk(relaxUnitFun = true)
+        httpService.cancelRequest(id, cancelRequestCallback)
         callbackSlot.captured.onResponse(call, mockk(relaxed = true))
 
         verify(exactly = 0) { nativeCallback.run(any()) }
+        verify(exactly = 1) { cancelRequestCallback.run(false) }
     }
 }


### PR DESCRIPTION
This is done to match the version of the common library with the one that Nav Native builds against, which unfortunately contains breaking changes. In the future, Nav Native can bring the common library dependency transitively, so that it can be managed from a single repo.

/cc @mskurydin 