### PR TITLE
Exposed MapMatcherResultObserver

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayHistoryActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayHistoryActivity.kt
@@ -31,6 +31,8 @@ import com.mapbox.navigation.core.replay.history.ReplayEventBase
 import com.mapbox.navigation.core.replay.history.ReplayEventsObserver
 import com.mapbox.navigation.core.replay.history.ReplayHistoryMapper
 import com.mapbox.navigation.core.replay.history.ReplaySetRoute
+import com.mapbox.navigation.core.trip.session.MapMatcherResult
+import com.mapbox.navigation.core.trip.session.MapMatcherResultObserver
 import com.mapbox.navigation.core.trip.session.TripSessionState
 import com.mapbox.navigation.examples.R
 import com.mapbox.navigation.examples.history.HistoryFilesActivity
@@ -227,6 +229,23 @@ class ReplayHistoryActivity : AppCompatActivity() {
             mapboxReplayer.play()
             mapboxNavigation.startTripSession()
         }
+
+        mapboxNavigation.registerMapMatcherResultObserver(
+            object : MapMatcherResultObserver {
+                @SuppressLint("SetTextI18n")
+                override fun onNewMapMatcherResult(mapMatcherResult: MapMatcherResult) {
+                    mapMatcherDataTv.text =
+                        """
+                            enhancedLoc: ${mapMatcherResult.enhancedLocation}
+                            keyPoints: ${mapMatcherResult.keyPoints}
+                            isOffRoad: ${mapMatcherResult.isOffRoad}
+                            offRoadProbability: ${mapMatcherResult.offRoadProbability}
+                            isTeleport: ${mapMatcherResult.isTeleport}
+                            roadEdgeMatchProbability: ${mapMatcherResult.roadEdgeMatchProbability}
+                        """.trimIndent()
+                }
+            }
+        )
     }
 
     @SuppressLint("SetTextI18n")

--- a/examples/src/main/res/layout/activity_replay_history_layout.xml
+++ b/examples/src/main/res/layout/activity_replay_history_layout.xml
@@ -18,6 +18,13 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"/>
 
+    <TextView
+        android:id="@+id/mapMatcherDataTv"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
     <Button
         android:id="@+id/selectHistoryButton"
         android:layout_width="wrap_content"

--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -18,6 +18,7 @@ package com.mapbox.navigation.core {
     method public void registerBannerInstructionsObserver(com.mapbox.navigation.core.trip.session.BannerInstructionsObserver bannerInstructionsObserver);
     method public void registerEHorizonObserver(com.mapbox.navigation.core.trip.session.EHorizonObserver eHorizonObserver);
     method public void registerLocationObserver(com.mapbox.navigation.core.trip.session.LocationObserver locationObserver);
+    method public void registerMapMatcherResultObserver(com.mapbox.navigation.core.trip.session.MapMatcherResultObserver mapMatcherResultObserver);
     method public void registerOffRouteObserver(com.mapbox.navigation.core.trip.session.OffRouteObserver offRouteObserver);
     method public void registerRouteAlertsObserver(com.mapbox.navigation.core.trip.session.RouteAlertsObserver routeAlertsObserver);
     method public void registerRouteProgressObserver(com.mapbox.navigation.core.trip.session.RouteProgressObserver routeProgressObserver);
@@ -41,6 +42,7 @@ package com.mapbox.navigation.core {
     method public void unregisterBannerInstructionsObserver(com.mapbox.navigation.core.trip.session.BannerInstructionsObserver bannerInstructionsObserver);
     method public void unregisterEHorizonObserver(com.mapbox.navigation.core.trip.session.EHorizonObserver eHorizonObserver);
     method public void unregisterLocationObserver(com.mapbox.navigation.core.trip.session.LocationObserver locationObserver);
+    method public void unregisterMapMatcherResultObserver(com.mapbox.navigation.core.trip.session.MapMatcherResultObserver mapMatcherResultObserver);
     method public void unregisterOffRouteObserver(com.mapbox.navigation.core.trip.session.OffRouteObserver offRouteObserver);
     method public void unregisterRouteAlertsObserver(com.mapbox.navigation.core.trip.session.RouteAlertsObserver routeAlertsObserver);
     method public void unregisterRouteProgressObserver(com.mapbox.navigation.core.trip.session.RouteProgressObserver routeProgressObserver);
@@ -138,6 +140,13 @@ package com.mapbox.navigation.core.fasterroute {
   public static final class FasterRouteObserver.Companion {
     method public long getDEFAULT_INTERVAL_MILLIS();
     property public final long DEFAULT_INTERVAL_MILLIS;
+  }
+
+}
+
+package com.mapbox.navigation.core.navigator {
+
+  public final class NavigatorMapperKt {
   }
 
 }
@@ -516,6 +525,19 @@ package com.mapbox.navigation.core.trip.session {
   public interface LocationObserver {
     method public void onEnhancedLocationChanged(android.location.Location enhancedLocation, java.util.List<? extends android.location.Location> keyPoints);
     method public void onRawLocationChanged(android.location.Location rawLocation);
+  }
+
+  public final class MapMatcherResult {
+    method public android.location.Location getEnhancedLocation();
+    method public java.util.List<android.location.Location> getKeyPoints();
+    method public float getOffRoadProbability();
+    method public float getRoadEdgeMatchProbability();
+    method public boolean isOffRoad();
+    method public boolean isTeleport();
+  }
+
+  public interface MapMatcherResultObserver {
+    method public void onNewMapMatcherResult(com.mapbox.navigation.core.trip.session.MapMatcherResult mapMatcherResult);
   }
 
   public interface OffRouteObserver {

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -50,6 +50,8 @@ import com.mapbox.navigation.core.trip.service.TripService
 import com.mapbox.navigation.core.trip.session.BannerInstructionsObserver
 import com.mapbox.navigation.core.trip.session.EHorizonObserver
 import com.mapbox.navigation.core.trip.session.LocationObserver
+import com.mapbox.navigation.core.trip.session.MapMatcherResult
+import com.mapbox.navigation.core.trip.session.MapMatcherResultObserver
 import com.mapbox.navigation.core.trip.session.OffRouteObserver
 import com.mapbox.navigation.core.trip.session.RouteAlertsObserver
 import com.mapbox.navigation.core.trip.session.RouteProgressObserver
@@ -351,6 +353,7 @@ class MapboxNavigation(
         tripSession.unregisterAllVoiceInstructionsObservers()
         tripSession.unregisterAllRouteAlertsObservers()
         tripSession.unregisterAllEHorizonObservers()
+        tripSession.unregisterAllMapMatcherResultObservers()
         directionsSession.routes = emptyList()
         resetTripSession()
 
@@ -635,6 +638,26 @@ class MapboxNavigation(
      */
     fun unregisterEHorizonObserver(eHorizonObserver: EHorizonObserver) {
         tripSession.unregisterEHorizonObserver(eHorizonObserver)
+    }
+
+    /**
+     * Registers an observer that gets notified whenever a new enhanced location update is available
+     * with details about the status of the enhanced location.
+     *
+     * @see [MapMatcherResult]
+     * @see [startTripSession]
+     */
+    fun registerMapMatcherResultObserver(mapMatcherResultObserver: MapMatcherResultObserver) {
+        tripSession.registerMapMatcherResultObserver(mapMatcherResultObserver)
+    }
+
+    /**
+     * Unregisters a [MapMatcherResultObserver].
+     *
+     * @see [MapMatcherResult]
+     */
+    fun unregisterMapMatcherResultObserver(mapMatcherResultObserver: MapMatcherResultObserver) {
+        tripSession.unregisterMapMatcherResultObserver(mapMatcherResultObserver)
     }
 
     /**

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/navigator/NavigatorMapper.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/navigator/NavigatorMapper.kt
@@ -1,0 +1,15 @@
+package com.mapbox.navigation.core.navigator
+
+import com.mapbox.navigation.core.trip.session.MapMatcherResult
+import com.mapbox.navigation.navigator.internal.TripStatus
+
+internal fun TripStatus.getMapMatcherResult(): MapMatcherResult {
+    return MapMatcherResult(
+        enhancedLocation,
+        keyPoints,
+        navigationStatus.offRoadProba > 0.5,
+        navigationStatus.offRoadProba,
+        navigationStatus.map_matcher_output.isTeleport,
+        navigationStatus.map_matcher_output.matches.firstOrNull()?.proba ?: 0f
+    )
+}

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapMatcherResult.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapMatcherResult.kt
@@ -1,0 +1,70 @@
+package com.mapbox.navigation.core.trip.session
+
+import android.location.Location
+
+/**
+ * Provides information about the status of the enhanced location updates generated
+ * by the map matching engine of the Navigation SDK.
+ *
+ * @param enhancedLocation the best possible location update, snapped to the route or map matched to the road if possible.
+ * Equal to data from [LocationObserver.onEnhancedLocationChanged].
+ * @param keyPoints a list (can be empty) of predicted location points leading up to the target update.
+ * The last point on the list (if not empty) is always equal to [enhancedLocation].
+ * Equal to data from [LocationObserver.onEnhancedLocationChanged].
+ * @param isOffRoad whether the SDK thinks that the user is off road, based on the [offRoadProbability].
+ * @param offRoadProbability probability that the user is off road.
+ * @param isTeleport returns true if map matcher changed its opinion about most probable path on last update.
+ * In practice it means we don't need to animate puck movement from previous to current location
+ * and just do an immediate transition instead.
+ * @param roadEdgeMatchProbability when map matcher snaps to a road, this is the confidence in the chosen edge from all nearest edges.
+ */
+class MapMatcherResult internal constructor(
+    val enhancedLocation: Location,
+    val keyPoints: List<Location>,
+    val isOffRoad: Boolean,
+    val offRoadProbability: Float,
+    val isTeleport: Boolean,
+    val roadEdgeMatchProbability: Float
+) {
+
+    /**
+     * Indicates whether some other object is "equal to" this one.
+     */
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as MapMatcherResult
+
+        if (enhancedLocation != other.enhancedLocation) return false
+        if (keyPoints != other.keyPoints) return false
+        if (isOffRoad != other.isOffRoad) return false
+        if (offRoadProbability != other.offRoadProbability) return false
+        if (isTeleport != other.isTeleport) return false
+        if (roadEdgeMatchProbability != other.roadEdgeMatchProbability) return false
+
+        return true
+    }
+
+    /**
+     * Returns a hash code value for the object.
+     */
+    override fun hashCode(): Int {
+        var result = enhancedLocation.hashCode()
+        result = 31 * result + keyPoints.hashCode()
+        result = 31 * result + isOffRoad.hashCode()
+        result = 31 * result + offRoadProbability.hashCode()
+        result = 31 * result + isTeleport.hashCode()
+        result = 31 * result + roadEdgeMatchProbability.hashCode()
+        return result
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    override fun toString(): String {
+        return "MapMatcherResult(enhancedLocation=$enhancedLocation, " +
+            "keyPoints=$keyPoints, isOffRoad=$isOffRoad, offRoadProbability=$offRoadProbability, " +
+            "isTeleport=$isTeleport, roadEdgeMatchProbability=$roadEdgeMatchProbability)"
+    }
+}

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapMatcherResultObserver.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapMatcherResultObserver.kt
@@ -1,0 +1,16 @@
+package com.mapbox.navigation.core.trip.session
+
+/**
+ * Observer that gets notified whenever a new enhanced location is available.
+ *
+ * @see [MapMatcherResult]
+ */
+interface MapMatcherResultObserver {
+
+    /**
+     * Called whenever a new enhanced location is available.
+     *
+     * @param mapMatcherResult details about the status of the enhanced location.
+     */
+    fun onNewMapMatcherResult(mapMatcherResult: MapMatcherResult)
+}

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/TripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/TripSession.kt
@@ -53,4 +53,8 @@ internal interface TripSession {
     fun registerEHorizonObserver(eHorizonObserver: EHorizonObserver)
     fun unregisterEHorizonObserver(eHorizonObserver: EHorizonObserver)
     fun unregisterAllEHorizonObservers()
+
+    fun registerMapMatcherResultObserver(mapMatcherResultObserver: MapMatcherResultObserver)
+    fun unregisterMapMatcherResultObserver(mapMatcherResultObserver: MapMatcherResultObserver)
+    fun unregisterAllMapMatcherResultObservers()
 }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
@@ -27,6 +27,7 @@ import com.mapbox.navigation.core.internal.formatter.MapboxDistanceFormatter
 import com.mapbox.navigation.core.reroute.RerouteController
 import com.mapbox.navigation.core.reroute.RerouteState
 import com.mapbox.navigation.core.trip.service.TripService
+import com.mapbox.navigation.core.trip.session.MapMatcherResultObserver
 import com.mapbox.navigation.core.trip.session.OffRouteObserver
 import com.mapbox.navigation.core.trip.session.RouteAlertsObserver
 import com.mapbox.navigation.core.trip.session.TripSession
@@ -233,6 +234,22 @@ class MapboxNavigationTest {
     }
 
     @Test
+    fun registerMapMatcherResultObserver() {
+        val observer: MapMatcherResultObserver = mockk()
+        mapboxNavigation.registerMapMatcherResultObserver(observer)
+
+        verify(exactly = 1) { tripSession.registerMapMatcherResultObserver(observer) }
+    }
+
+    @Test
+    fun unregisterMapMatcherResultObserver() {
+        val observer: MapMatcherResultObserver = mockk()
+        mapboxNavigation.unregisterMapMatcherResultObserver(observer)
+
+        verify(exactly = 1) { tripSession.unregisterMapMatcherResultObserver(observer) }
+    }
+
+    @Test
     fun init_registerStateObserver_navigationSession() {
         verify(exactly = 1) { tripSession.registerStateObserver(any()) }
 
@@ -328,6 +345,13 @@ class MapboxNavigationTest {
         mapboxNavigation.onDestroy()
 
         verify(exactly = 1) { navigationSession.unregisterAllNavigationSessionStateObservers() }
+    }
+
+    @Test
+    fun unregisterAllMapMatcherResultObservers() {
+        mapboxNavigation.onDestroy()
+
+        verify(exactly = 1) { tripSession.unregisterAllMapMatcherResultObservers() }
     }
 
     @Test

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/navigator/NavigatorMapperTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/navigator/NavigatorMapperTest.kt
@@ -1,0 +1,179 @@
+package com.mapbox.navigation.core.navigator
+
+import android.location.Location
+import com.mapbox.navigation.base.trip.model.RouteProgress
+import com.mapbox.navigation.core.trip.session.MapMatcherResult
+import com.mapbox.navigation.navigator.internal.TripStatus
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class NavigatorMapperTest {
+
+    private val enhancedLocation: Location = mockk(relaxed = true)
+    private val keyPoints: List<Location> = mockk(relaxed = true)
+    private val routeProgress: RouteProgress = mockk(relaxed = true)
+    private val offRoute: Boolean = mockk(relaxed = true)
+
+    @Test
+    fun `map matcher result sanity`() {
+        val tripStatus = TripStatus(
+            enhancedLocation,
+            keyPoints,
+            routeProgress,
+            offRoute,
+            mockk {
+                every { offRoadProba } returns 0f
+                every { map_matcher_output } returns mockk {
+                    every { isTeleport } returns false
+                    every { matches } returns listOf(
+                        mockk {
+                            every { proba } returns 1f
+                        }
+                    )
+                }
+            }
+        )
+        val expected = MapMatcherResult(
+            enhancedLocation,
+            keyPoints,
+            isOffRoad = false,
+            offRoadProbability = 0f,
+            isTeleport = false,
+            roadEdgeMatchProbability = 1f
+        )
+
+        val result = tripStatus.getMapMatcherResult()
+
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `map matcher result when close to being off road`() {
+        val tripStatus = TripStatus(
+            enhancedLocation,
+            keyPoints,
+            routeProgress,
+            offRoute,
+            mockk {
+                every { offRoadProba } returns 0.5f
+                every { map_matcher_output } returns mockk {
+                    every { isTeleport } returns false
+                    every { matches } returns listOf(
+                        mockk {
+                            every { proba } returns 1f
+                        }
+                    )
+                }
+            }
+        )
+        val expected = MapMatcherResult(
+            enhancedLocation,
+            keyPoints,
+            isOffRoad = false,
+            offRoadProbability = 0.5f,
+            isTeleport = false,
+            roadEdgeMatchProbability = 1f
+        )
+
+        val result = tripStatus.getMapMatcherResult()
+
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `map matcher result when off road`() {
+        val tripStatus = TripStatus(
+            enhancedLocation,
+            keyPoints,
+            routeProgress,
+            offRoute,
+            mockk {
+                every { offRoadProba } returns 0.500009f
+                every { map_matcher_output } returns mockk {
+                    every { isTeleport } returns false
+                    every { matches } returns listOf(
+                        mockk {
+                            every { proba } returns 1f
+                        }
+                    )
+                }
+            }
+        )
+        val expected = MapMatcherResult(
+            enhancedLocation,
+            keyPoints,
+            isOffRoad = true,
+            offRoadProbability = 0.500009f,
+            isTeleport = false,
+            roadEdgeMatchProbability = 1f
+        )
+
+        val result = tripStatus.getMapMatcherResult()
+
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `map matcher result teleport`() {
+        val tripStatus = TripStatus(
+            enhancedLocation,
+            keyPoints,
+            routeProgress,
+            offRoute,
+            mockk {
+                every { offRoadProba } returns 0f
+                every { map_matcher_output } returns mockk {
+                    every { isTeleport } returns true
+                    every { matches } returns listOf(
+                        mockk {
+                            every { proba } returns 1f
+                        }
+                    )
+                }
+            }
+        )
+        val expected = MapMatcherResult(
+            enhancedLocation,
+            keyPoints,
+            isOffRoad = false,
+            offRoadProbability = 0f,
+            isTeleport = true,
+            roadEdgeMatchProbability = 1f
+        )
+
+        val result = tripStatus.getMapMatcherResult()
+
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `map matcher result no edge matches`() {
+        val tripStatus = TripStatus(
+            enhancedLocation,
+            keyPoints,
+            routeProgress,
+            offRoute,
+            mockk {
+                every { offRoadProba } returns 1f
+                every { map_matcher_output } returns mockk {
+                    every { isTeleport } returns false
+                    every { matches } returns listOf()
+                }
+            }
+        )
+        val expected = MapMatcherResult(
+            enhancedLocation,
+            keyPoints,
+            isOffRoad = true,
+            offRoadProbability = 1f,
+            isTeleport = false,
+            roadEdgeMatchProbability = 0f
+        )
+
+        val result = tripStatus.getMapMatcherResult()
+
+        assertEquals(expected, result)
+    }
+}

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigatorImpl.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigatorImpl.kt
@@ -117,7 +117,8 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
                 status.location.toLocation(),
                 status.key_points.map { it.toLocation() },
                 navigatorMapper.getRouteProgress(route, routeBufferGeoJson, status),
-                status.routeState == RouteState.OFF_ROUTE
+                status.routeState == RouteState.OFF_ROUTE,
+                status
             )
         }
 

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/TripStatus.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/TripStatus.kt
@@ -2,6 +2,7 @@ package com.mapbox.navigation.navigator.internal
 
 import android.location.Location
 import com.mapbox.navigation.base.trip.model.RouteProgress
+import com.mapbox.navigator.NavigationStatus
 
 /**
  * State of a trip at a particular timestamp.
@@ -17,5 +18,6 @@ data class TripStatus(
     val enhancedLocation: Location,
     val keyPoints: List<Location>,
     val routeProgress: RouteProgress?,
-    val offRoute: Boolean
+    val offRoute: Boolean,
+    val navigationStatus: NavigationStatus
 )


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

Exposes `MapMatcherResultObserver` that provides additional information about the status of the enhanced location update and the confidence of decisions that the map matcher made to generate this position.

### Implementation

The `MapMatcherResult` intentionally introduces some redundancy to data available in the `LocationObserver`. For example, the `MapMatcherResult#isTeleport` flag will most probably be used with the Maps SDK's `LocationComponent`, so it's convenient to have all of the location sample data in one callback, rather than trying to put it together on the client-side from 2 different ones.

I opted to make the constructor of the `MapMatcherResult` internal, which will let us extend this class in the future without compromising nullability safety or breaking semver. In order to do that, the class needs to be a part of the `core` module. This seems to be the case with a lot of other DTOs and it looks like we are not consistent with how and where we od the conversion from Nav Native types to public SDK types.

Following this PR, we should move all of the essential mappings to the `core` module (basically merging `com.mapbox.navigation.navigator.internal.NavigatorMapper` with `com.mapbox.navigation.core.navigator.NavigatorMapperKt` extension introduced in this PR). I tried to accomplish this refactor as part of this PR, but it introduces changes in the threads that are used to parse objects, so I think we should aim to introduce this change after the 1.2 branches cut to get more time for testing.