### PR TITLE
Reverting fix for a bug that is actually rooted in bindgen rather tha…

### DIFF
--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtils.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtils.kt
@@ -70,8 +70,7 @@ object MapboxRouteLineUtils {
                 literal(0.0)
             }
         }
-        val filteredItems = routeLineExpressionData
-            .filter { it.offset > distanceOffset }.distinctBy { it.offset }
+        val filteredItems = routeLineExpressionData.filter { it.offset > distanceOffset }
         when (filteredItems.isEmpty()) {
             true -> when (routeLineExpressionData.isEmpty()) {
                 true -> listOf(RouteLineExpressionData(distanceOffset, fallbackRouteColor))

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtilsTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtilsTest.kt
@@ -75,30 +75,6 @@ class MapboxRouteLineUtilsTest {
     }
 
     @Test
-    fun getTrafficLineExpressionDuplicateOffsetsRemoved() {
-        val expectedExpression = "[step, [line-progress], [rgba, 0.0, 0.0, 0.0, 0.0], 0.0, " +
-            "[rgba, 86.0, 168.0, 251.0, 1.0], 0.7868200761181402, " +
-            "[rgba, 86.0, 168.0, 251.0, 1.0], 0.7930120224665551, " +
-            "[rgba, 86.0, 168.0, 251.0, 1.0], 0.7932530928525063, " +
-            "[rgba, 86.0, 168.0, 251.0, 1.0], 0.7964017663976524, [rgba, 86.0, 168.0, 251.0, 1.0]]"
-        val expressionDatas = listOf(
-            RouteLineExpressionData(0.7868200761181402, -11097861),
-            RouteLineExpressionData(0.7930120224665551, -11097861),
-            RouteLineExpressionData(0.7932530928525063, -11097861),
-            RouteLineExpressionData(0.7932530928525063, -11097861),
-            RouteLineExpressionData(0.7964017663976524, -11097861)
-        )
-
-        val result = MapboxRouteLineUtils.getTrafficLineExpression(
-            0.0,
-            expressionDatas,
-            -11097861
-        )
-
-        assertEquals(result.toString(), expectedExpression)
-    }
-
-    @Test
     fun getVanishingRouteLineExpressionTest() {
         val expectedExpression = "[step, [line-progress], [rgba, 255.0, 77.0, 77.0, 1.0]" +
             ", 3.0, [rgba, 86.0, 168.0, 251.0, 1.0]]"


### PR DESCRIPTION
### Description
Issue #4079 described an issue with duplicate values in the traffic Expression that resulted in a change in the SDK that would filter out duplicate values to avoid the crash that was originally reported.  I has since been discovered the error originated in bindgen and is being addressed here: https://github.com/mapbox/mapbox-bindgen/issues/996.

Therefore the the fix put into the Navigation SDK is unnecessary and is removed in this PR. 

### Screenshots or Gifs

