### PR TITLE
Pull in the latest translations from Transifex

### DIFF
--- a/examples/src/main/res/values-vi/strings.xml
+++ b/examples/src/main/res/values-vi/strings.xml
@@ -1,9 +1,62 @@
 <resources>
-    <string name="app_name">SDK 1.0 Điều hướng của Mapbox</string>
+    <string name="app_name">Mapbox SDK Điều hướng 1.0 cho Android</string>
 
+    <!-- MainActivity -->
+    <string name="navigation_core_sdk_title">SDK Nhân Điều hướng</string>
+    <string name="navigation_ui_sdk_title">SDK Giao diện Điều hướng</string>
+    <string name="title_simple_navigation_kotlin">MapboxNavigation Đơn giản trong Kotlin</string>
+    <string name="title_navigation_view">NavigationView</string>
+    <string name="title_custom_camera_example">Camera tùy biến</string>
+    <string name="title_custom_ui_component_style">Kiểu bộ phận giao diện tùy biến</string>
+    <string name="title_building_highlight_kotlin">Tô đậm diện tích chiếm đất của tòa nhà</string>
+    <string name="title_ui_building_extrusions_kotlin">Nhô ra và tô đậm tòa nhà</string>
+    <string name="title_replay_route">Phát lại tuyến đường</string>
+    <string name="replay_playback_speed_seekbar">Phát lại gấp %d lần</string>
+
+    <string name="title_replay_history_kotlin">Phát lại lịch sử</string>
+    <string name="title_select_replay_history">Chọn lịch sử</string>
+
+    <string name="title_replay_waypoints">Phát lại tọa độ điểm</string>
+    <string name="title_reroute_view">Sự kiện tìm đường đi mới</string>
+    <string name="title_basic_navigation_kotlin">Điều hướng cơ bản</string>
+    <string name="title_basic_navigation_fragment">Điều hướng cơ bản trong Fragment</string>
+    <string name="title_basic_navigation_sdk_only_kotlin">Tích hợp SDK Điều hướng + SDK Bản đồ một cách cơ bản</string>
+    <string name="title_free_drive_kotlin">Điều hướng khi lái xe tự do</string>
+    <string name="title_guidance_view">GuidanceView</string>
+    <string name="title_faster_route">Tuyến đường nhanh hơn</string>
+    <string name="title_summary_bottom_sheet">SummaryBottomSheet</string>
+    <string name="title_feedback_button">Nút phản hồi</string>
+    <string name="title_instruction_view">InstructionView</string>
+    <string name="title_debug_navigation_kotlin">Gỡ lỗi MapboxNavigation trong Kotlin</string>
+    <string name="title_custom_route_styling_kotlin">Đặt kiểu Tuyến đường Tùy biến trong Kotlin</string>
+    <string name="title_navigation_view_fragment">NavigationView trong Fragment</string>
+    <string name="title_navigation_route_ui">NavigationMapRoute</string>
+    <string name="title_traffic_toggle">Hiện/ẩn giao thông</string>
+    <string name="title_runtime_styling">RuntimeRouteStyling</string>
+    <string name="title_map_matching">Khớp Bản đồ</string>
     <string name="settings">Thiết lập</string>
     <string name="simulate_route">Mô phỏng Tuyến đường</string>
     <string name="language">Ngôn ngữ</string>
     <string name="unit_type">Hệ Đo lường</string>
     <string name="route_profile">Chế độ</string>
+    <string name="nav_native_history_collect">Thu thập lịch sử Điều hướng Native</string>
+    <string name="start_navigation">Bắt đầu Điều hướng</string>
+    <string name="navigate_waypoints_next_stop">Điểm dừng sau</string>
+    <string name="play_history">Phát lại lịch sử</string>
+    <string name="select_history">Chọn lịch sử</string>
+    <string name="msg_long_press_map_to_place_waypoint">Chạm lâu vào bản đồ để thả ghim tọa độ điểm</string>
+    <string name="no_routes">Không có đường đi đến nơi đó</string>
+    <string name="steps_in_route">Tuyến đường có %1$d bước</string>
+    <string name="route_request_failed">Thất bại khi yêu cầu tuyến đường</string>
+    <string name="offline_category_title">Ngoại tuyến</string>
+    <string name="offline_enabled_title">Định tuyến ngoại tuyến được kích hoạt</string>
+    <string name="offline_version_title">Chọn phiên bản ngoại tuyến</string>
+    <string name="general_category_title">Tổng quát</string>
+    <string name="send_user_feedback">Gửi Phản hồi từ Người dùng</string>
+    <string name="simple_mapbox_navigation_clear_routes">XÓA CÁC TUYẾN ĐƯỜNG</string>
+    <string name="simple_mapbox_navigation_add_original_route">THÊM TUYẾN ĐƯỜNG BAN ĐẦU</string>
+    <string name="history_failed_to_load_item">Thất bại khi tải mục lịch sử</string>
+    <string name="history_failed_to_load_list">Thất bại khi tải danh sách</string>
+    <string name="history_local_history_file">Tập tin lịch sử trên thiết bị</string>
+
 </resources>

