### PR TITLE
Bumped Java SDK dependencies to 5.3.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,8 +8,8 @@ ext {
 
   version = [
       mapboxMapSdk              : '9.2.1',
-      mapboxSdkServices         : '5.2.1',
-      mapboxSdkDirectionsModels : '5.2.1',
+      mapboxSdkServices         : '5.3.0',
+      mapboxSdkDirectionsModels : '5.3.0',
       mapboxEvents              : '6.0.0',
       mapboxCore                : '3.0.0',
       mapboxNavigator           : '14.1.1',


### PR DESCRIPTION
## Description

The Mapbox Java SDK `5.3.0` release went out about two weeks ago:

- https://github.com/mapbox/mapbox-java/issues/1155
- https://github.com/mapbox/mapbox-java/releases/tag/v5.3.0

This pr bumps the Nav core SDK dependencies to `5.3.0`.

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->