### PR TITLE
[core] use the newest raw location sample

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/trip/session/MapboxTripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/trip/session/MapboxTripSession.kt
@@ -387,7 +387,7 @@ class MapboxTripSession(
 
     private var locationEngineCallback = object : LocationEngineCallback<LocationEngineResult> {
         override fun onSuccess(result: LocationEngineResult?) {
-            result?.locations?.firstOrNull()?.let {
+            result?.locations?.lastOrNull()?.let {
                 updateRawLocation(it)
             }
         }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/internal/trip/session/MapboxTripSessionTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/internal/trip/session/MapboxTripSessionTest.kt
@@ -181,6 +181,21 @@ class MapboxTripSessionTest {
     }
 
     @Test
+    fun locationObserverSuccessWhenMultipleSamples() = coroutineRule.runBlockingTest {
+        every { locationEngineResult.locations } returns listOf(mockk(), location)
+        tripSession.start()
+        val observer: LocationObserver = mockk(relaxUnitFun = true)
+        tripSession.registerLocationObserver(observer)
+
+        updateLocationAndJoin()
+
+        verify { observer.onRawLocationChanged(location) }
+        assertEquals(location, tripSession.getRawLocation())
+
+        tripSession.stop()
+    }
+
+    @Test
     fun locationObserverOnFailure() {
         tripSession.start()
 
@@ -218,6 +233,15 @@ class MapboxTripSessionTest {
 
     @Test
     fun locationPush() = coroutineRule.runBlockingTest {
+        tripSession.start()
+        updateLocationAndJoin()
+        coVerify { navigator.updateLocation(location, any()) }
+        tripSession.stop()
+    }
+
+    @Test
+    fun locationPushWhenMultipleSamples() = coroutineRule.runBlockingTest {
+        every { locationEngineResult.locations } returns listOf(mockk(), location)
         tripSession.start()
         updateLocationAndJoin()
         coVerify { navigator.updateLocation(location, any()) }


### PR DESCRIPTION
This PR makes sure that we're using the newest location sample returned by the location engine implementation. In a case where there are multiple samples delivered at the same time, which is unclear how often this can happen, the list is sorted from oldest to newest.

Thanks for pointing this out @SiarheiFedartsou!