### PR TITLE
Rename EHorizonGraphAccessor and EHorizonObjectsStore

### DIFF
--- a/docs/eh_v3.md
+++ b/docs/eh_v3.md
@@ -59,14 +59,14 @@ interface EHorizonObserver {
 }
 ```
 
-Anytime you need edge's shape or metadata you can get it with `EHorizonGraphAccessor`.
+Anytime you need edge's shape or metadata you can get it with `GraphAccessor`.
 It's available with
 ```kotlin
-mapboxNavigation.getEHorizonGraphAccessor()
+mapboxNavigation.graphAccessor
 ```
 
 ```kotlin
-interface EHorizonGraphAccessor {
+class GraphAccessor {
     /**
      * Returns Graph Edge geometry for the given GraphId of the edge.
      * If edge with given edgeId is not accessible, returns null
@@ -87,14 +87,14 @@ interface EHorizonGraphAccessor {
 }
 ```
 
-Anytime you need road object's metadata or location you can get it with `EHorizonObjectsStore`
+Anytime you need road object's metadata or location you can get it with `RoadObjectsStore`
 It's available with
 ```kotlin
-mapboxNavigation.getEHorizonObjectsStore()
+mapboxNavigation.roadObjectsStore
 ```
 
 ```kotlin
-interface EHorizonObjectsStore {
+class RoadObjectsStore {
     /**
      * Returns mapping `road object id -> EHorizonObjectEdgeLocation` for all road objects
      * which are lying on the edge with given id.

--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -6,10 +6,10 @@ package com.mapbox.navigation.core {
     method public void addHistoryEvent(String eventType, String eventJsonProperties);
     method public void attachFasterRouteObserver(com.mapbox.navigation.core.fasterroute.FasterRouteObserver fasterRouteObserver);
     method public void detachFasterRouteObserver();
-    method public com.mapbox.navigation.core.trip.session.EHorizonGraphAccessor getEHorizonGraphAccessor();
-    method public com.mapbox.navigation.core.trip.session.EHorizonObjectsStore getEHorizonObjectsStore();
+    method public com.mapbox.navigation.core.trip.session.GraphAccessor getGraphAccessor();
     method public com.mapbox.navigation.base.options.NavigationOptions getNavigationOptions();
     method public com.mapbox.navigation.core.reroute.RerouteController? getRerouteController();
+    method public com.mapbox.navigation.core.trip.session.RoadObjectsStore getRoadObjectsStore();
     method public java.util.List<com.mapbox.api.directions.v5.models.DirectionsRoute> getRoutes();
     method public com.mapbox.navigation.core.trip.session.TripSessionState getTripSessionState();
     method public boolean navigateNextRouteLeg();
@@ -51,6 +51,8 @@ package com.mapbox.navigation.core {
     method public void unregisterTripSessionStateObserver(com.mapbox.navigation.core.trip.session.TripSessionStateObserver tripSessionStateObserver);
     method public void unregisterVoiceInstructionsObserver(com.mapbox.navigation.core.trip.session.VoiceInstructionsObserver voiceInstructionsObserver);
     method public void updateSensorEvent(android.hardware.SensorEvent sensorEvent);
+    property public final com.mapbox.navigation.core.trip.session.GraphAccessor graphAccessor;
+    property public final com.mapbox.navigation.core.trip.session.RoadObjectsStore roadObjectsStore;
     field public static final com.mapbox.navigation.core.MapboxNavigation.Companion! Companion;
   }
 
@@ -655,20 +657,6 @@ package com.mapbox.navigation.core.trip.session {
     method public void onNewBannerInstructions(com.mapbox.api.directions.v5.models.BannerInstructions bannerInstructions);
   }
 
-  public final class EHorizonGraphAccessor {
-    method public com.mapbox.navigation.core.trip.model.eh.EHorizonEdgeMetadata? getEdgeMetadata(long edgeId);
-    method public java.util.List<com.mapbox.geojson.Point>? getEdgeShape(long edgeId);
-  }
-
-  public final class EHorizonObjectsStore {
-    method public void addCustomRoadObject(String roadObjectId, String openLRLocation, @com.mapbox.navigation.core.trip.model.eh.OpenLRStandard.Type String openLRStandard);
-    method public java.util.List<java.lang.String> getRoadObjectIdsByEdgeIds(java.util.List<java.lang.Long> edgeIds);
-    method public com.mapbox.navigation.core.trip.model.eh.EHorizonObjectLocation? getRoadObjectLocation(String roadObjectId);
-    method public com.mapbox.navigation.core.trip.model.eh.EHorizonObjectMetadata? getRoadObjectMetadata(String roadObjectId);
-    method public java.util.Map<java.lang.String,com.mapbox.navigation.core.trip.model.eh.EHorizonObjectEdgeLocation> getRoadObjectsOnTheEdge(long edgeId);
-    method public void removeCustomRoadObject(String roadObjectId);
-  }
-
   public interface EHorizonObserver {
     method public void onPositionUpdated(com.mapbox.navigation.core.trip.model.eh.EHorizonPosition position, java.util.Map<java.lang.String,com.mapbox.navigation.core.trip.model.eh.EHorizonObjectDistanceInfo> distances);
     method public void onRoadObjectAdded(String roadObjectId);
@@ -676,6 +664,11 @@ package com.mapbox.navigation.core.trip.session {
     method public void onRoadObjectExit(com.mapbox.navigation.core.trip.model.eh.EHorizonObjectEnterExitInfo objectEnterExitInfo);
     method public void onRoadObjectRemoved(String roadObjectId);
     method public void onRoadObjectUpdated(String roadObjectId);
+  }
+
+  public final class GraphAccessor {
+    method public com.mapbox.navigation.core.trip.model.eh.EHorizonEdgeMetadata? getEdgeMetadata(long edgeId);
+    method public java.util.List<com.mapbox.geojson.Point>? getEdgeShape(long edgeId);
   }
 
   public interface LocationObserver {
@@ -699,6 +692,15 @@ package com.mapbox.navigation.core.trip.session {
 
   public interface OffRouteObserver {
     method public void onOffRouteStateChanged(boolean offRoute);
+  }
+
+  public final class RoadObjectsStore {
+    method public void addCustomRoadObject(String roadObjectId, String openLRLocation, @com.mapbox.navigation.core.trip.model.eh.OpenLRStandard.Type String openLRStandard);
+    method public java.util.List<java.lang.String> getRoadObjectIdsByEdgeIds(java.util.List<java.lang.Long> edgeIds);
+    method public com.mapbox.navigation.core.trip.model.eh.EHorizonObjectLocation? getRoadObjectLocation(String roadObjectId);
+    method public com.mapbox.navigation.core.trip.model.eh.EHorizonObjectMetadata? getRoadObjectMetadata(String roadObjectId);
+    method public java.util.Map<java.lang.String,com.mapbox.navigation.core.trip.model.eh.EHorizonObjectEdgeLocation> getRoadObjectsOnTheEdge(long edgeId);
+    method public void removeCustomRoadObject(String roadObjectId);
   }
 
   public interface RouteAlertsObserver {

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -50,13 +50,13 @@ import com.mapbox.navigation.core.trip.model.eh.EHorizonEdge
 import com.mapbox.navigation.core.trip.model.eh.EHorizonEdgeMetadata
 import com.mapbox.navigation.core.trip.service.TripService
 import com.mapbox.navigation.core.trip.session.BannerInstructionsObserver
-import com.mapbox.navigation.core.trip.session.EHorizonGraphAccessor
-import com.mapbox.navigation.core.trip.session.EHorizonObjectsStore
 import com.mapbox.navigation.core.trip.session.EHorizonObserver
+import com.mapbox.navigation.core.trip.session.GraphAccessor
 import com.mapbox.navigation.core.trip.session.LocationObserver
 import com.mapbox.navigation.core.trip.session.MapMatcherResult
 import com.mapbox.navigation.core.trip.session.MapMatcherResultObserver
 import com.mapbox.navigation.core.trip.session.OffRouteObserver
+import com.mapbox.navigation.core.trip.session.RoadObjectsStore
 import com.mapbox.navigation.core.trip.session.RouteAlertsObserver
 import com.mapbox.navigation.core.trip.session.RouteProgressObserver
 import com.mapbox.navigation.core.trip.session.TripSession
@@ -166,8 +166,17 @@ class MapboxNavigation(
      */
     private var rerouteController: RerouteController?
     private val defaultRerouteController: RerouteController
-    private val eHorizonObjectsStore: EHorizonObjectsStore
-    private val eHorizonGraphAccessor: EHorizonGraphAccessor
+    /**
+     * [MapboxNavigation.roadObjectsStore] provides methods to get road objects metadata,
+     * add and remove custom road
+     * objects.
+     */
+    val roadObjectsStore: RoadObjectsStore
+    /**
+     * [MapboxNavigation.graphAccessor] provides methods to get edge (e.g. [EHorizonEdge]) shape and
+     * metadata.
+     */
+    val graphAccessor: GraphAccessor
 
     init {
         ThreadController.init()
@@ -259,8 +268,8 @@ class MapboxNavigation(
         tripSession.registerOffRouteObserver(internalOffRouteObserver)
         directionsSession.registerRoutesObserver(internalRoutesObserver)
 
-        eHorizonObjectsStore = EHorizonObjectsStore(navigator)
-        eHorizonGraphAccessor = EHorizonGraphAccessor(navigator)
+        roadObjectsStore = RoadObjectsStore(navigator)
+        graphAccessor = GraphAccessor(navigator)
     }
 
     /**
@@ -632,8 +641,8 @@ class MapboxNavigation(
      * To start listening EHorizon updates [EHorizonObserver] should be registered.
      * Observer will be called when the EHorizon changes.
      * To save resources and be more efficient callbacks return minimum data.
-     * To get [EHorizonEdge] shape or [EHorizonEdgeMetadata] use [EHorizonGraphAccessor]
-     * To get more data about EHorizon road object use [EHorizonObjectsStore]
+     * To get [EHorizonEdge] shape or [EHorizonEdgeMetadata] use [MapboxNavigation.graphAccessor]
+     * To get more data about EHorizon road object use [MapboxNavigation.roadObjectsStore]
      *
      * Registering an EHorizonObserver activates the Electronic Horizon module.
      *
@@ -653,16 +662,6 @@ class MapboxNavigation(
     fun unregisterEHorizonObserver(eHorizonObserver: EHorizonObserver) {
         tripSession.unregisterEHorizonObserver(eHorizonObserver)
     }
-
-    /**
-     * Provides [EHorizonGraphAccessor] interface
-     */
-    fun getEHorizonGraphAccessor(): EHorizonGraphAccessor = eHorizonGraphAccessor
-
-    /**
-     * Provides [EHorizonObjectsStore] interface
-     */
-    fun getEHorizonObjectsStore(): EHorizonObjectsStore = eHorizonObjectsStore
 
     /**
      * Registers an observer that gets notified whenever a new enhanced location update is available

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/model/eh/EHorizonObjectType.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/model/eh/EHorizonObjectType.kt
@@ -1,7 +1,7 @@
 package com.mapbox.navigation.core.trip.model.eh
 
 import androidx.annotation.StringDef
-import com.mapbox.navigation.core.trip.session.EHorizonObjectsStore
+import com.mapbox.navigation.core.trip.session.RoadObjectsStore
 
 /**
  * RoadObject type
@@ -60,7 +60,7 @@ object EHorizonObjectType {
 
     /**
      * Road object was added by user
-     * (via [EHorizonObjectsStore.addCustomRoadObject])
+     * (via [RoadObjectsStore.addCustomRoadObject])
      */
     const val CUSTOM = "CUSTOM"
 

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/GraphAccessor.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/GraphAccessor.kt
@@ -1,15 +1,17 @@
 package com.mapbox.navigation.core.trip.session
 
 import com.mapbox.geojson.Point
+import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.trip.model.eh.EHorizonEdge
 import com.mapbox.navigation.core.trip.model.eh.EHorizonEdgeMetadata
 import com.mapbox.navigation.core.trip.model.eh.mapToEHorizonEdgeMetadata
 import com.mapbox.navigation.navigator.internal.MapboxNativeNavigator
 
 /**
- * [EHorizonGraphAccessor] provides methods to get [EHorizonEdge] shape and metadata.
+ * [MapboxNavigation.graphAccessor] provides methods to get edge (e.g. [EHorizonEdge]) shape and
+ * metadata.
  */
-class EHorizonGraphAccessor internal constructor(
+class GraphAccessor internal constructor(
     private val navigator: MapboxNativeNavigator,
 ) {
 

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/RoadObjectsStore.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/RoadObjectsStore.kt
@@ -1,5 +1,6 @@
 package com.mapbox.navigation.core.trip.session
 
+import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.trip.model.eh.EHorizonObjectEdgeLocation
 import com.mapbox.navigation.core.trip.model.eh.EHorizonObjectLocation
 import com.mapbox.navigation.core.trip.model.eh.EHorizonObjectMetadata
@@ -12,9 +13,10 @@ import com.mapbox.navigation.core.trip.model.eh.mapToOpenLRStandard
 import com.mapbox.navigation.navigator.internal.MapboxNativeNavigator
 
 /**
- * [EHorizonObjectsStore] provides methods to get road objects metadata, add and remove it.
+ * [MapboxNavigation.roadObjectsStore] provides methods to get road objects metadata, add and remove
+ * custom road objects.
  */
-class EHorizonObjectsStore internal constructor(
+class RoadObjectsStore internal constructor(
     private val navigator: MapboxNativeNavigator,
 ) {
 


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
`EHorizonGraphAccessor` and `EHorizonObjectsStore` might be used not only in the `EH` context
- You can do map matching to some edge and get metadata of this edge via `GraphAccessor` without building `EH`.
- You can do map matching to some edge and get list of object on this edge via `RoadObjectStore` without building `EH`.
I.e. RoadObjectStore and GraphAccessor gives you ability to get some information about certain edge, no matter from where you obtained this edge.

They were renamed:
`EHorizonGraphAccessor` -> `GraphAccessor`
`EHorizonObjectsStore`     -> `RoadObjectsStore`

removed methods and make values public
`MapboxNavigation.getGraphAccessor()` -> public val graphAccessor
`MapboxNavigation.getRoadObjectsStore()` public val roadObjectsStore

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Renamed EHorizonGraphAccessor and EHorizonObjectsStore to GraphAccessor and RoadObjectsStore, removed getters and made values public.</changelog>
```

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
