### PR TITLE
MapboxNavigationProvider API

### DIFF
--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -56,6 +56,8 @@ package com.mapbox.navigation.core {
 
   public final class MapboxNavigationProvider {
     method public static com.mapbox.navigation.core.MapboxNavigation create(com.mapbox.navigation.base.options.NavigationOptions navigationOptions);
+    method public static void destroy();
+    method public static boolean isCreated();
     method public static com.mapbox.navigation.core.MapboxNavigation retrieve();
     field public static final com.mapbox.navigation.core.MapboxNavigationProvider! INSTANCE;
   }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigationProvider.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigationProvider.kt
@@ -17,14 +17,12 @@ object MapboxNavigationProvider {
      */
     @JvmStatic
     fun create(navigationOptions: NavigationOptions): MapboxNavigation {
-        synchronized(MapboxNavigationProvider::class.java) {
-            mapboxNavigation?.onDestroy()
-            mapboxNavigation = MapboxNavigation(
-                navigationOptions
-            )
+        mapboxNavigation?.onDestroy()
+        mapboxNavigation = MapboxNavigation(
+            navigationOptions
+        )
 
-            return mapboxNavigation!!
-        }
+        return mapboxNavigation!!
     }
 
     /**
@@ -33,16 +31,29 @@ object MapboxNavigationProvider {
      */
     @JvmStatic
     fun retrieve(): MapboxNavigation {
-        var instance = mapboxNavigation
-        if (instance == null) {
-            synchronized(MapboxNavigationProvider::class.java) {
-                instance = mapboxNavigation
-                if (instance == null) {
-                    throw RuntimeException("Need to create MapboxNavigation before using it.")
-                }
-            }
+        if (!isCreated()) {
+            throw RuntimeException("Need to create MapboxNavigation before using it.")
         }
 
-        return instance!!
+        return mapboxNavigation!!
+    }
+
+    /**
+     * Destroy MapboxNavigation with provided options.
+     * Should be called after [create]
+     *
+     */
+    @JvmStatic
+    fun destroy() {
+        mapboxNavigation?.onDestroy()
+        mapboxNavigation = null
+    }
+
+    /**
+     * Check if MapboxNavigation is created.
+     */
+    @JvmStatic
+    fun isCreated(): Boolean {
+        return mapboxNavigation != null
     }
 }


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Add more methods to `MapboxNavigationProvider`
Made all methods `Synchronized` to prevent concurrent issues, not just some blocks.
closes #3224 

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [x] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->