### PR TITLE
Fix #2837/#3168: catch the exception and fallback to use TTS for voice instruction

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/DownloadTask.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/DownloadTask.kt
@@ -2,10 +2,12 @@ package com.mapbox.navigation.ui
 
 import android.os.AsyncTask
 import java.io.File
+import java.io.FileNotFoundException
 import java.io.FileOutputStream
 import java.io.InputStream
 import java.io.OutputStream
 import okhttp3.ResponseBody
+import timber.log.Timber
 
 /**
  * This class is an [AsyncTask] that downloads a file from a [ResponseBody].
@@ -52,30 +54,35 @@ constructor(
             return null
         }
 
-        val filePath = StringBuilder().append(destDirectory)
-            .append(File.separator)
-            .append(fileName)
-            .append(retrieveUniqueId())
-            .append(".")
-            .append(extension)
-            .toString()
-        val file = File(filePath)
-        val inputStream: InputStream = responseBody.byteStream()
-        val outputStream: OutputStream = FileOutputStream(file)
-        val buffer = ByteArray(BUFFER_SIZE)
+        try {
+            val filePath = StringBuilder().append(destDirectory)
+                    .append(File.separator)
+                    .append(fileName)
+                    .append(retrieveUniqueId())
+                    .append(".")
+                    .append(extension)
+                    .toString()
+            val file = File(filePath)
+            val inputStream: InputStream = responseBody.byteStream()
+            val outputStream: OutputStream = FileOutputStream(file)
+            val buffer = ByteArray(BUFFER_SIZE)
 
-        inputStream.use { input ->
-            outputStream.use { fileOut ->
-                while (true) {
-                    val length = input.read(buffer)
-                    if (length <= 0)
-                        break
-                    fileOut.write(buffer, 0, length)
+            inputStream.use { input ->
+                outputStream.use { fileOut ->
+                    while (true) {
+                        val length = input.read(buffer)
+                        if (length <= 0)
+                            break
+                        fileOut.write(buffer, 0, length)
+                    }
+                    fileOut.flush()
                 }
-                fileOut.flush()
             }
+            return file
+        } catch (e: FileNotFoundException) {
+            Timber.e(e, "There was an exception during saveAsFile.")
+            return null
         }
-        return file
     }
 
     private fun retrieveUniqueId(): String =


### PR DESCRIPTION

<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Fix #2837 & #3168: catch the exception and fallback to use TTS for voice instruction

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal

To have the UI SDK working without crash the app when the device is out of space.

### Implementation

When device is running out of space, the UI SDK can't create new voice instruction mp3 file which will result in app's crash. In out of space scenario, the SDK can't do anything to save the file. Simply catch the exception so the SDK can fall back to use the Android TTS to play the voice instruction.

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->