### PR TITLE
Backport #3761 to 1.2

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -11,7 +11,7 @@ ext {
       mapboxSdkServices         : '5.8.0-beta.3',
       mapboxEvents              : '6.2.1',
       mapboxCore                : '3.1.0',
-      mapboxNavigator           : '26.2.0',
+      mapboxNavigator           : '26.3.0',
       mapboxCommonNative        : '9.1.0',
       mapboxCrashMonitor        : '2.0.0',
       mapboxAnnotationPlugin    : '0.8.0',


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Backports https://github.com/mapbox/mapbox-navigation-android/pull/3761 to 1.2.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Fixed an issue where the location was sometimes map-matched to a road heading in the opposite direction if the raw location's accuracy was very poor.</changelog>
<changelog>Added support for routing tiles v2.</changelog>
```