### PR TITLE
Refresh route fix: refresh alternative route when selected

### DIFF
--- a/libnavigation-router/src/main/java/com/mapbox/navigation/route/internal/offboard/MapboxOffboardRouter.kt
+++ b/libnavigation-router/src/main/java/com/mapbox/navigation/route/internal/offboard/MapboxOffboardRouter.kt
@@ -114,6 +114,7 @@ class MapboxOffboardRouter(
             val refreshBuilder = MapboxDirectionsRefresh.builder()
                 .accessToken(accessToken)
                 .requestId(route.routeOptions()?.requestUuid())
+                .routeIndex(route.routeIndex()?.toIntOrNull() ?: 0)
                 .legIndex(legIndex)
                 .interceptor {
                     val httpUrl = it.request().url()


### PR DESCRIPTION
### Description
Route refresh fix. Specify route index to refresh selected(alternative) route, not primary only(by default).

Closes #3992 

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Fixed Route refresh: refresh alternative route when selected</changelog>
```
