### PR TITLE
Verify Common SDK version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -433,6 +433,7 @@ jobs:
     steps:
       - read-workspace
       - verify-codebase
+      - verify-common-sdk-version
       - check-api-core
       - check-api-ui
       - check-public-documentation

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,6 +106,12 @@ commands:
           name: Check codebase
           command: make check
 
+  verify-common-sdk-version:
+    steps:
+      - run:
+          name: Verify Common SDK version
+          command: make verify-common-sdk-version
+
   verify-changelog:
     steps:
       - run:

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,10 @@ dependency-updates:
 	$(call run-gradle-tasks,$(CORE_MODULES),dependencyUpdates) \
 	&& $(call run-gradle-tasks,$(UI_MODULES),dependencyUpdates)
 
+.PHONY: verify-common-sdk-version
+verify-common-sdk-version:
+    ./gradlew verifyCommonSdkVersion
+
 .PHONY: dex-count
 dex-count:
 	./gradlew countDebugDexMethods

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ dependency-updates:
 
 .PHONY: verify-common-sdk-version
 verify-common-sdk-version:
-    ./gradlew verifyCommonSdkVersion
+	./gradlew verifyCommonSdkVersion
 
 .PHONY: dex-count
 dex-count:

--- a/build.gradle
+++ b/build.gradle
@@ -119,6 +119,7 @@ subprojects {
 }
 
 apply from: "${rootDir}/gradle/kdoc-settings.gradle"
