### PR TITLE
Fix #3194: only set max width when it is greater than 0

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/instruction/InstructionView.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/instruction/InstructionView.java
@@ -1023,7 +1023,7 @@ public class InstructionView extends RelativeLayout implements LifecycleObserver
     stepSecondaryText.setVisibility(GONE);
     adjustBannerTextVerticalBias(0.5f);
 
-    if (ViewUtils.isLandscape(getContext())) {
+    if (ViewUtils.isLandscape(getContext()) && instructionLayoutText.getWidth() > 0) {
       stepPrimaryText.setMaxWidth(instructionLayoutText.getWidth());
     }
     loadTextWith(primaryBannerText, stepPrimaryText);
@@ -1037,13 +1037,18 @@ public class InstructionView extends RelativeLayout implements LifecycleObserver
     if (ViewUtils.isLandscape(getContext())) {
       int primaryTextMaxWidth = (int) (instructionLayoutText.getWidth()
           * MAXIMUM_PRIMARY_INSTRUCTION_TEXT_WIDTH_RATIO_IN_LANDSCAPE);
-      stepPrimaryText.setMaxWidth(primaryTextMaxWidth);
+      if (primaryTextMaxWidth > 0) {
+        stepPrimaryText.setMaxWidth(primaryTextMaxWidth);
+      }
     }
     loadTextWith(primaryBannerText, stepPrimaryText);
 
     if (ViewUtils.isLandscape(getContext())) {
-      int primaryTextWidth = (int) stepPrimaryText.getPaint().measureText(String.valueOf(stepPrimaryText.getText()));
-      stepSecondaryText.setMaxWidth(instructionLayoutText.getWidth() - primaryTextWidth);
+      int secondaryTextMaxWidth = instructionLayoutText.getWidth()
+          - (int) stepPrimaryText.getPaint().measureText(String.valueOf(stepPrimaryText.getText()));
+      if (secondaryTextMaxWidth > 0) {
+        stepSecondaryText.setMaxWidth(secondaryTextMaxWidth);
+      }
     }
     loadTextWith(secondaryBannerText, stepSecondaryText);
   }


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Fix #3194: only set max width when it is greater than 0

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal

Improve InstructionView quality

### Implementation

* only set max width when it is greater than 0
* reorganize the two methods to separate landscape / portrait logic

## Testing

Verify screen rotation case.

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->