### PR TITLE
Fix README.md - Add ``` backticks to separate source bode blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ allprojects {
 dependencies {
    implementation 'com.mapbox.navigation:ui-v1:1.0.0-SNAPSHOT'
 }
+```
 
 ##### Pre-`1.0.0` versions of the Navigation SDK:
 


### PR DESCRIPTION
## Description

Please include a brief summary of the change and which issue is fixed (e.g., fixes [#issue](link)):

Fixed the two code blocks being rendered as one. The `####` part is a section, but it wasn't rendered as such, because the first code block was not closed.

### Goal

Fix 

## Testing
Please describe the manual tests that you ran to verify your changes:

Tested it via the Github Markdown Preview tab.

## Checklist

- [x] I have performed a self-review of my own code
[x] I have made corresponding changes to the documentation