### PR TITLE
Compare routes using step names

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayActivity.kt
@@ -23,6 +23,7 @@ import com.mapbox.navigation.base.internal.extensions.applyDefaultParams
 import com.mapbox.navigation.base.internal.extensions.coordinates
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesRequestCallback
+import com.mapbox.navigation.core.fasterroute.FasterRouteObserver
 import com.mapbox.navigation.core.replay.MapboxReplayer
 import com.mapbox.navigation.core.replay.ReplayLocationEngine
 import com.mapbox.navigation.core.replay.route.ReplayRouteMapper
@@ -39,7 +40,7 @@ import kotlinx.android.synthetic.main.activity_replay_route_layout.*
 
 /**
  * This activity shows how to use the MapboxNavigation
- * class with the Navigation SDK's [ReplayHistoryLocationEngine].
+ * class with the Navigation SDK's [MapboxReplayer] and [ReplayLocationEngine].
  */
 class ReplayActivity : AppCompatActivity(), OnMapReadyCallback {
 
@@ -82,6 +83,13 @@ class ReplayActivity : AppCompatActivity(), OnMapReadyCallback {
                 navigationMapboxMap?.restoreFrom(state)
             }
             initializeFirstLocation()
+
+            mapboxNavigation?.attachFasterRouteObserver(object : FasterRouteObserver {
+                override fun onFasterRoute(currentRoute: DirectionsRoute, alternatives: List<DirectionsRoute>, isAlternativeFaster: Boolean) {
+                    navigationMapboxMap?.drawRoutes(alternatives)
+                    mapboxNavigation?.setRoutes(alternatives)
+                }
+            })
         }
         mapboxMap.addOnMapLongClickListener { latLng ->
             mapboxMap.locationComponent.lastKnownLocation?.let { originLocation ->
@@ -110,7 +118,7 @@ class ReplayActivity : AppCompatActivity(), OnMapReadyCallback {
         override fun onRoutesReady(routes: List<DirectionsRoute>) {
             MapboxLogger.d(Message("route request success $routes"))
             if (routes.isNotEmpty()) {
-                navigationMapboxMap?.drawRoute(routes[0])
+                navigationMapboxMap?.drawRoutes(routes)
 
                 val replayEvents = replayRouteMapper.mapGeometry(routes[0].geometry()!!)
                 mapboxReplayer.pushEvents(replayEvents)

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayHistoryActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayHistoryActivity.kt
@@ -23,6 +23,7 @@ import com.mapbox.navigation.base.internal.extensions.applyDefaultParams
 import com.mapbox.navigation.base.internal.extensions.coordinates
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesRequestCallback
+import com.mapbox.navigation.core.fasterroute.FasterRouteObserver
 import com.mapbox.navigation.core.replay.MapboxReplayer
 import com.mapbox.navigation.core.replay.ReplayLocationEngine
 import com.mapbox.navigation.core.replay.history.CustomEventMapper
@@ -171,6 +172,13 @@ class ReplayHistoryActivity : AppCompatActivity() {
             }
         })
 
+        mapboxNavigation.attachFasterRouteObserver(object : FasterRouteObserver {
+            override fun onFasterRoute(currentRoute: DirectionsRoute, alternatives: List<DirectionsRoute>, isAlternativeFaster: Boolean) {
+                navigationContext?.navigationMapboxMap?.drawRoutes(alternatives)
+                navigationContext?.mapboxNavigation?.setRoutes(alternatives)
+            }
+        })
+
         playReplay.setOnClickListener {
             mapboxReplayer.play()
             mapboxNavigation.startTripSession()
@@ -235,7 +243,7 @@ class ReplayHistoryActivity : AppCompatActivity() {
         override fun onRoutesReady(routes: List<DirectionsRoute>) {
             MapboxLogger.d(Message("route request success $routes"))
             if (routes.isNotEmpty()) {
-                navigationContext?.navigationMapboxMap?.drawRoute(routes[0])
+                navigationContext?.navigationMapboxMap?.drawRoutes(routes)
                 navigationContext?.startNavigation()
             }
         }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -32,7 +32,9 @@ import com.mapbox.navigation.core.directions.session.DirectionsSession
 import com.mapbox.navigation.core.directions.session.RoutesObserver
 import com.mapbox.navigation.core.directions.session.RoutesRequestCallback
 import com.mapbox.navigation.core.fasterroute.FasterRouteController
+import com.mapbox.navigation.core.fasterroute.FasterRouteDetector
 import com.mapbox.navigation.core.fasterroute.FasterRouteObserver
+import com.mapbox.navigation.core.fasterroute.RouteComparator
 import com.mapbox.navigation.core.internal.MapboxDistanceFormatter
 import com.mapbox.navigation.core.internal.accounts.MapboxNavigationAccounts
 import com.mapbox.navigation.core.internal.trip.service.TripService
@@ -207,6 +209,7 @@ class MapboxNavigation(
             directionsSession,
             tripSession,
             routeOptionsProvider,
+            FasterRouteDetector(RouteComparator()),
             logger
         )
         routeRefreshController = RouteRefreshController(directionsSession, tripSession, logger)

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/fasterroute/FasterRouteDetector.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/fasterroute/FasterRouteDetector.kt
@@ -2,12 +2,21 @@ package com.mapbox.navigation.core.fasterroute
 
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.navigation.base.trip.model.RouteProgress
+import com.mapbox.navigation.utils.internal.ThreadController
+import kotlinx.coroutines.withContext
 
-internal class FasterRouteDetector {
-    fun isRouteFaster(newRoute: DirectionsRoute, routeProgress: RouteProgress): Boolean {
-        val newRouteDuration = newRoute.duration() ?: return false
+internal class FasterRouteDetector(
+    private val routeComparator: RouteComparator
+) {
+
+    suspend fun isRouteFaster(
+        alternativeRoute: DirectionsRoute,
+        routeProgress: RouteProgress
+    ): Boolean = withContext(ThreadController.IODispatcher) {
+        val alternativeDuration = alternativeRoute.duration() ?: return@withContext false
         val weightedDuration = routeProgress.durationRemaining * PERCENTAGE_THRESHOLD
-        return newRouteDuration < weightedDuration
+        val isRouteFaster = alternativeDuration < weightedDuration
+        return@withContext isRouteFaster && routeComparator.isRouteDescriptionDifferent(routeProgress, alternativeRoute)
     }
 
     companion object {

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/fasterroute/RouteComparator.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/fasterroute/RouteComparator.kt
@@ -1,0 +1,46 @@
+package com.mapbox.navigation.core.fasterroute
+
+import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.api.directions.v5.models.LegStep
+import com.mapbox.navigation.base.trip.model.RouteProgress
+
+/**
+ * Compares if an alternative route is different from the current route progress.
+ */
+internal class RouteComparator {
+
+    private val mapLegStepToName: (LegStep) -> String = { it.name() ?: "" }
+
+    /**
+     * @param routeProgress current route progress
+     * @param alternativeRoute suggested new route
+     *
+     * @return true when the alternative route has different
+     * geometry from the current route progress
+     */
+    fun isRouteDescriptionDifferent(routeProgress: RouteProgress, alternativeRoute: DirectionsRoute): Boolean {
+        val currentDescription = routeDescription(routeProgress)
+        val alternativeDescription = alternativeDescription(alternativeRoute)
+        alternativeDescription.ifEmpty {
+            return false
+        }
+
+        return currentDescription != alternativeDescription
+    }
+
+    private fun routeDescription(routeProgress: RouteProgress): String {
+        val routeLeg = routeProgress.currentLegProgress?.routeLeg
+        val steps = routeLeg?.steps()
+        val stepIndex = routeProgress.currentLegProgress?.currentStepProgress?.stepIndex
+            ?: return ""
+
+        return steps?.listIterator(stepIndex)?.asSequence()
+            ?.joinToString(transform = mapLegStepToName) ?: ""
+    }
+
+    private fun alternativeDescription(directionsRoute: DirectionsRoute): String {
+        val steps = directionsRoute.legs()?.firstOrNull()?.steps()
+        return steps?.asSequence()
+            ?.joinToString(transform = mapLegStepToName) ?: ""
+    }
+}

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/fasterroute/RouteComparatorTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/fasterroute/RouteComparatorTest.kt
@@ -1,0 +1,114 @@
+package com.mapbox.navigation.core.fasterroute
+
+import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.navigation.base.trip.model.RouteProgress
+import io.mockk.every
+import io.mockk.mockk
+import junit.framework.TestCase.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RouteComparatorTest {
+
+    private val routeComparator = RouteComparator()
+
+    @Test
+    fun `route with different steps is new`() {
+        val routeProgress: RouteProgress = mockk {
+            every { currentLegProgress } returns mockk {
+                every { legIndex } returns 0
+                every { currentStepProgress } returns mockk {
+                    every { stepIndex } returns 0
+                }
+                every { routeLeg } returns mockk {
+                    every { steps() } returns listOf(
+                        mockk { every { name() } returns "Pennsylvania Avenue" },
+                        mockk { every { name() } returns "19th Street" },
+                        mockk { every { name() } returns "Arkansas Street" }
+                    )
+                }
+            }
+        }
+        val directionsRoute: DirectionsRoute = mockk {
+            every { legs() } returns listOf(mockk {
+                every { steps() } returns listOf(
+                    mockk { every { name() } returns "Pennsylvania Avenue" },
+                    mockk { every { name() } returns "20th Street" },
+                    mockk { every { name() } returns "Arkansas Street" }
+                )
+            })
+        }
+
+        val isNewRoute = routeComparator.isRouteDescriptionDifferent(routeProgress, directionsRoute)
+
+        assertTrue(isNewRoute)
+    }
+
+    @Test
+    fun `route with same steps is not new`() {
+        val routeProgress: RouteProgress = mockk {
+            every { currentLegProgress } returns mockk {
+                every { legIndex } returns 0
+                every { currentStepProgress } returns mockk {
+                    every { stepIndex } returns 0
+                }
+                every { routeLeg } returns mockk {
+                    every { steps() } returns listOf(
+                        mockk { every { name() } returns "Pennsylvania Avenue" },
+                        mockk { every { name() } returns "20th Street" },
+                        mockk { every { name() } returns "De Haro Street" }
+                    )
+                }
+            }
+        }
+        val directionsRoute: DirectionsRoute = mockk {
+            every { legs() } returns listOf(mockk {
+                every { steps() } returns listOf(
+                    mockk { every { name() } returns "Pennsylvania Avenue" },
+                    mockk { every { name() } returns "20th Street" },
+                    mockk { every { name() } returns "De Haro Street" }
+                )
+            })
+        }
+
+        val isNewRoute = routeComparator.isRouteDescriptionDifferent(routeProgress, directionsRoute)
+
+        assertFalse(isNewRoute)
+    }
+
+    @Test
+    fun `stepIndex should clip route progress`() {
+        val routeProgress: RouteProgress = mockk {
+            every { currentLegProgress } returns mockk {
+                every { legIndex } returns 0
+                every { currentStepProgress } returns mockk {
+                    every { stepIndex } returns 4
+                }
+                every { routeLeg } returns mockk {
+                    every { steps() } returns listOf(
+                        mockk { every { name() } returns "Pennsylvania Avenue" },
+                        mockk { every { name() } returns "Cesar Chavez Street" },
+                        mockk { every { name() } returns "Bryant Street" },
+                        mockk { every { name() } returns "Precita Avenue" },
+                        mockk { every { name() } returns "Alabama Street" },
+                        mockk { every { name() } returns "Bradford Street" },
+                        mockk { every { name() } returns "Nevada Street" }
+                    )
+                }
+            }
+        }
+        val directionsRoute: DirectionsRoute = mockk {
+            every { legs() } returns listOf(mockk {
+                every { steps() } returns listOf(
+                    mockk { every { name() } returns "Alabama Street" },
+                    mockk { every { name() } returns "Bradford Street" },
+                    mockk { every { name() } returns "Nevada Street" }
+                )
+            })
+        }
+
+        val isNewRoute = routeComparator.isRouteDescriptionDifferent(routeProgress, directionsRoute)
+
+        assertFalse(isNewRoute)
+    }
+}


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Resolves https://github.com/mapbox/mapbox-navigation-android/issues/3144

Midway through a route we request a new route, and we're looking to see if it's faster. This is working as design. The problem is the route we're checking, can be the current route.

This is the 3rd approach considered for this.
- compare geometry strings https://github.com/mapbox/mapbox-navigation-android/pull/3262 ❌ 
- compare [leg summaries](https://github.com/mapbox/mapbox-navigation-android/blob/2476bab1fd0201af45e43c33dedbc20d991e1958/libandroid-navigation-ui/src/main/java/com/mapbox/services/android/navigation/ui/v5/RouteComparator.java#L62) ❌ 
- This change is to compare remaining LegStep.names 🥗 

Going to test this in a few regions

- [x] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

## Screenshots
![output](https://user-images.githubusercontent.com/3021882/86186008-baf6b500-baec-11ea-9139-96d9a977a4d5.gif)

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->