### PR TITLE
Fix flaky telemetry tests

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetry.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetry.kt
@@ -130,6 +130,8 @@ internal object MapboxNavigationTelemetry :
         logger: Logger?,
         locationsCollector: LocationsCollector = LocationsCollectorImpl(logger)
     ) {
+        reset()
+        sessionState = IDLE
         this.logger = logger
         this.locationsCollector = locationsCollector
         navigationOptions = options
@@ -278,9 +280,7 @@ internal object MapboxNavigationTelemetry :
         if (dynamicValues.sessionStarted) {
             log("sessionStop")
             handleSessionCanceled()
-            dynamicValues.reset()
-            resetOriginalRoute()
-            resetRouteProgress()
+            reset()
         }
     }
 
@@ -425,6 +425,14 @@ internal object MapboxNavigationTelemetry :
 
             eventVersion = EVENT_VERSION
         }
+    }
+
+    private fun reset() {
+        dynamicValues.reset()
+        resetOriginalRoute()
+        resetRouteProgress()
+        needHandleReroute = false
+        needStartSession = false
     }
 
     private fun resetRouteProgress() {

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetryTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetryTest.kt
@@ -36,7 +36,6 @@ import com.mapbox.navigation.core.telemetry.events.NavigationRerouteEvent
 import com.mapbox.navigation.metrics.MapboxMetricsReporter
 import com.mapbox.navigation.metrics.internal.event.NavigationAppUserTurnstileEvent
 import io.mockk.Runs
-import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -47,10 +46,8 @@ import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertNotSame
 import junit.framework.TestCase.assertTrue
 import org.junit.After
-import org.junit.Ignore
 import org.junit.Test
 
-@Ignore
 class MapboxNavigationTelemetryTest {
 
     private companion object {
@@ -592,7 +589,7 @@ class MapboxNavigationTelemetryTest {
     }
 
     private fun mockLocationCollector() {
-        coEvery { locationsCollector.flushBuffers() } just Runs
+        every { locationsCollector.flushBuffers() } just Runs
         every { locationsCollector.lastLocation } returns lastLocation
         every { lastLocation.latitude } returns LAST_LOCATION_LAT
         every { lastLocation.longitude } returns LAST_LOCATION_LON


### PR DESCRIPTION
## Description

Fixes flaky telemetry tests resetting the state in `MapboxNavigationTelemetry#initialize`

Regression from https://github.com/mapbox/mapbox-navigation-android/pull/3540

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Fix flaky telemetry tests `@Ignored` in https://github.com/mapbox/mapbox-navigation-android/pull/3705/commits/eb7dce6bfc378f371d8496c260be5813546d6145

### Implementation

`MapboxNavigationTelemetry` is an `object` (singleton) :trollface: and `originalRoute` was retained across tests violating the `I`ndependent principle from [F.I.R.S.T.](https://dzone.com/articles/writing-your-first-unit-tests). Tests executed before `MapboxNavigationTelemetryTest` could leave `MapboxNavigationTelemetry` in an undesired state which caused the flakiness / exception

```
depart_events_are_different_on_external_route
sessionState=ACTIVE_GUIDANCE
originalRoute=DirectionsRoute(#793)
needHandleReroute=true
routeProgress=null
```

In this particular case `originalRoute` was retained from a previous test causing `depart_events_are_different_on_external_route` to fail as `routeProgress` was `null` / not initialized when `onRoutesChanged` > `handleReroute` were executed.

We need to make sure that the state is reset appropriately.

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs