### PR TITLE
FeedbackFlow: added `fun onFeedbackFlowFinished`

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationFeedbackFlowListener.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationFeedbackFlowListener.kt
@@ -22,4 +22,8 @@ internal class NavigationFeedbackFlowListener(
     override fun onArrivalExperienceFeedbackFinished(arrivalFeedbackItem: FeedbackItem) {
         navigationViewModel.updateFeedback(arrivalFeedbackItem)
     }
+
+    override fun onFeedbackFlowFinished() {
+        // do nothing
+    }
 }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/internal/feedback/FeedbackArrivalFragment.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/internal/feedback/FeedbackArrivalFragment.kt
@@ -78,6 +78,11 @@ class FeedbackArrivalFragment : DialogFragment() {
         initListeners()
     }
 
+    override fun dismiss() {
+        feedbackFlowListener.onFeedbackFlowFinished()
+        super.dismiss()
+    }
+
     private fun initView() {
         cancelBtn.setColorFilter(Color.WHITE)
         initTitleTextView()

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/internal/feedback/FeedbackDetailsFragment.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/internal/feedback/FeedbackDetailsFragment.kt
@@ -219,6 +219,8 @@ class FeedbackDetailsFragment : DialogFragment() {
         )
         if (arrivalExperienceFeedbackEnabled) {
             goToArrivalExperienceFragment()
+        } else {
+            feedbackFlowListener.onFeedbackFlowFinished()
         }
         dismiss()
     }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/internal/feedback/FeedbackFlowListener.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/internal/feedback/FeedbackFlowListener.kt
@@ -23,4 +23,9 @@ interface FeedbackFlowListener {
      * @param arrivalFeedbackItem the overall experience of a navigation
      */
     fun onArrivalExperienceFeedbackFinished(arrivalFeedbackItem: FeedbackItem)
+
+    /**
+     * The callback gets triggered when **Feedback flow** finished.
+     */
+    fun onFeedbackFlowFinished()
 }


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
FeedbackFlow: added `onFeedbackFlowFinished` method to have listener when feedback flow has finished

Closes #3849 

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Added `onFeedbackFlowFinished` method to `FeedbackFlowListener`.</changelog>
```

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
