### PR TITLE
Fix crash when upcomming geometry is missing

### DIFF
--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/arrow/RouteArrowUtils.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/arrow/RouteArrowUtils.kt
@@ -25,18 +25,17 @@ import com.mapbox.turf.TurfMisc
 internal object RouteArrowUtils {
 
     fun obtainArrowPointsFrom(routeProgress: RouteProgress): List<Point> {
-        val reversedCurrent: List<Point> =
-            routeProgress.currentLegProgress?.currentStepProgress?.stepPoints?.reversed()
-                ?: listOf()
-
+        val reversedCurrent: List<Point> = routeProgress.currentLegProgress
+            ?.currentStepProgress?.stepPoints?.reversed()
+            ?: listOf()
         val arrowLineCurrent = LineString.fromLngLats(reversedCurrent)
-        val arrowLineUpcoming = LineString.fromLngLats(routeProgress.upcomingStepPoints!!)
-
-        if (arrowLineCurrent.coordinates().size < 2) {
+        if (reversedCurrent.size < 2) {
             return listOf()
         }
 
-        if (arrowLineUpcoming.coordinates().size < 2) {
+        val upcomingStepPoints = routeProgress.upcomingStepPoints ?: emptyList()
+        val arrowLineUpcoming = LineString.fromLngLats(upcomingStepPoints)
+        if (upcomingStepPoints.size < 2) {
             return listOf()
         }
 

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/arrow/RouteArrowUtilsTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/arrow/RouteArrowUtilsTest.kt
@@ -87,6 +87,29 @@ class RouteArrowUtilsTest {
     }
 
     @Test
+    fun `obtainArrowPointsFrom does not crash when upcomming step geometry is null`() {
+        val routeStepPoints = listOf(
+            Point.fromLngLat(-122.477395, 37.859513),
+            Point.fromLngLat(-122.4784726, 37.8587617),
+            Point.fromLngLat(-122.4784726, 37.8587617)
+        )
+        val stepProgress = mockk<RouteStepProgress> {
+            every { stepPoints } returns routeStepPoints
+        }
+        val routeLegProgress = mockk<RouteLegProgress> {
+            every { currentStepProgress } returns stepProgress
+        }
+        val routeProgress = mockk<RouteProgress> {
+            every { currentLegProgress } returns routeLegProgress
+            every { upcomingStepPoints } returns null
+        }
+
+        val result = RouteArrowUtils.obtainArrowPointsFrom(routeProgress)
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
     fun obtainArrowPointsFrom() {
         val upcomingPoints = listOf(
             Point.fromLngLat(-122.477395, 37.859513),


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Resolves https://github.com/mapbox/mapbox-navigation-android/issues/4249

`LineString.fromLngLats(routeProgress.upcomingStepPoints!!)` << !! causes the crash
`RouteArrowUtils` is making an assumption that the geometry exists and we don't have a definition for saying this is an assumption we can make. I'm looking into improving this upstream in core or native, but we should also fix the crash by removing the assumption. 

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Fix crash when routing new waypoints</changelog>
```

### Screenshots or Gifs
(ignore the buildings in the after video, they're unrelated 😄  )

| Before | After |
| -- | -- |
| ![output](https://user-images.githubusercontent.com/3021882/114448256-2a272c80-9b88-11eb-91de-4eb533378a9d.gif) | ![output](https://user-images.githubusercontent.com/3021882/114468274-0a9bfe00-9ba0-11eb-9d8b-dc8581aee41a.gif) |


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
