### PR TITLE
Fix RouteProgress toString typo

### DIFF
--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteProgress.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteProgress.kt
@@ -139,7 +139,7 @@ class RouteProgress private constructor(
             "distanceTraveled=$distanceTraveled, " +
             "durationRemaining=$durationRemaining, " +
             "fractionTraveled=$fractionTraveled, " +
-            "remainingWaypoints=$remainingWaypoints" +
+            "remainingWaypoints=$remainingWaypoints, " +
             "upcomingRouteAlerts=$upcomingRouteAlerts" +
             ")"
     }


### PR DESCRIPTION
### Description
Fixes `RouteProgress` `toString` typo