### PR TITLE
Check if faster route is new route

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayHistoryActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayHistoryActivity.kt
@@ -23,6 +23,7 @@ import com.mapbox.navigation.base.internal.extensions.applyDefaultParams
 import com.mapbox.navigation.base.internal.extensions.coordinates
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesRequestCallback
+import com.mapbox.navigation.core.fasterroute.FasterRouteObserver
 import com.mapbox.navigation.core.replay.MapboxReplayer
 import com.mapbox.navigation.core.replay.ReplayLocationEngine
 import com.mapbox.navigation.core.replay.history.CustomEventMapper
@@ -171,6 +172,13 @@ class ReplayHistoryActivity : AppCompatActivity() {
             }
         })
 
+        mapboxNavigation.attachFasterRouteObserver(object : FasterRouteObserver {
+            override fun onFasterRoute(currentRoute: DirectionsRoute, alternatives: List<DirectionsRoute>, isAlternativeFaster: Boolean) {
+                navigationContext?.navigationMapboxMap?.drawRoutes(alternatives)
+                navigationContext?.mapboxNavigation?.setRoutes(alternatives)
+            }
+        })
+
         playReplay.setOnClickListener {
             mapboxReplayer.play()
             mapboxNavigation.startTripSession()
@@ -235,7 +243,7 @@ class ReplayHistoryActivity : AppCompatActivity() {
         override fun onRoutesReady(routes: List<DirectionsRoute>) {
             MapboxLogger.d(Message("route request success $routes"))
             if (routes.isNotEmpty()) {
-                navigationContext?.navigationMapboxMap?.drawRoute(routes[0])
+                navigationContext?.navigationMapboxMap?.drawRoutes(routes)
                 navigationContext?.startNavigation()
             }
         }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/fasterroute/FasterRouteController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/fasterroute/FasterRouteController.kt
@@ -19,7 +19,7 @@ internal class FasterRouteController(
 ) {
 
     private val fasterRouteTimer = MapboxTimer()
-    private val fasterRouteDetector = FasterRouteDetector()
+    private val fasterRouteDetector = FasterRouteDetector(RouteComparator())
     private var fasterRouteObserver: FasterRouteObserver? = null
 
     fun attach(fasterRouteObserver: FasterRouteObserver) {

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/fasterroute/FasterRouteDetector.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/fasterroute/FasterRouteDetector.kt
@@ -3,11 +3,15 @@ package com.mapbox.navigation.core.fasterroute
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.navigation.base.trip.model.RouteProgress
 
-internal class FasterRouteDetector {
-    fun isRouteFaster(newRoute: DirectionsRoute, routeProgress: RouteProgress): Boolean {
-        val newRouteDuration = newRoute.duration() ?: return false
+internal class FasterRouteDetector(
+    private val routeComparator: RouteComparator
+) {
+
+    fun isRouteFaster(alternativeRoute: DirectionsRoute, routeProgress: RouteProgress): Boolean {
+        val alternativeDuration = alternativeRoute.duration() ?: return false
         val weightedDuration = routeProgress.durationRemaining * PERCENTAGE_THRESHOLD
-        return newRouteDuration < weightedDuration
+        val isNewRouteFaster = alternativeDuration < weightedDuration
+        return isNewRouteFaster && routeComparator.isNewRoute(routeProgress, alternativeRoute)
     }
 
     companion object {

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/fasterroute/RouteComparator.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/fasterroute/RouteComparator.kt
@@ -1,0 +1,30 @@
+package com.mapbox.navigation.core.fasterroute
+
+import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.navigation.base.trip.model.RouteProgress
+
+/**
+ * Compares if an alternative route is different from the current route.
+ */
+internal class RouteComparator {
+
+    /**
+     * @param routeProgress current route progress
+     * @param alternativeRoute suggested new route
+     *
+     * @return true when the alternative route has different
+     * geometry from the current route progress
+     */
+    fun isNewRoute(routeProgress: RouteProgress, alternativeRoute: DirectionsRoute): Boolean {
+        val currentGeometry = routeProgress.route.geometry() ?: ""
+        val alternativeGeometry = (alternativeRoute.geometry() ?: "").ifEmpty {
+            return false
+        }
+
+        return isNewRoute(currentGeometry, alternativeGeometry)
+    }
+
+    private fun isNewRoute(currentGeometry: String, alternativeGeometry: String): Boolean {
+        return currentGeometry != alternativeGeometry
+    }
+}

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/fasterroute/FasterRouteControllerTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/fasterroute/FasterRouteControllerTest.kt
@@ -122,6 +122,9 @@ class FasterRouteControllerTest {
         }
         every { tripSession.getRouteProgress() } returns mockk {
             every { durationRemaining } returns 601.334
+            every { route } returns mockk {
+                every { geometry() } returns "y{v|bA{}diiGOuDpBiMhM{k@~Syj@bLuZlEiM"
+            }
         }
         every { directionsSession.requestFasterRoute(any(), capture(routesRequestCallbacks)) } returns mockk()
 
@@ -130,6 +133,7 @@ class FasterRouteControllerTest {
         val routes = listOf<DirectionsRoute>(mockk {
                 every { routeIndex() } returns "0"
                 every { duration() } returns 351.013
+                every { geometry() } returns "{au|bAqtiiiG|TnI`B\\dEzAl_@hMxGxB"
             })
         routesRequestCallbacks.captured.onRoutesReady(routes)
 

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/fasterroute/FasterRouteDetectorTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/fasterroute/FasterRouteDetectorTest.kt
@@ -10,10 +10,14 @@ import org.junit.Test
 
 class FasterRouteDetectorTest {
 
-    private val fasterRouteDetector = FasterRouteDetector()
+    private val routeComparator: RouteComparator = mockk {
+        every { isNewRoute(any(), any()) } returns true
+    }
+    private val fasterRouteDetector = FasterRouteDetector(routeComparator)
 
     @Test
     fun shouldDetectWhenRouteIsFaster() {
+        every { routeComparator.isNewRoute(any(), any()) } returns true
         val newRoute: DirectionsRoute = mockk()
         every { newRoute.duration() } returns 402.6
         val routeProgress: RouteProgress = mockk()
@@ -22,6 +26,19 @@ class FasterRouteDetectorTest {
         val isFasterRoute = fasterRouteDetector.isRouteFaster(newRoute, routeProgress)
 
         assertTrue(isFasterRoute)
+    }
+
+    @Test
+    fun shouldDetectWhenRouteIsFasterOnlyIfDifferent() {
+        every { routeComparator.isNewRoute(any(), any()) } returns false
+        val newRoute: DirectionsRoute = mockk()
+        every { newRoute.duration() } returns 402.6
+        val routeProgress: RouteProgress = mockk()
+        every { routeProgress.durationRemaining } returns 797.447
+
+        val isFasterRoute = fasterRouteDetector.isRouteFaster(newRoute, routeProgress)
+
+        assertFalse(isFasterRoute)
     }
 
     @Test

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/fasterroute/RouteComparatorTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/fasterroute/RouteComparatorTest.kt
@@ -83,4 +83,22 @@ class RouteComparatorTest {
 
         assertTrue(isNewRoute)
     }
+
+    @Test
+    fun `route progress should be on route`() {
+        val currentGeometry = """}u`}bAwgejiGd@tDVdCzA~ItKxa@rIbXhH~W~@jD`CzClGbIbDlE|DpEhHvIlJ`KpKvLlQ|U`BjBza@|d@fA`BdClDda@zk@zA~Bp_@|k@lBxC`BdCzHrLpOjW~FxJbG`KjPfYlBzCdDjDt@rD`Ltk@zJ~e@vCnNlBtKxB|JdC~IvDdGlEdGvC`CrB`B`DpB|KjEtEl@fF?lBGdYkA~@KnAWdL{ErKyCxBe@hGY~BN`DvA|BnA`CvAbBxB`BbCvDxHjApC}TrPqDlEx@jPh@rc@DzCmAp^qFra@yIzd@gZpc@kH|K`EbB"""
+        val alternativeGeometry = """mq||bAwm~iiGdS~TfA`BdClDda@zk@zA~Bp_@|k@lBxC`BdCzHrLpOjW~FxJbG`KjPfYlBzCdDjDt@rD`Ltk@zJ~e@vCnNlBtKxB|JdC~IvDdGlEdGvC`CrB`B`DpB|KjEtEl@fF?lBGdYkA~@KnAWdL{ErKyCxBe@hGY~BN`DvA|BnA`CvAbBxB`BbCvDxHjApC}TrPqDlEx@jPh@rc@DzCmAp^qFra@yIzd@gZpc@kH|K`EbB"""
+        val routeProgress: RouteProgress = mockk {
+            every { route } returns mockk {
+                every { geometry() } returns currentGeometry
+            }
+        }
+        val directionsRoute: DirectionsRoute = mockk {
+            every { geometry() } returns alternativeGeometry
+        }
+
+        val isNewRoute = routeComparator.isNewRoute(routeProgress, directionsRoute)
+
+        assertFalse(isNewRoute)
+    }
 }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/fasterroute/RouteComparatorTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/fasterroute/RouteComparatorTest.kt
@@ -1,0 +1,86 @@
+package com.mapbox.navigation.core.fasterroute
+
+import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.navigation.base.trip.model.RouteProgress
+import io.mockk.every
+import io.mockk.mockk
+import junit.framework.TestCase.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RouteComparatorTest {
+
+    private val routeComparator = RouteComparator()
+
+    @Test
+    fun `route with different geometry is new`() {
+        val currentRoute = """indacAcvqniGkFBmJB{FJ_JrEqBbAoRvEwJdBmC\sJb@eEDkEI_Mc@oIUsEF_FTgFt@qHjBmFjB}ItEqItAkE~BeW`NcEbCsNjIcCaFq@wA"""
+        val alternative = """{{dacAiaqniGdAlIjA^vC\nD?GwX\sFgH?oJ?yF\_JtEqBz@qRtEuJxBoC?uJ|@_E?mE?aM}@oI?sE?}E^cF\yHxBkFzA_JrEmIzAmExBcWfNeExCoNnHgCuEu@yA"""
+        val routeProgress: RouteProgress = mockk {
+            every { route } returns mockk {
+                every { geometry() } returns currentRoute
+            }
+        }
+        val directionsRoute: DirectionsRoute = mockk {
+            every { geometry() } returns alternative
+        }
+
+        val isNewRoute = routeComparator.isNewRoute(routeProgress, directionsRoute)
+
+        assertTrue(isNewRoute)
+    }
+
+    @Test
+    fun `route with same geometry is not new`() {
+        val currentRoute = """indacAcvqniGkFBmJB{FJ_JrEqBbAoRvEwJdBmC\sJb@eEDkEI_Mc@oIUsEF_FTgFt@qHjBmFjB}ItEqItAkE~BeW`NcEbCsNjIcCaFq@wA"""
+        val alternative = """indacAcvqniGkFBmJB{FJ_JrEqBbAoRvEwJdBmC\sJb@eEDkEI_Mc@oIUsEF_FTgFt@qHjBmFjB}ItEqItAkE~BeW`NcEbCsNjIcCaFq@wA"""
+        val routeProgress: RouteProgress = mockk {
+            every { route } returns mockk {
+                every { geometry() } returns currentRoute
+            }
+        }
+        val directionsRoute: DirectionsRoute = mockk {
+            every { geometry() } returns alternative
+        }
+
+        val isNewRoute = routeComparator.isNewRoute(routeProgress, directionsRoute)
+
+        assertFalse(isNewRoute)
+    }
+
+    @Test
+    fun `alternative is not new when alternative is empty`() {
+        val currentGeometry = """indacAcvqniGkFBmJB{FJ_JrEqBbAoRvEwJdBmC\sJb@eEDkEI_Mc@oIUsEF_FTgFt@qHjBmFjB}ItEqItAkE~BeW`NcEbCsNjIcCaFq@wA"""
+        val alternativeGeometry = ""
+        val routeProgress: RouteProgress = mockk {
+            every { route } returns mockk {
+                every { geometry() } returns currentGeometry
+            }
+        }
+        val directionsRoute: DirectionsRoute = mockk {
+            every { geometry() } returns alternativeGeometry
+        }
+
+        val isNewRoute = routeComparator.isNewRoute(routeProgress, directionsRoute)
+
+        assertFalse(isNewRoute)
+    }
+
+    @Test
+    fun `routes with same beginning and end, can still be different`() {
+        val currentGeometry = """e|h~bAslcjiGvBab@tHe}AnEs~@AqdAB{d@EsQCii@Ie\EeUFoh@Reg@nHwEbUsNjUuM`ZiQ|McI`e@eZbf@yX|[wRdCyAfYcQpYwPlVcOvn@y^nUqKfPwFnLeDvW{Hd^sKhr@kTzk@yd@jMuK|IqC`PrgAhM|u@nInm@pB`KnCjMbFzS`EtOrIl_@`T|{@rChMzL`i@jGbX|CzMtd@bjBbEfPdU~}@pFdTjAxDzH~XjGrSdOlc@xTvs@tUzt@jKl_@hP`d@bM``@tQ`h@vVlu@dYlw@pLl]nNrd@lApEtCdIpXpv@|AtExUpt@bXps@`Stk@lDfKlSbl@rv@~{BdD~HdIdMnOpQ|e@la@tt@|m@nEpDlItBxYhVlJ~H|P|L`LhI~SdL~FnBbXjElYbFlW`G|f@|Hpt@|J|Fm^vJs`@|Swk@jPee@j@_BpA{BrEaIfHcM~]vS`EbB"""
+        val alternativeGeometry = """e|h~bAslcjiGvBab@tHe}AnEs~@AqdAB{d@EsQCii@Ie\EeUh`@}@ta@_@x\mAlE~YjA`IpAxGvCzSxG`c@lJjn@~AxKZvIIvDfYzSpAdAbHvFlLnEnJHvJEXtKnBdh@mCxV\~H|Jv`@zc@uKtZoIz]aKva@kKj]mIzOyDf_@mJvNcEbOqD`SmF~XiH\bOj@jXZnIX`Lt@jMt@fLnAlPn@bJ|BfS`Pg@nFOpDUde@iFbOk@fq@}BrRL|SCfBWfa@wU|[eR\SrOaJpJkFxTvs@tUzt@jKl_@hP`d@bM``@tQ`h@vVlu@dYlw@pLl]nNrd@lApEtCdIpXpv@|AtExUpt@bXps@`Stk@lDfKlSbl@rv@~{BdD~HdIdMnOpQ|e@la@tt@|m@nEpDlItBxYhVlJ~H|P|L`LhI~SdL~FnBbXjElYbFlW`G|f@|Hpt@|J|Fm^vJs`@|Swk@jPee@j@_BpA{BrEaIfHcM~]vS`EbB"""
+        val routeProgress: RouteProgress = mockk {
+            every { route } returns mockk {
+                every { geometry() } returns currentGeometry
+            }
+        }
+        val directionsRoute: DirectionsRoute = mockk {
+            every { geometry() } returns alternativeGeometry
+        }
+
+        val isNewRoute = routeComparator.isNewRoute(routeProgress, directionsRoute)
+
+        assertTrue(isNewRoute)
+    }
+}


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Resolves https://github.com/mapbox/mapbox-navigation-android/issues/3144
Resolves https://github.com/mapbox/mapbox-navigation-android/issues/3116

Looked at pulling over code from Legacy https://github.com/mapbox/mapbox-navigation-android/pull/808, but it won't work. The current status is, as you traverse a route, the route needs to be clipped. Legacy does not do this, and this current solution does not do this. Wonder how we should do this 🤔 

Curious if showing alternatives will help us debug reroutes: https://github.com/mapbox/mapbox-navigation-android/pull/3184.

- [ ] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

## Screenshots or Gifs

![output](https://user-images.githubusercontent.com/3021882/86186008-baf6b500-baec-11ea-9139-96d9a977a4d5.gif)

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->