### PR TITLE
Bump Android Base to `0.1.2`

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -17,7 +17,7 @@ ext {
       mapboxAnnotationPlugin    : '0.8.0',
       mapboxAccounts            : '0.4.0',
       mapboxSearchSdk           : '0.1.0-SNAPSHOT',
-      mapboxBaseAndroid         : '0.1.1',
+      mapboxBaseAndroid         : '0.1.2',
       androidXCoreVersion       : '1.2.0',
       androidXAppCompatVersion  : '1.1.0',
       androidXAnnotationVersion : '1.1.0',


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-navigation-android/issues/3263.