### PR TITLE
Remove Electronic Horizon experimental note from EHorizonOptions and set EHorizonOptions from NavigationOptions to NavigatorConfig

### DIFF
--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/EHorizonOptions.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/EHorizonOptions.kt
@@ -4,13 +4,15 @@ package com.mapbox.navigation.base.options
  * Defines options for [EHorizon].
  *
  * @param length the minimum length of the MPP in meters. This does not include the trailingLength.
- * The actual MPP length may be bigger
+ * The actual MPP length may be bigger. Double in range [1.0, 20000.0]. Default value 500.0
  * @param expansion the number of branches to include from the MPP. When set to 0 only the MPP
- * is returned. Higher values will result in deeper nesting
+ * is returned. Higher values will result in deeper nesting. Int in range [0, 2]. Default value 0
  * @param branchLength when expansion is set to anything but 0, this specifies the minimum length
- * in meters branches will be expanded from the MPP
+ * in meters branches will be expanded from the MPP. Double in range [1.0, 5000.0].
+ * Default value 50.0
  * @param includeGeometries will geometries be included for edges. Excluding the edge shapes may
- * save some processing time on shape extraction and decoding
+ * save some processing time on shape extraction and decoding. Boolean to enable/disable.
+ * Default value false
  */
 class EHorizonOptions private constructor(
     val length: Double,

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/EHorizonOptions.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/EHorizonOptions.kt
@@ -3,11 +3,6 @@ package com.mapbox.navigation.base.options
 /**
  * Defines options for [EHorizon].
  *
- * Electronic Horizon is still **experimental**, which means that the design of the
- * APIs has open issues which may (or may not) lead to their changes in the future.
- * Roughly speaking, there is a chance that those declarations will be deprecated in the near
- * future or the semantics of their behavior may change in some way that may break some code.
- *
  * @param length the minimum length of the MPP in meters. This does not include the trailingLength.
  * The actual MPP length may be bigger
  * @param expansion the number of branches to include from the MPP. When set to 0 only the MPP

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -67,6 +67,7 @@ import com.mapbox.navigation.utils.internal.NetworkStatusService
 import com.mapbox.navigation.utils.internal.ThreadController
 import com.mapbox.navigation.utils.internal.ifNonNull
 import com.mapbox.navigation.utils.internal.monitorChannelWithException
+import com.mapbox.navigator.ElectronicHorizonOptions
 import com.mapbox.navigator.NavigatorConfig
 import com.mapbox.navigator.TileEndpointConfiguration
 import com.mapbox.navigator.TilesConfig
@@ -145,7 +146,13 @@ class MapboxNavigation(
     private val fasterRouteController: FasterRouteController
     private val routeRefreshController: RouteRefreshController
     private val arrivalProgressObserver: ArrivalProgressObserver
-    private val navigatorConfig = NavigatorConfig(null, null, null)
+    private val electronicHorizonOptions: ElectronicHorizonOptions = ElectronicHorizonOptions(
+        navigationOptions.eHorizonOptions.length,
+        navigationOptions.eHorizonOptions.expansion.toByte(),
+        navigationOptions.eHorizonOptions.branchLength,
+        navigationOptions.eHorizonOptions.includeGeometries
+    )
+    private val navigatorConfig = NavigatorConfig(null, electronicHorizonOptions, null)
 
     private var notificationChannelField: Field? = null
 


### PR DESCRIPTION
## Description

Remove Electronic Horizon experimental note from `EHorizonOptions` and set `EHorizonOptions` from `NavigationOptions` to `NavigatorConfig`

Quick follow up from https://github.com/mapbox/mapbox-navigation-android/pull/3740

- [x] I have added any issue links
- [x] I have added all related labels (`bug`, `feature`, `new API(s)`, `SEMVER`, etc.)
- [x] I have added the appropriate milestone and project boards

### Goal

Keep `EHorizonOptions` KDocs up to date and use the `EHorizonOptions` provided by `NavigationOptions`

### Implementation

Remove Electronic Horizon experimental note from `EHorizonOptions` and set `EHorizonOptions` from `NavigationOptions` to `NavigatorConfig`

## Testing

- [x] New and existing unit tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have updated the `CHANGELOG` including this PR
- [ ] We might need to update / push `api/current.txt` files after running `$> make core-update-api` (Core) / `$> make ui-update-api` (UI) if there are changes / errors we're 🆗 with (e.g. `AddedMethod` changes are marked as errors but don't break SemVer) 🚀 If there are SemVer breaking changes add the `SEMVER` label. See [Metalava](https://github.com/mapbox/mapbox-navigation-android/blob/master/docs/metalava.md) docs