--- a/libnavigation-ui/src/main/res/values-de/strings.xml
+++ b/libnavigation-ui/src/main/res/values-de/strings.xml
@@ -12,10 +12,73 @@
     <!-- Indicates voice instructions are unmuted -->
     <string name="mapbox_unmuted">Ton an</string>
 
+    <!-- Feedback -->
+    <string name="mapbox_report_feedback">Feedback geben</string>
+
+    <!-- Feedback Guidance Issue -->
+    <string name="mapbox_feedback_guidance_issue">Problem bei der Routenführung</string>
+
+    <!-- Feedback type for Looks Incorrect -->
+    <string name="mapbox_feedback_type_looks_incorrect">Sieht falsch aus</string>
+
+    <!-- Feedback type for Confusing Audio -->
+    <string name="mapbox_feedback_type_confusing_audio">Verwirrende\nSprachanweisung</string>
+
+    <!-- Feedback type for Positioning Issue -->
+    <string name="mapbox_feedback_type_positioning_issue">Falsche\nPositionierung</string>
+
+    <!-- Feedback Navigation Issue -->
+    <string name="mapbox_feedback_navigation_issue">Navigationsproblem</string>
+
+    <!-- Feedback type for Route Quality -->
+    <string name="mapbox_feedback_type_route_quality">Routenqualität</string>
+
+    <!-- Feedback type for Illegal Route -->
+    <string name="mapbox_feedback_type_illegal_route">Unerlaubte\nRoute</string>
+
+    <!-- Feedback type for Road Closure -->
+    <string name="mapbox_feedback_type_road_closure">Straße\ngesperrt</string>
+
+    <!-- Shown after a feedback type has been submitted -->
+    <string name="mapbox_feedback_reported">Vielen Dank! Problem wurde gemeldet.</string>
+
+    <!-- Feedback description for Looks Incorrect -->
+    <string name="mapbox_feedback_description_turn_icon_incorrect">Wende-Bild falsch</string>
+    <string name="mapbox_feedback_description_street_name_incorrect">Straßenname falsch</string>
+    <string name="mapbox_feedback_description_instruction_unnecessary">Anweisung überflüssig</string>
+    <string name="mapbox_feedback_description_instruction_missing">Anweisung fehlt</string>
+    <string name="mapbox_feedback_description_maneuver_incorrect">Falsches Manöver</string>
+    <string name="mapbox_feedback_description_exit_info_incorrect">Falsche Ausfahrt</string>
+    <string name="mapbox_feedback_description_lane_guidance_incorrect">Falsche Spuranweisung</string>
+    <string name="mapbox_feedback_description_road_known_by_different_name">Straße ist unter einem anderen Namen bekannt</string>
+
+    <!-- Feedback description for Confusing Audio -->
+    <string name="mapbox_feedback_description_guidance_too_early">Anweisung erfolgt zu früh</string>
+    <string name="mapbox_feedback_description_guidance_too_late">Anweisung erfolgt zu spät</string>
+    <string name="mapbox_feedback_description_pronunciation_incorrect">Falsche Aussprache</string>
+    <string name="mapbox_feedback_description_road_name_repeated">Straßenname wiederholt</string>
+
+    <!-- Feedback description for Route Quality -->
+    <string name="mapbox_feedback_description_route_not_drive_able">Straße ist nicht befahrbar</string>
+    <string name="mapbox_feedback_description_route_not_preferred">Keine bevorzugte Route</string>
+    <string name="mapbox_feedback_description_alternative_route_not_expected">Unerwartete alternative Route</string>
+    <string name="mapbox_feedback_description_route_included_missing_roads">Route enthält fehlende Straßen</string>
+    <string name="mapbox_feedback_description_route_had_roads_too_narrow_to_pass">Route enthält zu enge Straßen, um zu passieren</string>
+
+    <!-- Feedback description for Illegal Route -->
+    <string name="mapbox_feedback_description_routed_down_a_one_way">Weitergeleitet auf Einbahnstraße</string>
+    <string name="mapbox_feedback_description_turn_was_not_allowed">Wenden war nicht erlaubt</string>
+    <string name="mapbox_feedback_description_cars_not_allowed_on_street">Autos auf der Straße nicht erlaubt</string>
+    <string name="mapbox_feedback_description_turn_at_intersection_was_unprotected">Abbiegung an der Kreuzung war ungeschützt</string>
+
+    <!-- Feedback description for Road Closure -->
+    <string name="mapbox_feedback_description_street_permanently_blocked_off">Straße dauerhaft gesperrt</string>
+    <string name="mapbox_feedback_description_road_is_missing_from_map">Straße fehlt auf Karte</string>
+
     <!-- Shown after a feedback type has been submitted -->
     <string name="mapbox_feedback_submitted">Rückmeldung gesendet</string>
 
     <!-- Shown in off-route scenarios to provide feedback -->
     <string name="mapbox_report_problem">Problem melden</string>
 
