### PR TITLE
Prevent NPE when route overview is requested but route progress is not available yet

### DIFF
--- a/libnavigation-ui/api/current.txt
+++ b/libnavigation-ui/api/current.txt
@@ -81,7 +81,8 @@ package com.mapbox.navigation.ui {
     method public void stopNavigation();
     method public void takeScreenshot();
     method public void toggleMute();
-    method public void updateCameraRouteOverview();
+    method public boolean updateCameraRouteGeometryOverview();
+    method @Deprecated public void updateCameraRouteOverview();
     method public void updateWayNameView(String);
   }
 
@@ -229,7 +230,8 @@ package com.mapbox.navigation.ui.camera {
     method public void resetCameraPositionWith(@com.mapbox.navigation.ui.camera.NavigationCamera.TrackingMode int);
     method public void resume(android.location.Location?);
     method public void setCamera(com.mapbox.navigation.ui.camera.Camera!);
-    method public void showRouteOverview(int[]);
+    method public boolean showRouteGeometryOverview(int[]);
+    method @Deprecated public void showRouteOverview(int[]);
     method public void start(com.mapbox.api.directions.v5.models.DirectionsRoute?);
     method public void update(com.mapbox.navigation.ui.camera.NavigationCameraUpdate);
     method public void update(com.mapbox.navigation.ui.camera.NavigationCameraUpdate, int);
@@ -477,7 +479,8 @@ package com.mapbox.navigation.ui.map {
     method public void setPuckDrawableSupplier(com.mapbox.navigation.ui.puck.PuckDrawableSupplier);
     method public void showAlternativeRoutes(boolean);
     method public void showRoute();
-    method public void showRouteOverview(int[]!);
+    method public boolean showRouteGeometryOverview(int[]!);
+    method @Deprecated public void showRouteOverview(int[]!);
     method public void startCamera(com.mapbox.api.directions.v5.models.DirectionsRoute);
     method public void takeScreenshot(com.mapbox.mapboxsdk.maps.MapboxMap.SnapshotReadyCallback);
     method public void updateCameraTrackingMode(@com.mapbox.navigation.ui.camera.NavigationCamera.TrackingMode int);

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationPresenter.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationPresenter.java
@@ -52,7 +52,7 @@ class NavigationPresenter {
   void onRouteUpdate(DirectionsRoute directionsRoute) {
     view.drawRoute(directionsRoute);
     if (resumeState && view.isRecenterButtonVisible()) {
-      view.updateCameraRouteOverview();
+      view.updateCameraRouteGeometryOverview();
     } else {
       view.startCamera(directionsRoute);
     }
@@ -90,10 +90,11 @@ class NavigationPresenter {
   }
 
   void onRouteOverviewClick() {
-    view.setWayNameActive(false);
-    view.setWayNameVisibility(false);
-    view.updateCameraRouteOverview();
-    view.showRecenterBtn();
+    if (view.updateCameraRouteGeometryOverview()) {
+      view.setWayNameActive(false);
+      view.setWayNameVisibility(false);
+      view.showRecenterBtn();
+    }
   }
 
   void onFeedbackSent() {

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationView.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationView.java
@@ -409,11 +409,18 @@ public class NavigationView extends CoordinatorLayout implements LifecycleOwner,
   }
 
   @Override
+  @Deprecated
   public void updateCameraRouteOverview() {
+    updateCameraRouteGeometryOverview();
+  }
+
+  @Override
+  public boolean updateCameraRouteGeometryOverview() {
     if (navigationMap != null) {
       int[] padding = buildRouteOverviewPadding(getContext());
-      navigationMap.showRouteOverview(padding);
+      return navigationMap.showRouteGeometryOverview(padding);
     }
+    return false;
   }
 
   @Override

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/internal/NavigationContract.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/internal/NavigationContract.java
@@ -43,7 +43,13 @@ public interface NavigationContract {
 
     boolean isRecenterButtonVisible();
 
+    /**
+     * @deprecated use {@link #updateCameraRouteGeometryOverview()}
+     */
+    @Deprecated
     void updateCameraRouteOverview();
+
+    boolean updateCameraRouteGeometryOverview();
 
     void onFeedbackSent();
 

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/NavigationMapboxMap.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/NavigationMapboxMap.java
@@ -712,10 +712,24 @@ public class NavigationMapboxMap implements LifecycleObserver {
    * Also includes the given padding.
    *
    * @param padding for creating the overview camera position
+   * @deprecated use {@link #showRouteGeometryOverview(int[])} instead
    */
+  @Deprecated
   public void showRouteOverview(int[] padding) {
+    showRouteGeometryOverview(padding);
+  }
+
+  /**
+   * Adjusts the map camera to {@link DirectionsRoute} being traveled along.
+   * <p>
+   * Also includes the given padding.
+   *
+   * @param padding for creating the overview camera position
+   * @return true if the transition to overview succeeded, false otherwise
+   */
+  public boolean showRouteGeometryOverview(int[] padding) {
     mapPaddingAdjustor.updatePaddingWith(ZERO_MAP_PADDING);
-    mapCamera.showRouteOverview(padding);
+    return mapCamera.showRouteGeometryOverview(padding);
   }
 
   /**

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/NavigationPresenterTest.java
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/NavigationPresenterTest.java
@@ -6,6 +6,7 @@ import com.mapbox.navigation.ui.internal.NavigationContract;
 import org.junit.Test;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -18,12 +19,13 @@ public class NavigationPresenterTest {
 
     presenter.onRouteOverviewClick();
 
-    verify(view).updateCameraRouteOverview();
+    verify(view).updateCameraRouteGeometryOverview();
   }
 
   @Test
   public void onRouteOverviewButtonClick_recenterBtnIsShown() {
     NavigationContract.View view = mock(NavigationContract.View.class);
+    when(view.updateCameraRouteGeometryOverview()).thenReturn(true);
     NavigationPresenter presenter = new NavigationPresenter(view);
 
     presenter.onRouteOverviewClick();
@@ -32,8 +34,20 @@ public class NavigationPresenterTest {
   }
 
   @Test
+  public void onRouteOverviewButtonClick_failed_recenterBtnIsNotShown() {
+    NavigationContract.View view = mock(NavigationContract.View.class);
+    when(view.updateCameraRouteGeometryOverview()).thenReturn(false);
+    NavigationPresenter presenter = new NavigationPresenter(view);
+
+    presenter.onRouteOverviewClick();
+
+    verify(view, times(0)).showRecenterBtn();
+  }
+
+  @Test
   public void onRouteOverviewButtonClick_mapWaynameIsHidden() {
     NavigationContract.View view = mock(NavigationContract.View.class);
+    when(view.updateCameraRouteGeometryOverview()).thenReturn(true);
     NavigationPresenter presenter = new NavigationPresenter(view);
 
     presenter.onRouteOverviewClick();
@@ -151,7 +165,7 @@ public class NavigationPresenterTest {
 
     presenter.onRouteUpdate(directionsRoute);
 
-    verify(view).updateCameraRouteOverview();
+    verify(view).updateCameraRouteGeometryOverview();
   }
 
   @Test


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-navigation-android/issues/3593 by checking whether current route progress is available and alternatively falling back to the initially provided route when generating the overview camera position.