### PR TITLE
Fix route / isOffRoute race condition

### DIFF
--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
@@ -321,7 +321,7 @@ class MapboxNavigationTest {
 
         offRouteObserverSlot.captured.onOffRouteStateChanged(false)
 
-        verify(exactly = 0) { directionsSession.requestRoutes(any(), any()) }
+        verify(exactly = 0) { rerouteController.reroute(any()) }
     }
 
     @Test


### PR DESCRIPTION
## Description

Fixes `route` / `isOffRoute` race condition and remove unnecessary `Mutex` from `MapboxTripSession`

Fixes #3383 
Follow up from https://github.com/mapbox/mapbox-navigation-android/pull/3322#discussion_r465187851

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Deliver up to date status to clients even after they have cleared the route

### Implementation

**Edited**

~- Guard `reroute` / `isOffRoute` around `route` state - that's the best "mutex" we can use~ 😅 🚀 
- Implement a list of `Job`s for `updateNavigatorStatusData` work which are canceled (`cancelOngoingUpdateNavigatorStatusDataJobs`) as part of `route` setter and add https://github.com/mapbox/mapbox-navigation-android/blob/11b71f3172a92aec46d46e8903b2238a0351e03b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt#L414-L416 checks to short circuit pushing out of date updates if the job is inactive (canceled)
- Remove unnecessary `Mutex` from `MapboxTripSession` as it's not necessary anymore as above-mentioned 🎉 

Noting that getting the lock from different dispatchers (as we were) affects the overall order of the calls as it's a `suspend` function.

There is an open question as if we want to send a "last" `OffRouteObserver` notification callback or not as part of https://github.com/mapbox/mapbox-navigation-android/blob/06575cdd7cb3df8b02110329527e9cf207838f2d/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt#L77 Currently is sent but if we opt to not doing so we should add non-null `route` check here https://github.com/mapbox/mapbox-navigation-android/blob/06575cdd7cb3df8b02110329527e9cf207838f2d/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt#L111 What do you think @LukasPaczos @kmadsen?

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs