### PR TITLE
CherryPick - Fix bearings calculations when reroute

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/routeoptions/MapboxRouteOptionsUpdater.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/routeoptions/MapboxRouteOptionsUpdater.kt
@@ -54,10 +54,10 @@ class MapboxRouteOptionsUpdater(
                     )
                     .bearingsList(
                         getUpdatedBearingList(
-                            index,
                             coordinates.size,
                             location.bearing.toDouble(),
-                            routeOptions.bearingsList()
+                            routeOptions.bearingsList(),
+                            remainingWaypoints
                         )
                     )
                     .radiusesList(
@@ -117,10 +117,10 @@ class MapboxRouteOptionsUpdater(
     }
 
     private fun getUpdatedBearingList(
-        legIndex: Int,
         coordinates: Int,
         currentAngle: Double,
-        legacyBearingList: List<List<Double>?>?
+        legacyBearingList: List<List<Double>?>?,
+        remainingWaypoints: Int
     ): MutableList<List<Double>?> {
         return ArrayList<List<Double>?>().also { newList ->
             val originTolerance = legacyBearingList?.getOrNull(0)
@@ -131,13 +131,13 @@ class MapboxRouteOptionsUpdater(
             if (legacyBearingList != null) {
                 newList.addAll(
                     legacyBearingList.subList(
-                        legIndex + 1,
+                        coordinates - remainingWaypoints,
                         min(legacyBearingList.size, coordinates)
                     )
                 )
             }
 
-            while (newList.size < coordinates) {
+            while (newList.size < remainingWaypoints + 1) {
                 newList.add(null)
             }
         }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/routeoptions/MapboxRouteOptionsUpdaterTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/routeoptions/MapboxRouteOptionsUpdaterTest.kt
@@ -208,7 +208,7 @@ class MapboxRouteOptionsUpdaterTest {
                             DEFAULT_REROUTE_BEARING_ANGLE.toDouble(),
                             2.0
                         ),
-                        listOf(3.0, 4.0),
+                        null,
                         null
                     )
                 ),

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/routeoptions/MapboxRouteOptionsUpdaterTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/routeoptions/MapboxRouteOptionsUpdaterTest.kt
@@ -159,6 +159,7 @@ class MapboxRouteOptionsUpdaterTest {
     @RunWith(Parameterized::class)
     class BearingOptionsParameterized(
         val routeOptions: RouteOptions,
+        val remainingWaypointsParameter: Int,
         val expectedBearings: List<List<Double>?>
     ) {
         @MockK
@@ -173,6 +174,7 @@ class MapboxRouteOptionsUpdaterTest {
             fun params() = listOf(
                 arrayOf(
                     provideRouteOptionsWithCoordinatesAndBearings(),
+                    3,
                     listOf(
                         listOf(DEFAULT_REROUTE_BEARING_ANGLE.toDouble(), 10.0),
                         listOf(20.0, 20.0),
@@ -182,13 +184,12 @@ class MapboxRouteOptionsUpdaterTest {
                 ),
                 arrayOf(
                     provideRouteOptionsWithCoordinates(),
+                    1,
                     listOf(
                         listOf(
                             DEFAULT_REROUTE_BEARING_ANGLE.toDouble(),
                             DEFAULT_REROUTE_BEARING_TOLERANCE
                         ),
-                        null,
-                        null,
                         null
                     )
                 ),
@@ -201,13 +202,13 @@ class MapboxRouteOptionsUpdaterTest {
                             )
                         )
                         .build(),
+                    2,
                     listOf(
                         listOf(
                             DEFAULT_REROUTE_BEARING_ANGLE.toDouble(),
                             2.0
                         ),
                         listOf(3.0, 4.0),
-                        null,
                         null
                     )
                 ),
@@ -222,6 +223,7 @@ class MapboxRouteOptionsUpdaterTest {
                             )
                         )
                         .build(),
+                    3,
                     listOf(
                         listOf(
                             DEFAULT_REROUTE_BEARING_ANGLE.toDouble(),
@@ -246,9 +248,8 @@ class MapboxRouteOptionsUpdaterTest {
         @Test
         fun bearingOptions() {
             val routeProgress: RouteProgress = mockk(relaxed = true) {
-                every { remainingWaypoints } returns routeOptions.coordinates().size - 1
+                every { remainingWaypoints } returns remainingWaypointsParameter
             }
-
 
             val newRouteOptions =
                 routeRefreshAdapter.update(routeOptions, routeProgress, location)

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/routeoptions/MapboxRouteOptionsUpdaterTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/routeoptions/MapboxRouteOptionsUpdaterTest.kt
@@ -51,9 +51,7 @@ class MapboxRouteOptionsUpdaterTest {
                         listOf(10.0, 10.0),
                         listOf(20.0, 20.0),
                         listOf(30.0, 30.0),
-                        listOf(40.0, 40.0),
-                        listOf(50.0, 50.0),
-                        listOf(60.0, 60.0)
+                        listOf(40.0, 40.0)
                     )
                 )
                 .build()
@@ -82,7 +80,9 @@ class MapboxRouteOptionsUpdaterTest {
     @Test
     fun new_options_return_with_null_bearings() {
         val routeOptions = provideRouteOptionsWithCoordinates()
-        val routeProgress: RouteProgress = mockk(relaxed = true)
+        val routeProgress: RouteProgress = mockk(relaxed = true) {
+            every { remainingWaypoints } returns 1
+        }
 
         val newRouteOptions =
             routeRefreshAdapter.update(routeOptions, routeProgress, location)
@@ -97,8 +97,6 @@ class MapboxRouteOptionsUpdaterTest {
                 DEFAULT_REROUTE_BEARING_ANGLE.toDouble(),
                 DEFAULT_REROUTE_BEARING_TOLERANCE
             ),
-            null,
-            null,
             null
         )
         val actualBearings = newRouteOptions.bearingsList()
@@ -109,7 +107,9 @@ class MapboxRouteOptionsUpdaterTest {
     @Test
     fun new_options_return_with_bearing() {
         val routeOptions = provideRouteOptionsWithCoordinatesAndBearings()
-        val routeProgress: RouteProgress = mockk(relaxed = true)
+        val routeProgress: RouteProgress = mockk(relaxed = true) {
+            every { remainingWaypoints } returns 1
+        }
 
         val newRouteOptions =
             routeRefreshAdapter.update(routeOptions, routeProgress, location)
@@ -121,8 +121,6 @@ class MapboxRouteOptionsUpdaterTest {
 
         val expectedBearings = listOf(
             listOf(DEFAULT_REROUTE_BEARING_ANGLE.toDouble(), 10.0),
-            listOf(20.0, 20.0),
-            listOf(30.0, 30.0),
             listOf(40.0, 40.0)
         )
         val actualBearings = newRouteOptions.bearingsList()
@@ -212,6 +210,27 @@ class MapboxRouteOptionsUpdaterTest {
                         null,
                         null
                     )
+                ),
+                arrayOf(
+                    provideRouteOptionsWithCoordinates().toBuilder()
+                        .bearingsList(
+                            listOf(
+                                listOf(1.0, 2.0),
+                                listOf(3.0, 4.0),
+                                listOf(5.0, 6.0),
+                                listOf(7.0, 8.0)
+                            )
+                        )
+                        .build(),
+                    listOf(
+                        listOf(
+                            DEFAULT_REROUTE_BEARING_ANGLE.toDouble(),
+                            2.0
+                        ),
+                        listOf(3.0, 4.0),
+                        listOf(5.0, 6.0),
+                        listOf(7.0, 8.0)
+                    )
                 )
             )
         }
@@ -226,7 +245,10 @@ class MapboxRouteOptionsUpdaterTest {
 
         @Test
         fun bearingOptions() {
-            val routeProgress: RouteProgress = mockk(relaxed = true)
+            val routeProgress: RouteProgress = mockk(relaxed = true) {
+                every { remainingWaypoints } returns routeOptions.coordinates().size - 1
+            }
+
 
             val newRouteOptions =
                 routeRefreshAdapter.update(routeOptions, routeProgress, location)


### PR DESCRIPTION
### Description
This PR is cherry pick of [this changes](https://github.com/mapbox/mapbox-navigation-android/pull/4169)

### Changelog
```
<changelog>Fixed bearings calculation when reroute happened</changelog>
```