+apply from: "${rootDir}/gradle/verify-common-sdk-version.gradle"
 
 dokkaHtmlMultiModule {
   outputDirectory.set(kdocPath)

--- a/gradle/verify-common-sdk-version.gradle
+++ b/gradle/verify-common-sdk-version.gradle
@@ -1,24 +1,46 @@
+def navigatorModuleName = "libnavigator"
+def moduleNames = ["libnavigation-core", navigatorModuleName]
+
 task verifyCommonSdkVersion {
-    String commonLibDependencyCore = getCommonLibDependency("libnavigation-core")
-    String commonLibDependencyNavigator = getCommonLibDependency("libnavigator")
-    if (commonLibDependencyCore != commonLibDependencyNavigator) {
-        throw new GradleException("Navigation SDK and Navigation Native have different versions of" +
-                "Common SDK library. Please align Common SDK version in both SDKs before push changes.")
+    moduleNames.each { moduleName ->
+        dependsOn ":" + moduleName + ":generateDependencyReportFile"
+    }
+    doLast {
+        def moduleDependencyMap = [:]
+        moduleNames.each { moduleName ->
+            String commonDependency = parseCommonLibDependency(moduleName)
+            moduleDependencyMap[moduleName] = commonDependency
+        }
+        moduleNames.each { moduleName ->
+            if (moduleName != navigatorModuleName
+                    && moduleDependencyMap[moduleName] != moduleDependencyMap[navigatorModuleName]) {
+                throw new GradleException(moduleName + " (" + moduleDependencyMap[moduleName] + ") " +
+                        "and " + navigatorModuleName + " (" + moduleDependencyMap[navigatorModuleName] + ") " +
+                        "have different versions of Common SDK library. " +
+                        "Please align Common SDK version in both SDKs before push changes.")
+            }
+        }
+        println("Common SDK versions are equal for Navigation SDK and for Navigation Native")
+        println(moduleDependencyMap)
     }
 }
 
-def getCommonLibDependency(String moduleName) {
-    File dependenciesFile = new File(moduleName + '_dependencies.txt')
-    if (dependenciesFile.exists() ) {
-        project.delete(moduleName + '_dependencies.txt')
+allprojects.findAll {it.name in moduleNames}.each { p ->
+    configure(p) {
+        task generateDependencyReportFile(type: DependencyReportTask) {
+            outputFile = file("build/reports/dependencies_report.txt")
+        }
     }
+}
 
-    "./gradlew :" + moduleName + ":dependencyInsight --dependency com.mapbox.common:common: --configuration releaseRuntimeClasspath >> " + moduleName + "_dependencies.txt"
-            .execute().text.trim()
-
-    dependenciesFile = new File(moduleName + '_dependencies.txt')
-    int firstIndexCommonLib = dependenciesFile.text.indexOf("com.mapbox.common:common:")
-    int lastIndexCommonLib = dependenciesFile.text.indexOf("variant", firstIndexCommonLib)
+static def parseCommonLibDependency(String moduleName) {
+    File dependenciesFile = new File(moduleName + "/build/reports/dependencies_report.txt")
+    int startSearchIndex = dependenciesFile.text.indexOf("releaseCompileClasspath")
+    int firstIndexCommonLib = dependenciesFile.text.indexOf("com.mapbox.common:common:", startSearchIndex)
+    int lastIndexCommonLib = Math.min(
+            dependenciesFile.text.indexOf("\n", firstIndexCommonLib),
+            dependenciesFile.text.indexOf(" ", firstIndexCommonLib)
+    )
     String commonLibDependency = dependenciesFile.text.substring(firstIndexCommonLib, lastIndexCommonLib)
     return commonLibDependency
 }

--- a/gradle/verify-common-sdk-version.gradle
+++ b/gradle/verify-common-sdk-version.gradle
@@ -13,12 +13,12 @@ def getCommonLibDependency(String moduleName) {
         project.delete(moduleName + '_dependencies.txt')
     }
 
-    "./gradlew :" + moduleName + ":dependencies --configuration releaseRuntimeClasspath >> " + moduleName + "_dependencies.txt"
+    "./gradlew :" + moduleName + ":dependencyInsight --dependency com.mapbox.common:common: --configuration releaseRuntimeClasspath >> " + moduleName + "_dependencies.txt"
             .execute().text.trim()
 
     dependenciesFile = new File(moduleName + '_dependencies.txt')
     int firstIndexCommonLib = dependenciesFile.text.indexOf("com.mapbox.common:common:")
-    int lastIndexCommonLib = dependenciesFile.text.indexOf("|", firstIndexCommonLib)
+    int lastIndexCommonLib = dependenciesFile.text.indexOf("variant", firstIndexCommonLib)
     String commonLibDependency = dependenciesFile.text.substring(firstIndexCommonLib, lastIndexCommonLib)
     return commonLibDependency
 }

--- a/gradle/verify-common-sdk-version.gradle
+++ b/gradle/verify-common-sdk-version.gradle
@@ -1,0 +1,24 @@
+task verifyCommonSdkVersion {
+    String commonLibDependencyCore = getCommonLibDependency("libnavigation-core")
+    String commonLibDependencyNavigator = getCommonLibDependency("libnavigator")
+    if (commonLibDependencyCore != commonLibDependencyNavigator) {
+        throw new GradleException("Navigation SDK and Navigation Native have different versions of" +
+                "Common SDK library. Please align Common SDK version in both SDKs before push changes.")
+    }
+}
+
+def getCommonLibDependency(String moduleName) {
+    File dependenciesFile = new File(moduleName + '_dependencies.txt')
+    if (dependenciesFile.exists() ) {
+        project.delete(moduleName + '_dependencies.txt')
+    }
+
+    "./gradlew :" + moduleName + ":dependencies --configuration releaseRuntimeClasspath >> " + moduleName + "_dependencies.txt"
+            .execute().text.trim()
+
+    dependenciesFile = new File(moduleName + '_dependencies.txt')
+    int firstIndexCommonLib = dependenciesFile.text.indexOf("com.mapbox.common:common:")
+    int lastIndexCommonLib = dependenciesFile.text.indexOf("|", firstIndexCommonLib)
+    String commonLibDependency = dependenciesFile.text.substring(firstIndexCommonLib, lastIndexCommonLib)
+    return commonLibDependency
+}

--- a/gradle/verify-common-sdk-version.gradle
+++ b/gradle/verify-common-sdk-version.gradle
@@ -1,5 +1,5 @@
 def navigatorModuleName = "libnavigator"
-def moduleNames = ["libnavigation-core", navigatorModuleName]
+def moduleNames = ["libnavigation-core"]
 
 task verifyCommonSdkVersion {
     moduleNames.each { moduleName ->
@@ -11,6 +11,7 @@ task verifyCommonSdkVersion {
             String commonDependency = parseCommonLibDependency(moduleName)
             moduleDependencyMap[moduleName] = commonDependency
         }
+        moduleDependencyMap[navigatorModuleName] = parseNavigatorCommonLibDependency()
         moduleNames.each { moduleName ->
             if (moduleName != navigatorModuleName
                     && moduleDependencyMap[moduleName] != moduleDependencyMap[navigatorModuleName]) {
@@ -36,6 +37,17 @@ allprojects.findAll {it.name in moduleNames}.each { p ->
 static def parseCommonLibDependency(String moduleName) {
     File dependenciesFile = new File(moduleName + "/build/reports/dependencies_report.txt")
     int startSearchIndex = dependenciesFile.text.indexOf("releaseCompileClasspath")
+    return getCommonLibDependency(dependenciesFile, startSearchIndex)
+}
+
+static def parseNavigatorCommonLibDependency() {
+    File dependenciesFile = new File("libnavigator/build/reports/dependencies_report.txt")
+    int configurationStartIndex = dependenciesFile.text.indexOf("releaseCompileClasspath")
+    int startSearchIndex = dependenciesFile.text.indexOf("com.mapbox.navigator:mapbox-navigation-native", configurationStartIndex)
+    return getCommonLibDependency(dependenciesFile, startSearchIndex)
+}
+
+static def getCommonLibDependency(File dependenciesFile, int startSearchIndex) {
     int firstIndexCommonLib = dependenciesFile.text.indexOf("com.mapbox.common:common:", startSearchIndex)
     int lastIndexCommonLib = Math.min(
             dependenciesFile.text.indexOf("\n", firstIndexCommonLib),

--- a/gradle/verify-common-sdk-version.gradle
+++ b/gradle/verify-common-sdk-version.gradle
@@ -1,5 +1,5 @@
 def navigatorModuleName = "libnavigator"
-def moduleNames = ["libnavigation-core"]
+def moduleNames = ["libnavigation-core", navigatorModuleName]
 
 task verifyCommonSdkVersion {
     moduleNames.each { moduleName ->
@@ -8,10 +8,14 @@ task verifyCommonSdkVersion {
     doLast {
         def moduleDependencyMap = [:]
         moduleNames.each { moduleName ->
-            String commonDependency = parseCommonLibDependency(moduleName)
+            String commonDependency = ""
+            if (moduleName == navigatorModuleName) {
+                commonDependency = parseNavigatorCommonLibDependency()
+            } else {
+                commonDependency = parseCommonLibDependency(moduleName)
+            }
             moduleDependencyMap[moduleName] = commonDependency
         }
-        moduleDependencyMap[navigatorModuleName] = parseNavigatorCommonLibDependency()
         moduleNames.each { moduleName ->
             if (moduleName != navigatorModuleName
                     && moduleDependencyMap[moduleName] != moduleDependencyMap[navigatorModuleName]) {
@@ -43,7 +47,10 @@ static def parseCommonLibDependency(String moduleName) {
 static def parseNavigatorCommonLibDependency() {
     File dependenciesFile = new File("libnavigator/build/reports/dependencies_report.txt")
     int configurationStartIndex = dependenciesFile.text.indexOf("releaseCompileClasspath")
-    int startSearchIndex = dependenciesFile.text.indexOf("com.mapbox.navigator:mapbox-navigation-native", configurationStartIndex)
+    int startSearchIndex = dependenciesFile.text.indexOf(
+            "com.mapbox.navigator:mapbox-navigation-native",
+            configurationStartIndex
+    )
     return getCommonLibDependency(dependenciesFile, startSearchIndex)
 }
 


### PR DESCRIPTION
### Description
This PR is about adding check if Common SDK version from Navigation SDK equal with Common SDK version used by NavNative. [issue](https://app.zenhub.com/workspaces/navigation-sdk-5f0fab2813faf4002040b014/issues/mapbox/navigation-sdks/598)

Using `DependencyReportTask` we get all dependencies for all configurations in txt report files. We run this task for list of needed modules (now we used only two: `libnavigation-core` and `libnavigator`). Parsing this files starts with `releaseCompileClasspath` configuration as it is the most full report. For this configuration was found first `com.mapbox.common:common:` mention and stored into map: `[moduleName -> commonDependency]`. In the end just comparing `libnavigator`'s Common SDK version with version from all another modules.
