### PR TITLE
Add missed EH road object mapping

### DIFF
--- a/libnavigation-base/api/current.txt
+++ b/libnavigation-base/api/current.txt
@@ -493,6 +493,19 @@ package com.mapbox.navigation.base.trip.model.alert {
     method public com.mapbox.navigation.base.trip.model.alert.CountryBorderCrossingAlert.Builder to(com.mapbox.navigation.base.trip.model.alert.CountryBorderCrossingAdminInfo? to);
   }
 
+  public final class CountryBorderCrossingInfo {
+    method public com.mapbox.navigation.base.trip.model.alert.CountryBorderCrossingAdminInfo? getFrom();
+    method public com.mapbox.navigation.base.trip.model.alert.CountryBorderCrossingAdminInfo? getTo();
+    method public com.mapbox.navigation.base.trip.model.alert.CountryBorderCrossingInfo.Builder toBuilder();
+    property public final com.mapbox.navigation.base.trip.model.alert.CountryBorderCrossingAdminInfo? from;
+    property public final com.mapbox.navigation.base.trip.model.alert.CountryBorderCrossingAdminInfo? to;
+  }
+
+  public static final class CountryBorderCrossingInfo.Builder {
+    ctor public CountryBorderCrossingInfo.Builder(com.mapbox.navigation.base.trip.model.alert.CountryBorderCrossingAdminInfo? from, com.mapbox.navigation.base.trip.model.alert.CountryBorderCrossingAdminInfo? to);
+    method public com.mapbox.navigation.base.trip.model.alert.CountryBorderCrossingInfo build();
+  }
+
   public final class IncidentAlert extends com.mapbox.navigation.base.trip.model.alert.RouteAlert {
     method public com.mapbox.navigation.base.trip.model.alert.IncidentInfo? getInfo();
     method public com.mapbox.navigation.base.trip.model.alert.IncidentAlert.Builder toBuilder();

--- a/libnavigation-base/api/current.txt
+++ b/libnavigation-base/api/current.txt
@@ -478,19 +478,16 @@ package com.mapbox.navigation.base.trip.model.alert {
   }
 
   public final class CountryBorderCrossingAlert extends com.mapbox.navigation.base.trip.model.alert.RouteAlert {
-    method public com.mapbox.navigation.base.trip.model.alert.CountryBorderCrossingAdminInfo? getFrom();
-    method public com.mapbox.navigation.base.trip.model.alert.CountryBorderCrossingAdminInfo? getTo();
+    method public com.mapbox.navigation.base.trip.model.alert.CountryBorderCrossingInfo? getCountryBorderCrossingInfo();
     method public com.mapbox.navigation.base.trip.model.alert.CountryBorderCrossingAlert.Builder toBuilder();
-    property public final com.mapbox.navigation.base.trip.model.alert.CountryBorderCrossingAdminInfo? from;
-    property public final com.mapbox.navigation.base.trip.model.alert.CountryBorderCrossingAdminInfo? to;
+    property public final com.mapbox.navigation.base.trip.model.alert.CountryBorderCrossingInfo? countryBorderCrossingInfo;
   }
 
   public static final class CountryBorderCrossingAlert.Builder {
     ctor public CountryBorderCrossingAlert.Builder(com.mapbox.geojson.Point coordinate, double distance);
     method public com.mapbox.navigation.base.trip.model.alert.CountryBorderCrossingAlert.Builder alertGeometry(com.mapbox.navigation.base.trip.model.alert.RouteAlertGeometry? alertGeometry);
     method public com.mapbox.navigation.base.trip.model.alert.CountryBorderCrossingAlert build();
-    method public com.mapbox.navigation.base.trip.model.alert.CountryBorderCrossingAlert.Builder from(com.mapbox.navigation.base.trip.model.alert.CountryBorderCrossingAdminInfo? from);
-    method public com.mapbox.navigation.base.trip.model.alert.CountryBorderCrossingAlert.Builder to(com.mapbox.navigation.base.trip.model.alert.CountryBorderCrossingAdminInfo? to);
+    method public com.mapbox.navigation.base.trip.model.alert.CountryBorderCrossingAlert.Builder countryBorderCrossingInfo(com.mapbox.navigation.base.trip.model.alert.CountryBorderCrossingInfo? borderCrossingInfo);
   }
 
   public final class CountryBorderCrossingInfo {

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/alert/CountryBorderCrossingAlert.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/alert/CountryBorderCrossingAlert.kt
@@ -5,8 +5,7 @@ import com.mapbox.geojson.Point
 /**
  * Route alert type that provides information about country border crossings on the route.
  *
- * @param from origin administrative info when crossing the country border
- * @param to destination administrative info when crossing the country border
+ * @param countryBorderCrossingInfo administrative info when crossing the country border
  * @see RouteAlert
  * @see RouteAlertType.CountryBorderCrossing
  */
@@ -14,8 +13,7 @@ class CountryBorderCrossingAlert private constructor(
     coordinate: Point,
     distance: Double,
     alertGeometry: RouteAlertGeometry?,
-    val from: CountryBorderCrossingAdminInfo?,
-    val to: CountryBorderCrossingAdminInfo?
+    val countryBorderCrossingInfo: CountryBorderCrossingInfo?,
 ) : RouteAlert(
     RouteAlertType.CountryBorderCrossing,
     coordinate,
@@ -28,8 +26,7 @@ class CountryBorderCrossingAlert private constructor(
      */
     fun toBuilder(): Builder = Builder(coordinate, distance)
         .alertGeometry(alertGeometry)
-        .from(from)
-        .to(to)
+        .countryBorderCrossingInfo(countryBorderCrossingInfo)
 
     /**
      * Indicates whether some other object is "equal to" this one.
@@ -41,8 +38,7 @@ class CountryBorderCrossingAlert private constructor(
 
         other as CountryBorderCrossingAlert
 
-        if (from != other.from) return false
-        if (to != other.to) return false
+        if (countryBorderCrossingInfo != other.countryBorderCrossingInfo) return false
 
         return true
     }
@@ -52,8 +48,7 @@ class CountryBorderCrossingAlert private constructor(
      */
     override fun hashCode(): Int {
         var result = super.hashCode()
-        result = 31 * result + (from?.hashCode() ?: 0)
-        result = 31 * result + (to?.hashCode() ?: 0)
+        result = 31 * result + (countryBorderCrossingInfo?.hashCode() ?: 0)
         return result
     }
 
@@ -61,7 +56,8 @@ class CountryBorderCrossingAlert private constructor(
      * Returns a string representation of the object.
      */
     override fun toString(): String {
-        return "CountryBorderCrossingAlert(from=$from, to=$to), ${super.toString()}"
+        return "CountryBorderCrossingAlert(" +
+            "countryBorderCrossingInfo=$countryBorderCrossingInfo), ${super.toString()}"
     }
 
     /**
@@ -75,8 +71,7 @@ class CountryBorderCrossingAlert private constructor(
     ) {
 
         private var alertGeometry: RouteAlertGeometry? = null
-        private var from: CountryBorderCrossingAdminInfo? = null
-        private var to: CountryBorderCrossingAdminInfo? = null
+        private var countryBorderCrossingInfo: CountryBorderCrossingInfo? = null
 
         /**
          * Add optional geometry if the alert has a length.
@@ -86,18 +81,12 @@ class CountryBorderCrossingAlert private constructor(
         }
 
         /**
-         * Add the origin administrative info when crossing the country border.
+         * Add the administrative info when crossing the country border.
          */
-        fun from(from: CountryBorderCrossingAdminInfo?): Builder = apply {
-            this.from = from
-        }
-
-        /**
-         * Add the destination administrative info when crossing the country border.
-         */
-        fun to(to: CountryBorderCrossingAdminInfo?): Builder = apply {
-            this.to = to
-        }
+        fun countryBorderCrossingInfo(borderCrossingInfo: CountryBorderCrossingInfo?): Builder =
+            apply {
+                this.countryBorderCrossingInfo = borderCrossingInfo
+            }
 
         /**
          * Build the object instance.
@@ -107,8 +96,7 @@ class CountryBorderCrossingAlert private constructor(
                 coordinate = coordinate,
                 distance = distance,
                 alertGeometry = alertGeometry,
-                from = from,
-                to = to
+                countryBorderCrossingInfo = countryBorderCrossingInfo
             )
     }
 }

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/alert/CountryBorderCrossingInfo.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/alert/CountryBorderCrossingInfo.kt
@@ -1,0 +1,68 @@
+package com.mapbox.navigation.base.trip.model.alert
+
+/**
+ * Administrative information.
+ *
+ * @param from origin administrative info when crossing the country border
+ * @param to destination administrative info when crossing the country border
+ */
+class CountryBorderCrossingInfo private constructor(
+    val from: CountryBorderCrossingAdminInfo?,
+    val to: CountryBorderCrossingAdminInfo?
+) {
+
+    /**
+     * Transform this object into a builder to mutate the values.
+     */
+    fun toBuilder(): CountryBorderCrossingInfo.Builder =
+        CountryBorderCrossingInfo.Builder(from, to)
+
+    /**
+     * Indicates whether some other object is "equal to" this one.
+     */
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as CountryBorderCrossingInfo
+
+        if (from != other.from) return false
+        if (to != other.to) return false
+
+        return true
+    }
+
+    /**
+     * Returns a hash code value for the object.
+     */
+    override fun hashCode(): Int {
+        var result = from?.hashCode() ?: 0
+        result = 31 * result + (to?.hashCode() ?: 0)
+        return result
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    override fun toString(): String {
+        return "CountryBorderCrossingInfo(" +
+            "from=$from, " +
+            "to=$to)"
+    }
+
+    /**
+     * Use to create a new instance.
+     *
+     * @see CountryBorderCrossingInfo
+     */
+    class Builder(
+        private val from: CountryBorderCrossingAdminInfo?,
+        private val to: CountryBorderCrossingAdminInfo?
+    ) {
+
+        /**
+         * Build the object instance.
+         */
+        fun build() = CountryBorderCrossingInfo(from, to)
+    }
+}

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/alert/CountryBorderCrossingInfo.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/alert/CountryBorderCrossingInfo.kt
@@ -14,8 +14,7 @@ class CountryBorderCrossingInfo private constructor(
     /**
      * Transform this object into a builder to mutate the values.
      */
-    fun toBuilder(): CountryBorderCrossingInfo.Builder =
-        CountryBorderCrossingInfo.Builder(from, to)
+    fun toBuilder(): Builder = Builder(from, to)
 
     /**
      * Indicates whether some other object is "equal to" this one.

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/trip/model/alert/CountryBorderCrossingAlertTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/trip/model/alert/CountryBorderCrossingAlertTest.kt
@@ -13,7 +13,9 @@ class CountryBorderCrossingAlertTest :
     override fun getFilledUpBuilder() = CountryBorderCrossingAlert.Builder(
         Point.fromLngLat(0.0, 0.0),
         1.0
-    ).alertGeometry(mockk(relaxed = true)).from(mockk(relaxed = true)).to(mockk(relaxed = true))
+    )
+        .alertGeometry(mockk(relaxed = true))
+        .countryBorderCrossingInfo(mockk(relaxed = true))
 
     @Test
     override fun trigger() {

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/trip/model/alert/CountryBorderCrossingInfoTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/trip/model/alert/CountryBorderCrossingInfoTest.kt
@@ -1,0 +1,21 @@
+package com.mapbox.navigation.base.trip.model.alert
+
+import com.mapbox.navigation.testing.BuilderTest
+import io.mockk.mockk
+import org.junit.Test
+
+class CountryBorderCrossingInfoTest :
+    BuilderTest<CountryBorderCrossingInfo, CountryBorderCrossingInfo.Builder>() {
+
+    override fun getImplementationClass() = CountryBorderCrossingInfo::class
+
+    override fun getFilledUpBuilder() = CountryBorderCrossingInfo.Builder(
+        mockk(relaxed = true),
+        mockk(relaxed = true)
+    )
+
+    @Test
+    override fun trigger() {
+        // only used to trigger JUnit4 to run this class if all test cases come from the parent
+    }
+}

--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -646,11 +646,19 @@ package com.mapbox.navigation.core.trip.model.eh {
   }
 
   public final class EHorizonObjectMetadata {
+    method public com.mapbox.navigation.base.trip.model.alert.CountryBorderCrossingInfo? getBorderCrossingInfo();
     method public com.mapbox.navigation.base.trip.model.alert.IncidentInfo? getIncidentInfo();
     method public String getObjectProvider();
+    method public Integer? getRestStopType();
+    method public Integer? getTollCollectionType();
+    method public com.mapbox.navigation.base.trip.model.alert.TunnelInfo? getTunnelInfo();
     method public String getType();
+    property public final com.mapbox.navigation.base.trip.model.alert.CountryBorderCrossingInfo? borderCrossingInfo;
     property public final com.mapbox.navigation.base.trip.model.alert.IncidentInfo? incidentInfo;
     property public final String objectProvider;
+    property public final Integer? restStopType;
+    property public final Integer? tollCollectionType;
+    property public final com.mapbox.navigation.base.trip.model.alert.TunnelInfo? tunnelInfo;
     property public final String type;
   }
 

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/model/eh/EHorizonObjectMetadata.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/model/eh/EHorizonObjectMetadata.kt
@@ -1,6 +1,8 @@
 package com.mapbox.navigation.core.trip.model.eh
 
+import com.mapbox.navigation.base.trip.model.alert.CountryBorderCrossingInfo
 import com.mapbox.navigation.base.trip.model.alert.IncidentInfo
+import com.mapbox.navigation.base.trip.model.alert.TunnelInfo
 
 /**
  * RoadObject metadata
@@ -9,11 +11,24 @@ import com.mapbox.navigation.base.trip.model.alert.IncidentInfo
  * @param objectProvider provider of road object
  * @param incidentInfo will be filled only if [type] is [EHorizonObjectType.INCIDENT] and
  * [objectProvider] is [EHorizonObjectProvider.MAPBOX]
+ * @param tunnelInfo will be filled only if [type] is [EHorizonObjectType.TUNNEL_ENTRANCE] and
+ * [objectProvider] is [EHorizonObjectProvider.MAPBOX]
+ * @param borderCrossingInfo will be filled only if [type] is [EHorizonObjectType.BORDER_CROSSING]
+ * and [objectProvider] is [EHorizonObjectProvider.MAPBOX]
+ * @param tollCollectionType will be filled only if [type] is
+ * [EHorizonObjectType.TOLL_COLLECTION_POINT] and [objectProvider] is
+ * [EHorizonObjectProvider.MAPBOX]
+ * @param restStopType will be filled only if [type] is [EHorizonObjectType.SERVICE_AREA] and
+ * [objectProvider] is [EHorizonObjectProvider.MAPBOX]
  */
 class EHorizonObjectMetadata internal constructor(
     @EHorizonObjectType.Type val type: String,
     @EHorizonObjectProvider.Type val objectProvider: String,
     val incidentInfo: IncidentInfo?,
+    val tunnelInfo: TunnelInfo?,
+    val borderCrossingInfo: CountryBorderCrossingInfo?,
+    val tollCollectionType: Int?,
+    val restStopType: Int?,
 ) {
 
     /**
@@ -28,6 +43,10 @@ class EHorizonObjectMetadata internal constructor(
         if (type != other.type) return false
         if (objectProvider != other.objectProvider) return false
         if (incidentInfo != other.incidentInfo) return false
+        if (tunnelInfo != other.tunnelInfo) return false
+        if (borderCrossingInfo != other.borderCrossingInfo) return false
+        if (tollCollectionType != other.tollCollectionType) return false
+        if (restStopType != other.restStopType) return false
 
         return true
     }
@@ -39,6 +58,10 @@ class EHorizonObjectMetadata internal constructor(
         var result = type.hashCode()
         result = 31 * result + objectProvider.hashCode()
         result = 31 * result + (incidentInfo?.hashCode() ?: 0)
+        result = 31 * result + (tunnelInfo?.hashCode() ?: 0)
+        result = 31 * result + (borderCrossingInfo?.hashCode() ?: 0)
+        result = 31 * result + (tollCollectionType ?: 0)
+        result = 31 * result + (restStopType ?: 0)
         return result
     }
 
@@ -47,8 +70,12 @@ class EHorizonObjectMetadata internal constructor(
      */
     override fun toString(): String {
         return "EHorizonObjectMetadata(" +
-            "type=$type, " +
+            "type='$type', " +
             "objectProvider='$objectProvider', " +
-            "incidentInfo=$incidentInfo)"
+            "incidentInfo=$incidentInfo, " +
+            "tunnelInfo=$tunnelInfo, " +
+            "borderCrossingInfo=$borderCrossingInfo, " +
+            "tollCollectionType=$tollCollectionType, " +
+            "restStopType=$restStopType)"
     }
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/RoadObjectsStore.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/RoadObjectsStore.kt
@@ -40,11 +40,17 @@ class RoadObjectsStore internal constructor(
      */
     fun getRoadObjectMetadata(roadObjectId: String): EHorizonObjectMetadata? {
         return navigator.roadObjectsStore?.getRoadObjectMetadata(roadObjectId)?.let {
-            EHorizonObjectMetadata(
-                it.type.mapToEHorizonObjectType(),
-                it.provider.mapToEHorizonObjectProvider(),
-                navigator.navigatorMapper.getIncidentInfo(it.incident)
-            )
+            navigator.navigatorMapper.run {
+                EHorizonObjectMetadata(
+                    it.type.mapToEHorizonObjectType(),
+                    it.provider.mapToEHorizonObjectProvider(),
+                    getIncidentInfo(it.incident),
+                    getTunnelInfo(it.tunnelInfo),
+                    getBorderCrossingInfo(it.borderCrossingInfo),
+                    getTollCollectionType(it.tollCollectionInfo),
+                    getRestStopType(it.serviceAreaInfo),
+                )
+            }
         }
     }
 

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/NavigatorMapper.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/NavigatorMapper.kt
@@ -16,6 +16,7 @@ import com.mapbox.navigation.base.trip.model.RouteProgressState
 import com.mapbox.navigation.base.trip.model.RouteStepProgress
 import com.mapbox.navigation.base.trip.model.alert.CountryBorderCrossingAdminInfo
 import com.mapbox.navigation.base.trip.model.alert.CountryBorderCrossingAlert
+import com.mapbox.navigation.base.trip.model.alert.CountryBorderCrossingInfo
 import com.mapbox.navigation.base.trip.model.alert.IncidentAlert
 import com.mapbox.navigation.base.trip.model.alert.IncidentCongestion
 import com.mapbox.navigation.base.trip.model.alert.IncidentImpact
@@ -36,6 +37,7 @@ import com.mapbox.navigator.AdminInfo
 import com.mapbox.navigator.BannerComponent
 import com.mapbox.navigator.BannerInstruction
 import com.mapbox.navigator.BannerSection
+import com.mapbox.navigator.BorderCrossingInfo
 import com.mapbox.navigator.NavigationStatus
 import com.mapbox.navigator.Navigator
 import com.mapbox.navigator.RouteAlertType
@@ -72,6 +74,21 @@ class NavigatorMapper internal constructor() {
     }
 
     fun getIncidentInfo(info: com.mapbox.navigator.IncidentInfo?) = info?.toIncidentInfo()
+
+    fun getBorderCrossingInfo(info: BorderCrossingInfo?): CountryBorderCrossingInfo? {
+        return info?.let {
+            CountryBorderCrossingInfo.Builder(
+                it.from.toBorderCrossingAdminInfo(),
+                it.to.toBorderCrossingAdminInfo()
+            ).build()
+        }
+    }
+
+    fun getTunnelInfo(info: com.mapbox.navigator.TunnelInfo?): TunnelInfo? = info.toTunnelInfo()
+
+    fun getTollCollectionType(info: TollCollectionInfo?): Int? = info.toTollCollectionType()
+
+    fun getRestStopType(info: ServiceAreaInfo?): Int? = info.toRestStopType()
 
     private fun NavigationStatus.getRouteProgress(
         route: DirectionsRoute?,

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/NavigatorMapper.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/NavigatorMapper.kt
@@ -315,8 +315,12 @@ class NavigatorMapper internal constructor() {
                     alert.distance
                 )
                     .alertGeometry(alert.getAlertGeometry())
-                    .from(alert.borderCrossingInfo?.from.toBorderCrossingAdminInfo())
-                    .to(alert.borderCrossingInfo?.to.toBorderCrossingAdminInfo())
+                    .countryBorderCrossingInfo(
+                        CountryBorderCrossingInfo.Builder(
+                            alert.borderCrossingInfo?.from.toBorderCrossingAdminInfo(),
+                            alert.borderCrossingInfo?.to.toBorderCrossingAdminInfo()
+                        ).build()
+                    )
                     .build()
             }
             RouteAlertType.TOLL_COLLECTION_POINT -> {

--- a/libnavigator/src/test/java/com/mapbox/navigation/navigator/NavigatorMapperTest.kt
+++ b/libnavigator/src/test/java/com/mapbox/navigation/navigator/NavigatorMapperTest.kt
@@ -6,6 +6,7 @@ import com.mapbox.geojson.utils.PolylineUtils
 import com.mapbox.navigation.base.trip.model.RouteStepProgress
 import com.mapbox.navigation.base.trip.model.alert.CountryBorderCrossingAdminInfo
 import com.mapbox.navigation.base.trip.model.alert.CountryBorderCrossingAlert
+import com.mapbox.navigation.base.trip.model.alert.CountryBorderCrossingInfo
 import com.mapbox.navigation.base.trip.model.alert.IncidentAlert
 import com.mapbox.navigation.base.trip.model.alert.IncidentCongestion
 import com.mapbox.navigation.base.trip.model.alert.IncidentImpact
@@ -187,8 +188,12 @@ class NavigatorMapperTest {
             Point.fromLngLat(10.0, 20.0),
             123.0
         )
-            .from(CountryBorderCrossingAdminInfo.Builder("US", "USA").build())
-            .to(CountryBorderCrossingAdminInfo.Builder("CA", "CAN").build())
+            .countryBorderCrossingInfo(
+                CountryBorderCrossingInfo.Builder(
+                    CountryBorderCrossingAdminInfo.Builder("US", "USA").build(),
+                    CountryBorderCrossingAdminInfo.Builder("CA", "CAN").build()
+                ).build()
+            )
             .build()
         assertEquals(expected, upcomingRouteAlert.routeAlert)
         assertEquals(expected.hashCode(), upcomingRouteAlert.routeAlert.hashCode())


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
There are some missed values in `RoadObjectMetadata` . We should map them to new values in `EHorizonObjectMetadata` 

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Add missed EH road object values to EHorizonObjectMetadata</changelog>
```

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
