### PR TITLE
Stop notifying arrival when route is invalid

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayWaypointsActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayWaypointsActivity.kt
@@ -163,8 +163,8 @@ class ReplayWaypointsActivity : AppCompatActivity(), OnMapReadyCallback {
         startNavigation.setOnClickListener {
             updateCameraOnNavigationStateChange(true)
             navigationMapboxMap?.addProgressChangeListener(mapboxNavigation!!)
-            if (mapboxNavigation?.getRoutes()?.isNotEmpty() == true) {
-                navigationMapboxMap?.startCamera(mapboxNavigation?.getRoutes()!![0])
+            mapboxNavigation?.getRoutes()?.firstOrNull()?.let {
+                navigationMapboxMap?.startCamera(it)
             }
             mapboxNavigation?.registerRouteProgressObserver(replayProgressObserver)
             mapboxNavigation?.startTripSession()
@@ -201,7 +201,9 @@ class ReplayWaypointsActivity : AppCompatActivity(), OnMapReadyCallback {
         override fun navigateNextRouteLeg(routeLegProgress: RouteLegProgress): Boolean {
             // This example shows you can use both time and distance.
             // Move to the next step when the distance is small
-            findViewById<Button>(R.id.navigateNextRouteLeg).visibility = View.VISIBLE
+            val hasNextStep = routeLegProgress.upcomingStep != null
+            val nextStepButtonVisibility = if (hasNextStep) View.VISIBLE else View.GONE
+            findViewById<Button>(R.id.navigateNextRouteLeg).visibility = nextStepButtonVisibility
             return false
         }
     }
@@ -213,6 +215,8 @@ class ReplayWaypointsActivity : AppCompatActivity(), OnMapReadyCallback {
 
         override fun onFinalDestinationArrival(routeProgress: RouteProgress) {
             findViewById<Button>(R.id.navigateNextRouteLeg).visibility = View.GONE
+            navigationMapboxMap?.removeRoute()
+            mapboxReplayer.clearEvents()
         }
     }
 

--- a/examples/src/main/res/layout/activity_replay_waypoints_layout.xml
+++ b/examples/src/main/res/layout/activity_replay_waypoints_layout.xml
@@ -78,6 +78,7 @@
             android:textColor="@android:color/white"
             android:visibility="gone"
             />
+
     </LinearLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/arrival/ArrivalProgressObserver.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/arrival/ArrivalProgressObserver.kt
@@ -48,6 +48,11 @@ internal class ArrivalProgressObserver(
     }
 
     override fun onRouteProgressChanged(routeProgress: RouteProgress) {
+        if (routeProgress.currentState != RouteProgressState.ROUTE_INITIALIZED &&
+            routeProgress.currentState != RouteProgressState.ROUTE_COMPLETE &&
+            routeProgress.currentState != RouteProgressState.LOCATION_TRACKING) {
+            return
+        }
         val routeLegProgress = routeProgress.currentLegProgress
             ?: return
 

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/arrival/ArrivalProgressObserverTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/arrival/ArrivalProgressObserverTest.kt
@@ -207,12 +207,47 @@ internal class ArrivalProgressObserverTest {
                 every { distanceRemaining } returns 15.0f
             }
         }
-        every { tripSession.getRouteProgress() } returns routeProgress
 
         arrivalProgressObserver.attach(customArrivalController)
         arrivalProgressObserver.onRouteProgressChanged(routeProgress)
 
         assertTrue(onArrivalCalls.isCaptured)
+    }
+
+    @Test
+    fun `should not notify observers for invalid states`() {
+        val onArrivalCalls = slot<RouteLegProgress>()
+        val customArrivalController: ArrivalController = mockk {
+            every { navigateNextRouteLeg(capture(onArrivalCalls)) } returns false
+            every { arrivalOptions() } returns mockk {
+                every { arrivalInSeconds } returns 5.0
+                every { arrivalInMeters } returns null
+            }
+        }
+
+        arrivalProgressObserver.attach(customArrivalController)
+        arrivalProgressObserver.onRouteProgressChanged(mockk {
+            every { currentState } returns RouteProgressState.ROUTE_INVALID
+            every { durationRemaining } returns 1.0
+            every { distanceRemaining } returns 1.0f
+        })
+        arrivalProgressObserver.onRouteProgressChanged(mockk {
+            every { currentState } returns RouteProgressState.ROUTE_UNCERTAIN
+            every { durationRemaining } returns 1.0
+            every { distanceRemaining } returns 1.0f
+        })
+        arrivalProgressObserver.onRouteProgressChanged(mockk {
+            every { currentState } returns RouteProgressState.LOCATION_STALE
+            every { durationRemaining } returns 1.0
+            every { distanceRemaining } returns 1.0f
+        })
+        arrivalProgressObserver.onRouteProgressChanged(mockk {
+            every { currentState } returns RouteProgressState.OFF_ROUTE
+            every { durationRemaining } returns 1.0
+            every { distanceRemaining } returns 1.0f
+        })
+
+        assertFalse(onArrivalCalls.isCaptured)
     }
 
     @Test


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Looking to address feedback here https://github.com/mapbox/navigation-sdks/issues/392

Found a separate issue with arrival. When you arrive at the final destination, the route progress state transitions from ROUTE_ARRIVED to ROUTE_INVALID. It seems like the state should be ARRIVED, but proposing this because we shouldn't notify when the route is invalid either.

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

## Screenshots or Gifs

![output](https://user-images.githubusercontent.com/3021882/84722340-c87e3d80-af37-11ea-80e8-6e3d0c8d96d6.gif)

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->