### PR TITLE
Follow up from GuidanceViewImageProviderTest fix

### DIFF
--- a/libnavigation-ui/api/current.txt
+++ b/libnavigation-ui/api/current.txt
@@ -349,7 +349,6 @@ package com.mapbox.navigation.ui.instruction {
 
   public final class GuidanceViewImageProvider {
     ctor public GuidanceViewImageProvider();
-    method public void cancelRender();
     method public void renderGuidanceView(com.mapbox.api.directions.v5.models.BannerInstructions bannerInstructions, com.mapbox.navigation.ui.instruction.GuidanceViewImageProvider.OnGuidanceImageDownload callback);
     field public static final com.mapbox.navigation.ui.instruction.GuidanceViewImageProvider.Companion! Companion;
   }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/instruction/GuidanceViewImageProvider.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/instruction/GuidanceViewImageProvider.kt
@@ -5,13 +5,13 @@ import android.graphics.BitmapFactory
 import com.mapbox.api.directions.v5.models.BannerComponents
 import com.mapbox.api.directions.v5.models.BannerInstructions
 import com.mapbox.navigation.utils.internal.ifNonNull
+import java.io.IOException
 import okhttp3.Call
 import okhttp3.Callback
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
-import java.io.IOException
 
 /**
  * The class serves as a medium to emit bitmaps for the respective guidance view URL embedded in

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/instruction/GuidanceViewImageProvider.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/instruction/GuidanceViewImageProvider.kt
@@ -4,20 +4,14 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import com.mapbox.api.directions.v5.models.BannerComponents
 import com.mapbox.api.directions.v5.models.BannerInstructions
-import com.mapbox.navigation.utils.internal.JobControl
-import com.mapbox.navigation.utils.internal.ThreadController
 import com.mapbox.navigation.utils.internal.ifNonNull
-import java.io.IOException
-import kotlin.coroutines.suspendCoroutine
-import kotlinx.coroutines.cancelChildren
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import okhttp3.Call
 import okhttp3.Callback
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
+import java.io.IOException
 
 /**
  * The class serves as a medium to emit bitmaps for the respective guidance view URL embedded in
@@ -31,7 +25,6 @@ class GuidanceViewImageProvider {
         private const val USER_AGENT_VALUE = "MapboxJava/"
     }
 
-    private val mainJobController: JobControl by lazy { ThreadController.getMainScopeAndRootJob() }
     private val okHttpClient = OkHttpClient.Builder().addInterceptor { chain: Interceptor.Chain ->
         chain.proceed(
             chain.request().newBuilder().addHeader(USER_AGENT_KEY, USER_AGENT_VALUE).build()
@@ -60,13 +53,6 @@ class GuidanceViewImageProvider {
                 }
             } ?: callback.onNoGuidanceImageUrl()
         } ?: callback.onNoGuidanceImageUrl()
-    }
-
-    /**
-     * The API allows you to cancel the rendering of guidance view.
-     */
-    fun cancelRender() {
-        mainJobController.job.cancelChildren()
     }
 
     private fun getBitmap(url: String, callback: OnGuidanceImageDownload) {


### PR DESCRIPTION
## Description

Follow up from `GuidanceViewImageProviderTest` fix https://github.com/mapbox/mapbox-navigation-android/pull/3401 as `when url has invalid access token` is still failing sometimes in CI

E.g. https://app.circleci.com/pipelines/github/mapbox/mapbox-navigation-android/8106/workflows/9e449e56-94e5-45fb-a39b-8fd6aa215994/jobs/30514

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Fix flaky test and unblock outstanding PRs

### Implementation

- Remove `suspend` from `getBitmap` as `enqueue` does the request in a background thread already problem we're discussing is that we need to think about `cancelRender` (removed for now) as it's easier to handle with coroutines

In any case, what we've confirmed is that there's definitely something going on with that coroutines setup because it's exiting the coroutine somehow and not executing the rest (`callback.onFailure`) making the test fail - not sure if could be because coroutines and MockWebServer 💔 

## Testing

- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [x] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs

cc @abhishek1508 @korshaknn 