### PR TITLE
Add Electronic Horizon Builder tests

### DIFF
--- a/libnavigation-base/api/current.txt
+++ b/libnavigation-base/api/current.txt
@@ -200,8 +200,6 @@ package com.mapbox.navigation.base.trip.model {
   public final class EHorizonPosition {
     method public long getEdgeId();
     method public double getPercentAlong();
-    method public void setEdgeId(long p);
-    method public void setPercentAlong(double p);
     method public com.mapbox.navigation.base.trip.model.EHorizonPosition.Builder toBuilder();
   }
 

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/EHorizonPosition.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/EHorizonPosition.kt
@@ -12,8 +12,8 @@ package com.mapbox.navigation.base.trip.model
  * @param percentAlong the progress along the current edge [0,1)
  */
 class EHorizonPosition private constructor(
-    var edgeId: Long,
-    var percentAlong: Double
+    val edgeId: Long,
+    val percentAlong: Double
 ) {
 
     /**

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/Edge.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/Edge.kt
@@ -139,6 +139,7 @@ class Edge private constructor(
         if (frc != other.frc) return false
         if (wayId != other.wayId) return false
         if (positiveDirection != other.positiveDirection) return false
+        if (speed != other.speed) return false
         if (ramp != other.ramp) return false
         if (motorway != other.motorway) return false
         if (bridge != other.bridge) return false
@@ -169,6 +170,7 @@ class Edge private constructor(
         result = 31 * result + frc.hashCode()
         result = 31 * result + wayId.hashCode()
         result = 31 * result + positiveDirection.hashCode()
+        result = 31 * result + speed.hashCode()
         result = 31 * result + ramp.hashCode()
         result = 31 * result + motorway.hashCode()
         result = 31 * result + bridge.hashCode()
@@ -199,6 +201,7 @@ class Edge private constructor(
             "frc=$frc, " +
             "wayId=$wayId, " +
             "positiveDirection=$positiveDirection, " +
+            "speed=$speed, " +
             "ramp=$ramp, " +
             "motorway=$motorway, " +
             "bridge=$bridge, " +
@@ -210,7 +213,6 @@ class Edge private constructor(
             "speedLimit=$speedLimit, " +
             "laneCount=$laneCount, " +
             "meanElevation=$meanElevation, " +
-            "speedLimit=$speedLimit, " +
             "countryCode=$countryCode, " +
             "stateCode=$stateCode" +
             ")"

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/options/EHorizonOptionsTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/options/EHorizonOptionsTest.kt
@@ -1,0 +1,20 @@
+package com.mapbox.navigation.base.options
+
+import com.mapbox.navigation.testing.BuilderTest
+import org.junit.Test
+
+class EHorizonOptionsTest : BuilderTest<EHorizonOptions, EHorizonOptions.Builder>() {
+
+    override fun getImplementationClass() = EHorizonOptions::class
+
+    override fun getFilledUpBuilder() = EHorizonOptions.Builder()
+        .length(1500.0)
+        .expansion(1)
+        .branchLength(150.0)
+        .includeGeometries(true)
+
+    @Test
+    override fun trigger() {
+        // trigger, see KDoc
+    }
+}

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/trip/model/EHorizonPositionTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/trip/model/EHorizonPositionTest.kt
@@ -1,0 +1,18 @@
+package com.mapbox.navigation.base.trip.model
+
+import com.mapbox.navigation.testing.BuilderTest
+import org.junit.Test
+
+class EHorizonPositionTest : BuilderTest<EHorizonPosition, EHorizonPosition.Builder>() {
+
+    override fun getImplementationClass() = EHorizonPosition::class
+
+    override fun getFilledUpBuilder() = EHorizonPosition.Builder()
+        .edgeId(3)
+        .percentAlong(25.0)
+
+    @Test
+    override fun trigger() {
+        // trigger, see KDoc
+    }
+}

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/trip/model/EHorizonTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/trip/model/EHorizonTest.kt
@@ -1,0 +1,18 @@
+package com.mapbox.navigation.base.trip.model
+
+import com.mapbox.navigation.testing.BuilderTest
+import io.mockk.mockk
+import org.junit.Test
+
+class EHorizonTest : BuilderTest<EHorizon, EHorizon.Builder>() {
+
+    override fun getImplementationClass() = EHorizon::class
+
+    override fun getFilledUpBuilder() = EHorizon.Builder()
+        .start(mockk())
+
+    @Test
+    override fun trigger() {
+        // trigger, see KDoc
+    }
+}

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/trip/model/EdgeTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/trip/model/EdgeTest.kt
@@ -1,0 +1,40 @@
+package com.mapbox.navigation.base.trip.model
+
+import com.mapbox.navigation.testing.BuilderTest
+import io.mockk.mockk
+import org.junit.Test
+
+class EdgeTest : BuilderTest<Edge, Edge.Builder>() {
+
+    override fun getImplementationClass() = Edge::class
+
+    override fun getFilledUpBuilder() = Edge.Builder()
+        .id(3)
+        .level(2.toByte())
+        .probability(0.5)
+        .heading(180.0)
+        .length(100.0)
+        .out(mockk(relaxed = true))
+        .frc("MOTORWAY")
+        .wayId("way id")
+        .positiveDirection(false)
+        .speed(40.0)
+        .ramp(true)
+        .motorway(true)
+        .bridge(true)
+        .tunnel(true)
+        .toll(true)
+        .names(mockk(relaxed = true))
+        .curvature(8.toByte())
+        .geometry(mockk())
+        .speedLimit(30.0)
+        .laneCount(3)
+        .meanElevation(5.0)
+        .countryCode("US")
+        .stateCode("MD")
+
+    @Test
+    override fun trigger() {
+        // trigger, see KDoc
+    }
+}

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/trip/model/NameInfoTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/trip/model/NameInfoTest.kt
@@ -1,0 +1,18 @@
+package com.mapbox.navigation.base.trip.model
+
+import com.mapbox.navigation.testing.BuilderTest
+import org.junit.Test
+
+class NameInfoTest : BuilderTest<NameInfo, NameInfo.Builder>() {
+
+    override fun getImplementationClass() = NameInfo::class
+
+    override fun getFilledUpBuilder() = NameInfo.Builder()
+        .name("King Farm Blvd")
+        .shielded(true)
+
+    @Test
+    override fun trigger() {
+        // trigger, see KDoc
+    }
+}

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigator.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigator.kt
@@ -219,6 +219,7 @@ interface MapboxNativeNavigator {
     // EH
 
     /**
+     * Sets the Electronic Horizon observer
      *
      * @param eHorizonObserver
      */

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigatorImpl.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigatorImpl.kt
@@ -291,6 +291,7 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
     // EH
 
     /**
+     * Sets the Electronic Horizon observer
      *
      * @param eHorizonObserver
      */


### PR DESCRIPTION
## Description

Adds Electronic Horizon `Builder` tests and fixes some regressions

Follow up from https://github.com/mapbox/mapbox-navigation-android/pull/3630


- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Add Electronic Horizon `Builder` tests and fix some regressions

### Implementation

Add `Builder` tests:

- `EHorizonOptionsTest`
- `EHorizonPositionTest`
- `EHorizonTest`
- `EdgeTest`
- `NameInfoTest`

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [x] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs