### PR TITLE
replaced algorithm for the vanishing route line to previous iteration…

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteProgressChangeListener.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteProgressChangeListener.kt
@@ -30,8 +30,6 @@ internal class MapRouteProgressChangeListener(
     }
 
     private fun updateRoute(directionsRoute: DirectionsRoute?, routeProgress: RouteProgress) {
-        routeLine.updateDistanceRemainingCache(routeProgress.route, routeProgress.distanceRemaining)
-
         val currentRoute = routeProgress.route
         val hasGeometry = currentRoute.geometry()?.isNotEmpty() ?: false
         if (hasGeometry && currentRoute != directionsRoute) {

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteLineTest.kt
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteLineTest.kt
@@ -26,7 +26,8 @@ import com.mapbox.navigation.ui.internal.route.RouteConstants.PRIMARY_ROUTE_LAYE
 import com.mapbox.navigation.ui.internal.route.RouteConstants.PRIMARY_ROUTE_TRAFFIC_LAYER_ID
 import com.mapbox.navigation.ui.internal.route.RouteConstants.WAYPOINT_LAYER_ID
 import com.mapbox.navigation.ui.internal.route.RouteLayerProvider
-import com.mapbox.navigation.ui.route.MapRouteLine.MapRouteLineSupport.calculatePreciseDistanceTraveledAlongLine
+import com.mapbox.navigation.ui.route.MapRouteLine.MapRouteLineSupport.findDistanceOfPointAlongLine
+import com.mapbox.navigation.ui.route.MapRouteLine.MapRouteLineSupport.getDistanceSum
 import com.mapbox.turf.TurfMeasurement
 import io.mockk.every
 import io.mockk.mockk
@@ -1248,48 +1249,6 @@ class MapRouteLineTest {
     }
 
     @Test
-    fun calculatePreciseDistanceTraveledAlongLineTest() {
-        val route = getDirectionsRoute()
-        val lineString = LineString.fromPolyline(
-            route.geometry()!!,
-            Constants.PRECISION_6
-        )
-        val targetPoint = TurfMeasurement.midpoint(
-            lineString.coordinates()[6],
-            lineString.coordinates()[7]
-        )
-
-        val result = calculatePreciseDistanceTraveledAlongLine(
-            lineString,
-            (route.distance() / 2).toFloat(),
-            targetPoint
-        )
-
-        assertEquals(620.1892777997383, result, 0.0)
-    }
-
-    @Test
-    fun calculatePreciseDistanceTraveledAlongLineWhenTargetDistanceZero() {
-        val route = getDirectionsRoute()
-        val lineString = LineString.fromPolyline(
-            route.geometry()!!,
-            Constants.PRECISION_6
-        )
-        val targetPoint = TurfMeasurement.midpoint(
-            lineString.coordinates()[6],
-            lineString.coordinates()[7]
-        )
-
-        val result = calculatePreciseDistanceTraveledAlongLine(
-            lineString,
-            0f,
-            targetPoint
-        )
-
-        assertEquals(392.2066920656183, result, 0.0)
-    }
-
-    @Test
     fun getStyledFloatArrayTest() {
         val result = MapRouteLine.MapRouteLineSupport.getStyledFloatArray(
             R.styleable.MapboxStyleNavigationMapRoute_routeLineScaleStops,
@@ -1334,6 +1293,33 @@ class MapRouteLineTest {
         assertEquals(4.0f, result[0].scaleStop)
         assertEquals(3.0f, result[0].scaleMultiplier)
         assertEquals(1.0f, result[0].scale)
+    }
+
+    @Test
+    fun findDistanceOfPointAlongLineTest() {
+        val route = getDirectionsRoute()
+        val routeLineString = LineString.fromPolyline(route.geometry()!!, Constants.PRECISION_6)
+        val testPoint = TurfMeasurement.midpoint(
+            routeLineString.coordinates()[8],
+            routeLineString.coordinates()[9]
+        )
+
+        val result = findDistanceOfPointAlongLine(
+            routeLineString,
+            testPoint
+        )
+
+        assertEquals(266.122135806527, result, 0.0)
+    }
+
+    @Test
+    fun getDistanceSumTest() {
+        val route = getDirectionsRoute()
+        val routeLineString = LineString.fromPolyline(route.geometry()!!, Constants.PRECISION_6)
+
+        val result = getDistanceSum(routeLineString.coordinates())
+
+        assertEquals(route.distance(), result, .1)
     }
 
     private fun getMultilegRoute(): DirectionsRoute {


### PR DESCRIPTION
##Description

Reverting the algorithm for the vanishing route line to a version that was more tested and isn't dependent on the distance remaining from the progress updates.  There was a bug reported that is currently unreproducible and I think going to this more tested algorithm that doesn't depend on anything but the location from the maps animator may resolve the issue. Merging this PR will give us some time to test in 1Tap.

- [ ] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal



### Implementation


## Screenshots or Gifs



## Testing


- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->