### PR TITLE
Make DirectionsRoute from RouteProgress non-null and only send updates when in Active Guidance

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/DebugMapboxNavigationKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/DebugMapboxNavigationKt.kt
@@ -73,12 +73,13 @@ import timber.log.Timber
  * enhanced(blue) location updates.
  */
 class DebugMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
-        VoiceInstructionsObserver {
+    VoiceInstructionsObserver {
 
     companion object {
         private const val VOICE_INSTRUCTION_CACHE = "voice-instruction-cache"
         private const val PRIMARY_ROUTE_BUNDLE_KEY = "myPrimaryRouteBundleKey"
     }
+
     private val locationEngineCallback = MyLocationEngineCallback(this)
     private val restartSessionEventChannel = Channel<RestartTripSessionAction>(1)
 
@@ -101,10 +102,10 @@ class DebugMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
         findViewById<Button>(R.id.btn_send_user_feedback)?.let { button ->
             button.setOnClickListener {
                 MapboxNavigation.postUserFeedback(
-                        FeedbackEvent.GENERAL_ISSUE,
-                        "User feedback test at: ${Date().time}",
-                        FeedbackEvent.UI,
-                        null
+                    FeedbackEvent.GENERAL_ISSUE,
+                    "User feedback test at: ${Date().time}",
+                    FeedbackEvent.UI,
+                    null
                 )
             }
         }
@@ -139,7 +140,7 @@ class DebugMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
         localLocationEngine = LocationEngineProvider.getBestLocationEngine(applicationContext)
 
         val options =
-                MapboxNavigation.defaultNavigationOptions(this, Utils.getMapboxAccessToken(this))
+            MapboxNavigation.defaultNavigationOptions(this, Utils.getMapboxAccessToken(this))
 
         val newOptions = options.toBuilder()
             .onboardRouterOptions(OnboardRouterOptions.Builder()
@@ -160,20 +161,20 @@ class DebugMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
         mapboxMap.addOnMapLongClickListener { click ->
             locationComponent?.lastKnownLocation?.let { location ->
                 mapboxNavigation.requestRoutes(
-                        RouteOptions.builder().applyDefaultParams()
-                                .accessToken(Utils.getMapboxAccessToken(applicationContext))
-                                .coordinates(location.toPoint(), null, click.toPoint())
-                                .alternatives(true)
-                                .profile(DirectionsCriteria.PROFILE_DRIVING_TRAFFIC)
-                                .build(),
-                        routesReqCallback
+                    RouteOptions.builder().applyDefaultParams()
+                        .accessToken(Utils.getMapboxAccessToken(applicationContext))
+                        .coordinates(location.toPoint(), null, click.toPoint())
+                        .alternatives(true)
+                        .profile(DirectionsCriteria.PROFILE_DRIVING_TRAFFIC)
+                        .build(),
+                    routesReqCallback
                 )
 
                 symbolManager?.deleteAll()
                 symbolManager?.create(
-                        SymbolOptions()
-                                .withIconImage("marker")
-                                .withGeometry(click.toPoint())
+                    SymbolOptions()
+                        .withIconImage("marker")
+                        .withGeometry(click.toPoint())
                 )
             }
             false
@@ -182,9 +183,9 @@ class DebugMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
         mapboxMap.setStyle(Style.MAPBOX_STREETS) { style ->
             locationComponent = mapboxMap.locationComponent.apply {
                 activateLocationComponent(
-                        LocationComponentActivationOptions.builder(this@DebugMapboxNavigationKt, style)
-                                .useDefaultLocationEngine(false)
-                                .build()
+                    LocationComponentActivationOptions.builder(this@DebugMapboxNavigationKt, style)
+                        .useDefaultLocationEngine(false)
+                        .build()
                 )
                 cameraMode = CameraMode.TRACKING
                 isLocationComponentEnabled = true
@@ -224,9 +225,9 @@ class DebugMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
     private fun initializeSpeechPlayer() {
         val cache = Cache(File(application.cacheDir, VOICE_INSTRUCTION_CACHE), 10 * 1024 * 1024)
         val voiceInstructionLoader =
-                VoiceInstructionLoader(application, Mapbox.getAccessToken(), cache)
+            VoiceInstructionLoader(application, Mapbox.getAccessToken(), cache)
         val speechPlayerProvider =
-                SpeechPlayerProvider(application, Locale.US.language, true, voiceInstructionLoader)
+            SpeechPlayerProvider(application, Locale.US.language, true, voiceInstructionLoader)
         speechPlayer = NavigationSpeechPlayer(speechPlayerProvider)
     }
 
@@ -246,14 +247,14 @@ class DebugMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
 
     private fun startLocationUpdates() {
         val request = LocationEngineRequest.Builder(1000L)
-                .setFastestInterval(500L)
-                .setPriority(LocationEngineRequest.PRIORITY_HIGH_ACCURACY)
-                .build()
+            .setFastestInterval(500L)
+            .setPriority(LocationEngineRequest.PRIORITY_HIGH_ACCURACY)
+            .build()
         try {
             localLocationEngine.requestLocationUpdates(
-                    request,
-                    locationEngineCallback,
-                    Looper.getMainLooper()
+                request,
+                locationEngineCallback,
+                Looper.getMainLooper()
             )
             localLocationEngine.getLastLocation(locationEngineCallback)
         } catch (exception: SecurityException) {
@@ -268,9 +269,7 @@ class DebugMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
     private val routeProgressObserver = object : RouteProgressObserver {
         override fun onRouteProgressChanged(routeProgress: RouteProgress) {
             Timber.d("route progress %s", routeProgress.toString())
-            if (routeProgress.route != null) {
-                navigationMapboxMap.onNewRouteProgress(routeProgress)
-            }
+            navigationMapboxMap.onNewRouteProgress(routeProgress)
         }
     }
 
@@ -279,7 +278,7 @@ class DebugMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
             navigationMapboxMap.drawRoutes(routes)
             if (routes.isEmpty()) {
                 Toast.makeText(this@DebugMapboxNavigationKt, "Empty routes", Toast.LENGTH_SHORT)
-                        .show()
+                    .show()
             } else {
                 if (mapboxNavigation.getTripSessionState() == TripSessionState.STARTED) {
                     initDynamicCamera(routes[0])
@@ -411,7 +410,7 @@ class DebugMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
     }
 
     private class MyLocationEngineCallback(activity: DebugMapboxNavigationKt) :
-            LocationEngineCallback<LocationEngineResult> {
+        LocationEngineCallback<LocationEngineResult> {
 
         private val activityRef = WeakReference(activity)
 
@@ -430,9 +429,9 @@ class DebugMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
     private fun getMapboxNavigation(options: NavigationOptions): MapboxNavigation {
         return if (shouldSimulateRoute()) {
             return MapboxNavigation(
-                    applicationContext,
-                    navigationOptions = options,
-                    locationEngine = ReplayLocationEngine(mapboxReplayer)
+                applicationContext,
+                navigationOptions = options,
+                locationEngine = ReplayLocationEngine(mapboxReplayer)
             ).apply {
                 registerRouteProgressObserver(ReplayProgressObserver(mapboxReplayer))
                 mapboxReplayer.pushRealLocation(this@DebugMapboxNavigationKt, 0.0)
@@ -440,15 +439,15 @@ class DebugMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
             }
         } else {
             MapboxNavigation(
-                    applicationContext,
-                    navigationOptions = options
+                applicationContext,
+                navigationOptions = options
             )
         }
     }
 
     private fun shouldSimulateRoute(): Boolean {
         return PreferenceManager.getDefaultSharedPreferences(this.applicationContext)
-                .getBoolean(this.getString(R.string.simulate_route_key), false)
+            .getBoolean(this.getString(R.string.simulate_route_key), false)
     }
 
     private fun updateCameraOnNavigationStateChange(

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/SimpleMapboxNavigationKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/SimpleMapboxNavigationKt.kt
@@ -272,9 +272,7 @@ class SimpleMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
     private val routeProgressObserver = object : RouteProgressObserver {
         override fun onRouteProgressChanged(routeProgress: RouteProgress) {
             Timber.d("route progress %s", routeProgress.toString())
-            if (routeProgress.route != null) {
-                navigationMapboxMap.onNewRouteProgress(routeProgress)
-            }
+            navigationMapboxMap.onNewRouteProgress(routeProgress)
         }
     }
 

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/TripServiceActivityKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/TripServiceActivityKt.kt
@@ -14,9 +14,6 @@ import com.mapbox.navigation.base.TimeFormat.TWENTY_FOUR_HOURS
 import com.mapbox.navigation.base.internal.VoiceUnit.METRIC
 import com.mapbox.navigation.base.internal.extensions.inferDeviceLocale
 import com.mapbox.navigation.base.options.NavigationOptions
-import com.mapbox.navigation.base.trip.model.RouteLegProgress
-import com.mapbox.navigation.base.trip.model.RouteProgress
-import com.mapbox.navigation.base.trip.model.RouteStepProgress
 import com.mapbox.navigation.base.trip.notification.NotificationAction
 import com.mapbox.navigation.core.Rounding
 import com.mapbox.navigation.core.internal.MapboxDistanceFormatter
@@ -183,17 +180,7 @@ class TripServiceActivityKt : AppCompatActivity(), OnMapReadyCallback {
             while (isActive) {
                 val text = "Time elapsed: + ${SystemClock.elapsedRealtime()}"
                 notifyTextView.text = text
-                mapboxTripService.updateNotification(
-                    RouteProgress.Builder()
-                        .currentLegProgress(
-                            RouteLegProgress.Builder()
-                                .currentStepProgress(
-                                    RouteStepProgress.Builder()
-                                        .distanceRemaining(100f)
-                                        .build()
-                                ).build()
-                        ).build()
-                )
+                mapboxTripService.updateNotification(null)
                 Timber.i(text)
                 delay(1000L)
             }

--- a/libnavigation-base/api/current.txt
+++ b/libnavigation-base/api/current.txt
@@ -216,8 +216,8 @@ package com.mapbox.navigation.base.trip.model {
   }
 
   public final class RouteProgress {
-    ctor public RouteProgress(com.mapbox.api.directions.v5.models.DirectionsRoute? route, com.mapbox.geojson.Geometry? routeGeometryWithBuffer, com.mapbox.api.directions.v5.models.BannerInstructions? bannerInstructions, com.mapbox.api.directions.v5.models.VoiceInstructions? voiceInstructions, com.mapbox.navigation.base.trip.model.RouteProgressState currentState, com.mapbox.navigation.base.trip.model.RouteLegProgress? currentLegProgress, java.util.List<com.mapbox.geojson.Point>? upcomingStepPoints, boolean inTunnel, float distanceRemaining, float distanceTraveled, double durationRemaining, float fractionTraveled, int remainingWaypoints);
-    method public com.mapbox.api.directions.v5.models.DirectionsRoute? component1();
+    ctor public RouteProgress(com.mapbox.api.directions.v5.models.DirectionsRoute route, com.mapbox.geojson.Geometry? routeGeometryWithBuffer, com.mapbox.api.directions.v5.models.BannerInstructions? bannerInstructions, com.mapbox.api.directions.v5.models.VoiceInstructions? voiceInstructions, com.mapbox.navigation.base.trip.model.RouteProgressState currentState, com.mapbox.navigation.base.trip.model.RouteLegProgress? currentLegProgress, java.util.List<com.mapbox.geojson.Point>? upcomingStepPoints, boolean inTunnel, float distanceRemaining, float distanceTraveled, double durationRemaining, float fractionTraveled, int remainingWaypoints);
+    method public com.mapbox.api.directions.v5.models.DirectionsRoute component1();
     method public float component10();
     method public double component11();
     method public float component12();
@@ -230,7 +230,7 @@ package com.mapbox.navigation.base.trip.model {
     method public java.util.List<com.mapbox.geojson.Point>? component7();
     method public boolean component8();
     method public float component9();
-    method public com.mapbox.navigation.base.trip.model.RouteProgress copy(com.mapbox.api.directions.v5.models.DirectionsRoute? route, com.mapbox.geojson.Geometry? routeGeometryWithBuffer, com.mapbox.api.directions.v5.models.BannerInstructions? bannerInstructions, com.mapbox.api.directions.v5.models.VoiceInstructions? voiceInstructions, com.mapbox.navigation.base.trip.model.RouteProgressState currentState, com.mapbox.navigation.base.trip.model.RouteLegProgress? currentLegProgress, java.util.List<com.mapbox.geojson.Point>? upcomingStepPoints, boolean inTunnel, float distanceRemaining, float distanceTraveled, double durationRemaining, float fractionTraveled, int remainingWaypoints);
+    method public com.mapbox.navigation.base.trip.model.RouteProgress copy(com.mapbox.api.directions.v5.models.DirectionsRoute route, com.mapbox.geojson.Geometry? routeGeometryWithBuffer, com.mapbox.api.directions.v5.models.BannerInstructions? bannerInstructions, com.mapbox.api.directions.v5.models.VoiceInstructions? voiceInstructions, com.mapbox.navigation.base.trip.model.RouteProgressState currentState, com.mapbox.navigation.base.trip.model.RouteLegProgress? currentLegProgress, java.util.List<com.mapbox.geojson.Point>? upcomingStepPoints, boolean inTunnel, float distanceRemaining, float distanceTraveled, double durationRemaining, float fractionTraveled, int remainingWaypoints);
     method public com.mapbox.api.directions.v5.models.BannerInstructions? getBannerInstructions();
     method public com.mapbox.navigation.base.trip.model.RouteLegProgress? getCurrentLegProgress();
     method public com.mapbox.navigation.base.trip.model.RouteProgressState getCurrentState();
@@ -240,7 +240,7 @@ package com.mapbox.navigation.base.trip.model {
     method public float getFractionTraveled();
     method public boolean getInTunnel();
     method public int getRemainingWaypoints();
-    method public com.mapbox.api.directions.v5.models.DirectionsRoute? getRoute();
+    method public com.mapbox.api.directions.v5.models.DirectionsRoute getRoute();
     method public com.mapbox.geojson.Geometry? getRouteGeometryWithBuffer();
     method public java.util.List<com.mapbox.geojson.Point>? getUpcomingStepPoints();
     method public com.mapbox.api.directions.v5.models.VoiceInstructions? getVoiceInstructions();
@@ -321,7 +321,7 @@ package com.mapbox.navigation.base.trip.notification {
     method public int getNotificationId();
     method public void onTripSessionStarted();
     method public void onTripSessionStopped();
-    method public void updateNotification(com.mapbox.navigation.base.trip.model.RouteProgress routeProgress);
+    method public void updateNotification(com.mapbox.navigation.base.trip.model.RouteProgress? routeProgress);
   }
 
 }

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteProgress.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteProgress.kt
@@ -38,7 +38,7 @@ import com.mapbox.geojson.Point
  * @param remainingWaypoints [Int] number of waypoints remaining on the current route.
  */
 data class RouteProgress(
-    val route: DirectionsRoute?,
+    val route: DirectionsRoute,
     val routeGeometryWithBuffer: Geometry?,
     val bannerInstructions: BannerInstructions?,
     val voiceInstructions: VoiceInstructions?,
@@ -72,6 +72,8 @@ data class RouteProgress(
 
         /**
          * [DirectionsRoute] currently is used for the navigation session
+         *
+         * This is required in order to build a [RouteProgress]
          *
          * @return Builder
          */
@@ -184,10 +186,11 @@ data class RouteProgress(
          * Build new instance of [RouteProgress]
          *
          * @return RouteProgress
+         * @throws IllegalStateException if [DirectionsRoute] is not provided
          */
         fun build(): RouteProgress {
             return RouteProgress(
-                directionsRoute,
+                requireNotNull(directionsRoute) { "DirectionsRoute is required to build a RouteProgress." },
                 routeGeometryWithBuffer,
                 bannerInstructions,
                 voiceInstructions,

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/notification/TripNotification.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/notification/TripNotification.kt
@@ -36,7 +36,7 @@ interface TripNotification {
      *
      * @param routeProgress with the latest progress data
      */
-    fun updateNotification(routeProgress: RouteProgress)
+    fun updateNotification(routeProgress: RouteProgress?)
 
     /**
      * Callback for when trip session is started via [TripSession.start].

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -681,7 +681,8 @@ constructor(
             @FeedbackEvent.Source feedbackSource: String,
             screenshot: String?,
             feedbackSubType: Array<String>? = emptyArray()
-        ) { MapboxNavigationTelemetry.postUserFeedback(
+        ) {
+            MapboxNavigationTelemetry.postUserFeedback(
                 feedbackType,
                 description,
                 feedbackSource,

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/arrival/ArrivalProgressObserver.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/arrival/ArrivalProgressObserver.kt
@@ -64,7 +64,7 @@ internal class ArrivalProgressObserver(
 
     private fun hasMoreLegs(routeProgress: RouteProgress): Boolean {
         val currentLegIndex = routeProgress.currentLegProgress?.legIndex
-        val lastLegIndex = routeProgress.route?.legs()?.lastIndex
+        val lastLegIndex = routeProgress.route.legs()?.lastIndex
         return (currentLegIndex != null && lastLegIndex != null) && currentLegIndex < lastLegIndex
     }
 

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/trip/service/MapboxTripService.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/trip/service/MapboxTripService.kt
@@ -132,7 +132,7 @@ class MapboxTripService(
     /**
      * Update the trip's information in the notification bar
      */
-    override fun updateNotification(routeProgress: RouteProgress) {
+    override fun updateNotification(routeProgress: RouteProgress?) {
         tripNotification.updateNotification(routeProgress)
     }
 

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/trip/service/TripService.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/trip/service/TripService.kt
@@ -24,7 +24,7 @@ interface TripService {
     /**
      * Update the trip's information in the notification bar
      */
-    fun updateNotification(routeProgress: RouteProgress)
+    fun updateNotification(routeProgress: RouteProgress?)
 
     /**
      * Return *true* if service is started

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/trip/session/MapboxTripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/trip/session/MapboxTripSession.kt
@@ -448,18 +448,20 @@ class MapboxTripSession(
         locationObservers.forEach { it.onEnhancedLocationChanged(location, keyPoints) }
     }
 
-    private fun updateRouteProgress(progress: RouteProgress) {
+    private fun updateRouteProgress(progress: RouteProgress?) {
         routeProgress = progress
         tripService.updateNotification(progress)
-        routeProgressObservers.forEach { it.onRouteProgressChanged(progress) }
-        checkBannerInstructionEvent(progress) { bannerInstruction ->
-            bannerInstructionsObservers.forEach {
-                it.onNewBannerInstructions(bannerInstruction)
+        progress?.let {
+            routeProgressObservers.forEach { it.onRouteProgressChanged(progress) }
+            checkBannerInstructionEvent(progress) { bannerInstruction ->
+                bannerInstructionsObservers.forEach {
+                    it.onNewBannerInstructions(bannerInstruction)
+                }
             }
-        }
-        checkVoiceInstructionEvent(progress) { voiceInstruction ->
-            voiceInstructionsObservers.forEach {
-                it.onNewVoiceInstructions(voiceInstruction)
+            checkVoiceInstructionEvent(progress) { voiceInstruction ->
+                voiceInstructionsObservers.forEach {
+                    it.onNewVoiceInstructions(voiceInstruction)
+                }
             }
         }
     }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetry.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetry.kt
@@ -628,7 +628,7 @@ internal object MapboxNavigationTelemetry : MapboxNavigationTelemetryInterface {
             sessionIdentifier = dynamicValues.sessionId
             tripIdentifier = dynamicValues.tripIdentifier.get()
             originalRequestIdentifier = callbackDispatcher.getOriginalRouteReadOnly()?.route?.routeOptions()?.requestUuid()
-            requestIdentifier = callbackDispatcher.getRouteProgress().routeProgress.route?.routeOptions()?.requestUuid()
+            requestIdentifier = callbackDispatcher.getRouteProgress().routeProgress.route.routeOptions()?.requestUuid()
             mockLocation = locationEngineName == MOCK_PROVIDER
             rerouteCount = dynamicValues.rerouteCount.get()
             startTimestamp = dynamicValues.sessionStartTime
@@ -645,10 +645,10 @@ internal object MapboxNavigationTelemetry : MapboxNavigationTelemetryInterface {
         navigationEvent.startTimestamp = TelemetryUtils.generateCreateDateFormatted(dynamicValues.sessionStartTime)
         navigationEvent.sdkIdentifier = generateSdkIdentifier()
         navigationEvent.sessionIdentifier = dynamicValues.sessionId
-        navigationEvent.geometry = callbackDispatcher.getRouteProgress().routeProgress.route?.geometry()
-        navigationEvent.profile = callbackDispatcher.getRouteProgress().routeProgress.route?.routeOptions()?.profile()
+        navigationEvent.geometry = callbackDispatcher.getRouteProgress().routeProgress.route.geometry()
+        navigationEvent.profile = callbackDispatcher.getRouteProgress().routeProgress.route.routeOptions()?.profile()
         navigationEvent.originalRequestIdentifier = callbackDispatcher.getOriginalRouteReadOnly()?.route?.routeOptions()?.requestUuid()
-        navigationEvent.requestIdentifier = callbackDispatcher.getRouteProgress().routeProgress.route?.routeOptions()?.requestUuid()
+        navigationEvent.requestIdentifier = callbackDispatcher.getRouteProgress().routeProgress.route.routeOptions()?.requestUuid()
         navigationEvent.originalGeometry = callbackDispatcher.getOriginalRouteReadOnly()?.route?.geometry()
         navigationEvent.locationEngine = locationEngineNameExternal
         navigationEvent.tripIdentifier = TelemetryUtils.obtainUniversalUniqueIdentifier()
@@ -669,8 +669,8 @@ internal object MapboxNavigationTelemetry : MapboxNavigationTelemetryInterface {
         navigationEvent.originalEstimatedDuration = callbackDispatcher.getOriginalRouteReadOnly()?.route?.duration()?.toInt() ?: 0
         navigationEvent.stepCount = obtainStepCount(callbackDispatcher.getRouteProgress().routeProgress.route)
         navigationEvent.originalStepCount = obtainStepCount(callbackDispatcher.getOriginalRouteReadOnly()?.route)
-        navigationEvent.legIndex = callbackDispatcher.getRouteProgress().routeProgress.route?.routeIndex()?.toInt() ?: 0
-        navigationEvent.legCount = callbackDispatcher.getRouteProgress().routeProgress.route?.legs()?.size ?: 0
+        navigationEvent.legIndex = callbackDispatcher.getRouteProgress().routeProgress.route.routeIndex()?.toInt() ?: 0
+        navigationEvent.legCount = callbackDispatcher.getRouteProgress().routeProgress.route.legs()?.size ?: 0
         navigationEvent.stepIndex = callbackDispatcher.getRouteProgress().routeProgress.currentLegProgress?.currentStepProgress?.stepIndex ?: 0
 
         // TODO:OZ voiceIndex is not available in SDK 1.0 and was not set in the legacy telemetry        navigationEvent.voiceIndex

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/TelemetryLocationAndProgressDispatcher.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/TelemetryLocationAndProgressDispatcher.kt
@@ -30,7 +30,7 @@ internal class TelemetryLocationAndProgressDispatcher(scope: CoroutineScope) :
     RouteProgressObserver, LocationObserver, RoutesObserver, OffRouteObserver {
     private var lastLocation: AtomicReference<Location?> = AtomicReference(null)
     private var routeProgress: AtomicReference<RouteProgressWithTimestamp> =
-        AtomicReference(RouteProgressWithTimestamp(0, RouteProgress.Builder().build()))
+        AtomicReference(RouteProgressWithTimestamp(0, RouteProgress.Builder().route(DirectionsRoute.builder().build()).build()))
     private val channelOffRouteEvent = Channel<Boolean>(Channel.CONFLATED)
     private val channelNewRouteAvailable = Channel<RouteAvailable>(Channel.CONFLATED)
     private val channelLocationReceived = Channel<Location>(Channel.CONFLATED)

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/MapOfflineManager.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/MapOfflineManager.java
@@ -53,6 +53,7 @@ class MapOfflineManager implements RouteProgressObserver {
     Geometry currentRouteGeometry = routeProgress.getRouteGeometryWithBuffer();
     if (previousRouteGeometry == null || !previousRouteGeometry.equals(currentRouteGeometry)) {
       previousRouteGeometry = currentRouteGeometry;
+      // TODO Method invocation 'requestUuid' may produce 'NullPointerException'
       String routeSummary = routeProgress.getRoute().routeOptions().requestUuid();
       download(routeSummary, previousRouteGeometry, regionDownloadCallback);
     }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteProgressChangeListener.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteProgressChangeListener.kt
@@ -78,10 +78,10 @@ internal class MapRouteProgressChangeListener(
             routeArrow.addUpcomingManeuverArrow(routeProgress)
         }
         val currentRoute = routeProgress.route
-        val hasGeometry = currentRoute?.geometry()?.isNotEmpty() ?: false
+        val hasGeometry = currentRoute.geometry()?.isNotEmpty() ?: false
         if (hasGeometry && currentRoute != directionsRoute) {
             vanishingLineAnimator?.cancel()
-            routeLine.draw(currentRoute!!)
+            routeLine.draw(currentRoute)
             this.lastDistanceValue = routeLine.vanishPointOffset
         } else {
             // if there is no geometry then the session is in free drive and the vanishing

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/summary/SummaryModel.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/summary/SummaryModel.java
@@ -3,17 +3,15 @@ package com.mapbox.navigation.ui.summary;
 import android.content.Context;
 import android.text.SpannableStringBuilder;
 import android.text.format.DateFormat;
-
-import com.mapbox.navigation.base.internal.extensions.LocaleEx;
-import com.mapbox.navigation.base.formatter.DistanceFormatter;
-import com.mapbox.navigation.base.trip.model.RouteProgress;
 import com.mapbox.navigation.base.TimeFormat;
+import com.mapbox.navigation.base.formatter.DistanceFormatter;
+import com.mapbox.navigation.base.internal.extensions.LocaleEx;
+import com.mapbox.navigation.base.trip.model.RouteProgress;
 import com.mapbox.navigation.trip.notification.internal.TimeFormatter;
+import timber.log.Timber;
 
 import java.util.Calendar;
 import java.util.Locale;
-
-import timber.log.Timber;
 
 public class SummaryModel {
 
@@ -23,9 +21,9 @@ public class SummaryModel {
 
   public SummaryModel(final Context context, final DistanceFormatter distanceFormatter, final RouteProgress progress,
                       final @TimeFormat.Type int timeFormatType) {
-    final Locale locale = progress.getRoute() == null ? null :
-      LocaleEx.getLocaleDirectionsRoute(progress.getRoute(), context);
+    final Locale locale = LocaleEx.getLocaleDirectionsRoute(progress.getRoute(), context);
     distanceRemaining = distanceFormatter.formatDistance(progress.getDistanceRemaining()).toString();
+    // TODO Method invocation 'getDurationRemaining' may produce 'NullPointerException'
     final double legDurationRemaining = progress.getCurrentLegProgress().getDurationRemaining();
     timeRemaining = TimeFormatter.formatTimeRemaining(context, legDurationRemaining, locale);
     final Calendar time = Calendar.getInstance();

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/camera/DynamicCameraTest.java
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/camera/DynamicCameraTest.java
@@ -25,9 +25,8 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -50,7 +49,7 @@ public class DynamicCameraTest extends BaseTest {
 
     double zoom = cameraEngine.zoom(routeInformation);
 
-    assertEquals(15d, zoom);
+    assertEquals(15d, zoom, 0.1);
   }
 
   @Test
@@ -61,7 +60,7 @@ public class DynamicCameraTest extends BaseTest {
 
     double defaultZoom = theCameraEngine.zoom(anyRouteInformation);
 
-    assertEquals(15d, defaultZoom);
+    assertEquals(15d, defaultZoom, 0.1);
   }
 
   @Test
@@ -77,7 +76,7 @@ public class DynamicCameraTest extends BaseTest {
 
     double maxCameraZoom = theCameraEngine.zoom(anyRouteInformation);
 
-    assertEquals(16d, maxCameraZoom);
+    assertEquals(16d, maxCameraZoom, 0.1);
   }
 
   @Test
@@ -93,7 +92,7 @@ public class DynamicCameraTest extends BaseTest {
 
     double maxCameraZoom = theCameraEngine.zoom(anyRouteInformation);
 
-    assertEquals(12d, maxCameraZoom);
+    assertEquals(12d, maxCameraZoom, 0.1);
   }
 
   @Test
@@ -109,7 +108,7 @@ public class DynamicCameraTest extends BaseTest {
 
     double maxCameraZoom = theCameraEngine.zoom(anyRouteInformation);
 
-    assertEquals(14d, maxCameraZoom);
+    assertEquals(14d, maxCameraZoom, 0.1);
   }
 
   @Test
@@ -120,7 +119,7 @@ public class DynamicCameraTest extends BaseTest {
 
     double zoom = cameraEngine.zoom(routeInformation);
 
-    assertEquals(15d, zoom);
+    assertEquals(15d, zoom, 0.1);
   }
 
   @Test
@@ -130,7 +129,7 @@ public class DynamicCameraTest extends BaseTest {
 
     double tilt = cameraEngine.tilt(routeInformation);
 
-    assertEquals(50d, tilt);
+    assertEquals(50d, tilt, 0.1);
   }
 
   @Test
@@ -141,7 +140,7 @@ public class DynamicCameraTest extends BaseTest {
 
     double tilt = cameraEngine.tilt(routeInformation);
 
-    assertEquals(60d, tilt);
+    assertEquals(60d, tilt, 0.1);
   }
 
   @Test
@@ -152,7 +151,7 @@ public class DynamicCameraTest extends BaseTest {
 
     double tilt = cameraEngine.tilt(routeInformation);
 
-    assertEquals(45d, tilt);
+    assertEquals(45d, tilt, 0.1);
   }
 
   @Test
@@ -163,7 +162,7 @@ public class DynamicCameraTest extends BaseTest {
 
     double tilt = cameraEngine.tilt(routeInformation);
 
-    assertEquals(45d, tilt);
+    assertEquals(45d, tilt, 0.1);
   }
 
   @Test
@@ -197,7 +196,7 @@ public class DynamicCameraTest extends BaseTest {
 
     List<Point> overviewPoints = cameraEngine.overview(routeInformation);
 
-    assertTrue(overviewPoints.isEmpty());
+    assertEquals(true, overviewPoints.isEmpty());
   }
 
   @Nullable
@@ -241,7 +240,7 @@ public class DynamicCameraTest extends BaseTest {
   }
 
   private List<Point> generateRouteCoordinates(DirectionsRoute route) {
-    if (route == null) {
+    if (route.geometry() == null) {
       return Collections.emptyList();
     }
     LineString lineString = LineString.fromPolyline(route.geometry(), Constants.PRECISION_6);

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteProgressChangeListenerTest.kt
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteProgressChangeListenerTest.kt
@@ -68,9 +68,10 @@ class MapRouteProgressChangeListenerTest {
 
     @Test
     fun `should not draw route without directions route`() {
+        val routeWithNoGeometry = DirectionsRoute.builder().build()
         every { routeLine.getPrimaryRoute() } returns null
         val routeProgress: RouteProgress = mockk {
-            every { route } returns null
+            every { route } returns routeWithNoGeometry
         }
 
         progressChangeListener.onRouteProgressChanged(routeProgress)

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/NavigationMapRouteTest.java
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/NavigationMapRouteTest.java
@@ -16,11 +16,7 @@ import edu.emory.mathcs.backport.java.util.Collections;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class NavigationMapRouteTest {
 
@@ -412,7 +408,7 @@ public class NavigationMapRouteTest {
             mockedProgressChangeListener, mockedMapRouteLine, mockedMapRouteArrow);
 
     theNavigationMapRoute.onStart();
-    theNavigationMapRoute.onNewRouteProgress(mock(RouteProgress.class));
+    theNavigationMapRoute.onNewRouteProgress(mock(RouteProgress.class, RETURNS_DEEP_STUBS));
 
     verify(mockedProgressChangeListener, never()).onRouteProgressChanged(any());
   }

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/TripStatus.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/TripStatus.kt
@@ -16,6 +16,6 @@ import com.mapbox.navigation.base.trip.model.RouteProgress
 data class TripStatus(
     val enhancedLocation: Location,
     val keyPoints: List<Location>,
-    val routeProgress: RouteProgress,
+    val routeProgress: RouteProgress?,
     val offRoute: Boolean
 )

--- a/libtrip-notification/api/current.txt
+++ b/libtrip-notification/api/current.txt
@@ -9,7 +9,7 @@ package com.mapbox.navigation.trip.notification {
     method public int getNotificationId();
     method public void onTripSessionStarted();
     method public void onTripSessionStopped();
-    method public void updateNotification(com.mapbox.navigation.base.trip.model.RouteProgress routeProgress);
+    method public void updateNotification(com.mapbox.navigation.base.trip.model.RouteProgress? routeProgress);
     property public final String? currentManeuverModifier;
     property public final String? currentManeuverType;
     field public static final com.mapbox.navigation.trip.notification.MapboxTripNotification.Companion! Companion;

--- a/libtrip-notification/src/main/java/com/mapbox/navigation/trip/notification/MapboxTripNotification.kt
+++ b/libtrip-notification/src/main/java/com/mapbox/navigation/trip/notification/MapboxTripNotification.kt
@@ -145,7 +145,7 @@ class MapboxTripNotification constructor(
      *
      * @param routeProgress with the latest progress data
      */
-    override fun updateNotification(routeProgress: RouteProgress) {
+    override fun updateNotification(routeProgress: RouteProgress?) {
         // RemoteView has an internal mActions, which stores every change and cannot be cleared.
         // As we set new bitmaps, the mActions parcelable size will grow and eventually cause a crash.
         // buildRemoteViews() will rebuild the RemoteViews and clear the stored mActions.
@@ -296,8 +296,8 @@ class MapboxTripNotification constructor(
         }
     }
 
-    private fun updateNotificationViews(routeProgress: RouteProgress) {
-        routeProgress.route?.let {
+    private fun updateNotificationViews(routeProgress: RouteProgress?) {
+        routeProgress?.let {
             updateInstructionText(routeProgress.bannerInstructions)
             updateDistanceText(routeProgress)
             generateArrivalTime(routeProgress)?.let { formattedTime ->

--- a/libtrip-notification/src/test/java/com/mapbox/navigation/trip/notification/MapboxTripNotificationTest.kt
+++ b/libtrip-notification/src/test/java/com/mapbox/navigation/trip/notification/MapboxTripNotificationTest.kt
@@ -329,12 +329,11 @@ class MapboxTripNotificationTest {
 
     @Test
     fun whenFreeDrive() {
-        val routeProgress = mockk<RouteProgress>(relaxed = true)
-        every { routeProgress.route } returns null
+        val nullRouteProgress = null
         mockUpdateNotificationAndroidInteractions()
 
         notification.onTripSessionStarted()
-        notification.updateNotification(routeProgress)
+        notification.updateNotification(nullRouteProgress)
 
         verify(exactly = 0) { expandedViews.setTextViewText(any(), END_NAVIGATION) }
         verify(exactly = 1) { expandedViews.setTextViewText(any(), STOP_SESSION) }


### PR DESCRIPTION
## Description

As part of the segregation of the progress interfaces we're planning to do (`RouteProgress` updates will not be delivered if there's no route present) this PR makes `DirectionsRoute` from `RouteProgress` non-null and implements sending `RouteProgress` updates only when in _Active Guidance_

Refs. https://github.com/mapbox/mapbox-navigation-android/pull/3192

Refs. [Null References: The Billion Dollar Mistake](https://www.infoq.com/presentations/Null-References-The-Billion-Dollar-Mistake-Tony-Hoare)

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Long term goal as above-mentioned is to report `RouteProgress` to clients only when in _Active Guidance_, since in _Free Drive_ it's uninitialized and requires unnecessary null checks / extra logic

### Implementation

Refactor `DirectionsRoute` from `RouteProgress` to be non-null ~implementing [Null Object](https://sourcemaking.com/design_patterns/null_object) / empty Design pattern `DirectionsRoute.builder().build()` and~ adapt the code accordingly (remove unnecessary `null` checks and `?.` and `?:`) and send `RouteProgress` updates only when in _Active Guidance_

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [x] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs

These are the errors reported by Metalava before updating `current.txt` 👀 

~src/main/java/com/mapbox/navigation/base/trip/model/RouteProgress.kt:41: error: Attempted to change parameter from @Nullable to @NonNull: incompatible change for parameter route in com.mapbox.navigation.base.trip.model.RouteProgress(com.mapbox.api.directions.v5.models.DirectionsRoute route, com.mapbox.geojson.Geometry routeGeometryWithBuffer, com.mapbox.api.directions.v5.models.BannerInstructions bannerInstructions, com.mapbox.api.directions.v5.models.VoiceInstructions voiceInstructions, com.mapbox.navigation.base.trip.model.RouteProgressState currentState, com.mapbox.navigation.base.trip.model.RouteLegProgress currentLegProgress, java.util.List<com.mapbox.geojson.Point> upcomingStepPoints, boolean inTunnel, float distanceRemaining, float distanceTraveled, double durationRemaining, float fractionTraveled, int remainingWaypoints) [InvalidNullConversion]
src/main/java/com/mapbox/navigation/base/trip/model/RouteProgress.kt:1: error: AAborting: Found compatibility problems checking the public API (/Users/pabloguardiola/mapbox/mapbox-navigation-android/libnavigation-base/src/main/java) against the API in /Users/pabloguardiola/mapbox/mapbox-navigation-android/libnavigation-base/api/current.txtBuffer, com.mapbox.api.directions.v5.models.BannerInstructions bannerInstructions, com.mapbox.api.directions.v5.models.VoiceInstructions~

```
> Task :libnavigation-base:checkApi

src/main/java/com/mapbox/navigation/base/trip/model/RouteProgress.kt:41: error: Attempted to change parameter from @Nullable to @NonNull: incompatible change for parameter route in com.mapbox.navigation.base.trip.model.RouteProgress(com.mapbox.api.directions.v5.models.DirectionsRoute route, com.mapbox.geojson.Geometry routeGeometryWithBuffer, com.mapbox.api.directions.v5.models.BannerInstructions bannerInstructions, com.mapbox.api.directions.v5.models.VoiceInstructions voiceInstructions, com.mapbox.navigation.base.trip.model.RouteProgressState currentState, com.mapbox.navigation.base.trip.model.RouteLegProgress currentLegProgress, java.util.List<com.mapbox.geojson.Point> upcomingStepPoints, boolean inTunnel, float distanceRemaining, float distanceTraveled, double durationRemaining, float fractionTraveled, int remainingWaypoints) [InvalidNullConversion]
src/main/java/com/mapbox/navigation/base/trip/model/RouteProgress.kt:1: error: Attempted to change parameter from @Nullable to @NonNull: incompatible change for parameter route in com.mapbox.navigation.base.trip.model.RouteProgress.copy(com.mapbox.api.directions.v5.models.DirectionsRoute route, com.mapbox.geojson.Geometry routeGeometryWithBuffer, com.mapbox.api.directions.v5.models.BannerInstructions bannerInstructions, com.mapbox.api.directions.v5.models.VoiceInstructions voiceInstructions, com.mapbox.navigation.base.trip.model.RouteProgressState currentState, com.mapbox.navigation.base.trip.model.RouteLegProgress currentLegProgress, java.util.List<com.mapbox.geojson.Point> upcomingStepPoints, boolean inTunnel, float distanceRemaining, float distanceTraveled, double durationRemaining, float fractionTraveled, int remainingWaypoints) [InvalidNullConversion]
Aborting: Found compatibility problems checking the public API (/Users/pabloguardiola/mapbox/mapbox-navigation-android/libnavigation-base/src/main/java) against the API in /Users/pabloguardiola/mapbox/mapbox-navigation-android/libnavigation-base/api/current.txt
```

```
> Task :libtrip-notification:checkApi FAILED

Aborting: Your changes have resulted in differences in the signature file
for the public API.

The changes may be compatible, but the signature file needs to be updated.

Diffs:
--- /Users/pabloguardiola/mapbox/mapbox-navigation-android/libtrip-notification/api/current.txt 2020-06-23 18:57:09.000000000 -0400
+++ /var/folders/lp/3yj9qw651gn7kqsj2gsbdf840000gp/T/compat-diff-signatures-public1959711135346981664.txt       2020-06-23 19:03:13.000000000 -0400
@@ -9,7 +9,7 @@
     method public int getNotificationId();
     method public void onTripSessionStarted();
     method public void onTripSessionStopped();
-    method public void updateNotification(com.mapbox.navigation.base.trip.model.RouteProgress routeProgress);
+    method public void updateNotification(com.mapbox.navigation.base.trip.model.RouteProgress? routeProgress);
     property public final String? currentManeuverModifier;
     property public final String? currentManeuverType;
     field public static final com.mapbox.navigation.trip.notification.MapboxTripNotification.Companion! Companion;
```