### PR TITLE
use a version-less navigation predictive cache controller constructor

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/PredictiveCache.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/PredictiveCache.kt
@@ -2,7 +2,6 @@ package com.mapbox.navigation.core.internal
 
 import com.mapbox.common.TileStore
 import com.mapbox.navigation.base.options.PredictiveCacheLocationOptions
-import com.mapbox.navigation.base.options.RoutingTilesOptions
 import com.mapbox.navigation.navigator.internal.MapboxNativeNavigatorImpl
 import com.mapbox.navigator.PredictiveCacheController
 
@@ -14,12 +13,10 @@ object PredictiveCache {
         mutableMapOf<String, PredictiveCacheController>()
 
     fun createNavigationController(
-        routingTilesOptions: RoutingTilesOptions,
         predictiveCacheLocationOptions: PredictiveCacheLocationOptions
     ) {
         val predictiveCacheController =
             MapboxNativeNavigatorImpl.createNavigationPredictiveCacheController(
-                routingTilesOptions,
                 predictiveCacheLocationOptions
             )
         cachedNavigationPredictiveCacheControllers.add(predictiveCacheController)

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigator.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigator.kt
@@ -7,6 +7,7 @@ import com.mapbox.bindgen.Expected
 import com.mapbox.common.TileStore
 import com.mapbox.geojson.Point
 import com.mapbox.navigation.base.options.DeviceProfile
+import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.options.PredictiveCacheLocationOptions
 import com.mapbox.navigation.base.options.RoutingTilesOptions
 import com.mapbox.navigator.BannerInstruction
@@ -269,15 +270,14 @@ interface MapboxNativeNavigator {
     ): PredictiveCacheController
 
     /**
-     * Creates a Navigation [PredictiveCacheController].
+     * Creates a Navigation [PredictiveCacheController]. Uses the option passed in
+     * [RoutingTilesOptions] via [NavigationOptions].
      *
-     * @param routingTilesOptions Navigation [RoutingTilesOptions]
      * @param predictiveCacheLocationOptions [PredictiveCacheLocationOptions]
      *
      * @return [PredictiveCacheController]
      */
     fun createNavigationPredictiveCacheController(
-        routingTilesOptions: RoutingTilesOptions,
         predictiveCacheLocationOptions: PredictiveCacheLocationOptions
     ): PredictiveCacheController
 

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigatorImpl.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigatorImpl.kt
@@ -12,6 +12,7 @@ import com.mapbox.geojson.Geometry
 import com.mapbox.geojson.Point
 import com.mapbox.geojson.gson.GeometryGeoJson
 import com.mapbox.navigation.base.options.DeviceProfile
+import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.options.PredictiveCacheLocationOptions
 import com.mapbox.navigation.base.options.RoutingTilesOptions
 import com.mapbox.navigation.navigator.ActiveGuidanceOptionsMapper
@@ -408,19 +409,17 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
         )
 
     /**
-     * Creates a Navigation [PredictiveCacheController].
+     * Creates a Navigation [PredictiveCacheController]. Uses the option passed in
+     * [RoutingTilesOptions] via [NavigationOptions].
      *
-     * @param routingTilesOptions Navigation [RoutingTilesOptions]
      * @param predictiveCacheLocationOptions [PredictiveCacheLocationOptions]
      *
      * @return [PredictiveCacheController]
      */
     override fun createNavigationPredictiveCacheController(
-        routingTilesOptions: RoutingTilesOptions,
         predictiveCacheLocationOptions: PredictiveCacheLocationOptions
     ): PredictiveCacheController =
         navigator!!.createPredictiveCacheController(
-            createDefaultNavigationPredictiveCacheControllerOptions(routingTilesOptions),
             createDefaultPredictiveLocationTrackerOptions(predictiveCacheLocationOptions)
         )
 
@@ -439,15 +438,6 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
         PredictiveCacheControllerOptions(
             "",
             tileVariant,
-            MAX_NUMBER_TILES_LOAD_PARALLEL_REQUESTS
-        )
-
-    private fun createDefaultNavigationPredictiveCacheControllerOptions(
-        routingTilesOptions: RoutingTilesOptions
-    ): PredictiveCacheControllerOptions =
-        PredictiveCacheControllerOptions(
-            routingTilesOptions.tilesVersion,
-            "${routingTilesOptions.tilesDataset}/${routingTilesOptions.tilesProfile}",
             MAX_NUMBER_TILES_LOAD_PARALLEL_REQUESTS
         )
 }

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/PredictiveCacheController.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/PredictiveCacheController.kt
@@ -81,7 +81,6 @@ class PredictiveCacheController @JvmOverloads constructor(
     init {
         // Navigation PredictiveCacheController
         PredictiveCache.createNavigationController(
-            routingTilesOptions = navigation.navigationOptions.routingTilesOptions,
             predictiveCacheLocationOptions =
             navigation.navigationOptions.predictiveCacheLocationOptions
         )

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/PredictiveCacheControllerTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/PredictiveCacheControllerTest.kt
@@ -35,7 +35,7 @@ class PredictiveCacheControllerTest {
         val mockedMapboxNavigation = mockk<MapboxNavigation>(relaxed = true)
         mockkObject(PredictiveCache)
         every {
-            PredictiveCache.createNavigationController(any(), any())
+            PredictiveCache.createNavigationController(any())
         } just Runs
 
         PredictiveCacheController(
@@ -44,7 +44,6 @@ class PredictiveCacheControllerTest {
 
         verify {
             PredictiveCache.createNavigationController(
-                mockedMapboxNavigation.navigationOptions.routingTilesOptions,
                 mockedMapboxNavigation.navigationOptions.predictiveCacheLocationOptions
             )
         }
@@ -57,7 +56,7 @@ class PredictiveCacheControllerTest {
         val mockedMapboxNavigation = mockk<MapboxNavigation>(relaxed = true)
         mockkObject(PredictiveCache)
         every {
-            PredictiveCache.createNavigationController(any(), any())
+            PredictiveCache.createNavigationController(any())
         } just Runs
         val mockedMapboxMap = mockk<MapboxMap>(relaxed = true)
         val style = mockk<Style>()
@@ -131,7 +130,7 @@ class PredictiveCacheControllerTest {
         val mockedMapboxNavigation = mockk<MapboxNavigation>(relaxed = true)
         mockkObject(PredictiveCache)
         every {
-            PredictiveCache.createNavigationController(any(), any())
+            PredictiveCache.createNavigationController(any())
         } just Runs
         val mockedMapboxMap = mockk<MapboxMap>(relaxed = true)
         val style = mockk<Style>()


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
This change ensures that Nav Native infers the version of the tiles that Predictive Cache Controller should be downloading by itself. Passing an empty string to the PCC creator as we used to do will not use an automatic tiles version.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Fixed an issue where Predictive Caching did not work correctly when paired with an automatic tiles version generation (`PredictiveCacheController` used when `RoutingTilesOptions#tilesVersion` was empty). The version of tiles had to be specified explicitly via `RoutingTilesOption`.</changelog>
```

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
