### PR TITLE
fixed an issue where snapshotter failure was not delivered when there was not instructions

### DIFF
--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/snapshotter/SnapshotterAction.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/snapshotter/SnapshotterAction.kt
@@ -6,7 +6,7 @@ import com.mapbox.navigation.ui.maps.snapshotter.model.MapboxSnapshotterOptions
 
 internal sealed class SnapshotterAction {
     data class GenerateSnapshot(
-        val bannerInstruction: BannerInstructions
+        val bannerInstruction: BannerInstructions?
     ) : SnapshotterAction()
 
     data class GenerateCameraPosition(

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/snapshotter/SnapshotterProcessor.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/snapshotter/SnapshotterProcessor.kt
@@ -57,14 +57,14 @@ internal object SnapshotterProcessor {
         }
     }
 
-    private fun isSnapshotAvailable(instruction: BannerInstructions): SnapshotterResult {
+    private fun isSnapshotAvailable(instruction: BannerInstructions?): SnapshotterResult {
         return ifNonNull(getComponentContainingSnapshot(instruction)) {
             SnapshotterResult.SnapshotAvailable
         } ?: SnapshotterResult.SnapshotUnavailable
     }
 
     private fun getComponentContainingSnapshot(
-        bannerInstructions: BannerInstructions
+        bannerInstructions: BannerInstructions?
     ): BannerComponents? {
         val bannerComponents = bannerInstructions.getBannerComponents()
         return when {

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/snapshotter/api/MapboxSnapshotterApi.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/snapshotter/api/MapboxSnapshotterApi.kt
@@ -65,117 +65,117 @@ class MapboxSnapshotterApi(
      * @param callback informs about the state of the snapshot
      */
     override fun generateSnapshot(progress: RouteProgress, callback: SnapshotReadyCallback) {
-        val bannerInstructions = progress.bannerInstructions
-        ifNonNull(bannerInstructions) { instruction ->
-            val action = SnapshotterAction.GenerateSnapshot(instruction)
-            val result = SnapshotterProcessor.process(action)
+        val action = SnapshotterAction.GenerateSnapshot(progress.bannerInstructions)
+        val result = SnapshotterProcessor.process(action)
 
-            when (result) {
-                is SnapshotterResult.SnapshotUnavailable -> {
-                    callback.onFailure(
-                        SnapshotState.SnapshotFailure.SnapshotUnavailable
+        when (result) {
+            is SnapshotterResult.SnapshotUnavailable -> {
+                callback.onFailure(
+                    SnapshotState.SnapshotFailure.SnapshotUnavailable
+                )
+            }
+            is SnapshotterResult.SnapshotAvailable -> {
+                val currentGeometry =
+                    progress.currentLegProgress?.currentStepProgress?.step?.geometry()
+                val upcomingGeometry = progress.currentLegProgress?.upcomingStep?.geometry()
+                val camera = SnapshotterProcessor.process(
+                    SnapshotterAction.GenerateCameraPosition(
+                        currentGeometry,
+                        upcomingGeometry,
+                        options
                     )
-                }
-                is SnapshotterResult.SnapshotAvailable -> {
-                    val currentGeometry =
-                        progress.currentLegProgress?.currentStepProgress?.step?.geometry()
-                    val upcomingGeometry = progress.currentLegProgress?.upcomingStep?.geometry()
-                    val camera = SnapshotterProcessor.process(
-                        SnapshotterAction.GenerateCameraPosition(
-                            currentGeometry,
-                            upcomingGeometry,
-                            options
+                ) as SnapshotterResult.SnapshotterCameraPosition
+                ifNonNull(camera.cameraPosition) {
+                    routeLinePoints.addAll(it.points.plus(progress.upcomingStepPoints!!))
+                    val mapInterface = getMapInterface()
+                    val oldSize = mapInterface.size
+                    mapInterface.size = Size(options.size.width, options.size.height)
+                    val cameraOptions = mapboxMap.cameraForCoordinates(
+                        it.points,
+                        it.insets,
+                        it.bearing,
+                        it.pitch
+                    )
+                    val centerTop =
+                        (
+                            (mapInterface.size.height * options.density) -
+                                (options.edgeInsets.top + options.edgeInsets.bottom)
+                            ) / 2 + (options.edgeInsets.top)
+                    val centerLeft =
+                        (
+                            (mapInterface.size.width * options.density) -
+                                (options.edgeInsets.left + options.edgeInsets.right)
+                            ) / 2 + (options.edgeInsets.left)
+                    cameraOptions.padding = getEdgeInsets(
+                        Size(
+                            mapInterface.size.width * options.density,
+                            mapInterface.size.height * options.density
+                        ),
+                        ScreenCoordinate(
+                            centerLeft,
+                            centerTop
                         )
-                    ) as SnapshotterResult.SnapshotterCameraPosition
-                    ifNonNull(camera.cameraPosition) {
-                        routeLinePoints.addAll(it.points.plus(progress.upcomingStepPoints!!))
-                        val mapInterface = getMapInterface()
-                        val oldSize = mapInterface.size
-                        mapInterface.size = Size(options.size.width, options.size.height)
-                        val cameraOptions = mapboxMap.cameraForCoordinates(
-                            it.points,
-                            it.insets,
-                            it.bearing,
-                            it.pitch
-                        )
-                        val centerTop =
-                            (
-                                (mapInterface.size.height * options.density) -
-                                    (options.edgeInsets.top + options.edgeInsets.bottom)
-                                ) / 2 + (options.edgeInsets.top)
-                        val centerLeft =
-                            (
-                                (mapInterface.size.width * options.density) -
-                                    (options.edgeInsets.left + options.edgeInsets.right)
-                                ) / 2 + (options.edgeInsets.left)
-                        cameraOptions.padding = getEdgeInsets(
-                            Size(
-                                mapInterface.size.width * options.density,
-                                mapInterface.size.height * options.density
-                            ),
-                            ScreenCoordinate(
-                                centerLeft,
-                                centerTop
+                    )
+                    snapshotter.setCameraOptions(cameraOptions)
+                    snapshotter.setUri(options.styleUri)
+                    mapInterface.size = oldSize
+                    snapshotter.setStyleListener(object : SnapshotStyleListener {
+                        override fun onDidFinishLoadingStyle(style: Style) {
+                            style.addSource(
+                                geoJsonSource(RouteConstants.PRIMARY_ROUTE_SOURCE_ID) {
+                                    geometry(LineString.fromLngLats(routeLinePoints))
+                                }
                             )
-                        )
-                        snapshotter.setCameraOptions(cameraOptions)
-                        snapshotter.setUri(options.styleUri)
-                        mapInterface.size = oldSize
-                        snapshotter.setStyleListener(object : SnapshotStyleListener {
-                            override fun onDidFinishLoadingStyle(style: Style) {
-                                style.addSource(
-                                    geoJsonSource(RouteConstants.PRIMARY_ROUTE_SOURCE_ID) {
-                                        geometry(LineString.fromLngLats(routeLinePoints))
-                                    }
-                                )
-                                style.addLayer(
-                                    (
-                                        SnapshotterProcessor
-                                            .process(SnapshotterAction.GenerateLineLayer)
-                                            as SnapshotterResult.SnapshotLineLayer
-                                        ).layer
-                                )
-                            }
-                        })
-                        snapshotter.start(object : SnapshotCreatedListener {
-                            override fun onSnapshotResult(snapshot: MapSnapshotInterface?) {
-                                val bitmapAction = SnapshotterAction.GenerateBitmap(
-                                    options,
-                                    snapshot
-                                )
-                                val bitmapResult = SnapshotterProcessor.process(bitmapAction)
+                            style.addLayer(
+                                (
+                                    SnapshotterProcessor
+                                        .process(SnapshotterAction.GenerateLineLayer)
+                                        as SnapshotterResult.SnapshotLineLayer
+                                    ).layer
+                            )
+                        }
+                    })
+                    snapshotter.start(object : SnapshotCreatedListener {
+                        override fun onSnapshotResult(snapshot: MapSnapshotInterface?) {
+                            val bitmapAction = SnapshotterAction.GenerateBitmap(
+                                options,
+                                snapshot
+                            )
+                            val bitmapResult = SnapshotterProcessor.process(bitmapAction)
 
-                                when (bitmapResult) {
-                                    is SnapshotterResult.Snapshot.Success -> {
-                                        callback.onSnapshotReady(
-                                            SnapshotState.SnapshotReady(bitmapResult.bitmap)
+                            when (bitmapResult) {
+                                is SnapshotterResult.Snapshot.Success -> {
+                                    callback.onSnapshotReady(
+                                        SnapshotState.SnapshotReady(bitmapResult.bitmap)
+                                    )
+                                }
+                                is SnapshotterResult.Snapshot.Failure -> {
+                                    callback.onFailure(
+                                        SnapshotState.SnapshotFailure.SnapshotError(
+                                            bitmapResult.error
                                         )
-                                    }
-                                    is SnapshotterResult.Snapshot.Failure -> {
-                                        callback.onFailure(
-                                            SnapshotState.SnapshotFailure.SnapshotError(
-                                                bitmapResult.error
-                                            )
-                                        )
-                                    }
-                                    else -> {
-                                        throw RuntimeException(
-                                            "Inappropriate $bitmapResult emitted for " +
-                                                "$bitmapAction processed."
-                                        )
-                                    }
+                                    )
+                                }
+                                else -> {
+                                    throw RuntimeException(
+                                        "Inappropriate $bitmapResult emitted for " +
+                                            "$bitmapAction processed."
+                                    )
                                 }
                             }
-                        })
-                    } ?: callback.onFailure(
-                        SnapshotState.SnapshotFailure.SnapshotError(
-                            "Camera position cannot be null"
-                        )
+                        }
+                    })
+                } ?: callback.onFailure(
+                    SnapshotState.SnapshotFailure.SnapshotError(
+                        "Camera position cannot be null"
                     )
-                }
-                else -> {
-                    throw RuntimeException("Inappropriate $result emitted for $action processed.")
-                }
+                )
+            }
+            is SnapshotterResult.SnapshotterCameraPosition,
+            is SnapshotterResult.Snapshot.Success,
+            is SnapshotterResult.Snapshot.Failure,
+            is SnapshotterResult.SnapshotLineLayer -> check(false) {
+                "Inappropriate $result emitted for $action processed."
             }
         }
     }

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/snapshotter/SnapshotterProcessorTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/snapshotter/SnapshotterProcessorTest.kt
@@ -35,6 +35,15 @@ class SnapshotterProcessorTest {
     }
 
     @Test
+    fun `process action generate snapshot result snapshot unavailable no banner instructions`() {
+        val bannerInstructions: BannerInstructions? = null
+
+        val action = SnapshotterAction.GenerateSnapshot(bannerInstructions)
+        val result = SnapshotterProcessor.process(action)
+        assert(result is SnapshotterResult.SnapshotUnavailable)
+    }
+
+    @Test
     fun `process action generate snapshot result snapshot unavailable no banner view`() {
         val bannerInstructions: BannerInstructions = mockk()
 

--- a/libnavui-util/src/main/java/com/mapbox/navigation/ui/utils/internal/extensions/BannerInstructionEx.kt
+++ b/libnavui-util/src/main/java/com/mapbox/navigation/ui/utils/internal/extensions/BannerInstructionEx.kt
@@ -18,8 +18,8 @@ fun BannerInstructions.getBannerView(): BannerView? =
  * Given [BannerInstructions] returns list of [BannerComponents] if present; null otherwise
  * @return MutableList<BannerComponents>? if present or null
  */
-fun BannerInstructions.getBannerComponents(): MutableList<BannerComponents>? =
-    ifNonNull(getBannerView()) { bannerView ->
+fun BannerInstructions?.getBannerComponents(): MutableList<BannerComponents>? =
+    ifNonNull(this?.getBannerView()) { bannerView ->
         ifNonNull(bannerView.components()) {
             it
         }


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Adds missing check and correct error handling for a case where banner instructions are `null`.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Fixed an issue where `SnapshotReadyCallback#onFailure` was not called when banner intructions were empty.</changelog>
```

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
