### PR TITLE
Fix mobile metrics parameters

### DIFF
--- a/scripts/trigger-mobile-metrics.py
+++ b/scripts/trigger-mobile-metrics.py
@@ -8,7 +8,7 @@ import requests
 import sys
 
 def TriggerPipeline(token, commit, job, run_benchmark):
-    url = "https://circleci.com/api/v1.1/project/github/mapbox/mobile-metrics/tree/master"
+    url = "https://circleci.com/api/v2/project/github/mapbox/mobile-metrics/pipeline"
 
     headers = {
         "Content-Type": "application/json",
@@ -17,13 +17,14 @@ def TriggerPipeline(token, commit, job, run_benchmark):
 
     data = {
         "parameters": {
-          "run_android_navigation_benchmark": run_benchmark
-        },
-        "build_parameters": {
-          "CIRCLE_JOB": job,
-          "BENCHMARK_COMMIT": commit
+          "run_android_navigation_benchmark": run_benchmark,
+          "mapbox_slug": "mapbox/mapbox-navigation-android",
+          "mapbox_hash": commit
         }
     }
+
+    # Use this to test your mobile-metrics branches.
+    # data["branch"]: "mobile-metrics-branch-name"
 
     response = requests.post(url, auth=(token, ""), headers=headers, json=data)
 
@@ -32,8 +33,7 @@ def TriggerPipeline(token, commit, job, run_benchmark):
       sys.exit(1)
     else:
       response_dict = json.loads(response.text)
-      build_url = response_dict['build_url']
-      print("Started %s: %s" % (job, build_url))
+      print("Started %s: %s" % (job, response_dict))
 
 def Main():
   token = os.getenv("MOBILE_METRICS_TOKEN")


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Fixing mobile metrics benchmarks, circle ci parameters were introduced in version 2. 

https://github.com/mapbox/mapbox-navigation-android/pull/3728 Introducing the ability to run mobile metrics without publishing results, made it so all benchmarks were not being published 🤦 

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
