### PR TITLE
Fix MapboxOnboardRouterTest

### DIFF
--- a/libdirections-onboard/src/test/java/com/mapbox/navigation/route/onboard/internal/MapboxOnboardRouterTest.kt
+++ b/libdirections-onboard/src/test/java/com/mapbox/navigation/route/onboard/internal/MapboxOnboardRouterTest.kt
@@ -1,6 +1,5 @@
 package com.mapbox.navigation.route.onboard.internal
 
-import android.content.Context
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.RouteOptions
 import com.mapbox.base.common.logger.Logger
@@ -9,7 +8,6 @@ import com.mapbox.navigation.base.internal.accounts.SkuTokenProvider
 import com.mapbox.navigation.base.internal.extensions.applyDefaultParams
 import com.mapbox.navigation.base.internal.extensions.coordinates
 import com.mapbox.navigation.base.internal.route.RouteUrl
-import com.mapbox.navigation.base.options.OnboardRouterOptions
 import com.mapbox.navigation.base.route.Router
 import com.mapbox.navigation.navigator.internal.MapboxNativeNavigator
 import com.mapbox.navigation.testing.MainCoroutineRule
@@ -59,15 +57,11 @@ class MapboxOnboardRouterTest {
 
     private lateinit var onboardRouter: MapboxOnboardRouter
 
-    private val applicationContext: Context = mockk()
     private val navigator: MapboxNativeNavigator = mockk(relaxUnitFun = true)
     private val routerCallback: Router.Callback = mockk(relaxUnitFun = true)
     private val routerResultSuccess: RouterResult = mockk(relaxUnitFun = true)
     private val routerResultFailure: RouterResult = mockk(relaxUnitFun = true)
     private val routerOptions: RouteOptions = provideDefaultRouteOptions()
-    private val onboardRouterOptions = OnboardRouterOptions.Builder()
-        .filePath("test_file_path")
-        .build()
     private val logger: Logger = mockk(relaxUnitFun = true)
     private val mockSkuTokenProvider = mockk<SkuTokenProvider>(relaxed = true)
 
@@ -75,7 +69,7 @@ class MapboxOnboardRouterTest {
     fun setUp() {
         every { navigator.configureRouter(any()) } just Runs
         every { mockSkuTokenProvider.obtainSkuToken() } returns ("102ka34odzf38e3b8f5f1ba42818e94d31090d6479f")
-        onboardRouter = MapboxOnboardRouter(applicationContext, ACCESS_TOKEN, navigator, onboardRouterOptions, logger, mockSkuTokenProvider)
+        onboardRouter = MapboxOnboardRouter(navigator, logger)
 
         every { routerResultSuccess.json } returns SUCCESS_RESPONSE
         every { routerResultFailure.json } returns FAILURE_RESPONSE


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Following up from https://github.com/mapbox/mapbox-navigation-android/pull/3395/files

I only saw this issue while trying to upgrade mobile metrics to latest https://github.com/mapbox/mobile-metrics/pull/410

for some reason it passed CI in this repository

- [ ] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->