### PR TITLE
Remove flaky test from legacy

### DIFF
--- a/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/route/MapRouteLineTest.java
+++ b/libandroid-navigation-ui/src/test/java/com/mapbox/services/android/navigation/ui/v5/route/MapRouteLineTest.java
@@ -266,41 +266,6 @@ public class MapRouteLineTest extends BaseTest {
   }
 
   @Test
-  public void updatePrimaryIndex_newPrimaryRouteIndexIsNotUpdated() throws Exception {
-    GeoJsonSource routeLineSource = mock(GeoJsonSource.class);
-    GeoJsonSource wayPointSource = mock(GeoJsonSource.class);
-    List<String> routeLayerIds = buildMockLayers();
-    MapRouteLine routeLine = new MapRouteLine(routeLineSource, wayPointSource, routeLayerIds);
-    List<DirectionsRoute> routes = new ArrayList<>();
-    routes.add(buildTestDirectionsRoute());
-    routes.add(buildTestDirectionsRoute());
-    routes.add(buildTestDirectionsRoute());
-    routes.add(buildTestDirectionsRoute());
-    ArgumentCaptor<Runnable> runnableFeatures = ArgumentCaptor.forClass(Runnable.class);
-    ArgumentCaptor<Runnable> runnablePrimary = ArgumentCaptor.forClass(Runnable.class);
-    CountDownLatch latchRunnableFeatures = new CountDownLatch(1);
-    CountDownLatch latchRunnablePrimary = new CountDownLatch(1);
-    CountDownLatch latch = new CountDownLatch(1);
-    Handler handlerFeatures = mock(Handler.class);
-    buildFeatureProcessingTask(routes, routeLine, handlerFeatures);
-    Handler handlerPrimary = mock(Handler.class);
-    buildPrimaryRouteUpdateTask(routeLine, handlerPrimary);
-    routeLine.draw(routes);
-    latchRunnableFeatures.await(25, TimeUnit.MILLISECONDS);
-    verify(handlerFeatures).post(runnableFeatures.capture());
-    runnableFeatures.getValue().run();
-    latchRunnablePrimary.await(25, TimeUnit.MILLISECONDS);
-    verify(handlerPrimary).post(runnablePrimary.capture());
-    runnablePrimary.getValue().run();
-
-    boolean isNewIndex = routeLine.updatePrimaryRouteIndex(-1);
-
-    latch.await(25, TimeUnit.MILLISECONDS);
-    assertFalse(isNewIndex);
-    assertEquals(0, routeLine.retrievePrimaryRouteIndex());
-  }
-
-  @Test
   public void routeLineCap_defaultIsSet() {
     Context context = mock(Context.class);
     TypedArray typedArray = mock(TypedArray.class);


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

This test [fails sometimes](https://app.circleci.com/pipelines/github/mapbox/mapbox-navigation-android/7713/workflows/98ec0ddd-64f1-47ba-b54c-593bd759cb0b/jobs/29327/steps)
```
com.******.services.android.navigation.ui.v5.route.MapRouteLineTest > updatePrimaryIndex_newPrimaryRouteIndexIsNotUpdated FAILED
    org.mockito.exceptions.verification.WantedButNotInvoked at MapRouteLineTest.java:290

322 tests completed, 1 failed

> Task :libandroid-navigation-ui:testDebugUnitTest FAILED

FAILURE: Build failed with an exception.
```

These are legacy tests and have been [improved in 1.0.0](https://github.com/mapbox/mapbox-navigation-android/blob/master/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteLineTest.kt)

- [ ] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->