### PR TITLE
Fix material card crashes in examples

### DIFF
--- a/examples/src/main/res/layout/activity_replay_history_layout.xml
+++ b/examples/src/main/res/layout/activity_replay_history_layout.xml
@@ -33,6 +33,7 @@
     <com.google.android.material.card.MaterialCardView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:theme="@style/Theme.MaterialComponents.Light"
         app:layout_constraintBottom_toTopOf="@id/playReplay"
         app:cardElevation="3dp"
         app:cardUseCompatPadding="true">

--- a/examples/src/main/res/layout/activity_replay_waypoints_layout.xml
+++ b/examples/src/main/res/layout/activity_replay_waypoints_layout.xml
@@ -21,6 +21,7 @@
     <com.google.android.material.card.MaterialCardView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:theme="@style/Theme.MaterialComponents.Light"
         app:layout_constraintBottom_toTopOf="@id/navigationLayout"
         app:cardElevation="3dp"
         app:cardUseCompatPadding="true">
@@ -62,7 +63,8 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:text="@string/start_navigation"
-            style="@style/Widget.MaterialComponents.Button"
+            android:background="@color/colorPrimary"
+            android:textColor="@android:color/white"
             android:visibility="gone"
             />
 
@@ -72,7 +74,8 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:text="@string/navigate_waypoints_next_stop"
-            style="@style/Widget.MaterialComponents.Button"
+            android:background="@color/colorPrimary"
+            android:textColor="@android:color/white"
             android:visibility="gone"
             />
     </LinearLayout>


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

```
     Caused by: android.view.InflateException: Binary XML file line #21 in com.mapbox.navigation.examples:layout/activity_replay_waypoints_layout: Binary XML file line #21 in com.mapbox.navigation.examples:layout/activity_replay_waypoints_layout: Error inflating class <unknown>
     Caused by: android.view.InflateException: Binary XML file line #21 in com.mapbox.navigation.examples:layout/activity_replay_waypoints_layout: Error inflating class <unknown>
     Caused by: java.lang.reflect.InvocationTargetException
        at java.lang.reflect.Constructor.newInstance0(Native Method)
        at java.lang.reflect.Constructor.newInstance(Constructor.java:343)
        at android.view.LayoutInflater.createView(LayoutInflater.java:854)
        at android.view.LayoutInflater.createViewFromTag(LayoutInflater.java:1006)
        at android.view.LayoutInflater.createViewFromTag(LayoutInflater.java:961)
        at android.view.LayoutInflater.rInflate(LayoutInflater.java:1123)
        at android.view.LayoutInflater.rInflateChildren(LayoutInflater.java:1084)
        at android.view.LayoutInflater.inflate(LayoutInflater.java:682)
        at android.view.LayoutInflater.inflate(LayoutInflater.java:534)
        at android.view.LayoutInflater.inflate(LayoutInflater.java:481)
        at androidx.appcompat.app.AppCompatDelegateImpl.setContentView(AppCompatDelegateImpl.java:555)
        at androidx.appcompat.app.AppCompatActivity.setContentView(AppCompatActivity.java:161)
        at com.mapbox.navigation.examples.core.ReplayWaypointsActivity.onCreate(ReplayWaypointsActivity.kt:77)
```

Adding a material theme because these cards are crashing

- [ ] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->