### PR TITLE
refactored string resources to avoid naming collision with external developers

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/MapboxDistanceFormatter.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/MapboxDistanceFormatter.kt
@@ -137,10 +137,10 @@ class MapboxDistanceFormatter private constructor(
     }
 
     private fun getUnitString(resources: Resources, @TurfConstants.TurfUnitCriteria unit: String) = when (unit) {
-        TurfConstants.UNIT_KILOMETERS -> resources.getString(R.string.kilometers)
-        TurfConstants.UNIT_METERS -> resources.getString(R.string.meters)
-        TurfConstants.UNIT_MILES -> resources.getString(R.string.miles)
-        TurfConstants.UNIT_FEET -> resources.getString(R.string.feet)
+        TurfConstants.UNIT_KILOMETERS -> resources.getString(R.string.mapbox_kilometers)
+        TurfConstants.UNIT_METERS -> resources.getString(R.string.mapbox_meters)
+        TurfConstants.UNIT_MILES -> resources.getString(R.string.mapbox_miles)
+        TurfConstants.UNIT_FEET -> resources.getString(R.string.mapbox_feet)
         else -> ""
     }
 

--- a/libnavigation-util/src/main/res/values-ar/strings.xml
+++ b/libnavigation-util/src/main/res/values-ar/strings.xml
@@ -1,6 +1,6 @@
 <resources>
-    <string name="kilometers">كم</string>
-    <string name="meters">م</string>
-    <string name="miles">ميل</string>
-    <string name="feet">قدم</string>
+    <string name="mapbox_kilometers">كم</string>
+    <string name="mapbox_meters">م</string>
+    <string name="mapbox_miles">ميل</string>
+    <string name="mapbox_feet">قدم</string>
 </resources>

--- a/libnavigation-util/src/main/res/values-bg/strings.xml
+++ b/libnavigation-util/src/main/res/values-bg/strings.xml
@@ -1,6 +1,6 @@
 <resources>
-    <string name="kilometers">км</string>
-    <string name="meters">м</string>
-    <string name="miles">мили</string>
-    <string name="feet">фута</string>
+    <string name="mapbox_kilometers">км</string>
+    <string name="mapbox_meters">м</string>
+    <string name="mapbox_miles">мили</string>
+    <string name="mapbox_feet">фута</string>
 </resources>

--- a/libnavigation-util/src/main/res/values-cs/strings.xml
+++ b/libnavigation-util/src/main/res/values-cs/strings.xml
@@ -1,6 +1,6 @@
 <resources>
-    <string name="kilometers">km</string>
-    <string name="meters">m</string>
-    <string name="miles">míle</string>
-    <string name="feet">stopy</string>
+    <string name="mapbox_kilometers">km</string>
+    <string name="mapbox_meters">m</string>
+    <string name="mapbox_miles">míle</string>
+    <string name="mapbox_feet">stopy</string>
 </resources>

--- a/libnavigation-util/src/main/res/values-da/strings.xml
+++ b/libnavigation-util/src/main/res/values-da/strings.xml
@@ -1,6 +1,6 @@
 <resources>
-    <string name="kilometers">km</string>
-    <string name="meters">m</string>
-    <string name="miles">mi</string>
-    <string name="feet">ft</string>
+    <string name="mapbox_kilometers">km</string>
+    <string name="mapbox_meters">m</string>
+    <string name="mapbox_miles">mi</string>
+    <string name="mapbox_feet">ft</string>
 </resources>

--- a/libnavigation-util/src/main/res/values-de/strings.xml
+++ b/libnavigation-util/src/main/res/values-de/strings.xml
@@ -1,6 +1,6 @@
 <resources>
-    <string name="kilometers">km</string>
-    <string name="meters">m</string>
-    <string name="miles">mile</string>
-    <string name="feet">Fuß</string>
+    <string name="mapbox_kilometers">km</string>
+    <string name="mapbox_meters">m</string>
+    <string name="mapbox_miles">mile</string>
+    <string name="mapbox_feet">Fuß</string>
 </resources>

--- a/libnavigation-util/src/main/res/values-el/strings.xml
+++ b/libnavigation-util/src/main/res/values-el/strings.xml
@@ -1,6 +1,6 @@
 <resources>
-    <string name="kilometers">χλμ.</string>
-    <string name="meters">μέτρ.</string>
-    <string name="miles">μίλ.</string>
-    <string name="feet">πόδ.</string>
+    <string name="mapbox_kilometers">χλμ.</string>
+    <string name="mapbox_meters">μέτρ.</string>
+    <string name="mapbox_miles">μίλ.</string>
+    <string name="mapbox_feet">πόδ.</string>
 </resources>

--- a/libnavigation-util/src/main/res/values-es/strings.xml
+++ b/libnavigation-util/src/main/res/values-es/strings.xml
@@ -1,6 +1,6 @@
 <resources>
-    <string name="kilometers">km</string>
-    <string name="meters">m</string>
-    <string name="miles">mi</string>
-    <string name="feet">pie</string>
+    <string name="mapbox_kilometers">km</string>
+    <string name="mapbox_meters">m</string>
+    <string name="mapbox_miles">mi</string>
+    <string name="mapbox_feet">pie</string>
 </resources>

--- a/libnavigation-util/src/main/res/values-fa/strings.xml
+++ b/libnavigation-util/src/main/res/values-fa/strings.xml
@@ -1,6 +1,6 @@
 <resources>
-    <string name="kilometers">کیلومتر</string>
-    <string name="meters">متر</string>
-    <string name="miles">مایل</string>
-    <string name="feet">قدم</string>
+    <string name="mapbox_kilometers">کیلومتر</string>
+    <string name="mapbox_meters">متر</string>
+    <string name="mapbox_miles">مایل</string>
+    <string name="mapbox_feet">قدم</string>
 </resources>

--- a/libnavigation-util/src/main/res/values-fr/strings.xml
+++ b/libnavigation-util/src/main/res/values-fr/strings.xml
@@ -1,6 +1,6 @@
 <resources>
-    <string name="kilometers">km</string>
-    <string name="meters">m</string>
-    <string name="miles">mi</string>
-    <string name="feet">ft</string>
+    <string name="mapbox_kilometers">km</string>
+    <string name="mapbox_meters">m</string>
+    <string name="mapbox_miles">mi</string>
+    <string name="mapbox_feet">ft</string>
 </resources>

--- a/libnavigation-util/src/main/res/values-gl/strings.xml
+++ b/libnavigation-util/src/main/res/values-gl/strings.xml
@@ -1,6 +1,6 @@
 <resources>
-    <string name="kilometers">km</string>
-    <string name="meters">m</string>
-    <string name="miles">mi</string>
-    <string name="feet">pé</string>
+    <string name="mapbox_kilometers">km</string>
+    <string name="mapbox_meters">m</string>
+    <string name="mapbox_miles">mi</string>
+    <string name="mapbox_feet">pé</string>
 </resources>

--- a/libnavigation-util/src/main/res/values-he/strings.xml
+++ b/libnavigation-util/src/main/res/values-he/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="kilometers">ק״מ</string>
-    <string name="meters">מ׳</string>
-    <string name="miles">מייל</string>
+    <string name="mapbox_kilometers">ק״מ</string>
+    <string name="mapbox_meters">מ׳</string>
+    <string name="mapbox_miles">מייל</string>
     </resources>

--- a/libnavigation-util/src/main/res/values-hu/strings.xml
+++ b/libnavigation-util/src/main/res/values-hu/strings.xml
@@ -1,6 +1,6 @@
 <resources>
-    <string name="kilometers">km</string>
-    <string name="meters">m</string>
-    <string name="miles">mérföld</string>
-    <string name="feet">láb</string>
+    <string name="mapbox_kilometers">km</string>
+    <string name="mapbox_meters">m</string>
+    <string name="mapbox_miles">mérföld</string>
+    <string name="mapbox_feet">láb</string>
 </resources>

--- a/libnavigation-util/src/main/res/values-ja/strings.xml
+++ b/libnavigation-util/src/main/res/values-ja/strings.xml
@@ -1,6 +1,6 @@
 <resources>
