### PR TITLE
separating the geojson sources for the route line and casing line for …

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/internal/route/RouteConstants.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/internal/route/RouteConstants.java
@@ -2,6 +2,7 @@ package com.mapbox.navigation.ui.internal.route;
 
 public class RouteConstants {
   public static final String PRIMARY_ROUTE_SOURCE_ID = "mapbox-navigation-route-source";
+  public static final String PRIMARY_ROUTE_CASING_SOURCE_ID = "mapbox-navigation-route-casing-source";
   public static final String PRIMARY_ROUTE_TRAFFIC_SOURCE_ID = "mapbox-navigation-route-traffic-source";
   public static final String PRIMARY_ROUTE_LAYER_ID = "mapbox-navigation-route-layer";
   public static final String PRIMARY_ROUTE_TRAFFIC_LAYER_ID = "mapbox-navigation-route-traffic-layer";

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteLine.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteLine.kt
@@ -125,6 +125,7 @@ internal class MapRouteLine(
 
     private var wayPointSource: GeoJsonSource
     private val primaryRouteLineSource: GeoJsonSource
+    private val primaryRouteLineCasingSource: GeoJsonSource
     private val primaryRouteLineTrafficSource: GeoJsonSource
     private val alternativeRouteLineSource: GeoJsonSource
     private val routeLayerIds = mutableSetOf<String>()
@@ -354,6 +355,13 @@ internal class MapRouteLine(
             routeLineGeoJsonOptions
         )
         style.addSource(primaryRouteLineSource)
+
+        primaryRouteLineCasingSource = mapRouteSourceProvider.build(
+            RouteConstants.PRIMARY_ROUTE_CASING_SOURCE_ID,
+            drawnPrimaryRouteFeatureCollection,
+            routeLineGeoJsonOptions
+        )
+        style.addSource(primaryRouteLineCasingSource)
 
         val routeLineTrafficGeoJsonOptions = GeoJsonOptions().withMaxZoom(16).withLineMetrics(true)
         primaryRouteLineTrafficSource = mapRouteSourceProvider.build(
@@ -783,6 +791,7 @@ internal class MapRouteLine(
 
     private fun setPrimaryRoutesSource(featureCollection: FeatureCollection) {
         drawnPrimaryRouteFeatureCollection = featureCollection
+        primaryRouteLineCasingSource.setGeoJson(drawnPrimaryRouteFeatureCollection)
         primaryRouteLineSource.setGeoJson(drawnPrimaryRouteFeatureCollection)
         primaryRouteLineTrafficSource.setGeoJson(drawnPrimaryRouteFeatureCollection)
     }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapboxRouteLayerProvider.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapboxRouteLayerProvider.kt
@@ -33,6 +33,7 @@ import com.mapbox.navigation.ui.internal.route.RouteConstants.DEFAULT_ROUTE_DESC
 import com.mapbox.navigation.ui.internal.route.RouteConstants.DESTINATION_MARKER_NAME
 import com.mapbox.navigation.ui.internal.route.RouteConstants.ORIGIN_MARKER_NAME
 import com.mapbox.navigation.ui.internal.route.RouteConstants.PRIMARY_ROUTE_CASING_LAYER_ID
+import com.mapbox.navigation.ui.internal.route.RouteConstants.PRIMARY_ROUTE_CASING_SOURCE_ID
 import com.mapbox.navigation.ui.internal.route.RouteConstants.PRIMARY_ROUTE_LAYER_ID
 import com.mapbox.navigation.ui.internal.route.RouteConstants.PRIMARY_ROUTE_SOURCE_ID
 import com.mapbox.navigation.ui.internal.route.RouteConstants.PRIMARY_ROUTE_TRAFFIC_LAYER_ID
@@ -132,7 +133,7 @@ internal interface MapboxRouteLayerProvider : RouteLayerProvider {
             style,
             true,
             PRIMARY_ROUTE_CASING_LAYER_ID,
-            PRIMARY_ROUTE_SOURCE_ID,
+            PRIMARY_ROUTE_CASING_SOURCE_ID,
             lineWidthScaleExpression,
             routeLineColorExpressions)
     }

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteLineTest.kt
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteLineTest.kt
@@ -46,6 +46,7 @@ class MapRouteLineTest {
     var styleRes: Int = 0
     lateinit var wayPointSource: GeoJsonSource
     lateinit var primaryRouteLineSource: GeoJsonSource
+    lateinit var primaryRouteCasingSource: GeoJsonSource
     lateinit var primaryRouteLineTrafficSource: GeoJsonSource
     lateinit var alternativeRouteLineSource: GeoJsonSource
 
@@ -103,6 +104,7 @@ class MapRouteLineTest {
 
         wayPointSource = mockk(relaxUnitFun = true)
         primaryRouteLineSource = mockk(relaxUnitFun = true)
+        primaryRouteCasingSource = mockk(relaxUnitFun = true)
         primaryRouteLineTrafficSource = mockk(relaxUnitFun = true)
         alternativeRouteLineSource = mockk(relaxUnitFun = true)
 
@@ -111,6 +113,7 @@ class MapRouteLineTest {
             every { build(RouteConstants.PRIMARY_ROUTE_SOURCE_ID, any(), any()) } returns primaryRouteLineSource
             every { build(RouteConstants.PRIMARY_ROUTE_TRAFFIC_SOURCE_ID, any(), any()) } returns primaryRouteLineTrafficSource
             every { build(RouteConstants.ALTERNATIVE_ROUTE_SOURCE_ID, any(), any()) } returns alternativeRouteLineSource
+            every { build(RouteConstants.PRIMARY_ROUTE_CASING_SOURCE_ID, any(), any()) } returns primaryRouteCasingSource
         }
         layerProvider = mockk {
             every {


### PR DESCRIPTION
## Description

There was a bug on the maps side that resulted in the route line casing not appearing.  See https://github.com/mapbox/mapbox-gl-native-internal/issues/268

As a work around for a maps issue not drawing the casing for the route line when they share the same geoJson source, this PR creates separate sources so the the casing line will appear.

- [ ] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal


### Implementation


## Screenshots or Gifs


## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->