### PR TITLE
Bump routing tiles version to 2020_11_15-03_00_00

### DIFF
--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/OnboardRouterOptions.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/OnboardRouterOptions.kt
@@ -65,7 +65,7 @@ class OnboardRouterOptions private constructor(
      */
     class Builder {
         private var tilesUri: URI = URI("https://api.mapbox.com")
-        private var tilesVersion: String = "2020_10_18-03_00_00"
+        private var tilesVersion: String = "2020_11_15-03_00_00"
         private var filePath: String? = null
 
         /**


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Update default routing tiles version to `2020_11_15-03_00_00`

`https://api.mapbox.com/route-tiles/v1/versions?access_token={token}`

```
{"availableVersions":["2020_11_15-03_00_00","2020_11_08-03_00_00","2020_11_01-03_00_00","2020_10_25-03_00_00","2020_10_18-03_00_00","2020_10_17-03_00_00","2020_10_11-03_00_00","2020_10_01-03_00_00","2020_09_23-03_00_00","2020_09_13-03_00_00","2020_09_11-03_00_00","2020_09_05-03_00_00","2020_08_28-03_00_00","2020_08_22-03_00_00","2020_08_14-03_00_00","2020_08_08-03_00_00","2020_08_07-03_00_00","2020_07_28-03_00_00","2020_07_25-03_00_00","2020_07_18-03_00_00","2020_07_08-03_00_00","2020_07_03-03_00_00","2020_06_25-03_00_00","2020_06_19-03_00_00","2020_06_13-03_00_00","2020_06_05-03_00_00","2020_05_30-03_00_00","2020_05_29-03_00_00","2020_05_24-03_00_00","2020_02_02-03_00_00"]}
```

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Updated default routing tiles version to `2020_11_15-03_00_00`.</changelog>
```
