### PR TITLE
Receive enhanced locations without navigating

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/SimpleMapboxNavigationKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/SimpleMapboxNavigationKt.kt
@@ -3,7 +3,6 @@ package com.mapbox.navigation.examples.core
 import android.annotation.SuppressLint
 import android.os.Bundle
 import android.os.CountDownTimer
-import android.os.Looper
 import android.preference.PreferenceManager
 import android.view.View
 import android.view.View.GONE
@@ -14,11 +13,6 @@ import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.snackbar.BaseTransientBottomBar.LENGTH_SHORT
 import com.google.android.material.snackbar.Snackbar
-import com.mapbox.android.core.location.LocationEngine
-import com.mapbox.android.core.location.LocationEngineCallback
-import com.mapbox.android.core.location.LocationEngineProvider
-import com.mapbox.android.core.location.LocationEngineRequest
-import com.mapbox.android.core.location.LocationEngineResult
 import com.mapbox.api.directions.v5.DirectionsCriteria
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.RouteOptions
@@ -62,7 +56,6 @@ import com.mapbox.navigation.ui.voice.NavigationSpeechPlayer
 import com.mapbox.navigation.ui.voice.SpeechPlayerProvider
 import com.mapbox.navigation.ui.voice.VoiceInstructionLoader
 import java.io.File
-import java.lang.ref.WeakReference
 import java.util.Date
 import java.util.Locale
 import kotlinx.android.synthetic.main.activity_trip_service.mapView
@@ -85,7 +78,6 @@ class SimpleMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
     private val startTimeInMillis = 5000L
     private val countdownInterval = 10L
     private val maxProgress = startTimeInMillis / countdownInterval
-    private val locationEngineCallback = MyLocationEngineCallback(this)
     private val restartSessionEventChannel = Channel<RestartTripSessionAction>(1)
 
     private var mapboxMap: MapboxMap? = null
@@ -95,7 +87,6 @@ class SimpleMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
     private var originalRoute: DirectionsRoute? = null
 
     private lateinit var mapboxNavigation: MapboxNavigation
-    private lateinit var localLocationEngine: LocationEngine
     private lateinit var bottomSheetBehavior: BottomSheetBehavior<View>
     private lateinit var navigationMapboxMap: NavigationMapboxMap
     private lateinit var speechPlayer: NavigationSpeechPlayer
@@ -138,11 +129,10 @@ class SimpleMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
         initViews()
         mapView.onCreate(savedInstanceState)
         mapView.getMapAsync(this)
-        localLocationEngine = LocationEngineProvider.getBestLocationEngine(applicationContext)
 
-        val mapboxNavigationOptions = MapboxNavigation
+        val optionsBuilder = MapboxNavigation
             .defaultNavigationOptionsBuilder(this, Utils.getMapboxAccessToken(this))
-        mapboxNavigation = getMapboxNavigation(mapboxNavigationOptions)
+        mapboxNavigation = getMapboxNavigation(optionsBuilder)
     }
 
     override fun onMapReady(mapboxMap: MapboxMap) {
@@ -245,29 +235,6 @@ class SimpleMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
         }
     }
 
-    private fun startLocationUpdates() {
-        val request = LocationEngineRequest.Builder(1000L)
-            .setFastestInterval(500L)
-            .setPriority(LocationEngineRequest.PRIORITY_HIGH_ACCURACY)
-            .build()
-        try {
-            localLocationEngine.requestLocationUpdates(
-                request,
-                locationEngineCallback,
-                Looper.getMainLooper()
-            )
-            if (originalRoute == null) {
-                localLocationEngine.getLastLocation(locationEngineCallback)
-            }
-        } catch (exception: SecurityException) {
-            Timber.e(exception)
-        }
-    }
-
-    private fun stopLocationUpdates() {
-        localLocationEngine.removeLocationUpdates(locationEngineCallback)
-    }
-
     private val routeProgressObserver = object : RouteProgressObserver {
         override fun onRouteProgressChanged(routeProgress: RouteProgress) {
             Timber.d("route progress %s", routeProgress.toString())
@@ -337,11 +304,9 @@ class SimpleMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
         override fun onSessionStateChanged(tripSessionState: TripSessionState) {
             when (tripSessionState) {
                 TripSessionState.STARTED -> {
-                    stopLocationUpdates()
                     startNavigation.visibility = GONE
                 }
                 TripSessionState.STOPPED -> {
-                    startLocationUpdates()
                     startNavigation.visibility = VISIBLE
                     updateCameraOnNavigationStateChange(false)
                 }
@@ -371,14 +336,17 @@ class SimpleMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
         navigationMapboxMap.startCamera(route)
     }
 
+    @SuppressLint("MissingPermission")
     public override fun onResume() {
         super.onResume()
         mapView.onResume()
+        mapboxNavigation.startLocationUpdates()
     }
 
     public override fun onPause() {
         super.onPause()
         mapView.onPause()
+        mapboxNavigation.stopLocationUpdates()
     }
 
     @SuppressLint("MissingPermission")
@@ -405,7 +373,6 @@ class SimpleMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
         mapboxNavigation.unregisterRoutesObserver(routesObserver)
         mapboxNavigation.unregisterTripSessionStateObserver(tripSessionStateObserver)
         mapboxNavigation.detachFasterRouteObserver()
-        stopLocationUpdates()
 
         if (mapboxNavigation.getRoutes()
                 .isEmpty() && mapboxNavigation.getTripSessionState() == TripSessionState.STARTED
@@ -427,7 +394,6 @@ class SimpleMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
         super.onDestroy()
         mapView.onDestroy()
 
-        mapboxReplayer.finish()
         mapboxNavigation.unregisterVoiceInstructionsObserver(this)
         mapboxNavigation.stopTripSession()
         mapboxNavigation.onDestroy()
@@ -456,21 +422,6 @@ class SimpleMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
 
     override fun onNewVoiceInstructions(voiceInstructions: VoiceInstructions) {
         speechPlayer.play(voiceInstructions)
-    }
-
-    private class MyLocationEngineCallback(activity: SimpleMapboxNavigationKt) :
-        LocationEngineCallback<LocationEngineResult> {
-
-        private val activityRef = WeakReference(activity)
-
-        override fun onSuccess(result: LocationEngineResult?) {
-            result?.locations?.firstOrNull()?.let {
-                activityRef.get()?.locationComponent?.forceLocationUpdate(it)
-            }
-        }
-
-        override fun onFailure(exception: Exception) {
-        }
     }
 
     private object RestartTripSessionAction

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/TripSessionActivityKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/TripSessionActivityKt.kt
@@ -60,7 +60,7 @@ class TripSessionActivityKt : AppCompatActivity(), OnMapReadyCallback {
                     true -> {
                         mapboxMap.locationComponent.isLocationComponentEnabled = false
                         tripSession.unregisterLocationObserver(locationObserver)
-                        tripSession.stop()
+                        tripSession.stopTripSession()
                         toggleSession.text = "Start"
                         isActive = false
                     }
@@ -74,7 +74,7 @@ class TripSessionActivityKt : AppCompatActivity(), OnMapReadyCallback {
                         mapboxMap.locationComponent.cameraMode = CameraMode.TRACKING_GPS
                         mapboxMap.locationComponent.renderMode = RenderMode.GPS
                         tripSession.registerLocationObserver(locationObserver)
-                        tripSession.start()
+                        tripSession.startTripSession()
                         mapboxMap.locationComponent.isLocationComponentEnabled = true
                         toggleSession.text = "Stop"
                         isActive = true
@@ -144,7 +144,7 @@ class TripSessionActivityKt : AppCompatActivity(), OnMapReadyCallback {
         mapView.onDestroy()
         if (::tripSession.isInitialized) {
             tripSession.unregisterLocationObserver(locationObserver)
-            tripSession.stop()
+            tripSession.stopTripSession()
         }
     }
 

--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -29,7 +29,9 @@ package com.mapbox.navigation.core {
     method public String retrieveHistory();
     method public String? retrieveSsmlAnnouncementInstruction(int index);
     method public void setRoutes(java.util.List<? extends com.mapbox.api.directions.v5.models.DirectionsRoute> routes);
+    method @RequiresPermission(anyOf={android.Manifest.permission.ACCESS_COARSE_LOCATION, android.Manifest.permission.ACCESS_FINE_LOCATION}) public void startLocationUpdates();
     method @RequiresPermission(anyOf={android.Manifest.permission.ACCESS_COARSE_LOCATION, android.Manifest.permission.ACCESS_FINE_LOCATION}) public void startTripSession();
+    method public void stopLocationUpdates();
     method public void stopTripSession();
     method public void toggleHistory(boolean isEnabled);
     method public void unregisterArrivalObserver(com.mapbox.navigation.core.arrival.ArrivalObserver arrivalObserver);

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/trip/session/MapboxRawLocationProvider.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/trip/session/MapboxRawLocationProvider.kt
@@ -1,0 +1,72 @@
+package com.mapbox.navigation.core.internal.trip.session
+
+import android.location.Location
+import android.os.Looper
+import com.mapbox.android.core.location.LocationEngine
+import com.mapbox.android.core.location.LocationEngineCallback
+import com.mapbox.android.core.location.LocationEngineRequest
+import com.mapbox.android.core.location.LocationEngineResult
+import com.mapbox.base.common.logger.Logger
+import com.mapbox.base.common.logger.model.Message
+
+internal class MapboxRawLocationProvider(
+    private val locationEngine: LocationEngine,
+    private val locationEngineRequest: LocationEngineRequest,
+    logger: Logger
+) {
+
+    private var tripSessionUpdates: ((Location) -> Unit)? = null
+    private var locationUpdates: ((Location) -> Unit)? = null
+    private var isObservingLocations = false
+
+    fun requestTripSessionUpdates(mapMatching: (Location) -> Unit) {
+        this.tripSessionUpdates = mapMatching
+        refreshLocationEngine(false)
+    }
+
+    fun stopTripSessionUpdates() {
+        this.tripSessionUpdates = null
+        refreshLocationEngine(false)
+    }
+
+    fun requestLocationUpdates(locationUpdates: (Location) -> Unit) {
+        this.locationUpdates = locationUpdates
+        refreshLocationEngine(false)
+    }
+
+    fun stopLocationUpdates() {
+        this.locationUpdates = null
+        refreshLocationEngine(false)
+    }
+
+    private fun refreshLocationEngine(forceRefresh: Boolean) {
+        val hasObserver = (tripSessionUpdates ?: locationUpdates) != null
+        if (forceRefresh || !hasObserver) {
+            locationEngine.removeLocationUpdates(locationEngineCallback)
+            isObservingLocations = false
+        }
+        if (hasObserver) {
+            if (!isObservingLocations) {
+                isObservingLocations = true
+                locationEngine.requestLocationUpdates(locationEngineRequest, locationEngineCallback, mainLooper)
+            }
+            locationEngine.getLastLocation(locationEngineCallback)
+        }
+    }
+
+    private val locationEngineCallback = object : LocationEngineCallback<LocationEngineResult> {
+        override fun onSuccess(result: LocationEngineResult?) {
+            result?.locations?.lastOrNull()?.let { rawLocation ->
+                (tripSessionUpdates ?: locationUpdates)?.invoke(rawLocation)
+            }
+        }
+
+        override fun onFailure(exception: Exception) {
+            logger.d(msg = Message("Location request failure"), tr = exception)
+        }
+    }
+
+    companion object {
+        private val mainLooper = Looper.getMainLooper()
+    }
+}

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/TripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/TripSession.kt
@@ -17,8 +17,10 @@ internal interface TripSession {
     fun getRouteProgress(): RouteProgress?
     fun getState(): TripSessionState
 
-    fun start()
-    fun stop()
+    fun startTripSession()
+    fun stopTripSession()
+    fun startLocationUpdates()
+    fun stopLocationUpdates()
 
     fun registerLocationObserver(locationObserver: LocationObserver)
     fun unregisterLocationObserver(locationObserver: LocationObserver)

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
@@ -216,7 +216,7 @@ class MapboxNavigationTest {
     fun onDestroyCallsTripSessionStop() {
         mapboxNavigation.onDestroy()
 
-        verify(exactly = 1) { tripSession.stop() }
+        verify(exactly = 1) { tripSession.stopTripSession() }
     }
 
     @Test

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/internal/trip/session/MapboxTripSessionTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/internal/trip/session/MapboxTripSessionTest.kt
@@ -4,7 +4,6 @@ import android.location.Location
 import android.os.Looper
 import com.mapbox.android.core.location.LocationEngine
 import com.mapbox.android.core.location.LocationEngineCallback
-import com.mapbox.android.core.location.LocationEngineRequest
 import com.mapbox.android.core.location.LocationEngineResult
 import com.mapbox.api.directions.v5.models.BannerInstructions
 import com.mapbox.api.directions.v5.models.DirectionsRoute
@@ -66,7 +65,6 @@ class MapboxTripSessionTest {
 
     private val tripService: TripService = mockk(relaxUnitFun = true)
     private val locationEngine: LocationEngine = mockk(relaxUnitFun = true)
-    private val locationEngineRequest: LocationEngineRequest = mockk()
     private val route: DirectionsRoute = mockk()
 
     private val locationCallbackSlot = slot<LocationEngineCallback<LocationEngineResult>>()
@@ -126,7 +124,7 @@ class MapboxTripSessionTest {
 
     @Test
     fun startSession() {
-        tripSession.start()
+        tripSession.startTripSession()
 
         verify { tripService.startService() }
         verify {
@@ -137,24 +135,24 @@ class MapboxTripSessionTest {
             )
         }
 
-        tripSession.stop()
+        tripSession.stopTripSession()
     }
 
     @Test
     fun stopSessionCallsTripServiceStopService() {
-        tripSession.start()
+        tripSession.startTripSession()
 
-        tripSession.stop()
+        tripSession.stopTripSession()
 
         verify { locationEngine.removeLocationUpdates(locationCallbackSlot.captured) }
     }
 
     @Test
     fun stopSessionCallsLocationEngineRemoveLocationUpdates() {
-        tripSession.start()
+        tripSession.startTripSession()
         locationCallbackSlot.captured.onSuccess(locationEngineResult)
 
-        tripSession.stop()
+        tripSession.stopTripSession()
 
         verify { locationEngine.removeLocationUpdates(locationCallbackSlot.captured) }
     }
@@ -162,16 +160,16 @@ class MapboxTripSessionTest {
     @Test
     fun stopSessionDoesNotClearUpRoute() {
         tripSession.route = route
-        tripSession.start()
+        tripSession.startTripSession()
 
-        tripSession.stop()
+        tripSession.stopTripSession()
 
         assertEquals(route, tripSession.route)
     }
 
     @Test
     fun locationObserverSuccess() = coroutineRule.runBlockingTest {
-        tripSession.start()
+        tripSession.startTripSession()
         val observer: LocationObserver = mockk(relaxUnitFun = true)
         tripSession.registerLocationObserver(observer)
 
@@ -180,13 +178,13 @@ class MapboxTripSessionTest {
         verify { observer.onRawLocationChanged(location) }
         assertEquals(location, tripSession.getRawLocation())
 
-        tripSession.stop()
+        tripSession.stopTripSession()
     }
 
     @Test
     fun locationObserverSuccessWhenMultipleSamples() = coroutineRule.runBlockingTest {
         every { locationEngineResult.locations } returns listOf(mockk(), location)
-        tripSession.start()
+        tripSession.startTripSession()
         val observer: LocationObserver = mockk(relaxUnitFun = true)
         tripSession.registerLocationObserver(observer)
 
@@ -195,23 +193,23 @@ class MapboxTripSessionTest {
         verify { observer.onRawLocationChanged(location) }
         assertEquals(location, tripSession.getRawLocation())
 
-        tripSession.stop()
+        tripSession.stopTripSession()
     }
 
     @Test
     fun locationObserverOnFailure() {
-        tripSession.start()
+        tripSession.startTripSession()
 
         locationCallbackSlot.captured.onFailure(Exception("location failure"))
 
         verify(exactly = 0) { locationEngine.removeLocationUpdates(locationCallbackSlot.captured) }
 
-        tripSession.stop()
+        tripSession.stopTripSession()
     }
 
     @Test
     fun locationObserverImmediate() = coroutineRule.runBlockingTest {
-        tripSession.start()
+        tripSession.startTripSession()
         val observer: LocationObserver = mockk(relaxUnitFun = true)
         updateLocationAndJoin()
 
@@ -219,41 +217,41 @@ class MapboxTripSessionTest {
 
         verify { observer.onRawLocationChanged(location) }
 
-        tripSession.stop()
+        tripSession.stopTripSession()
     }
 
     @Test
     fun unregisterLocationObserver() = coroutineRule.runBlockingTest {
-        tripSession.start()
+        tripSession.startTripSession()
         val observer: LocationObserver = mockk(relaxUnitFun = true)
         tripSession.registerLocationObserver(observer)
         tripSession.unregisterLocationObserver(observer)
         updateLocationAndJoin()
         verify(exactly = 0) { observer.onRawLocationChanged(any()) }
 
-        tripSession.stop()
+        tripSession.stopTripSession()
     }
 
     @Test
     fun locationPush() = coroutineRule.runBlockingTest {
-        tripSession.start()
+        tripSession.startTripSession()
         updateLocationAndJoin()
         coVerify { navigator.updateLocation(location, any()) }
-        tripSession.stop()
+        tripSession.stopTripSession()
     }
 
     @Test
     fun locationPushWhenMultipleSamples() = coroutineRule.runBlockingTest {
         every { locationEngineResult.locations } returns listOf(mockk(), location)
-        tripSession.start()
+        tripSession.startTripSession()
         updateLocationAndJoin()
         coVerify { navigator.updateLocation(location, any()) }
-        tripSession.stop()
+        tripSession.stopTripSession()
     }
 
     @Test
     fun getStatusImmediatelyAfterUpdateLocation() = coroutineRule.runBlockingTest {
-        tripSession.start()
+        tripSession.startTripSession()
         val currentDate = Date()
 
         updateLocationAndJoin()
@@ -261,24 +259,24 @@ class MapboxTripSessionTest {
         val slot = slot<Date>()
         coVerify { navigator.getStatus(capture(slot)) }
         assertTrue(slot.captured.time >= currentDate.time + navigatorPredictionMillis)
-        tripSession.stop()
+        tripSession.stopTripSession()
     }
 
     @Test
     fun noLocationUpdateLongerThanAPatienceUnconditionallyGetStatus() = coroutineRule.runBlockingTest {
-        tripSession.start()
+        tripSession.startTripSession()
 
         locationCallbackSlot.captured.onSuccess(locationEngineResult)
         advanceTimeBy(UNCONDITIONAL_STATUS_POLLING_PATIENCE)
         parentJob.cancelAndJoin()
 
         coVerify(exactly = 2) { navigator.getStatus(any()) }
-        tripSession.stop()
+        tripSession.stopTripSession()
     }
 
     @Test
     fun unconditionallGetStatusRepeated() = coroutineRule.runBlockingTest {
-        tripSession.start()
+        tripSession.startTripSession()
 
         locationCallbackSlot.captured.onSuccess(locationEngineResult)
         advanceTimeBy(UNCONDITIONAL_STATUS_POLLING_PATIENCE)
@@ -286,12 +284,12 @@ class MapboxTripSessionTest {
         parentJob.cancelAndJoin()
 
         coVerify(exactly = 3) { navigator.getStatus(any()) }
-        tripSession.stop()
+        tripSession.stopTripSession()
     }
 
     @Test
     fun rawLocationCancelsUnconditionalGetStatusRepetition() = coroutineRule.runBlockingTest {
-        tripSession.start()
+        tripSession.startTripSession()
 
         locationCallbackSlot.captured.onSuccess(locationEngineResult)
         advanceTimeBy(UNCONDITIONAL_STATUS_POLLING_PATIENCE - 100)
@@ -300,7 +298,7 @@ class MapboxTripSessionTest {
         parentJob.cancelAndJoin()
 
         coVerify(exactly = 2) { navigator.getStatus(any()) }
-        tripSession.stop()
+        tripSession.stopTripSession()
     }
 
     @Test
@@ -313,14 +311,14 @@ class MapboxTripSessionTest {
             ThreadController,
             logger = logger
         )
-        tripSession.start()
+        tripSession.startTripSession()
         val observer: RouteProgressObserver = mockk(relaxUnitFun = true)
         tripSession.registerRouteProgressObserver(observer)
         updateLocationAndJoin()
 
         verify { observer.onRouteProgressChanged(routeProgress) }
         assertEquals(routeProgress, tripSession.getRouteProgress())
-        tripSession.stop()
+        tripSession.stopTripSession()
     }
 
     @Test
@@ -334,14 +332,14 @@ class MapboxTripSessionTest {
             ThreadController,
             logger = logger
         )
-        tripSession.start()
+        tripSession.startTripSession()
         val observer: RouteProgressObserver = mockk(relaxUnitFun = true)
         tripSession.registerRouteProgressObserver(observer)
         updateLocationAndJoin()
 
         verify(exactly = 0) { observer.onRouteProgressChanged(routeProgress) }
         assertNull(tripSession.getRouteProgress())
-        tripSession.stop()
+        tripSession.stopTripSession()
     }
 
     @Test
@@ -354,14 +352,14 @@ class MapboxTripSessionTest {
             ThreadController,
             logger = logger
         )
-        tripSession.start()
+        tripSession.startTripSession()
         updateLocationAndJoin()
         val observer: RouteProgressObserver = mockk(relaxUnitFun = true)
         tripSession.registerRouteProgressObserver(observer)
 
         verify(exactly = 1) { observer.onRouteProgressChanged(routeProgress) }
         assertEquals(routeProgress, tripSession.getRouteProgress())
-        tripSession.stop()
+        tripSession.stopTripSession()
     }
 
     @Test
@@ -374,14 +372,14 @@ class MapboxTripSessionTest {
             ThreadController,
             logger = logger
         )
-        tripSession.start()
+        tripSession.startTripSession()
         val observer: RouteProgressObserver = mockk(relaxUnitFun = true)
         tripSession.registerRouteProgressObserver(observer)
         tripSession.unregisterRouteProgressObserver(observer)
         updateLocationAndJoin()
 
         verify(exactly = 0) { observer.onRouteProgressChanged(routeProgress) }
-        tripSession.stop()
+        tripSession.stopTripSession()
     }
 
     @Test
@@ -394,7 +392,7 @@ class MapboxTripSessionTest {
             ThreadController,
             logger = logger
         )
-        tripSession.start()
+        tripSession.startTripSession()
         val observer: RouteProgressObserver = mockk(relaxUnitFun = true)
         tripSession.registerRouteProgressObserver(observer)
         updateLocationAndJoin()
@@ -402,7 +400,7 @@ class MapboxTripSessionTest {
         tripSession.registerRouteProgressObserver(observer)
 
         verify(exactly = 2) { observer.onRouteProgressChanged(routeProgress) }
-        tripSession.stop()
+        tripSession.stopTripSession()
     }
 
     @Test
@@ -415,14 +413,14 @@ class MapboxTripSessionTest {
             ThreadController,
             logger = logger
         )
-        tripSession.start()
+        tripSession.startTripSession()
         val observer: LocationObserver = mockk(relaxUnitFun = true)
         tripSession.registerLocationObserver(observer)
         updateLocationAndJoin()
 
         verify { observer.onEnhancedLocationChanged(enhancedLocation, keyPoints) }
         assertEquals(enhancedLocation, tripSession.getEnhancedLocation())
-        tripSession.stop()
+        tripSession.stopTripSession()
     }
 
     @Test
@@ -435,14 +433,14 @@ class MapboxTripSessionTest {
             ThreadController,
             logger = logger
         )
-        tripSession.start()
+        tripSession.startTripSession()
         updateLocationAndJoin()
         val observer: LocationObserver = mockk(relaxUnitFun = true)
         tripSession.registerLocationObserver(observer)
 
         verify(exactly = 1) { observer.onEnhancedLocationChanged(enhancedLocation, emptyList()) }
         assertEquals(enhancedLocation, tripSession.getEnhancedLocation())
-        tripSession.stop()
+        tripSession.stopTripSession()
     }
 
     @Test
@@ -455,14 +453,14 @@ class MapboxTripSessionTest {
             ThreadController,
             logger = logger
         )
-        tripSession.start()
+        tripSession.startTripSession()
         val observer: LocationObserver = mockk(relaxUnitFun = true)
         tripSession.registerLocationObserver(observer)
         tripSession.unregisterLocationObserver(observer)
         updateLocationAndJoin()
         verify(exactly = 0) { observer.onEnhancedLocationChanged(enhancedLocation, keyPoints) }
 
-        tripSession.stop()
+        tripSession.stopTripSession()
     }
 
     @Test
@@ -498,7 +496,7 @@ class MapboxTripSessionTest {
 
     @Test
     fun stateObserverImmediateStart() {
-        tripSession.start()
+        tripSession.startTripSession()
         tripSession.registerStateObserver(stateObserver)
         verify(exactly = 1) { stateObserver.onSessionStateChanged(TripSessionState.STARTED) }
     }
@@ -506,32 +504,32 @@ class MapboxTripSessionTest {
     @Test
     fun stateObserverStart() {
         tripSession.registerStateObserver(stateObserver)
-        tripSession.start()
+        tripSession.startTripSession()
         verify(exactly = 1) { stateObserver.onSessionStateChanged(TripSessionState.STARTED) }
     }
 
     @Test
     fun stateObserverStop() {
-        tripSession.start()
+        tripSession.startTripSession()
         tripSession.registerStateObserver(stateObserver)
-        tripSession.stop()
+        tripSession.stopTripSession()
         verify(exactly = 1) { stateObserver.onSessionStateChanged(TripSessionState.STOPPED) }
     }
 
     @Test
     fun stateObserverDoubleStart() {
         tripSession.registerStateObserver(stateObserver)
-        tripSession.start()
-        tripSession.start()
+        tripSession.startTripSession()
+        tripSession.startTripSession()
         verify(exactly = 1) { stateObserver.onSessionStateChanged(TripSessionState.STARTED) }
     }
 
     @Test
     fun stateObserverDoubleStop() {
-        tripSession.start()
+        tripSession.startTripSession()
         tripSession.registerStateObserver(stateObserver)
-        tripSession.stop()
-        tripSession.stop()
+        tripSession.stopTripSession()
+        tripSession.stopTripSession()
         verify(exactly = 1) { stateObserver.onSessionStateChanged(TripSessionState.STOPPED) }
     }
 
@@ -540,8 +538,8 @@ class MapboxTripSessionTest {
         tripSession.registerStateObserver(stateObserver)
         clearMocks(stateObserver)
         tripSession.unregisterStateObserver(stateObserver)
-        tripSession.start()
-        tripSession.stop()
+        tripSession.startTripSession()
+        tripSession.stopTripSession()
         verify(exactly = 0) { stateObserver.onSessionStateChanged(any()) }
     }
 
@@ -550,7 +548,7 @@ class MapboxTripSessionTest {
         every { routeProgress.bannerInstructions } returns null
         every { routeProgress.voiceInstructions } returns null
 
-        tripSession.start()
+        tripSession.startTripSession()
         val observer: LocationObserver = mockk(relaxUnitFun = true)
         tripSession.registerLocationObserver(observer)
         tripSession.unregisterAllLocationObservers()
@@ -560,7 +558,7 @@ class MapboxTripSessionTest {
         verify(exactly = 0) { observer.onRawLocationChanged(location) }
         assertEquals(location, tripSession.getRawLocation())
 
-        tripSession.stop()
+        tripSession.stopTripSession()
     }
 
     @Test
@@ -573,7 +571,7 @@ class MapboxTripSessionTest {
             ThreadController,
             logger = logger
         )
-        tripSession.start()
+        tripSession.startTripSession()
         val routeProgressObserver: RouteProgressObserver = mockk(relaxUnitFun = true)
         tripSession.registerRouteProgressObserver(routeProgressObserver)
         tripSession.unregisterAllRouteProgressObservers()
@@ -581,7 +579,7 @@ class MapboxTripSessionTest {
 
         verify(exactly = 0) { routeProgressObserver.onRouteProgressChanged(any()) }
 
-        tripSession.stop()
+        tripSession.stopTripSession()
     }
 
     @Test
@@ -594,7 +592,7 @@ class MapboxTripSessionTest {
             ThreadController,
             logger = logger
         )
-        tripSession.start()
+        tripSession.startTripSession()
         val offRouteObserver: OffRouteObserver = mockk(relaxUnitFun = true)
         tripSession.registerOffRouteObserver(offRouteObserver)
         tripSession.unregisterAllOffRouteObservers()
@@ -609,7 +607,7 @@ class MapboxTripSessionTest {
         // of offRouteObservers should be empty.
         verify(exactly = 1) { offRouteObserver.onOffRouteStateChanged(false) }
 
-        tripSession.stop()
+        tripSession.stopTripSession()
     }
 
     @Test
@@ -618,7 +616,7 @@ class MapboxTripSessionTest {
         clearMocks(stateObserver)
         tripSession.unregisterAllStateObservers()
 
-        tripSession.stop()
+        tripSession.stopTripSession()
 
         verify(exactly = 0) { stateObserver.onSessionStateChanged(any()) }
     }
@@ -640,21 +638,21 @@ class MapboxTripSessionTest {
             ThreadController,
             logger = logger
         )
-        tripSession.start()
+        tripSession.startTripSession()
         tripSession.registerBannerInstructionsObserver(bannerInstructionsObserver)
 
         updateLocationAndJoin()
 
-        tripSession.stop()
+        tripSession.stopTripSession()
 
-        tripSession.start()
+        tripSession.startTripSession()
         tripSession.unregisterAllBannerInstructionsObservers()
 
         updateLocationAndJoin()
 
         verify(exactly = 1) { bannerInstructionsObserver.onNewBannerInstructions(any()) }
 
-        tripSession.stop()
+        tripSession.stopTripSession()
     }
 
     @Test
@@ -673,21 +671,21 @@ class MapboxTripSessionTest {
             ThreadController,
             logger = logger
         )
-        tripSession.start()
+        tripSession.startTripSession()
         tripSession.registerVoiceInstructionsObserver(voiceInstructionsObserver)
 
         updateLocationAndJoin()
 
-        tripSession.stop()
+        tripSession.stopTripSession()
 
-        tripSession.start()
+        tripSession.startTripSession()
         tripSession.unregisterAllVoiceInstructionsObservers()
 
         updateLocationAndJoin()
 
         verify(exactly = 1) { voiceInstructionsObserver.onNewVoiceInstructions(any()) }
 
-        tripSession.stop()
+        tripSession.stopTripSession()
     }
 
     @After


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Breaking up this large refactor into smaller pieces for better review: https://github.com/mapbox/mapbox-navigation-android/pull/3191

All examples include an interaction with the LocationEngine, to provide current location before starting to navigate. This change moves that logic into core navigation. This will make it easier to remove LocationEngine from the examples.

This change should not change any existing behavior. One functional change in behavior to the SimpleNavigationActivity, is that it will always be map matching 📌  🗺️ 

- [ ] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->