### PR TITLE
Adding result caching for geometry calculation related calls

### DIFF
--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/util/CacheResultUtils.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/util/CacheResultUtils.kt
@@ -1,0 +1,43 @@
+package com.mapbox.navigation.ui.maps.util
+
+import android.util.LruCache
+
+internal object CacheResultUtils {
+    private interface CacheResultCall<in F, out R> {
+        operator fun invoke(f: F): R
+    }
+
+    private data class CacheResultKey1<out P1, R>(val p1: P1) :
+        CacheResultCall<(P1) -> R, R> {
+        override fun invoke(f: (P1) -> R) = f(p1)
+    }
+
+    fun <P1, R> ((P1) -> R).cacheResult(maxSize: Int): (P1) -> R {
+        return object : (P1) -> R {
+            private val handler =
+                CacheResultHandler<((P1) -> R), CacheResultKey1<P1, R>, R>(
+                    this@cacheResult,
+                    maxSize
+                )
+            override fun invoke(p1: P1) = handler(CacheResultKey1(p1))
+        }
+    }
+
+    private class CacheResultHandler<F, in K : CacheResultCall<F, R>, out R>(
+        val f: F,
+        maxSize: Int
+    ) {
+        private val cache = LruCache<K, R>(maxSize)
+        operator fun invoke(k: K): R {
+            synchronized(cache) {
+                return cache[k] ?: run {
+                    val r = k(f)
+                    if (cache.get(k) == null) {
+                        cache.put(k, r)
+                    }
+                    r
+                }
+            }
+        }
+    }
+}

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/util/CacheResultUtilsTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/util/CacheResultUtilsTest.kt
@@ -1,0 +1,45 @@
+package com.mapbox.navigation.ui.maps.util
+
+import com.mapbox.navigation.ui.maps.util.CacheResultUtils.cacheResult
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class CacheResultUtilsTest {
+
+    @Test
+    fun cacheResult() {
+        var counter = 0
+        val testFun: (a: Int) -> Int = { a: Int ->
+            counter += 1
+            a + counter
+        }.cacheResult(1)
+        testFun(5)
+        testFun(5)
+
+        val result = testFun(5)
+
+        assertEquals(6, result)
+        assertEquals(1, counter)
+    }
+
+    @Test
+    fun cacheMaxSize() {
+        var counter = 0
+        val testFun: (a: Int) -> Int = { a: Int ->
+            counter += 1
+            a + counter
+        }.cacheResult(1)
+        testFun(5)
+        testFun(5)
+        testFun(5)
+        testFun(10)
+
+        val result = testFun(5)
+
+        assertEquals(8, result)
+        assertEquals(3, counter)
+    }
+}


### PR DESCRIPTION
### Description
Resolves #4194 by caching the result of geometry calculations to avoid duplicate processing.

With the vanishing route line feature **disabled** I tested the time to generate route data for a route from San Francisco to Manhattan N.Y. and the route generation time when selecting an alternative route.

the average initial set routes time was
57ms

the average set routes time when selecting an alternative route (which would hit the cache)
14ms


### Screenshots or Gifs

