### PR TITLE
Refactor building selection to use feature ids

### DIFF
--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/arrival/api/MapboxBuildingHighlightApiTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/arrival/api/MapboxBuildingHighlightApiTest.kt
@@ -25,9 +25,7 @@ class MapboxBuildingHighlightApiTest {
     }
     private val style: Style = mockk {
         every { styleLayerExists(any()) } returns false
-        every { styleSourceExists(any()) } returns false
         every { addStyleLayer(any(), any()) } returns expected
-        every { addStyleSource(any(), any()) } returns expected
     }
 
     /** Mock querying features **/
@@ -50,27 +48,6 @@ class MapboxBuildingHighlightApiTest {
     @Test
     fun `highlight null point is a no-op`() {
         buildingHighlightApi.highlightBuilding(null)
-    }
-
-    @Test
-    fun `should add style source when building is selected`() {
-        every { mapboxMap.pixelForCoordinate(any()) } returns mockk {
-            every { x } returns 134.0
-            every { y } returns 160.0
-        }
-        every { mapboxMap.queryRenderedFeatures(any<ScreenCoordinate>(), any(), any()) } answers {
-            thirdArg<QueryFeaturesCallback>().run(mockSuccessQueriedFeature())
-        }
-
-        val testPoint = Point.fromLngLat(-122.431969, 37.777663)
-        buildingHighlightApi.highlightBuilding(testPoint)
-        onStyleLoadedSlot.captured.onStyleLoaded(style)
-
-        val sourceIdSlot = CapturingSlot<String>()
-        val propertySlot = CapturingSlot<Value>()
-        verify { style.addStyleSource(capture(sourceIdSlot), capture(propertySlot)) }
-        assertTrue(sourceIdSlot.isCaptured)
-        assertTrue(propertySlot.isCaptured)
     }
 
     @Test


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

This is what I wanted to do originally. But I was having issues getting the types accepted by Mapbox Expressions to be exactly correct. 

highlighting a single building ✅

``` kotlin
.filter(eq(id(), literal(4687787688108675)))
```

highlighting multiple buildings ✅

``` kotlin
val ids = queriedFeature.mapNotNull { it.feature.id()?.toLong() }
FillExtrusionLayer(layerId, "composite")
    .filter(inExpression(id(), literal(ids)))
```

### What changed

No functional difference, this is only a refactor. Gifs on the experience can be found here https://github.com/mapbox/mapbox-navigation-android/pull/4078

### Why is this better

We get to remove the extra source layer and in favor of expressions. The experience I really want to be able to support, is to have all buildings shown, and then highlight the POI buildings. Using identifiers will support that, so am considering this more flexible.

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
