### PR TITLE
Display road closures on traffic line.

### DIFF
--- a/libnavui-base/api/current.txt
+++ b/libnavui-base/api/current.txt
@@ -28,6 +28,7 @@ package com.mapbox.navigation.ui.base.internal.model.route {
     method public int getALTERNATE_ROUTE_MODERATE_TRAFFIC_COLOR();
     method public int getALTERNATE_ROUTE_SEVERE_TRAFFIC_COLOR();
     method public int getALTERNATE_ROUTE_UNKNOWN_TRAFFIC_COLOR();
+    method public int getALTERNATIVE_ROUTE_CLOSURE_COLOR();
     method public Double![] getARROW_HEAD_CASING_OFFSET();
     method public Double![] getARROW_HEAD_OFFSET();
     method public int getDESTINATION_WAYPOINT_ICON();
@@ -39,6 +40,7 @@ package com.mapbox.navigation.ui.base.internal.model.route {
     method public int getRESTRICTED_ROAD_COLOR();
     method public java.util.List<java.lang.Double> getRESTRICTED_ROAD_DASH_ARRAY();
     method public int getROUTE_CASING_COLOR();
+    method public int getROUTE_CLOSURE_COLOR();
     method public int getROUTE_DEFAULT_COLOR();
     method public int getROUTE_HEAVY_TRAFFIC_COLOR();
     method public int getROUTE_LINE_TRAVELED_CASING_COLOR();
@@ -55,6 +57,7 @@ package com.mapbox.navigation.ui.base.internal.model.route {
     property public final int ALTERNATE_ROUTE_MODERATE_TRAFFIC_COLOR;
     property public final int ALTERNATE_ROUTE_SEVERE_TRAFFIC_COLOR;
     property public final int ALTERNATE_ROUTE_UNKNOWN_TRAFFIC_COLOR;
+    property public final int ALTERNATIVE_ROUTE_CLOSURE_COLOR;
     property public final Double![] ARROW_HEAD_CASING_OFFSET;
     property public final Double![] ARROW_HEAD_OFFSET;
     property public final int DESTINATION_WAYPOINT_ICON;
@@ -66,6 +69,7 @@ package com.mapbox.navigation.ui.base.internal.model.route {
     property public final int RESTRICTED_ROAD_COLOR;
     property public final java.util.List<java.lang.Double> RESTRICTED_ROAD_DASH_ARRAY;
     property public final int ROUTE_CASING_COLOR;
+    property public final int ROUTE_CLOSURE_COLOR;
     property public final int ROUTE_DEFAULT_COLOR;
     property public final int ROUTE_HEAVY_TRAFFIC_COLOR;
     property public final int ROUTE_LINE_TRAVELED_CASING_COLOR;
@@ -83,6 +87,7 @@ package com.mapbox.navigation.ui.base.internal.model.route {
     field public static final String ARROW_HEAD_SOURCE_ID = "mapbox-navigation-arrow-head-source";
     field public static final double ARROW_HIDDEN_ZOOM_LEVEL = 14.0;
     field public static final String ARROW_SHAFT_SOURCE_ID = "mapbox-navigation-arrow-shaft-source";
+    field public static final String ClOSURE_CONGESTION_VALUE = "closed";
     field public static final String DEFAULT_ROUTE_DESCRIPTOR_PLACEHOLDER = "mapboxDescriptorPlaceHolderUnused";
     field public static final double DEFAULT_ROUTE_SOURCES_TOLERANCE = 0.375;
     field public static final String DESTINATION_MARKER_NAME = "destinationMarker";

--- a/libnavui-base/src/main/java/com/mapbox/navigation/ui/base/internal/model/route/RouteConstants.kt
+++ b/libnavui-base/src/main/java/com/mapbox/navigation/ui/base/internal/model/route/RouteConstants.kt
@@ -42,6 +42,7 @@ object RouteConstants {
     const val HEAVY_CONGESTION_VALUE = "heavy"
     const val SEVERE_CONGESTION_VALUE = "severe"
     const val UNKNOWN_CONGESTION_VALUE = "unknown"
+    const val ClOSURE_CONGESTION_VALUE = "closed"
     const val ORIGIN_MARKER_NAME = "originMarker"
     const val DESTINATION_MARKER_NAME = "destinationMarker"
     const val ROUTE_LINE_UPDATE_MAX_DISTANCE_THRESHOLD_IN_METERS = 1.0
@@ -116,6 +117,12 @@ object RouteConstants {
 
     @ColorInt
     val MANEUVER_ARROW_BORDER_COLOR = Color.parseColor("#2D3F53")
+
+    @ColorInt
+    val ROUTE_CLOSURE_COLOR = Color.parseColor("#000000")
+
+    @ColorInt
+    val ALTERNATIVE_ROUTE_CLOSURE_COLOR = Color.parseColor("#333333")
 
     @DrawableRes
     val MANEUVER_ARROWHEAD_ICON_DRAWABLE: Int = R.drawable.mapbox_ic_arrow_head

--- a/libnavui-maps/api/current.txt
+++ b/libnavui-maps/api/current.txt
@@ -525,6 +525,7 @@ package com.mapbox.navigation.ui.maps.route.line.model {
 
   public final class RouteLineColorResources {
     method public int getAlternativeRouteCasingColor();
+    method public int getAlternativeRouteClosureColor();
     method public int getAlternativeRouteDefaultColor();
     method public int getAlternativeRouteHeavyColor();
     method public int getAlternativeRouteLowColor();
@@ -533,6 +534,7 @@ package com.mapbox.navigation.ui.maps.route.line.model {
     method public int getAlternativeRouteUnknownTrafficColor();
     method public int getRestrictedRoadColor();
     method public int getRouteCasingColor();
+    method public int getRouteClosureColor();
     method public int getRouteDefaultColor();
     method public int getRouteHeavyColor();
     method public int getRouteLineTraveledCasingColor();
@@ -543,6 +545,7 @@ package com.mapbox.navigation.ui.maps.route.line.model {
     method public int getRouteUnknownTrafficColor();
     method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineColorResources.Builder toBuilder();
     property public final int alternativeRouteCasingColor;
+    property public final int alternativeRouteClosureColor;
     property public final int alternativeRouteDefaultColor;
     property public final int alternativeRouteHeavyColor;
     property public final int alternativeRouteLowColor;
@@ -551,6 +554,7 @@ package com.mapbox.navigation.ui.maps.route.line.model {
     property public final int alternativeRouteUnknownTrafficColor;
     property public final int restrictedRoadColor;
     property public final int routeCasingColor;
+    property public final int routeClosureColor;
     property public final int routeDefaultColor;
     property public final int routeHeavyColor;
     property public final int routeLineTraveledCasingColor;
@@ -564,6 +568,7 @@ package com.mapbox.navigation.ui.maps.route.line.model {
   public static final class RouteLineColorResources.Builder {
     ctor public RouteLineColorResources.Builder();
     method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineColorResources.Builder alternativeRouteCasingColor(@ColorInt int color);
+    method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineColorResources.Builder alternativeRouteClosureColor(@ColorInt int color);
     method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineColorResources.Builder alternativeRouteDefaultColor(@ColorInt int color);
     method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineColorResources.Builder alternativeRouteHeavyColor(@ColorInt int color);
     method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineColorResources.Builder alternativeRouteLowColor(@ColorInt int color);
@@ -573,6 +578,7 @@ package com.mapbox.navigation.ui.maps.route.line.model {
     method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineColorResources build();
     method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineColorResources.Builder restrictedRoadColor(@ColorInt int color);
     method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineColorResources.Builder routeCasingColor(@ColorInt int color);
+    method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineColorResources.Builder routeClosureColor(@ColorInt int color);
     method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineColorResources.Builder routeDefaultColor(@ColorInt int color);
     method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineColorResources.Builder routeHeavyColor(@ColorInt int color);
     method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineColorResources.Builder routeLineTraveledCasingColor(@ColorInt int color);

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineColorResources.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineColorResources.kt
@@ -33,6 +33,8 @@ import com.mapbox.navigation.ui.base.internal.model.route.RouteConstants
  * @param alternativeRouteCasingColor the color used for the alternative route casing line(s) which
  * is positioned below the route line giving the line the appearance of a boarder
  * @param restrictedRoadColor the color for the restricted road indicator(s)
+ * @param routeClosureColor the color used for the route closure line
+ * @param alternativeRouteClosureColor the color used for the alternative route closure line(s)
  */
 class RouteLineColorResources private constructor(
     @ColorInt val routeLineTraveledColor: Int,
@@ -51,7 +53,9 @@ class RouteLineColorResources private constructor(
     @ColorInt val alternativeRouteHeavyColor: Int,
     @ColorInt val alternativeRouteSevereColor: Int,
     @ColorInt val alternativeRouteCasingColor: Int,
-    @ColorInt val restrictedRoadColor: Int
+    @ColorInt val restrictedRoadColor: Int,
+    @ColorInt val routeClosureColor: Int,
+    @ColorInt val alternativeRouteClosureColor: Int
 ) {
 
     /**
@@ -76,6 +80,8 @@ class RouteLineColorResources private constructor(
             .alternativeRouteSevereColor(alternativeRouteSevereColor)
             .alternativeRouteCasingColor(alternativeRouteCasingColor)
             .restrictedRoadColor(restrictedRoadColor)
+            .routeClosureColor(routeClosureColor)
+            .alternativeRouteClosureColor(alternativeRouteClosureColor)
     }
 
     /**
@@ -99,7 +105,10 @@ class RouteLineColorResources private constructor(
             "alternativeRouteHeavyColor=$alternativeRouteHeavyColor, " +
             "alternativeRouteSevereColor=$alternativeRouteSevereColor, " +
             "alternativeRouteCasingColor=$alternativeRouteCasingColor, " +
-            "restrictedRoadColor=$restrictedRoadColor)"
+            "restrictedRoadColor=$restrictedRoadColor, " +
+            "routeClosureColor=$routeClosureColor, " +
+            "alternativeRouteClosureColor=$alternativeRouteClosureColor" +
+            ")"
     }
 
     /**
@@ -129,6 +138,8 @@ class RouteLineColorResources private constructor(
         if (alternativeRouteUnknownTrafficColor != other.alternativeRouteUnknownTrafficColor)
             return false
         if (restrictedRoadColor != other.restrictedRoadColor) return false
+        if (routeClosureColor != other.routeClosureColor) return false
+        if (alternativeRouteClosureColor != other.alternativeRouteClosureColor) return false
 
         return true
     }
@@ -154,6 +165,8 @@ class RouteLineColorResources private constructor(
         result = 31 * result + alternativeRouteSevereColor
         result = 31 * result + alternativeRouteCasingColor
         result = 31 * result + restrictedRoadColor
+        result = 31 * result + routeClosureColor
+        result = 31 * result + alternativeRouteClosureColor
         return result
     }
 
@@ -183,6 +196,9 @@ class RouteLineColorResources private constructor(
         private var routeLineTraveledCasingColor: Int =
             RouteConstants.ROUTE_LINE_TRAVELED_CASING_COLOR
         private var restrictedRoadColor: Int = RouteConstants.RESTRICTED_ROAD_COLOR
+        private var routeClosureColor: Int = RouteConstants.ROUTE_CLOSURE_COLOR
+        private var alternativeRouteClosureColor: Int =
+            RouteConstants.ALTERNATIVE_ROUTE_CLOSURE_COLOR
 
         /**
          * The color of the section of route line behind the puck representing the section
@@ -360,6 +376,22 @@ class RouteLineColorResources private constructor(
             apply { this.restrictedRoadColor = color }
 
         /**
+         * The color used for road closure sections of a route.
+         *
+         * @param color the color to be used
+         */
+        fun routeClosureColor(@ColorInt color: Int): Builder =
+            apply { this.routeClosureColor = color }
+
+        /**
+         * The color used for road closure sections of an alternative route(s).
+         *
+         * @param color the color to be used
+         */
+        fun alternativeRouteClosureColor(@ColorInt color: Int): Builder =
+            apply { this.alternativeRouteClosureColor = color }
+
+        /**
          * Creates a instance of RouteLineResources
          *
          * @return the instance
@@ -382,7 +414,9 @@ class RouteLineColorResources private constructor(
                 alternativeRouteHeavyColor,
                 alternativeRouteSevereColor,
                 alternativeRouteCasingColor,
-                restrictedRoadColor
+                restrictedRoadColor,
+                routeClosureColor,
+                alternativeRouteClosureColor
             )
         }
     }

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtilsTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtilsTest.kt
@@ -2,6 +2,7 @@ package com.mapbox.navigation.ui.maps.internal.route.line
 
 import android.content.Context
 import android.graphics.Bitmap
+import android.graphics.Color
 import androidx.test.core.app.ApplicationProvider
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.bindgen.Expected
@@ -769,7 +770,7 @@ class MapboxRouteLineUtilsTest {
 
     @Test
     fun getRouteLineTrafficExpressionWithRoadClassesDuplicatesRemoved() {
-        val routeAsJsonJson = FileUtils.loadJsonFixture("route-with-road-classes.txt")
+        val routeAsJsonJson = loadJsonFixture("route-with-road-classes.txt")
         val route = DirectionsRoute.fromJson(routeAsJsonJson)
 
         val result = MapboxRouteLineUtils.getRouteLineTrafficExpressionData(route)
@@ -783,7 +784,7 @@ class MapboxRouteLineUtilsTest {
     @Test
     fun getRouteLineTrafficExpressionDataWithSomeRoadClassesDuplicatesRemoved() {
         val routeAsJsonJson =
-            FileUtils.loadJsonFixture("motorway-route-with-road-classes-mixed.json")
+            loadJsonFixture("motorway-route-with-road-classes-mixed.json")
         val route = DirectionsRoute.fromJson(routeAsJsonJson)
 
         val result = MapboxRouteLineUtils.getRouteLineTrafficExpressionData(route)
@@ -820,7 +821,7 @@ class MapboxRouteLineUtilsTest {
             .routeSevereColor(33)
             .build()
 
-        val routeAsJsonJson = FileUtils.loadJsonFixture("motorway-route-with-road-classes.json")
+        val routeAsJsonJson = loadJsonFixture("motorway-route-with-road-classes.json")
         val route = DirectionsRoute.fromJson(routeAsJsonJson)
 
         val trafficExpressionData = MapboxRouteLineUtils.getRouteLineTrafficExpressionData(route)
@@ -851,7 +852,7 @@ class MapboxRouteLineUtilsTest {
             .build()
 
         val routeAsJsonJson =
-            FileUtils.loadJsonFixture("motorway-route-with-road-classes-mixed.json")
+            loadJsonFixture("motorway-route-with-road-classes-mixed.json")
         val route = DirectionsRoute.fromJson(routeAsJsonJson)
 
         val trafficExpressionData = MapboxRouteLineUtils.getRouteLineTrafficExpressionData(route)
@@ -877,8 +878,43 @@ class MapboxRouteLineUtilsTest {
     }
 
     @Test
+    fun getRouteLineExpressionDataWithStreetClassOverrideWhenHasStreetClassesAndClosures() {
+        val colorResources = RouteLineColorResources.Builder()
+            .routeUnknownTrafficColor(-9)
+            .routeLowCongestionColor(-1)
+            .routeCasingColor(33)
+            .routeDefaultColor(33)
+            .routeHeavyColor(33)
+            .routeLineTraveledCasingColor(33)
+            .routeLineTraveledColor(33)
+            .routeModerateColor(33)
+            .routeSevereColor(99)
+            .routeClosureColor(-21)
+            .build()
+
+        val routeAsJsonJson = loadJsonFixture("route-with-closure.json")
+        val route = DirectionsRoute.fromJson(routeAsJsonJson)
+
+        val trafficExpressionData = MapboxRouteLineUtils.getRouteLineTrafficExpressionData(route)
+        val result = MapboxRouteLineUtils.getRouteLineExpressionDataWithStreetClassOverride(
+            trafficExpressionData,
+            route.distance(),
+            colorResources,
+            true,
+            listOf("tertiary")
+        )
+
+        assertEquals(0.0, result[0].offset, 0.0)
+        assertEquals(-1, result[0].segmentColor)
+        assertEquals(0.5467690917306824, result[1].offset, 0.0)
+        assertEquals(-21, result[1].segmentColor)
+        assertEquals(0.8698599186624492, result[2].offset, 0.0)
+        assertEquals(99, result[2].segmentColor)
+    }
+
+    @Test
     fun getRouteLineTrafficExpressionDataWithOutStreetClassesDuplicatesRemoved() {
-        val routeAsJsonJson = FileUtils.loadJsonFixture("route-with-traffic-no-street-classes.txt")
+        val routeAsJsonJson = loadJsonFixture("route-with-traffic-no-street-classes.txt")
         val route = DirectionsRoute.fromJson(routeAsJsonJson)
 
         val result = MapboxRouteLineUtils.getRouteLineTrafficExpressionData(route)
@@ -903,7 +939,7 @@ class MapboxRouteLineUtilsTest {
             .routeSevereColor(33)
             .build()
 
-        val routeAsJsonJson = FileUtils.loadJsonFixture("route-with-road-classes.txt")
+        val routeAsJsonJson = loadJsonFixture("route-with-road-classes.txt")
         val route = DirectionsRoute.fromJson(routeAsJsonJson)
         val trafficExpressionData = MapboxRouteLineUtils.getRouteLineTrafficExpressionData(route)
         assertEquals("service", trafficExpressionData[0].roadClass)
@@ -945,7 +981,7 @@ class MapboxRouteLineUtilsTest {
             .routeSevereColor(33)
             .build()
 
-        val routeAsJsonJson = FileUtils.loadJsonFixture("route-with-traffic-no-street-classes.txt")
+        val routeAsJsonJson = loadJsonFixture("route-with-traffic-no-street-classes.txt")
         val route = DirectionsRoute.fromJson(routeAsJsonJson)
         val trafficExpressionData = MapboxRouteLineUtils.getRouteLineTrafficExpressionData(route)
 
@@ -976,7 +1012,7 @@ class MapboxRouteLineUtilsTest {
             .routeSevereColor(-2)
             .build()
 
-        val routeAsJsonJson = FileUtils.loadJsonFixture(
+        val routeAsJsonJson = loadJsonFixture(
             "motorway-route-with-road-classes-unknown-not-on-intersection.json"
         )
         val route = DirectionsRoute.fromJson(routeAsJsonJson)
@@ -998,7 +1034,7 @@ class MapboxRouteLineUtilsTest {
 
     @Test
     fun getRouteLineTrafficExpressionDataMissingRoadClass() {
-        val routeAsJsonJson = FileUtils.loadJsonFixture(
+        val routeAsJsonJson = loadJsonFixture(
             "route-with-missing-road-classes.json"
         )
         val route = DirectionsRoute.fromJson(routeAsJsonJson)
@@ -1043,7 +1079,7 @@ class MapboxRouteLineUtilsTest {
             .routeModerateColor(33)
             .routeSevereColor(33)
             .build()
-        val routeAsJsonJson = FileUtils.loadJsonFixture(
+        val routeAsJsonJson = loadJsonFixture(
             "motorway-with-road-classes-multi-leg.json"
         )
         val route = DirectionsRoute.fromJson(routeAsJsonJson)
@@ -1059,6 +1095,21 @@ class MapboxRouteLineUtilsTest {
 
         assertTrue(result.all { it.segmentColor == -1 })
         assertEquals(1, result.size)
+    }
+
+    @Test
+    fun getRouteLineTrafficExpressionDataWithClosures() {
+        val routeAsJsonJson = loadJsonFixture("route-with-closure.json")
+        val route = DirectionsRoute.fromJson(routeAsJsonJson)
+
+        val trafficExpressionData = MapboxRouteLineUtils.getRouteLineTrafficExpressionData(route)
+
+        assertEquals(0.0, trafficExpressionData[0].distanceFromOrigin, 0.0)
+        assertEquals("low", trafficExpressionData[0].trafficCongestionIdentifier)
+        assertEquals(145.20000000000002, trafficExpressionData[1].distanceFromOrigin, 0.0)
+        assertEquals("closed", trafficExpressionData[1].trafficCongestionIdentifier)
+        assertEquals(231.0, trafficExpressionData[2].distanceFromOrigin, 0.0)
+        assertEquals("severe", trafficExpressionData[2].trafficCongestionIdentifier)
     }
 
     @Test
@@ -1214,6 +1265,19 @@ class MapboxRouteLineUtilsTest {
     }
 
     @Test
+    fun getRouteColorForCongestionPrimaryRouteCongestionClosure() {
+        val resources = RouteLineColorResources.Builder().build()
+
+        val result = MapboxRouteLineUtils.getRouteColorForCongestion(
+            RouteConstants.ClOSURE_CONGESTION_VALUE,
+            true,
+            resources
+        )
+
+        assertEquals(resources.routeClosureColor, result)
+    }
+
+    @Test
     fun getRouteColorForCongestionNonPrimaryRouteCongestionLow() {
         val resources = RouteLineColorResources.Builder().build()
 
@@ -1313,6 +1377,22 @@ class MapboxRouteLineUtilsTest {
         assertEquals(-122.526951, result[1].first().longitude(), 0.0)
         assertEquals(37.972061, result[1].last().latitude(), 0.0)
         assertEquals(-122.527206, result[1].last().longitude(), 0.0)
+    }
+
+    @Test
+    fun getRouteColorForCongestionNonPrimaryRouteCongestionClosure() {
+        val expectedColor = Color.parseColor("#ffcc00")
+        val resources = RouteLineColorResources.Builder()
+            .alternativeRouteClosureColor(expectedColor)
+            .build()
+
+        val result = MapboxRouteLineUtils.getRouteColorForCongestion(
+            RouteConstants.ClOSURE_CONGESTION_VALUE,
+            false,
+            resources
+        )
+
+        assertEquals(resources.alternativeRouteClosureColor, result)
     }
 
     @Test

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineColorResourcesTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineColorResourcesTest.kt
@@ -30,6 +30,8 @@ class RouteLineColorResourcesTest :
             .alternativeRouteSevereColor(15)
             .alternativeRouteCasingColor(16)
             .restrictedRoadColor(17)
+            .routeClosureColor(17)
+            .alternativeRouteClosureColor(18)
     }
 
     override fun trigger() {
@@ -165,6 +167,22 @@ class RouteLineColorResourcesTest :
     }
 
     @Test
+    fun withRoadClosure() {
+        val resources =
+            RouteLineColorResources.Builder().routeClosureColor(5).build()
+
+        assertEquals(5, resources.routeClosureColor)
+    }
+
+    @Test
+    fun alternativeRouteClosureColor() {
+        val resources =
+            RouteLineColorResources.Builder().alternativeRouteClosureColor(5).build()
+
+        assertEquals(5, resources.alternativeRouteClosureColor)
+    }
+
+    @Test
     fun toBuilder() {
         val routeLineColorResources = RouteLineColorResources.Builder()
             .routeLineTraveledColor(1)
@@ -184,6 +202,8 @@ class RouteLineColorResourcesTest :
             .alternativeRouteSevereColor(15)
             .alternativeRouteCasingColor(16)
             .restrictedRoadColor(17)
+            .routeClosureColor(17)
+            .alternativeRouteClosureColor(18)
             .build()
 
         val result = routeLineColorResources.toBuilder().build()
@@ -205,5 +225,7 @@ class RouteLineColorResourcesTest :
         assertEquals(15, result.alternativeRouteSevereColor)
         assertEquals(16, result.alternativeRouteCasingColor)
         assertEquals(17, result.restrictedRoadColor)
+        assertEquals(17, result.routeClosureColor)
+        assertEquals(18, result.alternativeRouteClosureColor)
     }
 }

--- a/libnavui-maps/src/test/resources/route-with-closure.json
+++ b/libnavui-maps/src/test/resources/route-with-closure.json
@@ -1,0 +1,332 @@
+{
+  "weight_typical": 49.666,
+  "duration_typical": 36.767,
+  "weight_name": "auto",
+  "weight": 49.666,
+  "duration": 36.767,
+  "distance": 265.56,
+  "legs": [
+    {
+      "admins": [
+        {
+          "iso_3166_1_alpha3": "USA",
+          "iso_3166_1": "US"
+        }
+      ],
+      "closures": [
+        {
+          "geometry_index_end": 19,
+          "geometry_index_start": 13
+        }
+      ],
+      "incidents": [
+        {
+          "id": "12887387251066566",
+          "type": "road_closure",
+          "description": "Washington Blvd: road closed from Kobbe Ave to Lincoln Blvd",
+          "long_description": "Road closed due to Slow Streets Program on Washington Blvd both ways from Kobbe Ave to Lincoln Blvd.",
+          "creation_time": "2021-03-29T20:25:39Z",
+          "start_time": "2020-07-02T15:26:14Z",
+          "end_time": "2021-06-14T22:59:00Z",
+          "impact": "low",
+          "sub_type": "CONSTRUCTION",
+          "alertc_codes": [
+            401,
+            703
+          ],
+          "lanes_blocked": [],
+          "closed": true,
+          "congestion": {
+            "value": 101
+          },
+          "geometry_index_start": 13,
+          "geometry_index_end": 19
+        }
+      ],
+      "annotation": {
+        "congestion": [
+          "low",
+          "low",
+          "low",
+          "low",
+          "low",
+          "low",
+          "low",
+          "low",
+          "low",
+          "low",
+          "low",
+          "low",
+          "low",
+          "unknown",
+          "severe",
+          "severe",
+          "severe",
+          "severe",
+          "severe",
+          "severe",
+          "severe"
+        ],
+        "distance": [
+          8.5,
+          28.8,
+          10.6,
+          8.3,
+          8,
+          8.1,
+          8.9,
+          8,
+          10.9,
+          27.4,
+          8.3,
+          2.4,
+          7,
+          5.9,
+          5.7,
+          6.4,
+          12.7,
+          17.1,
+          18.6,
+          19.4,
+          34.9
+        ]
+      },
+      "weight_typical": 49.666,
+      "duration_typical": 36.767,
+      "weight": 49.666,
+      "duration": 36.767,
+      "steps": [
+        {
+          "intersections": [
+            {
+              "entry": [
+                true
+              ],
+              "bearings": [
+                198
+              ],
+              "duration": 3.749,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              },
+              "is_urban": false,
+              "admin_index": 0,
+              "out": 0,
+              "weight": 3.562,
+              "geometry_index": 0,
+              "location": [
+                -122.477426,
+                37.801498
+              ]
+            },
+            {
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "bearings": [
+                19,
+                204
+              ],
+              "duration": 5.282,
+              "turn_weight": 0.5,
+              "turn_duration": 0.01,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              },
+              "is_urban": false,
+              "admin_index": 0,
+              "out": 1,
+              "weight": 5.508,
+              "geometry_index": 3,
+              "location": [
+                -122.477599,
+                37.801089
+              ]
+            },
+            {
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "bearings": [
+                29,
+                213
+              ],
+              "duration": 6.3,
+              "turn_weight": 0.5,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              },
+              "is_urban": false,
+              "admin_index": 0,
+              "out": 1,
+              "weight": 6.485,
+              "geometry_index": 8,
+              "location": [
+                -122.477809,
+                37.800758
+              ]
+            },
+            {
+              "bearings": [
+                33,
+                210
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "turn_weight": 2,
+              "lanes": [
+                {
+                  "indications": [
+                    "left",
+                    "straight"
+                  ],
+                  "valid_indication": "left",
+                  "valid": true,
+                  "active": true
+                }
+              ],
+              "turn_duration": 0.021,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              },
+              "is_urban": false,
+              "admin_index": 0,
+              "out": 1,
+              "geometry_index": 12,
+              "location": [
+                -122.478115,
+                37.800389
+              ]
+            }
+          ],
+          "maneuver": {
+            "type": "depart",
+            "instruction": "Drive south on Lincoln Boulevard.",
+            "bearing_after": 198,
+            "bearing_before": 0,
+            "location": [
+              -122.477426,
+              37.801498
+            ]
+          },
+          "name": "Lincoln Boulevard",
+          "weight_typical": 18.409,
+          "duration_typical": 16.252,
+          "duration": 16.252,
+          "distance": 144.905,
+          "driving_side": "right",
+          "weight": 18.409,
+          "mode": "driving",
+          "geometry": "s`fbgAbvlrhFpCz@jNjErDpAhCfA`CjA`CpAjC~AzB|AdDbCvK|I|BdBd@ZjBnA"
+        },
+        {
+          "intersections": [
+            {
+              "bearings": [
+                30,
+                161
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "turn_weight": 12.5,
+              "lanes": [
+                {
+                  "indications": [
+                    "left",
+                    "straight"
+                  ],
+                  "valid_indication": "left",
+                  "valid": true,
+                  "active": true
+                }
+              ],
+              "turn_duration": 0.772,
+              "mapbox_streets_v8": {
+                "class": "tertiary"
+              },
+              "is_urban": false,
+              "admin_index": 0,
+              "out": 1,
+              "geometry_index": 13,
+              "location": [
+                -122.478155,
+                37.800335
+              ]
+            }
+          ],
+          "maneuver": {
+            "type": "turn",
+            "instruction": "Turn left onto Washington Boulevard.",
+            "modifier": "left",
+            "bearing_after": 161,
+            "bearing_before": 210,
+            "location": [
+              -122.478155,
+              37.800335
+            ]
+          },
+          "name": "Washington Boulevard",
+          "weight_typical": 31.256,
+          "duration_typical": 20.516,
+          "duration": 20.516,
+          "distance": 120.655,
+          "driving_side": "right",
+          "weight": 31.256,
+          "mode": "driving",
+          "geometry": "}wcbgAtcnrhFlAyA~Ai@pBUbFLpHShIcArIcBhQ}G"
+        },
+        {
+          "intersections": [
+            {
+              "bearings": [
+                339
+              ],
+              "entry": [
+                true
+              ],
+              "in": 0,
+              "admin_index": 0,
+              "geometry_index": 21,
+              "location": [
+                -122.477848,
+                37.799296
+              ]
+            }
+          ],
+          "maneuver": {
+            "type": "arrive",
+            "instruction": "You have arrived at your destination.",
+            "bearing_after": 0,
+            "bearing_before": 159,
+            "location": [
+              -122.477848,
+              37.799296
+            ]
+          },
+          "name": "Washington Boulevard",
+          "weight_typical": 0,
+          "duration_typical": 0,
+          "duration": 0,
+          "distance": 0,
+          "driving_side": "right",
+          "weight": 0,
+          "mode": "driving",
+          "geometry": "_wabgAnpmrhF??"
+        }
+      ],
+      "distance": 265.56,
+      "summary": "Lincoln Boulevard, Washington Boulevard"
+    }
+  ],
+  "geometry": "s`fbgAbvlrhFpCz@jNjErDpAhCfA`CjA`CpAjC~AzB|AdDbCvK|I|BdBd@ZjBnAlAyA~Ai@pBUbFLpHShIcArIcBhQ}G"
+}


### PR DESCRIPTION
### Description
Resolves #4188 by displaying road closure(s) on the route traffic line.

In order to test this feature you need a route with a road closure as well as the following RouteOptions when requesting a route:

profile = DirectionsCriteria.PROFILE_DRIVING_TRAFFIC
snappingClosures ( listOf(true, true) ) // makes it easier to create a route starting in a closure, normally the directions API will route around closures rather than going through them.
annotationsList( listOf("closure", "congestion", "distance") )

### Changelog
```
<changelog>Added option to display road closures on the route traffic line.</changelog>
```

### Screenshots or Gifs
In the screen shot below the color options were configured to show low traffic congestion as yellow and road closures as black.
![Screenshot_20210331-090535](https://user-images.githubusercontent.com/2249818/113335101-59f94900-92d9-11eb-898b-39bb523f6d69.png)
