### PR TITLE
Sb 3246 redraw on reroute

### DIFF
--- a/libnavigation-ui/api/current.txt
+++ b/libnavigation-ui/api/current.txt
@@ -544,6 +544,9 @@ package com.mapbox.navigation.ui.route {
     method public void onInitialized(com.mapbox.navigation.ui.route.RouteLineLayerIds routeLineLayerIds);
   }
 
+  public final class MapRouteProgressChangeListenerKt {
+  }
+
   public class NavigationMapRoute implements androidx.lifecycle.LifecycleObserver {
     method public void addProgressChangeListener(com.mapbox.navigation.core.MapboxNavigation!);
     method public void addProgressChangeListener(com.mapbox.navigation.core.MapboxNavigation!, boolean);

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteLineTest.kt
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteLineTest.kt
@@ -1002,6 +1002,86 @@ class MapRouteLineTest {
         assertEquals(-7957339, result)
     }
 
+    @Test
+    fun reinitializeWithRoutes() {
+        every { style.layers } returns listOf(primaryRouteLayer)
+        val route = getDirectionsRoute(true)
+        val mapRouteLine = MapRouteLine(
+            ctx,
+            style,
+            styleRes,
+            null,
+            layerProvider,
+            mapRouteSourceProvider,
+            null
+        )
+
+        mapRouteLine.reinitializeWithRoutes(listOf(route))
+
+        assertEquals(route, mapRouteLine.getPrimaryRoute())
+    }
+
+    @Test
+    fun reinitializePrimaryRoute() {
+        every { style.layers } returns listOf(primaryRouteLayer)
+        every { style.isFullyLoaded } returns true
+        every { style.getLayer(PRIMARY_ROUTE_TRAFFIC_LAYER_ID) } returns primaryRouteLayer
+        every { primaryRouteLayer.setFilter(any()) } returns Unit
+        every { primaryRouteShieldLayer.setFilter(any()) } returns Unit
+        every { alternativeRouteLayer.setFilter(any()) } returns Unit
+        every { alternativeRouteShieldLayer.setFilter(any()) } returns Unit
+        every { primaryRouteTrafficLayer.setFilter(any()) } returns Unit
+        every { waypointLayer.setFilter(any()) } returns Unit
+        every { primaryRouteLayer.setProperties(any()) } returns Unit
+        every { primaryRouteShieldLayer.setProperties(any()) } returns Unit
+        every { alternativeRouteLayer.setProperties(any()) } returns Unit
+        every { alternativeRouteShieldLayer.setProperties(any()) } returns Unit
+        every { primaryRouteTrafficLayer.setProperties(any()) } returns Unit
+        every { waypointLayer.setProperties(any()) } returns Unit
+        every { style.getLayerAs<LineLayer>("mapbox-navigation-route-shield-layer") } returns primaryRouteShieldLayer
+
+        val route = getDirectionsRoute(true)
+        val mapRouteLine = MapRouteLine(
+            ctx,
+            style,
+            styleRes,
+            null,
+            layerProvider,
+            mapRouteSourceProvider,
+            null
+        )
+
+        mapRouteLine.reinitializeWithRoutes(listOf(route))
+        mapRouteLine.reinitializePrimaryRoute()
+
+        verify { primaryRouteLayer.setProperties(any()) }
+    }
+
+    @Test
+    fun getExpressionAtOffsetWhenExpressionDataEmpty() {
+        every { style.layers } returns listOf(primaryRouteLayer)
+        val expectedExpression = "[\"step\", [\"line-progress\"], [\"rgba\", 0.0, 0.0, 0.0, 0.0], 0.2, [\"rgba\", 86.0, 168.0, 251.0, 1.0]]"
+        val route = getDirectionsRoute(true)
+        val mapRouteLine = MapRouteLine(
+            ctx,
+            style,
+            styleRes,
+            null,
+            layerProvider,
+            listOf<RouteFeatureData>(),
+            listOf<RouteLineExpressionData>(),
+            true,
+            false,
+            mapRouteSourceProvider,
+            0f,
+            null
+        )
+
+        val expression = mapRouteLine.getExpressionAtOffset(.2f)
+
+        assertEquals(expectedExpression, expression.toString())
+    }
+
     private fun getDirectionsRoute(includeCongestion: Boolean): DirectionsRoute {
         val congestion = when (includeCongestion) {
             true -> "\"unknown\",\"heavy\",\"low\""


### PR DESCRIPTION
## Description

Fixes #3246 when a reroute happens the new line is drawn and the vanishing point is reset without displaying the previous route line. 

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal

The route line that has vanished should not appear when a reroute event occurs.

### Implementation

The new route is set on the progress update without drawing the line and the line is drawn on the next progress update to give the maps engine time to clear the previous line.

## Screenshots or Gifs


## Testing


- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->