### PR TITLE
Bump Maps SDK to v10.0.0-beta.18

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/IndependentRouteGenerationActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/IndependentRouteGenerationActivity.kt
@@ -16,18 +16,18 @@ import com.mapbox.maps.CameraOptions
 import com.mapbox.maps.MapboxMap
 import com.mapbox.maps.Style
 import com.mapbox.maps.plugin.animation.MapAnimationOptions
-import com.mapbox.maps.plugin.animation.getCameraAnimationsPlugin
+import com.mapbox.maps.plugin.animation.camera
+import com.mapbox.maps.plugin.annotation.annotations
 import com.mapbox.maps.plugin.annotation.generated.CircleAnnotationManager
 import com.mapbox.maps.plugin.annotation.generated.CircleAnnotationOptions
 import com.mapbox.maps.plugin.annotation.generated.PolylineAnnotationManager
 import com.mapbox.maps.plugin.annotation.generated.PolylineAnnotationOptions
 import com.mapbox.maps.plugin.annotation.generated.createCircleAnnotationManager
 import com.mapbox.maps.plugin.annotation.generated.createPolylineAnnotationManager
-import com.mapbox.maps.plugin.annotation.getAnnotationPlugin
 import com.mapbox.maps.plugin.gestures.OnMapLongClickListener
-import com.mapbox.maps.plugin.gestures.getGesturesPlugin
+import com.mapbox.maps.plugin.gestures.gestures
 import com.mapbox.maps.plugin.locationcomponent.LocationComponentPlugin
-import com.mapbox.maps.plugin.locationcomponent.getLocationComponentPlugin
+import com.mapbox.maps.plugin.locationcomponent.location
 import com.mapbox.navigation.base.formatter.DistanceFormatterOptions
 import com.mapbox.navigation.base.internal.extensions.applyDefaultParams
 import com.mapbox.navigation.base.options.NavigationOptions
@@ -85,11 +85,11 @@ class IndependentRouteGenerationActivity : AppCompatActivity() {
         setContentView(binding.root)
 
         mapboxMap = binding.mapView.getMapboxMap()
-        circleManager = binding.mapView.getAnnotationPlugin()
+        circleManager = binding.mapView.annotations
             .createCircleAnnotationManager(binding.mapView, null)
-        lineManager = binding.mapView.getAnnotationPlugin()
+        lineManager = binding.mapView.annotations
             .createPolylineAnnotationManager(binding.mapView, null)
-        locationComponent = binding.mapView.getLocationComponentPlugin().apply {
+        locationComponent = binding.mapView.location.apply {
             setLocationProvider(navigationLocationProvider)
             enabled = true
         }
@@ -102,7 +102,7 @@ class IndependentRouteGenerationActivity : AppCompatActivity() {
         mapboxMap.loadStyleUri(
             Style.MAPBOX_STREETS,
             { style: Style ->
-                binding.mapView.getGesturesPlugin().addOnMapLongClickListener(
+                binding.mapView.gestures.addOnMapLongClickListener(
                     mapLongClickListener
                 )
             }
@@ -195,7 +195,7 @@ class IndependentRouteGenerationActivity : AppCompatActivity() {
     private fun updateCamera(point: Point) {
         val mapAnimationOptionsBuilder = MapAnimationOptions.Builder()
         mapAnimationOptionsBuilder.duration(1500L)
-        binding.mapView.getCameraAnimationsPlugin().flyTo(
+        binding.mapView.camera.flyTo(
             CameraOptions.Builder()
                 .center(point)
                 .bearing(0.0)

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxBuildingHighlightActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxBuildingHighlightActivity.kt
@@ -16,11 +16,11 @@ import com.mapbox.maps.MapboxMap
 import com.mapbox.maps.Style.Companion.MAPBOX_STREETS
 import com.mapbox.maps.plugin.animation.CameraAnimationsPlugin
 import com.mapbox.maps.plugin.animation.MapAnimationOptions
-import com.mapbox.maps.plugin.animation.getCameraAnimationsPlugin
+import com.mapbox.maps.plugin.animation.camera
 import com.mapbox.maps.plugin.gestures.OnMapLongClickListener
-import com.mapbox.maps.plugin.gestures.getGesturesPlugin
+import com.mapbox.maps.plugin.gestures.gestures
 import com.mapbox.maps.plugin.locationcomponent.LocationComponentPlugin
-import com.mapbox.maps.plugin.locationcomponent.getLocationComponentPlugin
+import com.mapbox.maps.plugin.locationcomponent.location
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.MapboxNavigation
@@ -176,13 +176,13 @@ class MapboxBuildingHighlightActivity : AppCompatActivity(), OnMapLongClickListe
         mapboxMap.loadStyleUri(
             MAPBOX_STREETS
         ) {
-            binding.mapView.getGesturesPlugin().addOnMapLongClickListener(this)
+            binding.mapView.gestures.addOnMapLongClickListener(this)
 
             /**
              * Try attaching to the map click listener, highlight the building the
              * user has selected.
              */
-            binding.mapView.getGesturesPlugin().addOnMapClickListener { point ->
+            binding.mapView.gestures.addOnMapClickListener { point ->
                 buildingHighlightApi.highlightBuilding(point)
                 false
             }
@@ -194,7 +194,7 @@ class MapboxBuildingHighlightActivity : AppCompatActivity(), OnMapLongClickListe
     }
 
     private fun getMapCamera(): CameraAnimationsPlugin {
-        return binding.mapView.getCameraAnimationsPlugin()
+        return binding.mapView.camera
     }
 
     private fun startSimulation(route: DirectionsRoute) {
@@ -279,7 +279,7 @@ class MapboxBuildingHighlightActivity : AppCompatActivity(), OnMapLongClickListe
          */
         buildingsArrivalApi.buildingHighlightApi(buildingHighlightApi)
 
-        locationComponent = binding.mapView.getLocationComponentPlugin().apply {
+        locationComponent = binding.mapView.location.apply {
             setLocationProvider(navigationLocationProvider)
             enabled = true
         }

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxCustomStyleActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxCustomStyleActivity.kt
@@ -18,12 +18,12 @@ import com.mapbox.maps.MapboxMap
 import com.mapbox.maps.Style
 import com.mapbox.maps.plugin.animation.CameraAnimationsPlugin
 import com.mapbox.maps.plugin.animation.MapAnimationOptions
-import com.mapbox.maps.plugin.animation.getCameraAnimationsPlugin
+import com.mapbox.maps.plugin.animation.camera
 import com.mapbox.maps.plugin.gestures.GesturesPlugin
 import com.mapbox.maps.plugin.gestures.OnMapLongClickListener
-import com.mapbox.maps.plugin.gestures.getGesturesPlugin
+import com.mapbox.maps.plugin.gestures.gestures
 import com.mapbox.maps.plugin.locationcomponent.LocationComponentPlugin
-import com.mapbox.maps.plugin.locationcomponent.getLocationComponentPlugin
+import com.mapbox.maps.plugin.locationcomponent.location
 import com.mapbox.navigation.base.formatter.DistanceFormatterOptions
 import com.mapbox.navigation.base.internal.extensions.applyDefaultParams
 import com.mapbox.navigation.base.options.NavigationOptions
@@ -310,11 +310,11 @@ class MapboxCustomStyleActivity : AppCompatActivity(), OnMapLongClickListener {
     }
 
     private fun getMapCamera(): CameraAnimationsPlugin {
-        return binding.mapView.getCameraAnimationsPlugin()
+        return binding.mapView.camera
     }
 
     private fun getGesturePlugin(): GesturesPlugin {
-        return binding.mapView.getGesturesPlugin()
+        return binding.mapView.gestures
     }
 
     private fun updateCamera(location: Location) {
@@ -341,7 +341,7 @@ class MapboxCustomStyleActivity : AppCompatActivity(), OnMapLongClickListener {
         binding = LayoutActivityStyleBinding.inflate(layoutInflater)
         setContentView(binding.root)
         mapboxMap = binding.mapView.getMapboxMap()
-        locationComponent = binding.mapView.getLocationComponentPlugin().apply {
+        locationComponent = binding.mapView.location.apply {
             setLocationProvider(navigationLocationProvider)
             enabled = true
         }

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxJunctionActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxJunctionActivity.kt
@@ -15,12 +15,12 @@ import com.mapbox.maps.MapboxMap
 import com.mapbox.maps.Style.Companion.MAPBOX_STREETS
 import com.mapbox.maps.plugin.animation.CameraAnimationsPlugin
 import com.mapbox.maps.plugin.animation.MapAnimationOptions
-import com.mapbox.maps.plugin.animation.getCameraAnimationsPlugin
+import com.mapbox.maps.plugin.animation.camera
 import com.mapbox.maps.plugin.gestures.GesturesPlugin
 import com.mapbox.maps.plugin.gestures.OnMapLongClickListener
-import com.mapbox.maps.plugin.gestures.getGesturesPlugin
+import com.mapbox.maps.plugin.gestures.gestures
 import com.mapbox.maps.plugin.locationcomponent.LocationComponentPlugin
-import com.mapbox.maps.plugin.locationcomponent.getLocationComponentPlugin
+import com.mapbox.maps.plugin.locationcomponent.location
 import com.mapbox.navigation.base.internal.extensions.applyDefaultParams
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.trip.model.RouteProgress
@@ -240,11 +240,11 @@ class MapboxJunctionActivity : AppCompatActivity(), OnMapLongClickListener {
     }
 
     private fun getMapCamera(): CameraAnimationsPlugin {
-        return binding.mapView.getCameraAnimationsPlugin()
+        return binding.mapView.camera
     }
 
     private fun getGesturePlugin(): GesturesPlugin {
-        return binding.mapView.getGesturesPlugin()
+        return binding.mapView.gestures
     }
 
     private fun updateCamera(location: Location) {
@@ -292,7 +292,7 @@ class MapboxJunctionActivity : AppCompatActivity(), OnMapLongClickListener {
         binding = LayoutActivityJunctionBinding.inflate(layoutInflater)
         setContentView(binding.root)
         mapboxMap = binding.mapView.getMapboxMap()
-        locationComponent = binding.mapView.getLocationComponentPlugin().apply {
+        locationComponent = binding.mapView.location.apply {
             setLocationProvider(navigationLocationProvider)
             enabled = true
         }

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxManeuverActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxManeuverActivity.kt
@@ -15,11 +15,11 @@ import com.mapbox.maps.MapboxMap
 import com.mapbox.maps.Style.Companion.MAPBOX_STREETS
 import com.mapbox.maps.plugin.animation.CameraAnimationsPlugin
 import com.mapbox.maps.plugin.animation.MapAnimationOptions
-import com.mapbox.maps.plugin.animation.getCameraAnimationsPlugin
+import com.mapbox.maps.plugin.animation.camera
 import com.mapbox.maps.plugin.gestures.OnMapLongClickListener
-import com.mapbox.maps.plugin.gestures.getGesturesPlugin
+import com.mapbox.maps.plugin.gestures.gestures
 import com.mapbox.maps.plugin.locationcomponent.LocationComponentPlugin
-import com.mapbox.maps.plugin.locationcomponent.getLocationComponentPlugin
+import com.mapbox.maps.plugin.locationcomponent.location
 import com.mapbox.navigation.base.formatter.DistanceFormatterOptions
 import com.mapbox.navigation.base.internal.extensions.applyDefaultParams
 import com.mapbox.navigation.base.internal.extensions.coordinates
@@ -257,7 +257,7 @@ class MapboxManeuverActivity : AppCompatActivity(), OnMapLongClickListener {
         mapboxMap.loadStyleUri(
             MAPBOX_STREETS
         ) {
-            binding.mapView.getGesturesPlugin().addOnMapLongClickListener(this)
+            binding.mapView.gestures.addOnMapLongClickListener(this)
         }
     }
 
@@ -266,7 +266,7 @@ class MapboxManeuverActivity : AppCompatActivity(), OnMapLongClickListener {
     }
 
     private fun getMapCamera(): CameraAnimationsPlugin {
-        return binding.mapView.getCameraAnimationsPlugin()
+        return binding.mapView.camera
     }
 
     private fun startSimulation(route: DirectionsRoute) {
@@ -325,7 +325,7 @@ class MapboxManeuverActivity : AppCompatActivity(), OnMapLongClickListener {
         binding = LayoutActivityManeuverBinding.inflate(layoutInflater)
         setContentView(binding.root)
         mapboxMap = binding.mapView.getMapboxMap()
-        locationComponent = binding.mapView.getLocationComponentPlugin().apply {
+        locationComponent = binding.mapView.location.apply {
             setLocationProvider(navigationLocationProvider)
             enabled = true
         }

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxNavigationActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxNavigationActivity.kt
@@ -20,16 +20,16 @@ import com.mapbox.maps.EdgeInsets
 import com.mapbox.maps.MapboxMap
 import com.mapbox.maps.Style
 import com.mapbox.maps.plugin.LocationPuck2D
+import com.mapbox.maps.plugin.animation.camera
 import com.mapbox.maps.plugin.animation.easeTo
-import com.mapbox.maps.plugin.animation.getCameraAnimationsPlugin
 import com.mapbox.maps.plugin.delegates.listeners.OnMapLoadErrorListener
 import com.mapbox.maps.plugin.delegates.listeners.eventdata.MapLoadErrorType
 import com.mapbox.maps.plugin.gestures.GesturesPlugin
 import com.mapbox.maps.plugin.gestures.OnMapLongClickListener
-import com.mapbox.maps.plugin.gestures.getGesturesPlugin
+import com.mapbox.maps.plugin.gestures.gestures
 import com.mapbox.maps.plugin.locationcomponent.LocationComponentPlugin
 import com.mapbox.maps.plugin.locationcomponent.OnIndicatorPositionChangedListener
-import com.mapbox.maps.plugin.locationcomponent.getLocationComponentPlugin
+import com.mapbox.maps.plugin.locationcomponent.location
 import com.mapbox.navigation.base.TimeFormat
 import com.mapbox.navigation.base.formatter.DistanceFormatterOptions
 import com.mapbox.navigation.base.internal.extensions.applyDefaultParams
@@ -321,7 +321,7 @@ class MapboxNavigationActivity :
         binding = LayoutActivityNavigationBinding.inflate(layoutInflater)
         setContentView(binding.root)
         mapboxMap = binding.mapView.getMapboxMap()
-        locationComponent = binding.mapView.getLocationComponentPlugin().apply {
+        locationComponent = binding.mapView.location.apply {
             this.locationPuck = LocationPuck2D(
                 bearingImage = ContextCompat.getDrawable(
                     this@MapboxNavigationActivity,
@@ -338,10 +338,10 @@ class MapboxNavigationActivity :
         )
         navigationCamera = NavigationCamera(
             binding.mapView.getMapboxMap(),
-            binding.mapView.getCameraAnimationsPlugin(),
+            binding.mapView.camera,
             viewportDataSource
         )
-        binding.mapView.getCameraAnimationsPlugin().addCameraAnimationsLifecycleListener(
+        binding.mapView.camera.addCameraAnimationsLifecycleListener(
             NavigationBasicGesturesHandler(navigationCamera)
         )
         init()
@@ -590,7 +590,7 @@ class MapboxNavigationActivity :
     }
 
     private fun getGesturePlugin(): GesturesPlugin {
-        return binding.mapView.getGesturesPlugin()
+        return binding.mapView.gestures
     }
 
     private fun getMapboxAccessTokenFromResources(): String {

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxRouteLineAndArrowActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxRouteLineAndArrowActivity.kt
@@ -25,14 +25,14 @@ import com.mapbox.maps.Style
 import com.mapbox.maps.extension.style.layers.properties.generated.Visibility
 import com.mapbox.maps.plugin.LocationPuck2D
 import com.mapbox.maps.plugin.animation.MapAnimationOptions
-import com.mapbox.maps.plugin.animation.getCameraAnimationsPlugin
+import com.mapbox.maps.plugin.animation.camera
 import com.mapbox.maps.plugin.delegates.listeners.OnMapLoadErrorListener
 import com.mapbox.maps.plugin.delegates.listeners.eventdata.MapLoadErrorType
 import com.mapbox.maps.plugin.gestures.OnMapClickListener
 import com.mapbox.maps.plugin.gestures.OnMapLongClickListener
-import com.mapbox.maps.plugin.gestures.getGesturesPlugin
+import com.mapbox.maps.plugin.gestures.gestures
 import com.mapbox.maps.plugin.locationcomponent.OnIndicatorPositionChangedListener
-import com.mapbox.maps.plugin.locationcomponent.getLocationComponentPlugin
+import com.mapbox.maps.plugin.locationcomponent.location
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.MapboxNavigation
@@ -90,7 +90,7 @@ class MapboxRouteLineAndArrowActivity : AppCompatActivity(), OnMapLongClickListe
     }
 
     private val locationComponent by lazy {
-        viewBinding.mapView.getLocationComponentPlugin().apply {
+        viewBinding.mapView.location.apply {
             setLocationProvider(navigationLocationProvider)
             enabled = true
         }
@@ -106,7 +106,7 @@ class MapboxRouteLineAndArrowActivity : AppCompatActivity(), OnMapLongClickListe
     }
 
     private val mapCamera by lazy {
-        viewBinding.mapView.getCameraAnimationsPlugin()
+        viewBinding.mapView.camera
     }
 
     // RouteLine: Route line related colors can be customized via the RouteLineColorResources.
@@ -373,7 +373,7 @@ class MapboxRouteLineAndArrowActivity : AppCompatActivity(), OnMapLongClickListe
                 mapboxNavigation.navigationOptions.locationEngine.getLastLocation(
                     locationEngineCallback
                 )
-                viewBinding.mapView.getGesturesPlugin().addOnMapLongClickListener(this)
+                viewBinding.mapView.gestures.addOnMapLongClickListener(this)
             },
             object : OnMapLoadErrorListener {
                 override fun onMapLoadError(mapLoadError: MapLoadErrorType, message: String) {
@@ -470,7 +470,7 @@ class MapboxRouteLineAndArrowActivity : AppCompatActivity(), OnMapLongClickListe
                 startSimulation(route)
             }
         }
-        viewBinding.mapView.getGesturesPlugin().addOnMapClickListener(mapClickListener)
+        viewBinding.mapView.gestures.addOnMapClickListener(mapClickListener)
     }
 
     // Starts the navigation simulator

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxSignboardActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxSignboardActivity.kt
@@ -15,12 +15,12 @@ import com.mapbox.maps.MapboxMap
 import com.mapbox.maps.Style.Companion.MAPBOX_STREETS
 import com.mapbox.maps.plugin.animation.CameraAnimationsPlugin
 import com.mapbox.maps.plugin.animation.MapAnimationOptions
-import com.mapbox.maps.plugin.animation.getCameraAnimationsPlugin
+import com.mapbox.maps.plugin.animation.camera
 import com.mapbox.maps.plugin.gestures.GesturesPlugin
 import com.mapbox.maps.plugin.gestures.OnMapLongClickListener
-import com.mapbox.maps.plugin.gestures.getGesturesPlugin
+import com.mapbox.maps.plugin.gestures.gestures
 import com.mapbox.maps.plugin.locationcomponent.LocationComponentPlugin
-import com.mapbox.maps.plugin.locationcomponent.getLocationComponentPlugin
+import com.mapbox.maps.plugin.locationcomponent.location
 import com.mapbox.navigation.base.internal.extensions.applyDefaultParams
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.trip.model.RouteProgress
@@ -238,11 +238,11 @@ class MapboxSignboardActivity : AppCompatActivity(), OnMapLongClickListener {
     }
 
     private fun getMapCamera(): CameraAnimationsPlugin {
-        return binding.mapView.getCameraAnimationsPlugin()
+        return binding.mapView.camera
     }
 
     private fun getGesturePlugin(): GesturesPlugin {
-        return binding.mapView.getGesturesPlugin()
+        return binding.mapView.gestures
     }
 
     private fun updateCamera(location: Location) {
@@ -290,7 +290,7 @@ class MapboxSignboardActivity : AppCompatActivity(), OnMapLongClickListener {
         binding = LayoutActivitySignboardBinding.inflate(layoutInflater)
         setContentView(binding.root)
         mapboxMap = binding.mapView.getMapboxMap()
-        locationComponent = binding.mapView.getLocationComponentPlugin().apply {
+        locationComponent = binding.mapView.location.apply {
             setLocationProvider(navigationLocationProvider)
             enabled = true
         }

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxSnapshotActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxSnapshotActivity.kt
@@ -14,12 +14,12 @@ import com.mapbox.maps.MapboxMap
 import com.mapbox.maps.Style.Companion.MAPBOX_STREETS
 import com.mapbox.maps.plugin.animation.CameraAnimationsPlugin
 import com.mapbox.maps.plugin.animation.MapAnimationOptions
-import com.mapbox.maps.plugin.animation.getCameraAnimationsPlugin
+import com.mapbox.maps.plugin.animation.camera
 import com.mapbox.maps.plugin.gestures.GesturesPlugin
 import com.mapbox.maps.plugin.gestures.OnMapLongClickListener
-import com.mapbox.maps.plugin.gestures.getGesturesPlugin
+import com.mapbox.maps.plugin.gestures.gestures
 import com.mapbox.maps.plugin.locationcomponent.LocationComponentPlugin
-import com.mapbox.maps.plugin.locationcomponent.getLocationComponentPlugin
+import com.mapbox.maps.plugin.locationcomponent.location
 import com.mapbox.navigation.base.internal.extensions.applyDefaultParams
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.trip.model.RouteProgress
@@ -242,11 +242,11 @@ class MapboxSnapshotActivity : AppCompatActivity(), OnMapLongClickListener {
     }
 
     private fun getMapCamera(): CameraAnimationsPlugin {
-        return binding.mapView.getCameraAnimationsPlugin()
+        return binding.mapView.camera
     }
 
     private fun getGesturePlugin(): GesturesPlugin {
-        return binding.mapView.getGesturesPlugin()
+        return binding.mapView.gestures
     }
 
     private fun updateCamera(location: Location) {
@@ -294,7 +294,7 @@ class MapboxSnapshotActivity : AppCompatActivity(), OnMapLongClickListener {
         binding = LayoutActivitySnapshotBinding.inflate(layoutInflater)
         setContentView(binding.root)
         mapboxMap = binding.mapView.getMapboxMap()
-        locationComponent = binding.mapView.getLocationComponentPlugin().apply {
+        locationComponent = binding.mapView.location.apply {
             setLocationProvider(navigationLocationProvider)
             enabled = true
         }

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxTripProgressActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxTripProgressActivity.kt
@@ -16,11 +16,11 @@ import com.mapbox.maps.MapboxMap
 import com.mapbox.maps.Style.Companion.MAPBOX_STREETS
 import com.mapbox.maps.plugin.animation.CameraAnimationsPlugin
 import com.mapbox.maps.plugin.animation.MapAnimationOptions
-import com.mapbox.maps.plugin.animation.getCameraAnimationsPlugin
+import com.mapbox.maps.plugin.animation.camera
 import com.mapbox.maps.plugin.gestures.OnMapLongClickListener
-import com.mapbox.maps.plugin.gestures.getGesturesPlugin
+import com.mapbox.maps.plugin.gestures.gestures
 import com.mapbox.maps.plugin.locationcomponent.LocationComponentPlugin
-import com.mapbox.maps.plugin.locationcomponent.getLocationComponentPlugin
+import com.mapbox.maps.plugin.locationcomponent.location
 import com.mapbox.navigation.base.formatter.DistanceFormatterOptions
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.trip.model.RouteProgress
@@ -205,7 +205,7 @@ class MapboxTripProgressActivity : AppCompatActivity(), OnMapLongClickListener {
         mapboxMap.loadStyleUri(
             MAPBOX_STREETS
         ) {
-            binding.mapView.getGesturesPlugin().addOnMapLongClickListener(this)
+            binding.mapView.gestures.addOnMapLongClickListener(this)
         }
     }
 
@@ -214,7 +214,7 @@ class MapboxTripProgressActivity : AppCompatActivity(), OnMapLongClickListener {
     }
 
     private fun getMapCamera(): CameraAnimationsPlugin {
-        return binding.mapView.getCameraAnimationsPlugin()
+        return binding.mapView.camera
     }
 
     private fun startSimulation(route: DirectionsRoute) {
@@ -285,7 +285,7 @@ class MapboxTripProgressActivity : AppCompatActivity(), OnMapLongClickListener {
 
         setContentView(binding.root)
         mapboxMap = binding.mapView.getMapboxMap()
-        locationComponent = binding.mapView.getLocationComponentPlugin().apply {
+        locationComponent = binding.mapView.location.apply {
             setLocationProvider(navigationLocationProvider)
             enabled = true
         }

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxVoiceActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxVoiceActivity.kt
@@ -14,12 +14,12 @@ import com.mapbox.maps.MapboxMap
 import com.mapbox.maps.Style.Companion.MAPBOX_STREETS
 import com.mapbox.maps.plugin.animation.CameraAnimationsPlugin
 import com.mapbox.maps.plugin.animation.MapAnimationOptions
-import com.mapbox.maps.plugin.animation.getCameraAnimationsPlugin
+import com.mapbox.maps.plugin.animation.camera
 import com.mapbox.maps.plugin.gestures.GesturesPlugin
 import com.mapbox.maps.plugin.gestures.OnMapLongClickListener
-import com.mapbox.maps.plugin.gestures.getGesturesPlugin
+import com.mapbox.maps.plugin.gestures.gestures
 import com.mapbox.maps.plugin.locationcomponent.LocationComponentPlugin
-import com.mapbox.maps.plugin.locationcomponent.getLocationComponentPlugin
+import com.mapbox.maps.plugin.locationcomponent.location
 import com.mapbox.navigation.base.internal.extensions.applyDefaultParams
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.trip.model.RouteProgress
@@ -242,7 +242,7 @@ class MapboxVoiceActivity : AppCompatActivity(), OnMapLongClickListener {
     }
 
     private fun getGesturesPlugin(): GesturesPlugin {
-        return binding.mapView.getGesturesPlugin()
+        return binding.mapView.gestures
     }
 
     @SuppressLint("MissingPermission")
@@ -305,7 +305,7 @@ class MapboxVoiceActivity : AppCompatActivity(), OnMapLongClickListener {
     }
 
     private fun getMapCamera(): CameraAnimationsPlugin {
-        return binding.mapView.getCameraAnimationsPlugin()
+        return binding.mapView.camera
     }
 
     private fun startSimulation(route: DirectionsRoute) {
@@ -366,7 +366,7 @@ class MapboxVoiceActivity : AppCompatActivity(), OnMapLongClickListener {
         binding = LayoutActivityVoiceBinding.inflate(layoutInflater)
         setContentView(binding.root)
         mapboxMap = binding.mapView.getMapboxMap()
-        locationComponent = binding.mapView.getLocationComponentPlugin().apply {
+        locationComponent = binding.mapView.location.apply {
             setLocationProvider(navigationLocationProvider)
             enabled = true
         }

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayHistoryActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayHistoryActivity.kt
@@ -18,11 +18,11 @@ import com.mapbox.maps.MapView
 import com.mapbox.maps.Style
 import com.mapbox.maps.plugin.LocationPuck2D
 import com.mapbox.maps.plugin.animation.MapAnimationOptions
-import com.mapbox.maps.plugin.animation.getCameraAnimationsPlugin
+import com.mapbox.maps.plugin.animation.camera
 import com.mapbox.maps.plugin.delegates.listeners.OnMapLoadErrorListener
 import com.mapbox.maps.plugin.delegates.listeners.eventdata.MapLoadErrorType
 import com.mapbox.maps.plugin.locationcomponent.LocationComponentPlugin
-import com.mapbox.maps.plugin.locationcomponent.getLocationComponentPlugin
+import com.mapbox.maps.plugin.locationcomponent.location
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.replay.MapboxReplayer
@@ -114,7 +114,7 @@ class ReplayHistoryActivity : AppCompatActivity() {
                 mapboxNavigation.navigationOptions.locationEngine.getLastLocation(
                     locationEngineCallback
                 )
-                locationComponent = binding.mapView.getLocationComponentPlugin().apply {
+                locationComponent = binding.mapView.location.apply {
                     this.locationPuck = LocationPuck2D(
                         bearingImage = ContextCompat.getDrawable(
                             this@ReplayHistoryActivity,
@@ -126,7 +126,7 @@ class ReplayHistoryActivity : AppCompatActivity() {
                 }
                 navigationCamera = NavigationCamera(
                     binding.mapView.getMapboxMap(),
-                    binding.mapView.getCameraAnimationsPlugin(),
+                    binding.mapView.camera,
                     viewportDataSource
                 )
 
@@ -157,7 +157,7 @@ class ReplayHistoryActivity : AppCompatActivity() {
     private fun updateCamera(location: Location) {
         val mapAnimationOptionsBuilder = MapAnimationOptions.Builder()
             .duration(1500L)
-        binding.mapView.getCameraAnimationsPlugin().easeTo(
+        binding.mapView.camera.easeTo(
             CameraOptions.Builder()
                 .center(Point.fromLngLat(location.longitude, location.latitude))
                 .bearing(location.bearing.toDouble())

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/camera/MapboxCameraAnimationsActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/camera/MapboxCameraAnimationsActivity.kt
@@ -29,15 +29,15 @@ import com.mapbox.maps.extension.style.sources.addSource
 import com.mapbox.maps.extension.style.sources.generated.GeoJsonSource
 import com.mapbox.maps.plugin.LocationPuck2D
 import com.mapbox.maps.plugin.animation.MapAnimationOptions
-import com.mapbox.maps.plugin.animation.getCameraAnimationsPlugin
+import com.mapbox.maps.plugin.animation.camera
 import com.mapbox.maps.plugin.delegates.listeners.OnMapLoadErrorListener
 import com.mapbox.maps.plugin.delegates.listeners.eventdata.MapLoadErrorType
 import com.mapbox.maps.plugin.gestures.GesturesPlugin
 import com.mapbox.maps.plugin.gestures.OnMapLongClickListener
-import com.mapbox.maps.plugin.gestures.getGesturesPlugin
+import com.mapbox.maps.plugin.gestures.gestures
 import com.mapbox.maps.plugin.locationcomponent.LocationComponentPlugin
 import com.mapbox.maps.plugin.locationcomponent.OnIndicatorPositionChangedListener
-import com.mapbox.maps.plugin.locationcomponent.getLocationComponentPlugin
+import com.mapbox.maps.plugin.locationcomponent.location
 import com.mapbox.navigation.base.ExperimentalMapboxNavigationAPI
 import com.mapbox.navigation.base.internal.extensions.applyDefaultParams
 import com.mapbox.navigation.base.options.NavigationOptions
@@ -244,7 +244,7 @@ class MapboxCameraAnimationsActivity :
         binding = LayoutActivityCameraBinding.inflate(layoutInflater)
         setContentView(binding.root)
         mapboxMap = binding.mapView.getMapboxMap()
-        locationComponent = binding.mapView.getLocationComponentPlugin().apply {
+        locationComponent = binding.mapView.location.apply {
             this.locationPuck = LocationPuck2D(
                 bearingImage = ContextCompat.getDrawable(
                     this@MapboxCameraAnimationsActivity,
@@ -270,15 +270,15 @@ class MapboxCameraAnimationsActivity :
         viewportDataSource.debugger = debugger
         navigationCamera = NavigationCamera(
             binding.mapView.getMapboxMap(),
-            binding.mapView.getCameraAnimationsPlugin(),
+            binding.mapView.camera,
             viewportDataSource
         )
         navigationCamera.debugger = debugger
         /* Alternative to the NavigationScaleGestureHandler
-        mapView.getCameraAnimationsPlugin().addCameraAnimationsLifecycleListener(
+        mapView.camera.addCameraAnimationsLifecycleListener(
             NavigationBasicGesturesHandler(navigationCamera)
         )*/
-        binding.mapView.getCameraAnimationsPlugin().addCameraAnimationsLifecycleListener(
+        binding.mapView.camera.addCameraAnimationsLifecycleListener(
             NavigationScaleGestureHandler(
                 this,
                 navigationCamera,
@@ -509,8 +509,8 @@ class MapboxCameraAnimationsActivity :
                         it.latitude + 0.0123
                     )
                     // workaround for https://github.com/mapbox/mapbox-maps-android/issues/177
-                    // binding.mapView.getCameraAnimationsPlugin().flyTo(
-                    binding.mapView.getCameraAnimationsPlugin().easeTo(
+                    // binding.mapView.camera.flyTo(
+                    binding.mapView.camera.easeTo(
                         CameraOptions.Builder()
                             .padding(notPaddedEdgeInsets)
                             .center(center)
@@ -624,7 +624,7 @@ class MapboxCameraAnimationsActivity :
     }
 
     private fun getGesturesPlugin(): GesturesPlugin {
-        return binding.mapView.getGesturesPlugin()
+        return binding.mapView.gestures
     }
 
     override fun onRequestPermissionsResult(

--- a/examples/src/main/java/com/mapbox/navigation/examples/util/RouteDrawingActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/util/RouteDrawingActivity.kt
@@ -13,16 +13,17 @@ import com.mapbox.android.core.location.LocationEngineProvider
 import com.mapbox.android.core.location.LocationEngineResult
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.RouteOptions
+import com.mapbox.common.TileStore
 import com.mapbox.geojson.Point
 import com.mapbox.maps.CameraOptions
+import com.mapbox.maps.MapInitOptions
 import com.mapbox.maps.MapView
-import com.mapbox.maps.MapboxMapOptions
 import com.mapbox.maps.ResourceOptions
 import com.mapbox.maps.Style
 import com.mapbox.maps.plugin.animation.CameraAnimationsPlugin
-import com.mapbox.maps.plugin.animation.getCameraAnimationsPlugin
+import com.mapbox.maps.plugin.animation.camera
 import com.mapbox.maps.plugin.locationcomponent.LocationComponentPlugin
-import com.mapbox.maps.plugin.locationcomponent.getLocationComponentPlugin
+import com.mapbox.maps.plugin.locationcomponent.location
 import com.mapbox.navigation.core.directions.session.RoutesRequestCallback
 import com.mapbox.navigation.examples.core.R
 import com.mapbox.navigation.ui.maps.internal.route.line.MapboxRouteLineApiExtensions.clearRouteLine
@@ -81,20 +82,21 @@ class RouteDrawingActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.layout_route_drawing_activity)
-        val mapboxMapOptions = MapboxMapOptions(this, resources.displayMetrics.density, null)
+        val tileStore = TileStore.getInstance()
+        val mapboxMapOptions = MapInitOptions(this)
         val resourceOptions = ResourceOptions.Builder()
             .accessToken(getMapboxAccessTokenFromResources())
             .assetPath(filesDir.absolutePath)
             .cachePath(filesDir.absolutePath + "/mbx.db")
             .cacheSize(100000000L) // 100 MB
-            .tileStorePath(filesDir.absolutePath + "/maps_tile_store/")
+            .tileStore(tileStore)
             .build()
         mapboxMapOptions.resourceOptions = resourceOptions
         mapView = MapView(this, mapboxMapOptions)
         val mapLayout = findViewById<RelativeLayout>(R.id.mapView_container)
         mapLayout.addView(mapView)
         navigationLocationProvider = NavigationLocationProvider()
-        locationComponent = mapView.getLocationComponentPlugin().apply {
+        locationComponent = mapView.location.apply {
             setLocationProvider(navigationLocationProvider)
             enabled = true
         }
@@ -225,6 +227,6 @@ class RouteDrawingActivity : AppCompatActivity() {
     }
 
     private fun getMapCamera(): CameraAnimationsPlugin {
-        return mapView.getCameraAnimationsPlugin()
+        return mapView.camera
     }
 }

--- a/examples/src/main/java/com/mapbox/navigation/examples/util/RouteLineUtil.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/util/RouteLineUtil.kt
@@ -8,7 +8,7 @@ import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.maps.MapView
 import com.mapbox.maps.Style
 import com.mapbox.maps.plugin.locationcomponent.OnIndicatorPositionChangedListener
-import com.mapbox.maps.plugin.locationcomponent.getLocationComponentPlugin
+import com.mapbox.maps.plugin.locationcomponent.location
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesObserver
@@ -123,7 +123,7 @@ class RouteLineUtil(private val activity: AppCompatActivity) : LifecycleObserver
     private fun onStart() {
         mapView.getMapboxMap().getStyle { style ->
             this@RouteLineUtil.style = style
-            mapView.getLocationComponentPlugin().addOnIndicatorPositionChangedListener(
+            mapView.location.addOnIndicatorPositionChangedListener(
                 onIndicatorPositionChangedListener
             )
             mapboxNavigation.registerRoutesObserver(routesObserver)
@@ -133,7 +133,7 @@ class RouteLineUtil(private val activity: AppCompatActivity) : LifecycleObserver
 
     @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
     private fun onStop() {
-        mapView.getLocationComponentPlugin().removeOnIndicatorPositionChangedListener(
+        mapView.location.removeOnIndicatorPositionChangedListener(
             onIndicatorPositionChangedListener
         )
         mapboxNavigation.unregisterRoutesObserver(routesObserver)

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -16,7 +16,7 @@ ext {
   println("Navigation Native version: " + mapboxNavigatorVersion)
 
   version = [
-      mapboxMapSdk              : '10.0.0-beta.17',
+      mapboxMapSdk              : '10.0.0-beta.18',
       mapboxSdkServices         : '5.9.0-alpha.5',
       mapboxEvents              : '6.2.2',
       mapboxCore                : '3.1.1',

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/ui/SimpleMapViewNavigationTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/ui/SimpleMapViewNavigationTest.kt
@@ -5,9 +5,9 @@ import androidx.core.content.ContextCompat
 import androidx.test.espresso.Espresso
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.maps.plugin.LocationPuck2D
-import com.mapbox.maps.plugin.animation.getCameraAnimationsPlugin
+import com.mapbox.maps.plugin.animation.camera
 import com.mapbox.maps.plugin.locationcomponent.LocationComponentPlugin
-import com.mapbox.maps.plugin.locationcomponent.getLocationComponentPlugin
+import com.mapbox.maps.plugin.locationcomponent.location
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.MapboxNavigation
@@ -122,7 +122,7 @@ abstract class SimpleMapViewNavigationTest :
             )
             navigationCamera = NavigationCamera(
                 activity.mapboxMap,
-                activity.binding.mapView.getCameraAnimationsPlugin(),
+                activity.binding.mapView.camera,
                 mapboxNavigationViewportDataSource
             )
             navigationCamera.requestNavigationCameraToFollowing()
@@ -155,7 +155,7 @@ abstract class SimpleMapViewNavigationTest :
     protected fun addLocationPuck() {
         runOnMainSync {
             navigationLocationProvider = NavigationLocationProvider()
-            locationPlugin = activity.binding.mapView.getLocationComponentPlugin()
+            locationPlugin = activity.binding.mapView.location
             locationPlugin.setLocationProvider(navigationLocationProvider)
             locationPlugin.locationPuck = LocationPuck2D(
                 bearingImage = ContextCompat.getDrawable(

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/MapboxNavigationViewportDataSource.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/MapboxNavigationViewportDataSource.kt
@@ -178,7 +178,7 @@ import kotlin.math.min
  * ```kotlin
  * private fun animateToPOI() {
  *     // request camera to idle first or use `NavigationBasicGesturesHandler` or `NavigationScaleGestureHandler`
- *     mapView.getCameraAnimationsPlugin().flyTo(
+ *     mapView.camera.flyTo(
  *         CameraOptions.Builder()
  *             .padding(edgeInsets)
  *             .center(point)

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/debugger/MapboxNavigationViewportDataSourceDebugger.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/debugger/MapboxNavigationViewportDataSourceDebugger.kt
@@ -50,7 +50,7 @@ import com.mapbox.navigation.ui.maps.camera.state.NavigationCameraState
  * viewportDataSource.debugger = debugger
  * navigationCamera = NavigationCamera(
  *     mapView.getMapboxMap(),
- *     mapView.getCameraAnimationsPlugin(),
+ *     mapView.camera,
  *     viewportDataSource
  * )
  * navigationCamera.debugger = debugger

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/location/NavigationLocationProvider.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/location/NavigationLocationProvider.kt
@@ -22,7 +22,7 @@ import java.util.concurrent.CopyOnWriteArraySet
  * #### Example usage
  * Initialize the location plugin:
  * ```
- * locationComponent = mapView.getLocationComponentPlugin().apply {
+ * locationComponent = mapView.location.apply {
  *     setLocationProvider(navigationLocationProvider)
  *     addOnIndicatorPositionChangedListener(onIndicatorPositionChangedListener)
  *     enabled = true

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/snapshotter/api/MapboxSnapshotterApi.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/snapshotter/api/MapboxSnapshotterApi.kt
@@ -6,11 +6,11 @@ import com.mapbox.geojson.LineString
 import com.mapbox.geojson.Point
 import com.mapbox.maps.CameraOptions
 import com.mapbox.maps.EdgeInsets
+import com.mapbox.maps.MapInitOptions
 import com.mapbox.maps.MapInterface
 import com.mapbox.maps.MapSnapshotOptions
 import com.mapbox.maps.MapView
 import com.mapbox.maps.MapboxMap
-import com.mapbox.maps.MapboxOptions
 import com.mapbox.maps.ScreenCoordinate
 import com.mapbox.maps.Size
 import com.mapbox.maps.SnapshotStyleListener
@@ -50,7 +50,7 @@ class MapboxSnapshotterApi(
     private val snapshotter: Snapshotter
 
     init {
-        val resourceOptions = MapboxOptions.getDefaultResourceOptions(context)
+        val resourceOptions = MapInitOptions.getDefaultResourceOptions(context)
         val mapSnapshotOptions = MapSnapshotOptions.Builder()
             .resourceOptions(resourceOptions)
             .size(options.size)

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/AlternativeRouteActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/AlternativeRouteActivity.kt
@@ -67,7 +67,7 @@ class AlternativeRouteActivity : AppCompatActivity(), OnMapLongClickListener {
     }
 
     private val mapCamera: CameraAnimationsPlugin by lazy {
-        binding.mapView.getCameraAnimationsPlugin()
+        binding.mapView.camera
     }
 
     private val mapboxNavigation: MapboxNavigation by lazy {
@@ -131,7 +131,7 @@ class AlternativeRouteActivity : AppCompatActivity(), OnMapLongClickListener {
     }
 
     private fun initNavigation() {
-        binding.mapView.getLocationComponentPlugin().apply {
+        binding.mapView.location.apply {
             setLocationProvider(navigationLocationProvider)
             enabled = true
         }
@@ -188,7 +188,7 @@ class AlternativeRouteActivity : AppCompatActivity(), OnMapLongClickListener {
 
                     override fun onFailure(exception: Exception) {}
                 })
-            binding.mapView.getGesturesPlugin().addOnMapLongClickListener(this)
+            binding.mapView.gestures.addOnMapLongClickListener(this)
         }
     }
 
@@ -256,7 +256,7 @@ class AlternativeRouteActivity : AppCompatActivity(), OnMapLongClickListener {
             startSimulation(mapboxNavigation.getRoutes()[0])
         }
 
-        binding.mapView.getGesturesPlugin().addOnMapClickListener(mapClickListener)
+        binding.mapView.gestures.addOnMapClickListener(mapClickListener)
     }
 
     private fun startSimulation(route: DirectionsRoute) {


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Upgrades Maps SDK to v10.0.0-beta.18.

These changes (next to other smaller breaking changes) require the TileStore instance to be initialized differently, I updated the `PredictiveCacheController` docs to reflect that.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Map `ResourceOptions` contains tile store instance (TileStore API). Tile store usage is enabled by default, 'ResourceOptions.tileStoreEnabled' flag is introduced to disable it. This changed the integration with the `PredictiveCacheControler` which contains update integration docs.</changelog>
```

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
