### PR TITLE
CP: Pull in the latest translations from Transifex

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,7 +1,7 @@
 [main]
 host = https://www.transifex.com
-minimum_perc = 20
 lang_map = pt_BR: pt-rBR, pt_PT: pt-rPT
+minimum_perc = 20
 
 [mapbox-navigation-sdk-for-android.examples-app-strings-file]
 file_filter = examples/src/main/res/values-<lang>/strings.xml

--- a/examples/src/main/res/values-de/strings.xml
+++ b/examples/src/main/res/values-de/strings.xml
@@ -1,9 +1,120 @@
 <resources>
     <string name="app_name">Mapbox 1.0 Navigation SDK für Android</string>
 
+    <!-- MainActivity -->
+    <string name="navigation_core_sdk_title">Navigation Core SDK</string>
+    <string name="navigation_core_sdk_description">Gastgeber Beispiele zur Demonstration, wie das Core Navigation SDK verwendet wird.</string>
+
+    <string name="navigation_ui_sdk_title">Navigation UI SDK</string>
+    <string name="navigation_ui_sdk_description">Gastgeber Beispiele zur Demonstration, wie das Navigation UI SDK verwendet wird.</string>
+
+    <string name="title_simple_navigation_kotlin">Einfache MapboxNavigation in Kotlin</string>
+    <string name="description_simple_navigation_kotlin">Zeigt, wie die MapboxNavigation-Klasse im Kotlin-Code verwendet wird.</string>
+
+    <string name="title_navigation_view">NavigationView</string>
+    <string name="description_navigation_view">Präsentiert die Verwendung der NavigationView, um eine Schritt-für-Schritt-Navigation zu realisieren.</string>
+
+    <string name="title_custom_puck_example">Benutzerdefinierter Puck</string>
+    <string name="description_custom_puck_example">Zeigt die NavigationView mit einem benutzerdefinierten Puck.</string>
+
+    <string name="title_custom_camera_example">Benutzerdefinierte Kamera</string>
+    <string name="description_custom_camera_example">Zeigt die NavigationView mit benutzerdefinierter Kamera-Neigung und Zoom.</string>
+
+    <string name="title_custom_ui_component_style">Benutzerdefinierter UI-Komponentenstil</string>
+    <string name="description_custom_ui_component_style">Zeigt, wie eigene Farben zum Stylen von UI SDK Komponenten verwendet werden: InstructionView, SummaryBottomSheet, etc.</string>
+
+    <string name="title_building_highlight_kotlin">Gebäude-Footprints hervorheben</string>
+    <string name="description_building_highlight_kotlin">Verwenden Sie die SDKs der Navigationsoberfläche, um einen einzelnen hervorgehobenen Gebäude-Footprint anzuzeigen und anzupassen.</string>
+
+    <string name="title_ui_building_extrusions_kotlin">Gebäude-Extrusionen hervorheben</string>
+    <string name="description_ui_building_extrusions_kotlin">Verwenden Sie die SDKs der Navigationsoberfläche, um eine einzelne hervorgehobene 3D-Gebäudeextrusion anzuzeigen und anzupassen.</string>
+
+    <string name="title_replay_route">Route wiedergeben</string>
+    <string name="description_replay_route">Zeigt, wie die MapboxNavigation-Klasse mit der Replay Engine im Kotlin-Code verwendet wird</string>
+    <string name="replay_playback_speed_seekbar">Wiederholungsgeschwindigkeit %d</string>
+
+    <string name="title_replay_history_kotlin">Verlauf wiederholen</string>
+    <string name="description_replay_history_kotlin">Zeigt, wie der Verlauf der Fahrt im Kotlin-Code wiedergegeben werden kann.</string>
+    <string name="title_select_replay_history">Verlauf wählen</string>
+
+    <string name="title_replay_waypoints">Wegpunkte wiedergeben</string>
+    <string name="description_replay_waypoints">Zeigt die Navigation zu Wegpunkten.</string>
+
+    <string name="title_reroute_view">Routenneuberechnung Ereignisse</string>
+    <string name="description_reroute_view">Zeigt, wie Routenabweichung-Ereignisse beobachtet und eine benutzerdefinierte Routenneuberechnung-Logik implementiert werden kann.</string>
+
+    <string name="title_basic_navigation_kotlin">Basis-Navigation</string>
+    <string name="description_basic_navigation_kotlin">Zeigt, wie vom Geräte-Standort zu einem Ziel mit der MapboxNavigation-Klasse navigiert wird.</string>
+
+    <string name="title_basic_navigation_fragment">Basis-Navigation mit Fragment</string>
+    <string name="description_basic_navigation_fragment">Zeigt, wie vom Geräte-Standort zu einem Ziel mit der MapboxNavigation-Klasse in einem Fragment navigiert wird.</string>
+
+    <string name="title_basic_navigation_sdk_only_kotlin">Basis Navigation + Maps SDK Einbindung</string>
+    <string name="description_basic_navigation_sdk_only_kotlin">Zeigt die Kombination von Map SDK mit Navigation SDK, ohne das Navigation UI SDK in irgendeiner Art und Weise zu verwenden.</string>
+
+    <string name="title_free_drive_kotlin">Freie Fahrt-Navigation</string>
+    <string name="description_free_drive_kotlin">Zeigt, wie in einem freie Fahrt-Szenario mit der MapboxNavigation-Klasse navigiert wird.</string>
+
+    <string name="title_guidance_view">GuidanceView</string>
+    <string name="description_guidance_view">Demonstriert die Verwendung einer GuidanceView, um Anweisungsbilder an geeigneten Kreuzungen anzuzeigen.</string>
+
+    <string name="title_faster_route">Schnellere Route</string>
+    <string name="description_faster_route">Demonstriert, wie die MapboxNavigation-Klasse auf schnellere Routen horcht. </string>
+
+    <string name="title_summary_bottom_sheet">SummaryBottomSheet</string>
+    <string name="description_summary_bottom_sheet">Zeigt die Integration von SummaryButtomSheet und neu zentrieren mit dem Navigation SDK.</string>
+
+    <string name="title_feedback_button">Feedback-Taste</string>
+    <string name="description_feedback_button">Präsentiert die Integration des FeedbackButton in den Feedback Flow des Navigation SDKs.</string>
+
+    <string name="title_instruction_view">InstructionView</string>
+    <string name="description_instruction_view">Zeigt die Integration von InstructionView, FeedbackButton und SoundButton mit dem Navigation SDK.</string>
+
+    <string name="title_debug_navigation_kotlin">Debug MapboxNavigation Kotlin</string>
+    <string name="description_debug_navigation_kotlin">Zeigt die Debug-Punkte für rohe (rot) und verbesserter (blaue) Standort-Updates.</string>
+
+    <string name="title_custom_route_styling_kotlin">Benutzerdefiniertes Route-Styling in Kotlin</string>
+    <string name="description_custom_route_styling_kotlin">Demonstriert die Anwendung von einem benutzerdefinierten Style auf die Routen.</string>
+
+    <string name="title_navigation_view_fragment">NavigationView in einem Fragment</string>
+    <string name="description_navigation_view_fragment">Zeigt die Verwendung der NavigationView, um eine Schritt-für-Schritt-Navigation im Fragment zu realisieren.</string>
+
+    <string name="title_navigation_route_ui">Navigation Map Route</string>
+    <string name="description_navigation_route_ui">Beispiel für die Benutzung von NavigationMapRoute</string>
+
+    <string name="title_traffic_toggle">Verkehr umschalten</string>
+    <string name="description_traffic_toggle">Umschalten der Sichtbarkeit der Stau-Ebenen in der NavigationView.</string>
+
+    <string name="title_runtime_styling">Runtime Route Styling</string>
+    <string name="description_runtime_styling">Beispiel für die Benutzung von RuntimeRouteStyling</string>
+
+    <string name="title_map_matching">Map Matching</string>
+    <string name="description_map_matching">Verwendet MapMatching, um eine DirectionsRoute zu erhalten</string>
+
     <string name="settings">Einstellungen</string>
     <string name="simulate_route">Route simulieren</string>
     <string name="language">Sprache</string>
     <string name="unit_type">Einheitstyp</string>
     <string name="route_profile">Routenprofil</string>
