### PR TITLE
Bump mapbox-navigation-native dependency version to 26.3.1

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -11,7 +11,7 @@ ext {
       mapboxSdkServices         : '5.8.0-beta.3',
       mapboxEvents              : '6.2.1',
       mapboxCore                : '3.1.0',
-      mapboxNavigator           : '26.3.0',
+      mapboxNavigator           : '26.3.1',
       mapboxCommonNative        : '9.1.0',
       mapboxCrashMonitor        : '2.0.0',
       mapboxAnnotationPlugin    : '0.8.0',


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Bumps `mapbox-navigation-native` dependency version to `26.3.1`

cc @etl 