### PR TITLE
Simplify example to work towards handling configuration changes

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/DebugMapboxNavigationKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/DebugMapboxNavigationKt.kt
@@ -109,21 +109,6 @@ class DebugMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
                 )
             }
         }
-        findViewById<Button>(R.id.btn_add_original_route)?.let { button ->
-            button.setOnClickListener {
-                originalRoute?.let {
-                    val routes = mapboxNavigation.getRoutes()
-                    if (routes.isNotEmpty()) {
-                        mapboxNavigation.setRoutes(mapboxNavigation.getRoutes().toMutableList().apply {
-                            removeAt(0)
-                            add(0, it)
-                        })
-                    } else {
-                        mapboxNavigation.setRoutes(listOf(it))
-                    }
-                }
-            }
-        }
         findViewById<Button>(R.id.btn_clear_routes)?.let { button ->
             button.setOnClickListener {
                 mapboxNavigation.setRoutes(emptyList())

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/SimpleMapboxNavigationKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/SimpleMapboxNavigationKt.kt
@@ -3,28 +3,18 @@ package com.mapbox.navigation.examples.core
 import android.annotation.SuppressLint
 import android.os.Bundle
 import android.os.CountDownTimer
-import android.os.Looper
 import android.preference.PreferenceManager
 import android.view.View
-import android.view.View.GONE
-import android.view.View.VISIBLE
 import android.widget.Button
-import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.bottomsheet.BottomSheetBehavior
-import com.google.android.material.snackbar.BaseTransientBottomBar.LENGTH_SHORT
-import com.google.android.material.snackbar.Snackbar
-import com.mapbox.android.core.location.LocationEngine
-import com.mapbox.android.core.location.LocationEngineCallback
-import com.mapbox.android.core.location.LocationEngineProvider
-import com.mapbox.android.core.location.LocationEngineRequest
-import com.mapbox.android.core.location.LocationEngineResult
 import com.mapbox.api.directions.v5.DirectionsCriteria
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.RouteOptions
 import com.mapbox.api.directions.v5.models.VoiceInstructions
 import com.mapbox.mapboxsdk.Mapbox
 import com.mapbox.mapboxsdk.annotations.IconFactory
+import com.mapbox.mapboxsdk.camera.CameraPosition
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory
 import com.mapbox.mapboxsdk.location.LocationComponent
 import com.mapbox.mapboxsdk.location.LocationComponentActivationOptions
@@ -41,19 +31,15 @@ import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesObserver
-import com.mapbox.navigation.core.directions.session.RoutesRequestCallback
 import com.mapbox.navigation.core.fasterroute.FasterRouteObserver
 import com.mapbox.navigation.core.replay.MapboxReplayer
 import com.mapbox.navigation.core.replay.ReplayLocationEngine
 import com.mapbox.navigation.core.replay.route.ReplayProgressObserver
 import com.mapbox.navigation.core.telemetry.events.FeedbackEvent
 import com.mapbox.navigation.core.trip.session.RouteProgressObserver
-import com.mapbox.navigation.core.trip.session.TripSessionState
-import com.mapbox.navigation.core.trip.session.TripSessionStateObserver
 import com.mapbox.navigation.core.trip.session.VoiceInstructionsObserver
 import com.mapbox.navigation.examples.R
 import com.mapbox.navigation.examples.utils.Utils
-import com.mapbox.navigation.examples.utils.Utils.PRIMARY_ROUTE_BUNDLE_KEY
 import com.mapbox.navigation.examples.utils.extensions.toPoint
 import com.mapbox.navigation.ui.camera.DynamicCamera
 import com.mapbox.navigation.ui.camera.NavigationCamera
@@ -62,13 +48,11 @@ import com.mapbox.navigation.ui.voice.NavigationSpeechPlayer
 import com.mapbox.navigation.ui.voice.SpeechPlayerProvider
 import com.mapbox.navigation.ui.voice.VoiceInstructionLoader
 import java.io.File
-import java.lang.ref.WeakReference
 import java.util.Date
 import java.util.Locale
 import kotlinx.android.synthetic.main.activity_trip_service.mapView
 import kotlinx.android.synthetic.main.bottom_sheet_faster_route.*
 import kotlinx.android.synthetic.main.content_simple_mapbox_navigation.*
-import kotlinx.coroutines.channels.Channel
 import okhttp3.Cache
 import timber.log.Timber
 
@@ -85,17 +69,13 @@ class SimpleMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
     private val startTimeInMillis = 5000L
     private val countdownInterval = 10L
     private val maxProgress = startTimeInMillis / countdownInterval
-    private val locationEngineCallback = MyLocationEngineCallback(this)
-    private val restartSessionEventChannel = Channel<RestartTripSessionAction>(1)
 
     private var mapboxMap: MapboxMap? = null
     private var locationComponent: LocationComponent? = null
     private var symbolManager: SymbolManager? = null
     private var fasterRoutes: List<DirectionsRoute> = emptyList()
-    private var originalRoute: DirectionsRoute? = null
 
     private lateinit var mapboxNavigation: MapboxNavigation
-    private lateinit var localLocationEngine: LocationEngine
     private lateinit var bottomSheetBehavior: BottomSheetBehavior<View>
     private lateinit var navigationMapboxMap: NavigationMapboxMap
     private lateinit var speechPlayer: NavigationSpeechPlayer
@@ -115,21 +95,6 @@ class SimpleMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
                 )
             }
         }
