### PR TITLE
Reproduce stop session race condition

### DIFF
--- a/examples/src/main/res/layout/activity_replay_route_layout.xml
+++ b/examples/src/main/res/layout/activity_replay_route_layout.xml
@@ -27,7 +27,6 @@
         app:layout_constraintBottom_toBottomOf="parent"
         android:background="@color/colorPrimary"
         android:text="@string/start_navigation"
-        android:textColor="@android:color/white"
-        android:visibility="gone" />
+        android:textColor="@android:color/white" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
@@ -3,6 +3,7 @@ package com.mapbox.navigation.core.trip.session
 import android.hardware.SensorEvent
 import android.location.Location
 import android.os.Looper
+import android.util.Log
 import com.mapbox.android.core.location.LocationEngineCallback
 import com.mapbox.android.core.location.LocationEngineResult
 import com.mapbox.api.directions.v5.models.BannerComponents
@@ -76,6 +77,7 @@ internal class MapboxTripSession(
                     routeAlerts = it.routeAlerts
                 }
                 if (state == TripSessionState.STARTED) {
+                    Log.i("kyle_debug", "kyle_debug from route update")
                     updateDataFromNavigatorStatus()
                 }
             }
@@ -461,6 +463,7 @@ internal class MapboxTripSession(
     private var locationEngineCallback = object : LocationEngineCallback<LocationEngineResult> {
         override fun onSuccess(result: LocationEngineResult?) {
             result?.locations?.lastOrNull()?.let {
+                Log.i("kyle_debug", "kyle_debug locationEngineCallback $it")
                 updateRawLocation(it)
             }
         }
@@ -479,6 +482,7 @@ internal class MapboxTripSession(
         locationObservers.forEach { it.onRawLocationChanged(rawLocation) }
         mainJobController.scope.launch {
             navigator.updateLocation(rawLocation)
+            Log.i("kyle_debug", "kyle_debug unconditional location update")
             updateDataFromNavigatorStatus()
         }
 
@@ -486,6 +490,7 @@ internal class MapboxTripSession(
             delay(UNCONDITIONAL_STATUS_POLLING_PATIENCE)
             while (isActive) {
                 mainJobController.scope.launch {
+                    Log.i("kyle_debug", "kyle_debug unconditional status poll")
                     updateDataFromNavigatorStatus()
                 }
                 delay(UNCONDITIONAL_STATUS_POLLING_INTERVAL)


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Unit testing coroutines is hard. This reproduces this issue https://github.com/mapbox/mapbox-navigation-android/issues/3846. I also used these changes to verify this is fixes it https://github.com/mapbox/mapbox-navigation-android/pull/3919

1. Go to Replay Route
2. Start navigation
3. Long press on the map
4. Observe logcat 

```
2021-01-22 11:50:41 kyle_debug startTripSession
2021-01-22 11:50:46 kyle_debug stopTripSession
2021-01-22 11:50:46 kyle_debug onRouteProgressChanged LOCATION_TRACKING
2021-01-22 11:50:48 kyle_debug onRouteProgressChanged LOCATION_TRACKING
2021-01-22 11:50:49 kyle_debug onRouteProgressChanged LOCATION_TRACKING
2021-01-22 11:50:50 kyle_debug onRouteProgressChanged LOCATION_TRACKING
2021-01-22 11:50:51 kyle_debug onRouteProgressChanged LOCATION_TRACKING
2021-01-22 11:50:52 kyle_debug onRouteProgressChanged LOCATION_TRACKING
2021-01-22 11:50:53 kyle_debug onRouteProgressChanged LOCATION_TRACKING
```


### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog></changelog>
```

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
