### PR TITLE
Inhibiting route line by default since puck movements outside of acti…

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteLine.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteLine.kt
@@ -145,7 +145,7 @@ internal class MapRouteLine(
     private var primaryRoute: DirectionsRoute? = null
     var vanishPointOffset: Float = 0f
         private set
-    private var vanishingPointUpdateInhibited: Boolean = false
+    private var vanishingPointUpdateInhibited: Boolean = true
     private val distanceRemainingCache = LruCache<DirectionsRoute, Float>(2)
 
     @get:ColorInt

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteLineTest.kt
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteLineTest.kt
@@ -1151,12 +1151,59 @@ class MapRouteLineTest {
             mapRouteSourceProvider,
             null
         ).also { it.draw(listOf(route)) }
+        mapRouteLine.inhibitVanishingPointUpdate(false)
 
         mapRouteLine.updateTraveledRouteLine(inputPoint)
 
         verify { primaryRouteCasingLayer.setProperties(any()) }
         verify { primaryRouteLayer.setProperties(any()) }
         verify { primaryRouteTrafficLayer.setProperties(any()) }
+    }
+
+    @Test
+    fun updateVanishingPointInhibitedByDefault() {
+        every { style.layers } returns listOf(primaryRouteLayer)
+        every { style.isFullyLoaded } returnsMany listOf(
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            true,
+            true,
+            true
+        )
+        every {
+            style.getLayerAs<LineLayer>("mapbox-navigation-route-casing-layer")
+        } returns primaryRouteCasingLayer
+        every { style.getLayer("mapbox-navigation-route-layer") } returns primaryRouteLayer
+        every {
+            style.getLayer("mapbox-navigation-route-traffic-layer")
+        } returns primaryRouteTrafficLayer
+        val route = getDirectionsRoute()
+        val coordinates = LineString.fromPolyline(
+            route.geometry()!!,
+            Constants.PRECISION_6
+        ).coordinates()
+        val inputPoint = TurfMeasurement.midpoint(coordinates[4], coordinates[5])
+        val mapRouteLine = MapRouteLine(
+            ctx,
+            style,
+            styleRes,
+            null,
+            layerProvider,
+            mapRouteSourceProvider,
+            null
+        ).also { it.draw(listOf(route)) }
+
+        mapRouteLine.updateTraveledRouteLine(inputPoint)
+
+        verify(exactly = 0) { primaryRouteCasingLayer.setProperties(any()) }
+        verify(exactly = 0) { primaryRouteLayer.setProperties(any()) }
+        verify(exactly = 0) { primaryRouteTrafficLayer.setProperties(any()) }
     }
 
     @Test


### PR DESCRIPTION
##Description

A cherry pick of PR [3598](https://github.com/mapbox/mapbox-navigation-android/pull/3598) which inhibits the vanishing route line by default.

- [x] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal



### Implementation



## Screenshots or Gifs


## Testing


- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->