### PR TITLE
Expose feedback cache API for Feedback 2.0 UX

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/BasicNavigationFragment.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/BasicNavigationFragment.kt
@@ -463,6 +463,7 @@ class BasicNavigationFragment :
                 screenShot,
                 feedback.feedbackSubType.toTypedArray()
             )
+
             showFeedbackSentSnackBar(
                 context = requireContext(),
                 view = if (summaryBehavior.state == BottomSheetBehavior.STATE_HIDDEN) {

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/telemetry/CachedNavigationFeedbackEvent.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/telemetry/CachedNavigationFeedbackEvent.kt
@@ -1,0 +1,22 @@
+package com.mapbox.navigation.core.internal.telemetry
+
+import com.mapbox.navigation.core.telemetry.events.FeedbackEvent
+
+/**
+ * A cache version of an internal MapboxTelemetry feedback event.
+ * It holds the required data for Feedback UI to display and to be updated with user input.
+ *
+ * @param feedbackId the key of the feedback
+ * @param feedbackType one of [FeedbackEvent.Type]
+ * @param screenshot encoded screenshot (optional)
+ * @param description the user's additional comment about the feedback (optional)
+ * @param feedbackSubType array of [FeedbackEvent.Description] (optional)
+ */
+data class CachedNavigationFeedbackEvent @JvmOverloads internal constructor(
+    val feedbackId: String,
+    @FeedbackEvent.Type
+    val feedbackType: String,
+    val screenshot: String,
+    var description: String? = null,
+    val feedbackSubType: MutableSet<String> = HashSet()
+)

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/telemetry/MapboxNavigationFeedbackCache.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/telemetry/MapboxNavigationFeedbackCache.kt
@@ -1,0 +1,103 @@
+package com.mapbox.navigation.core.internal.telemetry
+
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.telemetry.MapboxNavigationTelemetry
+import com.mapbox.navigation.core.telemetry.events.AppMetadata
+import com.mapbox.navigation.core.telemetry.events.FeedbackEvent
+
+/**
+ * This object is only intent to be used internally and subject to change in future.
+ *
+ * This object is only a wrapper of [MapboxNavigationTelemetry] to cache/retrieve/post a navigation.feedback event.
+ * It must be used after [MapboxNavigationTelemetry.initialize] has been called.
+ *
+ * A complete feedback cache flow will be:
+ * 1. [cacheUserFeedback] to generate a navigation.feedback event in [MapboxNavigationTelemetry] internally.
+ * 2. [getCachedUserFeedback] to retrieve all cached navigation.feedback events from [MapboxNavigationTelemetry].
+ * 3. make possible changes to the list that is returned by [getCachedUserFeedback].
+ * 4. submit changed list from step 3 to [postCachedUserFeedback] to [MapboxNavigationTelemetry].
+ *
+ * Note:
+ * 1. Only the feedback events created by [cacheUserFeedback] and returned by [getCachedUserFeedback]
+ * are valid in [postCachedUserFeedback]. All user manually created events will be dropped.
+ * 2. The cache APIs should only be used when in Active Guidance mode since navigation.feedback events are only handled in that mode.
+ * 3. [postCachedUserFeedback] should be called before transitioning between modes. Otherwise, all cached events will be lost.
+ */
+object MapboxNavigationFeedbackCache {
+
+    /**
+     * Create and cache a user feedback about an issue or problem with the Navigation SDK.
+     *
+     * Instead of sending the feedback, this API will cache the feedback in the Navigation SDK. The cached feedbacks can be retrieved by calling [getCachedUserFeedback] so the user can update and send them in a later time. To send the cached feedbacks, please use [postCachedUserFeedback].
+     *
+     * If you want to send the feedback directly without caching it, you should use [MapboxNavigation.postUserFeedback].
+     *
+     * @param feedbackType one of [FeedbackEvent.Type]
+     * @param description description message
+     * @param feedbackSource one of [FeedbackEvent.Source]
+     * @param screenshot encoded screenshot (optional)
+     * @param feedbackSubType array of [FeedbackEvent.Description] (optional)
+     * @param appMetadata [AppMetadata] information (optional)
+     *
+     * @see [MapboxNavigation.postUserFeedback]
+     * @see [getCachedUserFeedback]
+     * @see [postCachedUserFeedback]
+     */
+    fun cacheUserFeedback(
+        @FeedbackEvent.Type feedbackType: String,
+        description: String,
+        @FeedbackEvent.Source feedbackSource: String,
+        screenshot: String?,
+        feedbackSubType: Array<String>? = emptyArray(),
+        appMetadata: AppMetadata? = null
+    ) {
+        MapboxNavigationTelemetry.cacheUserFeedback(
+            feedbackType,
+            description,
+            feedbackSource,
+            screenshot,
+            feedbackSubType,
+            appMetadata
+        )
+    }
+
+    /**
+     * Get a list of [CachedNavigationFeedbackEvent] which was created by [cacheUserFeedback].
+     *
+     * You can update the cached feedback to have more information like [CachedNavigationFeedbackEvent.feedbackSubType] and [CachedNavigationFeedbackEvent.description] or other fields. And use [postCachedUserFeedback] to send the updated cached feedbacks.
+     *
+     * @see [cacheUserFeedback]
+     * @see [postCachedUserFeedback]
+     *
+     * @return a list of [CachedNavigationFeedbackEvent]s
+     */
+    fun getCachedUserFeedback(): List<CachedNavigationFeedbackEvent> {
+        return MapboxNavigationTelemetry.getCachedUserFeedback()
+    }
+
+    /**
+     * Send a list of [CachedNavigationFeedbackEvent]s.
+     *
+     * Only the feedback that's been created by [cacheUserFeedback] will be sent. Otherwise that feedback will be dropped and not be sent.
+     *
+     * A complete caching feedback flow looks like this:
+     * 1. Create and cache feedback by calling [cacheUserFeedback].
+     * 2. Retrieve the cached feedback list by calling [getCachedUserFeedback].
+     * 3. Update the cached feedback list to provide more information of the feedback.
+     * 4. Call [postCachedUserFeedback] to send the updated cached feedback list.
+     *
+     * Note:
+     * 1. Only the feedback events created by [cacheUserFeedback] and returned by [getCachedUserFeedback]
+     * are valid in [postCachedUserFeedback]. All user manually created events will be dropped.
+     * 2. The cache APIs should only be used when in Active Guidance mode since navigation.feedback events are only handled in that mode.
+     * 3. [postCachedUserFeedback] should be called before transitioning between modes. Otherwise, all cached events will be lost.
+     *
+     * @param cachedFeedbackEventList the list should be the subset or the original list that you get from [getCachedUserFeedback].
+     *
+     * @see [cacheUserFeedback]
+     * @see [getCachedUserFeedback]
+     */
+    fun postCachedUserFeedback(cachedFeedbackEventList: List<CachedNavigationFeedbackEvent>) {
+        MapboxNavigationTelemetry.postCachedUserFeedback(cachedFeedbackEventList)
+    }
+}

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetry.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetry.kt
@@ -27,6 +27,7 @@ import com.mapbox.navigation.core.NavigationSessionStateObserver
 import com.mapbox.navigation.core.arrival.ArrivalObserver
 import com.mapbox.navigation.core.directions.session.RoutesObserver
 import com.mapbox.navigation.core.internal.accounts.MapboxNavigationAccounts
+import com.mapbox.navigation.core.internal.telemetry.CachedNavigationFeedbackEvent
 import com.mapbox.navigation.core.telemetry.events.AppMetadata
 import com.mapbox.navigation.core.telemetry.events.FeedbackEvent
 import com.mapbox.navigation.core.telemetry.events.FreeDriveEventType
@@ -126,6 +127,7 @@ internal object MapboxNavigationTelemetry :
     private lateinit var locationsCollector: LocationsCollector
     private lateinit var sdkIdentifier: String
     private var logger: Logger? = null
+    private val feedbackEventCacheMap = LinkedHashMap<String, NavigationFeedbackEvent>()
 
     private var needHandleReroute = false
     private var sessionState: NavigationSession.State = IDLE
@@ -157,6 +159,7 @@ internal object MapboxNavigationTelemetry :
             "mapbox-navigation-android"
         }
         metricsReporter = reporter
+        feedbackEventCacheMap.clear()
 
         registerListeners(mapboxNavigation)
         postTurnstileEvent()
@@ -174,6 +177,67 @@ internal object MapboxNavigationTelemetry :
         screenshot: String?,
         feedbackSubType: Array<String>?,
         appMetadata: AppMetadata?
+    ) {
+        createUserFeedback(
+            feedbackType,
+            description,
+            feedbackSource,
+            screenshot,
+            feedbackSubType,
+            appMetadata
+        ) {
+            sendMetricEvent(it)
+        }
+    }
+
+    fun cacheUserFeedback(
+        @FeedbackEvent.Type feedbackType: String,
+        description: String,
+        @FeedbackEvent.Source feedbackSource: String,
+        screenshot: String?,
+        feedbackSubType: Array<String>?,
+        appMetadata: AppMetadata?
+    ) {
+        createUserFeedback(
+            feedbackType,
+            description,
+            feedbackSource,
+            screenshot,
+            feedbackSubType,
+            appMetadata
+        ) {
+            feedbackEventCacheMap[it.feedbackId] = it
+        }
+    }
+
+    fun getCachedUserFeedback(): List<CachedNavigationFeedbackEvent> {
+        return feedbackEventCacheMap.map {
+            it.value.getCachedNavigationFeedbackEvent()
+        }
+    }
+
+    fun postCachedUserFeedback(cachedFeedbackEventList: List<CachedNavigationFeedbackEvent>) {
+        log("post cached user feedback events")
+        val feedbackEventCache = LinkedHashMap(feedbackEventCacheMap)
+        feedbackEventCacheMap.clear()
+
+        cachedFeedbackEventList.forEach { cachedFeedback ->
+            metricsReporter.addEvent(
+                feedbackEventCache[cachedFeedback.feedbackId]?.apply {
+                    update(cachedFeedback)
+                } ?: return@forEach
+            )
+        }
+    }
+
+    private fun createUserFeedback(
+        @FeedbackEvent.Type feedbackType: String,
+        description: String,
+        @FeedbackEvent.Source feedbackSource: String,
+        screenshot: String?,
+        feedbackSubType: Array<String>?,
+        appMetadata: AppMetadata?,
+        onEventCreated: (NavigationFeedbackEvent) -> Unit
     ) {
         if (dynamicValues.sessionStarted && dataInitialized()) {
             log("collect post event locations for user feedback")
@@ -196,7 +260,7 @@ internal object MapboxNavigationTelemetry :
                     locationsBefore = preEventBuffer.toTelemetryLocations()
                     locationsAfter = postEventBuffer.toTelemetryLocations()
                 }
-                sendMetricEvent(feedbackEvent)
+                onEventCreated(feedbackEvent)
             }
         }
     }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/events/NavigationFeedbackEvent.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/events/NavigationFeedbackEvent.kt