-    <string name="kilometers">km</string>
-    <string name="meters">m</string>
-    <string name="miles">マイル</string>
-    <string name="feet">フィート</string>
+    <string name="mapbox_kilometers">km</string>
+    <string name="mapbox_meters">m</string>
+    <string name="mapbox_miles">マイル</string>
+    <string name="mapbox_feet">フィート</string>
 </resources>

--- a/libnavigation-util/src/main/res/values-ko/strings.xml
+++ b/libnavigation-util/src/main/res/values-ko/strings.xml
@@ -1,6 +1,6 @@
 <resources>
-    <string name="kilometers">km</string>
-    <string name="meters">m</string>
-    <string name="miles">mi</string>
-    <string name="feet">ft</string>
+    <string name="mapbox_kilometers">km</string>
+    <string name="mapbox_meters">m</string>
+    <string name="mapbox_miles">mi</string>
+    <string name="mapbox_feet">ft</string>
 </resources>

--- a/libnavigation-util/src/main/res/values-my/strings.xml
+++ b/libnavigation-util/src/main/res/values-my/strings.xml
@@ -1,6 +1,6 @@
 <resources>
-    <string name="kilometers">ကီလိုမီတာ</string>
-    <string name="meters">မီတာ</string>
-    <string name="miles">မိုင်</string>
-    <string name="feet">ပေ</string>
+    <string name="mapbox_kilometers">ကီလိုမီတာ</string>
+    <string name="mapbox_meters">မီတာ</string>
+    <string name="mapbox_miles">မိုင်</string>
+    <string name="mapbox_feet">ပေ</string>
 </resources>

--- a/libnavigation-util/src/main/res/values-pt-rBR/strings.xml
+++ b/libnavigation-util/src/main/res/values-pt-rBR/strings.xml
@@ -1,6 +1,6 @@
 <resources>
-    <string name="kilometers">KM</string>
-    <string name="meters">M</string>
-    <string name="miles">MI</string>
-    <string name="feet">FT</string>
+    <string name="mapbox_kilometers">KM</string>
+    <string name="mapbox_meters">M</string>
+    <string name="mapbox_miles">MI</string>
+    <string name="mapbox_feet">FT</string>
 </resources>

--- a/libnavigation-util/src/main/res/values-pt-rPT/strings.xml
+++ b/libnavigation-util/src/main/res/values-pt-rPT/strings.xml
@@ -1,6 +1,6 @@
 <resources>
-    <string name="kilometers">km</string>
-    <string name="meters">m</string>
-    <string name="miles">mi</string>
-    <string name="feet">ft</string>
+    <string name="mapbox_kilometers">km</string>
+    <string name="mapbox_meters">m</string>
+    <string name="mapbox_miles">mi</string>
+    <string name="mapbox_feet">ft</string>
 </resources>

--- a/libnavigation-util/src/main/res/values-ru/strings.xml
+++ b/libnavigation-util/src/main/res/values-ru/strings.xml
@@ -1,6 +1,6 @@
 <resources>
-    <string name="kilometers">км</string>
-    <string name="meters">м</string>
-    <string name="miles">миль</string>
-    <string name="feet">футов</string>
+    <string name="mapbox_kilometers">км</string>
+    <string name="mapbox_meters">м</string>
+    <string name="mapbox_miles">миль</string>
+    <string name="mapbox_feet">футов</string>
 </resources>

--- a/libnavigation-util/src/main/res/values-sv/strings.xml
+++ b/libnavigation-util/src/main/res/values-sv/strings.xml
@@ -1,6 +1,6 @@
 <resources>
-    <string name="kilometers">km</string>
-    <string name="meters">m</string>
-    <string name="miles">mi</string>
-    <string name="feet">fot</string>
+    <string name="mapbox_kilometers">km</string>
+    <string name="mapbox_meters">m</string>
+    <string name="mapbox_miles">mi</string>
+    <string name="mapbox_feet">fot</string>
 </resources>

--- a/libnavigation-util/src/main/res/values-uk/strings.xml
+++ b/libnavigation-util/src/main/res/values-uk/strings.xml
@@ -1,6 +1,6 @@
 <resources>
-    <string name="kilometers">км</string>
-    <string name="meters">м</string>
-    <string name="miles">mi</string>
-    <string name="feet">фт</string>
+    <string name="mapbox_kilometers">км</string>
+    <string name="mapbox_meters">м</string>
+    <string name="mapbox_miles">mi</string>
+    <string name="mapbox_feet">фт</string>
 </resources>

