### PR TITLE
Enable native crashlytics for the test app

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -260,6 +260,19 @@ commands:
               echo "export POM_VERSION_NAME=$POM_VERSION_NAME" >> $BASH_ENV
             fi
 
+  generate-google-services-json:
+    steps:
+      - run:
+          name: Generate google services json for the test app
+          command:  |
+            echo "${TEST_APP_GOOGLE_SERVICES_JSON}" > /root/code/test-app/google-services.json
+
+  download-native-libs:
+    steps:
+      - run:
+          name: Download native libraries for crashlytics
+          command: ./gradlew downloadUnstrippedNativeLibsDir
+
   run-internal-firebase-instrumentation:
     parameters:
       module_wrapper:
@@ -415,6 +428,8 @@ jobs:
       GRADLE_OPTS: -Xmx4096m -Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process
     steps:
       - read-workspace
+      - download-native-libs
+      - generate-google-services-json
       - assemble-module:
           module_target: "test-app"
           variant: "Release"

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,10 @@ buildscript {
     classpath pluginDependencies.mapboxSdkVersions
     classpath pluginDependencies.mapboxSdkRegistry
     classpath pluginDependencies.mapboxAccessToken
+    classpath pluginDependencies.mapboxNativeDownload
     classpath pluginDependencies.dokka
+    classpath pluginDependencies.firebaseCrashlytics
+    classpath pluginDependencies.googleServices
   }
 }
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -42,7 +42,7 @@ ext {
       gmsLocation               : '17.0.0',
       ktlint                    : '0.40.0',
       kotlinStdLib              : '1.4.30',
-      firebaseCrashlytics       : '17.1.0',
+      firebaseCrashlytics       : '17.3.1',
       multidex                  : '2.0.0',
       json                      : '20180813',
       coroutinesAndroid         : '1.4.2',
@@ -146,37 +146,44 @@ ext {
 
       multidex                  : "androidx.multidex:multidex:${version.multidex}",
 
-      svgParser                 : "com.caverock:androidsvg-aar:${version.svgParser}"
+      svgParser                 : "com.caverock:androidsvg-aar:${version.svgParser}",
+
+      // Test app crashlytics
+      firebaseCrashlyticsNdk    : "com.google.firebase:firebase-crashlytics-ndk:${version.firebaseCrashlytics}"
   ]
 
   pluginVersion = [
-      checkstyle         : '8.2',
-      pmd                : '5.8.1',
-      gradle             : '4.0.1',
-      dependencyGraph    : '0.5.0',
-      dependencyUpdates  : '0.29.0',
-      kotlin             : '1.4.30',
-      license            : '0.8.5',
-      jacoco             : '0.2',
-      googleServices     : '4.3.3',
-      mapboxSdkVersions  : '1.1.0',
-      dokka              : '1.4.20',
-      mapboxSdkRegistry  : '0.4.0',
-      mapboxAccessToken  : '0.2.1'
+      checkstyle           : '8.2',
+      pmd                  : '5.8.1',
+      gradle               : '4.0.1',
+      dependencyGraph      : '0.5.0',
+      dependencyUpdates    : '0.29.0',
+      kotlin               : '1.4.30',
+      license              : '0.8.5',
+      jacoco               : '0.2',
+      googleServices       : '4.3.3',
+      mapboxSdkVersions    : '1.1.0',
+      dokka                : '1.4.20',
+      mapboxSdkRegistry    : '0.4.0',
+      mapboxAccessToken    : '0.2.1',
+      mapboxNativeDownload : '0.1.1',
+      firebaseCrashlytics  : '2.5.0'
   ]
 
   pluginDependencies = [
-      gradle             : "com.android.tools.build:gradle:${pluginVersion.gradle}",
-      kotlin             : "org.jetbrains.kotlin:kotlin-gradle-plugin:${pluginVersion.kotlin}",
-      checkstyle         : "com.puppycrawl.tools:checkstyle:${pluginVersion.checkstyle}",
-      license            : "com.jaredsburrows:gradle-license-plugin:${pluginVersion.license}",
-      dependencyGraph    : "com.vanniktech:gradle-dependency-graph-generator-plugin:${pluginVersion.dependencyGraph}",
-      dependencyUpdates  : "com.github.ben-manes:gradle-versions-plugin:${pluginVersion.dependencyUpdates}",
-      jacoco             : "com.hiya:jacoco-android:${pluginVersion.jacoco}",
-      googleServices     : "com.google.gms:google-services:${pluginVersion.googleServices}",
-      mapboxSdkVersions  : "com.mapbox.mapboxsdk:mapbox-android-sdk-versions:${pluginVersion.mapboxSdkVersions}",
-      dokka              : "org.jetbrains.dokka:dokka-gradle-plugin:${pluginVersion.dokka}",
-      mapboxSdkRegistry  : "com.mapbox.gradle.plugins:sdk-registry:${pluginVersion.mapboxSdkRegistry}",
-      mapboxAccessToken  : "com.mapbox.gradle.plugins:access-token:${pluginVersion.mapboxAccessToken}"
+      gradle               : "com.android.tools.build:gradle:${pluginVersion.gradle}",
+      kotlin               : "org.jetbrains.kotlin:kotlin-gradle-plugin:${pluginVersion.kotlin}",
+      checkstyle           : "com.puppycrawl.tools:checkstyle:${pluginVersion.checkstyle}",
+      license              : "com.jaredsburrows:gradle-license-plugin:${pluginVersion.license}",
+      dependencyGraph      : "com.vanniktech:gradle-dependency-graph-generator-plugin:${pluginVersion.dependencyGraph}",
+      dependencyUpdates    : "com.github.ben-manes:gradle-versions-plugin:${pluginVersion.dependencyUpdates}",
+      jacoco               : "com.hiya:jacoco-android:${pluginVersion.jacoco}",
+      googleServices       : "com.google.gms:google-services:${pluginVersion.googleServices}",
+      mapboxSdkVersions    : "com.mapbox.mapboxsdk:mapbox-android-sdk-versions:${pluginVersion.mapboxSdkVersions}",
+      dokka                : "org.jetbrains.dokka:dokka-gradle-plugin:${pluginVersion.dokka}",
+      mapboxSdkRegistry    : "com.mapbox.gradle.plugins:sdk-registry:${pluginVersion.mapboxSdkRegistry}",
+      mapboxAccessToken    : "com.mapbox.gradle.plugins:access-token:${pluginVersion.mapboxAccessToken}",
+      mapboxNativeDownload : "com.mapbox.gradle.plugins:native-download:${pluginVersion.mapboxNativeDownload}",
+      firebaseCrashlytics  : "com.google.firebase:firebase-crashlytics-gradle:${pluginVersion.firebaseCrashlytics}"
   ]
 }

