### PR TITLE
CP #3267 to 1.1.0 beta.6

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -554,6 +554,11 @@ License: [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
+Mapbox Navigation uses portions of the JaCoCo :: Agent (JaCoCo Agent).
+License: [Eclipse Public License v1.0](http://www.eclipse.org/legal/epl-v10.html)
+
+===========================================================================
+
 Mapbox Navigation uses portions of the JetBrains Java Annotations (A set of annotations used for code inspection support and code documentation.).
 URL: [https://github.com/JetBrains/java-annotations](https://github.com/JetBrains/java-annotations)
 License: [The Apache Software License, Version 2.0](http://www.apache.org/license/LICENSE-2.0.txt)

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -554,11 +554,6 @@ License: [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox Navigation uses portions of the JaCoCo :: Agent (JaCoCo Agent).
-License: [Eclipse Public License v1.0](http://www.eclipse.org/legal/epl-v10.html)
-
-===========================================================================
-
 Mapbox Navigation uses portions of the JetBrains Java Annotations (A set of annotations used for code inspection support and code documentation.).
 URL: [https://github.com/JetBrains/java-annotations](https://github.com/JetBrains/java-annotations)
 License: [The Apache Software License, Version 2.0](http://www.apache.org/license/LICENSE-2.0.txt)
@@ -598,6 +593,12 @@ License: [The MIT License](https://opensource.org/licenses/MIT)
 Mapbox Navigation uses portions of the Mapbox Java SDK.
 URL: [https://github.com/mapbox/mapbox-java](https://github.com/mapbox/mapbox-java)
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+===========================================================================
+
+Mapbox Navigation uses portions of the Mapbox Maps GL Core SDK for Android.
+URL: [https://github.com/mapbox/mapbox-gl-native-android](https://github.com/mapbox/mapbox-gl-native-android)
+License: [BSD](https://opensource.org/licenses/BSD-2-Clause)
 
 ===========================================================================
 

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,16 @@ allprojects {
     jcenter()
     maven { url 'https://plugins.gradle.org/m2' }
     maven {
+      url 'https://api.mapbox.com/downloads/v2/releases/maven'
+      authentication {
+        basic(BasicAuthentication)
+      }
+      credentials {
+        username = "mapbox"
+        password = project.hasProperty('SDK_REGISTRY_TOKEN') ? project.property('SDK_REGISTRY_TOKEN') : System.getenv('SDK_REGISTRY_TOKEN')
+      }
+    }
+    maven {
       url 'https://mapbox.bintray.com/mapbox_internal'
       credentials {
         username = project.hasProperty('BINTRAY_USER') ? project.property('BINTRAY_USER') : System.getenv('BINTRAY_USER')

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,7 +8,7 @@ ext {
   ]
 
   version = [
-      mapboxMapSdk              : '9.2.1',
+      mapboxMapSdk              : '9.3.0-alpha.1',
       mapboxSdkServices         : '5.2.1',
       mapboxSdkDirectionsModels : '5.2.1',
       mapboxEvents              : '5.0.1',

--- a/libnavigation-ui/build.gradle
+++ b/libnavigation-ui/build.gradle
@@ -77,6 +77,8 @@ dependencies {
 
   // Mapbox Maps SDK
   api dependenciesList.mapboxMapSdk
+  // workaround for a missing transitive artifact
+  implementation "com.mapbox.mapboxsdk:mapbox-android-sdk-gl-core:1.7.0"
   implementation dependenciesList.mapboxAnnotationPlugin
 
   // Support libraries


### PR DESCRIPTION
CPs https://github.com/mapbox/mapbox-navigation-android/pull/3267 to the `release-1.1.0-beta.6` based on https://github.com/mapbox/mapbox-navigation-android/releases/tag/qa_release_ui_1.0.0-qa.2020w26_core_1.0.0-qa.2020w26.