### PR TITLE
add api to clear markers

### DIFF
--- a/libnavigation-ui/api/current.txt
+++ b/libnavigation-ui/api/current.txt
@@ -439,14 +439,16 @@ package com.mapbox.navigation.ui.map {
     ctor public NavigationMapboxMap(com.mapbox.mapboxsdk.maps.MapView, com.mapbox.mapboxsdk.maps.MapboxMap, androidx.lifecycle.LifecycleOwner, boolean);
     ctor public NavigationMapboxMap(com.mapbox.mapboxsdk.maps.MapView, com.mapbox.mapboxsdk.maps.MapboxMap, androidx.lifecycle.LifecycleOwner, String?);
     ctor public NavigationMapboxMap(com.mapbox.mapboxsdk.maps.MapView, com.mapbox.mapboxsdk.maps.MapboxMap, androidx.lifecycle.LifecycleOwner, String?, boolean, boolean);
-    method public void addCustomMarker(com.mapbox.mapboxsdk.plugins.annotation.SymbolOptions!);
+    method public com.mapbox.mapboxsdk.plugins.annotation.Symbol! addCustomMarker(com.mapbox.mapboxsdk.plugins.annotation.SymbolOptions!);
     method public void addDestinationMarker(com.mapbox.geojson.Point!);
     method public void addOnCameraTrackingChangedListener(com.mapbox.mapboxsdk.location.OnCameraTrackingChangedListener);
     method public boolean addOnWayNameChangedListener(com.mapbox.navigation.ui.map.OnWayNameChangedListener!);
     method public void addProgressChangeListener(com.mapbox.navigation.core.MapboxNavigation);
     method public void addProgressChangeListener(com.mapbox.navigation.core.MapboxNavigation, boolean);
     method public void adjustLocationIconWith(int[]);
+    method public void clearMarkerWithId(long);
     method public void clearMarkers();
+    method public void clearMarkersWithIconImageProperty(String!);
     method public void drawIdentifiableRoute(com.mapbox.navigation.ui.route.IdentifiableRoute);
     method public void drawIdentifiableRoutes(java.util.List<com.mapbox.navigation.ui.route.IdentifiableRoute!>);
     method public void drawRoute(com.mapbox.api.directions.v5.models.DirectionsRoute);

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/NavigationMapboxMap.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/NavigationMapboxMap.java
@@ -18,6 +18,7 @@ import androidx.lifecycle.OnLifecycleEvent;
 
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.geojson.Point;
+import com.mapbox.mapboxsdk.plugins.annotation.Symbol;
 import com.mapbox.navigation.core.directions.session.RoutesObserver;
 import com.mapbox.navigation.core.trip.session.RouteProgressObserver;
 import com.mapbox.navigation.core.trip.session.TripSessionState;
@@ -248,7 +249,9 @@ public class NavigationMapboxMap implements LifecycleObserver {
    * @param position the point at which the marker will be placed
    */
   public void addDestinationMarker(Point position) {
-    navigationSymbolManager.addDestinationMarkerFor(position);
+    if (navigationSymbolManager != null) {
+      navigationSymbolManager.addDestinationMarkerFor(position);
+    }
   }
 
   /**
@@ -258,9 +261,41 @@ public class NavigationMapboxMap implements LifecycleObserver {
    * will clear all destination / custom markers that have been added to the map.
    *
    * @param options for the custom {@link com.mapbox.mapboxsdk.plugins.annotation.Symbol}
+   *
+   * @return the {@link com.mapbox.mapboxsdk.plugins.annotation.Symbol} that added to the map or null if adding fails
    */
-  public void addCustomMarker(SymbolOptions options) {
-    navigationSymbolManager.addCustomSymbolFor(options);
+  public Symbol addCustomMarker(SymbolOptions options) {
+    if (navigationSymbolManager != null) {
+      return navigationSymbolManager.addCustomSymbolFor(options);
+    } else {
+      return null;
+    }
+  }
+
+  /**
+   * Clears marker with the specified marker id.
+   * <p>
+   * Please note, this only clears the marker added by {@link NavigationMapboxMap#addCustomMarker(SymbolOptions)}
+   *
+   * @param markerId of the {@link com.mapbox.mapboxsdk.plugins.annotation.Symbol}
+   */
+  public void clearMarkerWithId(long markerId) {
+    if (navigationSymbolManager != null) {
+      navigationSymbolManager.clearSymbolWithId(markerId);
+    }
+  }
+
+  /**
+   * clears all markers with the specified icon image.
+   * <p>
+   * Please note, this only clears the markers added by {@link NavigationMapboxMap#addCustomMarker(SymbolOptions)}
+   *
+   * @param markerIconImageProperty of the {@link com.mapbox.mapboxsdk.plugins.annotation.Symbol}
+   */
+  public void clearMarkersWithIconImageProperty(String markerIconImageProperty) {
+    if (navigationSymbolManager != null) {
+      navigationSymbolManager.clearSymbolsWithIconImageProperty(markerIconImageProperty);
+    }
   }
 
   /**
@@ -270,7 +305,9 @@ public class NavigationMapboxMap implements LifecycleObserver {
    * if no markers have been added.
    */
   public void clearMarkers() {
-    navigationSymbolManager.removeAllMarkerSymbols();
+    if (navigationSymbolManager != null) {
+      navigationSymbolManager.clearAllMarkerSymbols();
+    }
   }
 
   /**
@@ -681,6 +718,7 @@ public class NavigationMapboxMap implements LifecycleObserver {
    *
    * @param isVisible true to show, false to hide
    */
+  @SuppressLint("MissingPermission")
   public void updateLocationVisibilityTo(boolean isVisible) {
     locationComponent.setLocationComponentEnabled(isVisible);
   }

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/map/NavigationMapboxMapTest.java
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/map/NavigationMapboxMapTest.java
@@ -3,9 +3,7 @@ package com.mapbox.navigation.ui.map;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.geojson.Point;
 import com.mapbox.mapboxsdk.location.LocationComponent;
-import com.mapbox.mapboxsdk.location.LocationComponentOptions;
 import com.mapbox.mapboxsdk.location.modes.RenderMode;
-import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.plugins.annotation.SymbolOptions;
@@ -323,6 +321,38 @@ public class NavigationMapboxMapTest {
     map.addCustomMarker(options);
 
     verify(navigationSymbolManager).addCustomSymbolFor(options);
+  }
+
+  @Test
+  public void clearMarkerWithId_navigationSymbolManagerReceivesId() {
+    long  markerId = 911L;
+    NavigationSymbolManager navigationSymbolManager = mock(NavigationSymbolManager.class);
+    NavigationMapboxMap map = new NavigationMapboxMap(navigationSymbolManager);
+
+    map.clearMarkerWithId(markerId);
+
+    verify(navigationSymbolManager).clearSymbolWithId(markerId);
+  }
+
+  @Test
+  public void clearMarkersWithIconImageProperty_navigationSymbolManagerReceivesIconImage() {
+    String markerIconImage = "icon-image";
+    NavigationSymbolManager navigationSymbolManager = mock(NavigationSymbolManager.class);
+    NavigationMapboxMap map = new NavigationMapboxMap(navigationSymbolManager);
+
+    map.clearMarkersWithIconImageProperty(markerIconImage);
+
+    verify(navigationSymbolManager).clearSymbolsWithIconImageProperty(markerIconImage);
+  }
+
+  @Test
+  public void clearMarkers_navigationSymbolManagerClearAllMarkerSymbols() {
+    NavigationSymbolManager navigationSymbolManager = mock(NavigationSymbolManager.class);
+    NavigationMapboxMap map = new NavigationMapboxMap(navigationSymbolManager);
+
+    map.clearMarkers();
+
+    verify(navigationSymbolManager).clearAllMarkerSymbols();
   }
 
   @Test

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/map/NavigationSymbolManagerTest.java
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/map/NavigationSymbolManagerTest.java
@@ -16,10 +16,13 @@ import static org.mockito.Mockito.when;
 
 public class NavigationSymbolManagerTest {
 
+  private static final long DEFAULT_SYMBOL_ID = 0L;
+  private static final String DEFAULT_SYMBOL_ICON_IMAGE = "defaultSymbolIconImage";
+
   @Test
   public void addDestinationMarkerFor_symbolManagerAddsOptions() {
     SymbolManager symbolManager = mock(SymbolManager.class);
-    Symbol symbol = mock(Symbol.class);
+    Symbol symbol = buildSymbolWith(DEFAULT_SYMBOL_ID, DEFAULT_SYMBOL_ICON_IMAGE);
     when(symbolManager.create(any(SymbolOptions.class))).thenReturn(symbol);
     NavigationSymbolManager navigationSymbolManager = new NavigationSymbolManager(symbolManager);
     Point position = Point.fromLngLat(1.2345, 1.3456);
@@ -46,7 +49,7 @@ public class NavigationSymbolManagerTest {
   }
 
   @Test
-  public void removeAllMarkerSymbols_previouslyAddedMarkersRemoved() {
+  public void clearAllMarkerSymbols_previouslyAddedMarkersCleared() {
     SymbolManager symbolManager = mock(SymbolManager.class);
     Symbol symbol = mock(Symbol.class);
     when(symbolManager.create(any(SymbolOptions.class))).thenReturn(symbol);
@@ -54,21 +57,82 @@ public class NavigationSymbolManagerTest {
     Point position = Point.fromLngLat(1.2345, 1.3456);
     navigationSymbolManager.addDestinationMarkerFor(position);
 
-    navigationSymbolManager.removeAllMarkerSymbols();
+    navigationSymbolManager.clearAllMarkerSymbols();
 
     verify(symbolManager).delete(symbol);
   }
 
   @Test
   public void addCustomSymbolFor_symbolManagerCreatesSymbol() {
-    SymbolManager symbolManager = mock(SymbolManager.class);
-    Symbol symbol = mock(Symbol.class);
+    Symbol symbol = buildSymbolWith(DEFAULT_SYMBOL_ID, DEFAULT_SYMBOL_ICON_IMAGE);
     SymbolOptions symbolOptions = mock(SymbolOptions.class);
-    when(symbolManager.create(symbolOptions)).thenReturn(symbol);
+    SymbolManager symbolManager = buildSymbolManager(symbolOptions, symbol);
     NavigationSymbolManager navigationSymbolManager = new NavigationSymbolManager(symbolManager);
 
     navigationSymbolManager.addCustomSymbolFor(symbolOptions);
 
     verify(symbolManager).create(symbolOptions);
+  }
+
+  @Test
+  public void clearSymbolWithId_previouslyAddedMarkersCleared() {
+    long symbolId = 911L;
+    Symbol symbol = buildSymbolWith(symbolId, DEFAULT_SYMBOL_ICON_IMAGE);
+    SymbolOptions symbolOptions = mock(SymbolOptions.class);
+    SymbolManager symbolManager = buildSymbolManager(symbolOptions, symbol);
+    NavigationSymbolManager navigationSymbolManager = new NavigationSymbolManager(symbolManager);
+    navigationSymbolManager.addCustomSymbolFor(symbolOptions);
+
+    navigationSymbolManager.clearSymbolWithId(symbolId);
+
+    verify(symbolManager).delete(symbol);
+  }
+
+  @Test
+  public void clearSymbolWithId_symbolBeClearedOnlyOnce() {
+    long symbolId = 911L;
+    Symbol symbol = buildSymbolWith(symbolId, DEFAULT_SYMBOL_ICON_IMAGE);
+    SymbolOptions symbolOptions = mock(SymbolOptions.class);
+    SymbolManager symbolManager = buildSymbolManager(symbolOptions, symbol);
+    NavigationSymbolManager navigationSymbolManager = new NavigationSymbolManager(symbolManager);
+    navigationSymbolManager.addCustomSymbolFor(symbolOptions);
+
+    navigationSymbolManager.clearSymbolWithId(symbolId);
+    navigationSymbolManager.clearSymbolWithId(symbolId);
+
+    verify(symbolManager, times(1)).delete(symbol);
+  }
+
+  @Test
+  public void clearSymbolsWithIconImageProperty_sameIconImageSymbolsCleared() {
+    Symbol defaultSymbol = buildSymbolWith(DEFAULT_SYMBOL_ID, DEFAULT_SYMBOL_ICON_IMAGE);
+    String iconImageFeedback = "feedback";
+    Symbol firstFeedbackSymbol = buildSymbolWith(DEFAULT_SYMBOL_ID + 1, iconImageFeedback);
+    Symbol secondFeedbackSymbol = buildSymbolWith(DEFAULT_SYMBOL_ID + 2, iconImageFeedback);
+    SymbolOptions symbolOptions = mock(SymbolOptions.class);
+    SymbolManager symbolManager = buildSymbolManager(symbolOptions, defaultSymbol, firstFeedbackSymbol, secondFeedbackSymbol);
+    NavigationSymbolManager navigationSymbolManager = new NavigationSymbolManager(symbolManager);
+    navigationSymbolManager.addCustomSymbolFor(symbolOptions);
+    navigationSymbolManager.addCustomSymbolFor(symbolOptions);
+    navigationSymbolManager.addCustomSymbolFor(symbolOptions);
+
+    navigationSymbolManager.clearSymbolsWithIconImageProperty(iconImageFeedback);
+
+    verify(symbolManager).delete(firstFeedbackSymbol);
+    verify(symbolManager).delete(secondFeedbackSymbol);
+    verify(symbolManager, times(0)).delete(defaultSymbol);
+  }
+
+  private Symbol buildSymbolWith(long symbolId, String iconImage) {
+    Symbol symbol = mock(Symbol.class);
+    when(symbol.getId()).thenReturn(symbolId);
+    when(symbol.getIconImage()).thenReturn(iconImage);
+    return symbol;
+  }
+
+  private SymbolManager buildSymbolManager(SymbolOptions symbolOptions, Symbol symbol, Symbol... symbols) {
+    SymbolManager symbolManager = mock(SymbolManager.class);
+    when(symbolManager.create(symbolOptions)).thenReturn(symbol, symbols);
+    return symbolManager;
   }
 }


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

`NavigationMapboxMap` has API to "add custom marker" and "clear all markers", but it doesn't offer API to delete the marker which added by the _**addCustomMarker**_.

This PR adds API to remove marker by **ID** or **IconImage**. It will be useful like when implementing Feedback UX.

- [ ] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->