### PR TITLE
Remove JVMOverloads on View

### DIFF
--- a/libnavui-speedlimit/api/current.txt
+++ b/libnavui-speedlimit/api/current.txt
@@ -42,9 +42,9 @@ package com.mapbox.navigation.ui.speedlimit.model {
 package com.mapbox.navigation.ui.speedlimit.view {
 
   public final class MapboxSpeedLimitView extends androidx.appcompat.widget.AppCompatTextView {
-    ctor public MapboxSpeedLimitView(android.content.Context context, android.util.AttributeSet? attrs = null, int defStyleAttr = 0);
-    ctor public MapboxSpeedLimitView(android.content.Context context, android.util.AttributeSet? attrs = null);
     ctor public MapboxSpeedLimitView(android.content.Context context);
+    ctor public MapboxSpeedLimitView(android.content.Context context, android.util.AttributeSet? attrs);
+    ctor public MapboxSpeedLimitView(android.content.Context context, android.util.AttributeSet? attrs, int defStyleAttr);
     method public void render(com.mapbox.navigation.ui.base.model.Expected<com.mapbox.navigation.ui.speedlimit.model.UpdateSpeedLimitValue,com.mapbox.navigation.ui.speedlimit.model.UpdateSpeedLimitError> expected);
     method public void updateStyle(@StyleRes int styleResource);
     field public static final int BORDER_INSET = 6; // 0x6

--- a/libnavui-speedlimit/src/main/java/com/mapbox/navigation/ui/speedlimit/view/MapboxSpeedLimitView.kt
+++ b/libnavui-speedlimit/src/main/java/com/mapbox/navigation/ui/speedlimit/view/MapboxSpeedLimitView.kt
@@ -25,21 +25,43 @@ import kotlinx.coroutines.launch
 /**
  * A view component intended to consume data produced by the [MapboxSpeedLimitApi].
  */
-class MapboxSpeedLimitView @JvmOverloads constructor(
-    context: Context,
-    attrs: AttributeSet? = null,
-    defStyleAttr: Int = 0
-) : AppCompatTextView(context, attrs, defStyleAttr) {
+class MapboxSpeedLimitView : AppCompatTextView {
 
     private var speedLimitBackgroundColor: Int = 0
     private var speedLimitViennaBorderColor: Int = 0
     private var speedLimitMutcdBorderColor: Int = 0
     private var speedLimitSign: SpeedLimitSign? = null
 
-    init {
+    /**
+     *
+     * @param context Context
+     * @constructor
+     */
+    constructor(context: Context) : super(context)
+
+    /**
+     *
+     * @param context Context
+     * @param attrs AttributeSet?
+     * @constructor
+     */
+    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs) {
         initAttributes(attrs)
-        gravity = Gravity.CENTER
-        textSize = context.resources.getDimension(R.dimen.mapbox_dimen_text_6sp)
+    }
+
+    /**
+     *
+     * @param context Context
+     * @param attrs AttributeSet?
+     * @param defStyleAttr Int
+     * @constructor
+     */
+    constructor(
+        context: Context,
+        attrs: AttributeSet?,
+        defStyleAttr: Int
+    ) : super(context, attrs, defStyleAttr) {
+        initAttributes(attrs)
     }
 
     /**
@@ -97,6 +119,8 @@ class MapboxSpeedLimitView @JvmOverloads constructor(
     }
 
     private fun initAttributes(attrs: AttributeSet?) {
+        gravity = Gravity.CENTER
+        textSize = context.resources.getDimension(R.dimen.mapbox_dimen_text_6sp)
         val typedArray: TypedArray = context.obtainStyledAttributes(
             attrs,
             R.styleable.MapboxSpeedLimitView,

--- a/libnavui-speedlimit/src/test/java/com/mapbox/navigation/ui/speedlimit/view/MapboxSpeedLimitViewTest.kt
+++ b/libnavui-speedlimit/src/test/java/com/mapbox/navigation/ui/speedlimit/view/MapboxSpeedLimitViewTest.kt
@@ -7,6 +7,7 @@ import com.mapbox.navigation.base.speed.model.SpeedLimitSign
 import com.mapbox.navigation.base.speed.model.SpeedLimitUnit
 import com.mapbox.navigation.testing.MainCoroutineRule
 import com.mapbox.navigation.ui.base.model.Expected
+import com.mapbox.navigation.ui.speedlimit.R
 import com.mapbox.navigation.ui.speedlimit.model.SpeedLimitFormatter
 import com.mapbox.navigation.ui.speedlimit.model.UpdateSpeedLimitValue
 import com.mapbox.navigation.utils.internal.JobControl
@@ -52,6 +53,29 @@ class MapboxSpeedLimitViewTest {
     @After
     fun tearDown() {
         unmockkObject(ThreadController)
+    }
+
+    @Test
+    fun `constructor with context`() {
+        val view = MapboxSpeedLimitView(ctx)
+
+        assertNotNull(view.currentTextColor)
+    }
+
+    @Test
+    fun `constructor with context and attr`() {
+        val view = MapboxSpeedLimitView(ctx, null)
+        val expectedColor = ctx.getColor(R.color.mapbox_speed_limit_text_color)
+
+        assertEquals(expectedColor, view.currentTextColor)
+    }
+
+    @Test
+    fun `constructor with context attr and defStyleAttr`() {
+        val view = MapboxSpeedLimitView(ctx, null)
+        val expectedColor = ctx.getColor(R.color.mapbox_speed_limit_text_color)
+
+        assertEquals(expectedColor, view.currentTextColor)
     }
 
     @Test

--- a/libnavui-tripprogress/api/current.txt
+++ b/libnavui-tripprogress/api/current.txt
@@ -79,9 +79,9 @@ package com.mapbox.navigation.ui.tripprogress.model {
 package com.mapbox.navigation.ui.tripprogress.view {
 
   public final class MapboxTripProgressView extends android.widget.FrameLayout {
-    ctor public MapboxTripProgressView(android.content.Context context, android.util.AttributeSet? attrs = null, int defStyleAttr = 0);
-    ctor public MapboxTripProgressView(android.content.Context context, android.util.AttributeSet? attrs = null);
     ctor public MapboxTripProgressView(android.content.Context context);
+    ctor public MapboxTripProgressView(android.content.Context context, android.util.AttributeSet? attrs);
+    ctor public MapboxTripProgressView(android.content.Context context, android.util.AttributeSet? attrs, int defStyleAttr);
     method public void render(com.mapbox.navigation.ui.tripprogress.model.TripProgressUpdateValue result);
     method public void updateStyle(@StyleRes int style);
   }

--- a/libnavui-tripprogress/src/main/java/com/mapbox/navigation/ui/tripprogress/view/MapboxTripProgressView.kt
+++ b/libnavui-tripprogress/src/main/java/com/mapbox/navigation/ui/tripprogress/view/MapboxTripProgressView.kt
@@ -15,11 +15,39 @@ import com.mapbox.navigation.ui.tripprogress.model.TripProgressUpdateValue
 /**
  * A view that can be added to activity layouts which displays trip progress.
  */
-class MapboxTripProgressView @JvmOverloads constructor(
-    context: Context,
-    attrs: AttributeSet? = null,
-    defStyleAttr: Int = 0
-) : FrameLayout(context, attrs, defStyleAttr) {
+class MapboxTripProgressView : FrameLayout {
+
+    /**
+     *
+     * @param context Context
+     * @constructor
+     */
+    constructor(context: Context) : super(context)
+
+    /**
+     *
+     * @param context Context
+     * @param attrs AttributeSet?
+     * @constructor
+     */
+    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs) {
+        initAttributes(attrs)
+    }
+
+    /**
+     *
+     * @param context Context
+     * @param attrs AttributeSet?
+     * @param defStyleAttr Int
+     * @constructor
+     */
+    constructor(
+        context: Context,
+        attrs: AttributeSet?,
+        defStyleAttr: Int
+    ) : super(context, attrs, defStyleAttr) {
+        initAttributes(attrs)
+    }
 
     private val binding =
         MapboxTripProgressLayoutBinding.inflate(
@@ -27,10 +55,6 @@ class MapboxTripProgressView @JvmOverloads constructor(
             this,
             true
         )
-
-    init {
-        initAttributes(attrs)
-    }
 
     /**
      * Allows you to change the style of [MapboxTripProgressView].

--- a/libnavui-tripprogress/src/test/java/com/mapbox/navigation/ui/tripprogress/view/MapboxTripProgressViewTest.kt
+++ b/libnavui-tripprogress/src/test/java/com/mapbox/navigation/ui/tripprogress/view/MapboxTripProgressViewTest.kt
@@ -12,6 +12,7 @@ import com.mapbox.navigation.ui.tripprogress.model.TripProgressUpdateValue
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -29,6 +30,32 @@ class MapboxTripProgressViewTest {
     }
 
     @Test
+    fun `constructor with context`() {
+        val view = MapboxTripProgressView(ctx)
+        val timeRemainingView = view.findViewById<TextView>(R.id.timeRemainingText)
+
+        assertNotNull(timeRemainingView.currentTextColor)
+    }
+
+    @Test
+    fun `constructor with context and attr`() {
+        val view = MapboxTripProgressView(ctx, null)
+        val timeRemainingView = view.findViewById<TextView>(R.id.timeRemainingText)
+        val expectedColor = ctx.getColor(R.color.mapbox_trip_progress_text_color)
+
+        assertEquals(expectedColor, timeRemainingView.currentTextColor)
+    }
+
+    @Test
+    fun `constructor with context attr and defStyleAttr`() {
+        val view = MapboxTripProgressView(ctx, null)
+        val timeRemainingView = view.findViewById<TextView>(R.id.distanceRemainingText)
+        val expectedColor = ctx.getColor(R.color.mapbox_trip_progress_text_color)
+
+        assertEquals(expectedColor, timeRemainingView.currentTextColor)
+    }
+
+    @Test
     fun initAttributes() {
         val expectedTextColor = ctx.getColor(R.color.mapbox_trip_progress_text_color)
         val expectedDividerColor = ctx.getColor(R.color.mapbox_trip_progress_divider_color)
@@ -36,7 +63,7 @@ class MapboxTripProgressViewTest {
             R.color.mapbox_trip_progress_view_background_color
         )
 
-        val view = MapboxTripProgressView(ctx)
+        val view = MapboxTripProgressView(ctx, null)
 
         assertEquals(
             expectedTextColor,
@@ -71,7 +98,7 @@ class MapboxTripProgressViewTest {
     fun initAttributes_landscape() {
         val expectedDividerColor = ctx.getColor(R.color.mapbox_trip_progress_divider_color)
 
-        val view = MapboxTripProgressView(ctx)
+        val view = MapboxTripProgressView(ctx, null)
 
         assertEquals(
             expectedDividerColor,


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Fix #4134 Remove `@JvmOverloads` on Mapbox standalone widgets.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Remove `@JvmOverloads` on Mapbox standalone widgets.</changelog>
```

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
