### PR TITLE
Exception when animation end callback is prevented by checking that the bottom sheet is still active.

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/feedback/FeedbackBottomSheet.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/feedback/FeedbackBottomSheet.java
@@ -80,6 +80,7 @@ public class FeedbackBottomSheet extends BottomSheetDialogFragment implements An
   private FeedbackItem selectedFeedbackItem;
   private Map<String, List<FeedbackSubTypeItem>> feedbackSubTypeMap;
   private Class<? extends FeedbackBottomSheetListener> listenerClass;
+  private DismissCommand dismissCommand = null;
 
   public static FeedbackBottomSheet newInstance(FeedbackBottomSheetListener feedbackBottomSheetListener,
                                                 long duration) {
@@ -160,8 +161,21 @@ public class FeedbackBottomSheet extends BottomSheetDialogFragment implements An
   }
 
   @Override
+  public void onResume() {
+    super.onResume();
+    if (dismissCommand != null) {
+      dismissCommand.invoke();
+    }
+    dismissCommand = null;
+  }
+
+  @Override
   public void onAnimationEnd(Animator animation) {
-    FeedbackBottomSheet.this.dismiss();
+    if (FeedbackBottomSheet.this.isResumed()) {
+      FeedbackBottomSheet.this.dismiss();
+    } else {
+      dismissCommand = delayedDismissCommand;
+    }
   }
 
   //region Unused Listener Methods
@@ -524,4 +538,9 @@ public class FeedbackBottomSheet extends BottomSheetDialogFragment implements An
   public static final int FEEDBACK_MAIN_FLOW = 0;
   public static final int FEEDBACK_DETAIL_FLOW = 1;
 
+  private interface DismissCommand {
+    void invoke();
+  }
+
+  private DismissCommand delayedDismissCommand = FeedbackBottomSheet.this::dismiss;
 }


### PR DESCRIPTION
## Description

A fix for #2285 to prevent an exception on animation end when the app is terminated.

- [x] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal

Prevent an exception occurring when the bottom sheet animation ends.

### Implementation

There is a check to see if the feedback fragment is still active before calling dismiss in the fragment's animation end callback.

## Screenshots or Gifs


## Testing


- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->