### PR TITLE
Move post user feedback out of companion

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/BasicNavigationFragment.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/BasicNavigationFragment.kt
@@ -454,7 +454,7 @@ class BasicNavigationFragment :
         val feedback = feedbackItem
         val screenShot = feedbackEncodedScreenShot
         if (feedback != null && !screenShot.isNullOrEmpty()) {
-            MapboxNavigation.postUserFeedback(
+            mapboxNavigation.postUserFeedback(
                 feedback.feedbackType,
                 feedback.description,
                 UI,

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/DebugMapboxNavigationKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/DebugMapboxNavigationKt.kt
@@ -104,7 +104,7 @@ class DebugMapboxNavigationKt :
         setContentView(R.layout.activity_debug_mapbox_navigation)
         findViewById<Button>(R.id.btn_send_user_feedback)?.let { button ->
             button.setOnClickListener {
-                MapboxNavigation.postUserFeedback(
+                mapboxNavigation.postUserFeedback(
                     FeedbackEvent.GENERAL_ISSUE,
                     "User feedback test at: ${Date().time}",
                     FeedbackEvent.UI,

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/FeedbackButtonActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/FeedbackButtonActivity.kt
@@ -325,7 +325,7 @@ class FeedbackButtonActivity :
         val feedback = feedbackItem
         val screenShot = feedbackEncodedScreenShot
         if (feedback != null && !screenShot.isNullOrEmpty()) {
-            MapboxNavigation.postUserFeedback(
+            mapboxNavigation?.postUserFeedback(
                 feedback.feedbackType,
                 feedback.description,
                 UI,

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/InstructionViewActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/InstructionViewActivity.kt
@@ -251,7 +251,7 @@ class InstructionViewActivity :
         val feedback = feedbackItem
         val screenShot = feedbackEncodedScreenShot
         if (feedback != null && !screenShot.isNullOrEmpty()) {
-            MapboxNavigation.postUserFeedback(
+            mapboxNavigation?.postUserFeedback(
                 feedback.feedbackType,
                 feedback.description,
                 UI,

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/SimpleMapboxNavigationKt.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/SimpleMapboxNavigationKt.kt
@@ -109,7 +109,7 @@ class SimpleMapboxNavigationKt :
         setContentView(R.layout.activity_simple_mapbox_navigation)
         findViewById<Button>(R.id.btn_send_user_feedback)?.let { button ->
             button.setOnClickListener {
-                MapboxNavigation.postUserFeedback(
+                mapboxNavigation.postUserFeedback(
                     FeedbackEvent.GENERAL_ISSUE,
                     "User feedback test at: ${Date().time}",
                     FeedbackEvent.UI,

--- a/examples/src/main/java/com/mapbox/navigation/examples/ui/CustomUIComponentStyleActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/ui/CustomUIComponentStyleActivity.kt
@@ -419,7 +419,7 @@ class CustomUIComponentStyleActivity :
         val feedback = feedbackItem
         val screenShot = feedbackEncodedScreenShot
         if (feedback != null && !screenShot.isNullOrEmpty()) {
-            MapboxNavigation.postUserFeedback(
+            mapboxNavigation.postUserFeedback(
                 feedback.feedbackType,
                 feedback.description,
                 UI,

--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -13,7 +13,7 @@ package com.mapbox.navigation.core {
     method public com.mapbox.navigation.core.trip.session.TripSessionState getTripSessionState();
     method public boolean navigateNextRouteLeg();
     method public void onDestroy();
-    method public static void postUserFeedback(@com.mapbox.navigation.core.telemetry.events.FeedbackEvent.Type String feedbackType, String description, @com.mapbox.navigation.core.telemetry.events.FeedbackEvent.Source String feedbackSource, String? screenshot, String![]? feedbackSubType = emptyArray(), com.mapbox.navigation.core.telemetry.events.AppMetadata? appMetadata = null);
+    method public void postUserFeedback(@com.mapbox.navigation.core.telemetry.events.FeedbackEvent.Type String feedbackType, String description, @com.mapbox.navigation.core.telemetry.events.FeedbackEvent.Source String feedbackSource, String? screenshot, String![]? feedbackSubType = emptyArray(), com.mapbox.navigation.core.telemetry.events.AppMetadata? appMetadata = null);
     method public void registerArrivalObserver(com.mapbox.navigation.core.arrival.ArrivalObserver arrivalObserver);
     method public void registerBannerInstructionsObserver(com.mapbox.navigation.core.trip.session.BannerInstructionsObserver bannerInstructionsObserver);
     method public void registerLocationObserver(com.mapbox.navigation.core.trip.session.LocationObserver locationObserver);
@@ -48,7 +48,6 @@ package com.mapbox.navigation.core {
 
   public static final class MapboxNavigation.Companion {
     method public com.mapbox.navigation.base.options.NavigationOptions.Builder defaultNavigationOptionsBuilder(android.content.Context context, String? accessToken);
-    method public void postUserFeedback(@com.mapbox.navigation.core.telemetry.events.FeedbackEvent.Type String feedbackType, String description, @com.mapbox.navigation.core.telemetry.events.FeedbackEvent.Source String feedbackSource, String? screenshot, String![]? feedbackSubType = emptyArray(), com.mapbox.navigation.core.telemetry.events.AppMetadata? appMetadata = null);
   }
 
   public final class MapboxNavigationKt {

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -576,6 +576,34 @@ class MapboxNavigation(
     }
 
     /**
+     * Send user feedback about an issue or problem with the Navigation SDK.
+     *
+     * @param feedbackType one of [FeedbackEvent.Type]
+     * @param description description message
+     * @param feedbackSource one of [FeedbackEvent.Source]
+     * @param screenshot encoded screenshot (optional)
+     * @param feedbackSubType array of [FeedbackEvent.Description] (optional)
+     * @param appMetadata [AppMetadata] information (optional)
+     */
+    fun postUserFeedback(
+        @FeedbackEvent.Type feedbackType: String,
+        description: String,
+        @FeedbackEvent.Source feedbackSource: String,
+        screenshot: String?,
+        feedbackSubType: Array<String>? = emptyArray(),
+        appMetadata: AppMetadata? = null
+    ) {
+        MapboxNavigationTelemetry.postUserFeedback(
+            feedbackType,
+            description,
+            feedbackSource,
+            screenshot,
+            feedbackSubType,
+            appMetadata
+        )
+    }
+
+    /**
      * Start observing faster routes for a trip session via [FasterRouteObserver]
      *
      * @param fasterRouteObserver FasterRouteObserver
@@ -730,35 +758,6 @@ class MapboxNavigation(
     companion object {
         private const val USER_AGENT: String = "MapboxNavigationNative"
         private const val THREADS_COUNT = 2
-
-        /**
-         * Send user feedback about an issue or problem with the Navigation SDK.
-         *
-         * @param feedbackType one of [FeedbackEvent.Type]
-         * @param description description message
-         * @param feedbackSource one of [FeedbackEvent.Source]
-         * @param screenshot encoded screenshot (optional)
-         * @param feedbackSubType array of [FeedbackEvent.Description] (optional)
-         * @param appMetadata [AppMetadata] information (optional)
-         */
-        @JvmStatic
-        fun postUserFeedback(
-            @FeedbackEvent.Type feedbackType: String,
-            description: String,
-            @FeedbackEvent.Source feedbackSource: String,
-            screenshot: String?,
-            feedbackSubType: Array<String>? = emptyArray(),
-            appMetadata: AppMetadata? = null
-        ) {
-            MapboxNavigationTelemetry.postUserFeedback(
-                feedbackType,
-                description,
-                feedbackSource,
-                screenshot,
-                feedbackSubType,
-                appMetadata
-            )
-        }
 
         /**
          * Returns a pre-build set of [NavigationOptions] with smart defaults.

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationViewModel.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationViewModel.java
@@ -406,7 +406,7 @@ public class NavigationViewModel extends AndroidViewModel {
 
   private synchronized void sendFeedback() {
     if (feedbackItem != null && !TextUtils.isEmpty(feedbackEncodedScreenShot)) {
-      MapboxNavigation.postUserFeedback(feedbackItem.getFeedbackType(),
+      navigation.postUserFeedback(feedbackItem.getFeedbackType(),
               feedbackItem.getDescription(), UI, feedbackEncodedScreenShot,
               feedbackItem.getFeedbackSubType().toArray(new String[0]), null);
 


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Looking into adding a function to MapboxNavigation, and noticed this is static. Don't think we want it to be, because are we trying to support

```
MapboxNavigation.postUserFeedback
val mapboxNavigation = MapboxNavigation(..)
```

We should require construction before allowing feedback.

- [ ] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->