### PR TITLE
Bump coroutines dependencies version to 1.4.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -47,7 +47,7 @@ ext {
       firebaseCrashlytics       : '17.1.0',
       multidex                  : '2.0.0',
       json                      : '20180813',
-      coroutinesAndroid         : '1.3.9',
+      coroutinesAndroid         : '1.4.0',
       okhttp                    : '3.12.10',
       okio                      : '2.4.3',
       androidxTestJunit         : '1.1.1',


### PR DESCRIPTION
## Description

Bumps Coroutines version to [`1.4.0`](https://github.com/Kotlin/kotlinx.coroutines/releases/tag/1.4.0) 🎉 

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Getting the latest version from Coroutines including the new features and bug fixes.

Highlights 🚀 

> - `StateFlow`, `SharedFlow` and corresponding operators are promoted to stable API ([#2316](https://github.com/Kotlin/kotlinx.coroutines/pull/2316)).

### Implementation

Bumping `coroutinesAndroid ` version to `1.4.0` in `dependencies.gradle`

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs

cc @mapbox/navigation-android 