### PR TITLE
Replace temporarily elapsedRealtimeNanos by 0 so legacy getStatus is used

### DIFF
--- a/libnavigator/build.gradle
+++ b/libnavigator/build.gradle
@@ -63,8 +63,6 @@ dependencies {
 
     implementation dependenciesList.androidXAnnotation
 
-    implementation dependenciesList.mapboxSdkGeoJSON
-
     implementation dependenciesList.coroutinesCore
 
     apply from: "${rootDir}/gradle/unit-testing-dependencies.gradle"

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/LocationEx.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/LocationEx.kt
@@ -37,7 +37,11 @@ internal fun Location.toFixLocation(date: Date): FixLocation {
 
     return FixLocation(
         Point.fromLngLat(longitude, latitude),
-        elapsedRealtimeNanos,
+        // TODO Replace by elapsedRealtimeNanos when monotonic approach is implemented
+        //  It turns out that if we send the elapsedRealtimeNanos NN expects clients to call
+        //  the overloaded getStatus method and if 0 is sent legacy getStatus is used instead
+        //  https://github.com/mapbox/mapbox-navigation-ios/pull/2477#issuecomment-665636356
+        0,
         date,
         if (hasSpeed()) speed else null,
         if (hasBearing()) bearing else null,


### PR DESCRIPTION
## Description

Replace temporarily `elapsedRealtimeNanos` by `0` so legacy `getStatus` method is used from NN until monotonic approach is implemented

Refs. https://github.com/mapbox/mapbox-navigation-ios/pull/2477#issuecomment-665636356

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Fix unexpected behaviors we were seeing from NN caused by sending `elapsedRealtimeNanos` but using the legacy `getStatus`

### Implementation

- Replace temporarily `elapsedRealtimeNanos` by `0` so legacy `getStatus` method is used from NN. It turns out that if we send the `elapsedRealtimeNanos` NN expects clients to call the overloaded `getStatus` method and if `0` is sent legacy `getStatus` is used instead.

- Remove duplicated `mapboxSdkGeoJSON` dependency from `libnavigator`s `build.gradle`

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs

cc @langsmith @abhishek1508 @korshaknn @SiarheiFedartsou @mskurydin @1ec5 