### PR TITLE
add speed limit to map matcher

### DIFF
--- a/libnavigation-base/api/current.txt
+++ b/libnavigation-base/api/current.txt
@@ -186,6 +186,31 @@ package com.mapbox.navigation.base.route {
 
 }
 
+package com.mapbox.navigation.base.speed.model {
+
+  public final class SpeedLimit {
+    ctor public SpeedLimit(Integer? speedKmph, com.mapbox.navigation.base.speed.model.SpeedLimitUnit speedLimitUnit, com.mapbox.navigation.base.speed.model.SpeedLimitSign speedLimitSign);
+    method public Integer? component1();
+    method public com.mapbox.navigation.base.speed.model.SpeedLimitUnit component2();
+    method public com.mapbox.navigation.base.speed.model.SpeedLimitSign component3();
+    method public com.mapbox.navigation.base.speed.model.SpeedLimit copy(Integer? speedKmph, com.mapbox.navigation.base.speed.model.SpeedLimitUnit speedLimitUnit, com.mapbox.navigation.base.speed.model.SpeedLimitSign speedLimitSign);
+    method public Integer? getSpeedKmph();
+    method public com.mapbox.navigation.base.speed.model.SpeedLimitSign getSpeedLimitSign();
+    method public com.mapbox.navigation.base.speed.model.SpeedLimitUnit getSpeedLimitUnit();
+  }
+
+  public enum SpeedLimitSign {
+    enum_constant public static final com.mapbox.navigation.base.speed.model.SpeedLimitSign MUTCD;
+    enum_constant public static final com.mapbox.navigation.base.speed.model.SpeedLimitSign VIENNA;
+  }
+
+  public enum SpeedLimitUnit {
+    enum_constant public static final com.mapbox.navigation.base.speed.model.SpeedLimitUnit KILOMETRES_PER_HOUR;
+    enum_constant public static final com.mapbox.navigation.base.speed.model.SpeedLimitUnit MILES_PER_HOUR;
+  }
+
+}
+
 package com.mapbox.navigation.base.time.span {
 
   public final class SpanExKt {

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/speed/model/SpeedLimit.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/speed/model/SpeedLimit.kt
@@ -1,0 +1,13 @@
+package com.mapbox.navigation.base.speed.model
+
+/**
+ * Object that holds speed limit properties
+ * @property speedKmph speed limit in kilometers per hour (optional)
+ * @property speedLimitUnit [SpeedLimitUnit]
+ * @property speedLimitSign [SpeedLimitSign]
+ */
+data class SpeedLimit(
+    val speedKmph: Int?,
+    val speedLimitUnit: SpeedLimitUnit,
+    val speedLimitSign: SpeedLimitSign
+)

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/speed/model/SpeedLimitSign.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/speed/model/SpeedLimitSign.kt
@@ -1,0 +1,16 @@
+package com.mapbox.navigation.base.speed.model
+
+/**
+ * Defines Speed Limit Sign
+ */
+enum class SpeedLimitSign {
+    /**
+     * Speed limit sign that follows MUTCD conventions
+     */
+    MUTCD,
+
+    /**
+     * Speed limit sign that follows VIENNA conventions
+     */
+    VIENNA
+}

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/speed/model/SpeedLimitUnit.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/speed/model/SpeedLimitUnit.kt
@@ -1,0 +1,16 @@
+package com.mapbox.navigation.base.speed.model
+
+/**
+ * Defines Speed Limit Unit
+ */
+enum class SpeedLimitUnit {
+    /**
+     * Speed limit in kilometers per hour
+     */
+    KILOMETRES_PER_HOUR,
+
+    /**
+     * Speed limit in miles per hour
+     */
+    MILES_PER_HOUR
+}

--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -604,6 +604,7 @@ package com.mapbox.navigation.core.trip.session {
     method public java.util.List<android.location.Location> getKeyPoints();
     method public float getOffRoadProbability();
     method public float getRoadEdgeMatchProbability();
+    method public com.mapbox.navigation.base.speed.model.SpeedLimit? getSpeedLimit();
     method public boolean isOffRoad();
     method public boolean isTeleport();
   }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/navigator/NavigatorMapper.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/navigator/NavigatorMapper.kt
@@ -1,7 +1,12 @@
 package com.mapbox.navigation.core.navigator
 
+import com.mapbox.navigation.base.speed.model.SpeedLimit
 import com.mapbox.navigation.core.trip.session.MapMatcherResult
 import com.mapbox.navigation.navigator.internal.TripStatus
+import com.mapbox.navigation.utils.internal.ifNonNull
+import com.mapbox.navigator.NavigationStatus
+import com.mapbox.navigator.SpeedLimitSign
+import com.mapbox.navigator.SpeedLimitUnit
 
 internal fun TripStatus.getMapMatcherResult(): MapMatcherResult {
     return MapMatcherResult(
@@ -10,6 +15,26 @@ internal fun TripStatus.getMapMatcherResult(): MapMatcherResult {
         navigationStatus.offRoadProba > 0.5,
         navigationStatus.offRoadProba,
         navigationStatus.map_matcher_output.isTeleport,
+        navigationStatus.prepareSpeedLimit(),
         navigationStatus.map_matcher_output.matches.firstOrNull()?.proba ?: 0f
     )
+}
+
+internal fun NavigationStatus.prepareSpeedLimit(): SpeedLimit? {
+    return ifNonNull(speedLimit) { limit ->
+        val speedLimitUnit = when (limit.localeUnit) {
+            SpeedLimitUnit.KILOMETRES_PER_HOUR ->
+                com.mapbox.navigation.base.speed.model.SpeedLimitUnit.KILOMETRES_PER_HOUR
+            else -> com.mapbox.navigation.base.speed.model.SpeedLimitUnit.MILES_PER_HOUR
+        }
+        val speedLimitSign = when (limit.localeSign) {
+            SpeedLimitSign.MUTCD -> com.mapbox.navigation.base.speed.model.SpeedLimitSign.MUTCD
+            else -> com.mapbox.navigation.base.speed.model.SpeedLimitSign.VIENNA
+        }
+        SpeedLimit(
+            limit.speedKmph,
+            speedLimitUnit,
+            speedLimitSign
+        )
+    }
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapMatcherResult.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapMatcherResult.kt
@@ -1,6 +1,7 @@
 package com.mapbox.navigation.core.trip.session
 
 import android.location.Location
+import com.mapbox.navigation.base.speed.model.SpeedLimit
 
 /**
  * Provides information about the status of the enhanced location updates generated
@@ -16,6 +17,7 @@ import android.location.Location
  * @param isTeleport returns true if map matcher changed its opinion about most probable path on last update.
  * In practice it means we don't need to animate puck movement from previous to current location
  * and just do an immediate transition instead.
+ * @param speedLimit current speed limit during free drive and active navigation session
  * @param roadEdgeMatchProbability when map matcher snaps to a road, this is the confidence in the chosen edge from all nearest edges.
  */
 class MapMatcherResult internal constructor(
@@ -24,6 +26,7 @@ class MapMatcherResult internal constructor(
     val isOffRoad: Boolean,
     val offRoadProbability: Float,
     val isTeleport: Boolean,
+    val speedLimit: SpeedLimit?,
     val roadEdgeMatchProbability: Float
 ) {
 
@@ -41,6 +44,7 @@ class MapMatcherResult internal constructor(
         if (isOffRoad != other.isOffRoad) return false
         if (offRoadProbability != other.offRoadProbability) return false
         if (isTeleport != other.isTeleport) return false
+        if (speedLimit != other.speedLimit) return false
         if (roadEdgeMatchProbability != other.roadEdgeMatchProbability) return false
 
         return true
@@ -55,6 +59,7 @@ class MapMatcherResult internal constructor(
         result = 31 * result + isOffRoad.hashCode()
         result = 31 * result + offRoadProbability.hashCode()
         result = 31 * result + isTeleport.hashCode()
+        result = 31 * result + speedLimit.hashCode()
         result = 31 * result + roadEdgeMatchProbability.hashCode()
         return result
     }
@@ -65,6 +70,7 @@ class MapMatcherResult internal constructor(
     override fun toString(): String {
         return "MapMatcherResult(enhancedLocation=$enhancedLocation, " +
             "keyPoints=$keyPoints, isOffRoad=$isOffRoad, offRoadProbability=$offRoadProbability, " +
-            "isTeleport=$isTeleport, roadEdgeMatchProbability=$roadEdgeMatchProbability)"
+            "isTeleport=$isTeleport, speedLimit=$speedLimit, " +
+            "roadEdgeMatchProbability=$roadEdgeMatchProbability)"
     }
 }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/navigator/NavigatorMapperTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/navigator/NavigatorMapperTest.kt
@@ -1,9 +1,12 @@
 package com.mapbox.navigation.core.navigator
 
 import android.location.Location
+import com.mapbox.navigation.base.speed.model.SpeedLimit
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.trip.session.MapMatcherResult
 import com.mapbox.navigation.navigator.internal.TripStatus
+import com.mapbox.navigator.SpeedLimitSign
+import com.mapbox.navigator.SpeedLimitUnit
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.Assert.assertEquals
@@ -25,6 +28,7 @@ class NavigatorMapperTest {
             offRoute,
             mockk {
                 every { offRoadProba } returns 0f
+                every { speedLimit } returns createSpeedLimit()
                 every { map_matcher_output } returns mockk {
                     every { isTeleport } returns false
                     every { matches } returns listOf(
@@ -41,6 +45,11 @@ class NavigatorMapperTest {
             isOffRoad = false,
             offRoadProbability = 0f,
             isTeleport = false,
+            SpeedLimit(
+                10,
+                com.mapbox.navigation.base.speed.model.SpeedLimitUnit.KILOMETRES_PER_HOUR,
+                com.mapbox.navigation.base.speed.model.SpeedLimitSign.MUTCD
+            ),
             roadEdgeMatchProbability = 1f
         )
 
@@ -58,6 +67,7 @@ class NavigatorMapperTest {
             offRoute,
             mockk {
                 every { offRoadProba } returns 0.5f
+                every { speedLimit } returns createSpeedLimit()
                 every { map_matcher_output } returns mockk {
                     every { isTeleport } returns false
                     every { matches } returns listOf(
@@ -74,6 +84,11 @@ class NavigatorMapperTest {
             isOffRoad = false,
             offRoadProbability = 0.5f,
             isTeleport = false,
+            SpeedLimit(
+                10,
+                com.mapbox.navigation.base.speed.model.SpeedLimitUnit.KILOMETRES_PER_HOUR,
+                com.mapbox.navigation.base.speed.model.SpeedLimitSign.MUTCD
+            ),
             roadEdgeMatchProbability = 1f
         )
 
@@ -91,6 +106,7 @@ class NavigatorMapperTest {
             offRoute,
             mockk {
                 every { offRoadProba } returns 0.500009f
+                every { speedLimit } returns createSpeedLimit()
                 every { map_matcher_output } returns mockk {
                     every { isTeleport } returns false
                     every { matches } returns listOf(
@@ -107,6 +123,11 @@ class NavigatorMapperTest {
             isOffRoad = true,
             offRoadProbability = 0.500009f,
             isTeleport = false,
+            SpeedLimit(
+                10,
+                com.mapbox.navigation.base.speed.model.SpeedLimitUnit.KILOMETRES_PER_HOUR,
+                com.mapbox.navigation.base.speed.model.SpeedLimitSign.MUTCD
+            ),
             roadEdgeMatchProbability = 1f
         )
 
@@ -124,6 +145,7 @@ class NavigatorMapperTest {
             offRoute,
             mockk {
                 every { offRoadProba } returns 0f
+                every { speedLimit } returns createSpeedLimit()
                 every { map_matcher_output } returns mockk {
                     every { isTeleport } returns true
                     every { matches } returns listOf(
@@ -140,6 +162,11 @@ class NavigatorMapperTest {
             isOffRoad = false,
             offRoadProbability = 0f,
             isTeleport = true,
+            SpeedLimit(
+                10,
+                com.mapbox.navigation.base.speed.model.SpeedLimitUnit.KILOMETRES_PER_HOUR,
+                com.mapbox.navigation.base.speed.model.SpeedLimitSign.MUTCD
+            ),
             roadEdgeMatchProbability = 1f
         )
 
@@ -157,6 +184,7 @@ class NavigatorMapperTest {
             offRoute,
             mockk {
                 every { offRoadProba } returns 1f
+                every { speedLimit } returns createSpeedLimit()
                 every { map_matcher_output } returns mockk {
                     every { isTeleport } returns false
                     every { matches } returns listOf()
@@ -169,11 +197,24 @@ class NavigatorMapperTest {
             isOffRoad = true,
             offRoadProbability = 1f,
             isTeleport = false,
+            SpeedLimit(
+                10,
+                com.mapbox.navigation.base.speed.model.SpeedLimitUnit.KILOMETRES_PER_HOUR,
+                com.mapbox.navigation.base.speed.model.SpeedLimitSign.MUTCD
+            ),
             roadEdgeMatchProbability = 0f
         )
 
         val result = tripStatus.getMapMatcherResult()
 
         assertEquals(expected, result)
+    }
+
+    private fun createSpeedLimit(): com.mapbox.navigator.SpeedLimit {
+        return com.mapbox.navigator.SpeedLimit(
+            10,
+            SpeedLimitUnit.KILOMETRES_PER_HOUR,
+            SpeedLimitSign.MUTCD
+        )
     }
 }


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Fixes [#126](https://github.com/mapbox/navigation-sdks/issues/126)
The PR adds speed limit to `MapMatcherResult`

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Added speedLimit to MapMatcher.</changelog>
```

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
