### PR TITLE
CP: updated nav ui day and night styles to new stable production v1

### DIFF
--- a/libnavigation-ui/src/main/res/values/strings.xml
+++ b/libnavigation-ui/src/main/res/values/strings.xml
@@ -83,9 +83,9 @@
 
     <!-- Should not be translated -->
     <string name="mapbox_navigation_guidance_day"
-            translatable="false">mapbox://styles/mapbox-map-design/ckd6dqf981hi71iqlyn3e896y</string>
+            translatable="false">mapbox://styles/mapbox/navigation-day-v1</string>
     <string name="mapbox_navigation_guidance_night"
-            translatable="false">mapbox://styles/mapbox-map-design/ckd6dnz2q0m0q1io1mssumxqd</string>
+            translatable="false">mapbox://styles/mapbox/navigation-night-v1</string>
     <string name="mapbox_navigation_view_instance_state"
             translatable="false">navigation_view_instance_state</string>
     <string name="mapbox_navigation_running"


### PR DESCRIPTION
### Description

This PR cherry-picks the changes brought to our main branch in https://github.com/mapbox/mapbox-navigation-android/pull/3520, to the `1.0` release branch

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Include recent Nav UI day and night styles to `1.0` release

### Implementation

```
$> git checkout release-v1.0
$> git checkout -b pg-nav-day-night-styles-cp
$> git cherry-pick 94d886891aadee76b79f86b7c8db94fcac5c038e
```

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
