### PR TITLE
Fix publish-to-sdk-registry script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ core-upload-to-sdk-registry:
 .PHONY: publish-to-sdk-registry
 publish-to-sdk-registry:
 	python3 -m pip install git-pull-request
-	$(call run-gradle-tasks,$(CORE_MODULES),mapboxSDKRegistryPublishAll)
+	./gradlew mapboxSDKRegistryPublishAll
 
 .PHONY: core-dependency-graph
 core-dependency-graph:


### PR DESCRIPTION
## Description

Fixes `publish-to-sdk-registry` script

Regression from https://github.com/mapbox/mapbox-navigation-android/pull/3695

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Simplify the release process making it semi-automated

### Implementation

`mapboxSDKRegistryPublishAll` should be called once from the root project. Replace `$(call run-gradle-tasks,$(CORE_MODULES),mapboxSDKRegistryPublishAll)` that was trying to call unavailable `mapboxSDKRegistryPublishAll` from every module by `./gradlew mapboxSDKRegistryPublishAll` that already handles that internally and publishes the configured modules

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs