### PR TITLE
Use immediate tracking transition when NN reports teleport

### DIFF
--- a/libnavigation-ui/api/current.txt
+++ b/libnavigation-ui/api/current.txt
@@ -486,7 +486,10 @@ package com.mapbox.navigation.ui.map {
     method public void updateCameraTrackingMode(@com.mapbox.navigation.ui.camera.NavigationCamera.TrackingMode int);
     method public void updateIncidentsVisibility(boolean);
     method public void updateLocation(android.location.Location?);
+    method public void updateLocation(android.location.Location?, Long?);
     method public void updateLocation(java.util.List<android.location.Location!>);
+    method public void updateLocation(java.util.List<android.location.Location!>, Long?);
+    method public void updateLocation(android.location.Location, java.util.List<android.location.Location!>, Long?);
     method public void updateLocationFpsThrottleEnabled(boolean);
     method public void updateLocationLayerRenderMode(@com.mapbox.mapboxsdk.location.modes.RenderMode.Mode int);
     method public void updateLocationVisibilityTo(boolean);


### PR DESCRIPTION
## Description

This PR takes advantage of https://github.com/mapbox/mapbox-navigation-android/pull/3730 in `NavigationMapboxMap` to do an immediate transition when NN reports `teleport`.

### Implementation

I swapped the `LocationObserver` with the `MapMatchResultObserver` to leverage the newly available data.

## Screenshots or Gifs

![ezgif com-optimize (86)](https://user-images.githubusercontent.com/16925074/98129509-7d020700-1eb9-11eb-8791-512e5ac54cf6.gif)
