### PR TITLE
Add OFF_ROUTE state to RouteProgressState and make RouteProgressState from RouteProgress non-null

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/ui/CustomPuckActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/ui/CustomPuckActivity.kt
@@ -137,7 +137,7 @@ class CustomPuckActivity : AppCompatActivity(), OnNavigationReadyCallback,
             RouteProgressState.ROUTE_INVALID -> R.drawable.custom_puck_icon_uncertain_location
             RouteProgressState.ROUTE_INITIALIZED -> R.drawable.custom_user_puck_icon
             RouteProgressState.LOCATION_TRACKING -> R.drawable.custom_user_puck_icon
-            RouteProgressState.ROUTE_ARRIVED -> R.drawable.custom_puck_icon_uncertain_location
+            RouteProgressState.ROUTE_COMPLETE -> R.drawable.custom_puck_icon_uncertain_location
             RouteProgressState.LOCATION_STALE -> R.drawable.custom_user_puck_icon
             else -> R.drawable.custom_puck_icon_uncertain_location
         }

--- a/libnavigation-base/api/current.txt
+++ b/libnavigation-base/api/current.txt
@@ -216,7 +216,7 @@ package com.mapbox.navigation.base.trip.model {
   }
 
   public final class RouteProgress {
-    ctor public RouteProgress(com.mapbox.api.directions.v5.models.DirectionsRoute? route, com.mapbox.geojson.Geometry? routeGeometryWithBuffer, com.mapbox.api.directions.v5.models.BannerInstructions? bannerInstructions, com.mapbox.api.directions.v5.models.VoiceInstructions? voiceInstructions, com.mapbox.navigation.base.trip.model.RouteProgressState? currentState, com.mapbox.navigation.base.trip.model.RouteLegProgress? currentLegProgress, java.util.List<com.mapbox.geojson.Point>? upcomingStepPoints, boolean inTunnel, float distanceRemaining, float distanceTraveled, double durationRemaining, float fractionTraveled, int remainingWaypoints);
+    ctor public RouteProgress(com.mapbox.api.directions.v5.models.DirectionsRoute? route, com.mapbox.geojson.Geometry? routeGeometryWithBuffer, com.mapbox.api.directions.v5.models.BannerInstructions? bannerInstructions, com.mapbox.api.directions.v5.models.VoiceInstructions? voiceInstructions, com.mapbox.navigation.base.trip.model.RouteProgressState currentState, com.mapbox.navigation.base.trip.model.RouteLegProgress? currentLegProgress, java.util.List<com.mapbox.geojson.Point>? upcomingStepPoints, boolean inTunnel, float distanceRemaining, float distanceTraveled, double durationRemaining, float fractionTraveled, int remainingWaypoints);
     method public com.mapbox.api.directions.v5.models.DirectionsRoute? component1();
     method public float component10();
     method public double component11();
@@ -225,15 +225,15 @@ package com.mapbox.navigation.base.trip.model {
     method public com.mapbox.geojson.Geometry? component2();
     method public com.mapbox.api.directions.v5.models.BannerInstructions? component3();
     method public com.mapbox.api.directions.v5.models.VoiceInstructions? component4();
-    method public com.mapbox.navigation.base.trip.model.RouteProgressState? component5();
+    method public com.mapbox.navigation.base.trip.model.RouteProgressState component5();
     method public com.mapbox.navigation.base.trip.model.RouteLegProgress? component6();
     method public java.util.List<com.mapbox.geojson.Point>? component7();
     method public boolean component8();
     method public float component9();
-    method public com.mapbox.navigation.base.trip.model.RouteProgress copy(com.mapbox.api.directions.v5.models.DirectionsRoute? route, com.mapbox.geojson.Geometry? routeGeometryWithBuffer, com.mapbox.api.directions.v5.models.BannerInstructions? bannerInstructions, com.mapbox.api.directions.v5.models.VoiceInstructions? voiceInstructions, com.mapbox.navigation.base.trip.model.RouteProgressState? currentState, com.mapbox.navigation.base.trip.model.RouteLegProgress? currentLegProgress, java.util.List<com.mapbox.geojson.Point>? upcomingStepPoints, boolean inTunnel, float distanceRemaining, float distanceTraveled, double durationRemaining, float fractionTraveled, int remainingWaypoints);
+    method public com.mapbox.navigation.base.trip.model.RouteProgress copy(com.mapbox.api.directions.v5.models.DirectionsRoute? route, com.mapbox.geojson.Geometry? routeGeometryWithBuffer, com.mapbox.api.directions.v5.models.BannerInstructions? bannerInstructions, com.mapbox.api.directions.v5.models.VoiceInstructions? voiceInstructions, com.mapbox.navigation.base.trip.model.RouteProgressState currentState, com.mapbox.navigation.base.trip.model.RouteLegProgress? currentLegProgress, java.util.List<com.mapbox.geojson.Point>? upcomingStepPoints, boolean inTunnel, float distanceRemaining, float distanceTraveled, double durationRemaining, float fractionTraveled, int remainingWaypoints);
     method public com.mapbox.api.directions.v5.models.BannerInstructions? getBannerInstructions();
     method public com.mapbox.navigation.base.trip.model.RouteLegProgress? getCurrentLegProgress();
-    method public com.mapbox.navigation.base.trip.model.RouteProgressState? getCurrentState();
+    method public com.mapbox.navigation.base.trip.model.RouteProgressState getCurrentState();
     method public float getDistanceRemaining();
     method public float getDistanceTraveled();
     method public double getDurationRemaining();
@@ -267,7 +267,8 @@ package com.mapbox.navigation.base.trip.model {
   public enum RouteProgressState {
     enum_constant public static final com.mapbox.navigation.base.trip.model.RouteProgressState LOCATION_STALE;
     enum_constant public static final com.mapbox.navigation.base.trip.model.RouteProgressState LOCATION_TRACKING;
-    enum_constant public static final com.mapbox.navigation.base.trip.model.RouteProgressState ROUTE_ARRIVED;
+    enum_constant public static final com.mapbox.navigation.base.trip.model.RouteProgressState OFF_ROUTE;
+    enum_constant public static final com.mapbox.navigation.base.trip.model.RouteProgressState ROUTE_COMPLETE;
     enum_constant public static final com.mapbox.navigation.base.trip.model.RouteProgressState ROUTE_INITIALIZED;
     enum_constant public static final com.mapbox.navigation.base.trip.model.RouteProgressState ROUTE_INVALID;
     enum_constant public static final com.mapbox.navigation.base.trip.model.RouteProgressState ROUTE_UNCERTAIN;

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteProgress.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteProgress.kt
@@ -42,7 +42,7 @@ data class RouteProgress(
     val routeGeometryWithBuffer: Geometry?,
     val bannerInstructions: BannerInstructions?,
     val voiceInstructions: VoiceInstructions?,
-    val currentState: RouteProgressState?,
+    val currentState: RouteProgressState,
     val currentLegProgress: RouteLegProgress?,
     val upcomingStepPoints: List<Point>?,
     val inTunnel: Boolean,
@@ -60,7 +60,7 @@ data class RouteProgress(
         private var routeGeometryWithBuffer: Geometry? = null
         private var bannerInstructions: BannerInstructions? = null
         private var voiceInstructions: VoiceInstructions? = null
-        private var currentState: RouteProgressState? = null
+        private var currentState: RouteProgressState = RouteProgressState.ROUTE_INVALID
         private var currentLegProgress: RouteLegProgress? = null
         private var upcomingStepPoints: List<Point>? = null
         private var inTunnel: Boolean = false

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteProgressState.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteProgressState.kt
@@ -25,7 +25,7 @@ enum class RouteProgressState {
     /**
      * The user has arrived at the destination of the given [com.mapbox.api.directions.v5.models.RouteLeg].
      */
-    ROUTE_ARRIVED,
+    ROUTE_COMPLETE,
 
     /**
      * [com.mapbox.navigation.core.MapboxNavigation] is now confidently tracking the
@@ -38,6 +38,11 @@ enum class RouteProgressState {
      * progress updates being sent.
      */
     LOCATION_STALE,
+
+    /**
+     * State when we detect an off-route.
+     */
+    OFF_ROUTE,
 
     /**
      * State when we start following a route.

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/arrival/ArrivalObserver.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/arrival/ArrivalObserver.kt
@@ -18,7 +18,7 @@ interface ArrivalObserver {
     fun onNextRouteLegStart(routeLegProgress: RouteLegProgress)
 
     /**
-     * This will be called once the [RouteProgress.currentState] has reached [RouteProgressState.ROUTE_ARRIVED].
+     * This will be called once the [RouteProgress.currentState] has reached [RouteProgressState.ROUTE_COMPLETE].
      * This means the device has reached the final destination on the route.
      */
     fun onFinalDestinationArrival(routeProgress: RouteProgress)

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/arrival/ArrivalProgressObserver.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/arrival/ArrivalProgressObserver.kt
@@ -52,14 +52,14 @@ internal class ArrivalProgressObserver(
             ?: return
 
         val arrivalOptions = arrivalController.arrivalOptions()
-        if (routeProgress.currentState == RouteProgressState.ROUTE_ARRIVED && !hasMoreLegs(routeProgress)) {
+        if (routeProgress.currentState == RouteProgressState.ROUTE_COMPLETE && !hasMoreLegs(routeProgress)) {
             doOnFinalDestinationArrival(routeProgress)
         } else if (arrivalOptions.arrivalInSeconds != null) {
             checkWaypointArrivalTime(arrivalOptions.arrivalInSeconds, routeLegProgress)
         } else if (arrivalOptions.arrivalInMeters != null) {
             checkWaypointArrivalDistance(arrivalOptions.arrivalInMeters, routeLegProgress)
         }
-        finalDestinationArrived = (routeProgress.currentState ?: RouteProgressState.ROUTE_UNCERTAIN) == RouteProgressState.ROUTE_ARRIVED
+        finalDestinationArrived = routeProgress.currentState == RouteProgressState.ROUTE_COMPLETE
     }
 
     private fun hasMoreLegs(routeProgress: RouteProgress): Boolean {

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetry.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetry.kt
@@ -536,7 +536,7 @@ internal object MapboxNavigationTelemetry : MapboxNavigationTelemetryInterface {
     }
 
     /**
-     * This method waits for an [RouteProgressState.ROUTE_ARRIVED] event. Once received, it terminates the wait-loop and
+     * This method waits for an [RouteProgressState.ROUTE_COMPLETE] event. Once received, it terminates the wait-loop and
      * sends the telemetry data to the servers.
      */
     private suspend fun monitorSession() {
@@ -549,7 +549,7 @@ internal object MapboxNavigationTelemetry : MapboxNavigationTelemetryInterface {
                 dynamicValues.distanceRemaining.set(routeData.routeProgress.distanceRemaining.toLong())
                 dynamicValues.durationRemaining.set(routeData.routeProgress.durationRemaining.toInt())
                 when (routeData.routeProgress.currentState) {
-                    RouteProgressState.ROUTE_ARRIVED -> {
+                    RouteProgressState.ROUTE_COMPLETE -> {
                         when (dynamicValues.sessionStarted.get()) {
                             true -> {
                                 processArrival()

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/TelemetryLocationAndProgressDispatcher.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/TelemetryLocationAndProgressDispatcher.kt
@@ -214,7 +214,7 @@ internal class TelemetryLocationAndProgressDispatcher(scope: CoroutineScope) :
         val data = RouteProgressWithTimestamp(Time.SystemImpl.millis(), routeProgress)
         this.routeProgress.set(data)
         channelOnRouteProgress.offer(data)
-        if (routeProgress.currentState == RouteProgressState.ROUTE_ARRIVED) {
+        if (routeProgress.currentState == RouteProgressState.ROUTE_COMPLETE) {
             routeProgressPredicate.set { progress -> afterArrival(progress) }
         }
     }
@@ -228,7 +228,7 @@ internal class TelemetryLocationAndProgressDispatcher(scope: CoroutineScope) :
             priorState -> {
             }
             else -> {
-                priorState = routeProgress.currentState ?: priorState
+                priorState = routeProgress.currentState
                 Log.d(TAG, "route progress state = ${routeProgress.currentState}")
             }
         }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/arrival/ArrivalProgressObserverTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/arrival/ArrivalProgressObserverTest.kt
@@ -63,7 +63,7 @@ internal class ArrivalProgressObserverTest {
 
         arrivalProgressObserver.attach(customArrivalController)
         arrivalProgressObserver.onRouteProgressChanged(mockk {
-            every { currentState } returns RouteProgressState.ROUTE_ARRIVED
+            every { currentState } returns RouteProgressState.ROUTE_COMPLETE
             every { route } returns mockk {
                 every { legs() } returns listOf(mockk(), mockk(), mockk())
             }
@@ -93,7 +93,7 @@ internal class ArrivalProgressObserverTest {
 
         arrivalProgressObserver.attach(customArrivalController)
         arrivalProgressObserver.onRouteProgressChanged(mockk {
-            every { currentState } returns RouteProgressState.ROUTE_ARRIVED
+            every { currentState } returns RouteProgressState.ROUTE_COMPLETE
             every { route } returns mockk {
                 every { legs() } returns listOf(mockk(), mockk(), mockk())
             }
@@ -121,7 +121,7 @@ internal class ArrivalProgressObserverTest {
         }
         every { arrivalObserver.onFinalDestinationArrival(capture(onFinalDestinationArrivalCalls)) } returns Unit
         val routeProgress: RouteProgress = mockk {
-            every { currentState } returns RouteProgressState.ROUTE_ARRIVED
+            every { currentState } returns RouteProgressState.ROUTE_COMPLETE
             every { route } returns mockk {
                 every { legs() } returns listOf(mockk(), mockk(), mockk())
             }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/puck/DefaultMapboxPuckDrawableSupplier.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/puck/DefaultMapboxPuckDrawableSupplier.kt
@@ -18,7 +18,7 @@ internal class DefaultMapboxPuckDrawableSupplier : PuckDrawableSupplier {
         RouteProgressState.ROUTE_INVALID -> R.drawable.user_puck_icon_uncertain_location
         RouteProgressState.ROUTE_INITIALIZED -> R.drawable.user_puck_icon
         RouteProgressState.LOCATION_TRACKING -> R.drawable.user_puck_icon
-        RouteProgressState.ROUTE_ARRIVED -> R.drawable.user_puck_icon_uncertain_location
+        RouteProgressState.ROUTE_COMPLETE -> R.drawable.user_puck_icon_uncertain_location
         RouteProgressState.LOCATION_STALE -> R.drawable.user_puck_icon
         else -> R.drawable.user_puck_icon_uncertain_location
     }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/puck/NavigationPuckPresenter.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/puck/NavigationPuckPresenter.kt
@@ -25,7 +25,7 @@ internal class NavigationPuckPresenter(private val mapboxMap: MapboxMap, puckDra
 
     private val routeProgressObserver = object : RouteProgressObserver {
         override fun onRouteProgressChanged(routeProgress: RouteProgress) {
-            routeProgress.currentState?.let {
+            routeProgress.currentState.let {
                 val drawable = puckDrawableSupplier.getPuckDrawable(it)
                 updateCurrentLocationDrawable(drawable)
             }

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigatorImpl.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigatorImpl.kt
@@ -384,7 +384,7 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
                     stepProgressBuilder.distanceTraveled(distanceTraveled)
                     stepProgressBuilder.fractionTraveled(distanceTraveled / currentStep.distance().toFloat())
 
-                    routeState.convertState()?.also {
+                    routeState.convertState().let {
                         routeProgressBuilder.currentState(it)
 
                         var bannerInstructions = bannerInstruction?.mapToDirectionsApi(currentStep)
@@ -496,13 +496,13 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
     }
 }
 
-private fun RouteState.convertState(): RouteProgressState? {
+private fun RouteState.convertState(): RouteProgressState {
     return when (this) {
         RouteState.INVALID -> RouteProgressState.ROUTE_INVALID
         RouteState.INITIALIZED -> RouteProgressState.ROUTE_INITIALIZED
         RouteState.TRACKING -> RouteProgressState.LOCATION_TRACKING
-        RouteState.COMPLETE -> RouteProgressState.ROUTE_ARRIVED
-        RouteState.OFF_ROUTE -> null // send in a callback instead
+        RouteState.COMPLETE -> RouteProgressState.ROUTE_COMPLETE
+        RouteState.OFF_ROUTE -> RouteProgressState.OFF_ROUTE
         RouteState.STALE -> RouteProgressState.LOCATION_STALE
         RouteState.UNCERTAIN -> RouteProgressState.ROUTE_UNCERTAIN
     }


### PR DESCRIPTION
## Description

As part of the segregation of the progress interfaces we're planning to do (`RouteProgress` updates will not be delivered if there's no route present) this PR adds `OFF_ROUTE` state to `RouteProgressState` and make `RouteProgressState` from `RouteProgress` non-null

Refs. [Null References: The Billion Dollar Mistake](https://www.infoq.com/presentations/Null-References-The-Billion-Dollar-Mistake-Tony-Hoare)

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Long term goal as above-mentioned is to report `RouteProgress` to clients only when in _Active Guidance_, since in _Free Drive_ it's uninitialized and requires unnecessary null checks / extra logic

### Implementation

- Add `OFF_ROUTE` state to `RouteProgressState` (previously we were reporting `null` i.e. `null` meant off-route)
- Make `RouteProgressState` from `RouteProgress` non-null
- Change `ROUTE_ARRIVED` by `ROUTE_COMPLETE` to match NN nomenclature cc @kmadsen 
- Remove null checks as they're not necessary anymore

This also allows clients to keep track of the off-route state easily and react accordingly without the need of relying on the `OffRouteObserver` or `else` clauses e.g. UI SDKs relies on these states to use different styles of the puck now if needed can be handled explicitly and not 👀 for `null` cc @abhishek1508 

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [x] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs

These are the errors reported by Metalava before updating `current.txt` 👀 

```
src/main/java/com/mapbox/navigation/base/trip/model/RouteProgress.kt:45: error: Attempted to change parameter from @Nullable to @NonNull: incompatible change for parameter currentState in com.mapbox.navigation.base.trip.model.RouteProgress(com.mapbox.api.directions.v5.models.DirectionsRoute route, com.mapbox.geojson.Geometry routeGeometryWithBuffer, com.mapbox.api.directions.v5.models.BannerInstructions bannerInstructions, com.mapbox.api.directions.v5.models.VoiceInstructions voiceInstructions, com.mapbox.navigation.base.trip.model.RouteProgressState currentState, com.mapbox.navigation.base.trip.model.RouteLegProgress currentLegProgress, java.util.List<com.mapbox.geojson.Point> upcomingStepPoints, boolean inTunnel, float distanceRemaining, float distanceTraveled, double durationRemaining, float fractionTraveled, int remainingWaypoints) [InvalidNullConversion]
src/main/java/com/mapbox/navigation/base/trip/model/RouteProgress.kt:1: error: Attempted to change parameter from @Nullable to @NonNull: incompatible change for parameter currentState in com.mapbox.navigation.base.trip.model.RouteProgress.copy(com.mapbox.api.directions.v5.models.DirectionsRoute route, com.mapbox.geojson.Geometry routeGeometryWithBuffer, com.mapbox.api.directions.v5.models.BannerInstructions bannerInstructions, com.mapbox.api.directions.v5.models.VoiceInstructions voiceInstructions, com.mapbox.navigation.base.trip.model.RouteProgressState currentState, com.mapbox.navigation.base.trip.model.RouteLegProgress currentLegProgress, java.util.List<com.mapbox.geojson.Point> upcomingStepPoints, boolean inTunnel, float distanceRemaining, float distanceTraveled, double durationRemaining, float fractionTraveled, int remainingWaypoints) [InvalidNullConversion]
src/main/java/com/mapbox/navigation/base/trip/model/RouteProgressState.kt:42: error: Added enum constant com.mapbox.navigation.base.trip.model.RouteProgressState.OFF_ROUTE [AddedField]
/Users/pabloguardiola/mapbox/mapbox-navigation-android/libnavigation-base/api/current.txt:270: error: Removed enum constant com.mapbox.navigation.base.trip.model.RouteProgressState.ROUTE_ARRIVED [RemovedField]
src/main/java/com/mapbox/navigation/base/trip/model/RouteProgressState.kt:25: error: Added enum constant com.mapbox.navigation.base.trip.model.RouteProgressState.ROUTE_COMPLETE [AddedField]
Aborting: Found compatibility problems checking the public API (/Users/pabloguardiola/mapbox/mapbox-navigation-android/libnavigation-base/src/main/java) against the API in /Users/pabloguardiola/mapbox/mapbox-navigation-android/libnavigation-base/api/current.txt
```