### PR TITLE
MapboxNavigationTelemetry: logging user feedback creating if failed

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetry.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetry.kt
@@ -274,6 +274,14 @@ internal object MapboxNavigationTelemetry :
                 }
                 onEventUpdated?.let { it(feedbackEvent) }
             }
+        } else {
+            logger?.e(
+                TAG,
+                Message(
+                    "User Feedback event creation failed. The event can only be created in " +
+                        "active guidance (trips session started and route is available)."
+                )
+            )
         }
     }
 


### PR DESCRIPTION
### Description
MapboxNavigationTelemetry: logging user feedback creating if failed

Closes #3865 
