### PR TITLE
Add jank detector user interface

### DIFF
--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -122,6 +122,8 @@ dependencies {
     implementation dependenciesList.materialDesign
     implementation dependenciesList.androidXAppCompat
     implementation dependenciesList.androidXConstraintLayout
+    implementation dependenciesList.lifecycleExtensions
+    annotationProcessor dependenciesList.lifecycleCompiler
 
     implementation dependenciesList.gmsLocation
 
@@ -133,6 +135,8 @@ dependencies {
     // Butter Knife
     implementation dependenciesList.butterKnife
     annotationProcessor dependenciesList.butterKnifeProcessor
+
+    implementation 'com.robinhood.spark:spark:1.2.0'
 
     // Leak Canary
     debugImplementation dependenciesList.leakCanaryDebug

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayActivity.kt
@@ -29,6 +29,7 @@ import com.mapbox.navigation.core.replay.route.ReplayRouteMapper
 import com.mapbox.navigation.core.trip.session.TripSessionState
 import com.mapbox.navigation.core.trip.session.TripSessionStateObserver
 import com.mapbox.navigation.examples.R
+import com.mapbox.navigation.examples.performance.FrameMetricsPerformance
 import com.mapbox.navigation.examples.utils.Utils
 import com.mapbox.navigation.examples.utils.extensions.toPoint
 import com.mapbox.navigation.ui.camera.NavigationCamera
@@ -55,6 +56,9 @@ class ReplayActivity : AppCompatActivity(), OnMapReadyCallback {
     @SuppressLint("MissingPermission")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        FrameMetricsPerformance().observe(this)
+
         setContentView(R.layout.activity_replay_route_layout)
         mapView.onCreate(savedInstanceState)
 

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayActivity.kt
@@ -1,6 +1,7 @@
 package com.mapbox.navigation.examples.core
 
 import android.annotation.SuppressLint
+import android.os.Build
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
@@ -29,7 +30,7 @@ import com.mapbox.navigation.core.replay.route.ReplayRouteMapper
 import com.mapbox.navigation.core.trip.session.TripSessionState
 import com.mapbox.navigation.core.trip.session.TripSessionStateObserver
 import com.mapbox.navigation.examples.R
-import com.mapbox.navigation.examples.performance.FrameMetricsPerformance
+import com.mapbox.navigation.examples.performance.FrameMetricsSparkUi
 import com.mapbox.navigation.examples.utils.Utils
 import com.mapbox.navigation.examples.utils.extensions.toPoint
 import com.mapbox.navigation.ui.camera.NavigationCamera
@@ -57,9 +58,8 @@ class ReplayActivity : AppCompatActivity(), OnMapReadyCallback {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        FrameMetricsPerformance().observe(this)
-
         setContentView(R.layout.activity_replay_route_layout)
+
         mapView.onCreate(savedInstanceState)
 
         val mapboxNavigationOptions = MapboxNavigation

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayHistoryActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayHistoryActivity.kt
@@ -31,6 +31,7 @@ import com.mapbox.navigation.core.replay.history.ReplayEventsObserver
 import com.mapbox.navigation.core.replay.history.ReplayHistoryMapper
 import com.mapbox.navigation.examples.R
 import com.mapbox.navigation.examples.history.HistoryFilesActivity
+import com.mapbox.navigation.examples.performance.FrameMetricsPerformance
 import com.mapbox.navigation.examples.utils.Utils
 import com.mapbox.navigation.examples.utils.extensions.toPoint
 import com.mapbox.navigation.ui.camera.NavigationCamera
@@ -64,6 +65,9 @@ class ReplayHistoryActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        FrameMetricsPerformance().observe(this)
+
         setContentView(R.layout.activity_replay_history_layout)
         mapView.onCreate(savedInstanceState)
 

--- a/examples/src/main/java/com/mapbox/navigation/examples/performance/FrameMetricsListener.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/performance/FrameMetricsListener.kt
@@ -1,0 +1,69 @@
+package com.mapbox.navigation.examples.performance
+
+import android.os.Build
+import android.view.FrameMetrics
+import android.view.Window
+import androidx.annotation.RequiresApi
+import kotlin.math.max
+import timber.log.Timber
+
+@RequiresApi(Build.VERSION_CODES.N)
+class FrameMetricsListener(
+    val options: FrameMetricOptions
+) : Window.OnFrameMetricsAvailableListener {
+
+    private var frameMetricsReport = FrameMetricsReport(options)
+
+    fun report(): FrameMetricsReport {
+        return frameMetricsReport.copy()
+    }
+
+    override fun onFrameMetricsAvailable(window: Window, frameMetrics: FrameMetrics, dropCountSinceLastInvocation: Int) {
+        val frameMetricsCopy = FrameMetrics(frameMetrics)
+        val totalDurationMs = frameMetricsCopy.nanosToMillis(FrameMetrics.TOTAL_DURATION)
+
+        frameMetricsReport.totalFrames++
+        frameMetricsReport.maxDuration = max(totalDurationMs, frameMetricsReport.maxDuration)
+        Timber.i("frame metric available total duration: %.2fms dropCount: %d".format(totalDurationMs, dropCountSinceLastInvocation))
+
+        if (totalDurationMs > options.warningLevelMs) {
+            val jankMessage = "Jank detected total duration: %.2fms\n".format(totalDurationMs) +
+                "${mapToFrameMetricsFull(frameMetricsCopy)}"
+            if (totalDurationMs > options.errorLevelMs) {
+                frameMetricsReport.errorFrames++
+                Timber.e(jankMessage)
+            } else {
+                frameMetricsReport.warningFrames++
+                Timber.w(jankMessage)
+            }
+        }
+    }
+
+    private fun mapToFrameMetricsFull(frameMetrics: FrameMetrics): FrameMetricsFull {
+        return FrameMetricsFull(
+            frameMetrics.nanosToMillis(FrameMetrics.UNKNOWN_DELAY_DURATION),
+            frameMetrics.nanosToMillis(FrameMetrics.INPUT_HANDLING_DURATION),
+            frameMetrics.nanosToMillis(FrameMetrics.ANIMATION_DURATION),
+            frameMetrics.nanosToMillis(FrameMetrics.LAYOUT_MEASURE_DURATION),
+            frameMetrics.nanosToMillis(FrameMetrics.DRAW_DURATION),
+            frameMetrics.nanosToMillis(FrameMetrics.SYNC_DURATION),
+            frameMetrics.nanosToMillis(FrameMetrics.COMMAND_ISSUE_DURATION),
+            frameMetrics.nanosToMillis(FrameMetrics.SWAP_BUFFERS_DURATION),
+            frameMetrics.nanosToMillis(FrameMetrics.TOTAL_DURATION)
+        )
+    }
+
+    private fun FrameMetrics.nanosToMillis(metric: Int): Double = getMetric(metric) * 0.000001
+}
+
+private data class FrameMetricsFull(
+    val unknownDelayDuration: Double,
+    val inputHandlingDuration: Double,
+    val animationDuration: Double,
+    val layoutMeasureDuration: Double,
+    val drawDuration: Double,
+    val syncDuration: Double,
+    val commandIssueDuration: Double,
+    val swapBuffersDuration: Double,
+    val totalDuration: Double
+)

--- a/examples/src/main/java/com/mapbox/navigation/examples/performance/FrameMetricsPerformance.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/performance/FrameMetricsPerformance.kt
@@ -3,6 +3,7 @@ package com.mapbox.navigation.examples.performance
 import android.app.Activity
 import android.os.Build
 import android.os.Handler
+import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -11,26 +12,38 @@ import timber.log.Timber
 
 data class FrameMetricOptions(
     val warningLevelMs: Long,
-    val errorLevelMs: Long
+    val errorLevelMs: Long,
+    val circleBufferSize: Int,
+    val windowSize: Int
 ) {
+
     class Builder {
         private var warningLevelMs: Long = 20
         private var errorLevelMs: Long = 200
+        private var circleBufferSize: Int = 50
+        private var windowSize: Int = 5
 
         fun warningLevelMs(warningLevelMs: Long) =
             apply { this.warningLevelMs = warningLevelMs }
         fun errorLevelMs(errorLevelMs: Long) =
             apply { this.errorLevelMs = errorLevelMs }
+        fun circleBufferSize(circleBufferSize: Int) =
+            apply { this.circleBufferSize = circleBufferSize }
+        fun windowSize(windowSize: Int) =
+            apply { this.windowSize = windowSize }
 
         fun build(): FrameMetricOptions {
             return FrameMetricOptions(
-                warningLevelMs,
-                errorLevelMs
+                warningLevelMs = warningLevelMs,
+                errorLevelMs = errorLevelMs,
+                circleBufferSize = circleBufferSize,
+                windowSize = windowSize
             )
         }
     }
 }
 
+@RequiresApi(Build.VERSION_CODES.N)
 class FrameMetricsPerformance @JvmOverloads constructor (
     val options: FrameMetricOptions = FrameMetricOptions.Builder().build()
 ) {
@@ -57,7 +70,7 @@ class FrameMetricsPerformance @JvmOverloads constructor (
         }
     }
 
-    fun observe(activity: AppCompatActivity) {
+    fun observe(activity: AppCompatActivity): FrameMetricsPerformance = apply {
         activity.lifecycle.addObserver(object : LifecycleEventObserver {
             override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
                 when (event) {
@@ -70,4 +83,6 @@ class FrameMetricsPerformance @JvmOverloads constructor (
             }
         })
     }
+
+    fun listener(): FrameMetricsListener? = frameMetricsListener
 }

--- a/examples/src/main/java/com/mapbox/navigation/examples/performance/FrameMetricsPerformance.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/performance/FrameMetricsPerformance.kt
@@ -1,0 +1,73 @@
+package com.mapbox.navigation.examples.performance
+
+import android.app.Activity
+import android.os.Build
+import android.os.Handler
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
+import timber.log.Timber
+
+data class FrameMetricOptions(
+    val warningLevelMs: Long,
+    val errorLevelMs: Long
+) {
+    class Builder {
+        private var warningLevelMs: Long = 20
+        private var errorLevelMs: Long = 200
+
+        fun warningLevelMs(warningLevelMs: Long) =
+            apply { this.warningLevelMs = warningLevelMs }
+        fun errorLevelMs(errorLevelMs: Long) =
+            apply { this.errorLevelMs = errorLevelMs }
+
+        fun build(): FrameMetricOptions {
+            return FrameMetricOptions(
+                warningLevelMs,
+                errorLevelMs
+            )
+        }
+    }
+}
+
+class FrameMetricsPerformance @JvmOverloads constructor (
+    val options: FrameMetricOptions = FrameMetricOptions.Builder().build()
+) {
+    private var frameMetricsListener: FrameMetricsListener? = null
+
+    fun start(activity: Activity) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            val listener = FrameMetricsListener(options)
+            activity.window.addOnFrameMetricsAvailableListener(listener, Handler())
+            frameMetricsListener = listener
+        } else {
+            Timber.w("FrameMetrics can work only with Android SDK 24 (Nougat) and higher")
+        }
+    }
+
+    fun stop(activity: Activity) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            frameMetricsListener?.let {
+                activity.window.removeOnFrameMetricsAvailableListener(it)
+            }
+            val report = frameMetricsListener?.report()
+            Timber.i("final report $report")
+            frameMetricsListener = null
+        }
+    }
+
+    fun observe(activity: AppCompatActivity) {
+        activity.lifecycle.addObserver(object : LifecycleEventObserver {
+            override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
+                when (event) {
+                    Lifecycle.Event.ON_CREATE -> start(activity)
+                    Lifecycle.Event.ON_DESTROY -> stop(activity)
+                    else -> {
+                        // intentionally empty
+                    }
+                }
+            }
+        })
+    }
+}

