### PR TITLE
Add jank detector to examples using FrameMetrics

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayActivity.kt
@@ -29,6 +29,7 @@ import com.mapbox.navigation.core.replay.route.ReplayRouteMapper
 import com.mapbox.navigation.core.trip.session.TripSessionState
 import com.mapbox.navigation.core.trip.session.TripSessionStateObserver
 import com.mapbox.navigation.examples.R
+import com.mapbox.navigation.examples.performance.FrameMetricsPerformance
 import com.mapbox.navigation.examples.utils.Utils
 import com.mapbox.navigation.examples.utils.extensions.toPoint
 import com.mapbox.navigation.ui.camera.NavigationCamera
@@ -55,6 +56,9 @@ class ReplayActivity : AppCompatActivity(), OnMapReadyCallback {
     @SuppressLint("MissingPermission")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        FrameMetricsPerformance().observe(this)
+
         setContentView(R.layout.activity_replay_route_layout)
         mapView.onCreate(savedInstanceState)
 

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayHistoryActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayHistoryActivity.kt
@@ -31,6 +31,7 @@ import com.mapbox.navigation.core.replay.history.ReplayEventsObserver
 import com.mapbox.navigation.core.replay.history.ReplayHistoryMapper
 import com.mapbox.navigation.examples.R
 import com.mapbox.navigation.examples.history.HistoryFilesActivity
+import com.mapbox.navigation.examples.performance.FrameMetricsPerformance
 import com.mapbox.navigation.examples.utils.Utils
 import com.mapbox.navigation.examples.utils.extensions.toPoint
 import com.mapbox.navigation.ui.camera.NavigationCamera
@@ -64,6 +65,9 @@ class ReplayHistoryActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        FrameMetricsPerformance().observe(this)
+
         setContentView(R.layout.activity_replay_history_layout)
         mapView.onCreate(savedInstanceState)
 

--- a/examples/src/main/java/com/mapbox/navigation/examples/performance/FrameMetricsListener.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/performance/FrameMetricsListener.kt
@@ -1,0 +1,69 @@
+package com.mapbox.navigation.examples.performance
+
+import android.os.Build
+import android.view.FrameMetrics
+import android.view.Window
+import androidx.annotation.RequiresApi
+import kotlin.math.max
+import timber.log.Timber
+
+@RequiresApi(Build.VERSION_CODES.N)
+class FrameMetricsListener(
+    val options: FrameMetricOptions
+) : Window.OnFrameMetricsAvailableListener {
+
+    private var frameMetricsReport = FrameMetricsReport(options)
+
+    fun report(): FrameMetricsReport {
+        return frameMetricsReport.copy()
+    }
+
+    override fun onFrameMetricsAvailable(window: Window, frameMetrics: FrameMetrics, dropCountSinceLastInvocation: Int) {
+        val frameMetricsCopy = FrameMetrics(frameMetrics)
+        val totalDurationMs = frameMetricsCopy.nanosToMillis(FrameMetrics.TOTAL_DURATION)
+
+        frameMetricsReport.totalFrames++
+        frameMetricsReport.maxDuration = max(totalDurationMs, frameMetricsReport.maxDuration)
+        Timber.i("frame metric available total duration: %.2fms dropCount: %d".format(totalDurationMs, dropCountSinceLastInvocation))
+
+        if (totalDurationMs > options.warningLevelMs) {
+            val jankMessage = "Jank detected total duration: %.2fms\n".format(totalDurationMs) +
+                "${mapToFrameMetricsFull(frameMetricsCopy)}"
+            if (totalDurationMs > options.errorLevelMs) {
+                frameMetricsReport.errorFrames++
+                Timber.e(jankMessage)
+            } else {
+                frameMetricsReport.warningFrames++
+                Timber.w(jankMessage)
+            }
+        }
+    }
+
+    private fun mapToFrameMetricsFull(frameMetrics: FrameMetrics): FrameMetricsFull {
+        return FrameMetricsFull(
+            frameMetrics.nanosToMillis(FrameMetrics.UNKNOWN_DELAY_DURATION),
+            frameMetrics.nanosToMillis(FrameMetrics.INPUT_HANDLING_DURATION),
+            frameMetrics.nanosToMillis(FrameMetrics.ANIMATION_DURATION),
+            frameMetrics.nanosToMillis(FrameMetrics.LAYOUT_MEASURE_DURATION),
+            frameMetrics.nanosToMillis(FrameMetrics.DRAW_DURATION),
+            frameMetrics.nanosToMillis(FrameMetrics.SYNC_DURATION),
+            frameMetrics.nanosToMillis(FrameMetrics.COMMAND_ISSUE_DURATION),
+            frameMetrics.nanosToMillis(FrameMetrics.SWAP_BUFFERS_DURATION),
+            frameMetrics.nanosToMillis(FrameMetrics.TOTAL_DURATION)
+        )
+    }
+
+    private fun FrameMetrics.nanosToMillis(metric: Int): Double = getMetric(metric) * 0.000001
+}
+
+private data class FrameMetricsFull(
+    val unknownDelayDuration: Double,
+    val inputHandlingDuration: Double,
+    val animationDuration: Double,
+    val layoutMeasureDuration: Double,
+    val drawDuration: Double,
+    val syncDuration: Double,
+    val commandIssueDuration: Double,
+    val swapBuffersDuration: Double,
+    val totalDuration: Double
+)

--- a/examples/src/main/java/com/mapbox/navigation/examples/performance/FrameMetricsPerformance.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/performance/FrameMetricsPerformance.kt
@@ -1,0 +1,73 @@
+package com.mapbox.navigation.examples.performance
+
+import android.app.Activity
+import android.os.Build
+import android.os.Handler
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
+import timber.log.Timber
+
+data class FrameMetricOptions(
+    val warningLevelMs: Long,
+    val errorLevelMs: Long
+) {
+    class Builder {
+        private var warningLevelMs: Long = 20
+        private var errorLevelMs: Long = 200
+
+        fun warningLevelMs(warningLevelMs: Long) =
+            apply { this.warningLevelMs = warningLevelMs }
+        fun errorLevelMs(errorLevelMs: Long) =
+            apply { this.errorLevelMs = errorLevelMs }
+
+        fun build(): FrameMetricOptions {
+            return FrameMetricOptions(
+                warningLevelMs,
+                errorLevelMs
+            )
+        }
+    }
+}
+
+class FrameMetricsPerformance @JvmOverloads constructor (
+    val options: FrameMetricOptions = FrameMetricOptions.Builder().build()
+) {
+    private var frameMetricsListener: FrameMetricsListener? = null
+
+    fun start(activity: Activity) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            val listener = FrameMetricsListener(options)
+            activity.window.addOnFrameMetricsAvailableListener(listener, Handler())
+            frameMetricsListener = listener
+        } else {
+            Timber.w("FrameMetrics can work only with Android SDK 24 (Nougat) and higher")
+        }
+    }
+
+    fun stop(activity: Activity) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            frameMetricsListener?.let {
+                activity.window.removeOnFrameMetricsAvailableListener(it)
+            }
+            val report = frameMetricsListener?.report()
+            Timber.i("final report $report")
+            frameMetricsListener = null
+        }
+    }
+
+    fun observe(activity: AppCompatActivity) {
+        activity.lifecycle.addObserver(object : LifecycleEventObserver {
+            override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
+                when (event) {
+                    Lifecycle.Event.ON_CREATE -> start(activity)
+                    Lifecycle.Event.ON_DESTROY -> stop(activity)
+                    else -> {
+                        // intentionally empty
+                    }
+                }
+            }
+        })
+    }
+}

