### PR TITLE
Override common okhttp dependency with 7.1.1

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -66,6 +66,7 @@ ext {
       mapboxCore                : "com.mapbox.mapboxsdk:mapbox-android-core:${version.mapboxCore}",
       mapboxNavigator           : "com.mapbox.navigator:mapbox-navigation-native:${version.mapboxNavigator}",
       mapboxCommonNative        : "com.mapbox.common:common:${version.mapboxCommonNative}",
+      mapboxCommonOkHttp        : "com.mapbox.common:okhttp:${version.mapboxCommonNative}",
       mapboxAnnotationPlugin    : "com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v9:${version.mapboxAnnotationPlugin}",
       mapboxCrashMonitor        : "com.mapbox.crashmonitor:mapbox-crash-monitor-native:${version.mapboxCrashMonitor}",
       mapboxAndroidAccounts     : "com.mapbox.mapboxsdk:mapbox-navigation-accounts-android:${version.mapboxAccounts}",

--- a/libnavigation-core/build.gradle
+++ b/libnavigation-core/build.gradle
@@ -54,6 +54,7 @@ dependencies {
     implementation project(':libnavigation-util')
     implementation project(':libnavigator')
     api dependenciesList.mapboxCommonNative
+    implementation dependenciesList.mapboxCommonOkHttp
     runtimeOnly project(':libnavigation-router')
     runtimeOnly project(':libtrip-notification')
     runtimeOnly dependenciesList.mapboxLogger


### PR DESCRIPTION
While testing downstream, I noticed that https://github.com/mapbox/mapbox-navigation-android/pull/3650 did not fully resolve the issue with the leaked OkHttp 4.x dependency.
```
+--- com.mapbox.navigation:navigator:1.1.1
|    +--- com.mapbox.navigator:mapbox-navigation-native:22.0.4
|    |    +--- com.mapbox.mapboxsdk:mapbox-sdk-geojson:5.2.1 -> 5.7.0 (*)
|    |    +--- com.mapbox.common:common:7.1.0 -> 7.1.1 (*)
|    |    +--- com.mapbox.common:okhttp:7.1.0
|    |    |    +--- com.mapbox.common:common:7.1.0 -> 7.1.1 (*)
|    |    |    +--- androidx.annotation:annotation:1.1.0
|    |    |    \--- com.squareup.okhttp3:okhttp:4.8.1 (*)
```

Before releasing, we should verify that the behavior is correct with a snapshot.