### PR TITLE
Add navigator single thread dispatcher scope to ThreadController

### DIFF
--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
@@ -87,8 +87,8 @@ class MapboxTripSessionTest {
     @Before
     fun setUp() {
         mockkObject(ThreadController)
-        every { ThreadController.IODispatcher } returns coroutineRule.testDispatcher
-        every { ThreadController.getIOScopeAndRootJob() } returns JobControl(parentJob, testScope)
+        every { ThreadController.NavigatorDispatcher } returns coroutineRule.testDispatcher
+        every { ThreadController.getNavigatorScopeAndRootJob() } returns JobControl(parentJob, testScope)
         every { ThreadController.getMainScopeAndRootJob() } returns JobControl(parentJob, testScope)
 
         tripSession = MapboxTripSession(

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigator.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigator.kt
@@ -39,7 +39,7 @@ interface MapboxNativeNavigator {
      *
      * @return true if the raw location was usable, false if not.
      */
-    suspend fun updateLocation(rawLocation: Location, date: Date): Boolean
+    fun updateLocation(rawLocation: Location, date: Date): Boolean
 
     /**
      * Passes in the current sensor data of the user.
@@ -64,7 +64,7 @@ interface MapboxNativeNavigator {
      * @return the last [TripStatus] as a result of fixed location updates. If the timestamp
      * is earlier than a previous call, the last status will be returned. The function does not support re-winding time.
      */
-    suspend fun getStatus(date: Date): TripStatus
+    fun getStatus(date: Date): TripStatus
 
     // Routing
 
@@ -79,7 +79,7 @@ interface MapboxNativeNavigator {
      * @return a [NavigationStatus] route state if no errors occurred.
      * Otherwise, it returns a invalid route state.
      */
-    suspend fun setRoute(
+    fun setRoute(
         route: DirectionsRoute?,
         legIndex: Int = INDEX_FIRST_LEG
     ): NavigationStatus


### PR DESCRIPTION
## Description

Adds navigator single thread dispatcher scope to `ThreadController` use it in `MapboxTripSession` for NN interactions instead of `IO` removing the need of the `MapboxNativeNavigatorImpl` `Mutex`

Follow up from https://github.com/mapbox/mapbox-navigation-android/pull/3424#issuecomment-672375626

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Have a single thread dispatcher dedicated for NN so that the `Mutex` from `MapboxNativeNavigatorImpl` can be removed

### Implementation

- Add navigator single thread dispatcher scope to `ThreadController` and use it in `MapboxTripSession` for NN interactions instead of `IO`
- Remove `MapboxNativeNavigatorImpl` `Mutex`

## Testing

We should run extensive and field testing but from the local one everything looks to work 👌 

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs