### PR TITLE
Refactored building highlight activities to display highlighting when 250 meters away

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/ui/BuildingFootprintHighlightActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/ui/BuildingFootprintHighlightActivity.kt
@@ -11,6 +11,7 @@ import com.mapbox.mapboxsdk.maps.MapboxMap
 import com.mapbox.navigation.base.trip.model.RouteLegProgress
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.arrival.ArrivalObserver
+import com.mapbox.navigation.core.trip.session.RouteProgressObserver
 import com.mapbox.navigation.examples.R
 import com.mapbox.navigation.ui.NavigationViewOptions
 import com.mapbox.navigation.ui.OnNavigationReadyCallback
@@ -21,19 +22,22 @@ import com.mapbox.navigation.utils.internal.ifNonNull
 import kotlinx.android.synthetic.main.activity_final_destination_arrival_building_highlight.*
 
 /**
- * This activity shows how to use the Navigation UI SDK's [BuildingFootprintHighlightLayer]
- * class to highlight a single building footprint or extrusion.
+ * This activity shows how to use the Navigation UI SDK's
+ * [BuildingFootprintHighlightLayer] to show and customize a building's
+ * footprint on the [com.mapbox.navigation.ui.NavigationView]'s map.
  */
 class BuildingFootprintHighlightActivity :
     AppCompatActivity(),
     OnNavigationReadyCallback,
     NavigationListener,
-    ArrivalObserver {
+    ArrivalObserver,
+    RouteProgressObserver {
 
     private lateinit var mapboxMap: MapboxMap
     private lateinit var navigationMapboxMap: NavigationMapboxMap
-    private val highlightQueryLatLng = LatLng(37.79115, -122.41376)
     private val route by lazy { getDirectionsRoute() }
+    private val highlightQueryLatLng = LatLng(37.79115, -122.41376)
+    private var higlightedFootprintAlreadyShown = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -106,6 +110,9 @@ class BuildingFootprintHighlightActivity :
                 // Pass the ArrivalObserver interface (this activity)
                 optionsBuilder.arrivalObserver(this)
 
+                // Pass the RouteProgressObserver interface (this activity)
+                optionsBuilder.routeProgressObserver(this)
+
                 optionsBuilder.directionsRoute(route)
                 optionsBuilder.shouldSimulateRoute(true)
                 navigationView.startNavigation(optionsBuilder.build())
@@ -119,30 +126,46 @@ class BuildingFootprintHighlightActivity :
 
     override fun onFinalDestinationArrival(routeProgress: RouteProgress) {
         mapboxMap.easeCamera(zoomTo(18.0), 1800)
+    }
 
+    override fun onRouteProgressChanged(routeProgress: RouteProgress) {
         /**
-         * Set the [LatLng] to be used by the [BuildingFootprintHighlightLayer].
-         * The footprint or extrusion that's shown is whatever is a maximum of 1 meter
-         * away from the query [LatLng].
-         *
-         * The LatLng passed through below is different than the coordinate used as the
-         * final destination coordinate in this example's [DirectionsRoute].
-         *
-         * This LatLng should be set before the visibility of either the extrusion
-         * or footprint is set to true.
+         * Show the building footprint when the device is a certain number of meters away
+         * from the end of the [DirectionsRoute] and if the highlighted footprint hasn't already been shown.
          */
+        if (routeProgress.distanceRemaining < METERS_DISTANCE_AWAY_TO_TRIGGER_HIGHLIGHTING &&
+            !higlightedFootprintAlreadyShown
+        ) {
+            mapboxMap.getStyle {
+                /**
+                 * Set the [LatLng] to be used by the [BuildingFootprintHighlightLayer].
+                 *
+                 * The LatLng passed through below is different than the coordinate used as the
+                 * final destination coordinate in this example's [DirectionsRoute].
+                 *
+                 * This LatLng should be set before the visibility of the footprint is set to true.
+                 */
 
-        // Initialize the Nav UI SDK's BuildingFootprintHighlightLayer class.
-        val buildingFootprintHighlightLayer = BuildingFootprintHighlightLayer(mapboxMap)
+                // Initialize the Nav UI SDK's BuildingFootprintHighlightLayer class.
+                val buildingFootprintHighlightLayer = BuildingFootprintHighlightLayer(mapboxMap)
 
-        buildingFootprintHighlightLayer.queryLatLng = highlightQueryLatLng
+                buildingFootprintHighlightLayer.queryLatLng = highlightQueryLatLng
 
-        buildingFootprintHighlightLayer.updateVisibility(true)
+                buildingFootprintHighlightLayer.updateVisibility(true)
 
-        // Click on a building footprint to move the highlighted footprint
-        mapboxMap.addOnMapClickListener {
-            buildingFootprintHighlightLayer.queryLatLng = it
-            true
+                /**
+                 * Set to true so that the code doesn't try to show highlighted footprint
+                 * again as the device remains less than a certain number of meters away
+                 * from the end of the [DirectionsRoute].
+                 */
+                higlightedFootprintAlreadyShown = true
+
+                // Click on a building footprint to move the highlighted footprint
+                mapboxMap.addOnMapClickListener {
+                    buildingFootprintHighlightLayer.queryLatLng = it
+                    true
+                }
+            }
         }
     }
 
@@ -173,5 +196,9 @@ class BuildingFootprintHighlightActivity :
             .bufferedReader()
             .use { it.readText() }
         return DirectionsRoute.fromJson(directionsRouteAsJson)
+    }
+
+    companion object {
+        private const val METERS_DISTANCE_AWAY_TO_TRIGGER_HIGHLIGHTING = 250f
     }
 }


### PR DESCRIPTION
## Description

This pr refactors the two building highlighting activities so that the highlighting appears when the device is 250 meters away from the end of the `DirectionsRoute`.

- [ ] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

To show the highlighting when the device is a bit further away from the end of the `DirectionsRoute` rather than showing the highlighting when `onFinalDestinationArrival()` fires. By default, `onFinalDestinationArrival()` fires when the device is 40 meters away from the end of the `DirectionsRoute`.

### Implementation

This pr's refactoring adds `RouteProgressObserver` usage to the two activities. As the device moves along the route, `routeProgress.distanceRemaining` is continuously checked until it's less than 250. The highlighting is then enabled.

This 250 meter refactoring was done to match the work that my colleagues on the iOS Nav UI SDK team are doing for showing these building highlights cc @d-prukop @MaximAlien 

## Screenshots or Gifs

![ezgif com-resize (1)](https://user-images.githubusercontent.com/4394910/91612127-9d4d9c80-e931-11ea-8432-0c217eb42138.gif)

![ezgif com-resize (3)](https://user-images.githubusercontent.com/4394910/91612307-fcabac80-e931-11ea-9fc2-444b6a84725b.gif)

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->