### PR TITLE
Resolve strict mode violation

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -65,6 +65,7 @@ import com.mapbox.navigator.RouterParams
 import com.mapbox.navigator.TileEndpointConfiguration
 import java.lang.reflect.Field
 import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.launch
 
 private const val MAPBOX_NAVIGATION_USER_AGENT_BASE = "mapbox-navigation-android"
 private const val MAPBOX_NAVIGATION_UI_USER_AGENT_BASE = "mapbox-navigation-ui-android"
@@ -687,25 +688,26 @@ class MapboxNavigation(
 
     private fun configureRouter() {
         with(navigationOptions) {
-            // TODO StrictMode may report a violation as we're creating a File from the Main
-            val offlineFilesPath = OnboardRouterFiles(applicationContext, logger)
-                .absolutePath(onboardRouterOptions)
-            offlineFilesPath?.let { path ->
-                val routerParams = RouterParams(
-                    path,
-                    null,
-                    null,
-                    THREADS_COUNT,
-                    TileEndpointConfiguration(
-                        onboardRouterOptions.tilesUri.toString(),
-                        onboardRouterOptions.tilesVersion,
-                        accessToken ?: "",
-                        USER_AGENT,
-                        "",
-                        NativeSkuTokenProvider(MapboxNavigationAccounts.getInstance(applicationContext))
+            ThreadController.getMainScopeAndRootJob().scope.launch {
+                val offlineFilesPath = OnboardRouterFiles(applicationContext, logger)
+                    .absolutePath(onboardRouterOptions)
+                offlineFilesPath?.let { path ->
+                    val routerParams = RouterParams(
+                        path,
+                        null,
+                        null,
+                        THREADS_COUNT,
+                        TileEndpointConfiguration(
+                            onboardRouterOptions.tilesUri.toString(),
+                            onboardRouterOptions.tilesVersion,
+                            accessToken ?: "",
+                            USER_AGENT,
+                            "",
+                            NativeSkuTokenProvider(MapboxNavigationAccounts.getInstance(applicationContext))
+                        )
                     )
-                )
-                navigator.configureRouter(routerParams)
+                    navigator.configureRouter(routerParams)
+                }
             }
         }
     }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/OnboardRouterFiles.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/OnboardRouterFiles.kt
@@ -5,20 +5,22 @@ import com.mapbox.base.common.logger.Logger
 import com.mapbox.base.common.logger.model.Message
 import com.mapbox.base.common.logger.model.Tag
 import com.mapbox.navigation.base.options.OnboardRouterOptions
+import com.mapbox.navigation.utils.internal.ThreadController
 import java.io.File
+import kotlinx.coroutines.withContext
 
 internal class OnboardRouterFiles(
     val applicationContext: Context,
     val logger: Logger
 ) {
 
-    fun absolutePath(options: OnboardRouterOptions): String? {
+    suspend fun absolutePath(options: OnboardRouterOptions): String? = withContext(ThreadController.IODispatcher) {
         val fileDirectory = options.filePath ?: defaultFilePath(options)
         val tileDir = File(fileDirectory)
         if (!tileDir.exists()) {
             tileDir.mkdirs()
         }
-        return if (tileDir.exists()) {
+        if (tileDir.exists()) {
             logger.i(loggerTag, Message("Initial size is ${tileDir.length()} bytes"))
             tileDir.absolutePath
         } else {

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
@@ -31,8 +31,6 @@ import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 
 /**
@@ -70,17 +68,13 @@ internal class MapboxTripSession(
             .build()
     }
 
-    private val mutex = Mutex()
-
     override var route: DirectionsRoute? = null
         set(value) {
             field = value
             ioJobController.scope.launch {
-                mutex.withLock {
-                    navigator.setRoute(value)
-                    mainJobController.scope.launch {
-                        isOffRoute = false
-                    }
+                navigator.setRoute(value)
+                mainJobController.scope.launch {
+                    isOffRoute = false
                 }
             }
         }
@@ -410,9 +404,7 @@ internal class MapboxTripSession(
             launch {
                 updateEnhancedLocation(status.enhancedLocation, status.keyPoints)
                 updateRouteProgress(status.routeProgress)
-                mutex.withLock {
-                    isOffRoute = status.offRoute
-                }
+                isOffRoute = status.offRoute
             }
         }
     }


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Reverting https://github.com/mapbox/mapbox-navigation-android/pull/3413
Resolving https://github.com/mapbox/mapbox-navigation-android/issues/3417

We haven't reproduced the root cause for the issue, but it's working again when adding this back in.

Repurposed this PR because while originally looking for a dead-lock, I was also unable to reproduce it.

- [ ] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->