### PR TITLE
OffboardRouter integration test

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -117,6 +117,7 @@ ext {
 
       // architecture
       lifecycleViewModelKtx     : "androidx.lifecycle:lifecycle-viewmodel-ktx:${version.lifecycleViewModelKtx}",
+      lifecycleRuntimeKtx       : "androidx.lifecycle:lifecycle-runtime-ktx:${version.lifecycleViewModelKtx}",
       lifecycleExtensions       : "androidx.lifecycle:lifecycle-extensions:${version.lifecycle}",
       lifecycleCompiler         : "androidx.lifecycle:lifecycle-compiler:${version.lifecycle}",
 
@@ -146,6 +147,7 @@ ext {
       mockwebserver             : "com.squareup.okhttp3:mockwebserver:${version.mockwebserver}",
       json                      : "org.json:json:${version.json}",
       androidxTestCore          : "androidx.test:core:${version.androidxTestCore}",
+      androidxTestCoreKtx       : "androidx.test:core-ktx:${version.androidxTestCore}",
 
       // play services
       gmsLocation               : "com.google.android.gms:play-services-location:${version.gmsLocation}",

--- a/libdirections-offboard/.gitignore
+++ b/libdirections-offboard/.gitignore
@@ -1,1 +1,3 @@
 /build
+
+developer-config.xml

--- a/libdirections-offboard/build.gradle
+++ b/libdirections-offboard/build.gradle
@@ -26,6 +26,10 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+
     defaultConfig {
         minSdkVersion androidVersions.minSdkVersion
         targetSdkVersion androidVersions.targetSdkVersion
@@ -59,7 +63,13 @@ dependencies {
         force = true
     }
 
+    implementation dependenciesList.androidXAppCompat
+    implementation dependenciesList.lifecycleRuntimeKtx
+
     apply from: "${rootDir}/gradle/unit-testing-dependencies.gradle"
+
+    androidTestImplementation dependenciesList.androidxTestCoreKtx
+    androidTestImplementation dependenciesList.testRules
 }
 
 apply from: "${rootDir}/gradle/track-public-apis.gradle"

--- a/libdirections-offboard/src/androidTest/java/com/mapbox/navigation/route/offboard/OffboardRouterTest.kt
+++ b/libdirections-offboard/src/androidTest/java/com/mapbox/navigation/route/offboard/OffboardRouterTest.kt
@@ -1,0 +1,24 @@
+package com.mapbox.navigation.route.offboard
+
+import androidx.test.core.app.launchActivity
+import com.mapbox.navigation.route.offboard.test.OffboardRouterTestActivity
+import com.mapbox.navigation.route.offboard.test.OffboardRouterTestActivity.Companion.ROUTE_READY
+import com.mapbox.navigation.route.offboard.test.OffboardRouterTestActivity.Companion.ROUTE_RESULT
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class OffboardRouterTest {
+
+    @Test
+    fun successRouteFetching() {
+        val activityScenario = launchActivity<OffboardRouterTestActivity>()
+        activityScenario.onActivity { activity ->
+            activity.checkRouteFetching()
+        }
+
+        activityScenario.result.let {
+            val result = it.resultData.getSerializableExtra(ROUTE_RESULT)
+            assertEquals(ROUTE_READY, result)
+        }
+    }
+}

--- a/libdirections-offboard/src/main/AndroidManifest.xml
+++ b/libdirections-offboard/src/main/AndroidManifest.xml
@@ -1,2 +1,17 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.mapbox.navigation.route.offboard" />
+    package="com.mapbox.navigation.route.offboard" >
+
+    <uses-permission android:name="android.permission.INTERNET" />
+
+
+    <application
+        android:theme="@style/AppTheme">
+        <activity
+            android:name=".test.OffboardRouterTestActivity"
+            android:screenOrientation="portrait"
+            android:launchMode="singleTop"
+            android:windowSoftInputMode="adjustNothing">
+        </activity>
+    </application>
+
+</manifest>

--- a/libdirections-offboard/src/main/java/com/mapbox/navigation/route/offboard/test/OffboardRouterTestActivity.kt
+++ b/libdirections-offboard/src/main/java/com/mapbox/navigation/route/offboard/test/OffboardRouterTestActivity.kt
@@ -1,0 +1,97 @@
+package com.mapbox.navigation.route.offboard.test
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.coroutineScope
+import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.api.directions.v5.models.RouteOptions
+import com.mapbox.geojson.Point
+import com.mapbox.navigation.base.internal.accounts.UrlSkuTokenProvider
+import com.mapbox.navigation.base.internal.extensions.applyDefaultParams
+import com.mapbox.navigation.base.internal.route.RouteUrl
+import com.mapbox.navigation.base.route.Router
+import com.mapbox.navigation.route.offboard.R
+import com.mapbox.navigation.route.offboard.internal.MapboxOffboardRouter
+import kotlin.coroutines.suspendCoroutine
+import kotlinx.coroutines.launch
+
+class OffboardRouterTestActivity : AppCompatActivity() {
+
+    private lateinit var router: Router
+    private val token: String by lazy { getString(R.string.mapbox_access_token) }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_offboard_router_test)
+
+        initRouter()
+    }
+
+    private fun initRouter() {
+        val dummyTokenProvider = object : UrlSkuTokenProvider {
+            override fun obtainUrlWithSkuToken(resourceUrl: String, querySize: Int): String {
+                return "$resourceUrl&sku=123456"
+            }
+        }
+
+        router = MapboxOffboardRouter(token, this, dummyTokenProvider)
+    }
+
+    fun checkRouteFetching() {
+        lifecycle.coroutineScope.launch {
+            val result = fetchRoute()
+            sendResult(result)
+        }
+    }
+
+    private fun sendResult(result: Int) {
+        val intent = Intent().apply {
+            putExtra(ROUTE_RESULT, result)
+        }
+        setResult(Activity.RESULT_OK, intent)
+        finish()
+    }
+
+    private suspend fun fetchRoute(): Int =
+        suspendCoroutine { cont ->
+            val options = RouteOptions.builder().applyDefaultParams()
+                .accessToken(token)
+                .coordinates(
+                    listOf(
+                        Point.fromLngLat(ORIGIN_TEST_LON, ORIGIN_TEST_LAT),
+                        Point.fromLngLat(DESTINATION_TEST_LON, DESTINATION_TEST_LAT)
+                    )
+                )
+                .profile(RouteUrl.PROFILE_DRIVING_TRAFFIC)
+                .build()
+
+            router.getRoute(options, object : Router.Callback {
+                override fun onResponse(routes: List<DirectionsRoute>) {
+                    cont.resumeWith(Result.success(ROUTE_READY))
+                }
+
+                override fun onFailure(throwable: Throwable) {
+                    cont.resumeWith(Result.success(ROUTE_FAILURE))
+                }
+
+                override fun onCanceled() {
+                    cont.resumeWith(Result.success(ROUTE_CANCELED))
+                }
+            })
+        }
+
+    companion object {
+        const val ROUTE_RESULT = "route_result"
+
+        const val ROUTE_READY = 1
+        const val ROUTE_FAILURE = -1
+        const val ROUTE_CANCELED = -2
+
+        private const val ORIGIN_TEST_LON = 1.1
+        private const val ORIGIN_TEST_LAT = 2.2
+        private const val DESTINATION_TEST_LON = 3.3
+        private const val DESTINATION_TEST_LAT = 4.4
+    }
+}

