### PR TITLE
Incorrect telemetry location timestamp format and missing locations from reroute events

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/events/NavigationFeedbackEvent.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/events/NavigationFeedbackEvent.kt
@@ -1,7 +1,6 @@
 package com.mapbox.navigation.core.telemetry.events
 
 import android.annotation.SuppressLint
-import com.google.gson.annotations.SerializedName
 import com.mapbox.navigation.base.metrics.NavigationMetrics
 
 @SuppressLint("ParcelCreator")
@@ -20,22 +19,11 @@ internal class NavigationFeedbackEvent(
     var feedbackType: String? = null
     var source: String? = null
     var description: String? = null
-    var locationsBefore: Array<FeedbackLocation>? = emptyArray()
-    var locationsAfter: Array<FeedbackLocation>? = emptyArray()
+    var locationsBefore: Array<TelemetryLocation>? = emptyArray()
+    var locationsAfter: Array<TelemetryLocation>? = emptyArray()
     var screenshot: String? = null
     var feedbackSubType: Array<String>? = emptyArray()
     var appMetadata: AppMetadata? = null
 
     override fun getEventName(): String = NavigationMetrics.FEEDBACK
 }
-
-internal data class FeedbackLocation(
-    @SerializedName("lat") val latitude: Double,
-    @SerializedName("lng") val longitude: Double,
-    @SerializedName("speed") val speed: Float,
-    @SerializedName("course") val bearing: Float,
-    @SerializedName("altitude") val altitude: Double,
-    @SerializedName("timestamp") val timestamp: Long,
-    @SerializedName("horizontalAccuracy") val horizontalAccuracy: Float,
-    @SerializedName("verticalAccuracy") val verticalAccuracy: Float
-)

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/events/NavigationRerouteEvent.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/events/NavigationRerouteEvent.kt
@@ -1,7 +1,6 @@
 package com.mapbox.navigation.core.telemetry.events
 
 import android.annotation.SuppressLint
-import android.location.Location
 import com.mapbox.navigation.base.metrics.NavigationMetrics
 
 @SuppressLint("ParcelCreator")
