### PR TITLE
Add guidance view image provider

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/GuidanceViewActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/GuidanceViewActivity.kt
@@ -49,8 +49,8 @@ import kotlinx.android.synthetic.main.activity_guidance_view.startNavigation
 class GuidanceViewActivity : AppCompatActivity(), OnMapReadyCallback {
 
     private val mapboxReplayer = MapboxReplayer()
-    private val origin: Point = Point.fromLngLat(139.7772481, 35.6818019)
-    private val destination: Point = Point.fromLngLat(139.7756523, 35.6789722)
+    private val origin: Point = Point.fromLngLat(139.7745686, 35.677573)
+    private val destination: Point = Point.fromLngLat(139.784915, 35.680960)
 
     private lateinit var mapboxNavigation: MapboxNavigation
     private var navigationMapboxMap: NavigationMapboxMap? = null

--- a/libnavigation-ui/api/current.txt
+++ b/libnavigation-ui/api/current.txt
@@ -358,6 +358,22 @@ package com.mapbox.navigation.ui.feedback {
 
 package com.mapbox.navigation.ui.instruction {
 
+  public final class GuidanceViewImageProvider {
+    ctor public GuidanceViewImageProvider();
+    method public void cancelRender(android.content.Context context);
+    method public void renderGuidanceView(com.mapbox.api.directions.v5.models.BannerInstructions bannerInstructions, android.content.Context context, com.mapbox.navigation.ui.instruction.GuidanceViewImageProvider.OnGuidanceImageDownload callback);
+    field public static final com.mapbox.navigation.ui.instruction.GuidanceViewImageProvider.Companion! Companion;
+  }
+
+  public static final class GuidanceViewImageProvider.Companion {
+  }
+
+  public static interface GuidanceViewImageProvider.OnGuidanceImageDownload {
+    method public void onFailure(String? message);
+    method public void onGuidanceImageReady(android.graphics.Bitmap bitmap);
+    method public void onNoGuidanceImageUrl();
+  }
+
   public class InstructionView extends android.widget.RelativeLayout implements com.mapbox.navigation.ui.feedback.FeedbackBottomSheetListener androidx.lifecycle.LifecycleObserver {
     ctor public InstructionView(android.content.Context!);
     ctor public InstructionView(android.content.Context!, android.util.AttributeSet?);

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/instruction/GuidanceViewImageProvider.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/instruction/GuidanceViewImageProvider.kt
@@ -1,0 +1,118 @@
+package com.mapbox.navigation.ui.instruction
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.drawable.Drawable
+import com.mapbox.api.directions.v5.models.BannerComponents
+import com.mapbox.api.directions.v5.models.BannerInstructions
+import com.mapbox.navigation.utils.internal.ifNonNull
+import com.squareup.picasso.OkHttp3Downloader
+import com.squareup.picasso.Picasso
+import com.squareup.picasso.Target
+import java.lang.Exception
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
+
+/**
+ * The class serves as a medium to emit bitmaps for the respective guidance view URL embedded in
+ * [BannerInstructions]
+ * @constructor
+ */
+class GuidanceViewImageProvider() {
+
+    companion object {
+        private val USER_AGENT_KEY = "User-Agent"
+        private val USER_AGENT_VALUE = "MapboxJava/"
+    }
+
+    /**
+     * This is added a solution to bypass the issue with Picasso where [com.squareup.picasso.Target]
+     * get's garbage collected and guidance view is hence not rendered. Found the solution here
+     * https://stackoverflow.com/questions/24180805/onbitmaploaded-of-target-object-not-called-on-first-load#answers
+     */
+    private val targets: MutableList<Target> = mutableListOf()
+    private val okHttpClient = OkHttpClient.Builder().addInterceptor { chain: Interceptor.Chain ->
+        chain.proceed(
+            chain.request().newBuilder().addHeader(USER_AGENT_KEY, USER_AGENT_VALUE).build()
+        )
+    }.build()
+
+    /**
+     * The API reads the bannerInstruction and returns a guidance view bitmap if one is available
+     * @param bannerInstructions [BannerInstructions]
+     * @param context [Context]
+     * @param callback [OnGuidanceImageDownload] Callback that is triggered based on appropriate state of image downloading
+     */
+    fun renderGuidanceView(
+        bannerInstructions: BannerInstructions,
+        context: Context,
+        callback: OnGuidanceImageDownload
+    ) {
+        val target = object : Target {
+            override fun onPrepareLoad(placeHolderDrawable: Drawable?) {
+            }
+
+            override fun onBitmapFailed(e: Exception?, errorDrawable: Drawable?) {
+                targets.remove(this)
+                callback.onFailure(e?.message)
+            }
+
+            override fun onBitmapLoaded(bitmap: Bitmap?, from: Picasso.LoadedFrom?) {
+                targets.remove(this)
+                ifNonNull(bitmap) { b ->
+                    callback.onGuidanceImageReady(b)
+                } ?: callback.onFailure("Something went wrong. Bitmap not received")
+            }
+        }
+        val bannerView = bannerInstructions.view()
+        ifNonNull(bannerView) { view ->
+            val bannerComponents = view.components()
+            ifNonNull(bannerComponents) { components ->
+                components.forEachIndexed { _, component ->
+                    component.takeIf { c -> c.type() == BannerComponents.GUIDANCE_VIEW }?.let {
+                        targets.add(target)
+                        Picasso.Builder(context).downloader(OkHttp3Downloader(okHttpClient))
+                            .build()
+                            .load(it.imageUrl())
+                            .into(target)
+                    }
+                }
+            } ?: callback.onNoGuidanceImageUrl()
+        } ?: callback.onNoGuidanceImageUrl()
+    }
+
+    /**
+     * The API allows you to cancel the rendering of guidance view.
+     * @param context Context
+     */
+    fun cancelRender(context: Context) {
+        if (targets.isNotEmpty()) {
+            for(target in targets) {
+                Picasso.Builder(context).build().cancelRequest(target)
+            }
+            targets.clear()
+        }
+    }
+
+    /**
+     * Callback that is triggered based on appropriate state of image downloading
+     */
+    interface OnGuidanceImageDownload {
+        /**
+         * Triggered when the image has been downloaded and is ready to be used.
+         * @param bitmap Bitmap
+         */
+        fun onGuidanceImageReady(bitmap: Bitmap)
+
+        /**
+         * Triggered when their is no URL to render
+         */
+        fun onNoGuidanceImageUrl()
+
+        /**
+         * Triggered when there is a failure to download the image
+         * @param message String?
+         */
+        fun onFailure(message: String?)
+    }
+}

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/instruction/GuidanceViewImageProviderTest.kt
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/instruction/GuidanceViewImageProviderTest.kt
@@ -1,0 +1,35 @@
+package com.mapbox.navigation.ui.instruction
+
+import android.content.Context
+import com.mapbox.api.directions.v5.models.BannerInstructions
+import com.mapbox.api.directions.v5.models.BannerView
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Test
+
+class GuidanceViewImageProviderTest {
+
+    private val context: Context = mockk(relaxed = true)
+    private val callback: GuidanceViewImageProvider.OnGuidanceImageDownload = mockk(relaxed = true)
+    private val guidanceViewImageProvider: GuidanceViewImageProvider = GuidanceViewImageProvider()
+
+    @Test
+    fun `when banner view is null`() {
+        val bannerInstructions: BannerInstructions = mockk()
+        every { bannerInstructions.view() } returns null
+        guidanceViewImageProvider.renderGuidanceView(bannerInstructions, context, callback)
+        verify(exactly = 1) { callback.onNoGuidanceImageUrl() }
+    }
+
+    @Test
+    fun `when banner component list is null`() {
+        val bannerInstructions: BannerInstructions = mockk()
+        val bannerView: BannerView = mockk()
+        every { bannerInstructions.view() } returns bannerView
+        every { bannerView.components() } returns null
+
+        guidanceViewImageProvider.renderGuidanceView(bannerInstructions, context, callback)
+        verify(exactly = 1) { callback.onNoGuidanceImageUrl() }
+    }
+}


### PR DESCRIPTION
## Description

Add Guidance View Image Provider that would return a bitmap of guidance view to be drawn on the screen. (Fix [#3365](https://github.com/mapbox/mapbox-navigation-android/issues/3365))

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Add Guidance View Image Provider that would return a bitmap of guidance view to be drawn on the screen.

### Implementation

Add Guidance View Image Provider that would return a bitmap of guidance view to be drawn on the screen.

## Screenshots or Gifs

Please include all the media files to give some context about what's being implemented or fixed. It's not mandatory to upload screenshots or gifs, but for most of the cases it becomes really handy to get into the scope of the feature / bug being fixed and also it's REALLY useful for UI related PRs ![screenshot gif](link)

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have updated the `CHANGELOG` including this PR
- [x] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->