### PR TITLE
Use OkHttp to download guidance view image

### DIFF
--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/DeviceProfile.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/DeviceProfile.kt
@@ -1,7 +1,5 @@
 package com.mapbox.navigation.base.options
 
-import java.lang.annotation.Inherited
-
 /**
  * The navigation SDK has algorithms optimized for the type of data
  * being provided. The device profile selects the optimization.

--- a/libnavigation-ui/api/current.txt
+++ b/libnavigation-ui/api/current.txt
@@ -348,8 +348,8 @@ package com.mapbox.navigation.ui.instruction {
 
   public final class GuidanceViewImageProvider {
     ctor public GuidanceViewImageProvider();
-    method public void cancelRender(android.content.Context context);
-    method public void renderGuidanceView(com.mapbox.api.directions.v5.models.BannerInstructions bannerInstructions, android.content.Context context, com.mapbox.navigation.ui.instruction.GuidanceViewImageProvider.OnGuidanceImageDownload callback);
+    method public void cancelRender();
+    method public void renderGuidanceView(com.mapbox.api.directions.v5.models.BannerInstructions bannerInstructions, com.mapbox.navigation.ui.instruction.GuidanceViewImageProvider.OnGuidanceImageDownload callback);
     field public static final com.mapbox.navigation.ui.instruction.GuidanceViewImageProvider.Companion! Companion;
   }
 

--- a/libnavigation-ui/build.gradle
+++ b/libnavigation-ui/build.gradle
@@ -115,6 +115,7 @@ dependencies {
   testImplementation dependenciesList.robolectric
   testImplementation dependenciesList.json
   testImplementation dependenciesList.androidxTestCore
+  testImplementation dependenciesList.mockwebserver
   testImplementation dependenciesList.coroutinesTestAndroid
   testImplementation project(':libtesting-utils')
 }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/instruction/InstructionView.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/instruction/InstructionView.java
@@ -417,7 +417,7 @@ public class InstructionView extends RelativeLayout implements LifecycleObserver
    */
   public void toggleGuidanceView(@Nullable BannerInstructions bannerInstructions) {
     if (bannerInstructions != null && guidanceViewImageProvider != null) {
-      guidanceViewImageProvider.renderGuidanceView(bannerInstructions, getContext(), callback);
+      guidanceViewImageProvider.renderGuidanceView(bannerInstructions, callback);
     } else {
       animateHideGuidanceViewImage();
     }

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/instruction/BannerComponentsFaker.java
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/instruction/BannerComponentsFaker.java
@@ -19,4 +19,20 @@ class BannerComponentsFaker {
       .abbreviation("abbreviation text")
       .build();
   }
+
+  static BannerComponents bannerComponentsWithNullGuidanceUrl() {
+    return BannerComponents.builder()
+            .type("guidance-view")
+            .text("some text")
+            .imageUrl(null)
+            .build();
+  }
+
+  static BannerComponents bannerComponentsWithGuidanceUrlNoAccessToken(String path) {
+    return BannerComponents.builder()
+            .type("guidance-view")
+            .text("some text")
+            .imageUrl(path)
+            .build();
+  }
 }

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/instruction/GuidanceViewImageProviderTest.kt
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/instruction/GuidanceViewImageProviderTest.kt
@@ -1,24 +1,51 @@
 package com.mapbox.navigation.ui.instruction
 
-import android.content.Context
+import com.mapbox.api.directions.v5.models.BannerComponents
 import com.mapbox.api.directions.v5.models.BannerInstructions
 import com.mapbox.api.directions.v5.models.BannerView
+import com.mapbox.navigation.testing.MainCoroutineRule
+import com.mapbox.navigation.utils.internal.ThreadController
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.slot
+import io.mockk.unmockkObject
 import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 
