### PR TITLE
Add ability to run CI with arbitrary navigation-native snapshot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,6 @@ executors:
       - image: mbgl/android-ndk-r21:latest
     working_directory: ~/code
     environment:
-      when: << pipeline.parameters.mapbox_navigation_native_upstream >>
       FORCE_MAPBOX_NAVIGATION_NATIVE_VERSION: << pipeline.parameters.mapbox_navigation_native_snapshot >>
       ALLOW_SNAPSHOT_REPOSITORY: true
       

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,9 +17,8 @@ executors:
       - image: mbgl/android-ndk-r21:latest
     working_directory: ~/code
     environment:
-      when: << pipeline.parameters.mapbox_navigation_native_upstream >>
       FORCE_MAPBOX_NAVIGATION_NATIVE_VERSION: << pipeline.parameters.mapbox_navigation_native_snapshot >>
-      ALLOW_SNAPSHOT_REPOSITORY: true
+      ALLOW_SNAPSHOT_REPOSITORY: << pipeline.parameters.mapbox_navigation_native_upstream >>
       
 #-------------------------------
 #---------- WORKFLOWS ----------

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ executors:
       - image: mbgl/android-ndk-r21:latest
     working_directory: ~/code
     environment:
+      when: << pipeline.parameters.mapbox_navigation_native_upstream >>
       FORCE_MAPBOX_NAVIGATION_NATIVE_VERSION: << pipeline.parameters.mapbox_navigation_native_snapshot >>
     
 #-------------------------------
@@ -24,25 +25,22 @@ executors:
 #-------------------------------
 workflows:
   version: 2
-  mapbox-navigation-native-validation:
-    when: << pipeline.parameters.mapbox_navigation_native_upstream >>
-    jobs: 
-      - prepare-and-assemble
-      - unit-tests:
-          requires:
-            - prepare-and-assemble
-      - ui-robo-tests:
-          requires:
-            - prepare-and-assemble
-      - internal-instrumentation-tests:
-          requires:
-            - prepare-and-assemble
-      - instrumentation-tests:
-          requires:
-            - prepare-and-assemble
-  default:
-    when:
+  release-workflow:
+    when: 
       not: << pipeline.parameters.mapbox_navigation_native_upstream >>
+    jobs: 
+      - release-snapshot:
+          filters:
+            branches:
+              only:
+                - main
+      - release:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
+  default:
     jobs:
       - prepare-and-assemble
       - static-analysis:
@@ -65,18 +63,7 @@ workflows:
             - static-analysis
           filters:
             branches:
-              ignore: /^(main|release-.*)/
-      - release-snapshot:
-          filters:
-            branches:
-              only:
-                - main
-      - release:
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/
+              ignore: /^(sf-trigger-pipeline|main|release-.*)/
 #      - mobile-metrics-dry-run:
 #          type: approval
 #      - mobile-metrics-benchmarks:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ executors:
       - image: mbgl/android-ndk-r21:latest
     working_directory: ~/code
     environment:
+      when: << pipeline.parameters.mapbox_navigation_native_upstream >>
       FORCE_MAPBOX_NAVIGATION_NATIVE_VERSION: << pipeline.parameters.mapbox_navigation_native_snapshot >>
       ALLOW_SNAPSHOT_REPOSITORY: true
       

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,13 @@
 version: 2.1
 
+parameters:
+  mapbox_navigation_native_upstream:
+    type: boolean
+    default: false
+  mapbox_navigation_native_snapshot:
+    type: string
+    default: ''
+
 #-------------------------------
 #---------- EXECUTORS ----------
 #-------------------------------
@@ -8,13 +16,33 @@ executors:
     docker:
       - image: mbgl/android-ndk-r21:latest
     working_directory: ~/code
-
+    environment:
+      FORCE_MAPBOX_NAVIGATION_NATIVE_VERSION: << pipeline.parameters.mapbox_navigation_native_snapshot >>
+    
 #-------------------------------
 #---------- WORKFLOWS ----------
 #-------------------------------
 workflows:
   version: 2
