### PR TITLE
TripNotification view: text `Stop Session` is always present before start of the trip session

### DIFF
--- a/libtrip-notification/src/main/java/com/mapbox/navigation/trip/notification/internal/MapboxTripNotification.kt
+++ b/libtrip-notification/src/main/java/com/mapbox/navigation/trip/notification/internal/MapboxTripNotification.kt
@@ -167,6 +167,10 @@ class MapboxTripNotification constructor(
         expandedNotificationRemoteViews?.apply {
             setViewVisibility(R.id.navigationIsStarting, View.VISIBLE)
         }
+        expandedNotificationRemoteViews?.setTextViewText(
+            R.id.endNavigationBtnText,
+            applicationContext.getString(R.string.mapbox_stop_session)
+        )
     }
 
     /**

--- a/libtrip-notification/src/test/java/com/mapbox/navigation/trip/notification/internal/MapboxTripNotificationTest.kt
+++ b/libtrip-notification/src/test/java/com/mapbox/navigation/trip/notification/internal/MapboxTripNotificationTest.kt
@@ -195,8 +195,12 @@ class MapboxTripNotificationTest {
         notification.updateNotification(routeProgress)
 
         verify(exactly = 1) { bannerText.text() }
-        verify(exactly = 1) { collapsedViews.setTextViewText(any(), primaryText()) }
-        verify(exactly = 1) { expandedViews.setTextViewText(any(), primaryText()) }
+        verify(exactly = 1) {
+            collapsedViews.setTextViewText(R.id.notificationInstructionText, primaryText())
+        }
+        verify(exactly = 1) {
+            expandedViews.setTextViewText(R.id.notificationInstructionText, primaryText())
+        }
         verify(exactly = 1) { expandedViews.setTextViewText(any(), END_NAVIGATION) }
         verify(exactly = 0) { expandedViews.setTextViewText(any(), STOP_SESSION) }
         assertEquals(notification.currentManeuverType, MANEUVER_TYPE)
@@ -214,8 +218,18 @@ class MapboxTripNotificationTest {
 
         notification.updateNotification(routeProgress)
 
-        verify(exactly = 1) { collapsedViews.setTextViewText(any(), distanceText) }
-        verify(exactly = 1) { expandedViews.setTextViewText(any(), distanceText) }
+        verify(exactly = 1) {
+            collapsedViews.setTextViewText(
+                R.id.notificationDistanceText,
+                distanceText
+            )
+        }
+        verify(exactly = 1) {
+            expandedViews.setTextViewText(
+                R.id.notificationDistanceText,
+                distanceText
+            )
+        }
     }
 
     @Test
@@ -390,6 +404,9 @@ class MapboxTripNotificationTest {
         verify(exactly = 3) {
             expandedViews.setViewVisibility(R.id.freeDriveText, any())
         }
+        verify(exactly = 2) {
+            expandedViews.setTextViewText(R.id.endNavigationBtnText, STOP_SESSION)
+        }
     }
 
     @Test
@@ -415,7 +432,7 @@ class MapboxTripNotificationTest {
             expandedViews.setViewVisibility(R.id.navigationIsStarting, any())
         }
         verify(exactly = 0) { expandedViews.setTextViewText(any(), END_NAVIGATION) }
-        verify(exactly = 1) { expandedViews.setTextViewText(any(), STOP_SESSION) }
+        verify(exactly = 2) { expandedViews.setTextViewText(any(), STOP_SESSION) }
     }
 
     private fun mockUpdateNotificationAndroidInteractions() {


### PR DESCRIPTION
### Description
TripNotification view: text `Stop Session` is always present before start of the trip session

ref https://github.com/mapbox/mapbox-navigation-android/issues/4163

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Fixed TripNotification view "Stop Session" label become hidden</changelog>
```

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