--- a/examples/src/main/java/com/mapbox/navigation/examples/performance/FrameMetricsReport.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/performance/FrameMetricsReport.kt
@@ -7,3 +7,15 @@ data class FrameMetricsReport(
     var errorFrames: Int = 0,
     var maxDuration: Double = 0.0
 )
+
+data class FrameMetricsJank(
+    val unknownDelayDuration: Double,
+    val inputHandlingDuration: Double,
+    val animationDuration: Double,
+    val layoutMeasureDuration: Double,
+    val drawDuration: Double,
+    val syncDuration: Double,
+    val commandIssueDuration: Double,
+    val swapBuffersDuration: Double,
+    val totalDuration: Double
+)

--- a/examples/src/main/java/com/mapbox/navigation/examples/performance/FrameMetricsReport.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/performance/FrameMetricsReport.kt
@@ -1,0 +1,9 @@
+package com.mapbox.navigation.examples.performance
+
+data class FrameMetricsReport(
+    val options: FrameMetricOptions,
+    var totalFrames: Int = 0,
+    var warningFrames: Int = 0,
+    var errorFrames: Int = 0,
+    var maxDuration: Double = 0.0
+)

--- a/examples/src/main/java/com/mapbox/navigation/examples/performance/FrameMetricsSparkAdapter.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/performance/FrameMetricsSparkAdapter.kt
@@ -1,0 +1,62 @@
+package com.mapbox.navigation.examples.performance
+
+import android.graphics.RectF
+import com.robinhood.spark.SparkAdapter
+import timber.log.Timber
+
+class FrameMetricsSparkAdapter(
+    val options: FrameMetricOptions
+) : SparkAdapter() {
+    private val yData = FloatArray(options.circleBufferSize)
+
+    var currentIndex = 0
+
+    fun addSample(sample: Float) {
+        if (currentIndex == yData.lastIndex) {
+            rotateLeft()
+        } else {
+            currentIndex++
+        }
+        yData[currentIndex] = sample
+        notifyDataSetChanged()
+    }
+
+    fun addEmptySample() {
+        addSample(yData[currentIndex])
+        notifyDataSetChanged()
+    }
+
+    private fun rotateLeft() {
+        for (i in 1..yData.lastIndex) {
+            yData[i-1] = yData[i]
+        }
+    }
+
+    override fun getCount(): Int {
+        Timber.i("what is this get count ${yData.size}")
+        return yData.size
+    }
+
+    override fun getItem(index: Int): Any {
+        return yData[index]
+    }
+
+    override fun getY(index: Int): Float {
+        return yData[index]
+    }
+
+    override fun getDataBounds(): RectF {
+        val count = count
+        val minY = 0.0f
+        val maxY = options.errorLevelMs.toFloat()
+        var minX = Float.MAX_VALUE
+        var maxX = -Float.MAX_VALUE
+        for (i in 0 until count) {
+            val x = getX(i)
+            minX = minX.coerceAtMost(x)
+            maxX = maxX.coerceAtLeast(x)
+        }
+
+        return RectF(minX, minY, maxX, maxY)
+    }
+}

