### PR TITLE
- NativeNavigator fix: upgrade route when refresh route; - TripSession alternative route fix : compare routes along with uuid

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -199,7 +199,8 @@ class MapboxNavigation(
         navigator = NavigationComponentProvider.createNativeNavigator(
             navigationOptions.deviceProfile,
             navigatorConfig,
-            createTilesConfig()
+            createTilesConfig(),
+            logger
         )
         navigationSession = NavigationComponentProvider.createNavigationSession()
         directionsSession = NavigationComponentProvider.createDirectionsSession(

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/NavigationComponentProvider.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/NavigationComponentProvider.kt
@@ -27,9 +27,10 @@ internal object NavigationComponentProvider {
     fun createNativeNavigator(
         deviceProfile: DeviceProfile,
         navigatorConfig: NavigatorConfig,
-        tilesConfig: TilesConfig
+        tilesConfig: TilesConfig,
+        logger: Logger
     ): MapboxNativeNavigator =
-        MapboxNativeNavigatorImpl.create(deviceProfile, navigatorConfig, tilesConfig)
+        MapboxNativeNavigatorImpl.create(deviceProfile, navigatorConfig, tilesConfig, logger)
 
     fun createTripService(
         applicationContext: Context,

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/utils/DirectionsRouteEx.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/utils/DirectionsRouteEx.kt
@@ -3,6 +3,31 @@
 package com.mapbox.navigation.core.internal.utils
 
 import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.api.directions.v5.models.LegStep
+import com.mapbox.navigation.utils.internal.ifNonNull
 
-fun DirectionsRoute?.isSameRoute(compare: DirectionsRoute?): Boolean =
-    this?.routeOptions()?.requestUuid() == compare?.routeOptions()?.requestUuid()
+fun DirectionsRoute.isSameUuid(compare: DirectionsRoute?): Boolean =
+    this.routeOptions()?.requestUuid() == compare?.routeOptions()?.requestUuid()
+
+/**
+ * Compare routes as geometries(if exist) or as a names of [LegStep] of the [DirectionsRoute]
+ */
+fun DirectionsRoute.isSameRoute(compare: DirectionsRoute?): Boolean {
+    if (compare == null) return false
+
+    ifNonNull(this.geometry(), compare.geometry()) { g1, g2 ->
+        return g1 == g2
+    }
+
+    ifNonNull(this.stepsNamesAsString(), compare.stepsNamesAsString()) { s1, s2 ->
+        return s1 == s2
+    }
+
+    return false
+}
+
+private fun DirectionsRoute.stepsNamesAsString(): String? =
+    this.legs()
+        ?.joinToString { leg ->
+            leg.steps()?.joinToString { step -> step.name() ?: "" } ?: ""
+        }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
@@ -157,7 +157,7 @@ class MapboxNavigationTest {
         mockDirectionSession()
         mockNavigationSession()
 
-        every { navigator.create(any(), any(), any()) } returns navigator
+        every { navigator.create(any(), any(), any(), any()) } returns navigator
 
         mapboxNavigation = MapboxNavigation(navigationOptions)
 
@@ -592,7 +592,7 @@ class MapboxNavigationTest {
         ThreadController.cancelAllUICoroutines()
         val slot = slot<TilesConfig>()
         every {
-            NavigationComponentProvider.createNativeNavigator(any(), any(), capture(slot))
+            NavigationComponentProvider.createNativeNavigator(any(), any(), capture(slot), any())
         } returns navigator
         val options = navigationOptions.toBuilder()
             .onboardRouterOptions(OnboardRouterOptions.Builder().build())
@@ -610,7 +610,7 @@ class MapboxNavigationTest {
         ThreadController.cancelAllUICoroutines()
         val slot = slot<TilesConfig>()
         every {
-            NavigationComponentProvider.createNativeNavigator(any(), any(), capture(slot))
+            NavigationComponentProvider.createNativeNavigator(any(), any(), capture(slot), any())
         } returns navigator
         val options = navigationOptions.toBuilder()
             .onboardRouterOptions(
@@ -633,7 +633,7 @@ class MapboxNavigationTest {
         ThreadController.cancelAllUICoroutines()
         val slot = slot<NavigatorConfig>()
         every {
-            NavigationComponentProvider.createNativeNavigator(any(), capture(slot), any())
+            NavigationComponentProvider.createNativeNavigator(any(), capture(slot), any(), any())
         } returns navigator
 
         mapboxNavigation = MapboxNavigation(navigationOptions)
@@ -648,7 +648,7 @@ class MapboxNavigationTest {
         ThreadController.cancelAllUICoroutines()
         val slot = slot<NavigatorConfig>()
         every {
-            NavigationComponentProvider.createNativeNavigator(any(), capture(slot), any())
+            NavigationComponentProvider.createNativeNavigator(any(), capture(slot), any(), any())
         } returns navigator
         val options = navigationOptions.toBuilder()
             .incidentsOptions(
@@ -671,7 +671,7 @@ class MapboxNavigationTest {
         ThreadController.cancelAllUICoroutines()
         val slot = slot<NavigatorConfig>()
         every {
-            NavigationComponentProvider.createNativeNavigator(any(), capture(slot), any())
+            NavigationComponentProvider.createNativeNavigator(any(), capture(slot), any(), any())
         } returns navigator
         val options = navigationOptions.toBuilder()
             .incidentsOptions(
@@ -697,7 +697,7 @@ class MapboxNavigationTest {
 
     private fun mockNativeNavigator() {
         every {
-            NavigationComponentProvider.createNativeNavigator(any(), any(), any())
+            NavigationComponentProvider.createNativeNavigator(any(), any(), any(), any())
         } returns navigator
     }
 

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/internal/utils/DirectionsRouteExTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/internal/utils/DirectionsRouteExTest.kt
@@ -1,0 +1,92 @@
+package com.mapbox.navigation.core.internal.utils
+
+import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.api.directions.v5.models.LegStep
+import com.mapbox.api.directions.v5.models.RouteLeg
+import io.mockk.mockk
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DirectionsRouteExTest {
+
+    @Test
+    fun isRouteTheSame() {
+        val comparing = listOf<Triple<DirectionsRoute, DirectionsRoute?, Boolean>>(
+            Triple(
+                getDirectionRouteBuilder().geometry("geomery").build(),
+                getDirectionRouteBuilder().geometry("geomery").build(),
+                true
+            ),
+            Triple(
+                getDirectionRouteBuilder().geometry("geomery_1").build(),
+                getDirectionRouteBuilder().geometry("geomery").build(),
+                false
+            ),
+            Triple(
+                getDirectionRouteBuilder().geometry("geomery").build(),
+                null,
+                false
+            ),
+            Triple(
+                getDirectionRouteBuilder().legs(
+                    listOf(
+                        getListOfRouteLegs("one, two"),
+                        getListOfRouteLegs("three, four"),
+                    )
+                ).build(),
+                getDirectionRouteBuilder().legs(
+                    listOf(
+                        getListOfRouteLegs("one, two"),
+                        getListOfRouteLegs("three, four"),
+                    )
+                ).build(),
+                true
+            ),
+            Triple(
+                getDirectionRouteBuilder().legs(
+                    listOf(
+                        getListOfRouteLegs("one, two"),
+                        getListOfRouteLegs("three, four"),
+                    )
+                ).build(),
+                getDirectionRouteBuilder().legs(
+                    listOf(
+                        getListOfRouteLegs("one, two"),
+                        getListOfRouteLegs("three, four_NOT"),
+                    )
+                ).build(),
+                false
+            )
+        )
+
+        comparing.forEach { (route1, route2, compareResult) ->
+            if (compareResult) {
+                assertTrue(route1.isSameRoute(route2))
+            } else {
+                assertFalse(route1.isSameRoute(route2))
+            }
+        }
+    }
+
+    private fun getDirectionRouteBuilder(): DirectionsRoute.Builder =
+        DirectionsRoute.builder().duration(1.0).distance(2.0)
+
+    private fun getListOfRouteLegs(vararg stepsNames: String): RouteLeg =
+        RouteLeg.builder()
+            .also { legBuilder ->
+                legBuilder.steps(
+                    stepsNames.map {
+                        LegStep.builder()
+                            .name(it)
+                            .distance(3.0)
+                            .duration(4.0)
+                            .mode("")
+                            .maneuver(mockk(relaxUnitFun = true))
+                            .weight(5.0)
+                            .build()
+                    }
+                )
+            }
+            .build()
+}

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigator.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigator.kt
@@ -2,6 +2,7 @@ package com.mapbox.navigation.navigator.internal
 
 import android.location.Location
 import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.base.common.logger.Logger
 import com.mapbox.bindgen.Expected
 import com.mapbox.common.TileStore
 import com.mapbox.geojson.Point
@@ -41,7 +42,8 @@ interface MapboxNativeNavigator {
     fun create(
         deviceProfile: DeviceProfile,
         navigatorConfig: NavigatorConfig,
-        tilesConfig: TilesConfig
+        tilesConfig: TilesConfig,
+        logger: Logger
     ): MapboxNativeNavigator
 
     /**
@@ -115,7 +117,7 @@ interface MapboxNativeNavigator {
      *
      * @return True if the annotations could be updated false if not (wrong number of annotations)
      */
-    suspend fun updateAnnotations(legAnnotationJson: String, legIndex: Int): Boolean
+    suspend fun updateAnnotations(route: DirectionsRoute)
 
     /**
      * Gets the banner at a specific step index in the route. If there is no

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigatorImpl.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigatorImpl.kt
@@ -3,6 +3,9 @@ package com.mapbox.navigation.navigator.internal
 import android.location.Location
 import android.os.SystemClock
 import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.base.common.logger.Logger
+import com.mapbox.base.common.logger.model.Message
+import com.mapbox.base.common.logger.model.Tag
 import com.mapbox.bindgen.Expected
 import com.mapbox.common.TileStore
 import com.mapbox.geojson.Geometry
@@ -52,6 +55,7 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
     private const val BUFFER_DILATION: Short = 1
     private const val PRIMARY_ROUTE_INDEX = 0
     private const val SINGLE_THREAD = 1
+    private const val TAG = "MapboxNativeNavigatorImpl"
 
     // TODO: What should be the default value? Should we expose it publicly?
     private const val MAX_NUMBER_TILES_LOAD_PARALLEL_REQUESTS = 2
@@ -67,6 +71,7 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
     override var graphAccessor: GraphAccessor? = null
     override var openLRDecoder: OpenLRDecoder? = null
     override var roadObjectsStore: RoadObjectsStore? = null
+    private var logger: Logger? = null
 
     // Route following
 
@@ -77,7 +82,8 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
     override fun create(
         deviceProfile: DeviceProfile,
         navigatorConfig: NavigatorConfig,
-        tilesConfig: TilesConfig
+        tilesConfig: TilesConfig,
+        logger: Logger
     ): MapboxNativeNavigator {
         val nativeComponents = NavigatorLoader.createNavigator(
             deviceProfile,
@@ -92,6 +98,7 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
         roadObjectsStore = nativeComponents.navigator.roadObjectStore()
         route = null
         routeBufferGeoJson = null
+        this.logger = logger
         return this
     }
 
@@ -203,14 +210,24 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
      *
      * @return True if the annotations could be updated false if not (wrong number of annotations)
      */
-    override suspend fun updateAnnotations(
-        legAnnotationJson: String,
-        legIndex: Int
-    ): Boolean = withContext(NavigatorDispatcher) {
-        navigator!!.updateAnnotations(
-            legAnnotationJson, PRIMARY_ROUTE_INDEX, legIndex
-        )
-    }
+    override suspend fun updateAnnotations(route: DirectionsRoute): Unit =
+        withContext(NavigatorDispatcher) {
+            MapboxNativeNavigatorImpl.route = route
+            route.legs()?.forEachIndexed { index, routeLeg ->
+                routeLeg.annotation()?.toJson()?.let { annotations ->
+                    navigator!!.updateAnnotations(annotations, PRIMARY_ROUTE_INDEX, index)
+                        .let { success ->
+                            logger?.d(
+                                tag = Tag(TAG),
+                                msg = Message(
+                                    "Annotation updated successfully=$success, for leg " +
+                                        "index $index, annotations: [$annotations]"
+                                )
+                            )
+                        }
+                }
+            }
+        }
 
     /**
      * Gets the banner at a specific step index in the route. If there is no


### PR DESCRIPTION
### Description
- MapboxNativeNavigatorImpl upgrade route on refresh route
Closes #4028 

- TripsSession compare route along with uuid to avoid collision with an alternative route 

### Changelog
```
<changelog>Fixed `RouteProgress` contains `route` without updates even when refresh route is enabled</changelog>
<changelog>Fixed `RouteProgerss#route` returns always primary route even if alternative is choosen</changelog>
```