### PR TITLE
Bump mapbox-android-telemetry version to 6.1.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -9,7 +9,7 @@ ext {
   version = [
       mapboxMapSdk              : '9.4.0-beta.1',
       mapboxSdkServices         : '5.4.1',
-      mapboxEvents              : '6.0.0',
+      mapboxEvents              : '6.1.0',
       mapboxCore                : '3.0.0',
       mapboxNavigator           : '18.0.3',
       mapboxCommon              : '4.0.0',


### PR DESCRIPTION
## Description

Bumps `mapbox-android-telemetry` version to `6.1.0`

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Getting the latest version from `mapboxEvents` including the new features and bug fixes.

### Implementation

Bumping the `mapboxEvents` version to `6.1.0` in `dependencies.gradle`

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs

cc @mr1sunshine @nagineni 