### PR TITLE
Cherry-pick EH to 1.1.0 beta.7

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/SimpleMapboxNavigationKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/SimpleMapboxNavigationKt.kt
@@ -38,6 +38,7 @@ import com.mapbox.mapboxsdk.plugins.annotation.SymbolOptions
 import com.mapbox.navigation.base.internal.extensions.applyDefaultParams
 import com.mapbox.navigation.base.internal.extensions.coordinates
 import com.mapbox.navigation.base.options.NavigationOptions
+import com.mapbox.navigation.base.trip.model.ElectronicHorizon
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesObserver
@@ -47,6 +48,7 @@ import com.mapbox.navigation.core.replay.MapboxReplayer
 import com.mapbox.navigation.core.replay.ReplayLocationEngine
 import com.mapbox.navigation.core.replay.route.ReplayProgressObserver
 import com.mapbox.navigation.core.telemetry.events.FeedbackEvent
+import com.mapbox.navigation.core.trip.session.EHorizonObserver
 import com.mapbox.navigation.core.trip.session.RouteProgressObserver
 import com.mapbox.navigation.core.trip.session.TripSessionState
 import com.mapbox.navigation.core.trip.session.TripSessionStateObserver
@@ -349,6 +351,21 @@ class SimpleMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
         }
     }
 
