### PR TITLE
Filtering out offset values less than threshold when creating traffic…

### DIFF
--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtils.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtils.kt
@@ -70,7 +70,8 @@ object MapboxRouteLineUtils {
                 literal(0.0)
             }
         }
-        val filteredItems = routeLineExpressionData.filter { it.offset > distanceOffset }
+        val filteredItems = routeLineExpressionData
+            .filter { it.offset > distanceOffset }.distinctBy { it.offset }
         when (filteredItems.isEmpty()) {
             true -> when (routeLineExpressionData.isEmpty()) {
                 true -> listOf(RouteLineExpressionData(distanceOffset, fallbackRouteColor))

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtilsTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtilsTest.kt
@@ -75,6 +75,30 @@ class MapboxRouteLineUtilsTest {
     }
 
     @Test
+    fun getTrafficLineExpressionDuplicateOffsetsRemoved() {
+        val expectedExpression = "[step, [line-progress], [rgba, 0.0, 0.0, 0.0, 0.0], 0.0, " +
+            "[rgba, 86.0, 168.0, 251.0, 1.0], 0.7868200761181402, " +
+            "[rgba, 86.0, 168.0, 251.0, 1.0], 0.7930120224665551, " +
+            "[rgba, 86.0, 168.0, 251.0, 1.0], 0.7932530928525063, " +
+            "[rgba, 86.0, 168.0, 251.0, 1.0], 0.7964017663976524, [rgba, 86.0, 168.0, 251.0, 1.0]]"
+        val expressionDatas = listOf(
+            RouteLineExpressionData(0.7868200761181402, -11097861),
+            RouteLineExpressionData(0.7930120224665551, -11097861),
+            RouteLineExpressionData(0.7932530928525063, -11097861),
+            RouteLineExpressionData(0.7932530928525063, -11097861),
+            RouteLineExpressionData(0.7964017663976524, -11097861)
+        )
+
+        val result = MapboxRouteLineUtils.getTrafficLineExpression(
+            0.0,
+            expressionDatas,
+            -11097861
+        )
+
+        assertEquals(result.toString(), expectedExpression)
+    }
+
+    @Test
     fun getVanishingRouteLineExpressionTest() {
         val expectedExpression = "[step, [line-progress], [rgba, 255.0, 77.0, 77.0, 1.0]" +
             ", 3.0, [rgba, 86.0, 168.0, 251.0, 1.0]]"


### PR DESCRIPTION
### Description
Resolves #4079 by filtering out values smaller than the minimum allowed value when creating a gradient line expression.

### Changelog
```
<changelog>Bug fix for the route line when calculating gradient line expressions</changelog>
```

### Screenshots or Gifs
