### PR TITLE
Adding NavigationView v5 style traffic visibility toggle example

### DIFF
--- a/examples/src/main/AndroidManifest.xml
+++ b/examples/src/main/AndroidManifest.xml
@@ -274,6 +274,14 @@
                 android:value=".CoreActivity" />
         </activity>
 
+        <activity
+            android:name=".ui.TrafficToggleActivity"
+            android:label="@string/title_traffic_toggle">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".UIActivity" />
+        </activity>
+        
         <meta-data
             android:name="com.mapbox.TestEventsServer"
             android:value="api-events-staging.tilestream.net" />

--- a/examples/src/main/java/com/mapbox/navigation/examples/UIActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/UIActivity.kt
@@ -13,6 +13,7 @@ import com.mapbox.navigation.examples.ui.CustomPuckActivity
 import com.mapbox.navigation.examples.ui.CustomUIComponentStyleActivity
 import com.mapbox.navigation.examples.ui.NavigationViewActivity
 import com.mapbox.navigation.examples.ui.NavigationViewFragmentActivity
+import com.mapbox.navigation.examples.ui.TrafficToggleActivity
 import kotlinx.android.synthetic.main.activity_ui.*
 
 class UIActivity : AppCompatActivity() {
@@ -72,6 +73,11 @@ class UIActivity : AppCompatActivity() {
                 getString(R.string.title_custom_ui_component_style),
                 getString(R.string.description_custom_ui_component_style),
                 CustomUIComponentStyleActivity::class.java
+            ),
+            SampleItem(
+                    getString(R.string.title_traffic_toggle),
+                    getString(R.string.description_traffic_toggle),
+                    TrafficToggleActivity::class.java
             )
         )
     }

