### PR TITLE
Using combined geojson source for route line components.

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/internal/route/RouteConstants.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/internal/route/RouteConstants.java
@@ -2,8 +2,6 @@ package com.mapbox.navigation.ui.internal.route;
 
 public class RouteConstants {
   public static final String PRIMARY_ROUTE_SOURCE_ID = "mapbox-navigation-route-source";
-  public static final String PRIMARY_ROUTE_CASING_SOURCE_ID = "mapbox-navigation-route-casing-source";
-  public static final String PRIMARY_ROUTE_TRAFFIC_SOURCE_ID = "mapbox-navigation-route-traffic-source";
   public static final String PRIMARY_ROUTE_LAYER_ID = "mapbox-navigation-route-layer";
   public static final String PRIMARY_ROUTE_TRAFFIC_LAYER_ID = "mapbox-navigation-route-traffic-layer";
   public static final String PRIMARY_ROUTE_CASING_LAYER_ID = "mapbox-navigation-route-casing-layer";

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteLine.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteLine.kt
@@ -30,13 +30,14 @@ import com.mapbox.navigation.ui.internal.route.RouteConstants.HEAVY_CONGESTION_V
 import com.mapbox.navigation.ui.internal.route.RouteConstants.MINIMUM_ROUTE_LINE_OFFSET
 import com.mapbox.navigation.ui.internal.route.RouteConstants.MODERATE_CONGESTION_VALUE
 import com.mapbox.navigation.ui.internal.route.RouteConstants.PRIMARY_ROUTE_LAYER_ID
+import com.mapbox.navigation.ui.internal.route.RouteConstants.PRIMARY_ROUTE_SOURCE_ID
 import com.mapbox.navigation.ui.internal.route.RouteConstants.PRIMARY_ROUTE_TRAFFIC_LAYER_ID
-import com.mapbox.navigation.ui.internal.route.RouteConstants.PRIMARY_ROUTE_TRAFFIC_SOURCE_ID
 import com.mapbox.navigation.ui.internal.route.RouteConstants.SEVERE_CONGESTION_VALUE
 import com.mapbox.navigation.ui.internal.route.RouteConstants.UNKNOWN_CONGESTION_VALUE
 import com.mapbox.navigation.ui.internal.route.RouteConstants.WAYPOINT_DESTINATION_VALUE
 import com.mapbox.navigation.ui.internal.route.RouteConstants.WAYPOINT_ORIGIN_VALUE
 import com.mapbox.navigation.ui.internal.route.RouteConstants.WAYPOINT_PROPERTY_KEY
+import com.mapbox.navigation.ui.internal.route.RouteConstants.WAYPOINT_SOURCE_ID
 import com.mapbox.navigation.ui.internal.route.RouteLayerProvider
 import com.mapbox.navigation.ui.internal.utils.MapUtils
 import com.mapbox.navigation.ui.route.MapRouteLine.MapRouteLineSupport.buildWayPointFeatureCollection
@@ -125,8 +126,6 @@ internal class MapRouteLine(
 
     private var wayPointSource: GeoJsonSource
     private val primaryRouteLineSource: GeoJsonSource
-    private val primaryRouteLineCasingSource: GeoJsonSource
-    private val primaryRouteLineTrafficSource: GeoJsonSource
     private val alternativeRouteLineSource: GeoJsonSource
     private val routeLayerIds = mutableSetOf<String>()
     private val directionsRoutes = mutableListOf<DirectionsRoute>()
@@ -342,7 +341,7 @@ internal class MapRouteLine(
 
         val wayPointGeoJsonOptions = GeoJsonOptions().withMaxZoom(16)
         wayPointSource = mapRouteSourceProvider.build(
-            RouteConstants.WAYPOINT_SOURCE_ID,
+            WAYPOINT_SOURCE_ID,
             drawnWaypointsFeatureCollection,
             wayPointGeoJsonOptions
         )
@@ -350,26 +349,11 @@ internal class MapRouteLine(
 
         val routeLineGeoJsonOptions = GeoJsonOptions().withMaxZoom(16).withLineMetrics(true)
         primaryRouteLineSource = mapRouteSourceProvider.build(
-            RouteConstants.PRIMARY_ROUTE_SOURCE_ID,
+            PRIMARY_ROUTE_SOURCE_ID,
             drawnPrimaryRouteFeatureCollection,
             routeLineGeoJsonOptions
         )
         style.addSource(primaryRouteLineSource)
-
-        primaryRouteLineCasingSource = mapRouteSourceProvider.build(
-            RouteConstants.PRIMARY_ROUTE_CASING_SOURCE_ID,
-            drawnPrimaryRouteFeatureCollection,
-            routeLineGeoJsonOptions
-        )
-        style.addSource(primaryRouteLineCasingSource)
-
-        val routeLineTrafficGeoJsonOptions = GeoJsonOptions().withMaxZoom(16).withLineMetrics(true)
-        primaryRouteLineTrafficSource = mapRouteSourceProvider.build(
-            PRIMARY_ROUTE_TRAFFIC_SOURCE_ID,
-            drawnPrimaryRouteFeatureCollection,
-            routeLineTrafficGeoJsonOptions
-        )
-        style.addSource(primaryRouteLineTrafficSource)
 
         val alternativeRouteLineGeoJsonOptions =
             GeoJsonOptions().withMaxZoom(16).withLineMetrics(true)
@@ -791,9 +775,7 @@ internal class MapRouteLine(
 
     private fun setPrimaryRoutesSource(featureCollection: FeatureCollection) {
         drawnPrimaryRouteFeatureCollection = featureCollection
-        primaryRouteLineCasingSource.setGeoJson(drawnPrimaryRouteFeatureCollection)
         primaryRouteLineSource.setGeoJson(drawnPrimaryRouteFeatureCollection)
-        primaryRouteLineTrafficSource.setGeoJson(drawnPrimaryRouteFeatureCollection)
     }
 
     private fun setAlternativeRoutesSource(featureCollection: FeatureCollection) {

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapboxRouteLayerProvider.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapboxRouteLayerProvider.kt
@@ -33,11 +33,9 @@ import com.mapbox.navigation.ui.internal.route.RouteConstants.DEFAULT_ROUTE_DESC
 import com.mapbox.navigation.ui.internal.route.RouteConstants.DESTINATION_MARKER_NAME
 import com.mapbox.navigation.ui.internal.route.RouteConstants.ORIGIN_MARKER_NAME
 import com.mapbox.navigation.ui.internal.route.RouteConstants.PRIMARY_ROUTE_CASING_LAYER_ID
-import com.mapbox.navigation.ui.internal.route.RouteConstants.PRIMARY_ROUTE_CASING_SOURCE_ID
 import com.mapbox.navigation.ui.internal.route.RouteConstants.PRIMARY_ROUTE_LAYER_ID
 import com.mapbox.navigation.ui.internal.route.RouteConstants.PRIMARY_ROUTE_SOURCE_ID
 import com.mapbox.navigation.ui.internal.route.RouteConstants.PRIMARY_ROUTE_TRAFFIC_LAYER_ID
-import com.mapbox.navigation.ui.internal.route.RouteConstants.PRIMARY_ROUTE_TRAFFIC_SOURCE_ID
 import com.mapbox.navigation.ui.internal.route.RouteConstants.WAYPOINT_DESTINATION_VALUE
 import com.mapbox.navigation.ui.internal.route.RouteConstants.WAYPOINT_LAYER_ID
 import com.mapbox.navigation.ui.internal.route.RouteConstants.WAYPOINT_ORIGIN_VALUE
@@ -117,7 +115,7 @@ internal interface MapboxRouteLayerProvider : RouteLayerProvider {
             style,
             roundedLineCap,
             PRIMARY_ROUTE_TRAFFIC_LAYER_ID,
-            PRIMARY_ROUTE_TRAFFIC_SOURCE_ID,
+            PRIMARY_ROUTE_SOURCE_ID,
             lineWidthScaleExpression,
             routeLineColorExpressions)
     }
@@ -133,7 +131,7 @@ internal interface MapboxRouteLayerProvider : RouteLayerProvider {
             style,
             true,
             PRIMARY_ROUTE_CASING_LAYER_ID,
-            PRIMARY_ROUTE_CASING_SOURCE_ID,
+            PRIMARY_ROUTE_SOURCE_ID,
             lineWidthScaleExpression,
             routeLineColorExpressions)
     }

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteLineTest.kt
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteLineTest.kt
@@ -111,9 +111,7 @@ class MapRouteLineTest {
         mapRouteSourceProvider = mockk {
             every { build(RouteConstants.WAYPOINT_SOURCE_ID, any(), any()) } returns wayPointSource
             every { build(RouteConstants.PRIMARY_ROUTE_SOURCE_ID, any(), any()) } returns primaryRouteLineSource
-            every { build(RouteConstants.PRIMARY_ROUTE_TRAFFIC_SOURCE_ID, any(), any()) } returns primaryRouteLineTrafficSource
             every { build(RouteConstants.ALTERNATIVE_ROUTE_SOURCE_ID, any(), any()) } returns alternativeRouteLineSource
-            every { build(RouteConstants.PRIMARY_ROUTE_CASING_SOURCE_ID, any(), any()) } returns primaryRouteCasingSource
         }
         layerProvider = mockk {
             every {


### PR DESCRIPTION
## Description

As a workaround a bug in the maps SDK, in preparation for the 1.0 RC the geojson sources were separated for the route line components so that the casing line, main line, and traffic line would display properly.  Since that work around has been merged into the RC branch the work in this PR modifies the code so that the route line components share the same geojson source.

- [ ] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal


### Implementation


## Screenshots or Gifs


## Testing


- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->