-        findViewById<Button>(R.id.btn_add_original_route)?.let { button ->
-            button.setOnClickListener {
-                originalRoute?.let {
-                    val routes = mapboxNavigation.getRoutes()
-                    when (routes.isNotEmpty()) {
-                        true -> mapboxNavigation.setRoutes(
-                            mapboxNavigation.getRoutes().toMutableList().apply {
-                                removeAt(0)
-                                add(0, it)
-                            })
-                        false -> mapboxNavigation.setRoutes(listOf(it))
-                    }
-                }
-            }
-        }
         findViewById<Button>(R.id.btn_clear_routes)?.let { button ->
             button.setOnClickListener {
                 mapboxNavigation.setRoutes(emptyList())
@@ -138,7 +103,6 @@ class SimpleMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
         initViews()
         mapView.onCreate(savedInstanceState)
         mapView.getMapAsync(this)
-        localLocationEngine = LocationEngineProvider.getBestLocationEngine(applicationContext)
 
         val mapboxNavigationOptions = MapboxNavigation
             .defaultNavigationOptionsBuilder(this, Utils.getMapboxAccessToken(this))
@@ -157,8 +121,7 @@ class SimpleMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
                         .coordinates(location.toPoint(), null, click.toPoint())
                         .alternatives(true)
                         .profile(DirectionsCriteria.PROFILE_DRIVING_TRAFFIC)
-                        .build(),
-                    routesReqCallback
+                        .build()
                 )
 
                 symbolManager?.deleteAll()
@@ -193,19 +156,6 @@ class SimpleMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
                     add(0, route)
                 })
             }
-
-            when (originalRoute) {
-                null -> {
-                    if (shouldSimulateRoute()) {
-                        mapboxNavigation.registerRouteProgressObserver(ReplayProgressObserver(mapboxReplayer))
-                        mapboxReplayer.pushRealLocation(this, 0.0)
-                        mapboxReplayer.play()
-                    }
-                    Snackbar.make(container, R.string.msg_long_press_map_to_place_waypoint, LENGTH_SHORT)
-                        .show()
-                }
-                else -> restoreNavigation()
-            }
         }
         initializeSpeechPlayer()
     }
@@ -225,13 +175,7 @@ class SimpleMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
         bottomSheetBehavior.peekHeight = 0
         fasterRouteAcceptProgress.max = maxProgress.toInt()
         startNavigation.setOnClickListener {
-            updateCameraOnNavigationStateChange(true)
             mapboxNavigation.registerVoiceInstructionsObserver(this)
-            mapboxNavigation.startTripSession()
-            val routes = mapboxNavigation.getRoutes()
-            if (routes.isNotEmpty()) {
-                initDynamicCamera(routes[0])
-            }
             navigationMapboxMap.showAlternativeRoutes(false)
         }
         dismissLayout.setOnClickListener {
@@ -245,29 +189,6 @@ class SimpleMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
         }
     }
 
