### PR TITLE
Added check for height and width of the drawable since a value below …

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteArrow.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/MapRouteArrow.java
@@ -240,7 +240,9 @@ class MapRouteArrow {
   private void addArrowHeadIcon() {
     int headResId = R.drawable.mapbox_ic_arrow_head;
     Drawable arrowHead = AppCompatResources.getDrawable(mapView.getContext(), headResId);
-    if (arrowHead == null) {
+    if (arrowHead == null
+            || arrowHead.getIntrinsicHeight() < 0
+            || arrowHead.getIntrinsicWidth() < 0) {
       return;
     }
     Drawable head = DrawableCompat.wrap(arrowHead);


### PR DESCRIPTION
### Description
A crash was reported with ver 1.4rc1 with the following stack trace: java.lang.IllegalArgumentException: width and height must be > 0
        at android.graphics.Bitmap.createBitmap(Bitmap.java:1033)
        at android.graphics.Bitmap.createBitmap(Bitmap.java:1000)
        at android.graphics.Bitmap.createBitmap(Bitmap.java:950)
        at android.graphics.Bitmap.createBitmap(Bitmap.java:911)
        at com.mapbox.navigation.ui.internal.utils.MapImageUtils.getBitmapFromDrawable(MapImageUtils.java:14)
        at com.mapbox.navigation.ui.route.MapRouteArrow.addArrowHeadIcon(MapRouteArrow.java:248)
        at com.mapbox.navigation.ui.route.MapRouteArrow.initialize(MapRouteArrow.java:199)
        at com.mapbox.navigation.ui.route.MapRouteArrow.<init>(MapRouteArrow.java:114)
        at com.mapbox.navigation.ui.route.NavigationMapRoute.<init>(NavigationMapRoute.java:135)

The code for this hasn't changed in a long time so it's unclear why it would have happened. There is a call to get intrinsic height/width of a drawable.  According to the docs the returned value would be less than 0 if the drawable were a color. The drawable used here is hardcoded so it's unclear why a value of less than 0 would have been returned.  

To address this I added to the a statement that checks if the drawable is null to also check that the intrinsic height/width greater than or equal to 0 in order for the method execution to continue.

It was reported that this error only occurred once and I have not been able to reproduce it but the check I added should prevent future crashed should the same conditions arise. 

### Changelog
```
<changelog>Added check for arrow head icon height and width to prevent reported crash.</changelog>
```

