### PR TITLE
Enable native crashlytics in robo test runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -302,6 +302,18 @@ commands:
           name: Download native libraries for crashlytics
           command: ./gradlew downloadUnstrippedNativeLibsDir
 
+  upload-native-libs-to-crashlytics:
+    steps:
+      - run:
+          name: Generate crashlytics symbol file felease
+          command: ./gradlew examples:generateCrashlyticsSymbolFileRelease -d | grep "com.google.firebase.crashlytics"
+      - run:
+          name: Upload crashlytics mapping file felease
+          command: ./gradlew examples:uploadCrashlyticsMappingFileRelease -d | grep "com.google.firebase.crashlytics"
+      - run:
+          name: Upload crashlytics symbol file release
+          command: ./gradlew examples:uploadCrashlyticsSymbolFileRelease -d | grep "com.google.firebase.crashlytics"
+
   run-internal-firebase-instrumentation:
     parameters:
       module_wrapper:
@@ -467,6 +479,7 @@ jobs:
           variant: "Release"
           inject_token: true
       - login-google-cloud-platform
+      - upload-native-libs-to-crashlytics
       - run-firebase-robo:
           module_target: "examples"
           variant: "release"


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

https://github.com/mapbox/mapbox-navigation-android/pull/4304

Confirmed it is working for glcoud now. These commands take a bit of time, which is why I didn't enable it before.

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->

![Screen Shot 2021-04-22 at 11 54 54 AM](https://user-images.githubusercontent.com/3021882/115770441-91e82f00-a361-11eb-8f19-4c73b90e09bd.png)

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
