### PR TITLE
Removing methods not needed for the latest iteration of the vanishing…

### DIFF
--- a/libnavigation-ui/api/current.txt
+++ b/libnavigation-ui/api/current.txt
@@ -578,7 +578,6 @@ package com.mapbox.navigation.ui.route {
     method public void addProgressChangeListener(com.mapbox.navigation.core.MapboxNavigation);
     method public void addRoute(com.mapbox.api.directions.v5.models.DirectionsRoute!);
     method public void addRoutes(@Size(min=1) java.util.List<? extends com.mapbox.api.directions.v5.models.DirectionsRoute>);
-    method public float getPercentDistanceTraveled();
     method public void onNewRouteProgress(com.mapbox.navigation.base.trip.model.RouteProgress);
     method @androidx.lifecycle.OnLifecycleEvent(androidx.lifecycle.Lifecycle.Event.ON_START) protected void onStart();
     method @androidx.lifecycle.OnLifecycleEvent(androidx.lifecycle.Lifecycle.Event.ON_STOP) protected void onStop();
@@ -587,7 +586,6 @@ package com.mapbox.navigation.ui.route {
     method public void setVanishRouteLineEnabled(boolean);
     method public void showAlternativeRoutes(boolean);
     method public void updateRouteArrowVisibilityTo(boolean);
-    method public void updateRouteLineWithDistanceTraveled(float);
     method public void updateRouteVisibilityTo(boolean);
   }
 

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/NavigationMapSettings.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/NavigationMapSettings.java
@@ -20,7 +20,6 @@ class NavigationMapSettings implements Parcelable {
   private boolean maxFpsEnabled = true;
   private boolean mapWayNameEnabled;
   private boolean locationFpsEnabled = true;
-  private float percentDistanceTraveled;
   private boolean vanishingRouteLineEnabled;
 
   NavigationMapSettings() {
@@ -80,14 +79,6 @@ class NavigationMapSettings implements Parcelable {
     this.locationFpsEnabled = locationFpsEnabled;
   }
 
-  void updatePercentDistanceTraveled(float distance) {
-    this.percentDistanceTraveled = distance;
-  }
-
-  float retrievePercentDistanceTraveled() {
-    return this.percentDistanceTraveled;
-  }
-
   boolean isLocationFpsEnabled() {
     return locationFpsEnabled;
   }
@@ -108,7 +99,6 @@ class NavigationMapSettings implements Parcelable {
     maxFpsEnabled = in.readByte() != 0;
     mapWayNameEnabled = in.readByte() != 0;
     locationFpsEnabled = in.readByte() != 0;
-    percentDistanceTraveled = in.readFloat();
     vanishingRouteLineEnabled = in.readByte() != 0;
   }
 
@@ -121,7 +111,6 @@ class NavigationMapSettings implements Parcelable {
     dest.writeByte((byte) (maxFpsEnabled ? 1 : 0));
     dest.writeByte((byte) (mapWayNameEnabled ? 1 : 0));
     dest.writeByte((byte) (locationFpsEnabled ? 1 : 0));
-    dest.writeFloat(percentDistanceTraveled);
     dest.writeByte((byte) (vanishingRouteLineEnabled ? 1 : 0));
   }
 

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/NavigationMapboxMap.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/NavigationMapboxMap.java
@@ -460,7 +460,6 @@ public class NavigationMapboxMap implements LifecycleObserver {
     settings.updateShouldUseDefaultPadding(mapPaddingAdjustor.isUsingDefault());
     settings.updateCameraTrackingMode(mapCamera.getCameraTrackingMode());
     settings.updateLocationFpsEnabled(locationFpsDelegate.isEnabled());
-    settings.updatePercentDistanceTraveled(mapRoute.getPercentDistanceTraveled());
     settings.updateVanishingRouteLineEnabled(vanishRouteLineEnabled);
     NavigationMapboxMapInstanceState instanceState = new NavigationMapboxMapInstanceState(settings);
     outState.putParcelable(STATE_BUNDLE_KEY, instanceState);
@@ -481,7 +480,6 @@ public class NavigationMapboxMap implements LifecycleObserver {
       NavigationMapboxMapInstanceState instanceState = (NavigationMapboxMapInstanceState) parcelable;
       settings = instanceState.retrieveSettings();
       restoreMapWith(settings);
-      restoreVanishingRouteLineSection(settings);
     } else {
       Timber.d("no instance state to restore");
     }
@@ -986,14 +984,6 @@ public class NavigationMapboxMap implements LifecycleObserver {
     LatLng latLng = new LatLng(location);
     PointF mapPoint = mapboxMap.getProjection().toScreenLocation(latLng);
     mapWayName.updateWayNameWithPoint(mapPoint);
-  }
-
-  private void restoreVanishingRouteLineSection(@NonNull NavigationMapSettings settings) {
-    float percentDistanceTraveled = settings.retrievePercentDistanceTraveled();
-    if (percentDistanceTraveled > 0) {
-      mapRoute.updateRouteLineWithDistanceTraveled(percentDistanceTraveled);
-      settings.updatePercentDistanceTraveled(0);
-    }
   }
 
   private void restoreMapWith(@NonNull NavigationMapSettings settings) {

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/NavigationMapRoute.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/NavigationMapRoute.java
@@ -487,30 +487,6 @@ public class NavigationMapRoute implements LifecycleObserver {
   }
 
   /**
-   * Returns the percentage of the distance traveled that was last calculated. This is only
-   * calculated if the vanishing route line feature is enabled.
-   *
-   * @return the value calculated during the last progress update event or 0 if not enabled.
-   */
-  public float getPercentDistanceTraveled() {
-    return mapRouteProgressChangeListener.getPercentDistanceTraveled();
-  }
-
-  /**
-   * Can be used to manually update the percentage of route traveled.
-   *
-   * This is also invoked automatically when the vanishing route line feature is enabled and
-   * a new route progress update is delivered.
-   * @see #addProgressChangeListener(MapboxNavigation, boolean)
-   * @see #onNewRouteProgress(RouteProgress)
-   */
-  public void updateRouteLineWithDistanceTraveled(float distanceTraveled) {
-    routeLine.hideCasingLineAtOffset(distanceTraveled);
-    routeLine.hideRouteLineAtOffset(distanceTraveled);
-    mapRouteProgressChangeListener.updatePercentDistanceTraveled(distanceTraveled);
-  }
-
-  /**
    * The Builder of {@link NavigationMapRoute}.
    */
   public static class Builder {


### PR DESCRIPTION
## Description

This is a cherry pick of PR https://github.com/mapbox/mapbox-navigation-android/pull/3561 so that when PR https://github.com/mapbox/mapbox-navigation-android/pull/3422 lands there will be consistency in the API.  There was a minor SEMVER break in PR 3422. This PR aims to line up the API in 1.0 and 1.1 so that there is no major SEMVER breakage.

- [ ] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal



### Implementation


## Screenshots or Gifs

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->