### PR TITLE
Fixing broken example activity by replacing call to set routes on Map…

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxRouteLineAndArrowActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxRouteLineAndArrowActivity.kt
@@ -215,7 +215,7 @@ class MapboxRouteLineAndArrowActivity : AppCompatActivity(), OnMapLongClickListe
             // to the MapboxRouteLineApi to generate the data necessary to draw the route(s)
             // on the map.
             val routeLines = routes.map { RouteLine(it, null) }
-            val routeDrawData = routeLineApi.setRoutes(
+            routeLineApi.setRoutes(
                 routeLines,
                 object : MapboxNavigationConsumer<Expected<RouteSetValue, RouteLineError>> {
                     override fun accept(value: Expected<RouteSetValue, RouteLineError>) {


### PR DESCRIPTION
### Description
Fixing broken example activity by replacing call to set routes on `MapboxNavigation`.


### Screenshots or Gifs