--- a/libnavigation-util/src/main/res/values-uz/strings.xml
+++ b/libnavigation-util/src/main/res/values-uz/strings.xml
@@ -1,6 +1,6 @@
 <resources>
-    <string name="kilometers">km</string>
-    <string name="meters">m</string>
-    <string name="miles">mil</string>
-    <string name="feet">fut</string>
+    <string name="mapbox_kilometers">km</string>
+    <string name="mapbox_meters">m</string>
+    <string name="mapbox_miles">mil</string>
+    <string name="mapbox_feet">fut</string>
 </resources>

--- a/libnavigation-util/src/main/res/values-vi/strings.xml
+++ b/libnavigation-util/src/main/res/values-vi/strings.xml
@@ -1,6 +1,6 @@
 <resources>
-    <string name="kilometers">km</string>
-    <string name="meters">m</string>
-    <string name="miles">dặm</string>
-    <string name="feet">foot</string>
+    <string name="mapbox_kilometers">km</string>
+    <string name="mapbox_meters">m</string>
+    <string name="mapbox_miles">dặm</string>
+    <string name="mapbox_feet">foot</string>
 </resources>

--- a/libnavigation-util/src/main/res/values-yo/strings.xml
+++ b/libnavigation-util/src/main/res/values-yo/strings.xml
@@ -1,6 +1,6 @@
 <resources>
-    <string name="kilometers">km</string>
-    <string name="meters">m</string>
-    <string name="miles">mi</string>
-    <string name="feet">ft</string>
+    <string name="mapbox_kilometers">km</string>
+    <string name="mapbox_meters">m</string>
+    <string name="mapbox_miles">mi</string>
+    <string name="mapbox_feet">ft</string>
 </resources>

--- a/libnavigation-util/src/main/res/values/strings.xml
+++ b/libnavigation-util/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <resources>
-    <string name="kilometers">km</string>
-    <string name="meters">m</string>
-    <string name="miles">mi</string>
-    <string name="feet">ft</string>
+    <string name="mapbox_kilometers">km</string>
+    <string name="mapbox_meters">m</string>
+    <string name="mapbox_miles">mi</string>
+    <string name="mapbox_feet">ft</string>
 </resources>

--- a/libtrip-notification/src/main/res/values-el/strings.xml
+++ b/libtrip-notification/src/main/res/values-el/strings.xml
@@ -1,10 +1,10 @@
 <resources>
     <!-- Notification Strings -->
     <string name="end_navigation">Τέλος πλοήγησης</string>
-    <string name="kilometers">χλμ</string>
-    <string name="meters">μ</string>
-    <string name="miles">μίλια</string>
-    <string name="feet">πόδια</string>
+    <string name="mapbox_kilometers">χλμ</string>
+    <string name="mapbox_meters">μ</string>
+    <string name="mapbox_miles">μίλια</string>
+    <string name="mapbox_feet">πόδια</string>
     <string name="eta_format">%s ETA</string>
 
     <!-- Time formatting -->

--- a/libtrip-notification/src/main/res/values-fr/strings.xml
+++ b/libtrip-notification/src/main/res/values-fr/strings.xml
@@ -1,10 +1,10 @@
 <resources>
     <!-- Notification Strings -->
     <string name="end_navigation">Fin de navigation</string>
-    <string name="kilometers">km</string>
-    <string name="meters">m</string>
-    <string name="miles">mi</string>
-    <string name="feet">ft</string>
+    <string name="mapbox_kilometers">km</string>
+    <string name="mapbox_meters">m</string>
+    <string name="mapbox_miles">mi</string>
+    <string name="mapbox_feet">ft</string>
     <!-- Time formatting -->
     <plurals name="numberOfDays">
         <item quantity="one">jour</item>


### PR DESCRIPTION
## Description

As described in #1793 some string resource names were conflicting with external developers by using common names like "miles". 

- [x] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal

Rename the appropriate string resource names to avoid conflicts.

### Implementation

The string resources were prepended with "mapbox_" in order to avoid future naming conflicts.

## Screenshots or Gifs


## Testing


- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->