### PR TITLE
[ui] fully unwrap the context before instantiating the view model

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationView.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationView.java
@@ -3,11 +3,11 @@ package com.mapbox.navigation.ui;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
+import android.content.ContextWrapper;
 import android.content.res.Resources;
 import android.location.Location;
 import android.os.Bundle;
 import android.util.AttributeSet;
-import android.view.ContextThemeWrapper;
 import android.view.View;
 import android.widget.ImageButton;
 import androidx.annotation.NonNull;
@@ -691,13 +691,12 @@ public class NavigationView extends CoordinatorLayout implements LifecycleOwner,
 
   private void initializeNavigationViewModel() {
     try {
-      if (getContext() instanceof ContextThemeWrapper) {
-        navigationViewModel = ViewModelProviders.of(
-                (FragmentActivity)(((ContextThemeWrapper) getContext()).getBaseContext()))
-                .get(NavigationViewModel.class);
-      } else {
-        navigationViewModel = ViewModelProviders.of((FragmentActivity) getContext()).get(NavigationViewModel.class);
+      Context context = getContext();
+      // unwrap the context if needed, see https://github.com/mapbox/mapbox-navigation-android/issues/2777
+      while (!(context instanceof FragmentActivity) && context instanceof ContextWrapper) {
+        context = ((ContextWrapper) context).getBaseContext();
       }
+      navigationViewModel = ViewModelProviders.of((FragmentActivity) context).get(NavigationViewModel.class);
     } catch (ClassCastException exception) {
       throw new ClassCastException("Please ensure that the provided Context is a valid FragmentActivity");
     }


### PR DESCRIPTION
Addresses the regression introduced in https://github.com/mapbox/mapbox-navigation-android/pull/3326 where the context wasn't fully unwrapped before casting to `FragmentActivity`. It produced below stacktrace when running an example activity:
```
2020-07-14 11:42:29.912 27146-27146/com.mapbox.navigation.examples E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.mapbox.navigation.examples, PID: 27146
    java.lang.RuntimeException: Unable to start activity ComponentInfo{com.mapbox.navigation.examples/com.mapbox.navigation.examples.ui.NavigationViewActivity}: android.view.InflateException: Binary XML file line #7 in com.mapbox.navigation.examples:layout/activity_navigation_view: Binary XML file line #7 in com.mapbox.navigation.examples:layout/activity_navigation_view: Error inflating class com.mapbox.navigation.ui.NavigationView
        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3270)
        at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3409)
        at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:83)
        at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135)
        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2016)
        at android.os.Handler.dispatchMessage(Handler.java:107)
        at android.os.Looper.loop(Looper.java:214)
        at android.app.ActivityThread.main(ActivityThread.java:7356)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:492)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:930)
     Caused by: android.view.InflateException: Binary XML file line #7 in com.mapbox.navigation.examples:layout/activity_navigation_view: Binary XML file line #7 in com.mapbox.navigation.examples:layout/activity_navigation_view: Error inflating class com.mapbox.navigation.ui.NavigationView
     Caused by: android.view.InflateException: Binary XML file line #7 in com.mapbox.navigation.examples:layout/activity_navigation_view: Error inflating class com.mapbox.navigation.ui.NavigationView
     Caused by: java.lang.reflect.InvocationTargetException
        at java.lang.reflect.Constructor.newInstance0(Native Method)
        at java.lang.reflect.Constructor.newInstance(Constructor.java:343)
        at android.view.LayoutInflater.createView(LayoutInflater.java:854)
        at android.view.LayoutInflater.createViewFromTag(LayoutInflater.java:1006)
        at android.view.LayoutInflater.createViewFromTag(LayoutInflater.java:961)
        at android.view.LayoutInflater.rInflate(LayoutInflater.java:1123)
        at android.view.LayoutInflater.rInflateChildren(LayoutInflater.java:1084)
        at android.view.LayoutInflater.inflate(LayoutInflater.java:682)
        at android.view.LayoutInflater.inflate(LayoutInflater.java:534)
        at android.view.LayoutInflater.inflate(LayoutInflater.java:481)
        at androidx.appcompat.app.AppCompatDelegateImpl.setContentView(AppCompatDelegateImpl.java:555)
        at androidx.appcompat.app.AppCompatActivity.setContentView(AppCompatActivity.java:161)
        at com.mapbox.navigation.examples.ui.NavigationViewActivity.onCreate(NavigationViewActivity.kt:35)
        at android.app.Activity.performCreate(Activity.java:7825)
        at android.app.Activity.performCreate(Activity.java:7814)
        at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1306)
        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3245)
        at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3409)
        at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:83)
        at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135)
        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2016)
        at android.os.Handler.dispatchMessage(Handler.java:107)
        at android.os.Looper.loop(Looper.java:214)
        at android.app.ActivityThread.main(ActivityThread.java:7356)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:492)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:930)
2020-07-14 11:42:29.912 27146-27146/com.mapbox.navigation.examples E/AndroidRuntime: Caused by: java.lang.ClassCastException: Please ensure that the provided Context is a valid FragmentActivity
        at com.mapbox.navigation.ui.NavigationView.initializeNavigationViewModel(NavigationView.java:702)
        at com.mapbox.navigation.ui.NavigationView.initializeView(NavigationView.java:674)
        at com.mapbox.navigation.ui.NavigationView.<init>(NavigationView.java:114)
        at com.mapbox.navigation.ui.NavigationView.<init>(NavigationView.java:108)
        	... 28 more
```