### PR TITLE
Update data from navigator status right after a route is set

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
@@ -78,6 +78,9 @@ internal class MapboxTripSession(
             ioJobController.scope.launch {
                 cancelOngoingUpdateNavigatorStatusDataJobs()
                 navigator.setRoute(value)
+                if (state == TripSessionState.STARTED) {
+                    updateDataFromNavigatorStatus(Date())
+                }
             }
             isOffRoute = false
         }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/internal/trip/session/MapboxTripSessionTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/internal/trip/session/MapboxTripSessionTest.kt
@@ -32,6 +32,7 @@ import com.mapbox.navigator.NavigationStatus
 import io.mockk.clearMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.coVerifyOrder
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -604,14 +605,36 @@ class MapboxTripSessionTest {
     fun setRoute() {
         tripSession.route = route
 
-        coVerify { navigator.setRoute(route) }
+        coVerify(exactly = 1) { navigator.setRoute(route) }
     }
 
     @Test
     fun setRoute_nullable() {
         tripSession.route = null
 
-        coVerify { navigator.setRoute(null) }
+        coVerify(exactly = 1) { navigator.setRoute(null) }
+    }
+
+    @Test
+    fun checksGetNavigatorStatusIsCalledAfterSettingARouteWhenTripSessionHasStarted() {
+        tripSession.start()
+
+        tripSession.route = route
+
+        coVerify(exactly = 1) { navigator.setRoute(route) }
+        coVerify(exactly = 1) { navigator.getStatus(any()) }
+        coVerifyOrder {
+            navigator.setRoute(route)
+            navigator.getStatus(any())
+        }
+    }
+
+    @Test
+    fun checksGetNavigatorStatusIsNotCalledAfterSettingARouteIfTripSessionHasNotStarted() {
+        tripSession.route = route
+
+        coVerify(exactly = 1) { navigator.setRoute(route) }
+        coVerify(exactly = 0) { navigator.getStatus(any()) }
     }
 
     @Test


### PR DESCRIPTION
## Description

Calls `updateDataFromNavigatorStatus` right after a route is set if `TripSessionState.STARTED`

Follow up from https://github.com/mapbox/mapbox-navigation-android/pull/3424#issuecomment-672375626

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

From @SiarheiFedartsou 

> if you call `getStatus`  again after setting the route it can do map matching in a little bit different way - candidates which belongs to route will have more chance to be your position - i.e. we suppose that you have more chance to be on route, than off route. Maybe it is better to call `getStatus`  again after `setRoute` , but it will have any impact in very small number of cases.

### Implementation

Calls `updateDataFromNavigatorStatus` right after a route is set if `TripSessionState.STARTED`

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs

cc @mskurydin 