### PR TITLE
resolving the maneuver arrows layer to be above the annotations layer

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/internal/route/RouteConstants.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/internal/route/RouteConstants.java
@@ -51,4 +51,5 @@ public class RouteConstants {
   public static final double MINIMUM_ROUTE_LINE_OFFSET = .001;
   public static final long ROUTE_LINE_VANISH_ANIMATION_DURATION = 900;
   public static final long ROUTE_LINE_VANISH_ANIMATION_DELAY = 100;
+  public static final String LAYER_ABOVE_UPCOMING_MANEUVER_ARROW = "com.mapbox.annotations.points";
 }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/NavigationMapRoute.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/NavigationMapRoute.java
@@ -29,6 +29,7 @@ import org.jetbrains.annotations.TestOnly;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.mapbox.navigation.ui.internal.route.RouteConstants.LAYER_ABOVE_UPCOMING_MANEUVER_ARROW;
 import static com.mapbox.navigation.ui.internal.route.RouteConstants.ROUTE_LINE_VANISH_ANIMATION_DELAY;
 import static com.mapbox.navigation.ui.internal.route.RouteConstants.ROUTE_LINE_VANISH_ANIMATION_DURATION;
 
@@ -98,7 +99,7 @@ public class NavigationMapRoute implements LifecycleObserver {
     this.mapboxMap = mapboxMap;
     this.navigation = navigation;
     this.routeLine = buildMapRouteLine(mapView, mapboxMap, styleRes, belowLayer, routeLineInitializedCallback);
-    this.routeArrow = new MapRouteArrow(mapView, mapboxMap, styleRes, routeLine.getTopLayerId());
+    this.routeArrow = new MapRouteArrow(mapView, mapboxMap, styleRes, LAYER_ABOVE_UPCOMING_MANEUVER_ARROW);
     this.mapRouteClickListener = new MapRouteClickListener(this.routeLine);
     this.mapRouteProgressChangeListener = buildMapRouteProgressChangeListener();
     this.routeLineInitializedCallback = routeLineInitializedCallback;


### PR DESCRIPTION
## Description

Resolves #3176 by setting the layer for the maneuver arrows above the annotations layer matching the legacy code implementation.

- [x] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal
The arrows should be above the street names.

### Implementation


## Screenshots or Gifs


## Testing


- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->