### PR TITLE
when adding new routes cancel any route line animation that may be in progress

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/NavigationMapRoute.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/NavigationMapRoute.java
@@ -175,11 +175,13 @@ public class NavigationMapRoute implements LifecycleObserver {
    */
   public void addRoutes(@NonNull @Size(min = 1) List<? extends DirectionsRoute> directionsRoutes) {
     if (directionsRoutes.isEmpty()) {
+      cancelVanishingRouteLineAnimator();
       routeLine.draw(directionsRoutes);
     } else if (!CompareUtils.areEqualContentsIgnoreOrder(
         routeLine.retrieveDirectionsRoutes(),
         directionsRoutes)
     ) {
+      cancelVanishingRouteLineAnimator();
       routeLine.draw(directionsRoutes);
     }
   }
@@ -362,6 +364,12 @@ public class NavigationMapRoute implements LifecycleObserver {
   private void shutdownVanishingRouteLineAnimator() {
     if (this.vanishingRouteLineAnimator != null) {
       this.vanishingRouteLineAnimator.removeAllUpdateListeners();
+      cancelVanishingRouteLineAnimator();
+    }
+  }
+
+  private void cancelVanishingRouteLineAnimator() {
+    if (this.vanishingRouteLineAnimator != null) {
       this.vanishingRouteLineAnimator.cancel();
     }
   }


### PR DESCRIPTION
## Description

When a new route(s) are added any progress update animator that may be running is cancelled.

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal

There should be a smooth transition when the route line is redrawn whether as a result of a reroute event or other event that results in a new route line being drawn.

### Implementation

NavigationMapRoute::addRoutes will cancel the animator if there is one.

## Screenshots or Gifs


## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->