### PR TITLE
Update builder pattern with private constructor and override equals/hashcode

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/NavigationApplication.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/NavigationApplication.kt
@@ -7,7 +7,7 @@ import androidx.multidex.MultiDexApplication
 import com.mapbox.base.common.logger.model.Message
 import com.mapbox.common.logger.MapboxLogger
 import com.mapbox.mapboxsdk.Mapbox
-import com.mapbox.navigation.base.options.HandheldProfile
+import com.mapbox.navigation.base.options.DeviceProfile
 import com.mapbox.navigation.examples.utils.Utils
 import com.mapbox.navigation.examples.utils.extensions.DelegatesExt
 import com.mapbox.navigation.navigator.internal.MapboxNativeNavigatorImpl
@@ -60,6 +60,6 @@ class NavigationApplication : MultiDexApplication() {
         }
 
         Mapbox.getInstance(applicationContext, mapboxAccessToken)
-        MapboxNativeNavigatorImpl.create(HandheldProfile(), MapboxLogger)
+        MapboxNativeNavigatorImpl.create(DeviceProfile.Builder().build(), MapboxLogger)
     }
 }

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayWaypointsActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayWaypointsActivity.kt
@@ -190,7 +190,7 @@ class ReplayWaypointsActivity : AppCompatActivity(), OnMapReadyCallback {
 
     private val arrivalController = object : ArrivalController {
         val arrivalOptions = ArrivalOptions.Builder()
-            .arriveInSeconds(5.0)
+            .arrivalInSeconds(5.0)
             .build()
         override fun arrivalOptions(): ArrivalOptions = arrivalOptions
 

--- a/libnavigation-base/api/current.txt
+++ b/libnavigation-base/api/current.txt
@@ -63,40 +63,26 @@ package com.mapbox.navigation.base.metrics {
 
 package com.mapbox.navigation.base.options {
 
-  public final class AutomobileProfile implements com.mapbox.navigation.base.options.DeviceProfile {
-    ctor public AutomobileProfile(String customConfig);
-    ctor public AutomobileProfile();
+  public final class DeviceProfile {
     method public String getCustomConfig();
+    method public com.mapbox.navigation.base.options.DeviceType getDeviceType();
   }
 
-  public interface DeviceProfile {
-    method public String getCustomConfig();
-    property public abstract String customConfig;
+  public static final class DeviceProfile.Builder {
+    ctor public DeviceProfile.Builder();
+    method public com.mapbox.navigation.base.options.DeviceProfile build();
+    method public com.mapbox.navigation.base.options.DeviceProfile.Builder customConfig(String customConfig);
+    method public com.mapbox.navigation.base.options.DeviceProfile.Builder deviceType(com.mapbox.navigation.base.options.DeviceType deviceType);
   }
 
-  public final class HandheldProfile implements com.mapbox.navigation.base.options.DeviceProfile {
-    ctor public HandheldProfile(String customConfig);
-    ctor public HandheldProfile();
-    method public String getCustomConfig();
+  public enum DeviceType {
+    enum_constant public static final com.mapbox.navigation.base.options.DeviceType AUTOMOBILE;
+    enum_constant public static final com.mapbox.navigation.base.options.DeviceType HANDHELD;
   }
 
   public final class NavigationOptions {
-    ctor public NavigationOptions(android.content.Context applicationContext, String? accessToken, com.mapbox.android.core.location.LocationEngine locationEngine, @com.mapbox.navigation.base.TimeFormat.Type int timeFormatType, long navigatorPredictionMillis, com.mapbox.navigation.base.formatter.DistanceFormatter? distanceFormatter, com.mapbox.navigation.base.options.OnboardRouterOptions onboardRouterOptions, boolean isFromNavigationUi, boolean isDebugLoggingEnabled, com.mapbox.navigation.base.options.DeviceProfile deviceProfile, com.mapbox.navigation.base.options.NavigationOptions.Builder builder);
-    method public android.content.Context component1();
-    method public com.mapbox.navigation.base.options.DeviceProfile component10();
-    method public com.mapbox.navigation.base.options.NavigationOptions.Builder component11();
-    method public String? component2();
-    method public com.mapbox.android.core.location.LocationEngine component3();
-    method public int component4();
-    method public long component5();
-    method public com.mapbox.navigation.base.formatter.DistanceFormatter? component6();
-    method public com.mapbox.navigation.base.options.OnboardRouterOptions component7();
-    method public boolean component8();
-    method public boolean component9();
-    method public com.mapbox.navigation.base.options.NavigationOptions copy(android.content.Context applicationContext, String? accessToken, com.mapbox.android.core.location.LocationEngine locationEngine, int timeFormatType, long navigatorPredictionMillis, com.mapbox.navigation.base.formatter.DistanceFormatter? distanceFormatter, com.mapbox.navigation.base.options.OnboardRouterOptions onboardRouterOptions, boolean isFromNavigationUi, boolean isDebugLoggingEnabled, com.mapbox.navigation.base.options.DeviceProfile deviceProfile, com.mapbox.navigation.base.options.NavigationOptions.Builder builder);
     method public String? getAccessToken();
     method public android.content.Context getApplicationContext();
-    method public com.mapbox.navigation.base.options.NavigationOptions.Builder getBuilder();
     method public com.mapbox.navigation.base.options.DeviceProfile getDeviceProfile();
     method public com.mapbox.navigation.base.formatter.DistanceFormatter? getDistanceFormatter();
     method public com.mapbox.android.core.location.LocationEngine getLocationEngine();
@@ -127,13 +113,6 @@ package com.mapbox.navigation.base.options {
   }
 
   public final class OnboardRouterOptions {
-    ctor public OnboardRouterOptions(java.net.URI tilesUri, String tilesVersion, String? filePath, com.mapbox.navigation.base.options.OnboardRouterOptions.Builder builder);
-    method public java.net.URI component1();
-    method public String component2();
-    method public String? component3();
-    method public com.mapbox.navigation.base.options.OnboardRouterOptions.Builder component4();
-    method public com.mapbox.navigation.base.options.OnboardRouterOptions copy(java.net.URI tilesUri, String tilesVersion, String? filePath, com.mapbox.navigation.base.options.OnboardRouterOptions.Builder builder);
-    method public com.mapbox.navigation.base.options.OnboardRouterOptions.Builder getBuilder();
     method public String? getFilePath();
     method public java.net.URI getTilesUri();
     method public String getTilesVersion();
@@ -143,7 +122,7 @@ package com.mapbox.navigation.base.options {
   public static final class OnboardRouterOptions.Builder {
     ctor public OnboardRouterOptions.Builder();
     method public com.mapbox.navigation.base.options.OnboardRouterOptions build();
-    method public com.mapbox.navigation.base.options.OnboardRouterOptions.Builder filePath(String filePath);
+    method public com.mapbox.navigation.base.options.OnboardRouterOptions.Builder filePath(String? filePath);
     method public com.mapbox.navigation.base.options.OnboardRouterOptions.Builder tilesUri(String tilesUri);
     method public com.mapbox.navigation.base.options.OnboardRouterOptions.Builder tilesUri(java.net.URI tilesUri);
     method public com.mapbox.navigation.base.options.OnboardRouterOptions.Builder tilesVersion(String version);
@@ -186,16 +165,6 @@ package com.mapbox.navigation.base.route {
 package com.mapbox.navigation.base.trip.model {
 
   public final class RouteLegProgress {
-    ctor public RouteLegProgress(int legIndex, com.mapbox.api.directions.v5.models.RouteLeg? routeLeg, float distanceTraveled, float distanceRemaining, double durationRemaining, float fractionTraveled, com.mapbox.navigation.base.trip.model.RouteStepProgress? currentStepProgress, com.mapbox.api.directions.v5.models.LegStep? upcomingStep);
-    method public int component1();
-    method public com.mapbox.api.directions.v5.models.RouteLeg? component2();
-    method public float component3();
-    method public float component4();
-    method public double component5();
-    method public float component6();
-    method public com.mapbox.navigation.base.trip.model.RouteStepProgress? component7();
-    method public com.mapbox.api.directions.v5.models.LegStep? component8();
-    method public com.mapbox.navigation.base.trip.model.RouteLegProgress copy(int legIndex, com.mapbox.api.directions.v5.models.RouteLeg? routeLeg, float distanceTraveled, float distanceRemaining, double durationRemaining, float fractionTraveled, com.mapbox.navigation.base.trip.model.RouteStepProgress? currentStepProgress, com.mapbox.api.directions.v5.models.LegStep? upcomingStep);
     method public com.mapbox.navigation.base.trip.model.RouteStepProgress? getCurrentStepProgress();
     method public float getDistanceRemaining();
     method public float getDistanceTraveled();
@@ -220,21 +189,6 @@ package com.mapbox.navigation.base.trip.model {
   }
 
   public final class RouteProgress {
-    ctor public RouteProgress(com.mapbox.api.directions.v5.models.DirectionsRoute route, com.mapbox.geojson.Geometry? routeGeometryWithBuffer, com.mapbox.api.directions.v5.models.BannerInstructions? bannerInstructions, com.mapbox.api.directions.v5.models.VoiceInstructions? voiceInstructions, com.mapbox.navigation.base.trip.model.RouteProgressState currentState, com.mapbox.navigation.base.trip.model.RouteLegProgress? currentLegProgress, java.util.List<com.mapbox.geojson.Point>? upcomingStepPoints, boolean inTunnel, float distanceRemaining, float distanceTraveled, double durationRemaining, float fractionTraveled, int remainingWaypoints);
-    method public com.mapbox.api.directions.v5.models.DirectionsRoute component1();
-    method public float component10();
-    method public double component11();
-    method public float component12();
-    method public int component13();
-    method public com.mapbox.geojson.Geometry? component2();
-    method public com.mapbox.api.directions.v5.models.BannerInstructions? component3();
-    method public com.mapbox.api.directions.v5.models.VoiceInstructions? component4();
-    method public com.mapbox.navigation.base.trip.model.RouteProgressState component5();
-    method public com.mapbox.navigation.base.trip.model.RouteLegProgress? component6();
-    method public java.util.List<com.mapbox.geojson.Point>? component7();
-    method public boolean component8();
-    method public float component9();
-    method public com.mapbox.navigation.base.trip.model.RouteProgress copy(com.mapbox.api.directions.v5.models.DirectionsRoute route, com.mapbox.geojson.Geometry? routeGeometryWithBuffer, com.mapbox.api.directions.v5.models.BannerInstructions? bannerInstructions, com.mapbox.api.directions.v5.models.VoiceInstructions? voiceInstructions, com.mapbox.navigation.base.trip.model.RouteProgressState currentState, com.mapbox.navigation.base.trip.model.RouteLegProgress? currentLegProgress, java.util.List<com.mapbox.geojson.Point>? upcomingStepPoints, boolean inTunnel, float distanceRemaining, float distanceTraveled, double durationRemaining, float fractionTraveled, int remainingWaypoints);
     method public com.mapbox.api.directions.v5.models.BannerInstructions? getBannerInstructions();
     method public com.mapbox.navigation.base.trip.model.RouteLegProgress? getCurrentLegProgress();
     method public com.mapbox.navigation.base.trip.model.RouteProgressState getCurrentState();
@@ -279,15 +233,6 @@ package com.mapbox.navigation.base.trip.model {
   }
 
   public final class RouteStepProgress {
-    ctor public RouteStepProgress(int stepIndex, com.mapbox.api.directions.v5.models.LegStep? step, java.util.List<com.mapbox.geojson.Point>? stepPoints, float distanceRemaining, float distanceTraveled, float fractionTraveled, double durationRemaining);
-    method public int component1();
-    method public com.mapbox.api.directions.v5.models.LegStep? component2();
-    method public java.util.List<com.mapbox.geojson.Point>? component3();
-    method public float component4();
-    method public float component5();
-    method public float component6();
-    method public double component7();
-    method public com.mapbox.navigation.base.trip.model.RouteStepProgress copy(int stepIndex, com.mapbox.api.directions.v5.models.LegStep? step, java.util.List<com.mapbox.geojson.Point>? stepPoints, float distanceRemaining, float distanceTraveled, float fractionTraveled, double durationRemaining);
     method public float getDistanceRemaining();
     method public float getDistanceTraveled();
     method public double getDurationRemaining();

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/DeviceProfile.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/DeviceProfile.kt
@@ -3,24 +3,76 @@ package com.mapbox.navigation.base.options
 /**
  * The navigation SDK has algorithms optimized for the type of data
  * being provided. The device profile selects the optimization.
+ *
+ * @param customConfig Json custom configuration used by the navigator
+ * @param deviceType The type of device providing data to the navigator.
  */
-interface DeviceProfile {
+class DeviceProfile private constructor(
+    val customConfig: String,
+    val deviceType: DeviceType
+) {
     /**
-     * Custom configuration in json format, understood by the navigator.
+     * Build a new [DeviceProfile]
      */
-    val customConfig: String
+    class Builder {
+        private var customConfig = ""
+        private var deviceType = DeviceType.HANDHELD
+
+        /**
+         * Json custom configuration used by the navigator
+         */
+        fun customConfig(customConfig: String) = apply { this.customConfig = customConfig }
+
+        /**
+         * Change the [DeviceType]
+         */
+        fun deviceType(deviceType: DeviceType) = apply { this.deviceType = deviceType }
+
+        /**
+         * Build the [DeviceType]
+         */
+        fun build() = DeviceProfile(
+            customConfig = customConfig,
+            deviceType = deviceType
+        )
+    }
+
+    /**
+     * Regenerate whenever a change is made
+     */
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as DeviceProfile
+
+        if (customConfig != other.customConfig) return false
+        if (deviceType != other.deviceType) return false
+
+        return true
+    }
+
+    /**
+     * Regenerate whenever a change is made
+     */
+    override fun hashCode(): Int {
+        var result = customConfig.hashCode()
+        result = 31 * result + deviceType.hashCode()
+        return result
+    }
 }
 
 /**
- * Any typical Android smart phone with GPS.
+ * The type of device providing data to the navigator.
  */
-class HandheldProfile @JvmOverloads constructor(
-    override val customConfig: String = ""
-) : DeviceProfile
+enum class DeviceType {
+    /**
+     * Any typical Android smart phone with GPS
+     */
+    HANDHELD,
 
-/**
- * Automobiles that provide data directly from the vehicle.
- */
-class AutomobileProfile @JvmOverloads constructor(
-    override val customConfig: String = ""
-) : DeviceProfile
+    /**
+     * Automobiles that provide data directly from the vehicle
+     */
+    AUTOMOBILE
+}

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/NavigationOptions.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/NavigationOptions.kt
@@ -16,11 +16,6 @@ import com.mapbox.navigation.base.formatter.DistanceFormatter
 const val DEFAULT_NAVIGATOR_PREDICTION_MILLIS = 1100L
 
 /**
- * Defines navigation options
- *
- * @param timeFormatType defines time format for calculation remaining trip time
- * @param navigatorPredictionMillis defines approximate navigator prediction in milliseconds
- *
  * This value will be used to offset the time at which the current location was calculated
  * in such a way as to project the location forward along the current trajectory so as to
  * appear more in sync with the users ground-truth location
@@ -28,14 +23,15 @@ const val DEFAULT_NAVIGATOR_PREDICTION_MILLIS = 1100L
  * @param applicationContext the Context of the Android Application
  * @param accessToken [Mapbox Access Token](https://docs.mapbox.com/help/glossary/access-token/)
  * @param locationEngine the mechanism responsible for providing location approximations to navigation
+ * @param timeFormatType defines time format for calculation remaining trip time
+ * @param navigatorPredictionMillis defines approximate navigator prediction in milliseconds
  * @param distanceFormatter [DistanceFormatter] for format distances showing in notification during navigation
  * @param onboardRouterOptions [OnboardRouterOptions] defines configuration for the default on-board router
  * @param isFromNavigationUi Boolean *true* if is called from UI, otherwise *false*
  * @param isDebugLoggingEnabled Boolean
  * @param deviceProfile [DeviceProfile] defines how navigation data should be interpretation
- * @param builder [Builder] used the create the [NavigationOptions]
  */
-data class NavigationOptions(
+class NavigationOptions private constructor(
     val applicationContext: Context,
     val accessToken: String?,
     val locationEngine: LocationEngine,
@@ -45,14 +41,63 @@ data class NavigationOptions(
     val onboardRouterOptions: OnboardRouterOptions,
     val isFromNavigationUi: Boolean,
     val isDebugLoggingEnabled: Boolean,
-    val deviceProfile: DeviceProfile,
-    val builder: Builder
+    val deviceProfile: DeviceProfile
 ) {
 
     /**
      * Get a builder to customize a subset of current options.
      */
-    fun toBuilder() = builder
+    fun toBuilder() = Builder(context = applicationContext).apply {
+        accessToken(accessToken)
+        locationEngine(locationEngine)
+        timeFormatType(timeFormatType)
+        navigatorPredictionMillis(navigatorPredictionMillis)
+        distanceFormatter(distanceFormatter)
+        onboardRouterOptions(onboardRouterOptions)
+        isFromNavigationUi(isFromNavigationUi)
+        isDebugLoggingEnabled(isDebugLoggingEnabled)
+        deviceProfile(deviceProfile)
+    }
+
+    /**
+     * Regenerate whenever a change is made
+     */
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as NavigationOptions
+
+        if (applicationContext != other.applicationContext) return false
+        if (accessToken != other.accessToken) return false
+        if (locationEngine != other.locationEngine) return false
+        if (timeFormatType != other.timeFormatType) return false
+        if (navigatorPredictionMillis != other.navigatorPredictionMillis) return false
+        if (distanceFormatter != other.distanceFormatter) return false
+        if (onboardRouterOptions != other.onboardRouterOptions) return false
+        if (isFromNavigationUi != other.isFromNavigationUi) return false
+        if (isDebugLoggingEnabled != other.isDebugLoggingEnabled) return false
+        if (deviceProfile != other.deviceProfile) return false
+
+        return true
+    }
+
+    /**
+     * Regenerate whenever a change is made
+     */
+    override fun hashCode(): Int {
+        var result = applicationContext.hashCode()
+        result = 31 * result + (accessToken?.hashCode() ?: 0)
+        result = 31 * result + locationEngine.hashCode()
+        result = 31 * result + timeFormatType
+        result = 31 * result + navigatorPredictionMillis.hashCode()
+        result = 31 * result + (distanceFormatter?.hashCode() ?: 0)
+        result = 31 * result + onboardRouterOptions.hashCode()
+        result = 31 * result + isFromNavigationUi.hashCode()
+        result = 31 * result + isDebugLoggingEnabled.hashCode()
+        result = 31 * result + deviceProfile.hashCode()
+        return result
+    }
 
     /**
      * Build a new [NavigationOptions]
@@ -67,7 +112,7 @@ data class NavigationOptions(
         private var onboardRouterOptions: OnboardRouterOptions = OnboardRouterOptions.Builder().build()
         private var isFromNavigationUi: Boolean = false
         private var isDebugLoggingEnabled: Boolean = false
-        private var deviceProfile: DeviceProfile = HandheldProfile()
+        private var deviceProfile: DeviceProfile = DeviceProfile.Builder().build()
 
         /**
          * Defines [Mapbox Access Token](https://docs.mapbox.com/help/glossary/access-token/)
@@ -138,8 +183,7 @@ data class NavigationOptions(
                 onboardRouterOptions = onboardRouterOptions,
                 isFromNavigationUi = isFromNavigationUi,
                 isDebugLoggingEnabled = isDebugLoggingEnabled,
-                deviceProfile = deviceProfile,
-                builder = this
+                deviceProfile = deviceProfile
             )
         }
     }

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/OnboardRouterOptions.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/OnboardRouterOptions.kt
@@ -9,18 +9,46 @@ import java.net.URI
  * @param tilesUri tiles endpoint
  * @param tilesVersion version of tiles
  * @param filePath used for storing road network tiles
- * @param builder used for updating options
  */
-data class OnboardRouterOptions(
+class OnboardRouterOptions private constructor(
     val tilesUri: URI,
     val tilesVersion: String,
-    val filePath: String?,
-    val builder: Builder
+    val filePath: String?
 ) {
     /**
      * @return the builder that created the [OnboardRouterOptions]
      */
-    fun toBuilder() = builder
+    fun toBuilder() = Builder().apply {
+        tilesUri(tilesUri)
+        tilesVersion(tilesVersion)
+        filePath(filePath)
+    }
+
+    /**
+     * Regenerate whenever a change is made
+     */
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as OnboardRouterOptions
+
+        if (tilesUri != other.tilesUri) return false
+        if (tilesVersion != other.tilesVersion) return false
+        if (filePath != other.filePath) return false
+
+        return true
+    }
+
+    /**
+     * Regenerate whenever a change is made
+     */
+    override fun hashCode(): Int {
+        var result = tilesUri.hashCode()
+        result = 31 * result + tilesVersion.hashCode()
+        result = 31 * result + (filePath?.hashCode() ?: 0)
+        return result
+    }
 
     /**
      * Builder for [OnboardRouterOptions]. You must choose a [filePath]
@@ -52,7 +80,7 @@ data class OnboardRouterOptions(
         /**
          * Creates a custom file path to store the road network tiles.
          */
-        fun filePath(filePath: String) =
+        fun filePath(filePath: String?) =
             apply { this.filePath = filePath }
 
         /**
@@ -62,8 +90,7 @@ data class OnboardRouterOptions(
             return OnboardRouterOptions(
                 tilesUri = tilesUri,
                 tilesVersion = tilesVersion,
-                filePath = filePath,
-                builder = this
+                filePath = filePath
             )
         }
     }

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteLegProgress.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteLegProgress.kt
@@ -25,7 +25,7 @@ import com.mapbox.api.directions.v5.models.RouteLeg
  * @param upcomingStep Next/upcoming step immediately after the current step. If the user is on the last step
  * on the last leg, this will return null since a next step doesn't exist
  */
-data class RouteLegProgress(
+class RouteLegProgress private constructor(
     val legIndex: Int,
     val routeLeg: RouteLeg?,
     val distanceTraveled: Float,
@@ -35,6 +35,43 @@ data class RouteLegProgress(
     val currentStepProgress: RouteStepProgress?,
     val upcomingStep: LegStep?
 ) {
+
+    /**
+     * Regenerate whenever a change is made
+     */
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as RouteLegProgress
+
+        if (legIndex != other.legIndex) return false
+        if (routeLeg != other.routeLeg) return false
+        if (distanceTraveled != other.distanceTraveled) return false
+        if (distanceRemaining != other.distanceRemaining) return false
+        if (durationRemaining != other.durationRemaining) return false
+        if (fractionTraveled != other.fractionTraveled) return false
+        if (currentStepProgress != other.currentStepProgress) return false
+        if (upcomingStep != other.upcomingStep) return false
+
+        return true
+    }
+
+    /**
+     * Regenerate whenever a change is made
+     */
+    override fun hashCode(): Int {
+        var result = legIndex
+        result = 31 * result + (routeLeg?.hashCode() ?: 0)
+        result = 31 * result + distanceTraveled.hashCode()
+        result = 31 * result + distanceRemaining.hashCode()
+        result = 31 * result + durationRemaining.hashCode()
+        result = 31 * result + fractionTraveled.hashCode()
+        result = 31 * result + (currentStepProgress?.hashCode() ?: 0)
+        result = 31 * result + (upcomingStep?.hashCode() ?: 0)
+        return result
+    }
+
     /**
      * Builder of [RouteLegProgress].
      */

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteProgress.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteProgress.kt
@@ -37,7 +37,7 @@ import com.mapbox.geojson.Point
  * between 0 and 1 and isn't guaranteed to reach 1 before the user reaches the end of the route.
  * @param remainingWaypoints [Int] number of waypoints remaining on the current route.
  */
-data class RouteProgress(
+class RouteProgress private constructor(
     val route: DirectionsRoute,
     val routeGeometryWithBuffer: Geometry?,
     val bannerInstructions: BannerInstructions?,
@@ -52,6 +52,53 @@ data class RouteProgress(
     val fractionTraveled: Float,
     val remainingWaypoints: Int
 ) {
+
+    /**
+     * Regenerate whenever a change is made
+     */
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as RouteProgress
+
+        if (route != other.route) return false
+        if (routeGeometryWithBuffer != other.routeGeometryWithBuffer) return false
+        if (bannerInstructions != other.bannerInstructions) return false
+        if (voiceInstructions != other.voiceInstructions) return false
+        if (currentState != other.currentState) return false
+        if (currentLegProgress != other.currentLegProgress) return false
+        if (upcomingStepPoints != other.upcomingStepPoints) return false
+        if (inTunnel != other.inTunnel) return false
+        if (distanceRemaining != other.distanceRemaining) return false
+        if (distanceTraveled != other.distanceTraveled) return false
+        if (durationRemaining != other.durationRemaining) return false
+        if (fractionTraveled != other.fractionTraveled) return false
+        if (remainingWaypoints != other.remainingWaypoints) return false
+
+        return true
+    }
+
+    /**
+     * Regenerate whenever a change is made
+     */
+    override fun hashCode(): Int {
+        var result = route.hashCode()
+        result = 31 * result + (routeGeometryWithBuffer?.hashCode() ?: 0)
+        result = 31 * result + (bannerInstructions?.hashCode() ?: 0)
+        result = 31 * result + (voiceInstructions?.hashCode() ?: 0)
+        result = 31 * result + currentState.hashCode()
+        result = 31 * result + (currentLegProgress?.hashCode() ?: 0)
+        result = 31 * result + (upcomingStepPoints?.hashCode() ?: 0)
+        result = 31 * result + inTunnel.hashCode()
+        result = 31 * result + distanceRemaining.hashCode()
+        result = 31 * result + distanceTraveled.hashCode()
+        result = 31 * result + durationRemaining.hashCode()
+        result = 31 * result + fractionTraveled.hashCode()
+        result = 31 * result + remainingWaypoints
+        return result
+    }
+
     /**
      * Builder for [RouteProgress]
      */

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteStepProgress.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteStepProgress.kt
@@ -18,9 +18,8 @@ import com.mapbox.geojson.Point
  * float value between 0 and 1 and isn't guaranteed to reach 1 before the user reaches the
  * next step (if another step exist in route)
  * @param durationRemaining [Double] The duration remaining in seconds until the user reaches the end of the current step
- * @param guidanceViewURL [String] Guidance image URL
  */
-data class RouteStepProgress(
+class RouteStepProgress private constructor(
     val stepIndex: Int,
     val step: LegStep?,
     val stepPoints: List<Point>?,
@@ -29,6 +28,41 @@ data class RouteStepProgress(
     val fractionTraveled: Float,
     val durationRemaining: Double
 ) {
+
+    /**
+     * Regenerate whenever a change is made
+     */
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as RouteStepProgress
+
+        if (stepIndex != other.stepIndex) return false
+        if (step != other.step) return false
+        if (stepPoints != other.stepPoints) return false
+        if (distanceRemaining != other.distanceRemaining) return false
+        if (distanceTraveled != other.distanceTraveled) return false
+        if (fractionTraveled != other.fractionTraveled) return false
+        if (durationRemaining != other.durationRemaining) return false
+
+        return true
+    }
+
+    /**
+     * Regenerate whenever a change is made
+     */
+    override fun hashCode(): Int {
+        var result = stepIndex
+        result = 31 * result + (step?.hashCode() ?: 0)
+        result = 31 * result + (stepPoints?.hashCode() ?: 0)
+        result = 31 * result + distanceRemaining.hashCode()
+        result = 31 * result + distanceTraveled.hashCode()
+        result = 31 * result + fractionTraveled.hashCode()
+        result = 31 * result + durationRemaining.hashCode()
+        return result
+    }
+
     /**
      * Builder of [RouteStepProgress]
      */

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/options/NavigationOptionsTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/options/NavigationOptionsTest.kt
@@ -13,6 +13,7 @@ import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
@@ -92,5 +93,33 @@ class NavigationOptionsTest {
         assertEquals(options.timeFormatType, newTimeFormat)
         assertEquals(options.navigatorPredictionMillis, newNavigatorPredictionMillis)
         assertEquals(options.distanceFormatter, distanceFormatter)
+    }
+
+    @Test
+    fun whenSeparateBuildersBuildSameOptions() {
+        val timeFormat = TWELVE_HOURS
+        val navigatorPredictionMillis = 1020L
+
+        val options = NavigationOptions.Builder(context)
+            .timeFormatType(timeFormat)
+            .navigatorPredictionMillis(navigatorPredictionMillis)
+            .build()
+
+        val otherOptions = NavigationOptions.Builder(context)
+            .timeFormatType(timeFormat)
+            .navigatorPredictionMillis(navigatorPredictionMillis)
+            .build()
+
+        assertEquals(options, otherOptions)
+    }
+
+    @Test
+    fun reuseChangedBuilder() {
+        val builder = NavigationOptions.Builder(context)
+        val options = builder.build()
+        builder.accessToken("pk.123")
+
+        assertNotEquals(options.toBuilder().build(), builder.build())
+        assertEquals(options.toBuilder().build(), options)
     }
 }

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/options/OnboardRouterOptionsTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/options/OnboardRouterOptionsTest.kt
@@ -1,6 +1,8 @@
 package com.mapbox.navigation.base.options
 
 import java.net.URISyntaxException
+import junit.framework.TestCase.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Test
@@ -40,5 +42,35 @@ class OnboardRouterOptionsTest {
         }
 
         assertNull(onboardRouterOptions)
+    }
+
+    @Test
+    fun `builders should build equal objects`() {
+        val options = OnboardRouterOptions.Builder()
+            .filePath(validFilePath)
+            .tilesVersion("2020_08_01-03_10_00")
+            .build()
+
+        val otherOptions = OnboardRouterOptions.Builder()
+            .filePath(validFilePath)
+            .tilesVersion("2020_08_01-03_10_00")
+            .build()
+
+        assertEquals(options, otherOptions)
+    }
+
+    @Test
+    fun `builders should detect u equal objects`() {
+        val options = OnboardRouterOptions.Builder()
+            .filePath(validFilePath)
+            .tilesVersion("2020_08_01-03_10_00")
+            .build()
+
+        val otherOptions = OnboardRouterOptions.Builder()
+            .filePath(validFilePath)
+            .tilesVersion("2020_08_02-03_10_00")
+            .build()
+
+        assertNotEquals(options, otherOptions)
     }
 }

--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -89,21 +89,15 @@ package com.mapbox.navigation.core.arrival {
   }
 
   public final class ArrivalOptions {
-    ctor public ArrivalOptions(Double? arrivalInSeconds, Double? arrivalInMeters, com.mapbox.navigation.core.arrival.ArrivalOptions.Builder builder);
-    method public Double? component1();
-    method public Double? component2();
-    method public com.mapbox.navigation.core.arrival.ArrivalOptions.Builder component3();
-    method public com.mapbox.navigation.core.arrival.ArrivalOptions copy(Double? arrivalInSeconds, Double? arrivalInMeters, com.mapbox.navigation.core.arrival.ArrivalOptions.Builder builder);
     method public Double? getArrivalInMeters();
     method public Double? getArrivalInSeconds();
-    method public com.mapbox.navigation.core.arrival.ArrivalOptions.Builder getBuilder();
     method public com.mapbox.navigation.core.arrival.ArrivalOptions.Builder toBuilder();
   }
 
   public static final class ArrivalOptions.Builder {
     ctor public ArrivalOptions.Builder();
-    method public com.mapbox.navigation.core.arrival.ArrivalOptions.Builder arriveInMeters(Double? arriveInMeters);
-    method public com.mapbox.navigation.core.arrival.ArrivalOptions.Builder arriveInSeconds(Double? arriveInSeconds);
+    method public com.mapbox.navigation.core.arrival.ArrivalOptions.Builder arrivalInMeters(Double? arriveInMeters);
+    method public com.mapbox.navigation.core.arrival.ArrivalOptions.Builder arrivalInSeconds(Double? arriveInSeconds);
     method public com.mapbox.navigation.core.arrival.ArrivalOptions build();
   }
 
@@ -288,8 +282,6 @@ package com.mapbox.navigation.core.replay.route {
   }
 
   public final class ReplayRouteOptions {
-    ctor public ReplayRouteOptions(double maxSpeedMps, double turnSpeedMps, double uTurnSpeedMps, double maxAcceleration, double minAcceleration, com.mapbox.navigation.core.replay.route.ReplayRouteOptions.Builder builder);
-    method public com.mapbox.navigation.core.replay.route.ReplayRouteOptions.Builder getBuilder();
     method public double getMaxAcceleration();
     method public double getMaxSpeedMps();
     method public double getMinAcceleration();
@@ -370,13 +362,7 @@ package com.mapbox.navigation.core.sensors {
   }
 
   public final class SensorOptions {
-    ctor public SensorOptions(java.util.Set<java.lang.Integer> enabledSensorTypes, int signalsPerSecond, com.mapbox.navigation.core.sensors.SensorOptions.Builder builder);
-    method public java.util.Set<java.lang.Integer> component1();
-    method public int component2();
-    method public com.mapbox.navigation.core.sensors.SensorOptions.Builder component3();
-    method public com.mapbox.navigation.core.sensors.SensorOptions copy(java.util.Set<java.lang.Integer> enabledSensorTypes, int signalsPerSecond, com.mapbox.navigation.core.sensors.SensorOptions.Builder builder);
-    method public com.mapbox.navigation.core.sensors.SensorOptions.Builder getBuilder();
-    method public java.util.Set<java.lang.Integer> getEnabledSensorTypes();
+    method public java.util.Set<java.lang.Integer> getEnableSensorTypes();
     method public int getSignalsPerSecond();
     method public com.mapbox.navigation.core.sensors.SensorOptions.Builder toBuilder();
   }
@@ -385,7 +371,7 @@ package com.mapbox.navigation.core.sensors {
     ctor public SensorOptions.Builder();
     method public com.mapbox.navigation.core.sensors.SensorOptions build();
     method public com.mapbox.navigation.core.sensors.SensorOptions.Builder enableAllSensors();
-    method public com.mapbox.navigation.core.sensors.SensorOptions.Builder enableSensors(java.util.Set<java.lang.Integer> sensorTypes);
+    method public com.mapbox.navigation.core.sensors.SensorOptions.Builder enableSensorTypes(java.util.Set<java.lang.Integer> sensorTypes);
     method public com.mapbox.navigation.core.sensors.SensorOptions.Builder signalsPerSecond(int signalsPerSecond);
   }
 

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/arrival/ArrivalController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/arrival/ArrivalController.kt
@@ -51,17 +51,42 @@ class AutoArrivalController : ArrivalController {
  * [ArrivalController.navigateNextRouteLeg] will be called
  * @param arrivalInMeters While the next stop is less than [arrivalInMeters] away,
  * [ArrivalController.navigateNextRouteLeg] will be called
- * @param builder used for updating options
  */
-data class ArrivalOptions(
+class ArrivalOptions private constructor(
     val arrivalInSeconds: Double?,
-    val arrivalInMeters: Double?,
-    val builder: Builder
+    val arrivalInMeters: Double?
 ) {
     /**
      * @return the builder that created the [ArrivalOptions]
      */
-    fun toBuilder() = builder
+    fun toBuilder() = Builder().apply {
+        arrivalInSeconds(arrivalInSeconds)
+        arrivalInMeters(arrivalInMeters)
+    }
+
+    /**
+     * Regenerate whenever a change is made
+     */
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as ArrivalOptions
+
+        if (arrivalInSeconds != other.arrivalInSeconds) return false
+        if (arrivalInMeters != other.arrivalInMeters) return false
+
+        return true
+    }
+
+    /**
+     * Regenerate whenever a change is made
+     */
+    override fun hashCode(): Int {
+        var result = arrivalInSeconds?.hashCode() ?: 0
+        result = 31 * result + (arrivalInMeters?.hashCode() ?: 0)
+        return result
+    }
 
     /**
      * Build your [ArrivalOptions].
@@ -75,7 +100,7 @@ data class ArrivalOptions(
          * (Recommended) Use time estimation for arrival, arrival is influenced by traffic conditions.
          * Arrive when the estimated time to a stop is less than or equal to this threshold.
          */
-        fun arriveInSeconds(arriveInSeconds: Double?): Builder {
+        fun arrivalInSeconds(arriveInSeconds: Double?): Builder {
             this.arrivalInSeconds = arriveInSeconds
             return this
         }
@@ -83,7 +108,7 @@ data class ArrivalOptions(
         /**
          * Arrive when the estimated distance to a stop is less than or equal to this threshold.
          */
-        fun arriveInMeters(arriveInMeters: Double?): Builder {
+        fun arrivalInMeters(arriveInMeters: Double?): Builder {
             this.arrivalInMeters = arriveInMeters
             return this
         }
@@ -97,8 +122,7 @@ data class ArrivalOptions(
             }
             return ArrivalOptions(
                 arrivalInSeconds = arrivalInSeconds,
-                arrivalInMeters = arrivalInMeters,
-                builder = this
+                arrivalInMeters = arrivalInMeters
             )
         }
     }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayRouteOptions.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayRouteOptions.kt
@@ -11,20 +11,54 @@ package com.mapbox.navigation.core.replay.route
  * @param uTurnSpeedMps Speed the driver will go when facing a u-turn
  * @param maxAcceleration How fast the driver will accelerate to [maxSpeedMps] in mps^2
  * @param minAcceleration How fast the driver will decelerate in mps^2
- * @param builder used for updating options
  */
-class ReplayRouteOptions(
+class ReplayRouteOptions private constructor(
     val maxSpeedMps: Double,
     val turnSpeedMps: Double,
     val uTurnSpeedMps: Double,
     val maxAcceleration: Double,
-    val minAcceleration: Double,
-    val builder: Builder
+    val minAcceleration: Double
 ) {
     /**
      * @return the builder that created the [ReplayRouteOptions]
      */
-    fun toBuilder() = builder
+    fun toBuilder() = Builder().apply {
+        maxSpeedMps(maxSpeedMps)
+        turnSpeedMps(turnSpeedMps)
+        uTurnSpeedMps(uTurnSpeedMps)
+        maxAcceleration(maxAcceleration)
+        minAcceleration(minAcceleration)
+    }
+
+    /**
+     * Regenerate whenever a change is made
+     */
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as ReplayRouteOptions
+
+        if (maxSpeedMps != other.maxSpeedMps) return false
+        if (turnSpeedMps != other.turnSpeedMps) return false
+        if (uTurnSpeedMps != other.uTurnSpeedMps) return false
+        if (maxAcceleration != other.maxAcceleration) return false
+        if (minAcceleration != other.minAcceleration) return false
+
+        return true
+    }
+
+    /**
+     * Regenerate whenever a change is made
+     */
+    override fun hashCode(): Int {
+        var result = maxSpeedMps.hashCode()
+        result = 31 * result + turnSpeedMps.hashCode()
+        result = 31 * result + uTurnSpeedMps.hashCode()
+        result = 31 * result + maxAcceleration.hashCode()
+        result = 31 * result + minAcceleration.hashCode()
+        return result
+    }
 
     /**
      * Used to build [ReplayRouteOptions].
@@ -47,8 +81,7 @@ class ReplayRouteOptions(
                 turnSpeedMps = turnSpeedMps,
                 uTurnSpeedMps = uTurnSpeedMps,
                 maxAcceleration = maxAcceleration,
-                minAcceleration = minAcceleration,
-                builder = this
+                minAcceleration = minAcceleration
             )
         }
 

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/sensors/SensorEventEmitter.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/sensors/SensorEventEmitter.kt
@@ -64,7 +64,7 @@ class SensorEventEmitter(
     private fun enabledSensors(sensorOptions: SensorOptions): List<Sensor> {
         return sensorManager.getSensorList(Sensor.TYPE_ALL)
             .filter { sensor ->
-                sensorOptions.enabledSensorTypes.contains(sensor.type)
+                sensorOptions.enableSensorTypes.contains(sensor.type)
             }
             .filterNotNull()
     }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/sensors/SensorOptions.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/sensors/SensorOptions.kt
@@ -4,25 +4,50 @@ package com.mapbox.navigation.core.sensors
  * Options for the [SensorEventEmitter]. Use this to decide which sensors are
  * enabled and the frequency.
  *
- * @param enabledSensorTypes set of enabled sensors
+ * @param enableSensorTypes set of enabled sensors
  * @param signalsPerSecond signals per second received from sensors
- * @param builder used for updating options
  */
-data class SensorOptions(
-    val enabledSensorTypes: Set<Int>,
-    val signalsPerSecond: Int,
-    val builder: Builder
+class SensorOptions private constructor(
+    val enableSensorTypes: Set<Int>,
+    val signalsPerSecond: Int
 ) {
     /**
      * @return the builder that created the [SensorOptions]
      */
-    fun toBuilder() = builder
+    fun toBuilder() = Builder().apply {
+        enableSensorTypes(enableSensorTypes)
+        signalsPerSecond(signalsPerSecond)
+    }
+
+    /**
+     * Regenerate whenever a change is made
+     */
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as SensorOptions
+
+        if (enableSensorTypes != other.enableSensorTypes) return false
+        if (signalsPerSecond != other.signalsPerSecond) return false
+
+        return true
+    }
+
+    /**
+     * Regenerate whenever a change is made
+     */
+    override fun hashCode(): Int {
+        var result = enableSensorTypes.hashCode()
+        result = 31 * result + signalsPerSecond
+        return result
+    }
 
     /**
      * Builder of [SensorOptions]
      */
     class Builder {
-        private val enabledSensors: MutableSet<Int> = mutableSetOf()
+        private val enableSensorTypes: MutableSet<Int> = mutableSetOf()
         private var signalsPerSecond: Int = 25
 
         /**
@@ -31,7 +56,7 @@ data class SensorOptions(
          * @return Builder
          */
         fun enableAllSensors(): Builder {
-            this.enabledSensors.addAll(SensorMapper.getSupportedSensorTypes())
+            this.enableSensorTypes.addAll(SensorMapper.getSupportedSensorTypes())
             return this
         }
 
@@ -41,8 +66,8 @@ data class SensorOptions(
          * @param sensorTypes that will be handled
          * @return Builder
          */
-        fun enableSensors(sensorTypes: Set<Int>): Builder {
-            this.enabledSensors.addAll(sensorTypes)
+        fun enableSensorTypes(sensorTypes: Set<Int>): Builder {
+            this.enableSensorTypes.addAll(sensorTypes)
             return this
         }
 
@@ -64,9 +89,8 @@ data class SensorOptions(
          */
         fun build(): SensorOptions {
             return SensorOptions(
-                enabledSensorTypes = enabledSensors,
-                signalsPerSecond = signalsPerSecond,
-                builder = this
+                enableSensorTypes = enableSensorTypes,
+                signalsPerSecond = signalsPerSecond
             )
         }
     }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/sensors/SensorEventEmitterTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/sensors/SensorEventEmitterTest.kt
@@ -32,7 +32,7 @@ class SensorEventEmitterTest {
     @Test
     fun `should convert signals per second to sampling period microseconds`() {
         val sensorOptions: SensorOptions = mockk {
-            every { enabledSensorTypes } returns setOf(
+            every { enableSensorTypes } returns setOf(
                 Sensor.TYPE_ACCELEROMETER
             )
             every { signalsPerSecond } returns 25
@@ -46,7 +46,7 @@ class SensorEventEmitterTest {
     @Test
     fun `should register multiple sensors`() {
         val sensorOptions: SensorOptions = mockk {
-            every { enabledSensorTypes } returns setOf(
+            every { enableSensorTypes } returns setOf(
                 Sensor.TYPE_ACCELEROMETER_UNCALIBRATED,
                 Sensor.TYPE_MAGNETIC_FIELD_UNCALIBRATED,
                 Sensor.TYPE_GYROSCOPE_UNCALIBRATED
@@ -62,7 +62,7 @@ class SensorEventEmitterTest {
     @Test
     fun `should only unregister once`() {
         val sensorOptions: SensorOptions = mockk {
-            every { enabledSensorTypes } returns setOf(
+            every { enableSensorTypes } returns setOf(
                 Sensor.TYPE_ACCELEROMETER_UNCALIBRATED,
                 Sensor.TYPE_MAGNETIC_FIELD_UNCALIBRATED,
                 Sensor.TYPE_GYROSCOPE_UNCALIBRATED
@@ -83,7 +83,7 @@ class SensorEventEmitterTest {
             mockSensor(Sensor.TYPE_ACCELEROMETER)
         )
         val sensorOptions: SensorOptions = mockk {
-            every { enabledSensorTypes } returns setOf(
+            every { enableSensorTypes } returns setOf(
                 Sensor.TYPE_ACCELEROMETER,
                 Sensor.TYPE_GYROSCOPE
             )
@@ -98,7 +98,7 @@ class SensorEventEmitterTest {
     @Test
     fun `should emit events`() {
         val sensorOptions: SensorOptions = mockk {
-            every { enabledSensorTypes } returns setOf(
+            every { enableSensorTypes } returns setOf(
                 Sensor.TYPE_ACCELEROMETER
             )
             every { signalsPerSecond } returns 25
@@ -117,7 +117,7 @@ class SensorEventEmitterTest {
     @Test
     fun `should not emit events after unregister`() {
         val sensorOptions: SensorOptions = mockk {
-            every { enabledSensorTypes } returns setOf(
+            every { enableSensorTypes } returns setOf(
                 Sensor.TYPE_ACCELEROMETER
             )
             every { signalsPerSecond } returns 25

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/NavigatorLoader.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/NavigatorLoader.kt
@@ -2,9 +2,8 @@ package com.mapbox.navigation.navigator.internal
 
 import com.mapbox.base.common.logger.Logger
 import com.mapbox.common.HttpServiceFactory
-import com.mapbox.navigation.base.options.AutomobileProfile
 import com.mapbox.navigation.base.options.DeviceProfile
-import com.mapbox.navigation.base.options.HandheldProfile
+import com.mapbox.navigation.base.options.DeviceType
 import com.mapbox.navigation.navigator.NavigationOkHttpService
 import com.mapbox.navigation.navigator.internal.NavigatorLoader.customConfig
 import com.mapbox.navigator.Navigator
@@ -33,12 +32,12 @@ internal object NavigatorLoader {
     }
 
     private fun settingsProfile(deviceProfile: DeviceProfile): SettingsProfile {
-        return when (deviceProfile) {
-            is AutomobileProfile -> {
-                SettingsProfile(ProfileApplication.KAUTO, ProfilePlatform.KANDROID)
-            }
-            is HandheldProfile -> {
+        return when (deviceProfile.deviceType) {
+            DeviceType.HANDHELD -> {
                 SettingsProfile(ProfileApplication.KMOBILE, ProfilePlatform.KANDROID)
+            }
+            DeviceType.AUTOMOBILE -> {
+                SettingsProfile(ProfileApplication.KAUTO, ProfilePlatform.KANDROID)
             }
             else -> throw NotImplementedError("Unknown device profile")
         }


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Resolves https://github.com/mapbox/mapbox-navigation-android/issues/2709

Making the SEMVER changes needed to resolve the issue.
Had to change the DeviceProfile to make it pass the new equals test

``` kotlin
    @Test
    fun whenSeparateBuildersBuildSameOptions() {
        val timeFormat = TWELVE_HOURS
        val navigatorPredictionMillis = 1020L

        val options = NavigationOptions.Builder(context)
            .timeFormatType(timeFormat)
            .navigatorPredictionMillis(navigatorPredictionMillis)
            .build()

        val otherOptions = NavigationOptions.Builder(context)
            .timeFormatType(timeFormat)
            .navigatorPredictionMillis(navigatorPredictionMillis)
            .build()

        assertEquals(options, otherOptions)
    }
```

- [ ] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [x] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->