### PR TITLE
Bump NN dependency version to 14.1.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -13,7 +13,7 @@ ext {
       mapboxSdkDirectionsModels : '5.2.1',
       mapboxEvents              : '5.0.1',
       mapboxCore                : '2.0.1',
-      mapboxNavigator           : '14.0.1',
+      mapboxNavigator           : '14.1.0',
       mapboxCrashMonitor        : '2.0.0',
       mapboxAnnotationPlugin    : '0.8.0',
       mapboxAccounts            : '0.4.0',


### PR DESCRIPTION
## Description

Bumps `mapbox-navigation-native` version to `14.1.0`

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Getting the latest version from `mapboxNavigator` including the new features and bug fixes.

### Implementation

- Bump the `mapboxNavigator` version to `14.1.0` in `dependencies.gradle` and fix breaking changes


## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR

cc @mskurydin @SiarheiFedartsou 