### PR TITLE
Expose test-only accessors for polling patience and interval

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/utils/InternalUtils.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/utils/InternalUtils.kt
@@ -1,0 +1,27 @@
+package com.mapbox.navigation.core.internal.utils
+
+import com.mapbox.navigation.core.trip.session.MapboxTripSession
+
+/**
+ * Internal API used for testing. Sets the static unconditional polling patience value for all
+ * instances in the process.
+ *
+ * Pass `null` to reset to default.
+ *
+ * Do not use in a production environment.
+ */
+fun setUnconditionalPollingPatience(patience: Long?) {
+    MapboxTripSession.UNCONDITIONAL_STATUS_POLLING_PATIENCE = patience ?: 2000L
+}
+
+/**
+ * Internal API used for testing. Sets the static unconditional polling interval value for all
+ * instances in the process.
+ *
+ * Pass `null` to reset to default.
+ *
+ * Do not use in a production environment.
+ */
+fun setUnconditionalPollingInterval(interval: Long?) {
+    MapboxTripSession.UNCONDITIONAL_STATUS_POLLING_INTERVAL = interval ?: 1000L
+}

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
@@ -55,8 +55,10 @@ internal class MapboxTripSession(
 ) : TripSession {
 
     companion object {
-        internal const val UNCONDITIONAL_STATUS_POLLING_PATIENCE = 2000L
-        internal const val UNCONDITIONAL_STATUS_POLLING_INTERVAL = 1000L
+        @Volatile
+        internal var UNCONDITIONAL_STATUS_POLLING_PATIENCE = 2000L
+        @Volatile
+        internal var UNCONDITIONAL_STATUS_POLLING_INTERVAL = 1000L
     }
 
     private var updateNavigatorStatusDataJobs: MutableList<Job> = CopyOnWriteArrayList()


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Workaround to manipulate the polling values and increase the stability of instrumentation tests. This is going to be replaced with a better solution when available.

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
