### PR TITLE
[core] update thread annotations and docs, expose route options updater

### DIFF
--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/DeviceProfile.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/DeviceProfile.kt
@@ -15,7 +15,7 @@ class DeviceProfile private constructor(
     /**
      * @return builder matching the one used to create this instance
      */
-    fun toBuilder() = Builder().customConfig(customConfig).deviceType(deviceType)
+    fun toBuilder(): Builder = Builder().customConfig(customConfig).deviceType(deviceType)
 
     /**
      * Build a new [DeviceProfile]

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/NavigationOptions.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/NavigationOptions.kt
@@ -47,7 +47,7 @@ class NavigationOptions private constructor(
     /**
      * Get a builder to customize a subset of current options.
      */
-    fun toBuilder() = Builder(context = applicationContext).apply {
+    fun toBuilder(): Builder = Builder(context = applicationContext).apply {
         accessToken(accessToken)
         locationEngine(locationEngine)
         timeFormatType(timeFormatType)
@@ -124,55 +124,55 @@ class NavigationOptions private constructor(
         /**
          * Defines [Mapbox Access Token](https://docs.mapbox.com/help/glossary/access-token/)
          */
-        fun accessToken(accessToken: String?) =
+        fun accessToken(accessToken: String?): Builder =
             apply { this.accessToken = accessToken }
 
         /**
          * Override the mechanism responsible for providing location approximations to navigation
          */
-        fun locationEngine(locationEngine: LocationEngine) =
+        fun locationEngine(locationEngine: LocationEngine): Builder =
             apply { this.locationEngine = locationEngine }
 
         /**
          * Defines the type of device creating localization data
          */
-        fun deviceProfile(deviceProfile: DeviceProfile) =
+        fun deviceProfile(deviceProfile: DeviceProfile): Builder =
             apply { this.deviceProfile = deviceProfile }
 
         /**
          * Defines time format for calculation remaining trip time
          */
-        fun timeFormatType(type: Int) =
+        fun timeFormatType(type: Int): Builder =
             apply { this.timeFormatType = type }
 
         /**
          * Defines approximate navigator prediction in milliseconds
          */
-        fun navigatorPredictionMillis(predictionMillis: Long) =
+        fun navigatorPredictionMillis(predictionMillis: Long): Builder =
             apply { navigatorPredictionMillis = predictionMillis }
 
         /**
          *  Defines format distances showing in notification during navigation
          */
-        fun distanceFormatter(distanceFormatter: DistanceFormatter?) =
+        fun distanceFormatter(distanceFormatter: DistanceFormatter?): Builder =
             apply { this.distanceFormatter = distanceFormatter }
 
         /**
          * Defines configuration for the default on-board router
          */
-        fun onboardRouterOptions(onboardRouterOptions: OnboardRouterOptions) =
+        fun onboardRouterOptions(onboardRouterOptions: OnboardRouterOptions): Builder =
             apply { this.onboardRouterOptions = onboardRouterOptions }
 
         /**
          * Defines if the builder instance is created from the Navigation UI
          */
-        fun isFromNavigationUi(flag: Boolean) =
+        fun isFromNavigationUi(flag: Boolean): Builder =
             apply { this.isFromNavigationUi = flag }
 
         /**
          * Defines if debug logging is enabled
          */
-        fun isDebugLoggingEnabled(flag: Boolean) =
+        fun isDebugLoggingEnabled(flag: Boolean): Builder =
             apply { this.isDebugLoggingEnabled = flag }
 
         /**

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/OnboardRouterOptions.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/OnboardRouterOptions.kt
@@ -18,7 +18,7 @@ class OnboardRouterOptions private constructor(
     /**
      * @return the builder that created the [OnboardRouterOptions]
      */
-    fun toBuilder() = Builder().apply {
+    fun toBuilder(): Builder = Builder().apply {
         tilesUri(tilesUri)
         tilesVersion(tilesVersion)
         filePath(filePath)
@@ -69,19 +69,19 @@ class OnboardRouterOptions private constructor(
         /**
          * Override the routing tiles endpoint with a [URI]
          */
-        fun tilesUri(tilesUri: URI) =
+        fun tilesUri(tilesUri: URI): Builder =
             apply { this.tilesUri = tilesUri }
 
         /**
          * Override the routing tiles version.
          */
-        fun tilesVersion(version: String) =
+        fun tilesVersion(version: String): Builder =
             apply { this.tilesVersion = version }
 
         /**
          * Creates a custom file path to store the road network tiles.
          */
-        fun filePath(filePath: String?) =
+        fun filePath(filePath: String?): Builder =
             apply { this.filePath = filePath }
 
         /**

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteLegProgress.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteLegProgress.kt
@@ -39,7 +39,7 @@ class RouteLegProgress private constructor(
     /**
      * @return builder matching the one used to create this instance
      */
-    fun toBuilder() = Builder()
+    fun toBuilder(): Builder = Builder()
         .legIndex(legIndex)
         .routeLeg(routeLeg)
         .distanceTraveled(distanceTraveled)
@@ -112,21 +112,21 @@ class RouteLegProgress private constructor(
          *
          * @return Builder
          */
-        fun legIndex(legIndex: Int) = apply { this.legIndex = legIndex }
+        fun legIndex(legIndex: Int): Builder = apply { this.legIndex = legIndex }
 
         /**
          * [RouteLeg] geometry
          *
          * @return Builder
          */
-        fun routeLeg(routeLeg: RouteLeg?) = apply { this.routeLeg = routeLeg }
+        fun routeLeg(routeLeg: RouteLeg?): Builder = apply { this.routeLeg = routeLeg }
 
         /**
          * Total distance traveled in meters along current leg
          *
          * @return Builder
          */
-        fun distanceTraveled(distanceTraveled: Float) =
+        fun distanceTraveled(distanceTraveled: Float): Builder =
             apply { this.distanceTraveled = distanceTraveled }
 
         /**
@@ -134,7 +134,7 @@ class RouteLegProgress private constructor(
          *
          * @return Builder
          */
-        fun distanceRemaining(distanceRemaining: Float) =
+        fun distanceRemaining(distanceRemaining: Float): Builder =
             apply { this.distanceRemaining = distanceRemaining }
 
         /**
@@ -142,7 +142,7 @@ class RouteLegProgress private constructor(
          *
          * @return Builder
          */
-        fun durationRemaining(durationRemaining: Double) =
+        fun durationRemaining(durationRemaining: Double): Builder =
             apply { this.durationRemaining = durationRemaining }
 
         /**
@@ -151,7 +151,7 @@ class RouteLegProgress private constructor(
          *
          * @return Builder
          */
-        fun fractionTraveled(fractionTraveled: Float) =
+        fun fractionTraveled(fractionTraveled: Float): Builder =
             apply { this.fractionTraveled = fractionTraveled }
 
         /**
@@ -160,7 +160,7 @@ class RouteLegProgress private constructor(
          *
          * @return Builder
          */
-        fun currentStepProgress(currentStepProgress: RouteStepProgress?) =
+        fun currentStepProgress(currentStepProgress: RouteStepProgress?): Builder =
             apply { this.currentStepProgress = currentStepProgress }
 
         /**
@@ -169,7 +169,7 @@ class RouteLegProgress private constructor(
          *
          * @return Builder
          */
-        fun upcomingStep(upcomingStep: LegStep?) =
+        fun upcomingStep(upcomingStep: LegStep?): Builder =
                 apply { this.upcomingStep = upcomingStep }
 
         /**

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteProgress.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteProgress.kt
@@ -56,7 +56,7 @@ class RouteProgress private constructor(
     /**
      * @return builder matching the one used to create this instance
      */
-    fun toBuilder() = Builder(route)
+    fun toBuilder(): Builder = Builder(route)
         .routeGeometryWithBuffer(routeGeometryWithBuffer)
         .bannerInstructions(bannerInstructions)
         .voiceInstructions(voiceInstructions)
@@ -151,7 +151,7 @@ class RouteProgress private constructor(
          *
          * @return Builder
          */
-        fun routeGeometryWithBuffer(routeGeometryWithBuffer: Geometry?) =
+        fun routeGeometryWithBuffer(routeGeometryWithBuffer: Geometry?): Builder =
             apply { this.routeGeometryWithBuffer = routeGeometryWithBuffer }
 
         /**
@@ -159,7 +159,7 @@ class RouteProgress private constructor(
          *
          * @return Builder
          */
-        fun bannerInstructions(bannerInstructions: BannerInstructions?) =
+        fun bannerInstructions(bannerInstructions: BannerInstructions?): Builder =
             apply { this.bannerInstructions = bannerInstructions }
 
         /**
@@ -167,7 +167,7 @@ class RouteProgress private constructor(
          *
          * @return Builder
          */
-        fun voiceInstructions(voiceInstructions: VoiceInstructions?) =
+        fun voiceInstructions(voiceInstructions: VoiceInstructions?): Builder =
             apply { this.voiceInstructions = voiceInstructions }
 
         /**
@@ -176,7 +176,7 @@ class RouteProgress private constructor(
          *
          * @return Builder
          */
-        fun currentState(currentState: RouteProgressState) =
+        fun currentState(currentState: RouteProgressState): Builder =
             apply { this.currentState = currentState }
 
         /**
@@ -185,7 +185,7 @@ class RouteProgress private constructor(
          *
          * @return Builder
          */
-        fun currentLegProgress(legProgress: RouteLegProgress?) =
+        fun currentLegProgress(legProgress: RouteLegProgress?): Builder =
             apply { this.currentLegProgress = legProgress }
 
         /**
@@ -193,7 +193,7 @@ class RouteProgress private constructor(
          *
          * @return Builder
          */
-        fun upcomingStepPoints(upcomingStepPoints: List<Point>?) =
+        fun upcomingStepPoints(upcomingStepPoints: List<Point>?): Builder =
             apply { this.upcomingStepPoints = upcomingStepPoints }
 
         /**
@@ -201,14 +201,14 @@ class RouteProgress private constructor(
          *
          * @return Builder
          */
-        fun inTunnel(inTunnel: Boolean) = apply { this.inTunnel = inTunnel }
+        fun inTunnel(inTunnel: Boolean): Builder = apply { this.inTunnel = inTunnel }
 
         /**
          * The distance remaining in meters until the user reaches the end of the route.
          *
          * @return Builder
          */
-        fun distanceRemaining(distanceRemaining: Float) =
+        fun distanceRemaining(distanceRemaining: Float): Builder =
             apply { this.distanceRemaining = distanceRemaining }
 
         /**
@@ -216,7 +216,7 @@ class RouteProgress private constructor(
          *
          * @return Builder
          */
-        fun distanceTraveled(distanceTraveled: Float) =
+        fun distanceTraveled(distanceTraveled: Float): Builder =
             apply { this.distanceTraveled = distanceTraveled }
 
         /**
@@ -224,7 +224,7 @@ class RouteProgress private constructor(
          *
          * @return Builder
          */
-        fun durationRemaining(durationRemaining: Double) =
+        fun durationRemaining(durationRemaining: Double): Builder =
             apply { this.durationRemaining = durationRemaining }
 
         /**
@@ -233,7 +233,7 @@ class RouteProgress private constructor(
          *
          * @return Builder
          */
-        fun fractionTraveled(fractionTraveled: Float) =
+        fun fractionTraveled(fractionTraveled: Float): Builder =
             apply { this.fractionTraveled = fractionTraveled }
 
         /**
@@ -241,7 +241,7 @@ class RouteProgress private constructor(
          *
          * @return Builder
          */
-        fun remainingWaypoints(remainingWaypoints: Int) =
+        fun remainingWaypoints(remainingWaypoints: Int): Builder =
             apply { this.remainingWaypoints = remainingWaypoints }
 
         /**

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteStepProgress.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteStepProgress.kt
@@ -32,7 +32,7 @@ class RouteStepProgress private constructor(
     /**
      * @return builder matching the one used to create this instance
      */
-    fun toBuilder() = Builder()
+    fun toBuilder(): Builder = Builder()
         .stepIndex(stepIndex)
         .step(step)
         .stepPoints(stepPoints)
@@ -99,7 +99,7 @@ class RouteStepProgress private constructor(
          *
          * @return Builder
          */
-        fun stepIndex(stepIndex: Int) =
+        fun stepIndex(stepIndex: Int): Builder =
             apply { this.stepIndex = stepIndex }
 
         /**
@@ -107,7 +107,7 @@ class RouteStepProgress private constructor(
          *
          * @return Builder
          */
-        fun step(step: LegStep?) =
+        fun step(step: LegStep?): Builder =
             apply { this.step = step }
 
         /**
@@ -115,7 +115,7 @@ class RouteStepProgress private constructor(
          *
          * @return Builder
          */
-        fun stepPoints(stepPoints: List<Point>?) =
+        fun stepPoints(stepPoints: List<Point>?): Builder =
             apply { this.stepPoints = stepPoints }
 
         /**
@@ -123,7 +123,7 @@ class RouteStepProgress private constructor(
          *
          * @return Builder
          */
-        fun distanceRemaining(distanceRemaining: Float) =
+        fun distanceRemaining(distanceRemaining: Float): Builder =
             apply { this.distanceRemaining = distanceRemaining }
 
         /**
@@ -131,7 +131,7 @@ class RouteStepProgress private constructor(
          *
          * @return Builder
          */
-        fun distanceTraveled(distanceTraveled: Float) =
+        fun distanceTraveled(distanceTraveled: Float): Builder =
             apply { this.distanceTraveled = distanceTraveled }
 
         /**
@@ -140,7 +140,7 @@ class RouteStepProgress private constructor(
          *
          * @return Builder
          */
-        fun fractionTraveled(fractionTraveled: Float) =
+        fun fractionTraveled(fractionTraveled: Float): Builder =
             apply { this.fractionTraveled = fractionTraveled }
 
         /**
@@ -148,7 +148,7 @@ class RouteStepProgress private constructor(
          *
          * @return Builder
          */
-        fun durationRemaining(durationRemaining: Double) =
+        fun durationRemaining(durationRemaining: Double): Builder =
             apply { this.durationRemaining = durationRemaining }
 
         /**

--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -154,7 +154,7 @@ package com.mapbox.navigation.core.replay {
     method public void seekTo(double replayTime);
     method public void seekTo(com.mapbox.navigation.core.replay.history.ReplayEventBase replayEvent);
     method public void stop();
-    method public boolean unregisterObserver(com.mapbox.navigation.core.replay.history.ReplayEventsObserver observer);
+    method public void unregisterObserver(com.mapbox.navigation.core.replay.history.ReplayEventsObserver observer);
     method public void unregisterObservers();
   }
 

--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -1,7 +1,7 @@
 // Signature format: 3.0
 package com.mapbox.navigation.core {
 
-  public final class MapboxNavigation {
+  @UiThread public final class MapboxNavigation {
     ctor public MapboxNavigation(com.mapbox.navigation.base.options.NavigationOptions navigationOptions);
     method public void addHistoryEvent(String eventType, String eventJsonProperties);
     method public void attachFasterRouteObserver(com.mapbox.navigation.core.fasterroute.FasterRouteObserver fasterRouteObserver);
@@ -28,7 +28,8 @@ package com.mapbox.navigation.core {
     method public String? retrieveSsmlAnnouncementInstruction(int index);
     method public void setArrivalController(com.mapbox.navigation.core.arrival.ArrivalController? arrivalController = com.mapbox.navigation.core.arrival.AutoArrivalController());
     method public void setArrivalController();
-    method public void setRerouteController(com.mapbox.navigation.core.reroute.RerouteController? rerouteController);
+    method public void setRerouteController(com.mapbox.navigation.core.reroute.RerouteController? rerouteController = com.mapbox.navigation.core.MapboxNavigation.defaultRerouteController);
+    method public void setRerouteController();
     method public void setRoutes(java.util.List<? extends com.mapbox.api.directions.v5.models.DirectionsRoute> routes);
     method @RequiresPermission(anyOf={android.Manifest.permission.ACCESS_COARSE_LOCATION, android.Manifest.permission.ACCESS_FINE_LOCATION}) public void startTripSession();
     method public void stopTripSession();
@@ -53,7 +54,7 @@ package com.mapbox.navigation.core {
   public final class MapboxNavigationKt {
   }
 
-  public final class MapboxNavigationProvider {
+  @UiThread public final class MapboxNavigationProvider {
     method public static com.mapbox.navigation.core.MapboxNavigation create(com.mapbox.navigation.base.options.NavigationOptions navigationOptions);
     method public static void destroy();
     method public static boolean isCreated();
@@ -346,6 +347,40 @@ package com.mapbox.navigation.core.reroute {
 
   public static final class RerouteState.RouteFetched extends com.mapbox.navigation.core.reroute.RerouteState {
     field public static final com.mapbox.navigation.core.reroute.RerouteState.RouteFetched! INSTANCE;
+  }
+
+}
+
+package com.mapbox.navigation.core.routeoptions {
+
+  public final class MapboxRouteOptionsUpdater implements com.mapbox.navigation.core.routeoptions.RouteOptionsUpdater {
+    ctor public MapboxRouteOptionsUpdater(com.mapbox.base.common.logger.Logger? logger);
+    ctor public MapboxRouteOptionsUpdater();
+    method public com.mapbox.navigation.core.routeoptions.RouteOptionsUpdater.RouteOptionsResult update(com.mapbox.api.directions.v5.models.RouteOptions? routeOptions, com.mapbox.navigation.base.trip.model.RouteProgress? routeProgress, android.location.Location? location);
+  }
+
+  public final class MapboxRouteOptionsUpdaterKt {
+  }
+
+  public interface RouteOptionsUpdater {
+    method public com.mapbox.navigation.core.routeoptions.RouteOptionsUpdater.RouteOptionsResult update(com.mapbox.api.directions.v5.models.RouteOptions? routeOptions, com.mapbox.navigation.base.trip.model.RouteProgress? routeProgress, android.location.Location? location);
+  }
+
+  public abstract static sealed class RouteOptionsUpdater.RouteOptionsResult {
+  }
+
+  public static final class RouteOptionsUpdater.RouteOptionsResult.Error extends com.mapbox.navigation.core.routeoptions.RouteOptionsUpdater.RouteOptionsResult {
+    ctor public RouteOptionsUpdater.RouteOptionsResult.Error(Throwable error);
+    method public Throwable component1();
+    method public com.mapbox.navigation.core.routeoptions.RouteOptionsUpdater.RouteOptionsResult.Error copy(Throwable error);
+    method public Throwable getError();
+  }
+
+  public static final class RouteOptionsUpdater.RouteOptionsResult.Success extends com.mapbox.navigation.core.routeoptions.RouteOptionsUpdater.RouteOptionsResult {
+    ctor public RouteOptionsUpdater.RouteOptionsResult.Success(com.mapbox.api.directions.v5.models.RouteOptions routeOptions);
+    method public com.mapbox.api.directions.v5.models.RouteOptions component1();
+    method public com.mapbox.navigation.core.routeoptions.RouteOptionsUpdater.RouteOptionsResult.Success copy(com.mapbox.api.directions.v5.models.RouteOptions routeOptions);
+    method public com.mapbox.api.directions.v5.models.RouteOptions getRouteOptions();
   }
 
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -115,7 +115,6 @@ private const val MAPBOX_NOTIFICATION_ACTION_CHANNEL = "notificationActionButton
  *
  * If the SDK is already in the `Free Drive` mode or entering it whenever a primary route is available,
  * the SDK will enter the `Active Guidance` mode instead and propagate meaningful [RouteProgress].
- * Additionally, the enhanced location's map-matching will be more precise and based on the primary route itself.
  *
  * If a new routes request is made, or the routes are manually cleared, the SDK automatically fall back to either `Idle` or `Free Drive` state.
  *
@@ -304,7 +303,7 @@ class MapboxNavigation(
      * If the list is empty, the SDK will exit the `Active Guidance` state.
      *
      * If the list is not empty, the route at index 0 is going to be treated as the primary route
-     * and used for route progress, off route events and map-matching calculations.
+     * and used for route progress calculations and off route events.
      *
      * Use [RoutesObserver] and [MapboxNavigation.registerRoutesObserver] to observe whenever the routes list reference managed by the SDK changes, regardless of a source.
      *
@@ -439,7 +438,7 @@ class MapboxNavigation(
 
     /**
      * Registers [RoutesObserver]. The updates are available when a new list of routes is set.
-     * The route at index 0, if exist, will be treated as the primary route for 'Active Guidance' and location map-matching.
+     * The route at index 0, if exist, will be treated as the primary route for 'Active Guidance'.
      */
     fun registerRoutesObserver(routesObserver: RoutesObserver) {
         directionsSession.registerRoutesObserver(routesObserver)

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -274,7 +274,7 @@ class MapboxNavigation(
      * @return current [TripSessionState]
      * @see [registerTripSessionStateObserver]
      */
-    fun getTripSessionState() = tripSession.getState()
+    fun getTripSessionState(): TripSessionState = tripSession.getState()
 
     /**
      * Requests a route using the provided [Router] implementation.
@@ -323,7 +323,7 @@ class MapboxNavigation(
      *
      * @return a list of [DirectionsRoute]s
      */
-    fun getRoutes() = directionsSession.routes
+    fun getRoutes(): List<DirectionsRoute> = directionsSession.routes
 
     /**
      * Call this method whenever this instance of the [MapboxNavigation] is not going to be used anymore and should release all of its resources.

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigationProvider.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigationProvider.kt
@@ -1,10 +1,12 @@
 package com.mapbox.navigation.core
 
+import androidx.annotation.UiThread
 import com.mapbox.navigation.base.options.NavigationOptions
 
 /**
  * Singleton responsible for ensuring there is only one MapboxNavigation instance.
  */
+@UiThread
 object MapboxNavigationProvider {
     @Volatile
     private var mapboxNavigation: MapboxNavigation? = null
@@ -26,8 +28,9 @@ object MapboxNavigationProvider {
     }
 
     /**
-     * Retrieve MapboxNavigation instance.
-     * Should be called after [create]
+     * Retrieve MapboxNavigation instance. Should be called after [create].
+     *
+     * @see [isCreated]
      */
     @JvmStatic
     fun retrieve(): MapboxNavigation {
@@ -39,9 +42,7 @@ object MapboxNavigationProvider {
     }
 
     /**
-     * Destroy MapboxNavigation with provided options.
-     * Should be called after [create]
-     *
+     * Destroy MapboxNavigation when your process/activity exits.
      */
     @JvmStatic
     fun destroy() {

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/arrival/ArrivalController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/arrival/ArrivalController.kt
@@ -59,7 +59,7 @@ class ArrivalOptions private constructor(
     /**
      * @return the builder that created the [ArrivalOptions]
      */
-    fun toBuilder() = Builder().apply {
+    fun toBuilder(): Builder = Builder().apply {
         arrivalInSeconds(arrivalInSeconds)
         arrivalInMeters(arrivalInMeters)
     }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/RoutesObserver.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/RoutesObserver.kt
@@ -1,6 +1,7 @@
 package com.mapbox.navigation.core.directions.session
 
 import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.navigation.core.MapboxNavigation
 
 /**
  * Interface definition for an observer that get's notified whenever a list of maintained routes changes.
@@ -11,6 +12,9 @@ interface RoutesObserver {
      * Invoked whenever a list of routes changes.
      *
      * The route at index 0, if exist, will be treated as the primary route for 'Active Guidance' and location map-matching.
+     *
+     * A list of routes can be modified internally and externally at any time with methods like
+     * [MapboxNavigation.requestRoutes], [MapboxNavigation.setRoutes], or during automatic reroutes, faster route and route refresh operations.
      *
      * @param routes list of currently maintained routes
      */

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/RoutesObserver.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/RoutesObserver.kt
@@ -11,7 +11,7 @@ interface RoutesObserver {
     /**
      * Invoked whenever a list of routes changes.
      *
-     * The route at index 0, if exist, will be treated as the primary route for 'Active Guidance' and location map-matching.
+     * The route at index 0, if exist, will be treated as the primary route for 'Active Guidance'.
      *
      * A list of routes can be modified internally and externally at any time with methods like
      * [MapboxNavigation.requestRoutes], [MapboxNavigation.setRoutes], or during automatic reroutes, faster route and route refresh operations.

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/RoutesRequestCallback.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/RoutesRequestCallback.kt
@@ -31,7 +31,6 @@ interface RoutesRequestCallback {
      * @param throwable the exception
      * @param routeOptions the original request options
      */
-    // return a boolean here, or a long that will indicate when should we retry the request? or leave that to the user?
     fun onRoutesRequestFailure(throwable: Throwable, routeOptions: RouteOptions)
 
     /**

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/RoutesRequestCallback.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/RoutesRequestCallback.kt
@@ -14,7 +14,7 @@ interface RoutesRequestCallback {
      * Invoked whenever a new set of routes is available.
      *
      * The provided list is the list of routes created by this request and assigned to be managed by the SDK.
-     * The route at index 0, if exist, is treated as the primary route for 'Active Guidance' and location map-matching.
+     * The route at index 0, if exist, is treated as the primary route for 'Active Guidance'.
      *
      * The list provided by this callback is not guaranteed to still be the one managed by the SDK at the moment of invocation.
      * Use [RoutesObserver] and [MapboxNavigation.registerRoutesObserver] to observe whenever the routes list reference managed by the SDK changes, regardless of a source.

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/fasterroute/FasterRouteController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/fasterroute/FasterRouteController.kt
@@ -6,7 +6,7 @@ import com.mapbox.base.common.logger.Logger
 import com.mapbox.base.common.logger.model.Message
 import com.mapbox.navigation.core.directions.session.DirectionsSession
 import com.mapbox.navigation.core.directions.session.RoutesRequestCallback
-import com.mapbox.navigation.core.routeoptions.RouteOptionsProvider
+import com.mapbox.navigation.core.routeoptions.RouteOptionsUpdater
 import com.mapbox.navigation.core.trip.session.TripSession
 import com.mapbox.navigation.utils.internal.MapboxTimer
 import com.mapbox.navigation.utils.internal.ThreadController
@@ -17,7 +17,7 @@ import kotlinx.coroutines.launch
 internal class FasterRouteController(
     private val directionsSession: DirectionsSession,
     private val tripSession: TripSession,
-    private val routeOptionsProvider: RouteOptionsProvider,
+    private val routeOptionsUpdater: RouteOptionsUpdater,
     private val fasterRouteDetector: FasterRouteDetector,
     private val logger: Logger
 ) {
@@ -57,19 +57,19 @@ internal class FasterRouteController(
 
         fasterRouteTimer.restartAfterMillis = restartAfterMillis
 
-        routeOptionsProvider.update(
+        routeOptionsUpdater.update(
             directionsSession.getRouteOptions(),
             tripSession.getRouteProgress(),
             tripSession.getEnhancedLocation()
         )
             .let { routeOptionsResult ->
                 when (routeOptionsResult) {
-                    is RouteOptionsProvider.RouteOptionsResult.Success ->
+                    is RouteOptionsUpdater.RouteOptionsResult.Success ->
                         directionsSession.requestFasterRoute(
                             routeOptionsResult.routeOptions,
                             fasterRouteRequestCallback
                         )
-                    is RouteOptionsProvider.RouteOptionsResult.Error -> Unit
+                    is RouteOptionsUpdater.RouteOptionsResult.Error -> Unit
                 }
             }
     }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/MapboxDistanceFormatter.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/MapboxDistanceFormatter.kt
@@ -30,7 +30,6 @@ import kotlin.math.roundToInt
  * @param locale the locale to use for localization of distance resources
  * @param unitType to use, or UNDEFINED to use default for locale country
  * @param roundingIncrement increment by which to round small distances
- * @param builder used for updating options
  */
 class MapboxDistanceFormatter private constructor(
     private val applicationContext: Context,

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/MapboxReplayer.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/MapboxReplayer.kt
@@ -58,10 +58,9 @@ class MapboxReplayer {
      * Remove registered observers.
      *
      * @param observer the observer being removed
-     * @return true if the observer was registered, false otherwise
      */
-    fun unregisterObserver(observer: ReplayEventsObserver): Boolean {
-        return replayEventsObservers.remove(observer)
+    fun unregisterObserver(observer: ReplayEventsObserver) {
+        replayEventsObservers.remove(observer)
     }
 
     /**

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayRouteOptions.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayRouteOptions.kt
@@ -22,7 +22,7 @@ class ReplayRouteOptions private constructor(
     /**
      * @return the builder that created the [ReplayRouteOptions]
      */
-    fun toBuilder() = Builder().apply {
+    fun toBuilder(): Builder = Builder().apply {
         maxSpeedMps(maxSpeedMps)
         turnSpeedMps(turnSpeedMps)
         uTurnSpeedMps(uTurnSpeedMps)

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/reroute/MapboxRerouteController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/reroute/MapboxRerouteController.kt
@@ -8,7 +8,7 @@ import com.mapbox.base.common.logger.model.Message
 import com.mapbox.base.common.logger.model.Tag
 import com.mapbox.navigation.core.directions.session.DirectionsSession
 import com.mapbox.navigation.core.directions.session.RoutesRequestCallback
-import com.mapbox.navigation.core.routeoptions.RouteOptionsProvider
+import com.mapbox.navigation.core.routeoptions.RouteOptionsUpdater
 import com.mapbox.navigation.core.trip.session.TripSession
 import com.mapbox.navigation.utils.internal.JobControl
 import com.mapbox.navigation.utils.internal.ThreadController
@@ -21,7 +21,7 @@ import kotlinx.coroutines.launch
 internal class MapboxRerouteController(
     private val directionsSession: DirectionsSession,
     private val tripSession: TripSession,
-    private val routeOptionsProvider: RouteOptionsProvider,
+    private val routeOptionsUpdater: RouteOptionsUpdater,
     threadController: ThreadController = ThreadController,
     private val logger: Logger
 ) : RerouteController {
@@ -47,17 +47,17 @@ internal class MapboxRerouteController(
             Tag(TAG),
             Message("Fetching route")
         )
-        routeOptionsProvider.update(
+        routeOptionsUpdater.update(
             directionsSession.getRouteOptions(),
             tripSession.getRouteProgress(),
             tripSession.getEnhancedLocation()
         )
             .let { routeOptionsResult ->
                 when (routeOptionsResult) {
-                    is RouteOptionsProvider.RouteOptionsResult.Success -> {
+                    is RouteOptionsUpdater.RouteOptionsResult.Success -> {
                         request(routeOptionsResult.routeOptions)
                     }
-                    is RouteOptionsProvider.RouteOptionsResult.Error -> {
+                    is RouteOptionsUpdater.RouteOptionsResult.Error -> {
                         mainJobController.scope.launch {
                             state = RerouteState.Failed(
                                 "Cannot combine route options", routeOptionsResult.error

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/reroute/RerouteController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/reroute/RerouteController.kt
@@ -2,6 +2,7 @@ package com.mapbox.navigation.core.reroute
 
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.routeoptions.MapboxRouteOptionsUpdater
 import com.mapbox.navigation.core.trip.session.OffRouteObserver
 
 /**
@@ -93,6 +94,9 @@ sealed class RerouteState {
 
     /**
      * Re-route request has failed.
+     *
+     * You can [MapboxNavigation.requestRoutes] with [MapboxRouteOptionsUpdater] to retry the request.
+     *
      * @param message describes error
      * @param throwable is optional
      */

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/routeoptions/MapboxRouteOptionsUpdater.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/routeoptions/MapboxRouteOptionsUpdater.kt
@@ -8,36 +8,34 @@ import com.mapbox.base.common.logger.model.Tag
 import com.mapbox.geojson.Point
 import com.mapbox.navigation.base.trip.model.RouteProgress
 
-/**
- * Default implementation of [RouteOptionsProvider]
- */
-internal class MapboxRouteOptionsProvider(
-    private val logger: Logger
-) : RouteOptionsProvider {
+private const val DEFAULT_REROUTE_BEARING_TOLERANCE = 90.0
 
-    private companion object {
-        const val DEFAULT_REROUTE_BEARING_TOLERANCE = 90.0
-    }
+/**
+ * Default implementation of [RouteOptionsUpdater].
+ */
+class MapboxRouteOptionsUpdater(
+    private val logger: Logger? = null
+) : RouteOptionsUpdater {
 
     /**
-     * Provides a new instance of *RouteOptions* based on initial *RouteOptions*, *RouteProgress* and
-     * current *Location*
+     * Provides a new [RouteOptions] instance based on the original request options and the current route progress.
      *
-     * Returns *null* if a new [RouteOptions] instance cannot be combined based on the input given.
+     * Returns *null* if a new [RouteOptions] instance cannot be combined based on the input given. When *null*
+     * is returned new route is not fetched.
      */
     override fun update(
         routeOptions: RouteOptions?,
         routeProgress: RouteProgress?,
         location: Location?
-    ): RouteOptionsProvider.RouteOptionsResult {
+    ): RouteOptionsUpdater.RouteOptionsResult {
         if (routeOptions == null || routeProgress == null || location == null) {
             val msg = "Cannot combine RouteOptions, invalid inputs. routeOptions, " +
                 "routeProgress, and location mustn't be null"
-            logger.w(
+            logger?.w(
                 Tag("MapboxRouteOptionsProvider"),
                 Message(msg)
             )
-            return RouteOptionsProvider.RouteOptionsResult.Error(Throwable(msg))
+            return RouteOptionsUpdater.RouteOptionsResult.Error(Throwable(msg))
         }
 
         val optionsBuilder = routeOptions.toBuilder()
@@ -127,6 +125,6 @@ internal class MapboxRouteOptionsProvider(
                 })
         }
 
-        return RouteOptionsProvider.RouteOptionsResult.Success(optionsBuilder.build())
+        return RouteOptionsUpdater.RouteOptionsResult.Success(optionsBuilder.build())
     }
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/routeoptions/RouteOptionsUpdater.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/routeoptions/RouteOptionsUpdater.kt
@@ -7,19 +7,20 @@ import com.mapbox.navigation.core.fasterroute.FasterRouteController
 import com.mapbox.navigation.core.trip.session.OffRouteObserver
 
 /**
- * Provider is used for *Reroute* and *Faster Route* flow.
+ * Updater is used for *Reroute* and *Faster Route* flow.
  *
  * It's used every time when turn-by-turn navigation goes off-route (see [OffRouteObserver])
- * and when needs to find faster route (see [FasterRouteController]).
+ * and when needs to find faster route (see [FasterRouteController]) to fetch a new route using a transformed original request.
+ *
+ * @see MapboxRouteOptionsUpdater
  */
-internal interface RouteOptionsProvider {
+interface RouteOptionsUpdater {
 
     /**
-     * Provides a new *RouteOptions* instance based on *RouteOptions*, *RouteProgress*, and
-     * *Location*
+     * Provides a new [RouteOptions] instance based on the original request options and the current route progress.
      *
      * Returns *null* if a new [RouteOptions] instance cannot be combined based on the input given. When *null*
-     * is returned new route is not fetched
+     * is returned new route is not fetched.
      */
     fun update(
         routeOptions: RouteOptions?,
@@ -27,8 +28,22 @@ internal interface RouteOptionsProvider {
         location: Location?
     ): RouteOptionsResult
 
+    /**
+     * Describes a result of generating new options from the original request and the current route progress.
+     */
     sealed class RouteOptionsResult {
+        /**
+         * Successful operation.
+         *
+         * @param routeOptions the recreated route option from the current route progress
+         */
         data class Success(val routeOptions: RouteOptions) : RouteOptionsResult()
+
+        /**
+         * Failed operation.
+         *
+         * @param error reason
+         */
         data class Error(val error: Throwable) : RouteOptionsResult()
     }
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/sensors/SensorOptions.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/sensors/SensorOptions.kt
@@ -14,7 +14,7 @@ class SensorOptions private constructor(
     /**
      * @return the builder that created the [SensorOptions]
      */
-    fun toBuilder() = Builder().apply {
+    fun toBuilder(): Builder = Builder().apply {
         enableSensorTypes(enableSensorTypes)
         signalsPerSecond(signalsPerSecond)
     }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/events/AppMetadata.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/events/AppMetadata.kt
@@ -28,7 +28,7 @@ class AppMetadata private constructor(
     /**
      * Get a builder to customize a subset of current options.
      */
-    fun toBuilder() = Builder(name, version).apply {
+    fun toBuilder(): Builder = Builder(name, version).apply {
         userId(userId)
         sessionId(sessionId)
     }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/fasterroute/FasterRouteControllerTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/fasterroute/FasterRouteControllerTest.kt
@@ -5,7 +5,7 @@ import com.mapbox.api.directions.v5.models.RouteOptions
 import com.mapbox.base.common.logger.Logger
 import com.mapbox.navigation.core.directions.session.DirectionsSession
 import com.mapbox.navigation.core.directions.session.RoutesRequestCallback
-import com.mapbox.navigation.core.routeoptions.RouteOptionsProvider
+import com.mapbox.navigation.core.routeoptions.RouteOptionsUpdater
 import com.mapbox.navigation.core.trip.session.TripSession
 import com.mapbox.navigation.testing.MainCoroutineRule
 import io.mockk.coEvery
@@ -35,13 +35,13 @@ class FasterRouteControllerTest {
     }
     private val routesRequestCallbacks = slot<RoutesRequestCallback>()
     private val logger: Logger = mockk()
-    private val routeOptionsProvider: RouteOptionsProvider = mockk()
+    private val routeOptionsUpdater: RouteOptionsUpdater = mockk()
 
-    private val routeOptionsResultSuccess: RouteOptionsProvider.RouteOptionsResult.Success = mockk()
+    private val routeOptionsResultSuccess: RouteOptionsUpdater.RouteOptionsResult.Success = mockk()
     private val routeOptionsResultSuccessRouteOptions: RouteOptions = mockk()
     private val fasterRouteDetector: FasterRouteDetector = mockk()
 
-    private val fasterRouteController = FasterRouteController(directionsSession, tripSession, routeOptionsProvider, fasterRouteDetector, logger)
+    private val fasterRouteController = FasterRouteController(directionsSession, tripSession, routeOptionsUpdater, fasterRouteDetector, logger)
 
     @Before
     fun setup() {
@@ -164,7 +164,7 @@ class FasterRouteControllerTest {
         coroutineRule.testDispatcher.cleanupTestCoroutines()
     }
 
-    private fun mockRouteOptionsProvider(routeOptionsResult: RouteOptionsProvider.RouteOptionsResult) {
-        every { routeOptionsProvider.update(any(), any(), any()) } returns routeOptionsResult
+    private fun mockRouteOptionsProvider(routeOptionsResult: RouteOptionsUpdater.RouteOptionsResult) {
+        every { routeOptionsUpdater.update(any(), any(), any()) } returns routeOptionsResult
     }
 }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/reroute/MapboxRerouteControllerTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/reroute/MapboxRerouteControllerTest.kt
@@ -4,7 +4,7 @@ import com.mapbox.api.directions.v5.models.RouteOptions
 import com.mapbox.base.common.logger.Logger
 import com.mapbox.navigation.core.directions.session.DirectionsSession
 import com.mapbox.navigation.core.directions.session.RoutesRequestCallback
-import com.mapbox.navigation.core.routeoptions.RouteOptionsProvider
+import com.mapbox.navigation.core.routeoptions.RouteOptionsUpdater
 import com.mapbox.navigation.core.trip.session.TripSession
 import com.mapbox.navigation.testing.MainCoroutineRule
 import com.mapbox.navigation.utils.internal.ThreadController
@@ -37,19 +37,19 @@ class MapboxRerouteControllerTest {
     private lateinit var tripSession: TripSession
 
     @MockK
-    private lateinit var routeOptionsProvider: RouteOptionsProvider
+    private lateinit var routeOptionsUpdater: RouteOptionsUpdater
 
     @MockK
     private lateinit var logger: Logger
 
     @MockK
-    private lateinit var successFromResult: RouteOptionsProvider.RouteOptionsResult.Success
+    private lateinit var successFromResult: RouteOptionsUpdater.RouteOptionsResult.Success
 
     @MockK
     private lateinit var routeOptionsFromSuccessResult: RouteOptions
 
     @MockK
-    private lateinit var errorFromResult: RouteOptionsProvider.RouteOptionsResult.Error
+    private lateinit var errorFromResult: RouteOptionsUpdater.RouteOptionsResult.Error
 
     @MockK
     private lateinit var routeCallback: RerouteController.RoutesCallback
@@ -67,7 +67,7 @@ class MapboxRerouteControllerTest {
             MapboxRerouteController(
                 directionsSession,
                 tripSession,
-                routeOptionsProvider,
+                routeOptionsUpdater,
                 ThreadController,
                 logger
             )
@@ -332,13 +332,13 @@ class MapboxRerouteControllerTest {
         return rerouteController.registerRerouteStateObserver(rerouteStateObserver)
     }
 
-    private fun mockRouteOptionsResult(_routeOptionsResult: RouteOptionsProvider.RouteOptionsResult) {
+    private fun mockRouteOptionsResult(_routeOptionsResult: RouteOptionsUpdater.RouteOptionsResult) {
         assertFalse(
             "routeOptionsResult mustn't be the *RouteOptionsProvider.RouteOptionsResult*, subclass is applied only",
             _routeOptionsResult::class.isAbstract
         )
         every {
-            routeOptionsProvider.update(
+            routeOptionsUpdater.update(
                 any(),
                 any(),
                 any()

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/routeoptions/MapboxRouteOptionsUpdaterTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/routeoptions/MapboxRouteOptionsUpdaterTest.kt
@@ -15,14 +15,14 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
-class MapboxRouteOptionsProviderTest {
+class MapboxRouteOptionsUpdaterTest {
 
     @MockK
     private lateinit var logger: Logger
 
     private val accessToken = "pk.1234pplffd"
 
-    private lateinit var routeRefreshAdapter: MapboxRouteOptionsProvider
+    private lateinit var routeRefreshAdapter: MapboxRouteOptionsUpdater
     private lateinit var location: Location
 
     companion object {
@@ -35,7 +35,7 @@ class MapboxRouteOptionsProviderTest {
         MockKAnnotations.init(this, relaxUnitFun = true, relaxed = true)
         mockLocation()
 
-        routeRefreshAdapter = MapboxRouteOptionsProvider(logger)
+        routeRefreshAdapter = MapboxRouteOptionsUpdater(logger)
     }
 
     @Test
@@ -46,8 +46,8 @@ class MapboxRouteOptionsProviderTest {
         val newRouteOptions =
             routeRefreshAdapter.update(routeOptions, routeProgress, location)
                 .let {
-                    assertTrue(it is RouteOptionsProvider.RouteOptionsResult.Success)
-                    return@let it as RouteOptionsProvider.RouteOptionsResult.Success
+                    assertTrue(it is RouteOptionsUpdater.RouteOptionsResult.Success)
+                    return@let it as RouteOptionsUpdater.RouteOptionsResult.Success
                 }
                 .routeOptions
 
@@ -73,8 +73,8 @@ class MapboxRouteOptionsProviderTest {
         val newRouteOptions =
             routeRefreshAdapter.update(routeOptions, routeProgress, location)
                 .let {
-                    assertTrue(it is RouteOptionsProvider.RouteOptionsResult.Success)
-                    return@let it as RouteOptionsProvider.RouteOptionsResult.Success
+                    assertTrue(it is RouteOptionsUpdater.RouteOptionsResult.Success)
+                    return@let it as RouteOptionsUpdater.RouteOptionsResult.Success
                 }
                 .routeOptions
 
@@ -102,7 +102,7 @@ class MapboxRouteOptionsProviderTest {
 
             assertTrue(
                 message,
-                routeRefreshAdapter.update(routeOptions, routeProgress, location) is RouteOptionsProvider.RouteOptionsResult.Error
+                routeRefreshAdapter.update(routeOptions, routeProgress, location) is RouteOptionsUpdater.RouteOptionsResult.Error
             )
         }
     }


### PR DESCRIPTION
I briefly went through all of Nav Core classes, updated the docs, references, annotations, and URLs wherever needed in preparation for the stable release.

As part of auditing the public APIs, I also exposed (and renamed) the `MapboxRouteOptionsUpdater` which rebuilds the route options using the initial route request and the current progress. Since there is no internal retry mechanism for rerouting requests, I think we need to expose an easy to use way to retry this request manually to help developers build a robust navigation experience. I'm happy to discuss and revert this change if there are any concerns. /cc @asinghal22 