### PR TITLE
Returning the found route when searching the map for a route

### DIFF
--- a/libnavui-maps/api/current.txt
+++ b/libnavui-maps/api/current.txt
@@ -355,8 +355,8 @@ package com.mapbox.navigation.ui.maps.route.line.api {
   public final class MapboxRouteLineApi {
     ctor public MapboxRouteLineApi(com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions routeLineOptions);
     method public com.mapbox.navigation.ui.base.model.Expected<com.mapbox.navigation.ui.maps.route.line.model.RouteLineClearValue,com.mapbox.navigation.ui.maps.route.line.model.RouteLineError> clearRouteLine();
-    method public void findClosestRoute(com.mapbox.geojson.Point target, com.mapbox.maps.MapboxMap mapboxMap, float padding, com.mapbox.navigation.ui.base.util.MapboxNavigationConsumer<com.mapbox.navigation.ui.base.model.Expected<com.mapbox.navigation.ui.maps.route.line.model.ClosestRouteValue,com.mapbox.navigation.ui.maps.route.line.model.RouteLineError>> resultConsumer);
-    method public suspend Object? findClosestRoute(com.mapbox.geojson.Point target, com.mapbox.maps.MapboxMap mapboxMap, float padding, kotlin.coroutines.Continuation<? super com.mapbox.navigation.ui.base.model.Expected<com.mapbox.navigation.ui.maps.route.line.model.ClosestRouteValue,com.mapbox.navigation.ui.maps.route.line.model.RouteLineError>> p);
+    method public void findClosestRoute(com.mapbox.geojson.Point target, com.mapbox.maps.MapboxMap mapboxMap, float padding, com.mapbox.navigation.ui.base.util.MapboxNavigationConsumer<com.mapbox.navigation.ui.base.model.Expected<com.mapbox.navigation.ui.maps.route.line.model.ClosestRouteValue,com.mapbox.navigation.ui.maps.route.line.model.RouteNotFound>> resultConsumer);
+    method public suspend Object? findClosestRoute(com.mapbox.geojson.Point target, com.mapbox.maps.MapboxMap mapboxMap, float padding, kotlin.coroutines.Continuation<? super com.mapbox.navigation.ui.base.model.Expected<com.mapbox.navigation.ui.maps.route.line.model.ClosestRouteValue,com.mapbox.navigation.ui.maps.route.line.model.RouteNotFound>> p);
     method public com.mapbox.api.directions.v5.models.DirectionsRoute? getPrimaryRoute();
     method public com.mapbox.navigation.ui.base.model.Expected<com.mapbox.navigation.ui.maps.route.line.model.RouteSetValue,com.mapbox.navigation.ui.maps.route.line.model.RouteLineError> getRouteDrawData();
     method public java.util.List<com.mapbox.api.directions.v5.models.DirectionsRoute> getRoutes();
@@ -392,8 +392,8 @@ package com.mapbox.navigation.ui.maps.route.line.api {
 package com.mapbox.navigation.ui.maps.route.line.model {
 
   public final class ClosestRouteValue {
-    method public int getRouteIndex();
-    property public final int routeIndex;
+    method public com.mapbox.api.directions.v5.models.DirectionsRoute getRoute();
+    property public final com.mapbox.api.directions.v5.models.DirectionsRoute route;
   }
 
   public final class MapboxRouteLineOptions {
@@ -597,6 +597,13 @@ package com.mapbox.navigation.ui.maps.route.line.model {
     property public final float scale;
     property public final float scaleMultiplier;
     property public final float scaleStop;
+  }
+
+  public final class RouteNotFound {
+    method public String getErrorMessage();
+    method public Throwable? getThrowable();
+    property public final String errorMessage;
+    property public final Throwable? throwable;
   }
 
   public final class RoutePoints {

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/ClosestRouteValue.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/ClosestRouteValue.kt
@@ -1,9 +1,10 @@
 package com.mapbox.navigation.ui.maps.route.line.model
 
+import com.mapbox.api.directions.v5.models.DirectionsRoute
+
 /**
- * Represents the index of a route found by searching for the nearest route to to a map
- * click point. The index corresponds to the MapboxRouteArrowApi's collection of routes.
+ * The nearest route to a touch point on the [Map].
  *
- * @param routeIndex the index of the route in the collection
+ * @param route the route found
  */
-class ClosestRouteValue internal constructor(val routeIndex: Int)
+class ClosestRouteValue internal constructor(val route: DirectionsRoute)

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/RouteNotFound.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/RouteNotFound.kt
@@ -1,0 +1,12 @@
+package com.mapbox.navigation.ui.maps.route.line.model
+
+/**
+ * Indicates no route was found when searching the map for a route.
+ *
+ * @param errorMessage an error message
+ * @param throwable an optional throwable value expressing the error
+ */
+class RouteNotFound internal constructor(
+    val errorMessage: String,
+    val throwable: Throwable?
+)

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApiTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApiTest.kt
@@ -605,7 +605,7 @@ class MapboxRouteLineApiTest {
 
         val result = api.findClosestRoute(point, mockkMap, 50f) as Expected.Success
 
-        assertEquals(1, result.value.routeIndex)
+        assertEquals(route2, result.value.route)
         unmockkStatic(UUID::class)
     }
 
@@ -651,7 +651,7 @@ class MapboxRouteLineApiTest {
 
         val result = api.findClosestRoute(point, mockkMap, 50f) as Expected.Success
 
-        assertEquals(1, result.value.routeIndex)
+        assertEquals(route2, result.value.route)
         unmockkStatic(UUID::class)
     }
 
@@ -711,7 +711,7 @@ class MapboxRouteLineApiTest {
 
         val result = api.findClosestRoute(point, mockkMap, 50f) as Expected.Success
 
-        assertEquals(0, result.value.routeIndex)
+        assertEquals(route1, result.value.route)
         unmockkStatic(UUID::class)
     }
 

--- a/test-app/src/main/java/com/mapbox/navigation/examples/core/MapboxRouteLineActivity.java
+++ b/test-app/src/main/java/com/mapbox/navigation/examples/core/MapboxRouteLineActivity.java
@@ -78,6 +78,7 @@ import com.mapbox.navigation.ui.speedlimit.api.MapboxSpeedLimitApi;
 import com.mapbox.navigation.ui.speedlimit.model.UpdateSpeedLimitError;
 import com.mapbox.navigation.ui.speedlimit.model.UpdateSpeedLimitValue;
 import com.mapbox.navigation.ui.speedlimit.view.MapboxSpeedLimitView;
+import com.mapbox.navigation.ui.maps.route.line.model.RouteNotFound;
 import com.mapbox.navigation.ui.maps.route.line.model.RouteSetValue;
 import com.mapbox.navigation.ui.maps.route.line.model.VanishingRouteLineUpdateValue;
 
@@ -498,23 +499,19 @@ public class MapboxRouteLineActivity extends AppCompatActivity implements OnMapL
     }
   };
 
-    private final MapboxNavigationConsumer<Expected<ClosestRouteValue, RouteLineError>> closestRouteResultConsumer =
-            new MapboxNavigationConsumer<Expected<ClosestRouteValue, RouteLineError>>() {
+  private final MapboxNavigationConsumer<Expected<ClosestRouteValue, RouteNotFound>> closestRouteResultConsumer =
+      new MapboxNavigationConsumer<Expected<ClosestRouteValue, RouteNotFound>>() {
         @Override
-        public void accept(Expected<ClosestRouteValue, RouteLineError> closestRouteResult) {
+        public void accept(Expected<ClosestRouteValue, RouteNotFound> closestRouteResult) {
           if (closestRouteResult instanceof Expected.Success) {
-            final int index = ((ClosestRouteValue)((Expected.Success) closestRouteResult)
-                    .getValue())
-                    .getRouteIndex();
-            if (index > 0) {
-              final DirectionsRoute selectedRoute = mapboxRouteLineApi.getRoutes().get(index);
-              if (selectedRoute != mapboxRouteLineApi.getPrimaryRoute()) {
-                mapboxRouteLineApi.updateToPrimaryRoute(selectedRoute);
-                // NOTE: We don't have to render the state because there is a RoutesObserver on the
-                // MapboxNavigation object which will draw the routes. Rendering the state would draw the routes
-                // twice unnecessarily in this implementation.
-                mapboxNavigation.setRoutes(mapboxRouteLineApi.getRoutes());
-              }
+            final ClosestRouteValue closestRouteValue = (ClosestRouteValue) ((Expected.Success) closestRouteResult).getValue();
+            final DirectionsRoute routeFound = closestRouteValue.getRoute();
+            if (routeFound != mapboxRouteLineApi.getPrimaryRoute()) {
+              mapboxRouteLineApi.updateToPrimaryRoute(routeFound);
+              // NOTE: We don't have to render the state because there is a RoutesObserver on the
+              // MapboxNavigation object which will draw the routes. Rendering the state would draw the routes
+              // twice unnecessarily in this implementation.
+              mapboxNavigation.setRoutes(mapboxRouteLineApi.getRoutes());
             }
           }
         }


### PR DESCRIPTION
### Description
Resolves #4090 by returning the found route rather than the index in the route collection when searching for a route on the map nearest to a touch point.

### Changelog
```
<changelog>Call to find closest route in the MapboxRouteLineApi returns the found route rather than the route's index in the route collection.</changelog>
```

### Screenshots or Gifs

