### PR TITLE
Building highlighting layer addition adjustments

### DIFF
--- a/examples/src/main/res/values/strings.xml
+++ b/examples/src/main/res/values/strings.xml
@@ -24,10 +24,10 @@
     <string name="description_custom_ui_component_style" translatable="false">Shows how to use your own colors to style the UI SDK Components: InstructionView, SummaryBottomSheet, and so on.</string>
 
     <string name="title_building_highlight_kotlin" translatable="false">Building footprint highlight</string>
-    <string name="description_building_highlight_kotlin" translatable="false">Use the Navigation UI SDK\'s to show and customize a highlighted building footprint. Great to show the final destination building location. Example\'s in Kotlin.</string>
+    <string name="description_building_highlight_kotlin" translatable="false">Use the Navigation UI SDK\'s to show and customize a single highlighted building footprint.</string>
 
     <string name="title_ui_building_extrusions_kotlin" translatable="false">Building extrusions highlight</string>
-    <string name="description_ui_building_extrusions_kotlin" translatable="false">Use the Navigation UI SDK\'s to show and customize 3D building extrusions.</string>
+    <string name="description_ui_building_extrusions_kotlin" translatable="false">Use the Navigation UI SDK\'s to show and customize a single highlighted 3D building extrusion.</string>
 
     <string name="title_replay_route" translatable="false">Replay route</string>
     <string name="description_replay_route" translatable="false">Shows how to use the MapboxNavigation class with the replay engine in Kotlin code.</string>

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/internal/utils/MapUtils.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/internal/utils/MapUtils.java
@@ -34,4 +34,23 @@ public final class MapUtils {
       style.addLayerBelow(layer, idBelowLayer);
     }
   }
+
+  /**
+   * Generic method for adding a new layer to the map that's above another specific layer.
+   *
+   * @param style that the current mapView is using
+   * @param layer a layer that will be added to the map
+   * @param idAboveLayer optionally providing the layer which the new layer should be placed above
+   */
+  public static void addLayerToMapAbove(@NonNull Style style, @NonNull Layer layer,
+                                   @Nullable String idAboveLayer) {
+    if (layer != null && style.getLayer(layer.getId()) != null) {
+      return;
+    }
+    if (idAboveLayer == null) {
+      style.addLayer(layer);
+    } else {
+      style.addLayerAbove(layer, idAboveLayer);
+    }
+  }
 }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/building/BuildingExtrusionHighlightLayer.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/building/BuildingExtrusionHighlightLayer.kt
@@ -11,7 +11,6 @@ import com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillExtrusionHeight
 import com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillExtrusionOpacity
 import com.mapbox.mapboxsdk.style.layers.PropertyFactory.visibility
 import com.mapbox.navigation.ui.internal.utils.MapUtils
