### PR TITLE
Fix current horizon, type and position assignment done from 2 threads

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/ElectronicHorizonObserverImpl.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/ElectronicHorizonObserverImpl.kt
@@ -41,10 +41,10 @@ internal class ElectronicHorizonObserverImpl(
         type: ElectronicHorizonResultType
     ) {
         val horizon = horizon.mapToEHorizon()
-        currentHorizon = horizon
         val type = type.convertResultType()
-        currentType = type
         jobController.scope.launch {
+            currentHorizon = horizon
+            currentType = type
             eHorizonObservers.forEach {
                 it.onElectronicHorizonUpdated(
                     horizon,
@@ -56,9 +56,9 @@ internal class ElectronicHorizonObserverImpl(
 
     override fun onPositionUpdated(position: GraphPosition) {
         val position = position.mapToEHorizonPosition()
-        currentPosition = position
         jobController.scope.launch {
             eHorizonObservers.forEach {
+                currentPosition = position
                 it.onPositionUpdated(position)
             }
         }


### PR DESCRIPTION
## Description

Fixes `currentHorizon`, `currentType` and `currentPosition` so they are assigned from the same thread (main) to avoid holding / emitting invalid states if `MapboxTripSession` is `reset` and `EHorizonObserver` is registered

Follow up from https://github.com/mapbox/mapbox-navigation-android/pull/3630 and https://github.com/mapbox/mapbox-navigation-android/pull/3630#discussion_r504726772


- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Avoid holding / emitting invalid states if `MapboxTripSession` is `reset` and `EHorizonObserver` is registered. Due to a race condition it can hold a non-null value after `reset` which is incorrect

### Implementation

Move `currentHorizon`, `currentType` and `currentPosition` assignments inside the `mainJobController`

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->