### PR TITLE
Update ArrivalObservers to arrive based on ArrivalOption thresholds

### DIFF
--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -101,7 +101,7 @@ package com.mapbox.navigation.core.arrival {
     method public com.mapbox.navigation.core.arrival.ArrivalOptions build();
   }
 
-  public final class AutoArrivalController implements com.mapbox.navigation.core.arrival.ArrivalController {
+  public class AutoArrivalController implements com.mapbox.navigation.core.arrival.ArrivalController {
     ctor public AutoArrivalController();
     method public com.mapbox.navigation.core.arrival.ArrivalOptions arrivalOptions();
     method public boolean navigateNextRouteLeg(com.mapbox.navigation.base.trip.model.RouteLegProgress routeLegProgress);

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/arrival/ArrivalController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/arrival/ArrivalController.kt
@@ -107,8 +107,11 @@ class ArrivalOptions private constructor(
          * Build the object. If you want to disable this feature set *null* in [MapboxNavigation.setArrivalController].
          */
         fun build(): ArrivalOptions {
-            check(arrivalInSeconds != null || arrivalInSeconds != null) {
+            check(arrivalInSeconds != null || arrivalInMeters != null) {
                 "Choose a method to be notified of arrival, time and/or distance."
+            }
+            check(arrivalInSeconds ?: 0.0 >= 0.0 && arrivalInMeters ?: 0.0 >= 0.0) {
+                "Arrival values must be >= 0.0 [$arrivalInSeconds, $arrivalInMeters]"
             }
             return ArrivalOptions(
                 arrivalInSeconds = arrivalInSeconds,

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/arrival/ArrivalObserver.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/arrival/ArrivalObserver.kt
@@ -2,7 +2,6 @@ package com.mapbox.navigation.core.arrival
 
 import com.mapbox.navigation.base.trip.model.RouteLegProgress
 import com.mapbox.navigation.base.trip.model.RouteProgress
-import com.mapbox.navigation.base.trip.model.RouteProgressState
 import com.mapbox.navigation.core.MapboxNavigation
 
 /**
@@ -12,7 +11,7 @@ import com.mapbox.navigation.core.MapboxNavigation
 interface ArrivalObserver {
 
     /**
-     * Called when the [RouteProgress.currentState] has reached [RouteProgressState.ROUTE_COMPLETE],
+     * Called once the [ArrivalOptions] conditions have been met
      * and the route progress has reached a waypoint on the route.
      */
     fun onWaypointArrival(routeProgress: RouteProgress)
@@ -24,7 +23,7 @@ interface ArrivalObserver {
     fun onNextRouteLegStart(routeLegProgress: RouteLegProgress)
 
     /**
-     * Called once the [RouteProgress.currentState] has reached [RouteProgressState.ROUTE_COMPLETE],
+     * Called once the [ArrivalOptions] conditions have been met
      * and the route progress has reached the final destination on the route.
      */
     fun onFinalDestinationArrival(routeProgress: RouteProgress)

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/arrival/AutoArrivalController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/arrival/AutoArrivalController.kt
@@ -9,7 +9,7 @@ import java.util.concurrent.TimeUnit
  * The default controller for arrival. This will move onto the next leg automatically
  * if there is one.
  */
-class AutoArrivalController : ArrivalController {
+open class AutoArrivalController : ArrivalController {
 
     private var routeLegCompletedTime: Long? = null
     private var currentRouteLeg: RouteLeg? = null

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/arrival/ArrivalOptionsTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/arrival/ArrivalOptionsTest.kt
@@ -17,4 +17,26 @@ class ArrivalOptionsTest : BuilderTest<ArrivalOptions, ArrivalOptions.Builder>()
     override fun trigger() {
         // only used to trigger JUnit4 to run this class if all test cases come from the parent
     }
+
+    @Test(expected = Throwable::class)
+    fun `negative arrival time is not supported`() {
+        ArrivalOptions.Builder()
+            .arrivalInMeters(-1.0)
+            .build()
+    }
+
+    @Test(expected = Throwable::class)
+    fun `negative arrival distance is not supported`() {
+        ArrivalOptions.Builder()
+            .arrivalInMeters(-1.0)
+            .build()
+    }
+
+    @Test(expected = Throwable::class)
+    fun `time or distance is required`() {
+        ArrivalOptions.Builder()
+            .arrivalInSeconds(null)
+            .arrivalInMeters(null)
+            .build()
+    }
 }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/arrival/ArrivalProgressObserverTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/arrival/ArrivalProgressObserverTest.kt
@@ -115,6 +115,7 @@ internal class ArrivalProgressObserverTest {
                     mockMultipleLegs()
                 }
                 every { currentLegProgress } returns mockk {
+                    every { routeLeg } returns mockk()
                     every { legIndex } returns 1
                     every { durationRemaining } returns 2.0
                     every { distanceRemaining } returns 8.0f
@@ -147,8 +148,11 @@ internal class ArrivalProgressObserverTest {
                 every { currentState } returns RouteProgressState.ROUTE_COMPLETE
                 every { route } returns mockk {
                     mockMultipleLegs()
+                    every { durationRemaining } returns 2.0
+                    every { distanceRemaining } returns 8.0f
                 }
                 every { currentLegProgress } returns mockk {
+                    every { routeLeg } returns mockk()
                     every { legIndex } returns 2
                     every { durationRemaining } returns 2.0
                     every { distanceRemaining } returns 8.0f
@@ -178,8 +182,11 @@ internal class ArrivalProgressObserverTest {
             every { currentState } returns RouteProgressState.ROUTE_COMPLETE
             every { route } returns mockk {
                 mockMultipleLegs()
+                every { durationRemaining } returns 2.0
+                every { distanceRemaining } returns 8.0f
             }
             every { currentLegProgress } returns mockk {
+                every { routeLeg } returns mockk()
                 every { legIndex } returns 2
                 every { durationRemaining } returns 2.0
                 every { distanceRemaining } returns 8.0f
@@ -212,6 +219,7 @@ internal class ArrivalProgressObserverTest {
             mockk {
                 every { currentState } returns RouteProgressState.LOCATION_TRACKING
                 every { currentLegProgress } returns mockk {
+                    every { routeLeg } returns mockk()
                     every { durationRemaining } returns 1.0
                     every { distanceRemaining } returns 15.0f
                     every { legIndex } returns 0
@@ -245,6 +253,7 @@ internal class ArrivalProgressObserverTest {
                     every { durationRemaining } returns 2.0
                     every { distanceRemaining } returns 8.0f
                     every { legIndex } returns 0
+                    every { routeLeg } returns mockk()
                 }
                 every { route } returns mockk {
                     mockMultipleLegs()
@@ -269,6 +278,7 @@ internal class ArrivalProgressObserverTest {
         val routeProgress: RouteProgress = mockk {
             every { currentState } returns RouteProgressState.LOCATION_TRACKING
             every { currentLegProgress } returns mockk {
+                every { routeLeg } returns mockk()
                 every { durationRemaining } returns 1.0
                 every { distanceRemaining } returns 15.0f
                 every { legIndex } returns 0
@@ -286,7 +296,7 @@ internal class ArrivalProgressObserverTest {
     }
 
     @Test
-    fun `should notify onWaypointArrival only once`() {
+    fun `should notify onWaypointArrival only once for early arrival`() {
         val onNextRouteLegStartCalls = slot<RouteLegProgress>()
         val onWaypointArrivalCalls = mutableListOf<RouteProgress>()
         val customArrivalController: ArrivalController = mockk {
@@ -300,11 +310,12 @@ internal class ArrivalProgressObserverTest {
             arrivalObserver.onWaypointArrival(capture(onWaypointArrivalCalls))
         } returns Unit
         val routeProgress: RouteProgress = mockk {
-            every { currentState } returns RouteProgressState.ROUTE_COMPLETE
+            every { currentState } returns RouteProgressState.LOCATION_TRACKING
             every { route } returns mockk {
                 mockMultipleLegs()
             }
             every { currentLegProgress } returns mockk {
+                every { routeLeg } returns mockk()
                 every { legIndex } returns 1
                 every { durationRemaining } returns 2.0
                 every { distanceRemaining } returns 8.0f
@@ -336,6 +347,7 @@ internal class ArrivalProgressObserverTest {
             mockk {
                 every { currentState } returns RouteProgressState.LOCATION_TRACKING
                 every { currentLegProgress } returns mockk {
+                    every { routeLeg } returns mockk()
                     every { durationRemaining } returns 360.0
                     every { distanceRemaining } returns 80.0f
                     every { legIndex } returns 0
@@ -358,6 +370,7 @@ internal class ArrivalProgressObserverTest {
                 mockMultipleLegs()
                 every { routeIndex() } returns "0"
                 every { currentLegProgress } returns mockk {
+                    every { routeLeg } returns mockk()
                     every { legIndex } returns 0
                     every { durationRemaining } returns 0.0
                     every { distanceRemaining } returns 0.0f


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Have been revising the `ArrivalObserver` interface for the building arrival experience https://github.com/mapbox/mapbox-navigation-android/pull/4078

I just introduced the onWaypointArrival https://github.com/mapbox/mapbox-navigation-android/pull/4238 but it has a big issue. It arrives for both, the completed state and the `ArrivalOptions`. The fix was so easy, I was confused why we didn't do this in the first place. Digging through issues, found that our navigator would stop reporting time/distance values when the state is COMPLETED. Making it so this interface needed to rely on the completed route state. Now that is fixed, we can rely  on`durationRemaining` and `distanceRemaining` instead.

This change makes the the `onWaypontArrival` and `onFinalDestinationArrival` callbacks consistent, and can be specified through the `ArrivalController` as `ArrivalOptions`

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Update ArrivalObservers to arrive based on ArrivalOptions</changelog>
```

<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->

### Extra description

```
This is a timeline. If each tick mark is 1 second, and the arrivalInSeconds is equal to 3.
w is a waypoint. 
d is the final destination.
----------w--------------------w------d
-------0--1-----------------2--3---4--|
0: onWaypointArrival
1: onNextRouteLegStart
2: onWaypointArrival
3: onNextRouteLegStart
4: onFinalDestinationArrival
```

The `AutoArrivalController` will navigate the next route after "arrivalInSeconds" time has passed. Now to configure these options, it makes sense to only override the AutoArrivalController and modify the ArrivalOptions. This is why we're changing AutoArrivalController to `open` - now you can do this.
``` kotlin
mapboxNavigation.setArrivalController(object : AutoArrivalController() {
    override fun arrivalOptions() = ArrivalOptions.Builder()
        .arrivalInSeconds(22.0)
        .build()
})
```