### PR TITLE
Bump mapbox-navigation-native version to 45.0.3 and fix banner instruction and route progress mismatch when in multi-leg scenarios

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -11,7 +11,7 @@ ext {
   // version which we should use in this build
   def mapboxNavigatorVersion = System.getenv("FORCE_MAPBOX_NAVIGATION_NATIVE_VERSION")
   if (mapboxNavigatorVersion == null || mapboxNavigatorVersion == '') {
-      mapboxNavigatorVersion = '45.0.1'
+      mapboxNavigatorVersion = '45.0.3'
   }
   println("Navigation Native version: " + mapboxNavigatorVersion)
 

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/BannerInstructionEvent.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/BannerInstructionEvent.kt
@@ -2,7 +2,6 @@ package com.mapbox.navigation.core.trip.session
 
 import com.mapbox.api.directions.v5.models.BannerInstructions
 import com.mapbox.navigation.base.trip.model.RouteProgress
-import com.mapbox.navigation.utils.internal.ifNonNull
 
 internal class BannerInstructionEvent {
 
@@ -12,16 +11,18 @@ internal class BannerInstructionEvent {
     var latestBannerInstructions: BannerInstructions? = null
         private set
 
-    fun isOccurring(routeProgress: RouteProgress) = updateCurrentBanner(routeProgress)
+    fun isOccurring(routeProgress: RouteProgress): Boolean = updateCurrentBanner(routeProgress)
 
     fun invalidateLatestBannerInstructions() {
         latestBannerInstructions = null
     }
 
-    private fun updateCurrentBanner(routeProgress: RouteProgress) {
+    private fun updateCurrentBanner(routeProgress: RouteProgress): Boolean {
         bannerInstructions = routeProgress.bannerInstructions
-        ifNonNull(bannerInstructions) {
-            latestBannerInstructions = it
+        if (bannerInstructions != null && bannerInstructions!! != latestBannerInstructions) {
+            latestBannerInstructions = bannerInstructions
+            return true
         }
+        return false
     }
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
@@ -408,6 +408,7 @@ internal class MapboxTripSession(
      * @return an initialized [NavigationStatus] if no errors, invalid otherwise
      */
     override fun updateLegIndex(legIndex: Int): Boolean {
+        invalidateLatestBannerInstructionEvent()
         return navigator.updateLegIndex(legIndex)
     }
 
@@ -552,10 +553,11 @@ internal class MapboxTripSession(
         tripService.updateNotification(progress)
         progress?.let { progress ->
             routeProgressObservers.forEach { it.onRouteProgressChanged(progress) }
-            bannerInstructionEvent.isOccurring(progress)
-            checkBannerInstructionEvent { bannerInstruction ->
-                bannerInstructionsObservers.forEach {
-                    it.onNewBannerInstructions(bannerInstruction)
+            if (bannerInstructionEvent.isOccurring(progress)) {
+                checkBannerInstructionEvent { bannerInstruction ->
+                    bannerInstructionsObservers.forEach {
+                        it.onNewBannerInstructions(bannerInstruction)
+                    }
                 }
             }
             checkVoiceInstructionEvent(progress.voiceInstructions) { voiceInstruction ->

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/BannerInstructionEventTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/BannerInstructionEventTest.kt
@@ -5,7 +5,9 @@ import com.mapbox.navigation.base.trip.model.RouteProgress
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class BannerInstructionEventTest {
@@ -17,8 +19,9 @@ class BannerInstructionEventTest {
         val anyBannerInstructions: BannerInstructions = mockk()
         every { mockedRouteProgress.bannerInstructions } returns anyBannerInstructions
 
-        bannerInstructionEvent.isOccurring(mockedRouteProgress)
+        val isOccurring = bannerInstructionEvent.isOccurring(mockedRouteProgress)
 
+        assertTrue(isOccurring)
         assertEquals(anyBannerInstructions, bannerInstructionEvent.bannerInstructions)
     }
 
@@ -29,8 +32,9 @@ class BannerInstructionEventTest {
         val nullBannerInstructions: BannerInstructions? = null
         every { mockedRouteProgress.bannerInstructions } returns nullBannerInstructions
 
-        bannerInstructionEvent.isOccurring(mockedRouteProgress)
+        val isOccurring = bannerInstructionEvent.isOccurring(mockedRouteProgress)
 
+        assertFalse(isOccurring)
         assertNull(bannerInstructionEvent.bannerInstructions)
     }
 
@@ -41,8 +45,9 @@ class BannerInstructionEventTest {
         val anyBannerInstructions: BannerInstructions = mockk()
         every { mockedRouteProgress.bannerInstructions } returns anyBannerInstructions
 
-        bannerInstructionEvent.isOccurring(mockedRouteProgress)
+        val isOccurring = bannerInstructionEvent.isOccurring(mockedRouteProgress)
 
+        assertTrue(isOccurring)
         assertEquals(anyBannerInstructions, bannerInstructionEvent.latestBannerInstructions)
     }
 
@@ -53,8 +58,9 @@ class BannerInstructionEventTest {
         val nullBannerInstructions: BannerInstructions? = null
         every { mockedRouteProgress.bannerInstructions } returns nullBannerInstructions
 
-        bannerInstructionEvent.isOccurring(mockedRouteProgress)
+        val isOccurring = bannerInstructionEvent.isOccurring(mockedRouteProgress)
 
+        assertFalse(isOccurring)
         assertNull(bannerInstructionEvent.latestBannerInstructions)
     }
 
@@ -68,9 +74,32 @@ class BannerInstructionEventTest {
             mockedNonNullBannerInstructionsRouteProgress.bannerInstructions
         } returns nonNullBannerInstructions andThen nullBannerInstructions
 
-        bannerInstructionEvent.isOccurring(mockedNonNullBannerInstructionsRouteProgress)
-        bannerInstructionEvent.isOccurring(mockedNonNullBannerInstructionsRouteProgress)
+        val isOccurringNonNullBannerInstructions =
+            bannerInstructionEvent.isOccurring(mockedNonNullBannerInstructionsRouteProgress)
+        val isOccurringNullBannerInstructions =
+            bannerInstructionEvent.isOccurring(mockedNonNullBannerInstructionsRouteProgress)
 
+        assertTrue(isOccurringNonNullBannerInstructions)
+        assertFalse(isOccurringNullBannerInstructions)
+        assertEquals(nonNullBannerInstructions, bannerInstructionEvent.latestBannerInstructions)
+    }
+
+    @Test
+    fun `isOccurring doesn't update current latestBannerInstructions if same instructions`() {
+        val bannerInstructionEvent = BannerInstructionEvent()
+        val mockedNonNullBannerInstructionsRouteProgress: RouteProgress = mockk()
+        val nonNullBannerInstructions: BannerInstructions = mockk()
+        every {
+            mockedNonNullBannerInstructionsRouteProgress.bannerInstructions
+        } returns nonNullBannerInstructions andThen nonNullBannerInstructions
+
+        val isOccurringNonNullBannerInstructions =
+            bannerInstructionEvent.isOccurring(mockedNonNullBannerInstructionsRouteProgress)
+        val isOccurringNullBannerInstructions =
+            bannerInstructionEvent.isOccurring(mockedNonNullBannerInstructionsRouteProgress)
+
+        assertTrue(isOccurringNonNullBannerInstructions)
+        assertFalse(isOccurringNullBannerInstructions)
         assertEquals(nonNullBannerInstructions, bannerInstructionEvent.latestBannerInstructions)
     }
 


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Bumps `mapbox-navigation-native` version to `45.0.3` and fixed banner instruction and route progress mismatch when in multi-leg scenarios

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Fixed banner instruction and route progress mismatch when in multi-leg scenarios.</changelog>
```

cc @mskurydin @etl @jstratman @zugaldia 