### PR TITLE
Changed logic for drawing routes.

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteClickListener.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteClickListener.java
@@ -72,7 +72,8 @@ class MapRouteClickListener implements MapboxMap.OnMapClickListener {
 
     DirectionsRoute clickedRoute = routeDistancesAwayFromClick.get(distancesAwayFromClick.get(0));
     int newPrimaryRouteIndex = directionsRoutes.indexOf(clickedRoute);
-    if (routeLine.updatePrimaryRouteIndex(clickedRoute) && onRouteSelectionChangeListener != null) {
+    if (clickedRoute != routeLine.getPrimaryRoute() && onRouteSelectionChangeListener != null) {
+      routeLine.updatePrimaryRouteIndex(clickedRoute);
       DirectionsRoute selectedRoute = directionsRoutes.get(newPrimaryRouteIndex);
       onRouteSelectionChangeListener.onNewPrimaryRouteSelected(selectedRoute);
     }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteLine.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteLine.kt
@@ -473,14 +473,9 @@ internal class MapRouteLine(
      *
      * @param route the DirectionsRoute which should be designated as the primary
      */
-    fun updatePrimaryRouteIndex(route: DirectionsRoute): Boolean {
-        return if (route != this.primaryRoute) {
-            this.primaryRoute = route
-            drawRoutes(routeFeatureData)
-            true
-        } else {
-            false
-        }
+    fun updatePrimaryRouteIndex(route: DirectionsRoute) {
+        this.primaryRoute = route
+        drawRoutes(routeFeatureData)
     }
 
     /**
@@ -776,8 +771,9 @@ internal class MapRouteLine(
         )
     }
 
-    private fun clearRouteData() {
+    fun clearRouteData() {
         vanishPointOffset = 0f
+        primaryRoute = null
         directionsRoutes.clear()
         routeFeatureData.clear()
         routeLineExpressionData.clear()

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/NavigationMapRoute.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/NavigationMapRoute.java
@@ -195,14 +195,14 @@ public class NavigationMapRoute implements LifecycleObserver {
   public void addRoutes(@NonNull @Size(min = 1) List<? extends DirectionsRoute> directionsRoutes) {
     cancelVanishingRouteLineAnimator();
     if (directionsRoutes.isEmpty()) {
-      routeLine.draw(directionsRoutes);
-    } else if (!CompareUtils.areEqualContentsIgnoreOrder(
-      routeLine.retrieveDirectionsRoutes(),
-      directionsRoutes)
-    ) {
-      routeLine.draw(directionsRoutes);
+      routeLine.clearRouteData();
+    } else if (CompareUtils.areEqualContentsIgnoreOrder(
+            routeLine.retrieveDirectionsRoutes(),
+            directionsRoutes
+    )) {
+      routeLine.updatePrimaryRouteIndex(directionsRoutes.get(0));
     } else {
-      routeLine.reinitializePrimaryRoute();
+      routeLine.draw(directionsRoutes);
     }
   }
 
@@ -221,13 +221,13 @@ public class NavigationMapRoute implements LifecycleObserver {
     cancelVanishingRouteLineAnimator();
     if (directionsRoutes.isEmpty()) {
       routeLine.drawIdentifiableRoutes(directionsRoutes);
-    } else if (!CompareUtils.areEqualContentsIgnoreOrder(
+    } else if (CompareUtils.areEqualContentsIgnoreOrder(
             routeLine.retrieveDirectionsRoutes(),
             routeList)
     ) {
-      routeLine.drawIdentifiableRoutes(directionsRoutes);
+      routeLine.updatePrimaryRouteIndex(routeList.get(0));
     } else {
-      routeLine.reinitializePrimaryRoute();
+      routeLine.drawIdentifiableRoutes(directionsRoutes);
     }
   }
 

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteClickListenerTest.java
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteClickListenerTest.java
@@ -27,7 +27,6 @@ public class MapRouteClickListenerTest {
     HashMap<LineString, DirectionsRoute> anyLineStringDirectionsRouteMap =
       buildLineStringDirectionsRouteHashMap(anyRoute, anyRouteGeometry);
     MapRouteLine mockedMapRouteLine = buildMockMapRouteLine(true, anyLineStringDirectionsRouteMap);
-    when(mockedMapRouteLine.updatePrimaryRouteIndex(anyRoute)).thenReturn(true);
     when(mockedMapRouteLine.retrieveDirectionsRoutes()).thenReturn(anyDirectionsRoutes);
     MapRouteClickListener theMapRouteClickListener = new MapRouteClickListener(mockedMapRouteLine);
     OnRouteSelectionChangeListener mockedOnRouteSelectionChangeListener =
@@ -37,6 +36,24 @@ public class MapRouteClickListenerTest {
     theMapRouteClickListener.onMapClick(mockedPoint);
 
     verify(mockedOnRouteSelectionChangeListener).onNewPrimaryRouteSelected(any(DirectionsRoute.class));
+  }
+
+  @Test
+  public void updatesPrimaryRouteIndexWhenClickedRouteIsFound() {
+    DirectionsRoute anyRoute = buildMockDirectionsRoute();
+    List<DirectionsRoute> anyDirectionsRoutes = buildDirectionsRoutes(anyRoute);
+    LineString anyRouteGeometry = LineString.fromPolyline(anyRoute.geometry(), Constants.PRECISION_6);
+    HashMap<LineString, DirectionsRoute> anyLineStringDirectionsRouteMap =
+            buildLineStringDirectionsRouteHashMap(anyRoute, anyRouteGeometry);
+    MapRouteLine mockedMapRouteLine = buildMockMapRouteLine(true, anyLineStringDirectionsRouteMap);
+    when(mockedMapRouteLine.retrieveDirectionsRoutes()).thenReturn(anyDirectionsRoutes);
+    MapRouteClickListener theMapRouteClickListener = new MapRouteClickListener(mockedMapRouteLine);
+    buildMockOnRouteSelectionChangeListener(theMapRouteClickListener);
+    LatLng mockedPoint = mock(LatLng.class);
+
+    theMapRouteClickListener.onMapClick(mockedPoint);
+
+    verify(mockedMapRouteLine).updatePrimaryRouteIndex(anyRoute);
   }
 
   @Test

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteLineTest.kt
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteLineTest.kt
@@ -399,43 +399,6 @@ class MapRouteLineTest {
     }
 
     @Test
-    fun updatePrimaryRouteIndexSwapsProperties() {
-        every { style.layers } returns listOf(primaryRouteLayer)
-        val primaryRoute: DirectionsRoute = getDirectionsRoute(true)
-        val alternativeRoute: DirectionsRoute = getDirectionsRoute(true)
-        val mapRouteLine = MapRouteLine(
-            ctx,
-            style,
-            styleRes,
-            null,
-            layerProvider,
-            mapRouteSourceProvider,
-            null
-        ).also {
-            it.drawIdentifiableRoutes(
-                listOf(
-                    IdentifiableRoute(
-                        primaryRoute,
-                        "isPrimary"
-                    ),
-                    IdentifiableRoute(
-                        alternativeRoute,
-                        "isAlternative"
-                    )
-                )
-            )
-        }
-        assertEquals(mapRouteLine.getPrimaryRoute(), primaryRoute)
-        mapRouteLine.updatePrimaryRouteIndex(alternativeRoute)
-
-        val hasPrimaryProperty = mapRouteLine.retrieveRouteFeatureData()
-            .first { it.route == alternativeRoute }.featureCollection.features()!![0].properties()!!
-            .get("isPrimary").asBoolean
-
-        assertTrue(hasPrimaryProperty)
-    }
-
-    @Test
     fun getStyledColorRecyclesAttributes() {
         val context = mockk<Context>()
         val resources = mockk<Resources>()

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/NavigationMapRouteTest.java
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/NavigationMapRouteTest.java
@@ -10,6 +10,7 @@ import com.mapbox.navigation.core.MapboxNavigation;
 
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.List;
 
 import edu.emory.mathcs.backport.java.util.Collections;
@@ -207,7 +208,7 @@ public class NavigationMapRouteTest {
   }
 
   @Test
-  public void addRoutes() {
+  public void addRoutes_whenInputEmptyList() {
     MapboxNavigation mockedNavigation = mock(MapboxNavigation.class);
     MapView mockedMapView = mock(MapView.class);
     MapboxMap mockedMapboxMap = mock(MapboxMap.class);
@@ -236,11 +237,11 @@ public class NavigationMapRouteTest {
 
     theNavigationMapRoute.addRoutes(routes);
 
-    verify(mockedMapRouteLine).draw(eq(routes));
+    verify(mockedMapRouteLine).clearRouteData();
   }
 
   @Test
-  public void addRoutes_drawNotCalled() {
+  public void addRoutes_updatesPrimaryRouteIndex() {
     DirectionsRoute mockRoute = mock(DirectionsRoute.class);
     MapboxNavigation mockedNavigation = mock(MapboxNavigation.class);
     MapView mockedMapView = mock(MapView.class);
@@ -261,11 +262,11 @@ public class NavigationMapRouteTest {
 
     theNavigationMapRoute.addRoutes(routes);
 
-    verify(mockedMapRouteLine, never()).draw(eq(routes));
+    verify(mockedMapRouteLine).updatePrimaryRouteIndex(routes.get(0));
   }
 
   @Test
-  public void addRoutes_reInitializePrimaryRoute() {
+  public void addRoutes_drawWhenNewRoutes() {
     DirectionsRoute mockRoute = mock(DirectionsRoute.class);
     MapboxNavigation mockedNavigation = mock(MapboxNavigation.class);
     MapView mockedMapView = mock(MapView.class);
@@ -282,11 +283,11 @@ public class NavigationMapRouteTest {
     NavigationMapRoute theNavigationMapRoute = new NavigationMapRoute(mockedNavigation, mockedMapView, mockedMapboxMap,
             mockedLifecycleOwner, mockedStyleRes, "", mockedMapClickListener, mockedDidFinishLoadingStyleListener,
             mockedProgressChangeListener, mockedMapRouteLine, mockedMapRouteArrow);
-    when(mockedMapRouteLine.retrieveDirectionsRoutes()).thenReturn(Collections.singletonList(mockRoute));
+    when(mockedMapRouteLine.retrieveDirectionsRoutes()).thenReturn(Collections.singletonList(mock(DirectionsRoute.class)));
 
     theNavigationMapRoute.addRoutes(routes);
 
-    verify(mockedMapRouteLine).reinitializePrimaryRoute();
+    verify(mockedMapRouteLine).draw(routes);
   }
 
   @Test
@@ -313,7 +314,7 @@ public class NavigationMapRouteTest {
   }
 
   @Test
-  public void addIdentifiableRoutes() {
+  public void addIdentifiableRoutes_whenInputEmptyList() {
     MapboxNavigation mockedNavigation = mock(MapboxNavigation.class);
     MapView mockedMapView = mock(MapView.class);
     MapboxMap mockedMapboxMap = mock(MapboxMap.class);
@@ -337,8 +338,9 @@ public class NavigationMapRouteTest {
   }
 
   @Test
-  public void addIdentifiableRoutes_drawNotCalled() {
+  public void addIdentifiableRoutes_whenNewRoutes() {
     DirectionsRoute mockRoute = mock(DirectionsRoute.class);
+    DirectionsRoute anotherMockRoute = mock(DirectionsRoute.class);
     IdentifiableRoute mockIdentifiableRoute = new IdentifiableRoute(mockRoute, "foobar");
     MapboxNavigation mockedNavigation = mock(MapboxNavigation.class);
     MapView mockedMapView = mock(MapView.class);
@@ -355,17 +357,19 @@ public class NavigationMapRouteTest {
     NavigationMapRoute theNavigationMapRoute = new NavigationMapRoute(mockedNavigation, mockedMapView, mockedMapboxMap,
             mockedLifecycleOwner, mockedStyleRes, "", mockedMapClickListener, mockedDidFinishLoadingStyleListener,
             mockedProgressChangeListener, mockedMapRouteLine, mockedMapRouteArrow);
-    when(mockedMapRouteLine.retrieveDirectionsRoutes()).thenReturn(Collections.singletonList(mockRoute));
+    when(mockedMapRouteLine.retrieveDirectionsRoutes()).thenReturn(Collections.singletonList(anotherMockRoute));
 
     theNavigationMapRoute.addIdentifiableRoutes(routes);
 
-    verify(mockedMapRouteLine, never()).drawIdentifiableRoutes(eq(routes));
+    verify(mockedMapRouteLine).drawIdentifiableRoutes(eq(routes));
   }
 
   @Test
-  public void addIdentifiableRoutes_reInitializePrimaryRoute() {
+  public void addIdentifiableRoutes_updatePrimaryRouteIndexWhenSameRoutes() {
     DirectionsRoute mockRoute = mock(DirectionsRoute.class);
+    DirectionsRoute anotherMockRoute = mock(DirectionsRoute.class);
     IdentifiableRoute mockIdentifiableRoute = new IdentifiableRoute(mockRoute, "foobar");
+    IdentifiableRoute anotherMockIdentifiableRoute = new IdentifiableRoute(anotherMockRoute, "potHoleRoad");
     MapboxNavigation mockedNavigation = mock(MapboxNavigation.class);
     MapView mockedMapView = mock(MapView.class);
     MapboxMap mockedMapboxMap = mock(MapboxMap.class);
@@ -377,15 +381,15 @@ public class NavigationMapRouteTest {
     MapRouteLine mockedMapRouteLine = mock(MapRouteLine.class);
     MapRouteArrow mockedMapRouteArrow = mock(MapRouteArrow.class);
     LifecycleOwner mockedLifecycleOwner = mock(LifecycleOwner.class);
-    List<IdentifiableRoute> routes = Collections.singletonList(mockIdentifiableRoute);
+    List<IdentifiableRoute> routes = Arrays.asList(anotherMockIdentifiableRoute, mockIdentifiableRoute);
     NavigationMapRoute theNavigationMapRoute = new NavigationMapRoute(mockedNavigation, mockedMapView, mockedMapboxMap,
             mockedLifecycleOwner, mockedStyleRes, "", mockedMapClickListener, mockedDidFinishLoadingStyleListener,
             mockedProgressChangeListener, mockedMapRouteLine, mockedMapRouteArrow);
-    when(mockedMapRouteLine.retrieveDirectionsRoutes()).thenReturn(Collections.singletonList(mockRoute));
+    when(mockedMapRouteLine.retrieveDirectionsRoutes()).thenReturn(Arrays.asList(mockRoute, anotherMockRoute));
 
     theNavigationMapRoute.addIdentifiableRoutes(routes);
 
-    verify(mockedMapRouteLine).reinitializePrimaryRoute();
+    verify(mockedMapRouteLine).updatePrimaryRouteIndex(routes.get(0).getRoute());
   }
 
   @Test


### PR DESCRIPTION
## Description

A fix for #3523. The adding of routes to NaivgationMapRoute results in different behavior depending on the existing state of the MapRouteLine.  There should always be some kind of update to the MapRouteLine.

- [ ] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal



### Implementation

The NavigationMapRoute.addRoutes will behave differently depending on the state of the MapRouteLine. If the input is empty there will be a call to MapRouteLine.draw() which will clear the lines on the map. If the inputed routes are the same as routes the MapRouteLine already has (but perhaps different ordering) the FeatureCollections of the lines will be updated without clearing the line layers. This is to prevent a regression of #2473. If the inputted routes are different than the MapRouteLine's routes then a full redraw will be performed.

## Screenshots or Gifs

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->