### PR TITLE
Cherry pick of issue 3615 related to route line vanishing point.

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteLine.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteLine.kt
@@ -62,6 +62,7 @@ import com.mapbox.turf.TurfMeasurement
 import com.mapbox.turf.TurfMisc
 import timber.log.Timber
 import java.math.BigDecimal
+import kotlin.math.abs
 
 /**
  * Responsible for the appearance of the route lines on the map. This class applies styling
@@ -934,14 +935,15 @@ internal class MapRouteLine(
                 return
             }
 
-            val distanceRemainingFromCache: Float = distanceRemainingCache[primaryRoute] ?: 0f
+            val distanceRemainingFromCache: Float = distanceRemainingCache[primaryRoute]
+                ?: primaryRoute.distance().toFloat()
             val distanceRemaining = calculatePreciseDistanceTraveledAlongLine(
                 lineString,
                 distanceRemainingFromCache,
                 point
             )
             val distanceTraveled = (routeDistance - distanceRemaining)
-            val percentTraveled = (distanceTraveled / routeDistance).toFloat()
+            val percentTraveled = abs((distanceTraveled / routeDistance)).toFloat()
 
             if (percentTraveled > MINIMUM_ROUTE_LINE_OFFSET) {
                 val expression = getExpressionAtOffset(percentTraveled)
@@ -1379,6 +1381,8 @@ internal class MapRouteLine(
                     } else {
                         runningDistance += nextSectionDistance
                     }
+                } else {
+                    lastPointIndex = currentIndex
                 }
             }
 


### PR DESCRIPTION
## Description

A cherry pick for issue #3615 which described a problem correctly setting the vanishing point for a new route line after restoring the app from the background.

- [x] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Goal


### Implementation


## Screenshots or Gifs


## Testing


- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->