### PR TITLE
Fix MapboxDistanceFormatter ArithmeticException: divide by zero crash

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/MapboxDistanceFormatter.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/MapboxDistanceFormatter.kt
@@ -74,7 +74,7 @@ class MapboxDistanceFormatter private constructor(
     class Builder {
         private var unitType: String? = null
         private var locale: Locale? = null
-        private var roundingIncrement = 0
+        private var roundingIncrement = Rounding.INCREMENT_FIFTY
 
         /**
          * Policy for the various units of measurement, UNDEFINED uses default for locale country

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/internal/MapboxDistanceFormatterTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/internal/MapboxDistanceFormatterTest.kt
@@ -224,10 +224,10 @@ class MapboxDistanceFormatterTest {
     @Test
     fun formatDistanceBelowZeroDistance() {
         val result = MapboxDistanceFormatter.Builder()
-                .withUnitType(IMPERIAL)
-                .withRoundingIncrement(INCREMENT_FIFTY)
-                .build(ctx)
-                .formatDistance(-0.1)
+            .withUnitType(IMPERIAL)
+            .withRoundingIncrement(INCREMENT_FIFTY)
+            .build(ctx)
+            .formatDistance(-0.1)
 
         assertEquals("50 ft", result.toString())
     }
@@ -236,10 +236,10 @@ class MapboxDistanceFormatterTest {
     @Test
     fun formatDistanceBelowZeroDistanceRoundingIncrementFive() {
         val result = MapboxDistanceFormatter.Builder()
-                .withUnitType(IMPERIAL)
-                .withRoundingIncrement(INCREMENT_FIVE)
-                .build(ctx)
-                .formatDistance(-0.1)
+            .withUnitType(IMPERIAL)
+            .withRoundingIncrement(INCREMENT_FIVE)
+            .build(ctx)
+            .formatDistance(-0.1)
 
         assertEquals("5 ft", result.toString())
     }
@@ -248,10 +248,10 @@ class MapboxDistanceFormatterTest {
     @Test
     fun formatDistanceUnitTypeUndefinedImperial() {
         val result = MapboxDistanceFormatter.Builder()
-                .withUnitType(UNDEFINED)
-                .withRoundingIncrement(INCREMENT_FIFTY)
-                .build(ctx)
-                .formatDistance(19312.1)
+            .withUnitType(UNDEFINED)
+            .withRoundingIncrement(INCREMENT_FIFTY)
+            .build(ctx)
+            .formatDistance(19312.1)
 
         assertEquals("12 mi", result.toString())
     }
@@ -260,11 +260,21 @@ class MapboxDistanceFormatterTest {
     @Test
     fun formatDistanceUnitTypeUndefinedMetric() {
         val result = MapboxDistanceFormatter.Builder()
-                .withUnitType(UNDEFINED)
-                .withRoundingIncrement(INCREMENT_FIFTY)
-                .build(ctx)
-                .formatDistance(19312.1)
+            .withUnitType(UNDEFINED)
+            .withRoundingIncrement(INCREMENT_FIFTY)
+            .build(ctx)
+            .formatDistance(19312.1)
 
         assertEquals("19 km", result.toString())
+    }
+
+    @Test
+    fun formatDistanceDefaultBuilder() {
+        val distanceFormatter = MapboxDistanceFormatter.Builder()
+            .build(ctx)
+
+        val result = distanceFormatter.formatDistance(25.1)
+
+        assertEquals("50 ft", result.toString())
     }
 }


### PR DESCRIPTION
## Description

Fix `MapboxDistanceFormatter` `ArithmeticException: divide by zero` crash thrown when using default distance formatter as `roundingIncrement` is not initialized (`0`)

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Fix the following 💥 

```
06-26 17:53:27.728 26828-26828/com.mapbox.navigation.examples E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.mapbox.navigation.examples, PID: 26828
    java.lang.ArithmeticException: divide by zero
        at com.mapbox.navigation.core.internal.MapboxDistanceFormatter.formatDistanceAndSuffixForSmallUnit(MapboxDistanceFormatter.kt:162)
        at com.mapbox.navigation.core.internal.MapboxDistanceFormatter.formatDistance(MapboxDistanceFormatter.kt:142)
        at com.mapbox.navigation.trip.notification.MapboxTripNotification.updateDistanceText(MapboxTripNotification.kt:404)
        at com.mapbox.navigation.trip.notification.MapboxTripNotification.updateNotificationViews(MapboxTripNotification.kt:302)
        at com.mapbox.navigation.trip.notification.MapboxTripNotification.updateNotification(MapboxTripNotification.kt:153)
        at com.mapbox.navigation.core.internal.trip.service.MapboxTripService.updateNotification(MapboxTripService.kt:136)
        at com.mapbox.navigation.core.internal.trip.session.MapboxTripSession.updateRouteProgress(MapboxTripSession.kt:453)
        at com.mapbox.navigation.core.internal.trip.session.MapboxTripSession.access$updateRouteProgress(MapboxTripSession.kt:63)
        at com.mapbox.navigation.core.internal.trip.session.MapboxTripSession$updateDataFromNavigatorStatus$1$1.invokeSuspend(MapboxTripSession.kt:434)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:56)
        at android.os.Handler.handleCallback(Handler.java:739)
        at android.os.Handler.dispatchMessage(Handler.java:95)
        at android.os.Looper.loop(Looper.java:148)
        at android.app.ActivityThread.main(ActivityThread.java:5417)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616)
```

that I run into when testing 👇 valid setup

```kotlin
val formatter = MapboxDistanceFormatter.builder()
    .withUnitType(VoiceUnit.METRIC)
    .build(this)
val navigationOptions = MapboxNavigation.defaultNavigationOptionsBuilder(this, accessToken).build()

mapboxNavigation = MapboxNavigation(
    navigationOptions.toBuilder().distanceFormatter(formatter).build(),
    getLocationEngine()
)
```


### Implementation

Add a default `roundingIncrement` (`Rounding.INCREMENT_FIFTY`) to `MapboxDistanceFormatter.Builder`

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs