### PR TITLE
Upgrade Nav Native to 16.0.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -12,7 +12,8 @@ ext {
       mapboxSdkDirectionsModels : '5.3.0',
       mapboxEvents              : '6.0.0',
       mapboxCore                : '3.0.0',
-      mapboxNavigator           : '15.0.0',
+      mapboxNavigator           : '16.0.0',
+      mapboxCommonSdk           : '3.1.0', // Workaround. Remove when upgrading Nav Native.
       mapboxCrashMonitor        : '2.0.0',
       mapboxAnnotationPlugin    : '0.8.0',
       mapboxAccounts            : '0.4.0',
@@ -69,6 +70,7 @@ ext {
       mapboxEvents              : "com.mapbox.mapboxsdk:mapbox-android-telemetry:${version.mapboxEvents}",
       mapboxCore                : "com.mapbox.mapboxsdk:mapbox-android-core:${version.mapboxCore}",
       mapboxNavigator           : "com.mapbox.navigator:mapbox-navigation-native:${version.mapboxNavigator}",
+      mapboxCommonSdk           : "com.mapbox.common:common:${version.mapboxCommonSdk}", // Workaround. Remove when upgrading Nav Native.
       mapboxAnnotationPlugin    : "com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v9:${version.mapboxAnnotationPlugin}",
       mapboxSearchSdk           : "com.mapbox.mapboxsdk:mapbox-search-android:${version.mapboxSearchSdk}",
       mapboxCrashMonitor        : "com.mapbox.crashmonitor:mapbox-crash-monitor-native:${version.mapboxCrashMonitor}",

--- a/libnavigator/build.gradle
+++ b/libnavigator/build.gradle
@@ -42,6 +42,7 @@ dependencies {
 
     // Navigator
     api dependenciesList.mapboxNavigator
+    api dependenciesList.mapboxCommonSdk // Workaround. Remove when upgrading Nav Native.
 
     // mapbox-java GeoJSON
     api dependenciesList.mapboxSdkGeoJSON


### PR DESCRIPTION
This PR also adds the Common SDK dependency upgrade as it slipped from the Nav Native bump and the correct version is not provided transitively.