### PR TITLE
fixed check for adding snapshot repo reference

### DIFF
--- a/libnavui-maps/api/current.txt
+++ b/libnavui-maps/api/current.txt
@@ -415,6 +415,7 @@ package com.mapbox.navigation.ui.maps.route.line.model {
     method public com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions build();
     method public com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions.Builder withRouteLineBelowLayerId(String layerId);
     method public com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions.Builder withRouteLineResources(com.mapbox.navigation.ui.maps.route.line.model.RouteLineResources resourceProvider);
+    method public com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions.Builder withRouteStyleDescriptors(java.util.List<com.mapbox.navigation.ui.maps.route.line.model.RouteStyleDescriptor> routeStyleDescriptors);
     method public com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions.Builder withTolerance(double tolerance);
     method public com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions.Builder withVanishingRouteLineEnabled(boolean isEnabled);
   }
@@ -648,16 +649,16 @@ package com.mapbox.navigation.ui.maps.route.line.model {
   }
 
   public final class RouteStyleDescriptor {
-    ctor public RouteStyleDescriptor(String routeIdentifier, int lineColorResourceId, int lineCasingColorResourceId);
+    ctor public RouteStyleDescriptor(String routeIdentifier, @ColorInt int lineColor, @ColorInt int lineCasingColor);
     method public String component1();
     method public int component2();
     method public int component3();
-    method public com.mapbox.navigation.ui.maps.route.line.model.RouteStyleDescriptor copy(String routeIdentifier, int lineColorResourceId, int lineCasingColorResourceId);
-    method public int getLineCasingColorResourceId();
-    method public int getLineColorResourceId();
+    method public com.mapbox.navigation.ui.maps.route.line.model.RouteStyleDescriptor copy(String routeIdentifier, int lineColor, int lineCasingColor);
+    method public int getLineCasingColor();
+    method public int getLineColor();
     method public String getRouteIdentifier();
-    property public final int lineCasingColorResourceId;
-    property public final int lineColorResourceId;
+    property public final int lineCasingColor;
+    property public final int lineColor;
     property public final String routeIdentifier;
   }
 

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtils.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtils.kt
@@ -601,7 +601,7 @@ object MapboxRouteLineUtils {
         routeStyleDescriptors.forEach {
             expressions.add(
                 eq {
-                    get { it.routeIdentifier }
+                    get { literal(it.routeIdentifier) }
                     literal(true)
                 }
             )

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/MapboxRouteLayerProvider.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/MapboxRouteLayerProvider.kt
@@ -36,7 +36,7 @@ internal class MapboxRouteLayerProvider(
             getRouteLineColorExpressions(
                 color,
                 routeStyleDescriptors,
-                RouteStyleDescriptor::lineColorResourceId
+                RouteStyleDescriptor::lineColor
             )
         return initializeRouteLayer(
             style,
@@ -57,7 +57,7 @@ internal class MapboxRouteLayerProvider(
             getRouteLineColorExpressions(
                 color,
                 routeStyleDescriptors,
-                RouteStyleDescriptor::lineColorResourceId
+                RouteStyleDescriptor::lineColor
             )
         return initializeRouteLayer(
             style,
@@ -77,7 +77,7 @@ internal class MapboxRouteLayerProvider(
             getRouteLineColorExpressions(
                 color,
                 routeStyleDescriptors,
-                RouteStyleDescriptor::lineCasingColorResourceId
+                RouteStyleDescriptor::lineCasingColor
             )
         return initializeRouteLayer(
             style,
@@ -98,7 +98,7 @@ internal class MapboxRouteLayerProvider(
             getRouteLineColorExpressions(
                 color,
                 routeStyleDescriptors,
-                RouteStyleDescriptor::lineColorResourceId
+                RouteStyleDescriptor::lineColor
             )
 
         return listOf(
@@ -129,7 +129,7 @@ internal class MapboxRouteLayerProvider(
             getRouteLineColorExpressions(
                 color,
                 routeStyleDescriptors,
-                RouteStyleDescriptor::lineCasingColorResourceId
+                RouteStyleDescriptor::lineCasingColor
             )
 
         return listOf(
@@ -161,7 +161,7 @@ internal class MapboxRouteLayerProvider(
             getRouteLineColorExpressions(
                 color,
                 routeStyleDescriptors,
-                RouteStyleDescriptor::lineColorResourceId
+                RouteStyleDescriptor::lineColor
             )
 
         return listOf(

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/MapboxRouteLineOptions.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/MapboxRouteLineOptions.kt
@@ -166,6 +166,17 @@ class MapboxRouteLineOptions private constructor(
         }
 
         /**
+         * [RouteStyleDescriptor] is an override of an alternative route line coloring based on
+         * a provided identifier. Setting one or more [RouteStyleDescriptor] objects here
+         * will configure the layer such that any route set with a matching identifier will get
+         * colored according to the values provided in the [RouteStyleDescriptor].
+         *
+         * @param routeStyleDescriptors a collection of [RouteStyleDescriptor] objects
+         */
+        fun withRouteStyleDescriptors(routeStyleDescriptors: List<RouteStyleDescriptor>): Builder =
+            apply { this.routeStyleDescriptors = routeStyleDescriptors }
+
+        /**
          * @return an instance of [MapboxRouteLineOptions]
          */
         fun build(): MapboxRouteLineOptions {

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/RouteStyleDescriptor.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/RouteStyleDescriptor.kt
@@ -1,15 +1,17 @@
 package com.mapbox.navigation.ui.maps.route.line.model
 
+import androidx.annotation.ColorInt
+
 /**
  * This class is used for describing the route line color(s) at runtime.
  *
  * @param routeIdentifier a string that identifies routes which should have their color overridden
- * @param lineColorResourceId the color of the route line
- * @param lineCasingColorResourceId the color of the shield line which appears below the route line
+ * @param lineColor the color of the route line
+ * @param lineCasingColor the color of the shield line which appears below the route line
  * and is normally wider providing a visual border for the route line.
  */
 data class RouteStyleDescriptor(
     val routeIdentifier: String,
-    val lineColorResourceId: Int,
-    val lineCasingColorResourceId: Int
+    @ColorInt val lineColor: Int,
+    @ColorInt val lineCasingColor: Int
 )

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtilsTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtilsTest.kt
@@ -126,15 +126,15 @@ class MapboxRouteLineUtilsTest {
         val result = MapboxRouteLineUtils.getRouteLineColorExpressions(
             7,
             listOf(blueLineDescriptor, redLineDescriptor),
-            RouteStyleDescriptor::lineColorResourceId
+            RouteStyleDescriptor::lineColor
         )
 
         assertEquals(7, result.size)
         assertEquals("[==, [get, mapboxDescriptorPlaceHolderUnused], true]", result[0].toString())
         assertEquals("[rgba, 0.0, 0.0, 7.0, 0.0]", result[1].toString())
-        assertEquals("[==, [get], true]", result[2].toString())
+        assertEquals("[==, [get, blueLine], true]", result[2].toString())
         assertEquals("[rgba, 0.0, 0.0, 1.0, 0.0]", result[3].toString())
-        assertEquals("[==, [get], true]", result[4].toString())
+        assertEquals("[==, [get, redLine], true]", result[4].toString())
         assertEquals("[rgba, 0.0, 0.0, 2.0, 0.0]", result[5].toString())
         assertEquals("[rgba, 0.0, 0.0, 7.0, 0.0]", result[6].toString())
     }

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApiTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApiTest.kt
@@ -1,6 +1,7 @@
 package com.mapbox.navigation.ui.maps.route.line.api
 
 import android.content.Context
+import android.graphics.Color
 import androidx.test.core.app.ApplicationProvider
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.core.constants.Constants
@@ -21,6 +22,7 @@ import com.mapbox.navigation.ui.base.model.route.RouteLayerConstants.ALTERNATIVE
 import com.mapbox.navigation.ui.maps.internal.route.line.MapboxRouteLineUtils.parseRoutePoints
 import com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions
 import com.mapbox.navigation.ui.maps.route.line.model.RouteLine
+import com.mapbox.navigation.ui.maps.route.line.model.RouteStyleDescriptor
 import com.mapbox.navigation.ui.maps.route.line.model.VanishingPointState
 import io.mockk.every
 import io.mockk.mockk
@@ -227,6 +229,37 @@ class MapboxRouteLineApiTest {
         assertEquals(
             expectedAlternative2TrafficLineExpression,
             result.value.altRoute2TrafficExpression.toString()
+        )
+    }
+
+    @Test
+    fun setRoutesAlternativeRouteColorOverride() {
+        val routeStyleDescriptors = listOf(
+            RouteStyleDescriptor("alternativeRoute1", Color.YELLOW, Color.CYAN),
+            RouteStyleDescriptor("alternativeRoute2", Color.BLUE, Color.GREEN)
+        )
+        val options = MapboxRouteLineOptions.Builder(ctx)
+            .withRouteStyleDescriptors(routeStyleDescriptors)
+            .build()
+        val api = MapboxRouteLineApi(options)
+        val route = getRoute()
+        val altRoute1 = getRouteWithRoadClasses()
+        val altRoute2 = getMultilegRoute()
+        val routes = listOf(
+            RouteLine(route, null),
+            RouteLine(altRoute1, "alternativeRoute1"),
+            RouteLine(altRoute2, "alternativeRoute2")
+        )
+
+        val result = api.setRoutes(routes) as Expected.Success
+
+        assertEquals(
+            "{\"alternativeRoute1\":true}",
+            result.value.alternativeRoute1Source.features()!!.first().properties().toString()
+        )
+        assertEquals(
+            "{\"alternativeRoute2\":true}",
+            result.value.alternativeRoute2Source.features()!!.first().properties().toString()
         )
     }
 

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/model/MapboxRouteLineOptionsTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/model/MapboxRouteLineOptionsTest.kt
@@ -1,6 +1,7 @@
 package com.mapbox.navigation.ui.maps.route.line.model
 
 import android.content.Context
+import android.graphics.Color
 import androidx.test.core.app.ApplicationProvider
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -49,14 +50,28 @@ class MapboxRouteLineOptionsTest {
     }
 
     @Test
+    fun withRouteStyleDescriptors() {
+        val routeStyleDescriptors =
+            listOf(RouteStyleDescriptor("foobar", Color.CYAN, Color.YELLOW))
+        val options = MapboxRouteLineOptions.Builder(ctx)
+            .withRouteStyleDescriptors(routeStyleDescriptors)
+            .build()
+
+        assertEquals(routeStyleDescriptors, options.routeLayerProvider.routeStyleDescriptors)
+    }
+
+    @Test
     fun toBuilder() {
         val routeLineResources = RouteLineResources.Builder().build()
+        val routeStyleDescriptors =
+            listOf(RouteStyleDescriptor("foobar", Color.CYAN, Color.YELLOW))
 
         val options = MapboxRouteLineOptions.Builder(ctx)
             .withRouteLineResources(routeLineResources)
             .withVanishingRouteLineEnabled(true)
             .withRouteLineBelowLayerId("someLayerId")
             .withTolerance(.111)
+            .withRouteStyleDescriptors(routeStyleDescriptors)
             .build()
             .toBuilder(ctx)
             .build()
@@ -65,5 +80,6 @@ class MapboxRouteLineOptionsTest {
         assertEquals("someLayerId", options.routeLineBelowLayerId)
         assertNotNull(options.vanishingRouteLine)
         assertEquals(.111, options.tolerance, 0.0)
+        assertEquals(routeStyleDescriptors, options.routeLayerProvider.routeStyleDescriptors)
     }
 }


### PR DESCRIPTION
### Description
Fixes 4136 by including the missing option in the the MapboxRouteLineOptions builder and adds tests. Also fixed was an issue with the color expression syntax.

### Changelog
```
<changelog>bugfix: Exposed option to override alternative route color based on route identifier.</changelog>
```

### Screenshots or Gifs

