### PR TITLE
Bump mapbox-navigation-native version to 31.0.1

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -11,7 +11,7 @@ ext {
       mapboxSdkServices         : '5.8.0',
       mapboxEvents              : '6.2.2',
       mapboxCore                : '3.1.1',
-      mapboxNavigator           : '31.0.0',
+      mapboxNavigator           : '31.0.1',
       mapboxCommonNative        : '9.1.0',
       mapboxCrashMonitor        : '2.0.0',
       mapboxAnnotationPlugin    : '0.8.0',


### PR DESCRIPTION
### Description

Bumps `mapbox-navigation-native` version to `31.0.1`

cc @etl @mskurydin @truburt  