### PR TITLE
Fix auto enable route refresh

### DIFF
--- a/libdirections-offboard/src/main/java/com/mapbox/navigation/route/offboard/internal/MapboxOffboardRouter.kt
+++ b/libdirections-offboard/src/main/java/com/mapbox/navigation/route/offboard/internal/MapboxOffboardRouter.kt
@@ -3,7 +3,6 @@ package com.mapbox.navigation.route.offboard.internal
 import android.content.Context
 import com.mapbox.annotation.module.MapboxModule
 import com.mapbox.annotation.module.MapboxModuleType
-import com.mapbox.api.directions.v5.DirectionsCriteria
 import com.mapbox.api.directions.v5.MapboxDirections
 import com.mapbox.api.directions.v5.models.DirectionsResponse
 import com.mapbox.api.directions.v5.models.DirectionsRoute
@@ -54,7 +53,6 @@ class MapboxOffboardRouter(
     ) {
         mapboxDirections = RouteBuilderProvider.getBuilder(accessToken, context, urlSkuTokenProvider)
             .routeOptions(routeOptions)
-            .enableRefresh(routeOptions.profile() == DirectionsCriteria.PROFILE_DRIVING_TRAFFIC)
             .build()
         mapboxDirections?.enqueueCall(object : Callback<DirectionsResponse> {
 

--- a/libdirections-offboard/src/main/java/com/mapbox/navigation/route/offboard/router/MapboxDirectionsUtils.kt
+++ b/libdirections-offboard/src/main/java/com/mapbox/navigation/route/offboard/router/MapboxDirectionsUtils.kt
@@ -2,6 +2,7 @@ package com.mapbox.navigation.route.offboard.router
 
 import com.mapbox.api.directions.v5.MapboxDirections
 import com.mapbox.api.directions.v5.models.RouteOptions
+import com.mapbox.navigation.base.internal.extensions.supportsRefresh
 import java.util.Locale
 
 private val EVENT_LISTENER = NavigationRouteEventListener()
@@ -94,6 +95,8 @@ internal fun MapboxDirections.Builder.routeOptions(options: RouteOptions): Mapbo
     options.walkingOptions()?.let {
         walkingOptions(it)
     }
+
+    enableRefresh(options.supportsRefresh())
 
     eventListener(EVENT_LISTENER)
 

--- a/libdirections-offboard/src/test/java/com/mapbox/navigation/route/offboard/router/MapboxDirectionsUtilsTest.kt
+++ b/libdirections-offboard/src/test/java/com/mapbox/navigation/route/offboard/router/MapboxDirectionsUtilsTest.kt
@@ -1,0 +1,32 @@
+package com.mapbox.navigation.route.offboard.router
+
+import com.mapbox.api.directions.v5.MapboxDirections
+import com.mapbox.api.directions.v5.models.RouteOptions
+import com.mapbox.geojson.Point
+import com.mapbox.navigation.base.internal.extensions.applyDefaultParams
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Test
+
+class MapboxDirectionsUtilsTest {
+
+    private val mapboxDirectionsBuilder: MapboxDirections.Builder = mockk(relaxed = true)
+
+    @Test
+    fun `should create mapbox directions from options`() {
+        val routeOptions = RouteOptions.builder()
+            .accessToken("test_access_token")
+            .coordinates(listOf(
+                Point.fromLngLat(-121.470162, 38.563121),
+                Point.fromLngLat(-121.483304, 38.583313)
+            ))
+            .applyDefaultParams()
+            .build()
+
+        mapboxDirectionsBuilder.routeOptions(routeOptions)
+
+        verify { mapboxDirectionsBuilder.baseUrl(routeOptions.baseUrl()) }
+        verify { mapboxDirectionsBuilder.user(routeOptions.user()) }
+        verify { mapboxDirectionsBuilder.profile(routeOptions.profile()) }
+    }
+}

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/extensions/RouteRefreshEx.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/extensions/RouteRefreshEx.kt
@@ -1,0 +1,22 @@
+package com.mapbox.navigation.base.internal.extensions
+
+import com.mapbox.api.directions.v5.DirectionsCriteria
+import com.mapbox.api.directions.v5.models.RouteOptions
+
+/**
+ * Indicates whether the route options supports route refresh.
+ *
+ * @receiver RouteOptions
+ * @return Boolean
+ */
+fun RouteOptions?.supportsRefresh(): Boolean {
+    if (this == null) {
+        return false
+    }
+    val isTrafficProfile = profile() == DirectionsCriteria.PROFILE_DRIVING_TRAFFIC
+    val isOverviewFull = overview() == DirectionsCriteria.OVERVIEW_FULL
+    val hasCongestionOrMaxSpeed = annotationsList()?.any {
+        it == DirectionsCriteria.ANNOTATION_CONGESTION || it == DirectionsCriteria.ANNOTATION_MAXSPEED
+    } ?: false
+    return isTrafficProfile && isOverviewFull && hasCongestionOrMaxSpeed
+}

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/internal/extensions/RouteRefreshExTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/internal/extensions/RouteRefreshExTest.kt
@@ -1,0 +1,74 @@
+package com.mapbox.navigation.base.internal.extensions
+
+import com.mapbox.api.directions.v5.DirectionsCriteria
+import com.mapbox.api.directions.v5.models.RouteOptions
+import com.mapbox.geojson.Point
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RouteRefreshExTest {
+
+    private val defaultOptionsBuilder = RouteOptions.builder()
+        .accessToken("test_access_token")
+        .coordinates(listOf(
+            Point.fromLngLat(-121.470162, 38.563121),
+            Point.fromLngLat(-121.483304, 38.583313)
+        ))
+        .applyDefaultParams()
+
+    @Test
+    fun `should enable route refresh with all the criteria`() {
+        val routeOptions = defaultOptionsBuilder
+            .profile(DirectionsCriteria.PROFILE_DRIVING_TRAFFIC)
+            .annotationsList(listOf(DirectionsCriteria.ANNOTATION_MAXSPEED))
+            .overview(DirectionsCriteria.OVERVIEW_FULL)
+            .build()
+
+        assertTrue(routeOptions.supportsRefresh())
+    }
+
+    @Test
+    fun `should enable route refresh with annotation congestion`() {
+        val routeOptions = defaultOptionsBuilder
+            .profile(DirectionsCriteria.PROFILE_DRIVING_TRAFFIC)
+            .annotationsList(listOf(DirectionsCriteria.ANNOTATION_CONGESTION))
+            .overview(DirectionsCriteria.OVERVIEW_FULL)
+            .build()
+
+        assertTrue(routeOptions.supportsRefresh())
+    }
+
+    @Test
+    fun `should disable route refresh when overview is not full`() {
+        val routeOptions = defaultOptionsBuilder
+            .profile(DirectionsCriteria.PROFILE_DRIVING_TRAFFIC)
+            .annotationsList(listOf(DirectionsCriteria.ANNOTATION_MAXSPEED))
+            .overview(DirectionsCriteria.OVERVIEW_SIMPLIFIED)
+            .build()
+
+        assertFalse(routeOptions.supportsRefresh())
+    }
+
+    @Test
+    fun `should disable route refresh when annotations does not have maxspeed`() {
+        val routeOptions = defaultOptionsBuilder
+            .profile(DirectionsCriteria.PROFILE_DRIVING_TRAFFIC)
+            .annotationsList(listOf(DirectionsCriteria.ANNOTATION_SPEED, DirectionsCriteria.ANNOTATION_DISTANCE))
+            .overview(DirectionsCriteria.OVERVIEW_FULL)
+            .build()
+
+        assertFalse(routeOptions.supportsRefresh())
+    }
+
+    @Test
+    fun `should disable route refresh when profile is not driving-traffic`() {
+        val routeOptions = defaultOptionsBuilder
+            .profile(DirectionsCriteria.PROFILE_DRIVING_TRAFFIC)
+            .annotationsList(listOf(DirectionsCriteria.ANNOTATION_SPEED, DirectionsCriteria.ANNOTATION_DISTANCE))
+            .overview(DirectionsCriteria.OVERVIEW_FULL)
+            .build()
+
+        assertFalse(routeOptions.supportsRefresh())
+    }
+}

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/internal/route/RouteUrlTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/internal/route/RouteUrlTest.kt
@@ -1,9 +1,8 @@
-package com.mapbox.navigation.base.route.internal
+package com.mapbox.navigation.base.internal.route
 
 import android.net.Uri
 import com.mapbox.api.directions.v5.DirectionsCriteria
 import com.mapbox.geojson.Point
-import com.mapbox.navigation.base.internal.route.RouteUrl
 import java.net.URLDecoder
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/routerefresh/RouteRefreshController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/routerefresh/RouteRefreshController.kt
@@ -1,10 +1,9 @@
 package com.mapbox.navigation.core.routerefresh
 
-import com.mapbox.api.directions.v5.DirectionsCriteria
 import com.mapbox.api.directions.v5.models.DirectionsRoute
-import com.mapbox.api.directions.v5.models.RouteOptions
 import com.mapbox.base.common.logger.Logger
 import com.mapbox.base.common.logger.model.Message
+import com.mapbox.navigation.base.internal.extensions.supportsRefresh
 import com.mapbox.navigation.base.route.RouteRefreshCallback
 import com.mapbox.navigation.base.route.RouteRefreshError
 import com.mapbox.navigation.core.directions.session.DirectionsSession
@@ -50,18 +49,6 @@ internal class RouteRefreshController(
 
     fun stop() {
         routerRefreshTimer.stopJobs()
-    }
-
-    private fun RouteOptions?.supportsRefresh(): Boolean {
-        if (this == null) {
-            return false
-        }
-        val isTrafficProfile = profile() == DirectionsCriteria.PROFILE_DRIVING_TRAFFIC
-        val isOverviewFull = overview() == DirectionsCriteria.OVERVIEW_FULL
-        val hasCongestionOrMaxSpeed = annotationsList()?.any {
-            it == DirectionsCriteria.ANNOTATION_CONGESTION || it == DirectionsCriteria.ANNOTATION_MAXSPEED
-        } ?: false
-        return isTrafficProfile && isOverviewFull && hasCongestionOrMaxSpeed
     }
 
     private val routeRefreshCallback = object : RouteRefreshCallback {


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

When debugging this issue https://github.com/mapbox/mapbox-navigation-android/issues/3468

One of the issues can be, directions api will not give a response when enable_refresh is enabled and options are inaccurate.

https://api.mapbox.com/directions/v5/mapbox/driving-traffic/-121.467038,38.563066;-121.476844,38.574921?access_token={add_your_token}&alternatives=false&geometries=polyline6&overview=full&steps=true&continue_straight=false&annotations=speed%2Cdistance&language=en&roundabout_exits=false&voice_instructions=true&banner_instructions=true&voice_units=imperial&enable_refresh=true
```
{
  "message": "enable_refresh only works with maxspeed or congestion annotations"
}
```

- [ ] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->