### PR TITLE
fix upcoming maneuver crash on reroute.

### DIFF
--- a/libnavui-maneuver/src/main/java/com/mapbox/navigation/ui/maneuver/view/MapboxUpcomingManeuverAdapter.kt
+++ b/libnavui-maneuver/src/main/java/com/mapbox/navigation/ui/maneuver/view/MapboxUpcomingManeuverAdapter.kt
@@ -66,9 +66,11 @@ class MapboxUpcomingManeuverAdapter(
      */
     fun addUpcomingManeuvers(upcomingManeuvers: List<Maneuver>) {
         if (upcomingManeuvers.isNotEmpty()) {
+            val currentSize = this.upcomingManeuverList.size
             this.upcomingManeuverList.clear()
             this.upcomingManeuverList.addAll(upcomingManeuvers)
-            notifyItemRangeInserted(0, upcomingManeuverList.size)
+            notifyItemRangeRemoved(0, currentSize)
+            notifyItemRangeInserted(0, upcomingManeuvers.size)
         }
     }
 
@@ -77,8 +79,10 @@ class MapboxUpcomingManeuverAdapter(
      * @param maneuverToRemove Maneuver
      */
     fun removeManeuver(maneuverToRemove: Maneuver) {
-        if (this.upcomingManeuverList.contains(maneuverToRemove)) {
-            val index = this.upcomingManeuverList.indexOf(maneuverToRemove)
+        val index = this.upcomingManeuverList.indexOfFirst {
+            it.primary.text == maneuverToRemove.primary.text
+        }
+        if (index != -1) {
             this.upcomingManeuverList.removeAt(index)
             notifyItemRemoved(index)
         }

--- a/libnavui-maneuver/src/test/java/com/mapbox/navigation/ui/maneuver/view/MapboxUpcomingManeuverAdapterTest.kt
+++ b/libnavui-maneuver/src/test/java/com/mapbox/navigation/ui/maneuver/view/MapboxUpcomingManeuverAdapterTest.kt
@@ -44,7 +44,7 @@ class MapboxUpcomingManeuverAdapterTest {
 
     @Test
     fun `add upcoming maneuvers query item count`() {
-        val upcomingManeuverList = getUpcomingManeuver()
+        val upcomingManeuverList = getUpcomingManeuver("Besco Drive")
         val adapter = MapboxUpcomingManeuverAdapter(ctx)
         val expected = upcomingManeuverList.size
 
@@ -55,8 +55,35 @@ class MapboxUpcomingManeuverAdapterTest {
     }
 
     @Test
+    fun `remove upcoming maneuver success query item count`() {
+        val upcomingManeuverList = getUpcomingManeuver("Besco Drive")
+        val adapter = MapboxUpcomingManeuverAdapter(ctx)
+        val expected = upcomingManeuverList.size - 1
+
+        adapter.addUpcomingManeuvers(upcomingManeuverList)
+        adapter.removeManeuver(getUpcomingManeuver("Besco Drive")[0])
+        val actual = adapter.itemCount
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `remove upcoming maneuver failure query item count`() {
+        val upcomingManeuverList = getUpcomingManeuver("Besco Drive")
+        val maneuverToRemove = getUpcomingManeuver("Test Street")[0]
+        val adapter = MapboxUpcomingManeuverAdapter(ctx)
+        val expected = upcomingManeuverList.size
+
+        adapter.addUpcomingManeuvers(upcomingManeuverList)
+        adapter.removeManeuver(maneuverToRemove)
+        val actual = adapter.itemCount
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
     fun `add lanes query primary maneuver text`() {
-        val upcomingManeuverList = getUpcomingManeuver()
+        val upcomingManeuverList = getUpcomingManeuver("Besco Drive")
         val adapter = MapboxUpcomingManeuverAdapter(ctx)
         val rvParent = RecyclerView(ctx)
         rvParent.layoutManager = LinearLayoutManager(ctx)
@@ -73,7 +100,7 @@ class MapboxUpcomingManeuverAdapterTest {
 
     @Test
     fun `add lanes query secondary maneuver text`() {
-        val upcomingManeuverList = getUpcomingManeuver()
+        val upcomingManeuverList = getUpcomingManeuver("Besco Drive")
         val adapter = MapboxUpcomingManeuverAdapter(ctx)
         val rvParent = RecyclerView(ctx)
         rvParent.layoutManager = LinearLayoutManager(ctx)
@@ -93,7 +120,7 @@ class MapboxUpcomingManeuverAdapterTest {
         val distanceFormatter = MapboxDistanceFormatter(
             DistanceFormatterOptions.Builder(ctx).build()
         )
-        val upcomingManeuverList = getUpcomingManeuver()
+        val upcomingManeuverList = getUpcomingManeuver("Besco Drive")
         val adapter = MapboxUpcomingManeuverAdapter(ctx)
         val rvParent = RecyclerView(ctx)
         rvParent.layoutManager = LinearLayoutManager(ctx)
@@ -110,12 +137,12 @@ class MapboxUpcomingManeuverAdapterTest {
         assertEquals(expected.toString(), actual.toString())
     }
 
-    private fun getUpcomingManeuver(): List<Maneuver> {
+    private fun getUpcomingManeuver(primaryText: String): List<Maneuver> {
         val totalStepDistance = mockk<TotalManeuverDistance>() {
             every { totalDistance } returns 32.0
         }
         val primaryManeuver = mockk<PrimaryManeuver> {
-            every { text } returns "Besco Drive"
+            every { text } returns primaryText
             every { type } returns StepManeuver.TURN
             every { degrees } returns null
             every { modifier } returns ManeuverModifier.LEFT
@@ -125,7 +152,7 @@ class MapboxUpcomingManeuverAdapterTest {
                     BannerComponents.TEXT,
                     TextComponentNode
                         .Builder()
-                        .text("Besco Drive")
+                        .text(primaryText)
                         .abbr(null)
                         .abbrPriority(null)
                         .build()


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Fix crash when upcoming maneuver list is expanded and the user reroutes.


### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Fix upcoming maneuver crash on reroute.</changelog>
```

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
