### PR TITLE
refactored to change the naming from shield to casing

### DIFF
--- a/examples/src/main/res/values/colors.xml
+++ b/examples/src/main/res/values/colors.xml
@@ -24,7 +24,7 @@
     <color name="navigation_maneuver_view_secondary">@android:color/holo_blue_light</color>
 
     <!-- Custom Route Colors -->
-    <color name="customRouteShieldColor">#FA0A4E</color>
+    <color name="customRouteCasingColor">#FA0A4E</color>
     <color name="customRouteColor">#ffffff</color>
     <color name="customRouteLowCongestionColor">#00ff00</color>
     <color name="customRouteUnknownCongestionColor">#a8aaba</color>
@@ -32,12 +32,12 @@
     <color name="customRouteHeavyCongestionColor">#D16100</color>
     <color name="customRouteSevereCongestionColor">#FF0000</color>
     <color name="customRouteLineTraveledColor">#a8aaba</color>
-    <color name="customRouteLineShieldTraveledColor">#6E707A</color>
+    <color name="customRouteLineCasingTraveledColor">#6E707A</color>
 
     <color name="customAlternativeRouteColor">#7EC8CF</color>
     <color name="customAlternativeRouteUnknownCongestionColor">#7EC8CF</color>
     <color name="customAlternativeRouteModerateCongestionColor">#76BCC2</color>
     <color name="customAlternativeRouteHeavyCongestionColor">#67A3A8</color>
     <color name="customAlternativeRouteSevereCongestionColor">#4F7E82</color>
-    <color name="customAlternativeRouteShieldColor">#284042</color>
+    <color name="customAlternativeRouteCasingColor">#284042</color>
 </resources>

--- a/examples/src/main/res/values/styles.xml
+++ b/examples/src/main/res/values/styles.xml
@@ -118,9 +118,9 @@
         <item name="routeModerateCongestionColor">@color/customRouteModerateCongestionColor</item>
         <item name="routeHeavyCongestionColor">@color/customRouteHeavyCongestionColor</item>
         <item name="routeSevereCongestionColor">@color/customRouteSevereCongestionColor</item>
-        <item name="routeShieldColor">@color/customRouteShieldColor</item>
+        <item name="routeCasingColor">@color/customRouteCasingColor</item>
         <item name="routeLineTraveledColor">@color/customRouteLineTraveledColor</item>
-        <item name="routeLineShieldTraveledColor">@color/customRouteLineShieldTraveledColor</item>
+        <item name="routeLineCasingTraveledColor">@color/customRouteLineCasingTraveledColor</item>
         <item name="alternativeRouteColor">@color/customAlternativeRouteColor</item>
         <item name="alternativeRouteUnknownCongestionColor">
             @color/customAlternativeRouteUnknownCongestionColor
@@ -134,8 +134,8 @@
         <item name="alternativeRouteSevereCongestionColor">
             @color/customAlternativeRouteSevereCongestionColor
         </item>
-        <item name="alternativeRouteShieldColor">
-            @color/customAlternativeRouteShieldColor
+        <item name="alternativeRouteCasingColor">
+            @color/customAlternativeRouteCasingColor
         </item>
         <item name="routeTrafficScale">0.5</item>
     </style>

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/internal/route/MapRouteLayerProvider.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/internal/route/MapRouteLayerProvider.java
@@ -29,12 +29,12 @@ import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineColor;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineJoin;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineWidth;
 import static com.mapbox.navigation.ui.internal.route.RouteConstants.ALTERNATIVE_ROUTE_LAYER_ID;
-import static com.mapbox.navigation.ui.internal.route.RouteConstants.ALTERNATIVE_ROUTE_SHIELD_LAYER_ID;
+import static com.mapbox.navigation.ui.internal.route.RouteConstants.ALTERNATIVE_ROUTE_CASING_LAYER_ID;
 import static com.mapbox.navigation.ui.internal.route.RouteConstants.ALTERNATIVE_ROUTE_SOURCE_ID;
 import static com.mapbox.navigation.ui.internal.route.RouteConstants.DESTINATION_MARKER_NAME;
 import static com.mapbox.navigation.ui.internal.route.RouteConstants.ORIGIN_MARKER_NAME;
 import static com.mapbox.navigation.ui.internal.route.RouteConstants.PRIMARY_ROUTE_LAYER_ID;
