### PR TITLE
- NativeNavigator fix: upgrade route when refresh route; - TripSession alternative route fix : compare routes along with uuid

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -171,7 +171,8 @@ class MapboxNavigation(
         navigator = NavigationComponentProvider.createNativeNavigator(
             navigationOptions.deviceProfile,
             navigatorConfig,
-            createTilesConfig()
+            createTilesConfig(),
+            logger
         )
         navigationSession = NavigationComponentProvider.createNavigationSession()
         directionsSession = NavigationComponentProvider.createDirectionsSession(

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/NavigationComponentProvider.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/NavigationComponentProvider.kt
@@ -26,9 +26,10 @@ internal object NavigationComponentProvider {
     fun createNativeNavigator(
         deviceProfile: DeviceProfile,
         navigatorConfig: NavigatorConfig,
-        tilesConfig: TilesConfig
+        tilesConfig: TilesConfig,
+        logger: Logger
     ): MapboxNativeNavigator =
-        MapboxNativeNavigatorImpl.create(deviceProfile, navigatorConfig, tilesConfig)
+        MapboxNativeNavigatorImpl.create(deviceProfile, navigatorConfig, tilesConfig, logger)
 
     fun createTripService(
         applicationContext: Context,

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/utils/DirectionsRouteEx.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/utils/DirectionsRouteEx.kt
@@ -3,6 +3,31 @@
 package com.mapbox.navigation.core.internal.utils
 
 import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.api.directions.v5.models.LegStep
+import com.mapbox.navigation.utils.internal.ifNonNull
 
-fun DirectionsRoute?.isSameRoute(compare: DirectionsRoute?): Boolean =
-    this?.routeOptions()?.requestUuid() == compare?.routeOptions()?.requestUuid()
+fun DirectionsRoute.isSameUuid(compare: DirectionsRoute?): Boolean =
+    this.routeOptions()?.requestUuid() == compare?.routeOptions()?.requestUuid()
+
+/**
+ * Compare routes as geometries(if exist) or as a names of [LegStep] of the [DirectionsRoute]
+ */
+fun DirectionsRoute.isSameRoute(compare: DirectionsRoute?): Boolean {
+    if (compare == null) return false
+
+    ifNonNull(this.geometry(), compare.geometry()) { g1, g2 ->
+        return g1 == g2
+    }
+
+    ifNonNull(this.stepsNamesAsString(), compare.stepsNamesAsString()) { s1, s2 ->
+        return s1 == s2
+    }
+
+    return false
+}
+
+private fun DirectionsRoute.stepsNamesAsString(): String? =
+    this.legs()
+        ?.joinToString { leg ->
+            leg.steps()?.joinToString { step -> step.name() ?: "" } ?: ""
+        }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
@@ -11,12 +11,12 @@ import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.VoiceInstructions
 import com.mapbox.base.common.logger.Logger
 import com.mapbox.base.common.logger.model.Message
-import com.mapbox.base.common.logger.model.Tag
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.trip.model.RouteLegProgress
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.base.trip.model.alert.RouteAlert
 import com.mapbox.navigation.core.internal.utils.isSameRoute
+import com.mapbox.navigation.core.internal.utils.isSameUuid
 import com.mapbox.navigation.core.navigator.getMapMatcherResult
 import com.mapbox.navigation.core.sensors.SensorMapper
 import com.mapbox.navigation.core.trip.service.TripService
@@ -70,7 +70,8 @@ internal class MapboxTripSession(
 
     override var route: DirectionsRoute? = null
         set(value) {
-            val isSameRoute = field.isSameRoute(value)
+            val isSameUuid = value?.isSameUuid(field) ?: false
+            val isSameRoute = value?.isSameRoute(field) ?: false
             field = value
             if (value == null) {
                 routeAlerts = emptyList()
@@ -78,23 +79,14 @@ internal class MapboxTripSession(
             }
             cancelOngoingUpdateNavigatorStatusDataJobs()
             val updateRouteJob = threadController.getMainScopeAndRootJob().scope.launch {
-                if (isSameRoute && value != null) {
-                    value.legs()?.forEachIndexed { index, routeLeg ->
-                        routeLeg.annotation()?.toJson()?.let { annotations ->
-                            navigator.updateAnnotations(annotations, index).let { success ->
-                                logger.d(
-                                    tag = Tag(TAG),
-                                    msg = Message(
-                                        "Annotation updated successfully=$success, for leg " +
-                                            "index $index, annotations: [$annotations]"
-                                    )
-                                )
-                            }
-                        }
+                when {
+                    isSameUuid && isSameRoute && value != null -> {
+                        navigator.updateAnnotations(value)
                     }
-                } else {
-                    navigator.setRoute(value)?.let {
-                        routeAlerts = it.routeAlerts
+                    else -> {
+                        navigator.setRoute(value)?.let {
+                            routeAlerts = it.routeAlerts
+                        }
                     }
                 }
             }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
@@ -142,7 +142,7 @@ class MapboxNavigationTest {
         mockDirectionSession()
         mockNavigationSession()
 
-        every { navigator.create(any(), any(), any()) } returns navigator
+        every { navigator.create(any(), any(), any(), any()) } returns navigator
 
         mapboxNavigation = MapboxNavigation(navigationOptions)
 
@@ -580,7 +580,7 @@ class MapboxNavigationTest {
 
     private fun mockNativeNavigator() {
         every {
-            NavigationComponentProvider.createNativeNavigator(any(), any(), any())
+            NavigationComponentProvider.createNativeNavigator(any(), any(), any(), any())
         } returns navigator
     }
 

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/internal/utils/DirectionsRouteExTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/internal/utils/DirectionsRouteExTest.kt
@@ -1,0 +1,92 @@
+package com.mapbox.navigation.core.internal.utils
+
+import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.api.directions.v5.models.LegStep
+import com.mapbox.api.directions.v5.models.RouteLeg
+import io.mockk.mockk
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DirectionsRouteExTest {
+
+    @Test
+    fun isRouteTheSame() {
+        val comparing = listOf<Triple<DirectionsRoute, DirectionsRoute?, Boolean>>(
+            Triple(
+                getDirectionRouteBuilder().geometry("geomery").build(),
+                getDirectionRouteBuilder().geometry("geomery").build(),
+                true
+            ),
+            Triple(
+                getDirectionRouteBuilder().geometry("geomery_1").build(),
+                getDirectionRouteBuilder().geometry("geomery").build(),
+                false
+            ),
+            Triple(
+                getDirectionRouteBuilder().geometry("geomery").build(),
+                null,
+                false
+            ),
+            Triple(
+                getDirectionRouteBuilder().legs(
+                    listOf(
+                        getListOfRouteLegs("one, two"),
+                        getListOfRouteLegs("three, four"),
+                    )
+                ).build(),
+                getDirectionRouteBuilder().legs(
+                    listOf(
+                        getListOfRouteLegs("one, two"),
+                        getListOfRouteLegs("three, four"),
+                    )
+                ).build(),
+                true
+            ),
+            Triple(
+                getDirectionRouteBuilder().legs(
+                    listOf(
+                        getListOfRouteLegs("one, two"),
+                        getListOfRouteLegs("three, four"),
+                    )
+                ).build(),
+                getDirectionRouteBuilder().legs(
+                    listOf(
+                        getListOfRouteLegs("one, two"),
+                        getListOfRouteLegs("three, four_NOT"),
+                    )
+                ).build(),
+                false
+            )
+        )
+
+        comparing.forEach { (route1, route2, compareResult) ->
+            if (compareResult) {
+                assertTrue(route1.isSameRoute(route2))
+            } else {
+                assertFalse(route1.isSameRoute(route2))
+            }
+        }
+    }
+
+    private fun getDirectionRouteBuilder(): DirectionsRoute.Builder =
+        DirectionsRoute.builder().duration(1.0).distance(2.0)
+
+    private fun getListOfRouteLegs(vararg stepsNames: String): RouteLeg =
+        RouteLeg.builder()
+            .also { legBuilder ->
+                legBuilder.steps(
+                    stepsNames.map {
+                        LegStep.builder()
+                            .name(it)
+                            .distance(3.0)
+                            .duration(4.0)
+                            .mode("")
+                            .maneuver(mockk(relaxUnitFun = true))
+                            .weight(5.0)
+                            .build()
+                    }
+                )
+            }
+            .build()
+}

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/events/SchemaTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/events/SchemaTest.kt
@@ -340,6 +340,7 @@ class SchemaTest {
         properties.remove("locationEnabled")
         // temporary need to work out a solution to include this data
         properties.remove("platform")
+        properties.remove("version")
         return properties
     }
 

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
@@ -17,6 +17,7 @@ import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.base.trip.model.alert.RouteAlert
 import com.mapbox.navigation.core.internal.utils.isSameRoute
+import com.mapbox.navigation.core.internal.utils.isSameUuid
 import com.mapbox.navigation.core.navigator.getMapMatcherResult
 import com.mapbox.navigation.core.trip.service.TripService
 import com.mapbox.navigation.navigator.internal.MapboxNativeNavigator
@@ -114,12 +115,14 @@ class MapboxTripSessionTest {
         coEvery { navigator.getStatus(any()) } returns tripStatus
         coEvery { navigator.updateLocation(any()) } returns false
         coEvery { navigator.setRoute(any()) } returns null
+        coEvery { navigator.updateAnnotations(any()) } returns Unit
         every { tripStatus.enhancedLocation } returns enhancedLocation
         every { tripStatus.keyPoints } returns keyPoints
         every { tripStatus.offRoute } returns false
         every { tripStatus.getMapMatcherResult() } returns mapMatcherResult
         every { routeProgress.bannerInstructions } returns null
         every { routeProgress.voiceInstructions } returns null
+        every { route.isSameUuid(any()) } returns false
         every { route.isSameRoute(any()) } returns false
         every { route.routeOptions()?.requestUuid() } returns "uuid"
 
@@ -646,6 +649,40 @@ class MapboxTripSessionTest {
         tripSession.route = route
 
         coVerify(exactly = 1) { navigator.setRoute(route) }
+        coVerify(exactly = 1) { navigator.getStatus(any()) }
+        coVerifyOrder {
+            navigator.setRoute(route)
+            navigator.getStatus(any())
+        }
+    }
+
+    @Test
+    fun checkNavigatorUpdateAnnotationsWhenRouteIsTheSame() {
+        tripSession.start()
+        every { route.isSameRoute(any()) } returns true
+        every { route.isSameUuid(any()) } returns true
+
+        tripSession.route = route
+
+        coVerify(exactly = 1) { navigator.updateAnnotations(route) }
+        coVerify(exactly = 0) { navigator.setRoute(any()) }
+        coVerify(exactly = 1) { navigator.getStatus(any()) }
+        coVerifyOrder {
+            navigator.updateAnnotations(route)
+            navigator.getStatus(any())
+        }
+    }
+
+    @Test
+    fun checkNavigatorUpdateAnnotationsWhenRouteUuidSameButRouteIsAlternative() {
+        tripSession.start()
+        every { route.isSameRoute(any()) } returns false
+        every { route.isSameUuid(any()) } returns true
+
+        tripSession.route = route
+
+        coVerify(exactly = 1) { navigator.setRoute(route) }
+        coVerify(exactly = 0) { navigator.updateAnnotations(any()) }
         coVerify(exactly = 1) { navigator.getStatus(any()) }
         coVerifyOrder {
             navigator.setRoute(route)

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigator.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigator.kt
@@ -2,6 +2,7 @@ package com.mapbox.navigation.navigator.internal
 
 import android.location.Location
 import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.base.common.logger.Logger
 import com.mapbox.geojson.Point
 import com.mapbox.navigation.base.options.DeviceProfile
 import com.mapbox.navigator.BannerInstruction
@@ -31,7 +32,8 @@ interface MapboxNativeNavigator {
     fun create(
         deviceProfile: DeviceProfile,
         navigatorConfig: NavigatorConfig,
-        tilesConfig: TilesConfig
+        tilesConfig: TilesConfig,
+        logger: Logger
     ): MapboxNativeNavigator
 
     /**
@@ -105,7 +107,7 @@ interface MapboxNativeNavigator {
      *
      * @return True if the annotations could be updated false if not (wrong number of annotations)
      */
-    suspend fun updateAnnotations(legAnnotationJson: String, legIndex: Int): Boolean
+    suspend fun updateAnnotations(route: DirectionsRoute)
 
     /**
      * Gets the banner at a specific step index in the route. If there is no


### PR DESCRIPTION
### Description
- MapboxNativeNavigatorImpl upgrade route on refresh route
- TripsSession compare route along with uuid to avoid collision with an alternative route 

### Changelog
```
<changelog>Fixed `RouteProgress` contains `route` without updates even when refresh route is enabled</changelog>
<changelog>Fixed `RouteProgerss#route` returns always primary route even if alternative is choosen</changelog>
```