### PR TITLE
Fix changelog verification

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,10 @@ workflows:
   default:
     jobs:
       - prepare-and-assemble
+      - changelog-verification:
+          filters:
+            branches:
+              ignore: /^(main|release-.*)/
       - static-analysis:
           requires:
             - prepare-and-assemble
@@ -58,12 +62,6 @@ workflows:
       - instrumentation-tests:
           requires:
             - prepare-and-assemble
-      - changelog-verification:
-          requires:
-            - static-analysis
-          filters:
-            branches:
-              ignore: /^(main|release-.*)/
 #      - mobile-metrics-dry-run:
 #          type: approval
 #      - mobile-metrics-benchmarks:
@@ -126,12 +124,11 @@ commands:
       - run:
           name: Verify that a changelog entry is present in the PR description
           command: |
+            curl -Ls https://mapbox-release-engineering.s3.amazonaws.com/mbx-ci/latest/mbx-ci-linux-amd64 > mbx-ci
+            chmod 755 ./mbx-ci
+            MBX_CI_GITHUB_TOKEN=$(./mbx-ci github reader token)
             if [[ -n "$CIRCLE_PULL_REQUEST" ]]; then
-              if [[ -n "$GITHUB_ACCESS_TOKEN" ]]; then
-                python3 scripts/validate-changelog.py ${CIRCLE_PULL_REQUEST##*/} ${GITHUB_ACCESS_TOKEN}
-              else
-                echo "Missing access token, skipping changelog validation."
-              fi
+              python3 scripts/validate-changelog.py ${CIRCLE_PULL_REQUEST##*/} ${MBX_CI_GITHUB_TOKEN}
             else
               echo "Not a PR, skipping changelog validation."
             fi
@@ -449,7 +446,7 @@ jobs:
   changelog-verification:
     executor: ndk-r21-latest-executor
     steps:
-      - read-workspace
+      - checkout
       - verify-changelog
 
   ui-robo-tests:


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Resolves https://github.com/mapbox/mapbox-navigation-android/issues/4299

I've also updated when it will run, now your changelog failure will happen in ~1 minute rather than waiting for static analysis to complete. It used to take ~33 minutes as you can see below (waits for `prepare-and-assemble` and `static-analysis`).

Note that circleci now has the `MBX_CI_DOMAIN` environment variable to make this work

| **After** |
| -- |
| ![Screen Shot 2021-04-22 at 3 15 33 PM](https://user-images.githubusercontent.com/3021882/115791659-ab976f80-a37d-11eb-9c22-c5e3c320cdab.png)


| **Before** |
| -- |
| ![Screen Shot 2021-04-22 at 3 15 46 PM](https://user-images.githubusercontent.com/3021882/115791630-a1757100-a37d-11eb-89f6-4bdd8f041763.png) |

