### PR TITLE
Updated the maps version

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -596,6 +596,12 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 
 ===========================================================================
 
+Mapbox Navigation uses portions of the Mapbox Maps GL Core SDK for Android.
+URL: [https://github.com/mapbox/mapbox-gl-native-android](https://github.com/mapbox/mapbox-gl-native-android)
+License: [BSD](https://opensource.org/licenses/BSD-2-Clause)
+
+===========================================================================
+
 Mapbox Navigation uses portions of the Mapbox Maps SDK for Android.
 URL: [https://github.com/mapbox/mapbox-gl-native](https://github.com/mapbox/mapbox-gl-native)
 License: [BSD](https://opensource.org/licenses/BSD-2-Clause)

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,16 @@ allprojects {
     jcenter()
     maven { url 'https://plugins.gradle.org/m2' }
     maven {
+      url 'https://api.mapbox.com/downloads/v2/releases/maven'
+      authentication {
+        basic(BasicAuthentication)
+      }
+      credentials {
+        username = "mapbox"
+        password = project.hasProperty('SDK_REGISTRY_TOKEN') ? project.property('SDK_REGISTRY_TOKEN') : System.getenv('SDK_REGISTRY_TOKEN')
+      }
+    }
+    maven {
       url 'https://mapbox.bintray.com/mapbox_internal'
       credentials {
         username = project.hasProperty('BINTRAY_USER') ? project.property('BINTRAY_USER') : System.getenv('BINTRAY_USER')

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -7,7 +7,7 @@ ext {
   ]
 
   version = [
-      mapboxMapSdk              : '9.2.1',
+      mapboxMapSdk              : '9.3.0-beta.1',
       mapboxSdkServices         : '5.3.0',
       mapboxSdkDirectionsModels : '5.3.0',
       mapboxEvents              : '6.0.0',

--- a/libnavigation-ui/build.gradle
+++ b/libnavigation-ui/build.gradle
@@ -76,6 +76,8 @@ dependencies {
 
   // Mapbox Maps SDK
   api dependenciesList.mapboxMapSdk
+  // workaround for a missing transitive artifact
+  implementation "com.mapbox.mapboxsdk:mapbox-android-sdk-gl-core:1.8.1"
   implementation dependenciesList.mapboxAnnotationPlugin
 
   // Support libraries

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/internal/route/RouteConstants.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/internal/route/RouteConstants.java
@@ -50,6 +50,6 @@ public class RouteConstants {
   public static final String MAPBOX_LOCATION_ID = "mapbox-location";
   public static final double MINIMUM_ROUTE_LINE_OFFSET = .001;
   public static final long ROUTE_LINE_VANISH_ANIMATION_DURATION = 1000;
-  public static final long ROUTE_LINE_VANISH_ANIMATION_DELAY = 300;
+  public static final long ROUTE_LINE_VANISH_ANIMATION_DELAY = 350;
   public static final String LAYER_ABOVE_UPCOMING_MANEUVER_ARROW = "com.mapbox.annotations.points";
 }


### PR DESCRIPTION
## Description

Updating the maps SDK version to incorporate recent fixes.  The maps SDK update is expected to incorporate modifications to address https://github.com/mapbox/mapbox-gl-native-internal/issues/268 as well as a crash when starting navigation in an activity with a custom puck.

- [x] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal

Update Nav. SDK with the latest maps offering.

### Implementation



## Screenshots or Gifs


## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->