### PR TITLE
Revert #3269 from 1.1.0 beta.6

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -554,11 +554,6 @@ License: [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox Navigation uses portions of the JaCoCo :: Agent (JaCoCo Agent).
-License: [Eclipse Public License v1.0](http://www.eclipse.org/legal/epl-v10.html)
-
-===========================================================================
-
 Mapbox Navigation uses portions of the JetBrains Java Annotations (A set of annotations used for code inspection support and code documentation.).
 URL: [https://github.com/JetBrains/java-annotations](https://github.com/JetBrains/java-annotations)
 License: [The Apache Software License, Version 2.0](http://www.apache.org/license/LICENSE-2.0.txt)

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -554,6 +554,11 @@ License: [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
+Mapbox Navigation uses portions of the JaCoCo :: Agent (JaCoCo Agent).
+License: [Eclipse Public License v1.0](http://www.eclipse.org/legal/epl-v10.html)
+
+===========================================================================
+
 Mapbox Navigation uses portions of the JetBrains Java Annotations (A set of annotations used for code inspection support and code documentation.).
 URL: [https://github.com/JetBrains/java-annotations](https://github.com/JetBrains/java-annotations)
 License: [The Apache Software License, Version 2.0](http://www.apache.org/license/LICENSE-2.0.txt)
@@ -593,12 +598,6 @@ License: [The MIT License](https://opensource.org/licenses/MIT)
 Mapbox Navigation uses portions of the Mapbox Java SDK.
 URL: [https://github.com/mapbox/mapbox-java](https://github.com/mapbox/mapbox-java)
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-===========================================================================
-
-Mapbox Navigation uses portions of the Mapbox Maps GL Core SDK for Android.
-URL: [https://github.com/mapbox/mapbox-gl-native-android](https://github.com/mapbox/mapbox-gl-native-android)
-License: [BSD](https://opensource.org/licenses/BSD-2-Clause)
 
 ===========================================================================
 

--- a/build.gradle
+++ b/build.gradle
@@ -42,16 +42,6 @@ allprojects {
     jcenter()
     maven { url 'https://plugins.gradle.org/m2' }
     maven {
-      url 'https://api.mapbox.com/downloads/v2/releases/maven'
-      authentication {
-        basic(BasicAuthentication)
-      }
-      credentials {
-        username = "mapbox"
-        password = project.hasProperty('SDK_REGISTRY_TOKEN') ? project.property('SDK_REGISTRY_TOKEN') : System.getenv('SDK_REGISTRY_TOKEN')
-      }
-    }
-    maven {
       url 'https://mapbox.bintray.com/mapbox_internal'
       credentials {
         username = project.hasProperty('BINTRAY_USER') ? project.property('BINTRAY_USER') : System.getenv('BINTRAY_USER')

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,7 +8,7 @@ ext {
   ]
 
   version = [
-      mapboxMapSdk              : '9.3.0-alpha.1',
+      mapboxMapSdk              : '9.2.1',
       mapboxSdkServices         : '5.2.1',
       mapboxSdkDirectionsModels : '5.2.1',
       mapboxEvents              : '5.0.1',

--- a/libnavigation-ui/build.gradle
+++ b/libnavigation-ui/build.gradle
@@ -77,8 +77,6 @@ dependencies {
 
   // Mapbox Maps SDK
   api dependenciesList.mapboxMapSdk
-  // workaround for a missing transitive artifact
-  implementation "com.mapbox.mapboxsdk:mapbox-android-sdk-gl-core:1.7.0"
   implementation dependenciesList.mapboxAnnotationPlugin
 
   // Support libraries


### PR DESCRIPTION
## Description

This PR reverts #3269 (bump Maps SDK to `9.3.0-alpha.1`) so it's not included in `release-1.1.0-beta.6`

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Revert #3269 (bump Maps SDK to `9.3.0-alpha.1`) as introduced some regressions blocking `release-1.1.0-beta.6` 

### Implementation

```
$> git checkout release-1.1.0-beta.6
$> git checkout -b pg-revert-3269
$> git revert 257eda00ccf2a0e61a372efddeed46053631296f
$> git revert 8a929246e168a23c58e0cd7401c3345282efeeff
$> git revert 3df2e16729bbfd969e0d52eb0ef7c4ca1015be24
```

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs


cc @zugaldia @asinghal22 @AnnaStaley @Aurora-Boreal @shivani-patel23 @knov @mskurydin 