### PR TITLE
Bump NN dependency version to 14.0.0

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -202,15 +202,32 @@ License: [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
+Mapbox Navigation uses portions of the Hamcrest Core (This is the core API of hamcrest matcher framework to be used by third-party framework providers. This includes the a foundation set of matcher implementations for common operations.).
+License: [New BSD License](http://www.opensource.org/licenses/bsd-license.php)
+
+===========================================================================
+
 Mapbox Navigation uses portions of the JetBrains Java Annotations (A set of annotations used for code inspection support and code documentation.).
 URL: [https://github.com/JetBrains/java-annotations](https://github.com/JetBrains/java-annotations)
 License: [The Apache Software License, Version 2.0](http://www.apache.org/license/LICENSE-2.0.txt)
 
 ===========================================================================
 
+Mapbox Navigation uses portions of the JUnit (JUnit is a unit testing framework for Java, created by Erich Gamma and Kent Beck.).
+URL: [http://junit.org](http://junit.org)
+License: [Eclipse Public License 1.0](http://www.eclipse.org/legal/epl-v10.html)
+
+===========================================================================
+
 Mapbox Navigation uses portions of the Mapbox Accounts SDK for Android.
 URL: [https://github.com/mapbox/mapbox-accounts-android](https://github.com/mapbox/mapbox-accounts-android)
 License: [Mapbox Terms of Service](https://www.mapbox.com/tos/)
+
+===========================================================================
+
+Mapbox Navigation uses portions of the Mapbox Android Commmon SDK.
+URL: [https://github.com/mapbox/mapbox-sdk](https://github.com/mapbox/mapbox-sdk)
+License: [BSD](https://opensource.org/licenses/BSD-2-Clause)
 
 ===========================================================================
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -22,7 +22,7 @@ ext {
       mapboxAnnotations         : '0.1.0',
       mapboxAnnotationsProcessor: '0.1.0',
       mapboxAndroidCommon       : '0.1.0',
-      mapboxCoreCommon          : '1.3.1',
+      mapboxCoreCommon          : '1.4.0',
       mapboxBindgenSupport      : '1.0.0',
       mapboxLogger              : '0.1.0',
       androidXCoreVersion       : '1.2.0',

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,7 +1,6 @@
 ext {
 
   androidVersions = [
-      legacyMinSdkVersion     : 14,
       minSdkVersion           : 19,
       targetSdkVersion        : 28,
       compileSdkVersion       : 28,
@@ -14,7 +13,7 @@ ext {
       mapboxSdkDirectionsModels : '5.2.1',
       mapboxEvents              : '5.0.1',
       mapboxCore                : '2.0.1',
-      mapboxNavigator           : '13.0.2',
+      mapboxNavigator           : '14.0.0',
       mapboxCrashMonitor        : '2.0.0',
       mapboxAnnotationPlugin    : '0.8.0',
       mapboxAccounts            : '0.4.0',
@@ -22,8 +21,6 @@ ext {
       mapboxAnnotations         : '0.1.0',
       mapboxAnnotationsProcessor: '0.1.0',
       mapboxAndroidCommon       : '0.1.0',
-      mapboxCoreCommon          : '1.4.0',
-      mapboxBindgenSupport      : '1.0.0',
       mapboxLogger              : '0.1.0',
       androidXCoreVersion       : '1.2.0',
       androidXAppCompatVersion  : '1.1.0',
@@ -85,8 +82,6 @@ ext {
       mapboxAnnotationsProcessor: "com.mapbox.base:annotations-processor:${version.mapboxAnnotationsProcessor}",
       mapboxAndroidCommon       : "com.mapbox.base:common:${version.mapboxAndroidCommon}",
       mapboxLogger              : "com.mapbox.common:logger:${version.mapboxLogger}",
-      mapboxCoreCommon          : "com.mapbox.common:common:${version.mapboxCoreCommon}",
-      mapboxBindgenSupport      : "com.mapbox.bindgen:support:${version.mapboxBindgenSupport}",
 
       // Kotlin
       kotlinStdLib              : "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${version.kotlinStdLib}",

--- a/libandroid-navigation-ui/build.gradle
+++ b/libandroid-navigation-ui/build.gradle
@@ -8,7 +8,7 @@ android {
   buildToolsVersion androidVersions.buildToolsVersion
 
   defaultConfig {
-    minSdkVersion androidVersions.legacyMinSdkVersion
+    minSdkVersion androidVersions.minSdkVersion
     targetSdkVersion androidVersions.targetSdkVersion
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     vectorDrawables.useSupportLibrary = true

--- a/libandroid-navigation/build.gradle
+++ b/libandroid-navigation/build.gradle
@@ -9,7 +9,7 @@ android {
   buildToolsVersion androidVersions.buildToolsVersion
 
   defaultConfig {
-    minSdkVersion androidVersions.legacyMinSdkVersion
+    minSdkVersion androidVersions.minSdkVersion
     targetSdkVersion androidVersions.targetSdkVersion
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 

--- a/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/MapboxNavigator.kt
+++ b/libandroid-navigation/src/main/java/com/mapbox/services/android/navigation/v5/internal/navigation/MapboxNavigator.kt
@@ -1,6 +1,7 @@
 package com.mapbox.services.android.navigation.v5.internal.navigation
 
 import android.location.Location
+import android.os.Build
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.geojson.Geometry
 import com.mapbox.geojson.Point
@@ -101,7 +102,8 @@ internal class MapboxNavigator(val navigator: Navigator) {
 
     @Synchronized
     fun retrieveRouteGeometryWithBuffer(): Geometry? {
-        val routeGeometryWithBuffer = navigator.getRouteBufferGeoJson(GRID_SIZE, BUFFER_DILATION) ?: return null
+        val routeGeometryWithBuffer = navigator.getRouteBufferGeoJson(GRID_SIZE, BUFFER_DILATION)
+            ?: return null
         return GeometryGeoJson.fromJson(routeGeometryWithBuffer)
     }
 
@@ -119,15 +121,27 @@ internal class MapboxNavigator(val navigator: Navigator) {
         val altitude = checkFor(location.altitude.toFloat())
         val horizontalAccuracy = checkFor(location.accuracy)
         val provider = location.provider
+        var bearingAccuracy: Float? = null
+        var speedAccuracy: Float? = null
+        var verticalAccuracy: Float? = null
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            bearingAccuracy = location.bearingAccuracyDegrees
+            speedAccuracy = location.speedAccuracyMetersPerSecond
+            verticalAccuracy = location.verticalAccuracyMeters
+        }
 
         return FixLocation(
-                rawPoint,
-                time,
-                speed,
-                bearing,
-                altitude,
-                horizontalAccuracy,
-                provider
+            rawPoint,
+            time,
+            speed,
+            bearing,
+            altitude,
+            horizontalAccuracy,
+            provider,
+            bearingAccuracy,
+            speedAccuracy,
+            verticalAccuracy
         )
     }
 

--- a/libnavigator/build.gradle
+++ b/libnavigator/build.gradle
@@ -47,8 +47,6 @@ dependencies {
     // mapbox-java GeoJSON
     api dependenciesList.mapboxSdkGeoJSON
 
-    implementation dependenciesList.mapboxBindgenSupport
-    implementation dependenciesList.mapboxCoreCommon
     implementation dependenciesList.mapboxAndroidCommon
 
     // Network

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/LocationEx.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/LocationEx.kt
@@ -1,6 +1,7 @@
 package com.mapbox.navigation.navigator
 
 import android.location.Location
+import android.os.Build
 import com.mapbox.geojson.Point
 import com.mapbox.navigator.FixLocation
 import java.util.Date
@@ -13,14 +14,38 @@ internal fun FixLocation.toLocation(): Location = Location(this.provider).also {
     it.bearing = this.bearing ?: 0f
     it.altitude = this.altitude?.toDouble() ?: 0.0
     it.accuracy = this.accuracyHorizontal ?: 0f
+
+    if (isCurrentSdkVersionEqualOrGreaterThan(Build.VERSION_CODES.O)) {
+        it.bearingAccuracyDegrees = this.bearingAccuracy ?: 0f
+        it.speedAccuracyMetersPerSecond = this.speedAccuracy ?: 0f
+        it.verticalAccuracyMeters = this.verticalAccuracy ?: 0f
+    }
 }
 
-internal fun Location.toFixLocation(date: Date) = FixLocation(
-    Point.fromLngLat(this.longitude, this.latitude),
-    date,
-    this.speed,
-    this.bearing,
-    this.altitude.toFloat(),
-    this.accuracy,
-    this.provider
-)
+internal fun Location.toFixLocation(date: Date): FixLocation {
+    var bearingAccuracy: Float? = null
+    var speedAccuracy: Float? = null
+    var verticalAccuracy: Float? = null
+
+    if (isCurrentSdkVersionEqualOrGreaterThan(Build.VERSION_CODES.O)) {
+        bearingAccuracy = this.bearingAccuracyDegrees
+        speedAccuracy = this.speedAccuracyMetersPerSecond
+        verticalAccuracy = this.verticalAccuracyMeters
+    }
+
+    return FixLocation(
+        Point.fromLngLat(this.longitude, this.latitude),
+        date,
+        this.speed,
+        this.bearing,
+        this.altitude.toFloat(),
+        this.accuracy,
+        this.provider,
+        bearingAccuracy,
+        speedAccuracy,
+        verticalAccuracy
+    )
+}
+
+private fun isCurrentSdkVersionEqualOrGreaterThan(sdkCode: Int): Boolean =
+    Build.VERSION.SDK_INT >= sdkCode

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/NavigationOkHttpService.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/NavigationOkHttpService.kt
@@ -5,7 +5,8 @@ import com.mapbox.base.common.logger.model.Message
 import com.mapbox.base.common.logger.model.Tag
 import com.mapbox.bindgen.Expected
 import com.mapbox.bindgen.ExpectedFactory
-import com.mapbox.common.CancelRequestCallback
+import com.mapbox.common.DownloadOptions
+import com.mapbox.common.DownloadStatusCallback
 import com.mapbox.common.HttpRequest
 import com.mapbox.common.HttpRequestError
 import com.mapbox.common.HttpRequestErrorType
@@ -13,6 +14,7 @@ import com.mapbox.common.HttpResponse
 import com.mapbox.common.HttpResponseCallback
 import com.mapbox.common.HttpResponseData
 import com.mapbox.common.HttpServiceInterface
+import com.mapbox.common.ResultCallback
 import java.io.IOException
 import java.util.HashMap
 import java.util.Locale
@@ -96,7 +98,7 @@ internal class NavigationOkHttpService(
         return id
     }
 
-    override fun cancelRequest(id: Long, callback: CancelRequestCallback) {
+    override fun cancelRequest(id: Long, callback: ResultCallback) {
         lock.lock()
         val call = callMap.remove(id)
         if (call != null) {
@@ -106,6 +108,18 @@ internal class NavigationOkHttpService(
             callback.run(true)
         }
         lock.unlock()
+    }
+
+    override fun download(options: DownloadOptions, callback: DownloadStatusCallback): Long {
+        TODO("not implemented") // To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun pauseRequest(id: Long, callback: ResultCallback) {
+        TODO("not implemented") // To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun resumeRequest(id: Long, callback: ResultCallback) {
+        TODO("not implemented") // To change body of created functions use File | Settings | File Templates.
     }
 
     internal inner class HttpCallback constructor(

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/NavigationOkHttpService.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/NavigationOkHttpService.kt
@@ -5,6 +5,7 @@ import com.mapbox.base.common.logger.model.Message
 import com.mapbox.base.common.logger.model.Tag
 import com.mapbox.bindgen.Expected
 import com.mapbox.bindgen.ExpectedFactory
+import com.mapbox.common.CancelRequestCallback
 import com.mapbox.common.HttpRequest
 import com.mapbox.common.HttpRequestError
 import com.mapbox.common.HttpRequestErrorType
@@ -95,9 +96,15 @@ internal class NavigationOkHttpService(
         return id
     }
 
-    override fun cancelRequest(id: Long) {
+    override fun cancelRequest(id: Long, callback: CancelRequestCallback) {
         lock.lock()
-        callMap.remove(id)?.cancel()
+        val call = callMap.remove(id)
+        if (call != null) {
+            call.cancel()
+            callback.run(false)
+        } else {
+            callback.run(true)
+        }
         lock.unlock()
     }
 

--- a/libnavigator/src/test/java/com/mapbox/navigation/navigator/NavigationOkHttpServiceTest.kt
+++ b/libnavigator/src/test/java/com/mapbox/navigation/navigator/NavigationOkHttpServiceTest.kt
@@ -1,6 +1,7 @@
 package com.mapbox.navigation.navigator
 
 import com.mapbox.base.common.logger.Logger
+import com.mapbox.common.CancelRequestCallback
 import com.mapbox.common.HttpMethod
 import com.mapbox.common.HttpRequest
 import com.mapbox.common.HttpResponse
@@ -98,9 +99,11 @@ class NavigationOkHttpServiceTest {
         every { httpClient.newCall(any()) } returns call
 
         val id = httpService.request(nativeRequest, nativeCallback)
-        httpService.cancelRequest(id)
+        val cancelRequestCallback: CancelRequestCallback = mockk(relaxUnitFun = true)
+        httpService.cancelRequest(id, cancelRequestCallback)
 
         verify { call.cancel() }
+        verify(exactly = 1) { cancelRequestCallback.run(false) }
     }
 
     @Test
@@ -209,9 +212,11 @@ class NavigationOkHttpServiceTest {
 
         val id = httpService.request(nativeRequest, nativeCallback)
         callbackSlot.captured.onFailure(call, IOException("exceptionMessage"))
-        httpService.cancelRequest(id)
+        val cancelRequestCallback: CancelRequestCallback = mockk(relaxUnitFun = true)
+        httpService.cancelRequest(id, cancelRequestCallback)
 
         verify(exactly = 0) { call.cancel() }
+        verify(exactly = 1) { cancelRequestCallback.run(true) }
     }
 
     @Test
@@ -223,9 +228,11 @@ class NavigationOkHttpServiceTest {
         every { httpClient.newCall(capture(requestSlot)) } returns call
 
         val id = httpService.request(nativeRequest, nativeCallback)
-        httpService.cancelRequest(id)
+        val cancelRequestCallback: CancelRequestCallback = mockk(relaxUnitFun = true)
+        httpService.cancelRequest(id, cancelRequestCallback)
         callbackSlot.captured.onResponse(call, mockk(relaxed = true))
 
         verify(exactly = 0) { nativeCallback.run(any()) }
+        verify(exactly = 1) { cancelRequestCallback.run(false) }
     }
 }

--- a/libnavigator/src/test/java/com/mapbox/navigation/navigator/NavigationOkHttpServiceTest.kt
+++ b/libnavigator/src/test/java/com/mapbox/navigation/navigator/NavigationOkHttpServiceTest.kt
@@ -1,11 +1,11 @@
 package com.mapbox.navigation.navigator
 
 import com.mapbox.base.common.logger.Logger
-import com.mapbox.common.CancelRequestCallback
 import com.mapbox.common.HttpMethod
 import com.mapbox.common.HttpRequest
 import com.mapbox.common.HttpResponse
 import com.mapbox.common.HttpResponseCallback
+import com.mapbox.common.ResultCallback
 import com.mapbox.common.UserAgentComponents
 import com.mapbox.navigation.navigator.NavigationOkHttpService.Companion.GZIP
 import com.mapbox.navigation.navigator.NavigationOkHttpService.Companion.HEADER_ENCODING
@@ -25,7 +25,9 @@ import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.Response
 import okhttp3.ResponseBody
-import org.junit.Assert
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
@@ -62,7 +64,7 @@ class NavigationOkHttpServiceTest {
 
     @Test
     fun supportsKeepCompression() {
-        Assert.assertTrue(httpService.supportsKeepCompression())
+        assertTrue(httpService.supportsKeepCompression())
     }
 
     @Test
@@ -73,7 +75,7 @@ class NavigationOkHttpServiceTest {
         val id = httpService.request(nativeRequest, nativeCallback)
 
         verify { call.enqueue(any()) }
-        Assert.assertTrue(id > 0)
+        assertTrue(id > 0)
     }
 
     @Test
@@ -84,13 +86,13 @@ class NavigationOkHttpServiceTest {
         httpService.request(nativeRequest, nativeCallback)
 
         val request = requestSlot.captured
-        Assert.assertEquals(nativeRequest.url, request.url().toString())
-        Assert.assertEquals(nativeRequest.url.toLowerCase(Locale.US), request.tag())
+        assertEquals(nativeRequest.url, request.url().toString())
+        assertEquals(nativeRequest.url.toLowerCase(Locale.US), request.tag())
         val headers = Headers.Builder().addAll(nativeRequest.headers.toHeaders()).let {
             it.add(HEADER_ENCODING, GZIP)
             it.build()
         }
-        Assert.assertEquals(headers, request.headers())
+        assertEquals(headers, request.headers())
     }
 
     @Test
@@ -99,7 +101,7 @@ class NavigationOkHttpServiceTest {
         every { httpClient.newCall(any()) } returns call
 
         val id = httpService.request(nativeRequest, nativeCallback)
-        val cancelRequestCallback: CancelRequestCallback = mockk(relaxUnitFun = true)
+        val cancelRequestCallback: ResultCallback = mockk(relaxUnitFun = true)
         httpService.cancelRequest(id, cancelRequestCallback)
 
         verify { call.cancel() }
@@ -121,7 +123,7 @@ class NavigationOkHttpServiceTest {
         callbackSlot.captured.onFailure(call, exception)
 
         verify { nativeCallback.run(capture(nativeResponseSlot)) }
-        Assert.assertTrue(nativeResponseSlot.captured.result.isError)
+        assertTrue(nativeResponseSlot.captured.result.isError)
     }
 
     @Test
@@ -149,10 +151,10 @@ class NavigationOkHttpServiceTest {
 
         val nativeResponseSlot = slot<HttpResponse>()
         verify { nativeCallback.run(capture(nativeResponseSlot)) }
-        Assert.assertTrue(nativeResponseSlot.captured.result.isValue)
-        Assert.assertEquals(200, nativeResponseSlot.captured.result.value!!.code)
-        Assert.assertArrayEquals(byteArray, nativeResponseSlot.captured.result.value!!.data)
-        Assert.assertEquals(headers.toHashMap(), nativeResponseSlot.captured.result.value!!.headers)
+        assertTrue(nativeResponseSlot.captured.result.isValue)
+        assertEquals(200, nativeResponseSlot.captured.result.value!!.code)
+        assertArrayEquals(byteArray, nativeResponseSlot.captured.result.value!!.data)
+        assertEquals(headers.toHashMap(), nativeResponseSlot.captured.result.value!!.headers)
     }
 
     @Test
@@ -175,7 +177,7 @@ class NavigationOkHttpServiceTest {
 
         val nativeResponseSlot = slot<HttpResponse>()
         verify { nativeCallback.run(capture(nativeResponseSlot)) }
-        Assert.assertTrue(nativeResponseSlot.captured.result.isError)
+        assertTrue(nativeResponseSlot.captured.result.isError)
     }
 
     @Test
@@ -198,8 +200,8 @@ class NavigationOkHttpServiceTest {
 
         val nativeResponseSlot = slot<HttpResponse>()
         verify { nativeCallback.run(capture(nativeResponseSlot)) }
-        Assert.assertTrue(nativeResponseSlot.captured.result.isValue)
-        Assert.assertEquals(304, nativeResponseSlot.captured.result.value!!.code)
+        assertTrue(nativeResponseSlot.captured.result.isValue)
+        assertEquals(304, nativeResponseSlot.captured.result.value!!.code)
     }
 
     @Test
@@ -212,7 +214,7 @@ class NavigationOkHttpServiceTest {
 
         val id = httpService.request(nativeRequest, nativeCallback)
         callbackSlot.captured.onFailure(call, IOException("exceptionMessage"))
-        val cancelRequestCallback: CancelRequestCallback = mockk(relaxUnitFun = true)
+        val cancelRequestCallback: ResultCallback = mockk(relaxUnitFun = true)
         httpService.cancelRequest(id, cancelRequestCallback)
 
         verify(exactly = 0) { call.cancel() }
@@ -228,7 +230,7 @@ class NavigationOkHttpServiceTest {
         every { httpClient.newCall(capture(requestSlot)) } returns call
 
         val id = httpService.request(nativeRequest, nativeCallback)
-        val cancelRequestCallback: CancelRequestCallback = mockk(relaxUnitFun = true)
+        val cancelRequestCallback: ResultCallback = mockk(relaxUnitFun = true)
         httpService.cancelRequest(id, cancelRequestCallback)
         callbackSlot.captured.onResponse(call, mockk(relaxed = true))
 


### PR DESCRIPTION
## Description

Bumps `mapbox-navigation-native` version to `14.0.0`

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Getting the latest version from `mapboxNavigator` including the new features and bug fixes.

### Implementation

- Bump the `mapboxNavigator` version to `14.0.0` in `dependencies.gradle` and fix breaking changes
- Revert https://github.com/mapbox/mapbox-navigation-android/commit/5d02c86a9cf9324832a81a954100f35899c97d6c and adapt to `mapboxCoreCommon` `1.5.1` (now transitively added as part of NN)


## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

Took this for a quick spin and noticed that routing tiles are being saved to disk now 🎉 

Found though that sometimes we map-match to parking lots roads and also when stuck prediction somehow kicks in 😬 causing unexpected off-routes and missing arrival events

These are some preliminary findings running the `SimpleMapboxNavigationKt` from the `examples` test app using a mock location app in the background to fake the location updates

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR

cc @mskurydin @SiarheiFedartsou @LukasPaczos @Aurora-Boreal @zugaldia 