### PR TITLE
Bump mapboxMapSdk, mapboxNavigator and mapboxCommonNative dependencies version to 9.6.0-beta.1, 26.0.0 and 9.0.2 respectively

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -7,12 +7,12 @@ ext {
   ]
 
   version = [
-      mapboxMapSdk              : '9.6.0-alpha.1',
+      mapboxMapSdk              : '9.6.0-beta.1',
       mapboxSdkServices         : '5.8.0-beta.2',
       mapboxEvents              : '6.2.1',
       mapboxCore                : '3.1.0',
-      mapboxNavigator           : '25.0.0',
-      mapboxCommonNative        : '7.1.1',
+      mapboxNavigator           : '26.0.0',
+      mapboxCommonNative        : '9.0.2',
       mapboxCrashMonitor        : '2.0.0',
       mapboxAnnotationPlugin    : '0.8.0',
       mapboxAccounts            : '0.4.1',
@@ -66,7 +66,6 @@ ext {
       mapboxCore                : "com.mapbox.mapboxsdk:mapbox-android-core:${version.mapboxCore}",
       mapboxNavigator           : "com.mapbox.navigator:mapbox-navigation-native:${version.mapboxNavigator}",
       mapboxCommonNative        : "com.mapbox.common:common:${version.mapboxCommonNative}",
-      mapboxCommonOkHttp        : "com.mapbox.common:okhttp:${version.mapboxCommonNative}",
       mapboxAnnotationPlugin    : "com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v9:${version.mapboxAnnotationPlugin}",
       mapboxCrashMonitor        : "com.mapbox.crashmonitor:mapbox-crash-monitor-native:${version.mapboxCrashMonitor}",
       mapboxAndroidAccounts     : "com.mapbox.mapboxsdk:mapbox-navigation-accounts-android:${version.mapboxAccounts}",

--- a/libnavigation-core/build.gradle
+++ b/libnavigation-core/build.gradle
@@ -54,7 +54,6 @@ dependencies {
     implementation project(':libnavigation-util')
     implementation project(':libnavigator')
     api dependenciesList.mapboxCommonNative
-    implementation dependenciesList.mapboxCommonOkHttp
     runtimeOnly project(':libnavigation-router')
     runtimeOnly project(':libtrip-notification')
     runtimeOnly dependenciesList.mapboxLogger


### PR DESCRIPTION
## Description

Bump `mapboxMapSdk`, `mapboxNavigator` and `mapboxCommonNative` dependencies version to `9.6.0-beta.1`, `26.0.0` and `9.0.2` respectively

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Getting the latest version from `mapboxMapSdk`, `mapboxNavigator` and `mapboxCommonNative` including the new features and bug fixes.

### Implementation

- Bump the `mapboxMapSdk` version to `9.6.0-beta.1` in `dependencies.gradle`
- Bump the `mapboxNavigator` version to `26.0.0` in `dependencies.gradle`
- Bump the `mapboxCommonNative` version to `9.0.2` in `dependencies.gradle`

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs

cc @etl @zugaldia @knov 