### PR TITLE
Fix #3217: the Shields relate text has been added into the banner text when AbbreviationCreator process

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/instruction/InstructionTarget.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/instruction/InstructionTarget.java
@@ -25,13 +25,13 @@ class InstructionTarget implements Target {
   private TextViewUtils textViewUtils;
 
   InstructionTarget(TextView textView, Spannable instructionSpannable, List<BannerShield> shields,
-                    BannerShield shield, InstructionLoadedCallback instructionLoadedCallback) {
+      BannerShield shield, InstructionLoadedCallback instructionLoadedCallback) {
     this(textView, instructionSpannable, shields, shield, new TextViewUtils(), instructionLoadedCallback);
   }
 
   private InstructionTarget(TextView textView, Spannable instructionSpannable, List<BannerShield> shields,
-                            BannerShield shield, TextViewUtils textViewUtils,
-                            InstructionLoadedCallback instructionLoadedCallback) {
+      BannerShield shield, TextViewUtils textViewUtils,
+      InstructionLoadedCallback instructionLoadedCallback) {
     this.textView = textView;
     this.instructionSpannable = instructionSpannable;
     this.shields = shields;
@@ -53,7 +53,6 @@ class InstructionTarget implements Target {
 
   @Override
   public void onBitmapFailed(Exception exception, Drawable errorDrawable) {
-    setBackupText();
     sendInstructionLoadedCallback();
     Timber.e(exception);
   }
@@ -67,13 +66,9 @@ class InstructionTarget implements Target {
     void onInstructionLoaded(InstructionTarget target);
   }
 
-  private void setBackupText() {
-    textView.setText(shield.getText());
-  }
-
   private void createAndSetImageSpan(Drawable drawable) {
     instructionSpannable.setSpan(new ImageSpan(drawable),
-      shield.getStartIndex(), shield.getEndIndex(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+        shield.getStartIndex(), shield.getEndIndex(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
 
     if (shields.indexOf(shield) == shields.size() - 1) {
       CharSequence truncatedSequence = truncateImageSpan(instructionSpannable, textView);


### PR DESCRIPTION


<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Fix #3217:  the Shields relate text has been added into the banner text when AbbreviationCreator process.

Don't need to use the Shield's text to replace the whole banner text when shield icon download fails.

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal

Improve InstructionView quality.

### Implementation

When `AbbreviationCreator` processes, the Shield's text has been added. So when the Shield icon download fails, we don't need to use the shield's text to replace the whole banner text. The banner text has been well organized and it may contain Exit icon as in #3217 case.

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->