### PR TITLE
Make the route refresh interval configurable

### DIFF
--- a/libnavigation-base/api/current.txt
+++ b/libnavigation-base/api/current.txt
@@ -181,11 +181,11 @@ package com.mapbox.navigation.base.options {
     method public com.mapbox.android.core.location.LocationEngineRequest getLocationEngineRequest();
     method public long getNavigatorPredictionMillis();
     method public com.mapbox.navigation.base.options.PredictiveCacheLocationOptions getPredictiveCacheLocationOptions();
+    method public com.mapbox.navigation.base.route.RouteRefreshOptions getRouteRefreshOptions();
     method public com.mapbox.navigation.base.options.RoutingTilesOptions getRoutingTilesOptions();
     method public int getTimeFormatType();
     method public boolean isDebugLoggingEnabled();
     method public boolean isFromNavigationUi();
-    method public boolean isRouteRefreshEnabled();
     method public com.mapbox.navigation.base.options.NavigationOptions.Builder toBuilder();
     property public final String? accessToken;
     property public final android.content.Context applicationContext;
@@ -195,11 +195,11 @@ package com.mapbox.navigation.base.options {
     property public final com.mapbox.navigation.base.options.IncidentsOptions incidentsOptions;
     property public final boolean isDebugLoggingEnabled;
     property public final boolean isFromNavigationUi;
-    property public final boolean isRouteRefreshEnabled;
     property public final com.mapbox.android.core.location.LocationEngine locationEngine;
     property public final com.mapbox.android.core.location.LocationEngineRequest locationEngineRequest;
     property public final long navigatorPredictionMillis;
     property public final com.mapbox.navigation.base.options.PredictiveCacheLocationOptions predictiveCacheLocationOptions;
+    property public final com.mapbox.navigation.base.route.RouteRefreshOptions routeRefreshOptions;
     property public final com.mapbox.navigation.base.options.RoutingTilesOptions routingTilesOptions;
     property public final int timeFormatType;
   }
@@ -214,11 +214,11 @@ package com.mapbox.navigation.base.options {
     method public com.mapbox.navigation.base.options.NavigationOptions.Builder incidentsOptions(com.mapbox.navigation.base.options.IncidentsOptions incidentsOptions);
     method public com.mapbox.navigation.base.options.NavigationOptions.Builder isDebugLoggingEnabled(boolean flag);
     method public com.mapbox.navigation.base.options.NavigationOptions.Builder isFromNavigationUi(boolean flag);
-    method public com.mapbox.navigation.base.options.NavigationOptions.Builder isRouteRefreshEnabled(boolean flag);
     method public com.mapbox.navigation.base.options.NavigationOptions.Builder locationEngine(com.mapbox.android.core.location.LocationEngine locationEngine);
     method public com.mapbox.navigation.base.options.NavigationOptions.Builder locationEngineRequest(com.mapbox.android.core.location.LocationEngineRequest locationEngineRequest);
     method public com.mapbox.navigation.base.options.NavigationOptions.Builder navigatorPredictionMillis(long predictionMillis);
     method public com.mapbox.navigation.base.options.NavigationOptions.Builder predictiveCacheLocationOptions(com.mapbox.navigation.base.options.PredictiveCacheLocationOptions predictiveCacheLocationOptions);
+    method public com.mapbox.navigation.base.options.NavigationOptions.Builder routeRefreshOptions(com.mapbox.navigation.base.route.RouteRefreshOptions routeRefreshOptions);
     method public com.mapbox.navigation.base.options.NavigationOptions.Builder routingTilesOptions(com.mapbox.navigation.base.options.RoutingTilesOptions routingTilesOptions);
     method public com.mapbox.navigation.base.options.NavigationOptions.Builder timeFormatType(int type);
   }
@@ -324,6 +324,21 @@ package com.mapbox.navigation.base.route {
     method public Throwable? getThrowable();
     property public final String? message;
     property public final Throwable? throwable;
+  }
+
+  public final class RouteRefreshOptions {
+    method public boolean getEnabled();
+    method public long getIntervalMillis();
+    method public com.mapbox.navigation.base.route.RouteRefreshOptions.Builder toBuilder();
+    property public final boolean enabled;
+    property public final long intervalMillis;
+  }
+
+  public static final class RouteRefreshOptions.Builder {
+    ctor public RouteRefreshOptions.Builder();
+    method public com.mapbox.navigation.base.route.RouteRefreshOptions build();
+    method public com.mapbox.navigation.base.route.RouteRefreshOptions.Builder enabled(boolean enabled);
+    method public com.mapbox.navigation.base.route.RouteRefreshOptions.Builder intervalMillis(long intervalMillis);
   }
 
   public interface Router {

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/NavigationOptions.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/NavigationOptions.kt
@@ -6,6 +6,7 @@ import com.mapbox.android.core.location.LocationEngineProvider
 import com.mapbox.android.core.location.LocationEngineRequest
 import com.mapbox.navigation.base.TimeFormat
 import com.mapbox.navigation.base.formatter.DistanceFormatterOptions
+import com.mapbox.navigation.base.route.RouteRefreshOptions
 
 /**
  * Default navigator approximate prediction in milliseconds
@@ -34,7 +35,7 @@ const val DEFAULT_NAVIGATOR_PREDICTION_MILLIS = 1100L
  * @param isDebugLoggingEnabled Boolean
  * @param deviceProfile [DeviceProfile] defines how navigation data should be interpretation
  * @param eHorizonOptions [EHorizonOptions] defines configuration for the Electronic Horizon
- * @param isRouteRefreshEnabled Boolean *true* if need to enable route refresh mechanism, otherwise *false*
+ * @param routeRefreshOptions defines configuration for refreshing routes
  * @param incidentsOptions defines configuration for live incidents
  */
 class NavigationOptions private constructor(
@@ -51,7 +52,7 @@ class NavigationOptions private constructor(
     val isDebugLoggingEnabled: Boolean,
     val deviceProfile: DeviceProfile,
     val eHorizonOptions: EHorizonOptions,
-    val isRouteRefreshEnabled: Boolean,
+    val routeRefreshOptions: RouteRefreshOptions,
     val incidentsOptions: IncidentsOptions,
 ) {
 
@@ -71,7 +72,7 @@ class NavigationOptions private constructor(
         isDebugLoggingEnabled(isDebugLoggingEnabled)
         deviceProfile(deviceProfile)
         eHorizonOptions(eHorizonOptions)
-        isRouteRefreshEnabled(isRouteRefreshEnabled)
+        routeRefreshOptions(routeRefreshOptions)
         incidentsOptions(incidentsOptions)
     }
 
@@ -97,7 +98,7 @@ class NavigationOptions private constructor(
         if (isDebugLoggingEnabled != other.isDebugLoggingEnabled) return false
         if (deviceProfile != other.deviceProfile) return false
         if (eHorizonOptions != other.eHorizonOptions) return false
-        if (isRouteRefreshEnabled != other.isRouteRefreshEnabled) return false
+        if (routeRefreshOptions != other.routeRefreshOptions) return false
         if (incidentsOptions != other.incidentsOptions) return false
 
         return true
@@ -120,7 +121,7 @@ class NavigationOptions private constructor(
         result = 31 * result + isDebugLoggingEnabled.hashCode()
         result = 31 * result + deviceProfile.hashCode()
         result = 31 * result + eHorizonOptions.hashCode()
-        result = 31 * result + isRouteRefreshEnabled.hashCode()
+        result = 31 * result + routeRefreshOptions.hashCode()
         result = 31 * result + incidentsOptions.hashCode()
         return result
     }
@@ -143,7 +144,7 @@ class NavigationOptions private constructor(
             "isDebugLoggingEnabled=$isDebugLoggingEnabled, " +
             "deviceProfile=$deviceProfile, " +
             "eHorizonOptions=$eHorizonOptions " +
-            "isRouteRefreshEnabled=$isRouteRefreshEnabled " +
+            "routeRefreshOptions=$routeRefreshOptions " +
             "incidentsOptions=$incidentsOptions" +
             ")"
     }
@@ -173,7 +174,7 @@ class NavigationOptions private constructor(
         private var isDebugLoggingEnabled: Boolean = false
         private var deviceProfile: DeviceProfile = DeviceProfile.Builder().build()
         private var eHorizonOptions: EHorizonOptions = EHorizonOptions.Builder().build()
-        private var isRouteRefreshEnabled: Boolean = true
+        private var routeRefreshOptions: RouteRefreshOptions = RouteRefreshOptions.Builder().build()
         private var incidentsOptions: IncidentsOptions = IncidentsOptions.Builder().build()
 
         /**
@@ -251,14 +252,10 @@ class NavigationOptions private constructor(
             apply { this.eHorizonOptions = eHorizonOptions }
 
         /**
-         * Defines if route refresh is enabled.
-         *
-         * See [com.mapbox.navigation.base.extensions.supportsRouteRefresh]
-         * for a list of requirements that your route request needs to meet to be eligible for
-         * refresh calls.
+         * Defines configuration for route refresh
          */
-        fun isRouteRefreshEnabled(flag: Boolean): Builder =
-            apply { this.isRouteRefreshEnabled = flag }
+        fun routeRefreshOptions(routeRefreshOptions: RouteRefreshOptions): Builder =
+            apply { this.routeRefreshOptions = routeRefreshOptions }
 
         /**
          * Defines configuration for live incidents
@@ -286,7 +283,7 @@ class NavigationOptions private constructor(
                 isDebugLoggingEnabled = isDebugLoggingEnabled,
                 deviceProfile = deviceProfile,
                 eHorizonOptions = eHorizonOptions,
-                isRouteRefreshEnabled = isRouteRefreshEnabled,
+                routeRefreshOptions = routeRefreshOptions,
                 incidentsOptions = incidentsOptions,
             )
         }

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/route/RouteRefreshOptions.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/route/RouteRefreshOptions.kt
@@ -1,0 +1,104 @@
+package com.mapbox.navigation.base.route
+
+import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.api.directions.v5.models.LegAnnotation
+import java.util.concurrent.TimeUnit
+
+/**
+ * The options available for refreshing the active [DirectionsRoute]. Each refresh will update
+ * the current route's [LegAnnotation]. This includes traffic congestion and estimated travel time.
+ *
+ * @param enabled Periodically refreshes the route when enabled, defaults to true
+ * @param intervalMillis The refresh interval in milliseconds, default is 5 min.
+ */
+class RouteRefreshOptions private constructor(
+    val enabled: Boolean,
+    val intervalMillis: Long
+) {
+    /**
+     * @return the builder that created the [ArrivalOptions]
+     */
+    fun toBuilder(): Builder = Builder().apply {
+        enabled(enabled)
+        intervalMillis(intervalMillis)
+    }
+
+    /**
+     * Regenerate whenever a change is made
+     */
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as RouteRefreshOptions
+
+        if (enabled != other.enabled) return false
+        if (intervalMillis != other.intervalMillis) return false
+
+        return true
+    }
+
+    /**
+     * Regenerate whenever a change is made
+     */
+    override fun hashCode(): Int {
+        var result = enabled.hashCode()
+        result = 31 * result + (intervalMillis.hashCode())
+        return result
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    override fun toString(): String {
+        return "RouteRefreshOptions(" +
+            "enabled=$enabled, intervalMillis=$intervalMillis" +
+            ")"
+    }
+
+    /**
+     * Build your [RouteRefreshOptions].
+     */
+    class Builder {
+
+        private var enabled: Boolean = true
+        private var intervalMillis: Long = TimeUnit.MINUTES.toMillis(5)
+
+        /**
+         * Periodically refreshes the route when enabled, defaults to false
+         *
+         * See [com.mapbox.navigation.base.extensions.supportsRouteRefresh]
+         * for a list of requirements that your route request needs to meet to be eligible for
+         * refresh calls.
+         */
+        fun enabled(enabled: Boolean): Builder {
+            this.enabled = enabled
+            return this
+        }
+
+        /**
+         * Update the route refresh interval in milliseconds.
+         */
+        fun intervalMillis(intervalMillis: Long): Builder {
+            this.intervalMillis = intervalMillis
+            return this
+        }
+
+        /**
+         * Build the object.
+         */
+        fun build(): RouteRefreshOptions {
+            check(intervalMillis >= MINIMUM_REFRESH_INTERVAL) {
+                "Route refresh interval out of range $intervalMillis < $MINIMUM_REFRESH_INTERVAL"
+            }
+            return RouteRefreshOptions(
+                enabled = enabled,
+                intervalMillis = intervalMillis
+            )
+        }
+    }
+
+    private companion object {
+        private val MINIMUM_REFRESH_INTERVAL = TimeUnit.SECONDS.toMillis(30)
+    }
+}

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/options/NavigationOptionsTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/options/NavigationOptionsTest.kt
@@ -7,6 +7,7 @@ import com.mapbox.android.core.location.LocationEngineRequest
 import com.mapbox.navigation.base.TimeFormat.NONE_SPECIFIED
 import com.mapbox.navigation.base.TimeFormat.TWELVE_HOURS
 import com.mapbox.navigation.base.TimeFormat.TWENTY_FOUR_HOURS
+import com.mapbox.navigation.base.route.RouteRefreshOptions
 import com.mapbox.navigation.testing.BuilderTest
 import io.mockk.every
 import io.mockk.mockk
@@ -67,7 +68,12 @@ class NavigationOptionsTest : BuilderTest<NavigationOptions, NavigationOptions.B
             .predictiveCacheLocationOptions(mockk())
             .timeFormatType(1)
             .eHorizonOptions(mockk())
-            .isRouteRefreshEnabled(false)
+            .routeRefreshOptions(
+                RouteRefreshOptions.Builder()
+                    .enabled(false)
+                    .intervalMillis(132345L)
+                    .build()
+            )
             .incidentsOptions(mockk())
     }
 

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/route/RouteRefreshOptionsTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/route/RouteRefreshOptionsTest.kt
@@ -1,0 +1,19 @@
+package com.mapbox.navigation.base.route
+
+import com.mapbox.navigation.testing.BuilderTest
+import org.junit.Test
+import java.util.concurrent.TimeUnit
+
+class RouteRefreshOptionsTest : BuilderTest<RouteRefreshOptions, RouteRefreshOptions.Builder>() {
+
+    override fun getImplementationClass() = RouteRefreshOptions::class
+
+    override fun getFilledUpBuilder() = RouteRefreshOptions.Builder()
+        .enabled(false)
+        .intervalMillis(TimeUnit.SECONDS.toMillis(30))
+
+    @Test
+    override fun trigger() {
+        // trigger, see KDoc
+    }
+}

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -286,11 +286,12 @@ class MapboxNavigation(
             logger
         )
         routeRefreshController = RouteRefreshControllerProvider.createRouteRefreshController(
+            navigationOptions.routeRefreshOptions,
             directionsSession,
             tripSession,
             logger
         )
-        if (navigationOptions.isRouteRefreshEnabled) {
+        if (navigationOptions.routeRefreshOptions.enabled) {
             routeRefreshController.start()
         }
 
@@ -875,7 +876,10 @@ class MapboxNavigation(
                     NetworkStatusService::class.java,
                     NetworkStatusService(navigationOptions.applicationContext)
                 ),
-                ModuleProviderArgument(Boolean::class.java, navigationOptions.isRouteRefreshEnabled)
+                ModuleProviderArgument(
+                    Boolean::class.java,
+                    navigationOptions.routeRefreshOptions.enabled
+                )
             )
             MapboxModuleType.NavigationTripNotification -> arrayOf(
                 ModuleProviderArgument(NavigationOptions::class.java, navigationOptions),

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/routerefresh/RouteRefreshController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/routerefresh/RouteRefreshController.kt
@@ -7,12 +7,12 @@ import com.mapbox.base.common.logger.model.Tag
 import com.mapbox.navigation.base.extensions.supportsRouteRefresh
 import com.mapbox.navigation.base.route.RouteRefreshCallback
 import com.mapbox.navigation.base.route.RouteRefreshError
+import com.mapbox.navigation.base.route.RouteRefreshOptions
 import com.mapbox.navigation.core.directions.session.DirectionsSession
 import com.mapbox.navigation.core.internal.utils.isUuidValidForRefresh
 import com.mapbox.navigation.core.trip.session.TripSession
 import com.mapbox.navigation.utils.internal.MapboxTimer
 import kotlinx.coroutines.Job
-import java.util.concurrent.TimeUnit
 
 /**
  * This class is responsible for refreshing the current direction route's traffic.
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeUnit
  * can be refreshed are handled by this class. Calling [start] will restart the refresh timer.
  */
 internal class RouteRefreshController(
+    routeRefreshOptions: RouteRefreshOptions,
     private val directionsSession: DirectionsSession,
     private val tripSession: TripSession,
     private val logger: Logger
@@ -33,13 +34,11 @@ internal class RouteRefreshController(
         internal val TAG = Tag("MbxRouteRefreshController")
     }
 
-    private val routerRefreshTimer = MapboxTimer()
+    private val routerRefreshTimer = MapboxTimer().apply {
+        restartAfterMillis = routeRefreshOptions.intervalMillis
+    }
 
     private var requestId: Long? = null
-
-    init {
-        routerRefreshTimer.restartAfterMillis = TimeUnit.MINUTES.toMillis(5)
-    }
 
     fun start(): Job {
         stop()

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/routerefresh/RouteRefreshControllerProvider.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/routerefresh/RouteRefreshControllerProvider.kt
@@ -1,16 +1,19 @@
 package com.mapbox.navigation.core.routerefresh
 
 import com.mapbox.base.common.logger.Logger
+import com.mapbox.navigation.base.route.RouteRefreshOptions
 import com.mapbox.navigation.core.directions.session.DirectionsSession
 import com.mapbox.navigation.core.trip.session.TripSession
 
 internal object RouteRefreshControllerProvider {
 
     fun createRouteRefreshController(
+        routeRefreshOptions: RouteRefreshOptions,
         directionsSession: DirectionsSession,
         tripSession: TripSession,
         logger: Logger
     ) = RouteRefreshController(
+        routeRefreshOptions,
         directionsSession,
         tripSession,
         logger

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
@@ -19,6 +19,7 @@ import com.mapbox.navigation.base.internal.extensions.inferDeviceLocale
 import com.mapbox.navigation.base.options.IncidentsOptions
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.options.RoutingTilesOptions
+import com.mapbox.navigation.base.route.RouteRefreshOptions
 import com.mapbox.navigation.base.route.Router
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.base.trip.notification.TripNotification
@@ -233,16 +234,17 @@ class MapboxNavigationTest {
     fun init_routeRefreshController_start_called_when_isRouteRefresh_enabled() {
         ThreadController.cancelAllUICoroutines()
         mockkObject(RouteRefreshControllerProvider)
+        val routeRefreshOptions = RouteRefreshOptions.Builder()
+            .enabled(true)
+            .build()
         every {
             RouteRefreshControllerProvider.createRouteRefreshController(
-                directionsSession,
-                tripSession,
-                logger
+                any(), any(), any(), any()
             )
         } returns routeRefreshController
         every { routeRefreshController.start() } returns mockk()
         val navigationOptions = provideNavigationOptions()
-            .isRouteRefreshEnabled(true)
+            .routeRefreshOptions(routeRefreshOptions)
             .build()
 
         mapboxNavigation = MapboxNavigation(navigationOptions)
@@ -256,16 +258,17 @@ class MapboxNavigationTest {
     fun init_routeRefreshController_start_not_called_when_isRouteRefresh_disabled() {
         ThreadController.cancelAllUICoroutines()
         mockkObject(RouteRefreshControllerProvider)
+        val routeRefreshOptions = RouteRefreshOptions.Builder()
+            .enabled(false)
+            .build()
         every {
             RouteRefreshControllerProvider.createRouteRefreshController(
-                directionsSession,
-                tripSession,
-                logger
+                any(), any(), any(), any()
             )
         } returns routeRefreshController
         every { routeRefreshController.start() } returns mockk()
         val navigationOptions = provideNavigationOptions()
-            .isRouteRefreshEnabled(false)
+            .routeRefreshOptions(routeRefreshOptions)
             .build()
 
         mapboxNavigation = MapboxNavigation(navigationOptions)


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

It is a common request to make the route refresh interval configurable. This provides a quick solution to satisfy those requests.

### Approaches considered

I actually started implementing each of these but went with 1. Here's the pros and cons that were considered.

1. Create `RouteRefreshOptions` and set them through `NavigationOptions`
    - pros: Most consistent 
    - cons: Can't change the interval while in route, or any time after initializing
1. Add `routeRefreshInterval` and set them through `MapboxNavigationrouteRefreshInterval`
    - pros: Can change interval during active guidance, most simple change 
    - cons: Kind of inconsistent interface
1. Add `routeRefreshInterval` and set them through `NavigationOptions`
    - pros: Second most consistent 
    - cons: Can't change the interval while in route, or any time after initializing
1. Create `RouteRefreshOptions` and set them through `MapboxNavigation.routeRefreshOptions(options)`
    - pros: Most flexible, can change interval during active guidance, can disable the feature at any time 
    - cons: Most complicated sdk change, also need to update the Router interface

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Make the route refresh interval configurable</changelog>
```

### ~Screenshots or Gifs~ Usage because it's an API change
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->

``` kotlin
mapboxNavigation = MapboxNavigation(
    NavigationOptions.Builder(this)
        .accessToken(getMapboxAccessTokenFromResources())
        .routeRefreshOptions(RouteRefreshOptions.Builder()
            .intervalMillis(TimeUnit.SECONDS.toMillis(30))
            .build())
        .build()
)
```

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
