### PR TITLE
Test native crashlytics with gcloud again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -302,6 +302,18 @@ commands:
           name: Download native libraries for crashlytics
           command: ./gradlew downloadUnstrippedNativeLibsDir
 
+  upload-native-libs-to-crashlytics:
+    steps:
+      - run:
+          name: Generate crashlytics symbol file felease
+          command: ./gradlew examples:generateCrashlyticsSymbolFileRelease -d | grep "com.google.firebase.crashlytics"
+      - run:
+          name: Upload crashlytics mapping file felease
+          command: ./gradlew examples:uploadCrashlyticsMappingFileRelease -d | grep "com.google.firebase.crashlytics"
+      - run:
+          name: Upload crashlytics symbol file release
+          command: ./gradlew examples:uploadCrashlyticsSymbolFileRelease -d | grep "com.google.firebase.crashlytics"
+
   run-internal-firebase-instrumentation:
     parameters:
       module_wrapper:
@@ -467,6 +479,7 @@ jobs:
           variant: "Release"
           inject_token: true
       - login-google-cloud-platform
+      - upload-native-libs-to-crashlytics
       - run-firebase-robo:
           module_target: "examples"
           variant: "release"

--- a/build.gradle
+++ b/build.gradle
@@ -60,9 +60,9 @@ allprojects {
     // we allow access to snapshots repo if ALLOW_SNAPSHOT_REPOSITORY is set, what means we are running on CI 
     // with Navigation Native forced to be some snapshot version
     // if you need to use snapshots while development, just set `addSnapshotsRepo` to true manually
-    def addSnapshotsRepo = System.getenv("ALLOW_SNAPSHOT_REPOSITORY")?.toBoolean() ?: false
-    if (addSnapshotsRepo) {
-      println("Snapshot repository reference added.")
+//    def addSnapshotsRepo = System.getenv("ALLOW_SNAPSHOT_REPOSITORY")?.toBoolean() ?: false
+//    if (addSnapshotsRepo) {
+//      println("Snapshot repository reference added")
       maven {
         url 'https://api.mapbox.com/downloads/v2/snapshots/maven'
         authentication {
@@ -73,7 +73,7 @@ allprojects {
           password = project.hasProperty('SDK_REGISTRY_TOKEN') ? project.property('SDK_REGISTRY_TOKEN') : System.getenv('SDK_REGISTRY_TOKEN')
         }
       }
-    } 
+//    }
 
     /*maven {
       url 'https://mapbox.bintray.com/mapbox_internal'

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -9,18 +9,18 @@ ext {
   // Navigation Native CI can run SDK CI downstream with forced Navigation Native version
   // in this case `FORCE_MAPBOX_NAVIGATION_NATIVE_VERSION` environment variable will contain
   // version which we should use in this build
-  def mapboxNavigatorVersion = System.getenv("FORCE_MAPBOX_NAVIGATION_NATIVE_VERSION")
-  if (mapboxNavigatorVersion == null || mapboxNavigatorVersion == '') {
-      mapboxNavigatorVersion = '48.0.3'
-  }
-  println("Navigation Native version: " + mapboxNavigatorVersion)
+//  def mapboxNavigatorVersion = System.getenv("FORCE_MAPBOX_NAVIGATION_NATIVE_VERSION")
+//  if (mapboxNavigatorVersion == null || mapboxNavigatorVersion == '') {
+//      mapboxNavigatorVersion = '48.0.3'
+//  }
+//  println("Navigation Native version: " + mapboxNavigatorVersion)
 
   version = [
       mapboxMapSdk              : '10.0.0-beta.17',
       mapboxSdkServices         : '5.9.0-alpha.5',
       mapboxEvents              : '6.2.2',
       mapboxCore                : '3.1.1',
-      mapboxNavigator           : "${mapboxNavigatorVersion}",
+      mapboxNavigator           : "sf-crashes-3-SNAPSHOT",
       mapboxCommonNative        : '11.0.1',
       mapboxCrashMonitor        : '2.0.0',
       mapboxAnnotationPlugin    : '0.8.0',

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/navigator/TilesetDescriptorFactory.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/navigator/TilesetDescriptorFactory.kt
@@ -109,14 +109,14 @@ class TilesetDescriptorFactory internal constructor(
             cache: CacheHandle,
             tilesDatasetAndProfile: String
         ): TilesetDescriptor {
-            return NativeTilesetDescriptorFactory.buildLatestLocal(cache, tilesDatasetAndProfile)
+            return NativeTilesetDescriptorFactory.buildLatestLocal(cache)
         }
 
         override fun buildLatestServer(
             cache: CacheHandle,
             tilesDatasetAndProfile: String
         ): TilesetDescriptor {
-            return NativeTilesetDescriptorFactory.buildLatestServer(cache, tilesDatasetAndProfile)
+            return NativeTilesetDescriptorFactory.buildLatestServer(cache)
         }
     }
 }


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Rerun of this one https://github.com/mapbox/mapbox-navigation-android/pull/4159
One of the bullet points here https://github.com/mapbox/navigation-sdks/issues/908

I found a gcloud run that [deobfuscated a proguarded crash](https://github.com/mapbox/mapbox-navigation-android/pull/3592#issuecomment-824943330). So now I'm testing the firebase robo runs. This would confirm that there is a solution for this one https://github.com/firebase/firebase-android-sdk/issues/2550

