### PR TITLE
Post telemetry events on multi waypoint route

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayWaypointsActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayWaypointsActivity.kt
@@ -34,6 +34,7 @@ import com.mapbox.navigation.core.replay.MapboxReplayer
 import com.mapbox.navigation.core.replay.ReplayLocationEngine
 import com.mapbox.navigation.core.replay.route.ReplayProgressObserver
 import com.mapbox.navigation.core.replay.route.ReplayRouteMapper
+import com.mapbox.navigation.core.telemetry.events.FeedbackEvent
 import com.mapbox.navigation.core.trip.session.TripSessionState
 import com.mapbox.navigation.core.trip.session.TripSessionStateObserver
 import com.mapbox.navigation.examples.R
@@ -49,6 +50,7 @@ import kotlinx.android.synthetic.main.activity_replay_waypoints_layout.startNavi
 import timber.log.Timber
 import java.lang.ref.WeakReference
 import java.util.Collections
+import java.util.Date
 
 /**
  * This activity shows how to use navigate to various waypoints
@@ -166,6 +168,17 @@ class ReplayWaypointsActivity : AppCompatActivity(), OnMapReadyCallback {
             mapboxNavigation?.startTripSession()
             startNavigation.visibility = View.GONE
             mapboxReplayer.play()
+        }
+
+        findViewById<Button>(R.id.btn_send_user_feedback)?.let { button ->
+            button.setOnClickListener {
+                mapboxNavigation?.postUserFeedback(
+                    FeedbackEvent.GENERAL_ISSUE,
+                    "User feedback test at: ${Date().time}",
+                    FeedbackEvent.UI,
+                    null
+                )
+            }
         }
     }
 

--- a/examples/src/main/res/layout/activity_replay_waypoints_layout.xml
+++ b/examples/src/main/res/layout/activity_replay_waypoints_layout.xml
@@ -16,7 +16,14 @@
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"/>
+        app:layout_constraintBottom_toBottomOf="parent">
+
+        <Button
+            android:id="@+id/btn_send_user_feedback"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/send_user_feedback" />
+    </com.mapbox.mapboxsdk.maps.MapView>
 
     <com.google.android.material.card.MaterialCardView
         android:layout_width="match_parent"

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -189,6 +189,10 @@ class MapboxNavigation(
         )
         tripSession.registerStateObserver(navigationSession)
         navigationSession.registerNavigationSessionStateObserver(navigationAccountsSession)
+
+        arrivalProgressObserver = ArrivalProgressObserver(tripSession)
+        setArrivalController()
+
         ifNonNull(accessToken) { token ->
             logger.d(
                 MapboxNavigationTelemetry.TAG,
@@ -219,9 +223,6 @@ class MapboxNavigation(
         )
         routeRefreshController = RouteRefreshController(directionsSession, tripSession, logger)
         routeRefreshController.start()
-
-        arrivalProgressObserver = ArrivalProgressObserver(tripSession)
-        setArrivalController()
 
         defaultRerouteController = MapboxRerouteController(
             directionsSession,

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetry.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetry.kt
@@ -116,7 +116,6 @@ internal object MapboxNavigationTelemetry :
     private var sessionState: NavigationSession.State = IDLE
     private var routeProgress: RouteProgress? = null
     private var originalRoute: DirectionsRoute? = null
-    private var newRoute: DirectionsRoute? = null
     private var needStartSession = false
 
     /**
@@ -201,7 +200,6 @@ internal object MapboxNavigationTelemetry :
     override fun onRouteProgressChanged(routeProgress: RouteProgress) {
         this.routeProgress = routeProgress
         startSessionIfNeedAndCan()
-        handleRerouteIfNeed()
     }
 
     override fun onRoutesChanged(routes: List<DirectionsRoute>) {
@@ -211,8 +209,7 @@ internal object MapboxNavigationTelemetry :
                 if (originalRoute != null) {
                     if (needHandleReroute) {
                         needHandleReroute = false
-                        resetRouteProgress()
-                        newRoute = it
+                        handleReroute(it)
                     } else {
                         log("handle ExternalRoute")
                         sessionStop()
@@ -316,8 +313,8 @@ internal object MapboxNavigationTelemetry :
         return originalRoute != null && dynamicValues.sessionStarted
     }
 
-    private fun handleRerouteIfNeed() {
-        ifNonNull(newRoute, routeProgress) { route, _ ->
+    private fun handleReroute(route: DirectionsRoute) {
+        if (dynamicValues.sessionStarted && dataInitialized()) {
             log("handleReroute")
 
             dynamicValues.run {
@@ -346,8 +343,6 @@ internal object MapboxNavigationTelemetry :
 
                 sendMetricEvent(navigationRerouteEvent)
             }
-
-            newRoute = null
         }
     }
 
@@ -444,7 +439,6 @@ internal object MapboxNavigationTelemetry :
         dynamicValues.reset()
         resetOriginalRoute()
         resetRouteProgress()
-        newRoute = null
         needHandleReroute = false
         needStartSession = false
     }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetry.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetry.kt
@@ -15,8 +15,8 @@ import com.mapbox.base.common.logger.model.Tag
 import com.mapbox.navigation.base.metrics.MetricEvent
 import com.mapbox.navigation.base.metrics.MetricsReporter
 import com.mapbox.navigation.base.options.NavigationOptions
+import com.mapbox.navigation.base.trip.model.RouteLegProgress
 import com.mapbox.navigation.base.trip.model.RouteProgress
-import com.mapbox.navigation.base.trip.model.RouteProgressState.ROUTE_COMPLETE
 import com.mapbox.navigation.core.BuildConfig
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.NavigationSession
@@ -24,6 +24,7 @@ import com.mapbox.navigation.core.NavigationSession.State.ACTIVE_GUIDANCE
 import com.mapbox.navigation.core.NavigationSession.State.FREE_DRIVE
 import com.mapbox.navigation.core.NavigationSession.State.IDLE
 import com.mapbox.navigation.core.NavigationSessionStateObserver
+import com.mapbox.navigation.core.arrival.ArrivalObserver
 import com.mapbox.navigation.core.directions.session.RoutesObserver
 import com.mapbox.navigation.core.internal.accounts.MapboxNavigationAccounts
 import com.mapbox.navigation.core.telemetry.events.AppMetadata
@@ -50,22 +51,18 @@ private data class DynamicSessionValues(
     var timeOfReroute: Long = 0L,
     var timeSinceLastReroute: Int = 0,
     var sessionId: String? = null,
-    var tripIdentifier: String? = null,
     var sessionStartTime: Date? = null,
     var sessionArrivalTime: Date? = null,
     var sessionStarted: Boolean = false,
-    var handleArrive: Boolean = false
 ) {
     fun reset() {
         rerouteCount = 0
         timeOfReroute = 0
         timeSinceLastReroute = 0
         sessionId = null
-        tripIdentifier = null
         sessionStartTime = null
         sessionArrivalTime = null
         sessionStarted = false
-        handleArrive = false
     }
 }
 
@@ -85,7 +82,8 @@ internal object MapboxNavigationTelemetry :
     RouteProgressObserver,
     RoutesObserver,
     OffRouteObserver,
-    NavigationSessionStateObserver {
+    NavigationSessionStateObserver,
+    ArrivalObserver {
     internal val TAG = Tag("MAPBOX_TELEMETRY")
 
     private const val ONE_SECOND = 1000
@@ -195,6 +193,7 @@ internal object MapboxNavigationTelemetry :
             unregisterRoutesObserver(this@MapboxNavigationTelemetry)
             unregisterOffRouteObserver(this@MapboxNavigationTelemetry)
             unregisterNavigationSessionObserver(this@MapboxNavigationTelemetry)
+            unregisterArrivalObserver(this@MapboxNavigationTelemetry)
         }
         MapboxMetricsReporter.disable()
     }
@@ -203,10 +202,6 @@ internal object MapboxNavigationTelemetry :
         this.routeProgress = routeProgress
         startSessionIfNeedAndCan()
         handleRerouteIfNeed()
-
-        if (routeProgress.currentState == ROUTE_COMPLETE) {
-            processArrival()
-        }
     }
 
     override fun onRoutesChanged(routes: List<DirectionsRoute>) {
@@ -256,6 +251,19 @@ internal object MapboxNavigationTelemetry :
         }
     }
 
+    override fun onNextRouteLegStart(routeLegProgress: RouteLegProgress) {
+        log("onNextRouteLegStart")
+        processArrival()
+        handleSessionCanceled()
+        sessionStart()
+    }
+
+    override fun onFinalDestinationArrival(routeProgress: RouteProgress) {
+        log("onFinalDestinationArrival")
+        this.routeProgress = routeProgress
+        processArrival()
+    }
+
     private fun registerListeners(mapboxNavigation: MapboxNavigation) {
         mapboxNavigation.run {
             registerLocationObserver(locationsCollector)
@@ -263,6 +271,7 @@ internal object MapboxNavigationTelemetry :
             registerRoutesObserver(this@MapboxNavigationTelemetry)
             registerOffRouteObserver(this@MapboxNavigationTelemetry)
             registerNavigationSessionObserver(this@MapboxNavigationTelemetry)
+            registerArrivalObserver(this@MapboxNavigationTelemetry)
         }
     }
 
@@ -273,7 +282,6 @@ internal object MapboxNavigationTelemetry :
                 sessionId = obtainUniversalUniqueIdentifier()
                 sessionStartTime = Date()
                 sessionStarted = true
-                handleArrive = true
             }
 
             val departEvent = NavigationDepartEvent(PhoneState(context)).apply { populate() }
@@ -282,11 +290,9 @@ internal object MapboxNavigationTelemetry :
     }
 
     private fun sessionStop() {
-        if (dynamicValues.sessionStarted && dataInitialized()) {
-            log("sessionStop")
-            handleSessionCanceled()
-            reset()
-        }
+        log("sessionStop")
+        handleSessionCanceled()
+        reset()
     }
 
     private fun sendMetricEvent(event: MetricEvent) {
@@ -346,14 +352,16 @@ internal object MapboxNavigationTelemetry :
     }
 
     private fun handleSessionCanceled() {
-        log("handleSessionCanceled")
-        locationsCollector.flushBuffers()
+        if (dynamicValues.sessionStarted && dataInitialized()) {
+            log("handleSessionCanceled")
+            locationsCollector.flushBuffers()
 
-        val cancelEvent = NavigationCancelEvent(PhoneState(context)).apply { populate() }
-        ifNonNull(dynamicValues.sessionArrivalTime) {
-            cancelEvent.arrivalTimestamp = generateCreateDateFormatted(it)
+            val cancelEvent = NavigationCancelEvent(PhoneState(context)).apply { populate() }
+            ifNonNull(dynamicValues.sessionArrivalTime) {
+                cancelEvent.arrivalTimestamp = generateCreateDateFormatted(it)
+            }
+            sendMetricEvent(cancelEvent)
         }
-        sendMetricEvent(cancelEvent)
     }
 
     private fun postTurnstileEvent() {
@@ -366,14 +374,9 @@ internal object MapboxNavigationTelemetry :
     }
 
     private fun processArrival() {
-        if (dynamicValues.sessionStarted && dynamicValues.handleArrive && dataInitialized()) {
+        if (dynamicValues.sessionStarted && dataInitialized()) {
             log("you have arrived")
-
-            dynamicValues.run {
-                tripIdentifier = obtainUniversalUniqueIdentifier()
-                sessionArrivalTime = Date()
-                handleArrive = false
-            }
+            dynamicValues.sessionArrivalTime = Date()
 
             val arriveEvent = NavigationArriveEvent(PhoneState(context)).apply { populate() }
             sendMetricEvent(arriveEvent)

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetryTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetryTest.kt
@@ -20,7 +20,6 @@ import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.trip.model.RouteLegProgress
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.base.trip.model.RouteProgressState.LOCATION_TRACKING
-import com.mapbox.navigation.base.trip.model.RouteProgressState.ROUTE_COMPLETE
 import com.mapbox.navigation.base.trip.model.RouteStepProgress
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.NavigationSession
@@ -271,7 +270,6 @@ class MapboxNavigationTelemetryTest {
         postUserFeedback()
         offRoute()
         updateRoute(anotherRoute)
-        updateRouteProgress()
         postUserFeedback()
         arrive()
 
@@ -291,7 +289,6 @@ class MapboxNavigationTelemetryTest {
         postUserFeedback()
         offRoute()
         updateRoute(anotherRoute)
-        updateRouteProgress()
         postUserFeedback()
         postUserFeedback()
         postUserFeedback()
@@ -324,7 +321,6 @@ class MapboxNavigationTelemetryTest {
         postUserFeedback()
         offRoute()
         updateRoute(anotherRoute)
-        updateRouteProgress()
         postUserFeedback()
         updateSessionState(IDLE)
 
@@ -351,7 +347,6 @@ class MapboxNavigationTelemetryTest {
         baseInitialization()
         offRoute()
         updateRoute(anotherRoute)
-        updateRouteProgress()
         locationsCollector.flushBuffers()
 
         val events = captureAndVerifyMetricsReporter(exactly = 3)
@@ -359,23 +354,6 @@ class MapboxNavigationTelemetryTest {
         assertTrue(events[1] is NavigationDepartEvent)
         assertTrue(events[2] is NavigationRerouteEvent)
         assertEquals(3, events.size)
-    }
-
-    @Test
-    fun rerouteEvent_not_sent_on_offRoute_without_routeProgress() {
-        baseMock()
-        mockAnotherRoute()
-        mockRouteProgress()
-
-        baseInitialization()
-        offRoute()
-        updateRoute(anotherRoute)
-        locationsCollector.flushBuffers()
-
-        val events = captureAndVerifyMetricsReporter(exactly = 2)
-        assertTrue(events[0] is NavigationAppUserTurnstileEvent)
-        assertTrue(events[1] is NavigationDepartEvent)
-        assertEquals(2, events.size)
     }
 
     @Test
@@ -400,7 +378,6 @@ class MapboxNavigationTelemetryTest {
         baseInitialization()
         offRoute()
         updateRoute(anotherRoute)
-        updateRouteProgress()
         locationsCollector.flushBuffers()
 
         val rerouteEvent = events[2] as NavigationRerouteEvent


### PR DESCRIPTION
<!-- ⚠️ TEMPLATE ⚠️ -->
<!-- Template for GitHub PR descriptions. Use it as a guide on how to describe your work. Feel free to remove any section when you're opening a PR if you think it does not apply for your committed changes. -->

## Description

If a route contains waypoints (not silent) we should track each of them with appropriate telemetry event.
We have the next order for a route without waypoints (just `origin` and `destination`): `depart` - `arrive` - `cancel`

We should use the same ^^ for each pair of waypoints.
If we have the next route:
- `origin`
- `waypoint1`
- `waypoint2`
- `destination`

We will post the next events:

`depart` - start from origin
`arrive` - come from origin to waypoint1
`cancel` - finish session from origin to waypoint1

`depart` - start from waypoint1
`arrive` - come from waypoint1 to waypoint2
`cancel` - finish session from waypoint1 to waypoint2

`depart` - start from waypoint2
`arrive` - come from waypoint2 to destination
`cancel` - finish the session from waypoint2 to destination

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards


## Testing

Please describe the manual tests that you ran to verify your changes

- [x] I have tested locally (including `SNAPSHOT` upstream dependencies if needed) through testapp/demo app and run all activities to avoid regressions
- [x] I have tested via a test drive, or a simulation/mock location app
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
<!-- - [ ] I have added an `Activity` example in the test app showing the new feature implemented (where applicable) -->
<!-- - [ ] I have made corresponding changes to the documentation (where applicable) -->
<!-- - [ ] Any changes to strings have been published to our translation tool (where applicable) -->
<!-- - [ ] Publish `testapp` in Google Play `internal` test track (where applicable) -->