### PR TITLE
Upgrading Nav UI SDK to v5 day/night guidance styles

### DIFF
--- a/libnavigation-ui/src/main/res/values/colors.xml
+++ b/libnavigation-ui/src/main/res/values/colors.xml
@@ -4,9 +4,9 @@
   <color name="mapbox_navigation_route_layer_blue">#56A8FB</color>
   <color name="mapbox_navigation_route_traffic_layer_color">#56A8FB</color>
   <color name="mapbox_navigation_route_layer_congestion_unknown">#56A8FB</color>
-  <color name="mapbox_navigation_route_layer_congestion_yellow">#F3A64F</color>
-  <color name="mapbox_navigation_route_layer_congestion_heavy">#E93340</color>
-  <color name="mapbox_navigation_route_layer_congestion_red">#E93340</color>
+  <color name="mapbox_navigation_route_layer_congestion_yellow">#ff9500</color>
+  <color name="mapbox_navigation_route_layer_congestion_heavy">#ff4d4d</color>
+  <color name="mapbox_navigation_route_layer_congestion_red">#8f2447</color>
   <color name="mapbox_navigation_route_casing_layer_color">#2F7AC6</color>
   <color name="mapbox_navigation_route_line_traveled_color">#00000000</color>
   <color name="mapbox_navigation_route_casing_line_traveled_color">#00000000</color>

--- a/libnavigation-ui/src/main/res/values/strings.xml
+++ b/libnavigation-ui/src/main/res/values/strings.xml
@@ -83,9 +83,9 @@
 
     <!-- Should not be translated -->
     <string name="navigation_guidance_day"
-            translatable="false">mapbox://styles/mapbox/navigation-guidance-day-v4</string>
+            translatable="false">mapbox://styles/mapbox-map-design/ckd6dqf981hi71iqlyn3e896y</string>
     <string name="navigation_guidance_night"
