### PR TITLE
fix for timing issue with test activities.

### DIFF
--- a/test-app/src/main/java/com/mapbox/navigation/examples/util/RouteLine.kt
+++ b/test-app/src/main/java/com/mapbox/navigation/examples/util/RouteLine.kt
@@ -61,8 +61,6 @@ class RouteLine(private val activity: AppCompatActivity) : LifecycleObserver {
     fun initialize(mapView: MapView, mapboxNavigation: MapboxNavigation) {
         this.mapView = mapView
         this.mapboxNavigation = mapboxNavigation
-
-        mapView.getMapboxMap().getStyle { style -> this@RouteLine.style = style }
     }
 
     private val onIndicatorPositionChangedListener = OnIndicatorPositionChangedListener { point ->
@@ -107,11 +105,14 @@ class RouteLine(private val activity: AppCompatActivity) : LifecycleObserver {
 
     @OnLifecycleEvent(Lifecycle.Event.ON_START)
     private fun onStart() {
-        mapView.getLocationComponentPlugin().addOnIndicatorPositionChangedListener(
-            onIndicatorPositionChangedListener
-        )
-        mapboxNavigation.registerRoutesObserver(routesObserver)
-        mapboxNavigation.registerRouteProgressObserver(routeProgressObserver)
+        mapView.getMapboxMap().getStyle { style ->
+            this@RouteLine.style = style
+            mapView.getLocationComponentPlugin().addOnIndicatorPositionChangedListener(
+                onIndicatorPositionChangedListener
+            )
+            mapboxNavigation.registerRoutesObserver(routesObserver)
+            mapboxNavigation.registerRouteProgressObserver(routeProgressObserver)
+        }
     }
 
     @OnLifecycleEvent(Lifecycle.Event.ON_STOP)


### PR DESCRIPTION
### Description
There was a timing issue with the RouteLine wrapper used by the test activities. The onIndicatorChangePosition call back was being called before the style variable had been set. 


