### PR TITLE
Introduce reset function for the navigator

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/history/HistoryFilesActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/history/HistoryFilesActivity.kt
@@ -1,7 +1,6 @@
 package com.mapbox.navigation.examples.history
 
 import android.annotation.SuppressLint
-import android.content.Intent
 import android.os.Bundle
 import android.view.View.GONE
 import android.view.View.VISIBLE
@@ -10,13 +9,13 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.snackbar.Snackbar
 import com.mapbox.navigation.core.replay.history.ReplayHistoryDTO
 import com.mapbox.navigation.examples.R
-import com.mapbox.navigation.examples.core.ReplayHistoryActivity
 import kotlinx.android.synthetic.main.history_files_activity.*
 
 @SuppressLint("HardwareIds")
 class HistoryFilesActivity : AppCompatActivity() {
 
     companion object {
+        val REQUEST_CODE: Int = 123
         var selectedHistory: ReplayHistoryDTO? = null
             private set
     }
@@ -49,18 +48,12 @@ class HistoryFilesActivity : AppCompatActivity() {
                 ).show()
             } else {
                 selectedHistory = historyDataResponse
-                launchReplayHistory()
+                finish()
             }
         }
 
         requestFileList()
         fab.setOnClickListener { requestFileList() }
-    }
-
-    override fun onBackPressed() {
-        super.onBackPressed()
-
-        launchReplayHistory()
     }
 
     private fun requestFileList() {
@@ -78,17 +71,5 @@ class HistoryFilesActivity : AppCompatActivity() {
                 fab.visibility = VISIBLE
             }
         }
-    }
-
-    private fun launchReplayHistory() {
-        // startActivityForResult needs to destroy the calling activity to ensure mapbox
-        // components are destroyed. Use startActivity to control the Activity lifecycles.
-        // Note that if you want to call this from another Activity, you should consider
-        // creating parameters with the Intent.
-        val activityIntent = Intent(this, ReplayHistoryActivity::class.java)
-        activityIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        activityIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
-        startActivity(activityIntent)
-        finish()
     }
 }

--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -26,6 +26,7 @@ package com.mapbox.navigation.core {
     method public void registerVoiceInstructionsObserver(com.mapbox.navigation.core.trip.session.VoiceInstructionsObserver voiceInstructionsObserver);
     method public void requestRoutes(com.mapbox.api.directions.v5.models.RouteOptions routeOptions, com.mapbox.navigation.core.directions.session.RoutesRequestCallback? routesRequestCallback = null);
     method public void requestRoutes(com.mapbox.api.directions.v5.models.RouteOptions routeOptions);
+    method public void resetTripSession();
     method public String retrieveHistory();
     method public String? retrieveSsmlAnnouncementInstruction(int index);
     method public void setArrivalController(com.mapbox.navigation.core.arrival.ArrivalController? arrivalController = com.mapbox.navigation.core.arrival.AutoArrivalController());

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -263,6 +263,15 @@ class MapboxNavigation(
     }
 
     /**
+     * Reset the session with the same configuration. The location becomes unknown,
+     * but the [NavigationOptions] stay the same. This can be used to transport the
+     * navigator to a new location.
+     */
+    fun resetTripSession() {
+        navigator.resetRideSession()
+    }
+
+    /**
      * Return the current [TripSession]'s state.
      * The state is [TripSessionState.STARTED] when the session is active, running a foreground service and
      * requesting and returning location updates.
@@ -342,14 +351,8 @@ class MapboxNavigation(
         tripSession.unregisterAllVoiceInstructionsObservers()
         tripSession.unregisterAllRouteAlertsObservers()
         tripSession.unregisterAllEHorizonObservers()
-        tripSession.route = null
-
-        // TODO replace this with a destroy when nav-native has a destructor
-        navigator.create(
-            navigationOptions.deviceProfile,
-            navigatorConfig,
-            createTilesConfig()
-        )
+        directionsSession.routes = emptyList()
+        resetTripSession()
 
         navigationSession.unregisterAllNavigationSessionStateObservers()
         fasterRouteController.stop()

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
@@ -289,10 +289,10 @@ class MapboxNavigationTest {
     }
 
     @Test
-    fun onDestroySetsRouteToNullInTripSession() {
+    fun onDestroySetsRoutesToEmpty() {
         mapboxNavigation.onDestroy()
 
-        verify(exactly = 1) { tripSession.route = null }
+        verify(exactly = 1) { directionsSession.routes = emptyList() }
     }
 
     @Test
@@ -306,7 +306,7 @@ class MapboxNavigationTest {
     fun onDestroyCallsNativeNavigatorReset() {
         mapboxNavigation.onDestroy()
 
-        verify(exactly = 1) { navigator.create(any(), any(), any()) }
+        verify(exactly = 1) { navigator.resetRideSession() }
     }
 
     @Test
@@ -487,6 +487,13 @@ class MapboxNavigationTest {
         mapboxNavigation.unregisterRouteAlertsObserver(observer)
 
         verify(exactly = 1) { tripSession.unregisterRouteAlertsObserver(observer) }
+    }
+
+    @Test
+    fun `resetTripSession should reset the navigator`() {
+        mapboxNavigation.resetTripSession()
+
+        verify { navigator.resetRideSession() }
     }
 
     private fun mockLocation() {

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigator.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigator.kt
@@ -34,6 +34,13 @@ interface MapboxNativeNavigator {
         tilesConfig: TilesConfig
     ): MapboxNativeNavigator
 
+    /**
+     * Reset the navigator state with the same configuration. The location becomes unknown,
+     * but the [NavigatorConfig] stays the same. This can be used to transport the
+     * navigator to a new location.
+     */
+    fun resetRideSession()
+
     // Route following
 
     /**

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigatorImpl.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigatorImpl.kt
@@ -64,6 +64,10 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
         return this
     }
 
+    override fun resetRideSession() {
+        navigator!!.resetRideSession()
+    }
+
     /**
      * Passes in the current raw location of the user.
      *


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Opening this as a draft while working on examples that test out the function.

We are looking to add the ability to teleport the navigator to different locations. For example, simulate a route in new york and then jump to tokyo and simulate a new route - all while keeping the same SDK setup.

A more practical case, would be to simulate a route in your city. And then jump back to the beginning to drive it for real.

- [ ] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

## Testing

Notice that without the reset function, the navigator will not reliably reset to the new location selected.

| without reset function | with reset function |
| -- | -- |
| ![output](https://user-images.githubusercontent.com/3021882/97489047-486fd780-191c-11eb-9b64-1d9fce24b140.gif) | ![output](https://user-images.githubusercontent.com/3021882/97489091-57ef2080-191c-11eb-8119-2b2ff26347c8.gif) |



Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->