### PR TITLE
Bump mapboxEvents and mapboxCore dependency versions to 6.2.2 and 3.1.1 respectively

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -9,8 +9,8 @@ ext {
   version = [
       mapboxMapSdk              : '9.6.0',
       mapboxSdkServices         : '5.8.0-beta.4',
-      mapboxEvents              : '6.2.1',
-      mapboxCore                : '3.1.0',
+      mapboxEvents              : '6.2.2',
+      mapboxCore                : '3.1.1',
       mapboxNavigator           : '26.3.1',
       mapboxCommonNative        : '9.1.0',
       mapboxCrashMonitor        : '2.0.0',


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Bumps `mapboxEvents` and `mapboxCore` dependency versions to `6.2.2` and `3.1.1` respectively

Refs. https://github.com/mapbox/mapbox-navigation-android/pull/3804 https://github.com/mapbox/mapbox-events-android/issues/506

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Added `equals` and `hashCode` support for `LocationEngineRequest` in Mapbox Events library so it's possible to compare `NavigationOptions` classes.</changelog>
```

cc @zugaldia @alfwatt @brunoabinader 