### PR TITLE
Bump mapbox-navigation-native version to 29.0.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -11,7 +11,7 @@ ext {
       mapboxSdkServices         : '5.8.0-beta.5',
       mapboxEvents              : '6.2.2',
       mapboxCore                : '3.1.1',
-      mapboxNavigator           : '28.1.0',
+      mapboxNavigator           : '29.0.0',
       mapboxCommonNative        : '9.1.0',
       mapboxCrashMonitor        : '2.0.0',
       mapboxAnnotationPlugin    : '0.8.0',

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -152,7 +152,8 @@ class MapboxNavigation(
         navigationOptions.eHorizonOptions.expansion.toByte(),
         navigationOptions.eHorizonOptions.branchLength,
         navigationOptions.eHorizonOptions.includeGeometries,
-        false
+        false,
+        null
     )
     private val navigatorConfig = NavigatorConfig(null, electronicHorizonOptions, null)
 


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Bumps `mapbox-navigation-native` version to `29.0.0` and fixes breaking changes

cc @etl @mskurydin @SiarheiFedartsou 