### PR TITLE
Added fine grained programatic runtime configuration of route lines w…

### DIFF
--- a/examples/src/main/AndroidManifest.xml
+++ b/examples/src/main/AndroidManifest.xml
@@ -265,6 +265,15 @@
                 android:value=".core.ReplayHistoryActivity" />
         </activity>
 
+        <activity
+            android:name=".core.RuntimeRouteStylingActivity"
+            android:label="@string/title_runtime_styling"
+            android:screenOrientation="portrait">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".CoreActivity" />
+        </activity>
+
         <meta-data
             android:name="com.mapbox.TestEventsServer"
             android:value="api-events-staging.tilestream.net" />

--- a/examples/src/main/java/com/mapbox/navigation/examples/CoreActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/CoreActivity.kt
@@ -21,6 +21,7 @@ import com.mapbox.navigation.examples.core.ReRouteActivity
 import com.mapbox.navigation.examples.core.ReplayActivity
 import com.mapbox.navigation.examples.core.ReplayHistoryActivity
 import com.mapbox.navigation.examples.core.ReplayWaypointsActivity
+import com.mapbox.navigation.examples.core.RuntimeRouteStylingActivity
 import com.mapbox.navigation.examples.core.SimpleMapboxNavigationKt
 import com.mapbox.navigation.examples.core.SummaryBottomSheetActivity
 import kotlinx.android.synthetic.main.activity_core.*