--- a/examples/src/main/java/com/mapbox/navigation/examples/performance/FrameMetricsReport.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/performance/FrameMetricsReport.kt
@@ -1,0 +1,9 @@
+package com.mapbox.navigation.examples.performance
+
+data class FrameMetricsReport(
+    val options: FrameMetricOptions,
+    var totalFrames: Int = 0,
+    var warningFrames: Int = 0,
+    var errorFrames: Int = 0,
+    var maxDuration: Double = 0.0
+)


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Working on a Jank Detector and testing it in the examples. Using FrameMetrics here. It gives good results when the callback happens, problem is it will not always happen. There's a lot of jank that goes uncaptured.

Either way, I think examples is a good place to iterate on this. If we make a really good jank detector, would like to make it so we can debug with the same code.

Here is an example report after a little jank session, when using the tool it will report to logcat
```
FrameMetricsReport(
  options=FrameMetricOptions(warningLevelMs=20, errorLevelMs=200),
  totalFrames=62,
  warningFrames=16,
  errorFrames=3,
  maxDuration=375.61794
)
```

Also, so easy to add to an example if you want to use it and debug
``` kotlin
   override fun onCreate(savedInstanceState: Bundle?) {
        super.onCreate(savedInstanceState)

        FrameMetricsPerformance().observe(this)
  ..
```

- [ ] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

## Screenshots or Gifs

Video of some Jank on master
![output](https://user-images.githubusercontent.com/3021882/87100118-6ba53880-c200-11ea-85d4-68d405e004b5.gif)

What your logs will look like
![Screen Shot 2020-07-09 at 4 16 26 PM](https://user-images.githubusercontent.com/3021882/87100133-752ea080-c200-11ea-915f-53d09ffec21a.png)

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->

cc: @Guardiola31337 @zugaldia 