### PR TITLE
Use SDK Registry for stable artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,14 +112,6 @@ navigation-fixtures:
 1.0-core-unit-tests:
 	$(call run-gradle-tasks,$(CORE_MODULES),test)
 
-.PHONY: 1.0-core-publish-to-bintray
-1.0-core-publish-to-bintray:
-	$(call run-gradle-tasks,$(CORE_MODULES),bintrayUpload)
-
-.PHONY: 1.0-core-publish-to-artifactory
-1.0-core-publish-to-artifactory:
-	$(call run-gradle-tasks,$(CORE_MODULES),artifactoryPublish)
-
 .PHONY: 1.0-core-publish-to-sdk-registry
 1.0-core-publish-to-sdk-registry:
 	$(call run-gradle-tasks,$(CORE_MODULES),mapboxSDKRegistryUpload)
@@ -163,14 +155,6 @@ navigation-fixtures:
 .PHONY: 1.0-ui-unit-tests
 1.0-ui-unit-tests:
 	$(call run-gradle-tasks,$(UI_MODULES),test)
-
-.PHONY: 1.0-ui-publish-to-bintray
-1.0-ui-publish-to-bintray:
-	$(call run-gradle-tasks,$(UI_MODULES),bintrayUpload)
-
-.PHONY: 1.0-ui-publish-to-artifactory
-1.0-ui-publish-to-artifactory:
-	$(call run-gradle-tasks,$(UI_MODULES),artifactoryPublish)
 
 .PHONY: 1.0-ui-publish-to-sdk-registry
 1.0-ui-publish-to-sdk-registry:

--- a/README.md
+++ b/README.md
@@ -39,7 +39,26 @@ You can use a `-SNAPSHOT` release if you want to test recent bug fixes or featur
 
 ##### `1.0.0`+ versions of the Navigation SDK:
 
