### PR TITLE
Automated builder schema tests for Kotlin builders and refactor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@ endef
 .PHONY: check
 check:
 	$(call run-gradle-tasks,$(CORE_MODULES),ktlint) \
-	&& $(call run-gradle-tasks,$(CORE_MODULES),checkstyle)
+	&& $(call run-gradle-tasks,$(UI_MODULES),ktlint) \
+	&& $(call run-gradle-tasks,$(UI_MODULES),checkstyle)
 
 .PHONY: license-verification
 license-verification:

--- a/examples/src/main/java/com/mapbox/navigation/examples/NavigationApplication.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/NavigationApplication.kt
@@ -7,7 +7,7 @@ import androidx.multidex.MultiDexApplication
 import com.mapbox.base.common.logger.model.Message
 import com.mapbox.common.logger.MapboxLogger
 import com.mapbox.mapboxsdk.Mapbox
-import com.mapbox.navigation.base.options.HandheldProfile
+import com.mapbox.navigation.base.options.DeviceProfile
 import com.mapbox.navigation.examples.utils.Utils
 import com.mapbox.navigation.examples.utils.extensions.DelegatesExt
 import com.mapbox.navigation.navigator.internal.MapboxNativeNavigatorImpl
@@ -60,6 +60,6 @@ class NavigationApplication : MultiDexApplication() {
         }
 
         Mapbox.getInstance(applicationContext, mapboxAccessToken)
-        MapboxNativeNavigatorImpl.create(HandheldProfile(), MapboxLogger)
+        MapboxNativeNavigatorImpl.create(DeviceProfile.Builder().build(), MapboxLogger)
     }
 }

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/DebugMapboxNavigationKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/DebugMapboxNavigationKt.kt
@@ -61,6 +61,7 @@ import com.mapbox.navigation.ui.voice.SpeechPlayerProvider
 import com.mapbox.navigation.ui.voice.VoiceInstructionLoader
 import java.io.File
 import java.lang.ref.WeakReference
+import java.net.URI
 import java.util.Date
 import java.util.Locale
 import kotlinx.android.synthetic.main.content_simple_mapbox_navigation.*
@@ -142,7 +143,7 @@ class DebugMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
         val optionsBuilder = MapboxNavigation
             .defaultNavigationOptionsBuilder(this, Utils.getMapboxAccessToken(this))
             .onboardRouterOptions(OnboardRouterOptions.Builder()
-                .tilesUri("https://api-routing-tiles-staging.tilestream.net")
+                .tilesUri(URI("https://api-routing-tiles-staging.tilestream.net"))
                 .tilesVersion("2020_02_02-03_00_00")
                 .build())
             .navigatorPredictionMillis(1000L)

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/FreeDriveNavigationActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/FreeDriveNavigationActivity.kt
@@ -23,6 +23,7 @@ import com.mapbox.navigation.ui.camera.NavigationCamera
 import com.mapbox.navigation.ui.map.NavigationMapboxMap
 import com.mapbox.navigation.ui.map.NavigationMapboxMapInstanceState
 import java.lang.ref.WeakReference
+import java.net.URI
 import kotlinx.android.synthetic.main.free_drive_navigation_layout.*
 import timber.log.Timber
 
