### PR TITLE
SnappingClosures RouteOption

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -17,7 +17,7 @@ ext {
 
   version = [
       mapboxMapSdk              : '10.0.0-beta.15',
-      mapboxSdkServices         : '5.9.0-alpha.1',
+      mapboxSdkServices         : '5.9.0-alpha.3',
       mapboxEvents              : '6.2.2',
       mapboxCore                : '3.1.1',
       mapboxNavigator           : "${mapboxNavigatorVersion}",

--- a/libnavigation-router/src/main/java/com/mapbox/navigation/route/offboard/router/MapboxDirectionsUtils.kt
+++ b/libnavigation-router/src/main/java/com/mapbox/navigation/route/offboard/router/MapboxDirectionsUtils.kt
@@ -98,6 +98,10 @@ internal fun MapboxDirections.Builder.routeOptions(
         walkingOptions(it)
     }
 
+    options.snappingClosuresList()?.let {
+        snappingClosures(it)
+    }
+
     enableRefresh(refreshEnabled)
 
     eventListener(EVENT_LISTENER)


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

`RouteOptions` and `MapboxDirections` [support](https://github.com/mapbox/mapbox-java/pull/1232) a new option `snappingClosures` (not released yet).
We need support it on SDK side and build route request with the option.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Use SnappingClosures param to build route request.</changelog>
```

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
