### PR TITLE
Bumped Maps SDK dependency to 9.5.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -7,7 +7,7 @@ ext {
   ]
 
   version = [
-      mapboxMapSdk              : '9.4.0',
+      mapboxMapSdk              : '9.5.0',
       mapboxSdkServices         : '5.7.0',
       mapboxEvents              : '6.1.0',
       mapboxCore                : '3.0.0',


### PR DESCRIPTION
This pr bumps the Maps SDK dependency version to `9.5.0`. `9.5.0` went out 3 days ago https://github.com/mapbox/mapbox-gl-native-android/releases/tag/android-v9.5.0