+    private val eHorizonObserver = object : EHorizonObserver {
+        override fun onElectronicHorizonUpdated(eHorizon: ElectronicHorizon) {
+            Timber.d("DEBUG eHorizon %s", eHorizon.horizon()?.routes()?.get(0)?.toJson())
+            Timber.d("DEBUG eHorizon routeIndex %s", eHorizon.routeIndex())
+            Timber.d("DEBUG eHorizon legIndex %s", eHorizon.legIndex())
+            Timber.d("DEBUG eHorizon legDistanceRemaining %s", eHorizon.legDistanceRemaining())
+            Timber.d("DEBUG eHorizon legDurationRemaining %s", eHorizon.legDurationRemaining())
+            Timber.d("DEBUG eHorizon stepIndex %s", eHorizon.stepIndex())
+            Timber.d("DEBUG eHorizon stepDistanceRemaining %s", eHorizon.stepDistanceRemaining())
+            Timber.d("DEBUG eHorizon stepDurationRemaining %s", eHorizon.stepDurationRemaining())
+            Timber.d("DEBUG eHorizon shapeIndex %s", eHorizon.shapeIndex())
+            Timber.d("DEBUG eHorizon intersectionIndex %s", eHorizon.intersectionIndex())
+        }
+    }
+
     private fun updateCameraOnNavigationStateChange(
         navigationStarted: Boolean
     ) {
@@ -395,6 +412,7 @@ class SimpleMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
         mapboxNavigation.registerRoutesObserver(routesObserver)
         mapboxNavigation.registerTripSessionStateObserver(tripSessionStateObserver)
         mapboxNavigation.attachFasterRouteObserver(fasterRouteObserver)
+        mapboxNavigation.registerEHorizonObserver(eHorizonObserver)
     }
 
     override fun onStop() {
@@ -405,6 +423,7 @@ class SimpleMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
         mapboxNavigation.unregisterRoutesObserver(routesObserver)
         mapboxNavigation.unregisterTripSessionStateObserver(tripSessionStateObserver)
         mapboxNavigation.detachFasterRouteObserver()
+        mapboxNavigation.unregisterEHorizonObserver(eHorizonObserver)
         stopLocationUpdates()
 
         if (mapboxNavigation.getRoutes()

--- a/libnavigation-base/api/current.txt
+++ b/libnavigation-base/api/current.txt
@@ -186,6 +186,37 @@ package com.mapbox.navigation.base.route {
 
 package com.mapbox.navigation.base.trip.model {
 
+  public final class ElectronicHorizon {
+    method public com.mapbox.api.directions.v5.models.DirectionsResponse? horizon();
+    method public int intersectionIndex();
+    method public float legDistanceRemaining();
+    method public double legDurationRemaining();
+    method public int legIndex();
+    method public int routeIndex();
+    method public int shapeIndex();
+    method public float stepDistanceRemaining();
+    method public double stepDurationRemaining();
+    method public int stepIndex();
+    method public com.mapbox.navigation.base.trip.model.ElectronicHorizon.Builder toBuilder();
+  }
+
+  public static final class ElectronicHorizon.Builder {
+    ctor public ElectronicHorizon.Builder(com.mapbox.api.directions.v5.models.DirectionsResponse? horizon, int routeIndex, int legIndex, float legDistanceRemaining, double legDurationRemaining, int stepIndex, float stepDistanceRemaining, double stepDurationRemaining, int shapeIndex, int intersectionIndex);
+    ctor public ElectronicHorizon.Builder();
+    method public com.mapbox.navigation.base.trip.model.ElectronicHorizon build();
+    method public com.mapbox.navigation.base.trip.model.ElectronicHorizon.Builder copy(com.mapbox.api.directions.v5.models.DirectionsResponse? horizon, int routeIndex, int legIndex, float legDistanceRemaining, double legDurationRemaining, int stepIndex, float stepDistanceRemaining, double stepDurationRemaining, int shapeIndex, int intersectionIndex);
+    method public com.mapbox.navigation.base.trip.model.ElectronicHorizon.Builder horizon(com.mapbox.api.directions.v5.models.DirectionsResponse horizon);
+    method public com.mapbox.navigation.base.trip.model.ElectronicHorizon.Builder intersectionIndex(int intersectionIndex);
+    method public com.mapbox.navigation.base.trip.model.ElectronicHorizon.Builder legDistanceRemaining(float legDistanceRemaining);
+    method public com.mapbox.navigation.base.trip.model.ElectronicHorizon.Builder legDurationRemaining(double legDurationRemaining);
+    method public com.mapbox.navigation.base.trip.model.ElectronicHorizon.Builder legIndex(int legIndex);
+    method public com.mapbox.navigation.base.trip.model.ElectronicHorizon.Builder routeIndex(int routeIndex);
+    method public com.mapbox.navigation.base.trip.model.ElectronicHorizon.Builder shapeIndex(int shapeIndex);
+    method public com.mapbox.navigation.base.trip.model.ElectronicHorizon.Builder stepDistanceRemaining(float stepDistanceRemaining);
+    method public com.mapbox.navigation.base.trip.model.ElectronicHorizon.Builder stepDurationRemaining(double stepDurationRemaining);
+    method public com.mapbox.navigation.base.trip.model.ElectronicHorizon.Builder stepIndex(int stepIndex);
+  }
+
   public final class RouteLegProgress {
     ctor public RouteLegProgress(int legIndex, com.mapbox.api.directions.v5.models.RouteLeg? routeLeg, float distanceTraveled, float distanceRemaining, double durationRemaining, float fractionTraveled, com.mapbox.navigation.base.trip.model.RouteStepProgress? currentStepProgress, com.mapbox.api.directions.v5.models.LegStep? upcomingStep);
     method public int component1();

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/ElectronicHorizon.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/ElectronicHorizon.kt
@@ -1,0 +1,237 @@
+package com.mapbox.navigation.base.trip.model
+
+import com.mapbox.api.directions.v5.models.DirectionsResponse
+
+/**
+ * An Electronic Horizon is a path (or paths) within the road graph which is used to surface
+ * metadata about the underlying links of the graph for a certain distance in front of the vehicle.
+ * The Electronic Horizon module correlates the vehicles location to the road graph and broadcasts
+ * updates to the Electronic Horizon as the vehicles position and trajectory change.
+ *
+ * Electronic Horizon is still **experimental**, which means that the design of the
+ * APIs has open issues which may (or may not) lead to their changes in the future.
+ * Roughly speaking, there is a chance that those declarations will be deprecated in the near
+ * future or the semantics of their behavior may change in some way that may break some code.
+ *
+ * Note that the Electronic Horizon object's immutable.
+ */
+class ElectronicHorizon private constructor(
+    private val horizon: DirectionsResponse? = null,
+    private val routeIndex: Int = 0,
+    private val legIndex: Int = 0,
+    private val legDistanceRemaining: Float = 0f,
+    private val legDurationRemaining: Double = 0.0,
+    private val stepIndex: Int = 0,
+    private val stepDistanceRemaining: Float = 0f,
+    private val stepDurationRemaining: Double = 0.0,
+    private val shapeIndex: Int = 0,
+    private val intersectionIndex: Int = 0,
+    private val builder: Builder
+) {
+
+    /**
+     * [DirectionsResponse] including MPP. MPP is a route that consists of 1 leg.
+     *
+     * For now, no alternatives are returned.
+     *
+     * @return a [DirectionsResponse] object
+     */
+    fun horizon(): DirectionsResponse? = horizon
+
+    /**
+     * Index representing the current route the user is on.
+     *
+     * For now, always 0 since only MPP is returned. MPP is a route that consists of 1 leg.
+     *
+     * @return an integer representing the current route the user is on
+     */
+    fun routeIndex(): Int = routeIndex
+
+    /**
+     * Index representing the current leg the user is on.
+     *
+     * For now, always 0 since only MPP is returned. MPP is a route that consists of 1 leg.
+     *
+     * @return an integer representing the current leg the user is on
+     */
+    fun legIndex(): Int = legIndex
+
+    /**
+     * Provides the distance remaining in meters until the user reaches the end of the leg.
+     * Distance until the end of the Electronic Horizon itself.
+     *
+     * @return distance remaining till end of leg, in unit meters.
+     */
+    fun legDistanceRemaining(): Float = legDistanceRemaining
+
+    /**
+     * Provides the duration remaining in seconds until the user reaches the end of the current leg.
+     * Duration until the end of the Electronic Horizon itself.
+     *
+     * @return duration remaining till end of leg, in unit seconds.
+     */
+    fun legDurationRemaining(): Double = legDurationRemaining
+
+    /**
+     * Index representing the current step the user is on.
+     *
+     * @return an integer representing the current step the user is on
+     */
+    fun stepIndex(): Int = stepIndex
+
+    /**
+     * Provides the distance remaining in meters until the user reaches the end of the step.
+     *
+     * @return distance remaining till end of step, in unit meters.
+     */
+    fun stepDistanceRemaining(): Float = stepDistanceRemaining
+
+    /**
+     * Provides the duration remaining in seconds until the user reaches the end of the current step.
+     *
+     * @return duration remaining till end of step, in unit seconds.
+     */
+    fun stepDurationRemaining(): Double = stepDurationRemaining
+
+    /**
+     * Index representing the segment of the MPP geometry the user is on.
+     *
+     * @return an integer representing the current segment of the MPP geometry the user is on
+     */
+    fun shapeIndex(): Int = shapeIndex
+
+    /**
+     * Index representing the upcoming intersection.
+     *
+     * @return an integer representing the upcoming intersection
+     */
+    fun intersectionIndex(): Int = intersectionIndex
+
+    /**
+     * Get a builder to customize a subset of current options.
+     */
+    fun toBuilder() = builder
+
+    /**
+     * Builder of [ElectronicHorizon]
+     *
+     * @param horizon [DirectionsResponse] including MPP
+     * @param routeIndex index representing the current route the user is on
+     * @param legIndex index representing the current leg the user is on
+     * @param legDistanceRemaining distance remaining till end of leg, in unit meters
+     * @param legDurationRemaining duration remaining till end of leg, in unit seconds
+     * @param stepIndex index representing the current step the user is on
+     * @param stepDistanceRemaining distance remaining till end of step, in unit meters
+     * @param stepDurationRemaining duration remaining till end of step, in unit seconds
+     * @param shapeIndex index representing the segment of the MPP geometry the user is on
+     * @param intersectionIndex index representing the upcoming intersection
+     */
+    data class Builder(
+        private var horizon: DirectionsResponse? = null,
+        private var routeIndex: Int = 0,
+        private var legIndex: Int = 0,
+        private var legDistanceRemaining: Float = 0f,
+        private var legDurationRemaining: Double = 0.0,
+        private var stepIndex: Int = 0,
+        private var stepDistanceRemaining: Float = 0f,
+        private var stepDurationRemaining: Double = 0.0,
+        private var shapeIndex: Int = 0,
+        private var intersectionIndex: Int = 0
+    ) {
+
+        /**
+         * [DirectionsResponse] including MPP.
+         *
+         * @return Builder
+         */
+        fun horizon(horizon: DirectionsResponse) = apply { this.horizon = horizon }
+
+        /**
+         * Index representing the current route the user is on.
+         *
+         * @return Builder
+         */
+        fun routeIndex(routeIndex: Int) = apply { this.routeIndex = routeIndex }
+
+        /**
+         * Index representing the current leg the user is on.
+         *
+         * @return Builder
+         */
+        fun legIndex(legIndex: Int) = apply { this.legIndex = legIndex }
+
+        /**
+         * Distance remaining till end of leg, in unit meters.
+         *
+         * @return Builder
+         */
+        fun legDistanceRemaining(legDistanceRemaining: Float) =
+            apply { this.legDistanceRemaining = legDistanceRemaining }
+
+        /**
+         * Duration remaining till end of leg, in unit seconds.
+         *
+         * @return Builder
+         */
+        fun legDurationRemaining(legDurationRemaining: Double) =
+            apply { this.legDurationRemaining = legDurationRemaining }
+
+        /**
+         * Index representing the current step the user is on.
+         *
+         * @return Builder
+         */
+        fun stepIndex(stepIndex: Int) = apply { this.stepIndex = stepIndex }
+
+        /**
+         * Distance remaining till end of step, in unit meters.
+         *
+         * @return Builder
+         */
+        fun stepDistanceRemaining(stepDistanceRemaining: Float) =
+            apply { this.stepDistanceRemaining = stepDistanceRemaining }
+
+        /**
+         * Duration remaining till end of step, in unit seconds.
+         *
+         * @return Builder
+         */
+        fun stepDurationRemaining(stepDurationRemaining: Double) =
+            apply { this.stepDurationRemaining = stepDurationRemaining }
+
+        /**
+         * Index representing the segment of the MPP geometry the user is on.
+         *
+         * @return Builder
+         */
+        fun shapeIndex(shapeIndex: Int) = apply { this.shapeIndex = shapeIndex }
+
+        /**
+         * Index representing the upcoming intersection.
+         *
+         * @return Builder
+         */
+        fun intersectionIndex(intersectionIndex: Int) = apply { this.intersectionIndex = intersectionIndex }
+
+        /**
+         * Build new instance of [ElectronicHorizon]
+         *
+         * @return RouteLegProgress
+         */
+        fun build(): ElectronicHorizon {
+            return ElectronicHorizon(
+                horizon,
+                routeIndex,
+                legIndex,
+                legDistanceRemaining,
+                legDurationRemaining,
+                stepIndex,
+                stepDistanceRemaining,
+                stepDurationRemaining,
+                shapeIndex,
+                intersectionIndex,
+                this
+            )
+        }
+    }
+}

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteLegProgress.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteLegProgress.kt
@@ -113,7 +113,7 @@ data class RouteLegProgress(
          * @return Builder
          */
         fun upcomingStep(upcomingStep: LegStep) =
-                apply { this.upcomingStep = upcomingStep }
+            apply { this.upcomingStep = upcomingStep }
 
         /**
          * Build new instance of [RouteLegProgress]

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteProgress.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteProgress.kt
@@ -18,6 +18,16 @@ import com.mapbox.geojson.Point
  * @param route [DirectionsRoute] the navigation session is currently using. When a reroute occurs and a new
  * directions route gets obtained, with the next location update this directions route should
  * reflect the new route.
+ *
+ * @param eHorizon [ElectronicHorizon] object with Electronic Horizon information
+ *
+ * Electronic Horizon is still **experimental**, which means that the design of the
+ * APIs has open issues which may (or may not) lead to their changes in the future.
+ * Roughly speaking, there is a chance that those declarations will be deprecated in the near
+ * future or the semantics of their behavior may change in some way that may break some code.
+ *
+ * For now, Electronic Horizon only works in Free Drive.
+ *
  * @param routeGeometryWithBuffer [Geometry] of the current [DirectionsRoute] with a buffer
  * that encompasses visible tile surface are while navigating. This [Geometry] is ideal
  * for offline downloads of map or routing tile data.

--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -17,6 +17,7 @@ package com.mapbox.navigation.core {
     method public static void postUserFeedback(@com.mapbox.navigation.core.telemetry.events.FeedbackEvent.Type String feedbackType, String description, @com.mapbox.navigation.core.telemetry.events.FeedbackEvent.Source String feedbackSource, String? screenshot, String![]? feedbackSubType = emptyArray());
     method public void registerArrivalObserver(com.mapbox.navigation.core.arrival.ArrivalObserver arrivalObserver);
     method public void registerBannerInstructionsObserver(com.mapbox.navigation.core.trip.session.BannerInstructionsObserver bannerInstructionsObserver);
+    method public void registerEHorizonObserver(com.mapbox.navigation.core.trip.session.EHorizonObserver eHorizonObserver);
     method public void registerLocationObserver(com.mapbox.navigation.core.trip.session.LocationObserver locationObserver);
     method public void registerOffRouteObserver(com.mapbox.navigation.core.trip.session.OffRouteObserver offRouteObserver);
     method public void registerRouteProgressObserver(com.mapbox.navigation.core.trip.session.RouteProgressObserver routeProgressObserver);
@@ -34,6 +35,7 @@ package com.mapbox.navigation.core {
     method public void toggleHistory(boolean isEnabled);
     method public void unregisterArrivalObserver(com.mapbox.navigation.core.arrival.ArrivalObserver arrivalObserver);
     method public void unregisterBannerInstructionsObserver(com.mapbox.navigation.core.trip.session.BannerInstructionsObserver bannerInstructionsObserver);
+    method public void unregisterEHorizonObserver(com.mapbox.navigation.core.trip.session.EHorizonObserver eHorizonObserver);
     method public void unregisterLocationObserver(com.mapbox.navigation.core.trip.session.LocationObserver locationObserver);
     method public void unregisterOffRouteObserver(com.mapbox.navigation.core.trip.session.OffRouteObserver offRouteObserver);
     method public void unregisterRouteProgressObserver(com.mapbox.navigation.core.trip.session.RouteProgressObserver routeProgressObserver);
@@ -408,6 +410,10 @@ package com.mapbox.navigation.core.trip.session {
 
   public interface BannerInstructionsObserver {
     method public void onNewBannerInstructions(com.mapbox.api.directions.v5.models.BannerInstructions bannerInstructions);
+  }
+
+  public interface EHorizonObserver {
+    method public void onElectronicHorizonUpdated(com.mapbox.navigation.base.trip.model.ElectronicHorizon eHorizon);
   }
 
   public interface LocationObserver {

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -41,6 +41,7 @@ import com.mapbox.navigation.core.routerefresh.RouteRefreshController
 import com.mapbox.navigation.core.telemetry.MapboxNavigationTelemetry
 import com.mapbox.navigation.core.telemetry.events.FeedbackEvent
 import com.mapbox.navigation.core.trip.session.BannerInstructionsObserver
+import com.mapbox.navigation.core.trip.session.EHorizonObserver
 import com.mapbox.navigation.core.trip.session.LocationObserver
 import com.mapbox.navigation.core.trip.session.OffRouteObserver
 import com.mapbox.navigation.core.trip.session.RouteProgressObserver
@@ -303,6 +304,7 @@ class MapboxNavigation(
         tripSession.unregisterAllStateObservers()
         tripSession.unregisterAllBannerInstructionsObservers()
         tripSession.unregisterAllVoiceInstructionsObservers()
+        tripSession.unregisterAllEHorizonObservers()
         tripSession.route = null
 
         // TODO replace this with a destroy when nav-native has a destructor
@@ -643,6 +645,36 @@ class MapboxNavigation(
      */
     fun useExtendedKalmanFilter(useEKF: Boolean) {
         tripSession.useExtendedKalmanFilter(useEKF)
+    }
+
+    /**
+     * Registers [EHorizonObserver]. The updates are available whenever the trip session is started.
+     *
+     * Electronic Horizon is still **experimental**, which means that the design of the
+     * APIs has open issues which may (or may not) lead to their changes in the future.
+     * Roughly speaking, there is a chance that those declarations will be deprecated in the near
+     * future or the semantics of their behavior may change in some way that may break some code.
+     *
+     * For now, Electronic Horizon only works in Free Drive.
+     *
+     * @see [startTripSession]
+     */
+    fun registerEHorizonObserver(eHorizonObserver: EHorizonObserver) {
+        tripSession.registerEHorizonObserver(eHorizonObserver)
+    }
+
+    /**
+     * Unregisters [EHorizonObserver]. The updates are available as long as there are observers registered.
+     *
+     * Electronic Horizon is still **experimental**, which means that the design of the
+     * APIs has open issues which may (or may not) lead to their changes in the future.
+     * Roughly speaking, there is a chance that those declarations will be deprecated in the near
+     * future or the semantics of their behavior may change in some way that may break some code.
+     *
+     * For now, Electronic Horizon only works in Free Drive.
+     */
+    fun unregisterEHorizonObserver(eHorizonObserver: EHorizonObserver) {
+        tripSession.unegisterEHorizonObserver(eHorizonObserver)
     }
 
     companion object {

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/trip/session/MapboxTripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/trip/session/MapboxTripSession.kt
@@ -12,12 +12,14 @@ import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.VoiceInstructions
 import com.mapbox.base.common.logger.Logger
 import com.mapbox.base.common.logger.model.Message
+import com.mapbox.navigation.base.trip.model.ElectronicHorizon
 import com.mapbox.navigation.base.trip.model.RouteLegProgress
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.internal.trip.service.TripService
 import com.mapbox.navigation.core.sensors.SensorMapper
 import com.mapbox.navigation.core.trip.session.BannerInstructionEvent
 import com.mapbox.navigation.core.trip.session.BannerInstructionsObserver
+import com.mapbox.navigation.core.trip.session.EHorizonObserver
 import com.mapbox.navigation.core.trip.session.LocationObserver
 import com.mapbox.navigation.core.trip.session.OffRouteObserver
 import com.mapbox.navigation.core.trip.session.RouteProgressObserver
@@ -97,6 +99,7 @@ class MapboxTripSession(
     private val stateObservers = CopyOnWriteArraySet<TripSessionStateObserver>()
     private val bannerInstructionsObservers = CopyOnWriteArraySet<BannerInstructionsObserver>()
     private val voiceInstructionsObservers = CopyOnWriteArraySet<VoiceInstructionsObserver>()
+    private val eHorizonObservers = CopyOnWriteArraySet<EHorizonObserver>()
 
     private val bannerInstructionEvent = BannerInstructionEvent()
     private val voiceInstructionEvent = VoiceInstructionEvent()
@@ -383,6 +386,36 @@ class MapboxTripSession(
         }
     }
 
+    /**
+     * Register [EHorizonObserver] to receive Electronic Horizon updates
+     */
+    override fun registerEHorizonObserver(eHorizonObserver: EHorizonObserver) {
+        if (eHorizonObservers.isEmpty()) {
+            navigator.toggleElectronicHorizon(true)
+        }
+        eHorizonObservers.add(eHorizonObserver)
+    }
+
+    /**
+     * Unregister [EHorizonObserver]
+     */
+    override fun unegisterEHorizonObserver(eHorizonObserver: EHorizonObserver) {
+        eHorizonObservers.remove(eHorizonObserver)
+        if (eHorizonObservers.isEmpty()) {
+            navigator.toggleElectronicHorizon(false)
+        }
+    }
+
+    /**
+     * Unregister all [EHorizonObserver]
+     *
+     * @see [registerEHorizonObserver]
+     */
+    override fun unregisterAllEHorizonObservers() {
+        eHorizonObservers.clear()
+        navigator.toggleElectronicHorizon(false)
+    }
+
     private var locationEngineCallback = object : LocationEngineCallback<LocationEngineResult> {
         override fun onSuccess(result: LocationEngineResult?) {
             result?.locations?.lastOrNull()?.let {
@@ -426,6 +459,7 @@ class MapboxTripSession(
                 updateEnhancedLocation(status.enhancedLocation, status.keyPoints)
                 updateRouteProgress(status.routeProgress)
                 isOffRoute = status.offRoute
+                updateEHorizon(status.eHorizon)
             }
         }
     }
@@ -477,5 +511,9 @@ class MapboxTripSession(
         if (voiceInstructionEvent.isOccurring(progress)) {
             action(voiceInstructionEvent.voiceInstructions)
         }
+    }
+
+    private fun updateEHorizon(eHorizon: ElectronicHorizon) {
+        eHorizonObservers.forEach { it.onElectronicHorizonUpdated(eHorizon) }
     }
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/EHorizonObserver.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/EHorizonObserver.kt
@@ -1,0 +1,21 @@
+package com.mapbox.navigation.core.trip.session
+
+import com.mapbox.navigation.base.trip.model.ElectronicHorizon
+
+/**
+ * An interface which enables listening to Electronic Horizon updates
+ *
+ * Electronic Horizon is still **experimental**, which means that the design of the
+ * APIs has open issues which may (or may not) lead to their changes in the future.
+ * Roughly speaking, there is a chance that those declarations will be deprecated in the near
+ * future or the semantics of their behavior may change in some way that may break some code.
+ *
+ * For now, Electronic Horizon only works in Free Drive.
+ */
+interface EHorizonObserver {
+    /**
+     * Invoked every time the [ElectronicHorizon] is updated
+     * @param eHorizon [ElectronicHorizon]
+     */
+    fun onElectronicHorizonUpdated(eHorizon: ElectronicHorizon)
+}

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/TripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/TripSession.kt
@@ -47,4 +47,8 @@ internal interface TripSession {
     fun updateSensorEvent(sensorEvent: SensorEvent)
     fun useExtendedKalmanFilter(useEKF: Boolean)
     fun updateLegIndex(legIndex: Int): NavigationStatus
+
+    fun registerEHorizonObserver(eHorizonObserver: EHorizonObserver)
+    fun unegisterEHorizonObserver(eHorizonObserver: EHorizonObserver)
+    fun unregisterAllEHorizonObservers()
 }

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigator.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigator.kt
@@ -133,6 +133,15 @@ interface MapboxNativeNavigator {
      */
     fun updateLegIndex(legIndex: Int): NavigationStatus
 
+    // Free Drive
+
+    /**
+     * Toggles Electronic Horizon on or off.
+     *
+     * @param isEnabled set this to true to turn on Electronic Horizon and false to turn it off
+     */
+    fun toggleElectronicHorizon(isEnabled: Boolean)
+
     // Offline
 
     /**

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigatorImpl.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigatorImpl.kt
@@ -4,6 +4,7 @@ import android.location.Location
 import com.mapbox.api.directions.v5.models.BannerComponents
 import com.mapbox.api.directions.v5.models.BannerInstructions
 import com.mapbox.api.directions.v5.models.BannerText
+import com.mapbox.api.directions.v5.models.DirectionsResponse
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.LegStep
 import com.mapbox.api.directions.v5.models.RouteLeg
@@ -14,6 +15,7 @@ import com.mapbox.geojson.Point
 import com.mapbox.geojson.gson.GeometryGeoJson
 import com.mapbox.geojson.utils.PolylineUtils
 import com.mapbox.navigation.base.options.DeviceProfile
+import com.mapbox.navigation.base.trip.model.ElectronicHorizon
 import com.mapbox.navigation.base.trip.model.RouteLegProgress
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.base.trip.model.RouteProgressState
@@ -24,6 +26,7 @@ import com.mapbox.navigation.navigator.toLocation
 import com.mapbox.navigator.BannerComponent
 import com.mapbox.navigator.BannerInstruction
 import com.mapbox.navigator.BannerSection
+import com.mapbox.navigator.ElectronicHorizonOutput
 import com.mapbox.navigator.NavigationStatus
 import com.mapbox.navigator.Navigator
 import com.mapbox.navigator.NavigatorConfig
@@ -112,7 +115,8 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
                 status.location.toLocation(),
                 status.key_points.map { it.toLocation() },
                 status.getRouteProgress(),
-                status.routeState == RouteState.OFF_ROUTE
+                status.routeState == RouteState.OFF_ROUTE,
+                status.electronicHorizon.mapToElectronicHorizon()
             )
         }
     }
@@ -136,7 +140,8 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
     ): NavigationStatus {
         mutex.withLock {
             MapboxNativeNavigatorImpl.route = route
-            val result = navigator!!.setRoute(route?.toJson() ?: "{}", PRIMARY_ROUTE_INDEX, legIndex)
+            val result = navigator!!.setRoute(route?.toJson()
+                ?: "{}", PRIMARY_ROUTE_INDEX, legIndex)
             navigator!!.getRouteBufferGeoJson(GRID_SIZE, BUFFER_DILATION)?.also {
                 routeBufferGeoJson = GeometryGeoJson.fromJson(it)
             }
@@ -196,6 +201,20 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
      */
     override fun updateLegIndex(legIndex: Int): NavigationStatus =
         navigator!!.changeRouteLeg(PRIMARY_ROUTE_INDEX, legIndex)
+
+    // Free Drive
+
+    /**
+     * Toggles Electronic Horizon on or off.
+     *
+     * @param isEnabled set this to true to turn on Electronic Horizon and false to turn it off
+     */
+    override fun toggleElectronicHorizon(isEnabled: Boolean) {
+        when (isEnabled) {
+            true -> navigator!!.enableElectronicHorizon()
+            false -> navigator!!.disableElectronicHorizon()
+        }
+    }
 
     // Offline
 
@@ -494,6 +513,24 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
             .distanceAlongGeometry(this.remainingStepDistance.toDouble())
             .ssmlAnnouncement(this.ssmlAnnouncement)
             .build()
+    }
+
+    private fun ElectronicHorizonOutput.mapToElectronicHorizon(): ElectronicHorizon {
+        val eHorizonBuilder = ElectronicHorizon.Builder()
+            .routeIndex(this.routeIndex)
+            .legIndex(this.legIndex)
+            .legDistanceRemaining(this.remainingLegDistance)
+            .legDurationRemaining(this.remainingLegDuration / ONE_SECOND_IN_MILLISECONDS)
+            .stepIndex(this.stepIndex)
+            .stepDistanceRemaining(this.remainingStepDistance)
+            .stepDurationRemaining(this.remainingStepDuration / ONE_SECOND_IN_MILLISECONDS)
+            .shapeIndex(this.shapeIndex)
+            .intersectionIndex(this.intersectionIndex)
+        this.horizon?.let {
+            val eHorizonRoute = DirectionsResponse.fromJson(it)
+            eHorizonBuilder.horizon(eHorizonRoute)
+        }
+        return eHorizonBuilder.build()
     }
 }
 

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/TripStatus.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/TripStatus.kt
@@ -1,6 +1,7 @@
 package com.mapbox.navigation.navigator.internal
 
 import android.location.Location
+import com.mapbox.navigation.base.trip.model.ElectronicHorizon
 import com.mapbox.navigation.base.trip.model.RouteProgress
 
 /**
@@ -11,11 +12,21 @@ import com.mapbox.navigation.base.trip.model.RouteProgress
  * @param routeProgress [RouteProgress] is progress information
  * @param offRoute *true* if user is off-route, *false* otherwise
  *
+ * @param eHorizon [ElectronicHorizon] object with Electronic Horizon information
+ *
+ * Electronic Horizon is still **experimental**, which means that the design of the
+ * APIs has open issues which may (or may not) lead to their changes in the future.
+ * Roughly speaking, there is a chance that those declarations will be deprecated in the near
+ * future or the semantics of their behavior may change in some way that may break some code.
+ *
+ * For now, Electronic Horizon only works in Free Drive.
+ *
  * @see [MapboxNativeNavigator.getStatus]
  */
 data class TripStatus(
     val enhancedLocation: Location,
     val keyPoints: List<Location>,
     val routeProgress: RouteProgress?,
-    val offRoute: Boolean
+    val offRoute: Boolean,
+    val eHorizon: ElectronicHorizon
 )


### PR DESCRIPTION
## Description

Cherry-picks EH https://github.com/mapbox/mapbox-navigation-android/commit/e9b9f021147ee25ebc75c720b3cf22704b3a6c10 to `1.1.0 beta.7` based on https://github.com/mapbox/mapbox-navigation-android/releases/tag/qa_release_ui_1.0.0-qa.2020w27_core_1.0.0-qa.2020w27.

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Include EH recent changes to `1.1.0 beta.7` release

### Implementation

```
$> git checkout release-1.1.0-beta.7
$> git checkout -b pg-cherry-pick-eh-release-1.1.0-beta.7
$> git cherry-pick e9b9f021147ee25ebc75c720b3cf22704b3a6c10
```

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs

cc @LukasPaczos @zugaldia @asinghal22 