### PR TITLE
Use AppCompatResources#getDrawable instead of ContextCompat#getDrawable in ThemeSwitcher#retrieveThemeMapMarker

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/internal/ThemeSwitcher.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/internal/ThemeSwitcher.java
@@ -9,16 +9,14 @@ import android.graphics.drawable.Drawable;
 import android.preference.PreferenceManager;
 import android.util.AttributeSet;
 import android.util.TypedValue;
-
 import androidx.annotation.AnyRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.core.content.ContextCompat;
-
-import com.mapbox.navigation.ui.R;
+import androidx.appcompat.content.res.AppCompatResources;
 import com.mapbox.mapboxsdk.utils.BitmapUtils;
-import com.mapbox.navigation.ui.NavigationView;
 import com.mapbox.navigation.ui.NavigationConstants;
+import com.mapbox.navigation.ui.NavigationView;
+import com.mapbox.navigation.ui.R;
 
 /**
  * This class is used to switch theme colors in {@link NavigationView}.
@@ -43,7 +41,7 @@ public class ThemeSwitcher {
       }
     }
 
-    Drawable markerDrawable = ContextCompat.getDrawable(context, markerResId);
+    Drawable markerDrawable = AppCompatResources.getDrawable(context, markerResId);
     return BitmapUtils.getBitmapFromDrawable(markerDrawable);
   }
 


### PR DESCRIPTION
## Description

Markers are now vector drawables and [`AppCompatResources#getDrawable`](https://developer.android.com/reference/androidx/appcompat/content/res/AppCompatResources) should be used instead of [`ContextCompat#getDrawable`](https://developer.android.com/reference/kotlin/androidx/core/content/ContextCompat#getdrawable) to prevent issues / crashes with older versions

Fixes #3493 

Regression from #3487 

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Fix regression causing crashes in `ThemeSwitcher#retrieveThemeMapMarker`

### Implementation

Replace `ContextCompat#getDrawable` by `AppCompatResources#getDrawable` to support vector drawables in all versions

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