- </resources>
+    <string name="nav_native_history_collect">Verlauf aufnehmen</string>
+    <string name="start_navigation">Navigation starten</string>
+    <string name="navigate_waypoints_next_stop">Nächster Halt</string>
+    <string name="play_history">Verlauf abspielen</string>
+    <string name="select_history">Verlauf wählen</string>
+    <string name="msg_long_press_map_to_place_waypoint">Lange auf die Karte drücken, um einen Wegpunkt zu setzen</string>
+    <string name="no_routes">Es existieren keine Routen zu diesem Ziel</string>
+    <string name="steps_in_route">Es gibt %1$d Abschnitte in der Route</string>
+    <string name="route_request_failed">Die Routenanfrage schlug fehl</string>
+    <string name="offline_category_title">Offline</string>
+    <string name="offline_enabled_title">Offline Routenneuberechnung aktiviert</string>
+    <string name="offline_version_title">Offline-Version wählen</string>
+    <string name="general_category_title">Allgemein</string>
+    <string name="send_user_feedback">Benutzer-Feedback senden</string>
+    <string name="simple_mapbox_navigation_clear_routes">ROUTEN ENTFERNEN</string>
+    <string name="simple_mapbox_navigation_add_original_route">URSPRÜNGLICHE ROUTE HINZUFÜGEN</string>
+    <string name="history_failed_to_load_item">Das Element konnte aus dem Verlauf nicht geladen werden</string>
+    <string name="history_failed_to_load_list">Fehler beim Laden der Liste</string>
+    <string name="history_local_history_file">Lokale Verlaufsdatei</string>
+    <string name="history_recorded_history_file">Aufgenommene Verlaufsdatei</string>
+
+</resources>

