### PR TITLE
Fix #3189: add bitmap encode options so developer can decide how to compress the screenshot

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/InstructionViewActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/InstructionViewActivity.kt
@@ -52,6 +52,7 @@ import com.mapbox.navigation.ui.feedback.FeedbackBottomSheet
 import com.mapbox.navigation.ui.feedback.FeedbackBottomSheetListener
 import com.mapbox.navigation.ui.feedback.FeedbackItem
 import com.mapbox.navigation.ui.instruction.NavigationAlertView
+import com.mapbox.navigation.ui.internal.utils.BitmapEncodeOptions
 import com.mapbox.navigation.ui.internal.utils.ViewUtils
 import com.mapbox.navigation.ui.map.NavigationMapboxMap
 import com.mapbox.navigation.ui.voice.NavigationSpeechPlayer
@@ -285,7 +286,9 @@ class InstructionViewActivity : AppCompatActivity(), OnMapReadyCallback,
         screenshotView.visibility = VISIBLE
         screenshotView.setImageBitmap(snapshot)
         mapView.visibility = View.INVISIBLE
-        val encodedSnapshot = ViewUtils.encodeView(ViewUtils.captureView(mapView))
+        val encodedSnapshot = ViewUtils.encodeView(ViewUtils.captureView(mapView),
+                BitmapEncodeOptions.Builder()
+                        .width(400).compressQuality(40).build())
         screenshotView.visibility = View.INVISIBLE
         mapView.visibility = VISIBLE
         return encodedSnapshot

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/internal/utils/BitmapEncodeOptions.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/internal/utils/BitmapEncodeOptions.kt
@@ -1,0 +1,30 @@
+package com.mapbox.navigation.ui.internal.utils
+
+const val DEFAULT_BITMAP_ENCODE_WIDTH = 250
+const val DEFAULT_BITMAP_ENCODE_COMPRESS_QUALITY = 20
+
+data class BitmapEncodeOptions(val width: Int, val compressQuality: Int) {
+
+    class Builder {
+        private var width: Int = DEFAULT_BITMAP_ENCODE_WIDTH
+        private var compressQuality: Int = DEFAULT_BITMAP_ENCODE_COMPRESS_QUALITY
+
+        fun width(width: Int) = apply {
+            if (width <= 0) {
+                throw IllegalArgumentException("width must be > 0")
+            }
+            this.width = width
+        }
+
+        fun compressQuality(compressQuality: Int) = apply {
+            if (compressQuality !in 0..100) {
+                throw IllegalArgumentException("compressQuality must be 0..100")
+            }
+            this.compressQuality = compressQuality
+        }
+
+        fun build(): BitmapEncodeOptions {
+            return BitmapEncodeOptions(width, compressQuality)
+        }
+    }
+}

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/internal/utils/ViewUtils.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/internal/utils/ViewUtils.java
@@ -22,14 +22,18 @@ public class ViewUtils {
   }
 
   public static String encodeView(Bitmap capture) {
-    // Resize to 250px wide while keeping the aspect ratio
-    int width = 250;
+    return encodeView(capture, new BitmapEncodeOptions.Builder().build());
+  }
+
+  public static String encodeView(Bitmap capture, BitmapEncodeOptions options) {
+    // Resize up to original width while keeping the aspect ratio
+    int width = Math.min(capture.getWidth(), options.getWidth());
     int height = Math.round((float) width * capture.getHeight() / capture.getWidth());
     Bitmap scaled = Bitmap.createScaledBitmap(capture, width, height, /*filter=*/true);
 
-    // Convert to JPEG low-quality (~20%)
+    // Convert to JPEG at a quality between 20% ~ 100%
     ByteArrayOutputStream stream = new ByteArrayOutputStream();
-    scaled.compress(Bitmap.CompressFormat.JPEG, 20, stream);
+    scaled.compress(Bitmap.CompressFormat.JPEG, options.getCompressQuality(), stream);
 
     // Convert to base64 encoded string
     byte[] data = stream.toByteArray();

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/internal/utils/ViewUtilsTest.kt
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/internal/utils/ViewUtilsTest.kt
@@ -1,0 +1,148 @@
+package com.mapbox.navigation.ui.internal.utils
+
+import android.graphics.Bitmap
+import io.mockk.CapturingSlot
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+private const val LOW_DENSITY_BITMAP_WIDTH = 160
+private const val HIGH_DENSITY_BITMAP_WIDTH = 1080
+private const val BITMAP_HEIGHT = 240
+
+class ViewUtilsTest {
+
+    @Test
+    fun encodeViewWithDefaultCompressQuality() {
+        val (aBitmap, compressQualitySlot) = mockBitmapForCheckingCompressQuality()
+
+        ViewUtils.encodeView(aBitmap)
+
+        assertEquals(DEFAULT_BITMAP_ENCODE_COMPRESS_QUALITY, compressQualitySlot.captured)
+    }
+
+    @Test
+    fun encodeViewWithDefaultWidthOfLowDensityBitmap() {
+        val (aLowDensityBitmap, widthSlot) = mockBitmapForCheckingWidth(LOW_DENSITY_BITMAP_WIDTH)
+
+        ViewUtils.encodeView(aLowDensityBitmap)
+
+        assertEquals(LOW_DENSITY_BITMAP_WIDTH, widthSlot.captured)
+    }
+
+    @Test
+    fun encodeViewWithDefaultWidthOfHighDensityBitmap() {
+        val (aHighDensityBitmap, widthSlot) = mockBitmapForCheckingWidth()
+
+        ViewUtils.encodeView(aHighDensityBitmap)
+
+        assertEquals(DEFAULT_BITMAP_ENCODE_WIDTH, widthSlot.captured)
+    }
+
+    @Test
+    fun encodeViewWithCompressQualityZero() {
+        val (aBitmap, compressQualitySlot) = mockBitmapForCheckingCompressQuality()
+        val compressQualityZero = 0
+        val options = BitmapEncodeOptions.Builder().compressQuality(compressQualityZero).build()
+
+        ViewUtils.encodeView(aBitmap, options)
+
+        assertEquals(compressQualityZero, compressQualitySlot.captured)
+    }
+
+    @Test
+    fun encodeViewWithNormalCompressQuality() {
+        val (aBitmap, compressQualitySlot) = mockBitmapForCheckingCompressQuality()
+        val normalCompressQuality = 50
+        val options = BitmapEncodeOptions.Builder().compressQuality(normalCompressQuality).build()
+
+        ViewUtils.encodeView(aBitmap, options)
+
+        assertEquals(normalCompressQuality, compressQualitySlot.captured)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun encodeViewWithNegativeCompressQuality() {
+        val aBitmap: Bitmap = mockk()
+        val options = BitmapEncodeOptions.Builder().compressQuality(-10).build()
+
+        ViewUtils.encodeView(aBitmap, options)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun encodeViewWithBigCompressQuality() {
+        val aBitmap: Bitmap = mockk()
+        val options = BitmapEncodeOptions.Builder().compressQuality(200).build()
+
+        ViewUtils.encodeView(aBitmap, options)
+    }
+
+    @Test
+    fun encodeViewWithSmallWidth() {
+        val (aBitmap, widthSlot) = mockBitmapForCheckingWidth()
+        val smallWidth = 10
+        val options = BitmapEncodeOptions.Builder().width(smallWidth).build()
+
+        ViewUtils.encodeView(aBitmap, options)
+
+        assertEquals(smallWidth, widthSlot.captured)
+    }
+
+    @Test
+    fun encodeViewWithBigWidth() {
+        val (aBitmap, widthSlot) = mockBitmapForCheckingWidth()
+        val bigWidth = HIGH_DENSITY_BITMAP_WIDTH + 1
+        val options = BitmapEncodeOptions.Builder().width(bigWidth).build()
+
+        ViewUtils.encodeView(aBitmap, options)
+
+        assertEquals(HIGH_DENSITY_BITMAP_WIDTH, widthSlot.captured)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun encodeViewWithWidthZero() {
+        val aBitmap: Bitmap = mockk()
+        val options = BitmapEncodeOptions.Builder().width(0).build()
+
+        ViewUtils.encodeView(aBitmap, options)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun encodeViewWithNegativeWidth() {
+        val aBitmap: Bitmap = mockk()
+        val options = BitmapEncodeOptions.Builder().width(-1).build()
+
+        ViewUtils.encodeView(aBitmap, options)
+    }
+
+    private fun mockBitmapForCheckingWidth(width: Int = HIGH_DENSITY_BITMAP_WIDTH): BitmapWithSlot {
+        val aBitmap: Bitmap = mockk()
+        every { aBitmap.width }.returns(width)
+        every { aBitmap.height }.returns(BITMAP_HEIGHT)
+        val scaledBitmap: Bitmap = mockk()
+        every { scaledBitmap.compress(any(), any(), any()) }.returns(true)
+        mockkStatic(Bitmap::class)
+        val widthSlot = slot<Int>()
+        every { Bitmap.createScaledBitmap(any(), capture(widthSlot), any(), any()) } answers { scaledBitmap }
+
+        return BitmapWithSlot(aBitmap = aBitmap, slot = widthSlot)
+    }
+
+    private fun mockBitmapForCheckingCompressQuality(): BitmapWithSlot {
+        val aBitmap: Bitmap = mockk()
+        every { aBitmap.width }.returns(HIGH_DENSITY_BITMAP_WIDTH)
+        every { aBitmap.height }.returns(BITMAP_HEIGHT)
+        val scaledBitmap: Bitmap = mockk()
+        val compressQualitySlot = slot<Int>()
+        every { scaledBitmap.compress(any(), capture(compressQualitySlot), any()) }.returns(true)
+        mockkStatic(Bitmap::class)
+        every { Bitmap.createScaledBitmap(any(), any(), any(), any()) } answers { scaledBitmap }
+
+        return BitmapWithSlot(aBitmap = aBitmap, slot = compressQualitySlot)
+    }
+
+    private data class BitmapWithSlot(val aBitmap: Bitmap, val slot: CapturingSlot<Int>)
+}


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Fix #3189: add bitmap encode options so developer can decide how to compress the screenshot

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal

Allow developer to control how to compress the feedback screenshot bitmap.

## Testing

Update `InstructionViewActivity` example to show how to use the encode options.

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->