### PR TITLE
Fix #3121: use Right as default driving side when driving side is unavailable

### DIFF
--- a/libnavigation-ui/api/current.txt
+++ b/libnavigation-ui/api/current.txt
@@ -380,6 +380,7 @@ package com.mapbox.navigation.ui.instruction {
     method public void subscribe(androidx.lifecycle.LifecycleOwner!, com.mapbox.navigation.ui.NavigationViewModel!);
     method @androidx.lifecycle.OnLifecycleEvent(androidx.lifecycle.Lifecycle.Event.ON_DESTROY) public void unsubscribe();
     method public void updateBannerInstructionsWith(com.mapbox.api.directions.v5.models.BannerInstructions!);
+    method public void updateBannerInstructionsWith(com.mapbox.api.directions.v5.models.BannerInstructions!, String!);
     method public void updateDistanceWith(com.mapbox.navigation.base.trip.model.RouteProgress!);
   }
 


### PR DESCRIPTION


<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

This is a proposal to fix #3121: use Right as default driving side when driving side is unavailable.
Also add an API to allow user set the default "driving side".

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal

To make InstructionView API crash free.

### Implementation

Add an API to let the developer to set the default driving side, this value has higher priority than the one from RouteProgress. If developer doesn't set a default driving side and RouteProgress isn't available, then will use `Right` as default driving side. So we could avoid NPE crash.

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->