### PR TITLE
A couple minor improvements in hopes of getting native stack traces from Firebase

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -176,7 +176,7 @@ ext {
       mapboxSdkRegistry    : '0.4.0',
       mapboxAccessToken    : '0.2.1',
       mapboxNativeDownload : '0.1.2',
-      firebaseCrashlytics  : '2.5.0'
+      firebaseCrashlytics  : '2.5.1'
   ]
 
   pluginDependencies = [

--- a/test-app/build.gradle
+++ b/test-app/build.gradle
@@ -65,7 +65,7 @@ android {
             firebaseCrashlytics {
                 mappingFileUploadEnabled = true
                 nativeSymbolUploadEnabled = true
-                strippedNativeLibsDir = 'build/intermediates/stripped_native_libs/debug/release/lib/'
+                strippedNativeLibsDir = 'build/intermediates/stripped_native_libs/release/out/lib/'
                 unstrippedNativeLibsDir = com.mapbox.gradle.NativeDownloadTask.UNSTRIPPED_NATIVE_LIBS_PATH
             }
         }


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

It's still unclear what the issue is for showing the native stack traces https://github.com/mapbox/mapbox-navigation-android/pull/4159

This is an error I found while investigating. Firebase completes successfully with or without this change, so it's unclear what issues remain that are making it not work.

Updating the version because a few days ago this issue was closed claiming the new version fixes problems that are similar to ours https://github.com/firebase/firebase-android-sdk/issues/1700#issuecomment-802985499

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