-</resources>
+    </resources>

--- a/libnavigation-ui/src/main/res/values-el/strings.xml
+++ b/libnavigation-ui/src/main/res/values-el/strings.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Indicates that rerouting is in progress -->
+    <string name="mapbox_rerouting">Αναδρομολόγηση…</string>
+
+    <!-- Button title for re-centering tracking -->
+    <string name="mapbox_re_center">Επανεστίαση</string>
+
+    <!-- Indicates voice instructions are muted -->
+    <string name="mapbox_muted">Σίγαση</string>
+
+    <!-- Indicates voice instructions are unmuted -->
+    <string name="mapbox_unmuted">Σίγαση</string>
+
+    <!-- Feedback -->
+    <string name="mapbox_report_feedback">Σχόλια</string>
+
+    <!-- Feedback Guidance Issue -->
+    <string name="mapbox_feedback_guidance_issue">Θέμα καθοδήγησης</string>
+
+    <!-- Feedback type for Confusing Audio -->
+    <string name="mapbox_feedback_type_confusing_audio">Μπερδεμένη\nΟδηγία</string>
+
+    <!-- Feedback Navigation Issue -->
+    <string name="mapbox_feedback_navigation_issue">Πρόβλημα πλοήγησης</string>
+
+    <!-- Feedback type for Route Quality -->
+    <string name="mapbox_feedback_type_route_quality">Διαδρομή\nΠοιότητα</string>
+
+    <!-- Feedback type for Illegal Route -->
+    <string name="mapbox_feedback_type_illegal_route">Παράνομη\nΔιαδρομή</string>
+
+    <!-- Feedback type for Road Closure -->
+    <string name="mapbox_feedback_type_road_closure">Δρόμος\nΚλειστός</string>
+
+    <!-- Shown after a feedback type has been submitted -->
+    <string name="mapbox_feedback_submitted">Τα σχόλια σας υποβλήθηκαν</string>
+
+    <!-- Shown in off-route scenarios to provide feedback -->
+    <string name="mapbox_report_problem">Αναφορά προβλήματος</string>
+
+    </resources>

--- a/libnavigation-ui/src/main/res/values-hu/strings.xml
+++ b/libnavigation-ui/src/main/res/values-hu/strings.xml
@@ -12,10 +12,73 @@
     <!-- Indicates voice instructions are unmuted -->
     <string name="mapbox_unmuted">Visszahangosítva</string>
 
+    <!-- Feedback -->
+    <string name="mapbox_report_feedback">Visszajelzés küldése</string>
+
+    <!-- Feedback Guidance Issue -->
+    <string name="mapbox_feedback_guidance_issue">Útmutatási probléma</string>
+
+    <!-- Feedback type for Looks Incorrect -->
+    <string name="mapbox_feedback_type_looks_incorrect">Hibásnak\ntűnik</string>
+
+    <!-- Feedback type for Confusing Audio -->
+    <string name="mapbox_feedback_type_confusing_audio">Megtévesztő\nbemondás</string>
+
+    <!-- Feedback type for Positioning Issue -->
+    <string name="mapbox_feedback_type_positioning_issue">Helymegállapítási\nprobléma</string>
+
+    <!-- Feedback Navigation Issue -->
+    <string name="mapbox_feedback_navigation_issue">Navigációs probléma</string>
+
+    <!-- Feedback type for Route Quality -->
+    <string name="mapbox_feedback_type_route_quality">Útvonal\nminősége</string>
+
+    <!-- Feedback type for Illegal Route -->
+    <string name="mapbox_feedback_type_illegal_route">Érvénytelen\nútvonal</string>
+
+    <!-- Feedback type for Road Closure -->
+    <string name="mapbox_feedback_type_road_closure">Útlezárás</string>
+
+    <!-- Shown after a feedback type has been submitted -->
+    <string name="mapbox_feedback_reported">Köszönjük! Hiba jelentve.</string>
+
+    <!-- Feedback description for Looks Incorrect -->
+    <string name="mapbox_feedback_description_turn_icon_incorrect">Hibás kanyarodás ikon</string>
+    <string name="mapbox_feedback_description_street_name_incorrect">Hibás utcanév</string>
+    <string name="mapbox_feedback_description_instruction_unnecessary">Felesleges utasítás</string>
+    <string name="mapbox_feedback_description_instruction_missing">Hiányzó utasítás</string>
+    <string name="mapbox_feedback_description_maneuver_incorrect">Hibás manőver</string>
+    <string name="mapbox_feedback_description_exit_info_incorrect">Hibás kijárati infó</string>
+    <string name="mapbox_feedback_description_lane_guidance_incorrect">Hibás sávbeli útmutatás</string>
+    <string name="mapbox_feedback_description_road_known_by_different_name">Más néven ismert út/utca</string>
+
+    <!-- Feedback description for Confusing Audio -->
+    <string name="mapbox_feedback_description_guidance_too_early">Túl korai bemondás</string>
+    <string name="mapbox_feedback_description_guidance_too_late">Túl kései bemondás</string>
+    <string name="mapbox_feedback_description_pronunciation_incorrect">Hibás kiejtés</string>
+    <string name="mapbox_feedback_description_road_name_repeated">Megismételt utcanév</string>
+
+    <!-- Feedback description for Route Quality -->
+    <string name="mapbox_feedback_description_route_not_drive_able">Vezetésre alkalmatlan útvonal</string>
+    <string name="mapbox_feedback_description_route_not_preferred">Nem ajánlott útvonal</string>
+    <string name="mapbox_feedback_description_alternative_route_not_expected">Nem várt alternatív útvonal</string>
+    <string name="mapbox_feedback_description_route_included_missing_roads">Hiányzó utak az útvonalon</string>
+    <string name="mapbox_feedback_description_route_had_roads_too_narrow_to_pass">Túl szűk utakat tartalmazó útvonal</string>
+
+    <!-- Feedback description for Illegal Route -->
+    <string name="mapbox_feedback_description_routed_down_a_one_way">Szembe tervezett egyirányú úton</string>
+    <string name="mapbox_feedback_description_turn_was_not_allowed">Nem engedélyezett kanyarodás</string>
+    <string name="mapbox_feedback_description_cars_not_allowed_on_street">Autók által nem használható utca</string>
+    <string name="mapbox_feedback_description_turn_at_intersection_was_unprotected">Nem védett kanyarodás a kereszteződésben</string>
+
+    <!-- Feedback description for Road Closure -->
+    <string name="mapbox_feedback_description_street_permanently_blocked_off">Véglegesen lezárt út</string>
+    <string name="mapbox_feedback_description_road_is_missing_from_map">Térképről hiányzó út</string>
+
     <!-- Shown after a feedback type has been submitted -->
     <string name="mapbox_feedback_submitted">Visszajelzés elküldve</string>
 
     <!-- Shown in off-route scenarios to provide feedback -->
     <string name="mapbox_report_problem">Probléma jelentése</string>
 
-</resources>
+    </resources>

--- a/libnavigation-ui/src/main/res/values-ru/strings.xml
+++ b/libnavigation-ui/src/main/res/values-ru/strings.xml
@@ -15,10 +15,28 @@
     <!-- Feedback -->
     <string name="mapbox_report_feedback">Сообщить об ошибке</string>
 
+    <!-- Feedback Guidance Issue -->
+    <string name="mapbox_feedback_guidance_issue">Ошибка указаний</string>
+
+    <!-- Feedback type for Confusing Audio -->
+    <string name="mapbox_feedback_type_confusing_audio">Непонятное\nаудио</string>
+
+    <!-- Feedback Navigation Issue -->
+    <string name="mapbox_feedback_navigation_issue">Ошибка маршрута</string>
+
+    <!-- Feedback type for Route Quality -->
+    <string name="mapbox_feedback_type_route_quality">Качество\nмаршрута</string>
+
+    <!-- Feedback type for Illegal Route -->
+    <string name="mapbox_feedback_type_illegal_route">Недопустимый\nмаршрут</string>
+
+    <!-- Feedback type for Road Closure -->
+    <string name="mapbox_feedback_type_road_closure">Дорога\nзакрыта</string>
+
     <!-- Shown after a feedback type has been submitted -->
     <string name="mapbox_feedback_submitted">Отзыв отправлен</string>
 
     <!-- Shown in off-route scenarios to provide feedback -->
     <string name="mapbox_report_problem">Сообщить о проблеме</string>
 
-</resources>
+    </resources>

--- a/libnavigation-ui/src/main/res/values-uk/strings.xml
+++ b/libnavigation-ui/src/main/res/values-uk/strings.xml
@@ -15,10 +15,28 @@
     <!-- Feedback -->
     <string name="mapbox_report_feedback">Надіслати відгук</string>
 
+    <!-- Feedback Guidance Issue -->
+    <string name="mapbox_feedback_guidance_issue">Вади супроводження</string>
+
+    <!-- Feedback type for Confusing Audio -->
+    <string name="mapbox_feedback_type_confusing_audio">Голосова\nпідказка</string>
+
+    <!-- Feedback Navigation Issue -->
+    <string name="mapbox_feedback_navigation_issue">Вади навігації</string>
+
+    <!-- Feedback type for Route Quality -->
+    <string name="mapbox_feedback_type_route_quality">Якість\nмаршруту</string>
+
+    <!-- Feedback type for Illegal Route -->
+    <string name="mapbox_feedback_type_illegal_route">Заборонений\nмаршрут</string>
+
+    <!-- Feedback type for Road Closure -->
+    <string name="mapbox_feedback_type_road_closure">Перекриття\nдороги</string>
+
     <!-- Shown after a feedback type has been submitted -->
     <string name="mapbox_feedback_submitted">Відгук надіслано</string>
 
     <!-- Shown in off-route scenarios to provide feedback -->
     <string name="mapbox_report_problem">Повідомити про проблему</string>
 
-</resources>
+    </resources>

--- a/libnavigation-ui/src/main/res/values-vi/strings.xml
+++ b/libnavigation-ui/src/main/res/values-vi/strings.xml
@@ -15,10 +15,70 @@
     <!-- Feedback -->
     <string name="mapbox_report_feedback">Gửi phản hồi</string>
 
+    <!-- Feedback Guidance Issue -->
+    <string name="mapbox_feedback_guidance_issue">Vấn đề\nLời Hướng dẫn</string>
+
+    <!-- Feedback type for Looks Incorrect -->
+    <string name="mapbox_feedback_type_looks_incorrect">Có vẻ\nKhông chính xác</string>
+
+    <!-- Feedback type for Confusing Audio -->
+    <string name="mapbox_feedback_type_confusing_audio">Lời nói\nGây Nhầm lẫn</string>
+
+    <!-- Feedback type for Positioning Issue -->
+    <string name="mapbox_feedback_type_positioning_issue">Vấn đề\nĐịnh vị</string>
+
+    <!-- Feedback Navigation Issue -->
+    <string name="mapbox_feedback_navigation_issue">Vấn đề\nChỉ đường</string>
+
+    <!-- Feedback type for Route Quality -->
+    <string name="mapbox_feedback_type_route_quality">Chất lượng\nTuyến đường</string>
+
+    <!-- Feedback type for Illegal Route -->
+    <string name="mapbox_feedback_type_illegal_route">Tuyến đường\nBất hợp pháp</string>
+
+    <!-- Feedback type for Road Closure -->
+    <string name="mapbox_feedback_type_road_closure">Đường\nĐóng cửa</string>
+
+    <!-- Shown after a feedback type has been submitted -->
+    <string name="mapbox_feedback_reported">Cảm ơn, đã gửi lời báo cáo!</string>
+
+    <!-- Feedback description for Looks Incorrect -->
+    <string name="mapbox_feedback_description_turn_icon_incorrect">Hình quẹo phía sai</string>
+    <string name="mapbox_feedback_description_street_name_incorrect">Tên đường sai</string>
+    <string name="mapbox_feedback_description_instruction_unnecessary">Lời hướng dẫn thừa</string>
+    <string name="mapbox_feedback_description_instruction_missing">Lời hướng dẫn bị thiếu</string>
+    <string name="mapbox_feedback_description_maneuver_incorrect">Tháo tác sai</string>
+    <string name="mapbox_feedback_description_exit_info_incorrect">Chi tiết đường nhánh sai</string>
+    <string name="mapbox_feedback_description_lane_guidance_incorrect">Chi tiết làn xe sai</string>
+    <string name="mapbox_feedback_description_road_known_by_different_name">Đường có tên khác</string>
+
+    <!-- Feedback description for Confusing Audio -->
+    <string name="mapbox_feedback_description_guidance_too_early">Lời hướng dẫn quá sớm</string>
+    <string name="mapbox_feedback_description_guidance_too_late">Lời hướng dẫn quá chậm</string>
+    <string name="mapbox_feedback_description_pronunciation_incorrect">Phát âm sai</string>
+    <string name="mapbox_feedback_description_road_name_repeated">Đọc lại tên đường hai lần</string>
+
+    <!-- Feedback description for Route Quality -->
+    <string name="mapbox_feedback_description_route_not_drive_able">Không thể đi theo tuyến đường</string>
+    <string name="mapbox_feedback_description_route_not_preferred">Tuyến đường không ổn</string>
+    <string name="mapbox_feedback_description_alternative_route_not_expected">Tuyến đường thay thế bất ngờ</string>
+    <string name="mapbox_feedback_description_route_included_missing_roads">Đường sá bị thiếu trên tuyến đường</string>
+    <string name="mapbox_feedback_description_route_had_roads_too_narrow_to_pass">Tuyến đường đi theo đường quá hẹp</string>
+
+    <!-- Feedback description for Illegal Route -->
+    <string name="mapbox_feedback_description_routed_down_a_one_way">Tuyến đường đi ngược đường</string>
+    <string name="mapbox_feedback_description_turn_was_not_allowed">Không cho phép quẹo vào đấy</string>
+    <string name="mapbox_feedback_description_cars_not_allowed_on_street">Không cho phép lái xe trên đường đó</string>
+    <string name="mapbox_feedback_description_turn_at_intersection_was_unprotected">Khó quẹo tại ngã tư không có đèn giao thông hoặc bảng dừng lại</string>
+
+    <!-- Feedback description for Road Closure -->
+    <string name="mapbox_feedback_description_street_permanently_blocked_off">Đường chặn cố định</string>
+    <string name="mapbox_feedback_description_road_is_missing_from_map">Đường không hiển thị trên bản đồ</string>
+
     <!-- Shown after a feedback type has been submitted -->
     <string name="mapbox_feedback_submitted">Đã Gửi Phản hồi</string>
 
     <!-- Shown in off-route scenarios to provide feedback -->
     <string name="mapbox_report_problem">Báo cáo Sự cố</string>
 
-</resources>
+    </resources>

--- a/libnavigation-util/src/main/res/values-el/strings.xml
+++ b/libnavigation-util/src/main/res/values-el/strings.xml
@@ -1,6 +1,6 @@
 <resources>
-    <string name="mapbox_unit_kilometers">χλμ.</string>
-    <string name="mapbox_unit_meters">μέτρ.</string>
-    <string name="mapbox_unit_miles">μίλ.</string>
-    <string name="mapbox_unit_feet">πόδ.</string>
+    <string name="mapbox_unit_kilometers">χλμ</string>
+    <string name="mapbox_unit_meters">μ</string>
+    <string name="mapbox_unit_miles">μίλια</string>
+    <string name="mapbox_unit_feet">πόδια</string>
 </resources>

--- a/libtrip-notification/src/main/res/values-ar/strings.xml
+++ b/libtrip-notification/src/main/res/values-ar/strings.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">انهاء الرحلة</string>

--- a/libtrip-notification/src/main/res/values-bg/strings.xml
+++ b/libtrip-notification/src/main/res/values-bg/strings.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Край на навигация</string>

--- a/libtrip-notification/src/main/res/values-cs/strings.xml
+++ b/libtrip-notification/src/main/res/values-cs/strings.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Ukončit navigaci</string>

--- a/libtrip-notification/src/main/res/values-da/strings.xml
+++ b/libtrip-notification/src/main/res/values-da/strings.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Slut navigation </string>

--- a/libtrip-notification/src/main/res/values-de/strings.xml
+++ b/libtrip-notification/src/main/res/values-de/strings.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Navigation beenden</string>

--- a/libtrip-notification/src/main/res/values-es/strings.xml
+++ b/libtrip-notification/src/main/res/values-es/strings.xml
@@ -1,7 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification Strings -->
-    <string name="mapbox_end_navigation">Finaliza navegación</string>
+    <string name="mapbox_end_navigation">Salir de la navegación</string>
     <!-- Time formatting -->
     <plurals name="mapbox_number_of_days">
         <item quantity="one">día</item>

--- a/libtrip-notification/src/main/res/values-fa/strings.xml
+++ b/libtrip-notification/src/main/res/values-fa/strings.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">پایان مسیر یابی</string>

--- a/libtrip-notification/src/main/res/values-fr/strings.xml
+++ b/libtrip-notification/src/main/res/values-fr/strings.xml
@@ -1,7 +1,6 @@
 <resources>
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Fin de navigation</string>
-
     <!-- Time formatting -->
     <plurals name="mapbox_number_of_days">
         <item quantity="one">jour</item>

--- a/libtrip-notification/src/main/res/values-gl/strings.xml
+++ b/libtrip-notification/src/main/res/values-gl/strings.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Remata a navegación</string>

--- a/libtrip-notification/src/main/res/values-he/strings.xml
+++ b/libtrip-notification/src/main/res/values-he/strings.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">סיום ניווט</string>

--- a/libtrip-notification/src/main/res/values-hu/strings.xml
+++ b/libtrip-notification/src/main/res/values-hu/strings.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Navigáció vége</string>

--- a/libtrip-notification/src/main/res/values-ja/strings.xml
+++ b/libtrip-notification/src/main/res/values-ja/strings.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">ナビゲーションを終了</string>

--- a/libtrip-notification/src/main/res/values-ko/strings.xml
+++ b/libtrip-notification/src/main/res/values-ko/strings.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">네비게이션 종료</string>

--- a/libtrip-notification/src/main/res/values-pt-rBR/strings.xml
+++ b/libtrip-notification/src/main/res/values-pt-rBR/strings.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Finalizar navegação</string>

--- a/libtrip-notification/src/main/res/values-pt-rPT/strings.xml
+++ b/libtrip-notification/src/main/res/values-pt-rPT/strings.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Terminar Navegação</string>

--- a/libtrip-notification/src/main/res/values-ru/strings.xml
+++ b/libtrip-notification/src/main/res/values-ru/strings.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Завершить</string>

--- a/libtrip-notification/src/main/res/values-sv/strings.xml
+++ b/libtrip-notification/src/main/res/values-sv/strings.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Avsluta Navigering</string>

--- a/libtrip-notification/src/main/res/values-uk/strings.xml
+++ b/libtrip-notification/src/main/res/values-uk/strings.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Закінчити навігацію</string>

--- a/libtrip-notification/src/main/res/values-uz/strings.xml
+++ b/libtrip-notification/src/main/res/values-uz/strings.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Yo\'nalish tugallandi</string>

--- a/libtrip-notification/src/main/res/values-vi/strings.xml
+++ b/libtrip-notification/src/main/res/values-vi/strings.xml
@@ -1,7 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Kết thúc Điều hướng</string>
+    <string name="mapbox_stop_session">Ngừng phiên điều hướng</string>
+    <string name="mapbox_free_drive_session">Phiên Lái xe Tự do</string>
     <string name="mapbox_eta_format">Đến %s</string>
 
     <!-- Time formatting -->

--- a/libtrip-notification/src/main/res/values-yo/strings.xml
+++ b/libtrip-notification/src/main/res/values-yo/strings.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Muu Lilọ kiri</string>


### PR DESCRIPTION
## Description

Updates translations to latest Transifex

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Get newest and latest translations available in Transifex

### Implementation

Pull translations from Transifex and add them to the SDK and test app

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
