### PR TITLE
Bump mapbox-navigation-native version to 28.0.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -11,7 +11,7 @@ ext {
       mapboxSdkServices         : '5.8.0-beta.4',
       mapboxEvents              : '6.2.2',
       mapboxCore                : '3.1.1',
-      mapboxNavigator           : '27.0.0',
+      mapboxNavigator           : '28.0.0',
       mapboxCommonNative        : '9.1.0',
       mapboxCrashMonitor        : '2.0.0',
       mapboxAnnotationPlugin    : '0.8.0',

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -151,7 +151,8 @@ class MapboxNavigation(
         navigationOptions.eHorizonOptions.length,
         navigationOptions.eHorizonOptions.expansion.toByte(),
         navigationOptions.eHorizonOptions.branchLength,
-        navigationOptions.eHorizonOptions.includeGeometries
+        navigationOptions.eHorizonOptions.includeGeometries,
+        false
     )
     private val navigatorConfig = NavigatorConfig(null, electronicHorizonOptions, null)
 


### PR DESCRIPTION
### Description
Bumps `mapbox-navigation-native` dependency version to `28.0.0` and fixes breaking changes

cc @etl @SiarheiFedartsou 