### PR TITLE
Bump mapbox-java to 5.8.0-beta.4

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,7 +8,7 @@ ext {
 
   version = [
       mapboxMapSdk              : '9.6.0',
-      mapboxSdkServices         : '5.8.0-beta.3',
+      mapboxSdkServices         : '5.8.0-beta.4',
       mapboxEvents              : '6.2.1',
       mapboxCore                : '3.1.0',
       mapboxNavigator           : '26.3.1',


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Bumped version of `mapbox-java` to 5.8.0-beta.4. Exposes `active` and `validIndication` lane object information.</changelog>
```
