### PR TITLE
Bump mapbox-navigation-native version to 41.0.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -11,7 +11,7 @@ ext {
       mapboxSdkServices         : '5.9.0-alpha.1',
       mapboxEvents              : '6.2.2',
       mapboxCore                : '3.1.1',
-      mapboxNavigator           : '40.0.2',
+      mapboxNavigator           : '41.0.0',
       mapboxCommonNative        : '10.0.0-beta.9.1',
       mapboxCrashMonitor        : '2.0.0',
       mapboxAnnotationPlugin    : '0.8.0',

--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -590,12 +590,21 @@ package com.mapbox.navigation.core.trip.model.eh {
   }
 
   public final class EHorizonObjectType {
+    field public static final String BORDER_CROSSING = "BORDER_CROSSING";
+    field public static final String BRIDGE_ENTRANCE = "BRIDGE_ENTRANCE";
+    field public static final String BRIDGE_EXIT = "BRIDGE_EXIT";
     field public static final String CUSTOM = "CUSTOM";
     field public static final String INCIDENT = "INCIDENT";
     field public static final com.mapbox.navigation.core.trip.model.eh.EHorizonObjectType! INSTANCE;
+    field public static final String RESTRICTED_AREA_ENTRANCE = "RESTRICTED_AREA_ENTRANCE";
+    field public static final String RESTRICTED_AREA_EXIT = "RESTRICTED_AREA_EXIT";
+    field public static final String SERVICE_AREA = "SERVICE_AREA";
+    field public static final String TOLL_COLLECTION_POINT = "TOLL_COLLECTION_POINT";
+    field public static final String TUNNEL_ENTRANCE = "TUNNEL_ENTRANCE";
+    field public static final String TUNNEL_EXIT = "TUNNEL_EXIT";
   }
 
-  @StringDef({com.mapbox.navigation.core.trip.model.eh.EHorizonObjectType.INCIDENT, com.mapbox.navigation.core.trip.model.eh.EHorizonObjectType.CUSTOM}) @kotlin.annotation.Retention public static @interface EHorizonObjectType.Type {
+  @StringDef({com.mapbox.navigation.core.trip.model.eh.EHorizonObjectType.INCIDENT, com.mapbox.navigation.core.trip.model.eh.EHorizonObjectType.TOLL_COLLECTION_POINT, com.mapbox.navigation.core.trip.model.eh.EHorizonObjectType.BORDER_CROSSING, com.mapbox.navigation.core.trip.model.eh.EHorizonObjectType.TUNNEL_ENTRANCE, com.mapbox.navigation.core.trip.model.eh.EHorizonObjectType.TUNNEL_EXIT, com.mapbox.navigation.core.trip.model.eh.EHorizonObjectType.RESTRICTED_AREA_ENTRANCE, com.mapbox.navigation.core.trip.model.eh.EHorizonObjectType.RESTRICTED_AREA_EXIT, com.mapbox.navigation.core.trip.model.eh.EHorizonObjectType.SERVICE_AREA, com.mapbox.navigation.core.trip.model.eh.EHorizonObjectType.BRIDGE_ENTRANCE, com.mapbox.navigation.core.trip.model.eh.EHorizonObjectType.BRIDGE_EXIT, com.mapbox.navigation.core.trip.model.eh.EHorizonObjectType.CUSTOM}) @kotlin.annotation.Retention public static @interface EHorizonObjectType.Type {
   }
 
   public final class EHorizonPosition {

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/model/eh/EHorizonMapper.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/model/eh/EHorizonMapper.kt
@@ -77,6 +77,15 @@ internal fun RoadObjectLocation.mapToEHorizonObjectLocation(): EHorizonObjectLoc
 internal fun RoadObjectType.mapToEHorizonObjectType(): String {
     return when (this) {
         RoadObjectType.INCIDENT -> EHorizonObjectType.INCIDENT
+        RoadObjectType.TOLL_COLLECTION_POINT -> EHorizonObjectType.TOLL_COLLECTION_POINT
+        RoadObjectType.BORDER_CROSSING -> EHorizonObjectType.BORDER_CROSSING
+        RoadObjectType.TUNNEL_ENTRANCE -> EHorizonObjectType.TUNNEL_ENTRANCE
+        RoadObjectType.TUNNEL_EXIT -> EHorizonObjectType.TUNNEL_EXIT
+        RoadObjectType.RESTRICTED_AREA_ENTRANCE -> EHorizonObjectType.RESTRICTED_AREA_ENTRANCE
+        RoadObjectType.RESTRICTED_AREA_EXIT -> EHorizonObjectType.RESTRICTED_AREA_EXIT
+        RoadObjectType.SERVICE_AREA -> EHorizonObjectType.SERVICE_AREA
+        RoadObjectType.BRIDGE_ENTRANCE -> EHorizonObjectType.BRIDGE_ENTRANCE
+        RoadObjectType.BRIDGE_EXIT -> EHorizonObjectType.BRIDGE_EXIT
         RoadObjectType.CUSTOM -> EHorizonObjectType.CUSTOM
     }
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/model/eh/EHorizonObjectType.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/model/eh/EHorizonObjectType.kt
@@ -14,6 +14,51 @@ object EHorizonObjectType {
     const val INCIDENT = "INCIDENT"
 
     /**
+     * Road object represents some toll collection point
+     */
+    const val TOLL_COLLECTION_POINT = "TOLL_COLLECTION_POINT"
+
+    /**
+     * Road object represents some border crossing
+     */
+    const val BORDER_CROSSING = "BORDER_CROSSING"
+
+    /**
+     * Road object represents some tunnel entrance
+     */
+    const val TUNNEL_ENTRANCE = "TUNNEL_ENTRANCE"
+
+    /**
+     * Road object represents some tunnel exit
+     */
+    const val TUNNEL_EXIT = "TUNNEL_EXIT"
+
+    /**
+     * Road object represents some restricted area entrance
+     */
+    const val RESTRICTED_AREA_ENTRANCE = "RESTRICTED_AREA_ENTRANCE"
+
+    /**
+     * Road object represents some restricted area exit
+     */
+    const val RESTRICTED_AREA_EXIT = "RESTRICTED_AREA_EXIT"
+
+    /**
+     * Road object represents some service area
+     */
+    const val SERVICE_AREA = "SERVICE_AREA"
+
+    /**
+     * Road object represents some bridge entrance
+     */
+    const val BRIDGE_ENTRANCE = "BRIDGE_ENTRANCE"
+
+    /**
+     * Road object represents some bridge exit
+     */
+    const val BRIDGE_EXIT = "BRIDGE_EXIT"
+
+    /**
      * Road object was added by user
      * (via [EHorizonObjectsStore.addCustomRoadObject])
      */
@@ -23,6 +68,18 @@ object EHorizonObjectType {
      * Retention policy for the EHorizonObjectType
      */
     @Retention
-    @StringDef(INCIDENT, CUSTOM)
+    @StringDef(
+        INCIDENT,
+        TOLL_COLLECTION_POINT,
+        BORDER_CROSSING,
+        TUNNEL_ENTRANCE,
+        TUNNEL_EXIT,
+        RESTRICTED_AREA_ENTRANCE,
+        RESTRICTED_AREA_EXIT,
+        SERVICE_AREA,
+        BRIDGE_ENTRANCE,
+        BRIDGE_EXIT,
+        CUSTOM
+    )
     annotation class Type
 }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/events/SchemaTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/events/SchemaTest.kt
@@ -340,6 +340,7 @@ class SchemaTest {
         properties.remove("locationEnabled")
         // temporary need to work out a solution to include this data
         properties.remove("platform")
+        properties.remove("version")
         return properties
     }
 


### PR DESCRIPTION
### Description
Bumps `mapbox-navigation-native` version to `41.0.0` and fixes breaking changes

cc @etl @mskurydin 