### PR TITLE
Set `TilesConfig` `inMemoryTileCache` size to 1GB (1024 x 1024 x 1024)

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -901,7 +901,7 @@ class MapboxNavigation(
 
         return TilesConfig(
             offlineFilesPath,
-            null,
+            1024 * 1024 * 1024,
             null,
             null,
             THREADS_COUNT,


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Sets `TilesConfig` `inMemoryTileCache` size to 1GB (1024 x 1024 x 1024)

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Set `TilesConfig` `inMemoryTileCache` size to 1GB (1024 x 1024 x 1024).</changelog>
```

cc @etl 
