### PR TITLE
Dokka: removed from docs free modules `libnavui-util` and `libnavui-resources`

### DIFF
--- a/libnavui-resources/build.gradle
+++ b/libnavui-resources/build.gradle
@@ -7,7 +7,6 @@ apply plugin: 'com.jaredsburrows.license'
 apply plugin: 'com.mapbox.android.sdk.versions'
 apply from: "${rootDir}/gradle/ktlint.gradle"
 apply from: file("${rootDir}/gradle/artifact-settings.gradle")
-apply from: "${rootDir}/gradle/kdoc-settings.gradle"
 
 version = project.ext.versionName
 group = project.ext.mapboxArtifactGroupId
@@ -30,20 +29,6 @@ android {
 
 dependencies {
     implementation dependenciesList.kotlinStdLib
-}
-
-dokkaHtml {
-    outputDirectory.set(kdocPath)
-    moduleName.set("UI Resources")
-    dokkaSourceSets {
-        configureEach {
-            reportUndocumented.set(true)
-            perPackageOption {
-                matchingRegex.set("com.mapbox.navigation.ui.resources.internal.*")
-                suppress.set(true)
-            }
-        }
-    }
 }
 
 apply from: "${rootDir}/gradle/track-public-apis.gradle"

--- a/libnavui-util/build.gradle
+++ b/libnavui-util/build.gradle
@@ -6,7 +6,6 @@ apply plugin: 'com.jaredsburrows.license'
 apply plugin: 'com.mapbox.android.sdk.versions'
 apply from: "${rootDir}/gradle/ktlint.gradle"
 apply from: file("${rootDir}/gradle/artifact-settings.gradle")
-apply from: "${rootDir}/gradle/kdoc-settings.gradle"
 
 version = project.ext.versionName
 group = project.ext.mapboxArtifactGroupId
@@ -43,20 +42,6 @@ dependencies {
 
     apply from: "${rootDir}/gradle/unit-testing-dependencies.gradle"
     testImplementation(project(':libtesting-utils'))
-}
-
-dokkaHtml {
-    outputDirectory.set(kdocPath)
-    moduleName.set("UI Utils")
-    dokkaSourceSets {
-        configureEach {
-            reportUndocumented.set(true)
-            perPackageOption {
-                matchingRegex.set("com.mapbox.navigation.ui.utils.internal.*")
-                suppress.set(true)
-            }
-        }
-    }
 }
 
 apply from: "${rootDir}/gradle/track-public-apis.gradle"


### PR DESCRIPTION
### Description
Removed `Dokka` from `libnavui-util` and `libnavui-resources` as it's docs free modules

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