@@ -2,6 +2,7 @@ package com.mapbox.navigation.core.telemetry.events
 
 import android.annotation.SuppressLint
 import com.mapbox.navigation.base.metrics.NavigationMetrics
+import com.mapbox.navigation.core.internal.telemetry.CachedNavigationFeedbackEvent
 
 @SuppressLint("ParcelCreator")
 internal class NavigationFeedbackEvent(
@@ -26,4 +27,19 @@ internal class NavigationFeedbackEvent(
     var appMetadata: AppMetadata? = null
 
     override fun getEventName(): String = NavigationMetrics.FEEDBACK
+
+    fun getCachedNavigationFeedbackEvent() =
+        CachedNavigationFeedbackEvent(
+            feedbackId,
+            feedbackType ?: "",
+            screenshot ?: "",
+            description,
+            HashSet(feedbackSubType?.toSet() ?: emptySet())
+        )
+
+    fun update(cachedNavigationFeedbackEvent: CachedNavigationFeedbackEvent) {
+        feedbackType = cachedNavigationFeedbackEvent.feedbackType
+        description = cachedNavigationFeedbackEvent.description
+        feedbackSubType = cachedNavigationFeedbackEvent.feedbackSubType.toTypedArray()
+    }
 }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetryTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetryTest.kt
@@ -26,7 +26,10 @@ import com.mapbox.navigation.core.NavigationSession
 import com.mapbox.navigation.core.NavigationSession.State.ACTIVE_GUIDANCE
 import com.mapbox.navigation.core.NavigationSession.State.FREE_DRIVE
 import com.mapbox.navigation.core.NavigationSession.State.IDLE
+import com.mapbox.navigation.core.internal.telemetry.CachedNavigationFeedbackEvent
 import com.mapbox.navigation.core.telemetry.MapboxNavigationTelemetry.toTelemetryLocation
+import com.mapbox.navigation.core.telemetry.events.AppMetadata
+import com.mapbox.navigation.core.telemetry.events.FeedbackEvent
 import com.mapbox.navigation.core.telemetry.events.FreeDriveEventType.START
 import com.mapbox.navigation.core.telemetry.events.FreeDriveEventType.STOP
 import com.mapbox.navigation.core.telemetry.events.NavigationArriveEvent
@@ -363,6 +366,134 @@ class MapboxNavigationTelemetryTest {
         assertTrue(events[8] is NavigationFeedbackEvent)
         assertTrue(events[9] is NavigationCancelEvent)
         assertEquals(10, events.size)
+    }
+
+    @Test
+    fun cache_feedback_is_cached() {
+        baseMock()
+
+        baseInitialization()
+        val cacheFeedbackType = FeedbackEvent.POSITIONING_ISSUE
+        cacheUserFeedback(feedbackType = cacheFeedbackType)
+        val cacheFeedbackDescription = "cacheFeedbackDescription"
+        cacheUserFeedback(description = cacheFeedbackDescription)
+        updateSessionState(FREE_DRIVE)
+
+        val cachedFeedbackEvents = MapboxNavigationTelemetry.getCachedUserFeedback()
+        assertEquals(cachedFeedbackEvents.size, 2)
+        assertEquals(
+            cacheFeedbackType,
+            cachedFeedbackEvents[0].feedbackType
+        )
+        assertEquals(
+            "cacheFeedbackDescription",
+            cachedFeedbackEvents[1].description
+        )
+    }
+
+    @Test
+    fun cache_feedback_not_send_on_session_stop() {
+        baseMock()
+        mockAnotherRoute()
+
+        baseInitialization()
+        cacheUserFeedback()
+        offRoute()
+        updateRoute(anotherRoute)
+        updateRouteProgress()
+        postUserFeedback()
+        cacheUserFeedback()
+        updateSessionState(FREE_DRIVE)
+
+        val events = captureAndVerifyMetricsReporter(exactly = 6)
+        assertTrue(events[0] is NavigationAppUserTurnstileEvent)
+        assertTrue(events[1] is NavigationDepartEvent)
+        assertTrue(events[2] is NavigationRerouteEvent)
+        assertTrue(events[3] is NavigationFeedbackEvent)
+        assertTrue(events[4] is NavigationCancelEvent)
+        assertTrue(events[5] is NavigationFreeDriveEvent)
+        assertEquals(6, events.size)
+    }
+
+    @Test
+    fun cache_feedback_sent_even_after_session_stop() {
+        baseMock()
+        mockAnotherRoute()
+
+        baseInitialization()
+        cacheUserFeedback()
+        offRoute()
+        updateRoute(anotherRoute)
+        updateRouteProgress()
+        postUserFeedback()
+        cacheUserFeedback()
+        updateSessionState(FREE_DRIVE)
+        postCachedUserFeedback()
+
+        val events = captureAndVerifyMetricsReporter(exactly = 8)
+        assertTrue(events[0] is NavigationAppUserTurnstileEvent)
+        assertTrue(events[1] is NavigationDepartEvent)
+        assertTrue(events[2] is NavigationRerouteEvent)
+        assertTrue(events[3] is NavigationFeedbackEvent)
+        assertTrue(events[4] is NavigationCancelEvent)
+        assertTrue(events[5] is NavigationFreeDriveEvent)
+        assertTrue(events[6] is NavigationFeedbackEvent)
+        assertTrue(events[7] is NavigationFeedbackEvent)
+
+        assertEquals(8, events.size)
+    }
+
+    @Test
+    fun only_internal_cached_feedback_sent() {
+        baseMock()
+        mockAnotherRoute()
+
+        baseInitialization()
+        val cacheFeedbackType = FeedbackEvent.POSITIONING_ISSUE
+        cacheUserFeedback(feedbackType = cacheFeedbackType)
+        offRoute()
+        updateRoute(anotherRoute)
+        updateRouteProgress()
+        postUserFeedback()
+        val cacheFeedbackDescription = "cacheFeedbackDescription"
+        cacheUserFeedback(description = cacheFeedbackDescription)
+        updateSessionState(FREE_DRIVE)
+        postCachedUserFeedback(
+            MapboxNavigationTelemetry
+                .getCachedUserFeedback()
+                .plus(
+                    listOf(
+                        CachedNavigationFeedbackEvent(
+                            "",
+                            FeedbackEvent.ROAD_CLOSED,
+                            "",
+                            "a feedback that not created by telemetry " +
+                                "will be dropped and not be sent",
+                            HashSet()
+                        )
+                    )
+                )
+        )
+
+        val events = captureAndVerifyMetricsReporter(exactly = 8)
+        assertTrue(events[0] is NavigationAppUserTurnstileEvent)
+        assertTrue(events[1] is NavigationDepartEvent)
+        assertTrue(events[2] is NavigationRerouteEvent)
+        assertTrue(events[3] is NavigationFeedbackEvent)
+        assertTrue(events[4] is NavigationCancelEvent)
+        assertTrue(events[5] is NavigationFreeDriveEvent)
+        assertTrue(events[6] is NavigationFeedbackEvent)
+        assertEquals(
+            cacheFeedbackType,
+            (events[6] as NavigationFeedbackEvent).feedbackType
+        )
+        assertTrue(events[7] is NavigationFeedbackEvent)
+        assertEquals(
+            "cacheFeedbackDescription",
+            (events[7] as NavigationFeedbackEvent).description
+        )
+
+        assertEquals(8, events.size)
     }
 
     @Test
@@ -942,7 +1073,34 @@ class MapboxNavigationTelemetryTest {
     }
 
     private fun postUserFeedback() {
-        MapboxNavigationTelemetry.postUserFeedback("", "", "", null, null, null)
+        MapboxNavigationTelemetry.postUserFeedback("", "", "", null, emptyArray(), null)
+    }
+
+    private fun cacheUserFeedback(
+        feedbackType: String = "",
+        description: String = "",
+        feedbackSource: String = "",
+        screenshot: String? = null,
+        feedbackSubType: Array<String> = emptyArray(),
+        appMetadata: AppMetadata? = null
+    ) {
+        MapboxNavigationTelemetry.cacheUserFeedback(
+            feedbackType,
+            description,
+            feedbackSource,
+            screenshot,
+            feedbackSubType,
+            appMetadata
+        )
+    }
+
+    private fun postCachedUserFeedback(
+        cachedFeedbackEventList: List<CachedNavigationFeedbackEvent> =
+            MapboxNavigationTelemetry.getCachedUserFeedback()
+    ) {
+        MapboxNavigationTelemetry.postCachedUserFeedback(
+            cachedFeedbackEventList
+        )
     }
 
     /**


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

The Feedback 2.0 flow allows to add more information on arrival. To support the new feedback UX change, the Core SDK should provide these APIs:
* cache user feedback
* retrieve cached feedback list
* post cached feedbacks

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Expose APIs to support caching user feedback events.</changelog>
```

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->