### PR TITLE
Reset camera anchor to null before starting a camera transition

### DIFF
--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/NavigationCamera.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/NavigationCamera.kt
@@ -299,6 +299,10 @@ class NavigationCamera(
         if (instant) {
             animatorSet.duration = 0
         }
+
+        // workaround for https://github.com/mapbox/mapbox-maps-android/issues/277
+        cameraPlugin.anchor = null
+
         animatorSet.start()
         runningAnimation = animatorSet
     }

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/camera/NavigationCameraTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/camera/NavigationCameraTest.kt
@@ -129,6 +129,26 @@ class NavigationCameraTest {
         )
     }
 
+    /**
+     * workaround for https://github.com/mapbox/mapbox-maps-android/issues/277
+     */
+    @Test
+    fun `when following requested, anchor nullified`() {
+        navigationCamera.requestNavigationCameraToFollowing()
+
+        verify { cameraPlugin.anchor = null }
+    }
+
+    /**
+     * workaround for https://github.com/mapbox/mapbox-maps-android/issues/277
+     */
+    @Test
+    fun `when overview requested, anchor nullified`() {
+        navigationCamera.requestNavigationCameraToOverview()
+
+        verify { cameraPlugin.anchor = null }
+    }
+
     @Test
     fun `when following requested twice, transition executed once`() {
         navigationCamera.requestNavigationCameraToFollowing()


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Workaround for https://github.com/mapbox/mapbox-maps-android/issues/277. Restores the anchor to `null` before running each navigation camera transition to avoid incorrect camera transformations.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Fixed an issue with the `NavigationCamera` transitions occasionally finishing at an incorrect visual target. This could occur when a gesture interaction with the map preceded the transition. See [mapbox-maps-android/issues/277](https://github.com/mapbox/mapbox-maps-android/issues/277) for details and workarounds.</changelog>
```

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->
Before:

https://user-images.githubusercontent.com/16925074/115556158-a91b1400-a2b0-11eb-9e91-f874214d8fb5.mp4

After:

https://user-images.githubusercontent.com/16925074/115556316-da93df80-a2b0-11eb-9a72-7e2df60cf1ce.mp4


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
