### PR TITLE
Bump mapbox-navigation-native dependency version to 48.0.3

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -11,7 +11,7 @@ ext {
   // version which we should use in this build
   def mapboxNavigatorVersion = System.getenv("FORCE_MAPBOX_NAVIGATION_NATIVE_VERSION")
   if (mapboxNavigatorVersion == null || mapboxNavigatorVersion == '') {
-      mapboxNavigatorVersion = '48.0.2'
+      mapboxNavigatorVersion = '48.0.3'
   }
   println("Navigation Native version: " + mapboxNavigatorVersion)
 

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigator.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigator.kt
@@ -161,11 +161,6 @@ interface MapboxNativeNavigator {
     // Offline
 
     /**
-     * Caches tiles around the last set route
-     */
-    fun cacheLastRoute()
-
-    /**
      * Uses valhalla and local tile data to generate mapbox-directions-api-like json.
      *
      * @param url the directions-based uri used when hitting the http service

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigatorImpl.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigatorImpl.kt
@@ -268,13 +268,6 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
     // Offline
 
     /**
-     * Caches tiles around the last set route
-     */
-    override fun cacheLastRoute() {
-        navigator!!.cacheLastRoute()
-    }
-
-    /**
      * Uses valhalla and local tile data to generate mapbox-directions-api-like json.
      *
      * @param url the directions-based uri used when hitting the http service


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Bumps `mapbox-navigation-native` dependency version to `48.0.3`

cc @etl @zugaldia 
