### PR TITLE
Expose GeoJsonOptions#withTolerance param for route line sources

### DIFF
--- a/libnavigation-ui/api/current.txt
+++ b/libnavigation-ui/api/current.txt
@@ -527,6 +527,8 @@ package com.mapbox.navigation.ui.map {
     method public com.mapbox.navigation.ui.map.NavigationMapboxMap.Builder! vanishRouteLineEnabled(boolean);
     method public com.mapbox.navigation.ui.map.NavigationMapboxMap.Builder! vanishingRouteLineUpdateIntervalNano(long);
     method public com.mapbox.navigation.ui.map.NavigationMapboxMap.Builder! withRouteClickPadding(float);
+    method public com.mapbox.navigation.ui.map.NavigationMapboxMap.Builder withSourceMaxZoom(int);
+    method public com.mapbox.navigation.ui.map.NavigationMapboxMap.Builder withSourceTolerance(float);
   }
 
   public interface OnWayNameChangedListener {
@@ -638,6 +640,8 @@ package com.mapbox.navigation.ui.route {
     method public com.mapbox.navigation.ui.route.NavigationMapRoute.Builder withRouteClickPadding(float);
     method public com.mapbox.navigation.ui.route.NavigationMapRoute.Builder withRouteLineInitializedCallback(com.mapbox.navigation.ui.route.MapRouteLineInitializedCallback?);
     method public com.mapbox.navigation.ui.route.NavigationMapRoute.Builder withRouteStyleDescriptors(java.util.List<com.mapbox.navigation.ui.route.RouteStyleDescriptor!>!);
+    method public com.mapbox.navigation.ui.route.NavigationMapRoute.Builder withSourceMaxZoom(int);
+    method public com.mapbox.navigation.ui.route.NavigationMapRoute.Builder withSourceTolerance(float);
     method public com.mapbox.navigation.ui.route.NavigationMapRoute.Builder withStyle(@StyleRes int);
     method public com.mapbox.navigation.ui.route.NavigationMapRoute.Builder withVanishRouteLineEnabled(boolean);
     method public com.mapbox.navigation.ui.route.NavigationMapRoute.Builder withVanishingRouteLineUpdateIntervalNano(long);

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/internal/route/RouteConstants.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/internal/route/RouteConstants.java
@@ -54,4 +54,6 @@ public class RouteConstants {
   public static final float DEFAULT_ROUTE_CLICK_PADDING_IN_DIP = 30f;
   public static final double MAX_ELAPSED_SINCE_INDEX_UPDATE_NANO = 1_500_000_000; // 1.5s
   public static final double ROUTE_LINE_UPDATE_MAX_DISTANCE_THRESHOLD_IN_METERS = 3.0;
+  public static final int DEFAULT_ROUTE_SOURCES_MAX_ZOOM = 16;
+  public static final float DEFAULT_ROUTE_SOURCES_TOLERANCE = 0.375f;
 }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteArrow.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteArrow.java
@@ -97,7 +97,8 @@ class MapRouteArrow {
   private final MapboxMap mapboxMap;
   private boolean isVisible = true;
 
-  MapRouteArrow(@NonNull MapView mapView, MapboxMap mapboxMap, @StyleRes int styleRes, @NonNull String aboveLayer) {
+  MapRouteArrow(@NonNull MapView mapView, MapboxMap mapboxMap, @StyleRes int styleRes, @NonNull String aboveLayer,
+                int sourceMaxZoom, float sourceTolerance) {
     this.mapView = mapView;
     this.mapboxMap = mapboxMap;
     this.maneuverPoints = new ArrayList<>();
@@ -110,7 +111,7 @@ class MapRouteArrow {
             ContextCompat.getColor(context, R.color.mapbox_navigation_route_upcoming_maneuver_arrow_border_color));
     typedArray.recycle();
 
-    initialize(aboveLayer);
+    initialize(aboveLayer, sourceMaxZoom, sourceTolerance);
     updateVisibilityTo(isVisible);
   }
 
@@ -191,9 +192,9 @@ class MapRouteArrow {
     arrowHeadGeoJsonSource.setGeoJson(arrowHeadGeoJsonFeature);
   }
 
-  private void initialize(@NonNull String aboveLayer) {
-    initializeArrowShaft();
-    initializeArrowHead();
+  private void initialize(@NonNull String aboveLayer, int sourceMaxZoom, float sourceTolerance) {
+    initializeArrowShaft(sourceMaxZoom, sourceTolerance);
+    initializeArrowHead(sourceMaxZoom, sourceTolerance);
 
     addArrowHeadIcon();
     addArrowHeadIconCasing();
@@ -212,20 +213,26 @@ class MapRouteArrow {
     createArrowLayerList(shaftLayer, shaftCasingLayer, headLayer, headCasingLayer);
   }
 
-  private void initializeArrowShaft() {
+  private void initializeArrowShaft(int sourceMaxZoom, float sourceTolerance) {
+    GeoJsonOptions geoJsonOptions = new GeoJsonOptions();
+    geoJsonOptions.withMaxZoom(sourceMaxZoom);
+    geoJsonOptions.withTolerance(sourceTolerance);
     arrowShaftGeoJsonSource = new GeoJsonSource(
             ARROW_SHAFT_SOURCE_ID,
             FeatureCollection.fromFeatures(new Feature[]{}),
-            new GeoJsonOptions().withMaxZoom(16)
+            geoJsonOptions
     );
     mapboxMap.getStyle().addSource(arrowShaftGeoJsonSource);
   }
 
-  private void initializeArrowHead() {
+  private void initializeArrowHead(int sourceMaxZoom, float sourceTolerance) {
+    GeoJsonOptions geoJsonOptions = new GeoJsonOptions();
+    geoJsonOptions.withMaxZoom(sourceMaxZoom);
+    geoJsonOptions.withTolerance(sourceTolerance);
     arrowHeadGeoJsonSource = new GeoJsonSource(
             ARROW_HEAD_SOURCE_ID,
             FeatureCollection.fromFeatures(new Feature[]{}),
-            new GeoJsonOptions().withMaxZoom(16)
+            geoJsonOptions
     );
     mapboxMap.getStyle().addSource(arrowHeadGeoJsonSource);
   }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteLine.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteLine.kt
@@ -111,7 +111,9 @@ internal class MapRouteLine(
     alternativesVisible: Boolean,
     mapRouteSourceProvider: MapRouteSourceProvider,
     vanishPoint: Double,
-    routeLineInitializedCallback: MapRouteLineInitializedCallback?
+    routeLineInitializedCallback: MapRouteLineInitializedCallback?,
+    sourceMaxZoom: Int,
+    sourceTolerance: Float
 ) {
 
     /**
@@ -129,7 +131,9 @@ internal class MapRouteLine(
         belowLayerId: String?,
         layerProvider: RouteLayerProvider,
         mapRouteSourceProvider: MapRouteSourceProvider,
-        routeLineInitializedCallback: MapRouteLineInitializedCallback?
+        routeLineInitializedCallback: MapRouteLineInitializedCallback?,
+        sourceMaxZoom: Int,
+        sourceTolerance: Float
     ) : this(
         context,
         style,
@@ -142,7 +146,9 @@ internal class MapRouteLine(
         true,
         mapRouteSourceProvider,
         0.0,
-        routeLineInitializedCallback
+        routeLineInitializedCallback,
+        sourceMaxZoom,
+        sourceTolerance
     )
 
     private var drawnWaypointsFeatureCollection: FeatureCollection =
@@ -375,7 +381,10 @@ internal class MapRouteLine(
             initPrimaryRoutePoints(routeFeatureData.first().route)
         }
 
-        val wayPointGeoJsonOptions = GeoJsonOptions().withMaxZoom(16)
+        val wayPointGeoJsonOptions = GeoJsonOptions().apply {
+            withMaxZoom(sourceMaxZoom)
+            withTolerance(sourceTolerance)
+        }
         wayPointSource = mapRouteSourceProvider.build(
             WAYPOINT_SOURCE_ID,
             drawnWaypointsFeatureCollection,
@@ -383,7 +392,11 @@ internal class MapRouteLine(
         )
         style.addSource(wayPointSource)
 
-        val routeLineGeoJsonOptions = GeoJsonOptions().withMaxZoom(16).withLineMetrics(true)
+        val routeLineGeoJsonOptions = GeoJsonOptions().apply {
+            withLineMetrics(true)
+            withMaxZoom(sourceMaxZoom)
+            withTolerance(sourceTolerance)
+        }
         primaryRouteLineSource = mapRouteSourceProvider.build(
             PRIMARY_ROUTE_SOURCE_ID,
             drawnPrimaryRouteFeatureCollection,
@@ -391,8 +404,11 @@ internal class MapRouteLine(
         )
         style.addSource(primaryRouteLineSource)
 
-        val alternativeRouteLineGeoJsonOptions =
-            GeoJsonOptions().withMaxZoom(16).withLineMetrics(true)
+        val alternativeRouteLineGeoJsonOptions = GeoJsonOptions().apply {
+            withLineMetrics(true)
+            withMaxZoom(sourceMaxZoom)
+            withTolerance(sourceTolerance)
+        }
         alternativeRouteLineSource = mapRouteSourceProvider.build(
             ALTERNATIVE_ROUTE_SOURCE_ID,
             drawnAlternativeRouteFeatureCollection,

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteLineTest.kt
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/MapRouteLineTest.kt
@@ -25,6 +25,7 @@ import com.mapbox.mapboxsdk.style.layers.FillLayer
 import com.mapbox.mapboxsdk.style.layers.LineLayer
 import com.mapbox.mapboxsdk.style.layers.PropertyValue
 import com.mapbox.mapboxsdk.style.layers.SymbolLayer
+import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.base.trip.model.RouteProgressState
@@ -232,12 +233,35 @@ class MapRouteLineTest {
             null,
             layerProvider,
             mapRouteSourceProvider,
-            null
+            null,
+            16,
+            0.375f
         ).also { it.draw(listOf(directionsRoute)) }
 
         val result = mapRouteLine.getPrimaryRoute()
 
         assertEquals(result, directionsRoute)
+    }
+
+    @Test
+    fun createMapRouteLine_geoJsonOptionsCorrect() = coroutineRule.runBlockingTest {
+        val expected = GeoJsonOptions().withTolerance(0.2f).withMaxZoom(19)
+
+        every { style.layers } returns listOf(primaryRouteLayer)
+        val directionsRoute: DirectionsRoute = getDirectionsRoute(true)
+        MapRouteLine(
+            ctx,
+            style,
+            styleRes,
+            null,
+            layerProvider,
+            mapRouteSourceProvider,
+            null,
+            19,
+            0.2f
+        ).also { it.draw(listOf(directionsRoute)) }
+
+        verify { mapRouteSourceProvider.build(any(), any(), eq(expected)) }
     }
 
     @Test
@@ -251,7 +275,9 @@ class MapRouteLineTest {
             null,
             layerProvider,
             mapRouteSourceProvider,
-            null
+            null,
+            16,
+            0.375f
         ).also { it.draw(listOf(directionsRoute)) }
 
         val result = mapRouteLine.getLineStringForRoute(directionsRoute)
@@ -271,7 +297,9 @@ class MapRouteLineTest {
             null,
             layerProvider,
             mapRouteSourceProvider,
-            null
+            null,
+            16,
+            0.375f
         ).also { it.draw(listOf(directionsRoute)) }
 
         val result = mapRouteLine.getLineStringForRoute(directionsRoute2)
@@ -290,7 +318,9 @@ class MapRouteLineTest {
             null,
             layerProvider,
             mapRouteSourceProvider,
-            null
+            null,
+            16,
+            0.375f
         ).also { it.draw(listOf(directionsRoute)) }
 
         val result = mapRouteLine.retrieveRouteFeatureData()
@@ -310,7 +340,9 @@ class MapRouteLineTest {
             null,
             layerProvider,
             mapRouteSourceProvider,
-            null
+            null,
+            16,
+            0.375f
         ).also { it.draw(listOf(directionsRoute)) }
 
         val result = mapRouteLine.retrieveRouteLineStrings()
@@ -329,7 +361,9 @@ class MapRouteLineTest {
             null,
             layerProvider,
             mapRouteSourceProvider,
-            null
+            null,
+            16,
+            0.375f
         ).also { it.draw(listOf(directionsRoute)) }
 
         val result = mapRouteLine.retrieveDirectionsRoutes()
@@ -350,7 +384,9 @@ class MapRouteLineTest {
             null,
             layerProvider,
             mapRouteSourceProvider,
-            null
+            null,
+            16,
+            0.375f
         ).also { it.draw(directionsRoutes) }
         directionsRoutes.reverse()
 
@@ -387,7 +423,9 @@ class MapRouteLineTest {
             false,
             mapRouteSourceProvider,
             0.0,
-            null
+            null,
+            16,
+            0.375f
         )
 
         val result = mapRouteLine.retrieveDirectionsRoutes()
@@ -405,7 +443,9 @@ class MapRouteLineTest {
             null,
             layerProvider,
             mapRouteSourceProvider,
-            null
+            null,
+            16,
+            0.375f
         )
 
         val result = mapRouteLine.getTopLayerId()
@@ -425,7 +465,9 @@ class MapRouteLineTest {
             null,
             layerProvider,
             mapRouteSourceProvider,
-            null
+            null,
+            16,
+            0.375f
         ).also { it.draw(listOf(directionsRoute, directionsRoute2)) }
         val routeFeatureData = mapRouteLine.retrieveRouteFeatureData()
 
@@ -813,7 +855,9 @@ class MapRouteLineTest {
             null,
             layerProvider,
             mapRouteSourceProvider,
-            null
+            null,
+            16,
+            0.375f
         ).also { it.draw(listOf(route)) }
 
         val expression = mapRouteLine.getExpressionAtOffset(.2)
@@ -833,7 +877,9 @@ class MapRouteLineTest {
             null,
             layerProvider,
             mapRouteSourceProvider,
-            null
+            null,
+            16,
+            0.375f
         ).also { it.draw(listOf(route)) }
 
         val expression = mapRouteLine.getExpressionAtOffset(0.0)
@@ -855,7 +901,9 @@ class MapRouteLineTest {
             null,
             layerProvider,
             mapRouteSourceProvider,
-            null
+            null,
+            16,
+            0.375f
         ).also { it.draw(listOf(route)) }
 
         val expression = mapRouteLine.getExpressionAtOffset(.2)
@@ -877,7 +925,9 @@ class MapRouteLineTest {
             null,
             layerProvider,
             mapRouteSourceProvider,
-            null
+            null,
+            16,
+            0.375f
         ).also { it.draw(listOf(route)) }
 
         val expression = mapRouteLine.getExpressionAtOffset(.9)
@@ -989,7 +1039,9 @@ class MapRouteLineTest {
             null,
             layerProvider,
             mapRouteSourceProvider,
-            null
+            null,
+            16,
+            0.375f
         )
 
         val result =
@@ -1008,7 +1060,9 @@ class MapRouteLineTest {
             null,
             layerProvider,
             mapRouteSourceProvider,
-            null
+            null,
+            16,
+            0.375f
         )
 
         val result =
@@ -1027,7 +1081,9 @@ class MapRouteLineTest {
             null,
             layerProvider,
             mapRouteSourceProvider,
-            null
+            null,
+            16,
+            0.375f
         )
 
         val result =
@@ -1046,7 +1102,9 @@ class MapRouteLineTest {
             null,
             layerProvider,
             mapRouteSourceProvider,
-            null
+            null,
+            16,
+            0.375f
         )
 
         val result =
@@ -1065,7 +1123,9 @@ class MapRouteLineTest {
             null,
             layerProvider,
             mapRouteSourceProvider,
-            null
+            null,
+            16,
+            0.375f
         )
 
         val result = mapRouteLine.getRouteColorForCongestion("foobar", true)
@@ -1083,7 +1143,9 @@ class MapRouteLineTest {
             null,
             layerProvider,
             mapRouteSourceProvider,
-            null
+            null,
+            16,
+            0.375f
         )
 
         val result =
@@ -1102,7 +1164,9 @@ class MapRouteLineTest {
             null,
             layerProvider,
             mapRouteSourceProvider,
-            null
+            null,
+            16,
+            0.375f
         )
 
         val result =
@@ -1121,7 +1185,9 @@ class MapRouteLineTest {
             null,
             layerProvider,
             mapRouteSourceProvider,
-            null
+            null,
+            16,
+            0.375f
         )
 
         val result =
@@ -1140,7 +1206,9 @@ class MapRouteLineTest {
             null,
             layerProvider,
             mapRouteSourceProvider,
-            null
+            null,
+            16,
+            0.375f
         )
 
         val result =
@@ -1159,7 +1227,9 @@ class MapRouteLineTest {
             null,
             layerProvider,
             mapRouteSourceProvider,
-            null
+            null,
+            16,
+            0.375f
         )
 
         val result = mapRouteLine.getRouteColorForCongestion("foobar", false)
@@ -1178,7 +1248,9 @@ class MapRouteLineTest {
             null,
             layerProvider,
             mapRouteSourceProvider,
-            null
+            null,
+            16,
+            0.375f
         )
 
         mapRouteLine.reinitializeWithRoutes(listOf(route))
@@ -1215,7 +1287,9 @@ class MapRouteLineTest {
             null,
             layerProvider,
             mapRouteSourceProvider,
-            null
+            null,
+            16,
+            0.375f
         )
 
         mapRouteLine.reinitializeWithRoutes(listOf(route))
@@ -1241,7 +1315,9 @@ class MapRouteLineTest {
             false,
             mapRouteSourceProvider,
             0.0,
-            null
+            null,
+            16,
+            0.375f
         )
 
         val expression = mapRouteLine.getExpressionAtOffset(.2)
@@ -1687,7 +1763,9 @@ class MapRouteLineTest {
             null,
             layerProvider,
             mapRouteSourceProvider,
-            callback
+            callback,
+            16,
+            0.375f
         )
 
         verify {
@@ -1775,7 +1853,9 @@ class MapRouteLineTest {
             false,
             mapRouteSourceProvider,
             0.0,
-            null
+            null,
+            16,
+            0.375f
         )
         val primaryRouteBeforeRecreate = mapRouteLine.getPrimaryRoute()
 
@@ -1792,7 +1872,9 @@ class MapRouteLineTest {
             mapRouteLine.retrieveAlternativesVisible(),
             mapRouteSourceProvider,
             0.0,
-            null
+            null,
+            16,
+            0.375f
         )
 
         assertEquals(primaryRouteBeforeRecreate, firstRoute)
@@ -2102,7 +2184,9 @@ class MapRouteLineTest {
             null,
             layerProvider,
             mapRouteSourceProvider,
-            null
+            null,
+            16,
+            0.375f
         ).also { it.draw(listOf(primaryRoute, alternativeRoute)) }
         val featurePrimary = mockk<Feature> {
             every { id() } returns mapRouteLine.retrieveRouteFeatureData()[0]
@@ -2170,7 +2254,9 @@ class MapRouteLineTest {
             null,
             layerProvider,
             mapRouteSourceProvider,
-            null
+            null,
+            16,
+            0.375f
         ).also { it.draw(listOf(primaryRoute, alternativeRoute)) }
         val featurePrimary = mockk<Feature> {
             every { id() } returns mapRouteLine.retrieveRouteFeatureData()[0]
@@ -2239,7 +2325,9 @@ class MapRouteLineTest {
             null,
             layerProvider,
             mapRouteSourceProvider,
-            null
+            null,
+            16,
+            0.375f
         ).also { it.draw(listOf(primaryRoute, firstAlternativeRoute, secondAlternativeRoute)) }
         val featureAlternative = mockk<Feature> {
             every { id() } returns mapRouteLine.retrieveRouteFeatureData()[2]
@@ -2302,7 +2390,9 @@ class MapRouteLineTest {
             null,
             layerProvider,
             mapRouteSourceProvider,
-            null
+            null,
+            16,
+            0.375f
         ).also { it.draw(listOf(primaryRoute, firstAlternativeRoute, secondAlternativeRoute)) }
         val featureAlternative = mockk<Feature> {
             every { id() } returns mapRouteLine.retrieveRouteFeatureData()[2]
@@ -2365,7 +2455,9 @@ class MapRouteLineTest {
             null,
             layerProvider,
             mapRouteSourceProvider,
-            null
+            null,
+            16,
+            0.375f
         ).also { it.draw(listOf(primaryRoute, firstAlternativeRoute, secondAlternativeRoute)) }
         val featurePrimary = mockk<Feature> {
             every { id() } returns "whatever"
@@ -2452,7 +2544,9 @@ class MapRouteLineTest {
             null,
             layerProvider,
             mapRouteSourceProvider,
-            null
+            null,
+            16,
+            0.375f
         )
     }
 


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
The runtime sources that we generate to provide data for the route line elements are `GeoJsonSource`s that support a various degree of simplification when tiled on the device. In specific scenarios, when we have the data that's precise enough, we can decrease the tolerance to increase the precision of the display on the map geometry.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Expose GeoJsonOptions#withTolerance param for route line sources.</changelog>
```

/cc @tmpsantos 