### PR TITLE
Fix configureRouter sync issue

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -688,7 +688,7 @@ class MapboxNavigation(
 
     private fun configureRouter() {
         with(navigationOptions) {
-            ThreadController.getMainScopeAndRootJob().scope.launch {
+            ThreadController.getIOScopeAndRootJob().scope.launch {
                 val offlineFilesPath = OnboardRouterFiles(applicationContext, logger)
                     .absolutePath(onboardRouterOptions)
                 offlineFilesPath?.let { path ->

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -65,7 +65,6 @@ import com.mapbox.navigator.RouterParams
 import com.mapbox.navigator.TileEndpointConfiguration
 import java.lang.reflect.Field
 import kotlinx.coroutines.channels.ReceiveChannel
-import kotlinx.coroutines.launch
 
 private const val MAPBOX_NAVIGATION_USER_AGENT_BASE = "mapbox-navigation-android"
 private const val MAPBOX_NAVIGATION_UI_USER_AGENT_BASE = "mapbox-navigation-ui-android"
@@ -688,26 +687,25 @@ class MapboxNavigation(
 
     private fun configureRouter() {
         with(navigationOptions) {
-            ThreadController.getIOScopeAndRootJob().scope.launch {
-                val offlineFilesPath = OnboardRouterFiles(applicationContext, logger)
-                    .absolutePath(onboardRouterOptions)
-                offlineFilesPath?.let { path ->
-                    val routerParams = RouterParams(
-                        path,
-                        null,
-                        null,
-                        THREADS_COUNT,
-                        TileEndpointConfiguration(
-                            onboardRouterOptions.tilesUri.toString(),
-                            onboardRouterOptions.tilesVersion,
-                            accessToken ?: "",
-                            USER_AGENT,
-                            "",
-                            NativeSkuTokenProvider(MapboxNavigationAccounts.getInstance(applicationContext))
-                        )
+            // TODO StrictMode may report a violation as we're creating a File from the Main
+            val offlineFilesPath = OnboardRouterFiles(applicationContext, logger)
+                .absolutePath(onboardRouterOptions)
+            offlineFilesPath?.let { path ->
+                val routerParams = RouterParams(
+                    path,
+                    null,
+                    null,
+                    THREADS_COUNT,
+                    TileEndpointConfiguration(
+                        onboardRouterOptions.tilesUri.toString(),
+                        onboardRouterOptions.tilesVersion,
+                        accessToken ?: "",
+                        USER_AGENT,
+                        "",
+                        NativeSkuTokenProvider(MapboxNavigationAccounts.getInstance(applicationContext))
                     )
-                    navigator.configureRouter(routerParams)
-                }
+                )
+                navigator.configureRouter(routerParams)
             }
         }
     }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/OnboardRouterFiles.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/OnboardRouterFiles.kt
@@ -5,22 +5,20 @@ import com.mapbox.base.common.logger.Logger
 import com.mapbox.base.common.logger.model.Message
 import com.mapbox.base.common.logger.model.Tag
 import com.mapbox.navigation.base.options.OnboardRouterOptions
-import com.mapbox.navigation.utils.internal.ThreadController
 import java.io.File
-import kotlinx.coroutines.withContext
 
 internal class OnboardRouterFiles(
     val applicationContext: Context,
     val logger: Logger
 ) {
 
-    suspend fun absolutePath(options: OnboardRouterOptions): String? = withContext(ThreadController.IODispatcher) {
+    fun absolutePath(options: OnboardRouterOptions): String? {
         val fileDirectory = options.filePath ?: defaultFilePath(options)
         val tileDir = File(fileDirectory)
         if (!tileDir.exists()) {
             tileDir.mkdirs()
         }
-        if (tileDir.exists()) {
+        return if (tileDir.exists()) {
             logger.i(loggerTag, Message("Initial size is ${tileDir.length()} bytes"))
             tileDir.absolutePath
         } else {


### PR DESCRIPTION
## Description

Fixes `configureRouter` sync issue causing an out of order chain of calls and therefore NN malbehavior

Regression from https://github.com/mapbox/mapbox-navigation-android/pull/3395 👀 discussion https://github.com/mapbox/mapbox-navigation-android/pull/3395#pullrequestreview-461015227

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Fix synchronization issues as `setRoute` can be executed before `configureRouter`. We noticed this when running Navigation UI SDK examples from the test app - `setRoute` is executed in IO and `configureRouter` in Main which causes this out of order chain of calls (Drop-in UI and `ReplayEngine`) and therefore NN doesn't behave as expected (returns `INVALID` status state indefinitely)

### Implementation

**Edited**

~- Change `configureRouter` to be executed in IO~

Did some testing and changing to IO works (UI examples work as expected) but I'm wondering if somehow `setRoute` could be executed before `configureRouter` as we have a dispatcher of 2 threads. It doesn't seem so but until `configureRouter` goes away https://github.com/mapbox/mapbox-navigation-android/pull/3395#discussion_r464945142 wondering if we should implement something else to make sure that `configureRouter` is called always first and of course before `setRoute` 🤔 

https://github.com/mapbox/mapbox-navigation-android/pull/3413#pullrequestreview-462373945
> I think it does because of these concerns. The solution would be generating the tile path directory before creating the instance of the navigator and then configuring the router right away synchronously, in the `init` block

- Remove unnecessary `suspend` from `OnboardRouterFiles` `absolutePath` as we need to block either way to call `configureRouter` 👀 https://github.com/mapbox/mapbox-navigation-android/pull/3413#issuecomment-670023150

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs

cc @mskurydin @SiarheiFedartsou @1ec5 @MaximAlien @langsmith @abhishek1508 