### PR TITLE
Fix #3234: take snapshot when showing the FeedbackBottomSheet fragment

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationView.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationView.java
@@ -837,6 +837,7 @@ public class NavigationView extends CoordinatorLayout implements LifecycleOwner,
     cancelBtn.setOnClickListener(new CancelBtnClickListener(navigationViewEventDispatcher));
     recenterBtn.addOnClickListener(new RecenterBtnClickListener(navigationPresenter));
     routeOverviewBtn.setOnClickListener(new RouteOverviewBtnClickListener(navigationPresenter));
+    retrieveFeedbackButton().addOnClickListener(view -> navigationViewModel.takeScreenshot());
   }
 
   private void initializeOnCameraTrackingChangedListener() {

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationViewModel.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationViewModel.java
@@ -15,6 +15,7 @@ import com.mapbox.api.directions.v5.models.BannerInstructions;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.api.directions.v5.models.RouteOptions;
 import com.mapbox.api.directions.v5.models.VoiceInstructions;
+import com.mapbox.core.utils.TextUtils;
 import com.mapbox.geojson.Point;
 import com.mapbox.geojson.utils.PolylineUtils;
 import com.mapbox.mapboxsdk.Mapbox;
@@ -88,6 +89,7 @@ public class NavigationViewModel extends AndroidViewModel {
   private int voiceInstructionsToAnnounce = 0;
   private RouteProgress routeProgress;
   private FeedbackItem feedbackItem;
+  private String feedbackEncodedScreenShot;
   private String language;
   private DistanceFormatter distanceFormatter;
   private String accessToken;
@@ -152,8 +154,7 @@ public class NavigationViewModel extends AndroidViewModel {
    */
   public void updateFeedback(FeedbackItem feedbackItem) {
     this.feedbackItem = feedbackItem;
-    isFeedbackSentSuccess.setValue(false);
-    shouldRecordScreenshot.setValue(true);
+    sendFeedback();
   }
 
   /**
@@ -226,16 +227,8 @@ public class NavigationViewModel extends AndroidViewModel {
   }
 
   void updateFeedbackScreenshot(String screenshot) {
-    if (feedbackItem != null) {
-      MapboxNavigation.postUserFeedback(feedbackItem.getFeedbackType(),
-          feedbackItem.getDescription(), UI, screenshot,
-          feedbackItem.getFeedbackSubType().toArray(new String[0]));
-      sendEventFeedback(feedbackItem);
-      isFeedbackSentSuccess.setValue(true);
-      feedbackItem = null;
-    }
-
-    shouldRecordScreenshot.setValue(false);
+    feedbackEncodedScreenShot = screenshot;
+    sendFeedback();
   }
 
   boolean isRunning() {
@@ -270,6 +263,12 @@ public class NavigationViewModel extends AndroidViewModel {
 
   void updateLocation(Location location) {
     navigationLocation.setValue(location);
+  }
+
+  void takeScreenshot() {
+    clearFeedback();
+
+    shouldRecordScreenshot.setValue(true);
   }
 
   private void updateBannerInstruction(BannerInstructions bannerInstructions) {
@@ -434,6 +433,26 @@ public class NavigationViewModel extends AndroidViewModel {
     }
   }
 
+  private synchronized void sendFeedback() {
+    if (feedbackItem != null && !TextUtils.isEmpty(feedbackEncodedScreenShot)) {
+      MapboxNavigation.postUserFeedback(feedbackItem.getFeedbackType(),
+              feedbackItem.getDescription(), UI, feedbackEncodedScreenShot,
+              feedbackItem.getFeedbackSubType().toArray(new String[0]));
+
+      onFeedbackSent(feedbackItem);
+      isFeedbackSentSuccess.setValue(true);
+
+      clearFeedback();
+    }
+  }
+
+  private void clearFeedback() {
+    feedbackItem = null;
+    feedbackEncodedScreenShot = null;
+    isFeedbackSentSuccess.setValue(false);
+    shouldRecordScreenshot.setValue(false);
+  }
+
   private VoiceInstructionsObserver voiceInstructionsObserver = new VoiceInstructionsObserver() {
     @Override
     public void onNewVoiceInstructions(@NotNull VoiceInstructions voiceInstructions) {
@@ -511,7 +530,7 @@ public class NavigationViewModel extends AndroidViewModel {
     }
   }
 
-  private void sendEventFeedback(FeedbackItem feedbackItem) {
+  private void onFeedbackSent(FeedbackItem feedbackItem) {
     if (navigationViewEventDispatcher != null) {
       navigationViewEventDispatcher.onFeedbackSent(feedbackItem);
     }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationViewSubscriber.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationViewSubscriber.java
@@ -1,16 +1,9 @@
 package com.mapbox.navigation.ui;
 
-import android.location.Location;
-
-import androidx.annotation.Nullable;
 import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.LifecycleObserver;
 import androidx.lifecycle.LifecycleOwner;
-import androidx.lifecycle.Observer;
 import androidx.lifecycle.OnLifecycleEvent;
-
-import com.mapbox.api.directions.v5.models.DirectionsRoute;
-import com.mapbox.geojson.Point;
 
 class NavigationViewSubscriber implements LifecycleObserver {
 
@@ -27,48 +20,33 @@ class NavigationViewSubscriber implements LifecycleObserver {
   }
 
   void subscribe() {
-    navigationViewModel.retrieveRoute().observe(lifecycleOwner, new Observer<DirectionsRoute>() {
-      @Override
-      public void onChanged(@Nullable DirectionsRoute directionsRoute) {
-        if (directionsRoute != null) {
-          navigationPresenter.onRouteUpdate(directionsRoute);
-        }
+    navigationViewModel.retrieveRoute().observe(lifecycleOwner, directionsRoute -> {
+      if (directionsRoute != null) {
+        navigationPresenter.onRouteUpdate(directionsRoute);
       }
     });
 
-    navigationViewModel.retrieveDestination().observe(lifecycleOwner, new Observer<Point>() {
-      @Override
-      public void onChanged(@Nullable Point point) {
-        if (point != null) {
-          navigationPresenter.onDestinationUpdate(point);
-        }
+    navigationViewModel.retrieveDestination().observe(lifecycleOwner, point -> {
+      if (point != null) {
+        navigationPresenter.onDestinationUpdate(point);
       }
     });
 
-    navigationViewModel.retrieveNavigationLocation().observe(lifecycleOwner, new Observer<Location>() {
-      @Override
-      public void onChanged(@Nullable Location location) {
-        if (location != null) {
-          navigationPresenter.onNavigationLocationUpdate(location);
-        }
+    navigationViewModel.retrieveNavigationLocation().observe(lifecycleOwner, location -> {
+      if (location != null) {
+        navigationPresenter.onNavigationLocationUpdate(location);
       }
     });
 
-    navigationViewModel.retrieveShouldRecordScreenshot().observe(lifecycleOwner, new Observer<Boolean>() {
-      @Override
-      public void onChanged(@Nullable Boolean shouldRecordScreenshot) {
-        if (shouldRecordScreenshot != null && shouldRecordScreenshot) {
-          navigationPresenter.onShouldRecordScreenshot();
-        }
+    navigationViewModel.retrieveShouldRecordScreenshot().observe(lifecycleOwner, shouldRecordScreenshot -> {
+      if (shouldRecordScreenshot != null && shouldRecordScreenshot) {
+        navigationPresenter.onShouldRecordScreenshot();
       }
     });
 
-    navigationViewModel.retrieveIsFeedbackSentSuccess().observe(lifecycleOwner, new Observer<Boolean>() {
-      @Override
-      public void onChanged(Boolean isFeedbackSentSuccess) {
-        if (isFeedbackSentSuccess != null && isFeedbackSentSuccess) {
-          navigationPresenter.onFeedbackSent();
-        }
+    navigationViewModel.retrieveIsFeedbackSentSuccess().observe(lifecycleOwner, isFeedbackSentSuccess -> {
+      if (isFeedbackSentSuccess != null && isFeedbackSentSuccess) {
+        navigationPresenter.onFeedbackSent();
       }
     });
   }


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Fix #3234: take snapshot when showing the FeedbackBottomSheet fragment

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Implementation

Before this PR, we only take the snapshot when a feedback item has been selected.
The screenshot might not reflect the real location of the feedback.

This PR update NavigationView and all the examples to take the snapshot as soon
as the FeedbackBottomSheet fragment will be showing.

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->