### PR TITLE
fix for enable/disable long press on map and fix for clearing

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/util/RouteDrawingActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/util/RouteDrawingActivity.kt
@@ -113,12 +113,12 @@ class RouteDrawingActivity : AppCompatActivity() {
         findViewById<Button>(R.id.btnEnableLongPress).setOnClickListener {
             when (routeDrawingUtilEnabled) {
                 false -> {
-                    routeDrawingUtilEnabled != routeDrawingUtilEnabled
+                    routeDrawingUtilEnabled = true
                     routeDrawingUtil.enable()
                     (it as Button).text = "Disable Long Press Map"
                 }
                 true -> {
-                    routeDrawingUtilEnabled != routeDrawingUtilEnabled
+                    routeDrawingUtilEnabled = false
                     routeDrawingUtil.disable()
                     (it as Button).text = "Enable Long Press Map"
                 }

--- a/examples/src/main/java/com/mapbox/navigation/examples/util/RouteDrawingUtil.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/util/RouteDrawingUtil.kt
@@ -116,8 +116,8 @@ class RouteDrawingUtil(private val mapView: MapView) {
     fun clear() {
         touchPoints.clear()
         mapView.getMapboxMap().getStyle { style ->
-            style.getSourceAs<GeoJsonSource>(LINE_LAYER_SOURCE_ID)?.feature(
-                Feature.fromGeometry(LineString.fromLngLats(listOf()))
+            style.getSourceAs<GeoJsonSource>(LINE_LAYER_SOURCE_ID)?.featureCollection(
+                FeatureCollection.fromFeatures(listOf())
             )
             style.getSourceAs<GeoJsonSource>(LINE_END_SOURCE_ID)?.featureCollection(
                 FeatureCollection.fromFeatures(listOf())


### PR DESCRIPTION
### Description
Fixed a couple minor issues in the tool. The disable long press button wasn't correctly disabling long presses on the map. The clear route points wasn't correctly setting the layer source to an empty feature collection.


### Screenshots or Gifs

