### PR TITLE
Removed ACCESS_BACKGROUND_LOCATION permission requirement

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/LocationPermissionsHelper.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/LocationPermissionsHelper.kt
@@ -12,7 +12,6 @@ import java.util.ArrayList
 
 private const val COARSE_LOCATION_PERMISSION = Manifest.permission.ACCESS_COARSE_LOCATION
 private const val FINE_LOCATION_PERMISSION = Manifest.permission.ACCESS_FINE_LOCATION
-private const val BACKGROUND_LOCATION_PERMISSION = "android.permission.ACCESS_BACKGROUND_LOCATION"
 const val LOCATION_PERMISSIONS_REQUEST_CODE = 1612
 
 /**
@@ -23,23 +22,19 @@ class LocationPermissionsHelper(private val listener: PermissionsListener?) {
 
     fun requestLocationPermissions(activity: Activity) {
         // Request fine location permissions by default
-        requestLocationPermissions(activity, true, true)
+        requestLocationPermissions(activity, true)
     }
 
     // suppressed to have the same API as PermissionsManager from com.mapbox.android.core.permissions
     @Suppress("SameParameterValue")
     private fun requestLocationPermissions(
         activity: Activity,
-        requestFineLocation: Boolean,
-        requestBackgroundLocation: Boolean
+        requestFineLocation: Boolean
     ) {
         val permissions = if (requestFineLocation) {
             mutableListOf(FINE_LOCATION_PERMISSION)
         } else {
             mutableListOf(COARSE_LOCATION_PERMISSION)
-        }
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && requestBackgroundLocation) {
-            permissions.add(BACKGROUND_LOCATION_PERMISSION)
         }
         requestPermissions(activity, permissions.toTypedArray())
     }
@@ -100,17 +95,9 @@ class LocationPermissionsHelper(private val listener: PermissionsListener?) {
             return isPermissionGranted(context, FINE_LOCATION_PERMISSION)
         }
 
-        private fun isBackgroundLocationPermissionGranted(context: Context): Boolean {
-            return isPermissionGranted(context, BACKGROUND_LOCATION_PERMISSION)
-        }
-
         fun areLocationPermissionsGranted(context: Context): Boolean {
             return isCoarseLocationPermissionGranted(context) ||
-                isFineLocationPermissionGranted(context) ||
-                (
-                    (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) &&
-                        isBackgroundLocationPermissionGranted(context)
-                    )
+                isFineLocationPermissionGranted(context)
         }
 
         fun areRuntimePermissionsRequired(): Boolean {

--- a/libnavigation-core/src/main/AndroidManifest.xml
+++ b/libnavigation-core/src/main/AndroidManifest.xml
@@ -3,7 +3,6 @@
 
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <application>


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Removes the `ACCESS_BACKGROUND_LOCATION` permission requirement that was previously added in https://github.com/mapbox/mapbox-navigation-android/issues/3276. Capturing from [the documentation](https://developer.android.com/training/location/permissions), this should not be necessary to receive location updates when the app is running a foreground service:
> The system considers your app to be using foreground location if a feature of your app accesses the device's current location in one of the following situations:
...
Your app is running a foreground service. ...

And is confirmed by a couple of local tests that I run.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Removed the `ACCESS_BACKGROUND_LOCATION` permission requirement.</changelog>
```

/cc @nkukday 
