### PR TITLE
Fix simple navigation crash

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/SimpleMapboxNavigationKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/SimpleMapboxNavigationKt.kt
@@ -134,7 +134,6 @@ class SimpleMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
                 mapboxNavigation.setRoutes(emptyList())
             }
         }
-        initViews()
         mapView.onCreate(savedInstanceState)
         mapView.getMapAsync(this)
         localLocationEngine = LocationEngineProvider.getBestLocationEngine(applicationContext)
@@ -142,6 +141,7 @@ class SimpleMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
         val mapboxNavigationOptions = MapboxNavigation
             .defaultNavigationOptionsBuilder(this, Utils.getMapboxAccessToken(this))
         mapboxNavigation = getMapboxNavigation(mapboxNavigationOptions)
+        initViews()
     }
 
     override fun onMapReady(mapboxMap: MapboxMap) {
@@ -192,6 +192,7 @@ class SimpleMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
                     add(0, route)
                 })
             }
+            initNavigationButton()
 
             when (originalRoute) {
                 null -> {
@@ -218,11 +219,23 @@ class SimpleMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
         speechPlayer = NavigationSpeechPlayer(speechPlayerProvider)
     }
 
-    @SuppressLint("MissingPermission")
     private fun initViews() {
         bottomSheetBehavior = BottomSheetBehavior.from(bottomSheetFasterRoute)
         bottomSheetBehavior.peekHeight = 0
         fasterRouteAcceptProgress.max = maxProgress.toInt()
+        dismissLayout.setOnClickListener {
+            fasterRouteSelectionTimer.onFinish()
+        }
+        acceptLayout.setOnClickListener { _ ->
+            fasterRoutes.takeIf { it.isNotEmpty() }?.let { newRoutes ->
+                mapboxNavigation.setRoutes(newRoutes)
+                fasterRouteSelectionTimer.onFinish()
+            }
+        }
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun initNavigationButton() {
         startNavigation.setOnClickListener {
             updateCameraOnNavigationStateChange(true)
             mapboxNavigation.registerVoiceInstructionsObserver(this)
@@ -232,15 +245,6 @@ class SimpleMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
                 initDynamicCamera(routes[0])
             }
             navigationMapboxMap.showAlternativeRoutes(false)
-        }
-        dismissLayout.setOnClickListener {
-            fasterRouteSelectionTimer.onFinish()
-        }
-        acceptLayout.setOnClickListener { _ ->
-            fasterRoutes.takeIf { it.isNotEmpty() }?.let { newRoutes ->
-                mapboxNavigation.setRoutes(newRoutes)
-                fasterRouteSelectionTimer.onFinish()
-            }
         }
     }
 


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Resolves https://github.com/mapbox/mapbox-navigation-android/issues/3368 [another firebase link](https://console.firebase.google.com/u/0/project/mapbox-navigation-android/testlab/histories/bh.2e74b6b076d6fa53/matrices/6949324609649430590/executions/bs.d9ff1d836de81f6a)

The onClick is subscribed before the map is initialized. moving it so the onClick will not be set until after. 

- [ ] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->