### PR TITLE
Get deobfuscated reports from firebase robo

### DIFF
--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -59,11 +59,11 @@ android {
         }
         release {
             minifyEnabled true
+            firebaseCrashlytics {
+                mappingFileUploadEnabled true
+            }
             signingConfig signingConfigs.release
             manifestPlaceholders = [enableCrashReporting: "true"]
-            firebaseCrashlytics {
-                mappingFileUploadEnabled false
-            }
         }
     }
 

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -61,6 +61,9 @@ android {
             minifyEnabled true
             signingConfig signingConfigs.release
             manifestPlaceholders = [enableCrashReporting: "true"]
+            firebaseCrashlytics {
+                mappingFileUploadEnabled false
+            }
         }
     }
 

--- a/proguard/proguard-project.pro
+++ b/proguard/proguard-project.pro
@@ -3,3 +3,7 @@
 # We should at least keep the Exceptions, InnerClasses,
 # and Signature attributes when processing a library.
 -keepattributes Exceptions,InnerClasses,Signature,RuntimeVisibleParameterAnnotations,RuntimeVisibleAnnotations
+
+-keepattributes *Annotation*
+-keepattributes SourceFile,LineNumberTable
+-keep public class * extends java.lang.Exception


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Looking to fix this one https://github.com/mapbox/navigation-sdks/issues/582

Looking for a way to test this

- [ ] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->