### PR TITLE
Officially mark the Nav SDK v1 library Android SDK 21 dependency

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,7 +1,7 @@
 ext {
 
   androidVersions = [
-      minSdkVersion           : 19,
+      minSdkVersion           : 21,
       targetSdkVersion        : 29,
       compileSdkVersion       : 29
   ]


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
The Nav SDK v1 series always supported only devices running Lollipop or higher (due to transitive dependencies). This change makes that requirement explicit.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Explicitly mark the required min Android SDK version of 21. The Nav SDK v1 series always supported only devices running Lollipop or higher (due to transitive dependencies).</changelog>
```

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