-import com.mapbox.navigation.ui.map.building.BuildingFootprintHighlightLayer.Companion.HIGHLIGHTED_BUILDING_FOOTPRINT_LAYER_ID
 
 /**
  * This layer handles the creation and customization of a [FillExtrusionLayer]
@@ -115,7 +114,7 @@ class BuildingExtrusionHighlightLayer(private val mapboxMap: MapboxMap) {
                         fillExtrusionOpacity(opacity),
                         fillExtrusionHeight(get("height"))
                 )
-                MapUtils.addLayerToMap(style, this, HIGHLIGHTED_BUILDING_FOOTPRINT_LAYER_ID)
+                MapUtils.addLayerToMap(style, this, null)
             }
         }
     }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/building/BuildingFootprintHighlightLayer.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/building/BuildingFootprintHighlightLayer.kt
@@ -110,7 +110,7 @@ class BuildingFootprintHighlightLayer(private val mapboxMap: MapboxMap) {
                         fillColor(color),
                         fillOpacity(opacity)
                 )
-                MapUtils.addLayerToMap(style, this, BuildingLayerSupport.BUILDING_LAYER_ID)
+                MapUtils.addLayerToMapAbove(style, this, BuildingLayerSupport.BUILDING_LAYER_ID)
             }
         }
     }

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/map/MapUtilsTest.java
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/map/MapUtilsTest.java
@@ -1,0 +1,67 @@
+package com.mapbox.navigation.ui.map;
+
+import com.mapbox.mapboxsdk.maps.Style;
+import com.mapbox.mapboxsdk.style.layers.Layer;
+import com.mapbox.mapboxsdk.style.layers.LineLayer;
+import com.mapbox.mapboxsdk.style.layers.SymbolLayer;
+import com.mapbox.navigation.ui.internal.utils.MapUtils;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static junit.framework.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class MapUtilsTest {
+
+  @Test
+  public void addLayerToMapAbove_layerListSizeAmountCorrect() {
+    SymbolLayer layerOne = mock(SymbolLayer.class);
+    LineLayer layerTwo = mock(LineLayer.class);
+    LineLayer layerThree = mock(LineLayer.class);
+    LineLayer layerToAddViaMapUtils = mock(LineLayer.class);
+
+    List<Layer> layers = new ArrayList<>();
+    layers.add(layerOne);
+    layers.add(layerTwo);
+    layers.add(layerThree);
+    layers.add(layerToAddViaMapUtils);
+
+    Style mockedStyle = mock(Style.class);
+    mockedStyle.addLayer(layerOne);
+    mockedStyle.addLayer(layerTwo);
+    mockedStyle.addLayer(layerThree);
+    MapUtils.addLayerToMapAbove(mockedStyle, layerToAddViaMapUtils, null);
+
+    when(mockedStyle.getLayers()).thenReturn(layers);
+    assertEquals(mockedStyle.getLayers().size(), layers.size());
+  }
+
+  @Test
+  public void addLayerToMapAbove_declaredAboveLayer() {
+    SymbolLayer layerOne = mock(SymbolLayer.class);
+    LineLayer layerTwo = mock(LineLayer.class);
+    when(layerTwo.getId()).thenReturn("idForLayerTwo");
+    LineLayer layerThree = mock(LineLayer.class);
+    LineLayer layerToAddViaMapUtils = mock(LineLayer.class);
+    when(layerThree.getId()).thenReturn("idForLayerToAddViaMapUtils");
+
+    List<Layer> layers = new ArrayList<>();
+    layers.add(layerOne);
+    layers.add(layerTwo);
+    layers.add(layerThree);
+    layers.add(layerToAddViaMapUtils);
+
+    Style mockedStyle = mock(Style.class);
+    mockedStyle.addLayer(layerOne);
+    mockedStyle.addLayer(layerTwo);
+    mockedStyle.addLayer(layerThree);
+    MapUtils.addLayerToMapAbove(mockedStyle, layerToAddViaMapUtils, layerTwo.getId());
+
+    when(mockedStyle.getLayers()).thenReturn(layers);
+    assertEquals(mockedStyle.getLayers().get(2).getId(), "idForLayerToAddViaMapUtils");
+  }
+}


### PR DESCRIPTION
## Description

Follow up to https://github.com/mapbox/mapbox-navigation-android/pull/3361

Single extrusions and footprints weren't visible because the `BuildingFootprintHighlightLayer` and `BuildingExtrusionHighlightLayer` classes were passing in a layer ID as the third parameter of [`MapUtils.addLayerToMap()`](https://github.com/mapbox/mapbox-navigation-android/blob/master/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/internal/utils/MapUtils.java#L27). This affects where the highlight layer is in the `Style`'s z-index layer stack.

### Implementation

Passing in `null` [`MapUtils.addLayerToMap()`](https://github.com/mapbox/mapbox-navigation-android/blob/master/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/internal/utils/MapUtils.java#L27) in `BuildingExtrusionHighlightLayer` because the single extrusion should be above everything else.

Passing in `building` in the new `MapUtils.addLayerToMapAbove()` in `BuildingFootprintHighlightLayer ` because the single highlighted footprint should be directly above the `building` layer if the `building` layer exists in the `Style`.

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->