### PR TITLE
Add SDK Registry repo reference and bump Maps SDK to 9.3.0-alpha.1

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -554,6 +554,11 @@ License: [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
+Mapbox Navigation uses portions of the JaCoCo :: Agent (JaCoCo Agent).
+License: [Eclipse Public License v1.0](http://www.eclipse.org/legal/epl-v10.html)
+
+===========================================================================
+
 Mapbox Navigation uses portions of the JetBrains Java Annotations (A set of annotations used for code inspection support and code documentation.).
 URL: [https://github.com/JetBrains/java-annotations](https://github.com/JetBrains/java-annotations)
 License: [The Apache Software License, Version 2.0](http://www.apache.org/license/LICENSE-2.0.txt)

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -554,11 +554,6 @@ License: [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox Navigation uses portions of the JaCoCo :: Agent (JaCoCo Agent).
-License: [Eclipse Public License v1.0](http://www.eclipse.org/legal/epl-v10.html)
-
-===========================================================================
-
 Mapbox Navigation uses portions of the JetBrains Java Annotations (A set of annotations used for code inspection support and code documentation.).
 URL: [https://github.com/JetBrains/java-annotations](https://github.com/JetBrains/java-annotations)
 License: [The Apache Software License, Version 2.0](http://www.apache.org/license/LICENSE-2.0.txt)
@@ -598,6 +593,12 @@ License: [The MIT License](https://opensource.org/licenses/MIT)
 Mapbox Navigation uses portions of the Mapbox Java SDK.
 URL: [https://github.com/mapbox/mapbox-java](https://github.com/mapbox/mapbox-java)
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+===========================================================================
+
+Mapbox Navigation uses portions of the Mapbox Maps GL Core SDK for Android.
+URL: [https://github.com/mapbox/mapbox-gl-native-android](https://github.com/mapbox/mapbox-gl-native-android)
+License: [BSD](https://opensource.org/licenses/BSD-2-Clause)
 
 ===========================================================================
 

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,16 @@ allprojects {
     jcenter()
     maven { url 'https://plugins.gradle.org/m2' }
     maven {
+      url 'https://api.mapbox.com/downloads/v2/releases/maven'
+      authentication {
+        basic(BasicAuthentication)
+      }
+      credentials {
+        username = "mapbox"
+        password = project.hasProperty('SDK_REGISTRY_TOKEN') ? project.property('SDK_REGISTRY_TOKEN') : System.getenv('SDK_REGISTRY_TOKEN')
+      }
+    }
+    maven {
       url 'https://mapbox.bintray.com/mapbox_internal'
       credentials {
         username = project.hasProperty('BINTRAY_USER') ? project.property('BINTRAY_USER') : System.getenv('BINTRAY_USER')

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -7,7 +7,7 @@ ext {
   ]
 
   version = [
-      mapboxMapSdk              : '9.2.1',
+      mapboxMapSdk              : '9.3.0-alpha.1',
       mapboxSdkServices         : '5.3.0',
       mapboxSdkDirectionsModels : '5.3.0',
       mapboxEvents              : '6.0.0',

--- a/libnavigation-ui/build.gradle
+++ b/libnavigation-ui/build.gradle
@@ -76,6 +76,8 @@ dependencies {
 
   // Mapbox Maps SDK
   api dependenciesList.mapboxMapSdk
+  // workaround for a missing transitive artifact
+  implementation "com.mapbox.mapboxsdk:mapbox-android-sdk-gl-core:1.7.0"
   implementation dependenciesList.mapboxAnnotationPlugin
 
   // Support libraries


### PR DESCRIPTION
This PR adds SDK Registry build configuration that requires a private token to be added to the build script for everyone trying to build the project from source. The token needs to be available under `SDK_REGISTRY_TOKEN` variable and added to global or local `gradle.properties` file or exposed as an env variable. You can head over to your Mapbox account and create a new, private token with `DOWNLOADS:READ` scope, and add it to the script before building the project.

This PR also bumps the Maps SDK `9.3.0-alpha.1` and adds a missing transitive dependency workaround. /cc @tobrun 

/cc @mapbox/navigation-android 