### PR TITLE
Updated formatters to default rounding increment for trip progress wh…

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/formatter/MapboxDistanceFormatter.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/formatter/MapboxDistanceFormatter.kt
@@ -74,7 +74,7 @@ class MapboxDistanceFormatter(
         val resources = options.applicationContext.resourcesWithLocale(options.locale)
         val unitStringSuffix = getUnitString(resources, smallUnit)
 
-        if (distance <= 0) {
+        if (distance < 0) {
             return Pair("0", unitStringSuffix)
         }
 
@@ -85,7 +85,12 @@ class MapboxDistanceFormatter(
         )
 
         val roundedValue = if (options.roundingIncrement > 0) {
-            distanceUnit.roundToInt() / options.roundingIncrement * options.roundingIncrement
+            val roundedDistance = distanceUnit.roundToInt()
+            if (roundedDistance < options.roundingIncrement) {
+                options.roundingIncrement
+            } else {
+                roundedDistance / options.roundingIncrement * options.roundingIncrement
+            }
         } else {
             distanceUnit.roundToInt()
         }.toString()

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/internal/formatter/MapboxDistanceFormatterTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/internal/formatter/MapboxDistanceFormatterTest.kt
@@ -258,7 +258,7 @@ class MapboxDistanceFormatterTest {
                 .build()
         ).formatDistance(-0.1)
 
-        assertEquals("0 ft", result.toString())
+        assertEquals("$INCREMENT_FIFTY ft", result.toString())
     }
 
     @Config(qualifiers = "en-rUS")
@@ -307,5 +307,31 @@ class MapboxDistanceFormatterTest {
         ).formatDistance(55.3)
 
         assertEquals("181 ft", result.toString())
+    }
+
+    @Config(qualifiers = "en")
+    @Test
+    fun formatDistanceZero() {
+        val result = MapboxDistanceFormatter(
+            DistanceFormatterOptions.Builder(ctx)
+                .unitType(IMPERIAL)
+                .roundingIncrement(5)
+                .build()
+        ).formatDistance(0.0)
+
+        assertEquals("5 ft", result.toString())
+    }
+
+    @Config(qualifiers = "en")
+    @Test
+    fun formatDistanceZeroMetric() {
+        val result = MapboxDistanceFormatter(
+            DistanceFormatterOptions.Builder(ctx)
+                .unitType(METRIC)
+                .roundingIncrement(2)
+                .build()
+        ).formatDistance(0.0)
+
+        assertEquals("2 m", result.toString())
     }
 }

