### PR TITLE
Fix NPE in Telemetry and avoid dropping events when destroying MapboxNavigation

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -345,11 +345,7 @@ class MapboxNavigation(
      * Call this method whenever this instance of the [MapboxNavigation] is not going to be used anymore and should release all of its resources.
      */
     fun onDestroy() {
-        logger.d(
-            MapboxNavigationTelemetry.TAG,
-            Message("MapboxNavigation onDestroy")
-        )
-        MapboxNavigationTelemetry.unregisterListeners(this@MapboxNavigation)
+        logger.d(MapboxNavigationTelemetry.TAG, Message("MapboxNavigation onDestroy"))
         directionsSession.shutdown()
         directionsSession.unregisterAllRoutesObservers()
         tripSession.stop()
@@ -368,6 +364,7 @@ class MapboxNavigation(
         navigationSession.unregisterAllNavigationSessionStateObservers()
         fasterRouteController.stop()
         routeRefreshController.stop()
+        MapboxNavigationTelemetry.unregisterListeners(this@MapboxNavigation)
         ThreadController.cancelAllNonUICoroutines()
         ThreadController.cancelAllUICoroutines()
     }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
@@ -26,6 +26,7 @@ import com.mapbox.navigation.core.directions.session.RoutesRequestCallback
 import com.mapbox.navigation.core.internal.formatter.MapboxDistanceFormatter
 import com.mapbox.navigation.core.reroute.RerouteController
 import com.mapbox.navigation.core.reroute.RerouteState
+import com.mapbox.navigation.core.telemetry.MapboxNavigationTelemetry
 import com.mapbox.navigation.core.trip.service.TripService
 import com.mapbox.navigation.core.trip.session.MapMatcherResultObserver
 import com.mapbox.navigation.core.trip.session.OffRouteObserver
@@ -352,6 +353,31 @@ class MapboxNavigationTest {
         mapboxNavigation.onDestroy()
 
         verify(exactly = 1) { tripSession.unregisterAllMapMatcherResultObservers() }
+    }
+
+    @Test
+    fun unregisterAllTelemetryObservers() {
+        mockkObject(MapboxNavigationTelemetry)
+
+        mapboxNavigation.onDestroy()
+
+        verify(exactly = 1) { MapboxNavigationTelemetry.unregisterListeners(eq(mapboxNavigation)) }
+
+        unmockkObject(MapboxNavigationTelemetry)
+    }
+
+    @Test
+    fun unregisterAllTelemetryObserversIsCalledAfterTripSessionStop() {
+        mockkObject(MapboxNavigationTelemetry)
+
+        mapboxNavigation.onDestroy()
+
+        verifyOrder {
+            tripSession.stop()
+            MapboxNavigationTelemetry.unregisterListeners(mapboxNavigation)
+        }
+
+        unmockkObject(MapboxNavigationTelemetry)
     }
 
     @Test

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetryTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetryTest.kt
@@ -582,6 +582,7 @@ class MapboxNavigationTelemetryTest {
 
         val events = captureAndVerifyMetricsReporter(exactly = 1)
         assertTrue(events[0] is NavigationAppUserTurnstileEvent)
+        resetTelemetry()
     }
 
     @Test


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Fixes https://github.com/mapbox/mapbox-navigation-android/issues/3765

Follow up from https://github.com/mapbox/mapbox-navigation-android/pull/3751

Fixes NPE when formatting date in telemetry and avoids dropping events when destroying `MapboxNavigation`

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Avoid dropping events when destroying `MapboxNavigation`.</changelog>
<changelog>Fixed NPE when formatting date in Telemetry.</changelog>
```