@@ -20,8 +19,8 @@ internal class NavigationRerouteEvent(
     val newGeometry: String = rerouteEvent.newRouteGeometry
     val step: NavigationStepData = NavigationStepData(metricsRouteProgress)
     var secondsSinceLastReroute: Int = 0
-    var locationsBefore: Array<Location>? = emptyArray()
-    var locationsAfter: Array<Location>? = emptyArray()
+    var locationsBefore: Array<TelemetryLocation>? = emptyArray()
+    var locationsAfter: Array<TelemetryLocation>? = emptyArray()
     var screenshot: String? = null
 
     override fun getEventName(): String = NavigationMetrics.REROUTE

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/events/TelemetryLocation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/events/TelemetryLocation.kt
@@ -1,0 +1,14 @@
+package com.mapbox.navigation.core.telemetry.events
+
+import com.google.gson.annotations.SerializedName
+
+internal data class TelemetryLocation(
+    @SerializedName("lat") val latitude: Double,
+    @SerializedName("lng") val longitude: Double,
+    @SerializedName("speed") val speed: Float,
+    @SerializedName("course") val bearing: Float,
+    @SerializedName("altitude") val altitude: Double,
+    @SerializedName("timestamp") val timestamp: String,
+    @SerializedName("horizontalAccuracy") val horizontalAccuracy: Float,
+    @SerializedName("verticalAccuracy") val verticalAccuracy: Float
+)

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/FeedbackLocationTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/FeedbackLocationTest.kt
@@ -2,7 +2,7 @@ package com.mapbox.navigation.core.telemetry
 
 import android.location.Location
 import com.google.gson.Gson
-import com.mapbox.navigation.core.telemetry.events.FeedbackLocation
+import com.mapbox.navigation.core.telemetry.events.TelemetryLocation
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.Assert.assertEquals
@@ -28,20 +28,20 @@ class FeedbackLocationTest {
 
     @Test
     fun checkLocationSerialization() {
-        val feedbackLocation = FeedbackLocation(
+        val feedbackLocation = TelemetryLocation(
             location.latitude,
             location.longitude,
             location.speed,
             location.bearing,
             location.altitude,
-            location.time,
+            location.time.toString(),
             location.accuracy,
             location.verticalAccuracyMeters
         )
 
         val feedbackLocationJson = gson.toJson(feedbackLocation)
         val deserializedFeedbackLocation =
-            gson.fromJson(feedbackLocationJson, FeedbackLocation::class.java)
+            gson.fromJson(feedbackLocationJson, TelemetryLocation::class.java)
 
         deserializedFeedbackLocation.run {
             assertEquals(location.latitude, latitude, 0.0)
@@ -49,7 +49,7 @@ class FeedbackLocationTest {
             assertEquals(location.speed, speed)
             assertEquals(location.bearing, bearing)
             assertEquals(location.altitude, altitude, 0.0)
-            assertEquals(location.time, timestamp)
+            assertEquals(location.time.toString(), timestamp)
             assertEquals(location.accuracy, horizontalAccuracy)
             assertEquals(location.verticalAccuracyMeters, verticalAccuracy)
         }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/NavigationFeedbackEventTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/NavigationFeedbackEventTest.kt
@@ -2,10 +2,10 @@ package com.mapbox.navigation.core.telemetry
 
 import com.google.gson.Gson
 import com.mapbox.navigation.core.telemetry.events.AppMetadata
-import com.mapbox.navigation.core.telemetry.events.FeedbackLocation
 import com.mapbox.navigation.core.telemetry.events.MetricsRouteProgress
 import com.mapbox.navigation.core.telemetry.events.NavigationFeedbackEvent
 import com.mapbox.navigation.core.telemetry.events.PhoneState
+import com.mapbox.navigation.core.telemetry.events.TelemetryLocation
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.Assert.assertArrayEquals
@@ -23,7 +23,7 @@ class NavigationFeedbackEventTest {
         .sessionId(APP_METADATA_SESSION_ID)
         .build()
 
-    private val locationBefore = FeedbackLocation(
+    private val locationBefore = TelemetryLocation(
         LOCATION_BEFORE_LATITUDE,
         LOCATION_BEFORE_LONGITUDE,
         LOCATION_BEFORE_SPEED,
@@ -33,7 +33,7 @@ class NavigationFeedbackEventTest {
         LOCATION_BEFORE_HORIZONTAL_ACCURACY,
         LOCATION_BEFORE_VERTICAL_ACCURACY
     )
-    private val locationAfter = FeedbackLocation(
+    private val locationAfter = TelemetryLocation(
         LOCATION_AFTER_LATITUDE,
         LOCATION_AFTER_LONGITUDE,
         LOCATION_AFTER_SPEED,
@@ -171,7 +171,7 @@ class NavigationFeedbackEventTest {
         private const val LOCATION_BEFORE_SPEED = 30f
         private const val LOCATION_BEFORE_BEARING = 200f
         private const val LOCATION_BEFORE_ALTITUDE = 10.0
-        private const val LOCATION_BEFORE_TIMESTAMP = 999999L
+        private const val LOCATION_BEFORE_TIMESTAMP = "999999"
         private const val LOCATION_BEFORE_HORIZONTAL_ACCURACY = 1f
         private const val LOCATION_BEFORE_VERTICAL_ACCURACY = 2f
 
@@ -181,7 +181,7 @@ class NavigationFeedbackEventTest {
         private const val LOCATION_AFTER_SPEED = 50f
         private const val LOCATION_AFTER_BEARING = 330f
         private const val LOCATION_AFTER_ALTITUDE = 17.0
-        private const val LOCATION_AFTER_TIMESTAMP = 55555555L
+        private const val LOCATION_AFTER_TIMESTAMP = "55555555"
         private const val LOCATION_AFTER_HORIZONTAL_ACCURACY = 55f
         private const val LOCATION_AFTER_VERTICAL_ACCURACY = 44f
     }


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

This PR fixes a regression from https://github.com/mapbox/mapbox-navigation-android/pull/3386 that prevented out navigation feedback telemetry events from being ingested because of the incorrect `timestamp` format of the location sample. It should be a `string` while we were pushing a `number`.

### Implementation

I first extended the schema test to verify nested arrays and objects that reproduced the original issues and also caught the same issue of missing location samples for reroute events that https://github.com/mapbox/mapbox-navigation-android/pull/3386 fixed for feedback events.

I think my test extension now also duplicates a couple of checks that the schema test already does, but I'd prefer tackling the test class refactor in a separate PR.

## Testing

I'm going to push some events locally now and verify that they ended up in our pipeline tomorrow.