### PR TITLE
removing call to remove routes in order to fix route hiding upon app …

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/SimpleMapboxNavigationKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/SimpleMapboxNavigationKt.kt
@@ -362,7 +362,6 @@ class SimpleMapboxNavigationKt : AppCompatActivity(), OnMapReadyCallback,
                     updateLocationLayerRenderMode(RenderMode.GPS)
                 } else {
                     symbolManager?.deleteAll()
-                    removeRoute()
                     updateCameraTrackingMode(NavigationCamera.NAVIGATION_TRACKING_MODE_NONE)
                     updateLocationLayerRenderMode(RenderMode.COMPASS)
                 }


### PR DESCRIPTION
## Description

A fix for #3389. The SimpleMapboxNavigation example was calling removeRoute() which actually just hides the route but it was never restoring the visibility by calling showRoute(). The call to removeRoute was being made after the activity had been restored as a result of the trip session entering a STOPPED state. The other example activities didn't exhibit the same behavior.

- [x] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal


### Implementation

It seemed unnecessary for the activity make the call to removeRoute() so it was removed. 

## Screenshots or Gifs


## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->