### PR TITLE
Reinitializing the primary route on add routes when the routes in map…

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteLine.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteLine.kt
@@ -706,7 +706,7 @@ internal class MapRouteLine(
         setPrimaryRoutesSource(routeData.featureCollection)
         updateRouteTrafficSegments(routeData)
         if (style.isFullyLoaded) {
-            val expression = getExpressionAtOffset(0f)
+            val expression = getExpressionAtOffset(vanishPointOffset)
             style.getLayer(PRIMARY_ROUTE_TRAFFIC_LAYER_ID)?.setProperties(lineGradient(expression))
         }
     }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/NavigationMapRoute.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/NavigationMapRoute.java
@@ -193,15 +193,16 @@ public class NavigationMapRoute implements LifecycleObserver {
    * the routes are considered alternatives.
    */
   public void addRoutes(@NonNull @Size(min = 1) List<? extends DirectionsRoute> directionsRoutes) {
+    cancelVanishingRouteLineAnimator();
     if (directionsRoutes.isEmpty()) {
-      cancelVanishingRouteLineAnimator();
       routeLine.draw(directionsRoutes);
     } else if (!CompareUtils.areEqualContentsIgnoreOrder(
-        routeLine.retrieveDirectionsRoutes(),
-        directionsRoutes)
+      routeLine.retrieveDirectionsRoutes(),
+      directionsRoutes)
     ) {
-      cancelVanishingRouteLineAnimator();
       routeLine.draw(directionsRoutes);
+    } else {
+      routeLine.reinitializePrimaryRoute();
     }
   }
 
@@ -217,6 +218,7 @@ public class NavigationMapRoute implements LifecycleObserver {
       routeList.add(identifiableRoute.getRoute());
     }
 
+    cancelVanishingRouteLineAnimator();
     if (directionsRoutes.isEmpty()) {
       routeLine.drawIdentifiableRoutes(directionsRoutes);
     } else if (!CompareUtils.areEqualContentsIgnoreOrder(
@@ -224,6 +226,8 @@ public class NavigationMapRoute implements LifecycleObserver {
             routeList)
     ) {
       routeLine.drawIdentifiableRoutes(directionsRoutes);
+    } else {
+      routeLine.reinitializePrimaryRoute();
     }
   }
 

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/NavigationMapRouteTest.java
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/NavigationMapRouteTest.java
@@ -207,7 +207,7 @@ public class NavigationMapRouteTest {
   }
 
   @Test
-  public void addRoutes_mapRouteProgressChangeListenerIsAdded() {
+  public void addRoutes() {
     MapboxNavigation mockedNavigation = mock(MapboxNavigation.class);
     MapView mockedMapView = mock(MapView.class);
     MapboxMap mockedMapboxMap = mock(MapboxMap.class);
@@ -220,9 +220,19 @@ public class NavigationMapRouteTest {
     MapRouteArrow mockedMapRouteArrow = mock(MapRouteArrow.class);
     List<DirectionsRoute> routes = Collections.emptyList();
     LifecycleOwner mockedLifecycleOwner = mock(LifecycleOwner.class);
-    NavigationMapRoute theNavigationMapRoute = new NavigationMapRoute(mockedNavigation, mockedMapView, mockedMapboxMap,
-            mockedLifecycleOwner, mockedStyleRes, "", mockedMapClickListener, mockedDidFinishLoadingStyleListener,
-      mockedProgressChangeListener, mockedMapRouteLine, mockedMapRouteArrow);
+    NavigationMapRoute theNavigationMapRoute = new NavigationMapRoute(
+      mockedNavigation,
+      mockedMapView,
+      mockedMapboxMap,
+      mockedLifecycleOwner,
+      mockedStyleRes,
+      "",
+      mockedMapClickListener,
+      mockedDidFinishLoadingStyleListener,
+      mockedProgressChangeListener,
+      mockedMapRouteLine,
+      mockedMapRouteArrow
+    );
 
     theNavigationMapRoute.addRoutes(routes);
 
@@ -230,7 +240,7 @@ public class NavigationMapRouteTest {
   }
 
   @Test
-  public void addRoutesDrawNotCalled() {
+  public void addRoutes_drawNotCalled() {
     DirectionsRoute mockRoute = mock(DirectionsRoute.class);
     MapboxNavigation mockedNavigation = mock(MapboxNavigation.class);
     MapView mockedMapView = mock(MapView.class);
@@ -255,6 +265,31 @@ public class NavigationMapRouteTest {
   }
 
   @Test
+  public void addRoutes_reInitializePrimaryRoute() {
+    DirectionsRoute mockRoute = mock(DirectionsRoute.class);
+    MapboxNavigation mockedNavigation = mock(MapboxNavigation.class);
+    MapView mockedMapView = mock(MapView.class);
+    MapboxMap mockedMapboxMap = mock(MapboxMap.class);
+    int mockedStyleRes = 0;
+    MapRouteClickListener mockedMapClickListener = mock(MapRouteClickListener.class);
+    MapView.OnDidFinishLoadingStyleListener mockedDidFinishLoadingStyleListener =
+            mock(MapView.OnDidFinishLoadingStyleListener.class);
+    MapRouteProgressChangeListener mockedProgressChangeListener = mock(MapRouteProgressChangeListener.class);
+    MapRouteLine mockedMapRouteLine = mock(MapRouteLine.class);
+    MapRouteArrow mockedMapRouteArrow = mock(MapRouteArrow.class);
+    LifecycleOwner mockedLifecycleOwner = mock(LifecycleOwner.class);
+    List<DirectionsRoute> routes = Collections.singletonList(mockRoute);
+    NavigationMapRoute theNavigationMapRoute = new NavigationMapRoute(mockedNavigation, mockedMapView, mockedMapboxMap,
+            mockedLifecycleOwner, mockedStyleRes, "", mockedMapClickListener, mockedDidFinishLoadingStyleListener,
+            mockedProgressChangeListener, mockedMapRouteLine, mockedMapRouteArrow);
+    when(mockedMapRouteLine.retrieveDirectionsRoutes()).thenReturn(Collections.singletonList(mockRoute));
+
+    theNavigationMapRoute.addRoutes(routes);
+
+    verify(mockedMapRouteLine).reinitializePrimaryRoute();
+  }
+
+  @Test
   public void updateRouteVisibilityTo_routeLineVisibilityIsUpdated() {
     MapboxNavigation mockedNavigation = mock(MapboxNavigation.class);
     MapView mockedMapView = mock(MapView.class);
@@ -275,6 +310,82 @@ public class NavigationMapRouteTest {
     theNavigationMapRoute.updateRouteVisibilityTo(isVisible);
 
     verify(mockedMapRouteLine).updateVisibilityTo(isVisible);
+  }
+
+  @Test
+  public void addIdentifiableRoutes() {
+    MapboxNavigation mockedNavigation = mock(MapboxNavigation.class);
+    MapView mockedMapView = mock(MapView.class);
+    MapboxMap mockedMapboxMap = mock(MapboxMap.class);
+    int mockedStyleRes = 0;
+    MapRouteClickListener mockedMapClickListener = mock(MapRouteClickListener.class);
+    MapView.OnDidFinishLoadingStyleListener mockedDidFinishLoadingStyleListener =
+            mock(MapView.OnDidFinishLoadingStyleListener.class);
+    MapRouteProgressChangeListener mockedProgressChangeListener = mock(MapRouteProgressChangeListener.class);
+    MapRouteLine mockedMapRouteLine = mock(MapRouteLine.class);
+    MapRouteArrow mockedMapRouteArrow = mock(MapRouteArrow.class);
+    List<IdentifiableRoute> routes = Collections.emptyList();
+    LifecycleOwner mockedLifecycleOwner = mock(LifecycleOwner.class);
+    NavigationMapRoute theNavigationMapRoute = new NavigationMapRoute(mockedNavigation, mockedMapView, mockedMapboxMap,
+            mockedLifecycleOwner, mockedStyleRes, "", mockedMapClickListener, mockedDidFinishLoadingStyleListener,
+            mockedProgressChangeListener, mockedMapRouteLine, mockedMapRouteArrow);
+
+
+    theNavigationMapRoute.addIdentifiableRoutes(routes);
+
+    verify(mockedMapRouteLine).drawIdentifiableRoutes(eq(routes));
+  }
+
+  @Test
+  public void addIdentifiableRoutes_drawNotCalled() {
+    DirectionsRoute mockRoute = mock(DirectionsRoute.class);
+    IdentifiableRoute mockIdentifiableRoute = new IdentifiableRoute(mockRoute, "foobar");
+    MapboxNavigation mockedNavigation = mock(MapboxNavigation.class);
+    MapView mockedMapView = mock(MapView.class);
+    MapboxMap mockedMapboxMap = mock(MapboxMap.class);
+    int mockedStyleRes = 0;
+    MapRouteClickListener mockedMapClickListener = mock(MapRouteClickListener.class);
+    MapView.OnDidFinishLoadingStyleListener mockedDidFinishLoadingStyleListener =
+            mock(MapView.OnDidFinishLoadingStyleListener.class);
+    MapRouteProgressChangeListener mockedProgressChangeListener = mock(MapRouteProgressChangeListener.class);
+    MapRouteLine mockedMapRouteLine = mock(MapRouteLine.class);
+    MapRouteArrow mockedMapRouteArrow = mock(MapRouteArrow.class);
+    LifecycleOwner mockedLifecycleOwner = mock(LifecycleOwner.class);
+    List<IdentifiableRoute> routes = Collections.singletonList(mockIdentifiableRoute);
+    NavigationMapRoute theNavigationMapRoute = new NavigationMapRoute(mockedNavigation, mockedMapView, mockedMapboxMap,
+            mockedLifecycleOwner, mockedStyleRes, "", mockedMapClickListener, mockedDidFinishLoadingStyleListener,
+            mockedProgressChangeListener, mockedMapRouteLine, mockedMapRouteArrow);
+    when(mockedMapRouteLine.retrieveDirectionsRoutes()).thenReturn(Collections.singletonList(mockRoute));
+
+    theNavigationMapRoute.addIdentifiableRoutes(routes);
+
+    verify(mockedMapRouteLine, never()).drawIdentifiableRoutes(eq(routes));
+  }
+
+  @Test
+  public void addIdentifiableRoutes_reInitializePrimaryRoute() {
+    DirectionsRoute mockRoute = mock(DirectionsRoute.class);
+    IdentifiableRoute mockIdentifiableRoute = new IdentifiableRoute(mockRoute, "foobar");
+    MapboxNavigation mockedNavigation = mock(MapboxNavigation.class);
+    MapView mockedMapView = mock(MapView.class);
+    MapboxMap mockedMapboxMap = mock(MapboxMap.class);
+    int mockedStyleRes = 0;
+    MapRouteClickListener mockedMapClickListener = mock(MapRouteClickListener.class);
+    MapView.OnDidFinishLoadingStyleListener mockedDidFinishLoadingStyleListener =
+            mock(MapView.OnDidFinishLoadingStyleListener.class);
+    MapRouteProgressChangeListener mockedProgressChangeListener = mock(MapRouteProgressChangeListener.class);
+    MapRouteLine mockedMapRouteLine = mock(MapRouteLine.class);
+    MapRouteArrow mockedMapRouteArrow = mock(MapRouteArrow.class);
+    LifecycleOwner mockedLifecycleOwner = mock(LifecycleOwner.class);
+    List<IdentifiableRoute> routes = Collections.singletonList(mockIdentifiableRoute);
+    NavigationMapRoute theNavigationMapRoute = new NavigationMapRoute(mockedNavigation, mockedMapView, mockedMapboxMap,
+            mockedLifecycleOwner, mockedStyleRes, "", mockedMapClickListener, mockedDidFinishLoadingStyleListener,
+            mockedProgressChangeListener, mockedMapRouteLine, mockedMapRouteArrow);
+    when(mockedMapRouteLine.retrieveDirectionsRoutes()).thenReturn(Collections.singletonList(mockRoute));
+
+    theNavigationMapRoute.addIdentifiableRoutes(routes);
+
+    verify(mockedMapRouteLine).reinitializePrimaryRoute();
   }
 
   @Test


### PR DESCRIPTION
## Description

When calling addRoutes on NavigationMapRoute there is a check to see if the routes passed as a parameter match the routes the MapRouteLine already has. If there is a match nothing is done. This check of the routes matching was done in response to #2473. The work done for issue #3246 resulted in the route drawing done in two steps by the progress change listener.  It's possible that on a lifecycle change the progress update listener will get a route in its update and perform the first stage of the route drawing, then a call is made to NavigationMapRoute.addRoutes which wouldn't result in a redraw of the routes because that method would see that the routes in the MapRouteLine, which were set by the progress listener, would match. The result is the route line would not be visible on the map.

This PR adds a call to reinitialize the primary route in such a case so that the geojson source representing the line is reapplied thus making the line render.  This will occur without the other side effects that a full drawing of the routes causes.

- [ ] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal


### Implementation


## Screenshots or Gifs


## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->