### PR TITLE
Remove context from distance formatter options

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxCustomStyleActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxCustomStyleActivity.kt
@@ -95,9 +95,12 @@ class MapboxCustomStyleActivity : AppCompatActivity(), OnMapLongClickListener {
 
     private val tripProgressFormatter: TripProgressUpdateFormatter by lazy {
         val distanceFormatterOptions =
-            DistanceFormatterOptions.Builder(this).build()
+            DistanceFormatterOptions.Builder().build()
         TripProgressUpdateFormatter.Builder(this)
-            .distanceRemainingFormatter(DistanceRemainingFormatter(distanceFormatterOptions))
+            .distanceRemainingFormatter(DistanceRemainingFormatter(
+                this.applicationContext,
+                distanceFormatterOptions
+            ))
             .timeRemainingFormatter(TimeRemainingFormatter(this))
             .estimatedTimeToArrivalFormatter(EstimatedTimeToArrivalFormatter(this))
             .build()
@@ -108,11 +111,14 @@ class MapboxCustomStyleActivity : AppCompatActivity(), OnMapLongClickListener {
     }
 
     private val distanceFormatter: DistanceFormatterOptions by lazy {
-        DistanceFormatterOptions.Builder(this).build()
+        DistanceFormatterOptions.Builder().build()
     }
 
     private val maneuverApi: MapboxManeuverApi by lazy {
-        MapboxManeuverApi(MapboxDistanceFormatter(distanceFormatter))
+        MapboxManeuverApi(MapboxDistanceFormatter(
+            this.applicationContext,
+            distanceFormatter
+        ))
     }
 
     private val routeLineResources: RouteLineResources by lazy {

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxManeuverActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxManeuverActivity.kt
@@ -84,7 +84,7 @@ class MapboxManeuverActivity : AppCompatActivity(), OnMapLongClickListener {
      * The data in the view is formatted by default mapbox distance formatting implementation.
      */
     private val distanceFormatter: DistanceFormatterOptions by lazy {
-        DistanceFormatterOptions.Builder(this).build()
+        DistanceFormatterOptions.Builder().build()
     }
 
     /**
@@ -92,7 +92,10 @@ class MapboxManeuverActivity : AppCompatActivity(), OnMapLongClickListener {
      * and produces trip related data that is consumed by the [MapboxManeuverView] in the layout.
      */
     private val maneuverApi: MapboxManeuverApi by lazy {
-        MapboxManeuverApi(MapboxDistanceFormatter(distanceFormatter))
+        MapboxManeuverApi(MapboxDistanceFormatter(
+            this.applicationContext,
+            distanceFormatter
+        ))
     }
 
     private val routeLineResources: RouteLineResources by lazy {

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxNavigationActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxNavigationActivity.kt
@@ -331,7 +331,10 @@ class MapboxNavigationActivity :
         init()
         tripProgressApi = MapboxTripProgressApi(getTripProgressFormatter())
         maneuverApi = MapboxManeuverApi(
-            MapboxDistanceFormatter(DistanceFormatterOptions.Builder(this).build())
+            MapboxDistanceFormatter(
+                this.applicationContext,
+                DistanceFormatterOptions.Builder().build()
+            )
         )
         speechAPI = MapboxSpeechApi(
             this,
@@ -547,6 +550,7 @@ class MapboxNavigationActivity :
         return TripProgressUpdateFormatter.Builder(this)
             .distanceRemainingFormatter(
                 DistanceRemainingFormatter(
+                    this.applicationContext,
                     mapboxNavigation.navigationOptions.distanceFormatterOptions
                 )
             )

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxTripProgressActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxTripProgressActivity.kt
@@ -84,14 +84,17 @@ class MapboxTripProgressActivity : AppCompatActivity(), OnMapLongClickListener {
         // is instantiated and configured first. The formatting options in MapboxNavigation
         // can be found at: MapboxNavigation.navigationOptions.distanceFormatterOptions
         val distanceFormatterOptions =
-            DistanceFormatterOptions.Builder(this).build()
+            DistanceFormatterOptions.Builder().build()
 
         // These are Mapbox formatters being created with default values. You can provide your own
         // custom formatters by implementing the appropriate interface. The expected output of
         // a formatter is a SpannableString that is applied to the the view
         // component in MapboxTripProgressView.
         TripProgressUpdateFormatter.Builder(this)
-            .distanceRemainingFormatter(DistanceRemainingFormatter(distanceFormatterOptions))
+            .distanceRemainingFormatter(DistanceRemainingFormatter(
+                this.applicationContext,
+                distanceFormatterOptions
+            ))
             .timeRemainingFormatter(TimeRemainingFormatter(this))
             .estimatedTimeToArrivalFormatter(EstimatedTimeToArrivalFormatter(this))
             .build()

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/formatter/DistanceFormatterOptions.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/formatter/DistanceFormatterOptions.kt
@@ -1,22 +1,18 @@
 package com.mapbox.navigation.base.formatter
 
-import android.content.Context
 import com.mapbox.navigation.base.internal.VoiceUnit
 import com.mapbox.navigation.base.internal.extensions.LocaleEx.getUnitTypeForLocale
-import com.mapbox.navigation.base.internal.extensions.inferDeviceLocale
 import java.util.Locale
 
 /**
  * Gives options to format the distance in the trip notification.
  *
- * @param applicationContext from which to get localized strings from
  * @param locale the locale to use for localization of distance resources
  * @param unitType to use, or UNDEFINED to use default for locale country
  * @param roundingIncrement increment by which to round small distances
  */
 class DistanceFormatterOptions private constructor(
-    val applicationContext: Context,
-    val locale: Locale,
+    val locale: Locale?,
     @VoiceUnit.Type val unitType: String,
     @Rounding.Increment val roundingIncrement: Int
 ) {
@@ -24,7 +20,7 @@ class DistanceFormatterOptions private constructor(
     /**
      * @return the [Builder] that created the [DistanceFormatterOptions]
      */
-    fun toBuilder() = Builder(applicationContext)
+    fun toBuilder() = Builder()
         .locale(locale)
         .unitType(unitType)
         .roundingIncrement(roundingIncrement)
@@ -38,7 +34,6 @@ class DistanceFormatterOptions private constructor(
 
         other as DistanceFormatterOptions
 
-        if (applicationContext != other.applicationContext) return false
         if (locale != other.locale) return false
         if (unitType != other.unitType) return false
         if (roundingIncrement != other.roundingIncrement) return false
@@ -50,8 +45,7 @@ class DistanceFormatterOptions private constructor(
      * Regenerate whenever a change is made
      */
     override fun hashCode(): Int {
-        var result = applicationContext.hashCode()
-        result = 31 * result + locale.hashCode()
+        var result = locale.hashCode()
         result = 31 * result + unitType.hashCode()
         result = 31 * result + roundingIncrement
         return result
@@ -61,18 +55,15 @@ class DistanceFormatterOptions private constructor(
      * Regenerate whenever a change is made
      */
     override fun toString(): String {
-        return "DistanceFormatterOptions(applicationContext=$applicationContext," +
-            " locale=$locale," +
+        return "DistanceFormatterOptions(locale=$locale," +
             " unitType='$unitType'," +
             " roundingIncrement=$roundingIncrement)"
     }
 
     /**
      * Builder of [DistanceFormatterOptions]
-     * @param applicationContext converted to applicationContext to save memory leaks
      */
-    class Builder(applicationContext: Context) {
-        private val applicationContext: Context = applicationContext.applicationContext
+    class Builder {
         private var unitType: String = VoiceUnit.UNDEFINED
         private var locale: Locale? = null
         private var roundingIncrement = Rounding.INCREMENT_FIFTY
@@ -109,19 +100,11 @@ class DistanceFormatterOptions private constructor(
          *
          * @return [DistanceFormatterOptions]
          */
-        fun build(): DistanceFormatterOptions {
-            val localeToUse: Locale = locale ?: applicationContext.inferDeviceLocale()
-            val unitTypeToUse: String = when (unitType) {
-                VoiceUnit.UNDEFINED -> localeToUse.getUnitTypeForLocale()
-                else -> unitType
-            }
-
-            return DistanceFormatterOptions(
-                applicationContext = applicationContext,
-                locale = localeToUse,
-                unitType = unitTypeToUse,
+        fun build(): DistanceFormatterOptions =
+            DistanceFormatterOptions(
+                locale = locale,
+                unitType = unitType,
                 roundingIncrement = roundingIncrement
             )
-        }
     }
 }

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/NavigationOptions.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/NavigationOptions.kt
@@ -164,7 +164,7 @@ class NavigationOptions private constructor(
         private var timeFormatType: Int = TimeFormat.NONE_SPECIFIED
         private var navigatorPredictionMillis: Long = DEFAULT_NAVIGATOR_PREDICTION_MILLIS
         private var distanceFormatterOptions: DistanceFormatterOptions =
-            DistanceFormatterOptions.Builder(applicationContext).build()
+            DistanceFormatterOptions.Builder().build()
         private var routingTilesOptions: RoutingTilesOptions =
             RoutingTilesOptions.Builder().build()
         private var predictiveCacheLocationOptions: PredictiveCacheLocationOptions =

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -834,7 +834,9 @@ class MapboxNavigation(
                 ModuleProviderArgument(NavigationOptions::class.java, navigationOptions),
                 ModuleProviderArgument(
                     DistanceFormatter::class.java,
-                    MapboxDistanceFormatter(navigationOptions.distanceFormatterOptions)
+                    MapboxDistanceFormatter(
+                        navigationOptions.applicationContext,
+                        navigationOptions.distanceFormatterOptions)
                 ),
             )
             MapboxModuleType.CommonLogger -> arrayOf()

--- a/libnavui-maneuver/src/main/java/com/mapbox/navigation/ui/maneuver/view/MapboxUpcomingManeuverAdapter.kt
+++ b/libnavui-maneuver/src/main/java/com/mapbox/navigation/ui/maneuver/view/MapboxUpcomingManeuverAdapter.kt
@@ -108,7 +108,10 @@ class MapboxUpcomingManeuverAdapter(
         private fun drawTotalStepDistance(totalStepDistance: TotalManeuverDistance) {
             viewBinding.stepDistance.render(
                 StepDistance(
-                    MapboxDistanceFormatter(DistanceFormatterOptions.Builder(context).build()),
+                    MapboxDistanceFormatter(
+                        context.applicationContext,
+                        DistanceFormatterOptions.Builder().build()
+                    ),
                     totalStepDistance.totalDistance
                 )
             )

--- a/libnavui-tripprogress/src/main/java/com/mapbox/navigation/ui/tripprogress/model/DistanceRemainingFormatter.kt
+++ b/libnavui-tripprogress/src/main/java/com/mapbox/navigation/ui/tripprogress/model/DistanceRemainingFormatter.kt
@@ -1,5 +1,6 @@
 package com.mapbox.navigation.ui.tripprogress.model
 
+import android.content.Context
 import android.text.SpannableString
 import com.mapbox.navigation.base.formatter.DistanceFormatterOptions
 import com.mapbox.navigation.core.internal.formatter.MapboxDistanceFormatter
@@ -8,13 +9,15 @@ import com.mapbox.navigation.ui.base.formatter.ValueFormatter
 /**
  * Formats trip related data for displaying in the UI
  *
+ * @param applicationContext from which to get localized strings from
  * @param distanceFormatterOptions to build the [DistanceRemainingFormatter]
  */
 class DistanceRemainingFormatter(
+    private val applicationContext: Context,
     private val distanceFormatterOptions: DistanceFormatterOptions
 ) : ValueFormatter<Double, SpannableString> {
 
-    private val formatter = MapboxDistanceFormatter(distanceFormatterOptions)
+    private val formatter = MapboxDistanceFormatter(applicationContext, distanceFormatterOptions)
 
     /**
      * Formats the data in the [TripProgressUpdateValue] for displaying the route distance remaining

--- a/libnavui-tripprogress/src/main/java/com/mapbox/navigation/ui/tripprogress/model/TripProgressUpdateFormatter.kt
+++ b/libnavui-tripprogress/src/main/java/com/mapbox/navigation/ui/tripprogress/model/TripProgressUpdateFormatter.kt
@@ -223,13 +223,16 @@ class TripProgressUpdateFormatter private constructor(
 
         private fun getDefaultDistanceRemainingFormatter(context: Context):
             ValueFormatter<Double, SpannableString> {
-            val options = DistanceFormatterOptions.Builder(context).build()
+            val options = DistanceFormatterOptions.Builder().build()
             val roundingUnit = when (options.unitType) {
                 VoiceUnit.IMPERIAL -> DEFAULT_ROUNDING_IMPERIAL
                 else -> DEFAULT_ROUNDING_METRIC
             }
             val finalOptions = options.toBuilder().roundingIncrement(roundingUnit).build()
-            return DistanceRemainingFormatter(finalOptions)
+            return DistanceRemainingFormatter(
+                context.applicationContext,
+                finalOptions
+            )
         }
     }
 }


### PR DESCRIPTION
### Description
This PR is about removing `context` from `DistanceFormatterOptions` #3939 .

### Changelog
```
<changelog>Removed context from DistanceFormatterOptions</changelog>
```