### PR TITLE
Bump Maps SDK to v10.0.0-beta.13 and migrate to the new location plugin impl

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1142,7 +1142,7 @@ License: [BSD](https://opensource.org/licenses/BSD-2-Clause)
 
 ===========================================================================
 
-Mapbox Navigation uses portions of the The location module for the Mapbox Maps SDK for Android.
+Mapbox Navigation uses portions of the The location component module for the Mapbox Maps SDK for Android.
 URL: [https://github.com/mapbox/mapbox-maps-android](https://github.com/mapbox/mapbox-maps-android)
 License: [BSD](https://opensource.org/licenses/BSD-2-Clause)
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -7,12 +7,12 @@ ext {
   ]
 
   version = [
-      mapboxMapSdk              : '10.0.0-beta.12',
+      mapboxMapSdk              : '10.0.0-beta.13',
       mapboxSdkServices         : '5.8.0',
       mapboxEvents              : '6.2.2',
       mapboxCore                : '3.1.1',
       mapboxNavigator           : '40.0.2',
-      mapboxCommonNative        : '10.0.0-beta.8',
+      mapboxCommonNative        : '10.0.0-beta.9.1',
       mapboxCrashMonitor        : '2.0.0',
       mapboxAnnotationPlugin    : '0.8.0',
       mapboxAccounts            : '0.4.1',

--- a/libnavui-maps/api/current.txt
+++ b/libnavui-maps/api/current.txt
@@ -159,7 +159,7 @@ package com.mapbox.navigation.ui.maps.camera.lifecycle {
   }
 
   public final class NavigationScaleGestureHandler implements com.mapbox.maps.plugin.animation.CameraAnimationsLifecycleListener {
-    ctor public NavigationScaleGestureHandler(android.content.Context context, com.mapbox.navigation.ui.maps.camera.NavigationCamera navigationCamera, com.mapbox.maps.MapboxMap mapboxMap, com.mapbox.maps.plugin.gestures.GesturesPlugin gesturesPlugin, com.mapbox.maps.plugin.location.LocationPluginImpl locationPlugin, com.mapbox.navigation.ui.maps.camera.lifecycle.NavigationScaleGestureActionListener? scaleActionListener, com.mapbox.navigation.ui.maps.camera.lifecycle.NavigationScaleGestureHandlerOptions options);
+    ctor public NavigationScaleGestureHandler(android.content.Context context, com.mapbox.navigation.ui.maps.camera.NavigationCamera navigationCamera, com.mapbox.maps.MapboxMap mapboxMap, com.mapbox.maps.plugin.gestures.GesturesPlugin gesturesPlugin, com.mapbox.maps.plugin.locationcomponent.LocationComponentPlugin locationPlugin, com.mapbox.navigation.ui.maps.camera.lifecycle.NavigationScaleGestureActionListener? scaleActionListener, com.mapbox.navigation.ui.maps.camera.lifecycle.NavigationScaleGestureHandlerOptions options);
     method public void cleanup();
     method public com.mapbox.android.gestures.AndroidGesturesManager getCustomGesturesManager();
     method public com.mapbox.android.gestures.AndroidGesturesManager getInitialGesturesManager();
@@ -258,6 +258,21 @@ package com.mapbox.navigation.ui.maps.internal.route.line {
     method public kotlin.jvm.functions.Function0<java.util.List<com.mapbox.navigation.ui.maps.route.line.model.RouteFeatureData>> getRouteFeatureDataProvider(java.util.List<? extends com.mapbox.api.directions.v5.models.DirectionsRoute> directionsRoutes);
     method public kotlin.jvm.functions.Function0<java.util.List<com.mapbox.navigation.ui.maps.route.line.model.RouteFeatureData>> getRouteLineFeatureDataProvider(java.util.List<com.mapbox.navigation.ui.maps.route.line.model.RouteLine> directionsRoutes);
     field public static final com.mapbox.navigation.ui.maps.internal.route.line.MapboxRouteLineUtils! INSTANCE;
+  }
+
+}
+
+package com.mapbox.navigation.ui.maps.location {
+
+  public final class NavigationLocationProvider implements com.mapbox.maps.plugin.locationcomponent.LocationProvider {
+    ctor public NavigationLocationProvider();
+    method public void changePosition(android.location.Location location, java.util.List<? extends android.location.Location> keyPoints = emptyList(), kotlin.jvm.functions.Function1<? super android.animation.ValueAnimator,kotlin.Unit>? latLngTransitionOptions = null, kotlin.jvm.functions.Function1<? super android.animation.ValueAnimator,kotlin.Unit>? bearingTransitionOptions = null);
+    method public java.util.List<android.location.Location> getLastKeyPoints();
+    method public android.location.Location? getLastLocation();
+    method public void registerLocationConsumer(com.mapbox.maps.plugin.locationcomponent.LocationConsumer locationConsumer);
+    method public void unRegisterLocationConsumer(com.mapbox.maps.plugin.locationcomponent.LocationConsumer locationConsumer);
+    property public final java.util.List<android.location.Location> lastKeyPoints;
+    property public final android.location.Location? lastLocation;
   }
 
 }

--- a/libnavui-maps/build.gradle
+++ b/libnavui-maps/build.gradle
@@ -36,11 +36,7 @@ android {
 dependencies {
     api project(":libnavui-base")
 
-    // workaround for https://github.com/mapbox/mapbox-maps-android-internal/issues/215
-    api (dependenciesList.mapboxMapSdk) {
-        exclude group: "com.mapbox.plugin", module: "maps-locationcomponent"
-    }
-    api "com.mapbox.plugin:maps-location:10.0.0-beta.12"
+    api dependenciesList.mapboxMapSdk
     api dependenciesList.mapboxSdkTurf
 
     implementation dependenciesList.androidXAppCompat

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/lifecycle/NavigationScaleGestureHandler.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/lifecycle/NavigationScaleGestureHandler.kt
@@ -14,8 +14,8 @@ import com.mapbox.maps.plugin.delegates.listeners.OnCameraChangeListener
 import com.mapbox.maps.plugin.gestures.GesturesPlugin
 import com.mapbox.maps.plugin.gestures.OnMoveListener
 import com.mapbox.maps.plugin.gestures.generated.GesturesSettings
-import com.mapbox.maps.plugin.location.LocationPluginImpl
-import com.mapbox.maps.plugin.location.OnIndicatorPositionChangedListener
+import com.mapbox.maps.plugin.locationcomponent.LocationComponentPlugin
+import com.mapbox.maps.plugin.locationcomponent.OnIndicatorPositionChangedListener
 import com.mapbox.navigation.ui.maps.camera.NavigationCamera
 import com.mapbox.navigation.ui.maps.camera.NavigationCamera.Companion.NAVIGATION_CAMERA_OWNER
 import com.mapbox.navigation.ui.maps.camera.data.MapboxNavigationViewportDataSource
@@ -78,7 +78,7 @@ class NavigationScaleGestureHandler(
     private val navigationCamera: NavigationCamera,
     private val mapboxMap: MapboxMap,
     private val gesturesPlugin: GesturesPlugin,
-    private val locationPlugin: LocationPluginImpl,
+    private val locationPlugin: LocationComponentPlugin,
     private val scaleActionListener: NavigationScaleGestureActionListener? = null,
     private val options: NavigationScaleGestureHandlerOptions =
         NavigationScaleGestureHandlerOptions.Builder(context).build()

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtils.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtils.kt
@@ -20,7 +20,7 @@ import com.mapbox.maps.extension.style.expressions.generated.Expression
 import com.mapbox.maps.extension.style.layers.getLayer
 import com.mapbox.maps.extension.style.layers.properties.generated.Visibility
 import com.mapbox.maps.extension.style.sources.generated.geoJsonSource
-import com.mapbox.maps.plugin.location.LocationComponentConstants
+import com.mapbox.maps.plugin.locationcomponent.LocationComponentConstants
 import com.mapbox.navigation.ui.base.internal.route.RouteConstants
 import com.mapbox.navigation.ui.maps.R
 import com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions
@@ -555,7 +555,7 @@ object MapboxRouteLineUtils {
                 """Tried placing route line below "$layerId" which doesn't exist"""
             )
         }
-        return foundId ?: LocationComponentConstants.FOREGROUND_LAYER
+        return foundId ?: LocationComponentConstants.MODEL_LAYER
     }
 
     /**
@@ -575,7 +575,7 @@ object MapboxRouteLineUtils {
         } else {
             lastSymbolLayerFromTopIndex
         }
-        return layers.getOrNull(index)?.id ?: LocationComponentConstants.FOREGROUND_LAYER
+        return layers.getOrNull(index)?.id ?: LocationComponentConstants.MODEL_LAYER
     }
 
     /**

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/location/NavigationLocationProvider.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/location/NavigationLocationProvider.kt
@@ -1,0 +1,178 @@
+package com.mapbox.navigation.ui.maps.location
+
+import android.animation.ValueAnimator
+import android.annotation.SuppressLint
+import android.location.Location
+import com.mapbox.geojson.Point
+import com.mapbox.maps.plugin.locationcomponent.LocationComponentPlugin
+import com.mapbox.maps.plugin.locationcomponent.LocationConsumer
+import com.mapbox.maps.plugin.locationcomponent.LocationProvider
+import com.mapbox.maps.plugin.locationcomponent.OnIndicatorPositionChangedListener
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.trip.session.LocationObserver
+import com.mapbox.navigation.core.trip.session.MapMatcherResultObserver
+import com.mapbox.navigation.utils.internal.ifNonNull
+import java.util.concurrent.CopyOnWriteArraySet
+
+/**
+ * This class provides a [LocationProvider] implementation that can be used together with the
+ * [LocationComponentPlugin] and provides an easy integration with the [LocationObserver] and the
+ * [MapMatcherResultObserver] that produce enhanced location updates.
+ *
+ * #### Example usage
+ * Initialize the location plugin:
+ * ```
+ * locationComponent = mapView.getLocationComponentPlugin().apply {
+ *     setLocationProvider(navigationLocationProvider)
+ *     addOnIndicatorPositionChangedListener(onIndicatorPositionChangedListener)
+ *     enabled = true
+ * }
+ * ```
+ *
+ * Pass location data to transition the puck:
+ * ```
+ * private val locationObserver = object : LocationObserver {
+ *     override fun onRawLocationChanged(rawLocation: Location) {}
+ *     override fun onEnhancedLocationChanged(
+ *         enhancedLocation: Location,
+ *         keyPoints: List<Location>
+ *     ) {
+ *         navigationLocationProvider.changePosition(
+ *             enhancedLocation,
+ *             keyPoints,
+ *         )
+ *         updateCamera(enhancedLocation)
+ *     }
+ * }
+ * ```
+ * or:
+ * ```
+ * private val mapMatcherResultObserver = object : MapMatcherResultObserver {
+ *     override fun onNewMapMatcherResult(mapMatcherResult: MapMatcherResult) {
+ *         val transitionOptions: (ValueAnimator.() -> Unit)? = if (mapMatcherResult.isTeleport) {
+ *             {
+ *                 duration = 0
+ *             }
+ *         } else {
+ *             {
+ *                 duration = 1000
+ *             }
+ *         }
+ *         navigationLocationProvider.changePosition(
+ *             mapMatcherResult.enhancedLocation,
+ *             mapMatcherResult.keyPoints,
+ *             latLngTransitionOptions = transitionOptions,
+ *             bearingTransitionOptions = transitionOptions
+ *         )
+ * }
+ * ```
+ */
+class NavigationLocationProvider : LocationProvider {
+
+    private val locationConsumers = CopyOnWriteArraySet<LocationConsumer>()
+
+    /**
+     * Returns the last cached target location value.
+     *
+     * For precise puck's position use the [OnIndicatorPositionChangedListener].
+     */
+    var lastLocation: Location? = null
+        private set
+
+    /**
+     * Returns the last cached key points value.
+     *
+     * For precise puck's position use the [OnIndicatorPositionChangedListener].
+     */
+    var lastKeyPoints: List<Location> = emptyList()
+        private set
+
+    /**
+     * Register the location consumer to the Location Provider.
+     *
+     * The Location Consumer will get location and bearing updates from the Location Provider.
+     *
+     * @param locationConsumer
+     */
+    @SuppressLint("MissingPermission")
+    override fun registerLocationConsumer(locationConsumer: LocationConsumer) {
+        if (locationConsumers.add(locationConsumer)) {
+            ifNonNull(lastLocation, lastKeyPoints) { location, keyPoints ->
+                locationConsumer.notifyLocationUpdates(
+                    location,
+                    keyPoints,
+                    latLngTransitionOptions = {
+                        this.duration = 0
+                    },
+                    bearingTransitionOptions = {
+                        this.duration = 0
+                    }
+                )
+            }
+        }
+    }
+
+    /**
+     * Unregister the location consumer from the Location Provider.
+     *
+     * @param locationConsumer
+     */
+    override fun unRegisterLocationConsumer(locationConsumer: LocationConsumer) {
+        locationConsumers.remove(locationConsumer)
+    }
+
+    /**
+     * Provide the location update that puck should transition to.
+     *
+     * @param location the location update
+     * @param keyPoints a list (can be empty) of predicted location points
+     * leading up to and including the target update.
+     * The last point on the list (if not empty) should always be equal to [location].
+     * @param latLngTransitionOptions lambda that style that position transition of the puck. See
+     * [LocationConsumer.onLocationUpdated].
+     * @param bearingTransitionOptions lambda that style that bearing transition of the puck. See
+     * [LocationConsumer.onBearingUpdated].
+     *
+     * @see LocationObserver
+     * @see MapMatcherResultObserver
+     * @see MapboxNavigation.registerLocationObserver
+     * @see MapboxNavigation.registerMapMatcherResultObserver
+     */
+    fun changePosition(
+        location: Location,
+        keyPoints: List<Location> = emptyList(),
+        latLngTransitionOptions: (ValueAnimator.() -> Unit)? = null,
+        bearingTransitionOptions: (ValueAnimator.() -> Unit)? = null
+    ) {
+        locationConsumers.forEach {
+            it.notifyLocationUpdates(
+                location,
+                keyPoints,
+                latLngTransitionOptions,
+                bearingTransitionOptions
+            )
+        }
+        lastLocation = location
+        lastKeyPoints = keyPoints
+    }
+
+    private fun LocationConsumer.notifyLocationUpdates(
+        location: Location,
+        keyPoints: List<Location>,
+        latLngTransitionOptions: (ValueAnimator.() -> Unit)? = null,
+        bearingTransitionOptions: (ValueAnimator.() -> Unit)? = null
+    ) {
+        val latLngUpdates = if (keyPoints.isNotEmpty()) {
+            keyPoints.map { Point.fromLngLat(it.longitude, it.latitude) }.toTypedArray()
+        } else {
+            arrayOf(Point.fromLngLat(location.longitude, location.latitude))
+        }
+        val bearingUpdates = if (keyPoints.isNotEmpty()) {
+            keyPoints.map { it.bearing.toDouble() }.toDoubleArray()
+        } else {
+            doubleArrayOf(location.bearing.toDouble())
+        }
+        this.onLocationUpdated(location = *latLngUpdates, options = latLngTransitionOptions)
+        this.onBearingUpdated(bearing = *bearingUpdates, options = bearingTransitionOptions)
+    }
+}

--- a/libnavui-maps/src/main/res/drawable/mapbox_navigation_puck_icon.xml
+++ b/libnavui-maps/src/main/res/drawable/mapbox_navigation_puck_icon.xml
@@ -1,0 +1,17 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="75dp"
+    android:height="75dp"
+    android:viewportHeight="75.0"
+    android:viewportWidth="75.0">
+    <path
+        android:fillAlpha="0.16"
+        android:fillColor="#263D57"
+        android:pathData="M37.5,37.5m-37.5,0a37.5,37.5 0,1 1,75 0a37.5,37.5 0,1 1,-75 0"/>
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M37.5,37.5m-28.5,0a28.5,28.5 0,1 1,57 0a28.5,28.5 0,1 1,-57 0"/>
+    <path
+        android:fillColor="#4A90E2"
+        android:pathData="M39.2,28.46C39.01,27.99 38.54,27.68 38.02,27.69C37.5,27.7 37.02,28.01 36.81,28.49L27.05,45.83C26.83,46.32 26.92,46.89 27.28,47.26C27.65,47.64 28.21,47.75 28.71,47.54L37.07,44.03C37.39,43.89 37.75,43.89 38.06,44.02L46.27,47.34C46.75,47.54 47.33,47.42 47.71,47.03C48.09,46.64 48.21,46.07 48,45.59L39.2,28.46Z"/>
+</vector>

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/camera/lifecycle/NavigationScaleGestureHandlerTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/camera/lifecycle/NavigationScaleGestureHandlerTest.kt
@@ -12,8 +12,8 @@ import com.mapbox.maps.plugin.delegates.listeners.OnCameraChangeListener
 import com.mapbox.maps.plugin.gestures.GesturesPlugin
 import com.mapbox.maps.plugin.gestures.OnMoveListener
 import com.mapbox.maps.plugin.gestures.generated.GesturesSettings
-import com.mapbox.maps.plugin.location.LocationPluginImpl
-import com.mapbox.maps.plugin.location.OnIndicatorPositionChangedListener
+import com.mapbox.maps.plugin.locationcomponent.LocationComponentPlugin
+import com.mapbox.maps.plugin.locationcomponent.OnIndicatorPositionChangedListener
 import com.mapbox.navigation.ui.maps.R
 import com.mapbox.navigation.ui.maps.camera.NavigationCamera
 import com.mapbox.navigation.ui.maps.camera.NavigationCamera.Companion.NAVIGATION_CAMERA_OWNER
@@ -53,7 +53,7 @@ class NavigationScaleGestureHandlerTest {
     private val customGesturesManager: AndroidGesturesManager = mockk(relaxUnitFun = true)
     private val customMoveGestureDetector: MoveGestureDetector = mockk(relaxUnitFun = true)
     private val gesturesPlugin: GesturesPlugin = mockk(relaxUnitFun = true)
-    private val locationPlugin: LocationPluginImpl = mockk(relaxUnitFun = true)
+    private val locationPlugin: LocationComponentPlugin = mockk(relaxUnitFun = true)
     private val scaleActionListener: NavigationScaleGestureActionListener =
         mockk(relaxUnitFun = true)
     private val options = NavigationScaleGestureHandlerOptions.Builder(context)

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtilsTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtilsTest.kt
@@ -12,7 +12,7 @@ import com.mapbox.geojson.Point
 import com.mapbox.maps.LayerPosition
 import com.mapbox.maps.Style
 import com.mapbox.maps.StyleObjectInfo
-import com.mapbox.maps.plugin.location.LocationComponentConstants
+import com.mapbox.maps.plugin.locationcomponent.LocationComponentConstants
 import com.mapbox.navigation.testing.FileUtils
 import com.mapbox.navigation.testing.FileUtils.loadJsonFixture
 import com.mapbox.navigation.ui.base.internal.route.RouteConstants
@@ -306,7 +306,7 @@ class MapboxRouteLineUtilsTest {
                 styleLayerExists(RouteConstants.ALTERNATIVE_ROUTE2_TRAFFIC_LAYER_ID)
             } returns false
             every { styleLayerExists(RouteConstants.WAYPOINT_LAYER_ID) } returns false
-            every { styleLayerExists("mapbox-location-foreground-layer") } returns true
+            every { styleLayerExists(LocationComponentConstants.MODEL_LAYER) } returns true
             every {
                 addStyleSource(RouteConstants.WAYPOINT_SOURCE_ID, any())
             } returns ExpectedFactory.createValue()
@@ -494,43 +494,43 @@ class MapboxRouteLineUtilsTest {
             (addStyleLayerSlots[9].contents as HashMap<String, Value>)["id"]!!.contents
         )
         assertEquals(
-            "mapbox-location-foreground-layer",
+            LocationComponentConstants.MODEL_LAYER,
             addStyleLayerPositionSlots[0].below
         )
         assertEquals(
-            "mapbox-location-foreground-layer",
+            LocationComponentConstants.MODEL_LAYER,
             addStyleLayerPositionSlots[1].below
         )
         assertEquals(
-            "mapbox-location-foreground-layer",
+            LocationComponentConstants.MODEL_LAYER,
             addStyleLayerPositionSlots[2].below
         )
         assertEquals(
-            "mapbox-location-foreground-layer",
+            LocationComponentConstants.MODEL_LAYER,
             addStyleLayerPositionSlots[3].below
         )
         assertEquals(
-            "mapbox-location-foreground-layer",
+            LocationComponentConstants.MODEL_LAYER,
             addStyleLayerPositionSlots[4].below
         )
         assertEquals(
-            "mapbox-location-foreground-layer",
+            LocationComponentConstants.MODEL_LAYER,
             addStyleLayerPositionSlots[5].below
         )
         assertEquals(
-            "mapbox-location-foreground-layer",
+            LocationComponentConstants.MODEL_LAYER,
             addStyleLayerPositionSlots[6].below
         )
         assertEquals(
-            "mapbox-location-foreground-layer",
+            LocationComponentConstants.MODEL_LAYER,
             addStyleLayerPositionSlots[7].below
         )
         assertEquals(
-            "mapbox-location-foreground-layer",
+            LocationComponentConstants.MODEL_LAYER,
             addStyleLayerPositionSlots[8].below
         )
         assertEquals(
-            "mapbox-location-foreground-layer",
+            LocationComponentConstants.MODEL_LAYER,
             addStyleLayerPositionSlots[9].below
         )
     }
@@ -562,7 +562,7 @@ class MapboxRouteLineUtilsTest {
 
         val result = MapboxRouteLineUtils.getDefaultBelowLayer("foobar", style)
 
-        assertEquals(LocationComponentConstants.FOREGROUND_LAYER, result)
+        assertEquals(LocationComponentConstants.MODEL_LAYER, result)
     }
 
     @Test
@@ -624,7 +624,7 @@ class MapboxRouteLineUtilsTest {
 
         val result = MapboxRouteLineUtils.getDefaultBelowLayer(null, style)
 
-        assertEquals(LocationComponentConstants.FOREGROUND_LAYER, result)
+        assertEquals(LocationComponentConstants.MODEL_LAYER, result)
     }
 
     @Test

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/location/NavigationLocationProviderTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/location/NavigationLocationProviderTest.kt
@@ -1,0 +1,185 @@
+package com.mapbox.navigation.ui.maps.location
+
+import android.animation.ValueAnimator
+import android.location.Location
+import com.mapbox.geojson.Point
+import com.mapbox.maps.plugin.locationcomponent.LocationConsumer
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class NavigationLocationProviderTest {
+
+    private lateinit var navigationLocationProvider: NavigationLocationProvider
+
+    @Before
+    fun setup() {
+        navigationLocationProvider = NavigationLocationProvider()
+    }
+
+    @Test
+    fun `location is cached`() {
+        val location: Location = mockk()
+
+        navigationLocationProvider.changePosition(location)
+
+        assertEquals(location, navigationLocationProvider.lastLocation)
+    }
+
+    @Test
+    fun `keyPoints are cached`() {
+        val location: Location = mockk()
+        val keyPoints: List<Location> = mockk()
+
+        navigationLocationProvider.changePosition(location, keyPoints)
+
+        assertEquals(keyPoints, navigationLocationProvider.lastKeyPoints)
+    }
+
+    @Test
+    fun `location consumers are notified on update, without key points`() {
+        val location: Location = mockk {
+            every { latitude } returns 10.0
+            every { longitude } returns 20.0
+            every { bearing } returns 123f
+        }
+        val keyPoints: List<Location> = emptyList()
+        val latLngOptions: (ValueAnimator.() -> Unit) = mockk()
+        val bearingOptions: (ValueAnimator.() -> Unit) = mockk()
+        val consumer: LocationConsumer = mockk(relaxUnitFun = true)
+
+        navigationLocationProvider.registerLocationConsumer(consumer)
+        navigationLocationProvider.changePosition(
+            location,
+            keyPoints,
+            latLngOptions,
+            bearingOptions
+        )
+
+        val expectedPoints =
+            arrayOf(Point.fromLngLat(location.longitude, location.latitude))
+        verify(exactly = 1) { consumer.onLocationUpdated(*expectedPoints, options = latLngOptions) }
+        val expectedBearings = doubleArrayOf(location.bearing.toDouble())
+        verify(exactly = 1) {
+            consumer.onBearingUpdated(*expectedBearings, options = bearingOptions)
+        }
+    }
+
+    @Test
+    fun `location consumers are notified on update, with key points`() {
+        val location: Location = mockk {
+            every { latitude } returns 10.0
+            every { longitude } returns 20.0
+            every { bearing } returns 123f
+        }
+        val keyPoint: Location = mockk {
+            every { latitude } returns 30.0
+            every { longitude } returns 40.0
+            every { bearing } returns 456f
+        }
+        val keyPoints: List<Location> = listOf(keyPoint, location)
+        val latLngOptions: (ValueAnimator.() -> Unit) = mockk()
+        val bearingOptions: (ValueAnimator.() -> Unit) = mockk()
+        val consumer: LocationConsumer = mockk(relaxUnitFun = true)
+
+        navigationLocationProvider.registerLocationConsumer(consumer)
+        navigationLocationProvider.changePosition(
+            location,
+            keyPoints,
+            latLngOptions,
+            bearingOptions
+        )
+
+        val expectedPoints = arrayOf(
+            Point.fromLngLat(keyPoint.longitude, keyPoint.latitude),
+            Point.fromLngLat(location.longitude, location.latitude),
+        )
+        verify(exactly = 1) { consumer.onLocationUpdated(*expectedPoints, options = latLngOptions) }
+        val expectedBearings = doubleArrayOf(
+            keyPoint.bearing.toDouble(),
+            location.bearing.toDouble()
+        )
+        verify(exactly = 1) {
+            consumer.onBearingUpdated(*expectedBearings, options = bearingOptions)
+        }
+    }
+
+    @Test
+    fun `location consumers are notified immediately on registration`() {
+        val location: Location = mockk {
+            every { latitude } returns 10.0
+            every { longitude } returns 20.0
+            every { bearing } returns 123f
+        }
+        val keyPoint: Location = mockk {
+            every { latitude } returns 30.0
+            every { longitude } returns 40.0
+            every { bearing } returns 456f
+        }
+        val keyPoints: List<Location> = listOf(keyPoint, location)
+        val consumer: LocationConsumer = mockk(relaxUnitFun = true)
+        val latLngAnimator: ValueAnimator = mockk {
+            every { setDuration(any()) } returns this
+        }
+        every { consumer.onLocationUpdated(*anyVararg(), options = captureLambda()) } answers {
+            secondArg<(ValueAnimator.() -> Unit)>().invoke(latLngAnimator)
+        }
+        val bearingAnimator: ValueAnimator = mockk {
+            every { setDuration(any()) } returns this
+        }
+        every { consumer.onBearingUpdated(*anyDoubleVararg(), options = captureLambda()) } answers {
+            lambda<(ValueAnimator.() -> Unit)>().captured.invoke(bearingAnimator)
+        }
+
+        navigationLocationProvider.changePosition(
+            location,
+            keyPoints
+        )
+        navigationLocationProvider.registerLocationConsumer(consumer)
+
+        val expectedPoints = arrayOf(
+            Point.fromLngLat(keyPoint.longitude, keyPoint.latitude),
+            Point.fromLngLat(location.longitude, location.latitude),
+        )
+        verify(exactly = 1) { consumer.onLocationUpdated(*expectedPoints, options = any()) }
+        val expectedBearings = doubleArrayOf(
+            keyPoint.bearing.toDouble(),
+            location.bearing.toDouble()
+        )
+        verify(exactly = 1) {
+            consumer.onBearingUpdated(*expectedBearings, options = any())
+        }
+        verify { latLngAnimator.duration = 0 }
+        verify { bearingAnimator.duration = 0 }
+    }
+
+    @Test
+    fun `location consumers aren't notified when unregistered`() {
+        val location: Location = mockk {
+            every { latitude } returns 10.0
+            every { longitude } returns 20.0
+            every { bearing } returns 123f
+        }
+        val keyPoints: List<Location> = emptyList()
+        val latLngOptions: (ValueAnimator.() -> Unit) = mockk()
+        val bearingOptions: (ValueAnimator.() -> Unit) = mockk()
+        val consumer: LocationConsumer = mockk(relaxUnitFun = true)
+
+        navigationLocationProvider.registerLocationConsumer(consumer)
+        navigationLocationProvider.unRegisterLocationConsumer(consumer)
+        navigationLocationProvider.changePosition(
+            location,
+            keyPoints,
+            latLngOptions,
+            bearingOptions
+        )
+
+        verify(exactly = 0) { consumer.onLocationUpdated(any()) }
+        verify(exactly = 0) {
+            consumer.onBearingUpdated(any())
+        }
+    }
+}

--- a/test-app/src/main/java/com/mapbox/navigation/examples/util/Slackline.kt
+++ b/test-app/src/main/java/com/mapbox/navigation/examples/util/Slackline.kt
@@ -8,9 +8,8 @@ import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.geojson.Point
 import com.mapbox.maps.MapView
 import com.mapbox.maps.Style
-import com.mapbox.maps.plugin.location.LocationPluginImpl
-import com.mapbox.maps.plugin.location.OnIndicatorPositionChangedListener
-import com.mapbox.maps.plugin.location.getLocationPlugin
+import com.mapbox.maps.plugin.locationcomponent.OnIndicatorPositionChangedListener
+import com.mapbox.maps.plugin.locationcomponent.getLocationComponentPlugin
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesObserver
@@ -70,15 +69,6 @@ class Slackline(private val activity: AppCompatActivity) : LifecycleObserver {
                 }
             }
         )
-        getLocationComponent(mapView).addOnIndicatorPositionChangedListener(
-            onIndicatorPositionChangedListener
-        )
-        mapboxNavigation.registerRoutesObserver(routesObserver)
-        mapboxNavigation.registerRouteProgressObserver(routeProgressObserver)
-    }
-
-    private fun getLocationComponent(mapView: MapView): LocationPluginImpl {
-        return mapView.getLocationPlugin()
     }
 
     private val onIndicatorPositionChangedListener = object : OnIndicatorPositionChangedListener {
@@ -123,9 +113,18 @@ class Slackline(private val activity: AppCompatActivity) : LifecycleObserver {
         }
     }
 
+    @OnLifecycleEvent(Lifecycle.Event.ON_START)
+    private fun onStart() {
+        mapView.getLocationComponentPlugin().addOnIndicatorPositionChangedListener(
+            onIndicatorPositionChangedListener
+        )
+        mapboxNavigation.registerRoutesObserver(routesObserver)
+        mapboxNavigation.registerRouteProgressObserver(routeProgressObserver)
+    }
+
     @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
     private fun onStop() {
-        getLocationComponent(mapView).removeOnIndicatorPositionChangedListener(
+        mapView.getLocationComponentPlugin().removeOnIndicatorPositionChangedListener(
             onIndicatorPositionChangedListener
         )
         mapboxNavigation.unregisterRoutesObserver(routesObserver)

--- a/test-app/src/main/res/layout/activity_mapbox_route_line_api_example.xml
+++ b/test-app/src/main/res/layout/activity_mapbox_route_line_api_example.xml
@@ -6,15 +6,14 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <com.mapbox.maps.MapView
-        android:id="@+id/mapView"
+    <RelativeLayout
+        android:id="@+id/mapView_container"
         android:layout_width="0dp"
         android:layout_height="0dp"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
-        />
+        app:layout_constraintBottom_toBottomOf="parent" />
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/fabToggleStyle"

--- a/test-app/src/main/res/layout/layout_activity_maneuver.xml
+++ b/test-app/src/main/res/layout/layout_activity_maneuver.xml
@@ -15,17 +15,6 @@
       app:layout_constraintBottom_toBottomOf="parent"
       />
 
-  <androidx.appcompat.widget.AppCompatButton
-      android:id="@+id/startNavigation"
-      android:layout_width="0dp"
-      android:layout_height="wrap_content"
-      app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintBottom_toBottomOf="parent"
-      android:background="@color/colorPrimary"
-      android:text="@string/start_navigation"
-      android:textColor="@android:color/white" />
-
   <com.mapbox.navigation.ui.maneuver.view.MapboxManeuverView
       android:id="@+id/maneuverView"
       android:layout_width="0dp"

--- a/test-app/src/main/res/layout/layout_activity_signboard.xml
+++ b/test-app/src/main/res/layout/layout_activity_signboard.xml
@@ -15,17 +15,6 @@
         app:layout_constraintBottom_toBottomOf="parent"
         />
 
-    <androidx.appcompat.widget.AppCompatButton
-        android:id="@+id/startNavigation"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
-        android:background="@color/colorPrimary"
-        android:text="@string/start_navigation"
-        android:textColor="@android:color/white" />
-
     <com.mapbox.navigation.ui.maps.signboard.view.MapboxSignboardView
         android:id="@+id/signboardView"
         android:layout_width="wrap_content"

--- a/test-app/src/main/res/layout/layout_activity_snapshot.xml
+++ b/test-app/src/main/res/layout/layout_activity_snapshot.xml
@@ -15,17 +15,6 @@
         app:layout_constraintBottom_toBottomOf="parent"
         />
 
-    <androidx.appcompat.widget.AppCompatButton
-        android:id="@+id/startNavigation"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
-        android:background="@color/colorPrimary"
-        android:text="@string/start_navigation"
-        android:textColor="@android:color/white" />
-
     <androidx.cardview.widget.CardView
         android:layout_width="0dp"
         android:layout_height="wrap_content"

--- a/test-app/src/main/res/layout/trip_progress_activity_layout.xml
+++ b/test-app/src/main/res/layout/trip_progress_activity_layout.xml
@@ -1,37 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-  <RelativeLayout
-      android:id="@+id/mapView_container"
-      android:layout_width="0dp"
-      android:layout_height="0dp"
-      app:layout_constraintTop_toTopOf="parent"
-      app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintBottom_toBottomOf="parent"/>
+    <com.mapbox.maps.MapView
+        android:id="@+id/mapView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
-  <androidx.appcompat.widget.AppCompatButton
-      android:id="@+id/startNavigation"
-      android:layout_width="0dp"
-      android:layout_height="wrap_content"
-      app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintBottom_toBottomOf="parent"
-      android:background="@color/colorPrimary"
-      android:text="@string/start_navigation"
-      android:textColor="@android:color/white"
-      android:visibility="gone" />
+    <com.mapbox.navigation.ui.tripprogress.view.MapboxTripProgressView
+        android:id="@+id/tripProgressView"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:visibility="invisible"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
 
-  <com.mapbox.navigation.ui.tripprogress.view.MapboxTripProgressView
-      android:id="@+id/tripProgressView"
-      android:layout_width="0dp"
-      android:layout_height="wrap_content"
-      app:layout_constraintBottom_toBottomOf="parent"
-      app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="parent"
-      android:visibility="invisible"/>
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Closes #3952. This PR upgrades the Maps SDK to the latest `v10.0.0-beta.13` which reintroduces the `OnIndicatorPositionChangedListener` which means that we can rely on the new `LocationComponentPlugin` implementation instead of the legacy one.

Since the new `LocationComponentPlugin` introduces a concept of a `LocationProvider`, this PR also adds a utility class that can be paired with Nav SDK's enhanced location generators to transition the puck.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Upgraded Maps SDK top `v10.0.0-beta.13`. Together with the update, Nav SDK switches the puck rendering dependency to the new `LocationComponentPlugin`. You can use the `NavigationLocationProvider` to feed the puck with enhanced location updates.</changelog>
```

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
