### PR TITLE
Bumped Java SDK dependency to 5.5.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,7 +8,7 @@ ext {
 
   version = [
       mapboxMapSdk              : '9.4.0',
-      mapboxSdkServices         : '5.4.1',
+      mapboxSdkServices         : '5.5.0',
       mapboxEvents              : '6.1.0',
       mapboxCore                : '3.0.0',
       mapboxNavigator           : '19.0.0',

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/TelemetryLocationAndProgressDispatcher.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/TelemetryLocationAndProgressDispatcher.kt
@@ -33,7 +33,12 @@ internal class TelemetryLocationAndProgressDispatcher(scope: CoroutineScope) :
         AtomicReference(
             RouteProgressWithTimestamp(
                 0,
-                RouteProgress.Builder(DirectionsRoute.builder().build()).build()
+                RouteProgress.Builder(
+                    DirectionsRoute.builder()
+                        .distance(.0)
+                        .duration(.0)
+                        .build()
+                ).build()
             )
         )
     private val channelOffRouteEvent = Channel<Boolean>(Channel.CONFLATED)

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/fasterroute/FasterRouteDetectorTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/fasterroute/FasterRouteDetectorTest.kt
@@ -56,18 +56,6 @@ class FasterRouteDetectorTest {
     }
 
     @Test
-    fun shouldDefaultToFalseWhenDurationIsNull() = runBlocking {
-        val newRoute: DirectionsRoute = mockk()
-        every { newRoute.duration() } returns null
-        val routeProgress: RouteProgress = mockk()
-        every { routeProgress.durationRemaining } returns 727.228
-
-        val isFasterRoute = fasterRouteDetector.isRouteFaster(newRoute, routeProgress)
-
-        assertFalse(isFasterRoute)
-    }
-
-    @Test
     fun shouldNotAllowSlightlyFasterRoutes() = runBlocking {
         val newRoute: DirectionsRoute = mockk()
         every { newRoute.duration() } returns 634.7

--- a/libnavigation-router/src/test/java/com/mapbox/navigation/route/internal/hybrid/MapboxHybridRouterTest.kt
+++ b/libnavigation-router/src/test/java/com/mapbox/navigation/route/internal/hybrid/MapboxHybridRouterTest.kt
@@ -197,7 +197,10 @@ class MapboxHybridRouterTest {
         val additionalCallbackSecond: Router.Callback = mockk(relaxUnitFun = true)
         val additionalCallbackThird: Router.Callback = mockk(relaxUnitFun = true)
 
-        val originalResult = listOf<DirectionsRoute>(DirectionsRoute.builder().build())
+        val originalResult = listOf<DirectionsRoute>(
+            DirectionsRoute.builder().distance(.0).duration(.0).build()
+        )
+
         val additionalResultFirst = emptyList<DirectionsRoute>()
         val additionalResultSecond = emptyList<DirectionsRoute>()
         val additionalResultThird = emptyList<DirectionsRoute>()

--- a/libnavigation-router/src/test/java/com/mapbox/navigation/route/internal/onboard/MapboxOnboardRouterTest.kt
+++ b/libnavigation-router/src/test/java/com/mapbox/navigation/route/internal/onboard/MapboxOnboardRouterTest.kt
@@ -192,8 +192,8 @@ class MapboxOnboardRouterTest {
         // route
         assertEquals(ROUTE_SIZE, routesSlot.captured.size)
         val route = routesSlot.captured[0]
-        assertEquals(ROUTE_DISTANCE, route.distance())
-        assertEquals(ROUTE_DURATION, route.duration())
+        assertEquals(ROUTE_DISTANCE, route.distance(), delta)
+        assertEquals(ROUTE_DURATION, route.duration(), delta)
         assertEquals(ROUTE_WEIGHT_NAME, route.weightName())
         assertEquals(ROUTE_VOICE_LANGUAGE, route.voiceLanguage())
         assertEquals(ROUTE_WEIGHT, route.weight())

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteProgressChangeListenerTest.kt
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteProgressChangeListenerTest.kt
@@ -65,7 +65,10 @@ class MapRouteProgressChangeListenerTest {
 
     @Test
     fun `should not draw route without directions route`() {
-        val routeWithNoGeometry = DirectionsRoute.builder().build()
+        val routeWithNoGeometry = DirectionsRoute.builder()
+            .distance(.0)
+            .duration(.0)
+            .build()
         every { routeLine.getPrimaryRoute() } returns null
         val routeProgress: RouteProgress = mockk {
             every { route } returns routeWithNoGeometry


### PR DESCRIPTION
## Description

The Mapbox Java SDK `5.5.0` release just went out

- https://github.com/mapbox/mapbox-java/issues/1175
- https://github.com/mapbox/mapbox-java/releases/tag/v5.5.0

This pr bumps the Nav Core SDK dependencies to `5.5.0`.

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make 1.0-core-update-api` (Core) / `$> make 1.0-ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->