-SNAPSHOTs are currently unavailable, but the Mapbox team is working on setting up an infrastructure to provide them to you. Thank you for your patience.
+To access SNAPSHOT builds follow the [installation instructions](https://docs.mapbox.com/android/beta/navigation/overview/#installation) but replace the repository url and the version name:
+```groovy
+allprojects {
+   repositories {
+     maven {
+       url 'https://api.mapbox.com/downloads/v2/snapshots/maven'
+       authentication {
+         basic(BasicAuthentication)
+       }
+       credentials {
+         username = "mapbox"
+         password = "{secret Mapbox token with DOWNLOADS:READ scope}"
+       }
+     }
+   }
+}
+
+dependencies {
+   implementation 'com.mapbox.navigation:ui-v1:1.0.0-SNAPSHOT'
+}
 
 ##### Pre-`1.0.0` versions of the Navigation SDK:
 

--- a/build.gradle
+++ b/build.gradle
@@ -29,8 +29,6 @@ buildscript {
     classpath pluginDependencies.firebaseCrashlytics
     classpath pluginDependencies.license
     classpath pluginDependencies.mapboxSdkVersions
-    classpath pluginDependencies.bintray
-    classpath pluginDependencies.artifactory
     classpath pluginDependencies.dokka
     classpath pluginDependencies.mapbox
   }
@@ -57,6 +55,17 @@ allprojects {
         password = project.hasProperty('SDK_REGISTRY_TOKEN') ? project.property('SDK_REGISTRY_TOKEN') : System.getenv('SDK_REGISTRY_TOKEN')
       }
     }
+    // uncomment if snapshots access is needed
+    /*maven {
+      url 'https://api.mapbox.com/downloads/v2/snapshots/maven'
+      authentication {
+        basic(BasicAuthentication)
+      }
+      credentials {
+        username = "mapbox"
+        password = project.hasProperty('SDK_REGISTRY_TOKEN') ? project.property('SDK_REGISTRY_TOKEN') : System.getenv('SDK_REGISTRY_TOKEN')
+      }
+    }*/
     maven {
       url 'https://mapbox.bintray.com/mapbox_internal'
       credentials {
@@ -79,7 +88,8 @@ allprojects {
       }
     }
     maven { url 'https://mapbox.bintray.com/mapbox' }
-    maven { url 'https://oss.jfrog.org/artifactory/oss-snapshot-local/' }
+    // uncomment if snapshots access is needed
+    // maven { url 'https://oss.jfrog.org/artifactory/oss-snapshot-local/' }
   }
 }
 

--- a/circle.yml
+++ b/circle.yml
@@ -37,31 +37,6 @@ workflows:
               only: /^release_ui_.*_core_.*/
             branches:
               ignore: /.*/
-      - release-core-1_0-qa:
-          filters:
-            tags:
-              only: /^qa_release_core_.*/
-            branches:
-              ignore: /.*/
-      - release-ui-1_0-qa:
-          filters:
-            tags:
-              only: /^qa_release_ui_.*_core_.*/
-            branches:
-              ignore: /.*/
-      - release-core-1_0-prod:
-          filters:
-            tags:
-              only: /^prod_release_core_.*/
-            branches:
-              ignore: /.*/
-
-      - release-ui-1_0-prod:
-          filters:
-            tags:
-              only: /^prod_release_ui_.*_core_.*/
-            branches:
-              ignore: /.*/
       - ui-tests-1_0
       - publish:
           filters:
@@ -365,17 +340,14 @@ commands:
 
   publish-artifacts:
     parameters:
-      repository:
-        description: artifactory, bintray or sdk-registry
-        type: string
       artifact-type:
         description: core or ui
         type: string
     steps:
       - deploy:
-          name: Publish Navigation SDK 1.0 to << parameters.repository >>
+          name: Publish Navigation SDK 1.0 to SDK Registry
           command: |
-            make 1.0-<< parameters.artifact-type >>-publish-to-<< parameters.repository >>
+            make 1.0-<< parameters.artifact-type >>-publish-to-sdk-registry
 
   check-public-documentation:
     steps:
@@ -568,7 +540,6 @@ jobs:
       - check-public-documentation
       - generate-documentation
       - publish-artifacts:
-          repository: "sdk-registry"
           artifact-type: "core"
       - track-performance
 
@@ -576,8 +547,6 @@ jobs:
     working_directory: ~/code
     docker:
       - image: << pipeline.parameters.docker-image-tag >>
-    environment:
-      BINTRAY_REPO: mapbox_private
     steps:
       - generate-core-version-name
       - checkout
@@ -585,39 +554,6 @@ jobs:
       - check-public-documentation
       - generate-documentation
       - publish-artifacts:
-          repository: "bintray"
-          artifact-type: "core"
-
-  release-core-1_0-qa:
-    working_directory: ~/code
-    docker:
-      - image: << pipeline.parameters.docker-image-tag >>
-    environment:
-      BINTRAY_REPO: mapbox_internal
-    steps:
-      - generate-core-version-name
-      - checkout
-      - build-release-core-1_0
-      - check-public-documentation
-      - generate-documentation
-      - publish-artifacts:
-          repository: "bintray"
-          artifact-type: "core"
-
-  release-core-1_0-prod:
-    working_directory: ~/code
-    docker:
-      - image: << pipeline.parameters.docker-image-tag >>
-    environment:
-      BINTRAY_REPO: mapbox_collab
-    steps:
-      - generate-core-version-name
-      - checkout
-      - build-release-core-1_0
-      - check-public-documentation
-      - generate-documentation
-      - publish-artifacts:
-          repository: "bintray"
           artifact-type: "core"
 
   release-ui-1_0-snapshot:
@@ -630,7 +566,6 @@ jobs:
       - check-public-documentation
       - generate-documentation
       - publish-artifacts:
-          repository: "sdk-registry"
           artifact-type: "ui"
       - track-performance
 
@@ -638,8 +573,6 @@ jobs:
     working_directory: ~/code
     docker:
       - image: << pipeline.parameters.docker-image-tag >>
-    environment:
-      BINTRAY_REPO: mapbox_private
     steps:
       - generate-ui-version-name
       - checkout
@@ -647,39 +580,6 @@ jobs:
       - check-public-documentation
       - generate-documentation
       - publish-artifacts:
-          repository: "bintray"
-          artifact-type: "ui"
-
-  release-ui-1_0-qa:
-    working_directory: ~/code
-    docker:
-      - image: << pipeline.parameters.docker-image-tag >>
-    environment:
-      BINTRAY_REPO: mapbox_internal
-    steps:
-      - generate-ui-version-name
-      - checkout
-      - build-release-ui-1_0
-      - check-public-documentation
-      - generate-documentation
-      - publish-artifacts:
-          repository: "bintray"
-          artifact-type: "ui"
-
-  release-ui-1_0-prod:
-    working_directory: ~/code
-    docker:
-      - image: << pipeline.parameters.docker-image-tag >>
-    environment:
-      BINTRAY_REPO: mapbox_collab
-    steps:
-      - generate-ui-version-name
-      - checkout
-      - build-release-ui-1_0
-      - check-public-documentation
-      - generate-documentation
-      - publish-artifacts:
-          repository: "bintray"
           artifact-type: "ui"
 # ------------------------------------------------------------------------------
   publish:

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,0 +1,70 @@
+### Artifact distribution
+This project uses SDK Registry to distribute the binaries.
+
+1. Push an artifact:
+- Cut and push a new tag. It will publish a new artifact to `https://api.mapbox.com/downloads/v2/releases/maven`. The tag has to match the following pattern:
+  - `/^release_core_.{VERSION_CORE}/` for Navigation Core SDK
+  - `/^release_ui_.{VERSION_UI}_core_.{VERSION_CORE}/` for Navigation UI SDK
+- Each merge to `master` pushes new snapshots to `https://api.mapbox.com/downloads/v2/snapshots/maven`. To build a snapshot from a custom branch, modify the `branches` filter of the `release-*-snapshot` CI job.
+
+2. (**only for stable artifacts, skip for snapshots**) Go to https://github.com/mapbox/api-downloads and create a new PR that adds/modifies a `config/mobile-navigation-{artifact}}/{VERSION}.yaml` file. The file should contain this Android entry (next to anything that might be present for iOS):
+```yaml
+api-downloads: v2
+
+android:
+  group: navigation
+
+packages:
+  android:
+    - {artifactId}
+
+bundles:
+  android: {artifactId}-all
+```
+
+For example, the version 1.0.0 of the `core` artifact would need a `config/mobile-navigation-core/1.0.0.yaml`:
+```yaml
+api-downloads: v2
+
+android:
+  group: navigation
+
+packages:
+  android:
+    - core
+
+bundles:
+  android: core-all
+```
+
+This procedure has to be repeated for all Core and UI artifacts.
+
+After a PR is merged, an artifact will be resolvable.
+
+You can read more about the publishing process at https://platform.mapbox.com/managed-infrastructure/sdk-registry/reference/#configure-the-sdk-registry.
+
+### Consuming a stable artifact using Gradle
+```groovy
+allprojects {
+   repositories {
+     maven {
+       url 'https://api.mapbox.com/downloads/v2/releases/maven'
+       authentication {
+         basic(BasicAuthentication)
+       }
+       credentials {
+         username = "mapbox"
+         password = "{secret Mapbox token with DOWNLOADS:READ scope}"
+       }
+     }
+   }
+}
+
+dependencies {
+   implementation 'com.mapbox.navigation:core:VERSION'
+   implementation 'com.mapbox.navigation:ui-v1:VERSION'
+}
+```
+
+### Consuming a snapshot artifact using Gradle
+Similarly as above with a difference that the repository URL should be `https://api.mapbox.com/downloads/v2/snapshots/maven`.

--- a/gradle/artifact-settings.gradle
+++ b/gradle/artifact-settings.gradle
@@ -17,10 +17,4 @@ ext {
     else if ( releaseSdk == 'ui' ) {
         versionName = System.getenv('POM_UI_VERSION_NAME') ?: project.property('POM_UI_SNAPSHOT_VERSION_NAME')
     }
-
-    mapboxBintrayUserOrg = 'mapbox'
-    mapboxBintrayRepoName = System.getenv('BINTRAY_REPO') ?: 'mapbox_internal'
-    mapboxBintrayUser = project.hasProperty('BINTRAY_USER') ? project.property('BINTRAY_USER') : System.getenv('BINTRAY_USER')
-    mapboxBintrayApiKey = project.hasProperty('BINTRAY_API_KEY') ? project.property('BINTRAY_API_KEY') : System.getenv('BINTRAY_API_KEY')
-    mapboxGpgPassphrase = project.hasProperty('GPG_PASSPHRASE') ? project.property('GPG_PASSPHRASE') : System.getenv('GPG_PASSPHRASE')
 }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -173,8 +173,6 @@ ext {
       googleServices     : '4.3.3',
       firebaseCrashlytics: '2.2.0',
       mapboxSdkVersions  : '1.0.0',
-      bintray            : '1.8.4',
-      artifactory        : '4.9.3',
       dokka              : '0.10.1',
       mapbox             : '0.2.1'
   ]
@@ -194,8 +192,6 @@ ext {
       googleServices     : "com.google.gms:google-services:${pluginVersion.googleServices}",
       firebaseCrashlytics: "com.google.firebase:firebase-crashlytics-gradle:${pluginVersion.firebaseCrashlytics}",
       mapboxSdkVersions  : "com.mapbox.mapboxsdk:mapbox-android-sdk-versions:${pluginVersion.mapboxSdkVersions}",
-      bintray            : "com.jfrog.bintray.gradle:gradle-bintray-plugin:${pluginVersion.bintray}",
-      artifactory        : "org.jfrog.buildinfo:build-info-extractor-gradle:${pluginVersion.artifactory}",
       dokka              : "org.jetbrains.dokka:dokka-gradle-plugin:${pluginVersion.dokka}",
       mapbox             : "com.mapbox.gradle:plugins:${pluginVersion.mapbox}"
   ]

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -1,6 +1,4 @@
 apply plugin: 'maven-publish'
-apply plugin: 'com.jfrog.bintray'
-apply plugin: 'com.jfrog.artifactory'
 apply plugin: 'com.mapbox.sdkRegistry'
 apply from: file("${rootDir}/gradle/artifact-settings.gradle")
 
@@ -50,46 +48,6 @@ afterEvaluate {
     }
 }
 
