### PR TITLE
Fix missing destination marker regression when using the Drop-in UI

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/ui/TrafficToggleActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/ui/TrafficToggleActivity.kt
@@ -119,7 +119,6 @@ class TrafficToggleActivity : AppCompatActivity(), OnNavigationReadyCallback,
     }
 
     override fun onNavigationRunning() {
-        
     }
 
     override fun onNavigationFinished() {
@@ -147,4 +146,3 @@ class TrafficToggleActivity : AppCompatActivity(), OnNavigationReadyCallback,
         return DirectionsRoute.fromJson(directionsRouteAsJson)
     }
 }
-

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationViewModel.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationViewModel.java
@@ -467,6 +467,10 @@ public class NavigationViewModel extends AndroidViewModel {
   private RoutesObserver routesObserver = routes -> {
     if (routes.size() > 0) {
       route.setValue(routes.get(0));
+      RouteOptions routeOptions = routes.get(0).routeOptions();
+      if (routeOptions != null) {
+        destination.setValue(routeOptions.coordinates().get(routes.get(0).routeOptions().coordinates().size() - 1));
+      }
     }
   };
 

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/NavigationSymbolManager.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/NavigationSymbolManager.java
@@ -16,6 +16,7 @@ class NavigationSymbolManager {
 
   static final String MAPBOX_NAVIGATION_MARKER_NAME = "mapbox-navigation-marker";
   private final List<Symbol> mapMarkersSymbols = new ArrayList<>();
+  private Symbol destinationSymbol = null;
   @NonNull
   private final SymbolManager symbolManager;
 
@@ -26,8 +27,12 @@ class NavigationSymbolManager {
   }
 
   void addDestinationMarkerFor(@NonNull Point position) {
+    if (destinationSymbol != null) {
+      symbolManager.delete(destinationSymbol);
+      mapMarkersSymbols.remove(destinationSymbol);
+    }
     SymbolOptions options = createSymbolOptionsFor(position);
-    createSymbolFrom(options);
+    destinationSymbol = createSymbolFrom(options);
   }
 
   void addCustomSymbolFor(@NonNull SymbolOptions options) {
@@ -39,6 +44,7 @@ class NavigationSymbolManager {
       symbolManager.delete(markerSymbol);
     }
     mapMarkersSymbols.clear();
+    destinationSymbol = null;
   }
 
   @NonNull
@@ -50,8 +56,9 @@ class NavigationSymbolManager {
       .withIconImage(MAPBOX_NAVIGATION_MARKER_NAME);
   }
 
-  private void createSymbolFrom(@NonNull SymbolOptions options) {
+  private Symbol createSymbolFrom(@NonNull SymbolOptions options) {
     Symbol symbol = symbolManager.create(options);
     mapMarkersSymbols.add(symbol);
+    return symbol;
   }
 }

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/NavigationViewModelTest.java
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/NavigationViewModelTest.java
@@ -1,18 +1,14 @@
 package com.mapbox.navigation.ui;
 
 import android.app.Application;
-
-import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.navigation.core.MapboxNavigation;
 import com.mapbox.navigation.ui.voice.SpeechPlayer;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @RunWith(RobolectricTestRunner.class)

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/map/NavigationSymbolManagerTest.java
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/map/NavigationSymbolManagerTest.java
@@ -8,7 +8,9 @@ import com.mapbox.mapboxsdk.plugins.annotation.SymbolOptions;
 import org.junit.Test;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -28,6 +30,22 @@ public class NavigationSymbolManagerTest {
   }
 
   @Test
+  public void addDestinationMarkerFor_destinationSymbolRemovedIfPreviouslyAdded() {
+    SymbolManager symbolManager = mock(SymbolManager.class);
+    Symbol oldDestinationSymbol = mock(Symbol.class);
+    Symbol currentDestinationSymbol = mock(Symbol.class);
+    when(symbolManager.create(any(SymbolOptions.class))).thenReturn(oldDestinationSymbol, currentDestinationSymbol);
+    NavigationSymbolManager navigationSymbolManager = new NavigationSymbolManager(symbolManager);
+    Point position = Point.fromLngLat(1.2345, 1.3456);
+
+    navigationSymbolManager.addDestinationMarkerFor(position);
+    navigationSymbolManager.addDestinationMarkerFor(position);
+
+    verify(symbolManager, times(2)).create(any(SymbolOptions.class));
+    verify(symbolManager, times(1)).delete(eq(oldDestinationSymbol));
+  }
+
+  @Test
   public void removeAllMarkerSymbols_previouslyAddedMarkersRemoved() {
     SymbolManager symbolManager = mock(SymbolManager.class);
     Symbol symbol = mock(Symbol.class);
@@ -42,7 +60,7 @@ public class NavigationSymbolManagerTest {
   }
 
   @Test
-  public void addDestinationMarkerFor_previouslyAddedMarkersRemoved() {
+  public void addCustomSymbolFor_symbolManagerCreatesSymbol() {
     SymbolManager symbolManager = mock(SymbolManager.class);
     Symbol symbol = mock(Symbol.class);
     SymbolOptions symbolOptions = mock(SymbolOptions.class);


### PR DESCRIPTION
## Description

Fixes #3459 

Regression from legacy https://github.com/mapbox/mapbox-navigation-android/pull/1622 not caught by recent refactors

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Show destination markers when using the Drop-in UI

### Implementation

`destination` `LiveData` wasn't firing off as `setValue` was never called.

Noting that the Drop-in UI doesn't fully support neither the _Free Drive_ use-case nor _Active Guidance_ / _Free Drive_ transitions. We should cut a ticket to keep track of these. @abhishek1508 could you when you have a chance?

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

@JunDai could you run a quick test on your side and confirm dark and light destination markers are displayed and regression fixed?

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
