### PR TITLE
fix #3310: not calling the TTS to play voice guidance when it is not initialized

### DIFF
--- a/libnavigation-ui/api/current.txt
+++ b/libnavigation-ui/api/current.txt
@@ -711,16 +711,6 @@ package com.mapbox.navigation.ui.voice {
     method public void setIsFallbackAlwaysEnabled(boolean);
   }
 
-  public enum SpeechPlayerState {
-    enum_constant public static final com.mapbox.navigation.ui.voice.SpeechPlayerState IDLE;
-    enum_constant public static final com.mapbox.navigation.ui.voice.SpeechPlayerState OFFLINE_PLAYING;
-    enum_constant public static final com.mapbox.navigation.ui.voice.SpeechPlayerState ONLINE_PLAYING;
-  }
-
-  public interface SpeechPlayerStateChangeObserver {
-    method public void onStateChange(com.mapbox.navigation.ui.voice.SpeechPlayerState state);
-  }
-
   public class VoiceInstructionLoader {
     ctor public VoiceInstructionLoader(android.content.Context!, String!, okhttp3.Cache!);
     method public void cacheInstructions(java.util.List<java.lang.String!>!);

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/voice/AndroidSpeechPlayer.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/voice/AndroidSpeechPlayer.java
@@ -15,7 +15,6 @@ import timber.log.Timber;
  * Default player used to play voice instructions when a connection to Polly is unable to be established.
  * <p>
  * This instruction player uses {@link TextToSpeech} to play voice instructions.
- *
  */
 class AndroidSpeechPlayer implements SpeechPlayer {
 
@@ -30,7 +29,7 @@ class AndroidSpeechPlayer implements SpeechPlayer {
   /**
    * Creates an instance of {@link AndroidSpeechPlayer}.
    *
-   * @param context  used to create an instance of {@link TextToSpeech}
+   * @param context used to create an instance of {@link TextToSpeech}
    * @param language to initialize locale to set
    */
   AndroidSpeechPlayer(Context context, final String language, final VoiceListener voiceListener) {
@@ -53,11 +52,11 @@ class AndroidSpeechPlayer implements SpeechPlayer {
   @Override
   public void play(VoiceInstructions voiceInstructions) {
     boolean isValidAnnouncement = voiceInstructions != null
-      && !TextUtils.isEmpty(voiceInstructions.announcement());
+        && !TextUtils.isEmpty(voiceInstructions.announcement());
     boolean canPlay = isValidAnnouncement && languageSupported && !isMuted;
     if (!canPlay) {
       if (voiceListener != null) {
-        voiceListener.onDone();
+        voiceListener.onDone(SpeechPlayerState.IDLE);
       }
       return;
     }
@@ -124,6 +123,9 @@ class AndroidSpeechPlayer implements SpeechPlayer {
     }
     languageSupported = true;
     textToSpeech.setLanguage(language);
+    if (voiceListener != null) {
+      voiceListener.onDone(SpeechPlayerState.OFFLINE_PLAYER_INITIALIZED);
+    }
   }
 
   private void setVoiceListener(final VoiceListener voiceListener) {

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/voice/MapboxSpeechPlayer.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/voice/MapboxSpeechPlayer.java
@@ -123,7 +123,7 @@ class MapboxSpeechPlayer implements SpeechPlayer {
       isPlaying = false;
       mediaPlayer.stop();
       mediaPlayer.release();
-      voiceListener.onDone();
+      voiceListener.onDone(SpeechPlayerState.IDLE);
     }
   }
 
@@ -201,7 +201,7 @@ class MapboxSpeechPlayer implements SpeechPlayer {
       public void onCompletion(MediaPlayer mp) {
         mp.release();
         isPlaying = false;
-        voiceListener.onDone();
+        voiceListener.onDone(SpeechPlayerState.IDLE);
         onInstructionFinishedPlaying();
       }
     });

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/voice/NavigationVoiceListener.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/voice/NavigationVoiceListener.java
@@ -24,9 +24,11 @@ class NavigationVoiceListener implements VoiceListener {
   }
 
   @Override
-  public void onDone() {
-    speechPlayerProvider.onSpeechPlayerStateChanged(SpeechPlayerState.IDLE);
-    audioFocusManager.abandonAudioFocus();
+  public void onDone(@NonNull SpeechPlayerState state) {
+    speechPlayerProvider.onSpeechPlayerStateChanged(state);
+    if (state == SpeechPlayerState.IDLE) {
+      audioFocusManager.abandonAudioFocus();
+    }
   }
 
   @Override

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/voice/SpeechPlayerProvider.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/voice/SpeechPlayerProvider.java
@@ -33,7 +33,7 @@ public class SpeechPlayerProvider {
   private VoiceInstructionLoader voiceInstructionLoader;
   private ConnectivityStatusProvider connectivityStatus;
   @NonNull
-  private SpeechPlayerState speechPlayerState = SpeechPlayerState.IDLE;
+  private SpeechPlayerState speechPlayerState = SpeechPlayerState.OFFLINE_PLAYER_INITIALIZING;
   @Nullable
   private SpeechPlayerStateChangeObserver observer = null;
   private boolean isFallbackAlwaysEnabled = true;
@@ -114,9 +114,16 @@ public class SpeechPlayerProvider {
   }
 
   void onSpeechPlayerStateChanged(@NonNull SpeechPlayerState speechPlayerState) {
-    this.speechPlayerState = speechPlayerState;
+    if (speechPlayerState == SpeechPlayerState.OFFLINE_PLAYER_INITIALIZED) {
+      if (this.speechPlayerState == SpeechPlayerState.OFFLINE_PLAYER_INITIALIZING) {
+        this.speechPlayerState = SpeechPlayerState.IDLE;
+      }
+    } else {
+      this.speechPlayerState = speechPlayerState;
+    }
+
     if (observer != null) {
-      observer.onStateChange(speechPlayerState);
+      observer.onStateChange(this.speechPlayerState);
     }
   }
 

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/voice/SpeechPlayerState.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/voice/SpeechPlayerState.kt
@@ -3,9 +3,21 @@ package com.mapbox.navigation.ui.voice
 /**
  * The [SpeechPlayer] will be at one of these states.
  */
-enum class SpeechPlayerState {
+internal enum class SpeechPlayerState {
     /**
-     * No voice guidance is playing. [SpeechPlayer] is not idle.
+     * The offline player [AndroidSpeechPlayer] is initializing.
+     * In this state, can't use the [AndroidSpeechPlayer]. Only [MapboxSpeechPlayer] can be used.
+     */
+    OFFLINE_PLAYER_INITIALIZING,
+
+    /**
+     * The offline player [AndroidSpeechPlayer] is ready for use.
+     * This state will be only fired once.
+     */
+    OFFLINE_PLAYER_INITIALIZED,
+
+    /**
+     * No voice guidance is playing. [SpeechPlayer] is idle.
      */
     IDLE,
 

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/voice/SpeechPlayerStateChangeObserver.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/voice/SpeechPlayerStateChangeObserver.kt
@@ -4,7 +4,7 @@ package com.mapbox.navigation.ui.voice
  * Interface definition for an observer that get's notified
  * whenever the [SpeechPlayer]'s [SpeechPlayerState] changes.
  */
-interface SpeechPlayerStateChangeObserver {
+internal interface SpeechPlayerStateChangeObserver {
 
     /**
      * Invoked whenever the [SpeechPlayer]'s [SpeechPlayerState] changes.

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/voice/UtteranceListener.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/voice/UtteranceListener.java
@@ -16,12 +16,11 @@ class UtteranceListener extends UtteranceProgressListener {
 
   @Override
   public void onDone(String utteranceId) {
-    voiceListener.onDone();
+    voiceListener.onDone(SpeechPlayerState.IDLE);
   }
 
   @Override
   public void onError(String utteranceId) {
-    // Intentionally empty
-    voiceListener.onDone();
+    voiceListener.onDone(SpeechPlayerState.IDLE);
   }
 }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/voice/VoiceListener.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/voice/VoiceListener.java
@@ -8,7 +8,7 @@ interface VoiceListener {
 
   void onStart(@NonNull SpeechPlayerState state);
 
-  void onDone();
+  void onDone(@NonNull SpeechPlayerState state);
 
   void onError(String errorText, VoiceInstructions voiceInstructions);
 }

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/voice/NavigationVoiceListenerTest.java
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/voice/NavigationVoiceListenerTest.java
@@ -27,7 +27,7 @@ public class NavigationVoiceListenerTest {
     SpeechAudioFocusManager audioFocusManager = mock(SpeechAudioFocusManager.class);
     NavigationVoiceListener navigationSpeechListener = buildSpeechListener(audioFocusManager);
 
-    navigationSpeechListener.onDone();
+    navigationSpeechListener.onDone(SpeechPlayerState.IDLE);
 
     verify(audioFocusManager).abandonAudioFocus();
   }
@@ -61,7 +61,11 @@ public class NavigationVoiceListenerTest {
     SpeechPlayerProvider provider = mock(SpeechPlayerProvider.class);
     NavigationVoiceListener navigationSpeechListener = buildSpeechListener(provider);
 
-    navigationSpeechListener.onDone();
+    navigationSpeechListener.onDone(SpeechPlayerState.IDLE);
+
+    verify(provider).onSpeechPlayerStateChanged(SpeechPlayerState.IDLE);
+
+    navigationSpeechListener.onDone(SpeechPlayerState.OFFLINE_PLAYER_INITIALIZED);
 
     verify(provider).onSpeechPlayerStateChanged(SpeechPlayerState.IDLE);
   }

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/voice/SpeechPlayerProviderTest.java
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/voice/SpeechPlayerProviderTest.java
@@ -62,6 +62,7 @@ public class SpeechPlayerProviderTest {
     when(connectivityStatus.isConnectedFast()).thenReturn(false);
     SpeechPlayerProvider provider = new SpeechPlayerProvider(context, language, true,
       voiceInstructionLoader, connectivityStatus);
+    provider.onSpeechPlayerStateChanged(SpeechPlayerState.OFFLINE_PLAYER_INITIALIZED);
 
     SpeechPlayer speechPlayer = provider.retrieveSpeechPlayer();
 
@@ -78,6 +79,7 @@ public class SpeechPlayerProviderTest {
     when(connectivityStatus.isConnectedFast()).thenReturn(false);
     SpeechPlayerProvider provider = new SpeechPlayerProvider(context, language, true,
       voiceInstructionLoader, connectivityStatus);
+    provider.onSpeechPlayerStateChanged(SpeechPlayerState.OFFLINE_PLAYER_INITIALIZED);
 
     SpeechPlayer speechPlayer = provider.retrieveSpeechPlayer();
 
@@ -148,6 +150,7 @@ public class SpeechPlayerProviderTest {
     when(connectivityStatus.isConnected()).thenReturn(true);
     SpeechPlayerProvider provider = new SpeechPlayerProvider(context, language, true,
         voiceInstructionLoader, connectivityStatus);
+    provider.onSpeechPlayerStateChanged(SpeechPlayerState.OFFLINE_PLAYER_INITIALIZED);
 
     SpeechPlayer speechPlayer = provider.retrieveSpeechPlayer();
 
@@ -169,6 +172,44 @@ public class SpeechPlayerProviderTest {
     SpeechPlayer speechPlayer = provider.retrieveSpeechPlayer();
 
     assertTrue(speechPlayer instanceof MapboxSpeechPlayer);
+  }
+
+  @Test
+  public void offlinePlayerInitializingNoCacheNoConnectivity_returnNullSpeechPlayer() {
+    Context context = mock(Context.class);
+    String language = Locale.US.getLanguage();
+    VoiceInstructionLoader voiceInstructionLoader = mock(VoiceInstructionLoader.class);
+    ConnectivityStatusProvider connectivityStatus = mock(ConnectivityStatusProvider.class);
+    when(connectivityStatus.isConnectedFast()).thenReturn(false);
+    SpeechPlayerProvider provider = new SpeechPlayerProvider(context, language, true,
+        voiceInstructionLoader, connectivityStatus);
+
+    SpeechPlayer speechPlayer = provider.retrieveSpeechPlayer();
+
+    assertNull(speechPlayer);
+  }
+
+  @Test
+  public void offlinePlayerInitializedBeforePlaying_idleStateObserved() {
+    SpeechPlayerProvider provider = buildSpeechPlayerProvider(true);
+    SpeechPlayerStateChangeObserver observer = mock(SpeechPlayerStateChangeObserver.class);
+    provider.setSpeechPlayerStateChangeObserver(observer);
+
+    provider.onSpeechPlayerStateChanged(SpeechPlayerState.OFFLINE_PLAYER_INITIALIZED);
+
+    verify(observer).onStateChange(SpeechPlayerState.IDLE);
+  }
+
+  @Test
+  public void offlinePlayerInitializedAfterPlaying_noStateObserved() {
+    SpeechPlayerProvider provider = buildSpeechPlayerProvider(true);
+    provider.onSpeechPlayerStateChanged(SpeechPlayerState.ONLINE_PLAYING);
+    SpeechPlayerStateChangeObserver observer = mock(SpeechPlayerStateChangeObserver.class);
+    provider.setSpeechPlayerStateChangeObserver(observer);
+
+    provider.onSpeechPlayerStateChanged(SpeechPlayerState.OFFLINE_PLAYER_INITIALIZED);
+
+    verify(observer).onStateChange(SpeechPlayerState.ONLINE_PLAYING);
   }
 
   private SpeechPlayerProvider buildSpeechPlayerProvider(boolean voiceLanguageSupported) {


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Fix #3310: not calling the TTS to play voice guidance when it is not initialized

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Improve voice guidance offline experience.

### Implementation

Add offline player initialize state so that the TTS will only be called to play after it has been initialized.

## Testing

1. Turn off the data connection of device.
2. Run `NavigationViewActivity`

Without this PR, you will very likely to miss the first voice guidance.

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->