### PR TITLE
Include Codecov reports to Github PR checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,10 @@ assemble-core-release:
 core-unit-tests:
 	$(call run-gradle-tasks,$(CORE_MODULES),test)
 
+.PHONY: core-unit-tests-jacoco
+core-unit-tests-jacoco:
+	$(call run-gradle-tasks,$(CORE_MODULES),jacocoTestReport)
+
 .PHONY: core-publish-to-sdk-registry
 core-publish-to-sdk-registry:
 	$(call run-gradle-tasks,$(CORE_MODULES),mapboxSDKRegistryUpload)
@@ -114,6 +118,10 @@ assemble-ui-release:
 .PHONY: ui-unit-tests
 ui-unit-tests:
 	$(call run-gradle-tasks,$(UI_MODULES),test)
+
+.PHONY: ui-unit-tests-jacoco
+ui-unit-tests-jacoco:
+	$(call run-gradle-tasks,$(UI_MODULES),jacocoTestReport)
 
 .PHONY: ui-publish-to-sdk-registry
 ui-publish-to-sdk-registry:

--- a/circle.yml
+++ b/circle.yml
@@ -163,8 +163,9 @@ commands:
   unit-tests-core:
     steps:
       - run:
-          name: Run Navigation Core SDK Unit Tests
-          command: make core-unit-tests
+          name: Run Navigation Core SDK Unit Tests and generate Jacoco test report
+          command: |
+            make core-unit-tests-jacoco
       - store-results:
           module_target: "libnavigation-router"
       - store-results:
@@ -183,10 +184,17 @@ commands:
   unit-tests-ui:
     steps:
       - run:
-          name: Run Navigation UI SDK Unit Tests
-          command: make ui-unit-tests
+          name: Run Navigation UI SDK Unit Tests and generate Jacoco test report
+          command: |
+            make ui-unit-tests-jacoco
       - store-results:
           module_target: "libnavigation-ui"
+
+  codecov:
+    steps:
+      - run:
+          name: Post code coverage reports to Codecov.io
+          command: pip install --user codecov && /root/.local/bin/codecov
 
   generate-version-name:
     steps:
@@ -328,6 +336,7 @@ jobs:
       - checkout
       - unit-tests-core
       - unit-tests-ui
+      - codecov
 
   static-analysis:
     working_directory: ~/code


### PR DESCRIPTION
## Description

Includes Codecov reports to Github PR checks

Fixes #2655 

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Include Codecov reports to Github PR checks so we can see how we're doing on every PR.

### Implementation

Update `core-unit-tests` and `ui-unit-tests` `Makefile` so that Jacoco test reports are generete and update `circle.yml` so they're post to Codecov.io 

## Testing

- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
