### PR TITLE
CP: Fix publish-to-sdk-registry script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ core-upload-to-sdk-registry:
 .PHONY: publish-to-sdk-registry
 publish-to-sdk-registry:
 	python3 -m pip install git-pull-request
-	$(call run-gradle-tasks,$(CORE_MODULES),mapboxSDKRegistryPublishAll)
+	./gradlew mapboxSDKRegistryPublishAll
 
 .PHONY: core-dependency-graph
 core-dependency-graph:


### PR DESCRIPTION
### Description

This PR cherry-picks the changes brought to our main branch in https://github.com/mapbox/mapbox-navigation-android/pull/3708, to the `1.1` release branch

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Fix `publish-to-sdk-registry` script

### Implementation

```
$> git checkout release-v1.1
$> git checkout -b pg-cp-3708
$> git cherry-pick c2a82c657b4e300260cbc76e732f1089e7842166
```

## Testing

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