@@ -131,6 +132,11 @@ class CoreActivity : AppCompatActivity() {
                 getString(R.string.title_navigation_route_ui),
                 getString(R.string.description_navigation_route_ui),
                 NavigationMapRouteActivity::class.java
+            ),
+            SampleItem(
+                getString(R.string.title_runtime_styling),
+                getString(R.string.description_runtime_styling),
+                RuntimeRouteStylingActivity::class.java
             )
         )
     }

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/RuntimeRouteStylingActivity.java
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/RuntimeRouteStylingActivity.java
@@ -1,0 +1,359 @@
+package com.mapbox.navigation.examples.core;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.location.Location;
+import android.os.Build;
+import android.os.Bundle;
+import android.os.VibrationEffect;
+import android.os.Vibrator;
+import android.view.View;
+import android.widget.ProgressBar;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.ContextCompat;
+
+import com.google.android.material.snackbar.Snackbar;
+import com.mapbox.android.core.location.LocationEngineCallback;
+import com.mapbox.android.core.location.LocationEngineResult;
+import com.mapbox.api.directions.v5.models.DirectionsRoute;
+import com.mapbox.api.directions.v5.models.RouteOptions;
+import com.mapbox.geojson.Point;
+import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.location.LocationComponent;
+import com.mapbox.mapboxsdk.location.LocationComponentActivationOptions;
+import com.mapbox.mapboxsdk.location.modes.CameraMode;
+import com.mapbox.mapboxsdk.location.modes.RenderMode;
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.mapboxsdk.maps.Style;
+import com.mapbox.navigation.base.internal.route.RouteUrl;
+import com.mapbox.navigation.base.options.NavigationOptions;
+import com.mapbox.navigation.core.MapboxNavigation;
+import com.mapbox.navigation.core.directions.session.RoutesRequestCallback;
+import com.mapbox.navigation.core.replay.MapboxReplayer;
+import com.mapbox.navigation.core.replay.ReplayLocationEngine;
+import com.mapbox.navigation.core.replay.route.ReplayProgressObserver;
+import com.mapbox.navigation.core.trip.session.LocationObserver;
+import com.mapbox.navigation.examples.R;
+import com.mapbox.navigation.examples.utils.Utils;
+import com.mapbox.navigation.ui.camera.NavigationCamera;
+import com.mapbox.navigation.ui.route.IdentifiableRoute;
+import com.mapbox.navigation.ui.route.NavigationMapRoute;
+import com.mapbox.navigation.ui.route.RouteStyleDescriptor;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import butterknife.BindView;
+import butterknife.ButterKnife;
+import timber.log.Timber;
+
+/**
+ * This activity demonstrates fine grained control over the route line coloring. You can override
+ * the defined styling and apply a data driven line color that you can define at runtime.
+ */
+public class RuntimeRouteStylingActivity extends AppCompatActivity implements OnMapReadyCallback,
+        MapboxMap.OnMapLongClickListener {
+  private static final int ONE_HUNDRED_MILLISECONDS = 100;
+
+  @BindView(R.id.mapView)
+  MapView mapView;
+  @BindView(R.id.routeLoadingProgressBar)
+  ProgressBar routeLoading;
+
+  private MapboxMap mapboxMap;
+  private NavigationMapRoute navigationMapRoute;
+  private MapboxNavigation mapboxNavigation;
+  private NavigationCamera mapCamera;
+  private MapboxReplayer mapboxReplayer = new MapboxReplayer();
+
+  private static final String PRIMARY_ROUTE_IDENTIFIER = "undefined";
+  private static final String ALTERNATIVE_ROUTE_0 = "alternativeRoute0";
+  private static final String ALTERNATIVE_ROUTE_1 = "alternativeRoute1";
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_runtime_route_styling);
+    ButterKnife.bind(this);
+
+    mapView.onCreate(savedInstanceState);
+    mapView.getMapAsync(this);
+  }
+
+  @Override
+  public void onMapReady(MapboxMap mapboxMap) {
+    this.mapboxMap = mapboxMap;
+    mapboxMap.setStyle(Style.MAPBOX_STREETS, style -> {
+      initializeLocationComponent(mapboxMap, style);
+
+      NavigationOptions navigationOptions = MapboxNavigation
+        .defaultNavigationOptionsBuilder(this, Utils.getMapboxAccessToken(this))
+        .locationEngine(new ReplayLocationEngine(mapboxReplayer))
+        .build();
+      mapboxNavigation = new MapboxNavigation(navigationOptions);
+      mapboxNavigation.registerLocationObserver(locationObserver);
+      mapboxNavigation.registerRouteProgressObserver(replayProgressObserver);
+      mapboxReplayer.pushRealLocation(this, 0.0);
+      mapboxReplayer.play();
+
+      mapCamera = new NavigationCamera(mapboxMap, mapboxNavigation, mapboxMap.getLocationComponent());
+      mapCamera.addProgressChangeListener(mapboxNavigation);
+
+      List<RouteStyleDescriptor> routeDescriptors =
+              getRouteStyleDescriptors(this);
+
+      navigationMapRoute = new NavigationMapRoute.Builder(mapView, mapboxMap, this)
+              .withMapboxNavigation(mapboxNavigation, true)
+              .withRouteStyleDescriptors(routeDescriptors)
+              .build();
+
+      mapboxNavigation.getNavigationOptions().getLocationEngine().getLastLocation(locationEngineCallback);
+      mapboxMap.addOnMapLongClickListener(this);
+      Snackbar.make(mapView, R.string.msg_long_press_map_to_place_waypoint, Snackbar.LENGTH_SHORT).show();
+    });
+  }
+
+
+  @Override
+  public boolean onMapLongClick(@NonNull LatLng point) {
+    handleClicked(point);
+    return true;
+  }
+
+  @Override
+  public void onResume() {
+    super.onResume();
+    mapView.onResume();
+  }
+
+  @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+    if (mapboxNavigation != null) {
+      mapboxNavigation.registerLocationObserver(locationObserver);
+    }
+    if (mapCamera != null) {
+      mapCamera.onStart();
+    }
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapCamera.onStop();
+    mapboxNavigation.unregisterLocationObserver(locationObserver);
+    mapView.onStop();
+  }
+
+  @Override
+  public void onPause() {
+    super.onPause();
+    mapView.onPause();
+  }
+
+  @Override
+  public void onLowMemory() {
+    super.onLowMemory();
+    mapView.onLowMemory();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mapboxNavigation.unregisterRouteProgressObserver(replayProgressObserver);
+    mapboxNavigation.stopTripSession();
+    mapboxNavigation.onDestroy();
+    mapView.onDestroy();
+  }
+
+  @Override
+  protected void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    mapView.onSaveInstanceState(outState);
+  }
+
+  @SuppressWarnings("MissingPermission")
+  private void initializeLocationComponent(MapboxMap mapboxMap, Style style) {
+    LocationComponentActivationOptions activationOptions = LocationComponentActivationOptions.builder(this, style)
+            .useDefaultLocationEngine(false)
+            .build();
+    LocationComponent locationComponent = mapboxMap.getLocationComponent();
+    locationComponent.activateLocationComponent(activationOptions);
+    locationComponent.setLocationComponentEnabled(true);
+    locationComponent.setRenderMode(RenderMode.COMPASS);
+    locationComponent.setCameraMode(CameraMode.TRACKING);
+  }
+
+  private void handleClicked(@NonNull LatLng touchLocation) {
+    vibrate();
+    hideRoute();
+    Location currentLocation = mapboxMap.getLocationComponent().getLastKnownLocation();
+    if (currentLocation != null) {
+      Point originPoint = Point.fromLngLat(
+              currentLocation.getLongitude(),
+              currentLocation.getLatitude()
+      );
+      Point destinationPoint = Point.fromLngLat(touchLocation.getLongitude(), touchLocation.getLatitude());
+      findRoute(originPoint, destinationPoint);
+      routeLoading.setVisibility(View.VISIBLE);
+    }
+  }
+
+  @SuppressLint("MissingPermission")
+  private void vibrate() {
+    Vibrator vibrator = (Vibrator) getSystemService(Context.VIBRATOR_SERVICE);
+    if (vibrator == null) {
+      return;
+    }
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      vibrator.vibrate(VibrationEffect.createOneShot(ONE_HUNDRED_MILLISECONDS, VibrationEffect.DEFAULT_AMPLITUDE));
+    } else {
+      vibrator.vibrate(ONE_HUNDRED_MILLISECONDS);
+    }
+  }
+
+  private void hideRoute() {
+    navigationMapRoute.updateRouteVisibilityTo(false);
+  }
+
+  public void findRoute(Point origin, Point destination) {
+    RouteOptions routeOptions = RouteOptions.builder()
+            .baseUrl(RouteUrl.BASE_URL)
+            .user(RouteUrl.PROFILE_DEFAULT_USER)
+            .profile(RouteUrl.PROFILE_DRIVING_TRAFFIC)
+            .geometries(RouteUrl.GEOMETRY_POLYLINE6)
+            .requestUuid("")
+            .accessToken(Utils.getMapboxAccessToken(this.getApplicationContext()))
+            .coordinates(Arrays.asList(origin, destination))
+            .alternatives(true)
+            .build();
+
+    mapboxNavigation.requestRoutes(
+            routeOptions,
+            routesReqCallback
+    );
+  }
+
+  private RoutesRequestCallback routesReqCallback = new RoutesRequestCallback() {
+    @Override
+    public void onRoutesReady(@NotNull List<? extends DirectionsRoute> routes) {
+        if (!routes.isEmpty()) {
+
+          // By adding identifiable routes you can specify route colors be overridden with
+          // values you defined with the RouteStyleDescriptors. Below you can see
+          // the routes are identified with labels that match the RouteStyleDescriptors
+          // passed into the NavigationMapRoute builder. Routes that have no pre-defined
+          // identity will get the default color from the style applied.
+          List<IdentifiableRoute> identifiableRoutes = new ArrayList<>();
+          for (int i = 0; i < routes.size(); i++) {
+            if (i == 0) {
+              identifiableRoutes.add(new IdentifiableRoute(routes.get(i), PRIMARY_ROUTE_IDENTIFIER));
+            } else if (i == 1) {
+              identifiableRoutes.add(new IdentifiableRoute(routes.get(i), ALTERNATIVE_ROUTE_0));
+            } else {
+              identifiableRoutes.add(new IdentifiableRoute(routes.get(i), ALTERNATIVE_ROUTE_1));
+            }
+          }
+          navigationMapRoute.addIdentifiableRoutes(identifiableRoutes);
+          routeLoading.setVisibility(View.INVISIBLE);
+        }
+    }
+
+    @Override
+    public void onRoutesRequestFailure(@NotNull Throwable throwable, @NotNull RouteOptions routeOptions) {
+      Timber.e("route request failure %s", throwable.toString());
+    }
+
+    @Override
+    public void onRoutesRequestCanceled(@NotNull RouteOptions routeOptions) {
+      Timber.d("route request canceled");
+    }
+  };
+
+
+  private MyLocationEngineCallback locationEngineCallback = new MyLocationEngineCallback(this);
+
+  private static class MyLocationEngineCallback implements LocationEngineCallback<LocationEngineResult> {
+
+    private WeakReference<RuntimeRouteStylingActivity> activityRef;
+
+    MyLocationEngineCallback(RuntimeRouteStylingActivity activity) {
+      this.activityRef = new WeakReference<>(activity);
+    }
+
+
+    @Override
+    public void onSuccess(LocationEngineResult result) {
+      activityRef.get().updateLocation(result.getLocations());
+    }
+
+    @Override
+    public void onFailure(@NonNull Exception exception) {
+      Timber.i(exception);
+    }
+  }
+
+  private void updateLocation(Location location) {
+    updateLocation(Arrays.asList(location));
+  }
+
+  private void updateLocation(List<Location> locations) {
+    long minimalRequiredLookAheadTimestamp = System.currentTimeMillis();
+    boolean lookahead = locations.get(0).getTime() > minimalRequiredLookAheadTimestamp;
+    mapboxMap.getLocationComponent().forceLocationUpdate(locations, lookahead);
+  }
+
+  private LocationObserver locationObserver = new LocationObserver() {
+    @Override
+    public void onRawLocationChanged(@NotNull Location rawLocation) {
+      Timber.d("raw location %s", rawLocation.toString());
+    }
+
+    @Override
+    public void onEnhancedLocationChanged(
+            @NotNull Location enhancedLocation,
+            @NotNull List<? extends Location> keyPoints
+    ) {
+        if (keyPoints.isEmpty()) {
+          updateLocation(enhancedLocation);
+        } else {
+          updateLocation((List<Location>) keyPoints);
+        }
+    }
+  };
+
+  private ReplayProgressObserver replayProgressObserver = new ReplayProgressObserver(mapboxReplayer);
+
+  // The route style descriptors give you an opportunity to indicate route line(s) with
+  // a given identifier should be colored with a color other than the color specified in style.
+  // Routes with the same identifiers as those defined here will have their color overridden
+  // with the values defined in the descriptor.
+  private List<RouteStyleDescriptor> getRouteStyleDescriptors(Context context) {
+    int firstAlternativeRouteDefaultColor = ContextCompat.getColor(context, R.color.customAlternativeRouteColor);
+    int firstAlternativeRouteShieldColor = ContextCompat.getColor(context, R.color.customAlternativeRouteCasingColor);
+    int otherAlternativeRouteDefaultColor = ContextCompat.getColor(context, R.color.customRouteLowCongestionColor);
+    int otherAlternativeRouteShieldColor = ContextCompat.getColor(context, R.color.customRouteSevereCongestionColor);
+
+    return Arrays.asList(
+            new RouteStyleDescriptor(
+                    ALTERNATIVE_ROUTE_0,
+                    firstAlternativeRouteDefaultColor,
+                    firstAlternativeRouteShieldColor
+            ),
+            new RouteStyleDescriptor(
+                    ALTERNATIVE_ROUTE_1,
+                    otherAlternativeRouteDefaultColor,
+                    otherAlternativeRouteShieldColor
+            )
+    );
+  }
+}

