### PR TITLE
Bump mapboxSdkServices dependencies version to 5.8.0-beta.2

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,7 +8,7 @@ ext {
 
   version = [
       mapboxMapSdk              : '9.6.0-alpha.1',
-      mapboxSdkServices         : '5.8.0-beta.1',
+      mapboxSdkServices         : '5.8.0-beta.2',
       mapboxEvents              : '6.2.1',
       mapboxCore                : '3.1.0',
       mapboxNavigator           : '25.0.0',

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteLineTest.kt
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteLineTest.kt
@@ -1596,7 +1596,7 @@ class MapRouteLineTest {
             false,
             false,
             mapRouteSourceProvider,
-            0f,
+            0.0,
             null
         )
         val primaryRouteBeforeRecreate = mapRouteLine.getPrimaryRoute()
@@ -1613,7 +1613,7 @@ class MapRouteLineTest {
             mapRouteLine.retrieveVisibility(),
             mapRouteLine.retrieveAlternativesVisible(),
             mapRouteSourceProvider,
-            0f,
+            0.0,
             null
         )
 


### PR DESCRIPTION
## Description

Bumps `mapboxSdkServices` version to `5.8.0-beta.2`

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Getting the latest version from `mapboxSdkServices` including the new features and bug fixes.

### Implementation

Bumping `mapboxSdkServices` version to `5.8.0-beta.2` in `dependencies.gradle`

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs