### PR TITLE
TileEndpointConfiguration host fix

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -77,6 +77,7 @@ import com.mapbox.navigator.TileEndpointConfiguration
 import com.mapbox.navigator.TilesConfig
 import kotlinx.coroutines.channels.ReceiveChannel
 import java.lang.reflect.Field
+import java.net.URI
 
 private const val MAPBOX_NAVIGATION_USER_AGENT_BASE = "mapbox-navigation-android"
 private const val MAPBOX_NAVIGATION_UI_USER_AGENT_BASE = "mapbox-navigation-ui-android"
@@ -846,32 +847,35 @@ class MapboxNavigation(
 
     private fun createTilesConfig(): TilesConfig {
         // TODO StrictMode may report a violation as we're creating a File from the Main
-        val offlineFilesPath = OnboardRouterFiles(navigationOptions.applicationContext, logger)
-            .absolutePath(navigationOptions.onboardRouterOptions)
-        val dataset = StringBuilder().apply {
-            append(navigationOptions.onboardRouterOptions.tilesDataset)
-            append("/")
-            append(navigationOptions.onboardRouterOptions.tilesProfile)
-        }.toString()
+        navigationOptions.run {
+            val offlineFilesPath = OnboardRouterFiles(applicationContext, logger)
+                .absolutePath(onboardRouterOptions)
+            val dataset = StringBuilder().apply {
+                append(onboardRouterOptions.tilesDataset)
+                append("/")
+                append(onboardRouterOptions.tilesProfile)
+            }.toString()
+            val host = onboardRouterOptions.tilesUri.let { uri ->
+                URI(uri.scheme, uri.host, null, null)
+            }.toString()
 
-        return TilesConfig(
-            offlineFilesPath,
-            null,
-            null,
-            null,
-            THREADS_COUNT,
-            TileEndpointConfiguration(
-                navigationOptions.onboardRouterOptions.tilesUri.toString(),
-                dataset,
-                navigationOptions.onboardRouterOptions.tilesVersion,
-                navigationOptions.accessToken ?: "",
-                USER_AGENT,
-                BuildConfig.NAV_NATIVE_SDK_VERSION,
-                NativeSkuTokenProvider(
-                    MapboxNavigationAccounts.getInstance(navigationOptions.applicationContext)
+            return TilesConfig(
+                offlineFilesPath,
+                null,
+                null,
+                null,
+                THREADS_COUNT,
+                TileEndpointConfiguration(
+                    host,
+                    dataset,
+                    onboardRouterOptions.tilesVersion,
+                    accessToken ?: "",
+                    USER_AGENT,
+                    BuildConfig.NAV_NATIVE_SDK_VERSION,
+                    NativeSkuTokenProvider(MapboxNavigationAccounts.getInstance(applicationContext))
                 )
             )
-        )
+        }
     }
 
     companion object {


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
NavSDK passes `tilesUri` as a `host` param to `TileEndpointConfiguration`. 
NavNative can't handle it because it contains to much data, we need to pass `schema+"://"+host`
so, if we have the next `tilesUri` :
`https://api.mapbox.com/route-tiles/v2/dataset/profile`
we will pass `https://api.mapbox.com` to NN


### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>fix TileEndpointConfiguration host param</changelog>
```

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
