### PR TITLE
Fix LocationEx toFixLocation test and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ libnavigation-ui \
 
 define run-gradle-tasks
 	for module in $(1) ; do \
-		./gradlew $$module:$(2) ; \
+		./gradlew $$module:$(2) || exit 1 ; \
 	done
 endef
 

--- a/libnavigator/src/test/java/com/mapbox/navigation/navigator/LocationExTest.kt
+++ b/libnavigator/src/test/java/com/mapbox/navigation/navigator/LocationExTest.kt
@@ -31,7 +31,8 @@ class LocationExTest {
         location.toFixLocation(DATE).run {
             assertEquals(LATITUDE, coordinate.latitude(), .0)
             assertEquals(LONGITUDE, coordinate.longitude(), .0)
-            assertEquals(REAL_TIME, monotonicTimestampNanoseconds)
+            // TODO Replace by REAL_TIME when monotonic approach is implemented - check LocationEx
+            assertEquals(0, monotonicTimestampNanoseconds)
             assertEquals(DATE, time)
             assertEquals(SPEED, speed!!, .0f)
             assertEquals(BEARING, bearing!!, .0f)


### PR DESCRIPTION
## Description

Fixes `LocationEx` `toFixLocation` test and `Makefile` so it short circuits if any of the builds fails making CI to report a failure ❌ 
Fixes #3409 

Follow up from https://github.com/mapbox/mapbox-navigation-android/pull/3407

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

CI needs to catch if any of the builds fails and report 🔴 

### Implementation

- Add `|| exit 1 ;` to `Makefile` `run-gradle-tasks`
- Hardcode `0` as `monotonicTimestampNanoseconds` as was hardcoded temporarily in `LocationEx` `Location.toFixLocation` as part of https://github.com/mapbox/mapbox-navigation-android/pull/3407

## Testing

- [x] I have tested locally `make core-unit-tests` 👀 `LocationExTest` before and after adding `|| exit 1 ;` to `Makefile` `run-gradle-tasks`
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs