### PR TITLE
Bump maps to v10.0.0-beta.18 and common to 11.0.2

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/IndependentRouteGenerationActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/IndependentRouteGenerationActivity.kt
@@ -16,18 +16,18 @@ import com.mapbox.maps.CameraOptions
 import com.mapbox.maps.MapboxMap
 import com.mapbox.maps.Style
 import com.mapbox.maps.plugin.animation.MapAnimationOptions
-import com.mapbox.maps.plugin.animation.getCameraAnimationsPlugin
+import com.mapbox.maps.plugin.animation.camera
+import com.mapbox.maps.plugin.annotation.annotations
 import com.mapbox.maps.plugin.annotation.generated.CircleAnnotationManager
 import com.mapbox.maps.plugin.annotation.generated.CircleAnnotationOptions
 import com.mapbox.maps.plugin.annotation.generated.PolylineAnnotationManager
 import com.mapbox.maps.plugin.annotation.generated.PolylineAnnotationOptions
 import com.mapbox.maps.plugin.annotation.generated.createCircleAnnotationManager
 import com.mapbox.maps.plugin.annotation.generated.createPolylineAnnotationManager
-import com.mapbox.maps.plugin.annotation.getAnnotationPlugin
 import com.mapbox.maps.plugin.gestures.OnMapLongClickListener
-import com.mapbox.maps.plugin.gestures.getGesturesPlugin
+import com.mapbox.maps.plugin.gestures.gestures
 import com.mapbox.maps.plugin.locationcomponent.LocationComponentPlugin
-import com.mapbox.maps.plugin.locationcomponent.getLocationComponentPlugin
+import com.mapbox.maps.plugin.locationcomponent.location
 import com.mapbox.navigation.base.formatter.DistanceFormatterOptions
 import com.mapbox.navigation.base.internal.extensions.applyDefaultParams
 import com.mapbox.navigation.base.options.NavigationOptions
@@ -85,11 +85,11 @@ class IndependentRouteGenerationActivity : AppCompatActivity() {
         setContentView(binding.root)
 
         mapboxMap = binding.mapView.getMapboxMap()
-        circleManager = binding.mapView.getAnnotationPlugin()
+        circleManager = binding.mapView.annotations
             .createCircleAnnotationManager(binding.mapView, null)
-        lineManager = binding.mapView.getAnnotationPlugin()
+        lineManager = binding.mapView.annotations
             .createPolylineAnnotationManager(binding.mapView, null)
-        locationComponent = binding.mapView.getLocationComponentPlugin().apply {
+        locationComponent = binding.mapView.location.apply {
             setLocationProvider(navigationLocationProvider)
             enabled = true
         }
@@ -102,7 +102,7 @@ class IndependentRouteGenerationActivity : AppCompatActivity() {
         mapboxMap.loadStyleUri(
             Style.MAPBOX_STREETS,
             { style: Style ->
-                binding.mapView.getGesturesPlugin().addOnMapLongClickListener(
+                binding.mapView.gestures.addOnMapLongClickListener(
                     mapLongClickListener
                 )
             }
@@ -195,7 +195,7 @@ class IndependentRouteGenerationActivity : AppCompatActivity() {
     private fun updateCamera(point: Point) {
         val mapAnimationOptionsBuilder = MapAnimationOptions.Builder()
         mapAnimationOptionsBuilder.duration(1500L)
-        binding.mapView.getCameraAnimationsPlugin().flyTo(
+        binding.mapView.camera.flyTo(
             CameraOptions.Builder()
                 .center(point)
                 .bearing(0.0)

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxBuildingHighlightActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxBuildingHighlightActivity.kt
@@ -16,11 +16,11 @@ import com.mapbox.maps.MapboxMap
 import com.mapbox.maps.Style.Companion.MAPBOX_STREETS
 import com.mapbox.maps.plugin.animation.CameraAnimationsPlugin
 import com.mapbox.maps.plugin.animation.MapAnimationOptions
-import com.mapbox.maps.plugin.animation.getCameraAnimationsPlugin
+import com.mapbox.maps.plugin.animation.camera
 import com.mapbox.maps.plugin.gestures.OnMapLongClickListener
-import com.mapbox.maps.plugin.gestures.getGesturesPlugin
+import com.mapbox.maps.plugin.gestures.gestures
 import com.mapbox.maps.plugin.locationcomponent.LocationComponentPlugin
-import com.mapbox.maps.plugin.locationcomponent.getLocationComponentPlugin
+import com.mapbox.maps.plugin.locationcomponent.location
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.MapboxNavigation
@@ -176,13 +176,13 @@ class MapboxBuildingHighlightActivity : AppCompatActivity(), OnMapLongClickListe
         mapboxMap.loadStyleUri(
             MAPBOX_STREETS
         ) {
-            binding.mapView.getGesturesPlugin().addOnMapLongClickListener(this)
+            binding.mapView.gestures.addOnMapLongClickListener(this)
 
             /**
              * Try attaching to the map click listener, highlight the building the
              * user has selected.
              */
-            binding.mapView.getGesturesPlugin().addOnMapClickListener { point ->
+            binding.mapView.gestures.addOnMapClickListener { point ->
                 buildingHighlightApi.highlightBuilding(point)
                 false
             }
@@ -194,7 +194,7 @@ class MapboxBuildingHighlightActivity : AppCompatActivity(), OnMapLongClickListe
     }
 
     private fun getMapCamera(): CameraAnimationsPlugin {
-        return binding.mapView.getCameraAnimationsPlugin()
+        return binding.mapView.camera
     }
 
     private fun startSimulation(route: DirectionsRoute) {
@@ -279,7 +279,7 @@ class MapboxBuildingHighlightActivity : AppCompatActivity(), OnMapLongClickListe
          */
         buildingsArrivalApi.buildingHighlightApi(buildingHighlightApi)
 
-        locationComponent = binding.mapView.getLocationComponentPlugin().apply {
+        locationComponent = binding.mapView.location.apply {
             setLocationProvider(navigationLocationProvider)
             enabled = true
         }

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxCustomStyleActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxCustomStyleActivity.kt
@@ -16,14 +16,12 @@ import com.mapbox.maps.CameraOptions
 import com.mapbox.maps.EdgeInsets
 import com.mapbox.maps.MapboxMap
 import com.mapbox.maps.Style
-import com.mapbox.maps.plugin.animation.CameraAnimationsPlugin
 import com.mapbox.maps.plugin.animation.MapAnimationOptions
-import com.mapbox.maps.plugin.animation.getCameraAnimationsPlugin
-import com.mapbox.maps.plugin.gestures.GesturesPlugin
+import com.mapbox.maps.plugin.animation.camera
 import com.mapbox.maps.plugin.gestures.OnMapLongClickListener
-import com.mapbox.maps.plugin.gestures.getGesturesPlugin
+import com.mapbox.maps.plugin.gestures.gestures
 import com.mapbox.maps.plugin.locationcomponent.LocationComponentPlugin
-import com.mapbox.maps.plugin.locationcomponent.getLocationComponentPlugin
+import com.mapbox.maps.plugin.locationcomponent.location
 import com.mapbox.navigation.base.formatter.DistanceFormatterOptions
 import com.mapbox.navigation.base.internal.extensions.applyDefaultParams
 import com.mapbox.navigation.base.options.NavigationOptions
@@ -78,7 +76,6 @@ import java.util.Objects
 class MapboxCustomStyleActivity : AppCompatActivity(), OnMapLongClickListener {
 
     private lateinit var mapboxMap: MapboxMap
-    private lateinit var mapCamera: CameraAnimationsPlugin
     private lateinit var mapboxNavigation: MapboxNavigation
     private lateinit var binding: LayoutActivityStyleBinding
     private lateinit var locationComponent: LocationComponentPlugin
@@ -267,7 +264,7 @@ class MapboxCustomStyleActivity : AppCompatActivity(), OnMapLongClickListener {
         mapboxMap.loadStyleUri(
             Style.MAPBOX_STREETS
         ) {
-            getGesturePlugin().addOnMapLongClickListener(this)
+            binding.mapView.gestures.addOnMapLongClickListener(this)
         }
     }
 
@@ -309,18 +306,10 @@ class MapboxCustomStyleActivity : AppCompatActivity(), OnMapLongClickListener {
         )
     }
 
-    private fun getMapCamera(): CameraAnimationsPlugin {
-        return binding.mapView.getCameraAnimationsPlugin()
-    }
-
-    private fun getGesturePlugin(): GesturesPlugin {
-        return binding.mapView.getGesturesPlugin()
-    }
-
     private fun updateCamera(location: Location) {
         val mapAnimationOptionsBuilder = MapAnimationOptions.Builder()
         mapAnimationOptionsBuilder.duration(1500L)
-        mapCamera.easeTo(
+        binding.mapView.camera.easeTo(
             CameraOptions.Builder()
                 .center(Point.fromLngLat(location.longitude, location.latitude))
                 .bearing(location.bearing.toDouble())
@@ -341,11 +330,10 @@ class MapboxCustomStyleActivity : AppCompatActivity(), OnMapLongClickListener {
         binding = LayoutActivityStyleBinding.inflate(layoutInflater)
         setContentView(binding.root)
         mapboxMap = binding.mapView.getMapboxMap()
-        locationComponent = binding.mapView.getLocationComponentPlugin().apply {
+        locationComponent = binding.mapView.location.apply {
             setLocationProvider(navigationLocationProvider)
             enabled = true
         }
-        mapCamera = getMapCamera()
         init()
     }
 

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxJunctionActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxJunctionActivity.kt
@@ -13,14 +13,12 @@ import com.mapbox.maps.CameraOptions
 import com.mapbox.maps.EdgeInsets
 import com.mapbox.maps.MapboxMap
 import com.mapbox.maps.Style.Companion.MAPBOX_STREETS
-import com.mapbox.maps.plugin.animation.CameraAnimationsPlugin
 import com.mapbox.maps.plugin.animation.MapAnimationOptions
-import com.mapbox.maps.plugin.animation.getCameraAnimationsPlugin
-import com.mapbox.maps.plugin.gestures.GesturesPlugin
+import com.mapbox.maps.plugin.animation.camera
 import com.mapbox.maps.plugin.gestures.OnMapLongClickListener
-import com.mapbox.maps.plugin.gestures.getGesturesPlugin
+import com.mapbox.maps.plugin.gestures.gestures
 import com.mapbox.maps.plugin.locationcomponent.LocationComponentPlugin
-import com.mapbox.maps.plugin.locationcomponent.getLocationComponentPlugin
+import com.mapbox.maps.plugin.locationcomponent.location
 import com.mapbox.navigation.base.internal.extensions.applyDefaultParams
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.trip.model.RouteProgress
@@ -71,7 +69,6 @@ import kotlinx.coroutines.launch
 class MapboxJunctionActivity : AppCompatActivity(), OnMapLongClickListener {
 
     private lateinit var mapboxMap: MapboxMap
-    private lateinit var mapCamera: CameraAnimationsPlugin
     private lateinit var mapboxNavigation: MapboxNavigation
     private lateinit var binding: LayoutActivityJunctionBinding
     private lateinit var locationComponent: LocationComponentPlugin
@@ -198,7 +195,7 @@ class MapboxJunctionActivity : AppCompatActivity(), OnMapLongClickListener {
         mapboxMap.loadStyleUri(
             MAPBOX_STREETS
         ) {
-            getGesturePlugin().addOnMapLongClickListener(this)
+            binding.mapView.gestures.addOnMapLongClickListener(this)
         }
     }
 
@@ -239,18 +236,10 @@ class MapboxJunctionActivity : AppCompatActivity(), OnMapLongClickListener {
         )
     }
 
-    private fun getMapCamera(): CameraAnimationsPlugin {
-        return binding.mapView.getCameraAnimationsPlugin()
-    }
-
-    private fun getGesturePlugin(): GesturesPlugin {
-        return binding.mapView.getGesturesPlugin()
-    }
-
     private fun updateCamera(location: Location) {
         val mapAnimationOptionsBuilder = MapAnimationOptions.Builder()
         mapAnimationOptionsBuilder.duration(1500L)
-        mapCamera.easeTo(
+        binding.mapView.camera.easeTo(
             CameraOptions.Builder()
                 .center(Point.fromLngLat(location.longitude, location.latitude))
                 .bearing(location.bearing.toDouble())
@@ -292,11 +281,10 @@ class MapboxJunctionActivity : AppCompatActivity(), OnMapLongClickListener {
         binding = LayoutActivityJunctionBinding.inflate(layoutInflater)
         setContentView(binding.root)
         mapboxMap = binding.mapView.getMapboxMap()
-        locationComponent = binding.mapView.getLocationComponentPlugin().apply {
+        locationComponent = binding.mapView.location.apply {
             setLocationProvider(navigationLocationProvider)
             enabled = true
         }
-        mapCamera = getMapCamera()
         init()
     }
 

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxManeuverActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxManeuverActivity.kt
@@ -13,13 +13,12 @@ import com.mapbox.maps.CameraOptions
 import com.mapbox.maps.EdgeInsets
 import com.mapbox.maps.MapboxMap
 import com.mapbox.maps.Style.Companion.MAPBOX_STREETS
-import com.mapbox.maps.plugin.animation.CameraAnimationsPlugin
 import com.mapbox.maps.plugin.animation.MapAnimationOptions
-import com.mapbox.maps.plugin.animation.getCameraAnimationsPlugin
+import com.mapbox.maps.plugin.animation.camera
 import com.mapbox.maps.plugin.gestures.OnMapLongClickListener
-import com.mapbox.maps.plugin.gestures.getGesturesPlugin
+import com.mapbox.maps.plugin.gestures.gestures
 import com.mapbox.maps.plugin.locationcomponent.LocationComponentPlugin
-import com.mapbox.maps.plugin.locationcomponent.getLocationComponentPlugin
+import com.mapbox.maps.plugin.locationcomponent.location
 import com.mapbox.navigation.base.formatter.DistanceFormatterOptions
 import com.mapbox.navigation.base.internal.extensions.applyDefaultParams
 import com.mapbox.navigation.base.internal.extensions.coordinates
@@ -73,7 +72,6 @@ import kotlinx.coroutines.launch
 class MapboxManeuverActivity : AppCompatActivity(), OnMapLongClickListener {
 
     private lateinit var mapboxMap: MapboxMap
-    private lateinit var mapCamera: CameraAnimationsPlugin
     private lateinit var mapboxNavigation: MapboxNavigation
     private lateinit var binding: LayoutActivityManeuverBinding
     private lateinit var locationComponent: LocationComponentPlugin
@@ -257,16 +255,12 @@ class MapboxManeuverActivity : AppCompatActivity(), OnMapLongClickListener {
         mapboxMap.loadStyleUri(
             MAPBOX_STREETS
         ) {
-            binding.mapView.getGesturesPlugin().addOnMapLongClickListener(this)
+            binding.mapView.gestures.addOnMapLongClickListener(this)
         }
     }
 
     private fun getMapboxAccessTokenFromResources(): String {
         return getString(this.resources.getIdentifier("mapbox_access_token", "string", packageName))
-    }
-
-    private fun getMapCamera(): CameraAnimationsPlugin {
-        return binding.mapView.getCameraAnimationsPlugin()
     }
 
     private fun startSimulation(route: DirectionsRoute) {
@@ -308,7 +302,7 @@ class MapboxManeuverActivity : AppCompatActivity(), OnMapLongClickListener {
     private fun updateCamera(location: Location) {
         val mapAnimationOptionsBuilder = MapAnimationOptions.Builder()
         mapAnimationOptionsBuilder.duration(1500L)
-        mapCamera.easeTo(
+        binding.mapView.camera.easeTo(
             CameraOptions.Builder()
                 .center(Point.fromLngLat(location.longitude, location.latitude))
                 .bearing(location.bearing.toDouble())
@@ -325,11 +319,10 @@ class MapboxManeuverActivity : AppCompatActivity(), OnMapLongClickListener {
         binding = LayoutActivityManeuverBinding.inflate(layoutInflater)
         setContentView(binding.root)
         mapboxMap = binding.mapView.getMapboxMap()
-        locationComponent = binding.mapView.getLocationComponentPlugin().apply {
+        locationComponent = binding.mapView.location.apply {
             setLocationProvider(navigationLocationProvider)
             enabled = true
         }
-        mapCamera = getMapCamera()
         init()
     }
 

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxNavigationActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxNavigationActivity.kt
@@ -20,16 +20,15 @@ import com.mapbox.maps.EdgeInsets
 import com.mapbox.maps.MapboxMap
 import com.mapbox.maps.Style
 import com.mapbox.maps.plugin.LocationPuck2D
+import com.mapbox.maps.plugin.animation.camera
 import com.mapbox.maps.plugin.animation.easeTo
-import com.mapbox.maps.plugin.animation.getCameraAnimationsPlugin
 import com.mapbox.maps.plugin.delegates.listeners.OnMapLoadErrorListener
 import com.mapbox.maps.plugin.delegates.listeners.eventdata.MapLoadErrorType
-import com.mapbox.maps.plugin.gestures.GesturesPlugin
 import com.mapbox.maps.plugin.gestures.OnMapLongClickListener
-import com.mapbox.maps.plugin.gestures.getGesturesPlugin
+import com.mapbox.maps.plugin.gestures.gestures
 import com.mapbox.maps.plugin.locationcomponent.LocationComponentPlugin
 import com.mapbox.maps.plugin.locationcomponent.OnIndicatorPositionChangedListener
-import com.mapbox.maps.plugin.locationcomponent.getLocationComponentPlugin
+import com.mapbox.maps.plugin.locationcomponent.location
 import com.mapbox.navigation.base.TimeFormat
 import com.mapbox.navigation.base.formatter.DistanceFormatterOptions
 import com.mapbox.navigation.base.internal.extensions.applyDefaultParams
@@ -321,7 +320,7 @@ class MapboxNavigationActivity :
         binding = LayoutActivityNavigationBinding.inflate(layoutInflater)
         setContentView(binding.root)
         mapboxMap = binding.mapView.getMapboxMap()
-        locationComponent = binding.mapView.getLocationComponentPlugin().apply {
+        locationComponent = binding.mapView.location.apply {
             this.locationPuck = LocationPuck2D(
                 bearingImage = ContextCompat.getDrawable(
                     this@MapboxNavigationActivity,
@@ -338,10 +337,10 @@ class MapboxNavigationActivity :
         )
         navigationCamera = NavigationCamera(
             binding.mapView.getMapboxMap(),
-            binding.mapView.getCameraAnimationsPlugin(),
+            binding.mapView.camera,
             viewportDataSource
         )
-        binding.mapView.getCameraAnimationsPlugin().addCameraAnimationsLifecycleListener(
+        binding.mapView.camera.addCameraAnimationsLifecycleListener(
             NavigationBasicGesturesHandler(navigationCamera)
         )
         init()
@@ -506,7 +505,7 @@ class MapboxNavigationActivity :
         mapboxMap.loadStyleUri(
             Style.MAPBOX_STREETS,
             {
-                getGesturePlugin().addOnMapLongClickListener(this)
+                binding.mapView.gestures.addOnMapLongClickListener(this)
             },
             object : OnMapLoadErrorListener {
                 override fun onMapLoadError(mapLoadErrorType: MapLoadErrorType, msg: String) {
@@ -587,10 +586,6 @@ class MapboxNavigationActivity :
                 }
             )
         }
-    }
-
-    private fun getGesturePlugin(): GesturesPlugin {
-        return binding.mapView.getGesturesPlugin()
     }
 
     private fun getMapboxAccessTokenFromResources(): String {

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxRouteLineAndArrowActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxRouteLineAndArrowActivity.kt
@@ -25,14 +25,14 @@ import com.mapbox.maps.Style
 import com.mapbox.maps.extension.style.layers.properties.generated.Visibility
 import com.mapbox.maps.plugin.LocationPuck2D
 import com.mapbox.maps.plugin.animation.MapAnimationOptions
-import com.mapbox.maps.plugin.animation.getCameraAnimationsPlugin
+import com.mapbox.maps.plugin.animation.camera
 import com.mapbox.maps.plugin.delegates.listeners.OnMapLoadErrorListener
 import com.mapbox.maps.plugin.delegates.listeners.eventdata.MapLoadErrorType
 import com.mapbox.maps.plugin.gestures.OnMapClickListener
 import com.mapbox.maps.plugin.gestures.OnMapLongClickListener
-import com.mapbox.maps.plugin.gestures.getGesturesPlugin
+import com.mapbox.maps.plugin.gestures.gestures
 import com.mapbox.maps.plugin.locationcomponent.OnIndicatorPositionChangedListener
-import com.mapbox.maps.plugin.locationcomponent.getLocationComponentPlugin
+import com.mapbox.maps.plugin.locationcomponent.location
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.MapboxNavigation
@@ -90,7 +90,7 @@ class MapboxRouteLineAndArrowActivity : AppCompatActivity(), OnMapLongClickListe
     }
 
     private val locationComponent by lazy {
-        viewBinding.mapView.getLocationComponentPlugin().apply {
+        viewBinding.mapView.location.apply {
             setLocationProvider(navigationLocationProvider)
             enabled = true
         }
@@ -106,7 +106,7 @@ class MapboxRouteLineAndArrowActivity : AppCompatActivity(), OnMapLongClickListe
     }
 
     private val mapCamera by lazy {
-        viewBinding.mapView.getCameraAnimationsPlugin()
+        viewBinding.mapView.camera
     }
 
     // RouteLine: Route line related colors can be customized via the RouteLineColorResources.
@@ -373,7 +373,7 @@ class MapboxRouteLineAndArrowActivity : AppCompatActivity(), OnMapLongClickListe
                 mapboxNavigation.navigationOptions.locationEngine.getLastLocation(
                     locationEngineCallback
                 )
-                viewBinding.mapView.getGesturesPlugin().addOnMapLongClickListener(this)
+                viewBinding.mapView.gestures.addOnMapLongClickListener(this)
             },
             object : OnMapLoadErrorListener {
                 override fun onMapLoadError(mapLoadError: MapLoadErrorType, message: String) {
@@ -470,7 +470,7 @@ class MapboxRouteLineAndArrowActivity : AppCompatActivity(), OnMapLongClickListe
                 startSimulation(route)
             }
         }
-        viewBinding.mapView.getGesturesPlugin().addOnMapClickListener(mapClickListener)
+        viewBinding.mapView.gestures.addOnMapClickListener(mapClickListener)
     }
 
     // Starts the navigation simulator

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxSignboardActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxSignboardActivity.kt
@@ -13,14 +13,12 @@ import com.mapbox.maps.CameraOptions
 import com.mapbox.maps.EdgeInsets
 import com.mapbox.maps.MapboxMap
 import com.mapbox.maps.Style.Companion.MAPBOX_STREETS
-import com.mapbox.maps.plugin.animation.CameraAnimationsPlugin
 import com.mapbox.maps.plugin.animation.MapAnimationOptions
-import com.mapbox.maps.plugin.animation.getCameraAnimationsPlugin
-import com.mapbox.maps.plugin.gestures.GesturesPlugin
+import com.mapbox.maps.plugin.animation.camera
 import com.mapbox.maps.plugin.gestures.OnMapLongClickListener
-import com.mapbox.maps.plugin.gestures.getGesturesPlugin
+import com.mapbox.maps.plugin.gestures.gestures
 import com.mapbox.maps.plugin.locationcomponent.LocationComponentPlugin
-import com.mapbox.maps.plugin.locationcomponent.getLocationComponentPlugin
+import com.mapbox.maps.plugin.locationcomponent.location
 import com.mapbox.navigation.base.internal.extensions.applyDefaultParams
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.trip.model.RouteProgress
@@ -70,7 +68,6 @@ import kotlinx.coroutines.launch
 class MapboxSignboardActivity : AppCompatActivity(), OnMapLongClickListener {
 
     private lateinit var mapboxMap: MapboxMap
-    private lateinit var mapCamera: CameraAnimationsPlugin
     private lateinit var mapboxNavigation: MapboxNavigation
     private lateinit var binding: LayoutActivitySignboardBinding
     private lateinit var locationComponent: LocationComponentPlugin
@@ -197,7 +194,7 @@ class MapboxSignboardActivity : AppCompatActivity(), OnMapLongClickListener {
         mapboxMap.loadStyleUri(
             MAPBOX_STREETS
         ) {
-            getGesturePlugin().addOnMapLongClickListener(this)
+            binding.mapView.gestures.addOnMapLongClickListener(this)
         }
     }
 
@@ -237,18 +234,10 @@ class MapboxSignboardActivity : AppCompatActivity(), OnMapLongClickListener {
         )
     }
 
-    private fun getMapCamera(): CameraAnimationsPlugin {
-        return binding.mapView.getCameraAnimationsPlugin()
-    }
-
-    private fun getGesturePlugin(): GesturesPlugin {
-        return binding.mapView.getGesturesPlugin()
-    }
-
     private fun updateCamera(location: Location) {
         val mapAnimationOptionsBuilder = MapAnimationOptions.Builder()
         mapAnimationOptionsBuilder.duration(1500L)
-        mapCamera.easeTo(
+        binding.mapView.camera.easeTo(
             CameraOptions.Builder()
                 .center(Point.fromLngLat(location.longitude, location.latitude))
                 .bearing(location.bearing.toDouble())
@@ -290,11 +279,10 @@ class MapboxSignboardActivity : AppCompatActivity(), OnMapLongClickListener {
         binding = LayoutActivitySignboardBinding.inflate(layoutInflater)
         setContentView(binding.root)
         mapboxMap = binding.mapView.getMapboxMap()
-        locationComponent = binding.mapView.getLocationComponentPlugin().apply {
+        locationComponent = binding.mapView.location.apply {
             setLocationProvider(navigationLocationProvider)
             enabled = true
         }
-        mapCamera = getMapCamera()
         init()
     }
 

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxSnapshotActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxSnapshotActivity.kt
@@ -14,12 +14,11 @@ import com.mapbox.maps.MapboxMap
 import com.mapbox.maps.Style.Companion.MAPBOX_STREETS
 import com.mapbox.maps.plugin.animation.CameraAnimationsPlugin
 import com.mapbox.maps.plugin.animation.MapAnimationOptions
-import com.mapbox.maps.plugin.animation.getCameraAnimationsPlugin
-import com.mapbox.maps.plugin.gestures.GesturesPlugin
+import com.mapbox.maps.plugin.animation.camera
 import com.mapbox.maps.plugin.gestures.OnMapLongClickListener
-import com.mapbox.maps.plugin.gestures.getGesturesPlugin
+import com.mapbox.maps.plugin.gestures.gestures
 import com.mapbox.maps.plugin.locationcomponent.LocationComponentPlugin
-import com.mapbox.maps.plugin.locationcomponent.getLocationComponentPlugin
+import com.mapbox.maps.plugin.locationcomponent.location
 import com.mapbox.navigation.base.internal.extensions.applyDefaultParams
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.trip.model.RouteProgress
@@ -201,7 +200,7 @@ class MapboxSnapshotActivity : AppCompatActivity(), OnMapLongClickListener {
         mapboxMap.loadStyleUri(
             MAPBOX_STREETS
         ) {
-            getGesturePlugin().addOnMapLongClickListener(this)
+            binding.mapView.gestures.addOnMapLongClickListener(this)
         }
     }
 
@@ -239,14 +238,6 @@ class MapboxSnapshotActivity : AppCompatActivity(), OnMapLongClickListener {
                 }
             }
         )
-    }
-
-    private fun getMapCamera(): CameraAnimationsPlugin {
-        return binding.mapView.getCameraAnimationsPlugin()
-    }
-
-    private fun getGesturePlugin(): GesturesPlugin {
-        return binding.mapView.getGesturesPlugin()
     }
 
     private fun updateCamera(location: Location) {
@@ -294,11 +285,11 @@ class MapboxSnapshotActivity : AppCompatActivity(), OnMapLongClickListener {
         binding = LayoutActivitySnapshotBinding.inflate(layoutInflater)
         setContentView(binding.root)
         mapboxMap = binding.mapView.getMapboxMap()
-        locationComponent = binding.mapView.getLocationComponentPlugin().apply {
+        locationComponent = binding.mapView.location.apply {
             setLocationProvider(navigationLocationProvider)
             enabled = true
         }
-        mapCamera = getMapCamera()
+        mapCamera = binding.mapView.camera
         init()
     }
 

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxTripProgressActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxTripProgressActivity.kt
@@ -14,13 +14,12 @@ import com.mapbox.maps.CameraOptions
 import com.mapbox.maps.EdgeInsets
 import com.mapbox.maps.MapboxMap
 import com.mapbox.maps.Style.Companion.MAPBOX_STREETS
-import com.mapbox.maps.plugin.animation.CameraAnimationsPlugin
 import com.mapbox.maps.plugin.animation.MapAnimationOptions
-import com.mapbox.maps.plugin.animation.getCameraAnimationsPlugin
+import com.mapbox.maps.plugin.animation.camera
 import com.mapbox.maps.plugin.gestures.OnMapLongClickListener
-import com.mapbox.maps.plugin.gestures.getGesturesPlugin
+import com.mapbox.maps.plugin.gestures.gestures
 import com.mapbox.maps.plugin.locationcomponent.LocationComponentPlugin
-import com.mapbox.maps.plugin.locationcomponent.getLocationComponentPlugin
+import com.mapbox.maps.plugin.locationcomponent.location
 import com.mapbox.navigation.base.formatter.DistanceFormatterOptions
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.trip.model.RouteProgress
@@ -65,7 +64,6 @@ import kotlinx.coroutines.launch
 class MapboxTripProgressActivity : AppCompatActivity(), OnMapLongClickListener {
 
     private lateinit var mapboxMap: MapboxMap
-    private lateinit var mapCamera: CameraAnimationsPlugin
     private lateinit var mapboxNavigation: MapboxNavigation
     private lateinit var binding: LayoutActivityTripprogressBinding
     private lateinit var locationComponent: LocationComponentPlugin
@@ -205,16 +203,12 @@ class MapboxTripProgressActivity : AppCompatActivity(), OnMapLongClickListener {
         mapboxMap.loadStyleUri(
             MAPBOX_STREETS
         ) {
-            binding.mapView.getGesturesPlugin().addOnMapLongClickListener(this)
+            binding.mapView.gestures.addOnMapLongClickListener(this)
         }
     }
 
     private fun getMapboxAccessTokenFromResources(): String {
         return getString(this.resources.getIdentifier("mapbox_access_token", "string", packageName))
-    }
-
-    private fun getMapCamera(): CameraAnimationsPlugin {
-        return binding.mapView.getCameraAnimationsPlugin()
     }
 
     private fun startSimulation(route: DirectionsRoute) {
@@ -230,7 +224,7 @@ class MapboxTripProgressActivity : AppCompatActivity(), OnMapLongClickListener {
     private fun updateCamera(location: Location) {
         val mapAnimationOptionsBuilder = MapAnimationOptions.Builder()
         mapAnimationOptionsBuilder.duration(1500L)
-        mapCamera.easeTo(
+        binding.mapView.camera.easeTo(
             CameraOptions.Builder()
                 .center(Point.fromLngLat(location.longitude, location.latitude))
                 .bearing(location.bearing.toDouble())
@@ -285,11 +279,10 @@ class MapboxTripProgressActivity : AppCompatActivity(), OnMapLongClickListener {
 
         setContentView(binding.root)
         mapboxMap = binding.mapView.getMapboxMap()
-        locationComponent = binding.mapView.getLocationComponentPlugin().apply {
+        locationComponent = binding.mapView.location.apply {
             setLocationProvider(navigationLocationProvider)
             enabled = true
         }
-        mapCamera = getMapCamera()
         init()
     }
 

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxVoiceActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxVoiceActivity.kt
@@ -12,14 +12,12 @@ import com.mapbox.maps.CameraOptions
 import com.mapbox.maps.EdgeInsets
 import com.mapbox.maps.MapboxMap
 import com.mapbox.maps.Style.Companion.MAPBOX_STREETS
-import com.mapbox.maps.plugin.animation.CameraAnimationsPlugin
 import com.mapbox.maps.plugin.animation.MapAnimationOptions
-import com.mapbox.maps.plugin.animation.getCameraAnimationsPlugin
-import com.mapbox.maps.plugin.gestures.GesturesPlugin
+import com.mapbox.maps.plugin.animation.camera
 import com.mapbox.maps.plugin.gestures.OnMapLongClickListener
-import com.mapbox.maps.plugin.gestures.getGesturesPlugin
+import com.mapbox.maps.plugin.gestures.gestures
 import com.mapbox.maps.plugin.locationcomponent.LocationComponentPlugin
-import com.mapbox.maps.plugin.locationcomponent.getLocationComponentPlugin
+import com.mapbox.maps.plugin.locationcomponent.location
 import com.mapbox.navigation.base.internal.extensions.applyDefaultParams
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.trip.model.RouteProgress
@@ -72,7 +70,6 @@ class MapboxVoiceActivity : AppCompatActivity(), OnMapLongClickListener {
     private var isMuted: Boolean = false
 
     private lateinit var mapboxMap: MapboxMap
-    private lateinit var mapCamera: CameraAnimationsPlugin
     private lateinit var mapboxNavigation: MapboxNavigation
     private lateinit var binding: LayoutActivityVoiceBinding
     private lateinit var locationComponent: LocationComponentPlugin
@@ -241,10 +238,6 @@ class MapboxVoiceActivity : AppCompatActivity(), OnMapLongClickListener {
         private const val SOUND_BUTTON_TEXT_APPEAR_DURATION = 1000L
     }
 
-    private fun getGesturesPlugin(): GesturesPlugin {
-        return binding.mapView.getGesturesPlugin()
-    }
-
     @SuppressLint("MissingPermission")
     private fun init() {
         initNavigation()
@@ -269,7 +262,7 @@ class MapboxVoiceActivity : AppCompatActivity(), OnMapLongClickListener {
         mapboxMap.loadStyleUri(
             MAPBOX_STREETS
         ) {
-            getGesturesPlugin().addOnMapLongClickListener(
+            binding.mapView.gestures.addOnMapLongClickListener(
                 this@MapboxVoiceActivity
             )
         }
@@ -302,10 +295,6 @@ class MapboxVoiceActivity : AppCompatActivity(), OnMapLongClickListener {
 
     private fun getMapboxAccessTokenFromResources(): String {
         return getString(this.resources.getIdentifier("mapbox_access_token", "string", packageName))
-    }
-
-    private fun getMapCamera(): CameraAnimationsPlugin {
-        return binding.mapView.getCameraAnimationsPlugin()
     }
 
     private fun startSimulation(route: DirectionsRoute) {
@@ -349,7 +338,7 @@ class MapboxVoiceActivity : AppCompatActivity(), OnMapLongClickListener {
     private fun updateCamera(location: Location) {
         val mapAnimationOptionsBuilder = MapAnimationOptions.Builder()
         mapAnimationOptionsBuilder.duration(1500L)
-        mapCamera.easeTo(
+        binding.mapView.camera.easeTo(
             CameraOptions.Builder()
                 .center(Point.fromLngLat(location.longitude, location.latitude))
                 .bearing(location.bearing.toDouble())
@@ -366,11 +355,10 @@ class MapboxVoiceActivity : AppCompatActivity(), OnMapLongClickListener {
         binding = LayoutActivityVoiceBinding.inflate(layoutInflater)
         setContentView(binding.root)
         mapboxMap = binding.mapView.getMapboxMap()
-        locationComponent = binding.mapView.getLocationComponentPlugin().apply {
+        locationComponent = binding.mapView.location.apply {
             setLocationProvider(navigationLocationProvider)
             enabled = true
         }
-        mapCamera = getMapCamera()
         init()
     }
 

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayHistoryActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayHistoryActivity.kt
@@ -18,11 +18,11 @@ import com.mapbox.maps.MapView
 import com.mapbox.maps.Style
 import com.mapbox.maps.plugin.LocationPuck2D
 import com.mapbox.maps.plugin.animation.MapAnimationOptions
-import com.mapbox.maps.plugin.animation.getCameraAnimationsPlugin
+import com.mapbox.maps.plugin.animation.camera
 import com.mapbox.maps.plugin.delegates.listeners.OnMapLoadErrorListener
 import com.mapbox.maps.plugin.delegates.listeners.eventdata.MapLoadErrorType
 import com.mapbox.maps.plugin.locationcomponent.LocationComponentPlugin
-import com.mapbox.maps.plugin.locationcomponent.getLocationComponentPlugin
+import com.mapbox.maps.plugin.locationcomponent.location
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.replay.MapboxReplayer
@@ -114,7 +114,7 @@ class ReplayHistoryActivity : AppCompatActivity() {
                 mapboxNavigation.navigationOptions.locationEngine.getLastLocation(
                     locationEngineCallback
                 )
-                locationComponent = binding.mapView.getLocationComponentPlugin().apply {
+                locationComponent = binding.mapView.location.apply {
                     this.locationPuck = LocationPuck2D(
                         bearingImage = ContextCompat.getDrawable(
                             this@ReplayHistoryActivity,
@@ -126,7 +126,7 @@ class ReplayHistoryActivity : AppCompatActivity() {
                 }
                 navigationCamera = NavigationCamera(
                     binding.mapView.getMapboxMap(),
-                    binding.mapView.getCameraAnimationsPlugin(),
+                    binding.mapView.camera,
                     viewportDataSource
                 )
 
@@ -157,7 +157,7 @@ class ReplayHistoryActivity : AppCompatActivity() {
     private fun updateCamera(location: Location) {
         val mapAnimationOptionsBuilder = MapAnimationOptions.Builder()
             .duration(1500L)
-        binding.mapView.getCameraAnimationsPlugin().easeTo(
+        binding.mapView.camera.easeTo(
             CameraOptions.Builder()
                 .center(Point.fromLngLat(location.longitude, location.latitude))
                 .bearing(location.bearing.toDouble())

--- a/examples/src/main/java/com/mapbox/navigation/examples/util/RouteDrawingActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/util/RouteDrawingActivity.kt
@@ -13,16 +13,17 @@ import com.mapbox.android.core.location.LocationEngineProvider
 import com.mapbox.android.core.location.LocationEngineResult
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.RouteOptions
+import com.mapbox.common.TileStore
 import com.mapbox.geojson.Point
 import com.mapbox.maps.CameraOptions
+import com.mapbox.maps.MapInitOptions
 import com.mapbox.maps.MapView
-import com.mapbox.maps.MapboxMapOptions
 import com.mapbox.maps.ResourceOptions
 import com.mapbox.maps.Style
 import com.mapbox.maps.plugin.animation.CameraAnimationsPlugin
-import com.mapbox.maps.plugin.animation.getCameraAnimationsPlugin
+import com.mapbox.maps.plugin.animation.camera
 import com.mapbox.maps.plugin.locationcomponent.LocationComponentPlugin
-import com.mapbox.maps.plugin.locationcomponent.getLocationComponentPlugin
+import com.mapbox.maps.plugin.locationcomponent.location
 import com.mapbox.navigation.core.directions.session.RoutesRequestCallback
 import com.mapbox.navigation.examples.core.R
 import com.mapbox.navigation.ui.maps.internal.route.line.MapboxRouteLineApiExtensions.clearRouteLine
@@ -81,20 +82,21 @@ class RouteDrawingActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.layout_route_drawing_activity)
-        val mapboxMapOptions = MapboxMapOptions(this, resources.displayMetrics.density, null)
+        val tileStore = TileStore.getInstance()
+        val mapboxMapOptions = MapInitOptions(this)
         val resourceOptions = ResourceOptions.Builder()
             .accessToken(getMapboxAccessTokenFromResources())
             .assetPath(filesDir.absolutePath)
             .cachePath(filesDir.absolutePath + "/mbx.db")
             .cacheSize(100000000L) // 100 MB
-            .tileStorePath(filesDir.absolutePath + "/maps_tile_store/")
+            .tileStore(tileStore)
             .build()
         mapboxMapOptions.resourceOptions = resourceOptions
         mapView = MapView(this, mapboxMapOptions)
         val mapLayout = findViewById<RelativeLayout>(R.id.mapView_container)
         mapLayout.addView(mapView)
         navigationLocationProvider = NavigationLocationProvider()
-        locationComponent = mapView.getLocationComponentPlugin().apply {
+        locationComponent = mapView.location.apply {
             setLocationProvider(navigationLocationProvider)
             enabled = true
         }
@@ -225,6 +227,6 @@ class RouteDrawingActivity : AppCompatActivity() {
     }
 
     private fun getMapCamera(): CameraAnimationsPlugin {
-        return mapView.getCameraAnimationsPlugin()
+        return mapView.camera
     }
 }

--- a/examples/src/main/java/com/mapbox/navigation/examples/util/RouteLineUtil.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/util/RouteLineUtil.kt
@@ -8,7 +8,7 @@ import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.maps.MapView
 import com.mapbox.maps.Style
 import com.mapbox.maps.plugin.locationcomponent.OnIndicatorPositionChangedListener
-import com.mapbox.maps.plugin.locationcomponent.getLocationComponentPlugin
+import com.mapbox.maps.plugin.locationcomponent.location
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesObserver
@@ -123,7 +123,7 @@ class RouteLineUtil(private val activity: AppCompatActivity) : LifecycleObserver
     private fun onStart() {
         mapView.getMapboxMap().getStyle { style ->
             this@RouteLineUtil.style = style
-            mapView.getLocationComponentPlugin().addOnIndicatorPositionChangedListener(
+            mapView.location.addOnIndicatorPositionChangedListener(
                 onIndicatorPositionChangedListener
             )
             mapboxNavigation.registerRoutesObserver(routesObserver)
@@ -133,7 +133,7 @@ class RouteLineUtil(private val activity: AppCompatActivity) : LifecycleObserver
 
     @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
     private fun onStop() {
-        mapView.getLocationComponentPlugin().removeOnIndicatorPositionChangedListener(
+        mapView.location.removeOnIndicatorPositionChangedListener(
             onIndicatorPositionChangedListener
         )
         mapboxNavigation.unregisterRoutesObserver(routesObserver)

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -11,20 +11,20 @@ ext {
   // version which we should use in this build
   def mapboxNavigatorVersion = System.getenv("FORCE_MAPBOX_NAVIGATION_NATIVE_VERSION")
   if (mapboxNavigatorVersion == null || mapboxNavigatorVersion == '') {
-      mapboxNavigatorVersion = '48.0.3'
+      mapboxNavigatorVersion = '48.0.4'
   }
   println("Navigation Native version: " + mapboxNavigatorVersion)
 
   version = [
-      mapboxMapSdk              : '10.0.0-beta.17',
+      mapboxMapSdk              : '10.0.0-beta.18',
       mapboxSdkServices         : '5.9.0-alpha.5',
       mapboxEvents              : '6.2.2',
       mapboxCore                : '3.1.1',
       mapboxNavigator           : "${mapboxNavigatorVersion}",
-      mapboxCommonNative        : '11.0.1',
+      mapboxCommonNative        : '11.0.2',
       mapboxCrashMonitor        : '2.0.0',
       mapboxAnnotationPlugin    : '0.8.0',
-      mapboxBaseAndroid         : '0.4.0',
+      mapboxBaseAndroid         : '0.5.0',
       androidXCoreVersion       : '1.2.0',
       androidXAppCompatVersion  : '1.1.0',
       androidXAnnotationVersion : '1.1.0',

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/ui/SimpleMapViewNavigationTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/ui/SimpleMapViewNavigationTest.kt
@@ -5,9 +5,9 @@ import androidx.core.content.ContextCompat
 import androidx.test.espresso.Espresso
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.maps.plugin.LocationPuck2D
-import com.mapbox.maps.plugin.animation.getCameraAnimationsPlugin
+import com.mapbox.maps.plugin.animation.camera
 import com.mapbox.maps.plugin.locationcomponent.LocationComponentPlugin
-import com.mapbox.maps.plugin.locationcomponent.getLocationComponentPlugin
+import com.mapbox.maps.plugin.locationcomponent.location
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.MapboxNavigation
@@ -122,7 +122,7 @@ abstract class SimpleMapViewNavigationTest :
             )
             navigationCamera = NavigationCamera(
                 activity.mapboxMap,
-                activity.binding.mapView.getCameraAnimationsPlugin(),
+                activity.binding.mapView.camera,
                 mapboxNavigationViewportDataSource
             )
             navigationCamera.requestNavigationCameraToFollowing()
@@ -155,7 +155,7 @@ abstract class SimpleMapViewNavigationTest :
     protected fun addLocationPuck() {
         runOnMainSync {
             navigationLocationProvider = NavigationLocationProvider()
-            locationPlugin = activity.binding.mapView.getLocationComponentPlugin()
+            locationPlugin = activity.binding.mapView.location
             locationPlugin.setLocationProvider(navigationLocationProvider)
             locationPlugin.locationPuck = LocationPuck2D(
                 bearingImage = ContextCompat.getDrawable(

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/MapboxNavigationViewportDataSource.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/MapboxNavigationViewportDataSource.kt
@@ -178,7 +178,7 @@ import kotlin.math.min
  * ```kotlin
  * private fun animateToPOI() {
  *     // request camera to idle first or use `NavigationBasicGesturesHandler` or `NavigationScaleGestureHandler`
- *     mapView.getCameraAnimationsPlugin().flyTo(
+ *     mapView.camera.flyTo(
  *         CameraOptions.Builder()
  *             .padding(edgeInsets)
  *             .center(point)

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/debugger/MapboxNavigationViewportDataSourceDebugger.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/debugger/MapboxNavigationViewportDataSourceDebugger.kt
@@ -50,7 +50,7 @@ import com.mapbox.navigation.ui.maps.camera.state.NavigationCameraState
  * viewportDataSource.debugger = debugger
  * navigationCamera = NavigationCamera(
  *     mapView.getMapboxMap(),
- *     mapView.getCameraAnimationsPlugin(),
+ *     mapView.camera,
  *     viewportDataSource
  * )
  * navigationCamera.debugger = debugger

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/location/NavigationLocationProvider.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/location/NavigationLocationProvider.kt
@@ -22,7 +22,7 @@ import java.util.concurrent.CopyOnWriteArraySet
  * #### Example usage
  * Initialize the location plugin:
  * ```
- * locationComponent = mapView.getLocationComponentPlugin().apply {
+ * locationComponent = mapView.location.apply {
  *     setLocationProvider(navigationLocationProvider)
  *     addOnIndicatorPositionChangedListener(onIndicatorPositionChangedListener)
  *     enabled = true

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/snapshotter/api/MapboxSnapshotterApi.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/snapshotter/api/MapboxSnapshotterApi.kt
@@ -6,11 +6,11 @@ import com.mapbox.geojson.LineString
 import com.mapbox.geojson.Point
 import com.mapbox.maps.CameraOptions
 import com.mapbox.maps.EdgeInsets
+import com.mapbox.maps.MapInitOptions
 import com.mapbox.maps.MapInterface
 import com.mapbox.maps.MapSnapshotOptions
 import com.mapbox.maps.MapView
 import com.mapbox.maps.MapboxMap
-import com.mapbox.maps.MapboxOptions
 import com.mapbox.maps.ScreenCoordinate
 import com.mapbox.maps.Size
 import com.mapbox.maps.SnapshotStyleListener
@@ -50,7 +50,7 @@ class MapboxSnapshotterApi(
     private val snapshotter: Snapshotter
 
     init {
-        val resourceOptions = MapboxOptions.getDefaultResourceOptions(context)
+        val resourceOptions = MapInitOptions.getDefaultResourceOptions(context)
         val mapSnapshotOptions = MapSnapshotOptions.Builder()
             .resourceOptions(resourceOptions)
             .size(options.size)

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/AlternativeRouteActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/AlternativeRouteActivity.kt
@@ -27,6 +27,7 @@ import com.mapbox.maps.plugin.gestures.OnMapClickListener
 import com.mapbox.maps.plugin.gestures.OnMapLongClickListener
 import com.mapbox.maps.plugin.gestures.getGesturesPlugin
 import com.mapbox.maps.plugin.locationcomponent.getLocationComponentPlugin
+import com.mapbox.maps.plugin.locationcomponent.location
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesObserver
@@ -67,7 +68,7 @@ class AlternativeRouteActivity : AppCompatActivity(), OnMapLongClickListener {
     }
 
     private val mapCamera: CameraAnimationsPlugin by lazy {
-        binding.mapView.getCameraAnimationsPlugin()
+        binding.mapView.camera
     }
 
     private val mapboxNavigation: MapboxNavigation by lazy {
@@ -131,7 +132,7 @@ class AlternativeRouteActivity : AppCompatActivity(), OnMapLongClickListener {
     }
 
     private fun initNavigation() {
-        binding.mapView.getLocationComponentPlugin().apply {
+        binding.mapView.location.apply {
             setLocationProvider(navigationLocationProvider)
             enabled = true
         }
@@ -188,7 +189,7 @@ class AlternativeRouteActivity : AppCompatActivity(), OnMapLongClickListener {
 
                     override fun onFailure(exception: Exception) {}
                 })
-            binding.mapView.getGesturesPlugin().addOnMapLongClickListener(this)
+            binding.mapView.gestures.addOnMapLongClickListener(this)
         }
     }
 
@@ -256,7 +257,7 @@ class AlternativeRouteActivity : AppCompatActivity(), OnMapLongClickListener {
             startSimulation(mapboxNavigation.getRoutes()[0])
         }
 
-        binding.mapView.getGesturesPlugin().addOnMapClickListener(mapClickListener)
+        binding.mapView.gestures.addOnMapClickListener(mapClickListener)
     }
 
     private fun startSimulation(route: DirectionsRoute) {


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Preparing for 2.0.0-beta.7 release https://github.com/mapbox/mapbox-navigation-android/pull/4307

- Mapbox Maps SDK `v10.0.0-beta.18`
  - [release notes](https://github.com/mapbox/mapbox-maps-android/releases/tag/android-v10.0.0-beta.18)
- Mapbox Core Common `v11.0.2`
  - [tile store] Fix crash after trying to create a TileStore in a non-writable directory
- Nav Native `v48.0.4`
- mapboxBaseAndroid `0.5.0`
### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Map `ResourceOptions` contains tile store instance (TileStore API). Tile store usage is enabled by default, 'ResourceOptions.tileStoreEnabled' flag is introduced to disable it. This changed the integration with the `PredictiveCacheControler` which contains update integration docs.</changelog>
```

## Migration

Resolve your errors with `./gradlew clean && ./gradlew build`
Follow the migration guide in the maps release https://github.com/mapbox/mapbox-maps-android/releases/tag/android-v10.0.0-beta.18

## Issues discovered

 - Location puck is not in camera view https://github.com/mapbox/mapbox-navigation-android/pull/4310