### PR TITLE
Request route independently from the navigation session

### DIFF
--- a/examples/src/main/AndroidManifest.xml
+++ b/examples/src/main/AndroidManifest.xml
@@ -89,6 +89,11 @@
     </activity>
 
     <activity
+        android:name=".IndependentRouteGenerationActivity"
+        android:label="@string/title_independent_route">
+    </activity>
+
+    <activity
         android:name="com.mapbox.navigation.examples.MainActivity"
         android:screenOrientation="portrait">
       <intent-filter>

--- a/examples/src/main/java/com/mapbox/navigation/examples/MainActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/MainActivity.kt
@@ -10,6 +10,7 @@ import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.mapbox.android.core.permissions.PermissionsListener
+import com.mapbox.navigation.examples.core.IndependentRouteGenerationActivity
 import com.mapbox.navigation.examples.core.MapboxCustomStyleActivity
 import com.mapbox.navigation.examples.core.MapboxJunctionActivity
 import com.mapbox.navigation.examples.core.MapboxManeuverActivity
@@ -126,6 +127,11 @@ class MainActivity : AppCompatActivity(), PermissionsListener {
                 getString(R.string.title_draw_utility),
                 getString(R.string.description_draw_utility),
                 RouteDrawingActivity::class.java
+            ),
+            SampleItem(
+                getString(R.string.title_independent_route),
+                getString(R.string.description_independent_route),
+                IndependentRouteGenerationActivity::class.java
             )
         )
     }

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/IndependentRouteGenerationActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/IndependentRouteGenerationActivity.kt
@@ -1,0 +1,315 @@
+package com.mapbox.navigation.examples.core
+
+import android.annotation.SuppressLint
+import android.location.Location
+import android.os.Bundle
+import android.util.Log
+import android.view.View
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.api.directions.v5.models.RouteOptions
+import com.mapbox.geojson.Feature
+import com.mapbox.geojson.LineString
+import com.mapbox.geojson.Point
+import com.mapbox.maps.CameraOptions
+import com.mapbox.maps.MapboxMap
+import com.mapbox.maps.Style
+import com.mapbox.maps.plugin.animation.MapAnimationOptions
+import com.mapbox.maps.plugin.animation.getCameraAnimationsPlugin
+import com.mapbox.maps.plugin.annotation.generated.CircleManager
+import com.mapbox.maps.plugin.annotation.generated.CircleOptions
+import com.mapbox.maps.plugin.annotation.generated.LineManager
+import com.mapbox.maps.plugin.annotation.generated.LineOptions
+import com.mapbox.maps.plugin.annotation.generated.createCircleManager
+import com.mapbox.maps.plugin.annotation.generated.createLineManager
+import com.mapbox.maps.plugin.annotation.getAnnotationPlugin
+import com.mapbox.maps.plugin.gestures.OnMapLongClickListener
+import com.mapbox.maps.plugin.gestures.getGesturesPlugin
+import com.mapbox.maps.plugin.locationcomponent.LocationComponentPlugin
+import com.mapbox.maps.plugin.locationcomponent.getLocationComponentPlugin
+import com.mapbox.navigation.base.formatter.DistanceFormatterOptions
+import com.mapbox.navigation.base.internal.extensions.applyDefaultParams
+import com.mapbox.navigation.base.options.NavigationOptions
+import com.mapbox.navigation.base.trip.model.RouteProgress
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.directions.session.RoutesObserver
+import com.mapbox.navigation.core.directions.session.RoutesRequestCallback
+import com.mapbox.navigation.core.replay.MapboxReplayer
+import com.mapbox.navigation.core.replay.ReplayLocationEngine
+import com.mapbox.navigation.core.replay.route.ReplayProgressObserver
+import com.mapbox.navigation.core.replay.route.ReplayRouteMapper
+import com.mapbox.navigation.core.trip.session.LocationObserver
+import com.mapbox.navigation.core.trip.session.RouteProgressObserver
+import com.mapbox.navigation.examples.core.databinding.LayoutActivityIndependentRouteGenerationBinding
+import com.mapbox.navigation.examples.util.RouteLineUtil
+import com.mapbox.navigation.examples.util.Utils
+import com.mapbox.navigation.ui.maps.location.NavigationLocationProvider
+import com.mapbox.navigation.ui.tripprogress.api.MapboxTripProgressApi
+import com.mapbox.navigation.ui.tripprogress.model.DistanceRemainingFormatter
+import com.mapbox.navigation.ui.tripprogress.model.EstimatedTimeToArrivalFormatter
+import com.mapbox.navigation.ui.tripprogress.model.TimeRemainingFormatter
+import com.mapbox.navigation.ui.tripprogress.model.TripProgressUpdateFormatter
+
+class IndependentRouteGenerationActivity : AppCompatActivity() {
+
+    private lateinit var binding: LayoutActivityIndependentRouteGenerationBinding
+    private val routeLine = RouteLineUtil(this)
+    private lateinit var mapboxMap: MapboxMap
+    private val navigationLocationProvider = NavigationLocationProvider()
+    private lateinit var locationComponent: LocationComponentPlugin
+    private lateinit var mapboxNavigation: MapboxNavigation
+    private lateinit var circleManager: CircleManager
+    private lateinit var lineManager: LineManager
+    private val mapboxReplayer = MapboxReplayer()
+
+    private val tripProgressApi: MapboxTripProgressApi by lazy {
+        MapboxTripProgressApi(tripProgressFormatter)
+    }
+
+    private val tripProgressFormatter: TripProgressUpdateFormatter by lazy {
+        val distanceFormatterOptions =
+            DistanceFormatterOptions.Builder(this).build()
+        TripProgressUpdateFormatter.Builder(this)
+            .distanceRemainingFormatter(DistanceRemainingFormatter(distanceFormatterOptions))
+            .timeRemainingFormatter(TimeRemainingFormatter(this))
+            .estimatedTimeToArrivalFormatter(EstimatedTimeToArrivalFormatter(this))
+            .build()
+    }
+
+    private var routeRequestId: Long? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = LayoutActivityIndependentRouteGenerationBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        mapboxMap = binding.mapView.getMapboxMap()
+        circleManager = binding.mapView.getAnnotationPlugin()
+            .createCircleManager(binding.mapView, null)
+        lineManager = binding.mapView.getAnnotationPlugin()
+            .createLineManager(binding.mapView, null)
+        locationComponent = binding.mapView.getLocationComponentPlugin().apply {
+            setLocationProvider(navigationLocationProvider)
+            enabled = true
+        }
+        initStyle()
+        initNavigation()
+        routeLine.initialize(binding.mapView, mapboxNavigation)
+    }
+
+    private fun initStyle() {
+        mapboxMap.loadStyleUri(
+            Style.MAPBOX_STREETS,
+            { style: Style ->
+                binding.mapView.getGesturesPlugin().addOnMapLongClickListener(
+                    mapLongClickListener
+                )
+            }
+        )
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun initNavigation() {
+        mapboxNavigation = MapboxNavigation(
+            NavigationOptions.Builder(this)
+                .accessToken(Utils.getMapboxAccessToken(this))
+                .locationEngine(ReplayLocationEngine(mapboxReplayer))
+                .build()
+        )
+        mapboxNavigation.startTripSession()
+        mapboxReplayer.pushRealLocation(this, 0.0)
+        mapboxReplayer.play()
+    }
+
+    private val replayProgressObserver = ReplayProgressObserver(mapboxReplayer)
+
+    private val locationObserver = object : LocationObserver {
+        private var initialUpdateDone = false
+
+        override fun onRawLocationChanged(rawLocation: Location) {}
+        override fun onEnhancedLocationChanged(
+            enhancedLocation: Location,
+            keyPoints: List<Location>
+        ) {
+            if (!initialUpdateDone) {
+                updateCamera(
+                    Point.fromLngLat(enhancedLocation.longitude, enhancedLocation.latitude)
+                )
+                initialUpdateDone = true
+            }
+
+            navigationLocationProvider.changePosition(
+                enhancedLocation,
+                keyPoints,
+            )
+        }
+    }
+
+    private val routesObserver = object : RoutesObserver {
+        override fun onRoutesChanged(routes: List<DirectionsRoute>) {
+            if (routes.isNotEmpty()) {
+                startSimulation(routes[0])
+                binding.tripProgressView.visibility = View.VISIBLE
+            } else {
+                mapboxReplayer.stop()
+                binding.tripProgressView.visibility = View.GONE
+            }
+        }
+    }
+
+    private val routeProgressObserver = object : RouteProgressObserver {
+        override fun onRouteProgressChanged(routeProgress: RouteProgress) {
+            tripProgressApi.getTripProgress(routeProgress).let { update ->
+                binding.tripProgressView.render(update)
+            }
+        }
+    }
+
+    private val mapLongClickListener = object : OnMapLongClickListener {
+        override fun onMapLongClick(point: Point): Boolean {
+            Utils.vibrate(this@IndependentRouteGenerationActivity)
+
+            val currentLocation = navigationLocationProvider.lastLocation
+            if (currentLocation != null) {
+                val originPoint = Point.fromLngLat(
+                    currentLocation.longitude,
+                    currentLocation.latitude
+                )
+                findRoute(originPoint, point)
+            }
+            return true
+        }
+    }
+
+    private fun startSimulation(route: DirectionsRoute) {
+        mapboxReplayer.stop()
+        mapboxReplayer.clearEvents()
+        mapboxReplayer.pushRealLocation(this, 0.0)
+        val replayEvents = ReplayRouteMapper().mapDirectionsRouteGeometry(route)
+        mapboxReplayer.pushEvents(replayEvents)
+        mapboxReplayer.seekTo(replayEvents.first())
+        mapboxReplayer.play()
+    }
+
+    private fun updateCamera(point: Point) {
+        val mapAnimationOptionsBuilder = MapAnimationOptions.Builder()
+        mapAnimationOptionsBuilder.duration(1500L)
+        binding.mapView.getCameraAnimationsPlugin().flyTo(
+            CameraOptions.Builder()
+                .center(point)
+                .bearing(0.0)
+                .pitch(0.0)
+                .zoom(14.0)
+                .build(),
+            mapAnimationOptionsBuilder.build()
+        )
+    }
+
+    private fun findRoute(origin: Point, destination: Point) {
+        val currentRouteRequestId = routeRequestId
+        if (currentRouteRequestId != null) {
+            mapboxNavigation.cancelRouteRequest(currentRouteRequestId)
+        } else {
+            clearRouteSelectionUi()
+        }
+
+        val routeOptions = RouteOptions.builder()
+            .applyDefaultParams()
+            .accessToken(Utils.getMapboxAccessToken(this))
+            .coordinates(listOf(origin, destination))
+            .alternatives(false)
+            .build()
+        routeRequestId = mapboxNavigation.requestRoutes(
+            routeOptions,
+            object : RoutesRequestCallback {
+                override fun onRoutesReady(routes: List<DirectionsRoute>) {
+                    lineManager.create(
+                        LineOptions.fromFeature(
+                            Feature.fromGeometry(
+                                LineString.fromPolyline(routes[0].geometry()!!, 6)
+                            )
+                        )!!
+                    )
+
+                    binding.routeSelection.visibility = View.VISIBLE
+                    binding.acceptRoute.setOnClickListener {
+                        mapboxNavigation.setRoutes(routes)
+                        clearRouteSelectionUi()
+                    }
+                    binding.rejectRoute.setOnClickListener {
+                        updateCamera(origin)
+                        clearRouteSelectionUi()
+                    }
+
+                    routeRequestId = null
+                    updateCamera(destination)
+                }
+
+                override fun onRoutesRequestFailure(
+                    throwable: Throwable,
+                    routeOptions: RouteOptions
+                ) {
+                    Log.e(
+                        "RouteGenerationActivity",
+                        "route request failed:\n" + throwable.message
+                    )
+                    Toast.makeText(
+                        this@IndependentRouteGenerationActivity,
+                        "Route request failed.",
+                        Toast.LENGTH_LONG
+                    ).show()
+                    routeRequestId = null
+                    clearRouteSelectionUi()
+                }
+
+                override fun onRoutesRequestCanceled(routeOptions: RouteOptions) {
+                    Toast.makeText(
+                        this@IndependentRouteGenerationActivity,
+                        """Route request "$routeRequestId" canceled.""",
+                        Toast.LENGTH_LONG
+                    ).show()
+                    routeRequestId = null
+                    clearRouteSelectionUi()
+                }
+            }
+        )
+
+        circleManager.create(CircleOptions.fromFeature(Feature.fromGeometry(destination))!!)
+    }
+
+    private fun clearRouteSelectionUi() {
+        binding.routeSelection.visibility = View.GONE
+        circleManager.deleteAll()
+        lineManager.deleteAll()
+    }
+
+    override fun onStart() {
+        super.onStart()
+        mapboxNavigation.registerLocationObserver(locationObserver)
+        mapboxNavigation.registerRouteProgressObserver(replayProgressObserver)
+        mapboxNavigation.registerRoutesObserver(routesObserver)
+        mapboxNavigation.registerRouteProgressObserver(routeProgressObserver)
+        binding.mapView.onStart()
+    }
+
+    override fun onStop() {
+        super.onStop()
+        mapboxNavigation.unregisterLocationObserver(locationObserver)
+        mapboxNavigation.unregisterRouteProgressObserver(replayProgressObserver)
+        mapboxNavigation.unregisterRoutesObserver(routesObserver)
+        mapboxNavigation.unregisterRouteProgressObserver(routeProgressObserver)
+        binding.mapView.onStop()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        binding.mapView.onDestroy()
+        mapboxNavigation.onDestroy()
+    }
+
+    override fun onLowMemory() {
+        super.onLowMemory()
+        binding.mapView.onLowMemory()
+    }
+}

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxCustomStyleActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxCustomStyleActivity.kt
@@ -30,6 +30,7 @@ import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesObserver
+import com.mapbox.navigation.core.directions.session.RoutesRequestCallback
 import com.mapbox.navigation.core.internal.formatter.MapboxDistanceFormatter
 import com.mapbox.navigation.core.replay.MapboxReplayer
 import com.mapbox.navigation.core.replay.ReplayLocationEngine
