### PR TITLE
Adding transparent puck which is useful for watching the route line

### DIFF
--- a/examples/src/main/res/drawable/custom_user_puck_icon.xml
+++ b/examples/src/main/res/drawable/custom_user_puck_icon.xml
@@ -1,17 +1,14 @@
-<vector
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="75dp"
     android:height="75dp"
     android:viewportHeight="75.0"
     android:viewportWidth="75.0">
-    <path
-        android:fillAlpha="0.16"
-        android:fillColor="#263D57"
-        android:pathData="M37.5,37.5m-37.5,0a37.5,37.5 0,1 1,75 0a37.5,37.5 0,1 1,-75 0"/>
-    <path
-        android:fillColor="#FFFFFF"
-        android:pathData="M37.5,37.5m-28.5,0a28.5,28.5 0,1 1,57 0a28.5,28.5 0,1 1,-57 0"/>
-    <path
-        android:fillColor="@color/red"
-        android:pathData="M39.2,28.46C39.01,27.99 38.54,27.68 38.02,27.69C37.5,27.7 37.02,28.01 36.81,28.49L27.05,45.83C26.83,46.32 26.92,46.89 27.28,47.26C27.65,47.64 28.21,47.75 28.71,47.54L37.07,44.03C37.39,43.89 37.75,43.89 38.06,44.02L46.27,47.34C46.75,47.54 47.33,47.42 47.71,47.03C48.09,46.64 48.21,46.07 48,45.59L39.2,28.46Z"/>
-</vector>
+    <item>
+        <shape android:shape="oval">
+            <stroke android:color="#ffcc00" android:width="5dp"/>
+            <!-- Set the same value for both width and height to get a circular shape -->
+            <size android:width="75dp" android:height="75dp"/>
+        </shape>
+    </item>
+</selector>


### PR DESCRIPTION
## Description

Modified the custom puck example to use a transparent puck.

- [ ] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal

It can be useful to see what the route line is doing around the puck during navigation, especially when testing vanishing route line issues. Having a transparent puck readily available saves some time and it also shows what kind of customization is possible.

### Implementation

Changed the drawable resource to use a ring with a transparent center.

## Screenshots or Gifs

![Screenshot_20200624-161206](https://user-images.githubusercontent.com/2249818/85636510-a3738400-b635-11ea-9745-f64d2402a347.png)

## Testing


- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->