### PR TITLE
Fix Transifex 1.0 issues / regressions

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -3,21 +3,15 @@ host = https://www.transifex.com
 minimum_perc = 20
 lang_map = pt_BR: pt-rBR, pt_PT: pt-rPT
 
-[mapbox-navigation-sdk-for-android.test-app-strings-file]
-file_filter = app/src/main/res/values-<lang>/strings.xml
-source_file = app/src/main/res/values/strings.xml
+[mapbox-navigation-sdk-for-android.examples-app-strings-file]
+file_filter = examples/src/main/res/values-<lang>/strings.xml
+source_file = examples/src/main/res/values/strings.xml
 source_lang = en
 type = ANDROID
 
-[mapbox-navigation-sdk-for-android.libandroid-navigation-strings-file]
-file_filter = libandroid-navigation/src/main/res/values-<lang>/strings.xml
-source_file = libandroid-navigation/src/main/res/values/strings.xml
-source_lang = en
-type = ANDROID
-
-[mapbox-navigation-sdk-for-android.libandroid-navigation-ui-strings-file]
-file_filter = libandroid-navigation-ui/src/main/res/values-<lang>/strings.xml
-source_file = libandroid-navigation-ui/src/main/res/values/strings.xml
+[mapbox-navigation-sdk-for-android.libnavigation-ui-strings-file]
+file_filter = libnavigation-ui/src/main/res/values-<lang>/strings.xml
+source_file = libnavigation-ui/src/main/res/values/strings.xml
 source_lang = en
 type = ANDROID
 


### PR DESCRIPTION
## Description

Fixes Transifex 1.0 issues / regressions updating / adapting Transifex `config`
It also enables `examples` test app translations although most of them are marked as `translatable = false` (we should fix as part of https://github.com/mapbox/mapbox-navigation-android/issues/2909 cc @abhishek1508 @langsmith @1ec5 

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Fix Transifex config after latest changes / setup introduced for 1.0 so translations can be pulled

### Implementation

- Remove `libandroid-navigation`
- Replace `libandroid-navigation-ui` by `libnavigation-ui` (preventing translations to be pulled)
- Replace `app` by `examples` (enabling internationalization of the `examples` test app) 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