--- a/examples/src/main/java/com/mapbox/navigation/examples/ui/TrafficToggleActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/ui/TrafficToggleActivity.kt
@@ -1,0 +1,150 @@
+package com.mapbox.navigation.examples.ui
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.mapbox.api.directions.v5.models.BannerInstructions
+import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.mapboxsdk.camera.CameraPosition
+import com.mapbox.mapboxsdk.geometry.LatLng
+import com.mapbox.mapboxsdk.location.modes.RenderMode
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.examples.R
+import com.mapbox.navigation.ui.NavigationViewOptions
+import com.mapbox.navigation.ui.OnNavigationReadyCallback
+import com.mapbox.navigation.ui.listeners.BannerInstructionsListener
+import com.mapbox.navigation.ui.listeners.NavigationListener
+import com.mapbox.navigation.ui.map.NavigationMapboxMap
+import com.mapbox.navigation.utils.internal.ifNonNull
+import kotlinx.android.synthetic.main.activity_navigation_view.navigationView
+import kotlinx.android.synthetic.main.activity_traffic_toggle.*
+
+/**
+ * This activity shows how to use [NavigationMapboxMap.updateTrafficVisibility] to toggle
+ * the visibility of traffic congestion map layers.
+ */
+class TrafficToggleActivity : AppCompatActivity(), OnNavigationReadyCallback,
+        NavigationListener,
+        BannerInstructionsListener {
+
+    private lateinit var navigationMapboxMap: NavigationMapboxMap
+    private lateinit var mapboxNavigation: MapboxNavigation
+    private val route by lazy { getDirectionsRoute() }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_traffic_toggle)
+
+        navigationView.onCreate(savedInstanceState)
+        navigationView.initialize(
+                this,
+                getInitialCameraPosition()
+        )
+    }
+
+    override fun onLowMemory() {
+        super.onLowMemory()
+        navigationView.onLowMemory()
+    }
+
+    override fun onStart() {
+        super.onStart()
+        navigationView.onStart()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        navigationView.onResume()
+    }
+
+    override fun onStop() {
+        super.onStop()
+        navigationView.onStop()
+    }
+
+    override fun onPause() {
+        super.onPause()
+        navigationView.onPause()
+    }
+
+    override fun onDestroy() {
+        navigationView.onDestroy()
+        super.onDestroy()
+    }
+
+    override fun onBackPressed() {
+        // If the navigation view didn't need to do anything, call super
+        if (!navigationView.onBackPressed()) {
+            super.onBackPressed()
+        }
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        navigationView.onSaveInstanceState(outState)
+        super.onSaveInstanceState(outState)
+    }
+
+    override fun onRestoreInstanceState(savedInstanceState: Bundle) {
+        super.onRestoreInstanceState(savedInstanceState)
+        navigationView.onRestoreInstanceState(savedInstanceState)
+    }
+
+    override fun onNavigationReady(isRunning: Boolean) {
+        if (!isRunning && !::navigationMapboxMap.isInitialized) {
+            ifNonNull(navigationView.retrieveNavigationMapboxMap()) { navMapboxMap ->
+                this.navigationMapboxMap = navMapboxMap
+
+                /**
+                 * Set the Floating Action Button's click listener to toggle the traffic
+                 * congestion layers' visibility.
+                 */
+                toggle_traffic_button.setOnClickListener {
+                    navigationMapboxMap.updateTrafficVisibility(!navigationMapboxMap.isTrafficVisible)
+                }
+
+                this.navigationMapboxMap.updateLocationLayerRenderMode(RenderMode.NORMAL)
+                navigationView.retrieveMapboxNavigation()?.let { this.mapboxNavigation = it }
+
+                val optionsBuilder = NavigationViewOptions.builder(this)
+                optionsBuilder.navigationListener(this)
+                optionsBuilder.directionsRoute(route)
+                optionsBuilder.shouldSimulateRoute(true)
+                optionsBuilder.bannerInstructionsListener(this)
+                navigationView.startNavigation(optionsBuilder.build())
+            }
+        }
+    }
+
+    override fun willDisplay(instructions: BannerInstructions?): BannerInstructions {
+        return instructions!!
+    }
+
+    override fun onNavigationRunning() {
+        
+    }
+
+    override fun onNavigationFinished() {
+        finish()
+    }
+
+    override fun onCancelNavigation() {
+        navigationView.stopNavigation()
+        finish()
+    }
+
+    private fun getInitialCameraPosition(): CameraPosition {
+        val originCoordinate = route.routeOptions()?.coordinates()?.get(0)
+        return CameraPosition.Builder()
+                .target(LatLng(originCoordinate!!.latitude(), originCoordinate.longitude()))
+                .zoom(15.0)
+                .build()
+    }
+
+    private fun getDirectionsRoute(): DirectionsRoute {
+        val directionsRouteAsJson = """
+            {"routeIndex":"0","distance":2242.4,"duration":448.2,"geometry":"_hsagA~bomhFv@eArJoM|F_IlRgWvC_ExCtEvLjPfSrXbCdDeCdDmI~KkLzOyGbJqCzD}B`Bc\\xc@wBvES^Sb@cAtByApCu@v@_An@wGx@aSdCkCZZxE`Cn^x@zLt@bLF|@XdEXlEx@dMvDbn@TrDXvElClb@`@|G^|ElAlR|@~Mf@|H`@bGfHjgAv@vMX|EtAlRxA`UnCdb@jAvQdJtvAZvETlDXjE~Cdf@nEfr@JxAwDb@_o@pHgD`@[DYB{DnAgWxCmM?iH`A_AfB_@b@B\\ZpE|@`MlIhqAxE|t@JrAlAnRjBlYbKr~A\\~Erq@eIjFo@`@EvC]j@IfW{C","weight":753.0,"weight_name":"routability","legs":[{"distance":2242.4,"duration":448.2,"summary":"Pine Street, Sacramento Street","steps":[{"distance":113.9,"duration":28.3,"geometry":"_hsagA~bomhFv@eArJoM|F_IlRgWvC_E","name":"Beale Street","mode":"driving","maneuver":{"location":[-122.396736,37.791888],"bearing_before":0.0,"bearing_after":135.0,"instruction":"Head southeast on Beale Street","type":"depart","modifier":"right"},"voiceInstructions":[{"distanceAlongGeometry":113.9,"announcement":"Head southeast on Beale Street, then turn right onto Mission Street","ssmlAnnouncement":"\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eHead southeast on Beale Street, then turn right onto Mission Street\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"},{"distanceAlongGeometry":60.4,"announcement":"Turn right onto Mission Street, then turn right onto Fremont Street","ssmlAnnouncement":"\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eTurn right onto Mission Street, then turn right onto Fremont Street\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"}],"bannerInstructions":[{"distanceAlongGeometry":113.9,"primary":{"text":"Mission Street","components":[{"text":"Mission Street","type":"text","abbr":"Mission St","abbr_priority":0}],"type":"turn","modifier":"right"}},{"distanceAlongGeometry":60.4,"primary":{"text":"Mission Street","components":[{"text":"Mission Street","type":"text","abbr":"Mission St","abbr_priority":0}],"type":"turn","modifier":"right"},"sub":{"text":"Fremont Street","components":[{"text":"Fremont Street","type":"text","abbr":"Fremont St","abbr_priority":0}],"type":"turn","modifier":"right"}}],"driving_side":"right","weight":52.9,"intersections":[{"location":[-122.396736,37.791888],"bearings":[135],"entry":[true],"out":0}]},{"distance":108.6,"duration":30.2,"geometry":"ozqagA`jmmhFxCtEvLjPfSrXbCdD","name":"Mission Street","mode":"driving","maneuver":{"location":[-122.395825,37.79116],"bearing_before":135.0,"bearing_after":225.0,"instruction":"Turn right onto Mission Street","type":"turn","modifier":"right"},"voiceInstructions":[{"distanceAlongGeometry":53.9,"announcement":"Turn right onto Fremont Street","ssmlAnnouncement":"\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eTurn right onto Fremont Street\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"}],"bannerInstructions":[{"distanceAlongGeometry":108.6,"primary":{"text":"Fremont Street","components":[{"text":"Fremont Street","type":"text","abbr":"Fremont St","abbr_priority":0}],"type":"turn","modifier":"right"}}],"driving_side":"right","weight":55.0,"intersections":[{"location":[-122.395825,37.79116],"bearings":[45,135,225,315],"entry":[true,true,true,false],"in":3,"out":2}]},{"distance":283.1,"duration":48.2,"geometry":"qopagA|`omhFeCdDmI~KkLzOyGbJqCzD}B`Bc\\xc@wBvES^Sb@cAtByApCu@v@_An@wGx@aSdCkCZ","name":"Fremont Street","mode":"driving","maneuver":{"location":[-122.396703,37.790473],"bearing_before":223.0,"bearing_after":315.0,"instruction":"Turn right onto Fremont Street","type":"turn","modifier":"right"},"voiceInstructions":[{"distanceAlongGeometry":263.1,"announcement":"In 300 meters, turn left onto Pine Street","ssmlAnnouncement":"\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eIn 300 meters, turn left onto Pine Street\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"},{"distanceAlongGeometry":88.1,"announcement":"Turn left onto Pine Street","ssmlAnnouncement":"\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eTurn left onto Pine Street\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"}],"bannerInstructions":[{"distanceAlongGeometry":283.1,"primary":{"text":"Pine Street","components":[{"text":"Pine Street","type":"text","abbr":"Pine St","abbr_priority":0}],"type":"turn","modifier":"left"}}],"driving_side":"right","weight":104.7,"intersections":[{"location":[-122.396703,37.790473],"bearings":[45,135,225,315],"entry":[false,false,true,true],"in":0,"out":3},{"location":[-122.398298,37.791734],"bearings":[135,300],"entry":[false,true],"in":0,"out":1}]},{"distance":920.7,"duration":176.9,"geometry":"yhtagAbxrmhFZxE`Cn^x@zLt@bLF|@XdEXlEx@dMvDbn@TrDXvElClb@`@|G^|ElAlR|@~Mf@|H`@bGfHjgAv@vMX|EtAlRxA`UnCdb@jAvQdJtvAZvETlDXjE~Cdf@nEfr@JxA","name":"Pine Street","mode":"driving","maneuver":{"location":[-122.39861,37.792413],"bearing_before":350.0,"bearing_after":260.0,"instruction":"Turn left onto Pine Street","type":"turn","modifier":"left"},"voiceInstructions":[{"distanceAlongGeometry":900.7,"announcement":"Continue on Pine Street for 900 meters","ssmlAnnouncement":"\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eContinue on Pine Street for 900 meters\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"},{"distanceAlongGeometry":364.3,"announcement":"In 400 meters, turn right onto Powell Street","ssmlAnnouncement":"\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eIn 400 meters, turn right onto Powell Street\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"},{"distanceAlongGeometry":78.1,"announcement":"Turn right onto Powell Street","ssmlAnnouncement":"\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eTurn right onto Powell Street\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"}],"bannerInstructions":[{"distanceAlongGeometry":920.7,"primary":{"text":"Powell Street","components":[{"text":"Powell Street","type":"text","abbr":"Powell St","abbr_priority":0}],"type":"turn","modifier":"right"}}],"driving_side":"right","weight":274.5,"intersections":[{"location":[-122.39861,37.792413],"bearings":[75,165,255,345],"entry":[false,false,true,true],"in":1,"out":2},{"location":[-122.399785,37.792261],"bearings":[75,165,255,345],"entry":[false,true,true,false],"in":0,"out":2},{"location":[-122.400959,37.792116],"bearings":[75,165,255,345],"entry":[false,false,true,true],"in":0,"out":2},{"location":[-122.402598,37.791909],"bearings":[75,165,255,345],"entry":[false,true,true,false],"in":0,"out":2},{"location":[-122.404233,37.791703],"bearings":[75,180,255,345],"entry":[false,false,true,true],"in":0,"out":2},{"location":[-122.40576,37.791505],"bearings":[75,165,255,345],"entry":[false,false,true,true],"in":0,"out":2},{"location":[-122.407358,37.791301],"bearings":[75,165,255,345],"entry":[false,true,true,true],"in":0,"out":2}]},{"distance":214.7,"duration":45.400000000000006,"geometry":"svqagAn~fnhFwDb@_o@pHgD`@[DYB{DnAgWxCmM?iH`A_AfB_@b@","name":"Powell Street","mode":"driving","maneuver":{"location":[-122.408952,37.791098],"bearing_before":260.0,"bearing_after":350.0,"instruction":"Turn right onto Powell Street","type":"turn","modifier":"right"},"voiceInstructions":[{"distanceAlongGeometry":194.7,"announcement":"In 200 meters, turn left onto Sacramento Street","ssmlAnnouncement":"\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eIn 200 meters, turn left onto Sacramento Street\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"},{"distanceAlongGeometry":70.9,"announcement":"Turn left onto Sacramento Street","ssmlAnnouncement":"\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eTurn left onto Sacramento Street\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"}],"bannerInstructions":[{"distanceAlongGeometry":214.7,"primary":{"text":"Sacramento Street","components":[{"text":"Sacramento Street","type":"text","abbr":"Sacramento St","abbr_priority":0}],"type":"turn","modifier":"left"}}],"driving_side":"right","weight":102.4,"intersections":[{"location":[-122.408952,37.791098],"bearings":[75,165,255,345],"entry":[false,false,true,true],"in":0,"out":3},{"location":[-122.409143,37.792056],"bearings":[75,165,255,345],"entry":[true,false,false,true],"in":1,"out":3}]},{"distance":440.2,"duration":81.8,"geometry":"eluagAhxgnhFB\\ZpE|@`MlIhqAxE|t@JrAlAnRjBlYbKr~A\\~E","name":"Sacramento Street","mode":"driving","maneuver":{"location":[-122.409365,37.792979],"bearing_before":350.0,"bearing_after":260.0,"instruction":"Turn left onto Sacramento Street","type":"turn","modifier":"left"},"voiceInstructions":[{"distanceAlongGeometry":420.2,"announcement":"In 400 meters, turn left onto Jones Street","ssmlAnnouncement":"\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eIn 400 meters, turn left onto Jones Street\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"},{"distanceAlongGeometry":80.7,"announcement":"Turn left onto Jones Street","ssmlAnnouncement":"\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eTurn left onto Jones Street\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"}],"bannerInstructions":[{"distanceAlongGeometry":440.2,"primary":{"text":"Jones Street","components":[{"text":"Jones Street","type":"text","abbr":"Jones St","abbr_priority":0}],"type":"turn","modifier":"left"}}],"driving_side":"right","weight":114.1,"intersections":[{"location":[-122.409365,37.792979],"bearings":[75,165,255,345],"entry":[false,true,true,true],"in":1,"out":2},{"location":[-122.411027,37.792765],"bearings":[75,165,255,345],"entry":[false,true,true,true],"in":0,"out":2},{"location":[-122.411932,37.79265],"bearings":[75,165,255,345],"entry":[false,true,true,false],"in":0,"out":2},{"location":[-122.412667,37.792557],"bearings":[75,165,255,345],"entry":[false,true,true,true],"in":0,"out":2}]},{"distance":161.2,"duration":37.4,"geometry":"wdtagAhmqnhFrq@eIjFo@`@EvC]j@IfW{C","name":"Jones Street","mode":"driving","maneuver":{"location":[-122.414309,37.792348],"bearing_before":260.0,"bearing_after":170.0,"instruction":"Turn left onto Jones Street","type":"turn","modifier":"left"},"voiceInstructions":[{"distanceAlongGeometry":141.2,"announcement":"In 100 meters, you will arrive at your destination","ssmlAnnouncement":"\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eIn 100 meters, you will arrive at your destination\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"},{"distanceAlongGeometry":21.6,"announcement":"You have arrived at your destination","ssmlAnnouncement":"\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eYou have arrived at your destination\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"}],"bannerInstructions":[{"distanceAlongGeometry":161.2,"primary":{"text":"You will arrive","components":[{"text":"You will arrive","type":"text"}],"type":"arrive","modifier":"straight"}},{"distanceAlongGeometry":21.6,"primary":{"text":"You have arrived","components":[{"text":"You have arrived","type":"text"}],"type":"arrive","modifier":"straight"}}],"driving_side":"right","weight":49.4,"intersections":[{"location":[-122.414309,37.792348],"bearings":[75,165,255,345],"entry":[false,true,true,true],"in":0,"out":1},{"location":[-122.414122,37.79142],"bearings":[75,165,255,345],"entry":[true,true,true,false],"in":3,"out":1}]},{"distance":0.0,"duration":0.0,"geometry":"ikqagAh{pnhF","name":"Jones Street","mode":"driving","maneuver":{"location":[-122.414021,37.790917],"bearing_before":171.0,"bearing_after":0.0,"instruction":"You have arrived at your destination","type":"arrive"},"voiceInstructions":[],"bannerInstructions":[],"driving_side":"right","weight":0.0,"intersections":[{"location":[-122.414021,37.790917],"bearings":[351],"entry":[true],"in":0}]}],"annotation":{"distance":[4.377558046781132,29.048645741202307,19.932752580690952,48.576014751952926,11.943930596414795,12.720147968330114,34.58112560559672,50.96480933738249,10.349556668565532,10.428744124966986,26.062939337835754,33.61207745353073,22.152629772397148,11.584122498337331,8.22504067141732,73.25791925952063,11.603839142628226,1.7930152150745173,1.9339724019326627,6.4182775391464615,8.137686480966448,3.8827293592940286,4.137411880032337,15.778927074065876,36.18605026816596,7.882482295429149,9.70628239052936,44.88520535070527,19.777529614845466,18.70069668033605,2.7608352091952852,8.820943994209998,9.167951891088123,20.211271187411434,67.05841934336348,8.004641462478803,9.602196312248573,50.45852431578543,12.710488322858675,9.917381766860117,27.67756036992424,21.374879966188537,14.151341864692084,11.581827207587462,103.10585401718104,20.975906679342675,9.863007930072529,27.750876716852083,31.428390784757813,50.12927675688965,26.70541846540595,124.91524890087112,9.619673955896003,7.744241825057303,9.081282300519934,55.824774196397755,72.99751351106848,4.01125146327413,10.354407638921565,86.47389715542175,9.46174014762768,1.579336360053304,1.456588625710653,11.030579241536637,43.68327188987056,25.693275300415763,16.824625284570534,5.792905661239118,2.381194445403029,1.337050795424019,9.359356548680744,20.074574908738008,117.23790846433582,76.81587623559835,3.7514168675917774,27.764134475011225,37.66153518871731,136.19947456061075,9.984630741768928,91.22535667168732,13.293150952776184,1.90914496306627,8.555399787319097,2.4861312264216893,43.69699404532718],"congestion":["moderate","low","low","low","low","low","low","low","low","low","low","low","low","low","low","low","low","low","low","low","low","low","low","low","low","low","low","low","low","low","low","low","low","moderate","low","low","low","low","low","moderate","moderate","low","low","moderate","moderate","moderate","moderate","low","low","low","low","low","low","low","moderate","moderate","low","low","low","low","low","low","moderate","low","low","low","low","low","low","low","low","low","low","moderate","low","low","low","low","low","low","low","low","low","low","low"]}}],"routeOptions":{"baseUrl":"https://api.mapbox.com","user":"mapbox","profile":"driving-traffic","coordinates":[[-122.396796,37.7918406],[-122.4140199,37.7909168]],"alternatives":true,"language":"en","continue_straight":false,"roundabout_exits":false,"geometries":"polyline6","overview":"full","steps":true,"annotations":"congestion,distance","voice_instructions":true,"banner_instructions":true,"voice_units":"metric","access_token":"pk.ey","uuid":"ckblcybpcnz7379uen64vrcuj"},"voiceLocale":"en-US"}
+        """.trimIndent()
+
+        return DirectionsRoute.fromJson(directionsRouteAsJson)
+    }
+}
+

--- a/examples/src/main/res/layout/activity_traffic_toggle.xml
+++ b/examples/src/main/res/layout/activity_traffic_toggle.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.mapbox.navigation.ui.NavigationView
+        android:id="@+id/navigationView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/toggle_traffic_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|right"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="96dp"
+        android:tint="@android:color/white"
+        app:srcCompat="@drawable/ic_refresh"
+        tools:ignore="RtlHardcoded" />
+</FrameLayout>

--- a/examples/src/main/res/values/strings.xml
+++ b/examples/src/main/res/values/strings.xml
@@ -1,125 +1,128 @@
 <resources>
-    <string name="app_name" translatable="false">Mapbox 1.0 Navigation SDK for Android</string>
+    <string name="app_name">Mapbox 1.0 Navigation SDK for Android</string>
 
     <!-- MainActivity -->
-    <string name="navigation_core_sdk_title" translatable="false">Navigation Core SDK</string>
-    <string name="navigation_core_sdk_description" translatable="false">Hosts examples to demonstrate the use of the core Navigation SDK.</string>
+    <string name="navigation_core_sdk_title">Navigation Core SDK</string>
+    <string name="navigation_core_sdk_description">Hosts examples to demonstrate the use of the core Navigation SDK.</string>
 
-    <string name="navigation_ui_sdk_title" translatable="false">Navigation UI SDK</string>
-    <string name="navigation_ui_sdk_description" translatable="false">Hosts examples to demonstrate the use of the Navigation UI SDK.</string>
+    <string name="navigation_ui_sdk_title">Navigation UI SDK</string>
+    <string name="navigation_ui_sdk_description">Hosts examples to demonstrate the use of the Navigation UI SDK.</string>
 
-    <string name="title_simple_navigation_kotlin" translatable="false">Simple MapboxNavigation Kotlin</string>
-    <string name="description_simple_navigation_kotlin" translatable="false">Shows how to use the MapboxNavigation class in Kotlin code.</string>
+    <string name="title_simple_navigation_kotlin">Simple MapboxNavigation Kotlin</string>
+    <string name="description_simple_navigation_kotlin">Shows how to use the MapboxNavigation class in Kotlin code.</string>
 
-    <string name="title_navigation_view" translatable="false">NavigationView</string>
-    <string name="description_navigation_view" translatable="false">Shows how to use NavigationView to implement turn by turn.</string>
+    <string name="title_navigation_view">NavigationView</string>
+    <string name="description_navigation_view">Shows how to use NavigationView to implement turn by turn.</string>
 
-    <string name="title_custom_puck_example" translatable="false">Custom puck</string>
-    <string name="description_custom_puck_example" translatable="false">Shows how to use NavigationView with a custom puck.</string>
+    <string name="title_custom_puck_example">Custom puck</string>
+    <string name="description_custom_puck_example">Shows how to use NavigationView with a custom puck.</string>
 
-    <string name="title_custom_camera_example" translatable="false">Custom camera</string>
-    <string name="description_custom_camera_example" translatable="false">Shows how to use NavigationView with a custom camera tilt and zoom.</string>
+    <string name="title_custom_camera_example">Custom camera</string>
+    <string name="description_custom_camera_example">Shows how to use NavigationView with a custom camera tilt and zoom.</string>
 
