### PR TITLE
Backports #3650 to release 1.1

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -12,7 +12,7 @@ ext {
       mapboxEvents              : '6.1.0',
       mapboxCore                : '3.0.0',
       mapboxNavigator           : '22.0.4',
-      mapboxCommonNative        : '7.1.0',
+      mapboxCommonNative        : '7.1.1',
       mapboxCrashMonitor        : '2.0.0',
       mapboxAnnotationPlugin    : '0.8.0',
       mapboxAccounts            : '0.4.0',


### PR DESCRIPTION
Backports https://github.com/mapbox/mapbox-navigation-android/pull/3650 to release 1.1.