### PR TITLE
Backport of PR 3789

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteLine.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteLine.kt
@@ -66,6 +66,9 @@ import com.mapbox.navigation.utils.internal.parallelMap
 import com.mapbox.turf.TurfConstants
 import com.mapbox.turf.TurfException
 import com.mapbox.turf.TurfMisc
+import kotlinx.coroutines.cancelChildren
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import timber.log.Timber
 import kotlin.math.ln
 import kotlin.math.max
@@ -160,6 +163,8 @@ internal class MapRouteLine(
     private var primaryRouteLineGranularDistances: RouteLineGranularDistances? = null
     private var primaryRouteRemainingDistancesIndex: Int? = null
     private var lastIndexUpdateTimeNano: Long = 0
+    private var trafficSegmentCalculationsJob = ThreadController.getMainScopeAndRootJob()
+    private var calculateGranularDistancesJob = ThreadController.getMainScopeAndRootJob()
 
     @get:ColorInt
     private val routeLineTraveledColor: Int by lazy {
@@ -426,35 +431,17 @@ internal class MapRouteLine(
     }
 
     private fun initPrimaryRoutePoints(route: DirectionsRoute) {
-        primaryRoutePoints = parseRoutePoints(route)
-        primaryRouteLineGranularDistances =
-            calculateRouteGranularDistances(primaryRoutePoints?.flatList ?: emptyList())
-    }
-
-    /**
-     * Decodes the route geometry into nested arrays of legs -> steps -> points.
-     *
-     * The first and last point of adjacent steps overlap and are duplicated.
-     */
-    private fun parseRoutePoints(route: DirectionsRoute): RoutePoints? {
-        val precision =
-            if (route.routeOptions()?.geometries() == DirectionsCriteria.GEOMETRY_POLYLINE) {
-                Constants.PRECISION_5
-            } else {
-                Constants.PRECISION_6
-            }
-
-        val nestedList = route.legs()?.map { routeLeg ->
-            routeLeg.steps()?.map { legStep ->
-                legStep.geometry()?.let { geometry ->
-                    PolylineUtils.decode(geometry, precision).toList()
-                } ?: return null
-            } ?: return null
-        } ?: return null
-
-        val flatList = nestedList.flatten().flatten()
-
-        return RoutePoints(nestedList, flatList)
+        primaryRoutePoints = null
+        primaryRouteLineGranularDistances = null
+        calculateGranularDistancesJob.job.cancelChildren()
+        calculateGranularDistancesJob.scope.launch {
+            val parsedPoints = parseRoutePoints(route)
+            val parsedDistances = calculateRouteGranularDistances(
+                parsedPoints?.flatList ?: emptyList()
+            )
+            primaryRoutePoints = parsedPoints
+            primaryRouteLineGranularDistances = parsedDistances
+        }
     }
 
     /**
@@ -561,7 +548,6 @@ internal class MapRouteLine(
 
     fun reinitializePrimaryRoute() {
         this@MapRouteLine.routeFeatureData.firstOrNull { it.route == primaryRoute }?.let {
-            updateRouteTrafficSegments(it)
             drawPrimaryRoute(it)
             hideRouteLineAtOffset(vanishPointOffset)
             hideCasingLineAtOffset(vanishPointOffset)
@@ -578,14 +564,7 @@ internal class MapRouteLine(
             primaryRoute = this.directionsRoutes.first()
             alternativesVisible = directionsRoutes.size > 1
             allLayersAreVisible = true
-
-            val newRouteFeatureData = getRouteFeatureData().also {
-                routeFeatureData.addAll(it)
-            }
-
-            if (newRouteFeatureData.isNotEmpty()) {
-                updateRouteTrafficSegments(newRouteFeatureData.first())
-            }
+            routeFeatureData.addAll(getRouteFeatureData())
             drawWayPoints()
             updateAlternativeLayersVisibility(alternativesVisible, routeLayerIds)
             updateAllLayersVisibility(allLayersAreVisible)
@@ -604,7 +583,6 @@ internal class MapRouteLine(
             clear()
             addAll(listOf(partitionedRoutes.first, partitionedRoutes.second).flatten())
         }
-        updateRouteTrafficSegments(routeFeatureData.first())
         drawRoutes(routeFeatureData)
     }
 
@@ -833,17 +811,26 @@ internal class MapRouteLine(
             style.getLayer(PRIMARY_ROUTE_TRAFFIC_LAYER_ID)?.setProperties(lineGradient(expression))
         }
         initPrimaryRoutePoints(routeData.route)
+        applyTrafficMarkers(routeData.route)
     }
 
-    private fun updateRouteTrafficSegments(routeData: RouteFeatureData) {
-        val segments = calculateRouteLineSegments(
-            routeData.route,
-            trafficBackfillRoadClasses,
-            true,
-            ::getRouteColorForCongestion
-        )
+    private fun applyTrafficMarkers(route: DirectionsRoute) {
         routeLineExpressionData.clear()
-        routeLineExpressionData.addAll(segments)
+        trafficSegmentCalculationsJob.job.cancelChildren()
+        trafficSegmentCalculationsJob.scope.launch {
+            val segments = calculateRouteLineSegments(
+                route,
+                trafficBackfillRoadClasses,
+                true,
+                ::getRouteColorForCongestion
+            )
+            routeLineExpressionData.addAll(segments)
+            if (style.isFullyLoaded) {
+                val expression = getExpressionAtOffset(vanishPointOffset)
+                style.getLayer(PRIMARY_ROUTE_TRAFFIC_LAYER_ID)
+                    ?.setProperties(lineGradient(expression))
+            }
+        }
     }
 
     private fun drawAlternativeRoutes(routeData: List<RouteFeatureData>) {
@@ -900,6 +887,8 @@ internal class MapRouteLine(
     }
 
     fun clearRouteData() {
+        trafficSegmentCalculationsJob.job.cancelChildren()
+        calculateGranularDistancesJob.job.cancelChildren()
         vanishPointOffset = 0.0
         primaryRoutePoints = null
         primaryRouteLineGranularDistances = null
@@ -918,6 +907,33 @@ internal class MapRouteLine(
         drawnPrimaryRouteFeatureCollection = featureCollection
         primaryRouteLineSource.setGeoJson(drawnPrimaryRouteFeatureCollection)
     }
+
+    /**
+     * Decodes the route geometry into nested arrays of legs -> steps -> points.
+     *
+     * The first and last point of adjacent steps overlap and are duplicated.
+     */
+    private suspend fun parseRoutePoints(route: DirectionsRoute) =
+        withContext(ThreadController.IODispatcher) {
+            val precision =
+                if (route.routeOptions()?.geometries() == DirectionsCriteria.GEOMETRY_POLYLINE) {
+                    Constants.PRECISION_5
+                } else {
+                    Constants.PRECISION_6
+                }
+
+            val nestedList = route.legs()?.map { routeLeg ->
+                routeLeg.steps()?.map { legStep ->
+                    legStep.geometry()?.let { geometry ->
+                        PolylineUtils.decode(geometry, precision).toList()
+                    } ?: return@withContext null
+                } ?: return@withContext null
+            } ?: return@withContext null
+
+            val flatList = nestedList.flatten().flatten()
+
+            return@withContext RoutePoints(nestedList, flatList)
+        }
 
     private fun calculateRouteGranularDistances(coordinates: List<Point>):
         RouteLineGranularDistances? {
@@ -1423,14 +1439,14 @@ internal class MapRouteLine(
          * @return a list of items representing the distance offset of each route leg and the color
          * used to represent the traffic congestion.
          */
-        fun calculateRouteLineSegments(
+        suspend fun calculateRouteLineSegments(
             route: DirectionsRoute,
             trafficBackfillRoadClasses: List<String>,
             isPrimaryRoute: Boolean,
             congestionColorProvider: (String, Boolean) -> Int
-        ): List<RouteLineExpressionData> {
+        ) = withContext(ThreadController.IODispatcher) {
             val trafficExpressionData = getRouteLineTrafficExpressionData(route)
-            return when (trafficExpressionData.isEmpty()) {
+            return@withContext when (trafficExpressionData.isEmpty()) {
                 false -> getRouteLineExpressionDataWithStreetClassOverride(
                     trafficExpressionData,
                     route.distance(),

--- a/libtesting-utils/src/main/java/com/mapbox/navigation/testing/MainCoroutineRule.kt
+++ b/libtesting-utils/src/main/java/com/mapbox/navigation/testing/MainCoroutineRule.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.test.setMain
 import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
+import kotlin.jvm.Throws
 
 @ExperimentalCoroutinesApi
 class MainCoroutineRule : TestRule {


### PR DESCRIPTION
### Description
Backport of PR 3789 which was responsible for moving expensive route line related calculations off of the main thread.

### Changelog
<changelog>Route line calculations moved off of the main thread in order to improve performance and resolve ANR issue for long routes.</changelog>


### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
