### PR TITLE
Add api to get the current replay position

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayHistoryActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayHistoryActivity.kt
@@ -177,6 +177,7 @@ class ReplayHistoryActivity : AppCompatActivity() {
                             }
                         }
                     }
+                    updateReplayStatus(events)
                 }
             }
         )
@@ -197,6 +198,15 @@ class ReplayHistoryActivity : AppCompatActivity() {
         playReplay.setOnClickListener {
             mapboxReplayer.play()
             mapboxNavigation.startTripSession()
+        }
+    }
+
+    @SuppressLint("SetTextI18n")
+    private fun ReplayNavigationContext.updateReplayStatus(playbackEvents: List<ReplayEventBase>) {
+        playbackEvents.lastOrNull()?.eventTimestamp?.let {
+            val currentSecond = mapboxReplayer.eventSeconds(it).toInt()
+            val durationSecond = mapboxReplayer.durationSeconds().toInt()
+            playerStatus.text = "$currentSecond:$durationSecond"
         }
     }
 

--- a/examples/src/main/res/layout/activity_replay_history_layout.xml
+++ b/examples/src/main/res/layout/activity_replay_history_layout.xml
@@ -69,6 +69,13 @@
                 android:paddingTop="6dp"
                 />
 
+            <TextView
+                android:id="@+id/playerStatus"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:padding="6dp"
+                android:text="Paused"/>
+
         </LinearLayout>
 
     </com.google.android.material.card.MaterialCardView>

--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -144,6 +144,7 @@ package com.mapbox.navigation.core.replay {
     ctor public MapboxReplayer();
     method public void clearEvents();
     method public double durationSeconds();
+    method public double eventSeconds(double eventTimestamp);
     method public void finish();
     method public void play();
     method public void playFirstLocation();

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/MapboxReplayer.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/MapboxReplayer.kt
@@ -21,7 +21,7 @@ class MapboxReplayer {
     private val replayEvents = ReplayEvents(mutableListOf())
     private val replayEventSimulator = ReplayEventSimulator(replayEvents)
 
-    private val replayEventsObservers: MutableList<ReplayEventsObserver> = mutableListOf()
+    private val replayEventsObservers: MutableSet<ReplayEventsObserver> = mutableSetOf()
 
     /**
      * Appends events to be replayed. Notice the basis of your [ReplayEventBase.eventTimestamp].
@@ -156,6 +156,15 @@ class MapboxReplayer {
             ?: return 0.0
         val lastEvent = replayEvents.events.last()
         return lastEvent.eventTimestamp - firstEvent.eventTimestamp
+    }
+
+    /**
+     * The time of an event, relative to the duration of the replay.
+     */
+    fun eventSeconds(eventTimestamp: Double): Double {
+        val firstEvent = replayEvents.events.firstOrNull()
+            ?: return 0.0
+        return eventTimestamp - firstEvent.eventTimestamp
     }
 
     /**

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/history/MapboxReplayerTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/history/MapboxReplayerTest.kt
@@ -3,7 +3,6 @@ package com.mapbox.navigation.core.replay.history
 import android.os.SystemClock
 import com.mapbox.navigation.core.replay.MapboxReplayer
 import com.mapbox.navigation.testing.MainCoroutineRule
-import io.mockk.Called
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
@@ -273,7 +272,7 @@ class MapboxReplayerTest {
 
         mapboxReplayer.playFirstLocation()
 
-        verify { replayEventsObserver wasNot Called }
+        verify(exactly = 0) { replayEventsObserver.replayEvents(any()) }
     }
 
     @Test


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Minor interface update to allow someone to calculate the replay position. Notice the time ticking in the bottom left.

Slightly related https://github.com/mapbox/mapbox-navigation-android/issues/2998

![output](https://user-images.githubusercontent.com/3021882/92028823-7ddfb680-ed19-11ea-8d70-7751728c811e.gif)

- [ ] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->