### PR TITLE
Remove gl-native artifact workaround

### DIFF
--- a/libnavigation-ui/build.gradle
+++ b/libnavigation-ui/build.gradle
@@ -76,8 +76,7 @@ dependencies {
 
   // Mapbox Maps SDK
   api dependenciesList.mapboxMapSdk
-  // workaround for a missing transitive artifact
-  implementation "com.mapbox.mapboxsdk:mapbox-android-sdk-gl-core:1.8.1"
+
   implementation dependenciesList.mapboxAnnotationPlugin
 
   // Support libraries


### PR DESCRIPTION
The issue initially was caused by the SDK Registry CDN caching artifacts for 24hrs, that's why we couldn't see the fixes work immediately.