### PR TITLE
MapboxSoundButton allowed clicks when animation is running. Example VoiceActivity: fix sound inverse. 

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxVoiceActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxVoiceActivity.kt
@@ -173,11 +173,11 @@ class MapboxVoiceActivity : AppCompatActivity(), OnMapLongClickListener {
         override fun accept(value: Boolean) {
             isMuted = value.also {
                 if (it) {
-                    // This is used to set the speech volume to max
-                    voiceInstructionsPlayer.volume(SpeechVolume(1.0f))
-                } else {
                     // This is used to set the speech volume to mute.
                     voiceInstructionsPlayer.volume(SpeechVolume(0.0f))
+                } else {
+                    // This is used to set the speech volume to max
+                    voiceInstructionsPlayer.volume(SpeechVolume(1.0f))
                 }
             }
         }

--- a/libnavui-voice/api/current.txt
+++ b/libnavui-voice/api/current.txt
@@ -100,13 +100,16 @@ package com.mapbox.navigation.ui.voice.view {
     ctor public MapboxSoundButton(android.content.Context context);
     ctor public MapboxSoundButton(android.content.Context context, android.util.AttributeSet? attrs);
     ctor public MapboxSoundButton(android.content.Context context, android.util.AttributeSet? attrs, int defStyleAttr);
-    method public void mute(com.mapbox.navigation.ui.base.util.MapboxNavigationConsumer<java.lang.Boolean>? callback);
-    method public void muteAndExtend(long duration, com.mapbox.navigation.ui.base.util.MapboxNavigationConsumer<java.lang.Boolean> callback);
-    method public void unmute(com.mapbox.navigation.ui.base.util.MapboxNavigationConsumer<java.lang.Boolean>? callback);
-    method public void unmuteAndExtend(long duration, com.mapbox.navigation.ui.base.util.MapboxNavigationConsumer<java.lang.Boolean> callback);
+    method public void mute(com.mapbox.navigation.ui.base.util.MapboxNavigationConsumer<java.lang.Boolean>? callback = null);
+    method public void mute();
+    method public void muteAndExtend(long duration, com.mapbox.navigation.ui.base.util.MapboxNavigationConsumer<java.lang.Boolean>? callback = null);
+    method public void muteAndExtend(long duration);
+    method public void unmute(com.mapbox.navigation.ui.base.util.MapboxNavigationConsumer<java.lang.Boolean>? callback = null);
+    method public void unmute();
+    method public void unmuteAndExtend(long duration, com.mapbox.navigation.ui.base.util.MapboxNavigationConsumer<java.lang.Boolean>? callback = null);
+    method public void unmuteAndExtend(long duration);
     method public void updateStyle(@StyleRes int style);
-    field public static final int EXTEND_MUTED_TO_WIDTH = 150; // 0x96
-    field public static final int EXTEND_UNMUTED_TO_WIDTH = 165; // 0xa5
+    field public static final int EXTEND_TEXT_TO_WIDTH = 165; // 0xa5
     field public static final long SLIDE_DURATION = 300L; // 0x12cL
   }
 

--- a/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/view/MapboxSoundButton.kt
+++ b/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/view/MapboxSoundButton.kt
@@ -8,6 +8,7 @@ import android.os.Looper
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.View
+import androidx.annotation.StringRes
 import androidx.annotation.StyleRes
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
@@ -25,7 +26,6 @@ import com.mapbox.navigation.ui.voice.databinding.MapboxSoundButtonLayoutBinding
 class MapboxSoundButton : ConstraintLayout {
 
     private var textWidth = 0
-    private var isAnimationRunning = false
     private var muteDrawable: Drawable? = null
     private var unmuteDrawable: Drawable? = null
     private val binding = MapboxSoundButtonLayoutBinding.inflate(
@@ -66,124 +66,6 @@ class MapboxSoundButton : ConstraintLayout {
         initAttributes(attrs)
     }
 
-    override fun onFinishInflate() {
-        super.onFinishInflate()
-        binding.soundButtonText.afterMeasured {
-            textWidth = width
-        }
-    }
-
-    /**
-     * Allows you to change the style of [MapboxRouteOverviewButton].
-     * @param style Int
-     */
-    fun updateStyle(@StyleRes style: Int) {
-        val typedArray = context.obtainStyledAttributes(
-            style,
-            R.styleable.MapboxSoundButton
-        )
-        applyAttributes(typedArray)
-        typedArray.recycle()
-    }
-
-    /**
-     * Invoke the function to mute.
-     * @param callback MapboxNavigationConsumer<Boolean> invoked after the drawable has been set and
-     * returns true representing that view is in muted state.
-     */
-    fun mute(callback: MapboxNavigationConsumer<Boolean>?) {
-        binding.soundButtonIcon.setImageDrawable(muteDrawable)
-        callback?.accept(true)
-    }
-
-    /**
-     * Invoke the function to unmute.
-     * @param callback MapboxNavigationConsumer<Boolean> invoked after the drawable has been set and
-     * returns false representing that view is in unmuted state.
-     */
-    fun unmute(callback: MapboxNavigationConsumer<Boolean>?) {
-        binding.soundButtonIcon.setImageDrawable(unmuteDrawable)
-        callback?.accept(false)
-    }
-
-    /**
-     * Invoke the function to mute and show optional text associated with the action.
-     * @param duration for the view to be in the extended mode before it starts to shrink.
-     * @param callback MapboxNavigationConsumer<Boolean> invoked after the animation is finished and
-     * returns true representing that view is in muted state.
-     */
-    fun muteAndExtend(duration: Long, callback: MapboxNavigationConsumer<Boolean>) {
-        if (!isAnimationRunning) {
-            mute(null)
-            isAnimationRunning = true
-            val extendToWidth = EXTEND_MUTED_TO_WIDTH * context.resources.displayMetrics.density
-            val animator = getAnimator(textWidth, extendToWidth.toInt())
-            binding.soundButtonText.extend(
-                animator,
-                doOnStart = {
-                    binding.soundButtonText.text = context.getString(R.string.mapbox_muted)
-                    binding.soundButtonText.visibility = View.VISIBLE
-                    mainHandler.postDelayed(
-                        {
-                            val endAnimator = getAnimator(extendToWidth.toInt(), textWidth)
-                            binding.soundButtonText.shrink(
-                                endAnimator,
-                                doOnStart = {
-                                    binding.soundButtonText.text = null
-                                    isAnimationRunning = false
-                                    callback.accept(true)
-                                },
-                                doOnEnd = {
-                                    binding.soundButtonText.visibility = View.INVISIBLE
-                                }
-                            )
-                        },
-                        duration
-                    )
-                }
-            )
-        }
-    }
-
-    /**
-     * Invoke the function to unmute and show optional text associated with the action.
-     * @param duration for the view to be in the extended mode before it starts to shrink.
-     * @param callback MapboxNavigationConsumer<Boolean> invoked after the animation is finished and
-     * returns false representing that view is in unmuted state.
-     */
-    fun unmuteAndExtend(duration: Long, callback: MapboxNavigationConsumer<Boolean>) {
-        if (!isAnimationRunning) {
-            unmute(null)
-            isAnimationRunning = true
-            val extendToWidth = EXTEND_UNMUTED_TO_WIDTH * context.resources.displayMetrics.density
-            val animator = getAnimator(textWidth, extendToWidth.toInt())
-            binding.soundButtonText.extend(
-                animator,
-                doOnStart = {
-                    binding.soundButtonText.text = context.getString(R.string.mapbox_unmuted)
-                    binding.soundButtonText.visibility = View.VISIBLE
-                    mainHandler.postDelayed(
-                        {
-                            val endAnimator = getAnimator(extendToWidth.toInt(), textWidth)
-                            binding.soundButtonText.shrink(
-                                endAnimator,
-                                doOnStart = {
-                                    binding.soundButtonText.text = null
-                                    isAnimationRunning = false
-                                    callback.accept(false)
-                                },
-                                doOnEnd = {
-                                    binding.soundButtonText.visibility = View.INVISIBLE
-                                }
-                            )
-                        },
-                        duration
-                    )
-                }
-            )
-        }
-    }
-
     private fun initAttributes(attrs: AttributeSet?) {
         val typedArray = context.obtainStyledAttributes(
             attrs,
@@ -210,12 +92,112 @@ class MapboxSoundButton : ConstraintLayout {
         )
     }
 
+    override fun onFinishInflate() {
+        super.onFinishInflate()
+        binding.soundButtonText.afterMeasured {
+            textWidth = width
+        }
+    }
+
+    /**
+     * Allows you to change the style of [MapboxRouteOverviewButton].
+     * @param style Int
+     */
+    fun updateStyle(@StyleRes style: Int) {
+        val typedArray = context.obtainStyledAttributes(
+            style,
+            R.styleable.MapboxSoundButton
+        )
+        applyAttributes(typedArray)
+        typedArray.recycle()
+    }
+
+    /**
+     * Invoke the function to mute.
+     * @param callback MapboxNavigationConsumer<Boolean> invoked after the drawable has been set and
+     * returns true representing that view is in muted state.
+     */
+    @JvmOverloads
+    fun mute(callback: MapboxNavigationConsumer<Boolean>? = null) {
+        binding.soundButtonIcon.setImageDrawable(muteDrawable)
+        callback?.accept(true)
+    }
+
+    /**
+     * Invoke the function to unmute.
+     * @param callback MapboxNavigationConsumer<Boolean> invoked after the drawable has been set and
+     * returns false representing that view is in unmuted state.
+     */
+    @JvmOverloads
+    fun unmute(callback: MapboxNavigationConsumer<Boolean>? = null) {
+        binding.soundButtonIcon.setImageDrawable(unmuteDrawable)
+        callback?.accept(false)
+    }
+
+    /**
+     * Invoke the function to mute and show optional text associated with the action.
+     * @param duration for the view to be in the extended mode before it starts to shrink.
+     * @param callback MapboxNavigationConsumer<Boolean> invoked after the animation is finished and
+     * returns true representing that view is in muted state.
+     */
+    @JvmOverloads
+    fun muteAndExtend(duration: Long, callback: MapboxNavigationConsumer<Boolean>? = null) {
+        showTextWithAnimation(R.string.mapbox_muted, duration) {
+            mute(callback)
+        }
+    }
+
+    /**
+     * Invoke the function to unmute and show optional text associated with the action.
+     * @param duration for the view to be in the extended mode before it starts to shrink.
+     * @param callback MapboxNavigationConsumer<Boolean> invoked after the animation is finished and
+     * returns false representing that view is in unmuted state.
+     */
+    @JvmOverloads
+    fun unmuteAndExtend(duration: Long, callback: MapboxNavigationConsumer<Boolean>? = null) {
+        showTextWithAnimation(R.string.mapbox_unmuted, duration) {
+            unmute(callback)
+        }
+    }
+
+    private fun showTextWithAnimation(
+        @StringRes text: Int,
+        duration: Long,
+        beforeAnimation: () -> Unit
+    ) {
+        beforeAnimation()
+        val extendToWidth = EXTEND_TEXT_TO_WIDTH * context.resources.displayMetrics.density
+        val animator = getAnimator(textWidth, extendToWidth.toInt())
+        mainHandler.removeCallbacksAndMessages(null)
+        binding.soundButtonText.extend(
+            animator,
+            doOnStart = {
+                binding.soundButtonText.text = context.getString(text)
+                binding.soundButtonText.visibility = View.VISIBLE
+                mainHandler.postDelayed(
+                    {
+                        val endAnimator = getAnimator(extendToWidth.toInt(), textWidth)
+                        binding.soundButtonText.shrink(
+                            endAnimator,
+                            doOnStart = {
+                                binding.soundButtonText.text = null
+                            },
+                            doOnEnd = {
+                                binding.soundButtonText.visibility = View.INVISIBLE
+                            }
+                        )
+                    },
+                    duration
+                )
+            }
+        )
+    }
+
     private fun getAnimator(from: Int, to: Int) =
         binding.soundButtonText.slideWidth(from, to, SLIDE_DURATION)
 
     private companion object {
         const val SLIDE_DURATION = 300L
-        const val EXTEND_MUTED_TO_WIDTH = 150
-        const val EXTEND_UNMUTED_TO_WIDTH = 165
+        const val EXTEND_TEXT_TO_WIDTH = 165
     }
 }


### PR DESCRIPTION
### Description
- Fixed MapboxSoundButton allows clicks when animation is running;
- examples, VoiceActivity: fix sound inverse mute/unmute state.

Ref https://github.com/mapbox/mapbox-navigation-android/issues/3947

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Fixed MapboxSoundButton allows clicks when animation is running</changelog>
```

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
