### PR TITLE
Fix CI UI Instrumentation tests job typo

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -22,7 +22,7 @@ workflows:
             - assemble-debug
             - static-analysis
             - unit-tests
-      - ui-intrumentation-tests:
+      - ui-instrumentation-tests:
           requires:
             - assemble-release
             - assemble-debug
@@ -366,7 +366,7 @@ jobs:
       - run-firebase-robo:
           variant: "release"
 
-  ui-intrumentation-tests:
+  ui-instrumentation-tests:
     docker:
       - image: << pipeline.parameters.docker-image-tag >>
     working_directory: ~/code


### PR DESCRIPTION
## Description

Fixes CI UI Instrumentation tests job typo

Regression from https://github.com/mapbox/mapbox-navigation-android/pull/3534

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Fixes CI UI Instrumentation tests job typo

### Implementation

Fix CI UI Instrumentation tests job typo from `circle.yml` file. From `ui-intrumentation-tests` to `ui-instrumentation-tests`

## Testing

- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs