### PR TITLE
Add option to enable or disable route refresh

### DIFF
--- a/libnavigation-base/api/current.txt
+++ b/libnavigation-base/api/current.txt
@@ -112,6 +112,7 @@ package com.mapbox.navigation.base.options {
     method public int getTimeFormatType();
     method public boolean isDebugLoggingEnabled();
     method public boolean isFromNavigationUi();
+    method public boolean isRouteRefreshEnabled();
     method public com.mapbox.navigation.base.options.NavigationOptions.Builder toBuilder();
   }
 
@@ -124,6 +125,7 @@ package com.mapbox.navigation.base.options {
     method public com.mapbox.navigation.base.options.NavigationOptions.Builder eHorizonOptions(com.mapbox.navigation.base.options.EHorizonOptions eHorizonOptions);
     method public com.mapbox.navigation.base.options.NavigationOptions.Builder isDebugLoggingEnabled(boolean flag);
     method public com.mapbox.navigation.base.options.NavigationOptions.Builder isFromNavigationUi(boolean flag);
+    method public com.mapbox.navigation.base.options.NavigationOptions.Builder isRouteRefreshEnabled(boolean flag);
     method public com.mapbox.navigation.base.options.NavigationOptions.Builder locationEngine(com.mapbox.android.core.location.LocationEngine locationEngine);
     method public com.mapbox.navigation.base.options.NavigationOptions.Builder locationEngineRequest(com.mapbox.android.core.location.LocationEngineRequest locationEngineRequest);
     method public com.mapbox.navigation.base.options.NavigationOptions.Builder navigatorPredictionMillis(long predictionMillis);

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/NavigationOptions.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/NavigationOptions.kt
@@ -33,6 +33,7 @@ const val DEFAULT_NAVIGATOR_PREDICTION_MILLIS = 1100L
  * @param isDebugLoggingEnabled Boolean
  * @param deviceProfile [DeviceProfile] defines how navigation data should be interpretation
  * @param eHorizonOptions [EHorizonOptions] defines configuration for the Electronic Horizon
+ * @param isRouteRefreshEnabled Boolean *true* if need to enable route refresh mechanism, otherwise *false*
  */
 class NavigationOptions private constructor(
     val applicationContext: Context,
@@ -46,7 +47,8 @@ class NavigationOptions private constructor(
     val isFromNavigationUi: Boolean,
     val isDebugLoggingEnabled: Boolean,
     val deviceProfile: DeviceProfile,
-    val eHorizonOptions: EHorizonOptions
+    val eHorizonOptions: EHorizonOptions,
+    val isRouteRefreshEnabled: Boolean
 ) {
 
     /**
@@ -64,6 +66,7 @@ class NavigationOptions private constructor(
         isDebugLoggingEnabled(isDebugLoggingEnabled)
         deviceProfile(deviceProfile)
         eHorizonOptions(eHorizonOptions)
+        isRouteRefreshEnabled(isRouteRefreshEnabled)
     }
 
     /**
@@ -87,6 +90,7 @@ class NavigationOptions private constructor(
         if (isDebugLoggingEnabled != other.isDebugLoggingEnabled) return false
         if (deviceProfile != other.deviceProfile) return false
         if (eHorizonOptions != other.eHorizonOptions) return false
+        if (isRouteRefreshEnabled != other.isRouteRefreshEnabled) return false
 
         return true
     }
@@ -107,6 +111,7 @@ class NavigationOptions private constructor(
         result = 31 * result + isDebugLoggingEnabled.hashCode()
         result = 31 * result + deviceProfile.hashCode()
         result = 31 * result + eHorizonOptions.hashCode()
+        result = 31 * result + isRouteRefreshEnabled.hashCode()
         return result
     }
 
@@ -127,6 +132,7 @@ class NavigationOptions private constructor(
             "isDebugLoggingEnabled=$isDebugLoggingEnabled, " +
             "deviceProfile=$deviceProfile, " +
             "eHorizonOptions=$eHorizonOptions" +
+            "isRouteRefreshEnabled=$isRouteRefreshEnabled" +
             ")"
     }
 
@@ -152,6 +158,7 @@ class NavigationOptions private constructor(
         private var isDebugLoggingEnabled: Boolean = false
         private var deviceProfile: DeviceProfile = DeviceProfile.Builder().build()
         private var eHorizonOptions: EHorizonOptions = EHorizonOptions.Builder().build()
+        private var isRouteRefreshEnabled: Boolean = true
 
         /**
          * Defines [Mapbox Access Token](https://docs.mapbox.com/help/glossary/access-token/)
@@ -220,6 +227,12 @@ class NavigationOptions private constructor(
             apply { this.eHorizonOptions = eHorizonOptions }
 
         /**
+         * Defines if route refresh is enabled
+         */
+        fun isRouteRefreshEnabled(flag: Boolean): Builder =
+            apply { this.isRouteRefreshEnabled = flag }
+
+        /**
          * Build a new instance of [NavigationOptions]
          * @return NavigationOptions
          */
@@ -237,7 +250,8 @@ class NavigationOptions private constructor(
                 isFromNavigationUi = isFromNavigationUi,
                 isDebugLoggingEnabled = isDebugLoggingEnabled,
                 deviceProfile = deviceProfile,
-                eHorizonOptions = eHorizonOptions
+                eHorizonOptions = eHorizonOptions,
+                isRouteRefreshEnabled = isRouteRefreshEnabled
             )
         }
     }

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/options/NavigationOptionsTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/options/NavigationOptionsTest.kt
@@ -64,6 +64,7 @@ class NavigationOptionsTest : BuilderTest<NavigationOptions, NavigationOptions.B
             .onboardRouterOptions(mockk())
             .timeFormatType(1)
             .eHorizonOptions(mockk())
+            .isRouteRefreshEnabled(false)
     }
 
     @Test

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -43,6 +43,7 @@ import com.mapbox.navigation.core.reroute.RerouteController
 import com.mapbox.navigation.core.reroute.RerouteState
 import com.mapbox.navigation.core.routeoptions.MapboxRouteOptionsUpdater
 import com.mapbox.navigation.core.routerefresh.RouteRefreshController
+import com.mapbox.navigation.core.routerefresh.RouteRefreshControllerProvider
 import com.mapbox.navigation.core.telemetry.MapboxNavigationTelemetry
 import com.mapbox.navigation.core.telemetry.events.AppMetadata
 import com.mapbox.navigation.core.telemetry.events.FeedbackEvent
@@ -229,8 +230,14 @@ class MapboxNavigation(
             FasterRouteDetector(RouteComparator()),
             logger
         )
-        routeRefreshController = RouteRefreshController(directionsSession, tripSession, logger)
-        routeRefreshController.start()
+        routeRefreshController = RouteRefreshControllerProvider.createRouteRefreshController(
+            directionsSession,
+            tripSession,
+            logger
+        )
+        if (navigationOptions.isRouteRefreshEnabled) {
+            routeRefreshController.start()
+        }
 
         defaultRerouteController = MapboxRerouteController(
             directionsSession,

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/routerefresh/RouteRefreshController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/routerefresh/RouteRefreshController.kt
@@ -55,7 +55,7 @@ internal class RouteRefreshController(
     private val routeRefreshCallback = object : RouteRefreshCallback {
 
         override fun onRefresh(directionsRoute: DirectionsRoute) {
-            logger.i(msg = Message("Successful refresh"))
+            logger.i(msg = Message("Successful route refresh"))
             tripSession.route = directionsRoute
             val directionsSessionRoutes = directionsSession.routes.toMutableList()
             if (directionsSessionRoutes.isNotEmpty()) {

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/routerefresh/RouteRefreshControllerProvider.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/routerefresh/RouteRefreshControllerProvider.kt
@@ -1,0 +1,18 @@
+package com.mapbox.navigation.core.routerefresh
+
+import com.mapbox.base.common.logger.Logger
+import com.mapbox.navigation.core.directions.session.DirectionsSession
+import com.mapbox.navigation.core.trip.session.TripSession
+
+internal object RouteRefreshControllerProvider {
+
+    fun createRouteRefreshController(
+        directionsSession: DirectionsSession,
+        tripSession: TripSession,
+        logger: Logger
+    ) = RouteRefreshController(
+        directionsSession,
+        tripSession,
+        logger
+    )
+}


### PR DESCRIPTION
## Description

Implemented option for enable or disable route refresh

- [ ] I have added any issue links
- [ ] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [ ] I have added the appropriate milestone and project boards

### Implementation

Added public method `toggleRouteRefresh(Boolean)` in `MapboxNavigation` class. In this method we are calling `routeRefreshController.start()` or `stop()` accordingly to Boolean parameter.

## Testing

Please describe the manual tests that you ran to verify your changes

- [ ] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [ ] I have tested via a test drive, or a simulation/mock location app
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs

```
<changelog>Added an option in NavigationOptions for enable/disable route refresh</changelog>
```