--- a/examples/src/main/res/values-vi/strings.xml
+++ b/examples/src/main/res/values-vi/strings.xml
@@ -17,6 +17,8 @@
     <string name="title_select_replay_history">Chọn lịch sử</string>
 
     <string name="title_replay_waypoints">Phát lại tọa độ điểm</string>
+    <string name="description_replay_waypoints">Cho biết cách điều hướng đến các tọa độ điểm.</string>
+
     <string name="title_reroute_view">Sự kiện tìm đường đi mới</string>
     <string name="title_basic_navigation_kotlin">Điều hướng cơ bản</string>
     <string name="title_basic_navigation_fragment">Điều hướng cơ bản trong Fragment</string>
@@ -31,15 +33,19 @@
     <string name="title_custom_route_styling_kotlin">Đặt kiểu Tuyến đường Tùy biến trong Kotlin</string>
     <string name="title_navigation_view_fragment">NavigationView trong Fragment</string>
     <string name="title_navigation_route_ui">NavigationMapRoute</string>
+    <string name="description_navigation_route_ui">Ví dụ sử dụng NavigationMapRoute</string>
+
     <string name="title_traffic_toggle">Hiện/ẩn giao thông</string>
     <string name="title_runtime_styling">RuntimeRouteStyling</string>
+    <string name="description_runtime_styling">Ví dụ sử dụng RuntimeRouteStyling</string>
+
     <string name="title_map_matching">Khớp Bản đồ</string>
     <string name="settings">Thiết lập</string>
     <string name="simulate_route">Mô phỏng Tuyến đường</string>
     <string name="language">Ngôn ngữ</string>
     <string name="unit_type">Hệ Đo lường</string>
     <string name="route_profile">Chế độ</string>
-    <string name="nav_native_history_collect">Thu thập lịch sử Điều hướng Native</string>
+    <string name="nav_native_history_collect">Thu thập lịch sử</string>
     <string name="start_navigation">Bắt đầu Điều hướng</string>
     <string name="navigate_waypoints_next_stop">Điểm dừng sau</string>
     <string name="play_history">Phát lại lịch sử</string>
