### PR TITLE
Add extra data to Entrance road objects

### DIFF
--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/navigator/NavigatorMapperTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/navigator/NavigatorMapperTest.kt
@@ -54,6 +54,15 @@ class NavigatorMapperTest {
     private val route: DirectionsRoute = mockk(relaxed = true)
     private val routeBufferGeoJson: Geometry = mockk(relaxed = true)
 
+    private val beginCoordinate = Point.fromLngLat(10.0, 20.0)
+    private val endCoordinate = Point.fromLngLat(33.0, 44.0)
+    private val pointGeometry = RoadObjectGeometry.Builder(
+        length = null,
+        shape = beginCoordinate,
+        startGeometryIndex = START_GEOMETRY_INDEX,
+        endGeometryIndex = START_GEOMETRY_INDEX
+    ).build()
+
     @Test
     fun `map matcher result sanity`() {
         val tripStatus = TripStatus(
@@ -327,13 +336,23 @@ class NavigatorMapperTest {
         )
 
         val expectedFirst = TunnelEntrance.Builder(
-            RoadObjectGeometry.Builder(null, Point.fromLngLat(10.0, 20.0), null, null).build(),
+            RoadObjectGeometry.Builder(
+                LENGTH,
+                beginCoordinate,
+                START_GEOMETRY_INDEX,
+                END_GEOMETRY_INDEX
+            ).build(),
             TunnelInfo.Builder("Ted Williams Tunnel").build()
         ).distanceFromStartOfRoute(DISTANCE_FROM_START_OF_ROUTE)
             .build()
 
         val expectedSecond = TunnelExit.Builder(
-            RoadObjectGeometry.Builder(null, Point.fromLngLat(33.0, 44.0), null, null).build(),
+            RoadObjectGeometry.Builder(
+                LENGTH,
+                endCoordinate,
+                START_GEOMETRY_INDEX,
+                END_GEOMETRY_INDEX
+            ).build(),
             TunnelInfo.Builder("Ted Williams Tunnel").build()
         ).distanceFromStartOfRoute(DISTANCE_FROM_START_OF_ROUTE + LENGTH)
             .build()
@@ -412,12 +431,7 @@ class NavigatorMapperTest {
             .00001
         )
         val expected = CountryBorderCrossing.Builder(
-            RoadObjectGeometry.Builder(
-                null,
-                shape = Point.fromLngLat(10.0, 20.0),
-                startGeometryIndex = 1,
-                endGeometryIndex = 1
-            ).build(),
+            pointGeometry,
             CountryBorderCrossingInfo.Builder(
                 CountryBorderCrossingAdminInfo.Builder("US", "USA").build(),
                 CountryBorderCrossingAdminInfo.Builder("CA", "CAN").build()
@@ -451,12 +465,7 @@ class NavigatorMapperTest {
             .00001
         )
         val expected = TollCollection.Builder(
-            RoadObjectGeometry.Builder(
-                null,
-                shape = Point.fromLngLat(10.0, 20.0),
-                startGeometryIndex = 1,
-                endGeometryIndex = 1
-            ).build(),
+            pointGeometry,
             TollCollectionType.TOLL_GANTRY
         ).distanceFromStartOfRoute(DISTANCE_FROM_START_OF_ROUTE)
             .build()
@@ -486,12 +495,7 @@ class NavigatorMapperTest {
             .00001
         )
         val expected = TollCollection.Builder(
-            RoadObjectGeometry.Builder(
-                null,
-                shape = Point.fromLngLat(10.0, 20.0),
-                startGeometryIndex = 1,
-                endGeometryIndex = 1
-            ).build(),
+            pointGeometry,
             TollCollectionType.TOLL_BOOTH
         ).distanceFromStartOfRoute(DISTANCE_FROM_START_OF_ROUTE)
             .build()
@@ -521,12 +525,7 @@ class NavigatorMapperTest {
             .00001
         )
         val expected = RestStop.Builder(
-            RoadObjectGeometry.Builder(
-                null,
-                shape = Point.fromLngLat(10.0, 20.0),
-                startGeometryIndex = 1,
-                endGeometryIndex = 1
-            ).build(),
+            pointGeometry,
             RestStopType.REST_AREA
         ).distanceFromStartOfRoute(DISTANCE_FROM_START_OF_ROUTE)
             .build()
@@ -552,12 +551,7 @@ class NavigatorMapperTest {
 
         assertEquals(DISTANCE_TO_START, upcomingRoadObject.distanceToStart, .00001)
         val expected = RestStop.Builder(
-            RoadObjectGeometry.Builder(
-                null,
-                shape = Point.fromLngLat(10.0, 20.0),
-                startGeometryIndex = 1,
-                endGeometryIndex = 1
-            ).build(),
+            pointGeometry,
             RestStopType.SERVICE_AREA
         ).distanceFromStartOfRoute(DISTANCE_FROM_START_OF_ROUTE)
             .build()
@@ -583,12 +577,22 @@ class NavigatorMapperTest {
         val upcomingRoadObjectSecond = routeProgress.upcomingRoadObjects[1]
 
         val expectedFirst = RestrictedAreaEntrance.Builder(
-            RoadObjectGeometry.Builder(null, Point.fromLngLat(10.0, 20.0), null, null).build()
+            RoadObjectGeometry.Builder(
+                LENGTH,
+                beginCoordinate,
+                START_GEOMETRY_INDEX,
+                END_GEOMETRY_INDEX
+            ).build()
         ).distanceFromStartOfRoute(DISTANCE_FROM_START_OF_ROUTE)
             .build()
 
         val expectedSecond = RestrictedAreaExit.Builder(
-            RoadObjectGeometry.Builder(null, Point.fromLngLat(33.0, 44.0), null, null).build()
+            RoadObjectGeometry.Builder(
+                LENGTH,
+                endCoordinate,
+                START_GEOMETRY_INDEX,
+                END_GEOMETRY_INDEX
+            ).build()
         ).distanceFromStartOfRoute(DISTANCE_FROM_START_OF_ROUTE + LENGTH)
             .build()
 
@@ -626,11 +630,9 @@ class NavigatorMapperTest {
         val expected = Incident.Builder(
             RoadObjectGeometry.Builder(
                 LENGTH,
-                LineString.fromLngLats(
-                    listOf(Point.fromLngLat(10.0, 20.0), Point.fromLngLat(33.0, 44.0))
-                ),
-                1,
-                2
+                LineString.fromLngLats(listOf(beginCoordinate, endCoordinate)),
+                START_GEOMETRY_INDEX,
+                END_GEOMETRY_INDEX
             ).build(),
             IncidentInfo.Builder("some_id")
                 .type(CONSTRUCTION)
@@ -799,10 +801,10 @@ class NavigatorMapperTest {
         type,
         DISTANCE_FROM_START_OF_ROUTE,
         if (hasLength) LENGTH else null,
-        Point.fromLngLat(10.0, 20.0),
-        1,
-        if (hasLength) Point.fromLngLat(33.0, 44.0) else Point.fromLngLat(10.0, 20.0),
-        if (hasLength) 2 else 1,
+        beginCoordinate,
+        START_GEOMETRY_INDEX,
+        if (hasLength) endCoordinate else beginCoordinate,
+        if (hasLength) END_GEOMETRY_INDEX else START_GEOMETRY_INDEX,
         incidentInfo, tunnelInfo, countryBorderCrossingInfo, tollCollectionInfo, serviceAreaInfo
     )
 
@@ -814,5 +816,7 @@ class NavigatorMapperTest {
         private const val DISTANCE_TO_START = 1234.0
         private const val DISTANCE_FROM_START_OF_ROUTE = 123.0
         private const val LENGTH = 456.0
+        private const val START_GEOMETRY_INDEX = 1
+        private const val END_GEOMETRY_INDEX = 2
     }
 }


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
add length, startGeometryIndex, endGeometryIndex to `entrance`/`exit` road objects (Directions source)

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>add length, startGeometryIndex, endGeometryIndex to `entrance`/`exit` road objects (Directions source)</changelog>
```

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
