### PR TITLE
Clean up old PRs: #1970 and #2021

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/ui/NavigationViewActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/ui/NavigationViewActivity.kt
@@ -101,6 +101,7 @@ class NavigationViewActivity : AppCompatActivity(), OnNavigationReadyCallback,
                 optionsBuilder.directionsRoute(route)
                 optionsBuilder.shouldSimulateRoute(true)
                 optionsBuilder.bannerInstructionsListener(this)
+                optionsBuilder.muteVoiceGuidance(true)
                 navigationView.startNavigation(optionsBuilder.build())
             }
         }

--- a/libnavigation-ui/api/current.txt
+++ b/libnavigation-ui/api/current.txt
@@ -67,6 +67,7 @@ package com.mapbox.navigation.ui {
     method public abstract Integer? darkThemeResId();
     method public abstract com.mapbox.api.directions.v5.models.DirectionsRoute! directionsRoute();
     method public abstract Integer? lightThemeResId();
+    method public abstract boolean muteVoiceGuidance();
     method public abstract com.mapbox.navigation.ui.MapOfflineOptions? offlineMapOptions();
     method public abstract String? offlineRoutingTilesPath();
     method public abstract String? offlineRoutingTilesVersion();
@@ -87,6 +88,7 @@ package com.mapbox.navigation.ui {
     method public void initialize(com.mapbox.navigation.ui.OnNavigationReadyCallback!, com.mapbox.mapboxsdk.camera.CameraPosition, String!);
     method public boolean isRecenterButtonVisible();
     method public boolean isSummaryBottomSheetHidden();
+    method public boolean isVoiceGuidanceMuted();
     method public boolean isWayNameVisible();
     method public boolean onBackPressed();
     method public void onCreate(android.os.Bundle?);
@@ -118,6 +120,7 @@ package com.mapbox.navigation.ui {
     method public void startNavigation(com.mapbox.navigation.ui.NavigationViewOptions!);
     method public void stopNavigation();
     method public void takeScreenshot();
+    method public void toggleMute();
     method public void updateCameraRouteOverview();
     method public void updateWayNameView(String);
   }
@@ -166,6 +169,7 @@ package com.mapbox.navigation.ui {
     method public abstract com.mapbox.navigation.ui.NavigationViewOptions.Builder! lightThemeResId(Integer!);
     method public abstract com.mapbox.navigation.ui.NavigationViewOptions.Builder! locationEngine(com.mapbox.android.core.location.LocationEngine!);
     method public abstract com.mapbox.navigation.ui.NavigationViewOptions.Builder! locationObserver(com.mapbox.navigation.core.trip.session.LocationObserver!);
+    method public abstract com.mapbox.navigation.ui.NavigationViewOptions.Builder! muteVoiceGuidance(boolean);
     method public abstract com.mapbox.navigation.ui.NavigationViewOptions.Builder! navigationListener(com.mapbox.navigation.ui.listeners.NavigationListener!);
     method public abstract com.mapbox.navigation.ui.NavigationViewOptions.Builder! navigationOptions(com.mapbox.navigation.base.options.NavigationOptions!);
     method public abstract com.mapbox.navigation.ui.NavigationViewOptions.Builder! offlineMapOptions(com.mapbox.navigation.ui.MapOfflineOptions!);

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationUiOptions.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationUiOptions.java
@@ -34,4 +34,6 @@ public abstract class NavigationUiOptions {
 
   @Nullable
   public abstract PuckDrawableSupplier puckDrawableSupplier();
+
+  public abstract boolean muteVoiceGuidance();
 }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationView.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationView.java
@@ -553,6 +553,29 @@ public class NavigationView extends CoordinatorLayout implements LifecycleOwner,
   }
 
   /**
+   * Returns the state of speech player whether it is muted or unmuted
+   * @return true if speech player is mute else false
+   */
+  public boolean isVoiceGuidanceMuted() {
+    return navigationViewModel.isMuted();
+  }
+
+  /**
+   * This method toggles the mute state of speech player. It also updates the UI
+   * to reflect the new state of speech player.
+   * <p>
+   * Should be called after {@link NavigationView#startNavigation}.
+   * Otherwise, it does nothing.
+   * <p>
+   * Can check the current mute state by calling {@link NavigationView#isVoiceGuidanceMuted()}
+   */
+  public void toggleMute() {
+    if (isSubscribed) {
+      navigationViewModel.setMuted(((SoundButton) retrieveSoundButton()).toggleMute());
+    }
+  }
+
+  /**
    * Updates the visibility of the Mapbox logo and attribution button
    *
    * @param isVisible what the new visibility should be. True makes
@@ -816,6 +839,7 @@ public class NavigationView extends CoordinatorLayout implements LifecycleOwner,
       navigationMap.setCamera(options.camera());
     }
 
+    initializeVoiceGuidanceMuteState(options);
     initializeNavigationListeners(options, navigationViewModel);
     setupNavigationMapboxMap(options);
 
@@ -823,6 +847,12 @@ public class NavigationView extends CoordinatorLayout implements LifecycleOwner,
       initializeClickListeners();
       initializeOnCameraTrackingChangedListener();
       subscribeViewModels();
+    }
+  }
+
+  private void initializeVoiceGuidanceMuteState(final NavigationViewOptions options) {
+    if (options.muteVoiceGuidance() && !isVoiceGuidanceMuted()) {
+      navigationViewModel.setMuted(((SoundButton) retrieveSoundButton()).toggleMute());
     }
   }
 

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationViewModel.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationViewModel.java
@@ -226,14 +226,16 @@ public class NavigationViewModel extends AndroidViewModel {
   }
 
   void stopNavigation() {
-    navigation.unregisterRouteProgressObserver(navigationProgressObserver);
-    navigation.unregisterLocationObserver(navigationProgressObserver);
-    navigation.unregisterRoutesObserver(routesObserver);
-    navigation.unregisterOffRouteObserver(offRouteObserver);
-    navigation.unregisterBannerInstructionsObserver(bannerInstructionsObserver);
-    navigation.unregisterVoiceInstructionsObserver(voiceInstructionsObserver);
-    navigation.unregisterTripSessionStateObserver(tripSessionStateObserver);
-    navigation.stopTripSession();
+    if (navigation != null) {
+      navigation.unregisterRouteProgressObserver(navigationProgressObserver);
+      navigation.unregisterLocationObserver(navigationProgressObserver);
+      navigation.unregisterRoutesObserver(routesObserver);
+      navigation.unregisterOffRouteObserver(offRouteObserver);
+      navigation.unregisterBannerInstructionsObserver(bannerInstructionsObserver);
+      navigation.unregisterVoiceInstructionsObserver(voiceInstructionsObserver);
+      navigation.unregisterTripSessionStateObserver(tripSessionStateObserver);
+      navigation.stopTripSession();
+    }
   }
 
   void updateRouteProgress(RouteProgress routeProgress) {

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationViewOptions.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationViewOptions.java
@@ -169,6 +169,14 @@ public abstract class NavigationViewOptions extends NavigationUiOptions {
      */
     public abstract Builder puckDrawableSupplier(PuckDrawableSupplier puckDrawableSupplier);
 
+    /**
+     * Set true to mute the voice guidance when the Navigation starts
+     *
+     * @param muteVoiceGuidance true or false
+     * @return this {@link Builder}
+     */
+    public abstract Builder muteVoiceGuidance(boolean muteVoiceGuidance);
+
     public abstract NavigationViewOptions build();
   }
 


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Clean up legacy PRs:
1) #1970 add mute voice instruction when startNavigation and support mute voice without tapping the soundButton feature, this fix #1965 
2) #2021 add NPE protection in NavigationViewModel for 'navigation'

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal

Clean up old PRs and improve SDK quality.

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->