### PR TITLE
fill the guidance view to the width of screen in portrait mode.

### DIFF
--- a/libnavigation-ui/src/main/res/layout/instruction_view_layout.xml
+++ b/libnavigation-ui/src/main/res/layout/instruction_view_layout.xml
@@ -37,8 +37,8 @@
             android:id="@+id/guidanceImageView"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:scaleX="1.1"
-            android:scaleY="1.1"
+            android:scaleType="centerCrop"
+            android:adjustViewBounds="true"
             android:visibility="gone" />
 
     </LinearLayout>


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

fill the guidance view to the width of screen in portrait mode.

- [ ] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

## Screenshots or Gifs

![image](https://user-images.githubusercontent.com/3918950/86962796-50f79480-c118-11ea-9b18-dfb7ac8520ef.png)

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->