### PR TITLE
Bug fix. The route clearing API was not including the restricted road…

### DIFF
--- a/libnavui-maps/api/current.txt
+++ b/libnavui-maps/api/current.txt
@@ -627,10 +627,12 @@ package com.mapbox.navigation.ui.maps.route.line.model {
     method public com.mapbox.geojson.FeatureCollection getAltRoute1Source();
     method public com.mapbox.geojson.FeatureCollection getAltRoute2Source();
     method public com.mapbox.geojson.FeatureCollection getPrimaryRouteSource();
+    method public com.mapbox.geojson.FeatureCollection getRestrictedRoadSource();
     method public com.mapbox.geojson.FeatureCollection getWaypointsSource();
     property public final com.mapbox.geojson.FeatureCollection altRoute1Source;
     property public final com.mapbox.geojson.FeatureCollection altRoute2Source;
     property public final com.mapbox.geojson.FeatureCollection primaryRouteSource;
+    property public final com.mapbox.geojson.FeatureCollection restrictedRoadSource;
     property public final com.mapbox.geojson.FeatureCollection waypointsSource;
   }
 

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApi.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApi.kt
@@ -310,6 +310,7 @@ class MapboxRouteLineApi(
                             FeatureCollection.fromFeatures(listOf()),
                             FeatureCollection.fromFeatures(listOf()),
                             FeatureCollection.fromFeatures(listOf()),
+                            FeatureCollection.fromFeatures(listOf()),
                             FeatureCollection.fromFeatures(listOf())
                         )
                     )

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineView.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineView.kt
@@ -176,6 +176,11 @@ class MapboxRouteLineView(var options: MapboxRouteLineOptions) {
                     RouteConstants.WAYPOINT_SOURCE_ID,
                     clearRouteLineValue.value.waypointsSource
                 )
+                updateSource(
+                    style,
+                    RouteConstants.RESTRICTED_ROAD_SOURCE_ID,
+                    clearRouteLineValue.value.restrictedRoadSource
+                )
             }
         }
     }

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineClearValue.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineClearValue.kt
@@ -9,10 +9,12 @@ import com.mapbox.geojson.FeatureCollection
  * @param altRoute1Source a feature collection representing an alternative route
  * @param altRoute2Source a feature collection representing an alternative route
  * @param waypointsSource a feature collection representing the origin and destination icons
+ * @param restrictedRoadSource a feature collection representing the restricted roads
  */
 class RouteLineClearValue internal constructor(
     val primaryRouteSource: FeatureCollection,
     val altRoute1Source: FeatureCollection,
     val altRoute2Source: FeatureCollection,
-    val waypointsSource: FeatureCollection
+    val waypointsSource: FeatureCollection,
+    val restrictedRoadSource: FeatureCollection
 )

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApiTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApiTest.kt
@@ -743,6 +743,7 @@ class MapboxRouteLineApiTest {
         assertTrue(result.value.altRoute2Source.features()!!.isEmpty())
         assertTrue(result.value.primaryRouteSource.features()!!.isEmpty())
         assertTrue(result.value.waypointsSource.features()!!.isEmpty())
+        assertTrue(result.value.restrictedRoadSource.features()!!.isEmpty())
     }
 
     @Test


### PR DESCRIPTION
### Description
Fixes #4253 by including the restricted road sections in the clear route API call and rendering.

### Changelog
```
<changelog>Bug fix for restricted road sections not getting cleared when calling API.</changelog>
```

### Screenshots or Gifs
