### PR TITLE
Backport 3510 to release-v1.0

### DIFF
--- a/libnavigation-ui/api/current.txt
+++ b/libnavigation-ui/api/current.txt
@@ -593,7 +593,7 @@ package com.mapbox.navigation.ui.route {
 
   public static class NavigationMapRoute.Builder {
     ctor public NavigationMapRoute.Builder(com.mapbox.mapboxsdk.maps.MapView, com.mapbox.mapboxsdk.maps.MapboxMap, androidx.lifecycle.LifecycleOwner);
-    method public com.mapbox.navigation.ui.route.NavigationMapRoute? build();
+    method public com.mapbox.navigation.ui.route.NavigationMapRoute build();
     method public com.mapbox.navigation.ui.route.NavigationMapRoute.Builder withBelowLayer(String?);
     method public com.mapbox.navigation.ui.route.NavigationMapRoute.Builder withMapboxNavigation(com.mapbox.navigation.core.MapboxNavigation?);
     method public com.mapbox.navigation.ui.route.NavigationMapRoute.Builder withRouteLineInitializedCallback(com.mapbox.navigation.ui.route.MapRouteLineInitializedCallback?);

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/NavigationMapRoute.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/NavigationMapRoute.java
@@ -608,7 +608,7 @@ public class NavigationMapRoute implements LifecycleObserver {
     /**
      * Build an instance of {@link NavigationMapRoute}
      */
-    @Nullable
+    @NonNull
     public NavigationMapRoute build() {
       return new NavigationMapRoute(
           navigation,


### PR DESCRIPTION
Backports https://github.com/mapbox/mapbox-navigation-android/pull/3510 to `release-v1.0`.