### PR TITLE
[examples] ignore BaseRouterActivity clicks when style is not ready

### DIFF
--- a/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/MockNavigationActivity.java
+++ b/app/src/main/java/com/mapbox/services/android/navigation/testapp/activity/MockNavigationActivity.java
@@ -85,6 +85,9 @@ public class MockNavigationActivity extends AppCompatActivity implements OnMapRe
   @BindView(R.id.startRouteButton)
   Button startRouteButton;
 
+  @BindView(R.id.newLocationFab)
+  Button newLocationFab;
+
   private MapboxMap mapboxMap;
 
   // Navigation related variables
@@ -176,13 +179,11 @@ public class MockNavigationActivity extends AppCompatActivity implements OnMapRe
   }
 
   private void newOrigin() {
-    if (mapboxMap != null) {
-      LatLng latLng = Utils.getRandomLatLng(new double[] {-77.1825, 38.7825, -76.9790, 39.0157});
-      ((ReplayRouteLocationEngine) locationEngine).assignLastLocation(
-        Point.fromLngLat(latLng.getLongitude(), latLng.getLatitude())
-      );
-      mapboxMap.moveCamera(CameraUpdateFactory.newLatLngZoom(latLng, 12));
-    }
+    LatLng latLng = Utils.getRandomLatLng(new double[] {-77.1825, 38.7825, -76.9790, 39.0157});
+    ((ReplayRouteLocationEngine) locationEngine).assignLastLocation(
+      Point.fromLngLat(latLng.getLongitude(), latLng.getLatitude())
+    );
+    mapboxMap.moveCamera(CameraUpdateFactory.newLatLngZoom(latLng, 12));
   }
 
   @SuppressLint("MissingPermission")
@@ -191,6 +192,7 @@ public class MockNavigationActivity extends AppCompatActivity implements OnMapRe
     this.mapboxMap = mapboxMap;
     this.mapboxMap.addOnMapClickListener(this);
     mapboxMap.setStyle(Style.MAPBOX_STREETS, style -> {
+      newLocationFab.setVisibility(View.VISIBLE);
       LocationComponent locationComponent = mapboxMap.getLocationComponent();
       locationComponent.activateLocationComponent(
               LocationComponentActivationOptions.builder(this, style).build());

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/BaseRouterActivityJava.java
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/BaseRouterActivityJava.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.os.Environment;
+import android.view.View;
 import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -12,6 +13,8 @@ import androidx.core.content.ContextCompat;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
+
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.google.android.material.snackbar.Snackbar;
 import com.mapbox.api.directions.v5.DirectionsCriteria;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
@@ -117,6 +120,9 @@ public abstract class BaseRouterActivityJava extends AppCompatActivity
   @BindView(R.id.mapView)
   MapView mapView;
 
+  @BindView(R.id.newLocationFab)
+  FloatingActionButton newLocationFab;
+
   abstract Router setupRouter();
 
   @Override
@@ -141,12 +147,10 @@ public abstract class BaseRouterActivityJava extends AppCompatActivity
   }
 
   private void newOrigin() {
-    if (mapboxMap != null) {
-      clearMap();
-      LatLng latLng = Utils.getRandomLatLng(new double[] { -77.1825, 38.7825, -76.9790, 39.0157 });
-      origin = Point.fromLngLat(latLng.getLongitude(), latLng.getLatitude());
-      mapboxMap.moveCamera(CameraUpdateFactory.newLatLngZoom(latLng, 12));
-    }
+    clearMap();
+    LatLng latLng = Utils.getRandomLatLng(new double[] { -77.1825, 38.7825, -76.9790, 39.0157 });
+    origin = Point.fromLngLat(latLng.getLongitude(), latLng.getLatitude());
+    mapboxMap.moveCamera(CameraUpdateFactory.newLatLngZoom(latLng, 12));
   }
 
   @Override
@@ -155,6 +159,7 @@ public abstract class BaseRouterActivityJava extends AppCompatActivity
     MapboxLogger.INSTANCE.d(new Message("Map is ready"));
     mapboxMap.setStyle(Style.MAPBOX_STREETS, style -> {
       MapboxLogger.INSTANCE.d(new Message("Style setting finished"));
+      newLocationFab.setVisibility(View.VISIBLE);
       Drawable image = ContextCompat.getDrawable(this, R.drawable.mapbox_marker_icon_default);
       style.addImage(MARKER_ROUTE, image);
       navigationMapRoute = new NavigationMapRoute.Builder(mapView, mapboxMap, this).build();

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/BaseRouterActivityKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/BaseRouterActivityKt.kt
@@ -3,6 +3,7 @@ package com.mapbox.navigation.examples.core
 import android.content.Context
 import android.os.Bundle
 import android.os.Environment
+import android.view.View
 import android.widget.Toast
 import androidx.annotation.DrawableRes
 import androidx.appcompat.app.AppCompatActivity
@@ -102,6 +103,7 @@ abstract class BaseRouterActivityKt :
         MapboxLogger.d(Message("Map is ready"))
         mapboxMap.setStyle(Style.MAPBOX_STREETS) { style ->
             MapboxLogger.d(Message("Style setting finished"))
+            newLocationFab.visibility = View.VISIBLE
             style.addImage(MARKER_ROUTE, R.drawable.mapbox_marker_icon_default)
             navigationMapRoute = NavigationMapRoute.Builder(mapView, mapboxMap, this).build()
             symbolManager = SymbolManager(mapView, mapboxMap, style)

--- a/examples/src/main/res/layout/activity_mock_navigation.xml
+++ b/examples/src/main/res/layout/activity_mock_navigation.xml
@@ -1,47 +1,45 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/container"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fitsSystemWindows="true"
-    tools:context=".ui.MockNavigationActivity">
+    android:fitsSystemWindows="true">
 
     <com.mapbox.mapboxsdk.maps.MapView
         android:id="@+id/mapView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:mapbox_cameraZoom="14"
-        app:mapbox_uiAttribution="false"/>
+        app:mapbox_uiAttribution="false" />
 
     <Button
         android:id="@+id/startRouteButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center|bottom"
-        android:layout_marginBottom="8dp"
-        android:layout_marginEnd="8dp"
         android:layout_marginStart="8dp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
+        android:layout_marginEnd="8dp"
+        android:layout_marginBottom="8dp"
         android:text="Start route"
-        android:visibility="invisible"/>
+        android:visibility="invisible"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/newLocationFab"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="16dp"
+        android:layout_gravity="bottom|end"
         android:layout_marginEnd="16dp"
         android:layout_marginRight="16dp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:srcCompat="@drawable/ic_new_location"
+        android:layout_marginBottom="16dp"
         android:tint="@android:color/white"
-        android:layout_gravity="bottom|end"
-        app:backgroundTint="@color/colorPrimary"/>
+        android:visibility="invisible"
+        app:backgroundTint="@color/colorPrimary"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:srcCompat="@drawable/ic_new_location" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Fixes a crash caught by our robo tests:
```
java.lang.NullPointerException: Attempt to invoke virtual method 'void com.mapbox.mapboxsdk.t.a.b.a()' on a null object reference
	at com.mapbox.navigation.examples.core.BaseRouterActivityJava.r(Unknown Source:2)
	at com.mapbox.navigation.examples.core.BaseRouterActivityJava.t(Unknown Source:4)
	at com.mapbox.navigation.examples.core.BaseRouterActivityJava.onNewLocationClick(Unknown Source:0)
	at com.mapbox.navigation.examples.core.BaseRouterActivityJava_ViewBinding$a.a(Unknown Source:2)
	at butterknife.b.b.onClick(Unknown Source:12)
	at android.view.View.performClick(View.java:6256)
	at android.view.View$PerformClick.run(View.java:24697)
	at android.os.Handler.handleCallback(Handler.java:789)
	at android.os.Handler.dispatchMessage(Handler.java:98)
	at androidx.test.espresso.base.Interrogator.a(Interrogator.java:31)
	at androidx.test.espresso.base.UiControllerImpl.a(UiControllerImpl.java:130)
	at androidx.test.espresso.base.UiControllerImpl.a(UiControllerImpl.java:124)
	at androidx.test.espresso.base.UiControllerImpl.a(UiControllerImpl.java:40)
	at androidx.test.espresso.action.MotionEvents.a(MotionEvents.java:73)
	at androidx.test.espresso.action.Tap.b(Tap.java:16)
	at androidx.test.espresso.action.Tap$1.a(Tap.java:2)
	at androidx.test.espresso.action.GeneralClickAction.perform(GeneralClickAction.java:10)
	at androidx.test.espresso.ViewInteraction$SingleExecutionViewAction.perform(ViewInteraction.java:7)
	at androidx.test.espresso.ViewInteraction.a(ViewInteraction.java:31)
	at androidx.test.espresso.ViewInteraction$1.call(ViewInteraction.java:1)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at android.os.Handler.handleCallback(Handler.java:789)
	at android.os.Handler.dispatchMessage(Handler.java:98)
	at android.os.Looper.loop(Looper.java:164)
	at android.app.ActivityThread.main(ActivityThread.java:6541)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.Zygote$MethodAndArgsCaller.run(Zygote.java:240)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:767)
```