### PR TITLE
Refactor route's layer below id search

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteLine.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteLine.kt
@@ -1256,10 +1256,9 @@ internal class MapRouteLine(
         fun getBelowLayer(layerId: String?, style: Style): String {
             return when (layerId.isNullOrEmpty()) {
                 false -> style.layers.firstOrNull { it.id == layerId }?.id
-                true ->
-                    style.layers.reversed().filter { it !is SymbolLayer }
-                        .firstOrNull { !it.id.contains(RouteConstants.MAPBOX_LOCATION_ID) }
-                        ?.id
+                true -> style.layers.firstOrNull {
+                    it.id.contains(RouteConstants.MAPBOX_LOCATION_ID) || it is SymbolLayer
+                }?.id
             } ?: LocationComponentConstants.SHADOW_LAYER
         }
 

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteLineTest.kt
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteLineTest.kt
@@ -13,7 +13,8 @@ import com.mapbox.geojson.utils.PolylineUtils
 import com.mapbox.mapboxsdk.location.LocationComponentConstants
 import com.mapbox.mapboxsdk.maps.Style
 import com.mapbox.mapboxsdk.style.expressions.Expression
-import com.mapbox.mapboxsdk.style.layers.Layer
+import com.mapbox.mapboxsdk.style.layers.CircleLayer
+import com.mapbox.mapboxsdk.style.layers.FillLayer
 import com.mapbox.mapboxsdk.style.layers.LineLayer
 import com.mapbox.mapboxsdk.style.layers.PropertyValue
 import com.mapbox.mapboxsdk.style.layers.SymbolLayer
@@ -547,52 +548,94 @@ class MapRouteLineTest {
     }
 
     @Test
-    fun getBelowLayerWithNullLayerId() {
+    fun getBelowLayerWithNullLayerId_1() {
         val style = mockk<Style>()
-        val layerApple = mockk<Layer>()
-        val layerBanana = mockk<Layer>()
-        val layerCantaloupe = mockk<Layer>()
-        val layerDragonfruit = mockk<SymbolLayer>()
-        val layers = listOf(layerApple, layerBanana, layerCantaloupe, layerDragonfruit)
-        every { style.layers } returns layers
-        every { layerApple.id } returns "layerApple"
-        every { layerBanana.id } returns RouteConstants.MAPBOX_LOCATION_ID
-        every { layerCantaloupe.id } returns "layerCantaloupe"
-        every { layerDragonfruit.id } returns "layerDragonfruit"
+        every { style.layers } returns listOf(
+            mockk<FillLayer> {
+                every { id } returns "layerApple"
+            },
+            mockk<SymbolLayer> {
+                every { id } returns RouteConstants.MAPBOX_LOCATION_ID + "1"
+            },
+            mockk<SymbolLayer> {
+                every { id } returns RouteConstants.MAPBOX_LOCATION_ID + "2"
+            },
+            mockk<FillLayer> {
+                every { id } returns "layerCantaloupe"
+            },
+            mockk<SymbolLayer> {
+                every { id } returns "layerDragonfruit"
+            }
+        )
 
         val result = MapRouteLine.MapRouteLineSupport.getBelowLayer(null, style)
 
-        assertEquals("layerCantaloupe", result)
+        assertEquals(RouteConstants.MAPBOX_LOCATION_ID + "1", result)
+    }
+
+    @Test
+    fun getBelowLayerWithNullLayerId_2() {
+        val style = mockk<Style>()
+        every { style.layers } returns listOf(
+            mockk<FillLayer> {
+                every { id } returns "layerApple"
+            },
+            mockk<CircleLayer> {
+                every { id } returns "layerBanana"
+            },
+            mockk<FillLayer> {
+                every { id } returns "layerCantaloupe"
+            },
+            mockk<SymbolLayer> {
+                every { id } returns "layerDragonfruit"
+            }
+        )
+
+        val result = MapRouteLine.MapRouteLineSupport.getBelowLayer(null, style)
+
+        assertEquals("layerDragonfruit", result)
     }
 
     @Test
     fun getBelowLayerWithEmptyLayerId() {
         val style = mockk<Style>()
-        val layerApple = mockk<Layer>()
-        val layerBanana = mockk<Layer>()
-        val layerCantaloupe = mockk<Layer>()
-        val layerDragonfruit = mockk<SymbolLayer>()
-        val layers = listOf(layerApple, layerBanana, layerCantaloupe, layerDragonfruit)
-        every { style.layers } returns layers
-        every { layerApple.id } returns "layerApple"
-        every { layerBanana.id } returns RouteConstants.MAPBOX_LOCATION_ID
-        every { layerCantaloupe.id } returns "layerCantaloupe"
-        every { layerDragonfruit.id } returns "layerDragonfruit"
+        every { style.layers } returns listOf(
+            mockk<FillLayer> {
+                every { id } returns "layerApple"
+            },
+            mockk<SymbolLayer> {
+                every { id } returns "layerBanana"
+            },
+            mockk<SymbolLayer> {
+                every { id } returns "layerCantaloupe"
+            },
+            mockk<FillLayer> {
+                every { id } returns "layerDragonfruit"
+            }
+        )
 
         val result = MapRouteLine.MapRouteLineSupport.getBelowLayer("", style)
 
-        assertEquals("layerCantaloupe", result)
+        assertEquals("layerBanana", result)
     }
 
     @Test
     fun getBelowLayerReturnsShadowLayerIdAsDefault() {
         val style = mockk<Style>()
-        val layerApple = mockk<Layer>()
-        val layerBanana = mockk<SymbolLayer>()
-        val layers = listOf(layerApple, layerBanana)
-        every { style.layers } returns layers
-        every { layerApple.id } returns RouteConstants.MAPBOX_LOCATION_ID
-        every { layerBanana.id } returns "layerBanana"
+        every { style.layers } returns listOf(
+            mockk<FillLayer> {
+                every { id } returns "layerApple"
+            },
+            mockk<CircleLayer> {
+                every { id } returns "layerBanana"
+            },
+            mockk<FillLayer> {
+                every { id } returns "layerCantaloupe"
+            },
+            mockk<FillLayer> {
+                every { id } returns "layerDragonfruit"
+            }
+        )
 
         val result = MapRouteLine.MapRouteLineSupport.getBelowLayer(null, style)
 
@@ -602,16 +645,20 @@ class MapRouteLineTest {
     @Test
     fun getBelowLayerReturnsInputIdIfFound() {
         val style = mockk<Style>()
-        val layerApple = mockk<Layer>()
-        val layerBanana = mockk<Layer>()
-        val layerCantaloupe = mockk<Layer>()
-        val layerDragonfruit = mockk<Layer>()
-        val layers = listOf(layerApple, layerBanana, layerCantaloupe, layerDragonfruit)
-        every { style.layers } returns layers
-        every { layerApple.id } returns "layerApple"
-        every { layerBanana.id } returns "layerBanana"
-        every { layerCantaloupe.id } returns "layerCantaloupe"
-        every { layerDragonfruit.id } returns "layerDragonfruit"
+        every { style.layers } returns listOf(
+            mockk<FillLayer> {
+                every { id } returns "layerApple"
+            },
+            mockk<CircleLayer> {
+                every { id } returns "layerBanana"
+            },
+            mockk<FillLayer> {
+                every { id } returns "layerCantaloupe"
+            },
+            mockk<SymbolLayer> {
+                every { id } returns "layerDragonfruit"
+            }
+        )
 
         val result = MapRouteLine.MapRouteLineSupport.getBelowLayer("layerBanana", style)
 
@@ -621,16 +668,20 @@ class MapRouteLineTest {
     @Test
     fun getBelowLayerReturnsShadowLayerIfInputNotNullOrEmptyAndNotFound() {
         val style = mockk<Style>()
-        val layerApple = mockk<Layer>()
-        val layerBanana = mockk<Layer>()
-        val layerCantaloupe = mockk<Layer>()
-        val layerDragonfruit = mockk<Layer>()
-        val layers = listOf(layerApple, layerBanana, layerCantaloupe, layerDragonfruit)
-        every { style.layers } returns layers
-        every { layerApple.id } returns "layerApple"
-        every { layerBanana.id } returns "layerBanana"
-        every { layerCantaloupe.id } returns "layerCantaloupe"
-        every { layerDragonfruit.id } returns "layerDragonfruit"
+        every { style.layers } returns listOf(
+            mockk<FillLayer> {
+                every { id } returns "layerApple"
+            },
+            mockk<CircleLayer> {
+                every { id } returns "layerBanana"
+            },
+            mockk<FillLayer> {
+                every { id } returns "layerCantaloupe"
+            },
+            mockk<SymbolLayer> {
+                every { id } returns "layerDragonfruit"
+            }
+        )
 
         val result = MapRouteLine.MapRouteLineSupport.getBelowLayer("foobar", style)
 


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Fixes an issue with the incorrect layer below calculation. The replaced algorithm upon finding the last symbol layer would place the route line below the _previous_ layer that was in the stack, not the last symbol layer. Also, if the location layer was below any symbol layer, the route would be rendered on top of the puck.

### Implementation

Above and other smaller issues are fixed with an updated implementation and updated tests.