### PR TITLE
Telemetry reroute fix

### DIFF
--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetryTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetryTest.kt
@@ -165,7 +165,7 @@ class MapboxNavigationTelemetryTest {
 
         initTelemetry()
         updateSessionState(ACTIVE_GUIDANCE)
-        updateRouteProgress(routeProgress)
+        updateRouteProgress()
 
         val events = captureAndVerifyMetricsReporter(exactly = 1)
         assertTrue(events[0] is NavigationAppUserTurnstileEvent)
@@ -205,7 +205,7 @@ class MapboxNavigationTelemetryTest {
         every { routeProgress.currentState } returns ROUTE_COMPLETE
 
         baseInitialization()
-        updateRouteProgress(routeProgress)
+        updateRouteProgress()
 
         val events = captureAndVerifyMetricsReporter(exactly = 3)
         assertTrue(events[0] is NavigationAppUserTurnstileEvent)
@@ -221,7 +221,7 @@ class MapboxNavigationTelemetryTest {
 
         baseInitialization()
         updateRoute(anotherRoute)
-        updateRouteProgress(routeProgress)
+        updateRouteProgress()
 
         val events = captureAndVerifyMetricsReporter(exactly = 4)
         assertTrue(events[0] is NavigationAppUserTurnstileEvent)
@@ -254,7 +254,7 @@ class MapboxNavigationTelemetryTest {
 
         baseInitialization()
         updateRoute(anotherRoute)
-        updateRouteProgress(routeProgress)
+        updateRouteProgress()
 
         val firstDepart = events[1] as NavigationDepartEvent
         val secondDepart = events[3] as NavigationDepartEvent
@@ -272,7 +272,7 @@ class MapboxNavigationTelemetryTest {
         postUserFeedback()
         offRoute()
         updateRoute(anotherRoute)
-        updateRouteProgress(routeProgress)
+        updateRouteProgress()
         postUserFeedback()
 
         val events = captureAndVerifyMetricsReporter(exactly = 3)
@@ -291,7 +291,7 @@ class MapboxNavigationTelemetryTest {
         postUserFeedback()
         offRoute()
         updateRoute(anotherRoute)
-        updateRouteProgress(routeProgress)
+        updateRouteProgress()
         postUserFeedback()
         postUserFeedback()
         postUserFeedback()
@@ -324,7 +324,7 @@ class MapboxNavigationTelemetryTest {
         postUserFeedback()
         offRoute()
         updateRoute(anotherRoute)
-        updateRouteProgress(routeProgress)
+        updateRouteProgress()
         postUserFeedback()
         updateSessionState(IDLE)
 
@@ -351,7 +351,7 @@ class MapboxNavigationTelemetryTest {
         baseInitialization()
         offRoute()
         updateRoute(anotherRoute)
-        updateRouteProgress(routeProgress)
+        updateRouteProgress()
         locationsCollector.flushBuffers()
 
         val events = captureAndVerifyMetricsReporter(exactly = 3)
@@ -400,7 +400,7 @@ class MapboxNavigationTelemetryTest {
         baseInitialization()
         offRoute()
         updateRoute(anotherRoute)
-        updateRouteProgress(routeProgress)
+        updateRouteProgress()
         locationsCollector.flushBuffers()
 
         val rerouteEvent = events[2] as NavigationRerouteEvent
@@ -502,7 +502,7 @@ class MapboxNavigationTelemetryTest {
         initTelemetry()
         updateSessionState(ACTIVE_GUIDANCE)
         updateRoute(originalRoute)
-        updateRouteProgress(routeProgress)
+        updateRouteProgress()
     }
 
     private fun updateSessionState(state: NavigationSession.State) {
@@ -513,8 +513,10 @@ class MapboxNavigationTelemetryTest {
         MapboxNavigationTelemetry.onRoutesChanged(listOf(route))
     }
 
-    private fun updateRouteProgress(routeProgress: RouteProgress) {
-        MapboxNavigationTelemetry.onRouteProgressChanged(routeProgress)
+    private fun updateRouteProgress(count: Int = 10) {
+        repeat(count) {
+            MapboxNavigationTelemetry.onRouteProgressChanged(routeProgress)
+        }
     }
 
     private fun offRoute() {

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetryTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetryTest.kt
@@ -265,13 +265,14 @@ class MapboxNavigationTelemetryTest {
     @Test
     fun feedback_and_reroute_events_not_sent_on_arrival() {
         baseMock()
-        mockRouteProgress()
+        mockAnotherRoute()
         every { routeProgress.currentState } returns ROUTE_COMPLETE
 
         baseInitialization()
-        updateRouteProgress(routeProgress)
         postUserFeedback()
         offRoute()
+        updateRoute(anotherRoute)
+        updateRouteProgress(routeProgress)
         postUserFeedback()
 
         val events = captureAndVerifyMetricsReporter(exactly = 3)
@@ -290,6 +291,7 @@ class MapboxNavigationTelemetryTest {
         postUserFeedback()
         offRoute()
         updateRoute(anotherRoute)
+        updateRouteProgress(routeProgress)
         postUserFeedback()
         postUserFeedback()
         postUserFeedback()
@@ -322,6 +324,7 @@ class MapboxNavigationTelemetryTest {
         postUserFeedback()
         offRoute()
         updateRoute(anotherRoute)
+        updateRouteProgress(routeProgress)
         postUserFeedback()
         updateSessionState(IDLE)
 
@@ -346,9 +349,9 @@ class MapboxNavigationTelemetryTest {
         mockRouteProgress()
 
         baseInitialization()
-        updateRouteProgress(routeProgress)
         offRoute()
         updateRoute(anotherRoute)
+        updateRouteProgress(routeProgress)
         locationsCollector.flushBuffers()
 
         val events = captureAndVerifyMetricsReporter(exactly = 3)
@@ -356,6 +359,23 @@ class MapboxNavigationTelemetryTest {
         assertTrue(events[1] is NavigationDepartEvent)
         assertTrue(events[2] is NavigationRerouteEvent)
         assertEquals(3, events.size)
+    }
+
+    @Test
+    fun rerouteEvent_not_sent_on_offRoute_without_routeProgress() {
+        baseMock()
+        mockAnotherRoute()
+        mockRouteProgress()
+
+        baseInitialization()
+        offRoute()
+        updateRoute(anotherRoute)
+        locationsCollector.flushBuffers()
+
+        val events = captureAndVerifyMetricsReporter(exactly = 2)
+        assertTrue(events[0] is NavigationAppUserTurnstileEvent)
+        assertTrue(events[1] is NavigationDepartEvent)
+        assertEquals(2, events.size)
     }
 
     @Test
@@ -378,9 +398,9 @@ class MapboxNavigationTelemetryTest {
         val events = captureMetricsReporter()
 
         baseInitialization()
-        updateRouteProgress(routeProgress)
         offRoute()
         updateRoute(anotherRoute)
+        updateRouteProgress(routeProgress)
         locationsCollector.flushBuffers()
 
         val rerouteEvent = events[2] as NavigationRerouteEvent


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

When `reRoute` event happens and we get a `newRoute`, we should not send `NavigationRerouteEvent` immediately,  we need to reset current `routeProgress` which is related to a previous `originalRoute` and wait for a new `routeProgress`.
when we receive it, we are ready to populate the event and send it.

I've added a test, that we don't send `NavigationRerouteEvent` until we get a new `routeProgress`.
Also have changed test method `updateRouteProgress()` to call 
`MapboxNavigationTelemetry.onRouteProgressChanged(routeProgress)` multiple times (10 by default). It will help to find potential issues.

related to #3164 
 
- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->