### PR TITLE
cancel route line animation when drawing a new route

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteLine.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteLine.kt
@@ -620,7 +620,7 @@ internal class MapRouteLine(
             style,
             roundedLineCap,
             routeTrafficScale,
-            routeLowCongestionColor
+            routeDefaultColor
         ).apply {
             MapUtils.addLayerToMap(
                 style,

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteProgressChangeListener.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteProgressChangeListener.kt
@@ -74,9 +74,13 @@ internal class MapRouteProgressChangeListener(
     }
 
     private fun updateRoute(directionsRoute: DirectionsRoute?, routeProgress: RouteProgress) {
+        if (routeArrow.routeArrowIsVisible()) {
+            routeArrow.addUpcomingManeuverArrow(routeProgress)
+        }
         val currentRoute = routeProgress.route
         val hasGeometry = currentRoute?.geometry()?.isNotEmpty() ?: false
         if (hasGeometry && currentRoute != directionsRoute) {
+            vanishingLineAnimator?.cancel()
             routeLine.draw(currentRoute!!)
             this.lastDistanceValue = routeLine.vanishPointOffset
         } else {
@@ -91,9 +95,6 @@ internal class MapRouteProgressChangeListener(
                     }
                 }
             }
-        }
-        if (routeArrow.routeArrowIsVisible()) {
-            routeArrow.addUpcomingManeuverArrow(routeProgress)
         }
     }
 

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteProgressChangeListenerTest.kt
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteProgressChangeListenerTest.kt
@@ -103,6 +103,32 @@ class MapRouteProgressChangeListenerTest {
     }
 
     @Test
+    fun `should cancel animator when route progress has geometry`() {
+        val animator = mockk<ValueAnimator>(relaxUnitFun = true)
+        val routeProgressChangeListener = MapRouteProgressChangeListener(routeLine, routeArrow, animator)
+
+        every { routeLine.retrieveDirectionsRoutes() } returns listOf(
+            mockk {
+                every { geometry() } returns null
+            }
+        )
+        val routeProgress: RouteProgress = mockk {
+            every { route } returns mockk {
+                every { geometry() } returns "y{v|bA{}diiGOuDpBiMhM{k@~Syj@bLuZlEiM"
+            }
+        }
+        val newRoute: DirectionsRoute = mockk {
+            every { geometry() } returns null
+        }
+
+        every { routeLine.getPrimaryRoute() } returns newRoute
+
+        routeProgressChangeListener.onRouteProgressChanged(routeProgress)
+
+        verify(exactly = 1) { animator.cancel() }
+    }
+
+    @Test
     fun `should only add maneuver arrow when visible`() {
         val routes = listOf(
             mockk<DirectionsRoute> {


### PR DESCRIPTION
## Description

During a reroute event the progress change listener will initiate a draw of the new route. However the progress change listener may have already started an animator for the "vanishing" part of the route line. In some cases the new route would be drawn but the animator would update the vanishing section with the values from the previous route progress. The animator needed to be canceled when new routes are received.

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal

There should be a better visual representation of reroute events and the line should get drawn correctly.

### Implementation

The animator gets canceled when a new route is received by the progress change listener.

## Screenshots or Gifs

![20200612_164038](https://user-images.githubusercontent.com/2249818/84554509-ff9ce680-accc-11ea-8ac3-8e60a9225542.gif)


## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->