--- a/examples/src/main/java/com/mapbox/navigation/examples/performance/FrameMetricsSparkUi.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/performance/FrameMetricsSparkUi.kt
@@ -1,0 +1,108 @@
+package com.mapbox.navigation.examples.performance
+
+import android.graphics.Color
+import android.os.Build
+import android.widget.TextView
+import androidx.annotation.RequiresApi
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
+import com.robinhood.spark.SparkView
+import com.robinhood.spark.animation.MorphSparkAnimator
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+@RequiresApi(Build.VERSION_CODES.N)
+class FrameMetricsSparkUi(
+    private val activity: AppCompatActivity
+) {
+    private val frameMetricsPerformance = FrameMetricsPerformance().observe(activity)
+
+    fun attach(sparkView: SparkView) {
+        if (activity.lifecycle.currentState == Lifecycle.State.DESTROYED)
+            return
+
+        val sparkAdapter = FrameMetricsSparkAdapter(frameMetricsPerformance.options)
+        sparkView.adapter = sparkAdapter
+        sparkView.sparkAnimator = MorphSparkAnimator()
+        sparkView.yPoints
+
+        activity.lifecycle.addObserver(object : LifecycleEventObserver {
+            private val uiScope = CoroutineScope(Dispatchers.Main)
+
+            override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
+                when (event) {
+                    Lifecycle.Event.ON_CREATE -> uiScope.start(sparkView, sparkAdapter)
+                    Lifecycle.Event.ON_DESTROY -> uiScope.coroutineContext.cancel()
+                    else -> {
+                        // intentionally empty
+                    }
+                }
+            }
+        })
+    }
+
+    fun attach(reportText: TextView) {
+        activity.lifecycle.addObserver(object : LifecycleEventObserver {
+            private val uiScope = CoroutineScope(Dispatchers.Main)
+
+            override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
+                when (event) {
+                    Lifecycle.Event.ON_CREATE -> uiScope.start(reportText)
+                    Lifecycle.Event.ON_DESTROY -> uiScope.coroutineContext.cancel()
+                    else -> {
+                        // intentionally empty
+                    }
+                }
+            }
+        })
+    }
+
+    private fun CoroutineScope.start(reportText: TextView) = launch {
+        while (isActive) {
+            if (activity.lifecycle.currentState == Lifecycle.State.RESUMED) {
+                val report = frameMetricsPerformance.listener()?.report()
+                val largestJankValue =  "%.2fms".format(report?.maxDuration)
+                reportText.text = """
+                    Largest Jank: $largestJankValue
+                    Total frames measured: ${report?.totalFrames}
+                    - warning frames: ${report?.warningFrames}
+                    - error frames: ${report?.errorFrames}
+                    + good frames ${report?.totalFrames?.minus(report?.errorFrames)?.minus(report?.warningFrames)}
+                """.trimIndent()
+            }
+
+            delay(1000)
+        }
+    }
+
+    private fun CoroutineScope.start(sparkView: SparkView, sparkAdapter: FrameMetricsSparkAdapter) = launch {
+        while (isActive) {
+            val totalDuration = frameMetricsPerformance.listener()?.totalDuration()
+            Timber.i("what is this $totalDuration")
+            if (totalDuration != null) {
+                sparkAdapter.addSample(totalDuration)
+            } else {
+                sparkAdapter.addEmptySample()
+            }
+
+            val maxDuration = frameMetricsPerformance.listener()?.report()?.maxDuration
+            if (maxDuration != null) {
+                val options = frameMetricsPerformance.options
+                sparkView.lineColor = when {
+                    maxDuration > options.errorLevelMs -> Color.RED
+                    maxDuration > options.warningLevelMs -> Color.YELLOW
+                    else -> Color.GREEN
+                }
+            }
+
+            delay(1000)
+        }
+    }
+}

