### PR TITLE
Fix replay bearing for small maneuvers

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayRouteInterpolator.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayRouteInterpolator.kt
@@ -66,12 +66,17 @@ internal class ReplayRouteInterpolator {
      * point to the next location in the route.
      */
     fun createBearingProfile(replayRouteLocations: List<ReplayRouteLocation>) {
-        var bearing = replayRouteLocations.first().bearing
+        if (replayRouteLocations.size < 2) return
         val lookAhead = 2
+        var bearing = TurfMeasurement.bearing(
+            replayRouteLocations[0].point,
+            replayRouteLocations[1].point
+        )
         replayRouteLocations.forEachIndexed { index, location ->
-            if (index + lookAhead < replayRouteLocations.lastIndex) {
+            val nextIndex = min(index + lookAhead, replayRouteLocations.lastIndex)
+            if (index < nextIndex) {
                 val fromPoint = location.point
-                val toPoint = replayRouteLocations[index + lookAhead].point
+                val toPoint = replayRouteLocations[nextIndex].point
                 bearing = TurfMeasurement.bearing(fromPoint, toPoint)
             }
             location.bearing = bearing

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/route/ReplayRouteInterpolatorTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/route/ReplayRouteInterpolatorTest.kt
@@ -1,6 +1,7 @@
 package com.mapbox.navigation.core.replay.route
 
 import com.mapbox.geojson.Point
+import com.mapbox.turf.TurfMeasurement
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -254,5 +255,35 @@ class ReplayRouteInterpolatorTest {
         // To stop in 19 meters, you need to be going about 12mps
         assertEquals(19.0, speedProfile[2].distance, 0.5)
         assertEquals(12.0, speedProfile[2].speedMps, 0.5)
+    }
+
+    @Test
+    fun `should complete route with bearing in the last direction`() {
+        val coordinates = listOf(
+            ReplayRouteLocation(0, Point.fromLngLat(11.5774679, 48.163475)),
+            ReplayRouteLocation(1, Point.fromLngLat(11.5774440, 48.163593)),
+            ReplayRouteLocation(2, Point.fromLngLat(11.5774200, 48.163711)),
+            ReplayRouteLocation(3, Point.fromLngLat(11.5774634, 48.163716)),
+            ReplayRouteLocation(4, Point.fromLngLat(11.5775070, 48.163722))
+        )
+
+        val lastBearing = TurfMeasurement.bearing(coordinates[3].point, coordinates[4].point)
+        routeInterpolator.createBearingProfile(coordinates)
+
+        assertEquals(lastBearing, coordinates.last().bearing, 0.0001)
+    }
+
+    @Test
+    fun `should create bearing for a short route`() {
+        val coordinates = listOf(
+            ReplayRouteLocation(0, Point.fromLngLat(11.5774679, 48.163475)),
+            ReplayRouteLocation(1, Point.fromLngLat(11.5774440, 48.163593))
+        )
+
+        val bearing = TurfMeasurement.bearing(coordinates[0].point, coordinates[1].point)
+        routeInterpolator.createBearingProfile(coordinates)
+
+        assertEquals(bearing, coordinates[0].bearing, 0.0001)
+        assertEquals(bearing, coordinates[1].bearing, 0.0001)
     }
 }


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Replay simulated locations will not end a route with an accurate bearing.

| Before | After |
| -- | -- |
| ![Screen Shot 2020-10-08 at 6 16 23 PM](https://user-images.githubusercontent.com/3021882/95530341-7784d000-0992-11eb-8e03-20a96560f9c6.png) | ![Screen Shot 2020-10-09 at 11 19 31 AM](https://user-images.githubusercontent.com/3021882/95618093-57e8b880-0a21-11eb-89c8-ff11647051bc.png) |

- [ ] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->