--- a/libnavui-tripprogress/api/current.txt
+++ b/libnavui-tripprogress/api/current.txt
@@ -42,6 +42,7 @@ package com.mapbox.navigation.ui.tripprogress.model {
     method public android.text.SpannableString getPercentRouteTraveled(double value);
     method public android.text.SpannableString getTimeRemaining(double value);
     method public com.mapbox.navigation.ui.tripprogress.model.TripProgressUpdateFormatter.Builder toBuilder(android.content.Context context);
+    field public static final com.mapbox.navigation.ui.tripprogress.model.TripProgressUpdateFormatter.Companion Companion;
   }
 
   public static final class TripProgressUpdateFormatter.Builder {
@@ -51,6 +52,9 @@ package com.mapbox.navigation.ui.tripprogress.model {
     method public com.mapbox.navigation.ui.tripprogress.model.TripProgressUpdateFormatter.Builder estimatedTimeToArrivalFormatter(com.mapbox.navigation.ui.base.formatter.ValueFormatter<? super java.lang.Long,? extends android.text.SpannableString> formatter);
     method public com.mapbox.navigation.ui.tripprogress.model.TripProgressUpdateFormatter.Builder percentRouteTraveledFormatter(com.mapbox.navigation.ui.base.formatter.ValueFormatter<? super java.lang.Double,? extends android.text.SpannableString> formatter);
     method public com.mapbox.navigation.ui.tripprogress.model.TripProgressUpdateFormatter.Builder timeRemainingFormatter(com.mapbox.navigation.ui.base.formatter.ValueFormatter<? super java.lang.Double,? extends android.text.SpannableString> formatter);
+  }
+
+  public static final class TripProgressUpdateFormatter.Companion {
   }
 
   public final class TripProgressUpdateValue {

--- a/libnavui-tripprogress/src/main/java/com/mapbox/navigation/ui/tripprogress/model/TripProgressUpdateFormatter.kt
+++ b/libnavui-tripprogress/src/main/java/com/mapbox/navigation/ui/tripprogress/model/TripProgressUpdateFormatter.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.text.SpannableString
 import com.mapbox.navigation.base.TimeFormat
 import com.mapbox.navigation.base.formatter.DistanceFormatterOptions
+import com.mapbox.navigation.base.internal.VoiceUnit
 import com.mapbox.navigation.ui.base.formatter.ValueFormatter
 
 /**
@@ -21,6 +22,11 @@ class TripProgressUpdateFormatter private constructor(
     private val timeRemainingFormatter: ValueFormatter<Double, SpannableString>,
     private val percentRouteTraveledFormatter: ValueFormatter<Double, SpannableString>
 ) {
+
+    companion object {
+        private const val DEFAULT_ROUNDING_IMPERIAL = 5
+        private const val DEFAULT_ROUNDING_METRIC = 2
+    }
 
     /**
      * @param context a valid context
@@ -199,9 +205,7 @@ class TripProgressUpdateFormatter private constructor(
                     )
 
             val theDistanceRemainingFormatter: ValueFormatter<Double, SpannableString> =
-                distanceRemainingFormatter ?: DistanceRemainingFormatter(
-                    DistanceFormatterOptions.Builder(context).build()
-                )
+                distanceRemainingFormatter ?: getDefaultDistanceRemainingFormatter(context)
 
             val theTimeRemainingFormatter: ValueFormatter<Double, SpannableString> =
                 timeRemainingFormatter ?: TimeRemainingFormatter(context.applicationContext)
@@ -217,5 +221,16 @@ class TripProgressUpdateFormatter private constructor(
                 thePercentRouteTraveledFormatter
             )
         }
+
+        private fun getDefaultDistanceRemainingFormatter(context: Context):
+            ValueFormatter<Double, SpannableString> {
+                val options = DistanceFormatterOptions.Builder(context).build()
+                val roundingUnit = when (options.unitType) {
+                    VoiceUnit.IMPERIAL -> DEFAULT_ROUNDING_IMPERIAL
+                    else -> DEFAULT_ROUNDING_METRIC
+                }
+                val finalOptions = options.toBuilder().roundingIncrement(roundingUnit).build()
+                return DistanceRemainingFormatter(finalOptions)
+            }
     }
 }

--- a/libnavui-tripprogress/src/test/java/com/mapbox/navigation/ui/tripprogress/model/DistanceRemainingFormatterTest.kt
+++ b/libnavui-tripprogress/src/test/java/com/mapbox/navigation/ui/tripprogress/model/DistanceRemainingFormatterTest.kt
@@ -19,7 +19,7 @@ class DistanceRemainingFormatterTest {
     @Config(qualifiers = "en")
     @Test
     fun formatDistanceLargeDistanceImperialWithDefaultLocale() {
-        val formatter = com.mapbox.navigation.ui.tripprogress.model.DistanceRemainingFormatter(
+        val formatter = DistanceRemainingFormatter(
             DistanceFormatterOptions.Builder(ctx)
                 .unitType(VoiceUnit.IMPERIAL)
                 .build()
@@ -33,7 +33,7 @@ class DistanceRemainingFormatterTest {
     @Config(qualifiers = "en")
     @Test
     fun formatDistanceLargeDistanceUnitTypeDefault() {
-        val formatter = com.mapbox.navigation.ui.tripprogress.model.DistanceRemainingFormatter(
+        val formatter = DistanceRemainingFormatter(
             DistanceFormatterOptions.Builder(ctx)
                 .build()
         )
@@ -45,7 +45,7 @@ class DistanceRemainingFormatterTest {
 
     @Test
     fun formatDistanceJapaneseLocale() {
-        val formatter = com.mapbox.navigation.ui.tripprogress.model.DistanceRemainingFormatter(
+        val formatter = DistanceRemainingFormatter(
             DistanceFormatterOptions.Builder(ctx)
                 .locale(Locale.JAPAN)
                 .unitType(VoiceUnit.IMPERIAL)

--- a/libnavui-tripprogress/src/test/java/com/mapbox/navigation/ui/tripprogress/model/TripProgressUpdateFormatterTest.kt
+++ b/libnavui-tripprogress/src/test/java/com/mapbox/navigation/ui/tripprogress/model/TripProgressUpdateFormatterTest.kt
@@ -145,4 +145,24 @@ class TripProgressUpdateFormatterTest {
             "estimatedTimeToArrivalFormatter"
         )
     }
+
+    @Config(qualifiers = "en-rUS")
+    @Test
+    fun distanceRemainingFormatterDefaultRoundingIncrementImperial() {
+        val progressFormatter = TripProgressUpdateFormatter.Builder(ctx).build()
+
+        val result = progressFormatter.getDistanceRemaining(.5)
+
+        assertEquals("5 ft", result.toString())
+    }
+
+    @Config(qualifiers = "pt-rPT")
+    @Test
+    fun distanceRemainingFormatterDefaultRoundingIncrementMetric() {
+        val progressFormatter = TripProgressUpdateFormatter.Builder(ctx).build()
+
+        val result = progressFormatter.getDistanceRemaining(1.0)
+
+        assertEquals("2 m", result.toString())
+    }
 }

--- a/test-app/src/main/java/com/mapbox/navigation/examples/core/MapboxTripProgressActivity.kt
+++ b/test-app/src/main/java/com/mapbox/navigation/examples/core/MapboxTripProgressActivity.kt
@@ -42,7 +42,6 @@ import com.mapbox.navigation.examples.core.databinding.LayoutActivityTripprogres
 import com.mapbox.navigation.examples.util.RouteLine
 import com.mapbox.navigation.ui.maps.location.NavigationLocationProvider
 import com.mapbox.navigation.ui.tripprogress.api.MapboxTripProgressApi
-import com.mapbox.navigation.ui.tripprogress.model.DistanceRemainingFormatter
 import com.mapbox.navigation.ui.tripprogress.model.EstimatedTimeToArrivalFormatter
 import com.mapbox.navigation.ui.tripprogress.model.PercentDistanceTraveledFormatter
 import com.mapbox.navigation.ui.tripprogress.model.TimeRemainingFormatter
@@ -77,11 +76,6 @@ class MapboxTripProgressActivity : AppCompatActivity(), OnMapLongClickListener {
 
     private fun getTripProgressFormatter(): TripProgressUpdateFormatter {
         return TripProgressUpdateFormatter.Builder(this)
-            .distanceRemainingFormatter(
-                DistanceRemainingFormatter(
-                    mapboxNavigation.navigationOptions.distanceFormatterOptions
-                )
-            )
             .timeRemainingFormatter(TimeRemainingFormatter(this))
             .percentRouteTraveledFormatter(PercentDistanceTraveledFormatter())
             .estimatedTimeToArrivalFormatter(


### PR DESCRIPTION
### Description
#3982 Indicates that distance remaining should not state "0 ft" or "0 m". This work addresses that for the `TripProgressUpdateFormatter`.  The `MapboxDistanceFormatter` was modified so that if a calculated value is less than the rounding increment, the rounding increment value will be returned. This leaves the `MapboxDistanceFormatter` accurate when a rounding increment of 0 is used.  The `TripProgressUpdateFormatter` will create a default `MapboxDistanceFormatter` using either 5 or 2 (depending on the locale) as the rounding increment if no distance formatter was provided in the builder.

### Changelog
```
<changelog>The MapboxTripProgressApi component will use a default rounding increment of 5 ft or 2 m as a default for the distance remaining formatter if no formatter is provided in the TripProgressUpdateFormatter.</changelog>
```

### Screenshots or Gifs

