### PR TITLE
UI quick fix: align the Recenter icon with FeedbackButton

### DIFF
--- a/examples/src/main/res/layout/activity_custom_ui_component_style.xml
+++ b/examples/src/main/res/layout/activity_custom_ui_component_style.xml
@@ -32,11 +32,11 @@
         style="@style/CustomRecenterButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="top"
-        android:layout_margin="16dp"
+        android:layout_gravity="bottom"
+        android:paddingTop="@dimen/dimen_8dp"
         android:visibility="invisible"
-        app:layout_anchor="@id/summaryBottomSheet"
-        app:layout_anchorGravity="top|left" />
+        app:layout_anchor="@id/feedbackLayout"
+        app:layout_anchorGravity="bottom|right" />
 
     <com.mapbox.navigation.ui.map.WayNameView
         android:id="@+id/wayNameView"

--- a/examples/src/main/res/layout/fragment_basic_navigation.xml
+++ b/examples/src/main/res/layout/fragment_basic_navigation.xml
@@ -30,11 +30,11 @@
         android:id="@+id/recenterBtn"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="top"
-        android:layout_margin="16dp"
+        android:layout_gravity="bottom"
+        android:paddingTop="@dimen/dimen_8dp"
         android:visibility="invisible"
-        app:layout_anchor="@id/summaryBottomSheet"
-        app:layout_anchorGravity="top|left" />
+        app:layout_anchor="@id/feedbackLayout"
+        app:layout_anchorGravity="bottom|right" />
 
     <com.mapbox.navigation.ui.map.WayNameView
         android:id="@+id/wayNameView"

--- a/libnavigation-ui/src/main/res/layout/navigation_view_layout.xml
+++ b/libnavigation-ui/src/main/res/layout/navigation_view_layout.xml
@@ -31,6 +31,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="bottom"
+        android:paddingTop="@dimen/dimen_8dp"
         android:visibility="invisible"
         app:layout_anchor="@id/feedbackLayout"
         app:layout_anchorGravity="bottom|right" />


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

UI fix: 1) current banner should not be in the InstructionListView 2)recenter icon should anchor to FeedbackButton in examples

Check gif for detail.

- [ ] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Improve UX

### Implementation

The `toIndex` parameter of `List#subList()` method is **exclusive**, that's why the current banner instruction isn't removed from the InstructionListView.

## Screenshots or Gifs

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/3918950/89473555-03cb0a80-d738-11ea-9269-79376c7d6fa7.gif)


## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->