### PR TITLE
Add waypoints to the ArrivalObserver to navigation-core

### DIFF
--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/utils/idling/ArrivalIdlingResource.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/utils/idling/ArrivalIdlingResource.kt
@@ -23,6 +23,10 @@ class ArrivalIdlingResource(
     init {
         mapboxNavigation?.registerArrivalObserver(
             object : ArrivalObserver {
+                override fun onWaypointArrival(routeProgress: RouteProgress) {
+                    // do nothing
+                }
+
                 override fun onNextRouteLegStart(routeLegProgress: RouteLegProgress) {
                     // do nothing
                 }
@@ -44,6 +48,10 @@ class ArrivalIdlingResource(
         if (isIdleNow) {
             callback?.onTransitionToIdle()
         }
+    }
+
+    override fun onWaypointArrival(routeProgress: RouteProgress) {
+        // do nothing
     }
 
     override fun onNextRouteLegStart(routeLegProgress: RouteLegProgress) {

--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -83,6 +83,7 @@ package com.mapbox.navigation.core.arrival {
   public interface ArrivalObserver {
     method public void onFinalDestinationArrival(com.mapbox.navigation.base.trip.model.RouteProgress routeProgress);
     method public void onNextRouteLegStart(com.mapbox.navigation.base.trip.model.RouteLegProgress routeLegProgress);
+    method public void onWaypointArrival(com.mapbox.navigation.base.trip.model.RouteProgress routeProgress);
   }
 
   public final class ArrivalOptions {

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/arrival/ArrivalController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/arrival/ArrivalController.kt
@@ -26,25 +26,6 @@ interface ArrivalController {
 }
 
 /**
- * The default controller for arrival. This will move onto the next leg automatically
- * if there is one.
- */
-class AutoArrivalController : ArrivalController {
-
-    /**
-     * Default arrival options.
-     */
-    override fun arrivalOptions(): ArrivalOptions = ArrivalOptions.Builder().build()
-
-    /**
-     * By default this will move onto the next step.
-     */
-    override fun navigateNextRouteLeg(routeLegProgress: RouteLegProgress): Boolean {
-        return true
-    }
-}
-
-/**
  * Choose when to be notified of arrival.
  *
  * @param arrivalInSeconds While the next stop is less than [arrivalInSeconds] away,

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/arrival/ArrivalObserver.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/arrival/ArrivalObserver.kt
@@ -12,14 +12,20 @@ import com.mapbox.navigation.core.MapboxNavigation
 interface ArrivalObserver {
 
     /**
-     * Once [MapboxNavigation.navigateNextRouteLeg] has been called and returns true,
+     * Called when the [RouteProgress.currentState] has reached [RouteProgressState.ROUTE_COMPLETE],
+     * and the route progress has reached a waypoint on the route.
+     */
+    fun onWaypointArrival(routeProgress: RouteProgress)
+
+    /**
+     * Called when [MapboxNavigation.navigateNextRouteLeg] has been called and returns true,
      * this observer will be notified of the next route leg start.
      */
     fun onNextRouteLegStart(routeLegProgress: RouteLegProgress)
 
     /**
-     * This will be called once the [RouteProgress.currentState] has reached [RouteProgressState.ROUTE_COMPLETE].
-     * This means the device has reached the final destination on the route.
+     * Called once the [RouteProgress.currentState] has reached [RouteProgressState.ROUTE_COMPLETE],
+     * and the route progress has reached the final destination on the route.
      */
     fun onFinalDestinationArrival(routeProgress: RouteProgress)
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/arrival/AutoArrivalController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/arrival/AutoArrivalController.kt
@@ -1,0 +1,42 @@
+package com.mapbox.navigation.core.arrival
+
+import android.os.SystemClock
+import com.mapbox.api.directions.v5.models.RouteLeg
+import com.mapbox.navigation.base.trip.model.RouteLegProgress
+import java.util.concurrent.TimeUnit
+
+/**
+ * The default controller for arrival. This will move onto the next leg automatically
+ * if there is one.
+ */
+class AutoArrivalController : ArrivalController {
+
+    private var routeLegCompletedTime: Long? = null
+    private var currentRouteLeg: RouteLeg? = null
+
+    /**
+     * Default arrival options.
+     */
+    override fun arrivalOptions(): ArrivalOptions = ArrivalOptions.Builder().build()
+
+    /**
+     * By default this will move onto the next step after [ArrivalOptions.arrivalInSeconds]
+     * seconds have passed.
+     */
+    override fun navigateNextRouteLeg(routeLegProgress: RouteLegProgress): Boolean {
+        if (currentRouteLeg != routeLegProgress.routeLeg) {
+            currentRouteLeg = routeLegProgress.routeLeg
+            routeLegCompletedTime = SystemClock.elapsedRealtimeNanos()
+        }
+
+        val elapsedTimeNanos = SystemClock.elapsedRealtimeNanos() - (routeLegCompletedTime ?: 0L)
+        val arrivalInSeconds = arrivalOptions().arrivalInSeconds?.toLong() ?: 0L
+        val arrivalInNanos = TimeUnit.SECONDS.toNanos(arrivalInSeconds)
+        val shouldNavigateNextRouteLeg = elapsedTimeNanos >= arrivalInNanos
+        if (shouldNavigateNextRouteLeg) {
+            currentRouteLeg = null
+            routeLegCompletedTime = null
+        }
+        return shouldNavigateNextRouteLeg
+    }
+}

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetry.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetry.kt
@@ -410,6 +410,10 @@ internal object MapboxNavigationTelemetry :
         sessionStart()
     }
 
+    override fun onWaypointArrival(routeProgress: RouteProgress) {
+        log("onWaypointDestinationArrival")
+    }
+
     override fun onFinalDestinationArrival(routeProgress: RouteProgress) {
         log("onFinalDestinationArrival")
         this.routeProgress = routeProgress

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/arrival/AutoArrivalControllerTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/arrival/AutoArrivalControllerTest.kt
@@ -1,0 +1,68 @@
+package com.mapbox.navigation.core.arrival
+
+import android.os.SystemClock
+import com.mapbox.api.directions.v5.models.RouteLeg
+import com.mapbox.navigation.base.trip.model.RouteLegProgress
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkObject
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.TimeUnit
+
+class AutoArrivalControllerTest {
+
+    private val arrivalController = AutoArrivalController()
+
+    @Before
+    fun setup() {
+        mockkStatic(SystemClock::class)
+    }
+
+    @After
+    fun teardown() {
+        unmockkObject(SystemClock.elapsedRealtimeNanos())
+    }
+
+    @Test
+    fun `should navigate next at predicted arrival`() {
+        val arrivalInSeconds = arrivalController.arrivalOptions().arrivalInSeconds?.toInt() ?: 0
+        val routeLeg = mockk<RouteLeg>()
+
+        mockSecond(100)
+        assertFalse(arrivalController.navigateNextRouteLeg(mockProgress(routeLeg)))
+        mockSecond(100 + arrivalInSeconds - 1)
+        assertFalse(arrivalController.navigateNextRouteLeg(mockProgress(routeLeg)))
+        mockSecond(100 + arrivalInSeconds)
+        assertTrue(arrivalController.navigateNextRouteLeg(mockProgress(routeLeg)))
+    }
+
+    @Test
+    fun `should restart timer if rerouted`() {
+        val arrivalInSeconds = arrivalController.arrivalOptions().arrivalInSeconds?.toInt() ?: 0
+        val routeLeg = mockk<RouteLeg>()
+
+        mockSecond(100)
+        assertFalse(arrivalController.navigateNextRouteLeg(mockProgress(routeLeg)))
+        mockSecond(100 + arrivalInSeconds)
+        val reroutedRouteLeg = mockk<RouteLeg>()
+        assertFalse(arrivalController.navigateNextRouteLeg(mockProgress(reroutedRouteLeg)))
+        mockSecond(100 + arrivalInSeconds + arrivalInSeconds - 1)
+        assertFalse(arrivalController.navigateNextRouteLeg(mockProgress(reroutedRouteLeg)))
+
+        mockSecond(100 + arrivalInSeconds + arrivalInSeconds)
+        assertTrue(arrivalController.navigateNextRouteLeg(mockProgress(reroutedRouteLeg)))
+    }
+
+    private fun mockSecond(second: Int) = every {
+        SystemClock.elapsedRealtimeNanos()
+    } returns TimeUnit.SECONDS.toNanos(second.toLong())
+
+    private fun mockProgress(mockedRouteLeg: RouteLeg) = mockk<RouteLegProgress> {
+        every { routeLeg } returns mockedRouteLeg
+    }
+}


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

When highlighting buildings on arrival, I have found it difficult to create an experience for arriving at waypoints 
https://github.com/mapbox/mapbox-navigation-android/pull/4078. This pull request adds a callback to the `ArrivalObserver` specifically for waypoint experiences.

- AutoArrivalController will wait 5 seconds before calling navigateNextRouteLeg
- Add a function `fun onWaypointArrival(routeProgress: RouteProgress)`
- Add tests to show AutoArrivalController behavior

This is intended to be a SEMVOR MINOR change as it adds functionality in a backwards compatible manner.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Add waypoints to the ArrivalObserver to navigation-core</changelog>
```

### Screenshots or Gifs
This pull request creates no functional change. Although, the intended experience can be found on the gif in the full feature draft https://github.com/mapbox/mapbox-navigation-android/pull/4078

<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
