### PR TITLE
Refactor InstructionView landscape UX to move the stepDistanceText to the right of ManeuverIcon

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/instruction/InstructionView.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/instruction/InstructionView.java
@@ -629,8 +629,7 @@ public class InstructionView extends RelativeLayout implements LifecycleObserver
     instructionLayoutText.setBackgroundColor(primaryBackgroundColor);
 
     View instructionLayoutManeuver = findViewById(R.id.instructionManeuverLayout);
-    Drawable maneuverBackground = DrawableCompat.wrap(instructionLayoutManeuver.getBackground()).mutate();
-    DrawableCompat.setTint(maneuverBackground, primaryBackgroundColor);
+    instructionLayoutManeuver.setBackgroundColor(primaryBackgroundColor);
 
     Drawable subStepBackground = DrawableCompat.wrap(subStepLayout.getBackground()).mutate();
     DrawableCompat.setTint(subStepBackground, listViewBackgroundColor);
@@ -1070,7 +1069,8 @@ public class InstructionView extends RelativeLayout implements LifecycleObserver
   private void updateLandscapeConstraintsTo(int layoutRes) {
     final int feedbackButtonVisibility = feedbackButton.getVisibility();
     final int soundButtonVisibility = feedbackButton.getVisibility();
-    final int subInstructionLayoutVisitbility = subStepLayout.getVisibility();
+    final int subInstructionLayoutVisibility = subStepLayout.getVisibility();
+    final int turnLaneLayoutVisibility = turnLaneLayout.getVisibility();
 
     ConstraintSet collapsed = new ConstraintSet();
     collapsed.clone(getContext(), layoutRes);
@@ -1078,7 +1078,8 @@ public class InstructionView extends RelativeLayout implements LifecycleObserver
 
     feedbackButton.setVisibility(feedbackButtonVisibility);
     soundButton.setVisibility(soundButtonVisibility);
-    subStepLayout.setVisibility(subInstructionLayoutVisitbility);
+    subStepLayout.setVisibility(subInstructionLayoutVisibility);
+    turnLaneLayout.setVisibility(turnLaneLayoutVisibility);
   }
 
   /**

--- a/libnavigation-ui/src/main/res/drawable/instruction_background.xml
+++ b/libnavigation-ui/src/main/res/drawable/instruction_background.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-       android:shape="rectangle">
-
-    <corners android:bottomRightRadius="4dp"/>
-
-</shape>

--- a/libnavigation-ui/src/main/res/drawable/sub_banner_background.xml
+++ b/libnavigation-ui/src/main/res/drawable/sub_banner_background.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
-       android:shape="rectangle">
+    android:shape="rectangle">
 
-    <corners
-        android:bottomLeftRadius="4dp"
-        android:bottomRightRadius="4dp"/>
+    <corners android:bottomRightRadius="4dp" />
 
 </shape>

--- a/libnavigation-ui/src/main/res/layout-land/instruction_content_layout.xml
+++ b/libnavigation-ui/src/main/res/layout-land/instruction_content_layout.xml
@@ -11,13 +11,15 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_begin="88dp" />
+        app:layout_constraintGuide_begin="@dimen/instruction_layout_width" />
 
     <LinearLayout
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:gravity="center_horizontal"
-        android:orientation="vertical"
+        android:layout_marginBottom="4dp"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:padding="8dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/guideline"
         app:layout_constraintStart_toStartOf="parent"
@@ -31,13 +33,14 @@
 
         <TextView
             android:id="@+id/stepDistanceText"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:gravity="center"
+            android:layout_margin="4dp"
+            android:gravity="start"
             android:includeFontPadding="false"
             android:maxLines="1"
             android:textSize="20sp"
-            tools:text="302 mi" />
+            tools:text="3.2 mi" />
 
     </LinearLayout>
 

--- a/libnavigation-ui/src/main/res/layout-land/instruction_layout.xml
+++ b/libnavigation-ui/src/main/res/layout-land/instruction_layout.xml
@@ -9,49 +9,36 @@
     app:layout_constraintTop_toTopOf="parent"
     tools:showIn="@layout/instruction_view_layout">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <LinearLayout
         android:id="@+id/instructionManeuverLayout"
-        android:layout_width="88dp"
-        android:layout_height="104dp"
+        android:layout_width="@dimen/instruction_layout_width"
+        android:layout_height="@dimen/instruction_layout_height"
         android:layout_marginBottom="4dp"
-        android:background="@drawable/instruction_background"
         android:elevation="4dp"
-        android:gravity="center"
-        android:orientation="vertical"
+        android:foreground="?attr/selectableItemBackground"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
         android:padding="8dp"
-        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.0">
+        app:layout_constraintTop_toTopOf="parent">
 
         <com.mapbox.navigation.ui.instruction.maneuver.ManeuverView
             android:id="@+id/maneuverView"
             android:layout_width="40dp"
             android:layout_height="40dp"
-            android:layout_margin="8dp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            android:layout_margin="8dp" />
 
         <TextView
             android:id="@+id/stepDistanceText"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:layout_marginStart="4dp"
-            android:layout_marginTop="4dp"
-            android:layout_marginEnd="4dp"
-            android:layout_marginBottom="4dp"
-            android:gravity="center"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="4dp"
+            android:gravity="start"
             android:includeFontPadding="false"
             android:maxLines="1"
             android:textSize="20sp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/maneuverView"
             tools:text="3.2 mi" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
+    </LinearLayout>
 
     <LinearLayout
         android:id="@+id/instructionLayoutText"
@@ -60,7 +47,6 @@
         android:elevation="4dp"
         android:foreground="?attr/selectableItemBackground"
         android:gravity="center_vertical"
-        android:padding="8dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/instructionManeuverLayout"
         app:layout_constraintTop_toTopOf="parent">
@@ -95,27 +81,25 @@
         android:id="@+id/turnLaneLayout"
         layout="@layout/turn_lane_layout"
         android:layout_width="wrap_content"
-        android:layout_height="0dp"
+        android:layout_height="@dimen/instruction_sub_layout_height"
         android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="@+id/instructionManeuverLayout"
         app:layout_constraintEnd_toStartOf="@+id/soundLayout"
         app:layout_constraintHorizontal_bias="0.0"
-        app:layout_constraintStart_toEndOf="@+id/instructionManeuverLayout"
-        app:layout_constraintTop_toBottomOf="@+id/instructionLayoutText" />
+        app:layout_constraintStart_toStartOf="@+id/instructionManeuverLayout"
+        app:layout_constraintTop_toBottomOf="@+id/instructionManeuverLayout" />
 
     <include
         android:id="@+id/subStepLayout"
         layout="@layout/sub_instruction_layout"
         android:layout_width="wrap_content"
-        android:layout_height="0dp"
+        android:layout_height="@dimen/instruction_sub_layout_height"
         android:layout_marginEnd="8dp"
         android:layout_marginRight="8dp"
         android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="@+id/instructionManeuverLayout"
         app:layout_constraintEnd_toStartOf="@+id/soundLayout"
         app:layout_constraintHorizontal_bias="0.0"
-        app:layout_constraintStart_toEndOf="@+id/instructionManeuverLayout"
-        app:layout_constraintTop_toBottomOf="@+id/instructionLayoutText" />
+        app:layout_constraintStart_toStartOf="@+id/instructionManeuverLayout"
+        app:layout_constraintTop_toBottomOf="@+id/instructionManeuverLayout" />
 
     <ImageView
         android:id="@+id/guidanceImageView"

--- a/libnavigation-ui/src/main/res/layout-land/instruction_layout_alt.xml
+++ b/libnavigation-ui/src/main/res/layout-land/instruction_layout_alt.xml
@@ -12,18 +12,15 @@
 
     <LinearLayout
         android:id="@+id/instructionManeuverLayout"
-        android:layout_width="88dp"
-        android:layout_height="104dp"
-        android:layout_marginBottom="8dp"
-        android:background="@drawable/instruction_background"
+        android:layout_width="@dimen/instruction_layout_width"
+        android:layout_height="@dimen/instruction_layout_height"
+        android:layout_marginBottom="4dp"
         android:elevation="4dp"
         android:foreground="?attr/selectableItemBackground"
-        android:gravity="center"
-        android:orientation="vertical"
-        app:layout_constraintBottom_toBottomOf="parent"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.0">
+        app:layout_constraintTop_toTopOf="parent">
 
         <com.mapbox.navigation.ui.instruction.maneuver.ManeuverView
             android:id="@+id/maneuverView"
@@ -33,24 +30,24 @@
 
         <TextView
             android:id="@+id/stepDistanceText"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_margin="4dp"
+            android:gravity="start"
             android:includeFontPadding="false"
             android:maxLines="1"
             android:textSize="20sp"
             tools:text="3.2 mi" />
-
     </LinearLayout>
 
     <LinearLayout
         android:id="@+id/instructionLayoutText"
         android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:layout_marginBottom="8dp"
+        android:layout_height="@dimen/instruction_layout_height"
         android:elevation="4dp"
         android:foreground="?attr/selectableItemBackground"
         android:gravity="center_vertical"
-        app:layout_constraintBottom_toBottomOf="@+id/instructionManeuverLayout"
+        android:padding="8dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/instructionManeuverLayout"
         app:layout_constraintTop_toTopOf="parent">
@@ -82,33 +79,15 @@
     </LinearLayout>
 
     <include
-        android:id="@+id/turnLaneLayout"
-        layout="@layout/turn_lane_layout"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:visibility="invisible"
-        app:layout_constraintStart_toEndOf="@+id/instructionManeuverLayout"
-        app:layout_constraintTop_toBottomOf="@+id/instructionLayoutText" />
-
-    <include
         android:id="@+id/instructionListLayout"
         layout="@layout/instruction_list_layout"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:layout_marginTop="90dp"
         android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/rerouteLayout" />
-
-    <include
-        android:id="@+id/soundLayout"
-        layout="@layout/sound_layout"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/instructionLayoutText" />
+        app:layout_constraintTop_toBottomOf="@id/instructionManeuverLayout" />
 
     <LinearLayout
         android:id="@+id/rerouteLayout"

--- a/libnavigation-ui/src/main/res/layout-land/instruction_viewholder_layout.xml
+++ b/libnavigation-ui/src/main/res/layout-land/instruction_viewholder_layout.xml
@@ -10,10 +10,6 @@
         layout="@layout/instruction_content_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        android:layout_marginEnd="8dp"
-        android:layout_marginBottom="8dp"
         app:layout_constraintBottom_toTopOf="@+id/view"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -24,7 +20,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_begin="96dp" />
+        app:layout_constraintGuide_begin="@dimen/instruction_layout_width" />
 
     <View
         android:id="@+id/view"

--- a/libnavigation-ui/src/main/res/values/dimens.xml
+++ b/libnavigation-ui/src/main/res/values/dimens.xml
@@ -21,6 +21,8 @@
     <dimen name="mapbox_feedback_report_button_height">110dp</dimen>
 
     <dimen name="instruction_layout_height">64dp</dimen>
+    <dimen name="instruction_layout_width">150dp</dimen>
+    <dimen name="instruction_sub_layout_height">40dp</dimen>
     <dimen name="summary_bottomsheet_height">56dp</dimen>
     <dimen name="wayname_view_height">24dp</dimen>
     <dimen name="route_overview_left_right_padding">15dp</dimen>


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Refactor InstructionView landscape UX to move the stepDistanceText to the right of ManeuverIcon

This PR also fix several minor issues of current **landscape** implementation:
1. the `turnLaneLayout` will dismiss after close the InstructionList
2. the `distanceText` doesn't fit long text, like _1050ft_. The unit is truncated.
3. the `maneuverIcon`s are not aligned between the top banner instruction and the item in the InstructionList

All these three issues can be seen in the gif below.

- [ ] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal

Improve InstructionView landscape UX

### Implementation

Move the distance text view to the right of maneuver icon so in most cases the BannerInstructionView will be flat without the bump.

## Screenshots or Gifs

### This PR
![ezgif com-video-to-gif (2)](https://user-images.githubusercontent.com/3918950/87726949-da404400-c774-11ea-91e6-5a3a58ab96ed.gif)

### Before this PR
![ezgif com-video-to-gif (3)](https://user-images.githubusercontent.com/3918950/87726963-e2987f00-c774-11ea-958a-2bbe5f26b49e.gif)


## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->