### PR TITLE
Fix inferred `BannerInstructions#willDisplay` nullability

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/ui/CustomCameraActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/ui/CustomCameraActivity.kt
@@ -136,8 +136,8 @@ class CustomCameraActivity :
         }
     }
 
-    override fun willDisplay(instructions: BannerInstructions?): BannerInstructions {
-        return instructions!!
+    override fun willDisplay(instructions: BannerInstructions?): BannerInstructions? {
+        return instructions
     }
 
     override fun onNavigationRunning() {

--- a/examples/src/main/java/com/mapbox/navigation/examples/ui/CustomPuckActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/ui/CustomPuckActivity.kt
@@ -110,8 +110,8 @@ class CustomPuckActivity :
         }
     }
 
-    override fun willDisplay(instructions: BannerInstructions?): BannerInstructions {
-        return instructions!!
+    override fun willDisplay(instructions: BannerInstructions?): BannerInstructions? {
+        return instructions
     }
 
     override fun onNavigationRunning() {

--- a/examples/src/main/java/com/mapbox/navigation/examples/ui/NavigationViewActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/ui/NavigationViewActivity.kt
@@ -106,8 +106,8 @@ class NavigationViewActivity :
         }
     }
 
-    override fun willDisplay(instructions: BannerInstructions?): BannerInstructions {
-        return instructions!!
+    override fun willDisplay(instructions: BannerInstructions?): BannerInstructions? {
+        return instructions
     }
 
     override fun onNavigationRunning() {

--- a/examples/src/main/java/com/mapbox/navigation/examples/ui/TrafficToggleActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/ui/TrafficToggleActivity.kt
@@ -117,8 +117,8 @@ class TrafficToggleActivity :
         }
     }
 
-    override fun willDisplay(instructions: BannerInstructions?): BannerInstructions {
-        return instructions!!
+    override fun willDisplay(instructions: BannerInstructions?): BannerInstructions? {
+        return instructions
     }
 
     override fun onNavigationRunning() {

--- a/libnavigation-ui/api/current.txt
+++ b/libnavigation-ui/api/current.txt
@@ -360,7 +360,7 @@ package com.mapbox.navigation.ui.instruction {
     method public void subscribe(androidx.lifecycle.LifecycleOwner!, com.mapbox.navigation.ui.NavigationViewModel);
     method public void toggleGuidanceView(com.mapbox.api.directions.v5.models.BannerInstructions?);
     method @androidx.lifecycle.OnLifecycleEvent(androidx.lifecycle.Lifecycle.Event.ON_DESTROY) public void unsubscribe();
-    method public void updateBannerInstructionsWith(com.mapbox.api.directions.v5.models.BannerInstructions!);
+    method public void updateBannerInstructionsWith(com.mapbox.api.directions.v5.models.BannerInstructions?);
     method public void updateBannerInstructionsWith(com.mapbox.api.directions.v5.models.BannerInstructions?, String!);
     method public void updateDistanceWith(com.mapbox.navigation.base.trip.model.RouteProgress?);
   }
@@ -409,7 +409,7 @@ package com.mapbox.navigation.ui.instruction.turnlane {
 package com.mapbox.navigation.ui.listeners {
 
   public interface BannerInstructionsListener {
-    method public com.mapbox.api.directions.v5.models.BannerInstructions willDisplay(com.mapbox.api.directions.v5.models.BannerInstructions!);
+    method public com.mapbox.api.directions.v5.models.BannerInstructions? willDisplay(com.mapbox.api.directions.v5.models.BannerInstructions!);
   }
 
   public interface FeedbackListener {

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/instruction/InstructionView.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/instruction/InstructionView.java
@@ -283,7 +283,7 @@ public class InstructionView extends RelativeLayout implements LifecycleObserver
    *
    * @param instructions for banner info used to populate the views
    */
-  public void updateBannerInstructionsWith(BannerInstructions instructions) {
+  public void updateBannerInstructionsWith(@Nullable BannerInstructions instructions) {
     updateBannerInstructionsWith(instructions, ManeuverModifier.RIGHT);
   }
 

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/listeners/BannerInstructionsListener.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/listeners/BannerInstructionsListener.java
@@ -1,6 +1,6 @@
 package com.mapbox.navigation.ui.listeners;
 
-import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.mapbox.api.directions.v5.models.BannerInstructions;
 
@@ -21,6 +21,6 @@ public interface BannerInstructionsListener {
    * @param instructions about to be displayed
    * @return instructions to be displayed; null if should be ignored
    */
-  @NonNull
+  @Nullable
   BannerInstructions willDisplay(BannerInstructions instructions);
 }


### PR DESCRIPTION
This PR fixes a regression from trying to infer nullability of the `BannerInstructions#willDisplay`. Even though this change theoretically breaks semver's compilation compatibility for Kotlin, the interface in the current form is redundant and completely non-functional when referenced from Kotlin, so I would still opt to ship this change in the 1.x series.