### PR TITLE
[ui] remove lookahead updates

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/NavigationMapRouteActivity.java
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/NavigationMapRouteActivity.java
@@ -56,7 +56,6 @@ import timber.log.Timber;
 
 import static com.mapbox.navigation.examples.utils.Utils.PRIMARY_ROUTE_BUNDLE_KEY;
 import static com.mapbox.navigation.examples.utils.Utils.getRouteFromBundle;
-import static com.mapbox.navigation.ui.NavigationConstants.MINIMAL_LOOKAHEAD_LOCATION_TIME_VALUE;
 
 /**
  * This activity demonstrates turn by turn navigation using the NavigationMapRoute class. This can
@@ -326,9 +325,7 @@ public class NavigationMapRouteActivity extends AppCompatActivity implements OnM
   }
 
   private void updateLocation(List<Location> locations) {
-    long minimalRequiredLookAheadTimestamp = System.currentTimeMillis() + MINIMAL_LOOKAHEAD_LOCATION_TIME_VALUE;
-    boolean lookahead = locations.get(0).getTime() > minimalRequiredLookAheadTimestamp;
-    mapboxMap.getLocationComponent().forceLocationUpdate(locations, lookahead);
+    mapboxMap.getLocationComponent().forceLocationUpdate(locations, false);
   }
 
   private LocationObserver locationObserver = new LocationObserver() {

--- a/libnavigation-ui/api/current.txt
+++ b/libnavigation-ui/api/current.txt
@@ -46,7 +46,6 @@ package com.mapbox.navigation.ui {
     field public static final long ALERT_VIEW_PROBLEM_DURATION = 10000L; // 0x2710L
     field public static final long FEEDBACK_BOTTOM_SHEET_DURATION = 10000L; // 0x2710L
     field public static final com.mapbox.navigation.ui.NavigationConstants! INSTANCE;
-    field public static final long MINIMAL_LOOKAHEAD_LOCATION_TIME_VALUE = 250L; // 0xfaL
     field public static final int NAVIGATION_HIGH_ALERT_DURATION = 15; // 0xf
     field public static final int NAVIGATION_LOW_ALERT_DURATION = 125; // 0x7d
     field public static final long NAVIGATION_MAX_CAMERA_ADJUSTMENT_ANIMATION_DURATION = 1500L; // 0x5dcL

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationConstants.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationConstants.kt
@@ -66,9 +66,4 @@ object NavigationConstants {
      * Minimum duration of the tilt adjustment animation while tracking.
      */
     const val NAVIGATION_MIN_CAMERA_TILT_ADJUSTMENT_ANIMATION_DURATION = 750L
-
-    /**
-     * The minimal lookahead value in milliseconds required to perform a lookahead animation.
-     */
-    const val MINIMAL_LOOKAHEAD_LOCATION_TIME_VALUE = 250L
 }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/NavigationMapboxMap.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/NavigationMapboxMap.java
@@ -35,7 +35,6 @@ import com.mapbox.mapboxsdk.style.sources.VectorSource;
 import com.mapbox.navigation.base.trip.model.RouteProgress;
 import com.mapbox.navigation.core.MapboxNavigation;
 import com.mapbox.navigation.core.trip.session.LocationObserver;
-import com.mapbox.navigation.ui.NavigationConstants;
 import com.mapbox.navigation.ui.NavigationSnapshotReadyCallback;
 import com.mapbox.navigation.ui.internal.ThemeSwitcher;
 import com.mapbox.navigation.ui.camera.Camera;
@@ -54,7 +53,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
 
 import timber.log.Timber;
 
-import static com.mapbox.navigation.ui.NavigationConstants.MINIMAL_LOOKAHEAD_LOCATION_TIME_VALUE;
 import static com.mapbox.navigation.ui.map.NavigationSymbolManager.MAPBOX_NAVIGATION_MARKER_NAME;
 
 /**
@@ -282,19 +280,12 @@ public class NavigationMapboxMap implements LifecycleObserver {
    * and the rest are intermediate points used as the animation path.
    * The puck and the camera will be animated between each of the points linearly until reaching the target.
    *
-   * If the timestamp of the last location in the list is in the future by more than
-   * {@link NavigationConstants#MINIMAL_LOOKAHEAD_LOCATION_TIME_VALUE},
-   * the "lookahead animation" will be executed,
-   * which aims to position the puck at the desired location without a typical animation delay.
-   *
    * @param locations the path to update the location icon
    */
   public void updateLocation(@NonNull List<Location> locations) {
     if (locations.size() > 0) {
       Location targetLocation = locations.get(0);
-      long minimalRequiredLookAheadTimestamp = System.currentTimeMillis() + MINIMAL_LOOKAHEAD_LOCATION_TIME_VALUE;
-      boolean lookahead = targetLocation.getTime() > minimalRequiredLookAheadTimestamp;
-      locationComponent.forceLocationUpdate(locations, lookahead);
+      locationComponent.forceLocationUpdate(locations, false);
       updateMapWayNameWithLocation(targetLocation);
     }
   }


### PR DESCRIPTION
With Nav Native moving away from the prediction pattern, we will not continue to develop animation tools that use the predicted timestamp to execute the animation. The current default model of calculating `(current.timestamp - previous.timestamp) * multiplier` should be enough going forward. Especially with prospect of increasing the frequency of updates.

The old implementation that tried to switch between predicted and non-predicted updates on the fly was causing the puck to speed-up/slow-down significantly and frequently depending on whether the prediction value has hit the cut-off target.

/cc @mskurydin 