### PR TITLE
Bump mapbox-java version to 5.8.0-beta.5

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,7 +8,7 @@ ext {
 
   version = [
       mapboxMapSdk              : '9.6.0',
-      mapboxSdkServices         : '5.8.0-beta.4',
+      mapboxSdkServices         : '5.8.0-beta.5',
       mapboxEvents              : '6.2.2',
       mapboxCore                : '3.1.1',
       mapboxNavigator           : '28.1.0',


### PR DESCRIPTION
### Description
Bumps `mapbox-java` dependency version to `5.8.0-beta.5`

cc @Guardiola31337 @LukasPaczos 


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
