### PR TITLE
Removing cached route state.

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/camera/SimpleCamera.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/camera/SimpleCamera.kt
@@ -4,8 +4,6 @@ import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.core.constants.Constants
 import com.mapbox.geojson.LineString
 import com.mapbox.geojson.Point
-import com.mapbox.navigation.utils.internal.ifNonNull
-import java.util.ArrayList
 
 /**
  * The default camera used by [MapboxNavigation].
@@ -24,9 +22,6 @@ open class SimpleCamera : Camera() {
         protected const val DEFAULT_ZOOM = 15.0
     }
 
-    private var routeCoordinates: List<Point> = ArrayList()
-    private var initialRoute: DirectionsRoute? = null
-
     override fun tilt(routeInformation: RouteInformation): Double {
         return DEFAULT_TILT.toDouble()
     }
@@ -35,29 +30,16 @@ open class SimpleCamera : Camera() {
         return DEFAULT_ZOOM
     }
 
-    override fun overview(routeInformation: RouteInformation): List<Point> {
-        if (routeCoordinates.isEmpty()) {
-            buildRouteCoordinatesFromRouteData(routeInformation)
-        }
-        return routeCoordinates
-    }
+    override fun overview(routeInformation: RouteInformation): List<Point> =
+        getRoute(routeInformation)?.run {
+            generateRouteCoordinates(this)
+        } ?: emptyList()
 
-    private fun buildRouteCoordinatesFromRouteData(routeInformation: RouteInformation) {
-        ifNonNull(routeInformation.route) { route ->
-            setupLineStringAndBearing(route)
+    private fun getRoute(routeInformation: RouteInformation): DirectionsRoute? =
+        when (routeInformation.route) {
+            null -> routeInformation.routeProgress?.route
+            else -> routeInformation.route
         }
-            ?: ifNonNull(routeInformation.routeProgress?.route) { directionsRoute ->
-                setupLineStringAndBearing(directionsRoute)
-            }
-    }
-
-    private fun setupLineStringAndBearing(route: DirectionsRoute) {
-        if (route == initialRoute) {
-            return // no need to recalculate these values
-        }
-        initialRoute = route
-        routeCoordinates = generateRouteCoordinates(route)
-    }
 
     private fun generateRouteCoordinates(route: DirectionsRoute?): List<Point> =
         route?.geometry()?.let { geometry ->

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/camera/SimpleCameraTest.kt
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/camera/SimpleCameraTest.kt
@@ -1,0 +1,48 @@
+package com.mapbox.navigation.ui.camera
+
+import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.navigation.ui.BaseTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SimpleCameraTest : BaseTest() {
+
+    @Test
+    fun overview() {
+        val route = buildTestDirectionsRoute()
+
+        val result = SimpleCamera().overview(RouteInformation(route, null, null))
+
+        assertEquals(19, result.size)
+    }
+
+    @Test
+    fun overviewWillNotCachRoute() {
+        val route1 = buildTestDirectionsRoute()
+        val route2 = getMultilegRoute()
+        SimpleCamera().overview(RouteInformation(route1, null, null))
+
+        val result = SimpleCamera().overview(RouteInformation(route2, null, null))
+
+        assertEquals(114, result.size)
+    }
+
+    @Test
+    fun tilt() {
+        val result = SimpleCamera().tilt(RouteInformation(null, null, null))
+
+        assertEquals(50.0, result, 0.0)
+    }
+
+    @Test
+    fun zoom() {
+        val result = SimpleCamera().zoom(RouteInformation(null, null, null))
+
+        assertEquals(15.0, result, 0.0)
+    }
+
+    private fun getMultilegRoute(): DirectionsRoute {
+        val routeAsJson = loadJsonFixture("multileg_route.json")
+        return DirectionsRoute.fromJson(routeAsJson)
+    }
+}


### PR DESCRIPTION
## Description

Fix for the ticket #3207. 

- [x] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal

When a route changes the overview should return data for the route information that was inputted.

### Implementation

By removing the previously held state in the class the calculation is always performed on the input. I saw no value in caching the results. The overview calculation is done in response to a user initiated action.

## Screenshots or Gifs

## Testing


- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->