### PR TITLE
Adjusting the padding calculation to better support landscape orientation

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/MapPaddingAdjustor.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/MapPaddingAdjustor.java
@@ -1,16 +1,15 @@
 package com.mapbox.navigation.ui.map;
 
-import android.content.Context;
-import android.content.res.Resources;
-
-import com.mapbox.libnavigation.ui.R;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 
+import static com.mapbox.navigation.ui.map.MapPaddingCalculator.calculateDefaultPadding;
+
 class MapPaddingAdjustor {
 
-  private static final int BOTTOMSHEET_PADDING_MULTIPLIER = 4;
-  private static final int WAYNAME_PADDING_MULTIPLIER = 2;
+  public static final int BOTTOMSHEET_PADDING_MULTIPLIER_PORTRAIT = 4;
+  public static final int BOTTOMSHEET_PADDING_MULTIPLIER_LANDSCAPE = 3;
+  public static final int WAYNAME_PADDING_MULTIPLIER = 2;
 
   private final MapboxMap mapboxMap;
   private final int[] defaultPadding;
@@ -55,21 +54,5 @@ class MapPaddingAdjustor {
     } else {
       adjustLocationIconWith(customPadding);
     }
-  }
-
-  private int[] calculateDefaultPadding(MapView mapView) {
-    int defaultTopPadding = calculateTopPaddingWithoutWayname(mapView);
-    Resources resources = mapView.getContext().getResources();
-    int waynameLayoutHeight = (int) resources.getDimension(R.dimen.wayname_view_height);
-    int topPadding = defaultTopPadding - (waynameLayoutHeight * WAYNAME_PADDING_MULTIPLIER);
-    return new int[] {0, topPadding, 0, 0};
-  }
-
-  private int calculateTopPaddingWithoutWayname(MapView mapView) {
-    Context context = mapView.getContext();
-    Resources resources = context.getResources();
-    int mapViewHeight = mapView.getHeight();
-    int bottomSheetHeight = (int) resources.getDimension(R.dimen.summary_bottomsheet_height);
-    return mapViewHeight - (bottomSheetHeight * BOTTOMSHEET_PADDING_MULTIPLIER);
   }
 }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/MapPaddingCalculator.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/MapPaddingCalculator.kt
@@ -1,0 +1,45 @@
+package com.mapbox.navigation.ui.map
+
+import com.mapbox.libnavigation.ui.R
+import com.mapbox.mapboxsdk.maps.MapView
+
+internal object MapPaddingCalculator {
+
+    /**
+     * Calculates the default padding for the puck taking into account the screen orientation,
+     * the size of the bottom sheet and the wayname layout.
+     *
+     * @param mapView a reference to the MapView
+     *
+     * @return an array of integers representing the padding that was calculated.
+     */
+    @JvmStatic
+    fun calculateDefaultPadding(mapView: MapView): IntArray {
+        val defaultTopPadding = calculateTopPaddingWithoutWayname(mapView)
+        val resources = mapView.context.resources
+        val waynameLayoutHeight = resources.getDimension(R.dimen.wayname_view_height).toInt()
+        val topPadding =
+            defaultTopPadding - waynameLayoutHeight * MapPaddingAdjustor.WAYNAME_PADDING_MULTIPLIER
+        return intArrayOf(0, topPadding, 0, 0)
+    }
+
+    /**
+     * Calculates the default padding for the puck taking into account the screen orientation
+     * and the size of the bottom sheet.
+     *
+     * @param mapView a reference to the MapView
+     *
+     * @return the top padding value that was calculated
+     */
+    @JvmStatic
+    fun calculateTopPaddingWithoutWayname(mapView: MapView): Int {
+        val context = mapView.context
+        val bottomSheetHeight = context.resources.getDimension(R.dimen.summary_bottomsheet_height).toInt()
+
+        return if (mapView.height > mapView.width) {
+            mapView.height - bottomSheetHeight * MapPaddingAdjustor.BOTTOMSHEET_PADDING_MULTIPLIER_PORTRAIT
+        } else {
+            mapView.height - bottomSheetHeight * MapPaddingAdjustor.BOTTOMSHEET_PADDING_MULTIPLIER_LANDSCAPE
+        }
+    }
+}

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/map/MapPaddingCalculatorTest.kt
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/map/MapPaddingCalculatorTest.kt
@@ -1,0 +1,99 @@
+package com.mapbox.navigation.ui.map
+
+import android.content.Context
+import android.content.res.Resources
+import com.mapbox.libnavigation.ui.R
+import com.mapbox.mapboxsdk.maps.MapView
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MapPaddingCalculatorTest {
+
+    @Test
+    fun calculateDefaultPaddingPortrait() {
+        val resource: Resources = mockk {
+            every { getDimension(R.dimen.summary_bottomsheet_height) } returns 72f
+            every { getDimension(R.dimen.wayname_view_height) } returns 32f
+        }
+        val ctx: Context = mockk {
+            every { resources } returns resource
+        }
+        val mapView: MapView = mockk {
+            every { height } returns 1024
+            every { width } returns 768
+            every { context } returns ctx
+        }
+
+        val result = MapPaddingCalculator.calculateDefaultPadding(mapView)
+
+        assertEquals(4, result.size)
+        assertEquals(0, result[0])
+        assertEquals(672, result[1])
+        assertEquals(0, result[2])
+        assertEquals(0, result[3])
+    }
+
+    @Test
+    fun calculateDefaultPaddingLandscape() {
+        val resource: Resources = mockk {
+            every { getDimension(R.dimen.summary_bottomsheet_height) } returns 56f
+            every { getDimension(R.dimen.wayname_view_height) } returns 24f
+        }
+        val ctx: Context = mockk {
+            every { resources } returns resource
+        }
+        val mapView: MapView = mockk {
+            every { height } returns 1024
+            every { width } returns 768
+            every { context } returns ctx
+        }
+
+        val result = MapPaddingCalculator.calculateDefaultPadding(mapView)
+
+        assertEquals(4, result.size)
+        assertEquals(0, result[0])
+        assertEquals(752, result[1])
+        assertEquals(0, result[2])
+        assertEquals(0, result[3])
+    }
+
+    @Test
+    fun calculateTopPaddingWithoutWaynamePortrait() {
+        val resource: Resources = mockk {
+            every { getDimension(R.dimen.summary_bottomsheet_height) } returns 72f
+        }
+        val ctx: Context = mockk {
+            every { resources } returns resource
+        }
+        val mapView: MapView = mockk {
+            every { height } returns 1024
+            every { width } returns 768
+            every { context } returns ctx
+        }
+
+        val result = MapPaddingCalculator.calculateTopPaddingWithoutWayname(mapView)
+
+        assertEquals(736, result)
+    }
+
+    @Test
+    fun calculateTopPaddingWithoutWaynameLandscape() {
+        val resource: Resources = mockk {
+            every { getDimension(R.dimen.summary_bottomsheet_height) } returns 56f
+        }
+        val ctx: Context = mockk {
+            every { resources } returns resource
+        }
+        val mapView: MapView = mockk {
+            every { height } returns 768
+            every { width } returns 1024
+            every { context } returns ctx
+        }
+
+        val result = MapPaddingCalculator.calculateTopPaddingWithoutWayname(mapView)
+
+        assertEquals(600, result)
+    }
+}


### PR DESCRIPTION
## Description

As described in #3208 the puck padding in landscape orientation need some adjustment.

- [x] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal

The puck in landscape orientation should appear toward the bottom of the screen for all screens in landscape orientation.

### Implementation

Check for landscape orientation and use the appropriate multiplier for the padding calculation.

## Screenshots or Gifs



## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->