### PR TITLE
Bump NN dependency version to 14.1.6

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -12,7 +12,7 @@ ext {
       mapboxSdkDirectionsModels : '5.3.0',
       mapboxEvents              : '6.0.0',
       mapboxCore                : '3.0.0',
-      mapboxNavigator           : '14.1.2',
+      mapboxNavigator           : '14.1.6',
       mapboxCrashMonitor        : '2.0.0',
       mapboxAnnotationPlugin    : '0.8.0',
       mapboxAccounts            : '0.4.0',


### PR DESCRIPTION
## Description

Bumps `mapbox-navigation-native` version to ~`14.1.4`~ `14.1.6`

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Getting the latest version from `mapboxNavigator` including the new features and bug fixes.

### Implementation

- Bump the `mapboxNavigator` version to ~`14.1.4`~ `14.1.6` in `dependencies.gradle` and fix breaking changes


## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

**EDIT** Confirming that `14.1.6` solves 👇 issues 🎉 

While testing run into the following crashes 👀 

As soon as you start a _Free Drive_ session 💥 cc @LukasPaczos 

```
07-06 12:56:46.892 22109-22109/com.mapbox.navigation.examples E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.mapbox.navigation.examples, PID: 22109
    java.lang.IllegalArgumentException: latitude must be between -90 and 90
        at com.mapbox.mapboxsdk.geometry.LatLng.setLatitude(LatLng.java:132)
        at com.mapbox.mapboxsdk.geometry.LatLng.<init>(LatLng.java:79)
        at com.mapbox.mapboxsdk.geometry.LatLng.<init>(LatLng.java:90)
        at com.mapbox.mapboxsdk.location.LocationAnimatorCoordinator.getLatLngValues(LocationAnimatorCoordinator.java:274)
        at com.mapbox.mapboxsdk.location.LocationAnimatorCoordinator.feedNewLocation(LocationAnimatorCoordinator.java:110)
        at com.mapbox.mapboxsdk.location.LocationComponent.updateLocation(LocationComponent.java:1438)
        at com.mapbox.mapboxsdk.location.LocationComponent.forceLocationUpdate(LocationComponent.java:933)
        at com.mapbox.navigation.ui.map.NavigationMapboxMap.updateLocation(NavigationMapboxMap.java:288)
        at com.mapbox.navigation.ui.map.NavigationMapboxMap$1.onEnhancedLocationChanged(NavigationMapboxMap.java:993)
        at com.mapbox.navigation.core.internal.trip.session.MapboxTripSession.updateEnhancedLocation(MapboxTripSession.kt:441)
        at com.mapbox.navigation.core.internal.trip.session.MapboxTripSession.access$updateEnhancedLocation(MapboxTripSession.kt:61)
        at com.mapbox.navigation.core.internal.trip.session.MapboxTripSession$updateDataFromNavigatorStatus$1$1.invokeSuspend(MapboxTripSession.kt:426)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:56)
        at android.os.Handler.handleCallback(Handler.java:739)
        at android.os.Handler.dispatchMessage(Handler.java:95)
        at android.os.Looper.loop(Looper.java:148)
        at android.app.ActivityThread.main(ActivityThread.java:5417)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616)
```

NN 💥 cc @SiarheiFedartsou @mskurydin 

```
07-06 12:34:36.216 3925-3945/com.mapbox.navigation.examples E/AndroidRuntime: FATAL EXCEPTION: FinalizerWatchdogDaemon
    Process: com.mapbox.navigation.examples, PID: 3925
    java.util.concurrent.TimeoutException: com.mapbox.navigator.Navigator.finalize() timed out after 10 seconds
        at com.mapbox.navigator.Navigator.finalize(Native Method)
        at java.lang.Daemons$FinalizerDaemon.doFinalize(Daemons.java:202)
        at java.lang.Daemons$FinalizerDaemon.run(Daemons.java:185)
        at java.lang.Thread.run(Thread.java:818)
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR

cc @mskurydin @SiarheiFedartsou @LukasPaczos 