### PR TITLE
Add debug google services json

### DIFF
--- a/test-app/src/debug/google-services.json
+++ b/test-app/src/debug/google-services.json
@@ -1,0 +1,24 @@
+{
+  "project_info": {
+    "project_number": "empty-for-debugging",
+    "firebase_url": "empty-for-debugging",
+    "project_id": "mapbox-navigation-android",
+    "storage_bucket": "empty-for-debugging"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "empty-for-debugging",
+        "android_client_info": {
+          "package_name": "com.mapbox.navigation.test_app"
+        }
+      },
+      "api_key": [
+        {
+          "current_key": "empty-for-debugging"
+        }
+      ]
+    }
+  ],
+  "configuration_version": "1"
+}


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Resolves https://github.com/mapbox/mapbox-navigation-android/issues/4071

Went over a couple possible approaches in the ticket. A nice way to handle it, would be to disable firebase gradle plugins for debug builds. But I think the only way we could do that, is at the circle-ci level where would have separate apps. Once a plugin is applied, it applies to all build variants https://discuss.gradle.org/t/how-to-apply-plugin-based-on-build-type-android/15265

I'm adding this as a quick and easy solution, use an empty google-services.json for debug builds. When circle-ci runs, it will copy in a release version and that will be applied for the automated runs.

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
