### PR TITLE
MapRouteLine issue fix: keep the selected route as primary after map style has been changed

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/BasicNavigationActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/BasicNavigationActivity.kt
@@ -163,7 +163,7 @@ open class BasicNavigationActivity : AppCompatActivity(), OnMapReadyCallback {
         override fun onRoutesReady(routes: List<DirectionsRoute>) {
             if (routes.isNotEmpty()) {
                 directionRoute = routes[0]
-                navigationMapboxMap?.drawRoute(routes[0])
+                navigationMapboxMap?.drawRoutes(routes)
                 startNavigation.visibility = View.VISIBLE
             } else {
                 startNavigation.visibility = View.GONE

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteClickListener.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteClickListener.java
@@ -76,10 +76,12 @@ class MapRouteClickListener implements MapboxMap.OnMapClickListener {
 
     DirectionsRoute clickedRoute = routeDistancesAwayFromClick.get(distancesAwayFromClick.get(0));
     int newPrimaryRouteIndex = directionsRoutes.indexOf(clickedRoute);
-    if (clickedRoute != routeLine.getPrimaryRoute() && onRouteSelectionChangeListener != null) {
+    if (clickedRoute != routeLine.getPrimaryRoute()) {
       routeLine.updatePrimaryRouteIndex(clickedRoute);
-      DirectionsRoute selectedRoute = directionsRoutes.get(newPrimaryRouteIndex);
-      onRouteSelectionChangeListener.onNewPrimaryRouteSelected(selectedRoute);
+      if (onRouteSelectionChangeListener != null) {
+        DirectionsRoute selectedRoute = directionsRoutes.get(newPrimaryRouteIndex);
+        onRouteSelectionChangeListener.onNewPrimaryRouteSelected(selectedRoute);
+      }
     }
   }
 

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteLine.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteLine.kt
@@ -484,6 +484,11 @@ internal class MapRouteLine(
      */
     fun updatePrimaryRouteIndex(route: DirectionsRoute) {
         this.primaryRoute = route
+        val partitionedRoutes = routeFeatureData.partition { it.route == primaryRoute }
+        routeFeatureData.apply {
+            clear()
+            addAll(listOf(partitionedRoutes.first, partitionedRoutes.second).flatten())
+        }
         drawRoutes(routeFeatureData)
     }
 


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Fix an issue that: the previous selected primary route line will be reset to the default one when changing the map style.

#### For example,

1. request routes
2. get two routes, one is primary(**route A**) and one is alternative(**route B**)
3. select the alternative route as primary
4. changing the map style

#### Expected behavior: 
after step 4, expect the **route B** is still the primary route.
#### Actual behavior: 
after step 4, the primary route is reset to **route A** 

- [ ] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Implementation

as discussed with @cafesilencio offline, update the `routeFeatureData` order every time when updatePrimaryRouteIndex has been called.

## Screenshots or Gifs

#### After fix:
![ezgif com-gif-maker](https://user-images.githubusercontent.com/3918950/96521201-98b4ae80-1225-11eb-886e-d86b349c13cd.gif)

#### Before fix:
![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/3918950/96521271-bc77f480-1225-11eb-9af4-199a7b64f245.gif)

## Testing

Use BasicNavigationActivity for testing.

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->