### PR TITLE
Use raw location samples in telemtry traces

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/TelemetryLocationAndProgressDispatcher.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/TelemetryLocationAndProgressDispatcher.kt
@@ -268,15 +268,11 @@ internal class TelemetryLocationAndProgressDispatcher(scope: CoroutineScope) :
     }
 
     override fun onRawLocationChanged(rawLocation: Location) {
-        // Do nothing
-    }
-
-    override fun onEnhancedLocationChanged(enhancedLocation: Location, keyPoints: List<Location>) {
-        channelLocationReceived.offer(enhancedLocation)
-        lastLocation.set(enhancedLocation)
+        channelLocationReceived.offer(rawLocation)
+        lastLocation.set(rawLocation)
         when (firstLocationValue) {
             null -> {
-                firstLocationValue = enhancedLocation
+                firstLocationValue = rawLocation
                 firstLocationValue?.let { location ->
                     firstLocation.complete(location)
                 }
@@ -287,6 +283,10 @@ internal class TelemetryLocationAndProgressDispatcher(scope: CoroutineScope) :
                 }
             }
         }
+    }
+
+    override fun onEnhancedLocationChanged(enhancedLocation: Location, keyPoints: List<Location>) {
+        // Do nothing
     }
 
     fun getFirstLocationAsync() = firstLocation

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/TelemetryLocationAndProgressDispatcherTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/TelemetryLocationAndProgressDispatcherTest.kt
@@ -1,0 +1,46 @@
+package com.mapbox.navigation.core.telemetry
+
+import android.location.Location
+import com.mapbox.navigation.testing.MainCoroutineRule
+import com.mapbox.navigation.utils.internal.ThreadController
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class TelemetryLocationAndProgressDispatcherTest {
+    @get:Rule
+    var coroutineRule = MainCoroutineRule()
+
+    private val locationAndProgressDispatcher = TelemetryLocationAndProgressDispatcher(
+        ThreadController.getMainScopeAndRootJob().scope
+    )
+
+    @Test
+    fun ignoreEnhancedLocationUpdates() {
+        val enhancedLocation: Location = mockk()
+        locationAndProgressDispatcher.onEnhancedLocationChanged(enhancedLocation, mockk())
+
+        assertFalse(
+            "this job should not be completed",
+            locationAndProgressDispatcher.getFirstLocationAsync().isCompleted
+        )
+        assertNull(locationAndProgressDispatcher.getLastLocation())
+    }
+
+    @Test
+    fun useRawLocationUpdates() {
+        val rawLocation: Location = mockk()
+        locationAndProgressDispatcher.onRawLocationChanged(rawLocation)
+
+        assertEquals(
+            rawLocation,
+            locationAndProgressDispatcher.getFirstLocationAsync().getCompleted()
+        )
+        assertEquals(rawLocation, locationAndProgressDispatcher.getLastLocation())
+    }
+}


### PR DESCRIPTION
### Goal
Change the location samples type used in telemetry traces from enhanced to raw. 

### Implementation
I simply swapped the callbacks and added a test.