@@ -288,7 +289,23 @@ class MapboxCustomStyleActivity : AppCompatActivity(), OnMapLongClickListener {
                 .coordinates(listOf(origin, destination))
                 .alternatives(false)
                 .annotationsList(Collections.singletonList(DirectionsCriteria.ANNOTATION_MAXSPEED))
-                .build()
+                .build(),
+            object : RoutesRequestCallback {
+                override fun onRoutesReady(routes: List<DirectionsRoute>) {
+                    mapboxNavigation.setRoutes(routes)
+                }
+
+                override fun onRoutesRequestFailure(
+                    throwable: Throwable,
+                    routeOptions: RouteOptions
+                ) {
+                    // no impl
+                }
+
+                override fun onRoutesRequestCanceled(routeOptions: RouteOptions) {
+                    // no impl
+                }
+            }
         )
     }
 

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxJunctionActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxJunctionActivity.kt
@@ -26,6 +26,7 @@ import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesObserver
+import com.mapbox.navigation.core.directions.session.RoutesRequestCallback
 import com.mapbox.navigation.core.replay.MapboxReplayer
 import com.mapbox.navigation.core.replay.ReplayLocationEngine
 import com.mapbox.navigation.core.replay.route.ReplayProgressObserver
@@ -218,7 +219,23 @@ class MapboxJunctionActivity : AppCompatActivity(), OnMapLongClickListener {
                 .accessToken(getMapboxRouteAccessToken(this))
                 .coordinates(listOf(origin, destination))
                 .alternatives(true)
-                .build()
+                .build(),
+            object : RoutesRequestCallback {
+                override fun onRoutesReady(routes: List<DirectionsRoute>) {
+                    mapboxNavigation.setRoutes(routes)
+                }
+
+                override fun onRoutesRequestFailure(
+                    throwable: Throwable,
+                    routeOptions: RouteOptions
+                ) {
+                    // no impl
+                }
+
+                override fun onRoutesRequestCanceled(routeOptions: RouteOptions) {
+                    // no impl
+                }
+            }
         )
     }
 

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxManeuverActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxManeuverActivity.kt
@@ -27,6 +27,7 @@ import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesObserver
+import com.mapbox.navigation.core.directions.session.RoutesRequestCallback
 import com.mapbox.navigation.core.internal.formatter.MapboxDistanceFormatter
 import com.mapbox.navigation.core.replay.MapboxReplayer
 import com.mapbox.navigation.core.replay.ReplayLocationEngine
@@ -283,7 +284,25 @@ class MapboxManeuverActivity : AppCompatActivity(), OnMapLongClickListener {
             .accessToken(getMapboxAccessTokenFromResources())
             .coordinates(origin, null, destination)
             .build()
-        mapboxNavigation.requestRoutes(routeOptions)
+        mapboxNavigation.requestRoutes(
+            routeOptions,
+            object : RoutesRequestCallback {
+                override fun onRoutesReady(routes: List<DirectionsRoute>) {
+                    mapboxNavigation.setRoutes(routes)
+                }
+
+                override fun onRoutesRequestFailure(
+                    throwable: Throwable,
+                    routeOptions: RouteOptions
+                ) {
+                    // no impl
+                }
+
+                override fun onRoutesRequestCanceled(routeOptions: RouteOptions) {
+                    // no impl
+                }
+            }
+        )
     }
 
     private fun updateCamera(location: Location) {

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxNavigationActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxNavigationActivity.kt
@@ -38,6 +38,7 @@ import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesObserver
+import com.mapbox.navigation.core.directions.session.RoutesRequestCallback
 import com.mapbox.navigation.core.internal.formatter.MapboxDistanceFormatter
 import com.mapbox.navigation.core.trip.session.BannerInstructionsObserver
 import com.mapbox.navigation.core.trip.session.LocationObserver
@@ -509,7 +510,23 @@ class MapboxNavigationActivity :
                 .accessToken(getMapboxAccessTokenFromResources())
                 .coordinates(listOf(origin, destination))
                 .alternatives(true)
-                .build()
+                .build(),
+            object : RoutesRequestCallback {
+                override fun onRoutesReady(routes: List<DirectionsRoute>) {
+                    mapboxNavigation.setRoutes(routes)
+                }
+
+                override fun onRoutesRequestFailure(
+                    throwable: Throwable,
+                    routeOptions: RouteOptions
+                ) {
+                    // no impl
+                }
+
+                override fun onRoutesRequestCanceled(routeOptions: RouteOptions) {
+                    // no impl
+                }
+            }
         )
     }
 

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxSignboardActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxSignboardActivity.kt
@@ -26,6 +26,7 @@ import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesObserver
+import com.mapbox.navigation.core.directions.session.RoutesRequestCallback
 import com.mapbox.navigation.core.replay.MapboxReplayer
 import com.mapbox.navigation.core.replay.ReplayLocationEngine
 import com.mapbox.navigation.core.replay.route.ReplayProgressObserver
@@ -216,7 +217,23 @@ class MapboxSignboardActivity : AppCompatActivity(), OnMapLongClickListener {
                 .applyDefaultParams()
                 .accessToken(getMapboxRouteAccessToken(this))
                 .coordinates(listOf(origin, destination))
-                .build()
+                .build(),
+            object : RoutesRequestCallback {
+                override fun onRoutesReady(routes: List<DirectionsRoute>) {
+                    mapboxNavigation.setRoutes(routes)
+                }
+
+                override fun onRoutesRequestFailure(
+                    throwable: Throwable,
+                    routeOptions: RouteOptions
+                ) {
+                    // no impl
+                }
+
+                override fun onRoutesRequestCanceled(routeOptions: RouteOptions) {
+                    // no impl
+                }
+            }
         )
     }
 

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxSnapshotActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxSnapshotActivity.kt
@@ -25,6 +25,7 @@ import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesObserver
+import com.mapbox.navigation.core.directions.session.RoutesRequestCallback
 import com.mapbox.navigation.core.replay.MapboxReplayer
 import com.mapbox.navigation.core.replay.ReplayLocationEngine
 import com.mapbox.navigation.core.replay.route.ReplayProgressObserver
