### PR TITLE
Move application context to NavigationOptions

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/BasicNavSdkOnlyActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/BasicNavSdkOnlyActivity.kt
@@ -68,13 +68,11 @@ class BasicNavSdkOnlyActivity : AppCompatActivity(), OnMapReadyCallback, MapboxM
         mapView.onCreate(savedInstanceState)
         mapView.getMapAsync(this)
 
-        val mapboxNavigationOptions = MapboxNavigation.defaultNavigationOptions(
-                this,
-                Utils.getMapboxAccessToken(this)
-        )
+        val mapboxNavigationOptions = MapboxNavigation
+            .defaultNavigationOptionsBuilder(this, Utils.getMapboxAccessToken(this))
+            .build()
 
         mapboxNavigation = MapboxNavigation(
-                applicationContext,
                 mapboxNavigationOptions,
                 LocationEngineProvider.getBestLocationEngine(this)
         )

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/BasicNavigationActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/BasicNavigationActivity.kt
@@ -77,13 +77,11 @@ open class BasicNavigationActivity : AppCompatActivity(), OnMapReadyCallback {
         mapView.onCreate(savedInstanceState)
         mapView.getMapAsync(this)
 
-        val mapboxNavigationOptions = MapboxNavigation.defaultNavigationOptions(
-            this,
-            Utils.getMapboxAccessToken(this)
-        )
+        val mapboxNavigationOptions = MapboxNavigation
+            .defaultNavigationOptionsBuilder(this, Utils.getMapboxAccessToken(this))
+            .build()
 
         mapboxNavigation = MapboxNavigation(
-            applicationContext,
             mapboxNavigationOptions,
             locationEngine = getLocationEngine()
         ).apply {

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/BasicNavigationFragment.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/BasicNavigationFragment.kt
@@ -395,8 +395,7 @@ class BasicNavigationFragment : Fragment(), OnMapReadyCallback, FeedbackBottomSh
     private fun initNavigation() {
         val accessToken = Utils.getMapboxAccessToken(requireContext())
         mapboxNavigation = MapboxNavigation(
-            requireContext(),
-            MapboxNavigation.defaultNavigationOptions(requireContext(), accessToken),
+            MapboxNavigation.defaultNavigationOptionsBuilder(requireContext(), accessToken).build(),
             getLocationEngine()
         )
         mapboxNavigation.apply {

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/DebugMapboxNavigationKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/DebugMapboxNavigationKt.kt
@@ -139,10 +139,8 @@ class DebugMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
         mapView.getMapAsync(this)
         localLocationEngine = LocationEngineProvider.getBestLocationEngine(applicationContext)
 
-        val options =
-            MapboxNavigation.defaultNavigationOptions(this, Utils.getMapboxAccessToken(this))
-
-        val newOptions = options.toBuilder()
+        val options = MapboxNavigation
+            .defaultNavigationOptionsBuilder(this, Utils.getMapboxAccessToken(this))
             .onboardRouterOptions(OnboardRouterOptions.Builder()
                 .tilesUri("https://api-routing-tiles-staging.tilestream.net")
                 .tilesVersion("2020_02_02-03_00_00")
@@ -151,7 +149,7 @@ class DebugMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
             .navigatorPredictionMillis(1000L)
             .build()
 
-        mapboxNavigation = getMapboxNavigation(newOptions)
+        mapboxNavigation = getMapboxNavigation(options)
     }
 
     override fun onMapReady(mapboxMap: MapboxMap) {
@@ -429,7 +427,6 @@ class DebugMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
     private fun getMapboxNavigation(options: NavigationOptions): MapboxNavigation {
         return if (shouldSimulateRoute()) {
             return MapboxNavigation(
-                applicationContext,
                 navigationOptions = options,
                 locationEngine = ReplayLocationEngine(mapboxReplayer)
             ).apply {
@@ -439,7 +436,6 @@ class DebugMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
             }
         } else {
             MapboxNavigation(
-                applicationContext,
                 navigationOptions = options
             )
         }

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/FasterRouteActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/FasterRouteActivity.kt
@@ -153,11 +153,11 @@ class FasterRouteActivity : AppCompatActivity(), OnMapReadyCallback {
         mapView.onCreate(savedInstanceState)
         mapView.getMapAsync(this)
 
-        val mapboxNavigationOptions = MapboxNavigation.defaultNavigationOptions(
-            this,
-            Mapbox.getAccessToken()
-        )
-        mapboxNavigation = MapboxNavigation(applicationContext, mapboxNavigationOptions).also {
+        val mapboxNavigationOptions = MapboxNavigation
+            .defaultNavigationOptionsBuilder(this, Mapbox.getAccessToken())
+            .build()
+
+        mapboxNavigation = MapboxNavigation(mapboxNavigationOptions).also {
             it.registerRoutesObserver(routesObserver)
         }
 

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/FeedbackButtonActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/FeedbackButtonActivity.kt
@@ -68,13 +68,11 @@ class FeedbackButtonActivity : AppCompatActivity(), OnMapReadyCallback,
         mapView.onCreate(savedInstanceState)
         mapView.getMapAsync(this)
 
-        val mapboxNavigationOptions = MapboxNavigation.defaultNavigationOptions(
-            this,
-            Utils.getMapboxAccessToken(this)
-        )
+        val mapboxNavigationOptions = MapboxNavigation
+            .defaultNavigationOptionsBuilder(this, Utils.getMapboxAccessToken(this))
+            .build()
 
         mapboxNavigation = MapboxNavigation(
-            applicationContext,
             mapboxNavigationOptions,
             ReplayLocationEngine(mapboxReplayer)
         ).apply {

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/FreeDriveNavigationActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/FreeDriveNavigationActivity.kt
@@ -55,12 +55,8 @@ class FreeDriveNavigationActivity : AppCompatActivity(), OnMapReadyCallback {
         mapView.onCreate(savedInstanceState)
         mapView.getMapAsync(this)
 
-        val mapboxNavigationOptions = MapboxNavigation.defaultNavigationOptions(
-                this,
-                Utils.getMapboxAccessToken(this)
-        )
-
-        val updatedOptions = mapboxNavigationOptions.toBuilder()
+        val mapboxNavigationOptions = MapboxNavigation
+            .defaultNavigationOptionsBuilder(this, Utils.getMapboxAccessToken(this))
             .onboardRouterOptions(OnboardRouterOptions.Builder()
                 .tilesUri("https://api-routing-tiles-staging.tilestream.net")
                 .tilesVersion("2020_02_02-03_00_00")
@@ -69,8 +65,7 @@ class FreeDriveNavigationActivity : AppCompatActivity(), OnMapReadyCallback {
             .build()
 
         mapboxNavigation = MapboxNavigation(
-                applicationContext,
-                updatedOptions
+                mapboxNavigationOptions
         )
         initListeners()
     }

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/GuidanceViewActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/GuidanceViewActivity.kt
@@ -62,14 +62,12 @@ class GuidanceViewActivity : AppCompatActivity(), OnMapReadyCallback {
         mapView.onCreate(savedInstanceState)
         mapView.getMapAsync(this)
 
-        val options = MapboxNavigation.defaultNavigationOptions(
-                this,
-                Utils.getMapboxAccessToken(this)
-        )
+        val mapboxNavigationOptions = MapboxNavigation
+            .defaultNavigationOptionsBuilder(this, Utils.getMapboxAccessToken(this))
+            .build()
 
         mapboxNavigation = MapboxNavigation(
-                applicationContext,
-                options,
+                mapboxNavigationOptions,
                 locationEngine = ReplayLocationEngine(mapboxReplayer)
         ).also {
             it.registerRouteProgressObserver(routeProgressObserver)

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/InstructionViewActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/InstructionViewActivity.kt
@@ -92,13 +92,11 @@ class InstructionViewActivity : AppCompatActivity(), OnMapReadyCallback,
         mapView.onCreate(savedInstanceState)
         mapView.getMapAsync(this)
 
-        val mapboxNavigationOptions = MapboxNavigation.defaultNavigationOptions(
-            this,
-            Utils.getMapboxAccessToken(this)
-        )
+        val mapboxNavigationOptions = MapboxNavigation
+            .defaultNavigationOptionsBuilder(this, Utils.getMapboxAccessToken(this))
+            .build()
 
         mapboxNavigation = MapboxNavigation(
-            applicationContext,
             mapboxNavigationOptions,
             locationEngine = getLocationEngine()
         ).apply {

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/NavigationMapRouteActivity.java
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/NavigationMapRouteActivity.java
@@ -105,12 +105,10 @@ public class NavigationMapRouteActivity extends AppCompatActivity implements OnM
     this.mapboxMap = mapboxMap;
     mapboxMap.setStyle(Style.MAPBOX_STREETS, style -> {
       initializeLocationComponent(mapboxMap, style);
-      NavigationOptions navigationOptions = MapboxNavigation.defaultNavigationOptions(
-              this,
-              Utils.getMapboxAccessToken(this)
-      );
+      NavigationOptions navigationOptions = MapboxNavigation
+              .defaultNavigationOptionsBuilder(this, Utils.getMapboxAccessToken(this))
+              .build();
       mapboxNavigation = new MapboxNavigation(
-              this.getApplicationContext(),
               navigationOptions,
               new ReplayLocationEngine(mapboxReplayer)
       );

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/ReRouteActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/ReRouteActivity.kt
@@ -110,13 +110,11 @@ class ReRouteActivity : AppCompatActivity(), OnMapReadyCallback {
         mapView.onCreate(savedInstanceState)
         mapView.getMapAsync(this)
 
-        val mapboxNavigationOptions = MapboxNavigation.defaultNavigationOptions(
-            this,
-            Utils.getMapboxAccessToken(this)
-        )
+        val mapboxNavigationOptions = MapboxNavigation
+            .defaultNavigationOptionsBuilder(this, Utils.getMapboxAccessToken(this))
+            .build()
 
         mapboxNavigation = MapboxNavigation(
-            applicationContext,
             mapboxNavigationOptions,
             locationEngine = LocationEngineProvider.getBestLocationEngine(this)
         ).also {

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayActivity.kt
@@ -58,13 +58,11 @@ class ReplayActivity : AppCompatActivity(), OnMapReadyCallback {
         setContentView(R.layout.activity_replay_route_layout)
         mapView.onCreate(savedInstanceState)
 
-        val mapboxNavigationOptions = MapboxNavigation.defaultNavigationOptions(
-            this,
-            Utils.getMapboxAccessToken(this)
-        )
+        val mapboxNavigationOptions = MapboxNavigation
+            .defaultNavigationOptionsBuilder(this, Utils.getMapboxAccessToken(this))
+            .build()
 
         mapboxNavigation = MapboxNavigation(
-            applicationContext,
             mapboxNavigationOptions,
             locationEngine = ReplayLocationEngine(mapboxReplayer)
         ).apply {

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayHistoryActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayHistoryActivity.kt
@@ -120,12 +120,10 @@ class ReplayHistoryActivity : AppCompatActivity() {
     }
 
     private fun createMapboxNavigation(locationEngine: LocationEngine): MapboxNavigation {
-        val accessToken = Utils.getMapboxAccessToken(this)
-        val mapboxNavigationOptions = MapboxNavigation.defaultNavigationOptions(
-            this, accessToken)
-
+        val mapboxNavigationOptions = MapboxNavigation
+            .defaultNavigationOptionsBuilder(this, Utils.getMapboxAccessToken(this))
+            .build()
         return MapboxNavigation(
-            applicationContext,
             mapboxNavigationOptions,
             locationEngine
         )

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayWaypointsActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayWaypointsActivity.kt
@@ -77,13 +77,11 @@ class ReplayWaypointsActivity : AppCompatActivity(), OnMapReadyCallback {
         setContentView(R.layout.activity_replay_waypoints_layout)
         mapView.onCreate(savedInstanceState)
 
-        val mapboxNavigationOptions = MapboxNavigation.defaultNavigationOptions(
-            this,
-            Utils.getMapboxAccessToken(this)
-        )
+        val mapboxNavigationOptions = MapboxNavigation
+            .defaultNavigationOptionsBuilder(this, Utils.getMapboxAccessToken(this))
+            .build()
 
         mapboxNavigation = MapboxNavigation(
-            applicationContext,
             mapboxNavigationOptions,
             locationEngine = ReplayLocationEngine(mapboxReplayer)
         ).apply {

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/SimpleMapboxNavigationKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/SimpleMapboxNavigationKt.kt
@@ -140,10 +140,10 @@ class SimpleMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
         mapView.getMapAsync(this)
         localLocationEngine = LocationEngineProvider.getBestLocationEngine(applicationContext)
 
-        val options =
-            MapboxNavigation.defaultNavigationOptions(this, Utils.getMapboxAccessToken(this))
-
-        mapboxNavigation = getMapboxNavigation(options)
+        val mapboxNavigationOptions = MapboxNavigation
+            .defaultNavigationOptionsBuilder(this, Utils.getMapboxAccessToken(this))
+            .build()
+        mapboxNavigation = getMapboxNavigation(mapboxNavigationOptions)
     }
 
     override fun onMapReady(mapboxMap: MapboxMap) {
@@ -479,7 +479,6 @@ class SimpleMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
     private fun getMapboxNavigation(options: NavigationOptions): MapboxNavigation {
         return if (shouldSimulateRoute()) {
             MapboxNavigation(
-                applicationContext,
                 navigationOptions = options,
                 locationEngine = ReplayLocationEngine(mapboxReplayer)
             ).apply {
@@ -491,7 +490,6 @@ class SimpleMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
             }
         } else {
             MapboxNavigation(
-                applicationContext,
                 navigationOptions = options
             )
         }

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/SummaryBottomSheetActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/SummaryBottomSheetActivity.kt
@@ -73,13 +73,11 @@ class SummaryBottomSheetActivity : AppCompatActivity(), OnMapReadyCallback {
         mapView.onCreate(savedInstanceState)
         mapView.getMapAsync(this)
 
-        val mapboxNavigationOptions = MapboxNavigation.defaultNavigationOptions(
-            this,
-            Utils.getMapboxAccessToken(this)
-        )
+        val mapboxNavigationOptions = MapboxNavigation
+            .defaultNavigationOptionsBuilder(this, Utils.getMapboxAccessToken(this))
+            .build()
 
         mapboxNavigation = MapboxNavigation(
-            applicationContext,
             mapboxNavigationOptions,
             getLocationEngine()
         ).apply {

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/TripServiceActivityKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/TripServiceActivityKt.kt
@@ -88,8 +88,7 @@ class TripServiceActivityKt : AppCompatActivity(), OnMapReadyCallback {
             .build(this)
 
         mapboxTripNotification = MapboxTripNotification(
-            applicationContext,
-            NavigationOptions.Builder()
+            NavigationOptions.Builder(applicationContext)
                 .distanceFormatter(formatter)
                 .timeFormatType(TWENTY_FOUR_HOURS)
                 .build()

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/TripSessionActivityKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/TripSessionActivityKt.kt
@@ -104,8 +104,7 @@ class TripSessionActivityKt : AppCompatActivity(), OnMapReadyCallback {
             MapboxTripService(
                 applicationContext,
                 MapboxTripNotification(
-                    applicationContext,
-                    NavigationOptions.Builder()
+                    NavigationOptions.Builder(applicationContext)
                         .distanceFormatter(formatter)
                         .timeFormatType(TWENTY_FOUR_HOURS)
                         .build()

--- a/examples/src/main/java/com/mapbox/navigation/examples/ui/BuildingExtrusionActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/ui/BuildingExtrusionActivity.kt
@@ -8,7 +8,6 @@ import com.mapbox.mapboxsdk.camera.CameraPosition
 import com.mapbox.mapboxsdk.geometry.LatLng
 import com.mapbox.mapboxsdk.location.modes.RenderMode
 import com.mapbox.mapboxsdk.maps.MapboxMap
-import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.trip.session.RouteProgressObserver
 import com.mapbox.navigation.examples.R
@@ -101,12 +100,11 @@ class BuildingExtrusionActivity : AppCompatActivity(), OnNavigationReadyCallback
 
                 this.mapboxMap = navMapboxMap.retrieveMap()
 
-                val optionsBuilder = NavigationViewOptions.builder()
+                val optionsBuilder = NavigationViewOptions.builder(this)
                 optionsBuilder.navigationListener(this)
                 optionsBuilder.directionsRoute(route)
                 optionsBuilder.shouldSimulateRoute(true)
                 optionsBuilder.routeProgressObserver(this)
-                optionsBuilder.navigationOptions(NavigationOptions.Builder().build())
                 navigationView.startNavigation(optionsBuilder.build())
 
                 // Initialize the Navigation UI SDK's BuildingExtrusionLayer class.

--- a/examples/src/main/java/com/mapbox/navigation/examples/ui/BuildingFootprintHighlightActivityKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/ui/BuildingFootprintHighlightActivityKt.kt
@@ -10,7 +10,6 @@ import com.mapbox.mapboxsdk.camera.CameraUpdateFactory.zoomTo
 import com.mapbox.mapboxsdk.geometry.LatLng
 import com.mapbox.mapboxsdk.location.modes.RenderMode
 import com.mapbox.mapboxsdk.maps.MapboxMap
-import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.trip.model.RouteLegProgress
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.MapboxNavigation
@@ -107,7 +106,7 @@ class BuildingFootprintHighlightActivityKt : AppCompatActivity(), OnNavigationRe
                 this.mapboxMap = navMapboxMap.retrieveMap()
                 navigationView.retrieveMapboxNavigation()?.let { this.mapboxNavigation = it }
 
-                val optionsBuilder = NavigationViewOptions.builder()
+                val optionsBuilder = NavigationViewOptions.builder(this)
                 optionsBuilder.navigationListener(this)
 
                 // Pass the ArrivalObserver interface (this activity)
@@ -116,7 +115,6 @@ class BuildingFootprintHighlightActivityKt : AppCompatActivity(), OnNavigationRe
                 optionsBuilder.directionsRoute(route)
                 optionsBuilder.shouldSimulateRoute(true)
                 optionsBuilder.bannerInstructionsListener(this)
-                optionsBuilder.navigationOptions(NavigationOptions.Builder().build())
                 navigationView.startNavigation(optionsBuilder.build())
 
                 // Initialize the Nav UI SDK's BuildingFootprintHighlightLayer class.

--- a/examples/src/main/java/com/mapbox/navigation/examples/ui/CustomCameraActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/ui/CustomCameraActivity.kt
@@ -7,7 +7,6 @@ import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.mapboxsdk.camera.CameraPosition
 import com.mapbox.mapboxsdk.geometry.LatLng
 import com.mapbox.mapboxsdk.location.modes.RenderMode
-import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.examples.R
 import com.mapbox.navigation.ui.NavigationViewOptions
@@ -96,7 +95,7 @@ class CustomCameraActivity : AppCompatActivity(), OnNavigationReadyCallback,
                 this.navigationMapboxMap.updateLocationLayerRenderMode(RenderMode.NORMAL)
                 navigationView.retrieveMapboxNavigation()?.let { this.mapboxNavigation = it }
 
-                val optionsBuilder = NavigationViewOptions.builder()
+                val optionsBuilder = NavigationViewOptions.builder(this)
                 optionsBuilder.navigationListener(this)
                 optionsBuilder.directionsRoute(route)
                 optionsBuilder.shouldSimulateRoute(true)
@@ -104,8 +103,6 @@ class CustomCameraActivity : AppCompatActivity(), OnNavigationReadyCallback,
 
                 // Add the custom camera
                 optionsBuilder.camera(CustomCamera())
-
-                optionsBuilder.navigationOptions(NavigationOptions.Builder().build())
                 navigationView.startNavigation(optionsBuilder.build())
             }
         }

--- a/examples/src/main/java/com/mapbox/navigation/examples/ui/CustomPuckActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/ui/CustomPuckActivity.kt
@@ -7,7 +7,6 @@ import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.mapboxsdk.camera.CameraPosition
 import com.mapbox.mapboxsdk.geometry.LatLng
 import com.mapbox.mapboxsdk.location.modes.RenderMode
-import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.trip.model.RouteProgressState
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.examples.R
@@ -95,12 +94,11 @@ class CustomPuckActivity : AppCompatActivity(), OnNavigationReadyCallback,
                 this.navigationMapboxMap.updateLocationLayerRenderMode(RenderMode.NORMAL)
                 navigationView.retrieveMapboxNavigation()?.let { this.mapboxNavigation = it }
 
-                val optionsBuilder = NavigationViewOptions.builder()
+                val optionsBuilder = NavigationViewOptions.builder(this)
                 optionsBuilder.navigationListener(this)
                 optionsBuilder.directionsRoute(route)
                 optionsBuilder.shouldSimulateRoute(true)
                 optionsBuilder.bannerInstructionsListener(this)
-                optionsBuilder.navigationOptions(NavigationOptions.Builder().build())
                 optionsBuilder.puckDrawableSupplier(CustomPuckDrawableSupplier())
                 navigationView.startNavigation(optionsBuilder.build())
             }

--- a/examples/src/main/java/com/mapbox/navigation/examples/ui/CustomUIComponentStyleActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/ui/CustomUIComponentStyleActivity.kt
@@ -363,8 +363,7 @@ class CustomUIComponentStyleActivity : AppCompatActivity(), OnMapReadyCallback,
     private fun initNavigation() {
         val accessToken = Utils.getMapboxAccessToken(this)
         mapboxNavigation = MapboxNavigation(
-            applicationContext,
-            MapboxNavigation.defaultNavigationOptions(this, accessToken),
+            MapboxNavigation.defaultNavigationOptionsBuilder(this, accessToken).build(),
             getLocationEngine()
         )
         mapboxNavigation.apply {

--- a/examples/src/main/java/com/mapbox/navigation/examples/ui/NavigationViewActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/ui/NavigationViewActivity.kt
@@ -7,7 +7,6 @@ import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.mapboxsdk.camera.CameraPosition
 import com.mapbox.mapboxsdk.geometry.LatLng
 import com.mapbox.mapboxsdk.location.modes.RenderMode
-import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.examples.R
 import com.mapbox.navigation.ui.NavigationViewOptions
@@ -92,12 +91,11 @@ class NavigationViewActivity : AppCompatActivity(), OnNavigationReadyCallback,
                 this.navigationMapboxMap.updateLocationLayerRenderMode(RenderMode.NORMAL)
                 navigationView.retrieveMapboxNavigation()?.let { this.mapboxNavigation = it }
 
-                val optionsBuilder = NavigationViewOptions.builder()
+                val optionsBuilder = NavigationViewOptions.builder(this)
                 optionsBuilder.navigationListener(this)
                 optionsBuilder.directionsRoute(route)
                 optionsBuilder.shouldSimulateRoute(true)
                 optionsBuilder.bannerInstructionsListener(this)
-                optionsBuilder.navigationOptions(NavigationOptions.Builder().build())
                 navigationView.startNavigation(optionsBuilder.build())
             }
         }

--- a/examples/src/main/java/com/mapbox/navigation/examples/ui/NavigationViewFragment.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/ui/NavigationViewFragment.kt
@@ -9,7 +9,6 @@ import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.mapboxsdk.camera.CameraPosition
 import com.mapbox.mapboxsdk.geometry.LatLng
 import com.mapbox.mapboxsdk.location.modes.RenderMode
-import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.examples.R
 import com.mapbox.navigation.ui.NavigationViewOptions
@@ -96,11 +95,10 @@ class NavigationViewFragment : Fragment(), OnNavigationReadyCallback, Navigation
                 this.navigationMapboxMap = navMapboxMap
                 this.navigationMapboxMap.updateLocationLayerRenderMode(RenderMode.NORMAL)
                 navigationView.retrieveMapboxNavigation()?.let { this.mapboxNavigation = it }
-                val optionsBuilder = NavigationViewOptions.builder()
+                val optionsBuilder = NavigationViewOptions.builder(requireContext())
                 optionsBuilder.navigationListener(this)
                 optionsBuilder.directionsRoute(route)
                 optionsBuilder.shouldSimulateRoute(true)
-                optionsBuilder.navigationOptions(NavigationOptions.Builder().build())
                 optionsBuilder.enableVanishingRouteLine(true)
                 navigationView.startNavigation(optionsBuilder.build())
             }

--- a/libnavigation-base/api/current.txt
+++ b/libnavigation-base/api/current.txt
@@ -81,18 +81,20 @@ package com.mapbox.navigation.base.options {
   }
 
   public final class NavigationOptions {
-    ctor public NavigationOptions(String? accessToken, @com.mapbox.navigation.base.TimeFormat.Type int timeFormatType, long navigatorPredictionMillis, com.mapbox.navigation.base.formatter.DistanceFormatter? distanceFormatter, com.mapbox.navigation.base.options.OnboardRouterOptions? onboardRouterOptions, boolean isFromNavigationUi, boolean isDebugLoggingEnabled, com.mapbox.navigation.base.options.DeviceProfile deviceProfile, com.mapbox.navigation.base.options.NavigationOptions.Builder builder);
-    method public String? component1();
-    method public int component2();
-    method public long component3();
-    method public com.mapbox.navigation.base.formatter.DistanceFormatter? component4();
-    method public com.mapbox.navigation.base.options.OnboardRouterOptions? component5();
-    method public boolean component6();
+    ctor public NavigationOptions(android.content.Context applicationContext, String? accessToken, @com.mapbox.navigation.base.TimeFormat.Type int timeFormatType, long navigatorPredictionMillis, com.mapbox.navigation.base.formatter.DistanceFormatter? distanceFormatter, com.mapbox.navigation.base.options.OnboardRouterOptions? onboardRouterOptions, boolean isFromNavigationUi, boolean isDebugLoggingEnabled, com.mapbox.navigation.base.options.DeviceProfile deviceProfile, com.mapbox.navigation.base.options.NavigationOptions.Builder builder);
+    method public android.content.Context component1();
+    method public com.mapbox.navigation.base.options.NavigationOptions.Builder component10();
+    method public String? component2();
+    method public int component3();
+    method public long component4();
+    method public com.mapbox.navigation.base.formatter.DistanceFormatter? component5();
+    method public com.mapbox.navigation.base.options.OnboardRouterOptions? component6();
     method public boolean component7();
-    method public com.mapbox.navigation.base.options.DeviceProfile component8();
-    method public com.mapbox.navigation.base.options.NavigationOptions.Builder component9();
-    method public com.mapbox.navigation.base.options.NavigationOptions copy(String? accessToken, int timeFormatType, long navigatorPredictionMillis, com.mapbox.navigation.base.formatter.DistanceFormatter? distanceFormatter, com.mapbox.navigation.base.options.OnboardRouterOptions? onboardRouterOptions, boolean isFromNavigationUi, boolean isDebugLoggingEnabled, com.mapbox.navigation.base.options.DeviceProfile deviceProfile, com.mapbox.navigation.base.options.NavigationOptions.Builder builder);
+    method public boolean component8();
+    method public com.mapbox.navigation.base.options.DeviceProfile component9();
+    method public com.mapbox.navigation.base.options.NavigationOptions copy(android.content.Context applicationContext, String? accessToken, int timeFormatType, long navigatorPredictionMillis, com.mapbox.navigation.base.formatter.DistanceFormatter? distanceFormatter, com.mapbox.navigation.base.options.OnboardRouterOptions? onboardRouterOptions, boolean isFromNavigationUi, boolean isDebugLoggingEnabled, com.mapbox.navigation.base.options.DeviceProfile deviceProfile, com.mapbox.navigation.base.options.NavigationOptions.Builder builder);
     method public String? getAccessToken();
+    method public android.content.Context getApplicationContext();
     method public com.mapbox.navigation.base.options.NavigationOptions.Builder getBuilder();
     method public com.mapbox.navigation.base.options.DeviceProfile getDeviceProfile();
     method public com.mapbox.navigation.base.formatter.DistanceFormatter? getDistanceFormatter();
@@ -105,7 +107,7 @@ package com.mapbox.navigation.base.options {
   }
 
   public static final class NavigationOptions.Builder {
-    ctor public NavigationOptions.Builder();
+    ctor public NavigationOptions.Builder(android.content.Context context);
     method public com.mapbox.navigation.base.options.NavigationOptions.Builder accessToken(String? accessToken);
     method public com.mapbox.navigation.base.options.NavigationOptions build();
     method public com.mapbox.navigation.base.options.NavigationOptions.Builder deviceProfile(com.mapbox.navigation.base.options.DeviceProfile deviceProfile);

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/NavigationOptions.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/NavigationOptions.kt
@@ -1,5 +1,6 @@
 package com.mapbox.navigation.base.options
 
+import android.content.Context
 import com.mapbox.navigation.base.TimeFormat
 import com.mapbox.navigation.base.formatter.DistanceFormatter
 
@@ -22,6 +23,7 @@ const val DEFAULT_NAVIGATOR_PREDICTION_MILLIS = 1100L
  * in such a way as to project the location forward along the current trajectory so as to
  * appear more in sync with the users ground-truth location
  *
+ * @param applicationContext the Context of the Android Application
  * @param accessToken [Mapbox Access Token](https://docs.mapbox.com/help/glossary/access-token/)
  * @param distanceFormatter [DistanceFormatter] for format distances showing in notification during navigation
  * @param onboardRouterOptions [OnboardRouterOptions] defines configuration for the default on-board router
@@ -31,6 +33,7 @@ const val DEFAULT_NAVIGATOR_PREDICTION_MILLIS = 1100L
  * @param builder [Builder] used the create the [NavigationOptions]
  */
 data class NavigationOptions(
+    val applicationContext: Context,
     val accessToken: String?,
     @TimeFormat.Type val timeFormatType: Int,
     val navigatorPredictionMillis: Long,
@@ -50,8 +53,9 @@ data class NavigationOptions(
     /**
      * Build a new [NavigationOptions]
      */
-    class Builder {
-        private var _accessToken: String? = null
+    class Builder(context: Context) {
+        private val applicationContext = context.applicationContext
+        private var accessToken: String? = null
         private var timeFormatType: Int = TimeFormat.NONE_SPECIFIED
         private var navigatorPredictionMillis: Long = DEFAULT_NAVIGATOR_PREDICTION_MILLIS
         private var distanceFormatter: DistanceFormatter? = null
@@ -64,7 +68,7 @@ data class NavigationOptions(
          * Defines [Mapbox Access Token](https://docs.mapbox.com/help/glossary/access-token/)
          */
         fun accessToken(accessToken: String?) =
-            apply { this._accessToken = accessToken }
+            apply { this.accessToken = accessToken }
 
         /**
          * Defines the type of device creating localization data
@@ -114,7 +118,8 @@ data class NavigationOptions(
          */
         fun build(): NavigationOptions {
             return NavigationOptions(
-                accessToken = _accessToken,
+                applicationContext = applicationContext,
+                accessToken = accessToken,
                 timeFormatType = timeFormatType,
                 navigatorPredictionMillis = navigatorPredictionMillis,
                 distanceFormatter = distanceFormatter,

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/options/NavigationOptionsTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/options/NavigationOptionsTest.kt
@@ -1,18 +1,25 @@
 package com.mapbox.navigation.base.options
 
+import android.content.Context
 import android.text.SpannableString
 import com.mapbox.navigation.base.TimeFormat.NONE_SPECIFIED
 import com.mapbox.navigation.base.TimeFormat.TWELVE_HOURS
 import com.mapbox.navigation.base.TimeFormat.TWENTY_FOUR_HOURS
 import com.mapbox.navigation.base.formatter.DistanceFormatter
+import io.mockk.every
+import io.mockk.mockk
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class NavigationOptionsTest {
 
+    val context: Context = mockk {
+        every { applicationContext } returns mockk()
+    }
+
     @Test
     fun whenBuilderBuildWithNoValuesCalledThenDefaultValuesUsed() {
-        val options = NavigationOptions.Builder().build()
+        val options = NavigationOptions.Builder(context).build()
 
         assertEquals(options.timeFormatType, NONE_SPECIFIED)
         assertEquals(options.navigatorPredictionMillis, DEFAULT_NAVIGATOR_PREDICTION_MILLIS)
@@ -30,7 +37,7 @@ class NavigationOptionsTest {
             }
         }
 
-        val options = NavigationOptions.Builder()
+        val options = NavigationOptions.Builder(context)
             .timeFormatType(timeFormat)
             .navigatorPredictionMillis(navigatorPredictionMillis)
             .distanceFormatter(distanceFormatter)
@@ -51,7 +58,7 @@ class NavigationOptionsTest {
             }
         }
 
-        var options = NavigationOptions.Builder()
+        var options = NavigationOptions.Builder(context)
             .timeFormatType(timeFormat)
             .navigatorPredictionMillis(navigatorPredictionMillis)
             .distanceFormatter(distanceFormatter)

--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -2,14 +2,14 @@
 package com.mapbox.navigation.core {
 
   public final class MapboxNavigation {
-    ctor public MapboxNavigation(android.content.Context context, com.mapbox.navigation.base.options.NavigationOptions navigationOptions, com.mapbox.android.core.location.LocationEngine locationEngine, com.mapbox.android.core.location.LocationEngineRequest locationEngineRequest);
-    ctor public MapboxNavigation(android.content.Context context, com.mapbox.navigation.base.options.NavigationOptions navigationOptions, com.mapbox.android.core.location.LocationEngine locationEngine);
-    ctor public MapboxNavigation(android.content.Context context, com.mapbox.navigation.base.options.NavigationOptions navigationOptions);
+    ctor public MapboxNavigation(com.mapbox.navigation.base.options.NavigationOptions navigationOptions, com.mapbox.android.core.location.LocationEngine locationEngine, com.mapbox.android.core.location.LocationEngineRequest locationEngineRequest);
+    ctor public MapboxNavigation(com.mapbox.navigation.base.options.NavigationOptions navigationOptions, com.mapbox.android.core.location.LocationEngine locationEngine);
+    ctor public MapboxNavigation(com.mapbox.navigation.base.options.NavigationOptions navigationOptions);
     method public void addHistoryEvent(String eventType, String eventJsonProperties);
     method public void attachArrivalController(com.mapbox.navigation.core.arrival.ArrivalController arrivalController = com.mapbox.navigation.core.arrival.AutoArrivalController());
     method public void attachArrivalController();
     method public void attachFasterRouteObserver(com.mapbox.navigation.core.fasterroute.FasterRouteObserver fasterRouteObserver);
-    method public static com.mapbox.navigation.base.options.NavigationOptions defaultNavigationOptions(android.content.Context context, String? accessToken);
+    method public static com.mapbox.navigation.base.options.NavigationOptions.Builder defaultNavigationOptionsBuilder(android.content.Context context, String? accessToken);
     method public void detachFasterRouteObserver();
     method public com.mapbox.android.core.location.LocationEngine getLocationEngine();
     method public java.util.List<com.mapbox.api.directions.v5.models.DirectionsRoute> getRoutes();
@@ -48,7 +48,7 @@ package com.mapbox.navigation.core {
   }
 
   public static final class MapboxNavigation.Companion {
-    method public com.mapbox.navigation.base.options.NavigationOptions defaultNavigationOptions(android.content.Context context, String? accessToken);
+    method public com.mapbox.navigation.base.options.NavigationOptions.Builder defaultNavigationOptionsBuilder(android.content.Context context, String? accessToken);
     method public void postUserFeedback(@com.mapbox.navigation.core.telemetry.events.FeedbackEvent.Type String feedbackType, String description, @com.mapbox.navigation.core.telemetry.events.FeedbackEvent.Source String feedbackSource, String? screenshot, String![]? feedbackSubType = emptyArray());
   }
 
@@ -56,9 +56,9 @@ package com.mapbox.navigation.core {
   }
 
   public final class MapboxNavigationProvider {
-    method public static com.mapbox.navigation.core.MapboxNavigation create(android.content.Context context, com.mapbox.navigation.base.options.NavigationOptions navigationOptions, com.mapbox.android.core.location.LocationEngine locationEngine = LocationEngineProvider.getBestLocationEngine(context.applicationContext), com.mapbox.android.core.location.LocationEngineRequest locationEngineRequest = LocationEngineRequest.<init>(1000).setPriority(LocationEngineRequest.PRIORITY_HIGH_ACCURACY).build());
-    method public static com.mapbox.navigation.core.MapboxNavigation create(android.content.Context context, com.mapbox.navigation.base.options.NavigationOptions navigationOptions, com.mapbox.android.core.location.LocationEngine locationEngine = LocationEngineProvider.getBestLocationEngine(context.applicationContext));
-    method public static com.mapbox.navigation.core.MapboxNavigation create(android.content.Context context, com.mapbox.navigation.base.options.NavigationOptions navigationOptions);
+    method public static com.mapbox.navigation.core.MapboxNavigation create(com.mapbox.navigation.base.options.NavigationOptions navigationOptions, com.mapbox.android.core.location.LocationEngine locationEngine = LocationEngineProvider.getBestLocationEngine(navigationOptions.applicationContext), com.mapbox.android.core.location.LocationEngineRequest locationEngineRequest = LocationEngineRequest.<init>(1000).setPriority(LocationEngineRequest.PRIORITY_HIGH_ACCURACY).build());
+    method public static com.mapbox.navigation.core.MapboxNavigation create(com.mapbox.navigation.base.options.NavigationOptions navigationOptions, com.mapbox.android.core.location.LocationEngine locationEngine = LocationEngineProvider.getBestLocationEngine(navigationOptions.applicationContext));
+    method public static com.mapbox.navigation.core.MapboxNavigation create(com.mapbox.navigation.base.options.NavigationOptions navigationOptions);
     method public static com.mapbox.navigation.core.MapboxNavigation retrieve();
     field public static final com.mapbox.navigation.core.MapboxNavigationProvider! INSTANCE;
   }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -26,6 +26,7 @@ import com.mapbox.navigation.base.route.Router
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.base.trip.notification.NotificationAction
 import com.mapbox.navigation.base.trip.notification.TripNotification
+import com.mapbox.navigation.core.MapboxNavigation.Companion.defaultNavigationOptionsBuilder
 import com.mapbox.navigation.core.accounts.NavigationAccountsSession
 import com.mapbox.navigation.core.arrival.ArrivalController
 import com.mapbox.navigation.core.arrival.ArrivalObserver
@@ -65,15 +66,15 @@ private const val MAPBOX_NAVIGATION_USER_AGENT_BASE = "mapbox-navigation-android
 private const val MAPBOX_NAVIGATION_UI_USER_AGENT_BASE = "mapbox-navigation-ui-android"
 private const val MAPBOX_NAVIGATION_TOKEN_EXCEPTION_OFFBOARD_ROUTER =
     "You need to provide an access token in NavigationOptions in order to use the default OffboardRouter. " +
-        "Also see MapboxNavigation#defaultNavigationOptions"
+        "Also see MapboxNavigation#defaultNavigationOptionsBuilder"
 private const val MAPBOX_NAVIGATION_TOKEN_EXCEPTION_ONBOARD_ROUTER =
     "You need to provide an access token in NavigationOptions in order to use the default OnboardRouter. " +
-        "Also see MapboxNavigation#defaultNavigationOptions"
+        "Also see MapboxNavigation#defaultNavigationOptionsBuilder"
 private const val MAPBOX_NAVIGATION_OPTIONS_EXCEPTION_ONBOARD_ROUTER =
     "You need to provide OnboardRouterOptions in NavigationOptions in order to use the default OnboardRouter. " +
-        "Also see MapboxNavigation#defaultNavigationOptions"
+        "Also see MapboxNavigation#defaultNavigationOptionsBuilder"
 private const val MAPBOX_NAVIGATION_TOKEN_EXCEPTION = "You need to provide an access token in NavigationOptions " +
-    "Also see MapboxNavigation#defaultNavigationOptions"
+    "Also see MapboxNavigation#defaultNavigationOptionsBuilder"
 
 /**
  * ## Mapbox Navigation Core SDK
@@ -117,18 +118,16 @@ private const val MAPBOX_NAVIGATION_TOKEN_EXCEPTION = "You need to provide an ac
  * You can use [setRoutes] to provide new routes, clear current ones, or change the route at primary index 0.
  * todo should we expose a "primaryRouteIndex" field instead of relying on the list's order?
  *
- * @param context activity/fragment's context
  * @param navigationOptions a set of [NavigationOptions] used to customize various features of the SDK.
- * Use [defaultNavigationOptions] to set default options
+ * Use [defaultNavigationOptionsBuilder] to set default options
  * @param locationEngine used to listen for raw location updates
  * @param locationEngineRequest used to request raw location updates
  */
 class MapboxNavigation
 @JvmOverloads
 constructor(
-    private val context: Context,
     private val navigationOptions: NavigationOptions,
-    val locationEngine: LocationEngine = LocationEngineProvider.getBestLocationEngine(context.applicationContext),
+    val locationEngine: LocationEngine = LocationEngineProvider.getBestLocationEngine(navigationOptions.applicationContext),
     locationEngineRequest: LocationEngineRequest = LocationEngineRequest.Builder(1000L)
         .setPriority(LocationEngineRequest.PRIORITY_HIGH_ACCURACY)
         .build()
@@ -141,7 +140,7 @@ constructor(
     private val tripService: TripService
     private val tripSession: TripSession
     private val navigationSession: NavigationSession
-    private val navigationAccountsSession = NavigationAccountsSession(context)
+    private val navigationAccountsSession = NavigationAccountsSession(navigationOptions.applicationContext)
     private val logger: Logger
     private val internalRoutesObserver = createInternalRoutesObserver()
     private val internalOffRouteObserver = createInternalOffRouteObserver()
@@ -164,10 +163,8 @@ constructor(
         )
         directionsSession.registerRoutesObserver(internalRoutesObserver)
         directionsSession.registerRoutesObserver(navigationSession)
-        val notification: TripNotification = MapboxModuleProvider.createModule(
-            MapboxModuleType.NavigationTripNotification,
-            ::paramsProvider
-        )
+        val notification: TripNotification = MapboxModuleProvider
+            .createModule(MapboxModuleType.NavigationTripNotification, ::paramsProvider)
         if (notification.javaClass.name == MAPBOX_NAVIGATION_NOTIFICATION_PACKAGE_NAME) {
             notificationChannelField =
                 notification.javaClass.getDeclaredField(MAPBOX_NOTIFICATION_ACTION_CHANNEL).apply {
@@ -175,7 +172,7 @@ constructor(
                 }
         }
         tripService = NavigationComponentProvider.createTripService(
-            context.applicationContext,
+            navigationOptions.applicationContext,
             notification,
             logger
         )
@@ -196,13 +193,13 @@ constructor(
                 Message("MapboxMetricsReporter.init from MapboxNavigation main")
             )
             MapboxMetricsReporter.init(
-                context,
+                navigationOptions.applicationContext,
                 accessToken ?: throw RuntimeException(MAPBOX_NAVIGATION_TOKEN_EXCEPTION),
                 obtainUserAgent(navigationOptions.isFromNavigationUi)
             )
             MapboxMetricsReporter.toggleLogging(navigationOptions.isDebugLoggingEnabled)
             MapboxNavigationTelemetry.initialize(
-                context.applicationContext,
+                navigationOptions.applicationContext,
                 this,
                 MapboxMetricsReporter,
                 locationEngine.javaClass.name,
@@ -616,13 +613,13 @@ constructor(
                     MapboxModuleType.NavigationOffboardRouter,
                     ::paramsProvider
                 ),
-                NetworkStatusService::class.java to NetworkStatusService(context.applicationContext)
+                NetworkStatusService::class.java to NetworkStatusService(navigationOptions.applicationContext)
             )
             MapboxModuleType.NavigationOffboardRouter -> arrayOf(
                 String::class.java to (accessToken
                     ?: throw RuntimeException(MAPBOX_NAVIGATION_TOKEN_EXCEPTION_OFFBOARD_ROUTER)),
-                Context::class.java to context,
-                UrlSkuTokenProvider::class.java to MapboxNavigationAccounts.getInstance(context)
+                Context::class.java to navigationOptions.applicationContext,
+                UrlSkuTokenProvider::class.java to MapboxNavigationAccounts.getInstance(navigationOptions.applicationContext)
             )
             MapboxModuleType.NavigationOnboardRouter -> {
                 check(accessToken != null) { MAPBOX_NAVIGATION_TOKEN_EXCEPTION_ONBOARD_ROUTER }
@@ -632,11 +629,10 @@ constructor(
                     OnboardRouterOptions::class.java to (navigationOptions.onboardRouterOptions
                         ?: throw RuntimeException(MAPBOX_NAVIGATION_OPTIONS_EXCEPTION_ONBOARD_ROUTER)),
                     Logger::class.java to logger,
-                    SkuTokenProvider::class.java to MapboxNavigationAccounts.getInstance(context)
+                    SkuTokenProvider::class.java to MapboxNavigationAccounts.getInstance(navigationOptions.applicationContext)
                 )
             }
             MapboxModuleType.NavigationTripNotification -> arrayOf(
-                Context::class.java to context.applicationContext,
                 NavigationOptions::class.java to navigationOptions
             )
             MapboxModuleType.CommonLogger -> arrayOf()
@@ -701,12 +697,12 @@ constructor(
          * @return default [NavigationOptions]
          */
         @JvmStatic
-        fun defaultNavigationOptions(context: Context, accessToken: String?): NavigationOptions {
+        fun defaultNavigationOptionsBuilder(context: Context, accessToken: String?): NavigationOptions.Builder {
             val distanceFormatter = MapboxDistanceFormatter.builder()
                 .withUnitType(VoiceUnit.UNDEFINED)
                 .withRoundingIncrement(Rounding.INCREMENT_FIFTY)
                 .build(context)
-            val builder = NavigationOptions.Builder()
+            val builder = NavigationOptions.Builder(context)
                 .accessToken(accessToken)
                 .timeFormatType(TimeFormat.NONE_SPECIFIED)
                 .navigatorPredictionMillis(DEFAULT_NAVIGATOR_PREDICTION_MILLIS)
@@ -717,7 +713,7 @@ constructor(
                 .build()
             builder.onboardRouterOptions(onboardRouterOptions)
 
-            return builder.build()
+            return builder
         }
     }
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigationProvider.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigationProvider.kt
@@ -1,6 +1,5 @@
 package com.mapbox.navigation.core
 
-import android.content.Context
 import com.mapbox.android.core.location.LocationEngine
 import com.mapbox.android.core.location.LocationEngineProvider
 import com.mapbox.android.core.location.LocationEngineRequest
@@ -17,7 +16,6 @@ object MapboxNavigationProvider {
      * Create MapboxNavigation with provided options.
      * Should be called before [retrieve]
      *
-     * @param context
      * @param navigationOptions
      * @param locationEngine
      * @param locationEngineRequest
@@ -25,9 +23,8 @@ object MapboxNavigationProvider {
     @JvmOverloads
     @JvmStatic
     fun create(
-        context: Context,
         navigationOptions: NavigationOptions,
-        locationEngine: LocationEngine = LocationEngineProvider.getBestLocationEngine(context.applicationContext),
+        locationEngine: LocationEngine = LocationEngineProvider.getBestLocationEngine(navigationOptions.applicationContext),
         locationEngineRequest: LocationEngineRequest = LocationEngineRequest.Builder(1000L)
             .setPriority(LocationEngineRequest.PRIORITY_HIGH_ACCURACY)
             .build()
@@ -35,7 +32,6 @@ object MapboxNavigationProvider {
         synchronized(MapboxNavigationProvider::class.java) {
             mapboxNavigation?.onDestroy()
             mapboxNavigation = MapboxNavigation(
-                context,
                 navigationOptions,
                 locationEngine,
                 locationEngineRequest

--- a/libnavigation-ui/api/current.txt
+++ b/libnavigation-ui/api/current.txt
@@ -141,7 +141,7 @@ package com.mapbox.navigation.ui {
     method public abstract com.mapbox.navigation.core.arrival.ArrivalObserver? arrivalObserver();
     method public abstract com.mapbox.navigation.ui.listeners.BannerInstructionsListener? bannerInstructionsListener();
     method public abstract com.google.android.material.bottomsheet.BottomSheetBehavior.BottomSheetCallback? bottomSheetCallback();
-    method public static com.mapbox.navigation.ui.NavigationViewOptions.Builder! builder();
+    method public static com.mapbox.navigation.ui.NavigationViewOptions.Builder! builder(android.content.Context!);
     method public abstract boolean enableVanishingRouteLine();
     method public abstract com.mapbox.navigation.ui.listeners.FeedbackListener? feedbackListener();
     method public abstract com.mapbox.navigation.ui.listeners.InstructionListListener? instructionListListener();

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationViewModel.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationViewModel.java
@@ -200,8 +200,10 @@ public class NavigationViewModel extends AndroidViewModel {
     }
 
     if (options.navigationOptions().getOnboardRouterOptions() == null) {
-      OnboardRouterOptions onboardRouterOptions =
-          MapboxNavigation.defaultNavigationOptions(getApplication(), accessToken).getOnboardRouterOptions();
+      OnboardRouterOptions onboardRouterOptions = MapboxNavigation
+              .defaultNavigationOptionsBuilder(getApplication(), accessToken)
+              .build()
+              .getOnboardRouterOptions();
       updatedOptionsBuilder.onboardRouterOptions(onboardRouterOptions);
     }
 
@@ -209,7 +211,7 @@ public class NavigationViewModel extends AndroidViewModel {
     initializeTimeFormat(updatedOptions);
     if (!isRunning()) {
       LocationEngine locationEngine = initializeLocationEngineFrom(options);
-      initializeNavigation(getApplication(), updatedOptions, locationEngine);
+      initializeNavigation(updatedOptions, locationEngine);
       initializeVoiceInstructionLoader();
       initializeVoiceInstructionCache();
       initializeNavigationSpeechPlayer(options);
@@ -412,13 +414,12 @@ public class NavigationViewModel extends AndroidViewModel {
   }
 
   private void initializeNavigation(
-          Context context,
           NavigationOptions options,
           @Nullable LocationEngine locationEngine) {
     if (locationEngine == null) {
-      navigation = new MapboxNavigation(context, options);
+      navigation = new MapboxNavigation(options);
     } else {
-      navigation = new MapboxNavigation(context, options, locationEngine);
+      navigation = new MapboxNavigation(options, locationEngine);
     }
     addNavigationListeners();
   }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationViewOptions.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationViewOptions.java
@@ -1,5 +1,7 @@
 package com.mapbox.navigation.ui;
 
+import android.content.Context;
+
 import androidx.annotation.Nullable;
 
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
@@ -170,9 +172,9 @@ public abstract class NavigationViewOptions extends NavigationUiOptions {
     public abstract NavigationViewOptions build();
   }
 
-  public static Builder builder() {
+  public static Builder builder(Context context) {
     return new AutoValue_NavigationViewOptions.Builder()
-        .navigationOptions(new NavigationOptions.Builder().build())
+        .navigationOptions(new NavigationOptions.Builder(context).build())
         .roundingIncrement(Rounding.INCREMENT_FIFTY)
         .shouldSimulateRoute(false)
         .waynameChipEnabled(true)

--- a/libtrip-notification/api/current.txt
+++ b/libtrip-notification/api/current.txt
@@ -2,7 +2,7 @@
 package com.mapbox.navigation.trip.notification {
 
   @com.mapbox.annotation.module.MapboxModule(type=MapboxModuleType.NavigationTripNotification) public final class MapboxTripNotification implements com.mapbox.navigation.base.trip.notification.TripNotification {
-    ctor public MapboxTripNotification(android.content.Context applicationContext, com.mapbox.navigation.base.options.NavigationOptions navigationOptions);
+    ctor public MapboxTripNotification(com.mapbox.navigation.base.options.NavigationOptions navigationOptions);
     method public String? getCurrentManeuverModifier();
     method public String? getCurrentManeuverType();
     method public android.app.Notification getNotification();

--- a/libtrip-notification/src/main/java/com/mapbox/navigation/trip/notification/MapboxTripNotification.kt
+++ b/libtrip-notification/src/main/java/com/mapbox/navigation/trip/notification/MapboxTripNotification.kt
@@ -56,7 +56,6 @@ import kotlinx.coroutines.channels.ClosedSendChannelException
 /**
  * Default implementation of [TripNotification] interface
  *
- * @param applicationContext the application's [Context]
  * @param navigationOptions is [NavigationOptions] used here to format distance and time
  *
  * @property currentManeuverType This indicates the type of current maneuver. The same [BannerText.type] of primary [BannerInstructions]
@@ -64,7 +63,6 @@ import kotlinx.coroutines.channels.ClosedSendChannelException
  */
 @MapboxModule(MapboxModuleType.NavigationTripNotification)
 class MapboxTripNotification constructor(
-    private val applicationContext: Context,
     private val navigationOptions: NavigationOptions
 ) : TripNotification {
 
@@ -76,8 +74,10 @@ class MapboxTripNotification constructor(
 
         private const val MAPBOX_NAVIGATION_NOTIFICATION_FORMATTER_EXCEPTION =
             "You need to provide a DistanceFormatter in order to use the default TripNotification. " +
-                "Also see MapboxNavigation#defaultNavigationOptions"
+                "Also see MapboxNavigation#defaultNavigationOptionsBuilder"
     }
+
+    private val applicationContext = navigationOptions.applicationContext
 
     @StepManeuverType
     var currentManeuverType: String? = null

--- a/libtrip-notification/src/test/java/com/mapbox/navigation/trip/notification/MapboxTripNotificationTest.kt
+++ b/libtrip-notification/src/test/java/com/mapbox/navigation/trip/notification/MapboxTripNotificationTest.kt
@@ -63,9 +63,10 @@ class MapboxTripNotificationTest {
         mockkStatic(DateFormat::class)
         mockkStatic(PendingIntent::class)
         mockedContext = createContext()
+        every { mockedContext.applicationContext } returns mockedContext
+        every { navigationOptions.applicationContext } returns mockedContext
         mockRemoteViews()
         notification = MapboxTripNotification(
-            mockedContext,
             navigationOptions
         )
     }


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Resolves: https://github.com/mapbox/mapbox-navigation-android/issues/823
Addresses: https://github.com/mapbox/mapbox-navigation-android/issues/3187
Addresses: https://github.com/mapbox/mapbox-navigation-android/issues/3016

Breaking up this large refactor into smaller pieces for better review: https://github.com/mapbox/mapbox-navigation-android/pull/3191

The Application Context is used in various features, it is also a required parameter for navigation. 

- [ ] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [x] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->