### PR TITLE
Backport 3932

### DIFF
--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/OnboardRouterOptions.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/OnboardRouterOptions.kt
@@ -65,7 +65,7 @@ class OnboardRouterOptions private constructor(
      */
     class Builder {
         private var tilesUri: URI = URI("https://api.mapbox.com")
-        private var tilesVersion: String = "2021_01_30-03_00_00"
+        private var tilesVersion: String = "2021_01_24-03_00_00"
         private var filePath: String? = null
 
         /**


### PR DESCRIPTION
CP #3932.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Changed the default routing tiles version to 2021_01_24-03_00_00.</changelog>
```