@@ -220,7 +221,23 @@ class MapboxSnapshotActivity : AppCompatActivity(), OnMapLongClickListener {
                 .applyDefaultParams()
                 .accessToken(getMapboxRouteAccessToken(this))
                 .coordinates(listOf(origin, destination))
-                .build()
+                .build(),
+            object : RoutesRequestCallback {
+                override fun onRoutesReady(routes: List<DirectionsRoute>) {
+                    mapboxNavigation.setRoutes(routes)
+                }
+
+                override fun onRoutesRequestFailure(
+                    throwable: Throwable,
+                    routeOptions: RouteOptions
+                ) {
+                    // no impl
+                }
+
+                override fun onRoutesRequestCanceled(routeOptions: RouteOptions) {
+                    // no impl
+                }
+            }
         )
     }
 

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxTripProgressActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxTripProgressActivity.kt
@@ -26,6 +26,7 @@ import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesObserver
+import com.mapbox.navigation.core.directions.session.RoutesRequestCallback
 import com.mapbox.navigation.core.replay.MapboxReplayer
 import com.mapbox.navigation.core.replay.ReplayLocationEngine
 import com.mapbox.navigation.core.replay.route.ReplayProgressObserver
@@ -252,7 +253,25 @@ class MapboxTripProgressActivity : AppCompatActivity(), OnMapLongClickListener {
             .coordinates(listOf(origin, destination))
             .alternatives(true)
             .build()
-        mapboxNavigation.requestRoutes(routeOptions)
+        mapboxNavigation.requestRoutes(
+            routeOptions,
+            object : RoutesRequestCallback {
+                override fun onRoutesReady(routes: List<DirectionsRoute>) {
+                    mapboxNavigation.setRoutes(routes)
+                }
+
+                override fun onRoutesRequestFailure(
+                    throwable: Throwable,
+                    routeOptions: RouteOptions
+                ) {
+                    // no impl
+                }
+
+                override fun onRoutesRequestCanceled(routeOptions: RouteOptions) {
+                    // no impl
+                }
+            }
+        )
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxVoiceActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxVoiceActivity.kt
@@ -25,6 +25,7 @@ import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesObserver
+import com.mapbox.navigation.core.directions.session.RoutesRequestCallback
 import com.mapbox.navigation.core.replay.MapboxReplayer
 import com.mapbox.navigation.core.replay.ReplayLocationEngine
 import com.mapbox.navigation.core.replay.route.ReplayProgressObserver
@@ -324,7 +325,25 @@ class MapboxVoiceActivity : AppCompatActivity(), OnMapLongClickListener {
             .coordinates(listOf(origin, destination))
             .voiceInstructions(true)
             .build()
-        mapboxNavigation.requestRoutes(routeOptions)
+        mapboxNavigation.requestRoutes(
+            routeOptions,
+            object : RoutesRequestCallback {
+                override fun onRoutesReady(routes: List<DirectionsRoute>) {
+                    mapboxNavigation.setRoutes(routes)
+                }
+
+                override fun onRoutesRequestFailure(
+                    throwable: Throwable,
+                    routeOptions: RouteOptions
+                ) {
+                    // no impl
+                }
+
+                override fun onRoutesRequestCanceled(routeOptions: RouteOptions) {
+                    // no impl
+                }
+            }
+        )
     }
 
     private fun updateCamera(location: Location) {

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/camera/MapboxCameraAnimationsActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/camera/MapboxCameraAnimationsActivity.kt
@@ -43,6 +43,7 @@ import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesObserver
+import com.mapbox.navigation.core.directions.session.RoutesRequestCallback
 import com.mapbox.navigation.core.replay.MapboxReplayer
 import com.mapbox.navigation.core.replay.ReplayLocationEngine
 import com.mapbox.navigation.core.replay.route.ReplayRouteMapper
@@ -518,7 +519,25 @@ class MapboxCameraAnimationsActivity :
             )
             .build()
 
-        mapboxNavigation.requestRoutes(routeOptions)
+        mapboxNavigation.requestRoutes(
+            routeOptions,
+            object : RoutesRequestCallback {
+                override fun onRoutesReady(routes: List<DirectionsRoute>) {
+                    mapboxNavigation.setRoutes(routes)
+                }
+
+                override fun onRoutesRequestFailure(
+                    throwable: Throwable,
+                    routeOptions: RouteOptions
+                ) {
+                    // no impl
+                }
+
+                override fun onRoutesRequestCanceled(routeOptions: RouteOptions) {
+                    // no impl
+                }
+            }
+        )
     }
 
     override fun onMapLongClick(point: Point): Boolean {

--- a/examples/src/main/java/com/mapbox/navigation/examples/internal/MapboxRouteLineActivity.java
+++ b/examples/src/main/java/com/mapbox/navigation/examples/internal/MapboxRouteLineActivity.java
@@ -365,6 +365,7 @@ public class MapboxRouteLineActivity extends AppCompatActivity implements OnMapL
   private RoutesRequestCallback routesReqCallback = new RoutesRequestCallback() {
     @Override
     public void onRoutesReady(@NotNull List<? extends DirectionsRoute> routes) {
+      mapboxNavigation.setRoutes(routes);
       if (!routes.isEmpty()) {
         routeLoading.setVisibility(View.INVISIBLE);
         startNavigation.setVisibility(View.VISIBLE);

--- a/examples/src/main/java/com/mapbox/navigation/examples/util/Utils.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/util/Utils.kt
@@ -1,6 +1,10 @@
 package com.mapbox.navigation.examples.util
 
 import android.content.Context
+import android.os.Build
+import android.os.VibrationEffect
+import android.os.Vibrator
+import androidx.appcompat.app.AppCompatActivity
 
 object Utils {
     /**
@@ -13,5 +17,14 @@ object Utils {
         val tokenResId = context.resources
             .getIdentifier("mapbox_access_token", "string", context.packageName)
         return if (tokenResId != 0) context.getString(tokenResId) else ""
+    }
+
+    fun vibrate(context: Context) {
+        val vibrator = context.getSystemService(AppCompatActivity.VIBRATOR_SERVICE) as Vibrator
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            vibrator.vibrate(VibrationEffect.createOneShot(100L, VibrationEffect.DEFAULT_AMPLITUDE))
+        } else {
+            vibrator.vibrate(100L)
+        }
     }
 }

--- a/examples/src/main/res/layout/layout_activity_independent_route_generation.xml
+++ b/examples/src/main/res/layout/layout_activity_independent_route_generation.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".IndependentRouteGenerationActivity">
+
+    <com.mapbox.maps.MapView
+        android:id="@+id/mapView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toTopOf="@id/tripProgressView"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <LinearLayout
+        android:id="@+id/route_selection"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:visibility="gone"
+        app:layout_constraintBottom_toTopOf="@id/tripProgressView"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <Button
+            android:id="@+id/acceptRoute"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="12dp"
+            android:padding="4dp"
+            android:text="ACCEPT ROUTE" />
+
+        <Button
+            android:id="@+id/rejectRoute"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="12dp"
+            android:padding="4dp"
+            android:text="REJECT ROUTE" />
+
+    </LinearLayout>
+
+    <com.mapbox.navigation.ui.tripprogress.view.MapboxTripProgressView
+        android:id="@+id/tripProgressView"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/examples/src/main/res/values/strings.xml
+++ b/examples/src/main/res/values/strings.xml
@@ -21,6 +21,8 @@
     <string name="description_maneuver" translatable="false">Demonstrates the use of maneuver API.</string>
     <string name="title_voice" translatable="false">Voice Example</string>
     <string name="description_voice" translatable="false">Demonstrates the use of voice API.</string>
+    <string name="title_independent_route" translatable="false">Independent route generation</string>
+    <string name="description_independent_route" translatable="false">Use MapboxNavigation to request online and offline routes on demand thanks to the hybrid router implementation, without interrupting the current navigation session.</string>
     <string name="title_replay" translatable="false">Replay Example</string>
     <string name="description_replay" translatable="false">Demonstrates the use of replay API.</string>
     <string name="title_custom_style" translatable="false">Custom Style Example</string>

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/CoreRerouteTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/CoreRerouteTest.kt
@@ -1,6 +1,7 @@
 package com.mapbox.navigation.instrumentation_tests.core
 
 import androidx.test.espresso.Espresso
+import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.RouteOptions
 import com.mapbox.geojson.Point
 import com.mapbox.navigation.base.internal.extensions.applyDefaultParams
@@ -8,6 +9,7 @@ import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.trip.model.RouteProgressState
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.MapboxNavigationProvider
+import com.mapbox.navigation.core.directions.session.RoutesRequestCallback
 import com.mapbox.navigation.instrumentation_tests.R
 import com.mapbox.navigation.instrumentation_tests.activity.EmptyTestActivity
 import com.mapbox.navigation.instrumentation_tests.utils.MapboxNavigationRule
@@ -103,7 +105,23 @@ class CoreRerouteTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.jav
                 RouteOptions.builder().applyDefaultParams()
                     .baseUrl(mockWebServerRule.baseUrl)
                     .accessToken(getMapboxAccessTokenFromResources(activity))
-                    .coordinates(mockRoute.routeWaypoints).build()
+                    .coordinates(mockRoute.routeWaypoints).build(),
+                object : RoutesRequestCallback {
+                    override fun onRoutesReady(routes: List<DirectionsRoute>) {
+                        mapboxNavigation.setRoutes(routes)
+                    }
+
+                    override fun onRoutesRequestFailure(
+                        throwable: Throwable,
+                        routeOptions: RouteOptions
+                    ) {
+                        // no impl
+                    }
+
+                    override fun onRoutesRequestCanceled(routeOptions: RouteOptions) {
+                        // no impl
+                    }
+                }
             )
         }
 

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/SanityCoreRouteTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/SanityCoreRouteTest.kt
@@ -78,6 +78,7 @@ class SanityCoreRouteTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class
                     .coordinates(mockRoute.routeWaypoints).build(),
                 object : RoutesRequestCallback {
                     override fun onRoutesReady(routes: List<DirectionsRoute>) {
+                        mapboxNavigation.setRoutes(routes)
                         mockLocationReplayerRule.playRoute(routes[0])
                     }
 

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/ui/SanityUiRouteTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/ui/SanityUiRouteTest.kt
@@ -8,10 +8,8 @@ class SanityUiRouteTest : SimpleMapViewNavigationTest() {
 
     @Test
     fun route_completes() {
-        // puck needs to be added first,
-        // see https://github.com/mapbox/mapbox-navigation-android-internal/issues/102
-        addLocationPuck()
         addRouteLine()
+        addLocationPuck()
         addNavigationCamera()
         val arrivalIdlingResource = ArrivalIdlingResource(mapboxNavigation)
         arrivalIdlingResource.register()

--- a/libnavigation-base/api/current.txt
+++ b/libnavigation-base/api/current.txt
@@ -324,9 +324,11 @@ package com.mapbox.navigation.base.route {
   }
 
   public interface Router {
-    method public void cancel();
-    method public void getRoute(com.mapbox.api.directions.v5.models.RouteOptions routeOptions, com.mapbox.navigation.base.route.Router.Callback callback);
-    method public void getRouteRefresh(com.mapbox.api.directions.v5.models.DirectionsRoute route, int legIndex, com.mapbox.navigation.base.route.RouteRefreshCallback callback);
+    method public void cancelAll();
+    method public void cancelRouteRefreshRequest(long requestId);
+    method public void cancelRouteRequest(long requestId);
+    method public long getRoute(com.mapbox.api.directions.v5.models.RouteOptions routeOptions, com.mapbox.navigation.base.route.Router.Callback callback);
+    method public long getRouteRefresh(com.mapbox.api.directions.v5.models.DirectionsRoute route, int legIndex, com.mapbox.navigation.base.route.RouteRefreshCallback callback);
     method public void shutdown();
   }
 

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/route/Router.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/route/Router.kt
@@ -9,20 +9,29 @@ import com.mapbox.api.directions.v5.models.RouteOptions
 interface Router {
 
     /**
-     * Fetch route based on [RouteOptions]
+     * Fetch routes based on [RouteOptions].
      *
      * @param routeOptions RouteOptions
      * @param callback Callback that gets notified with the results of the request
+     *
+     * @return request ID, can be used to cancel the request with [cancelRouteRequest]
      */
     fun getRoute(
         routeOptions: RouteOptions,
         callback: Callback
-    )
+    ): Long
 
     /**
-     * Interrupts a route-fetching request if one is in progress.
+     * Cancels a specific route request.
+     *
+     * @see [getRoute]
      */
-    fun cancel()
+    fun cancelRouteRequest(requestId: Long)
+
+    /**
+     * Interrupts all in-progress requests.
+     */
+    fun cancelAll()
 
     /**
      * Refresh the traffic annotations for a given [DirectionsRoute]
@@ -30,12 +39,21 @@ interface Router {
      * @param route DirectionsRoute the direction route to refresh
      * @param legIndex Int the index of the current leg in the route
      * @param callback Callback that gets notified with the results of the request
+     *
+     * @return request ID, can be used to cancel the request with [cancelRouteRefreshRequest]
      */
     fun getRouteRefresh(
         route: DirectionsRoute,
         legIndex: Int,
         callback: RouteRefreshCallback
-    )
+    ): Long
+
+    /**
+     * Cancels a specific route refresh request.
+     *
+     * @see [getRouteRefresh]
+     */
+    fun cancelRouteRefreshRequest(requestId: Long)
 
     /**
      * Release used resources.

--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -5,6 +5,7 @@ package com.mapbox.navigation.core {
     ctor public MapboxNavigation(com.mapbox.navigation.base.options.NavigationOptions navigationOptions);
     method public void addHistoryEvent(String eventType, String eventJsonProperties);
     method public void attachFasterRouteObserver(com.mapbox.navigation.core.fasterroute.FasterRouteObserver fasterRouteObserver);
+    method public void cancelRouteRequest(long requestId);
     method public void detachFasterRouteObserver();
     method public com.mapbox.navigation.core.trip.session.GraphAccessor getGraphAccessor();
     method public com.mapbox.navigation.base.options.NavigationOptions getNavigationOptions();
@@ -26,8 +27,7 @@ package com.mapbox.navigation.core {
     method public void registerRoutesObserver(com.mapbox.navigation.core.directions.session.RoutesObserver routesObserver);
     method public void registerTripSessionStateObserver(com.mapbox.navigation.core.trip.session.TripSessionStateObserver tripSessionStateObserver);
     method public void registerVoiceInstructionsObserver(com.mapbox.navigation.core.trip.session.VoiceInstructionsObserver voiceInstructionsObserver);
-    method public void requestRoutes(com.mapbox.api.directions.v5.models.RouteOptions routeOptions, com.mapbox.navigation.core.directions.session.RoutesRequestCallback? routesRequestCallback = null);
-    method public void requestRoutes(com.mapbox.api.directions.v5.models.RouteOptions routeOptions);
+    method public long requestRoutes(com.mapbox.api.directions.v5.models.RouteOptions routeOptions, com.mapbox.navigation.core.directions.session.RoutesRequestCallback routesRequestCallback);
     method public void resetTripSession();
     method public String retrieveHistory();
     method public String? retrieveSsmlAnnouncementInstruction(int index);

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/NavigationComponentProvider.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/NavigationComponentProvider.kt
@@ -20,9 +20,9 @@ import com.mapbox.navigator.TilesConfig
 
 internal object NavigationComponentProvider {
     fun createDirectionsSession(
-        router: Router
-    ): DirectionsSession =
-        MapboxDirectionsSession(router)
+        router: Router,
+        logger: Logger
+    ): DirectionsSession = MapboxDirectionsSession(router, logger)
 
     fun createNativeNavigator(
         deviceProfile: DeviceProfile,

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/DirectionsSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/DirectionsSession.kt
@@ -16,33 +16,27 @@ internal interface DirectionsSession {
     var routes: List<DirectionsRoute>
 
     /**
-     * Provide route options for current [routes]
+     * Provide route options for current primary route.
      */
-    fun getRouteOptions(): RouteOptions?
+    fun getPrimaryRouteOptions(): RouteOptions?
 
     /**
      * Fetch route based on [RouteOptions]
      *
      * @param routeOptions RouteOptions
      * @param routesRequestCallback Callback that gets notified with the results of the request
+     *
+     * @return requestID, see [cancelRouteRequest]
      */
     fun requestRoutes(
         routeOptions: RouteOptions,
-        routesRequestCallback: RoutesRequestCallback? = null
-    )
+        routesRequestCallback: RoutesRequestCallback
+    ): Long
 
     /**
-     * Requests a route using the provided [Router] implementation.
-     * Unlike [DirectionsSession.requestRoutes] it ignores the result and it's up to the
-     * consumer to take an action with the route.
-     *
-     * @param adjustedRouteOptions: RouteOptions with adjusted parameters
-     * @param routesRequestCallback Callback that gets notified when request state changes
+     * Interrupts a route-fetching request if one is in progress.
      */
-    fun requestFasterRoute(
-        adjustedRouteOptions: RouteOptions,
-        routesRequestCallback: RoutesRequestCallback
-    )
+    fun cancelRouteRequest(requestId: Long)
 
     /**
      * Refresh the traffic annotations for a given [DirectionsRoute]
@@ -51,12 +45,21 @@ internal interface DirectionsSession {
      * @param legIndex Int the index of the current leg in the route
      * @param callback Callback that gets notified with the results of the request
      */
-    fun requestRouteRefresh(route: DirectionsRoute, legIndex: Int, callback: RouteRefreshCallback)
+    fun requestRouteRefresh(
+        route: DirectionsRoute,
+        legIndex: Int,
+        callback: RouteRefreshCallback
+    ): Long
 
     /**
-     * Interrupts a route-fetching request if one is in progress.
+     * Cancels [requestRouteRefresh].
      */
-    fun cancel()
+    fun cancelRouteRefreshRequest(requestId: Long)
+
+    /**
+     * Interrupts all requests if any are in progress.
+     */
+    fun cancelAll()
 
     /**
      * Registers [RoutesObserver]. Updated on each change of [routes]

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/RoutesObserver.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/RoutesObserver.kt
@@ -13,8 +13,7 @@ interface RoutesObserver {
      *
      * The route at index 0, if exist, will be treated as the primary route for 'Active Guidance'.
      *
-     * A list of routes can be modified internally and externally at any time with methods like
-     * [MapboxNavigation.requestRoutes], [MapboxNavigation.setRoutes], or during automatic reroutes, faster route and route refresh operations.
+     * A list of routes can be modified internally and externally at any time with [MapboxNavigation.setRoutes], or during automatic reroutes, faster route and route refresh operations.
      *
      * @param routes list of currently maintained routes
      */

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/fasterroute/FasterRouteController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/fasterroute/FasterRouteController.kt
@@ -43,6 +43,7 @@ internal class FasterRouteController(
     }
 
     fun stop() {
+        // TODO add cancellation of the request
         this.fasterRouteObserver = null
         fasterRouteTimer.stopJobs()
         jobControl.job.cancelChildren()
@@ -58,14 +59,14 @@ internal class FasterRouteController(
         fasterRouteTimer.restartAfterMillis = restartAfterMillis
 
         routeOptionsUpdater.update(
-            directionsSession.getRouteOptions(),
+            directionsSession.getPrimaryRouteOptions(),
             tripSession.getRouteProgress(),
             tripSession.getEnhancedLocation()
         )
             .let { routeOptionsResult ->
                 when (routeOptionsResult) {
                     is RouteOptionsUpdater.RouteOptionsResult.Success ->
-                        directionsSession.requestFasterRoute(
+                        directionsSession.requestRoutes(
                             routeOptionsResult.routeOptions,
                             fasterRouteRequestCallback
                         )

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/reroute/RerouteController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/reroute/RerouteController.kt
@@ -95,7 +95,7 @@ sealed class RerouteState {
     /**
      * Re-route request has failed.
      *
-     * You can [MapboxNavigation.requestRoutes] with [MapboxRouteOptionsUpdater] to retry the request.
+     * You can [MapboxNavigation.requestRoutes] or [MapboxNavigation.setRoutes] with [MapboxRouteOptionsUpdater] to retry the request.
      *
      * @param message describes error
      * @param throwable is optional

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/fasterroute/FasterRouteControllerTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/fasterroute/FasterRouteControllerTest.kt
@@ -55,13 +55,13 @@ class FasterRouteControllerTest {
             routeOptionsResultSuccess.routeOptions
         } returns routeOptionsResultSuccessRouteOptions
 
-        every { directionsSession.getRouteOptions() } returns mockk()
+        every { directionsSession.getPrimaryRouteOptions() } returns mockk()
         every {
-            directionsSession.requestFasterRoute(
+            directionsSession.requestRoutes(
                 any(),
                 capture(routesRequestCallbacks)
             )
-        } returns mockk()
+        } returns 1L
         every { tripSession.getRouteProgress() } returns mockk()
     }
 
@@ -104,7 +104,7 @@ class FasterRouteControllerTest {
         fasterRouteController.stop()
 
         coroutineRule.testDispatcher.cleanupTestCoroutines()
-        verify(exactly = 5) { directionsSession.requestFasterRoute(any(), any()) }
+        verify(exactly = 5) { directionsSession.requestRoutes(any(), any()) }
     }
 
     @Test
@@ -120,7 +120,7 @@ class FasterRouteControllerTest {
         fasterRouteController.stop()
 
         coroutineRule.testDispatcher.cleanupTestCoroutines()
-        verify(exactly = 0) { directionsSession.requestFasterRoute(any(), any()) }
+        verify(exactly = 0) { directionsSession.requestRoutes(any(), any()) }
     }
 
     @Test
@@ -136,11 +136,11 @@ class FasterRouteControllerTest {
             every { longitude } returns 151.206087
         }
         every {
-            directionsSession.requestFasterRoute(
+            directionsSession.requestRoutes(
                 any(),
                 capture(routesRequestCallbacks)
             )
-        } returns mockk()
+        } returns 1L
 
         fasterRouteController.attach(fasterRouteObserver)
         coroutineRule.testDispatcher.advanceTimeBy(TimeUnit.MINUTES.toMillis(6))
@@ -170,11 +170,11 @@ class FasterRouteControllerTest {
             every { longitude } returns 151.206087
         }
         every {
-            directionsSession.requestFasterRoute(
+            directionsSession.requestRoutes(
                 any(),
                 capture(routesRequestCallbacks)
             )
-        } returns mockk()
+        } returns 1L
 
         fasterRouteController.attach(fasterRouteObserver)
         coroutineRule.testDispatcher.advanceTimeBy(TimeUnit.MINUTES.toMillis(6))

--- a/libnavigation-router/src/main/java/com/mapbox/navigation/route/internal/hybrid/HybridRouterHandler.kt
+++ b/libnavigation-router/src/main/java/com/mapbox/navigation/route/internal/hybrid/HybridRouterHandler.kt
@@ -1,0 +1,248 @@
+package com.mapbox.navigation.route.internal.hybrid
+
+import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.api.directions.v5.models.RouteOptions
+import com.mapbox.base.common.logger.Logger
+import com.mapbox.base.common.logger.model.Message
+import com.mapbox.base.common.logger.model.Tag
+import com.mapbox.navigation.base.route.RouteRefreshCallback
+import com.mapbox.navigation.base.route.RouteRefreshError
+import com.mapbox.navigation.base.route.Router
+
+internal sealed class HybridRouterHandler(
+    protected val primaryRouter: Router,
+    protected val fallbackRouter: Router,
+    protected val logger: Logger
+) {
+
+    private companion object {
+        private val TAG = Tag("MbxHybridRouter")
+    }
+
+    protected val primaryRouterName = primaryRouter::class.java.canonicalName
+    protected val fallbackRouterName = fallbackRouter::class.java.canonicalName
+
+    protected var primaryRouterRequestId: Long? = null
+        set(value) {
+            if (field != null) {
+                throw IllegalArgumentException(
+                    "primaryRouterRequestId was already set for this request"
+                )
+            }
+            field = value
+        }
+    protected var fallbackRouterRequestId: Long? = null
+        set(value) {
+            if (field != null) {
+                throw IllegalArgumentException(
+                    "fallbackRouterRequestId was already set for this request"
+                )
+            }
+            field = value
+        }
+
+    internal class Directions(
+        primaryRouter: Router,
+        fallbackRouter: Router,
+        logger: Logger
+    ) : HybridRouterHandler(primaryRouter, fallbackRouter, logger) {
+
+        private inner class PrimaryCallback(
+            private val clientCallback: Router.Callback,
+            private val routeOptions: RouteOptions
+        ) : Router.Callback {
+            override fun onResponse(routes: List<DirectionsRoute>) {
+                clientCallback.onResponse(routes)
+            }
+
+            override fun onFailure(throwable: Throwable) {
+                logger.w(
+                    TAG,
+                    Message(
+                        """
+                            Route request for $primaryRouterName failed with:
+                            throwable = $throwable
+                            Trying to fallback to $fallbackRouterName...
+                        """.trimMargin()
+                    )
+                )
+
+                fallbackRouterRequestId = fallbackRouter.getRoute(
+                    routeOptions,
+                    FallbackCallback(clientCallback, throwable)
+                )
+            }
+
+            override fun onCanceled() {
+                clientCallback.onCanceled()
+            }
+        }
+
+        private inner class FallbackCallback(
+            private val clientCallback: Router.Callback,
+            private val primaryThrowable: Throwable
+        ) : Router.Callback {
+            override fun onResponse(routes: List<DirectionsRoute>) {
+                clientCallback.onResponse(routes)
+            }
+
+            override fun onFailure(throwable: Throwable) {
+                clientCallback.onFailure(
+                    Throwable(
+                        """
+                            Primary router failed with:
+                            message = ${primaryThrowable.message}
+                            stack = ${primaryThrowable.stackTraceToString()}
+                            
+                            Fallback router failed with:
+                            message = ${throwable.message}
+                            stack = ${throwable.stackTraceToString()}
+                        """.trimIndent(),
+                    )
+                )
+            }
+
+            override fun onCanceled() {
+                clientCallback.onCanceled()
+            }
+        }
+
+        fun getRoute(
+            routeOptions: RouteOptions,
+            callback: Router.Callback
+        ) {
+            primaryRouterRequestId = primaryRouter.getRoute(
+                routeOptions,
+                PrimaryCallback(
+                    callback,
+                    routeOptions
+                )
+            )
+        }
+
+        fun cancelRouteRequest() {
+            primaryRouterRequestId?.let {
+                primaryRouter.cancelRouteRequest(it)
+            }
+            fallbackRouterRequestId?.let {
+                fallbackRouter.cancelRouteRequest(it)
+            }
+        }
+    }
+
+    internal class Refresh(
+        primaryRouter: Router,
+        fallbackRouter: Router,
+        logger: Logger
+    ) : HybridRouterHandler(primaryRouter, fallbackRouter, logger) {
+
+        private inner class PrimaryCallback(
+            private val route: DirectionsRoute,
+            private val legIndex: Int,
+            private val clientCallback: RouteRefreshCallback
+        ) : RouteRefreshCallback {
+            override fun onRefresh(directionsRoute: DirectionsRoute) {
+                clientCallback.onRefresh(directionsRoute)
+            }
+
+            override fun onError(error: RouteRefreshError) {
+                logger.w(
+                    TAG,
+                    Message(
+                        """
+                            Route refresh for $primaryRouterName failed for
+                            UUID = ${route.routeOptions()?.requestUuid()}
+                            legIndex = $legIndex
+                            
+                            message = ${error.message}
+                            stack = ${error.throwable}
+                            Trying to fallback to $fallbackRouterName...
+                        """.trimIndent()
+                    )
+                )
+
+                fallbackRouterRequestId = fallbackRouter.getRouteRefresh(
+                    route,
+                    legIndex,
+                    FallbackCallback(route, legIndex, clientCallback, error)
+                )
+            }
+        }
+
+        private inner class FallbackCallback(
+            private val route: DirectionsRoute,
+            private val legIndex: Int,
+            private val clientCallback: RouteRefreshCallback,
+            private val primaryError: RouteRefreshError
+        ) : RouteRefreshCallback {
+
+            override fun onRefresh(directionsRoute: DirectionsRoute) {
+                logger.w(
+                    TAG,
+                    Message(
+                        """
+                            Route refresh successful fallback to a $fallbackRouterName.
+                        """.trimIndent()
+                    )
+                )
+                clientCallback.onRefresh(directionsRoute)
+            }
+
+            override fun onError(error: RouteRefreshError) {
+                logger.e(
+                    TAG,
+                    Message(
+                        """
+                            Fallback route refresh for $fallbackRouterName failed with:
+                            UUID = ${route.routeOptions()?.requestUuid()}
+                            legIndex = $legIndex
+                            
+                            message = ${error.message}
+                            stack = ${error.throwable}
+                        """.trimIndent()
+                    )
+                )
+                clientCallback.onError(
+                    RouteRefreshError(
+                        """
+                           ${primaryError.message}
+                           ${error.message}
+                        """.trimIndent(),
+                        Throwable(
+                            """
+                                Primary route refresh failed with:
+                                message = ${primaryError.message}
+                                stack = ${primaryError.throwable?.stackTraceToString()}
+                                
+                                Fallback route refresh failed with:
+                                message = ${error.message}
+                                stack = ${error.throwable?.stackTraceToString()}
+                            """.trimIndent()
+                        )
+                    )
+                )
+            }
+        }
+
+        fun getRouteRefresh(
+            route: DirectionsRoute,
+            legIndex: Int,
+            callback: RouteRefreshCallback
+        ) {
+            primaryRouterRequestId = primaryRouter.getRouteRefresh(
+                route,
+                legIndex,
+                PrimaryCallback(route, legIndex, callback)
+            )
+        }
+
+        fun cancelRouteRefreshRequest() {
+            primaryRouterRequestId?.let {
+                primaryRouter.cancelRouteRefreshRequest(it)
+            }
+            fallbackRouterRequestId?.let {
+                fallbackRouter.cancelRouteRefreshRequest(it)
+            }
+        }
+    }
+}

--- a/libnavigation-router/src/main/java/com/mapbox/navigation/route/offboard/routerefresh/RouteRefreshCallbackMapper.kt
+++ b/libnavigation-router/src/main/java/com/mapbox/navigation/route/offboard/routerefresh/RouteRefreshCallbackMapper.kt
@@ -3,52 +3,13 @@ package com.mapbox.navigation.route.offboard.routerefresh
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.LegAnnotation
 import com.mapbox.api.directions.v5.models.RouteLeg
-import com.mapbox.api.directionsrefresh.v1.models.DirectionsRefreshResponse
 import com.mapbox.api.directionsrefresh.v1.models.DirectionsRouteRefresh
-import com.mapbox.navigation.base.route.RouteRefreshCallback
-import com.mapbox.navigation.base.route.RouteRefreshError
-import retrofit2.Call
-import retrofit2.Callback
-import retrofit2.Response
-import java.lang.Exception
 
-internal class RouteRefreshCallbackMapper(
-    private val originalRoute: DirectionsRoute,
-    private val callback: RouteRefreshCallback
-) : Callback<DirectionsRefreshResponse> {
-
-    override fun onResponse(
-        call: Call<DirectionsRefreshResponse>,
-        response: Response<DirectionsRefreshResponse>
-    ) {
-        val routeAnnotations = response.body()?.route()
-        var errorThrowable: Throwable? = null
-        val refreshedDirectionsRoute = try {
-            mapToDirectionsRoute(routeAnnotations)
-        } catch (t: Throwable) {
-            errorThrowable = t
-            null
-        }
-        if (refreshedDirectionsRoute != null) {
-            callback.onRefresh(refreshedDirectionsRoute)
-        } else {
-            callback.onError(
-                RouteRefreshError(
-                    message = "Failed to read refresh response",
-                    throwable = errorThrowable ?: Exception(
-                        "Message=[${response.message()}]; errorBody = [${response.errorBody()}];" +
-                            "refresh route = [$routeAnnotations]"
-                    )
-                )
-            )
-        }
-    }
-
-    override fun onFailure(call: Call<DirectionsRefreshResponse>, t: Throwable) {
-        callback.onError(RouteRefreshError(throwable = t))
-    }
-
-    private fun mapToDirectionsRoute(routeAnnotations: DirectionsRouteRefresh?): DirectionsRoute? {
+internal object RouteRefreshCallbackMapper {
+    fun mapToDirectionsRoute(
+        originalRoute: DirectionsRoute,
+        routeAnnotations: DirectionsRouteRefresh?
+    ): DirectionsRoute? {
         val validRouteAnnotations = routeAnnotations ?: return null
         val updatedLegs = mutableListOf<RouteLeg?>()
         originalRoute.legs()?.let { oldRouteLegsList ->

--- a/libnavigation-router/src/test/java/com/mapbox/navigation/route/internal/offboard/MapboxOffboardRouterTest.kt
+++ b/libnavigation-router/src/test/java/com/mapbox/navigation/route/internal/offboard/MapboxOffboardRouterTest.kt
@@ -6,12 +6,15 @@ import com.mapbox.api.directions.v5.models.DirectionsResponse
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.RouteOptions
 import com.mapbox.api.directionsrefresh.v1.MapboxDirectionsRefresh
+import com.mapbox.api.directionsrefresh.v1.models.DirectionsRefreshResponse
+import com.mapbox.api.directionsrefresh.v1.models.DirectionsRouteRefresh
 import com.mapbox.navigation.base.internal.accounts.UrlSkuTokenProvider
 import com.mapbox.navigation.base.route.RouteRefreshCallback
 import com.mapbox.navigation.base.route.RouteRefreshError
 import com.mapbox.navigation.base.route.Router
 import com.mapbox.navigation.route.offboard.RouteBuilderProvider
 import com.mapbox.navigation.route.offboard.base.BaseTest
+import com.mapbox.navigation.route.offboard.routerefresh.RouteRefreshCallbackMapper
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -19,9 +22,7 @@ import io.mockk.slot
 import io.mockk.unmockkObject
 import io.mockk.verify
 import org.junit.After
-import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import retrofit2.Call
@@ -32,19 +33,20 @@ class MapboxOffboardRouterTest : BaseTest() {
 
     private val mapboxDirections = mockk<MapboxDirections>(relaxed = true)
     private val mapboxDirectionsBuilder = mockk<MapboxDirections.Builder>(relaxed = true)
+    private val mapboxDirectionsRefresh = mockk<MapboxDirectionsRefresh>(relaxed = true)
     private val mapboxDirectionsRefreshBuilder = mockk<MapboxDirectionsRefresh.Builder>()
     private val context = mockk<Context>()
     private val accessToken = "pk.1234"
     private lateinit var offboardRouter: MapboxOffboardRouter
-    private lateinit var callback: Callback<DirectionsResponse>
+    private lateinit var routeCallback: Callback<DirectionsResponse>
+    private lateinit var refreshCallback: Callback<DirectionsRefreshResponse>
     private val routeOptions: RouteOptions = mockk(relaxed = true)
     private val mockSkuTokenProvider = mockk<UrlSkuTokenProvider>(relaxed = true)
-    private val call: Call<DirectionsResponse> = mockk()
+    private val routeCall: Call<DirectionsResponse> = mockk()
+    private val refreshCall: Call<DirectionsRefreshResponse> = mockk()
 
     @Before
     fun setUp() {
-        val listener = slot<Callback<DirectionsResponse>>()
-
         mockkObject(RouteBuilderProvider)
         every {
             mockSkuTokenProvider.obtainUrlWithSkuToken(any())
@@ -55,13 +57,15 @@ class MapboxOffboardRouterTest : BaseTest() {
         every { mapboxDirectionsBuilder.interceptor(any()) } returns mapboxDirectionsBuilder
         every { mapboxDirectionsBuilder.enableRefresh(any()) } returns mapboxDirectionsBuilder
         every { mapboxDirectionsBuilder.build() } returns mapboxDirections
-        every { mapboxDirections.enqueueCall(capture(listener)) } answers {
-            callback = listener.captured
+        val routeListener = slot<Callback<DirectionsResponse>>()
+        every { mapboxDirections.enqueueCall(capture(routeListener)) } answers {
+            routeCallback = routeListener.captured
         }
         every { routeOptions.coordinates().size } returns 2
-        every { call.isCanceled } returns false
+        every { routeCall.isCanceled } returns false
 
         // refresh
+        mockkObject(RouteRefreshCallbackMapper)
         every { RouteBuilderProvider.getRefreshBuilder() } returns mapboxDirectionsRefreshBuilder
         every {
             mapboxDirectionsRefreshBuilder.accessToken(accessToken)
@@ -78,13 +82,20 @@ class MapboxOffboardRouterTest : BaseTest() {
         every {
             mapboxDirectionsRefreshBuilder.routeIndex(any())
         } returns mapboxDirectionsRefreshBuilder
+        every { mapboxDirectionsRefreshBuilder.build() } returns mapboxDirectionsRefresh
+        val refreshListener = slot<Callback<DirectionsRefreshResponse>>()
+        every { mapboxDirectionsRefresh.enqueueCall(capture(refreshListener)) } answers {
+            refreshCallback = refreshListener.captured
+        }
 
-        offboardRouter = MapboxOffboardRouter(accessToken, context, mockSkuTokenProvider, true)
+        offboardRouter =
+            MapboxOffboardRouter(accessToken, context, mockSkuTokenProvider, true, mockk())
     }
 
     @After
     fun freeRecourse() {
         unmockkObject(RouteBuilderProvider)
+        unmockkObject(RouteRefreshCallbackMapper)
     }
 
     @Test
@@ -94,23 +105,49 @@ class MapboxOffboardRouterTest : BaseTest() {
 
     @Test
     fun getRoute_NavigationRouteGetRouteCalled() {
-        getRoute(mockk())
+        offboardRouter.getRoute(routeOptions, mockk())
 
-        verify { mapboxDirections.enqueueCall(callback) }
+        verify { mapboxDirections.enqueueCall(routeCallback) }
     }
 
     @Test
-    fun cancel_NavigationRouteCancelCallCalled() {
-        getRoute(mockk())
+    fun cancelAll_NavigationRouteCancelCallCalled() {
+        offboardRouter.getRoute(routeOptions, mockk())
 
-        offboardRouter.cancel()
+        offboardRouter.cancelAll()
 
         verify { mapboxDirections.cancelCall() }
     }
 
     @Test
+    fun `cancel a specific route request when multiple are running`() {
+        val newMapboxDirections = mockk<MapboxDirections>(relaxed = true)
+        var firstCall = true
+        every { mapboxDirectionsBuilder.build() } answers {
+            if (firstCall) {
+                firstCall = false
+                mapboxDirections
+            } else {
+                newMapboxDirections
+            }
+        }
+        val firstId = offboardRouter.getRoute(routeOptions, mockk())
+        val secondId = offboardRouter.getRoute(routeOptions, mockk())
+        verify(exactly = 0) { mapboxDirections.cancelCall() }
+        verify(exactly = 0) { newMapboxDirections.cancelCall() }
+
+        offboardRouter.cancelRouteRequest(firstId)
+        verify(exactly = 1) { mapboxDirections.cancelCall() }
+        verify(exactly = 0) { newMapboxDirections.cancelCall() }
+
+        offboardRouter.cancelRouteRequest(secondId)
+        verify(exactly = 1) { mapboxDirections.cancelCall() }
+        verify(exactly = 1) { newMapboxDirections.cancelCall() }
+    }
+
+    @Test
     fun cancel_NavigationRouteCancelCallNotCalled() {
-        offboardRouter.cancel()
+        offboardRouter.cancelAll()
 
         verify(exactly = 0) { mapboxDirections.cancelCall() }
     }
@@ -119,22 +156,22 @@ class MapboxOffboardRouterTest : BaseTest() {
     fun onSuccessfulResponseAndHasRoutes_onRouteReadyCalled() {
         val routerCallback = mockk<Router.Callback>(relaxed = true)
         val route = buildMultipleLegRoute()
-        val response = buildResponse(listOf(route), true)
-        getRoute(routerCallback)
+        val response = buildRouteResponse(listOf(route), true)
+        offboardRouter.getRoute(routeOptions, routerCallback)
 
-        callback.onResponse(call, response)
+        routeCallback.onResponse(routeCall, response)
 
-        verify { routerCallback.onResponse(any()) }
+        verify { routerCallback.onResponse(listOf(route)) }
     }
 
     @Test
     fun onUnsuccessfulResponseAndHasRoutes_errorIsProvided() {
         val routerCallback = mockk<Router.Callback>(relaxed = true)
         val route = buildMultipleLegRoute()
-        val response = buildResponse(listOf(route), false)
-        getRoute(routerCallback)
+        val response = buildRouteResponse(listOf(route), false)
+        offboardRouter.getRoute(routeOptions, routerCallback)
 
-        callback.onResponse(call, response)
+        routeCallback.onResponse(routeCall, response)
 
         verify { routerCallback.onFailure(any()) }
     }
@@ -142,10 +179,10 @@ class MapboxOffboardRouterTest : BaseTest() {
     @Test
     fun onSuccessfulResponseAndNoRoutes_errorIsProvided() {
         val routerCallback = mockk<Router.Callback>(relaxed = true)
-        val response = buildResponse(listOf(), true)
-        getRoute(routerCallback)
+        val response = buildRouteResponse(listOf(), true)
+        offboardRouter.getRoute(routeOptions, routerCallback)
 
-        callback.onResponse(call, response)
+        routeCallback.onResponse(routeCall, response)
 
         verify { routerCallback.onFailure(any()) }
     }
@@ -153,10 +190,10 @@ class MapboxOffboardRouterTest : BaseTest() {
     @Test
     fun onUnsuccessfulResponseAndNoRoutes_errorIsProvided() {
         val routerCallback = mockk<Router.Callback>(relaxed = true)
-        val response = buildResponse(listOf(), false)
-        getRoute(routerCallback)
+        val response = buildRouteResponse(listOf(), false)
+        offboardRouter.getRoute(routeOptions, routerCallback)
 
-        callback.onResponse(call, response)
+        routeCallback.onResponse(routeCall, response)
 
         verify { routerCallback.onFailure(any()) }
     }
@@ -165,9 +202,9 @@ class MapboxOffboardRouterTest : BaseTest() {
     fun onFailure_errorIsProvided() {
         val routerCallback = mockk<Router.Callback>(relaxed = true)
         val throwable = mockk<Throwable>()
-        getRoute(routerCallback)
+        offboardRouter.getRoute(routeOptions, routerCallback)
 
-        callback.onFailure(call, throwable)
+        routeCallback.onFailure(routeCall, throwable)
 
         verify { routerCallback.onFailure(throwable) }
     }
@@ -176,12 +213,12 @@ class MapboxOffboardRouterTest : BaseTest() {
     fun onFailure_canceled_onCanceledIsCalled() {
         val routerCallback = mockk<Router.Callback>(relaxed = true)
         val throwable = mockk<Throwable>()
-        getRoute(routerCallback)
+        offboardRouter.getRoute(routeOptions, routerCallback)
 
         val call: Call<DirectionsResponse> = mockk()
         every { call.isCanceled } returns true
 
-        callback.onFailure(call, throwable)
+        routeCallback.onFailure(call, throwable)
 
         verify { routerCallback.onCanceled() }
     }
@@ -190,33 +227,56 @@ class MapboxOffboardRouterTest : BaseTest() {
     fun onSuccess_canceled_onCanceledIsCalled() {
         val routerCallback = mockk<Router.Callback>(relaxed = true)
         val route = buildMultipleLegRoute()
-        val response = buildResponse(listOf(route), true)
-        getRoute(routerCallback)
+        val response = buildRouteResponse(listOf(route), true)
+        offboardRouter.getRoute(routeOptions, routerCallback)
 
-        every { call.isCanceled } returns true
+        every { routeCall.isCanceled } returns true
 
-        callback.onResponse(call, response)
+        routeCallback.onResponse(routeCall, response)
 
         verify { routerCallback.onCanceled() }
     }
 
     @Test
+    fun `route request list cleared on response`() {
+        offboardRouter.getRoute(routeOptions, mockk(relaxUnitFun = true))
+        val route = buildMultipleLegRoute()
+        val response = buildRouteResponse(listOf(route), true)
+
+        routeCallback.onResponse(routeCall, response)
+        offboardRouter.cancelAll()
+
+        verify(exactly = 0) { mapboxDirections.cancelCall() }
+    }
+
+    @Test
+    fun `route request list cleared on failure`() {
+        offboardRouter.getRoute(routeOptions, mockk(relaxUnitFun = true))
+        val throwable = mockk<Throwable>()
+
+        routeCallback.onFailure(routeCall, throwable)
+        offboardRouter.cancelAll()
+
+        verify(exactly = 0) { mapboxDirections.cancelCall() }
+    }
+
+    @Test
     fun `route refresh set right params`() {
         val route = mockRouteForRefresh("uuid_123", "1")
-        getRouteRefresh(route, 0, mockk(relaxUnitFun = true))
+        offboardRouter.getRouteRefresh(route, 1, mockk(relaxUnitFun = true))
 
         verify(exactly = 1) {
             mapboxDirectionsRefreshBuilder.accessToken(accessToken)
             mapboxDirectionsRefreshBuilder.requestId("uuid_123")
             mapboxDirectionsRefreshBuilder.routeIndex(1)
-            mapboxDirectionsRefreshBuilder.legIndex(0)
+            mapboxDirectionsRefreshBuilder.legIndex(1)
         }
     }
 
     @Test
     fun `route refresh set non-valid route index`() {
         val route = mockRouteForRefresh("uuid_321", "")
-        getRouteRefresh(route, 1, mockk(relaxUnitFun = true))
+        offboardRouter.getRouteRefresh(route, 1, mockk(relaxUnitFun = true))
 
         verify(exactly = 1) {
             mapboxDirectionsRefreshBuilder.accessToken(accessToken)
@@ -227,32 +287,173 @@ class MapboxOffboardRouterTest : BaseTest() {
     }
 
     @Test
-    fun `route refresh throws exception`() {
-        val callback = mockk<RouteRefreshCallback>()
-        val routeRefreshError = slot<RouteRefreshError>()
-        every { callback.onError(capture(routeRefreshError)) } returns Unit
-        every { mapboxDirectionsRefreshBuilder.interceptor(any()) }.throws(Exception("Exception"))
+    fun `route refresh successful`() {
+        val originalRoute = mockRouteForRefresh("uuid_123", "1")
+        val annotationRoute = mockAnnotationsForRefresh()
+        val resultingRoute = mockk<DirectionsRoute>()
+        val callback = mockk<RouteRefreshCallback>(relaxUnitFun = true)
+        val response = buildRefreshResponse(mockk(), true)
+        every { response.body() } returns mockk {
+            every { route() } returns annotationRoute
+        }
+        every {
+            RouteRefreshCallbackMapper.mapToDirectionsRoute(
+                originalRoute,
+                annotationRoute
+            )
+        } returns resultingRoute
 
-        getRouteRefresh(mockRouteForRefresh("uuid_123", "2"), 0, callback)
+        offboardRouter.getRouteRefresh(originalRoute, 0, callback)
 
-        assertEquals("Route refresh call failed", routeRefreshError.captured.message)
-        assertTrue(routeRefreshError.captured.throwable is Exception)
-        assertEquals("Exception", routeRefreshError.captured.throwable?.message)
+        refreshCallback.onResponse(refreshCall, response)
+
+        verify(exactly = 1) { callback.onRefresh(resultingRoute) }
     }
 
-    private fun getRoute(routerCallback: Router.Callback) {
-        offboardRouter.getRoute(routeOptions, routerCallback)
+    @Test
+    fun `route refresh failure - failed to parse`() {
+        val originalRoute = mockRouteForRefresh("uuid_123", "1")
+        val annotationRoute = mockAnnotationsForRefresh()
+        val callback = mockk<RouteRefreshCallback>(relaxUnitFun = true)
+        val response = buildRefreshResponse(mockk(), true)
+        val ex = mockk<Exception>()
+        every { response.body() } returns mockk {
+            every { route() } returns annotationRoute
+        }
+        every {
+            RouteRefreshCallbackMapper.mapToDirectionsRoute(
+                originalRoute,
+                annotationRoute
+            )
+        }.throws(ex)
+
+        offboardRouter.getRouteRefresh(originalRoute, 0, callback)
+
+        refreshCallback.onResponse(refreshCall, response)
+
+        verify(exactly = 1) {
+            callback.onError(
+                RouteRefreshError("Failed to read refresh response", ex)
+            )
+        }
     }
 
-    private fun getRouteRefresh(
-        route: DirectionsRoute,
-        legIndex: Int,
-        callback: RouteRefreshCallback
-    ) {
-        offboardRouter.getRouteRefresh(route, legIndex, callback)
+    @Test
+    fun `route refresh failure - failed response`() {
+        val originalRoute = mockRouteForRefresh("uuid_123", "1")
+        val callback = mockk<RouteRefreshCallback>(relaxUnitFun = true)
+        val ex = mockk<Exception>()
+
+        offboardRouter.getRouteRefresh(originalRoute, 0, callback)
+
+        refreshCallback.onFailure(refreshCall, ex)
+
+        verify(exactly = 1) { callback.onError(RouteRefreshError(throwable = ex)) }
     }
 
-    private fun buildResponse(
+    @Test
+    fun `route refresh failure - unsuccessful response`() {
+        val originalRoute = mockRouteForRefresh("uuid_123", "1")
+        val annotationRoute = mockAnnotationsForRefresh()
+        val resultingRoute = mockk<DirectionsRoute>()
+        val callback = mockk<RouteRefreshCallback>(relaxUnitFun = true)
+        val response = buildRefreshResponse(mockk(), false)
+        every { response.body() } returns mockk {
+            every { route() } returns annotationRoute
+        }
+        every {
+            RouteRefreshCallbackMapper.mapToDirectionsRoute(
+                originalRoute,
+                annotationRoute
+            )
+        } returns resultingRoute
+
+        offboardRouter.getRouteRefresh(originalRoute, 0, callback)
+
+        refreshCallback.onResponse(refreshCall, response)
+
+        verify(exactly = 1) { callback.onError(any()) }
+    }
+
+    @Test
+    fun `cancel all refresh calls`() {
+        val originalRoute = mockRouteForRefresh("uuid_123", "1")
+        offboardRouter.getRouteRefresh(originalRoute, 0, mockk())
+
+        offboardRouter.cancelAll()
+
+        verify { mapboxDirectionsRefresh.cancelCall() }
+    }
+
+    @Test
+    fun `cancel a specific refresh request when multiple are running`() {
+        val originalRoute = mockRouteForRefresh("uuid_123", "1")
+        val newMapboxDirectionsRefresh = mockk<MapboxDirectionsRefresh>(relaxed = true)
+        var firstCall = true
+        every { mapboxDirectionsRefreshBuilder.build() } answers {
+            if (firstCall) {
+                firstCall = false
+                mapboxDirectionsRefresh
+            } else {
+                newMapboxDirectionsRefresh
+            }
+        }
+        val firstId = offboardRouter.getRouteRefresh(originalRoute, 0, mockk())
+        val secondId = offboardRouter.getRouteRefresh(originalRoute, 0, mockk())
+        verify(exactly = 0) { mapboxDirectionsRefresh.cancelCall() }
+        verify(exactly = 0) { newMapboxDirectionsRefresh.cancelCall() }
+
+        offboardRouter.cancelRouteRefreshRequest(firstId)
+        verify(exactly = 1) { mapboxDirectionsRefresh.cancelCall() }
+        verify(exactly = 0) { newMapboxDirectionsRefresh.cancelCall() }
+
+        offboardRouter.cancelRouteRefreshRequest(secondId)
+        verify(exactly = 1) { mapboxDirectionsRefresh.cancelCall() }
+        verify(exactly = 1) { newMapboxDirectionsRefresh.cancelCall() }
+    }
+
+    @Test
+    fun `refresh request list cleared on response`() {
+        val originalRoute = mockRouteForRefresh("uuid_123", "1")
+        val annotationRoute = mockAnnotationsForRefresh()
+        val resultingRoute = mockk<DirectionsRoute>()
+        val callback = mockk<RouteRefreshCallback>(relaxUnitFun = true)
+        val response = buildRefreshResponse(mockk(), true)
+        every { response.body() } returns mockk {
+            every { route() } returns annotationRoute
+        }
+        every {
+            RouteRefreshCallbackMapper.mapToDirectionsRoute(
+                originalRoute,
+                annotationRoute
+            )
+        } returns resultingRoute
+
+        offboardRouter.getRouteRefresh(originalRoute, 0, callback)
+
+        refreshCallback.onResponse(refreshCall, response)
+
+        offboardRouter.cancelAll()
+
+        verify(exactly = 0) { mapboxDirectionsRefresh.cancelCall() }
+    }
+
+    @Test
+    fun `refresh request list cleared on failure`() {
+        val originalRoute = mockRouteForRefresh("uuid_123", "1")
+        val callback = mockk<RouteRefreshCallback>(relaxUnitFun = true)
+        val ex = mockk<Exception>()
+
+        offboardRouter.getRouteRefresh(originalRoute, 0, callback)
+
+        refreshCallback.onFailure(refreshCall, ex)
+
+        offboardRouter.cancelAll()
+
+        verify(exactly = 0) { mapboxDirectionsRefresh.cancelCall() }
+    }
+
+    private fun buildRouteResponse(
         routeList: List<DirectionsRoute>,
         isSuccessful: Boolean
     ): Response<DirectionsResponse> {
@@ -261,6 +462,23 @@ class MapboxOffboardRouterTest : BaseTest() {
         every { directionsResponse.routes() } returns routeList
         every { response.body() } returns directionsResponse
         every { response.isSuccessful } returns isSuccessful
+        every { response.message() } returns "mock"
+
+        return response
+    }
+
+    private fun buildRefreshResponse(
+        route: DirectionsRouteRefresh,
+        isSuccessful: Boolean
+    ): Response<DirectionsRefreshResponse> {
+        val response = mockk<Response<DirectionsRefreshResponse>>()
+        val refreshResponse = mockk<DirectionsRefreshResponse>()
+        every { refreshResponse.route() } returns route
+        every { response.body() } returns refreshResponse
+        every { response.isSuccessful } returns isSuccessful
+        every { response.message() } returns "mock"
+        every { response.code() } returns 123
+        every { response.errorBody() } returns mockk()
 
         return response
     }
@@ -272,4 +490,6 @@ class MapboxOffboardRouterTest : BaseTest() {
         every { it.routeOptions()?.requestUuid() } returns uuid
         every { it.routeIndex() } returns routeIndex
     }
+
+    private fun mockAnnotationsForRefresh(): DirectionsRouteRefresh = mockk()
 }

--- a/libnavigation-router/src/test/java/com/mapbox/navigation/route/offboard/routerefresh/RouteRefreshCallbackMapperTest.kt
+++ b/libnavigation-router/src/test/java/com/mapbox/navigation/route/offboard/routerefresh/RouteRefreshCallbackMapperTest.kt
@@ -3,73 +3,30 @@ package com.mapbox.navigation.route.offboard.routerefresh
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.LegAnnotation
 import com.mapbox.api.directions.v5.models.RouteLeg
-import com.mapbox.api.directionsrefresh.v1.models.DirectionsRefreshResponse
 import com.mapbox.api.directionsrefresh.v1.models.DirectionsRouteRefresh
 import com.mapbox.api.directionsrefresh.v1.models.RouteLegRefresh
-import com.mapbox.navigation.base.route.RouteRefreshCallback
-import com.mapbox.navigation.base.route.RouteRefreshError
-import io.mockk.every
 import io.mockk.mockk
-import io.mockk.slot
-import io.mockk.verify
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
 import org.junit.Test
-import retrofit2.Response
 
 class RouteRefreshCallbackMapperTest {
 
     @Test
-    fun sanity() {
-        RouteRefreshCallbackMapper(mockk(), mockk())
-    }
-
-    @Test
-    fun testError() {
-        val callback = mockCallback()
-        val error = slot<RouteRefreshError>()
-        val throwable: Throwable = mockk()
-        every { callback.onError(capture(error)) } returns Unit
-        val routeRefreshCallbackMapper = RouteRefreshCallbackMapper(originalRoute(), callback)
-
-        routeRefreshCallbackMapper.onFailure(mockk(), throwable)
-
-        verify {
-            callback.onError(error.captured)
-        }
-        assertEquals(error.captured.throwable, throwable)
-    }
-
-    @Test
     fun testResponse() {
-        val callback = mockCallback()
-        val directionsRoute = slot<DirectionsRoute>()
-        every { callback.onRefresh(capture(directionsRoute)) } returns Unit
-        val routeRefreshCallbackMapper = RouteRefreshCallbackMapper(originalRoute(), callback)
-        val responseMock = mockResponse(refreshRoute())
+        val originalRoute = originalRoute()
+        val refreshRoute = refreshRoute()
+        val result = RouteRefreshCallbackMapper.mapToDirectionsRoute(
+            originalRoute,
+            refreshRoute
+        )
 
-        routeRefreshCallbackMapper.onResponse(mockk(), responseMock)
-        val captured = directionsRoute.captured
-
-        verify(exactly = 1) { callback.onRefresh(captured) }
-        assertNotNull(captured)
         for (i in 0..1) {
             assertEquals(
-                refreshRoute().legs()!![i].annotation(),
-                captured.legs()!![i].annotation()
+                refreshRoute.legs()!![i].annotation(),
+                result!!.legs()!![i].annotation()
             )
         }
     }
-
-    private fun mockResponse(
-        directionsRouteRefresh: DirectionsRouteRefresh
-    ): Response<DirectionsRefreshResponse> {
-        val response: Response<DirectionsRefreshResponse> = mockk()
-        every { response.body()?.route() } returns directionsRouteRefresh
-        return response
-    }
-
-    private fun mockCallback(): RouteRefreshCallback = mockk(relaxUnitFun = true)
 
     private fun refreshRoute(): DirectionsRouteRefresh =
         DirectionsRouteRefresh.builder()
@@ -94,6 +51,9 @@ class RouteRefreshCallbackMapperTest {
                                     )
                                 )
                                 .distance(listOf(1.0, 2.0, 3.0))
+                                .duration(listOf(4.0, 5.0, 6.0))
+                                .maxspeed(listOf(mockk(), mockk(), mockk()))
+                                .speed(listOf(7.0, 8.0, 9.0))
                                 .build()
                         )
                         .build()

--- a/libnavigation-util/build.gradle
+++ b/libnavigation-util/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation dependenciesList.coroutinesAndroid
     implementation dependenciesList.androidXCore
     api dependenciesList.mapboxSdkDirectionsModels
+    api dependenciesList.mapboxAndroidCommon
 
     apply from: "${rootDir}/gradle/unit-testing-dependencies.gradle"
     testImplementation project(':libtesting-utils')

--- a/libnavigation-util/src/main/java/com/mapbox/navigation/utils/internal/RequestMap.kt
+++ b/libnavigation-util/src/main/java/com/mapbox/navigation/utils/internal/RequestMap.kt
@@ -1,0 +1,58 @@
+package com.mapbox.navigation.utils.internal
+
+import com.mapbox.base.common.logger.Logger
+import com.mapbox.base.common.logger.model.Message
+import com.mapbox.base.common.logger.model.Tag
+
+class RequestMap<T> {
+    private val requestIdGenerator = RequestIdGenerator()
+    private val requests = mutableMapOf<Long, T>()
+
+    fun put(value: T): Long {
+        val requestId = requestIdGenerator.generateRequestId()
+        put(requestId, value)
+        return requestId
+    }
+
+    fun put(requestId: Long, value: T) {
+        requests.put(requestId, value)?.let {
+            throw IllegalArgumentException(
+                "The request with ID '$requestId' is already in progress."
+            )
+        }
+    }
+
+    fun get(id: Long): T? = requests[id]
+
+    fun remove(id: Long): T? = requests.remove(id)
+
+    fun removeAll(): List<T> {
+        val values = requests.values.toList()
+        requests.clear()
+        return values
+    }
+
+    fun generateNextRequestId() = requestIdGenerator.generateRequestId()
+}
+
+private class RequestIdGenerator {
+    private var lastRequestId = 0L
+    fun generateRequestId(): Long = ++lastRequestId
+}
+
+fun <T> RequestMap<T>.cancelRequest(
+    requestId: Long,
+    logger: Logger,
+    tag: Tag,
+    cancellationFn: (T) -> Unit
+) {
+    val request = this.remove(requestId)
+    if (request != null) {
+        cancellationFn(request)
+    } else {
+        logger.w(
+            tag,
+            Message("Trying to cancel non-existing route request with id '$requestId'")
+        )
+    }
+}


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

This PR adds an ability for a user of the SDK to request a route without that request result automatically being set as the primary route for turn-by-turn session.

Now, the `MapboxNavigation` class will expose 3 methods:
- `requestRoutes(callback)`, async method that requests routes using the hybrid router (generated offboard or onboard depending on connectivity state) and returns them in a callback without any other action. This route can be compared against the current primary route, shown as an alternative, or processed in any other way without impacting the current navigation experience.
- `cancelRouteRequest(requestId)`, method that cancels an ongoing route request.
- `setRoutes(route)`, method to set a route from external source, or from the result of  `requestRoutes` if desired.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Changed `MapboxNavigation#requestRoutes` to **not** automatically set the result as the primary route for the navigation experience. When calling `MapboxNavigation#requestRoutes` make sure to also call `MapboxNavigation#setRoutes` with a result. This change allows for dispatching and managing multiple route requests concurrently.</changelog>
```

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->

https://user-images.githubusercontent.com/16925074/112662498-0cec2180-8e58-11eb-8f4e-7a010557aaff.mp4


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->

cc @mapbox/navigation-android @zugaldia 