### PR TITLE
Moved some route line related calculations to improve the perceived performance

### DIFF
--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/ui/routeline/SetRouteOrderTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/ui/routeline/SetRouteOrderTest.kt
@@ -65,7 +65,8 @@ class SetRouteOrderTest : BaseTest<BasicNavigationViewActivity>(
             MapboxNavigationConsumer<Expected<RouteLineError, RouteSetValue>> { value ->
                 LoggerProvider.logger.e(Tag("SetRouteCancellationTest"), Message("long"))
                 val primaryRoute = routeLineApi.getPrimaryRoute()
-                val contents = value.value!!.trafficLineExpression.contents as ArrayList<*>
+                val contents =
+                    value.value!!.trafficLineExpressionProvider!!.invoke().contents as ArrayList<*>
                 assertEquals(
                     625,
                     contents.size
@@ -78,7 +79,8 @@ class SetRouteOrderTest : BaseTest<BasicNavigationViewActivity>(
             MapboxNavigationConsumer<Expected<RouteLineError, RouteSetValue>> { value ->
                 LoggerProvider.logger.e(Tag("SetRouteCancellationTest"), Message("short"))
                 val primaryRoute = routeLineApi.getPrimaryRoute()
-                val contents = value.value!!.trafficLineExpression.contents as ArrayList<*>
+                val contents =
+                    value.value!!.trafficLineExpressionProvider!!.invoke().contents as ArrayList<*>
                 assertEquals(shortRoute, primaryRoute)
                 assertEquals(
                     7,
@@ -113,14 +115,20 @@ class SetRouteOrderTest : BaseTest<BasicNavigationViewActivity>(
                 val primaryRoute = routeLineApi.getPrimaryRoute()
                 // The long route result should come in first even though it takes longer.
                 if (consumerCallCount == 0) {
-                    val contents = value.value!!.trafficLineExpression.contents as ArrayList<*>
+                    val contents = value.value!!
+                        .trafficLineExpressionProvider!!
+                        .invoke()
+                        .contents as ArrayList<*>
                     assertEquals(
                         625,
                         contents.size
                     )
                     assertEquals(longRoute, primaryRoute)
                 } else {
-                    val contents = value.value!!.trafficLineExpression.contents as ArrayList<*>
+                    val contents = value.value!!
+                        .trafficLineExpressionProvider!!
+                        .invoke()
+                        .contents as ArrayList<*>
                     assertEquals(shortRoute, primaryRoute)
                     assertEquals(
                         7,
@@ -154,7 +162,10 @@ class SetRouteOrderTest : BaseTest<BasicNavigationViewActivity>(
         val consumer = MapboxNavigationConsumer<Expected<RouteLineError, RouteSetValue>> { value ->
             check(!clearInvoked)
             val primaryRoute = routeLineApi.getPrimaryRoute()
-            val contents = value.value!!.trafficLineExpression.contents as ArrayList<*>
+            val contents = value.value!!
+                .trafficLineExpressionProvider!!
+                .invoke()
+                .contents as ArrayList<*>
             assertEquals(route, primaryRoute)
             assertEquals(
                 625,

--- a/libnavui-maps/api/current.txt
+++ b/libnavui-maps/api/current.txt
@@ -988,24 +988,59 @@ package com.mapbox.navigation.ui.maps.route.line.model {
   }
 
   public final class RouteSetValue {
-    method public com.mapbox.maps.extension.style.expressions.generated.Expression getAltRoute1TrafficExpression();
-    method public com.mapbox.maps.extension.style.expressions.generated.Expression getAltRoute2TrafficExpression();
+    method public kotlin.jvm.functions.Function0<com.mapbox.maps.extension.style.expressions.generated.Expression>? getAltRoute1TrafficExpressionProvider();
+    method public kotlin.jvm.functions.Function0<com.mapbox.maps.extension.style.expressions.generated.Expression>? getAltRoute2TrafficExpressionProvider();
     method public com.mapbox.geojson.FeatureCollection getAlternativeRoute1Source();
     method public com.mapbox.geojson.FeatureCollection getAlternativeRoute2Source();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression getCasingLineExpression();
     method public com.mapbox.geojson.FeatureCollection getPrimaryRouteSource();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression getRouteLineExpression();
-    method public com.mapbox.maps.extension.style.expressions.generated.Expression getTrafficLineExpression();
+    method public kotlin.jvm.functions.Function0<com.mapbox.maps.extension.style.expressions.generated.Expression>? getTrafficLineExpressionProvider();
     method public com.mapbox.geojson.FeatureCollection getWaypointsSource();
-    property public final com.mapbox.maps.extension.style.expressions.generated.Expression altRoute1TrafficExpression;
-    property public final com.mapbox.maps.extension.style.expressions.generated.Expression altRoute2TrafficExpression;
+    method public com.mapbox.navigation.ui.maps.route.line.model.RouteSetValue.MutableRouteSetValue toMutableValue();
+    property public final kotlin.jvm.functions.Function0<com.mapbox.maps.extension.style.expressions.generated.Expression>? altRoute1TrafficExpressionProvider;
+    property public final kotlin.jvm.functions.Function0<com.mapbox.maps.extension.style.expressions.generated.Expression>? altRoute2TrafficExpressionProvider;
     property public final com.mapbox.geojson.FeatureCollection alternativeRoute1Source;
     property public final com.mapbox.geojson.FeatureCollection alternativeRoute2Source;
     property public final com.mapbox.maps.extension.style.expressions.generated.Expression casingLineExpression;
     property public final com.mapbox.geojson.FeatureCollection primaryRouteSource;
     property public final com.mapbox.maps.extension.style.expressions.generated.Expression routeLineExpression;
-    property public final com.mapbox.maps.extension.style.expressions.generated.Expression trafficLineExpression;
+    property public final kotlin.jvm.functions.Function0<com.mapbox.maps.extension.style.expressions.generated.Expression>? trafficLineExpressionProvider;
     property public final com.mapbox.geojson.FeatureCollection waypointsSource;
+  }
+
+  public static final class RouteSetValue.MutableRouteSetValue {
+    method public kotlin.jvm.functions.Function0<com.mapbox.maps.extension.style.expressions.generated.Expression>? getAltRoute1TrafficExpression();
+    method public kotlin.jvm.functions.Function0<com.mapbox.maps.extension.style.expressions.generated.Expression>? getAltRoute2TrafficExpression();
+    method public com.mapbox.geojson.FeatureCollection getAlternativeRoute1Source();
+    method public com.mapbox.geojson.FeatureCollection getAlternativeRoute2Source();
+    method public com.mapbox.maps.extension.style.expressions.generated.Expression getCasingLineExpression();
+    method public com.mapbox.geojson.FeatureCollection getPrimaryRouteSource();
+    method public com.mapbox.maps.extension.style.expressions.generated.Expression getRouteLineExpression();
+    method public kotlin.jvm.functions.Function0<com.mapbox.maps.extension.style.expressions.generated.Expression>? getTrafficLineExpressionProvider();
+    method public com.mapbox.geojson.FeatureCollection getWaypointsSource();
+    method public void setAltRoute1TrafficExpression(kotlin.jvm.functions.Function0<com.mapbox.maps.extension.style.expressions.generated.Expression>? p);
+    method public void setAltRoute2TrafficExpression(kotlin.jvm.functions.Function0<com.mapbox.maps.extension.style.expressions.generated.Expression>? p);
+    method public void setAlternativeRoute1Source(com.mapbox.geojson.FeatureCollection p);
+    method public void setAlternativeRoute2Source(com.mapbox.geojson.FeatureCollection p);
+    method public void setCasingLineExpression(com.mapbox.maps.extension.style.expressions.generated.Expression p);
+    method public void setPrimaryRouteSource(com.mapbox.geojson.FeatureCollection p);
+    method public void setRouteLineExpression(com.mapbox.maps.extension.style.expressions.generated.Expression p);
+    method public void setTrafficLineExpressionProvider(kotlin.jvm.functions.Function0<com.mapbox.maps.extension.style.expressions.generated.Expression>? p);
+    method public void setWaypointsSource(com.mapbox.geojson.FeatureCollection p);
+    method public com.mapbox.navigation.ui.maps.route.line.model.RouteSetValue toImmutableValue();
+    property public final kotlin.jvm.functions.Function0<com.mapbox.maps.extension.style.expressions.generated.Expression>? altRoute1TrafficExpression;
+    property public final kotlin.jvm.functions.Function0<com.mapbox.maps.extension.style.expressions.generated.Expression>? altRoute2TrafficExpression;
+    property public final com.mapbox.geojson.FeatureCollection alternativeRoute1Source;
+    property public final com.mapbox.geojson.FeatureCollection alternativeRoute2Source;
+    property public final com.mapbox.maps.extension.style.expressions.generated.Expression casingLineExpression;
+    property public final com.mapbox.geojson.FeatureCollection primaryRouteSource;
+    property public final com.mapbox.maps.extension.style.expressions.generated.Expression routeLineExpression;
+    property public final kotlin.jvm.functions.Function0<com.mapbox.maps.extension.style.expressions.generated.Expression>? trafficLineExpressionProvider;
+    property public final com.mapbox.geojson.FeatureCollection waypointsSource;
+  }
+
+  public final class RouteSetValueKt {
   }
 
   public final class RouteStyleDescriptor {

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtils.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtils.kt
@@ -29,6 +29,7 @@ import com.mapbox.navigation.ui.maps.route.line.model.RouteLine
 import com.mapbox.navigation.ui.maps.route.line.model.RouteLineColorResources
 import com.mapbox.navigation.ui.maps.route.line.model.RouteLineDistancesIndex
 import com.mapbox.navigation.ui.maps.route.line.model.RouteLineExpressionData
+import com.mapbox.navigation.ui.maps.route.line.model.RouteLineExpressionProvider
 import com.mapbox.navigation.ui.maps.route.line.model.RouteLineGranularDistances
 import com.mapbox.navigation.ui.maps.route.line.model.RouteLineScaleValue
 import com.mapbox.navigation.ui.maps.route.line.model.RouteLineTrafficExpressionData
@@ -863,6 +864,30 @@ object MapboxRouteLineUtils {
         val flatList = nestedList.flatten().flatten()
 
         return RoutePoints(nestedList, flatList)
+    }
+
+    internal fun getTrafficLineExpressionProducer(
+        route: DirectionsRoute,
+        trafficBackfillRoadClasses: List<String>,
+        colorResources: RouteLineColorResources,
+        isPrimaryRoute: Boolean,
+        vanishingPointOffset: Double,
+        fallbackRouteColor: Int,
+        restrictedRoadSectionScale: Double
+    ): RouteLineExpressionProvider = {
+        val segments: List<RouteLineExpressionData> = calculateRouteLineSegments(
+            route,
+            trafficBackfillRoadClasses,
+            isPrimaryRoute,
+            colorResources,
+            restrictedRoadSectionScale,
+            false
+        )
+        getTrafficLineExpression(
+            vanishingPointOffset,
+            segments,
+            fallbackRouteColor
+        )
     }
 
     private fun projectX(x: Double): Double {

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/RouteSetValue.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/RouteSetValue.kt
@@ -7,23 +7,85 @@ import com.mapbox.maps.extension.style.expressions.generated.Expression
  * Represents the side effects for drawing routes on a map.
  *
  * @param primaryRouteSource the feature collection for the primary route line
- * @param trafficLineExpression the expression for the primary route traffic line
+ * @param trafficLineExpressionProvider the expression for the primary route traffic line
  * @param routeLineExpression the expression for the primary route line
  * @param casingLineExpression the expression for the primary route casing line
- * @param altRoute1TrafficExpression the expression for an alternative route traffic line
- * @param altRoute2TrafficExpression the expression for an alternative route traffic line
+ * @param altRoute1TrafficExpressionProvider the expression for an alternative route traffic line
+ * @param altRoute2TrafficExpressionProvider the expression for an alternative route traffic line
  * @param alternativeRoute1Source the feature collection for an alternative route line
  * @param alternativeRoute2Source the feature collection for an alternative route line
  * @param waypointsSource the feature collection for the origin and destination icons
  */
 class RouteSetValue internal constructor(
     val primaryRouteSource: FeatureCollection,
-    val trafficLineExpression: Expression,
+    val trafficLineExpressionProvider: RouteLineExpressionProvider?,
     val routeLineExpression: Expression,
     val casingLineExpression: Expression,
-    val altRoute1TrafficExpression: Expression,
-    val altRoute2TrafficExpression: Expression,
+    val altRoute1TrafficExpressionProvider: RouteLineExpressionProvider?,
+    val altRoute2TrafficExpressionProvider: RouteLineExpressionProvider?,
     val alternativeRoute1Source: FeatureCollection,
     val alternativeRoute2Source: FeatureCollection,
     val waypointsSource: FeatureCollection
-)
+) {
+
+    /**
+     * @return a class with mutable values for replacing.
+     */
+    fun toMutableValue() = MutableRouteSetValue(
+        primaryRouteSource,
+        trafficLineExpressionProvider,
+        routeLineExpression,
+        casingLineExpression,
+        altRoute1TrafficExpressionProvider,
+        altRoute2TrafficExpressionProvider,
+        alternativeRoute1Source,
+        alternativeRoute2Source,
+        waypointsSource
+    )
+
+    /**
+     * Represents the mutable side effects for drawing routes on a map.
+     *
+     * @param primaryRouteSource the feature collection for the primary route line
+     * @param trafficLineExpressionProvider the expression for the primary route traffic line
+     * @param routeLineExpression the expression for the primary route line
+     * @param casingLineExpression the expression for the primary route casing line
+     * @param altRoute1TrafficExpression the expression for an alternative route traffic line
+     * @param altRoute2TrafficExpression the expression for an alternative route traffic line
+     * @param alternativeRoute1Source the feature collection for an alternative route line
+     * @param alternativeRoute2Source the feature collection for an alternative route line
+     * @param waypointsSource the feature collection for the origin and destination icons
+     */
+    class MutableRouteSetValue internal constructor (
+        var primaryRouteSource: FeatureCollection,
+        var trafficLineExpressionProvider: RouteLineExpressionProvider?,
+        var routeLineExpression: Expression,
+        var casingLineExpression: Expression,
+        var altRoute1TrafficExpression: RouteLineExpressionProvider?,
+        var altRoute2TrafficExpression: RouteLineExpressionProvider?,
+        var alternativeRoute1Source: FeatureCollection,
+        var alternativeRoute2Source: FeatureCollection,
+        var waypointsSource: FeatureCollection
+    ) {
+
+        /**
+         * @return a RouteSetValue
+         */
+        fun toImmutableValue() = RouteSetValue(
+            primaryRouteSource,
+            trafficLineExpressionProvider,
+            routeLineExpression,
+            casingLineExpression,
+            altRoute1TrafficExpression,
+            altRoute2TrafficExpression,
+            alternativeRoute1Source,
+            alternativeRoute2Source,
+            waypointsSource
+        )
+    }
+}
+
+/**
+ * Represents a function that returns an [Expression]
+ */
+typealias RouteLineExpressionProvider = () -> Expression

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtilsTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtilsTest.kt
@@ -1642,6 +1642,30 @@ class MapboxRouteLineUtilsTest {
         assertEquals(result.flatList[126].longitude(), result.flatList[127].longitude(), 0.0)
     }
 
+    @Test
+    fun getTrafficLineExpressionProducer() {
+        val routeLineColorResources = RouteLineColorResources.Builder().build()
+        val expectedPrimaryTrafficLineExpression = "[step, [line-progress], " +
+            "[rgba, 0.0, 0.0, 0.0, 0.0], 0.0, [rgba, 86.0, 168.0, 251.0, 1.0], " +
+            "0.9429639111009005, [rgba, 255.0, 149.0, 0.0, 1.0]]"
+        val route = loadRoute("short_route.json")
+
+        val result = MapboxRouteLineUtils.getTrafficLineExpressionProducer(
+            route,
+            listOf(),
+            routeLineColorResources,
+            true,
+            0.0,
+            routeLineColorResources.routeUnknownTrafficColor,
+            10.0
+        ).invoke()
+
+        assertEquals(
+            expectedPrimaryTrafficLineExpression,
+            result.toString()
+        )
+    }
+
     private fun getMultilegRoute(): DirectionsRoute {
         return loadRoute("multileg_route.json")
     }

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/arrow/RouteArrowUtilsTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/arrow/RouteArrowUtilsTest.kt
@@ -27,7 +27,6 @@ import io.mockk.verify
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -334,9 +333,13 @@ class RouteArrowUtilsTest {
         unmockkStatic("com.mapbox.maps.extension.style.sources.SourceKt")
     }
 
-    @Ignore
     @Test
     fun initializeLayers_whenAboveLayerNotExists() {
+        GeoJsonSource.workerThread =
+            HandlerThread("STYLE_WORKER").apply {
+                priority = Thread.MAX_PRIORITY
+                start()
+            }
         mockkStatic("com.mapbox.maps.extension.style.layers.LayerKt")
         mockkStatic("com.mapbox.maps.extension.style.sources.SourceKt")
         val mockImage = mockk<Image>(relaxed = true)
@@ -464,7 +467,7 @@ class RouteArrowUtilsTest {
         unmockkStatic("com.mapbox.maps.extension.style.layers.LayerKt")
         unmockkStatic("com.mapbox.maps.extension.style.sources.SourceKt")
     }
-    //
+
     @Test
     fun initializeLayers_whenArrowHeadHeightZero() {
         val options = RouteArrowOptions.Builder(ctx).build()

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApiTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApiTest.kt
@@ -255,7 +255,7 @@ class MapboxRouteLineApiTest {
         assertEquals(expectedRouteLineExpression, result.value!!.routeLineExpression.toString())
         assertEquals(
             expectedTrafficLineExpression,
-            result.value!!.trafficLineExpression.toString()
+            result.value!!.trafficLineExpressionProvider!!.invoke().toString()
         )
         assertEquals(
             expectedPrimaryRouteSourceGeometry,
@@ -286,12 +286,8 @@ class MapboxRouteLineApiTest {
         val result = api.setRoutes(routes)
 
         assertNotEquals(
-            result.value!!.alternativeRoute1Source,
-            result.value!!.alternativeRoute2Source
-        )
-        assertNotEquals(
-            result.value!!.altRoute1TrafficExpression,
-            result.value!!.altRoute2TrafficExpression
+            result.value!!.altRoute1TrafficExpressionProvider,
+            result.value!!.altRoute2TrafficExpressionProvider
         )
     }
 
@@ -319,9 +315,9 @@ class MapboxRouteLineApiTest {
             "Point{type=Point, bbox=null, coordinates=[-122.523131, 37.975067]}"
         val route = getRoute()
         val routes = listOf(RouteLine(route, null))
-        val consumer = MapboxNavigationConsumer<Expected<RouteLineError, RouteSetValue>> { t ->
+        val consumer = MapboxNavigationConsumer<Expected<RouteLineError, RouteSetValue>> { result ->
             callbackCalled = true
-            val result = t
+
             assertEquals(expectedCasingExpression, result.value!!.casingLineExpression.toString())
             assertEquals(
                 expectedRouteLineExpression,
@@ -329,7 +325,7 @@ class MapboxRouteLineApiTest {
             )
             assertEquals(
                 expectedTrafficLineExpression,
-                result.value!!.trafficLineExpression.toString()
+                result.value!!.trafficLineExpressionProvider!!.invoke().toString()
             )
             assertEquals(
                 expectedPrimaryRouteSourceGeometry,
@@ -385,15 +381,15 @@ class MapboxRouteLineApiTest {
 
         assertEquals(
             expectedPrimaryTrafficLineExpression,
-            result.value!!.trafficLineExpression.toString()
+            result.value!!.trafficLineExpressionProvider!!.invoke().toString()
         )
         assertEquals(
             expectedAlternative1TrafficLineExpression,
-            result.value!!.altRoute1TrafficExpression.toString()
+            result.value!!.altRoute1TrafficExpressionProvider!!.invoke().toString()
         )
         assertEquals(
             expectedAlternative2TrafficLineExpression,
-            result.value!!.altRoute2TrafficExpression.toString()
+            result.value!!.altRoute2TrafficExpressionProvider!!.invoke().toString()
         )
     }
 
@@ -504,7 +500,10 @@ class MapboxRouteLineApiTest {
 
         assertEquals(expectedCasingExpression, result.value!!.casingLineExpression.toString())
         assertEquals(expectedRouteLineExpression, result.value!!.routeLineExpression.toString())
-        assertEquals(expectedTrafficLineExpression, result.value!!.trafficLineExpression.toString())
+        assertEquals(
+            expectedTrafficLineExpression,
+            result.value!!.trafficLineExpressionProvider!!.invoke().toString()
+        )
         assertEquals(
             expectedPrimaryRouteSourceGeometry,
             result.value!!.primaryRouteSource.features()!![0].geometry().toString()
@@ -981,12 +980,14 @@ class MapboxRouteLineApiTest {
 
         val longRouteDef = async {
             val result = api.setRoutes(longRoute)
-            (result.value!!.trafficLineExpression.contents as ArrayList<*>).size
+            (result.value!!.trafficLineExpressionProvider!!.invoke().contents as ArrayList<*>).size
         }
         delay(40)
         val shortRouteDef = async {
             val result = api.setRoutes(shortRoute)
-            (result.value!!.trafficLineExpression.contents as ArrayList<*>).size
+            (
+                result.value!!.trafficLineExpressionProvider!!.invoke().contents as ArrayList<*>
+                ).size
         }
 
         assertEquals(7, shortRouteDef.await())

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/model/RouteSetValueTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/model/RouteSetValueTest.kt
@@ -1,0 +1,100 @@
+package com.mapbox.navigation.ui.maps.route.line.model
+
+import com.mapbox.geojson.FeatureCollection
+import com.mapbox.maps.extension.style.expressions.generated.Expression
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class RouteSetValueTest {
+
+    @Test
+    fun toMutableValue() {
+        val primaryRouteSource = mockk<FeatureCollection>()
+        val trafficLineExpressionProvider = mockk<RouteLineExpressionProvider>()
+        val routeLineExpression = mockk<Expression>()
+        val casingLineExpression = mockk<Expression>()
+        val altRoute1TrafficExpression = mockk<RouteLineExpressionProvider>()
+        val altRoute2TrafficExpression = mockk<RouteLineExpressionProvider>()
+        val alternativeRoute1Source = mockk<FeatureCollection>()
+        val alternativeRoute2Source = mockk<FeatureCollection>()
+        val waypointsSource = mockk<FeatureCollection>()
+
+        val result = RouteSetValue(
+            primaryRouteSource,
+            trafficLineExpressionProvider,
+            routeLineExpression,
+            casingLineExpression,
+            altRoute1TrafficExpression,
+            altRoute2TrafficExpression,
+            alternativeRoute1Source,
+            alternativeRoute2Source,
+            waypointsSource
+        ).toMutableValue()
+
+        assertEquals(primaryRouteSource, result.primaryRouteSource)
+        assertEquals(trafficLineExpressionProvider, result.trafficLineExpressionProvider)
+        assertEquals(routeLineExpression, result.routeLineExpression)
+        assertEquals(casingLineExpression, result.casingLineExpression)
+        assertEquals(altRoute1TrafficExpression, result.altRoute1TrafficExpression)
+        assertEquals(altRoute2TrafficExpression, result.altRoute2TrafficExpression)
+        assertEquals(alternativeRoute1Source, result.alternativeRoute1Source)
+        assertEquals(alternativeRoute2Source, result.alternativeRoute2Source)
+        assertEquals(waypointsSource, result.waypointsSource)
+    }
+
+    @Test
+    fun toImmutableValue() {
+        val primaryRouteSource = mockk<FeatureCollection>()
+        val trafficLineExpressionProvider = mockk<RouteLineExpressionProvider>()
+        val routeLineExpression = mockk<Expression>()
+        val casingLineExpression = mockk<Expression>()
+        val altRoute1TrafficExpression = mockk<RouteLineExpressionProvider>()
+        val altRoute2TrafficExpression = mockk<RouteLineExpressionProvider>()
+        val alternativeRoute1Source = mockk<FeatureCollection>()
+        val alternativeRoute2Source = mockk<FeatureCollection>()
+        val waypointsSource = mockk<FeatureCollection>()
+
+        val replacedPrimaryRouteSource = mockk<FeatureCollection>()
+        val replacedTrafficLineExpressionProvider = mockk<RouteLineExpressionProvider>()
+        val replacedRouteLineExpression = mockk<Expression>()
+        val replacedCasingLineExpression = mockk<Expression>()
+        val replacedAltRoute1TrafficExpression = mockk<RouteLineExpressionProvider>()
+        val replacedAltRoute2TrafficExpression = mockk<RouteLineExpressionProvider>()
+        val replacedAlternativeRoute1Source = mockk<FeatureCollection>()
+        val replacedAlternativeRoute2Source = mockk<FeatureCollection>()
+        val replacedWaypointsSource = mockk<FeatureCollection>()
+        val immutableResult = RouteSetValue(
+            primaryRouteSource,
+            trafficLineExpressionProvider,
+            routeLineExpression,
+            casingLineExpression,
+            altRoute1TrafficExpression,
+            altRoute2TrafficExpression,
+            alternativeRoute1Source,
+            alternativeRoute2Source,
+            waypointsSource
+        ).toMutableValue()
+        immutableResult.primaryRouteSource = replacedPrimaryRouteSource
+        immutableResult.trafficLineExpressionProvider = replacedTrafficLineExpressionProvider
+        immutableResult.routeLineExpression = replacedRouteLineExpression
+        immutableResult.casingLineExpression = replacedCasingLineExpression
+        immutableResult.altRoute1TrafficExpression = replacedAltRoute1TrafficExpression
+        immutableResult.altRoute2TrafficExpression = replacedAltRoute2TrafficExpression
+        immutableResult.alternativeRoute1Source = replacedAlternativeRoute1Source
+        immutableResult.alternativeRoute2Source = replacedAlternativeRoute2Source
+        immutableResult.waypointsSource = replacedWaypointsSource
+
+        val result = immutableResult.toImmutableValue()
+
+        assertEquals(replacedPrimaryRouteSource, result.primaryRouteSource)
+        assertEquals(replacedTrafficLineExpressionProvider, result.trafficLineExpressionProvider)
+        assertEquals(replacedRouteLineExpression, result.routeLineExpression)
+        assertEquals(replacedCasingLineExpression, result.casingLineExpression)
+        assertEquals(replacedAltRoute1TrafficExpression, result.altRoute1TrafficExpressionProvider)
+        assertEquals(replacedAltRoute2TrafficExpression, result.altRoute2TrafficExpressionProvider)
+        assertEquals(replacedAlternativeRoute1Source, result.alternativeRoute1Source)
+        assertEquals(replacedAlternativeRoute2Source, result.alternativeRoute2Source)
+        assertEquals(replacedWaypointsSource, result.waypointsSource)
+    }
+}


### PR DESCRIPTION
### Description
In order to draw the route lines faster the calculation and application of the traffic line gradient has been moved so that it occurs after the drawing of the route lines. 

Previously all of the route line related data was calculated and returned in the set routes call, then the feature collections and traffic expressions passed to the map for rendering. Although the time to perform these operations has been improved recently there was an opportunity to increase the speed at which the route lines would render. 

With the work in this PR the calculation of the traffic expressions is deferred until after the route line sources are applied to the map.  This will cause the route lines to draw first, then the traffic line expressions will be calculated and applied giving the perception that the drawing of the route lines is faster. This would really only be (possibly) perceptible for extremely long routes. 

### Changelog
```
<changelog>Minor performance improvements in the drawing of the route line. Laying out traffic on top of the route is now decoupled from drawing the route itself, which decreases the time in which the core of the route line is first visible.</changelog>
```

### Screenshots or Gifs
![20210420_125441](https://user-images.githubusercontent.com/2249818/115456387-f5deec00-a1d7-11eb-851f-a35461a0e963.gif)


