### PR TITLE
Remove redundant default values

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -13,11 +13,9 @@ import com.mapbox.base.common.logger.Logger
 import com.mapbox.base.common.logger.model.Message
 import com.mapbox.base.common.logger.model.Tag
 import com.mapbox.common.module.provider.MapboxModuleProvider
-import com.mapbox.navigation.base.TimeFormat
 import com.mapbox.navigation.base.internal.VoiceUnit
 import com.mapbox.navigation.base.internal.accounts.SkuTokenProvider
 import com.mapbox.navigation.base.internal.accounts.UrlSkuTokenProvider
-import com.mapbox.navigation.base.options.DEFAULT_NAVIGATOR_PREDICTION_MILLIS
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.options.OnboardRouterOptions
 import com.mapbox.navigation.base.route.Router
@@ -692,8 +690,6 @@ class MapboxNavigation(
                 .build(context)
             val builder = NavigationOptions.Builder(context)
                 .accessToken(accessToken)
-                .timeFormatType(TimeFormat.NONE_SPECIFIED)
-                .navigatorPredictionMillis(DEFAULT_NAVIGATOR_PREDICTION_MILLIS)
                 .distanceFormatter(distanceFormatter)
 
             val onboardRouterOptions = OnboardRouterOptions.Builder()

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/MapboxDistanceFormatter.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/MapboxDistanceFormatter.kt
@@ -72,7 +72,7 @@ class MapboxDistanceFormatter private constructor(
      * Builder of [MapboxDistanceFormatter]
      */
     class Builder {
-        private var unitType: String? = null
+        private var unitType: String = VoiceUnit.UNDEFINED
         private var locale: Locale? = null
         private var roundingIncrement = Rounding.INCREMENT_FIFTY
 
@@ -112,9 +112,8 @@ class MapboxDistanceFormatter private constructor(
         fun build(context: Context): MapboxDistanceFormatter {
             val localeToUse: Locale = locale ?: context.applicationContext.inferDeviceLocale()
             val unitTypeToUse: String = when (unitType) {
-                null -> localeToUse.getUnitTypeForLocale()
                 VoiceUnit.UNDEFINED -> localeToUse.getUnitTypeForLocale()
-                else -> unitType!!
+                else -> unitType
             }
 
             return MapboxDistanceFormatter(


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Addresses https://github.com/mapbox/mapbox-navigation-android/issues/3187

Removing more defaults from defaultNavigationOptionsBuilder, as they are by [NavigationOptions.Builder](https://github.com/mapbox/mapbox-navigation-android/blob/46c731b1269746a68ffc9dfc67056af7f6574345/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/NavigationOptions.kt#L64-L65)

Moving the MapboxDistanceFormatter still requires some work, more details here https://github.com/mapbox/mapbox-navigation-android/issues/3016

The OnboardRouterOptions are still debatable so I'll leave that out of scope of this pull request. The reason it is debatable, is because the default file location lookup would be better on IO dispatchers. 

- [ ] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->