### PR TITLE
Fix some telemetry outstanding issues

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/TelemetryLocationAndProgressDispatcher.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/TelemetryLocationAndProgressDispatcher.kt
@@ -24,7 +24,6 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.launch
 
-private const val DISPATCHER_TAG = "TELEMETRY_TEST"
 private typealias RouteProgressReference = (RouteProgress) -> Unit
 
 internal class TelemetryLocationAndProgressDispatcher(scope: CoroutineScope) :
@@ -307,13 +306,12 @@ internal class TelemetryLocationAndProgressDispatcher(scope: CoroutineScope) :
     }
 
     override fun onRoutesChanged(routes: List<DirectionsRoute>) {
-
         when (routes.isEmpty()) {
             true -> {
-                Log.d(DISPATCHER_TAG, "onRoutesChanged received an empty route list")
+                Log.d(TAG, "onRoutesChanged received an empty route list")
             }
             false -> {
-                Log.d(DISPATCHER_TAG, "onRoutesChanged received a valid route list")
+                Log.d(TAG, "onRoutesChanged received a valid route list")
                 val date = Date()
                 channelNewRouteAvailable.offer(RouteAvailable(routes[0], date))
                 originalRouteDelegate(routes)
@@ -323,7 +321,7 @@ internal class TelemetryLocationAndProgressDispatcher(scope: CoroutineScope) :
     }
 
     override fun onOffRouteStateChanged(offRoute: Boolean) {
-        Log.d(DISPATCHER_TAG, "onOffRouteStateChanged $offRoute")
+        Log.d(TAG, "onOffRouteStateChanged $offRoute")
         channelOffRouteEvent.offer(offRoute)
     }
 }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetryTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetryTest.kt
@@ -63,11 +63,6 @@ class MapboxNavigationTelemetryTest {
     }
 
     @Test
-    fun onInit_registerTripSessionStateObserver_called() {
-        onInit { verify(exactly = 1) { mapboxNavigation.registerTripSessionStateObserver(any()) } }
-    }
-
-    @Test
     fun onInit_registerLocationObserver_called() {
         onInit { verify(exactly = 1) { mapboxNavigation.registerLocationObserver(any()) } }
     }
@@ -93,11 +88,6 @@ class MapboxNavigationTelemetryTest {
     }
 
     @Test
-    fun onUnregisterListeners_unregisterTripSessionStateObserver_called() {
-        onUnregister { verify(exactly = 1) { mapboxNavigation.unregisterTripSessionStateObserver(any()) } }
-    }
-
-    @Test
     fun onUnregisterListener_unregisterLocationObserver_called() {
         onUnregister { verify(exactly = 1) { mapboxNavigation.unregisterLocationObserver(any()) } }
     }
@@ -119,7 +109,6 @@ class MapboxNavigationTelemetryTest {
         initTelemetry()
 
         verify(exactly = 2) { mapboxNavigation.registerRouteProgressObserver(any()) }
-        verify(exactly = 2) { mapboxNavigation.registerTripSessionStateObserver(any()) }
         verify(exactly = 2) { mapboxNavigation.registerLocationObserver(any()) }
         verify(exactly = 2) { mapboxNavigation.registerRoutesObserver(any()) }
         verify(exactly = 2) { mapboxNavigation.registerOffRouteObserver(any()) }


### PR DESCRIPTION
## Description

Fixes 3 outstanding telemetry issues:

- `NavigationSession.State` transitions
- `sessionStop`
- `MapboxMetricsReporter` cancelation (`disable`)

Fixes #3135 

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Fix telemetry issues causing missing events

### Implementation

#### `NavigationSession.State` transitions

Remove unnecessary `TripSessionStateObserver` / `TripSessionState` and rely on `NavigationSessionStateObserver` / `NavigationSession.State`

#### `sessionStop`

Wasn't called in some situations (not sending `NavigationCancelEvent`s)  because `telemetryThreadControl` coroutines were canceled when `MapboxNavigation#onDestroy` was called https://github.com/mapbox/mapbox-navigation-android/blob/6f5359e789d4aa24ac01e937a98663198bedc8d1/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt#L325-L326 before finishing its work. For operations that shouldn't be cancelled `telemetryScope` was created as recommended in https://medium.com/androiddevelopers/coroutines-patterns-for-work-that-shouldnt-be-cancelled-e26c40f142ad

#### `MapboxMetricsReporter` cancelation (`disable`)

`MapboxMetricsReporter.disable()` should be called at the end as last operation when destroying `MapboxNavigation` i.e. as part of `monitorJobCancelation` and before was called prematurely in `unregisterListeners` when calling `MapboxNavigation#onDestroy` so any events sent afterwards (cancel and flushed events) were ignored by `MapboxTelemetry` downstream

#### General telemetry-related code cleanup

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs

cc @zugaldia @mskurydin @Aurora-Boreal 