### PR TITLE
Bump mapbox-navigation-native version to 43.0.1

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -11,7 +11,7 @@ ext {
       mapboxSdkServices         : '5.9.0-alpha.1',
       mapboxEvents              : '6.2.2',
       mapboxCore                : '3.1.1',
-      mapboxNavigator           : '42.0.1',
+      mapboxNavigator           : '43.0.1',
       mapboxCommonNative        : '10.0.0-beta.9.1',
       mapboxCrashMonitor        : '2.0.0',
       mapboxAnnotationPlugin    : '0.8.0',

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/NavigatorLoader.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/NavigatorLoader.kt
@@ -34,7 +34,7 @@ internal object NavigatorLoader {
             deviceProfile.customConfig
         )
         val runLoopExecutor = RunLoopExecutorFactory.build()
-        val historyRecorder = HistoryRecorderHandle.build(config)
+        val historyRecorder = HistoryRecorderHandle.build("", config)
         val cache = CacheFactory.build(tilesConfig, config, runLoopExecutor, historyRecorder)
 
         val navigator = Navigator(


### PR DESCRIPTION
### Description
Bumps `mapbox-navigation-native` version to `43.0.1` and fixes breaking changes

cc @etl 