@@ -58,5 +64,6 @@
     <string name="history_failed_to_load_item">Thất bại khi tải mục lịch sử</string>
     <string name="history_failed_to_load_list">Thất bại khi tải danh sách</string>
     <string name="history_local_history_file">Tập tin lịch sử trên thiết bị</string>
+    <string name="history_recorded_history_file">Tập tin lịch sử đã thu thập</string>
 
 </resources>

--- a/libnavigation-ui/src/main/res/values-es/strings.xml
+++ b/libnavigation-ui/src/main/res/values-es/strings.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Indicates that rerouting is in progress -->
-    <string name="mapbox_rerouting">Enrutando</string>
+    <string name="mapbox_rerouting">Redirigiendo…</string>
 
     <!-- Button title for re-centering tracking -->
-    <string name="mapbox_re_center">Centrando</string>
+    <string name="mapbox_re_center">Centrar</string>
 
     <!-- Indicates voice instructions are muted -->
     <string name="mapbox_muted">Silenciado</string>
@@ -12,4 +12,73 @@
     <!-- Indicates voice instructions are unmuted -->
     <string name="mapbox_unmuted">Sin silenciar</string>
 
-</resources>
+    <!-- Feedback -->
+    <string name="mapbox_report_feedback">Reportar feedback</string>
+
+    <!-- Feedback Guidance Issue -->
+    <string name="mapbox_feedback_guidance_issue">Problema\nde Guiado</string>
+
+    <!-- Feedback type for Looks Incorrect -->
+    <string name="mapbox_feedback_type_looks_incorrect">Parece\nIncorrecto</string>
+
+    <!-- Feedback type for Confusing Audio -->
+    <string name="mapbox_feedback_type_confusing_audio">Audio\nConfuso</string>
+
+    <!-- Feedback type for Positioning Issue -->
+    <string name="mapbox_feedback_type_positioning_issue">Problema de\nPosicionamiento</string>
+
+    <!-- Feedback Navigation Issue -->
+    <string name="mapbox_feedback_navigation_issue">Problema de\nNavegación</string>
+
+    <!-- Feedback type for Route Quality -->
+    <string name="mapbox_feedback_type_route_quality">Calidad\nde la Ruta</string>
+
+    <!-- Feedback type for Illegal Route -->
+    <string name="mapbox_feedback_type_illegal_route">Ruta\nNo permitida</string>
+
+    <!-- Feedback type for Road Closure -->
+    <string name="mapbox_feedback_type_road_closure">Camino\nCerrado</string>
+
+    <!-- Shown after a feedback type has been submitted -->
+    <string name="mapbox_feedback_reported">¡Muchísimas gracias! Se ha reportado el problema.</string>
+
+    <!-- Feedback description for Looks Incorrect -->
+    <string name="mapbox_feedback_description_turn_icon_incorrect">Ícono de giro incorrecto</string>
+    <string name="mapbox_feedback_description_street_name_incorrect">Nombre de calle incorrecto</string>
+    <string name="mapbox_feedback_description_instruction_unnecessary">Instrucción innecesaria</string>
+    <string name="mapbox_feedback_description_instruction_missing">Faltan instrucciones</string>
+    <string name="mapbox_feedback_description_maneuver_incorrect">Maniobra incorrecta</string>
+    <string name="mapbox_feedback_description_exit_info_incorrect">Detalles de la salida incorrectos</string>
+    <string name="mapbox_feedback_description_lane_guidance_incorrect">Guiado de carriles incorrecto</string>
+    <string name="mapbox_feedback_description_road_known_by_different_name">Calle conocida con un nombre diferente</string>
+
+    <!-- Feedback description for Confusing Audio -->
+    <string name="mapbox_feedback_description_guidance_too_early">Instrucciones tempranas</string>
+    <string name="mapbox_feedback_description_guidance_too_late">Instruccionies tardes</string>
+    <string name="mapbox_feedback_description_pronunciation_incorrect">Pronunciación incorrecta</string>
+    <string name="mapbox_feedback_description_road_name_repeated">Nombre de calle repetido</string>
+
+    <!-- Feedback description for Route Quality -->
+    <string name="mapbox_feedback_description_route_not_drive_able">La ruta no es transitable</string>
+    <string name="mapbox_feedback_description_route_not_preferred">No es la ruta preferida</string>
+    <string name="mapbox_feedback_description_alternative_route_not_expected">Ruta alternativa inesperada</string>
+    <string name="mapbox_feedback_description_route_included_missing_roads">La ruta incluye calles faltantes</string>
+    <string name="mapbox_feedback_description_route_had_roads_too_narrow_to_pass">La ruta tiene caminos angostos al tránsito</string>
+
+    <!-- Feedback description for Illegal Route -->
+    <string name="mapbox_feedback_description_routed_down_a_one_way">Ruta sigue contra un sentido único</string>
+    <string name="mapbox_feedback_description_turn_was_not_allowed">No se permite girar</string>
+    <string name="mapbox_feedback_description_cars_not_allowed_on_street">El tránsito de autos no está permitido en la calle</string>
+    <string name="mapbox_feedback_description_turn_at_intersection_was_unprotected">La intersección es peligrosa</string>
+
+    <!-- Feedback description for Road Closure -->
+    <string name="mapbox_feedback_description_street_permanently_blocked_off">Calle cerrada permanentemente</string>
+    <string name="mapbox_feedback_description_road_is_missing_from_map">Calle ausente del mapa</string>
+
+    <!-- Shown after a feedback type has been submitted -->
+    <string name="mapbox_feedback_submitted">Se ha enviado el feedback</string>
+
+    <!-- Shown in off-route scenarios to provide feedback -->
+    <string name="mapbox_report_problem">Reportar una problema</string>
+
+    </resources>

--- a/libnavigation-ui/src/main/res/values-vi/strings.xml
+++ b/libnavigation-ui/src/main/res/values-vi/strings.xml
@@ -54,7 +54,7 @@
 
     <!-- Feedback description for Confusing Audio -->
     <string name="mapbox_feedback_description_guidance_too_early">Lời hướng dẫn quá sớm</string>
-    <string name="mapbox_feedback_description_guidance_too_late">Lời hướng dẫn quá chậm</string>
+    <string name="mapbox_feedback_description_guidance_too_late">Lời hướng dẫn quá trễ</string>
     <string name="mapbox_feedback_description_pronunciation_incorrect">Phát âm sai</string>
     <string name="mapbox_feedback_description_road_name_repeated">Đọc lại tên đường hai lần</string>
 

--- a/libtrip-notification/src/main/res/values-de/strings.xml
+++ b/libtrip-notification/src/main/res/values-de/strings.xml
@@ -1,6 +1,8 @@
 <resources>
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Navigation beenden</string>
+    <string name="mapbox_stop_session">Sitzung beenden</string>
+    <string name="mapbox_free_drive_session">Freie Fahrt-Sitzung</string>
     <string name="mapbox_eta_format">%s ETA</string>
 
     <!-- Time formatting -->

--- a/libtrip-notification/src/main/res/values-es/strings.xml
+++ b/libtrip-notification/src/main/res/values-es/strings.xml
@@ -1,6 +1,10 @@
 <resources>
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Salir de la navegación</string>
+    <string name="mapbox_stop_session">Parar la sesión</string>
+    <string name="mapbox_free_drive_session">Sesión de manejar libremente</string>
+    <string name="mapbox_eta_format">%s ETA</string>
+
     <!-- Time formatting -->
     <plurals name="mapbox_number_of_days">
         <item quantity="one">día</item>


### PR DESCRIPTION
### Description

This PR cherry-picks the changes brought to our main branch in https://github.com/mapbox/mapbox-navigation-android/pull/3606, to the `1.1` release branch

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Get newest and latest translations available in Transifex

### Implementation

```
$> git checkout release-v1.1
$> git checkout -b pg-cp-3606
$> git cherry-pick c46fd0c72cc0747714fd9289b679454f5ab8cc42
```

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