-            translatable="false">mapbox://styles/mapbox/navigation-guidance-night-v4</string>
+            translatable="false">mapbox://styles/mapbox-map-design/ckd6dnz2q0m0q1io1mssumxqd</string>
     <string name="navigation_view_instance_state"
             translatable="false">navigation_view_instance_state</string>
     <string name="navigation_running"

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteLineTest.kt
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteLineTest.kt
@@ -640,7 +640,7 @@ class MapRouteLineTest {
     fun buildRouteLineExpression() {
         every { style.layers } returns listOf(primaryRouteLayer)
         val expectedExpression =
-            "[\"step\", [\"line-progress\"], [\"rgba\", 0.0, 0.0, 0.0, 0.0], 0.2, [\"rgba\", 86.0, 168.0, 251.0, 1.0], 0.31436133, [\"rgba\", 86.0, 168.0, 251.0, 1.0], 0.92972755, [\"rgba\", 233.0, 51.0, 64.0, 1.0], 1.0003215, [\"rgba\", 86.0, 168.0, 251.0, 1.0]]"
+            "[\"step\", [\"line-progress\"], [\"rgba\", 0.0, 0.0, 0.0, 0.0], 0.2, [\"rgba\", 86.0, 168.0, 251.0, 1.0], 0.31436133, [\"rgba\", 86.0, 168.0, 251.0, 1.0], 0.92972755, [\"rgba\", 255.0, 77.0, 77.0, 1.0], 1.0003215, [\"rgba\", 86.0, 168.0, 251.0, 1.0]]"
         val route = getDirectionsRoute(true)
         val mapRouteLine = MapRouteLine(
             ctx,
@@ -661,7 +661,7 @@ class MapRouteLineTest {
     fun buildRouteLineExpressionMultileg() {
         every { style.layers } returns listOf(primaryRouteLayer)
         val expectedExpression =
-            "[\"step\", [\"line-progress\"], [\"rgba\", 0.0, 0.0, 0.0, 0.0], 0.0, [\"rgba\", 86.0, 168.0, 251.0, 1.0], 0.021346012, [\"rgba\", 86.0, 168.0, 251.0, 1.0], 0.06847635, [\"rgba\", 86.0, 168.0, 251.0, 1.0], 0.09496192, [\"rgba\", 243.0, 166.0, 79.0, 1.0], 0.1054035, [\"rgba\", 86.0, 168.0, 251.0, 1.0], 0.31133384, [\"rgba\", 86.0, 168.0, 251.0, 1.0], 0.31479248, [\"rgba\", 86.0, 168.0, 251.0, 1.0], 0.38133165, [\"rgba\", 86.0, 168.0, 251.0, 1.0], 0.38438845, [\"rgba\", 86.0, 168.0, 251.0, 1.0], 0.41593167, [\"rgba\", 86.0, 168.0, 251.0, 1.0], 0.45903113, [\"rgba\", 86.0, 168.0, 251.0, 1.0], 0.7533547, [\"rgba\", 243.0, 166.0, 79.0, 1.0], 0.7613792, [\"rgba\", 86.0, 168.0, 251.0, 1.0], 0.7993399, [\"rgba\", 243.0, 166.0, 79.0, 1.0], 0.8467529, [\"rgba\", 86.0, 168.0, 251.0, 1.0], 0.86620295, [\"rgba\", 243.0, 166.0, 79.0, 1.0], 0.8693383, [\"rgba\", 86.0, 168.0, 251.0, 1.0], 0.9069854, [\"rgba\", 233.0, 51.0, 64.0, 1.0], 0.9224731, [\"rgba\", 233.0, 51.0, 64.0, 1.0], 0.9338598, [\"rgba\", 86.0, 168.0, 251.0, 1.0], 0.9950478, [\"rgba\", 86.0, 168.0, 251.0, 1.0]]"
+            "[\"step\", [\"line-progress\"], [\"rgba\", 0.0, 0.0, 0.0, 0.0], 0.0, [\"rgba\", 86.0, 168.0, 251.0, 1.0], 0.021346012, [\"rgba\", 86.0, 168.0, 251.0, 1.0], 0.06847635, [\"rgba\", 86.0, 168.0, 251.0, 1.0], 0.09496192, [\"rgba\", 255.0, 149.0, 0.0, 1.0], 0.1054035, [\"rgba\", 86.0, 168.0, 251.0, 1.0], 0.31133384, [\"rgba\", 86.0, 168.0, 251.0, 1.0], 0.31479248, [\"rgba\", 86.0, 168.0, 251.0, 1.0], 0.38133165, [\"rgba\", 86.0, 168.0, 251.0, 1.0], 0.38438845, [\"rgba\", 86.0, 168.0, 251.0, 1.0], 0.41593167, [\"rgba\", 86.0, 168.0, 251.0, 1.0], 0.45903113, [\"rgba\", 86.0, 168.0, 251.0, 1.0], 0.7533547, [\"rgba\", 255.0, 149.0, 0.0, 1.0], 0.7613792, [\"rgba\", 86.0, 168.0, 251.0, 1.0], 0.7993399, [\"rgba\", 255.0, 149.0, 0.0, 1.0], 0.8467529, [\"rgba\", 86.0, 168.0, 251.0, 1.0], 0.86620295, [\"rgba\", 255.0, 149.0, 0.0, 1.0], 0.8693383, [\"rgba\", 86.0, 168.0, 251.0, 1.0], 0.9069854, [\"rgba\", 143.0, 36.0, 71.0, 1.0], 0.9224731, [\"rgba\", 255.0, 77.0, 77.0, 1.0], 0.9338598, [\"rgba\", 86.0, 168.0, 251.0, 1.0], 0.9950478, [\"rgba\", 86.0, 168.0, 251.0, 1.0]]"
         val route = getMultilegRoute()
         val mapRouteLine = MapRouteLine(
             ctx,
@@ -830,7 +830,7 @@ class MapRouteLineTest {
         val result =
             mapRouteLine.getRouteColorForCongestion(RouteConstants.MODERATE_CONGESTION_VALUE, true)
 
-        assertEquals(-809393, result)
+        assertEquals(-27392, result)
     }
 
     @Test
@@ -849,7 +849,7 @@ class MapRouteLineTest {
         val result =
             mapRouteLine.getRouteColorForCongestion(RouteConstants.HEAVY_CONGESTION_VALUE, true)
 
-        assertEquals(-1494208, result)
+        assertEquals(-45747, result)
     }
 
     @Test
@@ -868,7 +868,7 @@ class MapRouteLineTest {
         val result =
             mapRouteLine.getRouteColorForCongestion(RouteConstants.SEVERE_CONGESTION_VALUE, true)
 
-        assertEquals(-1494208, result)
+        assertEquals(-7396281, result)
     }
 
     @Test


### PR DESCRIPTION
## Description

Mapbox's cartography team has created `v5` Navigation styles and this pr updates the Nav UI SDK's to account for the two new styles.

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Implementation

1. Updated the day and night style ID string resources in `libnavigation-ui/src/main/res/values/strings.xml`

2. Updated some of the congestion colors so that the congestion values in `libnavigation-ui/src/main/res/values/colors.xml` match the colors used in the styles.

## Screenshots or Gifs

`v5` version of `navigation_guidance_day`:

![v5 day](https://user-images.githubusercontent.com/4394910/89696243-d44d0700-d8cb-11ea-8fd9-4da205ff0690.gif)

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->