### PR TITLE
Removing unnecessary re-instantiation of progress change listener.

### DIFF
--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/NavigationMapRoute.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/route/NavigationMapRoute.java
@@ -136,7 +136,7 @@ public class NavigationMapRoute implements LifecycleObserver {
         mapView, mapboxMap, styleRes, LAYER_ABOVE_UPCOMING_MANEUVER_ARROW, sourceMaxZoom, sourceTolerance
     );
     this.routeClickPadding = routeClickPadding;
-    this.mapRouteProgressChangeListener = buildMapRouteProgressChangeListener();
+    this.mapRouteProgressChangeListener = new MapRouteProgressChangeListener(routeLine, routeArrow);
     this.routeLineInitializedCallback = routeLineInitializedCallback;
     this.lifecycleOwner = lifecycleOwner;
     this.sourceMaxZoom = sourceMaxZoom;
@@ -302,7 +302,6 @@ public class NavigationMapRoute implements LifecycleObserver {
    */
   public void addProgressChangeListener(@NonNull MapboxNavigation navigation) {
     this.navigation = navigation;
-    this.mapRouteProgressChangeListener = buildMapRouteProgressChangeListener();
     navigation.registerRouteProgressObserver(mapRouteProgressChangeListener);
   }
 
@@ -367,6 +366,7 @@ public class NavigationMapRoute implements LifecycleObserver {
    */
   @OnLifecycleEvent(Lifecycle.Event.ON_START)
   protected void onStart() {
+    this.mapRouteProgressChangeListener = new MapRouteProgressChangeListener(routeLine, routeArrow);
     addListeners();
     updateProgressChangeListener();
   }
@@ -494,15 +494,9 @@ public class NavigationMapRoute implements LifecycleObserver {
     if (navigation != null) {
       navigation.unregisterRouteProgressObserver(mapRouteProgressChangeListener);
     }
-    mapRouteProgressChangeListener = buildMapRouteProgressChangeListener();
     if (navigation != null) {
       navigation.registerRouteProgressObserver(mapRouteProgressChangeListener);
     }
-  }
-
-  @NonNull
-  private MapRouteProgressChangeListener buildMapRouteProgressChangeListener() {
-    return new MapRouteProgressChangeListener(routeLine, routeArrow);
   }
 
   protected final MapboxMap.OnMapClickListener mapClickListener = new MapboxMap.OnMapClickListener() {

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/NavigationMapRouteTest.java
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/route/NavigationMapRouteTest.java
@@ -11,12 +11,14 @@ import com.mapbox.navigation.base.trip.model.RouteProgress;
 import com.mapbox.navigation.core.MapboxNavigation;
 
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 import static com.mapbox.navigation.ui.internal.route.RouteConstants.DEFAULT_ROUTE_CLICK_PADDING_IN_DIP;
+import static org.junit.Assert.assertNotEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
@@ -498,6 +500,35 @@ public class NavigationMapRouteTest {
     theNavigationMapRoute.onNewRouteProgress(mock(RouteProgress.class, RETURNS_DEEP_STUBS));
 
     verify(mockedProgressChangeListener, never()).onRouteProgressChanged(any());
+  }
+
+  @Test
+  public void onStartCreatesNewProgressChangeListenerBeforeRegisteringExistingListener() {
+    ArgumentCaptor<MapRouteProgressChangeListener> changeListenerArgCaptor =
+            ArgumentCaptor.forClass(MapRouteProgressChangeListener.class);
+    MapboxNavigation mockedNavigation = mock(MapboxNavigation.class);
+    MapView mockedMapView = mock(MapView.class);
+    MapboxMap mockedMapboxMap = mock(MapboxMap.class);
+    int mockedStyleRes = 0;
+    MapView.OnDidFinishLoadingStyleListener mockedDidFinishLoadingStyleListener =
+            mock(MapView.OnDidFinishLoadingStyleListener.class);
+    MapRouteProgressChangeListener mockedProgressChangeListener = mock(MapRouteProgressChangeListener.class);
+    LifecycleOwner mockedLifecycleOwner = mock(LifecycleOwner.class);
+    MapRouteLine mockedMapRouteLine = mock(MapRouteLine.class);
+    MapRouteArrow mockedMapRouteArrow = mock(MapRouteArrow.class);
+    NavigationMapRoute theNavigationMapRoute = new NavigationMapRoute(mockedNavigation, mockedMapView, mockedMapboxMap,
+            mockedLifecycleOwner, mockedStyleRes, "", mockedDidFinishLoadingStyleListener,
+            mockedProgressChangeListener, mockedMapRouteLine, mockedMapRouteArrow);
+    theNavigationMapRoute.addProgressChangeListener(mockedNavigation);
+
+    theNavigationMapRoute.onStart();
+
+    verify(mockedNavigation, times(3))
+            .registerRouteProgressObserver(changeListenerArgCaptor.capture());
+    assertNotEquals(
+            changeListenerArgCaptor.getAllValues().get(0),
+            changeListenerArgCaptor.getAllValues().get(1)
+    );
   }
 
   @Test


### PR DESCRIPTION
### Description
Bug fix for scenario when a reroute occurs while the application is in the background and the application is restored just after the reroute. This sequence of events resulted in the route line not getting drawn with the new route, nor any route.
Fixes #4237

### Changelog
```
<changelog>Bug fix for restoring route line on map when bringing application into foreground just after a reroute.</changelog>
```

### Screenshots or Gifs