-import static com.mapbox.navigation.ui.internal.route.RouteConstants.PRIMARY_ROUTE_SHIELD_LAYER_ID;
+import static com.mapbox.navigation.ui.internal.route.RouteConstants.PRIMARY_ROUTE_CASING_LAYER_ID;
 import static com.mapbox.navigation.ui.internal.route.RouteConstants.PRIMARY_ROUTE_SOURCE_ID;
 import static com.mapbox.navigation.ui.internal.route.RouteConstants.PRIMARY_ROUTE_TRAFFIC_LAYER_ID;
 import static com.mapbox.navigation.ui.internal.route.RouteConstants.PRIMARY_ROUTE_TRAFFIC_SOURCE_ID;
@@ -46,15 +46,15 @@ import static com.mapbox.navigation.ui.internal.route.RouteConstants.WAYPOINT_SO
 
 public class MapRouteLayerProvider {
 
-  public LineLayer initializePrimaryRouteShieldLayer(Style style, float routeScale, int routeShieldColor) {
-    LineLayer primaryShieldLayer = style.getLayerAs(PRIMARY_ROUTE_SHIELD_LAYER_ID);
-    if (primaryShieldLayer != null) {
-      style.removeLayer(primaryShieldLayer);
+  public LineLayer initializePrimaryRouteCasingLayer(Style style, float routeScale, int routeCasingColor) {
+    LineLayer primaryCasingLayer = style.getLayerAs(PRIMARY_ROUTE_CASING_LAYER_ID);
+    if (primaryCasingLayer != null) {
+      style.removeLayer(primaryCasingLayer);
     }
 
     // fixme reduce all the duplicate code here
 
-    primaryShieldLayer = new LineLayer(PRIMARY_ROUTE_SHIELD_LAYER_ID, PRIMARY_ROUTE_SOURCE_ID).withProperties(
+    primaryCasingLayer = new LineLayer(PRIMARY_ROUTE_CASING_LAYER_ID, PRIMARY_ROUTE_SOURCE_ID).withProperties(
      lineCap(Property.LINE_CAP_ROUND),
      lineJoin(Property.LINE_JOIN_ROUND),
      lineWidth(
@@ -67,22 +67,22 @@ public class MapRouteLayerProvider {
              stop(22f, product(literal(29f), literal(routeScale)))
           )
      ),
-     lineColor(color(routeShieldColor))
+     lineColor(color(routeCasingColor))
    );
-    return primaryShieldLayer;
+    return primaryCasingLayer;
   }
 
-  public LineLayer initializeAlternativeRouteShieldLayer(
+  public LineLayer initializeAlternativeRouteCasingLayer(
     Style style,
     float alternativeRouteScale,
-    int alternativeRouteShieldColor) {
-    LineLayer alternativeShieldLayer = style.getLayerAs(ALTERNATIVE_ROUTE_SHIELD_LAYER_ID);
-    if (alternativeShieldLayer != null) {
-      style.removeLayer(alternativeShieldLayer);
+    int alternativeRouteCasingColor) {
+    LineLayer alternativeCasingLayer = style.getLayerAs(ALTERNATIVE_ROUTE_CASING_LAYER_ID);
+    if (alternativeCasingLayer != null) {
+      style.removeLayer(alternativeCasingLayer);
     }
 
-    alternativeShieldLayer = new LineLayer(
-            ALTERNATIVE_ROUTE_SHIELD_LAYER_ID,
+    alternativeCasingLayer = new LineLayer(
+            ALTERNATIVE_ROUTE_CASING_LAYER_ID,
             ALTERNATIVE_ROUTE_SOURCE_ID)
             .withProperties(
        lineCap(Property.LINE_CAP_ROUND),
@@ -97,9 +97,9 @@ public class MapRouteLayerProvider {
                    stop(22f, product(literal(29f), literal(alternativeRouteScale)))
                )
        ),
-       lineColor(alternativeRouteShieldColor)
+       lineColor(alternativeRouteCasingColor)
     );
-    return alternativeShieldLayer;
+    return alternativeCasingLayer;
   }
 
   public LineLayer initializePrimaryRouteLayer(Style style,

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/internal/route/RouteConstants.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/internal/route/RouteConstants.java
@@ -5,10 +5,10 @@ public class RouteConstants {
   public static final String PRIMARY_ROUTE_TRAFFIC_SOURCE_ID = "mapbox-navigation-route-traffic-source";
   public static final String PRIMARY_ROUTE_LAYER_ID = "mapbox-navigation-route-layer";
   public static final String PRIMARY_ROUTE_TRAFFIC_LAYER_ID = "mapbox-navigation-route-traffic-layer";
-  public static final String PRIMARY_ROUTE_SHIELD_LAYER_ID = "mapbox-navigation-route-shield-layer";
+  public static final String PRIMARY_ROUTE_CASING_LAYER_ID = "mapbox-navigation-route-casing-layer";
   public static final String ALTERNATIVE_ROUTE_SOURCE_ID = "mapbox-navigation-alt-route-source";
   public static final String ALTERNATIVE_ROUTE_LAYER_ID = "mapbox-navigation-alt-route-layer";
-  public static final String ALTERNATIVE_ROUTE_SHIELD_LAYER_ID = "mapbox-navigation-alt-route-shield-layer";
+  public static final String ALTERNATIVE_ROUTE_CASING_LAYER_ID = "mapbox-navigation-alt-route-casing-layer";
   public static final String WAYPOINT_SOURCE_ID = "mapbox-navigation-waypoint-source";
   public static final String WAYPOINT_LAYER_ID = "mapbox-navigation-waypoint-layer";
   public static final int TWO_POINTS = 2;

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteLine.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteLine.kt
@@ -145,10 +145,10 @@ internal class MapRouteLine(
         )
     }
 
-    private val routeLineShieldTraveledColor: Int by lazy {
+    private val routeLineCasingTraveledColor: Int by lazy {
         getStyledColor(
-            R.styleable.NavigationMapRoute_routeLineShieldTraveledColor,
-            R.color.mapbox_navigation_route_shield_line_traveled_color,
+            R.styleable.NavigationMapRoute_routeLineCasingTraveledColor,
+            R.color.mapbox_navigation_route_casing_line_traveled_color,
             context,
             styleRes
         )
@@ -208,10 +208,10 @@ internal class MapRouteLine(
         )
     }
 
-    private val routeShieldColor: Int by lazy {
+    private val routeCasingColor: Int by lazy {
         getStyledColor(
-            R.styleable.NavigationMapRoute_routeShieldColor,
-            R.color.mapbox_navigation_route_shield_layer_color,
+            R.styleable.NavigationMapRoute_routeCasingColor,
+            R.color.mapbox_navigation_route_casing_layer_color,
             context,
             styleRes
         )
@@ -298,10 +298,10 @@ internal class MapRouteLine(
         )
     }
 
-    private val alternativeRouteShieldColor: Int by lazy {
+    private val alternativeRouteCasingColor: Int by lazy {
         getStyledColor(
-            R.styleable.NavigationMapRoute_alternativeRouteShieldColor,
-            R.color.mapbox_navigation_route_alternative_shield_color,
+            R.styleable.NavigationMapRoute_alternativeRouteCasingColor,
+            R.color.mapbox_navigation_route_alternative_casing_color,
             context,
             styleRes
         )
@@ -397,7 +397,7 @@ internal class MapRouteLine(
             val expression = getExpressionAtOffset(vanishPointOffset)
             style.getLayer(PRIMARY_ROUTE_TRAFFIC_LAYER_ID)?.setProperties(lineGradient(expression))
             hideRouteLineAtOffset(vanishPointOffset)
-            hideShieldLineAtOffset(vanishPointOffset)
+            hideCasingLineAtOffset(vanishPointOffset)
         }
 
         routeLineInitializedCallback?.onInitialized(
@@ -449,7 +449,7 @@ internal class MapRouteLine(
         this.routeFeatureData.firstOrNull { it.route == primaryRoute }?.let {
             drawPrimaryRoute(it)
             hideRouteLineAtOffset(vanishPointOffset)
-            hideShieldLineAtOffset(vanishPointOffset)
+            hideCasingLineAtOffset(vanishPointOffset)
         }
     }
 
@@ -576,10 +576,10 @@ internal class MapRouteLine(
         belowLayerId: String
     ) {
 
-        layerProvider.initializeAlternativeRouteShieldLayer(
+        layerProvider.initializeAlternativeRouteCasingLayer(
             style,
             alternativeRouteScale,
-            alternativeRouteShieldColor
+            alternativeRouteCasingColor
         ).apply {
             MapUtils.addLayerToMap(
                 style,
@@ -603,10 +603,10 @@ internal class MapRouteLine(
             routeLayerIds.add(this.id)
         }
 
-        layerProvider.initializePrimaryRouteShieldLayer(
+        layerProvider.initializePrimaryRouteCasingLayer(
             style,
             routeScale,
-            routeShieldColor
+            routeCasingColor
         ).apply {
             MapUtils.addLayerToMap(
                 style,
@@ -667,7 +667,7 @@ internal class MapRouteLine(
         partitionedRoutes.first.firstOrNull()?.let {
             drawPrimaryRoute(it)
             hideRouteLineAtOffset(vanishPointOffset)
-            hideShieldLineAtOffset(vanishPointOffset)
+            hideCasingLineAtOffset(vanishPointOffset)
         }
         drawAlternativeRoutes(partitionedRoutes.second)
     }
@@ -774,7 +774,7 @@ internal class MapRouteLine(
         if (style.isFullyLoaded) {
             routeLayerIds.filter {
                 it == RouteConstants.ALTERNATIVE_ROUTE_LAYER_ID ||
-                    it == RouteConstants.ALTERNATIVE_ROUTE_SHIELD_LAYER_ID
+                    it == RouteConstants.ALTERNATIVE_ROUTE_CASING_LAYER_ID
             }.mapNotNull { style.getLayer(it) }.forEach {
                 (it as LineLayer).setFilter(Expression.literal(isAlternativeVisible))
             }
@@ -818,21 +818,21 @@ internal class MapRouteLine(
     }
 
     /**
-     * Hides the RouteShield Layer
+     * Hides the RouteCasing Layer
      *
      * @param offset the offset of the visibility in the expression
      */
-    fun hideShieldLineAtOffset(offset: Float) {
+    fun hideCasingLineAtOffset(offset: Float) {
         val expression = Expression.step(
             Expression.lineProgress(),
-            Expression.color(routeLineShieldTraveledColor),
+            Expression.color(routeLineCasingTraveledColor),
             Expression.stop(
                 offset.toBigDecimal().setScale(9, BigDecimal.ROUND_DOWN),
-                Expression.color(routeShieldColor)
+                Expression.color(routeCasingColor)
             )
         )
         if (style.isFullyLoaded) {
-            style.getLayerAs<LineLayer>(RouteConstants.PRIMARY_ROUTE_SHIELD_LAYER_ID)
+            style.getLayerAs<LineLayer>(RouteConstants.PRIMARY_ROUTE_CASING_LAYER_ID)
                 ?.setProperties(lineGradient(expression))
         }
     }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteProgressChangeListener.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteProgressChangeListener.kt
@@ -54,7 +54,7 @@ internal class MapRouteProgressChangeListener(
     private val routeLineAnimatorUpdateHandler: RouteLineValueAnimatorHandler = { animationValue ->
         if (animationValue > MINIMUM_ROUTE_LINE_OFFSET) {
             val expression = routeLine.getExpressionAtOffset(animationValue)
-            routeLine.hideShieldLineAtOffset(animationValue)
+            routeLine.hideCasingLineAtOffset(animationValue)
             routeLine.hideRouteLineAtOffset(animationValue)
             routeLine.decorateRouteLine(expression)
             lastDistanceValue = animationValue

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/NavigationMapRoute.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/NavigationMapRoute.java
@@ -445,7 +445,7 @@ public class NavigationMapRoute implements LifecycleObserver {
   }
 
   public void updateRouteLineWithDistanceTraveled(float distanceTraveled) {
-    routeLine.hideShieldLineAtOffset(distanceTraveled);
+    routeLine.hideCasingLineAtOffset(distanceTraveled);
     routeLine.hideRouteLineAtOffset(distanceTraveled);
     mapRouteProgressChangeListener.updatePercentDistanceTraveled(distanceTraveled);
   }

--- a/libnavigation-ui/src/main/res/values/attrs.xml
+++ b/libnavigation-ui/src/main/res/values/attrs.xml
@@ -8,9 +8,9 @@
     <attr name="routeModerateCongestionColor" format="color"/>
     <attr name="routeHeavyCongestionColor" format="color"/>
     <attr name="routeSevereCongestionColor" format="color"/>
-    <attr name="routeShieldColor" format="color"/>
+    <attr name="routeCasingColor" format="color"/>
     <attr name="routeLineTraveledColor" format="color"/>
-    <attr name="routeLineShieldTraveledColor" format="color"/>
+    <attr name="routeLineCasingTraveledColor" format="color"/>
 
     <!-- Alternative route colors -->
     <attr name="alternativeRouteColor" format="color"/>
@@ -19,7 +19,7 @@
     <attr name="alternativeRouteModerateCongestionColor" format="color"/>
     <attr name="alternativeRouteHeavyCongestionColor" format="color"/>
     <attr name="alternativeRouteSevereCongestionColor" format="color"/>
-    <attr name="alternativeRouteShieldColor" format="color"/>
+    <attr name="alternativeRouteCasingColor" format="color"/>
 
     <!-- Origin/Destination waypoint drawables -->
     <attr name="originWaypointIcon" format="reference"/>

--- a/libnavigation-ui/src/main/res/values/colors.xml
+++ b/libnavigation-ui/src/main/res/values/colors.xml
@@ -7,9 +7,9 @@
   <color name="mapbox_navigation_route_layer_congestion_yellow">#F3A64F</color>
   <color name="mapbox_navigation_route_layer_congestion_heavy">#E93340</color>
   <color name="mapbox_navigation_route_layer_congestion_red">#E93340</color>
-  <color name="mapbox_navigation_route_shield_layer_color">#2F7AC6</color>
+  <color name="mapbox_navigation_route_casing_layer_color">#2F7AC6</color>
   <color name="mapbox_navigation_route_line_traveled_color">#00000000</color>
-  <color name="mapbox_navigation_route_shield_line_traveled_color">#00000000</color>
+  <color name="mapbox_navigation_route_casing_line_traveled_color">#00000000</color>
 
   <!-- Alternative route colors -->
   <color name="mapbox_navigation_route_alternative_color">#8694A5</color>
@@ -17,7 +17,7 @@
   <color name="mapbox_navigation_route_alternative_congestion_yellow">#BEA087</color>
   <color name="mapbox_navigation_route_alternative_congestion_heavy">#B58281</color>
   <color name="mapbox_navigation_route_alternative_congestion_red">#B58281</color>
-  <color name="mapbox_navigation_route_alternative_shield_color">#727E8D</color>
+  <color name="mapbox_navigation_route_alternative_casing_color">#727E8D</color>
 
   <color name="mapbox_navigation_route_upcoming_maneuver_arrow_color">#FFFFFF</color>
   <color name="mapbox_navigation_route_upcoming_maneuver_arrow_border_color">#2D3F53</color>

--- a/libnavigation-ui/src/main/res/values/styles.xml
+++ b/libnavigation-ui/src/main/res/values/styles.xml
@@ -17,11 +17,11 @@
         <item name="routeSevereCongestionColor">
             @color/mapbox_navigation_route_layer_congestion_red
         </item>
-        <item name="routeShieldColor">@color/mapbox_navigation_route_shield_layer_color</item>
+        <item name="routeCasingColor">@color/mapbox_navigation_route_casing_layer_color</item>
         <item name="routeLineTraveledColor">@color/mapbox_navigation_route_line_traveled_color
         </item>
-        <item name="routeLineShieldTraveledColor">
-            @color/mapbox_navigation_route_shield_line_traveled_color
+        <item name="routeLineCasingTraveledColor">
+            @color/mapbox_navigation_route_casing_line_traveled_color
         </item>
         <item name="alternativeRouteColor">@color/mapbox_navigation_route_alternative_color</item>
         <item name="alternativeRouteUnknownCongestionColor">
@@ -39,8 +39,8 @@
         <item name="alternativeRouteSevereCongestionColor">
             @color/mapbox_navigation_route_alternative_congestion_red
         </item>
-        <item name="alternativeRouteShieldColor">
-            @color/mapbox_navigation_route_alternative_shield_color
+        <item name="alternativeRouteCasingColor">
+            @color/mapbox_navigation_route_alternative_casing_color
         </item>
         <!-- Scales -->
         <item name="routeScale">1.0</item>

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteLineTest.kt
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteLineTest.kt
@@ -20,10 +20,10 @@ import com.mapbox.navigation.ui.internal.ThemeSwitcher
 import com.mapbox.navigation.ui.internal.route.MapRouteLayerProvider
 import com.mapbox.navigation.ui.internal.route.MapRouteSourceProvider
 import com.mapbox.navigation.ui.internal.route.RouteConstants
+import com.mapbox.navigation.ui.internal.route.RouteConstants.ALTERNATIVE_ROUTE_CASING_LAYER_ID
 import com.mapbox.navigation.ui.internal.route.RouteConstants.ALTERNATIVE_ROUTE_LAYER_ID
-import com.mapbox.navigation.ui.internal.route.RouteConstants.ALTERNATIVE_ROUTE_SHIELD_LAYER_ID
+import com.mapbox.navigation.ui.internal.route.RouteConstants.PRIMARY_ROUTE_CASING_LAYER_ID
 import com.mapbox.navigation.ui.internal.route.RouteConstants.PRIMARY_ROUTE_LAYER_ID
-import com.mapbox.navigation.ui.internal.route.RouteConstants.PRIMARY_ROUTE_SHIELD_LAYER_ID
 import com.mapbox.navigation.ui.internal.route.RouteConstants.PRIMARY_ROUTE_TRAFFIC_LAYER_ID
 import com.mapbox.navigation.ui.internal.route.RouteConstants.WAYPOINT_LAYER_ID
 import io.mockk.every
@@ -51,9 +51,9 @@ class MapRouteLineTest {
 
     lateinit var mapRouteSourceProvider: MapRouteSourceProvider
     lateinit var layerProvider: MapRouteLayerProvider
-    lateinit var alternativeRouteShieldLayer: LineLayer
+    lateinit var alternativeRouteCasingdLayer: LineLayer
     lateinit var alternativeRouteLayer: LineLayer
-    lateinit var primaryRouteShieldLayer: LineLayer
+    lateinit var primaryRouteCasingLayer: LineLayer
     lateinit var primaryRouteLayer: LineLayer
     lateinit var primaryRouteTrafficLayer: LineLayer
     lateinit var waypointLayer: SymbolLayer
@@ -67,16 +67,16 @@ class MapRouteLineTest {
             ctx,
             R.attr.navigationViewRouteStyle, R.style.NavigationMapRoute
         )
-        alternativeRouteShieldLayer = mockk {
-            every { id } returns ALTERNATIVE_ROUTE_SHIELD_LAYER_ID
+        alternativeRouteCasingdLayer = mockk {
+            every { id } returns ALTERNATIVE_ROUTE_CASING_LAYER_ID
         }
 
         alternativeRouteLayer = mockk {
             every { id } returns ALTERNATIVE_ROUTE_LAYER_ID
         }
 
-        primaryRouteShieldLayer = mockk {
-            every { id } returns PRIMARY_ROUTE_SHIELD_LAYER_ID
+        primaryRouteCasingLayer = mockk {
+            every { id } returns PRIMARY_ROUTE_CASING_LAYER_ID
         }
 
         primaryRouteLayer = mockk {
@@ -93,10 +93,10 @@ class MapRouteLineTest {
 
         style = mockk(relaxUnitFun = true) {
             every { getLayer(ALTERNATIVE_ROUTE_LAYER_ID) } returns alternativeRouteLayer
-            every { getLayer(ALTERNATIVE_ROUTE_SHIELD_LAYER_ID) } returns alternativeRouteShieldLayer
+            every { getLayer(ALTERNATIVE_ROUTE_CASING_LAYER_ID) } returns alternativeRouteCasingdLayer
             every { getLayer(PRIMARY_ROUTE_LAYER_ID) } returns primaryRouteLayer
             every { getLayer(PRIMARY_ROUTE_TRAFFIC_LAYER_ID) } returns primaryRouteTrafficLayer
-            every { getLayer(PRIMARY_ROUTE_SHIELD_LAYER_ID) } returns primaryRouteShieldLayer
+            every { getLayer(PRIMARY_ROUTE_CASING_LAYER_ID) } returns primaryRouteCasingLayer
             every { getLayer(WAYPOINT_LAYER_ID) } returns waypointLayer
             every { isFullyLoaded } returns false
         }
@@ -114,12 +114,12 @@ class MapRouteLineTest {
         }
         layerProvider = mockk {
             every {
-                initializeAlternativeRouteShieldLayer(
+                initializeAlternativeRouteCasingLayer(
                     style,
                     1.0f,
                     -9273715
                 )
-            } returns alternativeRouteShieldLayer
+            } returns alternativeRouteCasingdLayer
             every {
                 initializeAlternativeRouteLayer(
                     style,
@@ -129,12 +129,12 @@ class MapRouteLineTest {
                 )
             } returns alternativeRouteLayer
             every {
-                initializePrimaryRouteShieldLayer(
+                initializePrimaryRouteCasingLayer(
                     style,
                     1.0f,
                     -13665594
                 )
-            } returns primaryRouteShieldLayer
+            } returns primaryRouteCasingLayer
             every {
                 initializePrimaryRouteLayer(
                     style,
@@ -1027,18 +1027,18 @@ class MapRouteLineTest {
         every { style.isFullyLoaded } returns true
         every { style.getLayer(PRIMARY_ROUTE_TRAFFIC_LAYER_ID) } returns primaryRouteLayer
         every { primaryRouteLayer.setFilter(any()) } returns Unit
-        every { primaryRouteShieldLayer.setFilter(any()) } returns Unit
+        every { primaryRouteCasingLayer.setFilter(any()) } returns Unit
         every { alternativeRouteLayer.setFilter(any()) } returns Unit
-        every { alternativeRouteShieldLayer.setFilter(any()) } returns Unit
+        every { alternativeRouteCasingdLayer.setFilter(any()) } returns Unit
         every { primaryRouteTrafficLayer.setFilter(any()) } returns Unit
         every { waypointLayer.setFilter(any()) } returns Unit
         every { primaryRouteLayer.setProperties(any()) } returns Unit
-        every { primaryRouteShieldLayer.setProperties(any()) } returns Unit
+        every { primaryRouteCasingLayer.setProperties(any()) } returns Unit
         every { alternativeRouteLayer.setProperties(any()) } returns Unit
-        every { alternativeRouteShieldLayer.setProperties(any()) } returns Unit
+        every { alternativeRouteCasingdLayer.setProperties(any()) } returns Unit
         every { primaryRouteTrafficLayer.setProperties(any()) } returns Unit
         every { waypointLayer.setProperties(any()) } returns Unit
-        every { style.getLayerAs<LineLayer>("mapbox-navigation-route-shield-layer") } returns primaryRouteShieldLayer
+        every { style.getLayerAs<LineLayer>("mapbox-navigation-route-casing-layer") } returns primaryRouteCasingLayer
 
         val route = getDirectionsRoute(true)
         val mapRouteLine = MapRouteLine(

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteProgressChangeListenerTest.kt
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteProgressChangeListenerTest.kt
@@ -235,7 +235,7 @@ class MapRouteProgressChangeListenerTest {
     }
 
     @Test
-    fun `hides shield line at offset when route progress route has geometry`() {
+    fun `hides casing line at offset when route progress route has geometry`() {
         val expression: Expression = mockk()
         val progressChangeListener = MapRouteProgressChangeListener(routeLine, routeArrow, animator)
         val routes = listOf(
@@ -258,11 +258,11 @@ class MapRouteProgressChangeListenerTest {
             progressChangeListener.onRouteProgressChanged(routeProgress)
         }
 
-        verify { routeLine.hideShieldLineAtOffset(any()) }
+        verify { routeLine.hideCasingLineAtOffset(any()) }
     }
 
     @Test
-    fun `does not hide shield line at offset when route progress route does not have geometry`() {
+    fun `does not hide casing line at offset when route progress route does not have geometry`() {
         val expression: Expression = mockk()
         val progressChangeListener = MapRouteProgressChangeListener(routeLine, routeArrow, animator)
         val routes = listOf(
@@ -285,7 +285,7 @@ class MapRouteProgressChangeListenerTest {
             progressChangeListener.onRouteProgressChanged(routeProgress)
         }
 
-        verify(exactly = 0) { routeLine.hideShieldLineAtOffset(any()) }
+        verify(exactly = 0) { routeLine.hideCasingLineAtOffset(any()) }
     }
 
     @Test


### PR DESCRIPTION
## Description

Fixes #3397 changing the terminology used when referring to the part of the route line that gives the appearance of borders to the route line. 

- [x] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal


### Implementation



## Screenshots or Gifs


## Testing


- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->