### PR TITLE
Added functionality to remove progress change listener(s). The mapway…

### DIFF
--- a/libnavigation-ui/api/current.txt
+++ b/libnavigation-ui/api/current.txt
@@ -265,6 +265,7 @@ package com.mapbox.navigation.ui.camera {
     method public void onStop();
     method public void removeOnTrackingModeChangedListener(com.mapbox.navigation.ui.camera.OnTrackingModeChangedListener);
     method public void removeOnTrackingModeTransitionListener(com.mapbox.navigation.ui.camera.OnTrackingModeTransitionListener);
+    method public void removeProgressChangeListener();
     method public void resetCameraPositionWith(@com.mapbox.navigation.ui.camera.NavigationCamera.TrackingMode int);
     method public void resume(android.location.Location!);
     method public void setCamera(com.mapbox.navigation.ui.camera.Camera!);
@@ -476,6 +477,7 @@ package com.mapbox.navigation.ui.map {
     method @androidx.lifecycle.OnLifecycleEvent(androidx.lifecycle.Lifecycle.Event.ON_STOP) protected void onStop();
     method public void removeOnCameraTrackingChangedListener(com.mapbox.mapboxsdk.location.OnCameraTrackingChangedListener!);
     method public boolean removeOnWayNameChangedListener(com.mapbox.navigation.ui.map.OnWayNameChangedListener!);
+    method public void removeProgressChangeListener();
     method public void removeRoute();
     method public void resetCameraPositionWith(@com.mapbox.navigation.ui.camera.NavigationCamera.TrackingMode int);
     method public void resetPadding();

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/camera/NavigationCamera.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/camera/NavigationCamera.java
@@ -340,6 +340,15 @@ public class NavigationCamera {
   }
 
   /**
+   * Removes the previously registered progress change listener.
+   */
+  public void removeProgressChangeListener() {
+    if (navigation != null) {
+      navigation.unregisterRouteProgressObserver(routeProgressObserver);
+    }
+  }
+
+  /**
    * Adds given tracking mode transition listener for receiving notification of camera
    * transition updates.
    *

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/MapFpsDelegate.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/MapFpsDelegate.java
@@ -57,6 +57,15 @@ class MapFpsDelegate implements OnTrackingModeChangedListener, OnTrackingModeTra
     navigation.registerRouteProgressObserver(fpsProgressListener);
   }
 
+  /**
+   * Removes the previously registered progress change listener.
+   */
+  void removeProgressChangeListener() {
+    if (navigation != null) {
+      navigation.unregisterRouteProgressObserver(fpsProgressListener);
+    }
+  }
+
   void onStart() {
     if (navigation != null) {
       navigation.registerRouteProgressObserver(fpsProgressListener);

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/MapWayName.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/MapWayName.java
@@ -70,6 +70,10 @@ class MapWayName {
     registerObservers();
   }
 
+  void removeProgressChangeListener() {
+    unregisterObservers();
+  }
+
   boolean addOnWayNameChangedListener(OnWayNameChangedListener listener) {
     return onWayNameChangedListeners.add(listener);
   }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/NavigationMapboxMap.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/NavigationMapboxMap.java
@@ -361,11 +361,9 @@ public class NavigationMapboxMap implements LifecycleObserver {
    */
   public void addProgressChangeListener(@NonNull MapboxNavigation navigation) {
     this.navigation = navigation;
-    initializeWayName(mapboxMap, mapPaddingAdjustor);
     initializeFpsDelegate(mapView);
     mapRoute.addProgressChangeListener(navigation, vanishRouteLineEnabled);
     mapCamera.addProgressChangeListener(navigation);
-    mapWayName.addProgressChangeListener(navigation);
     mapFpsDelegate.addProgressChangeListener(navigation);
     navigation.registerLocationObserver(locationObserver);
 
@@ -386,6 +384,42 @@ public class NavigationMapboxMap implements LifecycleObserver {
   public void addProgressChangeListener(@NonNull MapboxNavigation navigation, boolean enableVanishingRouteLine) {
     this.vanishRouteLineEnabled = enableVanishingRouteLine;
     addProgressChangeListener(navigation);
+  }
+
+  /**
+   * Removes the previously registered progress change listener.
+   */
+  public void removeProgressChangeListener() {
+    if (navigation != null) {
+      if (mapRoute != null) {
+        mapRoute.removeProgressChangeListener(navigation);
+      }
+
+      if (mapCamera != null) {
+        mapCamera.removeProgressChangeListener();
+      }
+
+      if (mapWayName != null) {
+        mapWayName.removeProgressChangeListener();
+        mapWayName.removeOnWayNameChangedListener(internalWayNameChangedListener);
+        mapWayName.updateWayNameQueryMap(!settings.isMapWayNameEnabled());
+        mapWayName = null;
+      }
+
+      if (mapFpsDelegate != null) {
+        mapFpsDelegate.removeProgressChangeListener();
+        removeFpsListenersFromCamera();
+        mapFpsDelegate = null;
+      }
+
+      if (navigation != null) {
+        navigation.unregisterLocationObserver(locationObserver);
+      }
+
+      if (navigationPuckPresenter != null) {
+        navigationPuckPresenter.removeProgressChangeListener();
+      }
+    }
   }
 
   /**
@@ -522,6 +556,8 @@ public class NavigationMapboxMap implements LifecycleObserver {
    * @param directionsRoute to update the camera position
    */
   public void startCamera(@NonNull DirectionsRoute directionsRoute) {
+    initializeWayName(mapboxMap, mapPaddingAdjustor);
+    mapWayName.addProgressChangeListener(navigation);
     mapCamera.start(directionsRoute);
   }
 

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/puck/NavigationPuckPresenter.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/puck/NavigationPuckPresenter.kt
@@ -46,6 +46,15 @@ internal class NavigationPuckPresenter(private val mapboxMap: MapboxMap, puckDra
     }
 
     /**
+     * Removes the previously registered progress change listener.
+     */
+    fun removeProgressChangeListener() {
+        mapboxNavigation?.unregisterRouteProgressObserver(routeProgressObserver).also {
+            observerRegistered = false
+        }
+    }
+
+    /**
      * Call in {@link FragmentActivity#onStart()} to properly add the {@link RouteProgressObserver}
      * for the puck updating and prevent any leaks or further updates.
      */


### PR DESCRIPTION
…name initialization and progress listener are called when starting camera instead of when adding an progress change listener as it created undesirable side effects when in free drive.

## Description

See #3198

- [x] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal

Better control over the progress change listener in the NavigationMapboxMap

### Implementation



## Screenshots or Gifs



## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [x] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->