### PR TITLE
Revert the NN and Common SDK bumps

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -22,7 +22,7 @@ ext {
       mapboxAnnotations         : '0.1.0',
       mapboxAnnotationsProcessor: '0.1.0',
       mapboxAndroidCommon       : '0.1.0',
-      mapboxCoreCommon          : '1.4.0',
+      mapboxCoreCommon          : '1.3.1',
       mapboxBindgenSupport      : '1.0.0',
       mapboxLogger              : '0.1.0',
       androidXCoreVersion       : '1.2.0',

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,6 +1,7 @@
 ext {
 
   androidVersions = [
+      legacyMinSdkVersion     : 14,
       minSdkVersion           : 19,
       targetSdkVersion        : 28,
       compileSdkVersion       : 28,
@@ -13,7 +14,7 @@ ext {
       mapboxSdkDirectionsModels : '5.2.1',
       mapboxEvents              : '5.0.1',
       mapboxCore                : '2.0.1',
-      mapboxNavigator           : '13.1.1',
+      mapboxNavigator           : '13.0.2',
       mapboxCrashMonitor        : '2.0.0',
       mapboxAnnotationPlugin    : '0.8.0',
       mapboxAccounts            : '0.4.0',

--- a/libandroid-navigation-ui/build.gradle
+++ b/libandroid-navigation-ui/build.gradle
@@ -8,7 +8,7 @@ android {
   buildToolsVersion androidVersions.buildToolsVersion
 
   defaultConfig {
-    minSdkVersion androidVersions.minSdkVersion
+    minSdkVersion androidVersions.legacyMinSdkVersion
     targetSdkVersion androidVersions.targetSdkVersion
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     vectorDrawables.useSupportLibrary = true

--- a/libandroid-navigation/build.gradle
+++ b/libandroid-navigation/build.gradle
@@ -9,7 +9,7 @@ android {
   buildToolsVersion androidVersions.buildToolsVersion
 
   defaultConfig {
-    minSdkVersion androidVersions.minSdkVersion
+    minSdkVersion androidVersions.legacyMinSdkVersion
     targetSdkVersion androidVersions.targetSdkVersion
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/NavigationOkHttpService.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/NavigationOkHttpService.kt
@@ -5,7 +5,6 @@ import com.mapbox.base.common.logger.model.Message
 import com.mapbox.base.common.logger.model.Tag
 import com.mapbox.bindgen.Expected
 import com.mapbox.bindgen.ExpectedFactory
-import com.mapbox.common.CancelRequestCallback
 import com.mapbox.common.HttpRequest
 import com.mapbox.common.HttpRequestError
 import com.mapbox.common.HttpRequestErrorType
@@ -96,15 +95,9 @@ internal class NavigationOkHttpService(
         return id
     }
 
-    override fun cancelRequest(id: Long, callback: CancelRequestCallback) {
+    override fun cancelRequest(id: Long) {
         lock.lock()
-        val call = callMap.remove(id)
-        if (call != null) {
-            call.cancel()
-            callback.run(false)
-        } else {
-            callback.run(true)
-        }
+        callMap.remove(id)?.cancel()
         lock.unlock()
     }
 

--- a/libnavigator/src/test/java/com/mapbox/navigation/navigator/NavigationOkHttpServiceTest.kt
+++ b/libnavigator/src/test/java/com/mapbox/navigation/navigator/NavigationOkHttpServiceTest.kt
@@ -1,7 +1,6 @@
 package com.mapbox.navigation.navigator
 
 import com.mapbox.base.common.logger.Logger
-import com.mapbox.common.CancelRequestCallback
 import com.mapbox.common.HttpMethod
 import com.mapbox.common.HttpRequest
 import com.mapbox.common.HttpResponse
@@ -99,11 +98,9 @@ class NavigationOkHttpServiceTest {
         every { httpClient.newCall(any()) } returns call
 
         val id = httpService.request(nativeRequest, nativeCallback)
-        val cancelRequestCallback: CancelRequestCallback = mockk(relaxUnitFun = true)
-        httpService.cancelRequest(id, cancelRequestCallback)
+        httpService.cancelRequest(id)
 
         verify { call.cancel() }
-        verify(exactly = 1) { cancelRequestCallback.run(false) }
     }
 
     @Test
@@ -212,11 +209,9 @@ class NavigationOkHttpServiceTest {
 
         val id = httpService.request(nativeRequest, nativeCallback)
         callbackSlot.captured.onFailure(call, IOException("exceptionMessage"))
-        val cancelRequestCallback: CancelRequestCallback = mockk(relaxUnitFun = true)
-        httpService.cancelRequest(id, cancelRequestCallback)
+        httpService.cancelRequest(id)
 
         verify(exactly = 0) { call.cancel() }
-        verify(exactly = 1) { cancelRequestCallback.run(true) }
     }
 
     @Test
@@ -228,11 +223,9 @@ class NavigationOkHttpServiceTest {
         every { httpClient.newCall(capture(requestSlot)) } returns call
 
         val id = httpService.request(nativeRequest, nativeCallback)
-        val cancelRequestCallback: CancelRequestCallback = mockk(relaxUnitFun = true)
-        httpService.cancelRequest(id, cancelRequestCallback)
+        httpService.cancelRequest(id)
         callbackSlot.captured.onResponse(call, mockk(relaxed = true))
 
         verify(exactly = 0) { nativeCallback.run(any()) }
-        verify(exactly = 1) { cancelRequestCallback.run(false) }
     }
 }


### PR DESCRIPTION
## Description

There's an issue with routing tiles not being saved to disk which we might want to consider a release blocker. This PR reverts the NN and Common SDK bumps https://github.com/mapbox/mapbox-navigation-android/pull/3143 and https://github.com/mapbox/mapbox-navigation-android/pull/3159 respectively

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Be able to release without known regressions (issue with routing tiles not being saved to disk)

### Implementation

Reverts https://github.com/mapbox/mapbox-navigation-android/commit/fc5002e28a7ea8a3b8c439cfd45d55be3eaa23be and https://github.com/mapbox/mapbox-navigation-android/commit/5d02c86a9cf9324832a81a954100f35899c97d6c 

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs

cc @zugaldia @mskurydin @Aurora-Boreal 