@@ -58,7 +59,7 @@ class FreeDriveNavigationActivity : AppCompatActivity(), OnMapReadyCallback {
         val mapboxNavigationOptions = MapboxNavigation
             .defaultNavigationOptionsBuilder(this, Utils.getMapboxAccessToken(this))
             .onboardRouterOptions(OnboardRouterOptions.Builder()
-                .tilesUri("https://api-routing-tiles-staging.tilestream.net")
+                .tilesUri(URI("https://api-routing-tiles-staging.tilestream.net"))
                 .tilesVersion("2020_02_02-03_00_00")
                 .build())
             .build()

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayWaypointsActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayWaypointsActivity.kt
@@ -190,7 +190,7 @@ class ReplayWaypointsActivity : AppCompatActivity(), OnMapReadyCallback {
 
     private val arrivalController = object : ArrivalController {
         val arrivalOptions = ArrivalOptions.Builder()
-            .arriveInSeconds(5.0)
+            .arrivalInSeconds(5.0)
             .build()
         override fun arrivalOptions(): ArrivalOptions = arrivalOptions
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -74,6 +74,7 @@ ext {
 
       // Kotlin
       kotlinStdLib              : "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${version.kotlinStdLib}",
+      kotlinReflect             : "org.jetbrains.kotlin:kotlin-reflect:${version.kotlinStdLib}",
 
       // Coroutines and Channels
       coroutinesAndroid         : "org.jetbrains.kotlinx:kotlinx-coroutines-android:${version.coroutinesAndroid}",

--- a/gradle/unit-testing-dependencies.gradle
+++ b/gradle/unit-testing-dependencies.gradle
@@ -4,4 +4,5 @@ dependencies {
     testImplementation dependenciesList.coroutinesTestAndroid
     testImplementation dependenciesList.mockk
     testImplementation dependenciesList.robolectric
+    testImplementation dependenciesList.kotlinReflect
 }

--- a/libdirections-onboard/src/main/java/com/mapbox/navigation/route/onboard/OfflineRoute.kt
+++ b/libdirections-onboard/src/main/java/com/mapbox/navigation/route/onboard/OfflineRoute.kt
@@ -9,27 +9,18 @@ import com.mapbox.navigation.utils.internal.ifNonNull
  * The [OfflineRoute] class wraps the [RouteUrl] class with parameters which
  * could be set in order for an offline navigation session to successfully begin.
  */
-internal class OfflineRoute
-private constructor(
+internal class OfflineRoute private constructor(
     private val routeUrl: RouteUrl,
-    bicycleType: OfflineCriteria.BicycleType?,
+    private val bicycleType: OfflineCriteria.BicycleType?,
     private val cyclingSpeed: Float?,
     private val cyclewayBias: Float?,
     private val hillBias: Float?,
     private val ferryBias: Float?,
     private val roughSurfaceBias: Float?,
-    waypointTypes: List<OfflineCriteria.WaypointType?>?
+    private val waypointTypes: List<OfflineCriteria.WaypointType?>?
 ) {
-    private val bicycleType: String?
-    private val waypointTypes: String?
-
-    init {
-        this.bicycleType = bicycleType?.type
-        this.waypointTypes = checkWaypointTypes(waypointTypes)
-    }
 
     companion object {
-
         private const val BICYCLE_TYPE_QUERY_PARAMETER = "bicycle_type"
         private const val CYCLING_SPEED_QUERY_PARAMETER = "cycling_speed"
         private const val CYCLEWAY_BIAS_QUERY_PARAMETER = "cycleway_bias"
@@ -37,17 +28,19 @@ private constructor(
         private const val FERRY_BIAS_QUERY_PARAMETER = "ferry_bias"
         private const val ROUGH_SURFACE_BIAS_QUERY_PARAMETER = "rough_surface_bias"
         private const val WAYPOINT_TYPES_QUERY_PARAMETER = "waypoint_types"
-
-        /**
-         * Build a new [OfflineRoute] object with the proper offline navigation parameters already setup.
-         *
-         * @return a [Builder] object for creating this object
-         */
-        @JvmStatic
-        fun builder(routeUrl: RouteUrl): Builder {
-            return Builder(routeUrl)
-        }
     }
+
+    /**
+     * @return builder matching the one used to create this instance
+     */
+    fun toBuilder() = Builder(routeUrl)
+        .bicycleType(bicycleType)
+        .cyclingSpeed(cyclingSpeed)
+        .cyclewayBias(cyclewayBias)
+        .hillBias(hillBias)
+        .ferryBias(ferryBias)
+        .roughSurfaceBias(roughSurfaceBias)
+        .waypointTypes(waypointTypes)
 
     /**
      * Builds a URL string for offline.
@@ -75,7 +68,7 @@ private constructor(
     private fun buildOfflineUrl(url: Uri): String {
         val offlineUrlBuilder = url.buildUpon()
 
-        offlineUrlBuilder.appendQueryParamIfNonNull(BICYCLE_TYPE_QUERY_PARAMETER, bicycleType)
+        offlineUrlBuilder.appendQueryParamIfNonNull(BICYCLE_TYPE_QUERY_PARAMETER, bicycleType?.type)
         offlineUrlBuilder.appendQueryParamIfNonNull(CYCLING_SPEED_QUERY_PARAMETER, cyclingSpeed)
         offlineUrlBuilder.appendQueryParamIfNonNull(CYCLEWAY_BIAS_QUERY_PARAMETER, cyclewayBias)
         offlineUrlBuilder.appendQueryParamIfNonNull(HILL_BIAS_QUERY_PARAMETER, hillBias)
@@ -84,7 +77,7 @@ private constructor(
             ROUGH_SURFACE_BIAS_QUERY_PARAMETER,
             roughSurfaceBias
         )
-        offlineUrlBuilder.appendQueryParamIfNonNull(WAYPOINT_TYPES_QUERY_PARAMETER, waypointTypes)
+        offlineUrlBuilder.appendQueryParamIfNonNull(WAYPOINT_TYPES_QUERY_PARAMETER, checkWaypointTypes(waypointTypes))
 
         return offlineUrlBuilder.build().toString()
     }
@@ -96,6 +89,40 @@ private constructor(
         ifNonNull(value) {
             appendQueryParameter(key, it)
         } ?: this
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as OfflineRoute
+
+        if (routeUrl != other.routeUrl) return false
+        if (bicycleType != other.bicycleType) return false
+        if (cyclingSpeed != other.cyclingSpeed) return false
+        if (cyclewayBias != other.cyclewayBias) return false
+        if (hillBias != other.hillBias) return false
+        if (ferryBias != other.ferryBias) return false
+        if (roughSurfaceBias != other.roughSurfaceBias) return false
+        if (waypointTypes != other.waypointTypes) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = routeUrl.hashCode()
+        result = 31 * result + (bicycleType?.hashCode() ?: 0)
+        result = 31 * result + (cyclingSpeed?.hashCode() ?: 0)
+        result = 31 * result + (cyclewayBias?.hashCode() ?: 0)
+        result = 31 * result + (hillBias?.hashCode() ?: 0)
+        result = 31 * result + (ferryBias?.hashCode() ?: 0)
+        result = 31 * result + (roughSurfaceBias?.hashCode() ?: 0)
+        result = 31 * result + (waypointTypes?.hashCode() ?: 0)
+        return result
+    }
+
+    override fun toString(): String {
+        return "OfflineRoute(routeUrl=$routeUrl, bicycleType=$bicycleType, cyclingSpeed=$cyclingSpeed, cyclewayBias=$cyclewayBias, hillBias=$hillBias, ferryBias=$ferryBias, roughSurfaceBias=$roughSurfaceBias, waypointTypes=$waypointTypes)"
+    }
 
     class Builder internal constructor(private val routeUrl: RouteUrl) {
         private var bicycleType: OfflineCriteria.BicycleType? = null

--- a/libdirections-onboard/src/main/java/com/mapbox/navigation/route/onboard/internal/MapboxOnboardRouter.kt
+++ b/libdirections-onboard/src/main/java/com/mapbox/navigation/route/onboard/internal/MapboxOnboardRouter.kt
@@ -84,7 +84,7 @@ class MapboxOnboardRouter(
         val destination = routeOptions.coordinates().last()
         val waypoints = routeOptions.coordinates().drop(1).dropLast(1)
 
-        val offlineRouter = OfflineRoute.builder(
+        val offlineRouter = OfflineRoute.Builder(
             RouteUrl(
                 accessToken = routeOptions.accessToken(),
                 user = routeOptions.user(),

--- a/libdirections-onboard/src/test/java/com/mapbox/navigation/route/onboard/OfflineRouteTest.kt
+++ b/libdirections-onboard/src/test/java/com/mapbox/navigation/route/onboard/OfflineRouteTest.kt
@@ -31,6 +31,11 @@ internal class OfflineRouteTest : BuilderTest<OfflineRoute, OfflineRoute.Builder
     }
 
     @Test
+    override fun trigger() {
+        // only used to trigger JUnit4 to run this class if all test cases come from the parent
+    }
+
+    @Test
     fun addBicycleTypeIncludedInRequest() {
         val routeUrl = provideOnlineRouteBuilder()
         val offlineRoute = OfflineRoute.Builder(routeUrl)

--- a/libdirections-onboard/src/test/java/com/mapbox/navigation/route/onboard/OfflineRouteTest.kt
+++ b/libdirections-onboard/src/test/java/com/mapbox/navigation/route/onboard/OfflineRouteTest.kt
@@ -2,8 +2,11 @@ package com.mapbox.navigation.route.onboard
 
 import com.mapbox.geojson.Point
 import com.mapbox.navigation.base.internal.route.RouteUrl
+import com.mapbox.navigation.testing.BuilderTest
+import io.mockk.mockk
 import java.io.UnsupportedEncodingException
 import java.net.URLDecoder
+import kotlin.reflect.KClass
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -12,12 +15,25 @@ import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = Config.NONE)
-class OfflineRouteTest {
+internal class OfflineRouteTest : BuilderTest<OfflineRoute, OfflineRoute.Builder>() {
+
+    override fun getImplementationClass(): KClass<OfflineRoute> = OfflineRoute::class
+
+    override fun getFilledUpBuilder(): OfflineRoute.Builder {
+        return OfflineRoute.Builder(mockk(relaxed = true))
+            .bicycleType(mockk(relaxed = true))
+            .cyclingSpeed(123f)
+            .cyclewayBias(456f)
+            .hillBias(789f)
+            .ferryBias(101112f)
+            .roughSurfaceBias(131415f)
+            .waypointTypes(mockk(relaxed = true))
+    }
 
     @Test
     fun addBicycleTypeIncludedInRequest() {
         val routeUrl = provideOnlineRouteBuilder()
-        val offlineRoute = OfflineRoute.builder(routeUrl)
+        val offlineRoute = OfflineRoute.Builder(routeUrl)
             .bicycleType(OfflineCriteria.BicycleType.ROAD).build()
 
         val offlineUrl = offlineRoute.buildUrl()
@@ -28,7 +44,7 @@ class OfflineRouteTest {
     @Test
     fun addCyclingSpeedIncludedInRequest() {
         val routeUrl = provideOnlineRouteBuilder()
-        val offlineRoute = OfflineRoute.builder(routeUrl)
+        val offlineRoute = OfflineRoute.Builder(routeUrl)
             .cyclingSpeed(10.0f).build()
 
         val offlineUrl = offlineRoute.buildUrl()
@@ -39,7 +55,7 @@ class OfflineRouteTest {
     @Test
     fun addCyclewayBiasIncludedInRequest() {
         val routeUrl = provideOnlineRouteBuilder()
-        val offlineRoute = OfflineRoute.builder(routeUrl)
+        val offlineRoute = OfflineRoute.Builder(routeUrl)
             .cyclewayBias(0.0f).build()
 
         val offlineUrl = offlineRoute.buildUrl()
@@ -50,7 +66,7 @@ class OfflineRouteTest {
     @Test
     fun addHillBiasIncludedInRequest() {
         val routeUrl = provideOnlineRouteBuilder()
-        val offlineRoute = OfflineRoute.builder(routeUrl)
+        val offlineRoute = OfflineRoute.Builder(routeUrl)
             .hillBias(0.0f).build()
 
         val offlineUrl = offlineRoute.buildUrl()
@@ -61,7 +77,7 @@ class OfflineRouteTest {
     @Test
     fun addFerryBiasIncludedInRequest() {
         val routeUrl = provideOnlineRouteBuilder()
-        val offlineRoute = OfflineRoute.builder(routeUrl)
+        val offlineRoute = OfflineRoute.Builder(routeUrl)
             .ferryBias(0.0f).build()
 
         val offlineUrl = offlineRoute.buildUrl()
@@ -72,7 +88,7 @@ class OfflineRouteTest {
     @Test
     fun addRoughSurfaceBiasIncludedInRequest() {
         val routeUrl = provideOnlineRouteBuilder()
-        val offlineRoute = OfflineRoute.builder(routeUrl)
+        val offlineRoute = OfflineRoute.Builder(routeUrl)
             .roughSurfaceBias(0.0f).build()
 
         val offlineUrl = offlineRoute.buildUrl()
@@ -90,7 +106,7 @@ class OfflineRouteTest {
             null,
             OfflineCriteria.WaypointType.BREAK
         )
-        val offlineRoute = OfflineRoute.builder(routeUrl)
+        val offlineRoute = OfflineRoute.Builder(routeUrl)
             .waypointTypes(waypointTypes).build()
         val offlineUrl = offlineRoute.buildUrl()
 

--- a/libnavigation-base/api/current.txt
+++ b/libnavigation-base/api/current.txt
@@ -66,6 +66,7 @@ package com.mapbox.navigation.base.options {
   public final class DeviceProfile {
     method public String getCustomConfig();
     method public com.mapbox.navigation.base.options.DeviceType getDeviceType();
+    method public com.mapbox.navigation.base.options.DeviceProfile.Builder toBuilder();
   }
 
   public static final class DeviceProfile.Builder {
@@ -123,7 +124,6 @@ package com.mapbox.navigation.base.options {
     ctor public OnboardRouterOptions.Builder();
     method public com.mapbox.navigation.base.options.OnboardRouterOptions build();
     method public com.mapbox.navigation.base.options.OnboardRouterOptions.Builder filePath(String? filePath);
-    method public com.mapbox.navigation.base.options.OnboardRouterOptions.Builder tilesUri(String tilesUri);
     method public com.mapbox.navigation.base.options.OnboardRouterOptions.Builder tilesUri(java.net.URI tilesUri);
     method public com.mapbox.navigation.base.options.OnboardRouterOptions.Builder tilesVersion(String version);
   }
@@ -173,19 +173,20 @@ package com.mapbox.navigation.base.trip.model {
     method public int getLegIndex();
     method public com.mapbox.api.directions.v5.models.RouteLeg? getRouteLeg();
     method public com.mapbox.api.directions.v5.models.LegStep? getUpcomingStep();
+    method public com.mapbox.navigation.base.trip.model.RouteLegProgress.Builder toBuilder();
   }
 
   public static final class RouteLegProgress.Builder {
     ctor public RouteLegProgress.Builder();
     method public com.mapbox.navigation.base.trip.model.RouteLegProgress build();
-    method public com.mapbox.navigation.base.trip.model.RouteLegProgress.Builder currentStepProgress(com.mapbox.navigation.base.trip.model.RouteStepProgress currentStepProgress);
+    method public com.mapbox.navigation.base.trip.model.RouteLegProgress.Builder currentStepProgress(com.mapbox.navigation.base.trip.model.RouteStepProgress? currentStepProgress);
     method public com.mapbox.navigation.base.trip.model.RouteLegProgress.Builder distanceRemaining(float distanceRemaining);
     method public com.mapbox.navigation.base.trip.model.RouteLegProgress.Builder distanceTraveled(float distanceTraveled);
     method public com.mapbox.navigation.base.trip.model.RouteLegProgress.Builder durationRemaining(double durationRemaining);
     method public com.mapbox.navigation.base.trip.model.RouteLegProgress.Builder fractionTraveled(float fractionTraveled);
     method public com.mapbox.navigation.base.trip.model.RouteLegProgress.Builder legIndex(int legIndex);
-    method public com.mapbox.navigation.base.trip.model.RouteLegProgress.Builder routeLeg(com.mapbox.api.directions.v5.models.RouteLeg routeLeg);
-    method public com.mapbox.navigation.base.trip.model.RouteLegProgress.Builder upcomingStep(com.mapbox.api.directions.v5.models.LegStep upcomingStep);
+    method public com.mapbox.navigation.base.trip.model.RouteLegProgress.Builder routeLeg(com.mapbox.api.directions.v5.models.RouteLeg? routeLeg);
+    method public com.mapbox.navigation.base.trip.model.RouteLegProgress.Builder upcomingStep(com.mapbox.api.directions.v5.models.LegStep? upcomingStep);
   }
 
   public final class RouteProgress {
@@ -202,13 +203,14 @@ package com.mapbox.navigation.base.trip.model {
     method public com.mapbox.geojson.Geometry? getRouteGeometryWithBuffer();
     method public java.util.List<com.mapbox.geojson.Point>? getUpcomingStepPoints();
     method public com.mapbox.api.directions.v5.models.VoiceInstructions? getVoiceInstructions();
+    method public com.mapbox.navigation.base.trip.model.RouteProgress.Builder toBuilder();
   }
 
   public static final class RouteProgress.Builder {
-    ctor public RouteProgress.Builder();
+    ctor public RouteProgress.Builder(com.mapbox.api.directions.v5.models.DirectionsRoute route);
     method public com.mapbox.navigation.base.trip.model.RouteProgress.Builder bannerInstructions(com.mapbox.api.directions.v5.models.BannerInstructions? bannerInstructions);
     method public com.mapbox.navigation.base.trip.model.RouteProgress build();
-    method public com.mapbox.navigation.base.trip.model.RouteProgress.Builder currentLegProgress(com.mapbox.navigation.base.trip.model.RouteLegProgress legProgress);
+    method public com.mapbox.navigation.base.trip.model.RouteProgress.Builder currentLegProgress(com.mapbox.navigation.base.trip.model.RouteLegProgress? legProgress);
     method public com.mapbox.navigation.base.trip.model.RouteProgress.Builder currentState(com.mapbox.navigation.base.trip.model.RouteProgressState currentState);
     method public com.mapbox.navigation.base.trip.model.RouteProgress.Builder distanceRemaining(float distanceRemaining);
     method public com.mapbox.navigation.base.trip.model.RouteProgress.Builder distanceTraveled(float distanceTraveled);
@@ -216,7 +218,6 @@ package com.mapbox.navigation.base.trip.model {
     method public com.mapbox.navigation.base.trip.model.RouteProgress.Builder fractionTraveled(float fractionTraveled);
     method public com.mapbox.navigation.base.trip.model.RouteProgress.Builder inTunnel(boolean inTunnel);
     method public com.mapbox.navigation.base.trip.model.RouteProgress.Builder remainingWaypoints(int remainingWaypoints);
-    method public com.mapbox.navigation.base.trip.model.RouteProgress.Builder route(com.mapbox.api.directions.v5.models.DirectionsRoute route);
     method public com.mapbox.navigation.base.trip.model.RouteProgress.Builder routeGeometryWithBuffer(com.mapbox.geojson.Geometry? routeGeometryWithBuffer);
     method public com.mapbox.navigation.base.trip.model.RouteProgress.Builder upcomingStepPoints(java.util.List<com.mapbox.geojson.Point>? upcomingStepPoints);
     method public com.mapbox.navigation.base.trip.model.RouteProgress.Builder voiceInstructions(com.mapbox.api.directions.v5.models.VoiceInstructions? voiceInstructions);
@@ -240,6 +241,7 @@ package com.mapbox.navigation.base.trip.model {
     method public com.mapbox.api.directions.v5.models.LegStep? getStep();
     method public int getStepIndex();
     method public java.util.List<com.mapbox.geojson.Point>? getStepPoints();
+    method public com.mapbox.navigation.base.trip.model.RouteStepProgress.Builder toBuilder();
   }
 
   public static final class RouteStepProgress.Builder {
@@ -249,9 +251,9 @@ package com.mapbox.navigation.base.trip.model {
     method public com.mapbox.navigation.base.trip.model.RouteStepProgress.Builder distanceTraveled(float distanceTraveled);
     method public com.mapbox.navigation.base.trip.model.RouteStepProgress.Builder durationRemaining(double durationRemaining);
     method public com.mapbox.navigation.base.trip.model.RouteStepProgress.Builder fractionTraveled(float fractionTraveled);
-    method public com.mapbox.navigation.base.trip.model.RouteStepProgress.Builder step(com.mapbox.api.directions.v5.models.LegStep step);
+    method public com.mapbox.navigation.base.trip.model.RouteStepProgress.Builder step(com.mapbox.api.directions.v5.models.LegStep? step);
     method public com.mapbox.navigation.base.trip.model.RouteStepProgress.Builder stepIndex(int stepIndex);
-    method public com.mapbox.navigation.base.trip.model.RouteStepProgress.Builder stepPoints(java.util.List<com.mapbox.geojson.Point> stepPoints);
+    method public com.mapbox.navigation.base.trip.model.RouteStepProgress.Builder stepPoints(java.util.List<com.mapbox.geojson.Point>? stepPoints);
   }
 
 }

--- a/libnavigation-base/api/current.txt
+++ b/libnavigation-base/api/current.txt
@@ -63,40 +63,26 @@ package com.mapbox.navigation.base.metrics {
 
 package com.mapbox.navigation.base.options {
 
-  public final class AutomobileProfile implements com.mapbox.navigation.base.options.DeviceProfile {
-    ctor public AutomobileProfile(String customConfig);
-    ctor public AutomobileProfile();
+  public final class DeviceProfile {
     method public String getCustomConfig();
+    method public com.mapbox.navigation.base.options.DeviceType getDeviceType();
   }
 
-  public interface DeviceProfile {
-    method public String getCustomConfig();
-    property public abstract String customConfig;
+  public static final class DeviceProfile.Builder {
+    ctor public DeviceProfile.Builder();
+    method public com.mapbox.navigation.base.options.DeviceProfile build();
+    method public com.mapbox.navigation.base.options.DeviceProfile.Builder customConfig(String customConfig);
+    method public com.mapbox.navigation.base.options.DeviceProfile.Builder deviceType(com.mapbox.navigation.base.options.DeviceType deviceType);
   }
 
-  public final class HandheldProfile implements com.mapbox.navigation.base.options.DeviceProfile {
-    ctor public HandheldProfile(String customConfig);
-    ctor public HandheldProfile();
-    method public String getCustomConfig();
+  public enum DeviceType {
+    enum_constant public static final com.mapbox.navigation.base.options.DeviceType AUTOMOBILE;
+    enum_constant public static final com.mapbox.navigation.base.options.DeviceType HANDHELD;
   }
 
   public final class NavigationOptions {
-    ctor public NavigationOptions(android.content.Context applicationContext, String? accessToken, com.mapbox.android.core.location.LocationEngine locationEngine, @com.mapbox.navigation.base.TimeFormat.Type int timeFormatType, long navigatorPredictionMillis, com.mapbox.navigation.base.formatter.DistanceFormatter? distanceFormatter, com.mapbox.navigation.base.options.OnboardRouterOptions onboardRouterOptions, boolean isFromNavigationUi, boolean isDebugLoggingEnabled, com.mapbox.navigation.base.options.DeviceProfile deviceProfile, com.mapbox.navigation.base.options.NavigationOptions.Builder builder);
-    method public android.content.Context component1();
-    method public com.mapbox.navigation.base.options.DeviceProfile component10();
-    method public com.mapbox.navigation.base.options.NavigationOptions.Builder component11();
-    method public String? component2();
-    method public com.mapbox.android.core.location.LocationEngine component3();
-    method public int component4();
-    method public long component5();
-    method public com.mapbox.navigation.base.formatter.DistanceFormatter? component6();
-    method public com.mapbox.navigation.base.options.OnboardRouterOptions component7();
-    method public boolean component8();
-    method public boolean component9();
-    method public com.mapbox.navigation.base.options.NavigationOptions copy(android.content.Context applicationContext, String? accessToken, com.mapbox.android.core.location.LocationEngine locationEngine, int timeFormatType, long navigatorPredictionMillis, com.mapbox.navigation.base.formatter.DistanceFormatter? distanceFormatter, com.mapbox.navigation.base.options.OnboardRouterOptions onboardRouterOptions, boolean isFromNavigationUi, boolean isDebugLoggingEnabled, com.mapbox.navigation.base.options.DeviceProfile deviceProfile, com.mapbox.navigation.base.options.NavigationOptions.Builder builder);
     method public String? getAccessToken();
     method public android.content.Context getApplicationContext();
-    method public com.mapbox.navigation.base.options.NavigationOptions.Builder getBuilder();
     method public com.mapbox.navigation.base.options.DeviceProfile getDeviceProfile();
     method public com.mapbox.navigation.base.formatter.DistanceFormatter? getDistanceFormatter();
     method public com.mapbox.android.core.location.LocationEngine getLocationEngine();
@@ -127,13 +113,6 @@ package com.mapbox.navigation.base.options {
   }
 
   public final class OnboardRouterOptions {
-    ctor public OnboardRouterOptions(java.net.URI tilesUri, String tilesVersion, String? filePath, com.mapbox.navigation.base.options.OnboardRouterOptions.Builder builder);
-    method public java.net.URI component1();
-    method public String component2();
-    method public String? component3();
-    method public com.mapbox.navigation.base.options.OnboardRouterOptions.Builder component4();
-    method public com.mapbox.navigation.base.options.OnboardRouterOptions copy(java.net.URI tilesUri, String tilesVersion, String? filePath, com.mapbox.navigation.base.options.OnboardRouterOptions.Builder builder);
-    method public com.mapbox.navigation.base.options.OnboardRouterOptions.Builder getBuilder();
     method public String? getFilePath();
     method public java.net.URI getTilesUri();
     method public String getTilesVersion();
@@ -143,7 +122,7 @@ package com.mapbox.navigation.base.options {
   public static final class OnboardRouterOptions.Builder {
     ctor public OnboardRouterOptions.Builder();
     method public com.mapbox.navigation.base.options.OnboardRouterOptions build();
-    method public com.mapbox.navigation.base.options.OnboardRouterOptions.Builder filePath(String filePath);
+    method public com.mapbox.navigation.base.options.OnboardRouterOptions.Builder filePath(String? filePath);
     method public com.mapbox.navigation.base.options.OnboardRouterOptions.Builder tilesUri(String tilesUri);
     method public com.mapbox.navigation.base.options.OnboardRouterOptions.Builder tilesUri(java.net.URI tilesUri);
     method public com.mapbox.navigation.base.options.OnboardRouterOptions.Builder tilesVersion(String version);
@@ -186,16 +165,6 @@ package com.mapbox.navigation.base.route {
 package com.mapbox.navigation.base.trip.model {
 
   public final class RouteLegProgress {
-    ctor public RouteLegProgress(int legIndex, com.mapbox.api.directions.v5.models.RouteLeg? routeLeg, float distanceTraveled, float distanceRemaining, double durationRemaining, float fractionTraveled, com.mapbox.navigation.base.trip.model.RouteStepProgress? currentStepProgress, com.mapbox.api.directions.v5.models.LegStep? upcomingStep);
-    method public int component1();
-    method public com.mapbox.api.directions.v5.models.RouteLeg? component2();
-    method public float component3();
-    method public float component4();
-    method public double component5();
-    method public float component6();
-    method public com.mapbox.navigation.base.trip.model.RouteStepProgress? component7();
-    method public com.mapbox.api.directions.v5.models.LegStep? component8();
-    method public com.mapbox.navigation.base.trip.model.RouteLegProgress copy(int legIndex, com.mapbox.api.directions.v5.models.RouteLeg? routeLeg, float distanceTraveled, float distanceRemaining, double durationRemaining, float fractionTraveled, com.mapbox.navigation.base.trip.model.RouteStepProgress? currentStepProgress, com.mapbox.api.directions.v5.models.LegStep? upcomingStep);
     method public com.mapbox.navigation.base.trip.model.RouteStepProgress? getCurrentStepProgress();
     method public float getDistanceRemaining();
     method public float getDistanceTraveled();
@@ -220,21 +189,6 @@ package com.mapbox.navigation.base.trip.model {
   }
 
   public final class RouteProgress {
-    ctor public RouteProgress(com.mapbox.api.directions.v5.models.DirectionsRoute route, com.mapbox.geojson.Geometry? routeGeometryWithBuffer, com.mapbox.api.directions.v5.models.BannerInstructions? bannerInstructions, com.mapbox.api.directions.v5.models.VoiceInstructions? voiceInstructions, com.mapbox.navigation.base.trip.model.RouteProgressState currentState, com.mapbox.navigation.base.trip.model.RouteLegProgress? currentLegProgress, java.util.List<com.mapbox.geojson.Point>? upcomingStepPoints, boolean inTunnel, float distanceRemaining, float distanceTraveled, double durationRemaining, float fractionTraveled, int remainingWaypoints);
-    method public com.mapbox.api.directions.v5.models.DirectionsRoute component1();
-    method public float component10();
-    method public double component11();
-    method public float component12();
-    method public int component13();
-    method public com.mapbox.geojson.Geometry? component2();
-    method public com.mapbox.api.directions.v5.models.BannerInstructions? component3();
-    method public com.mapbox.api.directions.v5.models.VoiceInstructions? component4();
-    method public com.mapbox.navigation.base.trip.model.RouteProgressState component5();
-    method public com.mapbox.navigation.base.trip.model.RouteLegProgress? component6();
-    method public java.util.List<com.mapbox.geojson.Point>? component7();
-    method public boolean component8();
-    method public float component9();
-    method public com.mapbox.navigation.base.trip.model.RouteProgress copy(com.mapbox.api.directions.v5.models.DirectionsRoute route, com.mapbox.geojson.Geometry? routeGeometryWithBuffer, com.mapbox.api.directions.v5.models.BannerInstructions? bannerInstructions, com.mapbox.api.directions.v5.models.VoiceInstructions? voiceInstructions, com.mapbox.navigation.base.trip.model.RouteProgressState currentState, com.mapbox.navigation.base.trip.model.RouteLegProgress? currentLegProgress, java.util.List<com.mapbox.geojson.Point>? upcomingStepPoints, boolean inTunnel, float distanceRemaining, float distanceTraveled, double durationRemaining, float fractionTraveled, int remainingWaypoints);
     method public com.mapbox.api.directions.v5.models.BannerInstructions? getBannerInstructions();
     method public com.mapbox.navigation.base.trip.model.RouteLegProgress? getCurrentLegProgress();
     method public com.mapbox.navigation.base.trip.model.RouteProgressState getCurrentState();
@@ -279,15 +233,6 @@ package com.mapbox.navigation.base.trip.model {
   }
 
   public final class RouteStepProgress {
-    ctor public RouteStepProgress(int stepIndex, com.mapbox.api.directions.v5.models.LegStep? step, java.util.List<com.mapbox.geojson.Point>? stepPoints, float distanceRemaining, float distanceTraveled, float fractionTraveled, double durationRemaining);
-    method public int component1();
-    method public com.mapbox.api.directions.v5.models.LegStep? component2();
-    method public java.util.List<com.mapbox.geojson.Point>? component3();
-    method public float component4();
-    method public float component5();
-    method public float component6();
-    method public double component7();
-    method public com.mapbox.navigation.base.trip.model.RouteStepProgress copy(int stepIndex, com.mapbox.api.directions.v5.models.LegStep? step, java.util.List<com.mapbox.geojson.Point>? stepPoints, float distanceRemaining, float distanceTraveled, float fractionTraveled, double durationRemaining);
     method public float getDistanceRemaining();
     method public float getDistanceTraveled();
     method public double getDurationRemaining();

--- a/libnavigation-base/build.gradle
+++ b/libnavigation-base/build.gradle
@@ -44,6 +44,7 @@ dependencies {
 
     implementation dependenciesList.kotlinStdLib
 
+    testImplementation project(':libtesting-utils')
     apply from: "${rootDir}/gradle/unit-testing-dependencies.gradle"
 }
 

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/DeviceProfile.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/DeviceProfile.kt
@@ -3,24 +3,76 @@ package com.mapbox.navigation.base.options
 /**
  * The navigation SDK has algorithms optimized for the type of data
  * being provided. The device profile selects the optimization.
+ *
+ * @param customConfig Json custom configuration used by the navigator
+ * @param deviceType The type of device providing data to the navigator.
  */
-interface DeviceProfile {
+class DeviceProfile private constructor(
+    val customConfig: String,
+    val deviceType: DeviceType
+) {
     /**
-     * Custom configuration in json format, understood by the navigator.
+     * Build a new [DeviceProfile]
      */
-    val customConfig: String
+    class Builder {
+        private var customConfig = ""
+        private var deviceType = DeviceType.HANDHELD
+
+        /**
+         * Json custom configuration used by the navigator
+         */
+        fun customConfig(customConfig: String) = apply { this.customConfig = customConfig }
+
+        /**
+         * Change the [DeviceType]
+         */
+        fun deviceType(deviceType: DeviceType) = apply { this.deviceType = deviceType }
+
+        /**
+         * Build the [DeviceType]
+         */
+        fun build() = DeviceProfile(
+            customConfig = customConfig,
+            deviceType = deviceType
+        )
+    }
+
+    /**
+     * Regenerate whenever a change is made
+     */
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as DeviceProfile
+
+        if (customConfig != other.customConfig) return false
+        if (deviceType != other.deviceType) return false
+
+        return true
+    }
+
+    /**
+     * Regenerate whenever a change is made
+     */
+    override fun hashCode(): Int {
+        var result = customConfig.hashCode()
+        result = 31 * result + deviceType.hashCode()
+        return result
+    }
 }
 
 /**
- * Any typical Android smart phone with GPS.
+ * The type of device providing data to the navigator.
  */
-class HandheldProfile @JvmOverloads constructor(
-    override val customConfig: String = ""
-) : DeviceProfile
+enum class DeviceType {
+    /**
+     * Any typical Android smart phone with GPS
+     */
+    HANDHELD,
 
-/**
- * Automobiles that provide data directly from the vehicle.
- */
-class AutomobileProfile @JvmOverloads constructor(
-    override val customConfig: String = ""
-) : DeviceProfile
+    /**
+     * Automobiles that provide data directly from the vehicle
+     */
+    AUTOMOBILE
+}

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/DeviceProfile.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/DeviceProfile.kt
@@ -1,5 +1,7 @@
 package com.mapbox.navigation.base.options
 
+import java.lang.annotation.Inherited
+
 /**
  * The navigation SDK has algorithms optimized for the type of data
  * being provided. The device profile selects the optimization.
@@ -67,6 +69,9 @@ class DeviceProfile private constructor(
         return result
     }
 
+    /**
+     * Returns a string representation of the object.
+     */
     override fun toString(): String {
         return "DeviceProfile(customConfig='$customConfig', deviceType=$deviceType)"
     }

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/DeviceProfile.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/DeviceProfile.kt
@@ -11,6 +11,12 @@ class DeviceProfile private constructor(
     val customConfig: String,
     val deviceType: DeviceType
 ) {
+
+    /**
+     * @return builder matching the one used to create this instance
+     */
+    fun toBuilder() = Builder().customConfig(customConfig).deviceType(deviceType)
+
     /**
      * Build a new [DeviceProfile]
      */
@@ -59,6 +65,10 @@ class DeviceProfile private constructor(
         var result = customConfig.hashCode()
         result = 31 * result + deviceType.hashCode()
         return result
+    }
+
+    override fun toString(): String {
+        return "DeviceProfile(customConfig='$customConfig', deviceType=$deviceType)"
     }
 }
 

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/NavigationOptions.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/NavigationOptions.kt
@@ -99,6 +99,9 @@ class NavigationOptions private constructor(
         return result
     }
 
+    /**
+     * Returns a string representation of the object.
+     */
     override fun toString(): String {
         return "NavigationOptions(applicationContext=$applicationContext, accessToken=$accessToken, locationEngine=$locationEngine, timeFormatType=$timeFormatType, navigatorPredictionMillis=$navigatorPredictionMillis, distanceFormatter=$distanceFormatter, onboardRouterOptions=$onboardRouterOptions, isFromNavigationUi=$isFromNavigationUi, isDebugLoggingEnabled=$isDebugLoggingEnabled, deviceProfile=$deviceProfile)"
     }

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/NavigationOptions.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/NavigationOptions.kt
@@ -16,11 +16,6 @@ import com.mapbox.navigation.base.formatter.DistanceFormatter
 const val DEFAULT_NAVIGATOR_PREDICTION_MILLIS = 1100L
 
 /**
- * Defines navigation options
- *
- * @param timeFormatType defines time format for calculation remaining trip time
- * @param navigatorPredictionMillis defines approximate navigator prediction in milliseconds
- *
  * This value will be used to offset the time at which the current location was calculated
  * in such a way as to project the location forward along the current trajectory so as to
  * appear more in sync with the users ground-truth location
@@ -28,14 +23,15 @@ const val DEFAULT_NAVIGATOR_PREDICTION_MILLIS = 1100L
  * @param applicationContext the Context of the Android Application
  * @param accessToken [Mapbox Access Token](https://docs.mapbox.com/help/glossary/access-token/)
  * @param locationEngine the mechanism responsible for providing location approximations to navigation
+ * @param timeFormatType defines time format for calculation remaining trip time
+ * @param navigatorPredictionMillis defines approximate navigator prediction in milliseconds
  * @param distanceFormatter [DistanceFormatter] for format distances showing in notification during navigation
  * @param onboardRouterOptions [OnboardRouterOptions] defines configuration for the default on-board router
  * @param isFromNavigationUi Boolean *true* if is called from UI, otherwise *false*
  * @param isDebugLoggingEnabled Boolean
  * @param deviceProfile [DeviceProfile] defines how navigation data should be interpretation
- * @param builder [Builder] used the create the [NavigationOptions]
  */
-data class NavigationOptions(
+class NavigationOptions private constructor(
     val applicationContext: Context,
     val accessToken: String?,
     val locationEngine: LocationEngine,
@@ -45,14 +41,63 @@ data class NavigationOptions(
     val onboardRouterOptions: OnboardRouterOptions,
     val isFromNavigationUi: Boolean,
     val isDebugLoggingEnabled: Boolean,
-    val deviceProfile: DeviceProfile,
-    val builder: Builder
+    val deviceProfile: DeviceProfile
 ) {
 
     /**
      * Get a builder to customize a subset of current options.
      */
-    fun toBuilder() = builder
+    fun toBuilder() = Builder(context = applicationContext).apply {
+        accessToken(accessToken)
+        locationEngine(locationEngine)
+        timeFormatType(timeFormatType)
+        navigatorPredictionMillis(navigatorPredictionMillis)
+        distanceFormatter(distanceFormatter)
+        onboardRouterOptions(onboardRouterOptions)
+        isFromNavigationUi(isFromNavigationUi)
+        isDebugLoggingEnabled(isDebugLoggingEnabled)
+        deviceProfile(deviceProfile)
+    }
+
+    /**
+     * Regenerate whenever a change is made
+     */
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as NavigationOptions
+
+        if (applicationContext != other.applicationContext) return false
+        if (accessToken != other.accessToken) return false
+        if (locationEngine != other.locationEngine) return false
+        if (timeFormatType != other.timeFormatType) return false
+        if (navigatorPredictionMillis != other.navigatorPredictionMillis) return false
+        if (distanceFormatter != other.distanceFormatter) return false
+        if (onboardRouterOptions != other.onboardRouterOptions) return false
+        if (isFromNavigationUi != other.isFromNavigationUi) return false
+        if (isDebugLoggingEnabled != other.isDebugLoggingEnabled) return false
+        if (deviceProfile != other.deviceProfile) return false
+
+        return true
+    }
+
+    /**
+     * Regenerate whenever a change is made
+     */
+    override fun hashCode(): Int {
+        var result = applicationContext.hashCode()
+        result = 31 * result + (accessToken?.hashCode() ?: 0)
+        result = 31 * result + locationEngine.hashCode()
+        result = 31 * result + timeFormatType
+        result = 31 * result + navigatorPredictionMillis.hashCode()
+        result = 31 * result + (distanceFormatter?.hashCode() ?: 0)
+        result = 31 * result + onboardRouterOptions.hashCode()
+        result = 31 * result + isFromNavigationUi.hashCode()
+        result = 31 * result + isDebugLoggingEnabled.hashCode()
+        result = 31 * result + deviceProfile.hashCode()
+        return result
+    }
 
     /**
      * Build a new [NavigationOptions]
@@ -67,7 +112,7 @@ data class NavigationOptions(
         private var onboardRouterOptions: OnboardRouterOptions = OnboardRouterOptions.Builder().build()
         private var isFromNavigationUi: Boolean = false
         private var isDebugLoggingEnabled: Boolean = false
-        private var deviceProfile: DeviceProfile = HandheldProfile()
+        private var deviceProfile: DeviceProfile = DeviceProfile.Builder().build()
 
         /**
          * Defines [Mapbox Access Token](https://docs.mapbox.com/help/glossary/access-token/)
@@ -138,8 +183,7 @@ data class NavigationOptions(
                 onboardRouterOptions = onboardRouterOptions,
                 isFromNavigationUi = isFromNavigationUi,
                 isDebugLoggingEnabled = isDebugLoggingEnabled,
-                deviceProfile = deviceProfile,
-                builder = this
+                deviceProfile = deviceProfile
             )
         }
     }

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/NavigationOptions.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/NavigationOptions.kt
@@ -99,6 +99,10 @@ class NavigationOptions private constructor(
         return result
     }
 
+    override fun toString(): String {
+        return "NavigationOptions(applicationContext=$applicationContext, accessToken=$accessToken, locationEngine=$locationEngine, timeFormatType=$timeFormatType, navigatorPredictionMillis=$navigatorPredictionMillis, distanceFormatter=$distanceFormatter, onboardRouterOptions=$onboardRouterOptions, isFromNavigationUi=$isFromNavigationUi, isDebugLoggingEnabled=$isDebugLoggingEnabled, deviceProfile=$deviceProfile)"
+    }
+
     /**
      * Build a new [NavigationOptions]
      */

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/OnboardRouterOptions.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/OnboardRouterOptions.kt
@@ -50,6 +50,9 @@ class OnboardRouterOptions private constructor(
         return result
     }
 
+    /**
+     * Returns a string representation of the object.
+     */
     override fun toString(): String {
         return "OnboardRouterOptions(tilesUri=$tilesUri, tilesVersion='$tilesVersion', filePath=$filePath)"
     }

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/OnboardRouterOptions.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/OnboardRouterOptions.kt
@@ -50,6 +50,10 @@ class OnboardRouterOptions private constructor(
         return result
     }
 
+    override fun toString(): String {
+        return "OnboardRouterOptions(tilesUri=$tilesUri, tilesVersion='$tilesVersion', filePath=$filePath)"
+    }
+
     /**
      * Builder for [OnboardRouterOptions]. You must choose a [filePath]
      * for this to be built successfully.
@@ -58,12 +62,6 @@ class OnboardRouterOptions private constructor(
         private var tilesUri: URI = URI("https://api.mapbox.com")
         private var tilesVersion: String = "2020_02_02-03_00_00"
         private var filePath: String? = null
-
-        /**
-         * Override the routing tiles endpoint with a [String]
-         */
-        fun tilesUri(tilesUri: String) =
-            apply { this.tilesUri = URI(tilesUri) }
 
         /**
          * Override the routing tiles endpoint with a [URI]

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/OnboardRouterOptions.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/OnboardRouterOptions.kt
@@ -9,18 +9,46 @@ import java.net.URI
  * @param tilesUri tiles endpoint
  * @param tilesVersion version of tiles
  * @param filePath used for storing road network tiles
- * @param builder used for updating options
  */
-data class OnboardRouterOptions(
+class OnboardRouterOptions private constructor(
     val tilesUri: URI,
     val tilesVersion: String,
-    val filePath: String?,
-    val builder: Builder
+    val filePath: String?
 ) {
     /**
      * @return the builder that created the [OnboardRouterOptions]
      */
-    fun toBuilder() = builder
+    fun toBuilder() = Builder().apply {
+        tilesUri(tilesUri)
+        tilesVersion(tilesVersion)
+        filePath(filePath)
+    }
+
+    /**
+     * Regenerate whenever a change is made
+     */
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as OnboardRouterOptions
+
+        if (tilesUri != other.tilesUri) return false
+        if (tilesVersion != other.tilesVersion) return false
+        if (filePath != other.filePath) return false
+
+        return true
+    }
+
+    /**
+     * Regenerate whenever a change is made
+     */
+    override fun hashCode(): Int {
+        var result = tilesUri.hashCode()
+        result = 31 * result + tilesVersion.hashCode()
+        result = 31 * result + (filePath?.hashCode() ?: 0)
+        return result
+    }
 
     /**
      * Builder for [OnboardRouterOptions]. You must choose a [filePath]
@@ -52,7 +80,7 @@ data class OnboardRouterOptions(
         /**
          * Creates a custom file path to store the road network tiles.
          */
-        fun filePath(filePath: String) =
+        fun filePath(filePath: String?) =
             apply { this.filePath = filePath }
 
         /**
@@ -62,8 +90,7 @@ data class OnboardRouterOptions(
             return OnboardRouterOptions(
                 tilesUri = tilesUri,
                 tilesVersion = tilesVersion,
-                filePath = filePath,
-                builder = this
+                filePath = filePath
             )
         }
     }

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteLegProgress.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteLegProgress.kt
@@ -85,6 +85,9 @@ class RouteLegProgress private constructor(
         return result
     }
 
+    /**
+     * Returns a string representation of the object.
+     */
     override fun toString(): String {
         return "RouteLegProgress(legIndex=$legIndex, routeLeg=$routeLeg, distanceTraveled=$distanceTraveled, distanceRemaining=$distanceRemaining, durationRemaining=$durationRemaining, fractionTraveled=$fractionTraveled, currentStepProgress=$currentStepProgress, upcomingStep=$upcomingStep)"
     }

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteLegProgress.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteLegProgress.kt
@@ -25,7 +25,7 @@ import com.mapbox.api.directions.v5.models.RouteLeg
  * @param upcomingStep Next/upcoming step immediately after the current step. If the user is on the last step
  * on the last leg, this will return null since a next step doesn't exist
  */
-data class RouteLegProgress(
+class RouteLegProgress private constructor(
     val legIndex: Int,
     val routeLeg: RouteLeg?,
     val distanceTraveled: Float,
@@ -35,6 +35,43 @@ data class RouteLegProgress(
     val currentStepProgress: RouteStepProgress?,
     val upcomingStep: LegStep?
 ) {
+
+    /**
+     * Regenerate whenever a change is made
+     */
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as RouteLegProgress
+
+        if (legIndex != other.legIndex) return false
+        if (routeLeg != other.routeLeg) return false
+        if (distanceTraveled != other.distanceTraveled) return false
+        if (distanceRemaining != other.distanceRemaining) return false
+        if (durationRemaining != other.durationRemaining) return false
+        if (fractionTraveled != other.fractionTraveled) return false
+        if (currentStepProgress != other.currentStepProgress) return false
+        if (upcomingStep != other.upcomingStep) return false
+
+        return true
+    }
+
+    /**
+     * Regenerate whenever a change is made
+     */
+    override fun hashCode(): Int {
+        var result = legIndex
+        result = 31 * result + (routeLeg?.hashCode() ?: 0)
+        result = 31 * result + distanceTraveled.hashCode()
+        result = 31 * result + distanceRemaining.hashCode()
+        result = 31 * result + durationRemaining.hashCode()
+        result = 31 * result + fractionTraveled.hashCode()
+        result = 31 * result + (currentStepProgress?.hashCode() ?: 0)
+        result = 31 * result + (upcomingStep?.hashCode() ?: 0)
+        return result
+    }
+
     /**
      * Builder of [RouteLegProgress].
      */

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteLegProgress.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteLegProgress.kt
@@ -37,6 +37,19 @@ class RouteLegProgress private constructor(
 ) {
 
     /**
+     * @return builder matching the one used to create this instance
+     */
+    fun toBuilder() = Builder()
+        .legIndex(legIndex)
+        .routeLeg(routeLeg)
+        .distanceTraveled(distanceTraveled)
+        .distanceRemaining(distanceRemaining)
+        .durationRemaining(durationRemaining)
+        .fractionTraveled(fractionTraveled)
+        .currentStepProgress(currentStepProgress)
+        .upcomingStep(upcomingStep)
+
+    /**
      * Regenerate whenever a change is made
      */
     override fun equals(other: Any?): Boolean {
@@ -72,6 +85,10 @@ class RouteLegProgress private constructor(
         return result
     }
 
+    override fun toString(): String {
+        return "RouteLegProgress(legIndex=$legIndex, routeLeg=$routeLeg, distanceTraveled=$distanceTraveled, distanceRemaining=$distanceRemaining, durationRemaining=$durationRemaining, fractionTraveled=$fractionTraveled, currentStepProgress=$currentStepProgress, upcomingStep=$upcomingStep)"
+    }
+
     /**
      * Builder of [RouteLegProgress].
      */
@@ -99,7 +116,7 @@ class RouteLegProgress private constructor(
          *
          * @return Builder
          */
-        fun routeLeg(routeLeg: RouteLeg) = apply { this.routeLeg = routeLeg }
+        fun routeLeg(routeLeg: RouteLeg?) = apply { this.routeLeg = routeLeg }
 
         /**
          * Total distance traveled in meters along current leg
@@ -140,7 +157,7 @@ class RouteLegProgress private constructor(
          *
          * @return Builder
          */
-        fun currentStepProgress(currentStepProgress: RouteStepProgress) =
+        fun currentStepProgress(currentStepProgress: RouteStepProgress?) =
             apply { this.currentStepProgress = currentStepProgress }
 
         /**
@@ -149,7 +166,7 @@ class RouteLegProgress private constructor(
          *
          * @return Builder
          */
-        fun upcomingStep(upcomingStep: LegStep) =
+        fun upcomingStep(upcomingStep: LegStep?) =
                 apply { this.upcomingStep = upcomingStep }
 
         /**

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteProgress.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteProgress.kt
@@ -116,6 +116,9 @@ class RouteProgress private constructor(
         return result
     }
 
+    /**
+     * Returns a string representation of the object.
+     */
     override fun toString(): String {
         return "RouteProgress(route=$route, routeGeometryWithBuffer=$routeGeometryWithBuffer, bannerInstructions=$bannerInstructions, voiceInstructions=$voiceInstructions, currentState=$currentState, currentLegProgress=$currentLegProgress, upcomingStepPoints=$upcomingStepPoints, inTunnel=$inTunnel, distanceRemaining=$distanceRemaining, distanceTraveled=$distanceTraveled, durationRemaining=$durationRemaining, fractionTraveled=$fractionTraveled, remainingWaypoints=$remainingWaypoints)"
     }

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteProgress.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteProgress.kt
@@ -37,7 +37,7 @@ import com.mapbox.geojson.Point
  * between 0 and 1 and isn't guaranteed to reach 1 before the user reaches the end of the route.
  * @param remainingWaypoints [Int] number of waypoints remaining on the current route.
  */
-data class RouteProgress(
+class RouteProgress private constructor(
     val route: DirectionsRoute,
     val routeGeometryWithBuffer: Geometry?,
     val bannerInstructions: BannerInstructions?,
@@ -52,6 +52,53 @@ data class RouteProgress(
     val fractionTraveled: Float,
     val remainingWaypoints: Int
 ) {
+
+    /**
+     * Regenerate whenever a change is made
+     */
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as RouteProgress
+
+        if (route != other.route) return false
+        if (routeGeometryWithBuffer != other.routeGeometryWithBuffer) return false
+        if (bannerInstructions != other.bannerInstructions) return false
+        if (voiceInstructions != other.voiceInstructions) return false
+        if (currentState != other.currentState) return false
+        if (currentLegProgress != other.currentLegProgress) return false
+        if (upcomingStepPoints != other.upcomingStepPoints) return false
+        if (inTunnel != other.inTunnel) return false
+        if (distanceRemaining != other.distanceRemaining) return false
+        if (distanceTraveled != other.distanceTraveled) return false
+        if (durationRemaining != other.durationRemaining) return false
+        if (fractionTraveled != other.fractionTraveled) return false
+        if (remainingWaypoints != other.remainingWaypoints) return false
+
+        return true
+    }
+
+    /**
+     * Regenerate whenever a change is made
+     */
+    override fun hashCode(): Int {
+        var result = route.hashCode()
+        result = 31 * result + (routeGeometryWithBuffer?.hashCode() ?: 0)
+        result = 31 * result + (bannerInstructions?.hashCode() ?: 0)
+        result = 31 * result + (voiceInstructions?.hashCode() ?: 0)
+        result = 31 * result + currentState.hashCode()
+        result = 31 * result + (currentLegProgress?.hashCode() ?: 0)
+        result = 31 * result + (upcomingStepPoints?.hashCode() ?: 0)
+        result = 31 * result + inTunnel.hashCode()
+        result = 31 * result + distanceRemaining.hashCode()
+        result = 31 * result + distanceTraveled.hashCode()
+        result = 31 * result + durationRemaining.hashCode()
+        result = 31 * result + fractionTraveled.hashCode()
+        result = 31 * result + remainingWaypoints
+        return result
+    }
+
     /**
      * Builder for [RouteProgress]
      */

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteProgress.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteProgress.kt
@@ -54,6 +54,23 @@ class RouteProgress private constructor(
 ) {
 
     /**
+     * @return builder matching the one used to create this instance
+     */
+    fun toBuilder() = Builder(route)
+        .routeGeometryWithBuffer(routeGeometryWithBuffer)
+        .bannerInstructions(bannerInstructions)
+        .voiceInstructions(voiceInstructions)
+        .currentState(currentState)
+        .currentLegProgress(currentLegProgress)
+        .upcomingStepPoints(upcomingStepPoints)
+        .inTunnel(inTunnel)
+        .distanceRemaining(distanceRemaining)
+        .distanceTraveled(distanceTraveled)
+        .durationRemaining(durationRemaining)
+        .fractionTraveled(fractionTraveled)
+        .remainingWaypoints(remainingWaypoints)
+
+    /**
      * Regenerate whenever a change is made
      */
     override fun equals(other: Any?): Boolean {
@@ -99,11 +116,16 @@ class RouteProgress private constructor(
         return result
     }
 
+    override fun toString(): String {
+        return "RouteProgress(route=$route, routeGeometryWithBuffer=$routeGeometryWithBuffer, bannerInstructions=$bannerInstructions, voiceInstructions=$voiceInstructions, currentState=$currentState, currentLegProgress=$currentLegProgress, upcomingStepPoints=$upcomingStepPoints, inTunnel=$inTunnel, distanceRemaining=$distanceRemaining, distanceTraveled=$distanceTraveled, durationRemaining=$durationRemaining, fractionTraveled=$fractionTraveled, remainingWaypoints=$remainingWaypoints)"
+    }
+
     /**
      * Builder for [RouteProgress]
+     *
+     * @param route [DirectionsRoute] currently is used for the navigation session
      */
-    class Builder {
-        private var directionsRoute: DirectionsRoute? = null
+    class Builder(private val route: DirectionsRoute) {
         private var routeGeometryWithBuffer: Geometry? = null
         private var bannerInstructions: BannerInstructions? = null
         private var voiceInstructions: VoiceInstructions? = null
@@ -116,16 +138,6 @@ class RouteProgress private constructor(
         private var durationRemaining: Double = 0.0
         private var fractionTraveled: Float = 0f
         private var remainingWaypoints: Int = 0
-
-        /**
-         * [DirectionsRoute] currently is used for the navigation session
-         *
-         * This is required in order to build a [RouteProgress]
-         *
-         * @return Builder
-         */
-        fun route(route: DirectionsRoute) =
-            apply { this.directionsRoute = route }
 
         /**
          * Current [DirectionsRoute] geometry with a buffer
@@ -170,7 +182,7 @@ class RouteProgress private constructor(
          *
          * @return Builder
          */
-        fun currentLegProgress(legProgress: RouteLegProgress) =
+        fun currentLegProgress(legProgress: RouteLegProgress?) =
             apply { this.currentLegProgress = legProgress }
 
         /**
@@ -237,7 +249,7 @@ class RouteProgress private constructor(
          */
         fun build(): RouteProgress {
             return RouteProgress(
-                requireNotNull(directionsRoute) { "DirectionsRoute is required to build a RouteProgress." },
+                route,
                 routeGeometryWithBuffer,
                 bannerInstructions,
                 voiceInstructions,

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteStepProgress.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteStepProgress.kt
@@ -75,6 +75,9 @@ class RouteStepProgress private constructor(
         return result
     }
 
+    /**
+     * Returns a string representation of the object.
+     */
     override fun toString(): String {
         return "RouteStepProgress(stepIndex=$stepIndex, step=$step, stepPoints=$stepPoints, distanceRemaining=$distanceRemaining, distanceTraveled=$distanceTraveled, fractionTraveled=$fractionTraveled, durationRemaining=$durationRemaining)"
     }

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteStepProgress.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteStepProgress.kt
@@ -30,6 +30,18 @@ class RouteStepProgress private constructor(
 ) {
 
     /**
+     * @return builder matching the one used to create this instance
+     */
+    fun toBuilder() = Builder()
+        .stepIndex(stepIndex)
+        .step(step)
+        .stepPoints(stepPoints)
+        .distanceRemaining(distanceRemaining)
+        .distanceTraveled(distanceTraveled)
+        .fractionTraveled(fractionTraveled)
+        .durationRemaining(durationRemaining)
+
+    /**
      * Regenerate whenever a change is made
      */
     override fun equals(other: Any?): Boolean {
@@ -63,6 +75,10 @@ class RouteStepProgress private constructor(
         return result
     }
 
+    override fun toString(): String {
+        return "RouteStepProgress(stepIndex=$stepIndex, step=$step, stepPoints=$stepPoints, distanceRemaining=$distanceRemaining, distanceTraveled=$distanceTraveled, fractionTraveled=$fractionTraveled, durationRemaining=$durationRemaining)"
+    }
+
     /**
      * Builder of [RouteStepProgress]
      */
@@ -88,7 +104,7 @@ class RouteStepProgress private constructor(
          *
          * @return Builder
          */
-        fun step(step: LegStep) =
+        fun step(step: LegStep?) =
             apply { this.step = step }
 
         /**
@@ -96,7 +112,7 @@ class RouteStepProgress private constructor(
          *
          * @return Builder
          */
-        fun stepPoints(stepPoints: List<Point>) =
+        fun stepPoints(stepPoints: List<Point>?) =
             apply { this.stepPoints = stepPoints }
 
         /**

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteStepProgress.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteStepProgress.kt
@@ -18,9 +18,8 @@ import com.mapbox.geojson.Point
  * float value between 0 and 1 and isn't guaranteed to reach 1 before the user reaches the
  * next step (if another step exist in route)
  * @param durationRemaining [Double] The duration remaining in seconds until the user reaches the end of the current step
- * @param guidanceViewURL [String] Guidance image URL
  */
-data class RouteStepProgress(
+class RouteStepProgress private constructor(
     val stepIndex: Int,
     val step: LegStep?,
     val stepPoints: List<Point>?,
@@ -29,6 +28,41 @@ data class RouteStepProgress(
     val fractionTraveled: Float,
     val durationRemaining: Double
 ) {
+
+    /**
+     * Regenerate whenever a change is made
+     */
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as RouteStepProgress
+
+        if (stepIndex != other.stepIndex) return false
+        if (step != other.step) return false
+        if (stepPoints != other.stepPoints) return false
+        if (distanceRemaining != other.distanceRemaining) return false
+        if (distanceTraveled != other.distanceTraveled) return false
+        if (fractionTraveled != other.fractionTraveled) return false
+        if (durationRemaining != other.durationRemaining) return false
+
+        return true
+    }
+
+    /**
+     * Regenerate whenever a change is made
+     */
+    override fun hashCode(): Int {
+        var result = stepIndex
+        result = 31 * result + (step?.hashCode() ?: 0)
+        result = 31 * result + (stepPoints?.hashCode() ?: 0)
+        result = 31 * result + distanceRemaining.hashCode()
+        result = 31 * result + distanceTraveled.hashCode()
+        result = 31 * result + fractionTraveled.hashCode()
+        result = 31 * result + durationRemaining.hashCode()
+        return result
+    }
+
     /**
      * Builder of [RouteStepProgress]
      */

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/options/DeviceProfileTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/options/DeviceProfileTest.kt
@@ -2,8 +2,8 @@ package com.mapbox.navigation.base.options
 
 import com.mapbox.navigation.testing.BuilderTest
 import io.mockk.mockk
-import org.junit.Test
 import kotlin.reflect.KClass
+import org.junit.Test
 
 class DeviceProfileTest : BuilderTest<DeviceProfile, DeviceProfile.Builder>() {
     override fun getImplementationClass(): KClass<DeviceProfile> = DeviceProfile::class

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/options/DeviceProfileTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/options/DeviceProfileTest.kt
@@ -1,0 +1,15 @@
+package com.mapbox.navigation.base.options
+
+import com.mapbox.navigation.testing.BuilderTest
+import io.mockk.mockk
+import kotlin.reflect.KClass
+
+class DeviceProfileTest : BuilderTest<DeviceProfile, DeviceProfile.Builder>() {
+    override fun getImplementationClass(): KClass<DeviceProfile> = DeviceProfile::class
+
+    override fun getFilledUpBuilder(): DeviceProfile.Builder {
+        return DeviceProfile.Builder()
+            .customConfig("123")
+            .deviceType(mockk(relaxed = true))
+    }
+}

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/options/DeviceProfileTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/options/DeviceProfileTest.kt
@@ -2,6 +2,7 @@ package com.mapbox.navigation.base.options
 
 import com.mapbox.navigation.testing.BuilderTest
 import io.mockk.mockk
+import org.junit.Test
 import kotlin.reflect.KClass
 
 class DeviceProfileTest : BuilderTest<DeviceProfile, DeviceProfile.Builder>() {
@@ -11,5 +12,10 @@ class DeviceProfileTest : BuilderTest<DeviceProfile, DeviceProfile.Builder>() {
         return DeviceProfile.Builder()
             .customConfig("123")
             .deviceType(mockk(relaxed = true))
+    }
+
+    @Test
+    override fun trigger() {
+        // only used to trigger JUnit4 to run this class if all test cases come from the parent
     }
 }

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/options/NavigationOptionsTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/options/NavigationOptionsTest.kt
@@ -13,6 +13,7 @@ import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
@@ -92,5 +93,33 @@ class NavigationOptionsTest {
         assertEquals(options.timeFormatType, newTimeFormat)
         assertEquals(options.navigatorPredictionMillis, newNavigatorPredictionMillis)
         assertEquals(options.distanceFormatter, distanceFormatter)
+    }
+
+    @Test
+    fun whenSeparateBuildersBuildSameOptions() {
+        val timeFormat = TWELVE_HOURS
+        val navigatorPredictionMillis = 1020L
+
+        val options = NavigationOptions.Builder(context)
+            .timeFormatType(timeFormat)
+            .navigatorPredictionMillis(navigatorPredictionMillis)
+            .build()
+
+        val otherOptions = NavigationOptions.Builder(context)
+            .timeFormatType(timeFormat)
+            .navigatorPredictionMillis(navigatorPredictionMillis)
+            .build()
+
+        assertEquals(options, otherOptions)
+    }
+
+    @Test
+    fun reuseChangedBuilder() {
+        val builder = NavigationOptions.Builder(context)
+        val options = builder.build()
+        builder.accessToken("pk.123")
+
+        assertNotEquals(options.toBuilder().build(), builder.build())
+        assertEquals(options.toBuilder().build(), options)
     }
 }

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/options/NavigationOptionsTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/options/NavigationOptionsTest.kt
@@ -57,6 +57,11 @@ class NavigationOptionsTest : BuilderTest<NavigationOptions, NavigationOptions.B
     }
 
     @Test
+    override fun trigger() {
+        // only used to trigger JUnit4 to run this class if all test cases come from the parent
+    }
+
+    @Test
     fun whenBuilderBuildWithNoValuesCalledThenDefaultValuesUsed() {
         val options = NavigationOptions.Builder(context).build()
 

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/options/NavigationOptionsTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/options/NavigationOptionsTest.kt
@@ -7,10 +7,12 @@ import com.mapbox.navigation.base.TimeFormat.NONE_SPECIFIED
 import com.mapbox.navigation.base.TimeFormat.TWELVE_HOURS
 import com.mapbox.navigation.base.TimeFormat.TWENTY_FOUR_HOURS
 import com.mapbox.navigation.base.formatter.DistanceFormatter
+import com.mapbox.navigation.testing.BuilderTest
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
+import kotlin.reflect.KClass
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
@@ -18,21 +20,40 @@ import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
 
-class NavigationOptionsTest {
+class NavigationOptionsTest : BuilderTest<NavigationOptions, NavigationOptions.Builder>() {
 
-    val context: Context = mockk()
+    private val context: Context = mockk()
 
     @Before
     fun setup() {
         every { context.applicationContext } returns context
 
         mockkStatic(LocationEngineProvider::class)
-        every { LocationEngineProvider.getBestLocationEngine(context) } returns mockk()
+        every { LocationEngineProvider.getBestLocationEngine(any()) } returns mockk()
     }
 
     @After
     fun teardown() {
         unmockkStatic(LocationEngineProvider::class)
+    }
+
+    override fun getImplementationClass(): KClass<NavigationOptions> = NavigationOptions::class
+
+    override fun getFilledUpBuilder(): NavigationOptions.Builder {
+        val context = mockk<Context>()
+        val appContext = mockk<Context>(relaxed = true)
+        every { appContext.applicationContext } returns appContext
+        every { context.applicationContext } returns appContext
+        return NavigationOptions.Builder(context)
+            .accessToken("pk.123")
+            .deviceProfile(mockk())
+            .distanceFormatter(mockk())
+            .isDebugLoggingEnabled(true)
+            .isFromNavigationUi(true)
+            .locationEngine(mockk())
+            .navigatorPredictionMillis(1)
+            .onboardRouterOptions(mockk())
+            .timeFormatType(1)
     }
 
     @Test

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/options/OnboardRouterOptionsTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/options/OnboardRouterOptionsTest.kt
@@ -1,6 +1,8 @@
 package com.mapbox.navigation.base.options
 
 import java.net.URISyntaxException
+import junit.framework.TestCase.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Test
@@ -40,5 +42,35 @@ class OnboardRouterOptionsTest {
         }
 
         assertNull(onboardRouterOptions)
+    }
+
+    @Test
+    fun `builders should build equal objects`() {
+        val options = OnboardRouterOptions.Builder()
+            .filePath(validFilePath)
+            .tilesVersion("2020_08_01-03_10_00")
+            .build()
+
+        val otherOptions = OnboardRouterOptions.Builder()
+            .filePath(validFilePath)
+            .tilesVersion("2020_08_01-03_10_00")
+            .build()
+
+        assertEquals(options, otherOptions)
+    }
+
+    @Test
+    fun `builders should detect u equal objects`() {
+        val options = OnboardRouterOptions.Builder()
+            .filePath(validFilePath)
+            .tilesVersion("2020_08_01-03_10_00")
+            .build()
+
+        val otherOptions = OnboardRouterOptions.Builder()
+            .filePath(validFilePath)
+            .tilesVersion("2020_08_02-03_10_00")
+            .build()
+
+        assertNotEquals(options, otherOptions)
     }
 }

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/options/OnboardRouterOptionsTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/options/OnboardRouterOptionsTest.kt
@@ -22,6 +22,11 @@ class OnboardRouterOptionsTest : BuilderTest<OnboardRouterOptions, OnboardRouter
             .tilesVersion("456")
     }
 
+    @Test
+    override fun trigger() {
+        // only used to trigger JUnit4 to run this class if all test cases come from the parent
+    }
+
     private val validFilePath = """/data/user/0/com.mapbox.navigation.examples/files/Offline/api.mapbox.com/2020_02_02-03_00_00/tiles"""
 
     @Test

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/options/OnboardRouterOptionsTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/options/OnboardRouterOptionsTest.kt
@@ -1,13 +1,26 @@
 package com.mapbox.navigation.base.options
 
+import com.mapbox.navigation.testing.BuilderTest
+import io.mockk.mockk
+import java.net.URI
 import java.net.URISyntaxException
 import junit.framework.TestCase.assertEquals
+import kotlin.reflect.KClass
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Test
 
-class OnboardRouterOptionsTest {
+class OnboardRouterOptionsTest : BuilderTest<OnboardRouterOptions, OnboardRouterOptions.Builder>() {
+
+    override fun getImplementationClass(): KClass<OnboardRouterOptions> = OnboardRouterOptions::class
+
+    override fun getFilledUpBuilder(): OnboardRouterOptions.Builder {
+        return OnboardRouterOptions.Builder()
+            .filePath("123")
+            .tilesUri(mockk(relaxed = true))
+            .tilesVersion("456")
+    }
 
     private val validFilePath = """/data/user/0/com.mapbox.navigation.examples/files/Offline/api.mapbox.com/2020_02_02-03_00_00/tiles"""
 
@@ -36,7 +49,7 @@ class OnboardRouterOptionsTest {
         val onboardRouterOptions = try {
             OnboardRouterOptions.Builder()
                 .filePath(validFilePath)
-                .tilesUri("fake uri")
+                .tilesUri(URI("fake uri"))
         } catch (e: URISyntaxException) {
             null
         }

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/trip/model/RouteLegProgressTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/trip/model/RouteLegProgressTest.kt
@@ -2,8 +2,8 @@ package com.mapbox.navigation.base.trip.model
 
 import com.mapbox.navigation.testing.BuilderTest
 import io.mockk.mockk
-import org.junit.Test
 import kotlin.reflect.KClass
+import org.junit.Test
 
 class RouteLegProgressTest : BuilderTest<RouteLegProgress, RouteLegProgress.Builder>() {
     override fun getImplementationClass(): KClass<RouteLegProgress> = RouteLegProgress::class

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/trip/model/RouteLegProgressTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/trip/model/RouteLegProgressTest.kt
@@ -2,6 +2,7 @@ package com.mapbox.navigation.base.trip.model
 
 import com.mapbox.navigation.testing.BuilderTest
 import io.mockk.mockk
+import org.junit.Test
 import kotlin.reflect.KClass
 
 class RouteLegProgressTest : BuilderTest<RouteLegProgress, RouteLegProgress.Builder>() {
@@ -17,5 +18,10 @@ class RouteLegProgressTest : BuilderTest<RouteLegProgress, RouteLegProgress.Buil
             .routeLeg(mockk(relaxed = true))
             .upcomingStep(mockk(relaxed = true))
             .legIndex(123)
+    }
+
+    @Test
+    override fun trigger() {
+        // only used to trigger JUnit4 to run this class if all test cases come from the parent
     }
 }

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/trip/model/RouteLegProgressTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/trip/model/RouteLegProgressTest.kt
@@ -1,0 +1,21 @@
+package com.mapbox.navigation.base.trip.model
+
+import com.mapbox.navigation.testing.BuilderTest
+import io.mockk.mockk
+import kotlin.reflect.KClass
+
+class RouteLegProgressTest : BuilderTest<RouteLegProgress, RouteLegProgress.Builder>() {
+    override fun getImplementationClass(): KClass<RouteLegProgress> = RouteLegProgress::class
+
+    override fun getFilledUpBuilder(): RouteLegProgress.Builder {
+        return RouteLegProgress.Builder()
+            .currentStepProgress(mockk(relaxed = true))
+            .distanceRemaining(123f)
+            .distanceTraveled(999f)
+            .durationRemaining(456.0)
+            .fractionTraveled(789f)
+            .routeLeg(mockk(relaxed = true))
+            .upcomingStep(mockk(relaxed = true))
+            .legIndex(123)
+    }
+}

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/trip/model/RouteProgressTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/trip/model/RouteProgressTest.kt
@@ -2,8 +2,8 @@ package com.mapbox.navigation.base.trip.model
 
 import com.mapbox.navigation.testing.BuilderTest
 import io.mockk.mockk
-import org.junit.Test
 import kotlin.reflect.KClass
+import org.junit.Test
 
 class RouteProgressTest : BuilderTest<RouteProgress, RouteProgress.Builder>() {
     override fun getImplementationClass(): KClass<RouteProgress> = RouteProgress::class

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/trip/model/RouteProgressTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/trip/model/RouteProgressTest.kt
@@ -2,6 +2,7 @@ package com.mapbox.navigation.base.trip.model
 
 import com.mapbox.navigation.testing.BuilderTest
 import io.mockk.mockk
+import org.junit.Test
 import kotlin.reflect.KClass
 
 class RouteProgressTest : BuilderTest<RouteProgress, RouteProgress.Builder>() {
@@ -21,5 +22,10 @@ class RouteProgressTest : BuilderTest<RouteProgress, RouteProgress.Builder>() {
             .durationRemaining(789.0)
             .fractionTraveled(101112f)
             .remainingWaypoints(131415)
+    }
+
+    @Test
+    override fun trigger() {
+        // only used to trigger JUnit4 to run this class if all test cases come from the parent
     }
 }

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/trip/model/RouteProgressTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/trip/model/RouteProgressTest.kt
@@ -1,0 +1,25 @@
+package com.mapbox.navigation.base.trip.model
+
+import com.mapbox.navigation.testing.BuilderTest
+import io.mockk.mockk
+import kotlin.reflect.KClass
+
+class RouteProgressTest : BuilderTest<RouteProgress, RouteProgress.Builder>() {
+    override fun getImplementationClass(): KClass<RouteProgress> = RouteProgress::class
+
+    override fun getFilledUpBuilder(): RouteProgress.Builder {
+        return RouteProgress.Builder(mockk(relaxed = true))
+            .routeGeometryWithBuffer(mockk(relaxed = true))
+            .bannerInstructions(mockk(relaxed = true))
+            .voiceInstructions(mockk(relaxed = true))
+            .currentState(mockk(relaxed = true))
+            .currentLegProgress(mockk(relaxed = true))
+            .upcomingStepPoints(mockk(relaxed = true))
+            .inTunnel(true)
+            .distanceRemaining(123f)
+            .distanceTraveled(456f)
+            .durationRemaining(789.0)
+            .fractionTraveled(101112f)
+            .remainingWaypoints(131415)
+    }
+}

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/trip/model/RouteStepProgressTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/trip/model/RouteStepProgressTest.kt
@@ -2,8 +2,8 @@ package com.mapbox.navigation.base.trip.model
 
 import com.mapbox.navigation.testing.BuilderTest
 import io.mockk.mockk
-import org.junit.Test
 import kotlin.reflect.KClass
+import org.junit.Test
 
 class RouteStepProgressTest : BuilderTest<RouteStepProgress, RouteStepProgress.Builder>() {
     override fun getImplementationClass(): KClass<RouteStepProgress> = RouteStepProgress::class

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/trip/model/RouteStepProgressTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/trip/model/RouteStepProgressTest.kt
@@ -2,6 +2,7 @@ package com.mapbox.navigation.base.trip.model
 
 import com.mapbox.navigation.testing.BuilderTest
 import io.mockk.mockk
+import org.junit.Test
 import kotlin.reflect.KClass
 
 class RouteStepProgressTest : BuilderTest<RouteStepProgress, RouteStepProgress.Builder>() {
@@ -16,5 +17,10 @@ class RouteStepProgressTest : BuilderTest<RouteStepProgress, RouteStepProgress.B
             .distanceTraveled(789f)
             .fractionTraveled(101112f)
             .durationRemaining(131415.0)
+    }
+
+    @Test
+    override fun trigger() {
+        // only used to trigger JUnit4 to run this class if all test cases come from the parent
     }
 }

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/trip/model/RouteStepProgressTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/trip/model/RouteStepProgressTest.kt
@@ -1,0 +1,20 @@
+package com.mapbox.navigation.base.trip.model
+
+import com.mapbox.navigation.testing.BuilderTest
+import io.mockk.mockk
+import kotlin.reflect.KClass
+
+class RouteStepProgressTest : BuilderTest<RouteStepProgress, RouteStepProgress.Builder>() {
+    override fun getImplementationClass(): KClass<RouteStepProgress> = RouteStepProgress::class
+
+    override fun getFilledUpBuilder(): RouteStepProgress.Builder {
+        return RouteStepProgress.Builder()
+            .stepIndex(123)
+            .step(mockk(relaxed = true))
+            .stepPoints(mockk(relaxed = true))
+            .distanceRemaining(456f)
+            .distanceTraveled(789f)
+            .fractionTraveled(101112f)
+            .durationRemaining(131415.0)
+    }
+}

--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -370,7 +370,6 @@ package com.mapbox.navigation.core.sensors {
   public static final class SensorOptions.Builder {
     ctor public SensorOptions.Builder();
     method public com.mapbox.navigation.core.sensors.SensorOptions build();
-    method public com.mapbox.navigation.core.sensors.SensorOptions.Builder enableAllSensors();
     method public com.mapbox.navigation.core.sensors.SensorOptions.Builder enableSensorTypes(java.util.Set<java.lang.Integer> sensorTypes);
     method public com.mapbox.navigation.core.sensors.SensorOptions.Builder signalsPerSecond(int signalsPerSecond);
   }
@@ -390,12 +389,6 @@ package com.mapbox.navigation.core.telemetry {
 package com.mapbox.navigation.core.telemetry.events {
 
   public final class AppMetadata {
-    ctor public AppMetadata(String name, String version, String? userId, String? sessionId);
-    method public String component1();
-    method public String component2();
-    method public String? component3();
-    method public String? component4();
-    method public com.mapbox.navigation.core.telemetry.events.AppMetadata copy(String name, String version, String? userId, String? sessionId);
     method public String getName();
     method public String? getSessionId();
     method public String? getUserId();

--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -89,21 +89,15 @@ package com.mapbox.navigation.core.arrival {
   }
 
   public final class ArrivalOptions {
-    ctor public ArrivalOptions(Double? arrivalInSeconds, Double? arrivalInMeters, com.mapbox.navigation.core.arrival.ArrivalOptions.Builder builder);
-    method public Double? component1();
-    method public Double? component2();
-    method public com.mapbox.navigation.core.arrival.ArrivalOptions.Builder component3();
-    method public com.mapbox.navigation.core.arrival.ArrivalOptions copy(Double? arrivalInSeconds, Double? arrivalInMeters, com.mapbox.navigation.core.arrival.ArrivalOptions.Builder builder);
     method public Double? getArrivalInMeters();
     method public Double? getArrivalInSeconds();
-    method public com.mapbox.navigation.core.arrival.ArrivalOptions.Builder getBuilder();
     method public com.mapbox.navigation.core.arrival.ArrivalOptions.Builder toBuilder();
   }
 
   public static final class ArrivalOptions.Builder {
     ctor public ArrivalOptions.Builder();
-    method public com.mapbox.navigation.core.arrival.ArrivalOptions.Builder arriveInMeters(Double? arriveInMeters);
-    method public com.mapbox.navigation.core.arrival.ArrivalOptions.Builder arriveInSeconds(Double? arriveInSeconds);
+    method public com.mapbox.navigation.core.arrival.ArrivalOptions.Builder arrivalInMeters(Double? arriveInMeters);
+    method public com.mapbox.navigation.core.arrival.ArrivalOptions.Builder arrivalInSeconds(Double? arriveInSeconds);
     method public com.mapbox.navigation.core.arrival.ArrivalOptions build();
   }
 
@@ -288,8 +282,6 @@ package com.mapbox.navigation.core.replay.route {
   }
 
   public final class ReplayRouteOptions {
-    ctor public ReplayRouteOptions(double maxSpeedMps, double turnSpeedMps, double uTurnSpeedMps, double maxAcceleration, double minAcceleration, com.mapbox.navigation.core.replay.route.ReplayRouteOptions.Builder builder);
-    method public com.mapbox.navigation.core.replay.route.ReplayRouteOptions.Builder getBuilder();
     method public double getMaxAcceleration();
     method public double getMaxSpeedMps();
     method public double getMinAcceleration();
@@ -370,13 +362,7 @@ package com.mapbox.navigation.core.sensors {
   }
 
   public final class SensorOptions {
-    ctor public SensorOptions(java.util.Set<java.lang.Integer> enabledSensorTypes, int signalsPerSecond, com.mapbox.navigation.core.sensors.SensorOptions.Builder builder);
-    method public java.util.Set<java.lang.Integer> component1();
-    method public int component2();
-    method public com.mapbox.navigation.core.sensors.SensorOptions.Builder component3();
-    method public com.mapbox.navigation.core.sensors.SensorOptions copy(java.util.Set<java.lang.Integer> enabledSensorTypes, int signalsPerSecond, com.mapbox.navigation.core.sensors.SensorOptions.Builder builder);
-    method public com.mapbox.navigation.core.sensors.SensorOptions.Builder getBuilder();
-    method public java.util.Set<java.lang.Integer> getEnabledSensorTypes();
+    method public java.util.Set<java.lang.Integer> getEnableSensorTypes();
     method public int getSignalsPerSecond();
     method public com.mapbox.navigation.core.sensors.SensorOptions.Builder toBuilder();
   }
@@ -385,7 +371,7 @@ package com.mapbox.navigation.core.sensors {
     ctor public SensorOptions.Builder();
     method public com.mapbox.navigation.core.sensors.SensorOptions build();
     method public com.mapbox.navigation.core.sensors.SensorOptions.Builder enableAllSensors();
-    method public com.mapbox.navigation.core.sensors.SensorOptions.Builder enableSensors(java.util.Set<java.lang.Integer> sensorTypes);
+    method public com.mapbox.navigation.core.sensors.SensorOptions.Builder enableSensorTypes(java.util.Set<java.lang.Integer> sensorTypes);
     method public com.mapbox.navigation.core.sensors.SensorOptions.Builder signalsPerSecond(int signalsPerSecond);
   }
 

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -737,10 +737,10 @@ class MapboxNavigation(
          */
         @JvmStatic
         fun defaultNavigationOptionsBuilder(context: Context, accessToken: String?): NavigationOptions.Builder {
-            val distanceFormatter = MapboxDistanceFormatter.builder()
-                .withUnitType(VoiceUnit.UNDEFINED)
-                .withRoundingIncrement(Rounding.INCREMENT_FIFTY)
-                .build(context)
+            val distanceFormatter = MapboxDistanceFormatter.Builder(context)
+                .unitType(VoiceUnit.UNDEFINED)
+                .roundingIncrement(Rounding.INCREMENT_FIFTY)
+                .build()
             return NavigationOptions.Builder(context)
                 .accessToken(accessToken)
                 .distanceFormatter(distanceFormatter)

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/arrival/ArrivalController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/arrival/ArrivalController.kt
@@ -88,6 +88,9 @@ class ArrivalOptions private constructor(
         return result
     }
 
+    /**
+     * Returns a string representation of the object.
+     */
     override fun toString(): String {
         return "ArrivalOptions(arrivalInSeconds=$arrivalInSeconds, arrivalInMeters=$arrivalInMeters)"
     }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/arrival/ArrivalController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/arrival/ArrivalController.kt
@@ -88,6 +88,10 @@ class ArrivalOptions private constructor(
         return result
     }
 
+    override fun toString(): String {
+        return "ArrivalOptions(arrivalInSeconds=$arrivalInSeconds, arrivalInMeters=$arrivalInMeters)"
+    }
+
     /**
      * Build your [ArrivalOptions].
      */

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/arrival/ArrivalController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/arrival/ArrivalController.kt
@@ -51,17 +51,42 @@ class AutoArrivalController : ArrivalController {
  * [ArrivalController.navigateNextRouteLeg] will be called
  * @param arrivalInMeters While the next stop is less than [arrivalInMeters] away,
  * [ArrivalController.navigateNextRouteLeg] will be called
- * @param builder used for updating options
  */
-data class ArrivalOptions(
+class ArrivalOptions private constructor(
     val arrivalInSeconds: Double?,
-    val arrivalInMeters: Double?,
-    val builder: Builder
+    val arrivalInMeters: Double?
 ) {
     /**
      * @return the builder that created the [ArrivalOptions]
      */
-    fun toBuilder() = builder
+    fun toBuilder() = Builder().apply {
+        arrivalInSeconds(arrivalInSeconds)
+        arrivalInMeters(arrivalInMeters)
+    }
+
+    /**
+     * Regenerate whenever a change is made
+     */
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as ArrivalOptions
+
+        if (arrivalInSeconds != other.arrivalInSeconds) return false
+        if (arrivalInMeters != other.arrivalInMeters) return false
+
+        return true
+    }
+
+    /**
+     * Regenerate whenever a change is made
+     */
+    override fun hashCode(): Int {
+        var result = arrivalInSeconds?.hashCode() ?: 0
+        result = 31 * result + (arrivalInMeters?.hashCode() ?: 0)
+        return result
+    }
 
     /**
      * Build your [ArrivalOptions].
@@ -75,7 +100,7 @@ data class ArrivalOptions(
          * (Recommended) Use time estimation for arrival, arrival is influenced by traffic conditions.
          * Arrive when the estimated time to a stop is less than or equal to this threshold.
          */
-        fun arriveInSeconds(arriveInSeconds: Double?): Builder {
+        fun arrivalInSeconds(arriveInSeconds: Double?): Builder {
             this.arrivalInSeconds = arriveInSeconds
             return this
         }
@@ -83,7 +108,7 @@ data class ArrivalOptions(
         /**
          * Arrive when the estimated distance to a stop is less than or equal to this threshold.
          */
-        fun arriveInMeters(arriveInMeters: Double?): Builder {
+        fun arrivalInMeters(arriveInMeters: Double?): Builder {
             this.arrivalInMeters = arriveInMeters
             return this
         }
@@ -97,8 +122,7 @@ data class ArrivalOptions(
             }
             return ArrivalOptions(
                 arrivalInSeconds = arrivalInSeconds,
-                arrivalInMeters = arrivalInMeters,
-                builder = this
+                arrivalInMeters = arrivalInMeters
             )
         }
     }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayRouteOptions.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayRouteOptions.kt
@@ -60,6 +60,9 @@ class ReplayRouteOptions private constructor(
         return result
     }
 
+    /**
+     * Returns a string representation of the object.
+     */
     override fun toString(): String {
         return "ReplayRouteOptions(maxSpeedMps=$maxSpeedMps, turnSpeedMps=$turnSpeedMps, uTurnSpeedMps=$uTurnSpeedMps, maxAcceleration=$maxAcceleration, minAcceleration=$minAcceleration)"
     }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayRouteOptions.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayRouteOptions.kt
@@ -60,6 +60,10 @@ class ReplayRouteOptions private constructor(
         return result
     }
 
+    override fun toString(): String {
+        return "ReplayRouteOptions(maxSpeedMps=$maxSpeedMps, turnSpeedMps=$turnSpeedMps, uTurnSpeedMps=$uTurnSpeedMps, maxAcceleration=$maxAcceleration, minAcceleration=$minAcceleration)"
+    }
+
     /**
      * Used to build [ReplayRouteOptions].
      */

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayRouteOptions.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayRouteOptions.kt
@@ -11,20 +11,54 @@ package com.mapbox.navigation.core.replay.route
  * @param uTurnSpeedMps Speed the driver will go when facing a u-turn
  * @param maxAcceleration How fast the driver will accelerate to [maxSpeedMps] in mps^2
  * @param minAcceleration How fast the driver will decelerate in mps^2
- * @param builder used for updating options
  */
-class ReplayRouteOptions(
+class ReplayRouteOptions private constructor(
     val maxSpeedMps: Double,
     val turnSpeedMps: Double,
     val uTurnSpeedMps: Double,
     val maxAcceleration: Double,
-    val minAcceleration: Double,
-    val builder: Builder
+    val minAcceleration: Double
 ) {
     /**
      * @return the builder that created the [ReplayRouteOptions]
      */
-    fun toBuilder() = builder
+    fun toBuilder() = Builder().apply {
+        maxSpeedMps(maxSpeedMps)
+        turnSpeedMps(turnSpeedMps)
+        uTurnSpeedMps(uTurnSpeedMps)
+        maxAcceleration(maxAcceleration)
+        minAcceleration(minAcceleration)
+    }
+
+    /**
+     * Regenerate whenever a change is made
+     */
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as ReplayRouteOptions
+
+        if (maxSpeedMps != other.maxSpeedMps) return false
+        if (turnSpeedMps != other.turnSpeedMps) return false
+        if (uTurnSpeedMps != other.uTurnSpeedMps) return false
+        if (maxAcceleration != other.maxAcceleration) return false
+        if (minAcceleration != other.minAcceleration) return false
+
+        return true
+    }
+
+    /**
+     * Regenerate whenever a change is made
+     */
+    override fun hashCode(): Int {
+        var result = maxSpeedMps.hashCode()
+        result = 31 * result + turnSpeedMps.hashCode()
+        result = 31 * result + uTurnSpeedMps.hashCode()
+        result = 31 * result + maxAcceleration.hashCode()
+        result = 31 * result + minAcceleration.hashCode()
+        return result
+    }
 
     /**
      * Used to build [ReplayRouteOptions].
@@ -47,8 +81,7 @@ class ReplayRouteOptions(
                 turnSpeedMps = turnSpeedMps,
                 uTurnSpeedMps = uTurnSpeedMps,
                 maxAcceleration = maxAcceleration,
-                minAcceleration = minAcceleration,
-                builder = this
+                minAcceleration = minAcceleration
             )
         }
 

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/sensors/SensorEventEmitter.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/sensors/SensorEventEmitter.kt
@@ -64,7 +64,7 @@ class SensorEventEmitter(
     private fun enabledSensors(sensorOptions: SensorOptions): List<Sensor> {
         return sensorManager.getSensorList(Sensor.TYPE_ALL)
             .filter { sensor ->
-                sensorOptions.enabledSensorTypes.contains(sensor.type)
+                sensorOptions.enableSensorTypes.contains(sensor.type)
             }
             .filterNotNull()
     }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/sensors/SensorOptions.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/sensors/SensorOptions.kt
@@ -43,6 +43,9 @@ class SensorOptions private constructor(
         return result
     }
 
+    /**
+     * Returns a string representation of the object.
+     */
     override fun toString(): String {
         return "SensorOptions(enableSensorTypes=$enableSensorTypes, signalsPerSecond=$signalsPerSecond)"
     }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/sensors/SensorOptions.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/sensors/SensorOptions.kt
@@ -4,25 +4,50 @@ package com.mapbox.navigation.core.sensors
  * Options for the [SensorEventEmitter]. Use this to decide which sensors are
  * enabled and the frequency.
  *
- * @param enabledSensorTypes set of enabled sensors
+ * @param enableSensorTypes set of enabled sensors
  * @param signalsPerSecond signals per second received from sensors
- * @param builder used for updating options
  */
-data class SensorOptions(
-    val enabledSensorTypes: Set<Int>,
-    val signalsPerSecond: Int,
-    val builder: Builder
+class SensorOptions private constructor(
+    val enableSensorTypes: Set<Int>,
+    val signalsPerSecond: Int
 ) {
     /**
      * @return the builder that created the [SensorOptions]
      */
-    fun toBuilder() = builder
+    fun toBuilder() = Builder().apply {
+        enableSensorTypes(enableSensorTypes)
+        signalsPerSecond(signalsPerSecond)
+    }
+
+    /**
+     * Regenerate whenever a change is made
+     */
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as SensorOptions
+
+        if (enableSensorTypes != other.enableSensorTypes) return false
+        if (signalsPerSecond != other.signalsPerSecond) return false
+
+        return true
+    }
+
+    /**
+     * Regenerate whenever a change is made
+     */
+    override fun hashCode(): Int {
+        var result = enableSensorTypes.hashCode()
+        result = 31 * result + signalsPerSecond
+        return result
+    }
 
     /**
      * Builder of [SensorOptions]
      */
     class Builder {
-        private val enabledSensors: MutableSet<Int> = mutableSetOf()
+        private val enableSensorTypes: MutableSet<Int> = mutableSetOf()
         private var signalsPerSecond: Int = 25
 
         /**
@@ -31,7 +56,7 @@ data class SensorOptions(
          * @return Builder
          */
         fun enableAllSensors(): Builder {
-            this.enabledSensors.addAll(SensorMapper.getSupportedSensorTypes())
+            this.enableSensorTypes.addAll(SensorMapper.getSupportedSensorTypes())
             return this
         }
 
@@ -41,8 +66,8 @@ data class SensorOptions(
          * @param sensorTypes that will be handled
          * @return Builder
          */
-        fun enableSensors(sensorTypes: Set<Int>): Builder {
-            this.enabledSensors.addAll(sensorTypes)
+        fun enableSensorTypes(sensorTypes: Set<Int>): Builder {
+            this.enableSensorTypes.addAll(sensorTypes)
             return this
         }
 
@@ -64,9 +89,8 @@ data class SensorOptions(
          */
         fun build(): SensorOptions {
             return SensorOptions(
-                enabledSensorTypes = enabledSensors,
-                signalsPerSecond = signalsPerSecond,
-                builder = this
+                enableSensorTypes = enableSensorTypes,
+                signalsPerSecond = signalsPerSecond
             )
         }
     }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/sensors/SensorOptions.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/sensors/SensorOptions.kt
@@ -43,31 +43,26 @@ class SensorOptions private constructor(
         return result
     }
 
+    override fun toString(): String {
+        return "SensorOptions(enableSensorTypes=$enableSensorTypes, signalsPerSecond=$signalsPerSecond)"
+    }
+
     /**
      * Builder of [SensorOptions]
      */
     class Builder {
-        private val enableSensorTypes: MutableSet<Int> = mutableSetOf()
+        private var enableSensorTypes: Set<Int> = emptySet()
         private var signalsPerSecond: Int = 25
-
-        /**
-         * Enable all available sensors
-         *
-         * @return Builder
-         */
-        fun enableAllSensors(): Builder {
-            this.enableSensorTypes.addAll(SensorMapper.getSupportedSensorTypes())
-            return this
-        }
 
         /**
          * Set a set of sensors that will be handled
          *
          * @param sensorTypes that will be handled
          * @return Builder
+         * @see SensorMapper.getSupportedSensorTypes
          */
         fun enableSensorTypes(sensorTypes: Set<Int>): Builder {
-            this.enableSensorTypes.addAll(sensorTypes)
+            this.enableSensorTypes = sensorTypes
             return this
         }
 

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/TelemetryLocationAndProgressDispatcher.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/TelemetryLocationAndProgressDispatcher.kt
@@ -30,7 +30,7 @@ internal class TelemetryLocationAndProgressDispatcher(scope: CoroutineScope) :
     RouteProgressObserver, LocationObserver, RoutesObserver, OffRouteObserver {
     private var lastLocation: AtomicReference<Location?> = AtomicReference(null)
     private var routeProgress: AtomicReference<RouteProgressWithTimestamp> =
-        AtomicReference(RouteProgressWithTimestamp(0, RouteProgress.Builder().route(DirectionsRoute.builder().build()).build()))
+        AtomicReference(RouteProgressWithTimestamp(0, RouteProgress.Builder(DirectionsRoute.builder().build()).build()))
     private val channelOffRouteEvent = Channel<Boolean>(Channel.CONFLATED)
     private val channelNewRouteAvailable = Channel<RouteAvailable>(Channel.CONFLATED)
     private val channelLocationReceived = Channel<Location>(Channel.CONFLATED)

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/events/AppMetadata.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/events/AppMetadata.kt
@@ -33,6 +33,9 @@ class AppMetadata private constructor(
         sessionId(sessionId)
     }
 
+    /**
+     * Regenerate whenever a change is made
+     */
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
@@ -47,6 +50,9 @@ class AppMetadata private constructor(
         return true
     }
 
+    /**
+     * Regenerate whenever a change is made
+     */
     override fun hashCode(): Int {
         var result = name.hashCode()
         result = 31 * result + version.hashCode()
@@ -55,6 +61,9 @@ class AppMetadata private constructor(
         return result
     }
 
+    /**
+     * Returns a string representation of the object.
+     */
     override fun toString(): String {
         return "AppMetadata(name='$name', version='$version', userId=$userId, sessionId=$sessionId)"
     }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/events/AppMetadata.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/events/AppMetadata.kt
@@ -3,7 +3,7 @@ package com.mapbox.navigation.core.telemetry.events
 /**
  * Custom metadata that can be used to associate app state with feedback events in the telemetry pipeline.
  */
-data class AppMetadata constructor(
+class AppMetadata private constructor(
     /**
      * Name of the application. Value should be non-empty.
      */
@@ -31,6 +31,32 @@ data class AppMetadata constructor(
     fun toBuilder() = Builder(name, version).apply {
         userId(userId)
         sessionId(sessionId)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as AppMetadata
+
+        if (name != other.name) return false
+        if (version != other.version) return false
+        if (userId != other.userId) return false
+        if (sessionId != other.sessionId) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = name.hashCode()
+        result = 31 * result + version.hashCode()
+        result = 31 * result + (userId?.hashCode() ?: 0)
+        result = 31 * result + (sessionId?.hashCode() ?: 0)
+        return result
+    }
+
+    override fun toString(): String {
+        return "AppMetadata(name='$name', version='$version', userId=$userId, sessionId=$sessionId)"
     }
 
     /**

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/arrival/ArrivalOptionsTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/arrival/ArrivalOptionsTest.kt
@@ -1,8 +1,8 @@
 package com.mapbox.navigation.core.arrival
 
 import com.mapbox.navigation.testing.BuilderTest
-import org.junit.Test
 import kotlin.reflect.KClass
+import org.junit.Test
 
 class ArrivalOptionsTest : BuilderTest<ArrivalOptions, ArrivalOptions.Builder>() {
     override fun getImplementationClass(): KClass<ArrivalOptions> = ArrivalOptions::class

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/arrival/ArrivalOptionsTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/arrival/ArrivalOptionsTest.kt
@@ -1,0 +1,14 @@
+package com.mapbox.navigation.core.arrival
+
+import com.mapbox.navigation.testing.BuilderTest
+import kotlin.reflect.KClass
+
+class ArrivalOptionsTest : BuilderTest<ArrivalOptions, ArrivalOptions.Builder>() {
+    override fun getImplementationClass(): KClass<ArrivalOptions> = ArrivalOptions::class
+
+    override fun getFilledUpBuilder(): ArrivalOptions.Builder {
+        return ArrivalOptions.Builder()
+            .arrivalInMeters(123.0)
+            .arrivalInSeconds(345.0)
+    }
+}

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/arrival/ArrivalOptionsTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/arrival/ArrivalOptionsTest.kt
@@ -1,6 +1,7 @@
 package com.mapbox.navigation.core.arrival
 
 import com.mapbox.navigation.testing.BuilderTest
+import org.junit.Test
 import kotlin.reflect.KClass
 
 class ArrivalOptionsTest : BuilderTest<ArrivalOptions, ArrivalOptions.Builder>() {
@@ -10,5 +11,10 @@ class ArrivalOptionsTest : BuilderTest<ArrivalOptions, ArrivalOptions.Builder>()
         return ArrivalOptions.Builder()
             .arrivalInMeters(123.0)
             .arrivalInSeconds(345.0)
+    }
+
+    @Test
+    override fun trigger() {
+        // only used to trigger JUnit4 to run this class if all test cases come from the parent
     }
 }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/internal/MapboxDistanceFormatterTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/internal/MapboxDistanceFormatterTest.kt
@@ -10,10 +10,12 @@ import com.mapbox.navigation.base.internal.VoiceUnit.METRIC
 import com.mapbox.navigation.base.internal.VoiceUnit.UNDEFINED
 import com.mapbox.navigation.core.Rounding.INCREMENT_FIFTY
 import com.mapbox.navigation.core.Rounding.INCREMENT_FIVE
+import com.mapbox.navigation.testing.BuilderTest
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import java.util.Locale
+import kotlin.reflect.KClass
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -23,9 +25,18 @@ import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = Config.NONE)
-class MapboxDistanceFormatterTest {
+class MapboxDistanceFormatterTest : BuilderTest<MapboxDistanceFormatter, MapboxDistanceFormatter.Builder>() {
 
     private lateinit var ctx: Context
+
+    override fun getImplementationClass(): KClass<MapboxDistanceFormatter> = MapboxDistanceFormatter::class
+
+    override fun getFilledUpBuilder(): MapboxDistanceFormatter.Builder {
+        return MapboxDistanceFormatter.Builder(ctx)
+            .locale(Locale("hu"))
+            .roundingIncrement(123)
+            .unitType("unitType")
+    }
 
     @Before
     fun setup() {
@@ -35,10 +46,10 @@ class MapboxDistanceFormatterTest {
     @Config(qualifiers = "en")
     @Test
     fun formatDistanceLargeDistanceImperialWithDefaultLocale() {
-        val result = MapboxDistanceFormatter.Builder()
-            .withUnitType(IMPERIAL)
-            .withRoundingIncrement(INCREMENT_FIFTY)
-            .build(ctx)
+        val result = MapboxDistanceFormatter.Builder(ctx)
+            .unitType(IMPERIAL)
+            .roundingIncrement(INCREMENT_FIFTY)
+            .build()
             .formatDistance(19312.1)
 
         assertEquals("12 mi", result.toString())
@@ -47,9 +58,9 @@ class MapboxDistanceFormatterTest {
     @Config(qualifiers = "en")
     @Test
     fun formatDistanceLargeDistanceUnitTypeNull() {
-        val result = MapboxDistanceFormatter.Builder()
-            .withRoundingIncrement(INCREMENT_FIFTY)
-            .build(ctx)
+        val result = MapboxDistanceFormatter.Builder(ctx)
+            .roundingIncrement(INCREMENT_FIFTY)
+            .build()
             .formatDistance(19312.1)
 
         assertEquals("19 km", result.toString())
@@ -58,10 +69,10 @@ class MapboxDistanceFormatterTest {
     @Config(qualifiers = "en")
     @Test
     fun formatDistanceLargeDistanceUnitTypeEmptyString() {
-        val result = MapboxDistanceFormatter.Builder()
-            .withUnitType("")
-            .withRoundingIncrement(INCREMENT_FIFTY)
-            .build(ctx)
+        val result = MapboxDistanceFormatter.Builder(ctx)
+            .unitType("")
+            .roundingIncrement(INCREMENT_FIFTY)
+            .build()
             .formatDistance(19312.1)
 
         assertEquals("19 km", result.toString())
@@ -70,10 +81,10 @@ class MapboxDistanceFormatterTest {
     @Config(qualifiers = "en")
     @Test
     fun formatDistanceLargeDistanceMetric() {
-        val result = MapboxDistanceFormatter.Builder()
-            .withUnitType(METRIC)
-            .withRoundingIncrement(INCREMENT_FIFTY)
-            .build(ctx)
+        val result = MapboxDistanceFormatter.Builder(ctx)
+            .unitType(METRIC)
+            .roundingIncrement(INCREMENT_FIFTY)
+            .build()
             .formatDistance(19312.1)
 
         assertEquals("19 km", result.toString())
@@ -82,10 +93,10 @@ class MapboxDistanceFormatterTest {
     @Config(qualifiers = "en")
     @Test
     fun formatDistanceSmallDistanceMetric() {
-        val result = MapboxDistanceFormatter.Builder()
-            .withUnitType(METRIC)
-            .withRoundingIncrement(INCREMENT_FIFTY)
-            .build(ctx)
+        val result = MapboxDistanceFormatter.Builder(ctx)
+            .unitType(METRIC)
+            .roundingIncrement(INCREMENT_FIFTY)
+            .build()
             .formatDistance(10.0)
 
         assertEquals("50 m", result.toString())
@@ -94,10 +105,10 @@ class MapboxDistanceFormatterTest {
     @Config(qualifiers = "en")
     @Test
     fun formatDistanceSmallDistanceImperial() {
-        val result = MapboxDistanceFormatter.Builder()
-            .withUnitType(IMPERIAL)
-            .withRoundingIncrement(INCREMENT_FIFTY)
-            .build(ctx)
+        val result = MapboxDistanceFormatter.Builder(ctx)
+            .unitType(IMPERIAL)
+            .roundingIncrement(INCREMENT_FIFTY)
+            .build()
             .formatDistance(10.0)
 
         assertEquals("50 ft", result.toString())
@@ -106,10 +117,10 @@ class MapboxDistanceFormatterTest {
     @Config(qualifiers = "ja")
     @Test
     fun formatDistanceJapaneseLocale() {
-        val result = MapboxDistanceFormatter.Builder()
-            .withUnitType(IMPERIAL)
-            .withRoundingIncrement(INCREMENT_FIFTY)
-            .build(ctx)
+        val result = MapboxDistanceFormatter.Builder(ctx)
+            .unitType(IMPERIAL)
+            .roundingIncrement(INCREMENT_FIFTY)
+            .build()
             .formatDistance(10.0)
 
         assertEquals("50 フィート", result.toString())
@@ -118,10 +129,10 @@ class MapboxDistanceFormatterTest {
     @Config(qualifiers = "en")
     @Test
     fun formatDistanceMediumMetric() {
-        val result = MapboxDistanceFormatter.Builder()
-            .withUnitType(METRIC)
-            .withRoundingIncrement(INCREMENT_FIFTY)
-            .build(ctx)
+        val result = MapboxDistanceFormatter.Builder(ctx)
+            .unitType(METRIC)
+            .roundingIncrement(INCREMENT_FIFTY)
+            .build()
             .formatDistance(1000.0)
 
         assertEquals("1 km", result.toString())
@@ -130,10 +141,10 @@ class MapboxDistanceFormatterTest {
     @Config(qualifiers = "en")
     @Test
     fun formatDistanceMediumMetricFractionalValue() {
-        val result = MapboxDistanceFormatter.Builder()
-            .withUnitType(METRIC)
-            .withRoundingIncrement(INCREMENT_FIFTY)
-            .build(ctx)
+        val result = MapboxDistanceFormatter.Builder(ctx)
+            .unitType(METRIC)
+            .roundingIncrement(INCREMENT_FIFTY)
+            .build()
             .formatDistance(400.5)
 
         assertEquals("0.4 km", result.toString())
@@ -142,10 +153,10 @@ class MapboxDistanceFormatterTest {
     @Config(qualifiers = "en")
     @Test
     fun formatDistanceMediumImperial() {
-        val result = MapboxDistanceFormatter.Builder()
-            .withUnitType(IMPERIAL)
-            .withRoundingIncrement(INCREMENT_FIFTY)
-            .build(ctx)
+        val result = MapboxDistanceFormatter.Builder(ctx)
+            .unitType(IMPERIAL)
+            .roundingIncrement(INCREMENT_FIFTY)
+            .build()
             .formatDistance(1000.0)
 
         assertEquals("0.6 mi", result.toString())
@@ -155,8 +166,8 @@ class MapboxDistanceFormatterTest {
     fun getSpannableDistanceStringFormatsString() {
         val input = Pair("12", "mi")
 
-        val result = MapboxDistanceFormatter.Builder()
-            .build(ctx)
+        val result = MapboxDistanceFormatter.Builder(ctx)
+            .build()
             .getSpannableDistanceString(input)
 
         assertEquals("12 mi", result.toString())
@@ -166,8 +177,8 @@ class MapboxDistanceFormatterTest {
     fun getSpannableDistanceStringHasCorrectNumberOfSpans() {
         val input = Pair("12", "mi")
 
-        val result = MapboxDistanceFormatter.Builder()
-            .build(ctx)
+        val result = MapboxDistanceFormatter.Builder(ctx)
+            .build()
             .getSpannableDistanceString(input)
 
         assertEquals(2, result.getSpans(0, result.count(), Object::class.java).size)
@@ -177,8 +188,8 @@ class MapboxDistanceFormatterTest {
     fun getSpannableDistanceStringTypeFace() {
         val input = Pair("12", "mi")
 
-        val result = MapboxDistanceFormatter.Builder()
-            .build(ctx)
+        val result = MapboxDistanceFormatter.Builder(ctx)
+            .build()
             .getSpannableDistanceString(input)
 
         assertEquals(Typeface.BOLD, (result.getSpans(0, result.count(), Object::class.java)[0] as StyleSpan).style)
@@ -188,10 +199,10 @@ class MapboxDistanceFormatterTest {
     fun getSpannableDistanceStringRelativeSizeSpan() {
         val input = Pair("12", "mi")
 
-        val result = MapboxDistanceFormatter.Builder()
-            .withUnitType(IMPERIAL)
-            .withRoundingIncrement(INCREMENT_FIFTY)
-            .build(ctx)
+        val result = MapboxDistanceFormatter.Builder(ctx)
+            .unitType(IMPERIAL)
+            .roundingIncrement(INCREMENT_FIFTY)
+            .build()
             .getSpannableDistanceString(input)
 
         assertEquals(0.65f, (result.getSpans(0, result.count(), Object::class.java)[1] as RelativeSizeSpan).sizeChange)
@@ -200,11 +211,11 @@ class MapboxDistanceFormatterTest {
     @Config(qualifiers = "en")
     @Test
     fun formatDistanceImperialWithNonDefaultLocale() {
-        val result = MapboxDistanceFormatter.Builder()
-            .withUnitType(IMPERIAL)
-            .withRoundingIncrement(INCREMENT_FIFTY)
-            .withLocale(Locale("hu"))
-            .build(ctx)
+        val result = MapboxDistanceFormatter.Builder(ctx)
+            .unitType(IMPERIAL)
+            .roundingIncrement(INCREMENT_FIFTY)
+            .locale(Locale("hu"))
+            .build()
             .formatDistance(19312.1)
 
         assertEquals("12 mérföld", result.toString())
@@ -215,18 +226,18 @@ class MapboxDistanceFormatterTest {
         val mockContext = mockk<Context>()
         every { mockContext.applicationContext } returns ctx
 
-        MapboxDistanceFormatter.Builder().build(mockContext)
+        MapboxDistanceFormatter.Builder(mockContext).build()
 
-        verify(exactly = 2) { mockContext.applicationContext }
+        verify(exactly = 1) { mockContext.applicationContext }
     }
 
     @Config(qualifiers = "en")
     @Test
     fun formatDistanceBelowZeroDistance() {
-        val result = MapboxDistanceFormatter.Builder()
-            .withUnitType(IMPERIAL)
-            .withRoundingIncrement(INCREMENT_FIFTY)
-            .build(ctx)
+        val result = MapboxDistanceFormatter.Builder(ctx)
+            .unitType(IMPERIAL)
+            .roundingIncrement(INCREMENT_FIFTY)
+            .build()
             .formatDistance(-0.1)
 
         assertEquals("50 ft", result.toString())
@@ -235,10 +246,10 @@ class MapboxDistanceFormatterTest {
     @Config(qualifiers = "en")
     @Test
     fun formatDistanceBelowZeroDistanceRoundingIncrementFive() {
-        val result = MapboxDistanceFormatter.Builder()
-            .withUnitType(IMPERIAL)
-            .withRoundingIncrement(INCREMENT_FIVE)
-            .build(ctx)
+        val result = MapboxDistanceFormatter.Builder(ctx)
+            .unitType(IMPERIAL)
+            .roundingIncrement(INCREMENT_FIVE)
+            .build()
             .formatDistance(-0.1)
 
         assertEquals("5 ft", result.toString())
@@ -247,10 +258,10 @@ class MapboxDistanceFormatterTest {
     @Config(qualifiers = "en-rUS")
     @Test
     fun formatDistanceUnitTypeUndefinedImperial() {
-        val result = MapboxDistanceFormatter.Builder()
-            .withUnitType(UNDEFINED)
-            .withRoundingIncrement(INCREMENT_FIFTY)
-            .build(ctx)
+        val result = MapboxDistanceFormatter.Builder(ctx)
+            .unitType(UNDEFINED)
+            .roundingIncrement(INCREMENT_FIFTY)
+            .build()
             .formatDistance(19312.1)
 
         assertEquals("12 mi", result.toString())
@@ -259,10 +270,10 @@ class MapboxDistanceFormatterTest {
     @Config(qualifiers = "jp-rJP")
     @Test
     fun formatDistanceUnitTypeUndefinedMetric() {
-        val result = MapboxDistanceFormatter.Builder()
-            .withUnitType(UNDEFINED)
-            .withRoundingIncrement(INCREMENT_FIFTY)
-            .build(ctx)
+        val result = MapboxDistanceFormatter.Builder(ctx)
+            .unitType(UNDEFINED)
+            .roundingIncrement(INCREMENT_FIFTY)
+            .build()
             .formatDistance(19312.1)
 
         assertEquals("19 km", result.toString())
@@ -270,8 +281,8 @@ class MapboxDistanceFormatterTest {
 
     @Test
     fun formatDistanceDefaultBuilder() {
-        val distanceFormatter = MapboxDistanceFormatter.Builder()
-            .build(ctx)
+        val distanceFormatter = MapboxDistanceFormatter.Builder(ctx)
+            .build()
 
         val result = distanceFormatter.formatDistance(25.1)
 

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/internal/MapboxDistanceFormatterTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/internal/MapboxDistanceFormatterTest.kt
@@ -38,6 +38,11 @@ class MapboxDistanceFormatterTest : BuilderTest<MapboxDistanceFormatter, MapboxD
             .unitType("unitType")
     }
 
+    @Test
+    override fun trigger() {
+        // only used to trigger JUnit4 to run this class if all test cases come from the parent
+    }
+
     @Before
     fun setup() {
         ctx = ApplicationProvider.getApplicationContext<Context>()

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/route/ReplayRouteOptionsTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/route/ReplayRouteOptionsTest.kt
@@ -1,8 +1,8 @@
 package com.mapbox.navigation.core.replay.route
 
 import com.mapbox.navigation.testing.BuilderTest
-import org.junit.Test
 import kotlin.reflect.KClass
+import org.junit.Test
 
 class ReplayRouteOptionsTest : BuilderTest<ReplayRouteOptions, ReplayRouteOptions.Builder>() {
     override fun getImplementationClass(): KClass<ReplayRouteOptions> = ReplayRouteOptions::class

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/route/ReplayRouteOptionsTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/route/ReplayRouteOptionsTest.kt
@@ -1,6 +1,7 @@
 package com.mapbox.navigation.core.replay.route
 
 import com.mapbox.navigation.testing.BuilderTest
+import org.junit.Test
 import kotlin.reflect.KClass
 
 class ReplayRouteOptionsTest : BuilderTest<ReplayRouteOptions, ReplayRouteOptions.Builder>() {
@@ -13,5 +14,10 @@ class ReplayRouteOptionsTest : BuilderTest<ReplayRouteOptions, ReplayRouteOption
             .minAcceleration(56.0)
             .turnSpeedMps(78.0)
             .uTurnSpeedMps(910.0)
+    }
+
+    @Test
+    override fun trigger() {
+        // only used to trigger JUnit4 to run this class if all test cases come from the parent
     }
 }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/route/ReplayRouteOptionsTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/route/ReplayRouteOptionsTest.kt
@@ -1,0 +1,17 @@
+package com.mapbox.navigation.core.replay.route
+
+import com.mapbox.navigation.testing.BuilderTest
+import kotlin.reflect.KClass
+
+class ReplayRouteOptionsTest : BuilderTest<ReplayRouteOptions, ReplayRouteOptions.Builder>() {
+    override fun getImplementationClass(): KClass<ReplayRouteOptions> = ReplayRouteOptions::class
+
+    override fun getFilledUpBuilder(): ReplayRouteOptions.Builder {
+        return ReplayRouteOptions.Builder()
+            .maxAcceleration(12.0)
+            .maxSpeedMps(34.0)
+            .minAcceleration(56.0)
+            .turnSpeedMps(78.0)
+            .uTurnSpeedMps(910.0)
+    }
+}

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/sensors/SensorEventEmitterTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/sensors/SensorEventEmitterTest.kt
@@ -32,7 +32,7 @@ class SensorEventEmitterTest {
     @Test
     fun `should convert signals per second to sampling period microseconds`() {
         val sensorOptions: SensorOptions = mockk {
-            every { enabledSensorTypes } returns setOf(
+            every { enableSensorTypes } returns setOf(
                 Sensor.TYPE_ACCELEROMETER
             )
             every { signalsPerSecond } returns 25
@@ -46,7 +46,7 @@ class SensorEventEmitterTest {
     @Test
     fun `should register multiple sensors`() {
         val sensorOptions: SensorOptions = mockk {
-            every { enabledSensorTypes } returns setOf(
+            every { enableSensorTypes } returns setOf(
                 Sensor.TYPE_ACCELEROMETER_UNCALIBRATED,
                 Sensor.TYPE_MAGNETIC_FIELD_UNCALIBRATED,
                 Sensor.TYPE_GYROSCOPE_UNCALIBRATED
@@ -62,7 +62,7 @@ class SensorEventEmitterTest {
     @Test
     fun `should only unregister once`() {
         val sensorOptions: SensorOptions = mockk {
-            every { enabledSensorTypes } returns setOf(
+            every { enableSensorTypes } returns setOf(
                 Sensor.TYPE_ACCELEROMETER_UNCALIBRATED,
                 Sensor.TYPE_MAGNETIC_FIELD_UNCALIBRATED,
                 Sensor.TYPE_GYROSCOPE_UNCALIBRATED
@@ -83,7 +83,7 @@ class SensorEventEmitterTest {
             mockSensor(Sensor.TYPE_ACCELEROMETER)
         )
         val sensorOptions: SensorOptions = mockk {
-            every { enabledSensorTypes } returns setOf(
+            every { enableSensorTypes } returns setOf(
                 Sensor.TYPE_ACCELEROMETER,
                 Sensor.TYPE_GYROSCOPE
             )
@@ -98,7 +98,7 @@ class SensorEventEmitterTest {
     @Test
     fun `should emit events`() {
         val sensorOptions: SensorOptions = mockk {
-            every { enabledSensorTypes } returns setOf(
+            every { enableSensorTypes } returns setOf(
                 Sensor.TYPE_ACCELEROMETER
             )
             every { signalsPerSecond } returns 25
@@ -117,7 +117,7 @@ class SensorEventEmitterTest {
     @Test
     fun `should not emit events after unregister`() {
         val sensorOptions: SensorOptions = mockk {
-            every { enabledSensorTypes } returns setOf(
+            every { enableSensorTypes } returns setOf(
                 Sensor.TYPE_ACCELEROMETER
             )
             every { signalsPerSecond } returns 25

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/sensors/SensorOptionsTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/sensors/SensorOptionsTest.kt
@@ -2,8 +2,8 @@ package com.mapbox.navigation.core.sensors
 
 import com.mapbox.navigation.testing.BuilderTest
 import io.mockk.mockk
-import org.junit.Test
 import kotlin.reflect.KClass
+import org.junit.Test
 
 class SensorOptionsTest : BuilderTest<SensorOptions, SensorOptions.Builder>() {
     override fun getImplementationClass(): KClass<SensorOptions> = SensorOptions::class

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/sensors/SensorOptionsTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/sensors/SensorOptionsTest.kt
@@ -1,0 +1,15 @@
+package com.mapbox.navigation.core.sensors
+
+import com.mapbox.navigation.testing.BuilderTest
+import io.mockk.mockk
+import kotlin.reflect.KClass
+
+class SensorOptionsTest : BuilderTest<SensorOptions, SensorOptions.Builder>() {
+    override fun getImplementationClass(): KClass<SensorOptions> = SensorOptions::class
+
+    override fun getFilledUpBuilder(): SensorOptions.Builder {
+        return SensorOptions.Builder()
+            .enableSensorTypes(mockk(relaxed = true))
+            .signalsPerSecond(123)
+    }
+}

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/sensors/SensorOptionsTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/sensors/SensorOptionsTest.kt
@@ -2,6 +2,7 @@ package com.mapbox.navigation.core.sensors
 
 import com.mapbox.navigation.testing.BuilderTest
 import io.mockk.mockk
+import org.junit.Test
 import kotlin.reflect.KClass
 
 class SensorOptionsTest : BuilderTest<SensorOptions, SensorOptions.Builder>() {
@@ -11,5 +12,10 @@ class SensorOptionsTest : BuilderTest<SensorOptions, SensorOptions.Builder>() {
         return SensorOptions.Builder()
             .enableSensorTypes(mockk(relaxed = true))
             .signalsPerSecond(123)
+    }
+
+    @Test
+    override fun trigger() {
+        // only used to trigger JUnit4 to run this class if all test cases come from the parent
     }
 }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/events/AppMetadataTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/events/AppMetadataTest.kt
@@ -1,8 +1,8 @@
 package com.mapbox.navigation.core.telemetry.events
 
 import com.mapbox.navigation.testing.BuilderTest
-import org.junit.Test
 import kotlin.reflect.KClass
+import org.junit.Test
 
 class AppMetadataTest : BuilderTest<AppMetadata, AppMetadata.Builder>() {
     override fun getImplementationClass(): KClass<AppMetadata> = AppMetadata::class

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/events/AppMetadataTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/events/AppMetadataTest.kt
@@ -1,0 +1,14 @@
+package com.mapbox.navigation.core.telemetry.events
+
+import com.mapbox.navigation.testing.BuilderTest
+import kotlin.reflect.KClass
+
+class AppMetadataTest : BuilderTest<AppMetadata, AppMetadata.Builder>() {
+    override fun getImplementationClass(): KClass<AppMetadata> = AppMetadata::class
+
+    override fun getFilledUpBuilder(): AppMetadata.Builder {
+        return AppMetadata.Builder("name", "version")
+            .sessionId("sessionId")
+            .userId("userId")
+    }
+}

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/events/AppMetadataTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/events/AppMetadataTest.kt
@@ -1,6 +1,7 @@
 package com.mapbox.navigation.core.telemetry.events
 
 import com.mapbox.navigation.testing.BuilderTest
+import org.junit.Test
 import kotlin.reflect.KClass
 
 class AppMetadataTest : BuilderTest<AppMetadata, AppMetadata.Builder>() {
@@ -10,5 +11,10 @@ class AppMetadataTest : BuilderTest<AppMetadata, AppMetadata.Builder>() {
         return AppMetadata.Builder("name", "version")
             .sessionId("sessionId")
             .userId("userId")
+    }
+
+    @Test
+    override fun trigger() {
+        // only used to trigger JUnit4 to run this class if all test cases come from the parent
     }
 }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationViewModel.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationViewModel.java
@@ -312,11 +312,11 @@ public class NavigationViewModel extends AndroidViewModel {
     final String unitType = initializeUnitType(options);
     final int roundingIncrement = options.roundingIncrement();
     final Locale locale = getLocaleDirectionsRoute(options.directionsRoute(), getApplication());
-    return new MapboxDistanceFormatter.Builder()
-        .withUnitType(unitType)
-        .withRoundingIncrement(roundingIncrement)
-        .withLocale(locale)
-        .build(getApplication());
+    return new MapboxDistanceFormatter.Builder(getApplication())
+        .unitType(unitType)
+        .roundingIncrement(roundingIncrement)
+        .locale(locale)
+        .build();
   }
 
   private void initializeNavigationSpeechPlayer(NavigationViewOptions options) {

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/instruction/GuidanceViewImageProvider.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/instruction/GuidanceViewImageProvider.kt
@@ -87,7 +87,7 @@ class GuidanceViewImageProvider() {
      */
     fun cancelRender(context: Context) {
         if (targets.isNotEmpty()) {
-            for(target in targets) {
+            for (target in targets) {
                 Picasso.Builder(context).build().cancelRequest(target)
             }
             targets.clear()

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/instruction/InstructionView.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/instruction/InstructionView.java
@@ -525,11 +525,11 @@ public class InstructionView extends RelativeLayout implements LifecycleObserver
     final String unitType = getUnitTypeForLocale(ContextEx.inferDeviceLocale(getContext()));
     final int roundingIncrement = Rounding.INCREMENT_FIFTY;
     final Locale locale = ContextEx.inferDeviceLocale(getContext());
-    distanceFormatter = new MapboxDistanceFormatter.Builder()
-        .withUnitType(unitType)
-        .withRoundingIncrement(roundingIncrement)
-        .withLocale(locale)
-        .build(getContext());
+    distanceFormatter = new MapboxDistanceFormatter.Builder(getContext())
+        .unitType(unitType)
+        .roundingIncrement(roundingIncrement)
+        .locale(locale)
+        .build();
     inflate(getContext(), R.layout.instruction_view_layout, this);
   }
 

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/internal/utils/BitmapEncodeOptions.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/internal/utils/BitmapEncodeOptions.kt
@@ -3,7 +3,36 @@ package com.mapbox.navigation.ui.internal.utils
 const val DEFAULT_BITMAP_ENCODE_WIDTH = 250
 const val DEFAULT_BITMAP_ENCODE_COMPRESS_QUALITY = 20
 
-data class BitmapEncodeOptions(val width: Int, val compressQuality: Int) {
+class BitmapEncodeOptions private constructor(val width: Int, val compressQuality: Int) {
+
+    /**
+     * @return builder matching the one used to create this instance
+     */
+    fun toBuilder() = Builder()
+        .compressQuality(compressQuality)
+        .width(width)
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as BitmapEncodeOptions
+
+        if (width != other.width) return false
+        if (compressQuality != other.compressQuality) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = width
+        result = 31 * result + compressQuality
+        return result
+    }
+
+    override fun toString(): String {
+        return "BitmapEncodeOptions(width=$width, compressQuality=$compressQuality)"
+    }
 
     class Builder {
         private var width: Int = DEFAULT_BITMAP_ENCODE_WIDTH

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/building/BuildingExtrusionHighlightLayer.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/building/BuildingExtrusionHighlightLayer.kt
@@ -10,8 +10,8 @@ import com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillExtrusionColor
 import com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillExtrusionHeight
 import com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillExtrusionOpacity
 import com.mapbox.mapboxsdk.style.layers.PropertyFactory.visibility
-import com.mapbox.navigation.ui.map.building.BuildingFootprintHighlightLayer.Companion.HIGHLIGHTED_BUILDING_FOOTPRINT_LAYER_ID
 import com.mapbox.navigation.ui.internal.utils.MapUtils
+import com.mapbox.navigation.ui.map.building.BuildingFootprintHighlightLayer.Companion.HIGHLIGHTED_BUILDING_FOOTPRINT_LAYER_ID
 
 /**
  * This layer handles the creation and customization of a [FillExtrusionLayer]

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/building/BuildingFootprintHighlightLayer.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/building/BuildingFootprintHighlightLayer.kt
@@ -2,7 +2,6 @@ package com.mapbox.navigation.ui.map.building
 
 import com.mapbox.mapboxsdk.geometry.LatLng
 import com.mapbox.mapboxsdk.maps.MapboxMap
-import com.mapbox.mapboxsdk.style.layers.FillExtrusionLayer
 import com.mapbox.mapboxsdk.style.layers.FillLayer
 import com.mapbox.mapboxsdk.style.layers.Property.NONE
 import com.mapbox.mapboxsdk.style.layers.Property.VISIBLE

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/summary/SummaryBottomSheet.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/summary/SummaryBottomSheet.java
@@ -230,11 +230,11 @@ public class SummaryBottomSheet extends FrameLayout implements LifecycleObserver
   private void initializeDistanceFormatter() {
     final Locale locale = ContextEx.inferDeviceLocale(getContext());
     final String unitType = getUnitTypeForLocale(locale);
-    distanceFormatter = new MapboxDistanceFormatter.Builder()
-            .withUnitType(unitType)
-            .withRoundingIncrement(Rounding.INCREMENT_FIFTY)
-            .withLocale(locale)
-            .build(getContext());
+    distanceFormatter = new MapboxDistanceFormatter.Builder(getContext())
+            .unitType(unitType)
+            .roundingIncrement(Rounding.INCREMENT_FIFTY)
+            .locale(locale)
+            .build();
   }
 
   /**

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/TestRouteProgressBuilder.java
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/TestRouteProgressBuilder.java
@@ -54,11 +54,10 @@ class TestRouteProgressBuilder {
     legProgressBuilder.distanceRemaining((float) legDurationRemaining);
     legProgressBuilder.upcomingStep(upcomingStep);
 
-    return new RouteProgress.Builder()
+    return new RouteProgress.Builder(route)
             .distanceRemaining((float) legDistanceRemaining)
             .upcomingStepPoints(currentStepPoints)
             .currentLegProgress(legProgressBuilder.build())
-            .route(route)
       .build();
   }
 

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/internal/utils/BitmapEncodeOptionsTest.kt
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/internal/utils/BitmapEncodeOptionsTest.kt
@@ -1,8 +1,8 @@
 package com.mapbox.navigation.ui.internal.utils
 
 import com.mapbox.navigation.testing.BuilderTest
-import org.junit.Test
 import kotlin.reflect.KClass
+import org.junit.Test
 
 class BitmapEncodeOptionsTest : BuilderTest<BitmapEncodeOptions, BitmapEncodeOptions.Builder>() {
     override fun getImplementationClass(): KClass<BitmapEncodeOptions> = BitmapEncodeOptions::class

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/internal/utils/BitmapEncodeOptionsTest.kt
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/internal/utils/BitmapEncodeOptionsTest.kt
@@ -1,6 +1,7 @@
 package com.mapbox.navigation.ui.internal.utils
 
 import com.mapbox.navigation.testing.BuilderTest
+import org.junit.Test
 import kotlin.reflect.KClass
 
 class BitmapEncodeOptionsTest : BuilderTest<BitmapEncodeOptions, BitmapEncodeOptions.Builder>() {
@@ -9,5 +10,10 @@ class BitmapEncodeOptionsTest : BuilderTest<BitmapEncodeOptions, BitmapEncodeOpt
         return BitmapEncodeOptions.Builder()
             .compressQuality(88)
             .width(456)
+    }
+
+    @Test
+    override fun trigger() {
+        // only used to trigger JUnit4 to run this class if all test cases come from the parent
     }
 }

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/internal/utils/BitmapEncodeOptionsTest.kt
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/internal/utils/BitmapEncodeOptionsTest.kt
@@ -1,0 +1,13 @@
+package com.mapbox.navigation.ui.internal.utils
+
+import com.mapbox.navigation.testing.BuilderTest
+import kotlin.reflect.KClass
+
+class BitmapEncodeOptionsTest : BuilderTest<BitmapEncodeOptions, BitmapEncodeOptions.Builder>() {
+    override fun getImplementationClass(): KClass<BitmapEncodeOptions> = BitmapEncodeOptions::class
+    override fun getFilledUpBuilder(): BitmapEncodeOptions.Builder {
+        return BitmapEncodeOptions.Builder()
+            .compressQuality(88)
+            .width(456)
+    }
+}

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/summary/SummaryModelTest.kt
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/summary/SummaryModelTest.kt
@@ -33,10 +33,10 @@ class SummaryModelTest : BaseTest() {
     @Test
     fun getDistanceRemaining() {
         val routeProgress = buildRouteProgress()
-        val distanceFormatter = MapboxDistanceFormatter.Builder()
-            .withUnitType(METRIC)
-            .withRoundingIncrement(INCREMENT_FIFTY)
-            .build(ctx)
+        val distanceFormatter = MapboxDistanceFormatter.Builder(ctx)
+            .unitType(METRIC)
+            .roundingIncrement(INCREMENT_FIFTY)
+            .build()
 
         val result = SummaryModel(
             ctx,
@@ -50,10 +50,10 @@ class SummaryModelTest : BaseTest() {
     @Test
     fun getTimeRemaining() {
         val routeProgress = buildRouteProgress()
-        val distanceFormatter = MapboxDistanceFormatter.Builder()
-            .withUnitType(METRIC)
-            .withRoundingIncrement(INCREMENT_FIFTY)
-            .build(ctx)
+        val distanceFormatter = MapboxDistanceFormatter.Builder(ctx)
+            .unitType(METRIC)
+            .roundingIncrement(INCREMENT_FIFTY)
+            .build()
 
         val result = SummaryModel(
             ctx,
@@ -67,10 +67,10 @@ class SummaryModelTest : BaseTest() {
     @Test
     fun getArrivalTime() {
         val routeProgress = buildRouteProgress()
-        val distanceFormatter = MapboxDistanceFormatter.Builder()
-            .withUnitType(METRIC)
-            .withRoundingIncrement(INCREMENT_FIFTY)
-            .build(ctx)
+        val distanceFormatter = MapboxDistanceFormatter.Builder(ctx)
+            .unitType(METRIC)
+            .roundingIncrement(INCREMENT_FIFTY)
+            .build()
         val time = Calendar.getInstance().also {
             it.set(2020, 2, 20, 20, 20, 20)
         }

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigatorImpl.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigatorImpl.kt
@@ -320,7 +320,7 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
         route?.let { route ->
             val upcomingStepIndex = stepIndex + ONE_INDEX
 
-            val routeProgressBuilder = RouteProgress.Builder()
+            val routeProgressBuilder = RouteProgress.Builder(route)
             val legProgressBuilder = RouteLegProgress.Builder()
             val stepProgressBuilder = RouteStepProgress.Builder()
 
@@ -428,8 +428,6 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
             routeProgressBuilder.routeGeometryWithBuffer(routeBufferGeoJson)
 
             routeProgressBuilder.voiceInstructions(voiceInstruction?.mapToDirectionsApi())
-
-            routeProgressBuilder.route(route)
 
             return routeProgressBuilder.build()
         }

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/NavigatorLoader.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/NavigatorLoader.kt
@@ -2,9 +2,8 @@ package com.mapbox.navigation.navigator.internal
 
 import com.mapbox.base.common.logger.Logger
 import com.mapbox.common.HttpServiceFactory
-import com.mapbox.navigation.base.options.AutomobileProfile
 import com.mapbox.navigation.base.options.DeviceProfile
-import com.mapbox.navigation.base.options.HandheldProfile
+import com.mapbox.navigation.base.options.DeviceType
 import com.mapbox.navigation.navigator.NavigationOkHttpService
 import com.mapbox.navigation.navigator.internal.NavigatorLoader.customConfig
 import com.mapbox.navigator.Navigator
@@ -33,12 +32,12 @@ internal object NavigatorLoader {
     }
 
     private fun settingsProfile(deviceProfile: DeviceProfile): SettingsProfile {
-        return when (deviceProfile) {
-            is AutomobileProfile -> {
-                SettingsProfile(ProfileApplication.KAUTO, ProfilePlatform.KANDROID)
-            }
-            is HandheldProfile -> {
+        return when (deviceProfile.deviceType) {
+            DeviceType.HANDHELD -> {
                 SettingsProfile(ProfileApplication.KMOBILE, ProfilePlatform.KANDROID)
+            }
+            DeviceType.AUTOMOBILE -> {
+                SettingsProfile(ProfileApplication.KAUTO, ProfilePlatform.KANDROID)
             }
             else -> throw NotImplementedError("Unknown device profile")
         }

--- a/libtesting-utils/build.gradle
+++ b/libtesting-utils/build.gradle
@@ -20,4 +20,5 @@ android {
 dependencies {
     implementation dependenciesList.junit
     implementation dependenciesList.coroutinesTestAndroid
+    implementation dependenciesList.kotlinReflect
 }

--- a/libtesting-utils/src/main/java/com/mapbox/navigation/testing/BuilderTest.kt
+++ b/libtesting-utils/src/main/java/com/mapbox/navigation/testing/BuilderTest.kt
@@ -154,6 +154,14 @@ abstract class BuilderTest<Implementation : Any, Builder> {
     private val buildMethod = builderClass.members.find { it.name == "build" } as? KFunction
         ?: throw RuntimeException("missing Builder.build method")
 
+    /**
+     * This method needs to be overridden and HAS TO explicitly add the @Test annotation in the child.
+     * This is needed to trick JUnit4 to process the test class if all the actual test cases are in the abstract parent.
+     * TODO add a lint rule to detect the missing annotation in the child, or create a new test runner
+     */
+    @Test
+    abstract fun trigger()
+
     @Test
     fun isNotDataClass() {
         assertFalse(implClass.isData)

--- a/libtesting-utils/src/main/java/com/mapbox/navigation/testing/BuilderTest.kt
+++ b/libtesting-utils/src/main/java/com/mapbox/navigation/testing/BuilderTest.kt
@@ -1,0 +1,176 @@
+package com.mapbox.navigation.testing
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.reflect.KClass
+import kotlin.reflect.KFunction
+import kotlin.reflect.KMutableProperty
+import kotlin.reflect.KProperty
+import kotlin.reflect.KVisibility
+import kotlin.reflect.jvm.isAccessible
+
+abstract class BuilderTest<Implementation : Any, Builder> {
+
+    private val implClass: KClass<*> by lazy { getImplementationClass() }
+
+    /**
+     * Your builder's resulting type.
+     */
+    abstract fun getImplementationClass(): KClass<Implementation>
+
+    /**
+     * Make sure that all of the required and optional values are provided and that they distinct from default ones.
+     */
+    abstract fun getFilledUpBuilder(): Builder
+
+    private val toBuilderMethod = implClass.members.find { it.name == "toBuilder" } as KFunction
+    private val toStringMethod = implClass.members.find { it.name == "toString" } as KFunction
+
+    private val builderClass = implClass.nestedClasses.find { it.simpleName == "Builder" }!!
+    private val requiredFieldNames =
+        builderClass.members.filter { it is KProperty && it !is KMutableProperty }.map { it.name }
+    private val optionalFieldNames =
+        builderClass.members.filter { it is KProperty && it is KMutableProperty }.map { it.name }
+    private val buildMethod = builderClass.members.find { it.name == "build" } as KFunction
+
+    @Test
+    fun isNotDataClass() {
+        assertFalse(implClass.isData)
+        assertFalse(builderClass.isData)
+    }
+
+    @Test
+    fun impl_onlyOneConstructor() {
+        assertEquals(1, implClass.constructors.size)
+    }
+
+    @Test
+    fun builder_onlyOneConstructor() {
+        assertEquals(1, builderClass.constructors.size)
+    }
+
+    @Test
+    fun impl_allConstructorsArePrivate() {
+        assertTrue(implClass.constructors.all { it.visibility == KVisibility.PRIVATE })
+    }
+
+    @Test
+    fun impl_allFieldsAreVals() {
+        assertTrue(
+            implClass.members.filterIsInstance<KProperty<*>>().all { it !is KMutableProperty }
+        )
+    }
+
+    @Test
+    fun builder_hasNoPublicFields() {
+        val publicFields = builderClass.members.filter {
+            it is KProperty<*> && it.visibility != KVisibility.PRIVATE
+        }
+        assertEquals("there should be no public fields", 0, publicFields.size)
+    }
+
+    @Test
+    fun builderAndImpl_fieldCountIsTheSame() {
+        assertEquals(
+            "number of fields in a builder should match number of fields in the implementation",
+            implClass.members.filterIsInstance<KProperty<*>>().size,
+            (requiredFieldNames.size + optionalFieldNames.size)
+        )
+    }
+
+    @Test
+    fun impl_toString_coversAllFields() {
+        val builderInstance = getFilledUpBuilder()
+        val implInstance = buildMethod.call(builderInstance)
+        val string = toStringMethod.call(implInstance) as String
+        (requiredFieldNames + optionalFieldNames).forEach {
+            assertTrue("$it is not included in the toString method", string.contains(it))
+        }
+    }
+
+    @Test
+    fun toBuilder_createsNewInstance() {
+        val builderInstance = getFilledUpBuilder()
+        val implInstance = buildMethod.call(builderInstance)
+        val retrievedBuilderInstance = toBuilderMethod.call(implInstance)
+        assertTrue(
+            "Retrieved builder instance is the same as the original one. The builder should be recreated.",
+            builderInstance !== retrievedBuilderInstance
+        )
+    }
+
+    @Test
+    fun toBuilder_rebuiltIsEqual() {
+        val builderInstance = getFilledUpBuilder()
+        val implInstance = buildMethod.call(builderInstance)
+        val retrievedBuilderInstance = toBuilderMethod.call(implInstance)
+        val rebuiltImplInstance = buildMethod.call(retrievedBuilderInstance)
+        assertTrue(
+            "Retrieved builder should create a new instance of the implementation.",
+            implInstance !== rebuiltImplInstance
+        )
+        assertEquals(
+            "New instance should be equal to the original one",
+            implInstance,
+            rebuiltImplInstance
+        )
+    }
+
+    @Test
+    fun equalsTest() {
+        compareOriginalNotEqualToRebuilt("equals") { instance ->
+            return@compareOriginalNotEqualToRebuilt instance
+        }
+    }
+
+    @Test
+    fun hashCodeTest() {
+        compareOriginalNotEqualToRebuilt("hashCode") { instance ->
+            return@compareOriginalNotEqualToRebuilt instance.hashCode()
+        }
+    }
+
+    private fun compareOriginalNotEqualToRebuilt(
+        methodName: String,
+        transformation: (instance: Any) -> Any
+    ) {
+        val builderInstance = getFilledUpBuilder()
+        val implInstance = buildMethod.call(builderInstance)!!
+
+        val requiredFields =
+            builderClass.members.filter { it is KProperty && it !is KMutableProperty } as List<KProperty<*>>
+        val requiredValues = mutableListOf<Any>()
+        requiredFields.forEachIndexed { index, kProperty ->
+            kProperty.isAccessible = true
+            requiredValues.add(kProperty.getter.call(builderInstance)!!)
+        }
+
+        val optionalFieldValues = mutableListOf<Pair<KProperty<*>, Any>>()
+        (builderClass.members.filter { it is KProperty && it is KMutableProperty } as List<KProperty<*>>).forEachIndexed { index, kProperty ->
+            kProperty.isAccessible = true
+            optionalFieldValues.add(Pair(kProperty, kProperty.getter.call(builderInstance)!!))
+        }
+
+        optionalFieldValues.forEach { exclude ->
+            val newBuilderInstance =
+                builderClass.constructors.first().call(*requiredValues.toTypedArray())
+            exclude.first.isAccessible = true
+            val defaultValue = exclude.first.getter.call(newBuilderInstance)
+            if (defaultValue == exclude.second) {
+                throw RuntimeException("make sure the provided value is different than default for \"${exclude.first.name}\"")
+            }
+            optionalFieldValues.filter { it != exclude }.forEach { fieldValue ->
+                builderClass.members.find { it is KFunction && it.name == fieldValue.first.name }!!
+                    .call(newBuilderInstance, fieldValue.second)
+            }
+            assertNotEquals(
+                "\"${exclude.first.name}\" is not included in the $methodName",
+                transformation(implInstance),
+                transformation(buildMethod.call(newBuilderInstance)!!)
+            )
+        }
+    }
+}


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-navigation-android/issues/2709 and closes https://github.com/mapbox/mapbox-navigation-android/issues/3369.

This PR builds on top of https://github.com/mapbox/mapbox-navigation-android/pull/3364 and adds an abstract `BuildeTest` class, that when extended by a regular test, runs a suite that aims to ensure that the builders are following the spec discussed in https://github.com/mapbox/mapbox-navigation-android/issues/2709#issuecomment-658869378.

We can consider this test suite as a mid-sized strainer - it will catch most of the issues that could be introduced, but there are still edge cases that are extremely hard to test in an automated fashion and we'll need to keep an eye on them when reviewing. One example could be `val` and  `var` definitions in Kotlin constructor - when access via reflection, they are listed as regular fields and we'd need to do a whole lot of checking and iterations to figure out that it could be a modifiable field passed through a constructor (and then having a separate setter method) which would be incorrect. This is mostly a concern for the new classes. Existing ones are still guarded by metalava which will give us insight when we're breaking something that wasn't caught by a test.

There's also a gotcha with JUint4 implementation - if a class doesn't have any JUnit `@Test` annotations, it will be ignored, even if the abstract parent does have tests. I'm working around that with the `trigger` method which **MUST HAVE** a `@Test` annotation in the overridden method as well. There are possible improvements here that could be made by creating a custom linter or a custom test runner, or maybe something else like a delegation pattern instead of inheritance.

This PR also re-enables `ktlint` for the UI module which has been disabled by accident in the repo refactor.

/cc @mapbox/navigation-android 