### PR TITLE
Temporarily disable github changelog check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,21 +120,22 @@ commands:
 
   verify-changelog:
     steps:
-      - run:
-          name: Install python dependencies
-          command: python3 -m pip install requests
-      - run:
-          name: Verify that a changelog entry is present in the PR description
-          command: |
-            if [[ -n "$CIRCLE_PULL_REQUEST" ]]; then
-              if [[ -n "$GITHUB_ACCESS_TOKEN" ]]; then
-                python3 scripts/validate-changelog.py ${CIRCLE_PULL_REQUEST##*/} ${GITHUB_ACCESS_TOKEN}
-              else
-                echo "Missing access token, skipping changelog validation."
-              fi
-            else
-              echo "Not a PR, skipping changelog validation."
-            fi
+      - run: echo "Update the github_access_token"
+#      - run:
+#          name: Install python dependencies
+#          command: python3 -m pip install requests
+#      - run:
+#          name: Verify that a changelog entry is present in the PR description
+#          command: |
+#            if [[ -n "$CIRCLE_PULL_REQUEST" ]]; then
+#              if [[ -n "$GITHUB_ACCESS_TOKEN" ]]; then
+#                python3 scripts/validate-changelog.py ${CIRCLE_PULL_REQUEST##*/} ${GITHUB_ACCESS_TOKEN}
+#              else
+#                echo "Missing access token, skipping changelog validation."
+#              fi
+#            else
+#              echo "Not a PR, skipping changelog validation."
+#            fi
 
   assemble-module:
     parameters:


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

It seems this is going to be broken soon, so I'm making this draft PR as a placeholder. 

Considering this issue minor, digging into issues that could be more severe.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog></changelog>
```

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
