### PR TITLE
Make examples keys not translatable

### DIFF
--- a/examples/src/main/res/values/strings.xml
+++ b/examples/src/main/res/values/strings.xml
@@ -96,19 +96,19 @@
     <string name="language">Language</string>
     <string name="unit_type">Unit Type</string>
     <string name="route_profile">Route Profile</string>
-    <string name="unit_type_key">unit_type</string>
-    <string name="simulate_route_key">simulate_route</string>
-    <string name="language_key">language</string>
-    <string name="route_profile_key">route_profile</string>
-    <string name="default_route_profile">driving-traffic</string>
-    <string name="git_hash_key">git_hash</string>
-    <string name="nav_native_history_retrieve_key">nav_native_history_retrieve</string>
-    <string name="nav_native_history_collect_key">nav_native_history_collect</string>
+    <string name="unit_type_key" translatable="false">unit_type</string>
+    <string name="simulate_route_key" translatable="false">simulate_route</string>
+    <string name="language_key" translatable="false">language</string>
+    <string name="route_profile_key" translatable="false">route_profile</string>
+    <string name="default_route_profile" translatable="false">driving-traffic</string>
+    <string name="git_hash_key" translatable="false">git_hash</string>
+    <string name="nav_native_history_retrieve_key" translatable="false">nav_native_history_retrieve</string>
+    <string name="nav_native_history_collect_key" translatable="false">nav_native_history_collect</string>
     <string name="nav_native_history_collect">Collect Nav Native history</string>
-    <string name="offline_version_key">offline_preference_key</string>
-    <string name="offline_enabled">offline_region_download</string>
-    <string name="default_locale">default_for_device</string>
-    <string name="default_unit_type">default_for_device</string>
+    <string name="offline_version_key" translatable="false">offline_preference_key</string>
+    <string name="offline_enabled" translatable="false">offline_region_download</string>
+    <string name="default_locale" translatable="false">default_for_device</string>
+    <string name="default_unit_type" translatable="false">default_for_device</string>
     <string name="start_navigation">Start Navigation</string>
     <string name="navigate_waypoints_next_stop">Next stop</string>
     <string name="play_history">Play history</string>


### PR DESCRIPTION
## Description

Regression from https://github.com/mapbox/mapbox-navigation-android/pull/3425#discussion_r471812462

Refs. https://github.com/mapbox/mapbox-navigation-android/issues/2909

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Make `examples` non user-facing keys not translatable

### Implementation

Add `translatable = false` to non user-facing `examples` keys 

## Testing

- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs

cc @1ec5 