+  mapbox-navigation-native-validation:
+    when: << pipeline.parameters.mapbox_navigation_native_upstream >>
+    jobs: 
+      - prepare-and-assemble
+      - unit-tests:
+          requires:
+            - prepare-and-assemble
+      - ui-robo-tests:
+          requires:
+            - prepare-and-assemble
+      - internal-instrumentation-tests:
+          requires:
+            - prepare-and-assemble
+      - instrumentation-tests:
+          requires:
+            - prepare-and-assemble
   default:
+    when:
+      not: << pipeline.parameters.mapbox_navigation_native_upstream >>
     jobs:
       - prepare-and-assemble
       - static-analysis:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ executors:
     environment:
       when: << pipeline.parameters.mapbox_navigation_native_upstream >>
       FORCE_MAPBOX_NAVIGATION_NATIVE_VERSION: << pipeline.parameters.mapbox_navigation_native_snapshot >>
+      ALLOW_SNAPSHOT_REPOSITORY: true
       
 #-------------------------------
 #---------- WORKFLOWS ----------

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ executors:
     environment:
       when: << pipeline.parameters.mapbox_navigation_native_upstream >>
       FORCE_MAPBOX_NAVIGATION_NATIVE_VERSION: << pipeline.parameters.mapbox_navigation_native_snapshot >>
-    
+      
 #-------------------------------
 #---------- WORKFLOWS ----------
 #-------------------------------
@@ -63,7 +63,7 @@ workflows:
             - static-analysis
           filters:
             branches:
-              ignore: /^(sf-trigger-pipeline|main|release-.*)/
+              ignore: /^(main|release-.*)/
 #      - mobile-metrics-dry-run:
 #          type: approval
 #      - mobile-metrics-benchmarks:

