### PR TITLE
normalize and round down the camera bearing value to 6 decimal places to avoid wrapping edge cases

### DIFF
--- a/libnavigation-util/src/main/java/com/mapbox/navigation/utils/internal/ConversionUtils.kt
+++ b/libnavigation-util/src/main/java/com/mapbox/navigation/utils/internal/ConversionUtils.kt
@@ -1,0 +1,8 @@
+package com.mapbox.navigation.utils.internal
+
+import android.location.Location
+import com.mapbox.geojson.Point
+
+fun Location.toPoint(): Point {
+    return Point.fromLngLat(this.longitude, this.latitude)
+}

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/NavigationCamera.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/NavigationCamera.kt
@@ -331,6 +331,7 @@ class NavigationCamera(
             } else {
                 finalState
             }
+
             finishAnimation(animation as AnimatorSet)
             externalListener?.onAnimationEnd(animation)
             updateFrame(viewportDataSource.getViewportData(), instant = false)

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/MapboxNavigationViewportDataSource.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/MapboxNavigationViewportDataSource.kt
@@ -22,13 +22,13 @@ import com.mapbox.navigation.ui.maps.camera.data.ViewportDataSourceProcessor.get
 import com.mapbox.navigation.ui.maps.camera.data.ViewportDataSourceProcessor.getPointsToFrameOnCurrentStep
 import com.mapbox.navigation.ui.maps.camera.data.ViewportDataSourceProcessor.getScreenBoxForFraming
 import com.mapbox.navigation.ui.maps.camera.data.ViewportDataSourceProcessor.getSmootherBearingForMap
-import com.mapbox.navigation.ui.maps.camera.data.ViewportDataSourceProcessor.normalizeBearing
 import com.mapbox.navigation.ui.maps.camera.data.ViewportDataSourceProcessor.processRouteForPostManeuverFramingGeometry
 import com.mapbox.navigation.ui.maps.camera.data.ViewportDataSourceProcessor.processRouteIntersections
 import com.mapbox.navigation.ui.maps.camera.data.ViewportDataSourceProcessor.processRoutePoints
 import com.mapbox.navigation.ui.maps.camera.data.debugger.MapboxNavigationViewportDataSourceDebugger
-import com.mapbox.navigation.ui.maps.camera.utils.toPoint
+import com.mapbox.navigation.ui.maps.camera.utils.normalizeBearing
 import com.mapbox.navigation.utils.internal.ifNonNull
+import com.mapbox.navigation.utils.internal.toPoint
 import java.util.concurrent.CopyOnWriteArraySet
 import kotlin.math.max
 import kotlin.math.min

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/ViewportDataSourceProcessor.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/ViewportDataSourceProcessor.kt
@@ -13,7 +13,6 @@ import com.mapbox.maps.ScreenCoordinate
 import com.mapbox.maps.Size
 import com.mapbox.navigation.base.trip.model.RouteLegProgress
 import com.mapbox.navigation.base.trip.model.RouteStepProgress
-import com.mapbox.navigation.ui.maps.camera.utils.shortestRotation
 import com.mapbox.turf.TurfConstants
 import com.mapbox.turf.TurfException
 import com.mapbox.turf.TurfMeasurement
@@ -334,12 +333,6 @@ internal object ViewportDataSourceProcessor {
         }
         return currentMapCameraBearing + shortestRotationDiff(output, currentMapCameraBearing)
     }
