### PR TITLE
Keep route properties to preserve alternative route styling if is being used.

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteLine.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteLine.kt
@@ -47,9 +47,7 @@ import com.mapbox.navigation.ui.route.MapRouteLine.MapRouteLineSupport.getBoolea
 import com.mapbox.navigation.ui.route.MapRouteLine.MapRouteLineSupport.getFloatStyledValue
 import com.mapbox.navigation.ui.route.MapRouteLine.MapRouteLineSupport.getResourceStyledValue
 import com.mapbox.navigation.ui.route.MapRouteLine.MapRouteLineSupport.getStyledColor
-import com.mapbox.navigation.ui.route.MapRouteLine.MapRouteLineSupport.swapProperties
 import com.mapbox.navigation.utils.internal.ThreadController
-import com.mapbox.navigation.utils.internal.ifNonNull
 import com.mapbox.navigation.utils.internal.parallelMap
 import com.mapbox.turf.TurfMeasurement
 import java.math.BigDecimal
@@ -478,9 +476,6 @@ internal class MapRouteLine(
      */
     fun updatePrimaryRouteIndex(route: DirectionsRoute): Boolean {
         return if (route != this.primaryRoute) {
-            val primaryRouteFeatures = routeFeatureData.firstOrNull { it.route == primaryRoute }?.featureCollection?.features()?.firstOrNull()
-            val newPrimaryRouteFeatures = routeFeatureData.firstOrNull { it.route == route }?.featureCollection?.features()?.firstOrNull()
-            ifNonNull(primaryRouteFeatures, newPrimaryRouteFeatures, ::swapProperties)
             this.primaryRoute = route
             drawRoutes(routeFeatureData)
             true
@@ -1212,23 +1207,6 @@ internal class MapRouteLine(
                 val propValue =
                     if (index == 0) WAYPOINT_ORIGIN_VALUE else WAYPOINT_DESTINATION_VALUE
                 it.addStringProperty(WAYPOINT_PROPERTY_KEY, propValue)
-            }
-        }
-
-        fun swapProperties(featureA: Feature, featureB: Feature) {
-            val featureAProperties = featureA.properties()
-            val featureAKeySetToRemove = featureAProperties?.keySet()?.toList()
-            val featureBProperties = featureB.properties()
-            val featureBKeySetToRemove = featureBProperties?.keySet()?.toList()
-
-            featureAKeySetToRemove?.forEach { key ->
-                featureB.addBooleanProperty(key, featureAProperties[key].asBoolean)
-                featureA.removeProperty(key)
-            }
-
-            featureBKeySetToRemove?.forEach { key ->
-                featureA.addBooleanProperty(key, featureBProperties[key].asBoolean)
-                featureB.removeProperty(key)
             }
         }
     }

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteLineTest.kt
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteLineTest.kt
@@ -6,7 +6,6 @@ import android.content.res.TypedArray
 import androidx.test.core.app.ApplicationProvider
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.core.constants.Constants
-import com.mapbox.geojson.Feature
 import com.mapbox.geojson.FeatureCollection
 import com.mapbox.geojson.LineString
 import com.mapbox.geojson.Point
@@ -1147,25 +1146,6 @@ class MapRouteLineTest {
             PRIMARY_ROUTE_LAYER_ID,
             listOf(ALTERNATIVE_ROUTE_LAYER_ID)
         )) }
-    }
-
-    @Test
-    fun swapProperties() {
-        val route = getDirectionsRoute(false)
-        val lineString = LineString.fromPolyline(route.geometry()!!, Constants.PRECISION_6)
-        val featureA = Feature.fromGeometry(lineString).also {
-            it.addBooleanProperty("featureAProperty", true)
-        }
-        val featureB = Feature.fromGeometry(lineString).also {
-            it.addBooleanProperty("featureBProperty", true)
-        }
-        assertEquals(true, featureA.properties()?.get("featureAProperty")!!.asBoolean)
-        assertEquals(true, featureB.properties()?.get("featureBProperty")!!.asBoolean)
-
-        MapRouteLine.MapRouteLineSupport.swapProperties(featureA, featureB)
-
-        assertEquals(true, featureA.properties()?.get("featureBProperty")!!.asBoolean)
-        assertEquals(true, featureB.properties()?.get("featureAProperty")!!.asBoolean)
     }
 
     private fun getMultilegRoute(): DirectionsRoute {


### PR DESCRIPTION
## Description

Fixes #3484 by preserving the custom route styling for alternative routes.

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

When switching choosing between routes, any alternative routes that were styled with a custom color will keep their color if the route goes from alternative route to primary route and back to an alternative rourte.

### Implementation


## Screenshots or Gifs

![20200820_145614](https://user-images.githubusercontent.com/2249818/90829860-6c4be700-e2f5-11ea-8e9b-c7ab5673bfed.gif)

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->