### PR TITLE
Add Probot Stale configuration

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,36 @@
+# Configuration for Probot (Stale) - https://github.com/probot/stale
+
+# Ignore issues in a project (defaults to false)
+exemptProjects: true
+
+# Ignore issues in a milestone (defaults to false)
+exemptMilestones: true
+
+# Label to use when marking as stale
+staleLabel: archived
+
+# Limit the number of actions to 1 per hour
+limitPerRun: 1
+
+# Do not archive issues that require a SEMVER major release, those normally
+# have a longer lifeycle.
+exemptLabels:
+  - SEMVER-MAJOR
+
+pulls:
+  daysUntilStale: 60
+  daysUntilClose: 5
+  markComment: >
+    This pull request has been automatically marked as stale because it has not had
+    recent activity. It will be closed if no further activity occurs. Thank you
+    for your contributions.
+  closeComment: Stale.
+
+issues:
+  daysUntilStale: 180
+  daysUntilClose: 5
+  markComment: >
+    This issue has been automatically marked as stale because it has not had
+    recent activity. It will be closed if no further activity occurs. Thank you
+    for your contributions.
+  closeComment: Stale.


### PR DESCRIPTION
This PR proposes adding configuration for the [Probot Stale app](https://github.com/probot/stale), a GitHub App that closes abandoned issues and Pull Requests after a period of inactivity. The configuration proposed here is based on the one used by Mapbox Maps SDK and it's somewhat conservative:
- Ignore issues or PRs in a project or a milestone.
- Ignore issues or PRs with the `SEMVER-MAJOR` label.
- PRs go stale after 60 days, and issues after 180 days.
- Bot waits for 5 additional days for any activity before closing the ticket or PR.
- It limits the number of actions to 1 per hour (default is 30).

Note that before this bot is active it needs to be [enabled here](https://github.com/apps/stale). That can happen after this PR has approved and merged.

/cc: @mapbox/navigation-android 