-    <string name="title_custom_ui_component_style" translatable="false">Custom UI component style</string>
-    <string name="description_custom_ui_component_style" translatable="false">Shows how to use your own colors to style the UI SDK Components: InstructionView, SummaryBottomSheet, and so on.</string>
+    <string name="title_custom_ui_component_style">Custom UI component style</string>
+    <string name="description_custom_ui_component_style">Shows how to use your own colors to style the UI SDK Components: InstructionView, SummaryBottomSheet, and so on.</string>
 
-    <string name="title_building_highlight_kotlin" translatable="false">Building footprint highlight</string>
-    <string name="description_building_highlight_kotlin" translatable="false">Use the Navigation UI SDK\'s to show and customize a single highlighted building footprint.</string>
+    <string name="title_building_highlight_kotlin">Building footprint highlight</string>
+    <string name="description_building_highlight_kotlin">Use the Navigation UI SDK\'s to show and customize a single highlighted building footprint.</string>
 
-    <string name="title_ui_building_extrusions_kotlin" translatable="false">Building extrusions highlight</string>
-    <string name="description_ui_building_extrusions_kotlin" translatable="false">Use the Navigation UI SDK\'s to show and customize a single highlighted 3D building extrusion.</string>
+    <string name="title_ui_building_extrusions_kotlin">Building extrusions highlight</string>
+    <string name="description_ui_building_extrusions_kotlin">Use the Navigation UI SDK\'s to show and customize a single highlighted 3D building extrusion.</string>
 
