### PR TITLE
upgrade Common SDK to v7.1.1

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -12,7 +12,7 @@ ext {
       mapboxEvents              : '6.2.1',
       mapboxCore                : '3.1.0',
       mapboxNavigator           : '25.0.0',
-      mapboxCommonNative        : '7.1.0',
+      mapboxCommonNative        : '7.1.1',
       mapboxCrashMonitor        : '2.0.0',
       mapboxAnnotationPlugin    : '0.8.0',
       mapboxAccounts            : '0.4.0',


### PR DESCRIPTION
This upgrade resolves an issue with an `OkHttp` dependency mismatch (unintentional upgrade to 4.x by a transitive dependency) which resulted in narrowing the supported OS versions to API level 21 and higher. Now, the supported range is back to expected API level 19 and higher.