### PR TITLE
Add scripts to "manually" publish to sdk-registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,9 +79,14 @@ core-unit-tests:
 core-unit-tests-jacoco:
 	$(call run-gradle-tasks,$(CORE_MODULES),jacocoTestReport)
 
+.PHONY: core-upload-to-sdk-registry
+core-upload-to-sdk-registry:
+	$(call run-gradle-tasks,$(CORE_MODULES),mapboxSDKRegistryUpload)
+
 .PHONY: core-publish-to-sdk-registry
 core-publish-to-sdk-registry:
-	$(call run-gradle-tasks,$(CORE_MODULES),mapboxSDKRegistryUpload)
+	python3 -m pip install git-pull-request
+	$(call run-gradle-tasks,$(CORE_MODULES),mapboxSDKRegistryPublish)
 
 .PHONY: core-dependency-graph
 core-dependency-graph:
@@ -123,9 +128,14 @@ ui-unit-tests:
 ui-unit-tests-jacoco:
 	$(call run-gradle-tasks,$(UI_MODULES),jacocoTestReport)
 
+.PHONY: ui-upload-to-sdk-registry
+ui-upload-to-sdk-registry:
+	$(call run-gradle-tasks,$(UI_MODULES),mapboxSDKRegistryUpload)
+
 .PHONY: ui-publish-to-sdk-registry
 ui-publish-to-sdk-registry:
-	$(call run-gradle-tasks,$(UI_MODULES),mapboxSDKRegistryUpload)
+	python3 -m pip install git-pull-request
+	$(call run-gradle-tasks,$(CORE_MODULES),mapboxSDKRegistryPublish)
 
 .PHONY: ui-check-api
 ui-check-api:

--- a/circle.yml
+++ b/circle.yml
@@ -263,9 +263,9 @@ commands:
         type: string
     steps:
       - deploy:
-          name: Publish Navigation SDK to SDK Registry
+          name: Upload Navigation SDK to SDK Registry
           command: |
-            make << parameters.artifact-type >>-publish-to-sdk-registry
+            make << parameters.artifact-type >>-upload-to-sdk-registry
 
   check-public-documentation:
     steps:

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -160,7 +160,8 @@ ext {
       googleServices     : '4.3.3',
       mapboxSdkVersions  : '1.1.0',
       dokka              : '0.10.1',
-      mapbox             : '0.2.1'
+      mapboxSdkRegistry  : '0.4.0',
+      mapboxAccessToken  : '0.2.1'
   ]
 
   pluginDependencies = [
@@ -174,7 +175,7 @@ ext {
       googleServices     : "com.google.gms:google-services:${pluginVersion.googleServices}",
       mapboxSdkVersions  : "com.mapbox.mapboxsdk:mapbox-android-sdk-versions:${pluginVersion.mapboxSdkVersions}",
       dokka              : "org.jetbrains.dokka:dokka-gradle-plugin:${pluginVersion.dokka}",
-      mapboxSdkRegistry  : "com.mapbox.gradle.plugins:sdk-registry:${pluginVersion.mapbox}",
-      mapboxAccessToken  : "com.mapbox.gradle.plugins:access-token:${pluginVersion.mapbox}"
+      mapboxSdkRegistry  : "com.mapbox.gradle.plugins:sdk-registry:${pluginVersion.mapboxSdkRegistry}",
+      mapboxAccessToken  : "com.mapbox.gradle.plugins:access-token:${pluginVersion.mapboxAccessToken}"
   ]
 }

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -64,6 +64,7 @@ registry {
     snapshot = project.ext.versionName.endsWith("-SNAPSHOT")
     override = snapshot ? true : false
     dryRun = false
+    publish = true
     publications = ["release"]
 }
 


### PR DESCRIPTION
## Description

Adds scripts to "manually" publish to `sdk-registry`

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Improve the overall release process 🚀 

### Implementation

- Add `core-publish-to-sdk-registry` to the `Makefile`
- Add `ui-publish-to-sdk-registry` to the `Makefile`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->