### PR TITLE
FeedbackFlow: don't show FeedbackDetailedFragment if no detailed items

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/utils/CachedNavigationFeedbackEventEx.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/utils/CachedNavigationFeedbackEventEx.kt
@@ -1,0 +1,11 @@
+@file:JvmName("CachedNavigationFeedbackEventEx")
+package com.mapbox.navigation.core.internal.utils
+
+import com.mapbox.navigation.core.internal.telemetry.CachedNavigationFeedbackEvent
+import com.mapbox.navigation.core.telemetry.events.FeedbackEvent
+
+fun CachedNavigationFeedbackEvent.hasDetailedFeedback(): Boolean =
+    this.feedbackType != FeedbackEvent.POSITIONING_ISSUE
+
+fun List<CachedNavigationFeedbackEvent>.hasDetailedFeedbackItems(): Boolean =
+    this.any { it.hasDetailedFeedback() }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationView.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/NavigationView.java
@@ -39,6 +39,7 @@ import com.mapbox.navigation.base.formatter.DistanceFormatter;
 import com.mapbox.navigation.base.route.Router;
 import com.mapbox.navigation.core.MapboxNavigation;
 import com.mapbox.navigation.core.internal.telemetry.MapboxNavigationFeedbackCache;
+import com.mapbox.navigation.core.internal.utils.CachedNavigationFeedbackEventEx;
 import com.mapbox.navigation.core.replay.MapboxReplayer;
 import com.mapbox.navigation.core.internal.telemetry.CachedNavigationFeedbackEvent;
 import com.mapbox.navigation.ui.camera.DynamicCamera;
@@ -746,7 +747,10 @@ public class NavigationView extends CoordinatorLayout implements LifecycleOwner,
     if (navigation != null) {
       List<CachedNavigationFeedbackEvent> cachedNavigationFeedbackEventList =
               MapboxNavigationFeedbackCache.INSTANCE.getCachedUserFeedback();
-      if (enableDetailedFeedbackFlowAfterTbt && !cachedNavigationFeedbackEventList.isEmpty()) {
+      if (enableDetailedFeedbackFlowAfterTbt
+        && !cachedNavigationFeedbackEventList.isEmpty()
+        && CachedNavigationFeedbackEventEx.hasDetailedFeedbackItems(cachedNavigationFeedbackEventList)
+      ) {
         FragmentTransaction fragmentTransaction = getFragmentActivity().getSupportFragmentManager().beginTransaction();
         fragmentTransaction.add(
                 R.id.navigationViewLayout,

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/internal/feedback/FeedbackDetailsFragment.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/internal/feedback/FeedbackDetailsFragment.kt
@@ -24,8 +24,8 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_COLLAPS
 import com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_HIDDEN
 import com.google.android.material.bottomsheet.BottomSheetBehavior.from
 import com.mapbox.navigation.core.internal.telemetry.CachedNavigationFeedbackEvent
+import com.mapbox.navigation.core.internal.utils.hasDetailedFeedback
 import com.mapbox.navigation.core.telemetry.events.FeedbackEvent
-import com.mapbox.navigation.core.telemetry.events.FeedbackEvent.POSITIONING_ISSUE
 import com.mapbox.navigation.ui.R
 import com.mapbox.navigation.ui.feedback.FeedbackHelper
 import com.mapbox.navigation.ui.feedback.FeedbackSubTypeAdapter
@@ -503,11 +503,9 @@ class FeedbackDetailsFragment : DialogFragment() {
                 retainInstance = true
                 this.arrivalExperienceFeedbackEnabled = enableArrivalExperienceFeedback
                 this.feedbackFlowListener = feedbackFlowListener
-                feedbackItemList.partition {
-                    it.feedbackType == POSITIONING_ISSUE
-                }.run {
-                    itemsThatDontNeedDetailedFeedback.addAll(first)
-                    itemsToProvideMoreDetailsOn.addAll(second)
+                feedbackItemList.partition { it.hasDetailedFeedback() }.run {
+                    itemsToProvideMoreDetailsOn.addAll(first)
+                    itemsThatDontNeedDetailedFeedback.addAll(second)
                 }
             }
     }


### PR DESCRIPTION
### Description
FeedbackFlow: don't show FeedbackDetailedFragment if no detailed items

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Fixed FeedbackFlow to skip Detailed Screen when detailed items aren't presented.</changelog>
```