### PR TITLE
CP: Expose TunnelInfo as part of TunnelEntranceAlert

### DIFF
--- a/examples/src/main/res/drawable/ic_circle_yellow.xml
+++ b/examples/src/main/res/drawable/ic_circle_yellow.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+
+    <solid
+        android:color="#ffff00"/>
+
+    <size
+        android:width="5dp"
+        android:height="5dp"/>
+</shape>

--- a/libnavigation-base/api/current.txt
+++ b/libnavigation-base/api/current.txt
@@ -372,6 +372,7 @@ package com.mapbox.navigation.base.trip.model.alert {
   }
 
   public final class TunnelEntranceAlert extends com.mapbox.navigation.base.trip.model.alert.RouteAlert {
+    method public com.mapbox.navigation.base.trip.model.alert.TunnelInfo? getInfo();
     method public com.mapbox.navigation.base.trip.model.alert.TunnelEntranceAlert.Builder toBuilder();
   }
 
@@ -379,6 +380,17 @@ package com.mapbox.navigation.base.trip.model.alert {
     ctor public TunnelEntranceAlert.Builder(com.mapbox.geojson.Point coordinate, double distance);
     method public com.mapbox.navigation.base.trip.model.alert.TunnelEntranceAlert.Builder alertGeometry(com.mapbox.navigation.base.trip.model.alert.RouteAlertGeometry? alertGeometry);
     method public com.mapbox.navigation.base.trip.model.alert.TunnelEntranceAlert build();
+    method public com.mapbox.navigation.base.trip.model.alert.TunnelEntranceAlert.Builder info(com.mapbox.navigation.base.trip.model.alert.TunnelInfo? info);
+  }
+
+  public final class TunnelInfo {
+    method public String getName();
+    method public com.mapbox.navigation.base.trip.model.alert.TunnelInfo.Builder toBuilder();
+  }
+
+  public static final class TunnelInfo.Builder {
+    ctor public TunnelInfo.Builder(String name);
+    method public com.mapbox.navigation.base.trip.model.alert.TunnelInfo build();
   }
 
   public final class UpcomingRouteAlert {

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/alert/TunnelEntranceAlert.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/alert/TunnelEntranceAlert.kt
@@ -5,13 +5,15 @@ import com.mapbox.geojson.Point
 /**
  * Route alert type that provides information about tunnels on the route.
  *
+ * @param info tunnel information
  * @see RouteAlert
  * @see RouteAlertType.TunnelEntrance
  */
 class TunnelEntranceAlert private constructor(
     coordinate: Point,
     distance: Double,
-    alertGeometry: RouteAlertGeometry?
+    alertGeometry: RouteAlertGeometry?,
+    val info: TunnelInfo?
 ) : RouteAlert(
     RouteAlertType.TunnelEntrance,
     coordinate,
@@ -22,13 +24,39 @@ class TunnelEntranceAlert private constructor(
     /**
      * Transform this object into a builder to mutate the values.
      */
-    fun toBuilder(): Builder = Builder(coordinate, distance).alertGeometry(alertGeometry)
+    fun toBuilder(): Builder = Builder(coordinate, distance)
+        .alertGeometry(alertGeometry)
+        .info(info)
+
+    /**
+     * Indicates whether some other object is "equal to" this one.
+     */
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        if (!super.equals(other)) return false
+
+        other as TunnelEntranceAlert
+
+        if (info != other.info) return false
+
+        return true
+    }
+
+    /**
+     * Returns a hash code value for the object.
+     */
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+        result = 31 * result + (info?.hashCode() ?: 0)
+        return result
+    }
 
     /**
      * Returns a string representation of the object.
      */
     override fun toString(): String {
-        return "TunnelEntranceAlert() ${super.toString()}"
+        return "TunnelEntranceAlert(info=$info), ${super.toString()}"
     }
 
     /**
@@ -40,7 +68,9 @@ class TunnelEntranceAlert private constructor(
         private val coordinate: Point,
         private val distance: Double
     ) {
+
         private var alertGeometry: RouteAlertGeometry? = null
+        private var info: TunnelInfo? = null
 
         /**
          * Add optional geometry if the alert has a length.
@@ -50,13 +80,21 @@ class TunnelEntranceAlert private constructor(
         }
 
         /**
+         * Add the tunnel info.
+         */
+        fun info(info: TunnelInfo?): Builder = apply {
+            this.info = info
+        }
+
+        /**
          * Build the object instance.
          */
         fun build() =
             TunnelEntranceAlert(
                 coordinate,
                 distance,
-                alertGeometry
+                alertGeometry,
+                info
             )
     }
 }

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/alert/TunnelInfo.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/alert/TunnelInfo.kt
@@ -1,0 +1,63 @@
+package com.mapbox.navigation.base.trip.model.alert
+
+/**
+ * Tunnel information.
+ */
+class TunnelInfo private constructor(
+    /**
+     * Tunnel name.
+     */
+    val name: String,
+) {
+
+    /**
+     * Transform this object into a builder to mutate the values.
+     */
+    fun toBuilder(): Builder = Builder(name)
+
+    /**
+     * Indicates whether some other object is "equal to" this one.
+     */
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as TunnelInfo
+
+        if (name != other.name) return false
+
+        return true
+    }
+
+    /**
+     * Returns a hash code value for the object.
+     */
+    override fun hashCode(): Int {
+        return name.hashCode()
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    override fun toString(): String {
+        return "TunnelInfo(name='$name')"
+    }
+
+    /**
+     * Use to create a new instance.
+     *
+     * @see TunnelInfo
+     */
+    class Builder(
+        private val name: String
+    ) {
+
+        /**
+         * Build the object instance.
+         */
+        fun build() =
+            TunnelInfo(
+                name
+            )
+    }
+}

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/trip/model/alert/TunnelEntranceAlertTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/trip/model/alert/TunnelEntranceAlertTest.kt
@@ -2,6 +2,7 @@ package com.mapbox.navigation.base.trip.model.alert
 
 import com.mapbox.geojson.Point
 import com.mapbox.navigation.testing.BuilderTest