-    <string name="title_replay_route" translatable="false">Replay route</string>
-    <string name="description_replay_route" translatable="false">Shows how to use the MapboxNavigation class with the replay engine in Kotlin code.</string>
-    <string name="replay_playback_speed_seekbar" translatable="false">Replay speed %d</string>
+    <string name="title_replay_route">Replay route</string>
+    <string name="description_replay_route">Shows how to use the MapboxNavigation class with the replay engine in Kotlin code.</string>
+    <string name="replay_playback_speed_seekbar">Replay speed %d</string>
 
-    <string name="title_replay_history_kotlin" translatable="false">Replay history</string>
-    <string name="description_replay_history_kotlin" translatable="false">Shows how to use replay ride history in Kotlin code.</string>
-    <string name="title_select_replay_history" translatable="false">Select history</string>
+    <string name="title_replay_history_kotlin">Replay history</string>
+    <string name="description_replay_history_kotlin">Shows how to use replay ride history in Kotlin code.</string>
+    <string name="title_select_replay_history">Select history</string>
 
-    <string name="title_replay_waypoints" translatable="false">Replay waypoints</string>
-    <string name="description_replay_waypoints" translatable="false">Shows how to use navigate to waypoints.</string>
+    <string name="title_replay_waypoints">Replay waypoints</string>
+    <string name="description_replay_waypoints">Shows how to use navigate to waypoints.</string>
 
-    <string name="title_reroute_view" translatable="false">Reroute events</string>
-    <string name="description_reroute_view" translatable="false">Shows how to observe off-route events and how to implement custom re-route logic.</string>
+    <string name="title_reroute_view">Reroute events</string>
+    <string name="description_reroute_view">Shows how to observe off-route events and how to implement custom re-route logic.</string>
 
-    <string name="title_basic_navigation_kotlin" translatable="false">Basic navigation</string>
-    <string name="description_basic_navigation_kotlin" translatable="false">Shows how to navigate from the device location to a destination using the MapboxNavigation class.</string>
+    <string name="title_basic_navigation_kotlin">Basic navigation</string>
+    <string name="description_basic_navigation_kotlin">Shows how to navigate from the device location to a destination using the MapboxNavigation class.</string>
 
-    <string name="title_basic_navigation_fragment" translatable="false">Basic navigation with Fragment</string>
-    <string name="description_basic_navigation_fragment" translatable="false">Shows how to navigate from the device location to a destination using the MapboxNavigation class from a Fragment.</string>
+    <string name="title_basic_navigation_fragment">Basic navigation with Fragment</string>
+    <string name="description_basic_navigation_fragment">Shows how to navigate from the device location to a destination using the MapboxNavigation class from a Fragment.</string>
 
-    <string name="title_basic_navigation_sdk_only_kotlin" translatable="false">Basic Navigation + Maps SDK integration</string>
-    <string name="description_basic_navigation_sdk_only_kotlin" translatable="false">Shows how to combine the Maps SDK with only the Navigation SDK and no Navigation UI SDK code of any kind.</string>
+    <string name="title_basic_navigation_sdk_only_kotlin">Basic Navigation + Maps SDK integration</string>
+    <string name="description_basic_navigation_sdk_only_kotlin">Shows how to combine the Maps SDK with only the Navigation SDK and no Navigation UI SDK code of any kind.</string>
 
