### PR TITLE
fixed check for adding snapshot repo reference

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,8 +60,9 @@ allprojects {
     // we allow access to snapshots repo if ALLOW_SNAPSHOT_REPOSITORY is set, what means we are running on CI 
     // with Navigation Native forced to be some snapshot version
     // if you need to use snapshots while development, just set `addSnapshotsRepo` to true manually
-    def addSnapshotsRepo = System.getenv("ALLOW_SNAPSHOT_REPOSITORY") ?: false
+    def addSnapshotsRepo = System.getenv("ALLOW_SNAPSHOT_REPOSITORY")?.toBoolean() ?: false
     if (addSnapshotsRepo) {
+      println("Snapshot repository reference added.")
       maven {
         url 'https://api.mapbox.com/downloads/v2/snapshots/maven'
         authentication {

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -13,6 +13,7 @@ ext {
   if (mapboxNavigatorVersion == null || mapboxNavigatorVersion == '') {
       mapboxNavigatorVersion = '45.0.1'
   }
+  println("Navigation Native version: " + mapboxNavigatorVersion)
 
   version = [
       mapboxMapSdk              : '10.0.0-beta.15',


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Refs https://github.com/mapbox/mapbox-navigation-android/pull/4059. `System.getenv` returns a `String`, so the condition for adding the snapshot repo reference was always `true` if there was any env variable set for `ALLOW_SNAPSHOT_REPOSITORY`, even if the string said `"false"`.

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
