### PR TITLE
Slow down replay driver for turns

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayRouteInterpolator.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayRouteInterpolator.kt
@@ -6,6 +6,7 @@ import com.mapbox.turf.TurfMeasurement
 import kotlin.math.abs
 import kotlin.math.ceil
 import kotlin.math.min
+import kotlin.math.pow
 
 internal class ReplayRouteInterpolator {
 
@@ -105,7 +106,7 @@ internal class ReplayRouteInterpolator {
             val speedMps = if (deltaBearing > 150) {
                 options.uTurnSpeedMps
             } else {
-                val velocityFraction = 1.0 - min(1.0, deltaBearing / 90.0)
+                val velocityFraction = (1.0 - min(1.0, deltaBearing / 90.0)).pow(2.0)
                 val offsetToMaxVelocity = options.maxSpeedMps - options.turnSpeedMps
                 (options.turnSpeedMps + (velocityFraction * offsetToMaxVelocity))
             }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayRouteOptions.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayRouteOptions.kt
@@ -80,7 +80,7 @@ class ReplayRouteOptions private constructor(
         private var maxSpeedMps = 30.0
         private var turnSpeedMps = 3.0
         private var uTurnSpeedMps = 1.0
-        private var maxAcceleration = 4.0
+        private var maxAcceleration = 3.0
         private var minAcceleration = -4.0
 
         /**

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/route/ReplayRouteInterpolatorTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/route/ReplayRouteInterpolatorTest.kt
@@ -164,6 +164,28 @@ class ReplayRouteInterpolatorTest {
     }
 
     @Test
+    fun `should reduce speed for turns`() {
+        val options = ReplayRouteOptions.Builder()
+            .maxSpeedMps(30.0)
+            .turnSpeedMps(3.0)
+            .build()
+        val coordinates = listOf(
+            Point.fromLngLat(-121.466857, 38.562993),
+            Point.fromLngLat(-121.466765, 38.563205),
+            Point.fromLngLat(-121.465571, 38.562884),
+            Point.fromLngLat(-121.465435, 38.563267),
+            Point.fromLngLat(-121.466527, 38.564469),
+            Point.fromLngLat(-121.466363, 38.564845)
+        )
+
+        val speedProfile = routeInterpolator.createSpeedProfile(options, coordinates)
+        assertEquals(3.0, speedProfile[1].speedMps, 0.0001)
+        assertEquals(3.0, speedProfile[2].speedMps, 0.0001)
+        assertTrue("${speedProfile[3].speedMps} < 10.0", speedProfile[3].speedMps < 10.0)
+        assertTrue("${speedProfile[4].speedMps} < 10.0", speedProfile[4].speedMps < 10.0)
+    }
+
+    @Test
     fun `should profile u turns to be very slow`() {
         val coordinates = listOf(
             Point.fromLngLat(-121.470231, 38.550964),


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Working on improving the replay driver. 

The replay driver will determine the speed based on the corner angle. For example, a right hand turn is 90º, a fork in the road is 45º, a u-turn is 180º. The replay driver configuration, gives speeds for 90º and 180º turns. But there is a formula for handling 45º turns. This pull request is updating that formula.

`val velocityFraction` is a multiplier to determine what the corner speed should be. Here is a table that demonstrates the before and after of this update. Notice, the speed profile for routes will be more smooth.

https://docs.google.com/spreadsheets/d/1UJFEN_SdmbUiubkTtw8NB6fISRkG8NcEwVszdJsSpP8/edit?usp=sharing
![Screen Shot 2020-09-19 at 11 00 38 AM](https://user-images.githubusercontent.com/3021882/93685883-5e5dc300-fa67-11ea-8c34-dfe7cc741424.png)

- [ ] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

## Formula references 

The variables used for the replay driver are slightly different, but the common variable is velocity. NACTO is giving recommendations for urban street turning speeds based on this formula, and I found that squaring the velocity is a good recommendation for corner speeds.

https://nacto.org/publication/urban-street-design-guide/intersection-design-elements/corner-radii/
![Screen Shot 2020-09-19 at 10 38 17 AM](https://user-images.githubusercontent.com/3021882/93685283-72ec8c00-fa64-11ea-98a2-23a9e6ee663a.png)

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->