### PR TITLE
Bump NN to version 14.1.2 and fix arrival issue

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -12,7 +12,7 @@ ext {
       mapboxSdkDirectionsModels : '5.2.1',
       mapboxEvents              : '6.0.0',
       mapboxCore                : '3.0.0',
-      mapboxNavigator           : '14.1.1',
+      mapboxNavigator           : '14.1.2',
       mapboxCrashMonitor        : '2.0.0',
       mapboxAnnotationPlugin    : '0.8.0',
       mapboxAccounts            : '0.4.0',

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/arrival/ArrivalProgressObserver.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/arrival/ArrivalProgressObserver.kt
@@ -52,14 +52,19 @@ internal class ArrivalProgressObserver(
             ?: return
 
         val arrivalOptions = arrivalController.arrivalOptions()
-        if (routeProgress.currentState == RouteProgressState.ROUTE_COMPLETE && !hasMoreLegs(routeProgress)) {
+        val hasMoreLegs = hasMoreLegs(routeProgress)
+        if (routeProgress.currentState == RouteProgressState.ROUTE_COMPLETE && !hasMoreLegs) {
             doOnFinalDestinationArrival(routeProgress)
-        } else if (arrivalOptions.arrivalInSeconds != null) {
+        } else if (routeProgress.currentState == RouteProgressState.ROUTE_COMPLETE && hasMoreLegs) {
+            doOnWaypointArrival(routeLegProgress)
+        } else if (arrivalOptions.arrivalInSeconds != null && hasMoreLegs) {
             checkWaypointArrivalTime(arrivalOptions.arrivalInSeconds, routeLegProgress)
-        } else if (arrivalOptions.arrivalInMeters != null) {
+        } else if (arrivalOptions.arrivalInMeters != null && hasMoreLegs) {
             checkWaypointArrivalDistance(arrivalOptions.arrivalInMeters, routeLegProgress)
         }
-        finalDestinationArrived = routeProgress.currentState == RouteProgressState.ROUTE_COMPLETE
+        if (!hasMoreLegs) {
+            finalDestinationArrived = routeProgress.currentState == RouteProgressState.ROUTE_COMPLETE
+        }
     }
 
     private fun hasMoreLegs(routeProgress: RouteProgress): Boolean {

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/arrival/ArrivalProgressObserverTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/arrival/ArrivalProgressObserverTest.kt
@@ -159,6 +159,12 @@ internal class ArrivalProgressObserverTest {
             every { currentLegProgress } returns mockk {
                 every { durationRemaining } returns 1.0
                 every { distanceRemaining } returns 15.0f
+                every { legIndex } returns 0
+            }
+            every { route } returns mockk {
+                every { legs() } returns listOf(
+                    mockk(), mockk(), mockk() // This route has three legs
+                )
             }
         })
 
@@ -183,6 +189,12 @@ internal class ArrivalProgressObserverTest {
             every { currentLegProgress } returns mockk {
                 every { durationRemaining } returns 2.0
                 every { distanceRemaining } returns 8.0f
+                every { legIndex } returns 0
+            }
+            every { route } returns mockk {
+                every { legs() } returns listOf(
+                    mockk(), mockk(), mockk() // This route has three legs
+                )
             }
         })
 
@@ -205,6 +217,12 @@ internal class ArrivalProgressObserverTest {
             every { currentLegProgress } returns mockk {
                 every { durationRemaining } returns 1.0
                 every { distanceRemaining } returns 15.0f
+                every { legIndex } returns 0
+            }
+            every { route } returns mockk {
+                every { legs() } returns listOf(
+                    mockk(), mockk(), mockk() // This route has three legs
+                )
             }
         }
         every { tripSession.getRouteProgress() } returns routeProgress
@@ -232,6 +250,12 @@ internal class ArrivalProgressObserverTest {
             every { currentLegProgress } returns mockk {
                 every { durationRemaining } returns 360.0
                 every { distanceRemaining } returns 80.0f
+                every { legIndex } returns 0
+            }
+            every { route } returns mockk {
+                every { legs() } returns listOf(
+                    mockk(), mockk(), mockk() // This route has three legs
+                )
             }
         })
 
@@ -240,28 +264,26 @@ internal class ArrivalProgressObserverTest {
 
     @Test
     fun `should navigate to next waypoint automatically by default`() {
-        every { tripSession.getRouteProgress() } returns mockk {
+        val routeProgress: RouteProgress = mockk {
             every { route } returns mockk {
+                every { currentState } returns RouteProgressState.LOCATION_TRACKING
                 every { legs() } returns listOf(
                     mockk(), mockk(), mockk() // This route has three legs
                 )
                 every { routeIndex() } returns "0"
                 every { currentLegProgress } returns mockk {
+                    every { durationRemaining } returns 0.0
+                    every { distanceRemaining } returns 0.0f
                     every { legIndex } returns 1
                 }
             }
         }
+        every { tripSession.getRouteProgress() } returns routeProgress
         every { tripSession.updateLegIndex(2) } returns mockk {
             every { legIndex } returns 2
         }
 
-        arrivalProgressObserver.onRouteProgressChanged(mockk {
-            every { currentState } returns RouteProgressState.LOCATION_TRACKING
-            every { currentLegProgress } returns mockk {
-                every { durationRemaining } returns 0.0
-                every { distanceRemaining } returns 0.0f
-            }
-        })
+        arrivalProgressObserver.onRouteProgressChanged(routeProgress)
 
         verify { tripSession.updateLegIndex(2) }
     }


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Alternative to https://github.com/mapbox/mapbox-navigation-android/pull/3180

Stop notifying navigateNextRouteLeg after destination has been reached 

Before
12.497 navigateNextRouteLeg
13.501 navigateNextRouteLeg
14.497 navigateNextRouteLeg
14.854 onNextRouteLegStart
28.620 onFinalDestinationArrival
29.529 navigateNextRouteLeg
30.527 navigateNextRouteLeg
32.523 navigateNextRouteLeg
33.521 navigateNextRouteLeg
34.522 navigateNextRouteLeg

After
35.019 debug_arrival: navigateNextRouteLeg
36.022 debug_arrival: navigateNextRouteLeg
36.650 debug_arrival: onNextRouteLegStart
53.087 debug_arrival: onFinalDestinationArrival

- [ ] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal

Please describe the PR goals. Just the stuff needed to implement the fix / feature and a simple rationale. It could contain many check points if needed

### Implementation

Please include all the relevant things implemented and also rationale, clarifications / disclaimers etc. related to the approach used. It could be as self code companion comments

## Screenshots or Gifs

Please include all the media files to give some context about what's being implemented or fixed. It's not mandatory to upload screenshots or gifs, but for most of the cases it becomes really handy to get into the scope of the feature / bug being fixed and also it's REALLY useful for UI related PRs ![screenshot gif](link)

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->