### PR TITLE
Removed the unused Picasso reference

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -46,7 +46,6 @@ ext {
       mockwebserver             : '4.9.0',
       lifecycle                 : '2.2.0',
       lifecycleViewModelKtx     : '2.2.0',
-      picasso                   : '2.71828',
       gmsLocation               : '17.0.0',
       ktlint                    : '0.41.0',
       kotlinStdLib              : '1.4.30',
@@ -127,7 +126,6 @@ ext {
 
       // square crew
       timber                    : "com.jakewharton.timber:timber:${version.timber}",
-      picasso                   : "com.squareup.picasso:picasso:${version.picasso}",
       leakCanaryDebug           : "com.squareup.leakcanary:leakcanary-android:${version.leakCanaryVersion}",
 
       // instrumentation test


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

We stopped using Picasso some time ago. This PR cleans up the reference in the script files.