### PR TITLE
Bump Maps SDK to v9.3.1

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -7,7 +7,7 @@ ext {
   ]
 
   version = [
-      mapboxMapSdk              : '9.3.0-beta.1',
+      mapboxMapSdk              : '9.3.1',
       mapboxSdkServices         : '5.3.0',
       mapboxEvents              : '6.0.0',
       mapboxCore                : '3.0.0',

--- a/libnavigation-ui/build.gradle
+++ b/libnavigation-ui/build.gradle
@@ -73,9 +73,6 @@ dependencies {
 
   // Mapbox Maps SDK
   api dependenciesList.mapboxMapSdk
-  // regression fix until it's included in the Maps SDK platform release
-  // remove with the next release
-  implementation "com.mapbox.mapboxsdk:mapbox-android-sdk-gl-core:1.8.2"
 
   implementation dependenciesList.mapboxAnnotationPlugin
 


### PR DESCRIPTION
Upgrades the Maps SDK to stable `v9.3.0`.