### PR TITLE
Fix when url has invalid access token GuidanceViewImageProvider flaky test

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/instruction/GuidanceViewImageProvider.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/instruction/GuidanceViewImageProvider.kt
@@ -24,7 +24,7 @@ import okhttp3.Response
  * [BannerInstructions]
  * @constructor
  */
-class GuidanceViewImageProvider() {
+class GuidanceViewImageProvider {
 
     companion object {
         private const val USER_AGENT_KEY = "User-Agent"

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/instruction/InstructionView.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/instruction/InstructionView.java
@@ -148,7 +148,7 @@ public class InstructionView extends RelativeLayout implements LifecycleObserver
     }
 
     @Override
-    public void onFailure(@org.jetbrains.annotations.Nullable String message) {
+    public void onFailure(@Nullable String message) {
       animateHideGuidanceViewImage();
     }
   };


### PR DESCRIPTION
## Description

Fixes `when url has invalid access token` `GuidanceViewImageProvider` flaky test blocking outstanding PRs as CI was failing

E.g. https://app.circleci.com/pipelines/github/mapbox/mapbox-navigation-android/8091/workflows/f67eb727-8a8b-4de5-9897-2b4f8ea29690/jobs/30481 from https://github.com/mapbox/mapbox-navigation-android/pull/3322

```
when url has invalid access token - com.mapbox.navigation.ui.instruction.GuidanceViewImageProviderTest

java.lang.AssertionError: Verification failed: call 1 of 1: OnGuidanceImageDownload(#63).onFailure(slotCapture<String>())) was not called
	at io.mockk.impl.recording.states.VerifyingState.failIfNotPassed(VerifyingState.kt:66)
	at io.mockk.impl.recording.states.VerifyingState.recordingDone(VerifyingState.kt:42)
	at io.mockk.impl.recording.CommonCallRecorder.done(CommonCallRecorder.kt:47)
	at io.mockk.impl.eval.RecordedBlockEvaluator.record(RecordedBlockEvaluator.kt:60)
	at io.mockk.impl.eval.VerifyBlockEvaluator.verify(VerifyBlockEvaluator.kt:30)
	at io.mockk.MockKDsl.internalVerify(API.kt:118)
	at io.mockk.MockKKt.verify(MockK.kt:146)
	at io.mockk.MockKKt.verify$default(MockK.kt:143)
	at com.mapbox.navigation.ui.instruction.GuidanceViewImageProviderTest$when url has invalid access token$1.invokeSuspend(GuidanceViewImageProviderTest.kt:99)
	at com.mapbox.navigation.ui.instruction.GuidanceViewImageProviderTest$when url has invalid access token$1.invoke(GuidanceViewImageProviderTest.kt)
	at com.mapbox.navigation.testing.MainCoroutineRule$runBlockingTest$1.invokeSuspend(MainCoroutineRule.kt:33)
	at com.mapbox.navigation.testing.MainCoroutineRule$runBlockingTest$1.invoke(MainCoroutineRule.kt)
	at kotlinx.coroutines.test.TestBuildersKt$runBlockingTest$deferred$1.invokeSuspend(TestBuilders.kt:50)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:56)
	at kotlinx.coroutines.test.TestCoroutineDispatcher.dispatch(TestCoroutineDispatcher.kt:50)
	at kotlinx.coroutines.DispatchedContinuationKt.resumeCancellableWith(DispatchedContinuation.kt:288)
	at kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable(Cancellable.kt:26)
	at kotlinx.coroutines.CoroutineStart.invoke(CoroutineStart.kt:109)
	at kotlinx.coroutines.AbstractCoroutine.start(AbstractCoroutine.kt:158)
	at kotlinx.coroutines.BuildersKt__Builders_commonKt.async(Builders.common.kt:89)
	at kotlinx.coroutines.BuildersKt.async(Unknown Source)
	at kotlinx.coroutines.BuildersKt__Builders_commonKt.async$default(Builders.common.kt:82)
	at kotlinx.coroutines.BuildersKt.async$default(Unknown Source)
	at kotlinx.coroutines.test.TestBuildersKt.runBlockingTest(TestBuilders.kt:49)
	at kotlinx.coroutines.test.TestBuildersKt.runBlockingTest(TestBuilders.kt:72)
	at com.mapbox.navigation.testing.MainCoroutineRule.runBlockingTest(MainCoroutineRule.kt:33)
	at com.mapbox.navigation.ui.instruction.GuidanceViewImageProviderTest.when url has invalid access token(GuidanceViewImageProviderTest.kt:79)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at com.mapbox.navigation.testing.MainCoroutineRule$apply$1.evaluate(MainCoroutineRule.kt:25)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.runTestClass(JUnitTestClassExecutor.java:110)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:58)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:38)
	at org.gradle.api.internal.tasks.testing.junit.AbstractJUnitTestClassProcessor.processTestClass(AbstractJUnitTestClassProcessor.java:62)
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.processTestClass(SuiteTestClassProcessor.java:51)
	at sun.reflect.GeneratedMethodAccessor69.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94)
	at com.sun.proxy.$Proxy2.processTestClass(Unknown Source)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.processTestClass(TestWorker.java:118)
	at sun.reflect.GeneratedMethodAccessor68.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.remote.internal.hub.MessageHubBackedObjectConnection$DispatchWrapper.dispatch(MessageHubBackedObjectConnection.java:182)
	at org.gradle.internal.remote.internal.hub.MessageHubBackedObjectConnection$DispatchWrapper.dispatch(MessageHubBackedObjectConnection.java:164)
	at org.gradle.internal.remote.internal.hub.MessageHub$Handler.run(MessageHub.java:412)
	at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
	at org.gradle.internal.concurrent.ManagedExecutorImpl$1.run(ManagedExecutorImpl.java:48)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at org.gradle.internal.concurrent.ThreadFactoryImpl$ManagedThreadRunnable.run(ThreadFactoryImpl.java:56)
	at java.lang.Thread.run(Thread.java:748)
```

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Fix flaky test and unblock outstanding PRs

### Implementation

Remove duplicated `guidanceViewImageProvider.renderGuidanceView(bannerInstructions, callback)`, use `coVerify` as `guidanceViewImageProvider.renderGuidanceView(bannerInstructions, callback)` runs a `suspend` function and most important mock `ThreadController.getMainScopeAndRootJob()` used in https://github.com/mapbox/mapbox-navigation-android/blob/817941f7eacbbd1196be6ed6c15a5a6a794cc0e0/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/instruction/GuidanceViewImageProvider.kt#L57 so that everything is executed under the same thread / dispatcher avoiding the option of running into this failure - caused because https://github.com/mapbox/mapbox-navigation-android/blob/817941f7eacbbd1196be6ed6c15a5a6a794cc0e0/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/instruction/GuidanceViewImageProvider.kt#L87 was exiting the coroutine and test was resumed and therefore `verify` was called but https://github.com/mapbox/mapbox-navigation-android/blob/817941f7eacbbd1196be6ed6c15a5a6a794cc0e0/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/instruction/GuidanceViewImageProvider.kt#L61 not yet

I've also done some _Scout_ work and cleaned up a couple of things in `GuidanceViewImageProvider` (remove unnecessary primary constructor) and `InstructionView` (use AndroidX `@Nullable` annotation instead of JetBrains one) that I saw as I was working on OP's issue

## Testing

- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs

cc @mapbox/navigation-android 