--- a/examples/src/main/res/layout/activity_runtime_route_styling.xml
+++ b/examples/src/main/res/layout/activity_runtime_route_styling.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.mapbox.mapboxsdk.maps.MapView
+        android:id="@+id/mapView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:mapbox_cameraZoom="14"/>
+
+    <ProgressBar
+        android:id="@+id/routeLoadingProgressBar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:visibility="invisible"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/examples/src/main/res/values/strings.xml
+++ b/examples/src/main/res/values/strings.xml
@@ -82,6 +82,9 @@
     <string name="title_navigation_route_ui">Navigation Map Route</string>
     <string name="description_navigation_route_ui">An example using NavigationMapRoute</string>
 
+    <string name="title_runtime_styling">Runtime Route Styling</string>
+    <string name="description_runtime_styling">An example using RuntimeRouteStyling</string>
+
     <string name="settings" translatable="false">Settings</string>
     <string name="simulate_route" translatable="false">Simulate Route</string>
     <string name="language" translatable="false">Language</string>

--- a/libnavigation-ui/api/current.txt
+++ b/libnavigation-ui/api/current.txt
@@ -478,6 +478,8 @@ package com.mapbox.navigation.ui.map {
     method public void addProgressChangeListener(com.mapbox.navigation.core.MapboxNavigation, boolean);
     method public void adjustLocationIconWith(int[]!);
     method public void clearMarkers();
+    method public void drawIdentifiableRoute(com.mapbox.navigation.ui.route.IdentifiableRoute);
+    method public void drawIdentifiableRoutes(java.util.List<com.mapbox.navigation.ui.route.IdentifiableRoute!>);
     method public void drawRoute(com.mapbox.api.directions.v5.models.DirectionsRoute);
     method public void drawRoutes(java.util.List<? extends com.mapbox.api.directions.v5.models.DirectionsRoute>);
     method public boolean isIncidentsVisible();
@@ -591,6 +593,15 @@ package com.mapbox.navigation.ui.puck {
 
 package com.mapbox.navigation.ui.route {
 
+  public final class IdentifiableRoute {
+    ctor public IdentifiableRoute(com.mapbox.api.directions.v5.models.DirectionsRoute route, String routeIdentifier);
+    method public com.mapbox.api.directions.v5.models.DirectionsRoute component1();
+    method public String component2();
+    method public com.mapbox.navigation.ui.route.IdentifiableRoute copy(com.mapbox.api.directions.v5.models.DirectionsRoute route, String routeIdentifier);
+    method public com.mapbox.api.directions.v5.models.DirectionsRoute getRoute();
+    method public String getRouteIdentifier();
+  }
+
   public interface MapRouteLineInitializedCallback {
     method public void onInitialized(com.mapbox.navigation.ui.route.RouteLineLayerIds routeLineLayerIds);
   }
@@ -599,6 +610,8 @@ package com.mapbox.navigation.ui.route {
   }
 
   public class NavigationMapRoute implements androidx.lifecycle.LifecycleObserver {
+    method public void addIdentifiableRoute(com.mapbox.navigation.ui.route.IdentifiableRoute!);
+    method public void addIdentifiableRoutes(@Size(min=1) java.util.List<com.mapbox.navigation.ui.route.IdentifiableRoute!>);
     method public void addProgressChangeListener(com.mapbox.navigation.core.MapboxNavigation!);
     method public void addProgressChangeListener(com.mapbox.navigation.core.MapboxNavigation!, boolean);
     method public void addRoute(com.mapbox.api.directions.v5.models.DirectionsRoute!);
@@ -621,6 +634,7 @@ package com.mapbox.navigation.ui.route {
     method public com.mapbox.navigation.ui.route.NavigationMapRoute.Builder! withBelowLayer(String?);
     method public com.mapbox.navigation.ui.route.NavigationMapRoute.Builder! withMapboxNavigation(com.mapbox.navigation.core.MapboxNavigation?, boolean);
     method public com.mapbox.navigation.ui.route.NavigationMapRoute.Builder! withRouteLineInitializedCallback(com.mapbox.navigation.ui.route.MapRouteLineInitializedCallback?);
+    method public com.mapbox.navigation.ui.route.NavigationMapRoute.Builder! withRouteStyleDescriptors(java.util.List<com.mapbox.navigation.ui.route.RouteStyleDescriptor!>!);
     method public com.mapbox.navigation.ui.route.NavigationMapRoute.Builder! withStyle(@StyleRes int);
   }
 
@@ -637,6 +651,17 @@ package com.mapbox.navigation.ui.route {
     method public String getAlternativeRouteLineLayerId();
     method public String getPrimaryRouteLineLayerId();
     method public String getPrimaryRouteTrafficLineLayerId();
+  }
+
+  public final class RouteStyleDescriptor {
+    ctor public RouteStyleDescriptor(String routeIdentifier, int lineColorResourceId, int lineShieldColorResourceId);
+    method public String component1();
+    method public int component2();
+    method public int component3();
+    method public com.mapbox.navigation.ui.route.RouteStyleDescriptor copy(String routeIdentifier, int lineColorResourceId, int lineShieldColorResourceId);
+    method public int getLineColorResourceId();
+    method public int getLineShieldColorResourceId();
+    method public String getRouteIdentifier();
   }
 
 }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/internal/route/MapboxRouteLayerProvider.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/internal/route/MapboxRouteLayerProvider.kt
@@ -1,0 +1,249 @@
+package com.mapbox.navigation.ui.internal.route
+
+import android.graphics.drawable.Drawable
+import com.mapbox.mapboxsdk.maps.Style
+import com.mapbox.mapboxsdk.style.expressions.Expression
+import com.mapbox.mapboxsdk.style.expressions.Expression.color
+import com.mapbox.mapboxsdk.style.expressions.Expression.eq
+import com.mapbox.mapboxsdk.style.expressions.Expression.exponential
+import com.mapbox.mapboxsdk.style.expressions.Expression.get
+import com.mapbox.mapboxsdk.style.expressions.Expression.interpolate
+import com.mapbox.mapboxsdk.style.expressions.Expression.literal
+import com.mapbox.mapboxsdk.style.expressions.Expression.match
+import com.mapbox.mapboxsdk.style.expressions.Expression.product
+import com.mapbox.mapboxsdk.style.expressions.Expression.stop
+import com.mapbox.mapboxsdk.style.expressions.Expression.switchCase
+import com.mapbox.mapboxsdk.style.expressions.Expression.zoom
+import com.mapbox.mapboxsdk.style.layers.LineLayer
+import com.mapbox.mapboxsdk.style.layers.Property
+import com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconAllowOverlap
+import com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconIgnorePlacement
+import com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconImage
+import com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconPitchAlignment
+import com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconSize
+import com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineCap
+import com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineColor
+import com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineJoin
+import com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineWidth
+import com.mapbox.mapboxsdk.style.layers.SymbolLayer
+import com.mapbox.navigation.ui.internal.route.RouteConstants.ALTERNATIVE_ROUTE_CASING_LAYER_ID
+import com.mapbox.navigation.ui.internal.route.RouteConstants.ALTERNATIVE_ROUTE_LAYER_ID
+import com.mapbox.navigation.ui.internal.route.RouteConstants.ALTERNATIVE_ROUTE_SOURCE_ID
+import com.mapbox.navigation.ui.internal.route.RouteConstants.DEFAULT_ROUTE_DESCRIPTOR_PLACEHOLDER
+import com.mapbox.navigation.ui.internal.route.RouteConstants.DESTINATION_MARKER_NAME
+import com.mapbox.navigation.ui.internal.route.RouteConstants.ORIGIN_MARKER_NAME
+import com.mapbox.navigation.ui.internal.route.RouteConstants.PRIMARY_ROUTE_CASING_LAYER_ID
+import com.mapbox.navigation.ui.internal.route.RouteConstants.PRIMARY_ROUTE_LAYER_ID
+import com.mapbox.navigation.ui.internal.route.RouteConstants.PRIMARY_ROUTE_SOURCE_ID
+import com.mapbox.navigation.ui.internal.route.RouteConstants.PRIMARY_ROUTE_TRAFFIC_LAYER_ID
+import com.mapbox.navigation.ui.internal.route.RouteConstants.PRIMARY_ROUTE_TRAFFIC_SOURCE_ID
+import com.mapbox.navigation.ui.internal.route.RouteConstants.WAYPOINT_DESTINATION_VALUE
+import com.mapbox.navigation.ui.internal.route.RouteConstants.WAYPOINT_LAYER_ID
+import com.mapbox.navigation.ui.internal.route.RouteConstants.WAYPOINT_ORIGIN_VALUE
+import com.mapbox.navigation.ui.internal.route.RouteConstants.WAYPOINT_PROPERTY_KEY
+import com.mapbox.navigation.ui.internal.route.RouteConstants.WAYPOINT_SOURCE_ID
+import com.mapbox.navigation.ui.internal.utils.MapImageUtils
+import com.mapbox.navigation.ui.route.RouteStyleDescriptor
+
+interface MapboxRouteLayerProvider : RouteLayerProvider {
+    val routeStyleDescriptors: List<RouteStyleDescriptor>
+
+    fun getRouteLineColorExpressions(defaultColor: Int): List<Expression> {
+        val expressions = mutableListOf<Expression>(
+            eq(get(DEFAULT_ROUTE_DESCRIPTOR_PLACEHOLDER), true),
+            color(defaultColor)
+        )
+        routeStyleDescriptors.forEach {
+            expressions.add(eq(get(it.routeIdentifier), true))
+            expressions.add(color(it.lineColorResourceId))
+        }
+        return expressions.plus(color(defaultColor))
+    }
+
+    fun getRouteLineShieldColorExpressions(defaultColor: Int): List<Expression> {
+        val expressions = mutableListOf<Expression>()
+        routeStyleDescriptors.forEach {
+            expressions.add(eq(get(it.routeIdentifier), true))
+            expressions.add(color(it.lineShieldColorResourceId))
+        }
+        return expressions.plus(color(defaultColor))
+    }
+
+    fun getRouteLineWidthExpressions(scale: Float): Expression {
+        return interpolate(
+            exponential(1.5f), zoom(),
+            stop(4f, product(literal(3f), literal(scale))),
+            stop(10f, product(literal(4f), literal(scale))),
+            stop(13f, product(literal(6f), literal(scale))),
+            stop(16f, product(literal(10f), literal(scale))),
+            stop(19f, product(literal(14f), literal(scale))),
+            stop(22f, product(literal(18f), literal(scale)))
+        )
+    }
+
+    fun getShieldLineWidthExpression(scale: Float): Expression {
+        return interpolate(
+            exponential(1.5f), zoom(),
+            stop(10f, 7f),
+            stop(14f, product(literal(10.5f), literal(scale))),
+            stop(16.5f, product(literal(15.5f), literal(scale))),
+            stop(19f, product(literal(24f), literal(scale))),
+            stop(22f, product(literal(29f), literal(scale)))
+        )
+    }
+
+    override fun initializePrimaryRouteLayer(
+        style: Style,
+        roundedLineCap: Boolean,
+        scale: Float,
+        color: Int
+    ): LineLayer {
+        val lineWidthScaleExpression = getRouteLineWidthExpressions(scale)
+        val routeLineColorExpressions = getRouteLineColorExpressions(color)
+        return initializeRouteLayer(
+            style,
+            roundedLineCap,
+            PRIMARY_ROUTE_LAYER_ID,
+            PRIMARY_ROUTE_SOURCE_ID,
+            lineWidthScaleExpression,
+            routeLineColorExpressions)
+    }
+
+    override fun initializePrimaryRouteTrafficLayer(
+        style: Style,
+        roundedLineCap: Boolean,
+        scale: Float,
+        color: Int
+    ): LineLayer {
+        val lineWidthScaleExpression = getRouteLineWidthExpressions(scale)
+        val routeLineColorExpressions = getRouteLineColorExpressions(color)
+        return initializeRouteLayer(
+            style,
+            roundedLineCap,
+            PRIMARY_ROUTE_TRAFFIC_LAYER_ID,
+            PRIMARY_ROUTE_TRAFFIC_SOURCE_ID,
+            lineWidthScaleExpression,
+            routeLineColorExpressions)
+    }
+
+    override fun initializePrimaryRouteCasingLayer(
+        style: Style,
+        scale: Float,
+        color: Int
+    ): LineLayer {
+        val lineWidthScaleExpression = getShieldLineWidthExpression(scale)
+        val routeLineColorExpressions = getRouteLineShieldColorExpressions(color)
+        return initializeRouteLayer(
+            style,
+            true,
+            PRIMARY_ROUTE_CASING_LAYER_ID,
+            PRIMARY_ROUTE_SOURCE_ID,
+            lineWidthScaleExpression,
+            routeLineColorExpressions)
+    }
+
+    override fun initializeAlternativeRouteLayer(
+        style: Style,
+        roundedLineCap: Boolean,
+        scale: Float,
+        color: Int
+    ): LineLayer {
+        val lineWidthExpression = getRouteLineWidthExpressions(scale)
+        val routeLineColorExpressions = getRouteLineColorExpressions(color)
+        return initializeRouteLayer(
+            style,
+            roundedLineCap,
+            ALTERNATIVE_ROUTE_LAYER_ID,
+            ALTERNATIVE_ROUTE_SOURCE_ID,
+            lineWidthExpression,
+            routeLineColorExpressions)
+    }
+
+    override fun initializeAlternativeRouteCasingLayer(
+        style: Style,
+        scale: Float,
+        color: Int
+    ): LineLayer {
+        val lineWidthScaleExpression = getShieldLineWidthExpression(scale)
+        val routeLineColorExpressions = getRouteLineShieldColorExpressions(color)
+        return initializeRouteLayer(
+            style,
+            true,
+            ALTERNATIVE_ROUTE_CASING_LAYER_ID,
+            ALTERNATIVE_ROUTE_SOURCE_ID,
+            lineWidthScaleExpression,
+            routeLineColorExpressions)
+    }
+
+    override fun initializeWayPointLayer(
+        style: Style,
+        originIcon: Drawable,
+        destinationIcon: Drawable
+    ): SymbolLayer {
+        style.getLayerAs<SymbolLayer>(WAYPOINT_LAYER_ID)?.let {
+            style.removeLayer(WAYPOINT_LAYER_ID)
+        }
+
+        MapImageUtils.getBitmapFromDrawable(originIcon).let {
+            style.addImage(ORIGIN_MARKER_NAME, it)
+        }
+
+        MapImageUtils.getBitmapFromDrawable(destinationIcon).let {
+            style.addImage(DESTINATION_MARKER_NAME, it)
+        }
+
+        return SymbolLayer(WAYPOINT_LAYER_ID, WAYPOINT_SOURCE_ID).withProperties(
+            iconImage(
+                match(
+                    Expression.toString(get(WAYPOINT_PROPERTY_KEY)), literal(ORIGIN_MARKER_NAME),
+                    stop(WAYPOINT_ORIGIN_VALUE, literal(ORIGIN_MARKER_NAME)),
+                    stop(WAYPOINT_DESTINATION_VALUE, literal(DESTINATION_MARKER_NAME))
+                )),
+            iconSize(
+                interpolate(
+                    exponential(1.5f), zoom(),
+                    stop(0f, 0.6f),
+                    stop(10f, 0.8f),
+                    stop(12f, 1.3f),
+                    stop(22f, 2.8f)
+                )
+            ),
+            iconPitchAlignment(Property.ICON_PITCH_ALIGNMENT_MAP),
+            iconAllowOverlap(true),
+            iconIgnorePlacement(true)
+        )
+    }
+
+    private fun initializeRouteLayer(
+        style: Style,
+        roundedLineCap: Boolean,
+        layerId: String,
+        layerSourceId: String,
+        lineWidthExpression: Expression,
+        colorExpressions: List<Expression>
+    ): LineLayer {
+        style.getLayerAs<LineLayer>(layerId)?.let {
+            style.removeLayer(it)
+        }
+
+        val lineCapValue = when (roundedLineCap) {
+            true -> Property.LINE_CAP_ROUND
+            false -> Property.LINE_CAP_BUTT
+        }
+
+        val lineJoinValue = when (roundedLineCap) {
+            true -> Property.LINE_JOIN_ROUND
+            false -> Property.LINE_JOIN_BEVEL
+        }
+
+        return LineLayer(layerId, layerSourceId).withProperties(
+            lineCap(lineCapValue),
+            lineJoin(lineJoinValue),
+            lineWidth(lineWidthExpression),
+            lineColor(
+                switchCase(
+                    *colorExpressions.toTypedArray()
+            ))
+        )
+    }
+}

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/internal/route/MapboxRouteLayerProviderFactory.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/internal/route/MapboxRouteLayerProviderFactory.kt
@@ -1,0 +1,22 @@
+package com.mapbox.navigation.ui.internal.route
+
+import com.mapbox.navigation.ui.route.RouteStyleDescriptor
+
+/**
+ * An internal Mapbox factory for creating a LayerProvider used for creating the layers needed
+ * to display route line related geometry on the map.
+ */
+object MapboxRouteLayerProviderFactory {
+
+    /**
+     * Creates a MapboxRouteLayerProvider.
+     *
+     * @param routeStyleDescriptors used for programatic styling of the route lines based on a
+     * route property which can be used for overriding the color styling defined in the theme.
+     */
+    @JvmStatic
+    fun getLayerProvider(routeStyleDescriptors: List<RouteStyleDescriptor>) =
+        object : MapboxRouteLayerProvider {
+            override val routeStyleDescriptors: List<RouteStyleDescriptor> = routeStyleDescriptors
+        }
+}

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/internal/route/RouteConstants.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/internal/route/RouteConstants.java
@@ -51,4 +51,7 @@ public class RouteConstants {
   public static final double MINIMUM_ROUTE_LINE_OFFSET = .000000001;
   public static final long ROUTE_LINE_VANISH_ANIMATION_DELAY = 0;
   public static final String LAYER_ABOVE_UPCOMING_MANEUVER_ARROW = "com.mapbox.annotations.points";
+  public static final String PRIMARY_ROUTE_PROPERTY_KEY = "primary-route";
+  public static final String ALTERNATIVE_ROUTE_PROPERTY_KEY = "alternative-route";
+  public static final String DEFAULT_ROUTE_DESCRIPTOR_PLACEHOLDER = "mapboxDescriptorPlaceHolderUnused";
 }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/internal/route/RouteLayerProvider.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/internal/route/RouteLayerProvider.kt
@@ -1,0 +1,15 @@
+package com.mapbox.navigation.ui.internal.route
+
+import android.graphics.drawable.Drawable
+import com.mapbox.mapboxsdk.maps.Style
+import com.mapbox.mapboxsdk.style.layers.LineLayer
+import com.mapbox.mapboxsdk.style.layers.SymbolLayer
+
+interface RouteLayerProvider {
+    fun initializePrimaryRouteCasingLayer(style: Style, scale: Float, color: Int): LineLayer
+    fun initializeAlternativeRouteCasingLayer(style: Style, scale: Float, color: Int): LineLayer
+    fun initializePrimaryRouteLayer(style: Style, roundedLineCap: Boolean, scale: Float, color: Int): LineLayer
+    fun initializePrimaryRouteTrafficLayer(style: Style, roundedLineCap: Boolean, scale: Float, color: Int): LineLayer
+    fun initializeAlternativeRouteLayer(style: Style, roundedLineCap: Boolean, scale: Float, color: Int): LineLayer
+    fun initializeWayPointLayer(style: Style, originIcon: Drawable, destinationIcon: Drawable): SymbolLayer
+}

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/NavigationMapboxMap.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/NavigationMapboxMap.java
@@ -39,6 +39,7 @@ import com.mapbox.navigation.ui.NavigationSnapshotReadyCallback;
 import com.mapbox.navigation.ui.internal.ThemeSwitcher;
 import com.mapbox.navigation.ui.camera.Camera;
 import com.mapbox.navigation.ui.camera.NavigationCamera;
+import com.mapbox.navigation.ui.route.IdentifiableRoute;
 import com.mapbox.navigation.ui.puck.NavigationPuckPresenter;
 import com.mapbox.navigation.ui.puck.PuckDrawableSupplier;
 import com.mapbox.navigation.ui.route.NavigationMapRoute;
@@ -480,6 +481,14 @@ public class NavigationMapboxMap implements LifecycleObserver {
    */
   public void drawRoutes(@NonNull List<? extends DirectionsRoute> routes) {
     mapRoute.addRoutes(routes);
+  }
+
+  public void drawIdentifiableRoute(@NonNull IdentifiableRoute route) {
+    mapRoute.addIdentifiableRoute(route);
+  }
+
+  public void drawIdentifiableRoutes(@NonNull List<IdentifiableRoute> routes) {
+    mapRoute.addIdentifiableRoutes(routes);
   }
 
   public void onNewRouteProgress(RouteProgress routeProgress) {

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/IdentifiableRoute.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/IdentifiableRoute.kt
@@ -1,0 +1,12 @@
+package com.mapbox.navigation.ui.route
+
+import com.mapbox.api.directions.v5.models.DirectionsRoute
+
+/**
+ * A wrapper class for [DirectionsRoute] that includes an identity property that can be used
+ * to override the color of the route line.
+ *
+ * @param route a [DirectionsRoute] to associate with an identifier
+ * @param routeIdentifier the identifier for the route
+ */
+data class IdentifiableRoute(val route: DirectionsRoute, val routeIdentifier: String)

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteLine.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteLine.kt
@@ -22,7 +22,6 @@ import com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineGradient
 import com.mapbox.mapboxsdk.style.layers.SymbolLayer
 import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource
-import com.mapbox.navigation.ui.internal.route.MapRouteLayerProvider
 import com.mapbox.navigation.ui.internal.route.MapRouteSourceProvider
 import com.mapbox.navigation.ui.internal.route.RouteConstants
 import com.mapbox.navigation.ui.internal.route.RouteConstants.ALTERNATIVE_ROUTE_LAYER_ID
@@ -38,6 +37,7 @@ import com.mapbox.navigation.ui.internal.route.RouteConstants.UNKNOWN_CONGESTION
 import com.mapbox.navigation.ui.internal.route.RouteConstants.WAYPOINT_DESTINATION_VALUE
 import com.mapbox.navigation.ui.internal.route.RouteConstants.WAYPOINT_ORIGIN_VALUE
 import com.mapbox.navigation.ui.internal.route.RouteConstants.WAYPOINT_PROPERTY_KEY
+import com.mapbox.navigation.ui.internal.route.RouteLayerProvider
 import com.mapbox.navigation.ui.internal.utils.MapUtils
 import com.mapbox.navigation.ui.route.MapRouteLine.MapRouteLineSupport.buildWayPointFeatureCollection
 import com.mapbox.navigation.ui.route.MapRouteLine.MapRouteLineSupport.calculateRouteLineSegments
@@ -47,7 +47,9 @@ import com.mapbox.navigation.ui.route.MapRouteLine.MapRouteLineSupport.getBoolea
 import com.mapbox.navigation.ui.route.MapRouteLine.MapRouteLineSupport.getFloatStyledValue
 import com.mapbox.navigation.ui.route.MapRouteLine.MapRouteLineSupport.getResourceStyledValue
 import com.mapbox.navigation.ui.route.MapRouteLine.MapRouteLineSupport.getStyledColor
+import com.mapbox.navigation.ui.route.MapRouteLine.MapRouteLineSupport.swapProperties
 import com.mapbox.navigation.utils.internal.ThreadController
+import com.mapbox.navigation.utils.internal.ifNonNull
 import com.mapbox.navigation.utils.internal.parallelMap
 import com.mapbox.turf.TurfMeasurement
 import java.math.BigDecimal
@@ -74,7 +76,7 @@ internal class MapRouteLine(
     private val style: Style,
     @androidx.annotation.StyleRes styleRes: Int,
     belowLayerId: String?,
-    layerProvider: MapRouteLayerProvider,
+    layerProvider: RouteLayerProvider,
     routeFeatureDatas: List<RouteFeatureData>,
     routeExpressionData: List<RouteLineExpressionData>,
     allRoutesVisible: Boolean,
@@ -97,7 +99,7 @@ internal class MapRouteLine(
         style: Style,
         @androidx.annotation.StyleRes styleRes: Int,
         belowLayerId: String?,
-        layerProvider: MapRouteLayerProvider,
+        layerProvider: RouteLayerProvider,
         mapRouteSourceProvider: MapRouteSourceProvider,
         routeLineInitializedCallback: MapRouteLineInitializedCallback?
     ) : this(
@@ -420,22 +422,38 @@ internal class MapRouteLine(
      * @param directionsRoutes the routes to be represented on the map.
      */
     fun draw(directionsRoutes: List<DirectionsRoute>) {
-        reinitializeWithRoutes(directionsRoutes)
+        val featureDataProvider: () -> List<RouteFeatureData> =
+            getRouteFeatureDataProvider(directionsRoutes)
+        reinitializeWithRoutes(directionsRoutes, featureDataProvider)
         drawRoutes(routeFeatureData)
     }
 
-    internal fun reinitializeWithRoutes(directionsRoutes: List<DirectionsRoute>) {
+    fun drawIdentifiableRoutes(directionsRoutes: List<IdentifiableRoute>) {
+        val routes = directionsRoutes.map { it.route }
+        val featureDataProvider: () -> List<RouteFeatureData> =
+            getIdentifiableRouteFeatureDataProvider(directionsRoutes)
+        reinitializeWithRoutes(routes, featureDataProvider)
+        drawRoutes(routeFeatureData)
+    }
+
+    fun reinitializeWithRoutes(directionsRoutes: List<DirectionsRoute>) {
+        val featureDataProvider: () -> List<RouteFeatureData> =
+            getRouteFeatureDataProvider(directionsRoutes)
+        reinitializeWithRoutes(directionsRoutes, featureDataProvider)
+    }
+
+    private fun reinitializeWithRoutes(directionsRoutes: List<DirectionsRoute>, getRouteFeatureData: () -> List<RouteFeatureData>) {
         if (directionsRoutes.isNotEmpty()) {
             clearRouteData()
             this.directionsRoutes.addAll(directionsRoutes)
             primaryRoute = this.directionsRoutes.first()
             alternativesVisible = directionsRoutes.size > 1
             allLayersAreVisible = true
-            val newRouteFeatureData = directionsRoutes.parallelMap(
-                ::generateFeatureCollection,
-                ThreadController.getMainScopeAndRootJob().scope
-            )
-            routeFeatureData.addAll(newRouteFeatureData)
+
+            val newRouteFeatureData = getRouteFeatureData().also {
+                routeFeatureData.addAll(it)
+            }
+
             if (newRouteFeatureData.isNotEmpty()) {
                 updateRouteTrafficSegments(newRouteFeatureData.first())
             }
@@ -445,7 +463,7 @@ internal class MapRouteLine(
         }
     }
 
-    internal fun reinitializePrimaryRoute() {
+    fun reinitializePrimaryRoute() {
         this.routeFeatureData.firstOrNull { it.route == primaryRoute }?.let {
             drawPrimaryRoute(it)
             hideRouteLineAtOffset(vanishPointOffset)
@@ -460,6 +478,9 @@ internal class MapRouteLine(
      */
     fun updatePrimaryRouteIndex(route: DirectionsRoute): Boolean {
         return if (route != this.primaryRoute) {
+            val primaryRouteFeatures = routeFeatureData.firstOrNull { it.route == primaryRoute }?.featureCollection?.features()?.firstOrNull()
+            val newPrimaryRouteFeatures = routeFeatureData.firstOrNull { it.route == route }?.featureCollection?.features()?.firstOrNull()
+            ifNonNull(primaryRouteFeatures, newPrimaryRouteFeatures, ::swapProperties)
             this.primaryRoute = route
             drawRoutes(routeFeatureData)
             true
@@ -558,6 +579,20 @@ internal class MapRouteLine(
         }?.lineString ?: LineString.fromPolyline(route.geometry()!!, Constants.PRECISION_6)
     }
 
+    private fun getIdentifiableRouteFeatureDataProvider(directionsRoutes: List<IdentifiableRoute>): () -> List<RouteFeatureData> = {
+        directionsRoutes.parallelMap(
+            ::generateFeatureCollection,
+            ThreadController.getMainScopeAndRootJob().scope
+        )
+    }
+
+    private fun getRouteFeatureDataProvider(directionsRoutes: List<DirectionsRoute>): () -> List<RouteFeatureData> = {
+        directionsRoutes.parallelMap(
+            ::generateFeatureCollection,
+            ThreadController.getMainScopeAndRootJob().scope
+        )
+    }
+
     /**
      * Initializes the layers used for drawing routes.
      *
@@ -570,7 +605,7 @@ internal class MapRouteLine(
      */
     private fun initializeLayers(
         style: Style,
-        layerProvider: MapRouteLayerProvider,
+        layerProvider: RouteLayerProvider,
         originIcon: Drawable,
         destinationIcon: Drawable,
         belowLayerId: String
@@ -798,7 +833,7 @@ internal class MapRouteLine(
      * @param isPrimaryRoute indicates if the congestion value for the primary route should
      * be returned or the color for an alternative route.
      */
-    internal fun getRouteColorForCongestion(congestionValue: String, isPrimaryRoute: Boolean): Int {
+    fun getRouteColorForCongestion(congestionValue: String, isPrimaryRoute: Boolean): Int {
         return when (isPrimaryRoute) {
             true -> when (congestionValue) {
                 MODERATE_CONGESTION_VALUE -> routeModerateColor
@@ -992,12 +1027,31 @@ internal class MapRouteLine(
          * @return a RouteFeatureData containing the original route and a FeatureCollection and
          * LineString
          */
-        fun generateFeatureCollection(route: DirectionsRoute): RouteFeatureData {
+        fun generateFeatureCollection(route: DirectionsRoute): RouteFeatureData =
+            generateFeatureCollection(route, null)
+
+        /**
+         * Generates a FeatureCollection and LineString based on the @param route.
+         * @param route the DirectionsRoute to used to derive the result
+         *
+         * @return a RouteFeatureData containing the original route and a FeatureCollection and
+         * LineString
+         */
+        fun generateFeatureCollection(routeData: IdentifiableRoute): RouteFeatureData =
+            generateFeatureCollection(routeData.route, routeData.routeIdentifier)
+
+        private fun generateFeatureCollection(route: DirectionsRoute, identifier: String?): RouteFeatureData {
             val routeGeometry = LineString.fromPolyline(
                 route.geometry() ?: "",
                 Constants.PRECISION_6
             )
-            val routeFeature = Feature.fromGeometry(routeGeometry)
+
+            val routeFeature = when (identifier) {
+                null -> Feature.fromGeometry(routeGeometry)
+                else -> Feature.fromGeometry(routeGeometry).also {
+                    it.addBooleanProperty(identifier, true)
+                }
+            }
 
             return RouteFeatureData(
                 route,
@@ -1158,6 +1212,23 @@ internal class MapRouteLine(
                 val propValue =
                     if (index == 0) WAYPOINT_ORIGIN_VALUE else WAYPOINT_DESTINATION_VALUE
                 it.addStringProperty(WAYPOINT_PROPERTY_KEY, propValue)
+            }
+        }
+
+        fun swapProperties(featureA: Feature, featureB: Feature) {
+            val featureAProperties = featureA.properties()
+            val featureAKeySetToRemove = featureAProperties?.keySet()?.toList()
+            val featureBProperties = featureB.properties()
+            val featureBKeySetToRemove = featureBProperties?.keySet()?.toList()
+
+            featureAKeySetToRemove?.forEach { key ->
+                featureB.addBooleanProperty(key, featureAProperties[key].asBoolean)
+                featureA.removeProperty(key)
+            }
+
+            featureBKeySetToRemove?.forEach { key ->
+                featureA.addBooleanProperty(key, featureBProperties[key].asBoolean)
+                featureB.removeProperty(key)
             }
         }
     }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/RouteStyleDescriptor.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/RouteStyleDescriptor.kt
@@ -1,0 +1,11 @@
+package com.mapbox.navigation.ui.route
+
+/**
+ * This class is used for describing the route line color(s) at runtime.
+ *
+ * @param routeIdentifier a string that identifies routes which should have their color overridden
+ * @param lineColorResourceId the color of the route line
+ * @param lineShieldColorResourceId the color of the shield line which appears below the route line
+ * and is normally wider providing a visual border for the route line.
+ */
+data class RouteStyleDescriptor(val routeIdentifier: String, val lineColorResourceId: Int, val lineShieldColorResourceId: Int)

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/internal/route/MapboxRouteLayerProviderFactoryTest.kt
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/internal/route/MapboxRouteLayerProviderFactoryTest.kt
@@ -1,0 +1,17 @@
+package com.mapbox.navigation.ui.internal.route
+
+import com.mapbox.navigation.ui.route.RouteStyleDescriptor
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MapboxRouteLayerProviderFactoryTest {
+
+    @Test
+    fun getLayerProvider() {
+        val descriptors = listOf<RouteStyleDescriptor>()
+
+        val result = MapboxRouteLayerProviderFactory.getLayerProvider(descriptors)
+
+        assertEquals(descriptors, result.routeStyleDescriptors)
+    }
+}

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/internal/route/MapboxRouteLayerProviderTest.kt
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/internal/route/MapboxRouteLayerProviderTest.kt
@@ -1,0 +1,59 @@
+package com.mapbox.navigation.ui.internal.route
+
+import com.mapbox.navigation.ui.route.RouteStyleDescriptor
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MapboxRouteLayerProviderTest {
+
+    @Test
+    fun getRouteLineColorExpressions() {
+        val expectedResult = "[[\"==\", [\"get\", \"mapboxDescriptorPlaceHolderUnused\"], true], [\"rgba\", 0.0, 8.0, 73.0, 0.0], [\"==\", [\"get\", \"myRouteId\"], true], [\"rgba\", 0.0, 2.0, 43.0, 0.0], [\"==\", [\"get\", \"anotherRouteId\"], true], [\"rgba\", 0.0, 0.0, 111.0, 0.0], [\"rgba\", 0.0, 8.0, 73.0, 0.0]]"
+        val layerProvider = object : MapboxRouteLayerProvider {
+            override val routeStyleDescriptors: List<RouteStyleDescriptor> = listOf(
+                RouteStyleDescriptor("myRouteId", 555, 999),
+                RouteStyleDescriptor("anotherRouteId", 111, 222)
+            )
+        }
+
+        val result = layerProvider.getRouteLineColorExpressions(2121)
+
+        assertEquals(expectedResult, result.toString())
+    }
+
+    @Test
+    fun getRouteLineColorExpressionsWhenDescriptorsEmpty() {
+        val expectedResult = "[[\"==\", [\"get\", \"mapboxDescriptorPlaceHolderUnused\"], true], [\"rgba\", 0.0, 8.0, 73.0, 0.0], [\"rgba\", 0.0, 8.0, 73.0, 0.0]]"
+        val layerProvider = object : MapboxRouteLayerProvider {
+            override val routeStyleDescriptors: List<RouteStyleDescriptor> = listOf()
+        }
+
+        val result = layerProvider.getRouteLineColorExpressions(2121)
+
+        assertEquals(expectedResult, result.toString())
+    }
+
+    @Test
+    fun getRouteLineWidthExpressions() {
+        val expectedResult = "[\"interpolate\", [\"exponential\", 1.5], [\"zoom\"], 4.0, [\"*\", 3.0, 0.75], 10.0, [\"*\", 4.0, 0.75], 13.0, [\"*\", 6.0, 0.75], 16.0, [\"*\", 10.0, 0.75], 19.0, [\"*\", 14.0, 0.75], 22.0, [\"*\", 18.0, 0.75]]"
+        val layerProvider = object : MapboxRouteLayerProvider {
+            override val routeStyleDescriptors: List<RouteStyleDescriptor> = listOf()
+        }
+
+        val result = layerProvider.getRouteLineWidthExpressions(0.75f)
+
+        assertEquals(expectedResult, result.toString())
+    }
+
+    @Test
+    fun getShieldLineWidthExpression() {
+        val expectedResult = "[\"interpolate\", [\"exponential\", 1.5], [\"zoom\"], 10.0, 7.0, 14.0, [\"*\", 10.5, 1.0], 16.5, [\"*\", 15.5, 1.0], 19.0, [\"*\", 24.0, 1.0], 22.0, [\"*\", 29.0, 1.0]]"
+        val layerProvider = object : MapboxRouteLayerProvider {
+            override val routeStyleDescriptors: List<RouteStyleDescriptor> = listOf()
+        }
+
+        val result = layerProvider.getShieldLineWidthExpression(1f)
+
+        assertEquals(expectedResult, result.toString())
+    }
+}


### PR DESCRIPTION
## Description

Ticket https://github.com/mapbox/navigation-sdks/issues/383 refers to a ticket describing a feature to allow for fine grained styling of the route lines. 

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal

Provide for an optional feature that can allow a developer to style the routes beyond what is defined in the style making the route line styling data driven. For example coloring the alternative routes differently from each other.

### Implementation

An optional mechanism for making the route line coloring data driven which would override the styles was added. The layer provider takes advantage of the data driven line color property in maps to optionally apply an alternative color defined programatically. The NavigationMapRoute builder was modified to take an optional collection of route color descriptors which can be defined by the developer in code. When the developer adds routes to the NavigationMapRoute, the routes can be wrapped in a class which include a user defined identity. If a line has the identity property when it is drawn the defined color will be applied. If the identity is not found the line will get the default color defined in the style. No additional code is needed to opt-out of the feature.

## Screenshots or Gifs

![Screenshot_20200617-143941](https://user-images.githubusercontent.com/2249818/85075326-d7046900-b172-11ea-848e-0815f4cdcb4c.png)

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [x] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [x] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->