### PR TITLE
Refresh route fix: refresh alternative route when selected

### DIFF
--- a/libnavigation-router/src/main/java/com/mapbox/navigation/route/internal/offboard/MapboxOffboardRouter.kt
+++ b/libnavigation-router/src/main/java/com/mapbox/navigation/route/internal/offboard/MapboxOffboardRouter.kt
@@ -112,9 +112,10 @@ class MapboxOffboardRouter(
         callback: RouteRefreshCallback
     ) {
         try {
-            val refreshBuilder = MapboxDirectionsRefresh.builder()
+            val refreshBuilder = RouteBuilderProvider.getRefreshBuilder()
                 .accessToken(accessToken)
                 .requestId(route.routeOptions()?.requestUuid())
+                .routeIndex(route.routeIndex()?.toIntOrNull() ?: 0)
                 .legIndex(legIndex)
                 .interceptor {
                     val httpUrl = it.request().url()

--- a/libnavigation-router/src/main/java/com/mapbox/navigation/route/offboard/RouteBuilderProvider.kt
+++ b/libnavigation-router/src/main/java/com/mapbox/navigation/route/offboard/RouteBuilderProvider.kt
@@ -3,6 +3,7 @@ package com.mapbox.navigation.route.offboard
 import android.content.Context
 import com.mapbox.api.directions.v5.DirectionsCriteria
 import com.mapbox.api.directions.v5.MapboxDirections
+import com.mapbox.api.directionsrefresh.v1.MapboxDirectionsRefresh
 import com.mapbox.navigation.base.internal.accounts.UrlSkuTokenProvider
 import com.mapbox.navigation.base.internal.extensions.LocaleEx.getUnitTypeForLocale
 import com.mapbox.navigation.base.internal.extensions.inferDeviceLocale
@@ -41,4 +42,7 @@ internal object RouteBuilderProvider {
                     )
                 it.proceed(it.request().newBuilder().url(skuUrl).build())
             }
+
+    fun getRefreshBuilder(): MapboxDirectionsRefresh.Builder =
+        MapboxDirectionsRefresh.builder()
 }

--- a/libnavigation-router/src/test/java/com/mapbox/navigation/route/internal/offboard/MapboxOffboardRouterTest.kt
+++ b/libnavigation-router/src/test/java/com/mapbox/navigation/route/internal/offboard/MapboxOffboardRouterTest.kt
@@ -5,7 +5,10 @@ import com.mapbox.api.directions.v5.MapboxDirections
 import com.mapbox.api.directions.v5.models.DirectionsResponse
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.RouteOptions
+import com.mapbox.api.directionsrefresh.v1.MapboxDirectionsRefresh
 import com.mapbox.navigation.base.internal.accounts.UrlSkuTokenProvider
+import com.mapbox.navigation.base.route.RouteRefreshCallback
+import com.mapbox.navigation.base.route.RouteRefreshError
 import com.mapbox.navigation.base.route.Router
 import com.mapbox.navigation.route.offboard.RouteBuilderProvider
 import com.mapbox.navigation.route.offboard.base.BaseTest
@@ -13,8 +16,12 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.slot
+import io.mockk.unmockkObject
 import io.mockk.verify
+import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import retrofit2.Call
@@ -25,6 +32,7 @@ class MapboxOffboardRouterTest : BaseTest() {
 
     private val mapboxDirections = mockk<MapboxDirections>(relaxed = true)
     private val mapboxDirectionsBuilder = mockk<MapboxDirections.Builder>(relaxed = true)
+    private val mapboxDirectionsRefreshBuilder = mockk<MapboxDirectionsRefresh.Builder>()
     private val context = mockk<Context>()
     private val accessToken = "pk.1234"
     private lateinit var offboardRouter: MapboxOffboardRouter
@@ -52,7 +60,31 @@ class MapboxOffboardRouterTest : BaseTest() {
         }
         every { routeOptions.coordinates().size } returns 2
         every { call.isCanceled } returns false
+
+        // refresh
+        every { RouteBuilderProvider.getRefreshBuilder() } returns mapboxDirectionsRefreshBuilder
+        every {
+            mapboxDirectionsRefreshBuilder.accessToken(accessToken)
+        } returns mapboxDirectionsRefreshBuilder
+        every {
+            mapboxDirectionsRefreshBuilder.interceptor(any())
+        } returns mapboxDirectionsRefreshBuilder
+        every {
+            mapboxDirectionsRefreshBuilder.requestId(any())
+        } returns mapboxDirectionsRefreshBuilder
+        every {
+            mapboxDirectionsRefreshBuilder.legIndex(any())
+        } returns mapboxDirectionsRefreshBuilder
+        every {
+            mapboxDirectionsRefreshBuilder.routeIndex(any())
+        } returns mapboxDirectionsRefreshBuilder
+
         offboardRouter = MapboxOffboardRouter(accessToken, context, mockSkuTokenProvider, true)
+    }
+
+    @After
+    fun freeRecourse() {
+        unmockkObject(RouteBuilderProvider)
     }
 
     @Test
@@ -168,8 +200,56 @@ class MapboxOffboardRouterTest : BaseTest() {
         verify { routerCallback.onCanceled() }
     }
 
+    @Test
+    fun `route refresh set right params`() {
+        val route = mockRouteForRefresh("uuid_123", "1")
+        getRouteRefresh(route, 0, mockk(relaxUnitFun = true))
+
+        verify(exactly = 1) {
+            mapboxDirectionsRefreshBuilder.accessToken(accessToken)
+            mapboxDirectionsRefreshBuilder.requestId("uuid_123")
+            mapboxDirectionsRefreshBuilder.routeIndex(1)
+            mapboxDirectionsRefreshBuilder.legIndex(0)
+        }
+    }
+
+    @Test
+    fun `route refresh set non-valid route index`() {
+        val route = mockRouteForRefresh("uuid_321", "")
+        getRouteRefresh(route, 1, mockk(relaxUnitFun = true))
+
+        verify(exactly = 1) {
+            mapboxDirectionsRefreshBuilder.accessToken(accessToken)
+            mapboxDirectionsRefreshBuilder.requestId("uuid_321")
+            mapboxDirectionsRefreshBuilder.routeIndex(0)
+            mapboxDirectionsRefreshBuilder.legIndex(1)
+        }
+    }
+
+    @Test
+    fun `route refresh throws exception`() {
+        val callback = mockk<RouteRefreshCallback>()
+        val routeRefreshError = slot<RouteRefreshError>()
+        every { callback.onError(capture(routeRefreshError)) } returns Unit
+        every { mapboxDirectionsRefreshBuilder.interceptor(any()) }.throws(Exception("Exception"))
+
+        getRouteRefresh(mockRouteForRefresh("uuid_123", "2"), 0, callback)
+
+        assertEquals("Route refresh call failed", routeRefreshError.captured.message)
+        assertTrue(routeRefreshError.captured.throwable is Exception)
+        assertEquals("Exception", routeRefreshError.captured.throwable?.message)
+    }
+
     private fun getRoute(routerCallback: Router.Callback) {
         offboardRouter.getRoute(routeOptions, routerCallback)
+    }
+
+    private fun getRouteRefresh(
+        route: DirectionsRoute,
+        legIndex: Int,
+        callback: RouteRefreshCallback
+    ) {
+        offboardRouter.getRouteRefresh(route, legIndex, callback)
     }
 
     private fun buildResponse(
@@ -183,5 +263,13 @@ class MapboxOffboardRouterTest : BaseTest() {
         every { response.isSuccessful } returns isSuccessful
 
         return response
+    }
+
+    private fun mockRouteForRefresh(
+        uuid: String? = null,
+        routeIndex: String? = null
+    ): DirectionsRoute = mockk<DirectionsRoute>().also {
+        every { it.routeOptions()?.requestUuid() } returns uuid
+        every { it.routeIndex() } returns routeIndex
     }
 }


### PR DESCRIPTION
### Description
Route refresh fix. Specify route index to refresh selected(alternative) route, not primary only(by default).

Cherry-pick of #4056 
Ref #3992 

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Fixed Route refresh: refresh alternative route when selected</changelog>
```
