### PR TITLE
Mock calendar time to fix flakey test

### DIFF
--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/summary/SummaryModelTest.kt
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/summary/SummaryModelTest.kt
@@ -9,6 +9,8 @@ import com.mapbox.navigation.core.Rounding.INCREMENT_FIFTY
 import com.mapbox.navigation.core.internal.MapboxDistanceFormatter
 import com.mapbox.navigation.trip.notification.internal.TimeFormatter.formatTime
 import com.mapbox.navigation.ui.BaseTest
+import io.mockk.every
+import io.mockk.mockkStatic
 import java.util.Calendar
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -69,7 +71,12 @@ class SummaryModelTest : BaseTest() {
             .withUnitType(METRIC)
             .withRoundingIncrement(INCREMENT_FIFTY)
             .build(ctx)
-        val time = Calendar.getInstance()
+        val time = Calendar.getInstance().also {
+            it.set(2020, 2, 20, 20, 20, 20)
+        }
+        mockkStatic(Calendar::class)
+        every { Calendar.getInstance() } returns time
+
         val legDurationRemaining: Double = routeProgress!!
             .currentLegProgress!!
             .durationRemaining


### PR DESCRIPTION
## Description

Fixes the flakey test specified in #3222

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal

Unflakify the test.

### Implementation

Mock Calendar.getInstance()

## Screenshots or Gifs


## Testing


- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->