-    <string name="title_free_drive_kotlin" translatable="false">Free drive navigation</string>
-    <string name="description_free_drive_kotlin" translatable="false">Shows how to navigate in a free drive scenario using the MapboxNavigation class.</string>
+    <string name="title_free_drive_kotlin">Free drive navigation</string>
+    <string name="description_free_drive_kotlin">Shows how to navigate in a free drive scenario using the MapboxNavigation class.</string>
 
-    <string name="title_guidance_view" translatable="false">GuidanceView</string>
-    <string name="description_guidance_view" translatable="false">Demonstrates the use of a GuidanceView to show an instructional image at proper junctions.</string>
+    <string name="title_guidance_view">GuidanceView</string>
+    <string name="description_guidance_view">Demonstrates the use of a GuidanceView to show an instructional image at proper junctions.</string>
 
-    <string name="title_faster_route" translatable="false">Faster route</string>
-    <string name="description_faster_route" translatable="false">Demonstrate how to use the MapboxNavigation class to listen for a faster route.</string>
+    <string name="title_faster_route">Faster route</string>
+    <string name="description_faster_route">Demonstrate how to use the MapboxNavigation class to listen for a faster route.</string>
 
-    <string name="title_summary_bottom_sheet" translatable="false">SummaryBottomSheet</string>
-    <string name="description_summary_bottom_sheet" translatable="false">Shows how to integrate SummaryBottomSheet and a recenter button with the Navigation SDK.</string>
+    <string name="title_summary_bottom_sheet">SummaryBottomSheet</string>
+    <string name="description_summary_bottom_sheet">Shows how to integrate SummaryBottomSheet and a recenter button with the Navigation SDK.</string>
 
-    <string name="title_feedback_button" translatable="false">Feedback button</string>
-    <string name="description_feedback_button" translatable="false">Shows how to integrate FeedbackButton about the Feedback Flow with the Navigation SDK.</string>
+    <string name="title_feedback_button">Feedback button</string>
+    <string name="description_feedback_button">Shows how to integrate FeedbackButton about the Feedback Flow with the Navigation SDK.</string>
 
-    <string name="title_instruction_view" translatable="false">InstructionView</string>
-    <string name="description_instruction_view" translatable="false">Shows how to integrate InstructionView, FeedbackButton and SoundButton with the Navigation SDK.</string>
+    <string name="title_instruction_view">InstructionView</string>
+    <string name="description_instruction_view">Shows how to integrate InstructionView, FeedbackButton and SoundButton with the Navigation SDK.</string>
 
-    <string name="title_debug_navigation_kotlin" translatable="false">Debug MapboxNavigation Kotlin</string>
-    <string name="description_debug_navigation_kotlin" translatable="false">Shows debug points for raw(red) and enhanced(blue) location update.</string>
+    <string name="title_debug_navigation_kotlin">Debug MapboxNavigation Kotlin</string>
+    <string name="description_debug_navigation_kotlin">Shows debug points for raw(red) and enhanced(blue) location update.</string>
 
-    <string name="title_custom_route_styling_kotlin" translatable="false">Custom Route Styling Kotlin</string>
-    <string name="description_custom_route_styling_kotlin" translatable="false">Demonstrates applying a custom style for the routes.</string>
+    <string name="title_custom_route_styling_kotlin">Custom Route Styling Kotlin</string>
+    <string name="description_custom_route_styling_kotlin">Demonstrates applying a custom style for the routes.</string>
 
-    <string name="title_navigation_view_fragment" translatable="false">NavigationView In A Fragment</string>
-    <string name="description_navigation_view_fragment" translatable="false">Shows how to use NavigationView to implement turn by turn in a fragment.</string>
+    <string name="title_navigation_view_fragment">NavigationView In A Fragment</string>
+    <string name="description_navigation_view_fragment">Shows how to use NavigationView to implement turn by turn in a fragment.</string>
 
     <string name="title_navigation_route_ui">Navigation Map Route</string>
     <string name="description_navigation_route_ui">An example using NavigationMapRoute</string>
 
+    <string name="title_traffic_toggle">Traffic toggle</string>
+    <string name="description_traffic_toggle">Toggle the visibility of the NavigationView\'s traffic congestion layers.</string>
+
     <string name="title_runtime_styling">Runtime Route Styling</string>
     <string name="description_runtime_styling">An example using RuntimeRouteStyling</string>
 