-    private fun startLocationUpdates() {
-        val request = LocationEngineRequest.Builder(1000L)
-            .setFastestInterval(500L)
-            .setPriority(LocationEngineRequest.PRIORITY_HIGH_ACCURACY)
-            .build()
-        try {
-            localLocationEngine.requestLocationUpdates(
-                request,
-                locationEngineCallback,
-                Looper.getMainLooper()
-            )
-            if (originalRoute == null) {
-                localLocationEngine.getLastLocation(locationEngineCallback)
-            }
-        } catch (exception: SecurityException) {
-            Timber.e(exception)
-        }
-    }
-
-    private fun stopLocationUpdates() {
-        localLocationEngine.removeLocationUpdates(locationEngineCallback)
-    }
-
     private val routeProgressObserver = object : RouteProgressObserver {
         override fun onRouteProgressChanged(routeProgress: RouteProgress) {
             Timber.d("route progress %s", routeProgress.toString())
@@ -277,15 +198,24 @@ class SimpleMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
 
     private val routesObserver = object : RoutesObserver {
         override fun onRoutesChanged(routes: List<DirectionsRoute>) {
-            navigationMapboxMap.drawRoutes(routes)
             if (routes.isEmpty()) {
-                Toast.makeText(this@SimpleMapboxNavigationKt, "Empty routes", Toast.LENGTH_SHORT)
-                    .show()
+                navigationMapboxMap.resetCameraPositionWith(NavigationCamera.NAVIGATION_TRACKING_MODE_NONE)
+                navigationMapboxMap.updateLocationLayerRenderMode(RenderMode.COMPASS)
+                val cameraPosition = CameraPosition.Builder()
+                    .tilt(0.0)
+                    .padding(doubleArrayOf(0.0, 0.0, 0.0, 0.0))
+                    .bearing(0.0)
+                    .build()
+                mapboxMap?.easeCamera(CameraUpdateFactory.newCameraPosition(cameraPosition))
+                navigationMapboxMap.removeRoute()
+                symbolManager?.deleteAll()
             } else {
-                if (mapboxNavigation.getTripSessionState() == TripSessionState.STARTED) {
-                    initDynamicCamera(routes[0])
-                }
+                navigationMapboxMap.updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_GPS)
+                navigationMapboxMap.updateLocationLayerRenderMode(RenderMode.GPS)
+                navigationMapboxMap.startCamera(routes.first())
+                navigationMapboxMap.drawRoutes(routes)
             }
+
             Timber.d("route changed %s", routes.toString())
         }
     }
@@ -315,62 +245,6 @@ class SimpleMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
         }
     }
 