--- a/examples/src/main/java/com/mapbox/navigation/examples/performance/JankFragment.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/performance/JankFragment.kt
@@ -1,0 +1,55 @@
+package com.mapbox.navigation.examples.performance
+
+import android.content.Context
+import android.os.Build
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
+import com.mapbox.navigation.examples.R
+import com.robinhood.spark.SparkView
+
+class JankFragment : Fragment() {
+
+    private var frameMetricsSparkUi: FrameMetricsSparkUi? = null
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        return inflater.inflate(R.layout.performance_jank_fragment, container, false)
+    }
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            frameMetricsSparkUi = FrameMetricsSparkUi(context as AppCompatActivity)
+        }
+    }
+
+    override fun onDetach() {
+        frameMetricsSparkUi = null
+        super.onDetach()
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            val sparkView = view.findViewById<SparkView>(R.id.sparkView)
+            val reportText = view.findViewById<TextView>(R.id.reportText)
+            val scrubText = view.findViewById<TextView>(R.id.scrubText)
+            frameMetricsSparkUi?.attach(sparkView)
+            frameMetricsSparkUi?.attach(reportText)
+            sparkView.scrubListener = SparkView.OnScrubListener {
+                val timeMessage = when (it) {
+                    is Float -> "%.2fms".format(it)
+                    else -> null
+                }
+                scrubText.text = timeMessage ?: ""
+                scrubText.visibility = if (timeMessage != null) View.VISIBLE else View.GONE
+            }
+        }
+    }
+}