--- a/test-app/build.gradle
+++ b/test-app/build.gradle
@@ -3,6 +3,8 @@ apply plugin: 'kotlin-android'
 apply plugin: 'com.mapbox.maps.token'
 apply from: "${rootDir}/gradle/script-git-version.gradle"
 apply from: "${rootDir}/gradle/ktlint.gradle"
+apply plugin: 'com.google.firebase.crashlytics'
+apply plugin: 'com.google.gms.google-services'
 
 android {
     compileSdkVersion androidVersions.compileSdkVersion
@@ -60,6 +62,12 @@ android {
             minifyEnabled true
             signingConfig signingConfigs.release
             manifestPlaceholders = [enableCrashReporting: "true"]
+            firebaseCrashlytics {
+                mappingFileUploadEnabled = true
+                nativeSymbolUploadEnabled = true
+                strippedNativeLibsDir = 'build/intermediates/stripped_native_libs/debug/release/lib/'
+                unstrippedNativeLibsDir = com.mapbox.gradle.NativeDownloadTask.UNSTRIPPED_NATIVE_LIBS_PATH
+            }
         }
     }
 
@@ -76,6 +84,14 @@ android {
     buildFeatures {
         viewBinding true
     }
+}
+
+task downloadUnstrippedNativeLibsDir(type: com.mapbox.gradle.NativeDownloadTask) {
+    mapboxDependencies = [
+            dependenciesList.mapboxMapSdk,
+            dependenciesList.mapboxNavigator,
+            dependenciesList.mapboxCommonNative
+    ]
 }
 
 dependencies {
@@ -112,4 +128,7 @@ dependencies {
 
     // Leak Canary
     debugImplementation dependenciesList.leakCanaryDebug
+
+    // Crashlytics
+    implementation dependenciesList.firebaseCrashlyticsNdk
 }


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Opened as a draft because I need to publish a new version of the gradle plugins in order to support an array of library dependencies.

The way I got this to work is by manually editing the `google-services.json` to update the package name. It is currently saved to the circleci variable `TEST_APP_GOOGLE_SERVICES_JSON`.
```
- "package_name": "com.mapbox.services.android.navigation.app"
+ "package_name": "com.mapbox.navigation.test_app"
```
^ I've added a new app to firebase, and we can remove the old one after this has been rolled out

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Enable native crashlytics for the test app</changelog>
```

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
