### PR TITLE
GuidanceViewImageProviderTest refactoring

### DIFF
--- a/libnavigation-ui/api/current.txt
+++ b/libnavigation-ui/api/current.txt
@@ -351,10 +351,7 @@ package com.mapbox.navigation.ui.instruction {
     ctor public GuidanceViewImageProvider();
     method public void cancelRender();
     method public void renderGuidanceView(com.mapbox.api.directions.v5.models.BannerInstructions bannerInstructions, com.mapbox.navigation.ui.instruction.GuidanceViewImageProvider.OnGuidanceImageDownload callback);
-    field public static final com.mapbox.navigation.ui.instruction.GuidanceViewImageProvider.Companion! Companion;
-  }
-
-  public static final class GuidanceViewImageProvider.Companion {
+    field @Deprecated public static final com.mapbox.navigation.ui.instruction.GuidanceViewImageProvider.Companion! Companion;
   }
 
   public static interface GuidanceViewImageProvider.OnGuidanceImageDownload {

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/instruction/GuidanceViewImageProvider.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/instruction/GuidanceViewImageProvider.kt
@@ -26,9 +26,10 @@ import okhttp3.Response
  */
 class GuidanceViewImageProvider {
 
-    companion object {
+    private companion object {
         private const val USER_AGENT_KEY = "User-Agent"
         private const val USER_AGENT_VALUE = "MapboxJava/"
+        private const val ERROR_VIEW_IMAGE_URL_NULL = "Guidance View Image URL is null"
     }
 
     private val mainJobController: JobControl by lazy { ThreadController.getMainScopeAndRootJob() }
@@ -60,7 +61,7 @@ class GuidanceViewImageProvider {
                                     callback.onGuidanceImageReady(b)
                                 } ?: callback.onFailure(response.error)
                             }
-                        } ?: callback.onFailure("Guidance View Image URL is null")
+                        } ?: callback.onFailure(ERROR_VIEW_IMAGE_URL_NULL)
                     }
                 }
             } ?: callback.onNoGuidanceImageUrl()


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Simplify test's logic, remove unnecessary code.

We don't need a real callback object to handle `CountDownLatch`, we can use a mocked one with
`every { callback.onFailure(capture(messageSlot)) } answers { latch.countDown() }`

also `Slot` is suitable, no need to use Atomic refs 

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->