-    private val routesReqCallback = object : RoutesRequestCallback {
-        override fun onRoutesReady(routes: List<DirectionsRoute>) {
-            originalRoute = routes[0]
-            navigationMapboxMap.drawRoutes(routes)
-            Timber.d("route request success %s", routes.toString())
-        }
-
-        override fun onRoutesRequestFailure(throwable: Throwable, routeOptions: RouteOptions) {
-            symbolManager?.deleteAll()
-            Timber.e("route request failure %s", throwable.toString())
-        }
-
-        override fun onRoutesRequestCanceled(routeOptions: RouteOptions) {
-            symbolManager?.deleteAll()
-            Timber.d("route request canceled")
-        }
-    }
-
-    private val tripSessionStateObserver = object : TripSessionStateObserver {
-        override fun onSessionStateChanged(tripSessionState: TripSessionState) {
-            when (tripSessionState) {
-                TripSessionState.STARTED -> {
-                    stopLocationUpdates()
-                    startNavigation.visibility = GONE
-                }
-                TripSessionState.STOPPED -> {
-                    startLocationUpdates()
-                    startNavigation.visibility = VISIBLE
-                    updateCameraOnNavigationStateChange(false)
-                }
-            }
-        }
-    }
-
-    private fun updateCameraOnNavigationStateChange(
-        navigationStarted: Boolean
-    ) {
-        if (::navigationMapboxMap.isInitialized) {
-            navigationMapboxMap.apply {
-                if (navigationStarted) {
-                    updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_GPS)
-                    updateLocationLayerRenderMode(RenderMode.GPS)
-                } else {
-                    symbolManager?.deleteAll()
-                    removeRoute()
-                    updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_NONE)
-                    updateLocationLayerRenderMode(RenderMode.COMPASS)
-                }
-            }
-        }
-    }
-
-    private fun initDynamicCamera(route: DirectionsRoute) {
-        navigationMapboxMap.startCamera(route)
-    }
-
     public override fun onResume() {
         super.onResume()
         mapView.onResume()
@@ -386,14 +260,9 @@ class SimpleMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
         super.onStart()
         mapView.onStart()
 
-        restartSessionEventChannel.poll()?.also {
-            mapboxNavigation.registerVoiceInstructionsObserver(this)
-            mapboxNavigation.startTripSession()
-        }
-
+        mapboxNavigation.startTripSession()
         mapboxNavigation.registerRouteProgressObserver(routeProgressObserver)
         mapboxNavigation.registerRoutesObserver(routesObserver)
-        mapboxNavigation.registerTripSessionStateObserver(tripSessionStateObserver)
         mapboxNavigation.attachFasterRouteObserver(fasterRouteObserver)
     }
 
@@ -403,19 +272,9 @@ class SimpleMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
 
         mapboxNavigation.unregisterRouteProgressObserver(routeProgressObserver)
         mapboxNavigation.unregisterRoutesObserver(routesObserver)
-        mapboxNavigation.unregisterTripSessionStateObserver(tripSessionStateObserver)
         mapboxNavigation.detachFasterRouteObserver()
-        stopLocationUpdates()
-
-        if (mapboxNavigation.getRoutes()
-                .isEmpty() && mapboxNavigation.getTripSessionState() == TripSessionState.STARTED
-        ) {
-            // use this to kill the service and hide the notification when going into the background in the Free Drive state,
-            // but also ensure to restart Free Drive when coming back from background by using the channel
-            mapboxNavigation.unregisterVoiceInstructionsObserver(this)
-            mapboxNavigation.stopTripSession()
-            restartSessionEventChannel.offer(RestartTripSessionAction)
-        }
+        mapboxNavigation.unregisterVoiceInstructionsObserver(this)
+        mapboxNavigation.stopTripSession()
     }
 
     override fun onLowMemory() {
@@ -428,11 +287,7 @@ class SimpleMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
         mapView.onDestroy()
 
         mapboxReplayer.finish()
-        mapboxNavigation.unregisterVoiceInstructionsObserver(this)
-        mapboxNavigation.stopTripSession()
         mapboxNavigation.onDestroy()
-
-        restartSessionEventChannel.cancel()
 
         speechPlayer.onDestroy()
     }
@@ -440,50 +295,19 @@ class SimpleMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
         mapView.onSaveInstanceState(outState)
-
-        // This is not the most efficient way to preserve the route on a device rotation.
-        // This is here to demonstrate that this event needs to be handled in order to
-        // redraw the route line after a rotation.
-        originalRoute?.let {
-            outState.putString(PRIMARY_ROUTE_BUNDLE_KEY, it.toJson())
-        }
-    }
-
-    override fun onRestoreInstanceState(savedInstanceState: Bundle?) {
-        super.onRestoreInstanceState(savedInstanceState)
-        originalRoute = Utils.getRouteFromBundle(savedInstanceState)
     }
 
     override fun onNewVoiceInstructions(voiceInstructions: VoiceInstructions) {
         speechPlayer.play(voiceInstructions)
     }
 
