### PR TITLE
Make route refresh check more required options

### DIFF
--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/routerefresh/RouteRefreshControllerTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/routerefresh/RouteRefreshControllerTest.kt
@@ -1,0 +1,89 @@
+package com.mapbox.navigation.core.routerefresh
+
+import com.mapbox.api.directions.v5.DirectionsCriteria
+import com.mapbox.base.common.logger.Logger
+import com.mapbox.navigation.core.directions.session.DirectionsSession
+import com.mapbox.navigation.core.trip.session.TripSession
+import com.mapbox.navigation.testing.MainCoroutineRule
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.util.concurrent.TimeUnit
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class RouteRefreshControllerTest {
+
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
+
+    private val directionsSession: DirectionsSession = mockk()
+    private val tripSession: TripSession = mockk()
+    private val logger: Logger = mockk()
+
+    private val routeRefreshController = RouteRefreshController(
+        directionsSession, tripSession, logger
+    )
+
+    @Before
+    fun setup() {
+        every { tripSession.getRouteProgress() } returns mockk {
+            every { currentLegProgress } returns mockk {
+                every { legIndex } returns 0
+            }
+        }
+        every { directionsSession.requestRouteRefresh(any(), any(), any()) } returns Unit
+    }
+
+    @Test
+    fun `should refresh route every 5 minutes`() = coroutineRule.runBlockingTest {
+        every { tripSession.route } returns mockk {
+            every { routeOptions() } returns mockk {
+                every { profile() } returns DirectionsCriteria.PROFILE_DRIVING_TRAFFIC
+                every { overview() } returns DirectionsCriteria.OVERVIEW_FULL
+                every { annotationsList() } returns listOf(DirectionsCriteria.ANNOTATION_MAXSPEED)
+            }
+        }
+
+        routeRefreshController.start()
+        coroutineRule.testDispatcher.advanceTimeBy(TimeUnit.MINUTES.toMillis(15))
+        routeRefreshController.stop()
+
+        verify(exactly = 3) { directionsSession.requestRouteRefresh(any(), any(), any()) }
+    }
+
+    @Test
+    fun `should refresh route with correct properties`() = coroutineRule.runBlockingTest {
+        every { tripSession.route } returns mockk {
+            every { routeOptions() } returns mockk {
+                every { profile() } returns DirectionsCriteria.PROFILE_DRIVING_TRAFFIC
+                every { overview() } returns DirectionsCriteria.OVERVIEW_FULL
+                every { annotationsList() } returns listOf(DirectionsCriteria.ANNOTATION_MAXSPEED)
+            }
+        }
+
+        routeRefreshController.start()
+        coroutineRule.testDispatcher.advanceTimeBy(TimeUnit.MINUTES.toMillis(6))
+        routeRefreshController.stop()
+
+        verify(exactly = 1) { directionsSession.requestRouteRefresh(any(), any(), any()) }
+    }
+
+    @Test
+    fun `should not refresh route without maxspeed or congestion annotation`() = coroutineRule.runBlockingTest {
+        every { tripSession.route } returns mockk {
+            every { routeOptions() } returns mockk {
+                every { profile() } returns DirectionsCriteria.PROFILE_DRIVING_TRAFFIC
+                every { overview() } returns DirectionsCriteria.OVERVIEW_FULL
+                every { annotationsList() } returns listOf(DirectionsCriteria.ANNOTATION_DISTANCE)
+            }
+        }
+
+        routeRefreshController.start()
+        coroutineRule.testDispatcher.advanceTimeBy(TimeUnit.MINUTES.toMillis(6))
+        routeRefreshController.stop()
+
+        verify(exactly = 0) { directionsSession.requestRouteRefresh(any(), any(), any()) }
+    }
+}


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Route refresh returns errors if the overview is not full. Add this check to enable.

- [ ] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->