### PR TITLE
Publish all artifacts in the project in a single PR to SDK Registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,10 +83,10 @@ core-unit-tests-jacoco:
 core-upload-to-sdk-registry:
 	$(call run-gradle-tasks,$(CORE_MODULES),mapboxSDKRegistryUpload)
 
-.PHONY: core-publish-to-sdk-registry
-core-publish-to-sdk-registry:
+.PHONY: publish-to-sdk-registry
+publish-to-sdk-registry:
 	python3 -m pip install git-pull-request
-	$(call run-gradle-tasks,$(CORE_MODULES),mapboxSDKRegistryPublish)
+	$(call run-gradle-tasks,$(CORE_MODULES),mapboxSDKRegistryPublishAll)
 
 .PHONY: core-dependency-graph
 core-dependency-graph:
@@ -131,11 +131,6 @@ ui-unit-tests-jacoco:
 .PHONY: ui-upload-to-sdk-registry
 ui-upload-to-sdk-registry:
 	$(call run-gradle-tasks,$(UI_MODULES),mapboxSDKRegistryUpload)
-
-.PHONY: ui-publish-to-sdk-registry
-ui-publish-to-sdk-registry:
-	python3 -m pip install git-pull-request
-	$(call run-gradle-tasks,$(CORE_MODULES),mapboxSDKRegistryPublish)
 
 .PHONY: ui-check-api
 ui-check-api:


### PR DESCRIPTION
## Description

Publishes all artifacts in the project in a single PR to SDK Registry
Follow up from https://github.com/mapbox/mapbox-navigation-android/pull/3688

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Simplify even more the release process taking advantage of `mapboxSDKRegistryPublishAll` task available

### Implementation

Replace `core-publish-to-sdk-registry` and `ui-publish-to-sdk-registry` scripts by `publish-to-sdk-registry` and use `mapboxSDKRegistryPublishAll` (`Publish all artifacts in the project in a single PR to Mapbox SDK Registry`) task available	 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->