### PR TITLE
Fix 3216: queue the VoiceInstruction so it just play one at a time.

### DIFF
--- a/libnavigation-ui/api/current.txt
+++ b/libnavigation-ui/api/current.txt
@@ -634,6 +634,16 @@ package com.mapbox.navigation.ui.voice {
     ctor public SpeechPlayerProvider(android.content.Context, String!, boolean, com.mapbox.navigation.ui.voice.VoiceInstructionLoader!);
   }
 
+  public enum SpeechPlayerState {
+    enum_constant public static final com.mapbox.navigation.ui.voice.SpeechPlayerState IDLE;
+    enum_constant public static final com.mapbox.navigation.ui.voice.SpeechPlayerState OFFLINE_PLAYING;
+    enum_constant public static final com.mapbox.navigation.ui.voice.SpeechPlayerState ONLINE_PLAYING;
+  }
+
+  public interface SpeechPlayerStateChangeObserver {
+    method public void onStateChange(com.mapbox.navigation.ui.voice.SpeechPlayerState state);
+  }
+
   public class VoiceInstructionLoader {
     ctor public VoiceInstructionLoader(android.content.Context!, String!, okhttp3.Cache!);
     method public void cacheInstructions(java.util.List<java.lang.String!>!);

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/voice/MapboxSpeechPlayer.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/voice/MapboxSpeechPlayer.java
@@ -50,7 +50,7 @@ class MapboxSpeechPlayer implements SpeechPlayer {
    * @param voiceInstructionLoader voice instruction loader
    */
   MapboxSpeechPlayer(Context context, @NonNull VoiceListener voiceListener,
-                     VoiceInstructionLoader voiceInstructionLoader) {
+      VoiceInstructionLoader voiceInstructionLoader) {
     this.voiceListener = voiceListener;
     this.voiceInstructionLoader = voiceInstructionLoader;
     setupCaches(context);
@@ -191,7 +191,7 @@ class MapboxSpeechPlayer implements SpeechPlayer {
     mediaPlayer.setOnPreparedListener(new MediaPlayer.OnPreparedListener() {
       @Override
       public void onPrepared(MediaPlayer mp) {
-        voiceListener.onStart();
+        voiceListener.onStart(SpeechPlayerState.ONLINE_PLAYING);
         isPlaying = true;
         mp.start();
       }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/voice/NavigationSpeechPlayer.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/voice/NavigationSpeechPlayer.java
@@ -5,6 +5,9 @@ import androidx.fragment.app.FragmentActivity;
 
 import com.mapbox.api.directions.v5.models.VoiceInstructions;
 
+import java.util.ArrayDeque;
+import java.util.Queue;
+
 /**
  * Used to play {@link VoiceInstructions}s.
  * <p>
@@ -17,11 +20,19 @@ import com.mapbox.api.directions.v5.models.VoiceInstructions;
  */
 public class NavigationSpeechPlayer implements SpeechPlayer {
 
+  private Queue<VoiceInstructions> voiceInstructionsQueue = new ArrayDeque<>();
   private SpeechPlayerProvider speechPlayerProvider;
   private boolean isMuted;
 
+  private SpeechPlayerStateChangeObserver observer = state -> {
+    if (!voiceInstructionsQueue.isEmpty() && state == SpeechPlayerState.IDLE) {
+      speechPlayerProvider.retrieveSpeechPlayer().play(voiceInstructionsQueue.poll());
+    }
+  };
+
   public NavigationSpeechPlayer(SpeechPlayerProvider speechPlayerProvider) {
     this.speechPlayerProvider = speechPlayerProvider;
+    this.speechPlayerProvider.setSpeechPlayerStateChangeObserver(observer);
   }
 
   /**
@@ -31,7 +42,11 @@ public class NavigationSpeechPlayer implements SpeechPlayer {
    */
   @Override
   public void play(VoiceInstructions voiceInstructions) {
-    speechPlayerProvider.retrieveSpeechPlayer().play(voiceInstructions);
+    voiceInstructionsQueue.offer(voiceInstructions);
+    SpeechPlayer player = speechPlayerProvider.retrieveSpeechPlayer();
+    if (player != null) {
+      player.play(voiceInstructionsQueue.poll());
+    }
   }
 
   /**
@@ -55,6 +70,7 @@ public class NavigationSpeechPlayer implements SpeechPlayer {
   @Override
   public void setMuted(boolean isMuted) {
     this.isMuted = isMuted;
+    voiceInstructionsQueue.clear();
     speechPlayerProvider.setMuted(isMuted);
   }
 
@@ -67,6 +83,7 @@ public class NavigationSpeechPlayer implements SpeechPlayer {
    */
   @Override
   public void onOffRoute() {
+    voiceInstructionsQueue.clear();
     speechPlayerProvider.onOffRoute();
   }
 
@@ -79,6 +96,9 @@ public class NavigationSpeechPlayer implements SpeechPlayer {
    */
   @Override
   public void onDestroy() {
+    voiceInstructionsQueue.clear();
+    speechPlayerProvider.setSpeechPlayerStateChangeObserver(null);
+    observer = null;
     speechPlayerProvider.onDestroy();
   }
 }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/voice/NavigationVoiceListener.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/voice/NavigationVoiceListener.java
@@ -1,5 +1,7 @@
 package com.mapbox.navigation.ui.voice;
 
+import androidx.annotation.NonNull;
+
 import com.mapbox.api.directions.v5.models.VoiceInstructions;
 
 import timber.log.Timber;
@@ -10,24 +12,27 @@ class NavigationVoiceListener implements VoiceListener {
   private SpeechAudioFocusManager audioFocusManager;
 
   NavigationVoiceListener(SpeechPlayerProvider speechPlayerProvider,
-                          SpeechAudioFocusManager audioFocusManager) {
+      SpeechAudioFocusManager audioFocusManager) {
     this.speechPlayerProvider = speechPlayerProvider;
     this.audioFocusManager = audioFocusManager;
   }
 
   @Override
-  public void onStart() {
+  public void onStart(@NonNull SpeechPlayerState state) {
+    speechPlayerProvider.onSpeechPlayerStateChanged(state);
     audioFocusManager.requestAudioFocus();
   }
 
   @Override
   public void onDone() {
+    speechPlayerProvider.onSpeechPlayerStateChanged(SpeechPlayerState.IDLE);
     audioFocusManager.abandonAudioFocus();
   }
 
   @Override
   public void onError(String errorText, VoiceInstructions voiceInstructions) {
     Timber.e(errorText);
+    speechPlayerProvider.onSpeechPlayerStateChanged(SpeechPlayerState.IDLE);
     speechPlayerProvider.retrieveAndroidSpeechPlayer().play(voiceInstructions);
   }
 }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/voice/SpeechPlayerState.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/voice/SpeechPlayerState.kt
@@ -1,0 +1,21 @@
+package com.mapbox.navigation.ui.voice
+
+/**
+ * The [SpeechPlayer] will be at one of these states.
+ */
+enum class SpeechPlayerState {
+    /**
+     * No voice guidance is playing. [SpeechPlayer] is not idle.
+     */
+    IDLE,
+
+    /**
+     * Voice guidance is playing through [AndroidSpeechPlayer].
+     */
+    OFFLINE_PLAYING,
+
+    /**
+     * Voice guidance is playing through [MapboxSpeechPlayer].
+     */
+    ONLINE_PLAYING
+}

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/voice/SpeechPlayerStateChangeObserver.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/voice/SpeechPlayerStateChangeObserver.kt
@@ -1,0 +1,15 @@
+package com.mapbox.navigation.ui.voice
+
+/**
+ * Interface definition for an observer that get's notified
+ * whenever the [SpeechPlayer]'s [SpeechPlayerState] changes.
+ */
+interface SpeechPlayerStateChangeObserver {
+
+    /**
+     * Invoked whenever the [SpeechPlayer]'s [SpeechPlayerState] changes.
+     *
+     * @param state the latest SpeechPlayer state
+     */
+    fun onStateChange(state: SpeechPlayerState)
+}

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/voice/UtteranceListener.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/voice/UtteranceListener.java
@@ -11,7 +11,7 @@ class UtteranceListener extends UtteranceProgressListener {
 
   @Override
   public void onStart(String utteranceId) {
-    voiceListener.onStart();
+    voiceListener.onStart(SpeechPlayerState.OFFLINE_PLAYING);
   }
 
   @Override
@@ -22,5 +22,6 @@ class UtteranceListener extends UtteranceProgressListener {
   @Override
   public void onError(String utteranceId) {
     // Intentionally empty
+    voiceListener.onDone();
   }
 }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/voice/VoiceListener.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/voice/VoiceListener.java
@@ -1,10 +1,12 @@
 package com.mapbox.navigation.ui.voice;
 
+import androidx.annotation.NonNull;
+
 import com.mapbox.api.directions.v5.models.VoiceInstructions;
 
 interface VoiceListener {
 
-  void onStart();
+  void onStart(@NonNull SpeechPlayerState state);
 
   void onDone();
 

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/voice/NavigationVoiceListenerTest.java
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/voice/NavigationVoiceListenerTest.java
@@ -4,6 +4,8 @@ import com.mapbox.api.directions.v5.models.VoiceInstructions;
 
 import org.junit.Test;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -15,7 +17,7 @@ public class NavigationVoiceListenerTest {
     SpeechAudioFocusManager audioFocusManager = mock(SpeechAudioFocusManager.class);
     NavigationVoiceListener navigationSpeechListener = buildSpeechListener(audioFocusManager);
 
-    navigationSpeechListener.onStart();
+    navigationSpeechListener.onStart(SpeechPlayerState.ONLINE_PLAYING);
 
     verify(audioFocusManager).requestAudioFocus();
   }
@@ -39,7 +41,42 @@ public class NavigationVoiceListenerTest {
     VoiceInstructions announcement = buildAnnouncement();
 
     navigationSpeechListener.onError("Error text", announcement);
+
     verify(androidSpeechPlayer).play(announcement);
+  }
+
+  @Test
+  public void onStart_speechPlayerStateChanged() {
+    SpeechPlayerProvider provider = mock(SpeechPlayerProvider.class);
+    NavigationVoiceListener navigationSpeechListener = buildSpeechListener(provider);
+    SpeechPlayerState speechPlayerState = mock(SpeechPlayerState.class);
+
+    navigationSpeechListener.onStart(speechPlayerState);
+
+    verify(provider).onSpeechPlayerStateChanged(speechPlayerState);
+  }
+
+  @Test
+  public void onDone_speechPlayerStateChangedToIdle() {
+    SpeechPlayerProvider provider = mock(SpeechPlayerProvider.class);
+    NavigationVoiceListener navigationSpeechListener = buildSpeechListener(provider);
+
+    navigationSpeechListener.onDone();
+
+    verify(provider).onSpeechPlayerStateChanged(SpeechPlayerState.IDLE);
+  }
+
+  @Test
+  public void onError_speechPlayerStateChangedToIdle() {
+    SpeechPlayerProvider provider = mock(SpeechPlayerProvider.class);
+    AndroidSpeechPlayer androidSpeechPlayer = mock(AndroidSpeechPlayer.class);
+    when(provider.retrieveAndroidSpeechPlayer()).thenReturn(androidSpeechPlayer);
+    NavigationVoiceListener navigationSpeechListener = buildSpeechListener(provider);
+    VoiceInstructions announcement = buildAnnouncement();
+
+    navigationSpeechListener.onError(anyString(), announcement);
+
+    verify(provider).onSpeechPlayerStateChanged(SpeechPlayerState.IDLE);
   }
 
   private NavigationVoiceListener buildSpeechListener(SpeechAudioFocusManager audioFocusManager) {


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Fix #3216: queue the VoiceInstruction so it just play one at a time.

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal

To improve the voice instruction quality.

### Implementation

Queue the voice instructions, and only play it when the speechPlayer is ready to play.

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->