+import io.mockk.mockk
 import org.junit.Test
 
 class TunnelEntranceAlertTest : BuilderTest<TunnelEntranceAlert, TunnelEntranceAlert.Builder>() {
@@ -19,7 +20,7 @@ class TunnelEntranceAlertTest : BuilderTest<TunnelEntranceAlert, TunnelEntranceA
             Point.fromLngLat(33.0, 44.0),
             2
         ).build()
-    )
+    ).info(mockk(relaxed = true))
 
     @Test
     override fun trigger() {

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/trip/model/alert/TunnelInfoTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/trip/model/alert/TunnelInfoTest.kt
@@ -1,0 +1,19 @@
+package com.mapbox.navigation.base.trip.model.alert
+
+import com.mapbox.navigation.testing.BuilderTest
+import org.junit.Test
+
+class TunnelInfoTest :
+    BuilderTest<TunnelInfo, TunnelInfo.Builder>() {
+
+    override fun getImplementationClass() = TunnelInfo::class
+
+    override fun getFilledUpBuilder() = TunnelInfo.Builder(
+        "Ted Williams Tunnel"
+    )
+
+    @Test
+    override fun trigger() {
+        // see docs
+    }
+}

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/NavigatorMapper.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/NavigatorMapper.kt
@@ -23,6 +23,7 @@ import com.mapbox.navigation.base.trip.model.alert.RouteAlertGeometry
 import com.mapbox.navigation.base.trip.model.alert.TollCollectionAlert
 import com.mapbox.navigation.base.trip.model.alert.TollCollectionType
 import com.mapbox.navigation.base.trip.model.alert.TunnelEntranceAlert
+import com.mapbox.navigation.base.trip.model.alert.TunnelInfo
 import com.mapbox.navigation.base.trip.model.alert.UpcomingRouteAlert
 import com.mapbox.navigation.utils.internal.ifNonNull
 import com.mapbox.navigator.BannerComponent
@@ -36,6 +37,7 @@ import com.mapbox.navigator.PassiveManeuverServiceAreaInfo
 import com.mapbox.navigator.PassiveManeuverServiceAreaType
 import com.mapbox.navigator.PassiveManeuverTollCollectionInfo
 import com.mapbox.navigator.PassiveManeuverTollCollectionType
+import com.mapbox.navigator.PassiveManeuverTunnelInfo
 import com.mapbox.navigator.PassiveManeuverType
 import com.mapbox.navigator.RouteInfo
 import com.mapbox.navigator.RouteState
@@ -282,6 +284,7 @@ internal class NavigatorMapper {
                     maneuver.distance
                 )
                     .alertGeometry(maneuver.getAlertGeometry())
+                    .info(maneuver.tunnelInfo?.toTunnelInfo())
                     .build()
             }
             PassiveManeuverType.KBORDER_CROSSING -> {
@@ -362,13 +365,21 @@ internal class NavigatorMapper {
         private const val TWO_LEGS: Short = 2
     }
 
+    private fun PassiveManeuverTunnelInfo?.toTunnelInfo() = ifNonNull(
+        this?.name,
+    ) { name ->
+        TunnelInfo.Builder(
+            name = name
+        ).build()
+    }
+
     private fun PassiveManeuverAdminInfo?.toCountryBorderCrossingAdminInfo() = ifNonNull(
         this?.iso_3166_1,
         this?.iso_3166_1_alpha3,
-    ) { countryCode, CountryCodeAlpha3 ->
+    ) { countryCode, countryCodeAlpha3 ->
         CountryBorderCrossingAdminInfo.Builder(
             code = countryCode,
-            codeAlpha3 = CountryCodeAlpha3
+            codeAlpha3 = countryCodeAlpha3
         ).build()
     }
 

--- a/libnavigator/src/test/java/com/mapbox/navigation/navigator/NavigatorMapperTest.kt
+++ b/libnavigator/src/test/java/com/mapbox/navigation/navigator/NavigatorMapperTest.kt
@@ -12,6 +12,7 @@ import com.mapbox.navigation.base.trip.model.alert.RouteAlertType
 import com.mapbox.navigation.base.trip.model.alert.TollCollectionAlert
 import com.mapbox.navigation.base.trip.model.alert.TollCollectionType
 import com.mapbox.navigation.base.trip.model.alert.TunnelEntranceAlert
+import com.mapbox.navigation.base.trip.model.alert.TunnelInfo
 import com.mapbox.navigation.navigator.internal.NavigatorMapper
 import com.mapbox.navigator.NavigationStatus
 import com.mapbox.navigator.PassiveManeuver
@@ -120,7 +121,9 @@ class NavigatorMapperTest {
                 Point.fromLngLat(33.0, 44.0),
                 2
             ).build()
-        ).build()
+        )
+            .info(TunnelInfo.Builder("Ted Williams Tunnel").build())
+            .build()
         assertEquals(expected, upcomingRouteAlert.routeAlert)
         assertEquals(expected.hashCode(), upcomingRouteAlert.routeAlert.hashCode())
         assertEquals(expected.toString(), upcomingRouteAlert.routeAlert.toString())
@@ -440,7 +443,10 @@ class NavigatorMapperTest {
 
     private val tunnelEntrancePassiveManeuver = createPassiveManeuver(
         hasLength = true,
-        type = PassiveManeuverType.KTUNNEL_ENTRANCE
+        type = PassiveManeuverType.KTUNNEL_ENTRANCE,
+        tunnelInfo = PassiveManeuverTunnelInfo(
+            "Ted Williams Tunnel"
+        )
     )
 
     private val countryBorderCrossingPassiveManeuver = createPassiveManeuver(


### PR DESCRIPTION
### Description

This PR cherry-picks the changes brought to our main branch in https://github.com/mapbox/mapbox-navigation-android/pull/3612, to the `1.1` release branch

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Exposes `TunnelInfo` as part of `TunnelEntranceAlert`

### Implementation

```
$> git checkout release-v1.1
$> git checkout -b pg-cp-3612
$> git cherry-pick 02608b363ead3bbbc766c8dfd86b41fc68c0edf5
```

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