+@ExperimentalCoroutinesApi
 class GuidanceViewImageProviderTest {
 
-    private val context: Context = mockk(relaxed = true)
+    @get:Rule
+    var coroutineRule = MainCoroutineRule()
+
     private val callback: GuidanceViewImageProvider.OnGuidanceImageDownload = mockk(relaxed = true)
     private val guidanceViewImageProvider: GuidanceViewImageProvider = GuidanceViewImageProvider()
+
+    @Before
+    fun setUp() {
+        mockkObject(ThreadController)
+        every { ThreadController.IODispatcher } returns coroutineRule.testDispatcher
+    }
+
+    @After
+    fun tearDown() {
+        unmockkObject(ThreadController)
+    }
 
     @Test
     fun `when banner view is null`() {
         val bannerInstructions: BannerInstructions = mockk()
         every { bannerInstructions.view() } returns null
-        guidanceViewImageProvider.renderGuidanceView(bannerInstructions, context, callback)
+        guidanceViewImageProvider.renderGuidanceView(bannerInstructions, callback)
         verify(exactly = 1) { callback.onNoGuidanceImageUrl() }
     }
 
@@ -29,7 +56,48 @@ class GuidanceViewImageProviderTest {
         every { bannerInstructions.view() } returns bannerView
         every { bannerView.components() } returns null
 
-        guidanceViewImageProvider.renderGuidanceView(bannerInstructions, context, callback)
+        guidanceViewImageProvider.renderGuidanceView(bannerInstructions, callback)
         verify(exactly = 1) { callback.onNoGuidanceImageUrl() }
+    }
+
+    @Test
+    fun `when guidance view url is null`() {
+        val captureData = slot<String>()
+        val bannerInstructions: BannerInstructions = mockk()
+        val bannerView: BannerView = mockk()
+        val bannerComponentList =
+            mutableListOf<BannerComponents>(BannerComponentsFaker.bannerComponentsWithNullGuidanceUrl())
+        every { bannerInstructions.view() } returns bannerView
+        every { bannerView.components() } returns bannerComponentList
+
+        guidanceViewImageProvider.renderGuidanceView(bannerInstructions, callback)
+        verify(exactly = 1) { callback.onFailure(capture(captureData)) }
+        assertEquals("Guidance View Image URL is null", captureData.captured)
+    }
+
+    @Test
+    fun `when url has invalid access token`() = coroutineRule.runBlockingTest {
+        val mockWebServer = MockWebServer()
+        mockWebServer.enqueue(MockResponse().setResponseCode(401))
+        mockWebServer.start()
+
+        val captureData = slot<String>()
+        val bannerInstructions: BannerInstructions = mockk()
+        val bannerView: BannerView = mockk()
+        val bannerComponentList =
+            mutableListOf<BannerComponents>(BannerComponentsFaker.bannerComponentsWithGuidanceUrlNoAccessToken(mockWebServer.url("guidance-views/v1/1580515200/jct/CA075101?arrow_ids=CA07510E&access_token=null").toString()))
+        every { bannerInstructions.view() } returns bannerView
+        every { bannerView.components() } returns bannerComponentList
+
+        guidanceViewImageProvider.renderGuidanceView(bannerInstructions, callback)
+
+        val job = launch {
+            guidanceViewImageProvider.renderGuidanceView(bannerInstructions, callback)
+        }
+        job.join()
+
+        verify(exactly = 1) { callback.onFailure(capture(captureData)) }
+        assertEquals("Client Error", captureData.captured)
+        mockWebServer.shutdown()
     }
 }


### PR DESCRIPTION
## Description

Remove the use of Picasso and use Okhttp to download the guidance view image. (Fixes [#3373](https://github.com/mapbox/mapbox-navigation-android/issues/3373)

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Remove the use of Picasso and use Okhttp to download the guidance view image.

### Implementation

Use coroutines to download the image on the background thread.

## Screenshots or Gifs

Please include all the media files to give some context about what's being implemented or fixed. It's not mandatory to upload screenshots or gifs, but for most of the cases it becomes really handy to get into the scope of the feature / bug being fixed and also it's REALLY useful for UI related PRs ![screenshot gif](link)

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->