### PR TITLE
Refactored route line related code to improve performance.

### DIFF
--- a/examples/src/main/res/layout/layout_activity_routeline.xml
+++ b/examples/src/main/res/layout/layout_activity_routeline.xml
@@ -38,15 +38,6 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:srcCompat="@drawable/ic_layers_24dp"/>
 
-    <com.mapbox.navigation.ui.speedlimit.view.MapboxSpeedLimitView
-        android:id="@+id/speedLimitView"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="64dp"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"/>
-
     <ProgressBar
         android:id="@+id/routeLoadingProgressBar"
         android:layout_width="wrap_content"


### PR DESCRIPTION
### Description
The initialization of the vanishing route line is computationally expensive. The computation was moved so that other route line related computations could be done first since they are needed for a drawing of the route line. The vanishing route line calculations aren't needed for the route line drawing so the computation was moved to free up resources for the more critical computations.

When testing with routes across the U.S. the time to redraw the routes when selecting an alternative route is around 30ms in my testing not including the map rendering time.

### Changelog
```
<changelog>Refactored the route line API to improve performance.</changelog>
```

### Screenshots or Gifs
![20210415_110127](https://user-images.githubusercontent.com/2249818/114917761-28a17280-9ddb-11eb-8a5b-563efab9b0dd.gif)


