### PR TITLE
Ensure that UI SDK does not depend on the modular notification classes

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -27,3 +27,8 @@ source_file = libnavigation-util/src/main/res/values/strings.xml
 source_lang = en
 type = ANDROID
 
+[mapbox-navigation-sdk-for-android.libnavigation-base-strings-file]
+file_filter = libnavigation-base/src/main/res/values-<lang>/strings.xml
+source_file = libnavigation-base/src/main/res/values/strings.xml
+source_lang = en
+type = ANDROID

--- a/libnavigation-base/api/current.txt
+++ b/libnavigation-base/api/current.txt
@@ -181,6 +181,13 @@ package com.mapbox.navigation.base.route {
 
 }
 
+package com.mapbox.navigation.base.time.span {
+
+  public final class SpanExKt {
+  }
+
+}
+
 package com.mapbox.navigation.base.trip.model {
 
   public final class EHorizon {

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/time/TimeFormatter.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/time/TimeFormatter.kt
@@ -1,4 +1,4 @@
-package com.mapbox.navigation.trip.notification.internal
+package com.mapbox.navigation.base.internal.time
 
 import android.content.Context
 import android.content.res.Configuration
@@ -7,12 +7,12 @@ import android.graphics.Typeface
 import android.text.SpannableStringBuilder
 import android.text.style.RelativeSizeSpan
 import android.text.style.StyleSpan
+import com.mapbox.navigation.base.R
 import com.mapbox.navigation.base.TimeFormat
-import com.mapbox.navigation.trip.notification.R
-import com.mapbox.navigation.trip.notification.time.TimeFormattingChain
-import com.mapbox.navigation.trip.notification.time.span.SpanItem
-import com.mapbox.navigation.trip.notification.time.span.TextSpanItem
-import com.mapbox.navigation.trip.notification.time.span.combineSpan
+import com.mapbox.navigation.base.time.TimeFormattingChain
+import com.mapbox.navigation.base.time.span.SpanItem
+import com.mapbox.navigation.base.time.span.TextSpanItem
+import com.mapbox.navigation.base.time.span.combineSpan
 import java.util.ArrayList
 import java.util.Calendar
 import java.util.Locale

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/time/NoneSpecifiedTimeFormat.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/time/NoneSpecifiedTimeFormat.kt
@@ -1,4 +1,4 @@
-package com.mapbox.navigation.trip.notification.time
+package com.mapbox.navigation.base.time
 
 import java.util.Calendar
 import java.util.Locale

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/time/TimeFormatResolver.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/time/TimeFormatResolver.kt
@@ -1,4 +1,4 @@
-package com.mapbox.navigation.trip.notification.time
+package com.mapbox.navigation.base.time
 
 import java.util.Calendar
 

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/time/TimeFormattingChain.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/time/TimeFormattingChain.kt
@@ -1,4 +1,4 @@
-package com.mapbox.navigation.trip.notification.time
+package com.mapbox.navigation.base.time
 
 internal class TimeFormattingChain {
 

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/time/TwelveHoursTimeFormat.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/time/TwelveHoursTimeFormat.kt
@@ -1,4 +1,4 @@
-package com.mapbox.navigation.trip.notification.time
+package com.mapbox.navigation.base.time
 
 import java.util.Calendar
 import java.util.Locale

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/time/TwentyFourHoursTimeFormat.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/time/TwentyFourHoursTimeFormat.kt
@@ -1,4 +1,4 @@
-package com.mapbox.navigation.trip.notification.time
+package com.mapbox.navigation.base.time
 
 import java.util.Calendar
 import java.util.Locale

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/time/span/SpanEx.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/time/span/SpanEx.kt
@@ -1,4 +1,4 @@
-package com.mapbox.navigation.trip.notification.time.span
+package com.mapbox.navigation.base.time.span
 
 import android.os.Build
 import android.text.Spannable

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/time/span/SpanItem.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/time/span/SpanItem.kt
@@ -1,0 +1,5 @@
+package com.mapbox.navigation.base.time.span
+
+internal interface SpanItem {
+    val span: Any
+}

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/time/span/TextSpanItem.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/time/span/TextSpanItem.kt
@@ -1,3 +1,3 @@
-package com.mapbox.navigation.trip.notification.time.span
+package com.mapbox.navigation.base.time.span
 
 internal class TextSpanItem(override val span: Any, val spanText: String) : SpanItem

--- a/libnavigation-base/src/main/res/values-ar/strings.xml
+++ b/libnavigation-base/src/main/res/values-ar/strings.xml
@@ -1,0 +1,15 @@
+<resources>
+    <!-- Time formatting -->
+    <plurals name="mapbox_number_of_days">
+        <item quantity="zero">يوم</item>
+        <item quantity="one">يوم</item>
+        <item quantity="two">يومان</item>
+        <item quantity="few">أيام</item>
+        <item quantity="many">أيام</item>
+        <item quantity="other">أيام</item>
+    </plurals>
+    <!-- Hour -->
+    <string name="mapbox_unit_hr">ساعة</string>
+    <!-- Minute -->
+    <string name="mapbox_unit_min">دقيقة</string>
+</resources>

--- a/libnavigation-base/src/main/res/values-bg/strings.xml
+++ b/libnavigation-base/src/main/res/values-bg/strings.xml
@@ -1,0 +1,11 @@
+<resources>
+    <!-- Time formatting -->
+    <plurals name="mapbox_number_of_days">
+        <item quantity="one">дни</item>
+        <item quantity="other">дни</item>
+    </plurals>
+    <!-- Hour -->
+    <string name="mapbox_unit_hr">ч</string>
+    <!-- Minute -->
+    <string name="mapbox_unit_min">мин</string>
+</resources>

--- a/libnavigation-base/src/main/res/values-cs/strings.xml
+++ b/libnavigation-base/src/main/res/values-cs/strings.xml
@@ -1,0 +1,13 @@
+<resources>
+    <!-- Time formatting -->
+    <plurals name="mapbox_number_of_days">
+        <item quantity="one">den</item>
+        <item quantity="few">dni</item>
+        <item quantity="many">dnů</item>
+        <item quantity="other">den</item>
+    </plurals>
+    <!-- Hour -->
+    <string name="mapbox_unit_hr">hod.</string>
+    <!-- Minute -->
+    <string name="mapbox_unit_min">min.</string>
+</resources>

--- a/libnavigation-base/src/main/res/values-da/strings.xml
+++ b/libnavigation-base/src/main/res/values-da/strings.xml
@@ -1,0 +1,11 @@
+<resources>
+    <!-- Time formatting -->
+    <plurals name="mapbox_number_of_days">
+        <item quantity="one">dag</item>
+        <item quantity="other">dage</item>
+    </plurals>
+    <!-- Hour -->
+    <string name="mapbox_unit_hr">t</string>
+    <!-- Minute -->
+    <string name="mapbox_unit_min">min</string>
+</resources>

--- a/libnavigation-base/src/main/res/values-de/strings.xml
+++ b/libnavigation-base/src/main/res/values-de/strings.xml
@@ -1,0 +1,11 @@
+<resources>
+    <!-- Time formatting -->
+    <plurals name="mapbox_number_of_days">
+        <item quantity="one">Tag</item>
+        <item quantity="other">Tage</item>
+    </plurals>
+    <!-- Hour -->
+    <string name="mapbox_unit_hr">Std.</string>
+    <!-- Minute -->
+    <string name="mapbox_unit_min">Min.</string>
+</resources>

--- a/libnavigation-base/src/main/res/values-el/strings.xml
+++ b/libnavigation-base/src/main/res/values-el/strings.xml
@@ -1,0 +1,11 @@
+<resources>
+    <!-- Time formatting -->
+    <plurals name="mapbox_number_of_days">
+        <item quantity="one">μέρα</item>
+        <item quantity="other">μέρες</item>
+    </plurals>
+    <!-- Hour -->
+    <string name="mapbox_unit_hr">ώρες</string>
+    <!-- Minute -->
+    <string name="mapbox_unit_min">λεπτά</string>
+</resources>

--- a/libnavigation-base/src/main/res/values-es/strings.xml
+++ b/libnavigation-base/src/main/res/values-es/strings.xml
@@ -1,0 +1,11 @@
+<resources>
+    <!-- Time formatting -->
+    <plurals name="mapbox_number_of_days">
+        <item quantity="one">día</item>
+        <item quantity="other">días</item>
+    </plurals>
+    <!-- Hour -->
+    <string name="mapbox_unit_hr">h</string>
+    <!-- Minute -->
+    <string name="mapbox_unit_min">min</string>
+</resources>

--- a/libnavigation-base/src/main/res/values-fa/strings.xml
+++ b/libnavigation-base/src/main/res/values-fa/strings.xml
@@ -1,0 +1,11 @@
+<resources>
+    <!-- Time formatting -->
+    <plurals name="mapbox_number_of_days">
+        <item quantity="one">روز</item>
+        <item quantity="other">روزها</item>
+    </plurals>
+    <!-- Hour -->
+    <string name="mapbox_unit_hr">ساعت</string>
+    <!-- Minute -->
+    <string name="mapbox_unit_min">دقیقه</string>
+</resources>

--- a/libnavigation-base/src/main/res/values-fr/strings.xml
+++ b/libnavigation-base/src/main/res/values-fr/strings.xml
@@ -1,0 +1,11 @@
+<resources>
+    <!-- Time formatting -->
+    <plurals name="mapbox_number_of_days">
+        <item quantity="one">jour</item>
+        <item quantity="other">jours</item>
+    </plurals>
+    <!-- Hour -->
+    <string name="mapbox_unit_hr">h</string>
+    <!-- Minute -->
+    <string name="mapbox_unit_min">min</string>
+</resources>

--- a/libnavigation-base/src/main/res/values-gl/strings.xml
+++ b/libnavigation-base/src/main/res/values-gl/strings.xml
@@ -1,0 +1,11 @@
+<resources>
+    <!-- Time formatting -->
+    <plurals name="mapbox_number_of_days">
+        <item quantity="one">día</item>
+        <item quantity="other">días</item>
+    </plurals>
+    <!-- Hour -->
+    <string name="mapbox_unit_hr">h</string>
+    <!-- Minute -->
+    <string name="mapbox_unit_min">min</string>
+</resources>

--- a/libnavigation-base/src/main/res/values-he/strings.xml
+++ b/libnavigation-base/src/main/res/values-he/strings.xml
@@ -1,0 +1,6 @@
+<resources>
+    <!-- Hour -->
+    <string name="mapbox_unit_hr">שעות</string>
+    <!-- Minute -->
+    <string name="mapbox_unit_min">דק׳</string>
+</resources>

--- a/libnavigation-base/src/main/res/values-hu/strings.xml
+++ b/libnavigation-base/src/main/res/values-hu/strings.xml
@@ -1,0 +1,11 @@
+<resources>
+    <!-- Time formatting -->
+    <plurals name="mapbox_number_of_days">
+        <item quantity="one">nap</item>
+        <item quantity="other">nap</item>
+    </plurals>
+    <!-- Hour -->
+    <string name="mapbox_unit_hr">óra</string>
+    <!-- Minute -->
+    <string name="mapbox_unit_min">perc</string>
+</resources>

--- a/libnavigation-base/src/main/res/values-ja/strings.xml
+++ b/libnavigation-base/src/main/res/values-ja/strings.xml
@@ -1,0 +1,10 @@
+<resources>
+    <!-- Time formatting -->
+    <plurals name="mapbox_number_of_days">
+        <item quantity="other">日</item>
+    </plurals>
+    <!-- Hour -->
+    <string name="mapbox_unit_hr">時間</string>
+    <!-- Minute -->
+    <string name="mapbox_unit_min">分</string>
+</resources>

--- a/libnavigation-base/src/main/res/values-ko/strings.xml
+++ b/libnavigation-base/src/main/res/values-ko/strings.xml
@@ -1,0 +1,6 @@
+<resources>
+    <!-- Hour -->
+    <string name="mapbox_unit_hr">시</string>
+    <!-- Minute -->
+    <string name="mapbox_unit_min">분</string>
+</resources>

--- a/libnavigation-base/src/main/res/values-pt-rBR/strings.xml
+++ b/libnavigation-base/src/main/res/values-pt-rBR/strings.xml
@@ -1,0 +1,11 @@
+<resources>
+    <!-- Time formatting -->
+    <plurals name="mapbox_number_of_days">
+        <item quantity="one">dia</item>
+        <item quantity="other">dias</item>
+    </plurals>
+    <!-- Hour -->
+    <string name="mapbox_unit_hr">hr</string>
+    <!-- Minute -->
+    <string name="mapbox_unit_min">min</string>
+</resources>

--- a/libnavigation-base/src/main/res/values-pt-rPT/strings.xml
+++ b/libnavigation-base/src/main/res/values-pt-rPT/strings.xml
@@ -1,0 +1,11 @@
+<resources>
+    <!-- Time formatting -->
+    <plurals name="mapbox_number_of_days">
+        <item quantity="one">dia</item>
+        <item quantity="other">dias</item>
+    </plurals>
+    <!-- Hour -->
+    <string name="mapbox_unit_hr">hor</string>
+    <!-- Minute -->
+    <string name="mapbox_unit_min">min</string>
+</resources>

--- a/libnavigation-base/src/main/res/values-ru/strings.xml
+++ b/libnavigation-base/src/main/res/values-ru/strings.xml
@@ -1,0 +1,13 @@
+<resources>
+    <!-- Time formatting -->
+    <plurals name="mapbox_number_of_days">
+        <item quantity="one">день</item>
+        <item quantity="few">дня</item>
+        <item quantity="many">дней</item>
+        <item quantity="other">дней</item>
+    </plurals>
+    <!-- Hour -->
+    <string name="mapbox_unit_hr">ч.</string>
+    <!-- Minute -->
+    <string name="mapbox_unit_min">мин.</string>
+</resources>

--- a/libnavigation-base/src/main/res/values-uk/strings.xml
+++ b/libnavigation-base/src/main/res/values-uk/strings.xml
@@ -1,0 +1,13 @@
+<resources>
+    <!-- Time formatting -->
+    <plurals name="mapbox_number_of_days">
+        <item quantity="one">день</item>
+        <item quantity="few">дні</item>
+        <item quantity="many">днів</item>
+        <item quantity="other">днів</item>
+    </plurals>
+    <!-- Hour -->
+    <string name="mapbox_unit_hr">год</string>
+    <!-- Minute -->
+    <string name="mapbox_unit_min">хв</string>
+</resources>

--- a/libnavigation-base/src/main/res/values-uz/strings.xml
+++ b/libnavigation-base/src/main/res/values-uz/strings.xml
@@ -1,0 +1,10 @@
+<resources>
+    <!-- Time formatting -->
+    <plurals name="mapbox_number_of_days">
+        <item quantity="other">kun</item>
+    </plurals>
+    <!-- Hour -->
+    <string name="mapbox_unit_hr">soat</string>
+    <!-- Minute -->
+    <string name="mapbox_unit_min">minut</string>
+</resources>

--- a/libnavigation-base/src/main/res/values-vi/strings.xml
+++ b/libnavigation-base/src/main/res/values-vi/strings.xml
@@ -1,0 +1,10 @@
+<resources>
+    <!-- Time formatting -->
+    <plurals name="mapbox_number_of_days">
+        <item quantity="other">ngày</item>
+    </plurals>
+    <!-- Hour -->
+    <string name="mapbox_unit_hr">giờ</string>
+    <!-- Minute -->
+    <string name="mapbox_unit_min">phút</string>
+</resources>

--- a/libnavigation-base/src/main/res/values-yo/strings.xml
+++ b/libnavigation-base/src/main/res/values-yo/strings.xml
@@ -1,0 +1,10 @@
+<resources>
+    <!-- Time formatting -->
+    <plurals name="mapbox_number_of_days">
+        <item quantity="other">ọjọ</item>
+    </plurals>
+    <!-- Hour -->
+    <string name="mapbox_unit_hr">hr</string>
+    <!-- Minute -->
+    <string name="mapbox_unit_min">min</string>
+</resources>

--- a/libnavigation-base/src/main/res/values/dimens.xml
+++ b/libnavigation-base/src/main/res/values/dimens.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="mapbox_notification_maneuver_image_width">48dp</dimen>
+    <dimen name="mapbox_notification_maneuver_image_height">48dp</dimen>
+</resources>

--- a/libnavigation-base/src/main/res/values/strings.xml
+++ b/libnavigation-base/src/main/res/values/strings.xml
@@ -1,0 +1,12 @@
+<resources>
+
+    <!-- Time formatting -->
+    <plurals name="mapbox_number_of_days">
+        <item quantity="one">day</item>
+        <item quantity="other">days</item>
+    </plurals>
+    <!-- Hour -->
+    <string name="mapbox_unit_hr">hr</string>
+    <!-- Minute -->
+    <string name="mapbox_unit_min">min</string>
+</resources>

--- a/libnavigation-ui/build.gradle
+++ b/libnavigation-ui/build.gradle
@@ -65,7 +65,6 @@ dependencies {
   // Navigation SDK
   api project(':libnavigation-core')
   implementation project(':libnavigation-util')
-  implementation project(':libtrip-notification')
 
   // Mapbox
   implementation dependenciesList.mapboxSdkServices

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/instruction/maneuver/ManeuverView.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/instruction/maneuver/ManeuverView.java
@@ -18,14 +18,13 @@ import androidx.core.util.Pair;
 import com.mapbox.api.directions.v5.models.ManeuverModifier;
 import com.mapbox.api.directions.v5.models.StepManeuver;
 import com.mapbox.navigation.ui.R;
-import com.mapbox.navigation.trip.notification.internal.maneuver.ManeuverIconHelper;
-import com.mapbox.navigation.trip.notification.internal.maneuver.ManeuverIconDrawer;
-import com.mapbox.navigation.trip.notification.internal.maneuver.ManeuversStyleKit;
+import com.mapbox.navigation.utils.internal.maneuver.ManeuverIconDrawer;
+import com.mapbox.navigation.utils.internal.maneuver.ManeuverIconHelper;
+import com.mapbox.navigation.utils.internal.maneuver.ManeuversStyleKit;
 
-import static com.mapbox.navigation.trip.notification.internal.maneuver.ManeuverIconHelper.DEFAULT_ROUNDABOUT_ANGLE;
-import static com.mapbox.navigation.trip.notification.internal.maneuver.ManeuverIconHelper.MANEUVER_TYPES_WITH_NULL_MODIFIERS;
-import static com.mapbox.navigation.trip.notification.internal.maneuver.ManeuverIconHelper.MANEUVER_ICON_DRAWER_MAP;
-import static com.mapbox.navigation.trip.notification.internal.maneuver.ManeuverIconHelper.ROUNDABOUT_MANEUVER_TYPES;
+import static com.mapbox.navigation.utils.internal.maneuver.ManeuverIconHelper.MANEUVER_ICON_DRAWER_MAP;
+import static com.mapbox.navigation.utils.internal.maneuver.ManeuverIconHelper.MANEUVER_TYPES_WITH_NULL_MODIFIERS;
+import static com.mapbox.navigation.utils.internal.maneuver.ManeuverIconHelper.ROUNDABOUT_MANEUVER_TYPES;
 
 
 /**
@@ -43,7 +42,7 @@ public class ManeuverView extends View {
   private int primaryColor;
   @ColorInt
   private int secondaryColor;
-  private float roundaboutAngle = DEFAULT_ROUNDABOUT_ANGLE;
+  private float roundaboutAngle = ManeuverIconHelper.DEFAULT_ROUNDABOUT_ANGLE;
   @Nullable
   private Pair<String, String> maneuverTypeAndModifier = new Pair<>(null, null);
   private PointF size;

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/summary/SummaryModel.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/summary/SummaryModel.java
@@ -9,8 +9,8 @@ import androidx.annotation.NonNull;
 import com.mapbox.navigation.base.TimeFormat;
 import com.mapbox.navigation.base.formatter.DistanceFormatter;
 import com.mapbox.navigation.base.internal.extensions.LocaleEx;
+import com.mapbox.navigation.base.internal.time.TimeFormatter;
 import com.mapbox.navigation.base.trip.model.RouteProgress;
-import com.mapbox.navigation.trip.notification.internal.TimeFormatter;
 import timber.log.Timber;
 
 import java.util.Calendar;

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/summary/SummaryModelTest.kt
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/summary/SummaryModelTest.kt
@@ -4,10 +4,10 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import com.mapbox.navigation.base.TimeFormat.TWELVE_HOURS
 import com.mapbox.navigation.base.internal.VoiceUnit.METRIC
+import com.mapbox.navigation.base.internal.time.TimeFormatter.formatTime
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.Rounding.INCREMENT_FIFTY
 import com.mapbox.navigation.core.internal.formatter.MapboxDistanceFormatter
-import com.mapbox.navigation.trip.notification.internal.TimeFormatter.formatTime
 import com.mapbox.navigation.ui.BaseTest
 import io.mockk.every
 import io.mockk.mockkStatic
@@ -18,6 +18,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import java.util.Calendar
+import kotlin.jvm.Throws
 
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = Config.NONE)

--- a/libnavigation-util/build.gradle
+++ b/libnavigation-util/build.gradle
@@ -37,6 +37,8 @@ android {
 dependencies {
     implementation dependenciesList.kotlinStdLib
     implementation dependenciesList.coroutinesAndroid
+    implementation dependenciesList.androidXCore
+    api dependenciesList.mapboxSdkDirectionsModels
 
     //ktlint
     ktlint dependenciesList.ktlint

--- a/libnavigation-util/src/main/java/com/mapbox/navigation/utils/internal/maneuver/ManeuverIconDrawer.kt
+++ b/libnavigation-util/src/main/java/com/mapbox/navigation/utils/internal/maneuver/ManeuverIconDrawer.kt
@@ -1,4 +1,4 @@
-package com.mapbox.navigation.trip.notification.internal.maneuver
+package com.mapbox.navigation.utils.internal.maneuver
 
 import android.graphics.Canvas
 import android.graphics.PointF

--- a/libnavigation-util/src/main/java/com/mapbox/navigation/utils/internal/maneuver/ManeuverIconHelper.kt
+++ b/libnavigation-util/src/main/java/com/mapbox/navigation/utils/internal/maneuver/ManeuverIconHelper.kt
@@ -1,4 +1,4 @@
-package com.mapbox.navigation.trip.notification.internal.maneuver
+package com.mapbox.navigation.utils.internal.maneuver
 
 import android.graphics.Canvas
 import android.graphics.PointF
@@ -28,7 +28,8 @@ object ManeuverIconHelper {
             init {
                 put(
                     Pair(StepManeuver.MERGE, null),
-                    object : ManeuverIconDrawer {
+                    object :
+                        ManeuverIconDrawer {
                         override fun drawManeuverIcon(
                             canvas: Canvas,
                             primaryColor: Int,
@@ -42,7 +43,8 @@ object ManeuverIconHelper {
                 )
                 put(
                     Pair(StepManeuver.OFF_RAMP, null),
-                    object : ManeuverIconDrawer {
+                    object :
+                        ManeuverIconDrawer {
                         override fun drawManeuverIcon(
                             canvas: Canvas,
                             primaryColor: Int,
@@ -61,7 +63,8 @@ object ManeuverIconHelper {
                 )
                 put(
                     Pair(StepManeuver.FORK, null),
-                    object : ManeuverIconDrawer {
+                    object :
+                        ManeuverIconDrawer {
                         override fun drawManeuverIcon(
                             canvas: Canvas,
                             primaryColor: Int,
@@ -75,7 +78,8 @@ object ManeuverIconHelper {
                 )
                 put(
                     Pair(StepManeuver.ROUNDABOUT, null),
-                    object : ManeuverIconDrawer {
+                    object :
+                        ManeuverIconDrawer {
                         override fun drawManeuverIcon(
                             canvas: Canvas,
                             primaryColor: Int,
@@ -95,7 +99,8 @@ object ManeuverIconHelper {
                 )
                 put(
                     Pair(StepManeuver.ROUNDABOUT_TURN, null),
-                    object : ManeuverIconDrawer {
+                    object :
+                        ManeuverIconDrawer {
                         override fun drawManeuverIcon(
                             canvas: Canvas,
                             primaryColor: Int,
@@ -115,7 +120,8 @@ object ManeuverIconHelper {
                 )
                 put(
                     Pair(StepManeuver.EXIT_ROUNDABOUT, null),
-                    object : ManeuverIconDrawer {
+                    object :
+                        ManeuverIconDrawer {
                         override fun drawManeuverIcon(
                             canvas: Canvas,
                             primaryColor: Int,
@@ -135,7 +141,8 @@ object ManeuverIconHelper {
                 )
                 put(
                     Pair(StepManeuver.ROTARY, null),
-                    object : ManeuverIconDrawer {
+                    object :
+                        ManeuverIconDrawer {
                         override fun drawManeuverIcon(
                             canvas: Canvas,
                             primaryColor: Int,
@@ -155,7 +162,8 @@ object ManeuverIconHelper {
                 )
                 put(
                     Pair(StepManeuver.EXIT_ROTARY, null),
-                    object : ManeuverIconDrawer {
+                    object :
+                        ManeuverIconDrawer {
                         override fun drawManeuverIcon(
                             canvas: Canvas,
                             primaryColor: Int,
@@ -175,7 +183,8 @@ object ManeuverIconHelper {
                 )
                 put(
                     Pair(StepManeuver.ARRIVE, null),
-                    object : ManeuverIconDrawer {
+                    object :
+                        ManeuverIconDrawer {
                         override fun drawManeuverIcon(
                             canvas: Canvas,
                             primaryColor: Int,
@@ -189,7 +198,8 @@ object ManeuverIconHelper {
                 )
                 put(
                     Pair(StepManeuver.ARRIVE, ManeuverModifier.STRAIGHT),
-                    object : ManeuverIconDrawer {
+                    object :
+                        ManeuverIconDrawer {
                         override fun drawManeuverIcon(
                             canvas: Canvas,
                             primaryColor: Int,
@@ -203,7 +213,8 @@ object ManeuverIconHelper {
                 )
                 put(
                     Pair(StepManeuver.ARRIVE, ManeuverModifier.RIGHT),
-                    object : ManeuverIconDrawer {
+                    object :
+                        ManeuverIconDrawer {
                         override fun drawManeuverIcon(
                             canvas: Canvas,
                             primaryColor: Int,
@@ -217,7 +228,8 @@ object ManeuverIconHelper {
                 )
                 put(
                     Pair(StepManeuver.ARRIVE, ManeuverModifier.LEFT),
-                    object : ManeuverIconDrawer {
+                    object :
+                        ManeuverIconDrawer {
                         override fun drawManeuverIcon(
                             canvas: Canvas,
                             primaryColor: Int,
@@ -231,7 +243,8 @@ object ManeuverIconHelper {
                 )
                 put(
                     Pair(null, ManeuverModifier.SLIGHT_RIGHT),
-                    object : ManeuverIconDrawer {
+                    object :
+                        ManeuverIconDrawer {
                         override fun drawManeuverIcon(
                             canvas: Canvas,
                             primaryColor: Int,
@@ -245,7 +258,8 @@ object ManeuverIconHelper {
                 )
                 put(
                     Pair(null, ManeuverModifier.RIGHT),
-                    object : ManeuverIconDrawer {
+                    object :
+                        ManeuverIconDrawer {
                         override fun drawManeuverIcon(
                             canvas: Canvas,
                             primaryColor: Int,
@@ -259,7 +273,8 @@ object ManeuverIconHelper {
                 )
                 put(
                     Pair(null, ManeuverModifier.SHARP_RIGHT),
-                    object : ManeuverIconDrawer {
+                    object :
+                        ManeuverIconDrawer {
                         override fun drawManeuverIcon(
                             canvas: Canvas,
                             primaryColor: Int,
@@ -273,7 +288,8 @@ object ManeuverIconHelper {
                 )
                 put(
                     Pair(null, ManeuverModifier.SLIGHT_LEFT),
-                    object : ManeuverIconDrawer {
+                    object :
+                        ManeuverIconDrawer {
                         override fun drawManeuverIcon(
                             canvas: Canvas,
                             primaryColor: Int,
@@ -287,7 +303,8 @@ object ManeuverIconHelper {
                 )
                 put(
                     Pair(null, ManeuverModifier.LEFT),
-                    object : ManeuverIconDrawer {
+                    object :
+                        ManeuverIconDrawer {
                         override fun drawManeuverIcon(
                             canvas: Canvas,
                             primaryColor: Int,
@@ -301,7 +318,8 @@ object ManeuverIconHelper {
                 )
                 put(
                     Pair(null, ManeuverModifier.SHARP_LEFT),
-                    object : ManeuverIconDrawer {
+                    object :
+                        ManeuverIconDrawer {
                         override fun drawManeuverIcon(
                             canvas: Canvas,
                             primaryColor: Int,
@@ -315,7 +333,8 @@ object ManeuverIconHelper {
                 )
                 put(
                     Pair(null, ManeuverModifier.UTURN),
-                    object : ManeuverIconDrawer {
+                    object :
+                        ManeuverIconDrawer {
                         override fun drawManeuverIcon(
                             canvas: Canvas,
                             primaryColor: Int,
@@ -329,7 +348,8 @@ object ManeuverIconHelper {
                 )
                 put(
                     Pair(null, ManeuverModifier.STRAIGHT),
-                    object : ManeuverIconDrawer {
+                    object :
+                        ManeuverIconDrawer {
                         override fun drawManeuverIcon(
                             canvas: Canvas,
                             primaryColor: Int,
@@ -343,7 +363,8 @@ object ManeuverIconHelper {
                 )
                 put(
                     Pair(null, null),
-                    object : ManeuverIconDrawer {
+                    object :
+                        ManeuverIconDrawer {
                         override fun drawManeuverIcon(
                             canvas: Canvas,
                             primaryColor: Int,

--- a/libnavigation-util/src/main/java/com/mapbox/navigation/utils/internal/maneuver/ManeuversStyleKit.java
+++ b/libnavigation-util/src/main/java/com/mapbox/navigation/utils/internal/maneuver/ManeuversStyleKit.java
@@ -1,4 +1,4 @@
-package com.mapbox.navigation.trip.notification.internal.maneuver;
+package com.mapbox.navigation.utils.internal.maneuver;
 
 import android.graphics.Canvas;
 import android.graphics.DashPathEffect;

--- a/libtrip-notification/api/current.txt
+++ b/libtrip-notification/api/current.txt
@@ -1,8 +1,1 @@
 // Signature format: 3.0
-package com.mapbox.navigation.trip.notification.time.span {
-
-  public final class SpanExKt {
-  }
-
-}
-

--- a/libtrip-notification/src/main/java/com/mapbox/navigation/trip/notification/internal/MapboxTripNotification.kt
+++ b/libtrip-notification/src/main/java/com/mapbox/navigation/trip/notification/internal/MapboxTripNotification.kt
@@ -30,6 +30,7 @@ import com.mapbox.api.directions.v5.models.ManeuverModifier
 import com.mapbox.api.directions.v5.models.StepManeuver
 import com.mapbox.api.directions.v5.models.StepManeuver.StepManeuverType
 import com.mapbox.navigation.base.formatter.DistanceFormatter
+import com.mapbox.navigation.base.internal.time.TimeFormatter.formatTime
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.base.trip.notification.NotificationAction
@@ -37,13 +38,6 @@ import com.mapbox.navigation.base.trip.notification.TripNotification
 import com.mapbox.navigation.trip.notification.NavigationNotificationProvider
 import com.mapbox.navigation.trip.notification.R
 import com.mapbox.navigation.trip.notification.RemoteViewsProvider
-import com.mapbox.navigation.trip.notification.internal.TimeFormatter.formatTime
-import com.mapbox.navigation.trip.notification.internal.maneuver.ManeuverIconHelper.DEFAULT_ROUNDABOUT_ANGLE
-import com.mapbox.navigation.trip.notification.internal.maneuver.ManeuverIconHelper.MANEUVER_ICON_DRAWER_MAP
-import com.mapbox.navigation.trip.notification.internal.maneuver.ManeuverIconHelper.MANEUVER_TYPES_WITH_NULL_MODIFIERS
-import com.mapbox.navigation.trip.notification.internal.maneuver.ManeuverIconHelper.ROUNDABOUT_MANEUVER_TYPES
-import com.mapbox.navigation.trip.notification.internal.maneuver.ManeuverIconHelper.adjustRoundaboutAngle
-import com.mapbox.navigation.trip.notification.internal.maneuver.ManeuverIconHelper.isManeuverIconNeedFlip
 import com.mapbox.navigation.utils.internal.END_NAVIGATION_ACTION
 import com.mapbox.navigation.utils.internal.NAVIGATION_NOTIFICATION_CHANNEL
 import com.mapbox.navigation.utils.internal.NOTIFICATION_CHANNEL
@@ -51,6 +45,12 @@ import com.mapbox.navigation.utils.internal.NOTIFICATION_ID
 import com.mapbox.navigation.utils.internal.SET_BACKGROUND_COLOR
 import com.mapbox.navigation.utils.internal.ifChannelException
 import com.mapbox.navigation.utils.internal.ifNonNull
+import com.mapbox.navigation.utils.internal.maneuver.ManeuverIconHelper.DEFAULT_ROUNDABOUT_ANGLE
+import com.mapbox.navigation.utils.internal.maneuver.ManeuverIconHelper.MANEUVER_ICON_DRAWER_MAP
+import com.mapbox.navigation.utils.internal.maneuver.ManeuverIconHelper.MANEUVER_TYPES_WITH_NULL_MODIFIERS
+import com.mapbox.navigation.utils.internal.maneuver.ManeuverIconHelper.ROUNDABOUT_MANEUVER_TYPES
+import com.mapbox.navigation.utils.internal.maneuver.ManeuverIconHelper.adjustRoundaboutAngle
+import com.mapbox.navigation.utils.internal.maneuver.ManeuverIconHelper.isManeuverIconNeedFlip
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ClosedReceiveChannelException
 import kotlinx.coroutines.channels.ClosedSendChannelException

--- a/libtrip-notification/src/main/java/com/mapbox/navigation/trip/notification/time/span/SpanItem.kt
+++ b/libtrip-notification/src/main/java/com/mapbox/navigation/trip/notification/time/span/SpanItem.kt
@@ -1,5 +1,0 @@
-package com.mapbox.navigation.trip.notification.time.span
-
-internal interface SpanItem {
-    val span: Any
-}

--- a/libtrip-notification/src/main/res/values-ar/strings.xml
+++ b/libtrip-notification/src/main/res/values-ar/strings.xml
@@ -2,18 +2,4 @@
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">انهاء الرحلة</string>
     <string name="mapbox_eta_format">%s الوقت المتوقع للوصول</string>
-
-    <!-- Time formatting -->
-    <plurals name="mapbox_number_of_days">
-        <item quantity="zero">يوم</item>
-        <item quantity="one">يوم</item>
-        <item quantity="two">يومان</item>
-        <item quantity="few">أيام</item>
-        <item quantity="many">أيام</item>
-        <item quantity="other">أيام</item>
-    </plurals>
-    <!-- Hour -->
-    <string name="mapbox_unit_hr">ساعة</string>
-    <!-- Minute -->
-    <string name="mapbox_unit_min">دقيقة</string>
 </resources>

--- a/libtrip-notification/src/main/res/values-bg/strings.xml
+++ b/libtrip-notification/src/main/res/values-bg/strings.xml
@@ -2,14 +2,4 @@
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Край на навигация</string>
     <string name="mapbox_eta_format">%s Пристигане</string>
-
-    <!-- Time formatting -->
-    <plurals name="mapbox_number_of_days">
-        <item quantity="one">дни</item>
-        <item quantity="other">дни</item>
-    </plurals>
-    <!-- Hour -->
-    <string name="mapbox_unit_hr">ч</string>
-    <!-- Minute -->
-    <string name="mapbox_unit_min">мин</string>
 </resources>

--- a/libtrip-notification/src/main/res/values-cs/strings.xml
+++ b/libtrip-notification/src/main/res/values-cs/strings.xml
@@ -2,16 +2,4 @@
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Ukončit navigaci</string>
     <string name="mapbox_eta_format">%s Předpokládaný čas příjezdu</string>
-
-    <!-- Time formatting -->
-    <plurals name="mapbox_number_of_days">
-        <item quantity="one">den</item>
-        <item quantity="few">dni</item>
-        <item quantity="many">dnů</item>
-        <item quantity="other">den</item>
-    </plurals>
-    <!-- Hour -->
-    <string name="mapbox_unit_hr">hod.</string>
-    <!-- Minute -->
-    <string name="mapbox_unit_min">min.</string>
 </resources>

--- a/libtrip-notification/src/main/res/values-da/strings.xml
+++ b/libtrip-notification/src/main/res/values-da/strings.xml
@@ -3,13 +3,4 @@
     <string name="mapbox_end_navigation">Slut navigation </string>
     <string name="mapbox_eta_format">%s ETA</string>
 
-    <!-- Time formatting -->
-    <plurals name="mapbox_number_of_days">
-        <item quantity="one">dag</item>
-        <item quantity="other">dage</item>
-    </plurals>
-    <!-- Hour -->
-    <string name="mapbox_unit_hr">t</string>
-    <!-- Minute -->
-    <string name="mapbox_unit_min">min</string>
 </resources>

--- a/libtrip-notification/src/main/res/values-de/strings.xml
+++ b/libtrip-notification/src/main/res/values-de/strings.xml
@@ -4,14 +4,4 @@
     <string name="mapbox_stop_session">Sitzung beenden</string>
     <string name="mapbox_free_drive_session">Freie Fahrt-Sitzung</string>
     <string name="mapbox_eta_format">%s ETA</string>
-
-    <!-- Time formatting -->
-    <plurals name="mapbox_number_of_days">
-        <item quantity="one">Tag</item>
-        <item quantity="other">Tage</item>
-    </plurals>
-    <!-- Hour -->
-    <string name="mapbox_unit_hr">Std.</string>
-    <!-- Minute -->
-    <string name="mapbox_unit_min">Min.</string>
 </resources>

--- a/libtrip-notification/src/main/res/values-el/strings.xml
+++ b/libtrip-notification/src/main/res/values-el/strings.xml
@@ -2,14 +2,4 @@
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Τέλος πλοήγησης</string>
     <string name="mapbox_eta_format">%s ETA</string>
-
-    <!-- Time formatting -->
-    <plurals name="mapbox_number_of_days">
-        <item quantity="one">μέρα</item>
-        <item quantity="other">μέρες</item>
-    </plurals>
-    <!-- Hour -->
-    <string name="mapbox_unit_hr">ώρες</string>
-    <!-- Minute -->
-    <string name="mapbox_unit_min">λεπτά</string>
 </resources>

--- a/libtrip-notification/src/main/res/values-es/strings.xml
+++ b/libtrip-notification/src/main/res/values-es/strings.xml
@@ -4,14 +4,4 @@
     <string name="mapbox_stop_session">Parar la sesión</string>
     <string name="mapbox_free_drive_session">Sesión de manejar libremente</string>
     <string name="mapbox_eta_format">%s ETA</string>
-
-    <!-- Time formatting -->
-    <plurals name="mapbox_number_of_days">
-        <item quantity="one">día</item>
-        <item quantity="other">días</item>
-    </plurals>
-    <!-- Hour -->
-    <string name="mapbox_unit_hr">h</string>
-    <!-- Minute -->
-    <string name="mapbox_unit_min">min</string>
 </resources>

--- a/libtrip-notification/src/main/res/values-fa/strings.xml
+++ b/libtrip-notification/src/main/res/values-fa/strings.xml
@@ -2,14 +2,4 @@
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">پایان مسیر یابی</string>
     <string name="mapbox_eta_format">%s ETA</string>
-
-    <!-- Time formatting -->
-    <plurals name="mapbox_number_of_days">
-        <item quantity="one">روز</item>
-        <item quantity="other">روزها</item>
-    </plurals>
-    <!-- Hour -->
-    <string name="mapbox_unit_hr">ساعت</string>
-    <!-- Minute -->
-    <string name="mapbox_unit_min">دقیقه</string>
 </resources>

--- a/libtrip-notification/src/main/res/values-fr/strings.xml
+++ b/libtrip-notification/src/main/res/values-fr/strings.xml
@@ -1,13 +1,4 @@
 <resources>
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Fin de navigation</string>
-    <!-- Time formatting -->
-    <plurals name="mapbox_number_of_days">
-        <item quantity="one">jour</item>
-        <item quantity="other">jours</item>
-    </plurals>
-    <!-- Hour -->
-    <string name="mapbox_unit_hr">h</string>
-    <!-- Minute -->
-    <string name="mapbox_unit_min">min</string>
 </resources>

--- a/libtrip-notification/src/main/res/values-gl/strings.xml
+++ b/libtrip-notification/src/main/res/values-gl/strings.xml
@@ -2,14 +2,4 @@
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Remata a navegación</string>
     <string name="mapbox_eta_format">%s ETA</string>
-
-    <!-- Time formatting -->
-    <plurals name="mapbox_number_of_days">
-        <item quantity="one">día</item>
-        <item quantity="other">días</item>
-    </plurals>
-    <!-- Hour -->
-    <string name="mapbox_unit_hr">h</string>
-    <!-- Minute -->
-    <string name="mapbox_unit_min">min</string>
 </resources>

--- a/libtrip-notification/src/main/res/values-he/strings.xml
+++ b/libtrip-notification/src/main/res/values-he/strings.xml
@@ -1,8 +1,4 @@
 <resources>
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">סיום ניווט</string>
-    <!-- Hour -->
-    <string name="mapbox_unit_hr">שעות</string>
-    <!-- Minute -->
-    <string name="mapbox_unit_min">דק׳</string>
 </resources>

--- a/libtrip-notification/src/main/res/values-hu/strings.xml
+++ b/libtrip-notification/src/main/res/values-hu/strings.xml
@@ -2,14 +2,4 @@
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Navigáció vége</string>
     <string name="mapbox_eta_format">%s érkezés</string>
-
-    <!-- Time formatting -->
-    <plurals name="mapbox_number_of_days">
-        <item quantity="one">nap</item>
-        <item quantity="other">nap</item>
-    </plurals>
-    <!-- Hour -->
-    <string name="mapbox_unit_hr">óra</string>
-    <!-- Minute -->
-    <string name="mapbox_unit_min">perc</string>
 </resources>

--- a/libtrip-notification/src/main/res/values-ja/strings.xml
+++ b/libtrip-notification/src/main/res/values-ja/strings.xml
@@ -2,13 +2,4 @@
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">ナビゲーションを終了</string>
     <string name="mapbox_eta_format">到着予定時刻%s</string>
-
-    <!-- Time formatting -->
-    <plurals name="mapbox_number_of_days">
-        <item quantity="other">日</item>
-    </plurals>
-    <!-- Hour -->
-    <string name="mapbox_unit_hr">時間</string>
-    <!-- Minute -->
-    <string name="mapbox_unit_min">分</string>
 </resources>

--- a/libtrip-notification/src/main/res/values-ko/strings.xml
+++ b/libtrip-notification/src/main/res/values-ko/strings.xml
@@ -1,8 +1,4 @@
 <resources>
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">네비게이션 종료</string>
-    <!-- Hour -->
-    <string name="mapbox_unit_hr">시</string>
-    <!-- Minute -->
-    <string name="mapbox_unit_min">분</string>
 </resources>

--- a/libtrip-notification/src/main/res/values-pt-rBR/strings.xml
+++ b/libtrip-notification/src/main/res/values-pt-rBR/strings.xml
@@ -2,14 +2,4 @@
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Finalizar navegação</string>
     <string name="mapbox_eta_format">%s estimado</string>
-
-    <!-- Time formatting -->
-    <plurals name="mapbox_number_of_days">
-        <item quantity="one">dia</item>
-        <item quantity="other">dias</item>
-    </plurals>
-    <!-- Hour -->
-    <string name="mapbox_unit_hr">hr</string>
-    <!-- Minute -->
-    <string name="mapbox_unit_min">min</string>
 </resources>

--- a/libtrip-notification/src/main/res/values-pt-rPT/strings.xml
+++ b/libtrip-notification/src/main/res/values-pt-rPT/strings.xml
@@ -2,14 +2,4 @@
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Terminar Navegação</string>
     <string name="mapbox_eta_format">%s TEC</string>
-
-    <!-- Time formatting -->
-    <plurals name="mapbox_number_of_days">
-        <item quantity="one">dia</item>
-        <item quantity="other">dias</item>
-    </plurals>
-    <!-- Hour -->
-    <string name="mapbox_unit_hr">hor</string>
-    <!-- Minute -->
-    <string name="mapbox_unit_min">min</string>
 </resources>

--- a/libtrip-notification/src/main/res/values-ru/strings.xml
+++ b/libtrip-notification/src/main/res/values-ru/strings.xml
@@ -2,16 +2,4 @@
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Завершить</string>
     <string name="mapbox_eta_format">Ожидаемое прибытие %s</string>
-
-    <!-- Time formatting -->
-    <plurals name="mapbox_number_of_days">
-        <item quantity="one">день</item>
-        <item quantity="few">дня</item>
-        <item quantity="many">дней</item>
-        <item quantity="other">дней</item>
-    </plurals>
-    <!-- Hour -->
-    <string name="mapbox_unit_hr">ч.</string>
-    <!-- Minute -->
-    <string name="mapbox_unit_min">мин.</string>
 </resources>

--- a/libtrip-notification/src/main/res/values-sv/strings.xml
+++ b/libtrip-notification/src/main/res/values-sv/strings.xml
@@ -2,5 +2,4 @@
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Avsluta Navigering</string>
     <string name="mapbox_eta_format">%s ETA</string>
-
-    </resources>
+</resources>

--- a/libtrip-notification/src/main/res/values-uk/strings.xml
+++ b/libtrip-notification/src/main/res/values-uk/strings.xml
@@ -2,16 +2,4 @@
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Закінчити навігацію</string>
     <string name="mapbox_eta_format">До прибуття %s</string>
-
-    <!-- Time formatting -->
-    <plurals name="mapbox_number_of_days">
-        <item quantity="one">день</item>
-        <item quantity="few">дні</item>
-        <item quantity="many">днів</item>
-        <item quantity="other">днів</item>
-    </plurals>
-    <!-- Hour -->
-    <string name="mapbox_unit_hr">год</string>
-    <!-- Minute -->
-    <string name="mapbox_unit_min">хв</string>
 </resources>

--- a/libtrip-notification/src/main/res/values-uz/strings.xml
+++ b/libtrip-notification/src/main/res/values-uz/strings.xml
@@ -1,12 +1,4 @@
 <resources>
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Yo\'nalish tugallandi</string>
-    <!-- Time formatting -->
-    <plurals name="mapbox_number_of_days">
-        <item quantity="other">kun</item>
-    </plurals>
-    <!-- Hour -->
-    <string name="mapbox_unit_hr">soat</string>
-    <!-- Minute -->
-    <string name="mapbox_unit_min">minut</string>
 </resources>

--- a/libtrip-notification/src/main/res/values-vi/strings.xml
+++ b/libtrip-notification/src/main/res/values-vi/strings.xml
@@ -4,13 +4,4 @@
     <string name="mapbox_stop_session">Ngừng phiên điều hướng</string>
     <string name="mapbox_free_drive_session">Phiên Lái xe Tự do</string>
     <string name="mapbox_eta_format">Đến %s</string>
-
-    <!-- Time formatting -->
-    <plurals name="mapbox_number_of_days">
-        <item quantity="other">ngày</item>
-    </plurals>
-    <!-- Hour -->
-    <string name="mapbox_unit_hr">giờ</string>
-    <!-- Minute -->
-    <string name="mapbox_unit_min">phút</string>
 </resources>

--- a/libtrip-notification/src/main/res/values-yo/strings.xml
+++ b/libtrip-notification/src/main/res/values-yo/strings.xml
@@ -2,13 +2,4 @@
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Muu Lilọ kiri</string>
     <string name="mapbox_eta_format">%s ETA</string>
-
-    <!-- Time formatting -->
-    <plurals name="mapbox_number_of_days">
-        <item quantity="other">ọjọ</item>
-    </plurals>
-    <!-- Hour -->
-    <string name="mapbox_unit_hr">hr</string>
-    <!-- Minute -->
-    <string name="mapbox_unit_min">min</string>
 </resources>

--- a/libtrip-notification/src/main/res/values/strings.xml
+++ b/libtrip-notification/src/main/res/values/strings.xml
@@ -4,14 +4,4 @@
     <string name="mapbox_stop_session">Stop session</string>
     <string name="mapbox_free_drive_session">Free Drive Session</string>
     <string name="mapbox_eta_format">%s ETA</string>
-
-    <!-- Time formatting -->
-    <plurals name="mapbox_number_of_days">
-        <item quantity="one">day</item>
-        <item quantity="other">days</item>
-    </plurals>
-    <!-- Hour -->
-    <string name="mapbox_unit_hr">hr</string>
-    <!-- Minute -->
-    <string name="mapbox_unit_min">min</string>
 </resources>

--- a/libtrip-notification/src/test/java/com/mapbox/navigation/trip/notification/internal/MapboxTripNotificationTest.kt
+++ b/libtrip-notification/src/test/java/com/mapbox/navigation/trip/notification/internal/MapboxTripNotificationTest.kt
@@ -15,6 +15,7 @@ import android.widget.RemoteViews
 import com.mapbox.api.directions.v5.models.BannerInstructions
 import com.mapbox.api.directions.v5.models.BannerText
 import com.mapbox.navigation.base.formatter.DistanceFormatter
+import com.mapbox.navigation.base.internal.time.TimeFormatter
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.trip.model.RouteLegProgress
 import com.mapbox.navigation.base.trip.model.RouteProgress

--- a/libtrip-notification/src/test/java/com/mapbox/navigation/trip/notification/internal/TimeFormatterTest.kt
+++ b/libtrip-notification/src/test/java/com/mapbox/navigation/trip/notification/internal/TimeFormatterTest.kt
@@ -8,6 +8,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.mapbox.navigation.base.TimeFormat.NONE_SPECIFIED
 import com.mapbox.navigation.base.TimeFormat.TWELVE_HOURS
 import com.mapbox.navigation.base.TimeFormat.TWENTY_FOUR_HOURS
+import com.mapbox.navigation.base.internal.time.TimeFormatter
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test


### PR DESCRIPTION
## Description

Closes https://github.com/mapbox/mapbox-navigation-android/issues/3662.

### Implementation

I moved some of the implementation pieces required by both the `libnavigation-ui` and `libtrip-notification` to shared `utils` and `base` modules so that we can remove the hard link between the UI SDK and default trip notification implementations.

## Testing

I will publish a snapshot from this branch to verify the fix in a standalone project.