### PR TITLE
Fix stop trip session issue

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
@@ -49,7 +49,7 @@ internal class MapboxTripSession(
     override val tripService: TripService,
     private val navigationOptions: NavigationOptions,
     private val navigator: MapboxNativeNavigator = MapboxNativeNavigatorImpl,
-    threadController: ThreadController = ThreadController,
+    private val threadController: ThreadController = ThreadController,
     private val logger: Logger,
     private val accessToken: String?
 ) : TripSession {
@@ -71,13 +71,14 @@ internal class MapboxTripSession(
                 routeProgress = null
             }
             cancelOngoingUpdateNavigatorStatusDataJobs()
-            mainJobController.scope.launch {
+            val setRouteJob = threadController.getMainScopeAndRootJob().scope.launch {
                 navigator.setRoute(value)?.let {
                     routeAlerts = it.routeAlerts
                 }
-                if (state == TripSessionState.STARTED) {
-                    updateDataFromNavigatorStatus()
-                }
+            }
+            mainJobController.scope.launch {
+                setRouteJob.join()
+                updateDataFromNavigatorStatus()
             }
             isOffRoute = false
         }
@@ -475,6 +476,8 @@ internal class MapboxTripSession(
 
     private fun updateRawLocation(rawLocation: Location) {
         unconditionalStatusPollingJob?.cancel()
+        if (state != TripSessionState.STARTED) return
+
         this.rawLocation = rawLocation
         locationObservers.forEach { it.onRawLocationChanged(rawLocation) }
         mainJobController.scope.launch {
@@ -495,6 +498,10 @@ internal class MapboxTripSession(
 
     private fun updateDataFromNavigatorStatus() {
         val updateNavigatorStatusDataJob = mainJobController.scope.launch {
+            if (state != TripSessionState.STARTED) {
+                return@launch
+            }
+
             val status = getNavigatorStatus()
             if (!isActive) {
                 return@launch

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
@@ -177,6 +177,16 @@ class MapboxTripSessionTest {
     }
 
     @Test
+    fun stopTripSessionShouldStopRouteProgress() = coroutineRule.runBlockingTest {
+        tripSession.route = route
+        tripSession.start()
+        tripSession.route = null
+        tripSession.stop()
+
+        coVerify(exactly = 1) { navigator.getStatus(any()) }
+    }
+
+    @Test
     fun locationObserverSuccess() = coroutineRule.runBlockingTest {
         tripSession.start()
         val observer: LocationObserver = mockk(relaxUnitFun = true)


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Resolves https://github.com/mapbox/mapbox-navigation-android/issues/3846

There's a race condition when trying to stop a session. Check that the session is stopped, inside the coroutine. Another approach is to join the setRoute call with the stopSession call https://github.com/mapbox/mapbox-navigation-android/pull/3864, but that makes the two operations depend on each other.

The unit test is not entirely perfect, because the issue is reproduced after waiting for multiple status polls. I also used a manual test to verify the fix https://github.com/mapbox/mapbox-navigation-android/pull/3920

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Fix stop trip session issue</changelog>
```

---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