-bintray {
-    user = mapboxBintrayUser
-    key = mapboxBintrayApiKey
-    publications('release')
-    pkg {
-        repo = project.ext.mapboxBintrayRepoName
-        name = mapboxArtifactGroupId + ":" + project.ext.mapboxArtifactId
-        userOrg = project.ext.mapboxBintrayUserOrg
-        licenses = [project.ext.mapboxArtifactLicenseName]
-        vcsUrl = project.ext.mapboxArtifactVcsUrl
-        publish = false
-        version {
-            name = project.ext.versionName
-            desc = project.ext.mapboxArtifactDescription
-            released = new Date()
-            gpg {
-                sign = true
-                passphrase = mapboxGpgPassphrase
-            }
-            mavenCentralSync {
-                sync = false
-            }
-        }
-    }
-}
-
-artifactory {
-    contextUrl = 'http://oss.jfrog.org'
-    publish {
-        repository {
-            repoKey = 'oss-snapshot-local'
-            username = mapboxBintrayUser
-            password = mapboxBintrayApiKey
-        }
-        defaults {
-            publications('release')
-        }
-    }
-}
-
 def sdkNameMap = [:]
 sdkNameMap["libnavigation-base"] = "mobile-navigation-base"
 sdkNameMap["libnavigation-core"] = "mobile-navigation-core"
@@ -106,7 +64,7 @@ registry {
     sdkName = sdkNameMap[project.name]
     production = true
     snapshot = project.ext.versionName.endsWith("-SNAPSHOT")
-    override = true
+    override = snapshot ? true : false
     dryRun = false
     publications = ["release"]
 }


### PR DESCRIPTION
This PR removes the Bintray configuration and fully switches the distribution of the artifacts to the SDK Registry. Please read `publishing.md` for all of the information.

Currently, we need to manually open a PR for each artifact that is released, we should be able to automate this process in the future by automatically cutting a PR.