### PR TITLE
TripNotification: default text place holder at the start of the trip

### DIFF
--- a/libtrip-notification/src/main/java/com/mapbox/navigation/trip/notification/internal/MapboxTripNotification.kt
+++ b/libtrip-notification/src/main/java/com/mapbox/navigation/trip/notification/internal/MapboxTripNotification.kt
@@ -16,6 +16,7 @@ import android.os.Build
 import android.text.SpannableString
 import android.text.TextUtils
 import android.text.format.DateFormat
+import android.view.View
 import android.view.View.GONE
 import android.view.View.VISIBLE
 import android.widget.RemoteViews
@@ -159,6 +160,13 @@ class MapboxTripNotification constructor(
     override fun onTripSessionStarted() {
         registerReceiver()
         notificationActionButtonChannel = Channel(1)
+
+        collapsedNotificationRemoteViews?.apply {
+            setViewVisibility(R.id.navigationIsStarting, View.VISIBLE)
+        }
+        expandedNotificationRemoteViews?.apply {
+            setViewVisibility(R.id.navigationIsStarting, View.VISIBLE)
+        }
     }
 
     /**
@@ -176,6 +184,9 @@ class MapboxTripNotification constructor(
             setTextViewText(R.id.notificationDistanceText, "")
             setTextViewText(R.id.notificationArrivalText, "")
             setTextViewText(R.id.notificationInstructionText, "")
+            setViewVisibility(R.id.etaContent, View.GONE)
+            setViewVisibility(R.id.notificationInstructionText, View.GONE)
+            setViewVisibility(R.id.freeDriveText, View.GONE)
         }
 
         expandedNotificationRemoteViews?.apply {
@@ -183,6 +194,9 @@ class MapboxTripNotification constructor(
             setTextViewText(R.id.notificationArrivalText, "")
             setTextViewText(R.id.notificationInstructionText, "")
             setTextViewText(R.id.endNavigationBtnText, "")
+            setViewVisibility(R.id.etaContent, View.GONE)
+            setViewVisibility(R.id.notificationInstructionText, View.GONE)
+            setViewVisibility(R.id.freeDriveText, View.GONE)
         }
 
         unregisterReceiver()
@@ -293,6 +307,13 @@ class MapboxTripNotification constructor(
     }
 
     private fun updateNotificationViews(routeProgress: RouteProgress?) {
+        collapsedNotificationRemoteViews?.apply {
+            setViewVisibility(R.id.navigationIsStarting, View.GONE)
+        }
+        expandedNotificationRemoteViews?.apply {
+            setViewVisibility(R.id.navigationIsStarting, View.GONE)
+        }
+
         routeProgress?.let {
             updateInstructionText(routeProgress.bannerInstructions)
             updateDistanceText(routeProgress)

--- a/libtrip-notification/src/main/res/layout/mapbox_notification_navigation_collapsed.xml
+++ b/libtrip-notification/src/main/res/layout/mapbox_notification_navigation_collapsed.xml
@@ -21,6 +21,19 @@
         android:padding="8dp"
         android:tint="@android:color/white" />
 
+    <TextView
+        android:id="@+id/navigationIsStarting"
+        style="@style/MapboxStyleNotificationTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignTop="@+id/maneuverImage"
+        android:layout_alignBottom="@+id/maneuverImage"
+        android:layout_toEndOf="@+id/maneuverImage"
+        android:lines="1"
+        android:gravity="center"
+        android:text="@string/mapbox_navigation_is_starting"
+        android:textColor="@android:color/white" />
+
     <LinearLayout
         android:id="@+id/etaContent"
         android:layout_width="wrap_content"
@@ -28,6 +41,8 @@
         android:layout_alignTop="@id/maneuverImage"
         android:layout_toEndOf="@id/maneuverImage"
         android:layout_toRightOf="@id/maneuverImage"
+        android:visibility="gone"
+        tools:visibility="visible"
         android:orientation="horizontal">
 
         <TextView

--- a/libtrip-notification/src/main/res/layout/mapbox_notification_navigation_expanded.xml
+++ b/libtrip-notification/src/main/res/layout/mapbox_notification_navigation_expanded.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/navigationExpandedNotificationLayout"
     style="@android:style/TextAppearance.StatusBar.EventContent"
     android:layout_width="match_parent"
@@ -33,7 +34,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="@android:color/transparent"
-            android:text="@string/mapbox_end_navigation"
+            tools:text="@string/mapbox_end_navigation"
             android:textAllCaps="true"
             android:textColor="@android:color/white" />
 

--- a/libtrip-notification/src/main/res/values/strings.xml
+++ b/libtrip-notification/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <resources>
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">End Navigation</string>
+    <string name="mapbox_navigation_is_starting">Navigation is starting…</string>
     <string name="mapbox_stop_session">Stop session</string>
     <string name="mapbox_free_drive_session">Free Drive Session</string>
     <string name="mapbox_eta_format">%s ETA</string>

--- a/libtrip-notification/src/test/java/com/mapbox/navigation/trip/notification/internal/MapboxTripNotificationTest.kt
+++ b/libtrip-notification/src/test/java/com/mapbox/navigation/trip/notification/internal/MapboxTripNotificationTest.kt
@@ -11,6 +11,7 @@ import android.content.res.Resources
 import android.text.SpannableString
 import android.text.TextUtils
 import android.text.format.DateFormat
+import android.view.View
 import android.widget.RemoteViews
 import com.mapbox.api.directions.v5.models.BannerInstructions
 import com.mapbox.api.directions.v5.models.BannerText
@@ -23,6 +24,7 @@ import com.mapbox.navigation.trip.notification.NavigationNotificationProvider
 import com.mapbox.navigation.trip.notification.R
 import com.mapbox.navigation.trip.notification.RemoteViewsProvider
 import com.mapbox.navigation.utils.internal.NOTIFICATION_ID
+import io.mockk.Ordering
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
@@ -43,6 +45,7 @@ private const val END_NAVIGATION = "End Navigation"
 private const val FORMAT_STRING = "%s 454545 ETA"
 private const val MANEUVER_TYPE = "MANEUVER TYPE"
 private const val MANEUVER_MODIFIER = "MANEUVER MODIFIER"
+private const val NAVIGATION_IS_STARTING = "Navigation is starting…"
 
 class MapboxTripNotificationTest {
 
@@ -113,6 +116,9 @@ class MapboxTripNotificationTest {
         every { mockedContext.getString(any()) } returns FORMAT_STRING
         every { mockedContext.getString(R.string.mapbox_stop_session) } returns STOP_SESSION
         every { mockedContext.getString(R.string.mapbox_end_navigation) } returns END_NAVIGATION
+        every {
+            mockedContext.getString(R.string.mapbox_navigation_is_starting)
+        } returns NAVIGATION_IS_STARTING
         val notificationManager = mockk<NotificationManager>(relaxed = true)
         every {
             mockedContext.getSystemService(Context.NOTIFICATION_SERVICE)
@@ -309,6 +315,7 @@ class MapboxTripNotificationTest {
         mockUpdateNotificationAndroidInteractions()
 
         notification.onTripSessionStarted()
+
         notification.updateNotification(routeProgress)
 
         verify(exactly = 1) { bannerText.text() }
@@ -331,6 +338,58 @@ class MapboxTripNotificationTest {
         verify(exactly = 1) { expandedViews.setTextViewText(any(), primaryText()) }
         assertNull(notification.currentManeuverType)
         assertNull(notification.currentManeuverModifier)
+
+        // navigationIsStarting
+        verify(ordering = Ordering.ORDERED) {
+            collapsedViews.setViewVisibility(R.id.navigationIsStarting, View.VISIBLE)
+            collapsedViews.setViewVisibility(R.id.navigationIsStarting, View.GONE)
+            collapsedViews.setViewVisibility(R.id.navigationIsStarting, View.VISIBLE)
+        }
+        verify(exactly = 3) {
+            collapsedViews.setViewVisibility(R.id.navigationIsStarting, any())
+        }
+        verify(ordering = Ordering.ORDERED) {
+            expandedViews.setViewVisibility(R.id.navigationIsStarting, View.VISIBLE)
+            expandedViews.setViewVisibility(R.id.navigationIsStarting, View.GONE)
+            expandedViews.setViewVisibility(R.id.navigationIsStarting, View.VISIBLE)
+        }
+        verify(exactly = 3) {
+            expandedViews.setViewVisibility(R.id.navigationIsStarting, any())
+        }
+        // etaContent
+        verify(ordering = Ordering.ORDERED) {
+            collapsedViews.setViewVisibility(R.id.etaContent, View.VISIBLE)
+            collapsedViews.setViewVisibility(R.id.etaContent, View.GONE)
+            collapsedViews.setViewVisibility(R.id.etaContent, View.GONE)
+        }
+        verify(exactly = 3) {
+            collapsedViews.setViewVisibility(R.id.etaContent, any())
+        }
+        verify(ordering = Ordering.ORDERED) {
+            expandedViews.setViewVisibility(R.id.etaContent, View.VISIBLE)
+            expandedViews.setViewVisibility(R.id.etaContent, View.GONE)
+            expandedViews.setViewVisibility(R.id.etaContent, View.GONE)
+        }
+        verify(exactly = 3) {
+            expandedViews.setViewVisibility(R.id.etaContent, any())
+        }
+        // freeDriveText
+        verify(ordering = Ordering.ORDERED) {
+            collapsedViews.setViewVisibility(R.id.freeDriveText, View.GONE)
+            collapsedViews.setViewVisibility(R.id.freeDriveText, View.GONE)
+            collapsedViews.setViewVisibility(R.id.freeDriveText, View.GONE)
+        }
+        verify(exactly = 3) {
+            collapsedViews.setViewVisibility(R.id.freeDriveText, any())
+        }
+        verify(ordering = Ordering.ORDERED) {
+            expandedViews.setViewVisibility(R.id.freeDriveText, View.GONE)
+            expandedViews.setViewVisibility(R.id.freeDriveText, View.GONE)
+            expandedViews.setViewVisibility(R.id.freeDriveText, View.GONE)
+        }
+        verify(exactly = 3) {
+            expandedViews.setViewVisibility(R.id.freeDriveText, any())
+        }
     }
 
     @Test
@@ -341,6 +400,20 @@ class MapboxTripNotificationTest {
         notification.onTripSessionStarted()
         notification.updateNotification(nullRouteProgress)
 
+        verify(ordering = Ordering.ORDERED) {
+            collapsedViews.setViewVisibility(R.id.navigationIsStarting, View.VISIBLE)
+            collapsedViews.setViewVisibility(R.id.navigationIsStarting, View.GONE)
+        }
+        verify(exactly = 2) {
+            collapsedViews.setViewVisibility(R.id.navigationIsStarting, any())
+        }
+        verify(ordering = Ordering.ORDERED) {
+            expandedViews.setViewVisibility(R.id.navigationIsStarting, View.VISIBLE)
+            expandedViews.setViewVisibility(R.id.navigationIsStarting, View.GONE)
+        }
+        verify(exactly = 2) {
+            expandedViews.setViewVisibility(R.id.navigationIsStarting, any())
+        }
         verify(exactly = 0) { expandedViews.setTextViewText(any(), END_NAVIGATION) }
         verify(exactly = 1) { expandedViews.setTextViewText(any(), STOP_SESSION) }
     }


### PR DESCRIPTION
### Description
Added text placeholder for TripNotification view
1.x ref https://github.com/mapbox/mapbox-navigation-android/pull/4156

Closes #2827

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Added text placeholder for TripNotification View</changelog>
```

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