-    <string name="settings" translatable="false">Settings</string>
-    <string name="simulate_route" translatable="false">Simulate Route</string>
-    <string name="language" translatable="false">Language</string>
-    <string name="unit_type" translatable="false">Unit Type</string>
-    <string name="route_profile" translatable="false">Route Profile</string>
-    <string name="unit_type_key" translatable="false">unit_type</string>
-    <string name="simulate_route_key" translatable="false">simulate_route</string>
-    <string name="language_key" translatable="false">language</string>
-    <string name="route_profile_key" translatable="false">route_profile</string>
-    <string name="default_route_profile" translatable="false">driving-traffic</string>
-    <string name="git_hash_key" translatable="false">git_hash</string>
-    <string name="nav_native_history_retrieve_key" translatable="false">nav_native_history_retrieve</string>
-    <string name="nav_native_history_collect_key" translatable="false">nav_native_history_collect</string>
-    <string name="nav_native_history_collect" translatable="false">Collect Nav Native history</string>
-    <string name="offline_version_key" translatable="false">offline_preference_key</string>
-    <string name="offline_enabled" translatable="false">offline_region_download</string>
-    <string name="default_locale" translatable="false">default_for_device</string>
-    <string name="default_unit_type" translatable="false">default_for_device</string>
-    <string name="start_navigation" translatable="false">Start Navigation</string>
-    <string name="navigate_waypoints_next_stop" translatable="false">Next stop</string>
-    <string name="play_history" translatable="false">Play history</string>
-    <string name="select_history" translatable="false">Select history</string>
-    <string name="msg_long_press_map_to_place_waypoint" translatable="false">Long press on the map to place a waypoint</string>
-    <string name="no_routes" translatable="false">No available routes to that destination</string>
-    <string name="steps_in_route" translatable="false">There are %1$d steps in the route</string>
-    <string name="route_request_failed" translatable="false">The route request failed</string>
-    <string name="offline_category_title" translatable="false">Offline</string>
-    <string name="offline_enabled_title" translatable="false">Offline routing enabled</string>
-    <string name="offline_version_title" translatable="false">Choose offline version</string>
-    <string name="general_category_title" translatable="false">General</string>
-    <string name="send_user_feedback" translatable="false">Send User Feedback</string>
-    <string name="simple_mapbox_navigation_clear_routes" translatable="false">CLEAR ROUTES</string>
-    <string name="simple_mapbox_navigation_add_original_route" translatable="false">ADD ORIGINAL ROUTE</string>
-    <string name="history_failed_to_load_item" translatable="false">History failed to load item</string>
-    <string name="history_failed_to_load_list" translatable="false">Failed to load list</string>
-    <string name="history_local_history_file" translatable="false">Local history file</string>
+    <string name="settings">Settings</string>
+    <string name="simulate_route">Simulate Route</string>
+    <string name="language">Language</string>
+    <string name="unit_type">Unit Type</string>
+    <string name="route_profile">Route Profile</string>
+    <string name="unit_type_key">unit_type</string>
+    <string name="simulate_route_key">simulate_route</string>
+    <string name="language_key">language</string>
+    <string name="route_profile_key">route_profile</string>
+    <string name="default_route_profile">driving-traffic</string>
+    <string name="git_hash_key">git_hash</string>
+    <string name="nav_native_history_retrieve_key">nav_native_history_retrieve</string>
+    <string name="nav_native_history_collect_key">nav_native_history_collect</string>
+    <string name="nav_native_history_collect">Collect Nav Native history</string>
+    <string name="offline_version_key">offline_preference_key</string>
+    <string name="offline_enabled">offline_region_download</string>
+    <string name="default_locale">default_for_device</string>
+    <string name="default_unit_type">default_for_device</string>
+    <string name="start_navigation">Start Navigation</string>
+    <string name="navigate_waypoints_next_stop">Next stop</string>
+    <string name="play_history">Play history</string>
+    <string name="select_history">Select history</string>
+    <string name="msg_long_press_map_to_place_waypoint">Long press on the map to place a waypoint</string>
+    <string name="no_routes">No available routes to that destination</string>
+    <string name="steps_in_route">There are %1$d steps in the route</string>
+    <string name="route_request_failed">The route request failed</string>
+    <string name="offline_category_title">Offline</string>
+    <string name="offline_enabled_title">Offline routing enabled</string>
+    <string name="offline_version_title">Choose offline version</string>
+    <string name="general_category_title">General</string>
+    <string name="send_user_feedback">Send User Feedback</string>
+    <string name="simple_mapbox_navigation_clear_routes">CLEAR ROUTES</string>
+    <string name="simple_mapbox_navigation_add_original_route">ADD ORIGINAL ROUTE</string>
+    <string name="history_failed_to_load_item">History failed to load item</string>
+    <string name="history_failed_to_load_list">Failed to load list</string>
+    <string name="history_local_history_file">Local history file</string>
 
 </resources>


### PR DESCRIPTION
## Description

https://github.com/mapbox/mapbox-navigation-android/pull/3423 updated the default day and night guidance styles to Mapbox's `v5` versions. These new styles have traffic congestion information layers already added to the style. I thought it'd be good for our test app to have an example that shows how to adjust this congestion visibility.

Also fixes #2909

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Add an `examples` test app example to show how to adjust the visibility of the traffic congestion information on the Nav UI SDK's `NavigationView`'s `NavigationMapboxMap`.

### Implementation

`NavigationMapboxMap.updateTrafficVisibility(boolean)` is where the toggling magic happens. The `NavigationMapboxMap` class already had this method exposed. 

```kotlin
toggle_traffic_button.setOnClickListener {
    navigationMapboxMap.updateTrafficVisibility(!navigationMapboxMap.isTrafficVisible)
}
```

## Screenshots or Gifs
![ezgif com-resize](https://user-images.githubusercontent.com/4394910/89959063-6452bf80-dbf0-11ea-837e-efd03e0d51e4.gif)


## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->