### PR TITLE
Fix MapboxNavigationTelemetry init logic

### DIFF
--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
@@ -161,6 +161,8 @@ class MapboxNavigationTest {
     @Test
     fun sanity() {
         assertNotNull(mapboxNavigation)
+
+        mapboxNavigation.onDestroy()
     }
 
     @Test
@@ -171,8 +173,58 @@ class MapboxNavigationTest {
     }
 
     @Test
-    fun init_registerOffRouteObserver_internalOffRouteObserver() {
-        verify(exactly = 1) { tripSession.registerOffRouteObserver(any()) }
+    fun init_registerOffRouteObserver() {
+        verify(exactly = 2) { tripSession.registerOffRouteObserver(any()) }
+
+        mapboxNavigation.onDestroy()
+    }
+
+    @Test
+    fun destroy_unregisterOffRouteObserver() {
+        mapboxNavigation.onDestroy()
+
+        verify(exactly = 1) { tripSession.unregisterOffRouteObserver(any()) }
+
+        mapboxNavigation.onDestroy()
+    }
+
+    @Test
+    fun init_registerOffRouteObserver_MapboxNavigation_recreated() {
+        ThreadController.cancelAllUICoroutines()
+        val navigationOptions = NavigationOptions
+            .Builder(applicationContext)
+            .accessToken(accessToken)
+            .distanceFormatter(distanceFormatter)
+            .navigatorPredictionMillis(1500L)
+            .onboardRouterOptions(onBoardRouterOptions)
+            .timeFormatType(NONE_SPECIFIED)
+            .locationEngine(locationEngine)
+            .build()
+
+        mapboxNavigation = MapboxNavigation(navigationOptions)
+
+        verify(exactly = 4) { tripSession.registerOffRouteObserver(any()) }
+
+        mapboxNavigation.onDestroy()
+    }
+
+    @Test
+    fun destroy_unregisterOffRouteObserver_MapboxNavigation_recreated() {
+        ThreadController.cancelAllUICoroutines()
+        val navigationOptions = NavigationOptions
+            .Builder(applicationContext)
+            .accessToken(accessToken)
+            .distanceFormatter(distanceFormatter)
+            .navigatorPredictionMillis(1500L)
+            .onboardRouterOptions(onBoardRouterOptions)
+            .timeFormatType(NONE_SPECIFIED)
+            .locationEngine(locationEngine)
+            .build()
+        mapboxNavigation = MapboxNavigation(navigationOptions)
+
+        mapboxNavigation.onDestroy()
+
+        verify(exactly = 2) { tripSession.unregisterOffRouteObserver(any()) }
 
         mapboxNavigation.onDestroy()
     }
@@ -272,12 +324,16 @@ class MapboxNavigationTest {
     fun fasterRoute_noRouteOptions_noRequest() {
         every { directionsSession.getRouteOptions() } returns null
         verify(exactly = 0) { directionsSession.requestFasterRoute(any(), any()) }
+
+        mapboxNavigation.onDestroy()
     }
 
     @Test
     fun fasterRoute_noEnhancedLocation_noRequest() {
         every { tripSession.getEnhancedLocation() } returns null
         verify(exactly = 0) { directionsSession.requestFasterRoute(any(), any()) }
+
+        mapboxNavigation.onDestroy()
     }
 
     @Test
@@ -287,6 +343,8 @@ class MapboxNavigationTest {
         mapboxNavigation.setArrivalController(arrivalController)
 
         verify { tripSession.registerRouteProgressObserver(any<ArrivalProgressObserver>()) }
+
+        mapboxNavigation.onDestroy()
     }
 
     @Test
@@ -296,6 +354,8 @@ class MapboxNavigationTest {
         mapboxNavigation.setArrivalController(arrivalController)
 
         verify { tripSession.unregisterRouteProgressObserver(any<ArrivalProgressObserver>()) }
+
+        mapboxNavigation.onDestroy()
     }
 
     @Test
@@ -312,6 +372,8 @@ class MapboxNavigationTest {
             tripSession.registerOffRouteObserver(any())
             rerouteController.reroute(any())
         }
+
+        mapboxNavigation.onDestroy()
     }
 
     @Test
@@ -322,6 +384,8 @@ class MapboxNavigationTest {
         offRouteObserverSlot.captured.onOffRouteStateChanged(false)
 
         verify(exactly = 0) { rerouteController.reroute(any()) }
+
+        mapboxNavigation.onDestroy()
     }
 
     @Test
@@ -337,6 +401,8 @@ class MapboxNavigationTest {
         }
 
         verify { tripSession.route = primary }
+
+        mapboxNavigation.onDestroy()
     }
 
     @Test
@@ -350,6 +416,7 @@ class MapboxNavigationTest {
         }
 
         verify { tripSession.route = null }
+        mapboxNavigation.onDestroy()
     }
 
     @Test
@@ -357,6 +424,8 @@ class MapboxNavigationTest {
         mapboxNavigation.requestRoutes(mockk())
 
         verify(exactly = 1) { rerouteController.interrupt() }
+
+        mapboxNavigation.onDestroy()
     }
 
     @Test
@@ -364,6 +433,8 @@ class MapboxNavigationTest {
         mapboxNavigation.setRoutes(mockk())
 
         verify(exactly = 1) { rerouteController.interrupt() }
+
+        mapboxNavigation.onDestroy()
     }
 
     @Test
@@ -386,6 +457,8 @@ class MapboxNavigationTest {
             rerouteController.interrupt()
             newRerouteController.reroute(any())
         }
+
+        mapboxNavigation.onDestroy()
     }
 
     private fun mockLocation() {

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetryTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetryTest.kt
@@ -78,6 +78,11 @@ class MapboxNavigationTelemetryTest {
     }
 
     @Test
+    fun onInit_registerNavigationSessionObserver_called() {
+        onInit { verify(exactly = 1) { mapboxNavigation.registerNavigationSessionObserver(any()) } }
+    }
+
+    @Test
     fun onInit_getRoutes_called() {
         onInit { verify(exactly = 1) { mapboxNavigation.getRoutes() } }
     }
@@ -103,6 +108,11 @@ class MapboxNavigationTelemetryTest {
     }
 
     @Test
+    fun onUnregisterListener_unregisterNavigationSessionObserver_called() {
+        onUnregister { verify(exactly = 1) { mapboxNavigation.unregisterNavigationSessionObserver(any()) } }
+    }
+
+    @Test
     fun after_unregister_onInit_registers_all_listeners_again() {
         initTelemetry()
         resetTelemetry()
@@ -112,7 +122,22 @@ class MapboxNavigationTelemetryTest {
         verify(exactly = 2) { mapboxNavigation.registerLocationObserver(any()) }
         verify(exactly = 2) { mapboxNavigation.registerRoutesObserver(any()) }
         verify(exactly = 2) { mapboxNavigation.registerOffRouteObserver(any()) }
+        verify(exactly = 2) { mapboxNavigation.registerNavigationSessionObserver(any()) }
         verify(exactly = 2) { mapboxNavigation.getRoutes() }
+
+        resetTelemetry()
+    }
+
+    @Test
+    fun onInitTwice_unregisters_all_listeners() {
+        initTelemetry()
+        initTelemetry()
+
+        verify(exactly = 1) { mapboxNavigation.unregisterRouteProgressObserver(any()) }
+        verify(exactly = 1) { mapboxNavigation.unregisterLocationObserver(any()) }
+        verify(exactly = 1) { mapboxNavigation.unregisterRoutesObserver(any()) }
+        verify(exactly = 1) { mapboxNavigation.unregisterOffRouteObserver(any()) }
+        verify(exactly = 1) { mapboxNavigation.unregisterNavigationSessionObserver(any()) }
 
         resetTelemetry()
     }


### PR DESCRIPTION
## Description

Fix `MapboxNavigationTelemetry` init logic so that `initialize` can be called multiple times and reset properly when `MapboxNavigation` instance is re-created

Fixes #3486 

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

All events are sent when in _Active Guidance_ irrespective of `MapboxNavigation` lifecycle

### Implementation

Fix `MapboxNavigationTelemetry` init logic so that `initialize` can be called multiple times and reset properly when `MapboxNavigation` instance is re-created. Note that `MapboxNavigationTelemetry` is an `object` (singleton) and was guarded by `preInitializePredicate` and `postInitializePredicate` `initializer` predicates. Those were removed and logic adapted so that `MapboxNavigationTelemetry` could be re-initialized and works as designed irrespective of the `MapboxNavigation` lifecycle that internally handles its instantiation

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
