### PR TITLE
Adding method to show camera overview

### DIFF
--- a/libnavigation-ui/api/current.txt
+++ b/libnavigation-ui/api/current.txt
@@ -242,6 +242,7 @@ package com.mapbox.navigation.ui.camera {
     method public void resume(android.location.Location?);
     method public void setCamera(com.mapbox.navigation.ui.camera.Camera!);
     method public boolean showRouteGeometryOverview(int[]);
+    method public boolean showRouteGeometryRemainingOverview(int[]);
     method @Deprecated public void showRouteOverview(int[]);
     method public void start(com.mapbox.api.directions.v5.models.DirectionsRoute?);
     method public void update(com.mapbox.navigation.ui.camera.NavigationCameraUpdate);
@@ -502,6 +503,7 @@ package com.mapbox.navigation.ui.map {
     method public void setOnRouteSelectionChangeListener(com.mapbox.navigation.ui.route.OnRouteSelectionChangeListener);
     method public void setPuckDrawableSupplier(com.mapbox.navigation.ui.puck.PuckDrawableSupplier);
     method public void showAlternativeRoutes(boolean);
+    method public boolean showRemainingRouteGeometryOverview(int[]!);
     method public void showRoute();
     method public boolean showRouteGeometryOverview(int[]!);
     method @Deprecated public void showRouteOverview(int[]!);

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/camera/SimpleCamera.kt
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/camera/SimpleCamera.kt
@@ -1,9 +1,14 @@
 package com.mapbox.navigation.ui.camera
 
+import com.mapbox.api.directions.v5.DirectionsCriteria
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.core.constants.Constants
 import com.mapbox.geojson.LineString
 import com.mapbox.geojson.Point
+import com.mapbox.navigation.base.trip.model.RouteProgress
+import com.mapbox.navigation.utils.internal.ifNonNull
+import com.mapbox.turf.TurfConstants
+import com.mapbox.turf.TurfMisc
 
 /**
  * The default camera used by [MapboxNavigation].
@@ -30,10 +35,20 @@ open class SimpleCamera : Camera() {
         return DEFAULT_ZOOM
     }
 
-    override fun overview(routeInformation: RouteInformation): List<Point> =
-        getRoute(routeInformation)?.run {
-            generateRouteCoordinates(this)
+    /**
+     * If the [RouteInformation] does not include a [RouteProgress] instance the points
+     * for the entire route will be returned. If a [RouteProgress] is present, the distance
+     * traveled will be used to truncate the route points such that the final collection of points
+     * returned will contain the point nearest the distance traveled until the end of the route.
+     */
+    override fun overview(routeInformation: RouteInformation): List<Point> {
+        return getRoute(routeInformation)?.run {
+            when (routeInformation.routeProgress) {
+                null -> generateRouteCoordinates(this)
+                else -> getCoordinates(this, routeInformation.routeProgress)
+            }
         } ?: emptyList()
+    }
 
     private fun getRoute(routeInformation: RouteInformation): DirectionsRoute? =
         when (routeInformation.route) {
@@ -41,9 +56,39 @@ open class SimpleCamera : Camera() {
             else -> routeInformation.route
         }
 
-    private fun generateRouteCoordinates(route: DirectionsRoute?): List<Point> =
-        route?.geometry()?.let { geometry ->
-            val lineString = LineString.fromPolyline(geometry, Constants.PRECISION_6)
-            lineString.coordinates()
+    private fun getCoordinates(
+        route: DirectionsRoute,
+        routeProgress: RouteProgress?
+    ): List<Point> {
+        return ifNonNull(
+            routeProgress
+        ) { theRouteProgress ->
+            getLineString(route)?.run {
+                TurfMisc.lineSliceAlong(
+                    this,
+                    theRouteProgress.distanceTraveled.toDouble(),
+                    route.distance(),
+                    TurfConstants.UNIT_METERS
+                ).coordinates()
+            } ?: emptyList()
         } ?: emptyList()
+    }
+
+    private fun generateRouteCoordinates(route: DirectionsRoute?): List<Point> {
+        return route?.run {
+            getLineString(this)?.coordinates()
+        } ?: emptyList()
+    }
+
+    private fun getLineString(route: DirectionsRoute): LineString? {
+        return ifNonNull(route.geometry()) { routeGeometry ->
+            val precision =
+                if (route.routeOptions()?.geometries() == DirectionsCriteria.GEOMETRY_POLYLINE) {
+                    Constants.PRECISION_5
+                } else {
+                    Constants.PRECISION_6
+                }
+            LineString.fromPolyline(routeGeometry, precision)
+        }
+    }
 }

--- a/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/NavigationMapboxMap.java
+++ b/libnavigation-ui/src/main/java/com/mapbox/navigation/ui/map/NavigationMapboxMap.java
@@ -864,6 +864,21 @@ public class NavigationMapboxMap implements LifecycleObserver {
   }
 
   /**
+   * Adjusts the map camera to {@link DirectionsRoute} being traveled along to display
+   * the portion of the route that has not been traveled. This is different from the
+   * method showRouteGeometryOverview which will display the entire route.
+   * <p>
+   * Also includes the given padding.
+   *
+   * @param padding for creating the overview camera position
+   * @return true if the transition to overview succeeded, false otherwise
+   */
+  public boolean showRemainingRouteGeometryOverview(int[] padding) {
+    mapPaddingAdjustor.updatePaddingWith(ZERO_MAP_PADDING);
+    return mapCamera.showRouteGeometryRemainingOverview(padding);
+  }
+
+  /**
    * Enables or disables the way name chip underneath the location icon.
    *
    * @param isEnabled true to enable, false to disable

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/camera/NavigationCameraTest.java
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/camera/NavigationCameraTest.java
@@ -14,13 +14,16 @@ import com.mapbox.navigation.core.trip.session.RouteProgressObserver;
 import com.mapbox.navigation.ui.BaseTest;
 
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
@@ -270,6 +273,137 @@ public class NavigationCameraTest extends BaseTest {
 
     assertFalse(result);
     // verify no crash
+  }
+
+  @Test
+  public void showRouteGeometryOverview_includesRouteProgress() {
+    ArgumentCaptor<RouteInformation> argumentCaptor =
+            ArgumentCaptor.forClass(RouteInformation.class);
+    MapboxMap mapboxMap = mock(MapboxMap.class);
+    when(mapboxMap.getCameraPosition()).thenReturn(CameraPosition.DEFAULT);
+    MapboxNavigation navigation = mock(MapboxNavigation.class);
+    DirectionsRoute directionsRoute = mock(DirectionsRoute.class);
+    RouteProgress routeProgress = mock(RouteProgress.class);
+    when(routeProgress.getRoute()).thenReturn(directionsRoute);
+    DynamicCamera dynamicCamera = mock(DynamicCamera.class);
+    NavigationCamera camera = buildCamera(mapboxMap, navigation);
+    camera.setCamera(dynamicCamera);
+    List<Point> points = new ArrayList<>();
+    when(dynamicCamera.overview(any())).thenReturn(points);
+
+    camera.start(null);
+    camera.routeProgressObserver.onRouteProgressChanged(routeProgress);
+    camera.showRouteGeometryOverview(new int[4]);
+
+    verify(dynamicCamera).overview(argumentCaptor.capture());
+    assertNull(argumentCaptor.getValue().getRouteProgress());
+    assertEquals(directionsRoute, argumentCaptor.getValue().getRoute());
+  }
+
+  @Test
+  public void showRouteGeometryRemainingOverview_whenRouteProgressAndRouteAreNull() {
+    MapboxMap mapboxMap = mock(MapboxMap.class);
+    MapboxNavigation navigation = mock(MapboxNavigation.class);
+    NavigationCamera camera = buildCamera(mapboxMap, navigation);
+
+    camera.start(null);
+    boolean result = camera.showRouteGeometryRemainingOverview(new int[4]);
+
+    assertFalse(result);
+    // verify no crash
+  }
+
+  @Test
+  public void showRouteGeometryRemainingOverview_animateCamera_whenRouteProgressIsNull() {
+    MapboxMap mapboxMap = mock(MapboxMap.class);
+    MapboxNavigation navigation = mock(MapboxNavigation.class);
+    DirectionsRoute directionsRoute = mock(DirectionsRoute.class);
+    DynamicCamera dynamicCamera = mock(DynamicCamera.class);
+    NavigationCamera camera = buildCamera(mapboxMap, navigation);
+    camera.setCamera(dynamicCamera);
+    List<Point> points = new ArrayList<>();
+    points.add(mock(Point.class));
+    points.add(mock(Point.class));
+    points.add(mock(Point.class));
+    when(dynamicCamera.overview(any())).thenReturn(points);
+
+    camera.start(directionsRoute);
+    boolean result = camera.showRouteGeometryRemainingOverview(new int[4]);
+
+    assertTrue(result);
+    verify(mapboxMap).animateCamera(any(), anyInt(), any());
+  }
+
+  @Test
+  public void showRouteGeometryRemainingOverview_animateCamera_whenRouteInfoIsNull() {
+    MapboxMap mapboxMap = mock(MapboxMap.class);
+    when(mapboxMap.getCameraPosition()).thenReturn(CameraPosition.DEFAULT);
+    MapboxNavigation navigation = mock(MapboxNavigation.class);
+    DirectionsRoute directionsRoute = mock(DirectionsRoute.class);
+    RouteProgress routeProgress = mock(RouteProgress.class);
+    when(routeProgress.getRoute()).thenReturn(directionsRoute);
+    DynamicCamera dynamicCamera = mock(DynamicCamera.class);
+    NavigationCamera camera = buildCamera(mapboxMap, navigation);
+    camera.setCamera(dynamicCamera);
+    List<Point> points = new ArrayList<>();
+    points.add(mock(Point.class));
+    points.add(mock(Point.class));
+    points.add(mock(Point.class));
+    when(dynamicCamera.overview(any())).thenReturn(points);
+
+    camera.start(null);
+    camera.routeProgressObserver.onRouteProgressChanged(routeProgress);
+    boolean result = camera.showRouteGeometryRemainingOverview(new int[4]);
+
+    assertTrue(result);
+    verify(mapboxMap).animateCamera(any(), anyInt(), any());
+  }
+
+  @Test
+  public void showRouteGeometryRemainingOverview_emptyRoute() {
+    MapboxMap mapboxMap = mock(MapboxMap.class);
+    when(mapboxMap.getCameraPosition()).thenReturn(CameraPosition.DEFAULT);
+    MapboxNavigation navigation = mock(MapboxNavigation.class);
+    DirectionsRoute directionsRoute = mock(DirectionsRoute.class);
+    RouteProgress routeProgress = mock(RouteProgress.class);
+    when(routeProgress.getRoute()).thenReturn(directionsRoute);
+    DynamicCamera dynamicCamera = mock(DynamicCamera.class);
+    NavigationCamera camera = buildCamera(mapboxMap, navigation);
+    camera.setCamera(dynamicCamera);
+    List<Point> points = new ArrayList<>();
+    when(dynamicCamera.overview(any())).thenReturn(points);
+
+    camera.start(null);
+    camera.routeProgressObserver.onRouteProgressChanged(routeProgress);
+    boolean result = camera.showRouteGeometryRemainingOverview(new int[4]);
+
+    assertFalse(result);
+    // verify no crash
+  }
+
+  @Test
+  public void showRouteGeometryRemainingOverview_includesRouteProgress() {
+    ArgumentCaptor<RouteInformation> argumentCaptor =
+            ArgumentCaptor.forClass(RouteInformation.class);
+    MapboxMap mapboxMap = mock(MapboxMap.class);
+    when(mapboxMap.getCameraPosition()).thenReturn(CameraPosition.DEFAULT);
+    MapboxNavigation navigation = mock(MapboxNavigation.class);
+    DirectionsRoute directionsRoute = mock(DirectionsRoute.class);
+    RouteProgress routeProgress = mock(RouteProgress.class);
+    when(routeProgress.getRoute()).thenReturn(directionsRoute);
+    DynamicCamera dynamicCamera = mock(DynamicCamera.class);
+    NavigationCamera camera = buildCamera(mapboxMap, navigation);
+    camera.setCamera(dynamicCamera);
+    List<Point> points = new ArrayList<>();
+    when(dynamicCamera.overview(any())).thenReturn(points);
+
+    camera.start(null);
+    camera.routeProgressObserver.onRouteProgressChanged(routeProgress);
+    camera.showRouteGeometryRemainingOverview(new int[4]);
+
+    verify(dynamicCamera).overview(argumentCaptor.capture());
+    assertEquals(routeProgress, argumentCaptor.getValue().getRouteProgress());
+    assertEquals(directionsRoute, argumentCaptor.getValue().getRoute());
   }
 
   private NavigationCamera buildCamera() {

--- a/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/camera/SimpleCameraTest.kt
+++ b/libnavigation-ui/src/test/java/com/mapbox/navigation/ui/camera/SimpleCameraTest.kt
@@ -1,7 +1,10 @@
 package com.mapbox.navigation.ui.camera
 
 import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.ui.BaseTest
+import io.mockk.every
+import io.mockk.mockk
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -17,7 +20,19 @@ class SimpleCameraTest : BaseTest() {
     }
 
     @Test
-    fun overviewWillNotCachRoute() {
+    fun overview_withRouteProgress() {
+        val route = buildTestDirectionsRoute()
+        val routeProgress = mockk<RouteProgress> {
+            every { distanceTraveled } returns (route.distance() / 2).toFloat()
+        }
+
+        val result = SimpleCamera().overview(RouteInformation(route, null, routeProgress))
+
+        assertEquals(9, result.size)
+    }
+
+    @Test
+    fun overviewWillNotCacheRoute() {
         val route1 = buildTestDirectionsRoute()
         val route2 = getMultilegRoute()
         SimpleCamera().overview(RouteInformation(route1, null, null))


### PR DESCRIPTION
### Description
There was a feature request to add a route overview which would show only the route left to travel rather than the entire route as was already implemented.  This feature addition will use the route progress to determine the distance traveled and find a point along the route to truncate the route's collection of points so that the map is framed around the points representing the part of the route not yet traveled. Depending on the shape of the route the origin point may still be visible but the origin point is not used in the calculation of the map bounding box.

### Changelog
```
<changelog>Added additional route overview method to NavigationMapboxMap to display section of route not yet traveled rather than the full route.</changelog>
```

### Screenshots or Gifs

