### PR TITLE
Modification so that there is no wait for vanishing route line initialization.

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/internal/MapboxRouteLineActivity.java
+++ b/examples/src/main/java/com/mapbox/navigation/examples/internal/MapboxRouteLineActivity.java
@@ -7,7 +7,6 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.VibrationEffect;
 import android.os.Vibrator;
-import android.util.Log;
 import android.view.View;
 import android.widget.Button;
 import android.widget.ProgressBar;

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApi.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApi.kt
@@ -619,10 +619,8 @@ class MapboxRouteLineApi(
         routeFeatureData.addAll(routeFeatureDataDef.await())
         val partitionedRoutes = routeFeatureData.partition { it.route == directionsRoutes.first() }
 
-        val vanishingRouteLineInitDef = jobControl.scope.async(ThreadController.IODispatcher) {
-            partitionedRoutes.first.firstOrNull()?.let {
-                routeLineOptions.vanishingRouteLine?.initWithRoute(it.route)
-            }
+        partitionedRoutes.first.firstOrNull()?.let {
+            routeLineOptions.vanishingRouteLine?.initWithRoute(it.route)
         }
 
         val trafficLineExpressionDef = jobControl.scope.async(ThreadController.IODispatcher) {
@@ -758,7 +756,6 @@ class MapboxRouteLineApi(
         val wayPointsFeatureCollection = wayPointsFeatureCollectionDef.await()
         val primaryRouteSource = primaryRouteSourceDef.await()
         val restrictedSectionFeatureCollection = restrictedSectionFeatureCollectionDef.await()
-        vanishingRouteLineInitDef.await()
 
         return Expected.Success(
             RouteSetValue(


### PR DESCRIPTION
### Description
Through some measurements of the route line calculations it was discovered the initialization of the vanishing route line is expensive and increases the total calculation time.  However, this calculation isn't needed for the drawing of the route line(s).  Instead of waiting for the calculation it is launched on a worker thread without waiting.

### Changelog
```
<changelog>Performance improvements for route line API.</changelog>
```

### Screenshots or Gifs
