### PR TITLE
Time formatting when 59 minutes gets rounded up will format to hours …

### DIFF
--- a/libtrip-notification/src/main/java/com/mapbox/navigation/trip/notification/internal/TimeFormatter.kt
+++ b/libtrip-notification/src/main/java/com/mapbox/navigation/trip/notification/internal/TimeFormatter.kt
@@ -67,10 +67,9 @@ object TimeFormatter {
 
         val days = TimeUnit.SECONDS.toDays(seconds)
         seconds -= TimeUnit.DAYS.toSeconds(days)
-        val hours = TimeUnit.SECONDS.toHours(seconds)
-        seconds -= TimeUnit.HOURS.toSeconds(hours)
-        val minutes =
-            TimeUnit.SECONDS.toMinutes(seconds + TimeUnit.MINUTES.toSeconds(1) / 2) // round it to next minute if seconds is more or equal than 30
+        val hoursAndMinutes = getHoursAndMinutes(seconds)
+        val hours = hoursAndMinutes.first
+        val minutes = hoursAndMinutes.second
 
         val textSpanItems = ArrayList<SpanItem>()
         val resources = context.resourcesWithLocale(locale)
@@ -134,5 +133,14 @@ object TimeFormatter {
             it.setLocale(locale)
         }
         return this.createConfigurationContext(config).resources
+    }
+
+    private fun getHoursAndMinutes(seconds: Long): Pair<Long, Long> {
+        val initialHoursValue = TimeUnit.SECONDS.toHours(seconds)
+        val leftOverSeconds = seconds - TimeUnit.HOURS.toSeconds(initialHoursValue)
+        val minutes =
+            TimeUnit.SECONDS.toMinutes(leftOverSeconds + TimeUnit.MINUTES.toSeconds(1) / 2)
+
+        return if (minutes == 60L) Pair(initialHoursValue + 1, 0) else Pair(initialHoursValue, minutes)
     }
 }

--- a/libtrip-notification/src/test/java/com/mapbox/navigation/trip/notification/internal/TimeFormatterTest.kt
+++ b/libtrip-notification/src/test/java/com/mapbox/navigation/trip/notification/internal/TimeFormatterTest.kt
@@ -173,4 +173,12 @@ class TimeFormatterTest {
 
         assertEquals("16:38", result)
     }
+
+    @Config(qualifiers = "en")
+    @Test
+    fun formatTimeRemainingDefaultLocaleFiveHours() {
+        val result = TimeFormatter.formatTimeRemaining(ctx, 17999.0, null)
+
+        assertEquals("5 hr ", result.toString())
+    }
 }


### PR DESCRIPTION
## Description

The time formatter wasn't correctly formatting certain duration values such as 4 hours 59 minutes rather than 5 hours. An adjustment was made for cases like these.

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal

Formatting should correctly handle duration values so that values like X hours 59 minutes are instead formatted with the hour incremented and a minutes value of 0.

### Implementation



## Screenshots or Gifs

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->