### PR TITLE
RouteOptionsProvider and RerouteController 

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayWaypointsActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayWaypointsActivity.kt
@@ -153,7 +153,7 @@ class ReplayWaypointsActivity : AppCompatActivity(), OnMapReadyCallback {
 
     @SuppressLint("MissingPermission")
     fun initListeners() {
-        mapboxNavigation?.attachArrivalController(arrivalController)
+        mapboxNavigation?.setArrivalController(arrivalController)
         mapboxNavigation?.registerArrivalObserver(arrivalObserver)
         setupReplayControls()
         startNavigation.setOnClickListener {

--- a/examples/src/main/res/values/strings.xml
+++ b/examples/src/main/res/values/strings.xml
@@ -65,7 +65,7 @@
     <string name="description_replay_waypoints" translatable="false">Shows how to use navigate to waypoints.</string>
 
     <string name="title_reroute_view" translatable="false">Reroute events</string>
-    <string name="description_reroute_view" translatable="false">Shows how to observe reroute events.</string>
+    <string name="description_reroute_view" translatable="false">Shows how to observe off-route events and how to implement custom re-route logic.</string>
 
     <string name="title_basic_navigation_kotlin" translatable="false">Basic navigation</string>
     <string name="description_basic_navigation_kotlin" translatable="false">Shows how to navigate from the device location to a destination using the MapboxNavigation class.</string>

--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -4,12 +4,11 @@ package com.mapbox.navigation.core {
   public final class MapboxNavigation {
     ctor public MapboxNavigation(com.mapbox.navigation.base.options.NavigationOptions navigationOptions);
     method public void addHistoryEvent(String eventType, String eventJsonProperties);
-    method public void attachArrivalController(com.mapbox.navigation.core.arrival.ArrivalController arrivalController = com.mapbox.navigation.core.arrival.AutoArrivalController());
-    method public void attachArrivalController();
     method public void attachFasterRouteObserver(com.mapbox.navigation.core.fasterroute.FasterRouteObserver fasterRouteObserver);
     method public static com.mapbox.navigation.base.options.NavigationOptions.Builder defaultNavigationOptionsBuilder(android.content.Context context, String? accessToken);
     method public void detachFasterRouteObserver();
     method public com.mapbox.navigation.base.options.NavigationOptions getNavigationOptions();
+    method public com.mapbox.navigation.core.reroute.RerouteController? getRerouteController();
     method public java.util.List<com.mapbox.api.directions.v5.models.DirectionsRoute> getRoutes();
     method public com.mapbox.navigation.core.trip.session.TripSessionState getTripSessionState();
     method public boolean navigateNextRouteLeg();
@@ -23,11 +22,13 @@ package com.mapbox.navigation.core {
     method public void registerRoutesObserver(com.mapbox.navigation.core.directions.session.RoutesObserver routesObserver);
     method public void registerTripSessionStateObserver(com.mapbox.navigation.core.trip.session.TripSessionStateObserver tripSessionStateObserver);
     method public void registerVoiceInstructionsObserver(com.mapbox.navigation.core.trip.session.VoiceInstructionsObserver voiceInstructionsObserver);
-    method public void removeArrivalController();
     method public void requestRoutes(com.mapbox.api.directions.v5.models.RouteOptions routeOptions, com.mapbox.navigation.core.directions.session.RoutesRequestCallback? routesRequestCallback = null);
     method public void requestRoutes(com.mapbox.api.directions.v5.models.RouteOptions routeOptions);
     method public String retrieveHistory();
     method public String? retrieveSsmlAnnouncementInstruction(int index);
+    method public void setArrivalController(com.mapbox.navigation.core.arrival.ArrivalController? arrivalController = com.mapbox.navigation.core.arrival.AutoArrivalController());
+    method public void setArrivalController();
+    method public void setRerouteController(com.mapbox.navigation.core.reroute.RerouteController? rerouteController);
     method public void setRoutes(java.util.List<? extends com.mapbox.api.directions.v5.models.DirectionsRoute> routes);
     method @RequiresPermission(anyOf={android.Manifest.permission.ACCESS_COARSE_LOCATION, android.Manifest.permission.ACCESS_FINE_LOCATION}) public void startTripSession();
     method public void stopTripSession();
@@ -303,6 +304,55 @@ package com.mapbox.navigation.core.replay.route {
     method public com.mapbox.navigation.core.replay.route.ReplayRouteOptions.Builder minAcceleration(double minAcceleration);
     method public com.mapbox.navigation.core.replay.route.ReplayRouteOptions.Builder turnSpeedMps(double minSpeedMps);
     method public com.mapbox.navigation.core.replay.route.ReplayRouteOptions.Builder uTurnSpeedMps(double uTurnSpeedMps);
+  }
+
+}
+
+package com.mapbox.navigation.core.reroute {
+
+  public interface RerouteController {
+    method public com.mapbox.navigation.core.reroute.RerouteState getState();
+    method public void interrupt();
+    method public boolean registerRerouteStateObserver(com.mapbox.navigation.core.reroute.RerouteController.RerouteStateObserver rerouteStateObserver);
+    method public void reroute(com.mapbox.navigation.core.reroute.RerouteController.RoutesCallback routesCallback);
+    method public boolean unregisterRerouteStateObserver(com.mapbox.navigation.core.reroute.RerouteController.RerouteStateObserver rerouteStateObserver);
+    property public abstract com.mapbox.navigation.core.reroute.RerouteState state;
+  }
+
+  public static interface RerouteController.RerouteStateObserver {
+    method public void onRerouteStateChanged(com.mapbox.navigation.core.reroute.RerouteState rerouteState);
+  }
+
+  public static interface RerouteController.RoutesCallback {
+    method public void onNewRoutes(java.util.List<? extends com.mapbox.api.directions.v5.models.DirectionsRoute> routes);
+  }
+
+  public abstract sealed class RerouteState {
+  }
+
+  public static final class RerouteState.Failed extends com.mapbox.navigation.core.reroute.RerouteState {
+    ctor public RerouteState.Failed(String message, Throwable? throwable);
+    method public String component1();
+    method public Throwable? component2();
+    method public com.mapbox.navigation.core.reroute.RerouteState.Failed copy(String message, Throwable? throwable);
+    method public String getMessage();
+    method public Throwable? getThrowable();
+  }
+
+  public static final class RerouteState.FetchingRoute extends com.mapbox.navigation.core.reroute.RerouteState {
+    field public static final com.mapbox.navigation.core.reroute.RerouteState.FetchingRoute! INSTANCE;
+  }
+
+  public static final class RerouteState.Idle extends com.mapbox.navigation.core.reroute.RerouteState {
+    field public static final com.mapbox.navigation.core.reroute.RerouteState.Idle! INSTANCE;
+  }
+
+  public static final class RerouteState.Interrupted extends com.mapbox.navigation.core.reroute.RerouteState {
+    field public static final com.mapbox.navigation.core.reroute.RerouteState.Interrupted! INSTANCE;
+  }
+
+  public static final class RerouteState.RouteFetched extends com.mapbox.navigation.core.reroute.RerouteState {
+    field public static final com.mapbox.navigation.core.reroute.RerouteState.RouteFetched! INSTANCE;
   }
 
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/arrival/ArrivalController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/arrival/ArrivalController.kt
@@ -5,7 +5,7 @@ import com.mapbox.navigation.core.MapboxNavigation
 
 /**
  * When navigating to points of interest, you may want to control the arrival experience.
- * This interface gives you options to control arrival via [MapboxNavigation.attachArrivalController].
+ * This interface gives you options to control arrival via [MapboxNavigation.setArrivalController].
  *
  * To observe arrival, see [ArrivalObserver]
  */
@@ -89,7 +89,7 @@ data class ArrivalOptions(
         }
 
         /**
-         * Build the object. If you want to disable this feature use [MapboxNavigation.removeArrivalController].
+         * Build the object. If you want to disable this feature set *null* in [MapboxNavigation.setArrivalController].
          */
         fun build(): ArrivalOptions {
             check(arrivalInSeconds != null || arrivalInSeconds != null) {

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/reroute/MapboxRerouteController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/reroute/MapboxRerouteController.kt
@@ -1,0 +1,139 @@
+package com.mapbox.navigation.core.reroute
+
+import androidx.annotation.MainThread
+import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.api.directions.v5.models.RouteOptions
+import com.mapbox.base.common.logger.Logger
+import com.mapbox.base.common.logger.model.Message
+import com.mapbox.base.common.logger.model.Tag
+import com.mapbox.navigation.core.directions.session.DirectionsSession
+import com.mapbox.navigation.core.directions.session.RoutesRequestCallback
+import com.mapbox.navigation.core.routeoptions.RouteOptionsProvider
+import com.mapbox.navigation.core.trip.session.TripSession
+import com.mapbox.navigation.utils.internal.JobControl
+import com.mapbox.navigation.utils.internal.ThreadController
+import java.util.concurrent.CopyOnWriteArraySet
+import kotlinx.coroutines.launch
+
+/**
+ * Default implementation of [RerouteController]
+ */
+internal class MapboxRerouteController(
+    private val directionsSession: DirectionsSession,
+    private val tripSession: TripSession,
+    private val routeOptionsProvider: RouteOptionsProvider,
+    threadController: ThreadController = ThreadController,
+    private val logger: Logger
+) : RerouteController {
+
+    private val observers = CopyOnWriteArraySet<RerouteController.RerouteStateObserver>()
+
+    private val mainJobController: JobControl = threadController.getMainScopeAndRootJob()
+
+    override var state: RerouteState = RerouteState.Idle
+        private set(value) {
+            if (field == value) {
+                return
+            }
+            field = value
+            observers.forEach { it.onRerouteStateChanged(field) }
+        }
+
+    private companion object {
+        const val TAG = "MapboxRerouteController"
+    }
+
+    // current implementation ignore `onNewRoutes` callback because `DirectionsSession` update routes internally
+    override fun reroute(routesCallback: RerouteController.RoutesCallback) {
+        state = RerouteState.FetchingRoute
+        logger.d(
+            Tag(TAG),
+            Message("Fetching route")
+        )
+        routeOptionsProvider.update(
+            directionsSession.getRouteOptions(),
+            tripSession.getRouteProgress(),
+            tripSession.getEnhancedLocation()
+        )
+            .let { routeOptionsResult ->
+                when (routeOptionsResult) {
+                    is RouteOptionsProvider.RouteOptionsResult.Success -> {
+                        request(routeOptionsResult.routeOptions)
+                    }
+                    is RouteOptionsProvider.RouteOptionsResult.Error -> {
+                        mainJobController.scope.launch {
+                            state = RerouteState.Failed(
+                                "Cannot combine route options", routeOptionsResult.error
+                            )
+                            state = RerouteState.Idle
+                        }
+                    }
+                }
+            }
+    }
+
+    private fun request(routeOptions: RouteOptions) {
+        directionsSession.requestRoutes(routeOptions, object : RoutesRequestCallback {
+            // ignore result, DirectionsSession sets routes internally
+            override fun onRoutesReady(routes: List<DirectionsRoute>) {
+                logger.d(
+                    Tag(TAG),
+                    Message("Route fetched")
+                )
+                mainJobController.scope.launch {
+                    state = RerouteState.RouteFetched
+                    state = RerouteState.Idle
+                }
+            }
+
+            override fun onRoutesRequestFailure(
+                throwable: Throwable,
+                routeOptions: RouteOptions
+            ) {
+                logger.e(
+                    Tag(TAG),
+                    Message("Route request failed"),
+                    throwable
+                )
+
+                mainJobController.scope.launch {
+                    state = RerouteState.Failed("Route request failed", throwable)
+                    state = RerouteState.Idle
+                }
+            }
+
+            override fun onRoutesRequestCanceled(routeOptions: RouteOptions) {
+                logger.d(
+                    Tag(TAG),
+                    Message("Route request canceled")
+                )
+                mainJobController.scope.launch {
+                    state = RerouteState.Interrupted
+                    state = RerouteState.Idle
+                }
+            }
+        })
+    }
+
+    @MainThread
+    override fun interrupt() {
+        if (state == RerouteState.FetchingRoute) {
+            directionsSession.cancel() // do not change state here because it's changed into onRoutesRequestCanceled callback
+            logger.d(
+                Tag(TAG),
+                Message("Route request interrupted")
+            )
+        }
+    }
+
+    override fun registerRerouteStateObserver(rerouteStateObserver: RerouteController.RerouteStateObserver): Boolean {
+        mainJobController.scope.launch {
+            rerouteStateObserver.onRerouteStateChanged(state)
+        }
+        return observers.add(rerouteStateObserver)
+    }
+
+    override fun unregisterRerouteStateObserver(rerouteStateObserver: RerouteController.RerouteStateObserver): Boolean {
+        return observers.remove(rerouteStateObserver)
+    }
+}

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/reroute/RerouteController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/reroute/RerouteController.kt
@@ -1,0 +1,110 @@
+package com.mapbox.navigation.core.reroute
+
+import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.trip.session.OffRouteObserver
+
+/**
+ * Reroute controller allows changing the reroute logic externally. Use [MapboxNavigation.rerouteController]
+ * to replace it.
+ */
+interface RerouteController {
+
+    /**
+     * Reroute state
+     */
+    val state: RerouteState
+
+    /**
+     * Invoked whenever re-route is needed. For instance when a driver is off-route. Called just after
+     * an off-route event.
+     *
+     * @see [OffRouteObserver]
+     */
+    fun reroute(routesCallback: RoutesCallback)
+
+    /**
+     * Invoked when re-route is not needed anymore (for instance when driver returns to previous route).
+     * Might be ignored depending on [RerouteState] e.g. if a route has been fetched it does not make sense to interrupt re-routing
+     */
+    fun interrupt()
+
+    /**
+     * Add a RerouteStateObserver to collection and immediately invoke [rerouteStateObserver] with current
+     * re-route state.
+     *
+     * @return `true` if the element has been added, `false` if the element is already present in the collection.
+     */
+    fun registerRerouteStateObserver(rerouteStateObserver: RerouteStateObserver): Boolean
+
+    /**
+     * Remove [rerouteStateObserver] from collection of observers.
+     *
+     * @return `true` if the element has been successfully removed; `false` if it was not present in the collection.
+     */
+    fun unregisterRerouteStateObserver(rerouteStateObserver: RerouteStateObserver): Boolean
+
+    /**
+     * Route Callback is useful to set new route(s) on reroute event. Doing the same as
+     * [MapboxNavigation.setRoutes].
+     */
+    interface RoutesCallback {
+        /**
+         * Called whenever new route(s) has been fetched.
+         * @see [MapboxNavigation.setRoutes]
+         */
+        fun onNewRoutes(routes: List<DirectionsRoute>)
+    }
+
+    /**
+     * [RerouteState] observer
+     */
+    interface RerouteStateObserver {
+
+        /**
+         * Invoked whenever re-route state has changed.
+         */
+        fun onRerouteStateChanged(rerouteState: RerouteState)
+    }
+}
+
+/**
+ * Reroute state
+ */
+sealed class RerouteState {
+
+    /**
+     * [RerouteController] is idle.
+     */
+    object Idle : RerouteState()
+
+    /**
+     * Reroute has been interrupted.
+     *
+     * Might be invoked by:
+     * - [RerouteController.interrupt];
+     * - [MapboxNavigation.setRoutes];
+     * - [MapboxNavigation.requestRoutes];
+     * - from the SDK internally if another route request has been requested (only when using the default
+     * implementation [MapboxRerouteController]).
+     *
+     */
+    object Interrupted : RerouteState()
+
+    /**
+     * Re-route request has failed.
+     * @param message describes error
+     * @param throwable is optional
+     */
+    data class Failed(val message: String, val throwable: Throwable? = null) : RerouteState()
+
+    /**
+     * Route fetching is in progress.
+     */
+    object FetchingRoute : RerouteState()
+
+    /**
+     * Route has been fetched.
+     */
+    object RouteFetched : RerouteState()
+}

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/routeoptions/RouteOptionsProvider.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/routeoptions/RouteOptionsProvider.kt
@@ -1,0 +1,34 @@
+package com.mapbox.navigation.core.routeoptions
+
+import android.location.Location
+import com.mapbox.api.directions.v5.models.RouteOptions
+import com.mapbox.navigation.base.trip.model.RouteProgress
+import com.mapbox.navigation.core.fasterroute.FasterRouteController
+import com.mapbox.navigation.core.trip.session.OffRouteObserver
+
+/**
+ * Provider is used for *Reroute* and *Faster Route* flow.
+ *
+ * It's used every time when turn-by-turn navigation goes off-route (see [OffRouteObserver])
+ * and when needs to find faster route (see [FasterRouteController]).
+ */
+internal interface RouteOptionsProvider {
+
+    /**
+     * Provides a new *RouteOptions* instance based on *RouteOptions*, *RouteProgress*, and
+     * *Location*
+     *
+     * Returns *null* if a new [RouteOptions] instance cannot be combined based on the input given. When *null*
+     * is returned new route is not fetched
+     */
+    fun update(
+        routeOptions: RouteOptions?,
+        routeProgress: RouteProgress?,
+        location: Location?
+    ): RouteOptionsResult
+
+    sealed class RouteOptionsResult {
+        data class Success(val routeOptions: RouteOptions) : RouteOptionsResult()
+        data class Error(val error: Throwable) : RouteOptionsResult()
+    }
+}

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
@@ -11,7 +11,6 @@ import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.RouteOptions
 import com.mapbox.base.common.logger.Logger
 import com.mapbox.common.module.provider.MapboxModuleProvider
-import com.mapbox.geojson.Point
 import com.mapbox.navigation.base.TimeFormat.NONE_SPECIFIED
 import com.mapbox.navigation.base.internal.extensions.inferDeviceLocale
 import com.mapbox.navigation.base.internal.route.RouteUrl
@@ -19,17 +18,21 @@ import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.options.OnboardRouterOptions
 import com.mapbox.navigation.base.route.Router
 import com.mapbox.navigation.base.trip.model.RouteProgress
-import com.mapbox.navigation.core.directions.session.AdjustedRouteOptionsProvider
+import com.mapbox.navigation.core.arrival.ArrivalController
+import com.mapbox.navigation.core.arrival.ArrivalProgressObserver
 import com.mapbox.navigation.core.directions.session.DirectionsSession
 import com.mapbox.navigation.core.directions.session.RoutesObserver
 import com.mapbox.navigation.core.directions.session.RoutesRequestCallback
 import com.mapbox.navigation.core.internal.MapboxDistanceFormatter
 import com.mapbox.navigation.core.internal.trip.service.TripService
+import com.mapbox.navigation.core.reroute.RerouteController
+import com.mapbox.navigation.core.reroute.RerouteState
 import com.mapbox.navigation.core.trip.session.OffRouteObserver
 import com.mapbox.navigation.core.trip.session.TripSession
 import com.mapbox.navigation.navigator.internal.MapboxNativeNavigator
 import com.mapbox.navigation.testing.MainCoroutineRule
 import com.mapbox.navigation.utils.internal.ThreadController
+import io.mockk.Ordering
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -37,11 +40,11 @@ import io.mockk.mockkStatic
 import io.mockk.slot
 import io.mockk.unmockkObject
 import io.mockk.verify
+import io.mockk.verifyOrder
 import java.util.Locale
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.InternalCoroutinesApi
 import org.junit.After
-import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.BeforeClass
@@ -70,11 +73,18 @@ class MapboxNavigationTest {
     private val routeProgress: RouteProgress = mockk(relaxed = true)
     private val navigationSession: NavigationSession = mockk(relaxUnitFun = true)
     private val logger: Logger = mockk(relaxUnitFun = true)
+    private lateinit var rerouteController: RerouteController
+
     private val applicationContext: Context = mockk(relaxed = true) {
         every { inferDeviceLocale() } returns Locale.US
         every { getSystemService(Context.NOTIFICATION_SERVICE) } returns mockk<NotificationManager>()
         every { getSystemService(Context.ALARM_SERVICE) } returns mockk<AlarmManager>()
-        every { getSharedPreferences(MAPBOX_SHARED_PREFERENCES, Context.MODE_PRIVATE) } returns mockk(relaxed = true) {
+        every {
+            getSharedPreferences(
+                MAPBOX_SHARED_PREFERENCES,
+                Context.MODE_PRIVATE
+            )
+        } returns mockk(relaxed = true) {
             every { getString("mapboxTelemetryState", "ENABLED"); } returns "DISABLED"
         }
         every { packageManager } returns mockk(relaxed = true)
@@ -135,6 +145,18 @@ class MapboxNavigationTest {
             .build()
 
         mapboxNavigation = MapboxNavigation(navigationOptions)
+
+        rerouteController = mockk(relaxUnitFun = true)
+        mapboxNavigation.setRerouteController(rerouteController)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkObject(MapboxModuleProvider)
+        unmockkObject(NavigationComponentProvider)
+
+        ThreadController.cancelAllNonUICoroutines()
+        ThreadController.cancelAllUICoroutines()
     }
 
     @Test
@@ -260,93 +282,59 @@ class MapboxNavigationTest {
     }
 
     @Test
-    fun reRoute_called() {
-        val offRouteObserverSlot = slot<OffRouteObserver>()
-        verify { tripSession.registerOffRouteObserver(capture(offRouteObserverSlot)) }
+    fun arrival_controller_register() {
+        val arrivalController: ArrivalController = mockk()
 
-        offRouteObserverSlot.captured.onOffRouteStateChanged(true)
+        mapboxNavigation.setArrivalController(arrivalController)
 
-        verify(exactly = 1) { directionsSession.requestRoutes(any(), any()) }
+        verify { tripSession.registerRouteProgressObserver(any<ArrivalProgressObserver>()) }
     }
 
     @Test
-    fun getEnhancedLocation_reRoute() {
+    fun arrival_controller_unregister() {
+        val arrivalController: ArrivalController? = null
+
+        mapboxNavigation.setArrivalController(arrivalController)
+
+        verify { tripSession.unregisterRouteProgressObserver(any<ArrivalProgressObserver>()) }
+    }
+
+    @Test
+    fun offroute_lead_to_reroute() {
         val observers = mutableListOf<OffRouteObserver>()
-        verify(exactly = 2) { tripSession.registerOffRouteObserver(capture(observers)) }
+        verify { tripSession.registerOffRouteObserver(capture(observers)) }
 
         observers.forEach {
             it.onOffRouteStateChanged(true)
         }
 
-        verify(exactly = 1) { tripSession.getEnhancedLocation() }
-        verify(exactly = 0) { tripSession.getRawLocation() }
+        verify(exactly = 1) { rerouteController.reroute(any()) }
+        verify(exactly = 0) { rerouteController.interrupt() }
+        verify(ordering = Ordering.ORDERED) {
+            tripSession.registerOffRouteObserver(any())
+            rerouteController.reroute(any())
+        }
     }
 
     @Test
-    fun enhanced_location_used_for_reroute() {
+    fun offroute_lead_to_reroute_and_after_interrupt_reroute() {
         val observers = mutableListOf<OffRouteObserver>()
-        verify(exactly = 2) { tripSession.registerOffRouteObserver(capture(observers)) }
-        mockkObject(AdjustedRouteOptionsProvider)
-        val mockedLocation = Location("mock")
-        every { tripSession.getEnhancedLocation() } returns mockedLocation
+        verify { tripSession.registerOffRouteObserver(capture(observers)) }
 
         observers.forEach {
             it.onOffRouteStateChanged(true)
         }
-
-        verify(exactly = 1) { AdjustedRouteOptionsProvider.getRouteOptions(eq(directionsSession), eq(tripSession), eq(mockedLocation)) }
-
-        unmockkObject(AdjustedRouteOptionsProvider)
-    }
-
-    @Test
-    fun reRoute_called_with_null_bearings() {
-        val routeOptions = provideRouteOptionsWithCoordinates()
-        every { directionsSession.getRouteOptions() } returns routeOptions
-
-        val offRouteObserverSlot = slot<OffRouteObserver>()
-        verify { tripSession.registerOffRouteObserver(capture(offRouteObserverSlot)) }
-
-        offRouteObserverSlot.captured.onOffRouteStateChanged(true)
-
-        val optionsSlot = slot<RouteOptions>()
-        verify(exactly = 1) { directionsSession.requestRoutes(capture(optionsSlot), any()) }
-
-        val expectedBearings = listOf(
-            listOf(DEFAULT_REROUTE_BEARING_ANGLE.toDouble(), DEFAULT_REROUTE_BEARING_TOLERANCE),
-            null,
-            null,
-            null
-        )
-        val actualBearings = optionsSlot.captured.bearingsList()
-
-        assertEquals(expectedBearings, actualBearings)
-    }
-
-    @Test
-    fun reRoute_called_with_bearings() {
-        val routeOptions = provideRouteOptionsWithCoordinatesAndBearings()
-        every { directionsSession.getRouteOptions() } returns routeOptions
-
-        val observers = mutableListOf<OffRouteObserver>()
-        verify(exactly = 2) { tripSession.registerOffRouteObserver(capture(observers)) }
-
         observers.forEach {
-            it.onOffRouteStateChanged(true)
+            it.onOffRouteStateChanged(false)
         }
 
-        val optionsSlot = slot<RouteOptions>()
-        verify(exactly = 1) { directionsSession.requestRoutes(capture(optionsSlot), any()) }
-
-        val expectedBearings = listOf(
-            listOf(DEFAULT_REROUTE_BEARING_ANGLE.toDouble(), 10.0),
-            listOf(20.0, 20.0),
-            listOf(30.0, 30.0),
-            listOf(40.0, 40.0)
-        )
-        val actualBearings = optionsSlot.captured.bearingsList()
-
-        assertEquals(expectedBearings, actualBearings)
+        verify(exactly = 1) { rerouteController.reroute(any()) }
+        verify(exactly = 1) { rerouteController.interrupt() }
+        verify(ordering = Ordering.ORDERED) {
+            tripSession.registerOffRouteObserver(capture(observers))
+            rerouteController.reroute(any())
+            rerouteController.interrupt()
+        }
     }
 
     @Test
@@ -366,7 +354,10 @@ class MapboxNavigationTest {
         val routes = listOf(primary, secondary)
         val routeObserversSlot = mutableListOf<RoutesObserver>()
         verify { directionsSession.registerRoutesObserver(capture(routeObserversSlot)) }
-        routeObserversSlot[0].onRoutesChanged(routes)
+
+        routeObserversSlot.forEach {
+            it.onRoutesChanged(routes)
+        }
 
         verify { tripSession.route = primary }
     }
@@ -376,9 +367,48 @@ class MapboxNavigationTest {
         val routes = emptyList<DirectionsRoute>()
         val routeObserversSlot = mutableListOf<RoutesObserver>()
         verify { directionsSession.registerRoutesObserver(capture(routeObserversSlot)) }
-        routeObserversSlot[0].onRoutesChanged(routes)
+
+        routeObserversSlot.forEach {
+            it.onRoutesChanged(routes)
+        }
 
         verify { tripSession.route = null }
+    }
+
+    @Test
+    fun interrupt_reroute_on_route_request() {
+        mapboxNavigation.requestRoutes(mockk())
+
+        verify(exactly = 1) { rerouteController.interrupt() }
+    }
+
+    @Test
+    fun interrupt_reroute_on_set_routes() {
+        mapboxNavigation.setRoutes(mockk())
+
+        verify(exactly = 1) { rerouteController.interrupt() }
+    }
+
+    @Test
+    fun interrupt_reroute_process_when_new_reroute_controller_has_been_set() {
+        val newRerouteController: RerouteController = mockk(relaxUnitFun = true)
+        val observers = mutableListOf<OffRouteObserver>()
+        verify { tripSession.registerOffRouteObserver(capture(observers)) }
+        every { rerouteController.state } returns RerouteState.FetchingRoute
+
+        observers.forEach {
+            it.onOffRouteStateChanged(true)
+        }
+        mapboxNavigation.setRerouteController(newRerouteController)
+
+        verify(exactly = 1) { rerouteController.reroute(any()) }
+        verify(exactly = 1) { rerouteController.interrupt() }
+        verify(exactly = 1) { newRerouteController.reroute(any()) }
+        verifyOrder {
+            rerouteController.reroute(any())
+            rerouteController.interrupt()
+            newRerouteController.reroute(any())
+        }
     }
 
     private fun mockLocation() {
@@ -445,40 +475,4 @@ class MapboxNavigationTest {
             .coordinates(emptyList())
             .geometries("")
             .requestUuid("")
-
-    private fun provideRouteOptionsWithCoordinates() =
-        provideDefaultRouteOptionsBuilder()
-            .coordinates(
-                listOf(
-                    Point.fromLngLat(1.0, 1.0),
-                    Point.fromLngLat(1.0, 1.0),
-                    Point.fromLngLat(1.0, 1.0),
-                    Point.fromLngLat(1.0, 1.0)
-                )
-            )
-            .build()
-
-    private fun provideRouteOptionsWithCoordinatesAndBearings() =
-        provideRouteOptionsWithCoordinates()
-            .toBuilder()
-            .bearingsList(
-                listOf(
-                    listOf(10.0, 10.0),
-                    listOf(20.0, 20.0),
-                    listOf(30.0, 30.0),
-                    listOf(40.0, 40.0),
-                    listOf(50.0, 50.0),
-                    listOf(60.0, 60.0)
-                )
-            )
-            .build()
-
-    @After
-    fun tearDown() {
-        unmockkObject(MapboxModuleProvider)
-        unmockkObject(NavigationComponentProvider)
-
-        ThreadController.cancelAllNonUICoroutines()
-        ThreadController.cancelAllUICoroutines()
-    }
 }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/reroute/MapboxRerouteControllerTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/reroute/MapboxRerouteControllerTest.kt
@@ -1,0 +1,313 @@
+package com.mapbox.navigation.core.reroute
+
+import com.mapbox.api.directions.v5.models.RouteOptions
+import com.mapbox.base.common.logger.Logger
+import com.mapbox.navigation.core.directions.session.DirectionsSession
+import com.mapbox.navigation.core.directions.session.RoutesRequestCallback
+import com.mapbox.navigation.core.routeoptions.RouteOptionsProvider
+import com.mapbox.navigation.core.trip.session.TripSession
+import com.mapbox.navigation.testing.MainCoroutineRule
+import com.mapbox.navigation.utils.internal.ThreadController
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.spyk
+import io.mockk.verify
+import io.mockk.verifyOrder
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class MapboxRerouteControllerTest {
+
+    private lateinit var rerouteController: MapboxRerouteController
+
+    @MockK
+    private lateinit var directionsSession: DirectionsSession
+
+    @MockK
+    private lateinit var tripSession: TripSession
+
+    @MockK
+    private lateinit var routeOptionsProvider: RouteOptionsProvider
+
+    @MockK
+    private lateinit var logger: Logger
+
+    @MockK
+    private lateinit var successFromResult: RouteOptionsProvider.RouteOptionsResult.Success
+
+    @MockK
+    private lateinit var routeOptionsFromSuccessResult: RouteOptions
+
+    @MockK
+    private lateinit var errorFromResult: RouteOptionsProvider.RouteOptionsResult.Error
+
+    @MockK
+    private lateinit var routeCallback: RerouteController.RoutesCallback
+
+    @MockK
+    lateinit var primaryRerouteObserver: RerouteController.RerouteStateObserver
+
+    @get:Rule
+    var coroutineRule = MainCoroutineRule()
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this, relaxUnitFun = true, relaxed = true)
+        rerouteController = spyk(
+            MapboxRerouteController(
+                directionsSession,
+                tripSession,
+                routeOptionsProvider,
+                ThreadController,
+                logger
+            )
+        )
+        every { successFromResult.routeOptions } returns routeOptionsFromSuccessResult
+    }
+
+    @After
+    fun cleanUp() {
+        assertEquals(RerouteState.Idle, rerouteController.state)
+        // routeCallback mustn't called in current implementation. DirectionSession update routes internally
+        verify(exactly = 0) { routeCallback.onNewRoutes(any()) }
+    }
+
+    @Test
+    fun initial_state() {
+        assertEquals(rerouteController.state, RerouteState.Idle)
+        verify(exactly = 0) { rerouteController.reroute(any()) }
+        verify(exactly = 0) { rerouteController.interrupt() }
+    }
+
+    @Test
+    fun initial_state_with_added_state_observer() {
+        val added = addRerouteStateObserver()
+
+        assertTrue("RerouteStateObserver is not added", added)
+        verify(exactly = 1) { primaryRerouteObserver.onRerouteStateChanged(RerouteState.Idle) }
+    }
+
+    @Test
+    fun reroute_get_from_inputs() {
+        mockRouteOptionsResult(successFromResult)
+        val routeRequestCallback = slot<RoutesRequestCallback>()
+        every {
+            directionsSession.requestRoutes(
+                routeOptionsFromSuccessResult,
+                capture(routeRequestCallback)
+            )
+        } returns mockk()
+
+        rerouteController.reroute(routeCallback)
+        routeRequestCallback.captured.onRoutesReady(mockk())
+
+        verify(exactly = 1) {
+            tripSession.getEnhancedLocation()
+        }
+        verify(exactly = 1) {
+            tripSession.getRouteProgress()
+        }
+        verify(exactly = 1) {
+            directionsSession.getRouteOptions()
+        }
+    }
+
+    @Test
+    fun reroute_success() {
+        mockRouteOptionsResult(successFromResult)
+        addRerouteStateObserver()
+        val routeRequestCallback = slot<RoutesRequestCallback>()
+        every {
+            directionsSession.requestRoutes(
+                routeOptionsFromSuccessResult,
+                capture(routeRequestCallback)
+            )
+        } returns mockk()
+
+        rerouteController.reroute(routeCallback)
+        routeRequestCallback.captured.onRoutesReady(mockk())
+
+        assertTrue(routeRequestCallback.isCaptured)
+        verify(exactly = 1) {
+            primaryRerouteObserver.onRerouteStateChanged(RerouteState.FetchingRoute)
+        }
+        verify(exactly = 1) {
+            primaryRerouteObserver.onRerouteStateChanged(RerouteState.RouteFetched)
+        }
+        verify(exactly = 2) {
+            primaryRerouteObserver.onRerouteStateChanged(RerouteState.Idle)
+        }
+        verifyOrder {
+            primaryRerouteObserver.onRerouteStateChanged(RerouteState.Idle)
+            primaryRerouteObserver.onRerouteStateChanged(RerouteState.FetchingRoute)
+            primaryRerouteObserver.onRerouteStateChanged(RerouteState.RouteFetched)
+            primaryRerouteObserver.onRerouteStateChanged(RerouteState.Idle)
+        }
+    }
+
+    @Test
+    fun reroute_unsuccess() {
+        addRerouteStateObserver()
+        mockRouteOptionsResult(successFromResult)
+        val routeRequestCallback = slot<RoutesRequestCallback>()
+        every {
+            directionsSession.requestRoutes(
+                routeOptionsFromSuccessResult,
+                capture(routeRequestCallback)
+            )
+        } returns mockk()
+
+        rerouteController.reroute(routeCallback)
+        routeRequestCallback.captured.onRoutesRequestFailure(mockk(), mockk())
+
+        assertTrue(routeRequestCallback.isCaptured)
+        verify(exactly = 1) {
+            primaryRerouteObserver.onRerouteStateChanged(RerouteState.FetchingRoute)
+        }
+        verify(exactly = 1) {
+            primaryRerouteObserver.onRerouteStateChanged(ofType<RerouteState.Failed>())
+        }
+        verify(exactly = 2) {
+            primaryRerouteObserver.onRerouteStateChanged(RerouteState.Idle)
+        }
+        verifyOrder {
+            primaryRerouteObserver.onRerouteStateChanged(RerouteState.Idle)
+            primaryRerouteObserver.onRerouteStateChanged(RerouteState.FetchingRoute)
+            primaryRerouteObserver.onRerouteStateChanged(ofType<RerouteState.Failed>())
+            primaryRerouteObserver.onRerouteStateChanged(RerouteState.Idle)
+        }
+    }
+
+    @Test
+    fun reroute_request_canceled_external() {
+        mockRouteOptionsResult(successFromResult)
+        addRerouteStateObserver()
+        val routeRequestCallback = slot<RoutesRequestCallback>()
+        every {
+            directionsSession.requestRoutes(
+                routeOptionsFromSuccessResult,
+                capture(routeRequestCallback)
+            )
+        } returns mockk()
+
+        rerouteController.reroute(routeCallback)
+        routeRequestCallback.captured.onRoutesRequestCanceled(mockk())
+
+        assertTrue(routeRequestCallback.isCaptured)
+        verify(exactly = 1) {
+            primaryRerouteObserver.onRerouteStateChanged(RerouteState.FetchingRoute)
+        }
+        verify(exactly = 1) {
+            primaryRerouteObserver.onRerouteStateChanged(RerouteState.Interrupted)
+        }
+        verify(exactly = 2) {
+            primaryRerouteObserver.onRerouteStateChanged(RerouteState.Idle)
+        }
+        verifyOrder {
+            primaryRerouteObserver.onRerouteStateChanged(RerouteState.Idle)
+            primaryRerouteObserver.onRerouteStateChanged(RerouteState.FetchingRoute)
+            primaryRerouteObserver.onRerouteStateChanged(RerouteState.Interrupted)
+            primaryRerouteObserver.onRerouteStateChanged(RerouteState.Idle)
+        }
+    }
+
+    @Test
+    fun interrupt_route_request() {
+        mockRouteOptionsResult(successFromResult)
+        addRerouteStateObserver()
+        val routeRequestCallback = slot<RoutesRequestCallback>()
+        every {
+            directionsSession.requestRoutes(
+                routeOptionsFromSuccessResult,
+                capture(routeRequestCallback)
+            )
+        } returns mockk()
+        every {
+            directionsSession.cancel()
+        } answers {
+            routeRequestCallback.captured.onRoutesRequestCanceled(mockk())
+        }
+
+        rerouteController.reroute(routeCallback)
+        rerouteController.interrupt()
+
+        assertTrue(routeRequestCallback.isCaptured)
+        verify(exactly = 1) {
+            primaryRerouteObserver.onRerouteStateChanged(RerouteState.FetchingRoute)
+        }
+        verify(exactly = 1) {
+            primaryRerouteObserver.onRerouteStateChanged(RerouteState.Interrupted)
+        }
+        verify(exactly = 2) {
+            primaryRerouteObserver.onRerouteStateChanged(RerouteState.Idle)
+        }
+        verifyOrder {
+            primaryRerouteObserver.onRerouteStateChanged(RerouteState.Idle)
+            primaryRerouteObserver.onRerouteStateChanged(RerouteState.FetchingRoute)
+            primaryRerouteObserver.onRerouteStateChanged(RerouteState.Interrupted)
+            primaryRerouteObserver.onRerouteStateChanged(RerouteState.Idle)
+        }
+    }
+
+    @Test
+    fun invalid_route_option() {
+        mockRouteOptionsResult(errorFromResult)
+        addRerouteStateObserver()
+
+        rerouteController.reroute(routeCallback)
+
+        verify(exactly = 1) {
+            primaryRerouteObserver.onRerouteStateChanged(RerouteState.FetchingRoute)
+        }
+        verify(exactly = 1) {
+            primaryRerouteObserver.onRerouteStateChanged(ofType<RerouteState.Failed>())
+        }
+        verify(exactly = 2) {
+            primaryRerouteObserver.onRerouteStateChanged(RerouteState.Idle)
+        }
+        verifyOrder {
+            primaryRerouteObserver.onRerouteStateChanged(RerouteState.Idle)
+            primaryRerouteObserver.onRerouteStateChanged(RerouteState.FetchingRoute)
+            primaryRerouteObserver.onRerouteStateChanged(ofType<RerouteState.Failed>())
+            primaryRerouteObserver.onRerouteStateChanged(RerouteState.Idle)
+        }
+        verify(exactly = 0) { directionsSession.requestRoutes(any(), any()) }
+    }
+
+    @Test
+    fun add_the_same_observer_twice_and_remove_twice() {
+        assertTrue(addRerouteStateObserver())
+        assertFalse(addRerouteStateObserver())
+
+        assertTrue(rerouteController.unregisterRerouteStateObserver(primaryRerouteObserver))
+        assertFalse(rerouteController.unregisterRerouteStateObserver(primaryRerouteObserver))
+    }
+
+    private fun addRerouteStateObserver(rerouteStateObserver: RerouteController.RerouteStateObserver = primaryRerouteObserver): Boolean {
+        return rerouteController.registerRerouteStateObserver(rerouteStateObserver)
+    }
+
+    private fun mockRouteOptionsResult(_routeOptionsResult: RouteOptionsProvider.RouteOptionsResult) {
+        assertFalse(
+            "routeOptionsResult mustn't be the *RouteOptionsProvider.RouteOptionsResult*, subclass is applied only",
+            _routeOptionsResult::class.isAbstract
+        )
+        every {
+            routeOptionsProvider.update(
+                any(),
+                any(),
+                any()
+            )
+        } returns _routeOptionsResult
+    }
+}

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/routeoptions/MapboxRouteOptionsProviderTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/routeoptions/MapboxRouteOptionsProviderTest.kt
@@ -1,0 +1,155 @@
+package com.mapbox.navigation.core.routeoptions
+
+import android.location.Location
+import com.mapbox.api.directions.v5.models.RouteOptions
+import com.mapbox.base.common.logger.Logger
+import com.mapbox.geojson.Point
+import com.mapbox.navigation.base.internal.route.RouteUrl
+import com.mapbox.navigation.base.trip.model.RouteProgress
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class MapboxRouteOptionsProviderTest {
+
+    @MockK
+    private lateinit var logger: Logger
+
+    private val accessToken = "pk.1234pplffd"
+
+    private lateinit var routeRefreshAdapter: MapboxRouteOptionsProvider
+    private lateinit var location: Location
+
+    companion object {
+        private const val DEFAULT_REROUTE_BEARING_ANGLE = 11f
+        private const val DEFAULT_REROUTE_BEARING_TOLERANCE = 90.0
+    }
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this, relaxUnitFun = true, relaxed = true)
+        mockLocation()
+
+        routeRefreshAdapter = MapboxRouteOptionsProvider(logger)
+    }
+
+    @Test
+    fun new_options_return_with_null_bearings() {
+        val routeOptions = provideRouteOptionsWithCoordinates()
+        val routeProgress: RouteProgress = mockk(relaxed = true)
+
+        val newRouteOptions =
+            routeRefreshAdapter.update(routeOptions, routeProgress, location)
+                .let {
+                    assertTrue(it is RouteOptionsProvider.RouteOptionsResult.Success)
+                    return@let it as RouteOptionsProvider.RouteOptionsResult.Success
+                }
+                .routeOptions
+
+        val expectedBearings = listOf(
+            listOf(
+                DEFAULT_REROUTE_BEARING_ANGLE.toDouble(),
+                DEFAULT_REROUTE_BEARING_TOLERANCE
+            ),
+            null,
+            null,
+            null
+        )
+        val actualBearings = newRouteOptions.bearingsList()
+
+        assertEquals(expectedBearings, actualBearings)
+    }
+
+    @Test
+    fun new_options_return_with_bearing() {
+        val routeOptions = provideRouteOptionsWithCoordinatesAndBearings()
+        val routeProgress: RouteProgress = mockk(relaxed = true)
+
+        val newRouteOptions =
+            routeRefreshAdapter.update(routeOptions, routeProgress, location)
+                .let {
+                    assertTrue(it is RouteOptionsProvider.RouteOptionsResult.Success)
+                    return@let it as RouteOptionsProvider.RouteOptionsResult.Success
+                }
+                .routeOptions
+
+        val expectedBearings = listOf(
+            listOf(DEFAULT_REROUTE_BEARING_ANGLE.toDouble(), 10.0),
+            listOf(20.0, 20.0),
+            listOf(30.0, 30.0),
+            listOf(40.0, 40.0)
+        )
+        val actualBearings = newRouteOptions.bearingsList()
+
+        assertEquals(expectedBearings, actualBearings)
+    }
+
+    @Test
+    fun no_options_on_invalid_input() {
+        val invalidInput = mutableListOf<Triple<RouteOptions?, RouteProgress?, Location?>>()
+        invalidInput.add(Triple(null, mockk(), mockk()))
+        invalidInput.add(Triple(mockk(), null, null))
+        invalidInput.add(Triple(mockk(), mockk(), null))
+
+        invalidInput.forEach { (routeOptions, routeProgress, location) ->
+            val message =
+                """routeOptions is ${routeOptions.isNullToString()}; routeProgress is ${routeProgress.isNullToString()}; location is ${location.isNullToString()}"""
+
+            assertTrue(
+                message,
+                routeRefreshAdapter.update(routeOptions, routeProgress, location) is RouteOptionsProvider.RouteOptionsResult.Error
+            )
+        }
+    }
+
+    private fun mockLocation() {
+        location = mockk(relaxUnitFun = true)
+        every { location.longitude } returns -122.4232
+        every { location.latitude } returns 23.54423
+        every { location.bearing } returns DEFAULT_REROUTE_BEARING_ANGLE
+    }
+
+    private fun provideRouteOptionsWithCoordinates() =
+        provideDefaultRouteOptionsBuilder()
+            .coordinates(
+                listOf(
+                    Point.fromLngLat(1.0, 1.0),
+                    Point.fromLngLat(1.0, 1.0),
+                    Point.fromLngLat(1.0, 1.0),
+                    Point.fromLngLat(1.0, 1.0)
+                )
+            )
+            .build()
+
+    private fun provideRouteOptionsWithCoordinatesAndBearings() =
+        provideRouteOptionsWithCoordinates()
+            .toBuilder()
+            .bearingsList(
+                listOf(
+                    listOf(10.0, 10.0),
+                    listOf(20.0, 20.0),
+                    listOf(30.0, 30.0),
+                    listOf(40.0, 40.0),
+                    listOf(50.0, 50.0),
+                    listOf(60.0, 60.0)
+                )
+            )
+            .build()
+
+    private fun provideDefaultRouteOptionsBuilder() =
+        RouteOptions.builder()
+            .accessToken(accessToken)
+            .baseUrl(RouteUrl.BASE_URL)
+            .user(RouteUrl.PROFILE_DEFAULT_USER)
+            .profile(RouteUrl.PROFILE_DRIVING)
+            .coordinates(emptyList())
+            .geometries("")
+            .requestUuid("")
+
+    private fun Any?.isNullToString(): String = if (this == null) "Null" else "NonNull"
+}


### PR DESCRIPTION
…Reroute` and `Faster Route`; - MapboxRouteRefreshAdapter is default implementation of RouteRefreshAdapter; - custom RouteRefreshAdapter is provided via NavigationOptions; - removed AdjustedRouteOptionsProvider.

<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description
`<changelog>`
- Added `RerouteController` provides interface to overwrite reroute logic;
- Added  `RouteOptionsProvider` interface.

`</changelog>`

Provide option to rewrite reroute logic 
Ref: #2404 

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal

Please describe the PR goals. Just the stuff needed to implement the fix / feature and a simple rationale. It could contain many check points if needed

### Implementation

Please include all the relevant things implemented and also rationale, clarifications / disclaimers etc. related to the approach used. It could be as self code companion comments

## Screenshots or Gifs

Please include all the media files to give some context about what's being implemented or fixed. It's not mandatory to upload screenshots or gifs, but for most of the cases it becomes really handy to get into the scope of the feature / bug being fixed and also it's REALLY useful for UI related PRs ![screenshot gif](link)

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->