### PR TITLE
Add ``` backticks to separate source bode blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ allprojects {
 dependencies {
    implementation 'com.mapbox.navigation:ui-v1:1.0.0-SNAPSHOT'
 }
+```
 
 ##### Pre-`1.0.0` versions of the Navigation SDK:
 


### PR DESCRIPTION
### Contribution from @carstenhag in https://github.com/mapbox/mapbox-navigation-android/pull/3432

## Description

> Fix README.md - Add ``` backticks to separate source bode blocks

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

> Fix README.md - Add ``` backticks to separate source bode blocks

### Implementation

Add syntax highlighting to some `README` snippets

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
