### PR TITLE
Reset routeProgress as part of MapboxTripSession setRoute

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
@@ -75,6 +75,7 @@ internal class MapboxTripSession(
             field = value
             if (value == null) {
                 routeAlerts = emptyList()
+                routeProgress = null
             }
             cancelOngoingUpdateNavigatorStatusDataJobs()
             mainJobController.scope.launch {

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
@@ -363,6 +363,29 @@ class MapboxTripSessionTest {
     }
 
     @Test
+    fun routeProgressObserverImmediateEmittedBelongsToCurrentRoute() =
+        coroutineRule.runBlockingTest {
+            tripSession = MapboxTripSession(
+                tripService,
+                locationEngine,
+                navigatorPredictionMillis,
+                navigator,
+                ThreadController,
+                logger = logger,
+                accessToken = "pk.1234"
+            )
+            tripSession.start()
+            updateLocationAndJoin()
+            tripSession.route = null
+            val observer: RouteProgressObserver = mockk(relaxUnitFun = true)
+            tripSession.registerRouteProgressObserver(observer)
+
+            verify(exactly = 0) { observer.onRouteProgressChanged(routeProgress) }
+            assertEquals(null, tripSession.getRouteProgress())
+            tripSession.stop()
+        }
+
+    @Test
     fun routeProgressObserverUnregister() = coroutineRule.runBlockingTest {
         tripSession = MapboxTripSession(
             tripService,


### PR DESCRIPTION
Reset routeProgress as part of MapboxTripSession setRoute logic to avoid sending route progress updates that do not belong to the current route (notification on subscription) when mapbox navigation register route progress observer is called

<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Resets `routeProgress` as part of `MapboxTripSession` `setRoute` logic

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Avoid sending route progress updates that do not belong to the current route (notification on subscription) when `MapboxNavigation#registerRouteProgressObserver` is called


### Implementation

```kotlin
override var route: DirectionsRoute? = null
        set(value) {
            field = value
            if (value == null) {
                // ...
                routeProgress = null
            }
            // ...
```

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
