### PR TITLE
Bump play-services-location version to 17.0.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -41,7 +41,7 @@ ext {
       lifecycle                 : '2.2.0',
       lifecycleViewModelKtx     : '2.2.0',
       picasso                   : '2.71828',
-      gmsLocation               : '16.0.0',
+      gmsLocation               : '17.0.0',
       ktlint                    : '0.36.0',
       kotlinStdLib              : '1.3.72',
       firebaseCrashlytics       : '17.1.0',


### PR DESCRIPTION
## Description

Bumps `play-services-location` version to `17.0.0`

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

Refs. https://github.com/mapbox/mapbox-navigation-android/issues/3390

### Goal

Getting the latest version from `gmsLocation` including the new features and bug fixes.

### Implementation

- Bump the `gmsLocation` version to `17.0.0` in `dependencies.gradle`


## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR