### PR TITLE
missing renaming branch `master` -> `main`

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -37,12 +37,13 @@ workflows:
             - static-analysis
           filters:
             branches:
-              ignore: /^(master|release-.*)/
+              ignore: /^(main|release-.*)/
       - release-snapshot:
           filters:
             branches:
               only:
-                - master
+                - main
+                - release-1.x
       - release:
           filters:
             tags:


### PR DESCRIPTION
### Description
missing renaming `master` to `main` branch 