### PR TITLE
CP: Bump NN dependency version to 22.0.1

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -11,7 +11,7 @@ ext {
       mapboxSdkServices         : '5.7.0',
       mapboxEvents              : '6.1.0',
       mapboxCore                : '3.0.0',
-      mapboxNavigator           : '22.0.0',
+      mapboxNavigator           : '22.0.1',
       mapboxCommonNative        : '7.1.0',
       mapboxCrashMonitor        : '2.0.0',
       mapboxAnnotationPlugin    : '0.8.0',


### PR DESCRIPTION
### Description

This PR cherry-picks the changes brought to our main branch in https://github.com/mapbox/mapbox-navigation-android/pull/3617, to the `1.1` release branch

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Bumps `mapbox-navigation-native` version to `22.0.1` and fixes breaking changes

### Implementation

```
$> git checkout release-v1.1
$> git checkout -b pg-cp-3617
$> git cherry-pick 22ca622eb1e9ee204c34fb9940ad53f1639ba9a3
```

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