--- a/examples/src/main/res/layout/activity_replay_route_layout.xml
+++ b/examples/src/main/res/layout/activity_replay_route_layout.xml
@@ -30,4 +30,13 @@
         android:textColor="@android:color/white"
         android:visibility="gone" />
 
+    <fragment
+        android:name="com.mapbox.navigation.examples.performance.JankFragment"
+        android:id="@+id/jankFragment"
+        android:layout_width="match_parent"
+        android:layout_height="200dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/examples/src/main/res/layout/performance_jank_fragment.xml
+++ b/examples/src/main/res/layout/performance_jank_fragment.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:background="#aaFFFFFF">
+
+    <TextView
+        android:id="@+id/reportText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/dimen_8dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        />
+
+    <TextView
+        android:id="@+id/scrubText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/dimen_8dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/reportText"
+        android:visibility="gone"
+        />
+
+    <com.robinhood.spark.SparkView
+        android:id="@+id/sparkView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:spark_scrubEnabled="true"
+        />
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Building on top of https://github.com/mapbox/mapbox-navigation-android/pull/3320

Made a user interface for showing jank

- [ ] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

## Screenshots or Gifs

| Some jank | Lots of jank |
| --- | --- |
| ![output](https://user-images.githubusercontent.com/3021882/87115729-e8e4a380-c228-11ea-9ed5-469f19b0e2e7.gif) | ![output](https://user-images.githubusercontent.com/3021882/87115745-f863ec80-c228-11ea-8947-a63775248689.gif) |

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->

@Guardiola31337 @zugaldia 