-
-    /**
-     * Returns a bearing change using the shortest path.
-     */
-    fun normalizeBearing(currentBearing: Double, targetBearing: Double) =
-        currentBearing + shortestRotation(currentBearing, targetBearing)
 
     private fun shortestRotationDiff(angle: Double, anchorAngle: Double): Double {
         if (angle.isNaN() || anchorAngle.isNaN()) {

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/transition/MapboxNavigationCameraTransition.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/transition/MapboxNavigationCameraTransition.kt
@@ -9,7 +9,7 @@ import com.mapbox.maps.MapboxMap
 import com.mapbox.maps.plugin.animation.CameraAnimationsPlugin
 import com.mapbox.maps.plugin.animation.CameraAnimatorOptions
 import com.mapbox.navigation.ui.maps.camera.NavigationCamera.Companion.NAVIGATION_CAMERA_OWNER
-import com.mapbox.navigation.ui.maps.camera.utils.shortestRotation
+import com.mapbox.navigation.ui.maps.camera.utils.normalizeBearing
 import kotlin.math.abs
 import kotlin.math.hypot
 
@@ -83,7 +83,7 @@ class MapboxNavigationCameraTransition(
         cameraOptions.bearing?.let { bearing ->
             var bearingShortestRotation = bearing
             currentMapCameraOptions.bearing?.let {
-                bearingShortestRotation = it + shortestRotation(it, bearing)
+                bearingShortestRotation = normalizeBearing(it, bearing)
             }
             val bearingDuration = 1800.0
             val bearingDelay = (zoomDelay + zoomDuration - bearingDuration).coerceAtLeast(0.0)
@@ -170,7 +170,7 @@ class MapboxNavigationCameraTransition(
         cameraOptions.bearing?.let { bearing ->
             var bearingShortestRotation = bearing
             currentMapCameraOptions.bearing?.let {
-                bearingShortestRotation = it + shortestRotation(it, bearing)
+                bearingShortestRotation = normalizeBearing(it, bearing)
             }
             val bearingAnimator = cameraPlugin.createBearingAnimator(
                 CameraAnimatorOptions.cameraAnimatorOptions(bearingShortestRotation) {
@@ -248,7 +248,7 @@ class MapboxNavigationCameraTransition(
         cameraOptions.bearing?.let { bearing ->
             var bearingShortestRotation = bearing
             currentMapCamera.bearing?.let {
-                bearingShortestRotation = it + shortestRotation(it, bearing)
+                bearingShortestRotation = normalizeBearing(it, bearing)
             }
             val bearingAnimator = cameraPlugin.createBearingAnimator(
                 CameraAnimatorOptions.cameraAnimatorOptions(bearingShortestRotation) {

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/utils/MapboxNavigationCameraUtils.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/utils/MapboxNavigationCameraUtils.kt
@@ -1,12 +1,25 @@
 package com.mapbox.navigation.ui.maps.camera.utils
 
-import android.location.Location
-import com.mapbox.geojson.Point
+import kotlin.math.pow
+import kotlin.math.roundToInt
 
-internal fun shortestRotation(from: Double, to: Double): Double {
+/**
+ * Returns a bearing change using the shortest path.
+ */
+internal fun normalizeBearing(currentBearing: Double, targetBearing: Double): Double {
+    /*
+    rounding is a workaround for https://github.com/mapbox/mapbox-maps-android/issues/274
+    it prevents wrapping to 360 degrees for very small, negative numbers and prevents the camera
+    from spinning around unintentionally
+    */
+    return (currentBearing + shortestRotation(currentBearing, targetBearing)).roundTo(6)
+}
+
+private fun shortestRotation(from: Double, to: Double): Double {
     return (to - from + 540) % 360 - 180
 }
 
-internal fun Location.toPoint(): Point {
-    return Point.fromLngLat(this.longitude, this.latitude)
+private fun Double.roundTo(numFractionDigits: Int): Double {
+    val factor = 10.0.pow(numFractionDigits.toDouble())
+    return (this * factor).roundToInt() / factor
 }

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/camera/data/MapboxNavigationViewportDataSourceTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/camera/data/MapboxNavigationViewportDataSourceTest.kt
@@ -26,7 +26,7 @@ import com.mapbox.navigation.ui.maps.camera.data.ViewportDataSourceProcessor.get
 import com.mapbox.navigation.ui.maps.camera.data.ViewportDataSourceProcessor.processRouteForPostManeuverFramingGeometry
 import com.mapbox.navigation.ui.maps.camera.data.ViewportDataSourceProcessor.processRouteIntersections
 import com.mapbox.navigation.ui.maps.camera.data.ViewportDataSourceProcessor.processRoutePoints
-import com.mapbox.navigation.ui.maps.camera.utils.toPoint
+import com.mapbox.navigation.utils.internal.toPoint
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/camera/data/ViewportDataSourceProcessorTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/camera/data/ViewportDataSourceProcessorTest.kt
@@ -18,7 +18,6 @@ import com.mapbox.navigation.ui.maps.camera.data.ViewportDataSourceProcessor.get
 import com.mapbox.navigation.ui.maps.camera.data.ViewportDataSourceProcessor.getPointsToFrameOnCurrentStep
 import com.mapbox.navigation.ui.maps.camera.data.ViewportDataSourceProcessor.getScreenBoxForFraming
 import com.mapbox.navigation.ui.maps.camera.data.ViewportDataSourceProcessor.getSmootherBearingForMap
-import com.mapbox.navigation.ui.maps.camera.data.ViewportDataSourceProcessor.normalizeBearing
 import com.mapbox.navigation.ui.maps.camera.data.ViewportDataSourceProcessor.processRouteForPostManeuverFramingGeometry
 import com.mapbox.navigation.ui.maps.camera.data.ViewportDataSourceProcessor.processRouteIntersections
 import com.mapbox.navigation.ui.maps.camera.data.ViewportDataSourceProcessor.processRoutePoints
@@ -612,66 +611,6 @@ class ViewportDataSourceProcessorTest {
                 Point.fromLngLat(-77.123, 38.77091)
             ),
             vehicleBearing = 110.0
-        )
-
-        assertEquals(expected, actual, 0.0000001)
-    }
-
-    @Test
-    fun `test normalizeBearing 1`() {
-        val expected = 0.0
-
-        val actual = normalizeBearing(
-            currentBearing = 10.0,
-            targetBearing = 0.0
-        )
-
-        assertEquals(expected, actual, 0.0000001)
-    }
-
-    @Test
-    fun `test normalizeBearing 2`() {
-        val expected = 10.0
-
-        val actual = normalizeBearing(
-            currentBearing = 0.0,
-            targetBearing = 10.0
-        )
-
-        assertEquals(expected, actual, 0.0000001)
-    }
-
-    @Test
-    fun `test normalizeBearing 3`() {
-        val expected = -0.5
-
-        val actual = normalizeBearing(
-            currentBearing = 1.0,
-            targetBearing = 359.5
-        )
-
-        assertEquals(expected, actual, 0.0000001)
-    }
-
-    @Test
-    fun `test normalizeBearing 4`() {
-        val expected = 360.0
-
-        val actual = normalizeBearing(
-            currentBearing = 359.5,
-            targetBearing = 0.0
-        )
-
-        assertEquals(expected, actual, 0.0000001)
-    }
-
-    @Test
-    fun `test normalizeBearing 5`() {
-        val expected = 361.0
-
-        val actual = normalizeBearing(
-            currentBearing = 359.5,
-            targetBearing = 1.0
         )
 
         assertEquals(expected, actual, 0.0000001)

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/camera/transition/MapboxNavigationCameraTransitionTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/camera/transition/MapboxNavigationCameraTransitionTest.kt
@@ -1,0 +1,85 @@
+package com.mapbox.navigation.ui.maps.camera.transition
+
+import com.mapbox.maps.CameraOptions
+import com.mapbox.maps.MapboxMap
+import com.mapbox.maps.plugin.animation.CameraAnimationsPlugin
+import com.mapbox.maps.plugin.animation.CameraAnimatorOptions
+import com.mapbox.navigation.ui.maps.camera.utils.normalizeBearing
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class MapboxNavigationCameraTransitionTest {
+
+    private val mapboxMap: MapboxMap = mockk()
+    private val cameraPlugin: CameraAnimationsPlugin = mockk()
+    private val transitions = MapboxNavigationCameraTransition(mapboxMap, cameraPlugin)
+
+    @Before
+    fun setup() {
+        mockkStatic("com.mapbox.navigation.ui.maps.camera.utils.MapboxNavigationCameraUtilsKt")
+    }
+
+    @Test
+    fun `transitionFromLowZoomToHighZoom - bearing is normalized`() {
+        every { mapboxMap.getCameraOptions() } returns CameraOptions.Builder()
+            .bearing(10.0)
+            .build()
+        val cameraOptions = CameraOptions.Builder()
+            .bearing(350.0)
+            .build()
+
+        val valueSlot = slot<CameraAnimatorOptions<Double>>()
+        every { cameraPlugin.createBearingAnimator(capture(valueSlot), any()) } returns mockk()
+        transitions.transitionFromLowZoomToHighZoom(cameraOptions)
+
+        assertEquals(-10.0, valueSlot.captured.targets.last(), 0.0000000001)
+        verify { normalizeBearing(10.0, 350.0) }
+    }
+
+    @Test
+    fun `transitionFromHighZoomToLowZoom - bearing is normalized`() {
+        every { mapboxMap.getCameraOptions() } returns CameraOptions.Builder()
+            .bearing(10.0)
+            .build()
+        val cameraOptions = CameraOptions.Builder()
+            .bearing(350.0)
+            .build()
+
+        val valueSlot = slot<CameraAnimatorOptions<Double>>()
+        every { cameraPlugin.createBearingAnimator(capture(valueSlot), any()) } returns mockk()
+        transitions.transitionFromHighZoomToLowZoom(cameraOptions)
+
+        assertEquals(-10.0, valueSlot.captured.targets.last(), 0.0000000001)
+        verify { normalizeBearing(10.0, 350.0) }
+    }
+
+    @Test
+    fun `transitionLinear - bearing is normalized`() {
+        every { mapboxMap.getCameraOptions() } returns CameraOptions.Builder()
+            .bearing(10.0)
+            .build()
+        val cameraOptions = CameraOptions.Builder()
+            .bearing(350.0)
+            .build()
+
+        val valueSlot = slot<CameraAnimatorOptions<Double>>()
+        every { cameraPlugin.createBearingAnimator(capture(valueSlot), any()) } returns mockk()
+        transitions.transitionLinear(cameraOptions)
+
+        assertEquals(-10.0, valueSlot.captured.targets.last(), 0.0000000001)
+        verify { normalizeBearing(10.0, 350.0) }
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic("com.mapbox.navigation.ui.maps.camera.utils.MapboxNavigationCameraUtilsKt")
+    }
+}

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/camera/utils/MapboxNavigationCameraUtilsKtTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/camera/utils/MapboxNavigationCameraUtilsKtTest.kt
@@ -1,0 +1,115 @@
+package com.mapbox.navigation.ui.maps.camera.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MapboxNavigationCameraUtilsKtTest {
+
+    @Test
+    fun `test normalizeBearing 1`() {
+        val expected = 0.0
+
+        val actual = normalizeBearing(
+            currentBearing = 10.0,
+            targetBearing = 0.0
+        )
+
+        assertEquals(expected, actual, 0.0000001)
+    }
+
+    @Test
+    fun `test normalizeBearing 2`() {
+        val expected = 10.0
+
+        val actual = normalizeBearing(
+            currentBearing = 0.0,
+            targetBearing = 10.0
+        )
+
+        assertEquals(expected, actual, 0.0000001)
+    }
+
+    @Test
+    fun `test normalizeBearing 3`() {
+        val expected = -0.5
+
+        val actual = normalizeBearing(
+            currentBearing = 1.0,
+            targetBearing = 359.5
+        )
+
+        assertEquals(expected, actual, 0.0000001)
+    }
+
+    @Test
+    fun `test normalizeBearing 4`() {
+        val expected = 360.0
+
+        val actual = normalizeBearing(
+            currentBearing = 359.5,
+            targetBearing = 0.0
+        )
+
+        assertEquals(expected, actual, 0.0000001)
+    }
+
+    @Test
+    fun `test normalizeBearing 5`() {
+        val expected = 361.0
+
+        val actual = normalizeBearing(
+            currentBearing = 359.5,
+            targetBearing = 1.0
+        )
+
+        assertEquals(expected, actual, 0.0000001)
+    }
+
+    @Test
+    fun `test normalizeBearing 6`() {
+        val expected = 110.0
+
+        val actual = normalizeBearing(
+            currentBearing = 50.0,
+            targetBearing = 110.0
+        )
+
+        assertEquals(expected, actual, 0.000001)
+    }
+
+    @Test
+    fun `test normalizeBearing 7`() {
+        val expected = 0.0
+
+        val actual = normalizeBearing(
+            currentBearing = -0.0,
+            targetBearing = 360.0
+        )
+
+        assertEquals(expected, actual, 0.000001)
+    }
+
+    @Test
+    fun `test normalizeBearing 8`() {
+        val expected = -0.0
+
+        val actual = normalizeBearing(
+            currentBearing = -0.0,
+            targetBearing = 0.0
+        )
+
+        assertEquals(expected, actual, 0.000001)
+    }
+
+    @Test
+    fun `test normalizeBearing 9`() {
+        val expected = 0.0
+
+        val actual = normalizeBearing(
+            currentBearing = 27.254667247679752,
+            targetBearing = 0.0
+        )
+
+        assertEquals(expected, actual, 1E-14)
+    }
+}


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Workaround for https://github.com/mapbox/mapbox-maps-android/issues/274.

This PR refactors the bearing normalization logic in the navigation camera and also rounds down the number of digits when this calculation happens. This successfully prevents the very small negative number from being wrapped to 360.0 by the Map SDK which in turn prevents unexpected unwrapping and spins of the camera.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Fixed an issue with the NavigationCamera occasionally spinning around when a transition to a state (typically `overview`) finished.</changelog>
```

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->
Video available in https://github.com/mapbox/mapbox-maps-android/issues/274.

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->

cc @d-prukop @MaximAlien not sure if this can also be an issue for the iOS SDK but the unexpected unwrapping probably comes from GL-Native, so might impact you as well