-    private class MyLocationEngineCallback(activity: SimpleMapboxNavigationKt) :
-        LocationEngineCallback<LocationEngineResult> {
-
-        private val activityRef = WeakReference(activity)
-
-        override fun onSuccess(result: LocationEngineResult?) {
-            result?.locations?.firstOrNull()?.let {
-                activityRef.get()?.locationComponent?.forceLocationUpdate(it)
-            }
-        }
-
-        override fun onFailure(exception: Exception) {
-        }
-    }
-
-    private object RestartTripSessionAction
-
     private fun getMapboxNavigation(optionsBuilder: NavigationOptions.Builder): MapboxNavigation {
         return if (shouldSimulateRoute()) {
             optionsBuilder.locationEngine(ReplayLocationEngine(mapboxReplayer))
             MapboxNavigation(optionsBuilder.build()).apply {
                 registerRouteProgressObserver(ReplayProgressObserver(mapboxReplayer))
-                if (originalRoute == null) {
-                    mapboxReplayer.pushRealLocation(applicationContext, 0.0)
-                    mapboxReplayer.play()
-                }
+                mapboxReplayer.pushRealLocation(applicationContext, 0.0)
+                mapboxReplayer.play()
             }
         } else {
             MapboxNavigation(optionsBuilder.build())
@@ -493,16 +317,5 @@ class SimpleMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
     private fun shouldSimulateRoute(): Boolean {
         return PreferenceManager.getDefaultSharedPreferences(this.applicationContext)
             .getBoolean(this.getString(R.string.simulate_route_key), false)
-    }
-
-    @SuppressLint("MissingPermission")
-    private fun restoreNavigation() {
-        originalRoute?.let {
-            mapboxNavigation.setRoutes(listOf(it))
-            navigationMapboxMap.addProgressChangeListener(mapboxNavigation)
-            navigationMapboxMap.startCamera(mapboxNavigation.getRoutes()[0])
-            updateCameraOnNavigationStateChange(true)
-            mapboxNavigation.startTripSession()
-        }
     }
 }

--- a/examples/src/main/res/layout/content_simple_mapbox_navigation.xml
+++ b/examples/src/main/res/layout/content_simple_mapbox_navigation.xml
@@ -31,20 +31,9 @@
         android:layout_height="wrap_content"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintBottom_toTopOf="@id/btn_add_original_route"
-        android:background="@color/colorPrimary"
-        android:text="@string/simple_mapbox_navigation_clear_routes"
-        android:textColor="@android:color/white"/>
-
-    <androidx.appcompat.widget.AppCompatButton
-        android:id="@+id/btn_add_original_route"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintBottom_toTopOf="@id/startNavigation"
         android:background="@color/colorPrimary"
-        android:text="@string/simple_mapbox_navigation_add_original_route"
+        android:text="@string/simple_mapbox_navigation_clear_routes"
         android:textColor="@android:color/white"/>
 
     <androidx.appcompat.widget.AppCompatButton

--- a/examples/src/main/res/values/strings.xml
+++ b/examples/src/main/res/values/strings.xml
@@ -121,7 +121,6 @@
     <string name="general_category_title" translatable="false">General</string>
     <string name="send_user_feedback" translatable="false">Send User Feedback</string>
     <string name="simple_mapbox_navigation_clear_routes" translatable="false">CLEAR ROUTES</string>
-    <string name="simple_mapbox_navigation_add_original_route" translatable="false">ADD ORIGINAL ROUTE</string>
     <string name="history_failed_to_load_item" translatable="false">History failed to load item</string>
     <string name="history_failed_to_load_list" translatable="false">Failed to load list</string>
     <string name="history_local_history_file" translatable="false">Local history file</string>


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Addresses: https://github.com/mapbox/navigation-sdks/issues/402

Trying to simplify example's state so that they can handle configuration changes. This issue is related to https://github.com/mapbox/mapbox-navigation-android/issues/3275. If we can create views on top of core that only respond to core state, we'll be able to handle configuration changes.

This change would make it so the SimpleMapboxNavigationKt will start free drive immediately. Once there is a route, it starts active guidance. To stop active guidance, you can remove the route. 

Note that this is not fixing configuration changes - that still doesn't work.

- [ ] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

## Screenshots

![output](https://user-images.githubusercontent.com/3021882/87610862-5fffb900-c6bb-11ea-8008-24931b0aa44e.gif)


## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->