### PR TITLE
Fix navigation-ui default location engine

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationViewModel.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationViewModel.java
@@ -396,7 +396,9 @@ public class NavigationViewModel extends AndroidViewModel {
   }
 
   private LocationEngine initializeLocationEngineFrom(final NavigationViewOptions options) {
-    if (options.shouldSimulateRoute()) {
+    if (options.locationEngine() != null) {
+      return options.locationEngine();
+    } else if (options.shouldSimulateRoute()) {
       ReplayLocationEngine replayLocationEngine = new ReplayLocationEngine(mapboxReplayer);
       final Point lastLocation = getOriginOfRoute(options.directionsRoute());
       ReplayEventBase replayEventOrigin = ReplayRouteMapper.mapToUpdateLocation(0.0, lastLocation);
@@ -404,7 +406,7 @@ public class NavigationViewModel extends AndroidViewModel {
       mapboxReplayer.play();
       return replayLocationEngine;
     } else {
-      return options.locationEngine();
+      return navigation.getLocationEngine();
     }
   }
 


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Resolves https://github.com/mapbox/mapbox-navigation-android/issues/3107

This issue was [introduced here](https://github.com/mapbox/mapbox-navigation-android/pull/3005/files#diff-a07531a3f785f009f485fc10ce1e4178L37). When the option's LocationEngine is null the default is created inside NavigationViewModel. Legacy seems to create multiple default LocationEngine instances.
![Screen Shot 2020-06-12 at 6 06 21 PM](https://user-images.githubusercontent.com/3021882/84556410-72ab5a80-acd7-11ea-9920-945646bfcc01.png)


Would like us to move the defaults up front into the [new Builder pattern](https://github.com/mapbox/mapbox-navigation-android/issues/2709#issuecomment-631117281). That way the defaults are closer to the user - theory being developers are comfortable figuring out how to override something when they see the default. 

The LocationEngine is included in the MapboxNavigation constructor, mostly because it needs an Application Context. Would be nice to provide the LocationEngine using the NavigationOptions.

- [ ] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->