### PR TITLE
Add InstructionView attribute to allow developer not showing InstructionListView

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/instruction/InstructionView.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/instruction/InstructionView.java
@@ -171,6 +171,7 @@ public class InstructionView extends RelativeLayout implements LifecycleObserver
   private int soundButtonStyle;
   private int feedbackButtonStyle;
   private int alertViewStyle;
+  private boolean disableInstructionViewList;
 
   public InstructionView(Context context) {
     this(context, null);
@@ -369,7 +370,6 @@ public class InstructionView extends RelativeLayout implements LifecycleObserver
    * can be animated appropriately.
    */
   public void showInstructionList() {
-    onInstructionListVisibilityChanged(true);
     instructionLayout.requestFocus();
     if (ViewUtils.isLandscape(getContext())) {
       updateLandscapeConstraintsTo(R.layout.mapbox_partial_instruction_view_alt);
@@ -381,6 +381,7 @@ public class InstructionView extends RelativeLayout implements LifecycleObserver
     animation.setAnimationListener(getInstructionListAnimationListener());
     instructionListLayout.setVisibility(VISIBLE);
     instructionListLayout.startAnimation(animation);
+    onInstructionListVisibilityChanged(true);
   }
 
   /**
@@ -528,6 +529,9 @@ public class InstructionView extends RelativeLayout implements LifecycleObserver
         R.styleable.MapboxStyleInstructionView_instructionViewFeedbackButtonStyle, -1);
     alertViewStyle = typedArray.getResourceId(
         R.styleable.MapboxStyleInstructionView_instructionViewAlertViewStyle, -1);
+
+    disableInstructionViewList =
+        typedArray.getBoolean(R.styleable.MapboxStyleInstructionView_instructionViewDisableList, false);
 
     typedArray.recycle();
 
@@ -737,6 +741,9 @@ public class InstructionView extends RelativeLayout implements LifecycleObserver
   }
 
   private void initializeStepListClickListener() {
+    if (disableInstructionViewList) {
+      return;
+    }
     if (ViewUtils.isLandscape(getContext())) {
       initializeLandscapeListListener();
     } else {

--- a/libnavigation-ui/src/main/res/values/attrs.xml
+++ b/libnavigation-ui/src/main/res/values/attrs.xml
@@ -95,6 +95,7 @@
     <attr name="instructionViewFeedbackButtonStyle" format="reference"/>
     <attr name="instructionViewSoundButtonStyle" format="reference"/>
     <attr name="instructionViewAlertViewStyle" format="reference"/>
+    <attr name="instructionViewDisableList" format="boolean"/>
   </declare-styleable>
 
   <declare-styleable name="MapboxStyleSoundButton">


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Fix #3505: add InstructionView attribute to allow developer not showing InstructionListView

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

* fix developer issue
* add ability to disable showing the InstructionListView by click InstructionView

### Implementation

* call the `onInstructionListVisibilityChanged` after setting the `instructionListLayout` to **VISIBLE**
* add a style attribute, so the developer can set the attribute `instructionViewDisableList` to **true** to disable showing the InstructionListView by click InstructionView

## Testing

Verified the change by testing InstructionViewActivity example.

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->