### PR TITLE
Pull in the latest translations from Transifex

### DIFF
--- a/libandroid-navigation-ui/src/main/res/values-el/strings.xml
+++ b/libandroid-navigation-ui/src/main/res/values-el/strings.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Indicates that rerouting is in progress -->
+    <string name="rerouting">Αναδρομολόγηση…</string>
+
+    <!-- Button title for re-centering tracking -->
+    <string name="re_center">Επανεστίαση</string>
+
+    <!-- Indicates voice instructions are muted -->
+    <string name="muted">Σίγαση</string>
+
+    <!-- Indicates voice instructions are unmuted -->
+    <string name="unmuted">Σίγαση</string>
+
+    <!-- Feedback -->
+    <string name="report_feedback">Σχόλια</string>
+
+    <!-- Feedback type for Bad Route -->
+    <string name="feedback_bad_route">Αναποτελεσματική ή\nΚακή διαδρομή</string>
+
+    <!-- Feedback type for Confusing Instruction -->
+    <string name="feedback_confusing_instruction">Μπερδεμένη\nΟδηγία</string>
+
+    <!-- Feedback type for Missing Exit -->
+    <string name="feedback_missing_exit">Λείπει\nΈξοδος</string>
+
+    <!-- Feedback type for Missing Road -->
+    <string name="feedback_missing_road">Λείπει\nΔρόμος</string>
+
+    <!-- Feedback type for a maneuver that is Not Allowed -->
+    <string name="feedback_not_allowed">Δεν\nΕπιτρέπετε</string>
+
+    <!-- Feedback type for Road Closed -->
+    <string name="feedback_road_closure">Δρόμος\nΚλειστός</string>
+
+    <!-- Shown after a feedback type has been submitted -->
+    <string name="feedback_submitted">Τα σχόλια σας υποβλήθηκαν</string>
+
+    <!-- Shown in off-route scenarios to provide feedback -->
+    <string name="report_problem">Αναφορά προβλήματος</string>
+
+    <!-- Test app dialog text -->
+    <string name="dropoff_dialog_text">Θέλετε να πλοηγηθείτε στον επόμενο προορισμό;</string>
+
+    <!-- Test app dialog text start next route -->
+    <string name="dropoff_dialog_positive_text">Ξεκινήστε στη συνέχεια</string>
+
+    <!-- Test app dialog text cancel navigation -->
+    <string name="dropoff_dialog_negative_text">Ματαίωση</string>
+
+    </resources>

--- a/libandroid-navigation/src/main/res/values-el/strings.xml
+++ b/libandroid-navigation/src/main/res/values-el/strings.xml
@@ -1,0 +1,21 @@
+<resources>
+    <!-- Notification Strings -->
+    <string name="end_navigation">Τερματισμόςς πλοήγησης</string>
+    <string name="channel_name">Ειδοποιήσεις πλοήγησης</string>
+    <string name="notification_arrival_time_format">Άφιξη σε %s</string>
+    <string name="kilometers">χλμ.</string>
+    <string name="meters">μέτρ.</string>
+    <string name="miles">μίλ.</string>
+    <string name="feet">πόδ.</string>
+    <string name="eta_format">%sETA</string>
+
+    <!-- Time formatting -->
+    <plurals name="numberOfDays">
+        <item quantity="one">μέρα</item>
+        <item quantity="other">μέρες</item>
+    </plurals>
+    <!-- Hour -->
+    <string name="hr">ώρ.</string>
+    <!-- Minute -->
+    <string name="min">λεπτ.</string>
+</resources>

--- a/libnavigation-util/src/main/res/values-el/strings.xml
+++ b/libnavigation-util/src/main/res/values-el/strings.xml
@@ -1,0 +1,6 @@
+<resources>
+    <string name="kilometers">χλμ.</string>
+    <string name="meters">μέτρ.</string>
+    <string name="miles">μίλ.</string>
+    <string name="feet">πόδ.</string>
+</resources>

--- a/libtrip-notification/src/main/res/values-el/strings.xml
+++ b/libtrip-notification/src/main/res/values-el/strings.xml
@@ -1,0 +1,21 @@
+<resources>
+    <!-- Notification Strings -->
+    <string name="end_navigation">Τέλος πλοήγησης</string>
+    <string name="channel_name">Ειδοποιήσεις πλοήγησης</string>
+    <string name="notification_arrival_time_format">Άφιξη στις %s</string>
+    <string name="kilometers">χλμ</string>
+    <string name="meters">μ</string>
+    <string name="miles">μίλια</string>
+    <string name="feet">πόδια</string>
+    <string name="eta_format">%s ETA</string>
+
+    <!-- Time formatting -->
+    <plurals name="numberOfDays">
+        <item quantity="one">μέρα</item>
+        <item quantity="other">μέρες</item>
+    </plurals>
+    <!-- Hour -->
+    <string name="hr">ώρες</string>
+    <!-- Minute -->
+    <string name="min">λεπτά</string>
+</resources>


### PR DESCRIPTION
### Contribution from @dnKaratzas in https://github.com/mapbox/mapbox-navigation-android/pull/3264

## Description

Adds Greek translation

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Get newest and latest translations available in Transifex

### Implementation

Pull translations from Transifex and add them to the SDK and test app

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
