### PR TITLE
Fix HybridRouter test

### DIFF
--- a/libdirections-hybrid/src/test/java/com/mapbox/navigation/route/hybrid/internal/MapboxHybridRouterTest.kt
+++ b/libdirections-hybrid/src/test/java/com/mapbox/navigation/route/hybrid/internal/MapboxHybridRouterTest.kt
@@ -18,7 +18,6 @@ import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.junit.Test
@@ -224,11 +223,7 @@ class MapboxHybridRouterTest {
     private suspend fun disableNetworkConnection() = networkConnected(false)
 
     private suspend fun networkConnected(networkConnected: Boolean) {
-        channel.offer(NetworkStatus(networkConnected))
-        // channel is listened with a coroutine. When channel is empty, coroutine suspends
-        // until channel has a new value. Need some small delay to give coroutine time to wake up
-        // and handle a value.
-        delay(10)
+        hybridRouter.onNetworkStatusChanged(NetworkStatus(networkConnected))
     }
 
     private fun provideDefaultRouteOptions(): RouteOptions {


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

closes #3221 
`delay` removed. Channel is not used to change `NetworkStatus`. It is changed directly with `internal` fun.

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->