### PR TITLE
CP: Publish all artifacts in the project in a single PR to SDK registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,10 +79,10 @@ core-unit-tests:
 core-upload-to-sdk-registry:
 	$(call run-gradle-tasks,$(CORE_MODULES),mapboxSDKRegistryUpload)
 
-.PHONY: core-publish-to-sdk-registry
-core-publish-to-sdk-registry:
+.PHONY: publish-to-sdk-registry
+publish-to-sdk-registry:
 	python3 -m pip install git-pull-request
-	$(call run-gradle-tasks,$(CORE_MODULES),mapboxSDKRegistryPublish)
+	$(call run-gradle-tasks,$(CORE_MODULES),mapboxSDKRegistryPublishAll)
 
 .PHONY: core-dependency-graph
 core-dependency-graph:
@@ -123,11 +123,6 @@ ui-unit-tests:
 .PHONY: ui-upload-to-sdk-registry
 ui-upload-to-sdk-registry:
 	$(call run-gradle-tasks,$(UI_MODULES),mapboxSDKRegistryUpload)
-
-.PHONY: ui-publish-to-sdk-registry
-ui-publish-to-sdk-registry:
-	python3 -m pip install git-pull-request
-	$(call run-gradle-tasks,$(CORE_MODULES),mapboxSDKRegistryPublish)
 
 .PHONY: ui-check-api
 ui-check-api:


### PR DESCRIPTION
### Description

This PR cherry-picks the changes brought to our main branch in https://github.com/mapbox/mapbox-navigation-android/pull/3695, to the `1.1` release branch

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Publish all artifacts in the project in a single PR to SDK registry

### Implementation

```
$> git checkout release-v1.1
$> git checkout -b pg-cp-3695
$> git cherry-pick 06be854240897e0a96853b2ddac3a630e0e72f5a
```

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
