### PR TITLE
reposition feedback landscape mode to make two categories equal width

### DIFF
--- a/libnavigation-ui/src/main/res/layout-land/mapbox_feedback_bottom_sheet_layout.xml
+++ b/libnavigation-ui/src/main/res/layout-land/mapbox_feedback_bottom_sheet_layout.xml
@@ -84,7 +84,7 @@
             style="@style/FeedbackBottomSheetIssueListLayout"
             android:layout_width="0dp"
             android:layout_height="match_parent"
-            android:layout_weight="2">
+            android:layout_weight="1">
 
             <TextView
                 style="@style/FeedbackBottomSheetIssueListTitle"
@@ -106,7 +106,7 @@
             style="@style/FeedbackBottomSheetIssueListLayout"
             android:layout_width="0dp"
             android:layout_height="match_parent"
-            android:layout_weight="3">
+            android:layout_weight="1">
 
             <TextView
                 style="@style/FeedbackBottomSheetIssueListTitle"


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

follow up of PR #3167
before #3167 , the two categories are 2:3 width, need to set to 1:1 after the new "Positioning Issue" option added.

- [ ] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal

Please describe the PR goals. Just the stuff needed to implement the fix / feature and a simple rationale. It could contain many check points if needed

### Implementation

Please include all the relevant things implemented and also rationale, clarifications / disclaimers etc. related to the approach used. It could be as self code companion comments

## Screenshots or Gifs
### with this PR:
![Screenshot_20200612-153652_Mapbox 10 Navigation SDK for Android](https://user-images.githubusercontent.com/3918950/84551745-57ceeb00-acc3-11ea-999c-48bcc9538026.jpg)

### before this PR:
![Screenshot_20200612-153740_Mapbox 10 Navigation SDK for Android](https://user-images.githubusercontent.com/3918950/84551747-5ac9db80-acc3-11ea-88f2-9d9636903d03.jpg)


## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->