### PR TITLE
Add "Positioning Issue" option into Feedback flow.

### DIFF
--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -368,6 +368,7 @@ package com.mapbox.navigation.core.telemetry.events {
     field public static final String MISSING_EXIT = "missing_exit";
     field public static final String MISSING_ROAD = "missing_road";
     field public static final String NOT_ALLOWED = "not_allowed";
+    field public static final String POSITIONING_ISSUE = "positioning_issue";
     field public static final String PRONUNCIATION_INCORRECT = "pronunciation_incorrect";
     field public static final String REROUTE = "reroute";
     field public static final String ROAD_CLOSED = "road_closed";
@@ -394,7 +395,7 @@ package com.mapbox.navigation.core.telemetry.events {
   @StringDef({com.mapbox.navigation.core.telemetry.events.FeedbackEvent.REROUTE, com.mapbox.navigation.core.telemetry.events.FeedbackEvent.UI}) @kotlin.annotation.Retention(AnnotationRetention.SOURCE) public static @interface FeedbackEvent.Source {
   }
 
-  @StringDef({com.mapbox.navigation.core.telemetry.events.FeedbackEvent.GENERAL_ISSUE, com.mapbox.navigation.core.telemetry.events.FeedbackEvent.ACCIDENT, com.mapbox.navigation.core.telemetry.events.FeedbackEvent.HAZARD, com.mapbox.navigation.core.telemetry.events.FeedbackEvent.ROAD_CLOSED, com.mapbox.navigation.core.telemetry.events.FeedbackEvent.NOT_ALLOWED, com.mapbox.navigation.core.telemetry.events.FeedbackEvent.ROUTING_ERROR, com.mapbox.navigation.core.telemetry.events.FeedbackEvent.MISSING_ROAD, com.mapbox.navigation.core.telemetry.events.FeedbackEvent.MISSING_EXIT, com.mapbox.navigation.core.telemetry.events.FeedbackEvent.CONFUSING_INSTRUCTION, com.mapbox.navigation.core.telemetry.events.FeedbackEvent.INACCURATE_GPS, com.mapbox.navigation.core.telemetry.events.FeedbackEvent.INCORRECT_VISUAL_GUIDANCE, com.mapbox.navigation.core.telemetry.events.FeedbackEvent.INCORRECT_AUDIO_GUIDANCE}) @kotlin.annotation.Retention(AnnotationRetention.SOURCE) public static @interface FeedbackEvent.Type {
+  @StringDef({com.mapbox.navigation.core.telemetry.events.FeedbackEvent.GENERAL_ISSUE, com.mapbox.navigation.core.telemetry.events.FeedbackEvent.ACCIDENT, com.mapbox.navigation.core.telemetry.events.FeedbackEvent.HAZARD, com.mapbox.navigation.core.telemetry.events.FeedbackEvent.ROAD_CLOSED, com.mapbox.navigation.core.telemetry.events.FeedbackEvent.NOT_ALLOWED, com.mapbox.navigation.core.telemetry.events.FeedbackEvent.ROUTING_ERROR, com.mapbox.navigation.core.telemetry.events.FeedbackEvent.MISSING_ROAD, com.mapbox.navigation.core.telemetry.events.FeedbackEvent.MISSING_EXIT, com.mapbox.navigation.core.telemetry.events.FeedbackEvent.CONFUSING_INSTRUCTION, com.mapbox.navigation.core.telemetry.events.FeedbackEvent.INACCURATE_GPS, com.mapbox.navigation.core.telemetry.events.FeedbackEvent.INCORRECT_VISUAL_GUIDANCE, com.mapbox.navigation.core.telemetry.events.FeedbackEvent.INCORRECT_AUDIO_GUIDANCE, com.mapbox.navigation.core.telemetry.events.FeedbackEvent.POSITIONING_ISSUE}) @kotlin.annotation.Retention(AnnotationRetention.SOURCE) public static @interface FeedbackEvent.Type {
   }
 
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/events/FeedbackEvent.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/events/FeedbackEvent.kt
@@ -70,6 +70,11 @@ object FeedbackEvent {
     const val INCORRECT_AUDIO_GUIDANCE = "incorrect_audio_guidance"
 
     /**
+     * Feedback type *positioning issue*: wrong positioning
+     */
+    const val POSITIONING_ISSUE = "positioning_issue"
+
+    /**
      * Feedback source *reroute*: the user tapped a feedback button in response to a reroute
      */
     const val REROUTE = "reroute"
@@ -214,7 +219,8 @@ object FeedbackEvent {
         CONFUSING_INSTRUCTION,
         INACCURATE_GPS,
         INCORRECT_VISUAL_GUIDANCE,
-        INCORRECT_AUDIO_GUIDANCE
+        INCORRECT_AUDIO_GUIDANCE,
+        POSITIONING_ISSUE
     )
     annotation class Type
 

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/feedback/FeedbackBottomSheet.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/feedback/FeedbackBottomSheet.java
@@ -57,7 +57,7 @@ public class FeedbackBottomSheet extends BottomSheetDialogFragment implements An
   private static final String EMPTY_FEEDBACK_DESCRIPTION = "";
   private static final long CLOSE_BOTTOM_SHEET_AFTER = 150L;
   private static final long TIMER_INTERVAL = 1L;
-  private static final int GRID_SPAN_GUIDANCE_LAYOUT = 2;
+  private static final int GRID_SPAN_GUIDANCE_LAYOUT = 3;
   private static final int GRID_SPAN_NAVIGATION_LAYOUT = 3;
 
   private FeedbackBottomSheetListener feedbackBottomSheetListener;
@@ -305,6 +305,10 @@ public class FeedbackBottomSheet extends BottomSheetDialogFragment implements An
       R.drawable.ic_feedback_confusing_audio,
       FeedbackEvent.INCORRECT_AUDIO_GUIDANCE,
       EMPTY_FEEDBACK_DESCRIPTION));
+    list.add(new FeedbackItem(getResources().getString(R.string.feedback_type_positioning_issue),
+        R.drawable.ic_feedback_positioning_issue,
+        FeedbackEvent.POSITIONING_ISSUE,
+        EMPTY_FEEDBACK_DESCRIPTION));
 
     return list;
   }
@@ -352,11 +356,12 @@ public class FeedbackBottomSheet extends BottomSheetDialogFragment implements An
   };
 
   private void onFeedbackSelected(FeedbackItem feedbackItem) {
-    if (feedbackFlowType == FEEDBACK_DETAIL_FLOW) {
-      launchDetailFlow(feedbackItem);
-    } else {
+    if (feedbackFlowType == FEEDBACK_MAIN_FLOW
+        || feedbackItem.getFeedbackType().equals(FeedbackEvent.POSITIONING_ISSUE)) {
       feedbackBottomSheetListener.onFeedbackSelected(feedbackItem);
       startTimer();
+    } else {
+      launchDetailFlow(feedbackItem);
     }
   }
 

--- a/libnavigation-ui/src/main/res/drawable/ic_feedback_positioning_issue.xml
+++ b/libnavigation-ui/src/main/res/drawable/ic_feedback_positioning_issue.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+  <item android:drawable="@drawable/ic_feedback_positioning_issue_circle_pressed" android:state_pressed="true" />
+  <item android:drawable="@drawable/ic_feedback_positioning_issue_circle" />
+</selector>

--- a/libnavigation-ui/src/main/res/drawable/ic_feedback_positioning_issue_circle.xml
+++ b/libnavigation-ui/src/main/res/drawable/ic_feedback_positioning_issue_circle.xml
@@ -1,0 +1,16 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="70dp"
+    android:viewportHeight="70"
+    android:viewportWidth="70"
+    android:width="70dp">
+  <path
+      android:fillColor="@android:color/white"
+      android:fillType="evenOdd"
+      android:pathData="M70,35C70,54.3305 54.327,70 35,70C15.673,70 0,54.3305 0,35C0,15.6695 15.673,0 35,0C54.327,0 70,15.6695 70,35Z"
+      android:strokeColor="#00000000"
+      android:strokeWidth="1" />
+  <path
+      android:fillColor="@color/mapbox_feedback_bottom_sheet_icon_primary"
+      android:fillType="evenOdd"
+      android:pathData="M35,0C15.67,0 0,15.67 0,35s15.67,35 35,35s35,-15.67 35,-35S54.33,0 35,0zM31.01,48.61v3.99H17.4V38.99h3.99v6.8l6.8,-6.8l2.82,2.82l-6.8,6.8H31.01zM31.01,21.39h-6.8l6.8,6.8l-2.82,2.82l-6.8,-6.8v6.8H17.4V17.4h13.61V21.39zM52.6,52.6H38.99v-3.99h6.8l-6.8,-6.8l2.82,-2.82l6.8,6.8v-6.8h3.99V52.6zM52.6,31.01h-3.99v-6.8l-6.8,6.8l-2.82,-2.82l6.8,-6.8h-6.8V17.4H52.6V31.01z" />
+</vector>

--- a/libnavigation-ui/src/main/res/drawable/ic_feedback_positioning_issue_circle_pressed.xml
+++ b/libnavigation-ui/src/main/res/drawable/ic_feedback_positioning_issue_circle_pressed.xml
@@ -1,0 +1,16 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="70dp"
+    android:viewportHeight="70"
+    android:viewportWidth="70"
+    android:width="70dp">
+  <path
+      android:fillColor="@android:color/white"
+      android:fillType="evenOdd"
+      android:pathData="M70,35C70,54.3305 54.327,70 35,70C15.673,70 0,54.3305 0,35C0,15.6695 15.673,0 35,0C54.327,0 70,15.6695 70,35Z"
+      android:strokeColor="#00000000"
+      android:strokeWidth="1" />
+  <path
+      android:fillColor="@color/mapbox_feedback_bottom_sheet_icon_secondary"
+      android:fillType="evenOdd"
+      android:pathData="M35,0C15.67,0 0,15.67 0,35s15.67,35 35,35s35,-15.67 35,-35S54.33,0 35,0zM31.01,48.61v3.99H17.4V38.99h3.99v6.8l6.8,-6.8l2.82,2.82l-6.8,6.8H31.01zM31.01,21.39h-6.8l6.8,6.8l-2.82,2.82l-6.8,-6.8v6.8H17.4V17.4h13.61V21.39zM52.6,52.6H38.99v-3.99h6.8l-6.8,-6.8l2.82,-2.82l6.8,6.8v-6.8h3.99V52.6zM52.6,31.01h-3.99v-6.8l-6.8,6.8l-2.82,-2.82l6.8,-6.8h-6.8V17.4H52.6V31.01z" />
+</vector>

--- a/libnavigation-ui/src/main/res/values/strings.xml
+++ b/libnavigation-ui/src/main/res/values/strings.xml
@@ -24,6 +24,9 @@
     <!-- Feedback type for Confusing Audio -->
     <string name="feedback_type_confusing_audio">Confusing\nAudio</string>
 
+    <!-- Feedback type for Positioning Issue -->
+    <string name="feedback_type_positioning_issue">Positioning\nIssue</string>
+
     <!-- Feedback Navigation Issue -->
     <string name="feedback_navigation_issue">Navigation Issue</string>
 


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Add "Positioning Issue" option into Feedback flow. The option will not have 2tap flow UI even user uses the FEEDBACK_DETAIL_FLOW mode.

- [ ] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

To help test drivers send **Positioning** related feedback quick and easy.

### Implementation

Add "Positioning Issue" option into Feedback flow. It's been temporary put under the `Guidance Issue` category for better UX, but we could revisit it if necessary. Plus, the "Positioning Issue" option will **NOT** have 2tap flow UI even user uses the FEEDBACK_DETAIL_FLOW mode.

## Screenshots or Gifs

You can see "Positioning Issue" will send the feedback directly in the 2tap Feedback UI flow. The other options remain 2steps behavior.

![ezgif com-video-to-gif (4)](https://user-images.githubusercontent.com/3918950/84536362-8be5e400-aca2-11ea-8d76-b789ed270d42.gif)

![Screenshot_20200612-113623_Mapbox 10 Navigation SDK for Android](https://user-images.githubusercontent.com/3918950/84536486-cd768f00-aca2-11ea-8027-cd8436ff0291.jpg)


## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->