### PR TITLE
Modified collection to copy on write to protect against concurrent modification

### DIFF
--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApi.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApi.kt
@@ -300,11 +300,11 @@ class MapboxRouteLineApi(
     ) {
         jobControl.scope.launch {
             mutex.withLock {
+                routeLineOptions.vanishingRouteLine?.clear()
                 routeLineOptions.vanishingRouteLine?.vanishPointOffset = 0.0
                 directionsRoutes.clear()
                 routeFeatureData.clear()
                 routeLineExpressionData.clear()
-                routeLineOptions.vanishingRouteLine?.clear()
 
                 consumer.accept(
                     Expected.Success(
@@ -617,6 +617,7 @@ class MapboxRouteLineApi(
     private suspend fun buildDrawRoutesState(
         featureDataProvider: () -> List<RouteFeatureData>
     ): Expected<RouteSetValue, RouteLineError> {
+        routeLineOptions.vanishingRouteLine?.clear()
         val routeFeatureDataDef = jobControl.scope.async(ThreadController.IODispatcher) {
             featureDataProvider()
         }

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApiTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApiTest.kt
@@ -177,6 +177,25 @@ class MapboxRouteLineApiTest {
     }
 
     @Test
+    fun setRoutes_clearsVanishingRouteLine() = coroutineRule.runBlockingTest {
+        val vanishingRouteLine = mockk<VanishingRouteLine>(relaxed = true)
+        val realOptions = MapboxRouteLineOptions.Builder(ctx).build()
+        val options = mockk<MapboxRouteLineOptions>()
+        every { options.routeLayerProvider } returns realOptions.routeLayerProvider
+        every { options.resourceProvider } returns realOptions.resourceProvider
+        every { options.vanishingRouteLine } returns vanishingRouteLine
+        every { options.enableRestrictedRoadLayer } returns false
+
+        val api = MapboxRouteLineApi(options)
+        val route = getRoute()
+        val routes = listOf(RouteLine(route, null))
+
+        api.setRoutes(routes)
+
+        verify { vanishingRouteLine.clear() }
+    }
+
+    @Test
     fun setRoutes_setsVanishPointToZero() = coroutineRule.runBlockingTest {
         val options = MapboxRouteLineOptions.Builder(ctx)
             .withVanishingRouteLineEnabled(true)


### PR DESCRIPTION
### Description
A fix for #4251, a collection was changed to copy on write since it is passed to external classes that read it. 

### Changelog
```
<changelog>Bug fix for route line related concurrent modification of collection.</changelog>
```

### Screenshots or Gifs

