### PR TITLE
[v2.0.0-alpha.12] Fix a issue where origin shows destination icon

### DIFF
--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/MapboxRouteLayerProvider.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/MapboxRouteLayerProvider.kt
@@ -210,7 +210,7 @@ internal class MapboxRouteLayerProvider(
                     toString {
                         get { literal(RouteConstants.WAYPOINT_PROPERTY_KEY) }
                     }
-                    literal(RouteConstants.ORIGIN_MARKER_NAME)
+                    literal(RouteConstants.WAYPOINT_ORIGIN_VALUE)
                     stop {
                         RouteConstants.WAYPOINT_ORIGIN_VALUE
                         literal(RouteConstants.ORIGIN_MARKER_NAME)


### PR DESCRIPTION
### Description
Fix the issue that origin icon and destination icons are same.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Fix the issue that origin icon and destination icons are same.</changelog>
```

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->
Green icon is for origin, Red icon is for destination.

Before:
![before](https://user-images.githubusercontent.com/13183117/110602913-cc3ea800-81c9-11eb-8799-c2b1557ef374.jpg)

After:
![after](https://user-images.githubusercontent.com/13183117/110602939-d2cd1f80-81c9-11eb-920d-3090a2ff7b9b.jpg)


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
