### PR TITLE
Add support for native downloads with snapshots

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -175,7 +175,7 @@ ext {
       dokka                : '1.4.20',
       mapboxSdkRegistry    : '0.4.0',
       mapboxAccessToken    : '0.2.1',
-      mapboxNativeDownload : '0.1.1',
+      mapboxNativeDownload : '0.1.2',
       firebaseCrashlytics  : '2.5.0'
   ]
 


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

We're trying to force a native crash to get the stack trace in Firebase. The library we're using is a snapshot, and I added support for snapshots awhile ago. Bumping this version will fix the snapshot issue. You can see the error here in the "Download native libraries for crashlytics" job
https://app.circleci.com/pipelines/github/mapbox/mapbox-navigation-android/10950/workflows/3b9e4ef4-b11a-4978-bb4c-1cf756a465b8/jobs/43203

```
Executing command: curl --user ******:%s https://api.******.com/downloads/v2/mobile-navigation-native/releases/android/sf-crashes-2-SNAPSHOT/******-navigation-native-all.zip --output /root/code/test-app/build/nativeArtifacts/******-navigation-native-all.zip

> Task :test-app:downloadUnstrippedNativeLibsDir
Completed: /root/code/test-app/build/unstrippedNativeLibsDir/arm64-v8a/lib******-maps.so, /root/code/test-app/build/unstrippedNativeLibsDir/armeabi-v7a/lib******-maps.so, /root/code/test-app/build/unstrippedNativeLibsDir/x86/lib******-maps.so, /root/code/test-app/build/unstrippedNativeLibsDir/x86_64/lib******-maps.so
Step 1 - Find library versions from dependency: com.******.navigator:******-navigation-native:sf-crashes-2-SNAPSHOT
Step 2 - Download libraries from s3: MapboxLibrary(releases=mobile-navigation-native/releases/android, version=sf-crashes-2-SNAPSHOT, artifacts=******-navigation-native-all.zip)
start downloading: MapboxLibrary(releases=mobile-navigation-native/releases/android, version=sf-crashes-2-SNAPSHOT, artifacts=******-navigation-native-all.zip)

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    23  100    23    0     0     89      0 --:--:-- --:--:-- --:--:--    89

> Task :test-app:downloadUnstrippedNativeLibsDir
completed downloading: /root/code/test-app/build/nativeArtifacts/******-navigation-native-all.zip
Step 3 - Extract into unstrippedNativeLibsDir: /root/code/test-app/build/nativeArtifacts/******-navigation-native-all.zip
java.util.zip.ZipException: error in opening zip file
	at java.util.zip.ZipFile.open(Native Method)
	at java.util.zip.ZipFile.<init>(ZipFile.java:225)
	at java.util.zip.ZipFile.<init>(ZipFile.java:155)
	at java.util.zip.ZipFile.<init>(ZipFile.java:126)
	at com.******.gradle.download.LibraryExtractor.unzip(LibraryExtractor.kt:85)
	at com.******.gradle.download.LibraryExtractor.extractLibraries(LibraryExtractor.kt:48)
	at com.******.gradle.download.LibraryExtractor.access$extractLibraries(LibraryExtractor.kt:16)
	at com.******.gradle.download.LibraryExtractor$extractToNativeLibsDir$$inlined$map$lambda$1.invokeSuspend(LibraryExtractor.kt:23)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:738)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)
```

Bumping the version fixes it.

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