--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ allprojects {
     // we allow access to snapshots repo if FORCE_MAPBOX_NAVIGATION_NATIVE_VERSION is set, what means we are running on CI 
     // with Navigation Native forced to be some snapshot version
     // if you need to use snapshots while development, just set `addSnapshotsRepo` to true manually
-    def addSnapshotsRepo = System.getenv("FORCE_MAPBOX_NAVIGATION_NATIVE_VERSION") != null
+    def addSnapshotsRepo = System.getenv("ALLOW_SNAPSHOT_REPOSITORY") ?: false
     if (addSnapshotsRepo) {
       maven {
         url 'https://api.mapbox.com/downloads/v2/snapshots/maven'

--- a/build.gradle
+++ b/build.gradle
@@ -59,9 +59,9 @@ allprojects {
     }
     // we allow access to snapshots repo if FORCE_MAPBOX_NAVIGATION_NATIVE_VERSION is set, what means we are running on CI 
     // with Navigation Native forced to be some snapshot version
-    // if you need to use snapshots while development, just set `addSnapshotRepo` to true manually
-    def addSnapshotRepo = System.getenv("FORCE_MAPBOX_NAVIGATION_NATIVE_VERSION") != null
-    if (addSnapshotRepo) {
+    // if you need to use snapshots while development, just set `addSnapshotsRepo` to true manually
+    def addSnapshotsRepo = System.getenv("FORCE_MAPBOX_NAVIGATION_NATIVE_VERSION") != null
+    if (addSnapshotsRepo) {
       maven {
         url 'https://api.mapbox.com/downloads/v2/snapshots/maven'
         authentication {

--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ allprojects {
       }
     }
     // uncomment if snapshots access is needed
-    /*maven {
+    maven {
       url 'https://api.mapbox.com/downloads/v2/snapshots/maven'
       authentication {
         basic(BasicAuthentication)
@@ -67,7 +67,7 @@ allprojects {
         username = "mapbox"
         password = project.hasProperty('SDK_REGISTRY_TOKEN') ? project.property('SDK_REGISTRY_TOKEN') : System.getenv('SDK_REGISTRY_TOKEN')
       }
-    }*/
+    }
     /*maven {
       url 'https://mapbox.bintray.com/mapbox_internal'
       credentials {

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ allprojects {
         password = project.hasProperty('SDK_REGISTRY_TOKEN') ? project.property('SDK_REGISTRY_TOKEN') : System.getenv('SDK_REGISTRY_TOKEN')
       }
     }
-    // we allow access to snapshots repo if FORCE_MAPBOX_NAVIGATION_NATIVE_VERSION is set, what means we are running on CI 
+    // we allow access to snapshots repo if ALLOW_SNAPSHOT_REPOSITORY is set, what means we are running on CI 
     // with Navigation Native forced to be some snapshot version
     // if you need to use snapshots while development, just set `addSnapshotsRepo` to true manually
     def addSnapshotsRepo = System.getenv("ALLOW_SNAPSHOT_REPOSITORY") ?: false

--- a/build.gradle
+++ b/build.gradle
@@ -57,17 +57,23 @@ allprojects {
         password = project.hasProperty('SDK_REGISTRY_TOKEN') ? project.property('SDK_REGISTRY_TOKEN') : System.getenv('SDK_REGISTRY_TOKEN')
       }
     }
-    // uncomment if snapshots access is needed
-    maven {
-      url 'https://api.mapbox.com/downloads/v2/snapshots/maven'
-      authentication {
-        basic(BasicAuthentication)
+    // we allow access to snapshots repo if FORCE_MAPBOX_NAVIGATION_NATIVE_VERSION is set, what means we are running on CI 
+    // with Navigation Native forced to be some snapshot version
+    // if you need to use snapshots while development, just set `addSnapshotRepo` to true manually
+    def addSnapshotRepo = System.getenv("FORCE_MAPBOX_NAVIGATION_NATIVE_VERSION") != null
+    if (addSnapshotRepo) {
+      maven {
+        url 'https://api.mapbox.com/downloads/v2/snapshots/maven'
+        authentication {
+          basic(BasicAuthentication)
+        }
+        credentials {
+          username = "mapbox"
+          password = project.hasProperty('SDK_REGISTRY_TOKEN') ? project.property('SDK_REGISTRY_TOKEN') : System.getenv('SDK_REGISTRY_TOKEN')
+        }
       }
-      credentials {
-        username = "mapbox"
-        password = project.hasProperty('SDK_REGISTRY_TOKEN') ? project.property('SDK_REGISTRY_TOKEN') : System.getenv('SDK_REGISTRY_TOKEN')
-      }
-    }
+    } 
+
     /*maven {
       url 'https://mapbox.bintray.com/mapbox_internal'
       credentials {

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -6,6 +6,9 @@ ext {
       compileSdkVersion       : 29
   ]
 
+  // Navigation Native CI can run SDK CI downstream with forced Navigation Native version
+  // in this case `FORCE_MAPBOX_NAVIGATION_NATIVE_VERSION` environment variable will contain
+  // version which we should use in this build
   def mapboxNavigatorVersion = System.getenv("FORCE_MAPBOX_NAVIGATION_NATIVE_VERSION")
   if (mapboxNavigatorVersion == null || mapboxNavigatorVersion == '') {
       mapboxNavigatorVersion = '43.0.1'

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -6,12 +6,17 @@ ext {
       compileSdkVersion       : 29
   ]
 
+  def mapboxNavigatorVersion = System.getenv("FORCE_MAPBOX_NAVIGATION_NATIVE_VERSION")
+  if (mapboxNavigatorVersion == null || mapboxNavigatorVersion == '') {
+      mapboxNavigatorVersion = '43.0.1'
+  }
+
   version = [
       mapboxMapSdk              : '10.0.0-beta.13',
       mapboxSdkServices         : '5.9.0-alpha.1',
       mapboxEvents              : '6.2.2',
       mapboxCore                : '3.1.1',
-      mapboxNavigator           : '43.0.1',
+      mapboxNavigator           : "${mapboxNavigatorVersion}",
       mapboxCommonNative        : '10.0.0-beta.9.2',
       mapboxCrashMonitor        : '2.0.0',
       mapboxAnnotationPlugin    : '0.8.0',


### PR DESCRIPTION
It will allow us to have downstream CI check in NN(i.e. we will periodically run SDK CI with snapshots of NN from master), i.e. we will be able to catch compatibility issues before NN release.

<changelog>Add ability to run CI with arbitrary navigation-native snapshot</changelog>