### PR TITLE
Fix MapboxTripSession isOffRoute set logic causing missing re-routes

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -604,9 +604,6 @@ class MapboxNavigation(
     private fun createInternalOffRouteObserver() = object : OffRouteObserver {
         override fun onOffRouteStateChanged(offRoute: Boolean) {
             if (offRoute) {
-                if (rerouteController?.state == RerouteState.FetchingRoute) {
-                    rerouteController?.interrupt()
-                }
                 reroute()
             }
         }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -604,9 +604,10 @@ class MapboxNavigation(
     private fun createInternalOffRouteObserver() = object : OffRouteObserver {
         override fun onOffRouteStateChanged(offRoute: Boolean) {
             if (offRoute) {
+                if (rerouteController?.state == RerouteState.FetchingRoute) {
+                    rerouteController?.interrupt()
+                }
                 reroute()
-            } else {
-                rerouteController?.interrupt()
             }
         }
     }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
@@ -101,10 +101,10 @@ internal class MapboxTripSession(
 
     private var isOffRoute: Boolean = false
         set(value) {
-            if (field == value) {
+            field = value
+            if (route == null) {
                 return
             }
-            field = value
             offRouteObservers.forEach { it.onOffRouteStateChanged(value) }
         }
 

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
@@ -300,7 +300,6 @@ class MapboxNavigationTest {
 
     @Test
     fun offroute_lead_to_reroute() {
-        every { rerouteController.state } returns RerouteState.Idle
         val observers = mutableListOf<OffRouteObserver>()
         verify { tripSession.registerOffRouteObserver(capture(observers)) }
 
@@ -309,28 +308,8 @@ class MapboxNavigationTest {
         }
 
         verify(exactly = 1) { rerouteController.reroute(any()) }
-        verify(exactly = 0) { rerouteController.interrupt() }
         verify(ordering = Ordering.ORDERED) {
             tripSession.registerOffRouteObserver(any())
-            rerouteController.reroute(any())
-        }
-    }
-
-    @Test
-    fun offroute_lead_to_interrupt_reroute_and_after_reroute_if_currently_fetching() {
-        every { rerouteController.state } returns RerouteState.FetchingRoute
-        val observers = mutableListOf<OffRouteObserver>()
-        verify { tripSession.registerOffRouteObserver(capture(observers)) }
-
-        observers.forEach {
-            it.onOffRouteStateChanged(true)
-        }
-
-        verify(exactly = 1) { rerouteController.interrupt() }
-        verify(exactly = 1) { rerouteController.reroute(any()) }
-        verify(ordering = Ordering.ORDERED) {
-            tripSession.registerOffRouteObserver(capture(observers))
-            rerouteController.interrupt()
             rerouteController.reroute(any())
         }
     }
@@ -400,11 +379,11 @@ class MapboxNavigationTest {
         mapboxNavigation.setRerouteController(newRerouteController)
 
         verify(exactly = 1) { rerouteController.reroute(any()) }
-        verify(exactly = 2) { rerouteController.interrupt() }
+        verify(exactly = 1) { rerouteController.interrupt() }
         verify(exactly = 1) { newRerouteController.reroute(any()) }
         verifyOrder {
-            rerouteController.interrupt()
             rerouteController.reroute(any())
+            rerouteController.interrupt()
             newRerouteController.reroute(any())
         }
     }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/internal/trip/session/MapboxTripSessionTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/internal/trip/session/MapboxTripSessionTest.kt
@@ -4,7 +4,6 @@ import android.location.Location
 import android.os.Looper
 import com.mapbox.android.core.location.LocationEngine
 import com.mapbox.android.core.location.LocationEngineCallback
-import com.mapbox.android.core.location.LocationEngineRequest
 import com.mapbox.android.core.location.LocationEngineResult
 import com.mapbox.api.directions.v5.models.BannerComponents
 import com.mapbox.api.directions.v5.models.BannerInstructions
@@ -69,7 +68,6 @@ class MapboxTripSessionTest {
 
     private val tripService: TripService = mockk(relaxUnitFun = true)
     private val locationEngine: LocationEngine = mockk(relaxUnitFun = true)
-    private val locationEngineRequest: LocationEngineRequest = mockk()
     private val route: DirectionsRoute = mockk()
 
     private val locationCallbackSlot = slot<LocationEngineCallback<LocationEngineResult>>()


### PR DESCRIPTION
## Description

Fixes `MapboxTripSession` `isOffRoute` `set` logic causing missing re-routes if multiple `OFF_ROUTE` events were sent

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Fix 👇 

> After setting a route, the initial `getStatus` is `invalid`, doesn't reroute, and even after returning to the route line, there are no progress updates (we're constantly `invalid`). 

### Implementation

NN is the source of truth for re-routes so we should trust it and be able to safely remove https://github.com/mapbox/mapbox-navigation-android/blob/432e283abf61e12ca9765143355b7d6b5a609cd4/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/trip/session/MapboxTripSession.kt#L115-L117 that was causing missing re-routes if NN sends 2 consecutive `OFF_ROUTE` events - the SDK is only emitting 1 re-route because the `isOffRoute` state never gets reset.

Also https://github.com/mapbox/mapbox-navigation-android/blob/432e283abf61e12ca9765143355b7d6b5a609cd4/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt#L606-L608 was interrupting on-going re-route requests as these could take some time and the `status.routeState` could change before the route being fetched. Again, if we can guarantee that NN sends `OFF_ROUTE` events correctly (only once when NN detects so) we can safely remove this `else` branch and all re-routes should be handled once and 👌 

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs

cc @SiarheiFedartsou @mskurydin 