### PR TITLE
add API to set access token and add user agent

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/GuidanceViewActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/GuidanceViewActivity.kt
@@ -80,25 +80,28 @@ class GuidanceViewActivity : AppCompatActivity(), OnMapReadyCallback {
     override fun onMapReady(mapboxMap: MapboxMap) {
         mapboxMap.setStyle(Style.MAPBOX_STREETS) { style ->
             val cameraPosition = CameraPosition.Builder()
-                    .target(LatLng(destination.latitude(), destination.longitude()))
-                    .zoom(16.5)
-                    .build()
+                .target(LatLng(destination.latitude(), destination.longitude()))
+                .zoom(16.5)
+                .build()
             mapboxMap.moveCamera(CameraUpdateFactory.newCameraPosition(cameraPosition))
             navigationMapboxMap = NavigationMapboxMap(mapView, mapboxMap, this, true).also {
                 it.addProgressChangeListener(mapboxNavigation)
             }
 
+            // Use the same token, you are using to fetch directionsRoute
+            instructionView.setAccessToken(Utils.getMapboxAccessToken(this))
+
             // Ideally we should use Mapbox.getAccessToken(), but to show GuidanceView we need a
             // specific access token for route request.
             mapboxNavigation.requestRoutes(
-                    RouteOptions.builder().applyDefaultParams()
-                            .accessToken(Utils.getMapboxAccessToken(this))
-                            .coordinates(origin, null, destination)
-                            .alternatives(true)
-                            .profile(DirectionsCriteria.PROFILE_DRIVING_TRAFFIC)
-                            .bannerInstructions(true)
-                            .build(),
-                    routesReqCallback
+                RouteOptions.builder().applyDefaultParams()
+                    .accessToken(Utils.getMapboxAccessToken(this))
+                    .coordinates(origin, null, destination)
+                    .alternatives(true)
+                    .profile(DirectionsCriteria.PROFILE_DRIVING_TRAFFIC)
+                    .bannerInstructions(true)
+                    .build(),
+                routesReqCallback
             )
 
             mapboxNavigation.registerRouteProgressObserver(ReplayProgressObserver(mapboxReplayer))

--- a/examples/src/main/java/com/mapbox/navigation/examples/ui/BuildingExtrusionActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/ui/BuildingExtrusionActivity.kt
@@ -11,6 +11,7 @@ import com.mapbox.mapboxsdk.maps.MapboxMap
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.trip.session.RouteProgressObserver
 import com.mapbox.navigation.examples.R
+import com.mapbox.navigation.examples.utils.Utils
 import com.mapbox.navigation.ui.NavigationViewOptions
 import com.mapbox.navigation.ui.OnNavigationReadyCallback
 import com.mapbox.navigation.ui.internal.building.BuildingExtrusionLayer
@@ -41,7 +42,11 @@ class BuildingExtrusionActivity : AppCompatActivity(), OnNavigationReadyCallback
         setContentView(R.layout.activity_building_extrusion)
 
         navigationView.onCreate(savedInstanceState)
-        navigationView.initialize(this, getInitialCameraPosition())
+        navigationView.initialize(
+            this,
+            getInitialCameraPosition(),
+            Utils.getMapboxAccessToken(this)
+        )
     }
 
     override fun onLowMemory() {

--- a/examples/src/main/java/com/mapbox/navigation/examples/ui/BuildingFootprintHighlightActivityKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/ui/BuildingFootprintHighlightActivityKt.kt
@@ -15,6 +15,7 @@ import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.arrival.ArrivalObserver
 import com.mapbox.navigation.examples.R
+import com.mapbox.navigation.examples.utils.Utils
 import com.mapbox.navigation.ui.NavigationViewOptions
 import com.mapbox.navigation.ui.OnNavigationReadyCallback
 import com.mapbox.navigation.ui.internal.building.BuildingFootprintHighlightLayer
@@ -47,7 +48,11 @@ class BuildingFootprintHighlightActivityKt : AppCompatActivity(), OnNavigationRe
         setContentView(R.layout.activity_final_destination_arrival_building_highlight)
 
         navigationView.onCreate(savedInstanceState)
-        navigationView.initialize(this, getInitialCameraPosition())
+        navigationView.initialize(
+            this,
+            getInitialCameraPosition(),
+            Utils.getMapboxAccessToken(this)
+        )
     }
 
     override fun onLowMemory() {
@@ -183,9 +188,9 @@ class BuildingFootprintHighlightActivityKt : AppCompatActivity(), OnNavigationRe
     private fun getInitialCameraPosition(): CameraPosition {
         val originCoordinate = route.routeOptions()?.coordinates()?.get(0)
         return CameraPosition.Builder()
-                .target(LatLng(originCoordinate!!.latitude(), originCoordinate.longitude()))
-                .zoom(15.0)
-                .build()
+            .target(LatLng(originCoordinate!!.latitude(), originCoordinate.longitude()))
+            .zoom(15.0)
+            .build()
     }
 
     private fun getDirectionsRoute(): DirectionsRoute {

--- a/examples/src/main/java/com/mapbox/navigation/examples/ui/CustomCameraActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/ui/CustomCameraActivity.kt
@@ -9,6 +9,7 @@ import com.mapbox.mapboxsdk.geometry.LatLng
 import com.mapbox.mapboxsdk.location.modes.RenderMode
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.examples.R
+import com.mapbox.navigation.examples.utils.Utils
 import com.mapbox.navigation.ui.NavigationViewOptions
 import com.mapbox.navigation.ui.OnNavigationReadyCallback
 import com.mapbox.navigation.ui.camera.Camera
@@ -26,8 +27,8 @@ import kotlinx.android.synthetic.main.activity_navigation_view.navigationView
  * [NavigationViewOptions.Builder.camera].
  */
 class CustomCameraActivity : AppCompatActivity(), OnNavigationReadyCallback,
-        NavigationListener,
-        BannerInstructionsListener {
+    NavigationListener,
+    BannerInstructionsListener {
 
     private lateinit var navigationMapboxMap: NavigationMapboxMap
     private lateinit var mapboxNavigation: MapboxNavigation
@@ -38,7 +39,11 @@ class CustomCameraActivity : AppCompatActivity(), OnNavigationReadyCallback,
         setContentView(R.layout.activity_navigation_view)
 
         navigationView.onCreate(savedInstanceState)
-        navigationView.initialize(this, getInitialCameraPosition())
+        navigationView.initialize(
+            this,
+            getInitialCameraPosition(),
+            Utils.getMapboxAccessToken(this)
+        )
     }
 
     override fun onLowMemory() {
@@ -150,9 +155,9 @@ class CustomCameraActivity : AppCompatActivity(), OnNavigationReadyCallback,
     private fun getInitialCameraPosition(): CameraPosition {
         val originCoordinate = route.routeOptions()?.coordinates()?.get(0)
         return CameraPosition.Builder()
-                .target(LatLng(originCoordinate!!.latitude(), originCoordinate.longitude()))
-                .zoom(15.0)
-                .build()
+            .target(LatLng(originCoordinate!!.latitude(), originCoordinate.longitude()))
+            .zoom(15.0)
+            .build()
     }
 
     private fun getDirectionsRoute(): DirectionsRoute {

--- a/examples/src/main/java/com/mapbox/navigation/examples/ui/CustomPuckActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/ui/CustomPuckActivity.kt
@@ -10,6 +10,7 @@ import com.mapbox.mapboxsdk.location.modes.RenderMode
 import com.mapbox.navigation.base.trip.model.RouteProgressState
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.examples.R
+import com.mapbox.navigation.examples.utils.Utils
 import com.mapbox.navigation.ui.NavigationViewOptions
 import com.mapbox.navigation.ui.OnNavigationReadyCallback
 import com.mapbox.navigation.ui.listeners.BannerInstructionsListener
@@ -26,8 +27,8 @@ import kotlinx.android.synthetic.main.activity_navigation_view.*
  * status.
  */
 class CustomPuckActivity : AppCompatActivity(), OnNavigationReadyCallback,
-        NavigationListener,
-        BannerInstructionsListener {
+    NavigationListener,
+    BannerInstructionsListener {
 
     private lateinit var navigationMapboxMap: NavigationMapboxMap
     private lateinit var mapboxNavigation: MapboxNavigation
@@ -38,7 +39,11 @@ class CustomPuckActivity : AppCompatActivity(), OnNavigationReadyCallback,
         setContentView(R.layout.activity_navigation_view)
 
         navigationView.onCreate(savedInstanceState)
-        navigationView.initialize(this, getInitialCameraPosition())
+        navigationView.initialize(
+            this,
+            getInitialCameraPosition(),
+            Utils.getMapboxAccessToken(this)
+        )
     }
 
     override fun onLowMemory() {
@@ -125,9 +130,9 @@ class CustomPuckActivity : AppCompatActivity(), OnNavigationReadyCallback,
     private fun getInitialCameraPosition(): CameraPosition {
         val originCoordinate = route.routeOptions()?.coordinates()?.get(0)
         return CameraPosition.Builder()
-                .target(LatLng(originCoordinate!!.latitude(), originCoordinate.longitude()))
-                .zoom(15.0)
-                .build()
+            .target(LatLng(originCoordinate!!.latitude(), originCoordinate.longitude()))
+            .zoom(15.0)
+            .build()
     }
 
     private fun getDirectionsRoute(): DirectionsRoute {
@@ -138,13 +143,14 @@ class CustomPuckActivity : AppCompatActivity(), OnNavigationReadyCallback,
     }
 
     class CustomPuckDrawableSupplier : PuckDrawableSupplier {
-        override fun getPuckDrawable(routeProgressState: RouteProgressState): Int = when (routeProgressState) {
-            RouteProgressState.ROUTE_INVALID -> R.drawable.custom_puck_icon_uncertain_location
-            RouteProgressState.ROUTE_INITIALIZED -> R.drawable.custom_user_puck_icon
-            RouteProgressState.LOCATION_TRACKING -> R.drawable.custom_user_puck_icon
-            RouteProgressState.ROUTE_COMPLETE -> R.drawable.custom_puck_icon_uncertain_location
-            RouteProgressState.LOCATION_STALE -> R.drawable.custom_user_puck_icon
-            else -> R.drawable.custom_puck_icon_uncertain_location
-        }
+        override fun getPuckDrawable(routeProgressState: RouteProgressState): Int =
+            when (routeProgressState) {
+                RouteProgressState.ROUTE_INVALID -> R.drawable.custom_puck_icon_uncertain_location
+                RouteProgressState.ROUTE_INITIALIZED -> R.drawable.custom_user_puck_icon
+                RouteProgressState.LOCATION_TRACKING -> R.drawable.custom_user_puck_icon
+                RouteProgressState.ROUTE_COMPLETE -> R.drawable.custom_puck_icon_uncertain_location
+                RouteProgressState.LOCATION_STALE -> R.drawable.custom_user_puck_icon
+                else -> R.drawable.custom_puck_icon_uncertain_location
+            }
     }
 }

--- a/examples/src/main/java/com/mapbox/navigation/examples/ui/NavigationViewActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/ui/NavigationViewActivity.kt
@@ -9,6 +9,7 @@ import com.mapbox.mapboxsdk.geometry.LatLng
 import com.mapbox.mapboxsdk.location.modes.RenderMode
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.examples.R
+import com.mapbox.navigation.examples.utils.Utils
 import com.mapbox.navigation.ui.NavigationViewOptions
 import com.mapbox.navigation.ui.OnNavigationReadyCallback
 import com.mapbox.navigation.ui.listeners.BannerInstructionsListener
@@ -22,8 +23,8 @@ import kotlinx.android.synthetic.main.activity_navigation_view.*
  * to implement a basic turn-by-turn navigation experience.
  */
 class NavigationViewActivity : AppCompatActivity(), OnNavigationReadyCallback,
-        NavigationListener,
-        BannerInstructionsListener {
+    NavigationListener,
+    BannerInstructionsListener {
 
     private lateinit var navigationMapboxMap: NavigationMapboxMap
     private lateinit var mapboxNavigation: MapboxNavigation
@@ -34,7 +35,11 @@ class NavigationViewActivity : AppCompatActivity(), OnNavigationReadyCallback,
         setContentView(R.layout.activity_navigation_view)
 
         navigationView.onCreate(savedInstanceState)
-        navigationView.initialize(this, getInitialCameraPosition())
+        navigationView.initialize(
+            this,
+            getInitialCameraPosition(),
+            Utils.getMapboxAccessToken(this)
+        )
     }
 
     override fun onLowMemory() {
@@ -121,9 +126,9 @@ class NavigationViewActivity : AppCompatActivity(), OnNavigationReadyCallback,
     private fun getInitialCameraPosition(): CameraPosition {
         val originCoordinate = route.routeOptions()?.coordinates()?.get(0)
         return CameraPosition.Builder()
-                .target(LatLng(originCoordinate!!.latitude(), originCoordinate.longitude()))
-                .zoom(15.0)
-                .build()
+            .target(LatLng(originCoordinate!!.latitude(), originCoordinate.longitude()))
+            .zoom(15.0)
+            .build()
     }
 
     private fun getDirectionsRoute(): DirectionsRoute {

--- a/examples/src/main/java/com/mapbox/navigation/examples/ui/NavigationViewFragment.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/ui/NavigationViewFragment.kt
@@ -11,6 +11,7 @@ import com.mapbox.mapboxsdk.geometry.LatLng
 import com.mapbox.mapboxsdk.location.modes.RenderMode
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.examples.R
+import com.mapbox.navigation.examples.utils.Utils
 import com.mapbox.navigation.ui.NavigationViewOptions
 import com.mapbox.navigation.ui.OnNavigationReadyCallback
 import com.mapbox.navigation.ui.listeners.NavigationListener
@@ -41,7 +42,13 @@ class NavigationViewFragment : Fragment(), OnNavigationReadyCallback, Navigation
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         navigationView.onCreate(savedInstanceState)
-        navigationView.initialize(this, getInitialCameraPosition())
+        activity?.let {
+            navigationView.initialize(
+                this,
+                getInitialCameraPosition(),
+                Utils.getMapboxAccessToken(it)
+            )
+        }
     }
 
     override fun onLowMemory() {
@@ -121,9 +128,9 @@ class NavigationViewFragment : Fragment(), OnNavigationReadyCallback, Navigation
     private fun getInitialCameraPosition(): CameraPosition {
         val originCoordinate = route.routeOptions()?.coordinates()?.get(0)
         return CameraPosition.Builder()
-                .target(LatLng(originCoordinate!!.latitude(), originCoordinate.longitude()))
-                .zoom(15.0)
-                .build()
+            .target(LatLng(originCoordinate!!.latitude(), originCoordinate.longitude()))
+            .zoom(15.0)
+            .build()
     }
 
     private fun getDirectionsRoute(): DirectionsRoute {

--- a/libnavigation-ui/api/current.txt
+++ b/libnavigation-ui/api/current.txt
@@ -83,8 +83,8 @@ package com.mapbox.navigation.ui {
     method public void drawRoute(com.mapbox.api.directions.v5.models.DirectionsRoute!);
     method public androidx.lifecycle.Lifecycle getLifecycle();
     method public void hideRecenterBtn();
-    method public void initialize(com.mapbox.navigation.ui.OnNavigationReadyCallback!);
-    method public void initialize(com.mapbox.navigation.ui.OnNavigationReadyCallback!, com.mapbox.mapboxsdk.camera.CameraPosition);
+    method public void initialize(com.mapbox.navigation.ui.OnNavigationReadyCallback!, String!);
+    method public void initialize(com.mapbox.navigation.ui.OnNavigationReadyCallback!, com.mapbox.mapboxsdk.camera.CameraPosition, String!);
     method public boolean isRecenterButtonVisible();
     method public boolean isSummaryBottomSheetHidden();
     method public boolean isWayNameVisible();
@@ -372,6 +372,7 @@ package com.mapbox.navigation.ui.instruction {
     method public com.mapbox.navigation.ui.instruction.NavigationAlertView! retrieveAlertView();
     method public com.mapbox.navigation.ui.NavigationButton! retrieveFeedbackButton();
     method public com.mapbox.navigation.ui.NavigationButton! retrieveSoundButton();
+    method public void setAccessToken(String!);
     method public void setDistanceFormatter(com.mapbox.navigation.base.formatter.DistanceFormatter!);
     method public void setInstructionListListener(com.mapbox.navigation.ui.listeners.InstructionListListener!);
     method public void showFeedbackBottomSheet();

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationView.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationView.java
@@ -9,7 +9,6 @@ import android.os.Bundle;
 import android.util.AttributeSet;
 import android.view.View;
 import android.widget.ImageButton;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
@@ -20,7 +19,6 @@ import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.LifecycleOwner;
 import androidx.lifecycle.LifecycleRegistry;
 import androidx.lifecycle.ViewModelProviders;
-
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
 import com.google.android.material.snackbar.Snackbar;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
@@ -35,11 +33,11 @@ import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.maps.UiSettings;
 import com.mapbox.navigation.base.internal.extensions.ContextEx;
+import com.mapbox.navigation.base.TimeFormat;
 import com.mapbox.navigation.base.formatter.DistanceFormatter;
 import com.mapbox.navigation.base.route.Router;
-import com.mapbox.navigation.base.TimeFormat;
-import com.mapbox.navigation.core.internal.MapboxDistanceFormatter;
 import com.mapbox.navigation.core.MapboxNavigation;
+import com.mapbox.navigation.core.internal.MapboxDistanceFormatter;
 import com.mapbox.navigation.core.replay.MapboxReplayer;
 import com.mapbox.navigation.ui.camera.DynamicCamera;
 import com.mapbox.navigation.ui.camera.NavigationCamera;
@@ -79,7 +77,6 @@ import static com.mapbox.navigation.base.internal.extensions.LocaleEx.getUnitTyp
  * and ACCESS_COARSE_LOCATION have already been granted.
  * <p>
  * A Mapbox access token must also be set by the developer (to initialize navigation).
- *
  */
 public class NavigationView extends CoordinatorLayout implements LifecycleOwner, OnMapReadyCallback,
     NavigationContract.View {
@@ -450,7 +447,6 @@ public class NavigationView extends CoordinatorLayout implements LifecycleOwner,
 
   /**
    * Call this when the navigation session needs to end navigation without finishing the whole view
-   *
    */
   public void stopNavigation() {
     navigationPresenter.onNavigationStopped();
@@ -464,9 +460,11 @@ public class NavigationView extends CoordinatorLayout implements LifecycleOwner,
    * which will fire the ready events for this view.
    *
    * @param onNavigationReadyCallback to be set to this view
+   * @param accessToken access token used to make  Directions API/Map Matching request
    */
-  public void initialize(OnNavigationReadyCallback onNavigationReadyCallback) {
+  public void initialize(OnNavigationReadyCallback onNavigationReadyCallback, String accessToken) {
     onNavigationReadyCallbacks.add(onNavigationReadyCallback);
+    instructionView.setAccessToken(accessToken);
     if (!isMapInitialized) {
       mapView.getMapAsync(this);
     } else {
@@ -485,9 +483,11 @@ public class NavigationView extends CoordinatorLayout implements LifecycleOwner,
    *
    * @param onNavigationReadyCallback to be set to this view
    * @param initialMapCameraPosition to be shown once the map is ready
+   * @param accessToken access token used to make Directions API/Map Matching request
    */
   public void initialize(OnNavigationReadyCallback onNavigationReadyCallback,
-      @NonNull CameraPosition initialMapCameraPosition) {
+      @NonNull CameraPosition initialMapCameraPosition, String accessToken) {
+    instructionView.setAccessToken(accessToken);
     this.initialMapCameraPosition = initialMapCameraPosition;
     onNavigationReadyCallbacks.add(onNavigationReadyCallback);
     if (!isMapInitialized) {


### PR DESCRIPTION
## Description

Update API to set access token in instruction view and add `User-Agent` to fetch `Junction` images. (Fixes [3225](https://github.com/mapbox/mapbox-navigation-android/issues/3225) and [3226](https://github.com/mapbox/mapbox-navigation-android/issues/3226))
Refers: https://github.com/mapbox/1tap-android/issues/381

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Update API to set access token in instruction view and add `User-Agent` to fetch `Junction` images.

### Implementation

Update API to set access token in instruction view and add `User-Agent` to fetch `Junction` images.

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have updated the `CHANGELOG` including this PR
- [x] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->