--- a/libdirections-offboard/src/main/res/layout/activity_offboard_router_test.xml
+++ b/libdirections-offboard/src/main/res/layout/activity_offboard_router_test.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+</FrameLayout>

--- a/libdirections-offboard/src/main/res/values/styles.xml
+++ b/libdirections-offboard/src/main/res/values/styles.xml
@@ -1,0 +1,5 @@
+<resources>
+
+    <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar"/>
+
+</resources>


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

when #3209 is merged the next activities will be removed:
- `BaseRouterActivityKt` 
- `HybridRouterActivityKt`
- `OffboardRouterActivityKt`
- `OnboardRouterActivityKt`
and the same with `java` language.

The activities ^^ are used like a "manual" testing tool. It's possible to check the whole flow, possible to fetch a route and check if nothing is broken inside a `Router`.

Each router is covered with `unit` tests. But they don't check the whole flow. If we want to do something similar to the activities ^^, we can do the next:
- create test activity
- fetch a route from `real API`
- set a fetching result and finish the activity
- check the result

There are some points to discuss:
- Do we want to test a real API? (if no, we can just use `unit` tests with mocked responses)
- Can we impact backend performance / break any metrics or statistics with our test API calls if we have many?
- Will such tests be flaky?
- Do we need such tests? Or `unit` tests is enough?

please provide your feedback.

@Guardiola31337 @LukasPaczos @RingerJK @Lebedinsky @kmadsen @zugaldia 
