### PR TITLE
Fix #3286: maintain the SoundButton mute state in screen rotation scenario

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/ui/NavigationViewActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/ui/NavigationViewActivity.kt
@@ -101,7 +101,6 @@ class NavigationViewActivity : AppCompatActivity(), OnNavigationReadyCallback,
                 optionsBuilder.directionsRoute(route)
                 optionsBuilder.shouldSimulateRoute(true)
                 optionsBuilder.bannerInstructionsListener(this)
-                optionsBuilder.muteVoiceGuidance(true)
                 navigationView.startNavigation(optionsBuilder.build())
             }
         }

--- a/examples/src/main/java/com/mapbox/navigation/examples/ui/NavigationViewFragment.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/ui/NavigationViewFragment.kt
@@ -107,6 +107,7 @@ class NavigationViewFragment : Fragment(), OnNavigationReadyCallback, Navigation
                 optionsBuilder.directionsRoute(route)
                 optionsBuilder.shouldSimulateRoute(true)
                 optionsBuilder.enableVanishingRouteLine(true)
+                optionsBuilder.muteVoiceGuidance(true)
                 navigationView.startNavigation(optionsBuilder.build())
             }
         }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationView.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationView.java
@@ -179,7 +179,7 @@ public class NavigationView extends CoordinatorLayout implements LifecycleOwner,
     wayNameView.updateWayNameText(navigationViewInstanceState.getWayNameText());
     resetBottomSheetState(navigationViewInstanceState.getBottomSheetBehaviorState());
     updateInstructionListState(navigationViewInstanceState.isInstructionViewVisible());
-    updateInstructionMutedState(navigationViewInstanceState.isMuted());
+    restoreInstructionMutedState(navigationViewInstanceState.isMuted());
     mapInstanceState = savedInstanceState.getParcelable(MAP_INSTANCE_STATE_KEY);
   }
 
@@ -570,9 +570,7 @@ public class NavigationView extends CoordinatorLayout implements LifecycleOwner,
    * Can check the current mute state by calling {@link NavigationView#isVoiceGuidanceMuted()}
    */
   public void toggleMute() {
-    if (isSubscribed) {
-      navigationViewModel.setMuted(((SoundButton) retrieveSoundButton()).toggleMute());
-    }
+    navigationViewModel.setMuted(((SoundButton) retrieveSoundButton()).toggleMute());
   }
 
   /**
@@ -788,10 +786,9 @@ public class NavigationView extends CoordinatorLayout implements LifecycleOwner,
     }
   }
 
-  private void updateInstructionMutedState(boolean isMuted) {
-    if (isMuted) {
-      ((SoundButton) instructionView.retrieveSoundButton()).soundFabOff();
-    }
+  private void restoreInstructionMutedState(boolean isMuted) {
+    navigationViewModel.setMuted(isMuted);
+    ((SoundButton) instructionView.retrieveSoundButton()).onRestoreInstanceState(isMuted);
   }
 
   private int[] buildRouteOverviewPadding(Context context) {

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationViewModel.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationViewModel.java
@@ -130,7 +130,9 @@ public class NavigationViewModel extends AndroidViewModel {
   }
 
   public void setMuted(boolean isMuted) {
-    speechPlayer.setMuted(isMuted);
+    if (speechPlayer != null) {
+      speechPlayer.setMuted(isMuted);
+    }
   }
 
   /**

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationViewOptions.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationViewOptions.java
@@ -186,6 +186,7 @@ public abstract class NavigationViewOptions extends NavigationUiOptions {
         .roundingIncrement(Rounding.INCREMENT_FIFTY)
         .shouldSimulateRoute(false)
         .waynameChipEnabled(true)
+        .muteVoiceGuidance(false)
         .enableVanishingRouteLine(false);
   }
 }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/SoundButton.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/SoundButton.java
@@ -131,11 +131,16 @@ public class SoundButton extends ConstraintLayout implements NavigationButton {
   }
 
   /**
-   * Changes sound {@link FloatingActionButton}
-   * {@link Drawable} to denote sound is off.
+   * Restore state
+   * @param isMuted true to show muted icon
    */
-  void soundFabOff() {
-    soundFab.setImageResource(R.drawable.ic_sound_off);
+  void onRestoreInstanceState(boolean isMuted) {
+    this.isMuted = isMuted;
+    if (isMuted) {
+      soundFabOff();
+    } else {
+      soundFabOn();
+    }
   }
 
   private void setupOnClickListeners() {
@@ -253,5 +258,13 @@ public class SoundButton extends ConstraintLayout implements NavigationButton {
    */
   private void soundFabOn() {
     soundFab.setImageResource(R.drawable.ic_sound_on);
+  }
+
+  /**
+   * Changes sound {@link FloatingActionButton}
+   * {@link Drawable} to denote sound is off.
+   */
+  private void soundFabOff() {
+    soundFab.setImageResource(R.drawable.ic_sound_off);
   }
 }


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Fix #3286: maintain the SoundButton mute state in screen rotation scenario

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Implementation

Need to restore the mute state in `NavigationViewModel` and `SoundButton`. Not only the icon resource.


## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->