### PR TITLE
Fix #1986: expose API to disable TTS fallback when connection is slow.

### DIFF
--- a/libnavigation-ui/api/current.txt
+++ b/libnavigation-ui/api/current.txt
@@ -60,6 +60,7 @@ package com.mapbox.navigation.ui {
     method public abstract com.mapbox.navigation.ui.camera.Camera? camera();
     method public abstract Integer? darkThemeResId();
     method public abstract com.mapbox.api.directions.v5.models.DirectionsRoute! directionsRoute();
+    method public abstract boolean isFallbackAlwaysEnabled();
     method public abstract Integer? lightThemeResId();
     method public abstract boolean muteVoiceGuidance();
     method public abstract com.mapbox.navigation.ui.puck.PuckDrawableSupplier? puckDrawableSupplier();
@@ -158,6 +159,7 @@ package com.mapbox.navigation.ui {
     method public abstract com.mapbox.navigation.ui.NavigationViewOptions.Builder! enableVanishingRouteLine(boolean);
     method public abstract com.mapbox.navigation.ui.NavigationViewOptions.Builder! feedbackListener(com.mapbox.navigation.ui.listeners.FeedbackListener!);
     method public abstract com.mapbox.navigation.ui.NavigationViewOptions.Builder! instructionListListener(com.mapbox.navigation.ui.listeners.InstructionListListener!);
+    method public abstract com.mapbox.navigation.ui.NavigationViewOptions.Builder! isFallbackAlwaysEnabled(boolean);
     method public abstract com.mapbox.navigation.ui.NavigationViewOptions.Builder! lightThemeResId(Integer!);
     method public abstract com.mapbox.navigation.ui.NavigationViewOptions.Builder! locationEngine(com.mapbox.android.core.location.LocationEngine!);
     method public abstract com.mapbox.navigation.ui.NavigationViewOptions.Builder! locationObserver(com.mapbox.navigation.core.trip.session.LocationObserver!);
@@ -681,6 +683,7 @@ package com.mapbox.navigation.ui.voice {
 
   public class SpeechPlayerProvider {
     ctor public SpeechPlayerProvider(android.content.Context, String!, boolean, com.mapbox.navigation.ui.voice.VoiceInstructionLoader!);
+    method public void setIsFallbackAlwaysEnabled(boolean);
   }
 
   public enum SpeechPlayerState {

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationUiOptions.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationUiOptions.java
@@ -27,4 +27,6 @@ public abstract class NavigationUiOptions {
   public abstract PuckDrawableSupplier puckDrawableSupplier();
 
   public abstract boolean muteVoiceGuidance();
+
+  public abstract boolean isFallbackAlwaysEnabled();
 }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationViewModel.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationViewModel.java
@@ -327,6 +327,7 @@ public class NavigationViewModel extends AndroidViewModel {
     }
     boolean isVoiceLanguageSupported = options.directionsRoute().voiceLanguage() != null;
     SpeechPlayerProvider speechPlayerProvider = initializeSpeechPlayerProvider(isVoiceLanguageSupported);
+    speechPlayerProvider.setIsFallbackAlwaysEnabled(options.isFallbackAlwaysEnabled());
     this.speechPlayer = new NavigationSpeechPlayer(speechPlayerProvider);
   }
 

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationViewOptions.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationViewOptions.java
@@ -147,6 +147,14 @@ public abstract class NavigationViewOptions extends NavigationUiOptions {
      */
     public abstract Builder muteVoiceGuidance(boolean muteVoiceGuidance);
 
+    /**
+     * Set false to not fallback to TTS for voice guidance when the connection is slow. The default setting is true.
+     *
+     * @param isFallbackAlwaysEnabled true or false
+     * @return this {@link Builder}
+     */
+    public abstract Builder isFallbackAlwaysEnabled(boolean isFallbackAlwaysEnabled);
+
     public abstract NavigationViewOptions build();
   }
 
@@ -157,6 +165,7 @@ public abstract class NavigationViewOptions extends NavigationUiOptions {
         .shouldSimulateRoute(false)
         .waynameChipEnabled(true)
         .muteVoiceGuidance(false)
+        .isFallbackAlwaysEnabled(true)
         .enableVanishingRouteLine(false);
   }
 }

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/voice/SpeechPlayerProviderTest.java
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/voice/SpeechPlayerProviderTest.java
@@ -11,7 +11,6 @@ import java.util.Locale;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertNull;
 import static junit.framework.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -137,6 +136,39 @@ public class SpeechPlayerProviderTest {
     provider.onSpeechPlayerStateChanged(state);
 
     verify(observer).onStateChange(state);
+  }
+
+  @Test
+  public void slowConnectionEnableFallback_returnAndroidSpeechPlayer() {
+    Context context = mock(Context.class);
+    String language = Locale.US.getLanguage();
+    VoiceInstructionLoader voiceInstructionLoader = mock(VoiceInstructionLoader.class);
+    ConnectivityStatusProvider connectivityStatus = mock(ConnectivityStatusProvider.class);
+    when(connectivityStatus.isConnectedFast()).thenReturn(false);
+    when(connectivityStatus.isConnected()).thenReturn(true);
+    SpeechPlayerProvider provider = new SpeechPlayerProvider(context, language, true,
+        voiceInstructionLoader, connectivityStatus);
+
+    SpeechPlayer speechPlayer = provider.retrieveSpeechPlayer();
+
+    assertTrue(speechPlayer instanceof AndroidSpeechPlayer);
+  }
+
+  @Test
+  public void slowConnectionDisableFallback_returnMapboxSpeechPlayer() {
+    Context context = mock(Context.class);
+    String language = Locale.US.getLanguage();
+    VoiceInstructionLoader voiceInstructionLoader = mock(VoiceInstructionLoader.class);
+    ConnectivityStatusProvider connectivityStatus = mock(ConnectivityStatusProvider.class);
+    when(connectivityStatus.isConnectedFast()).thenReturn(false);
+    when(connectivityStatus.isConnected()).thenReturn(true);
+    SpeechPlayerProvider provider = new SpeechPlayerProvider(context, language, true,
+        voiceInstructionLoader, connectivityStatus);
+    provider.setIsFallbackAlwaysEnabled(false);
+
+    SpeechPlayer speechPlayer = provider.retrieveSpeechPlayer();
+
+    assertTrue(speechPlayer instanceof MapboxSpeechPlayer);
   }
 
   private SpeechPlayerProvider buildSpeechPlayerProvider(boolean voiceLanguageSupported) {


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Fix #1986: expose API to disable TTS fallback when connection is slow. Default is enabled.

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

To give user flexibility to enable/disable the TTS fallback when connection is slow.

### Implementation

1. Expose API to allow the developer to disable the TTS fallback when connection is slow. This behaviour also aligns with iOS implementation. Ref: https://github.com/mapbox/mapbox-navigation-android/issues/1986#issuecomment-663690666
cc: @1ec5 

2. Add Navigation UI option to disable too.

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->