### PR TITLE
POC: Re-create NN navigator on the fly

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/FallbackVersionsObserver.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/FallbackVersionsObserver.kt
@@ -1,0 +1,18 @@
+package com.mapbox.navigation.core.trip.session
+
+interface FallbackVersionsObserver {
+
+    /**
+     * This callback is raised only if there are not enough tiles of current version.
+     * This callback is called to notify that the specified `versions` can be used for switching into Fallback mode.
+     * This means there are tiles downloaded (available offline) of the specified `versions` covering current location
+     * so MapMatching should work (even offline) after switching to the one of the specified `versions`.
+     */
+    fun onFallbackVersionsFound(versions: List<String>)
+
+    /**
+     * Notifies a caller that it's OK to switch back to the latest version.
+     * In order to use the latest version, it's sufficient to set "" in version configuration
+     */
+    fun onCanReturnToLatest()
+}

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/TripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/TripSession.kt
@@ -62,4 +62,8 @@ internal interface TripSession {
     fun registerMapMatcherResultObserver(mapMatcherResultObserver: MapMatcherResultObserver)
     fun unregisterMapMatcherResultObserver(mapMatcherResultObserver: MapMatcherResultObserver)
     fun unregisterAllMapMatcherResultObservers()
+
+    fun registerFallbackVersionsObserver(fallbackVersionsObserver: FallbackVersionsObserver)
+    fun unregisterFallbackVersionsObserver(fallbackVersionsObserver: FallbackVersionsObserver)
+    fun unregisterAllFallbackVersionsObservers()
 }

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigator.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigator.kt
@@ -49,6 +49,13 @@ interface MapboxNativeNavigator {
         logger: Logger
     ): MapboxNativeNavigator
 
+    fun recreateNavigatorInstance(
+        deviceProfile: DeviceProfile,
+        navigatorConfig: NavigatorConfig,
+        tilesConfig: TilesConfig,
+        logger: Logger
+    )
+
     /**
      * Reset the navigator state with the same configuration. The location becomes unknown,
      * but the [NavigatorConfig] stays the same. This can be used to transport the

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigator.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigator.kt
@@ -12,6 +12,7 @@ import com.mapbox.navigation.base.options.RoutingTilesOptions
 import com.mapbox.navigator.BannerInstruction
 import com.mapbox.navigator.CacheHandle
 import com.mapbox.navigator.ElectronicHorizonObserver
+import com.mapbox.navigator.FallbackVersionsObserver
 import com.mapbox.navigator.FixLocation
 import com.mapbox.navigator.GraphAccessor
 import com.mapbox.navigator.NavigationStatus
@@ -255,6 +256,8 @@ interface MapboxNativeNavigator {
      * @param roadObjectsStoreObserver
      */
     fun setRoadObjectsStoreObserver(roadObjectsStoreObserver: RoadObjectsStoreObserver?)
+
+    fun setFallbackVersionsObserver(fallbackVersionsObserver: FallbackVersionsObserver?)
 
     // Predictive cache
 

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigatorImpl.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigatorImpl.kt
@@ -107,6 +107,28 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
         return this
     }
 
+    override fun recreateNavigatorInstance(
+        deviceProfile: DeviceProfile,
+        navigatorConfig: NavigatorConfig,
+        tilesConfig: TilesConfig,
+        logger: Logger
+    ) {
+        val nativeComponents = NavigatorLoader.createNavigator(
+            deviceProfile,
+            navigatorConfig,
+            tilesConfig
+        )
+        navigator = nativeComponents.navigator
+        nativeRouter = nativeComponents.nativeRouter
+        historyRecorderHandle = nativeComponents.historyRecorderHandle
+        graphAccessor = nativeComponents.graphAccessor
+        openLRDecoder = nativeComponents.openLRDecoder
+        roadObjectsStore = nativeComponents.navigator.roadObjectStore()
+        cache = nativeComponents.cache
+
+        this.logger = logger
+    }
+
     override fun resetRideSession() {
         navigator!!.resetRideSession()
     }

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigatorImpl.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigatorImpl.kt
@@ -20,6 +20,7 @@ import com.mapbox.navigator.BannerInstruction
 import com.mapbox.navigator.CacheDataDomain
 import com.mapbox.navigator.CacheHandle
 import com.mapbox.navigator.ElectronicHorizonObserver
+import com.mapbox.navigator.FallbackVersionsObserver
 import com.mapbox.navigator.FixLocation
 import com.mapbox.navigator.GraphAccessor
 import com.mapbox.navigator.HistoryRecorderHandle
@@ -122,7 +123,7 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
         nativeRouter = nativeComponents.nativeRouter
         historyRecorderHandle = nativeComponents.historyRecorderHandle
         graphAccessor = nativeComponents.graphAccessor
-        openLRDecoder = nativeComponents.openLRDecoder
+        roadObjectMatcher = nativeComponents.roadObjectMatcher
         roadObjectsStore = nativeComponents.navigator.roadObjectStore()
         cache = nativeComponents.cache
 
@@ -395,6 +396,10 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
      */
     override fun setRoadObjectsStoreObserver(roadObjectsStoreObserver: RoadObjectsStoreObserver?) {
         roadObjectsStore?.setObserver(roadObjectsStoreObserver)
+    }
+
+    override fun setFallbackVersionsObserver(fallbackVersionsObserver: FallbackVersionsObserver?) {
+        navigator!!.setFallbackVersionsObserver(fallbackVersionsObserver)
     }
 
     /**

--- a/qa-test-app/src/main/AndroidManifest.xml
+++ b/qa-test-app/src/main/AndroidManifest.xml
@@ -22,6 +22,7 @@
             </intent-filter>
         </activity>
         <activity android:name=".view.AlternativeRouteActivity"/>
+        <activity android:name=".view.ForceRecreatingNavigatorInstanceActivity"/>
     </application>
 
 </manifest>

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/domain/TestActivitySuite.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/domain/TestActivitySuite.kt
@@ -1,9 +1,11 @@
 package com.mapbox.navigation.qa_test_app.domain
 
 import android.app.Activity
+import com.mapbox.navigation.base.ExperimentalMapboxNavigationAPI
 import com.mapbox.navigation.qa_test_app.R
 import com.mapbox.navigation.qa_test_app.utils.startActivity
 import com.mapbox.navigation.qa_test_app.view.AlternativeRouteActivity
+import com.mapbox.navigation.qa_test_app.view.ForceRecreatingNavigatorInstanceActivity
 
 typealias LaunchActivityFun = (Activity) -> Unit
 
@@ -15,6 +17,12 @@ object TestActivitySuite {
             R.string.alternative_route_selection_description
         ) { activity ->
             activity.startActivity<AlternativeRouteActivity>()
+        },
+        TestActivityDescription(
+            "Recreating Navigator",
+            R.string.force_navigator_recreating_description
+        ) { activity ->
+            activity.startActivity<ForceRecreatingNavigatorInstanceActivity>()
         }
     )
 }

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/utils/WaypointsController.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/utils/WaypointsController.kt
@@ -1,0 +1,22 @@
+package com.mapbox.navigation.qa_test_app.utils
+
+import com.mapbox.geojson.Point
+
+class WaypointsController {
+    private val waypoints = mutableListOf<Point>()
+
+    fun add(point: Point) {
+        waypoints.add(point)
+    }
+
+    fun clear() {
+        waypoints.clear()
+    }
+
+    fun coordinates(origin: Point): List<Point> {
+        val coordinates = mutableListOf<Point>()
+        coordinates.add(origin)
+        coordinates.addAll(waypoints)
+        return coordinates
+    }
+}

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/ForceRecreatingNavigatorInstanceActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/ForceRecreatingNavigatorInstanceActivity.kt
@@ -1,0 +1,314 @@
+package com.mapbox.navigation.qa_test_app.view
+
+import android.annotation.SuppressLint
+import android.location.Location
+import android.os.Bundle
+import android.util.Log
+import android.view.View
+import androidx.appcompat.app.AppCompatActivity
+import com.mapbox.android.core.location.LocationEngineCallback
+import com.mapbox.android.core.location.LocationEngineResult
+import com.mapbox.api.directions.v5.DirectionsCriteria
+import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.api.directions.v5.models.RouteOptions
+import com.mapbox.geojson.Point
+import com.mapbox.maps.CameraOptions
+import com.mapbox.maps.EdgeInsets
+import com.mapbox.maps.Style
+import com.mapbox.maps.plugin.animation.CameraAnimationsPlugin
+import com.mapbox.maps.plugin.animation.MapAnimationOptions
+import com.mapbox.maps.plugin.animation.camera
+import com.mapbox.maps.plugin.gestures.OnMapClickListener
+import com.mapbox.maps.plugin.gestures.OnMapLongClickListener
+import com.mapbox.maps.plugin.gestures.gestures
+import com.mapbox.maps.plugin.locationcomponent.location
+import com.mapbox.navigation.base.ExperimentalMapboxNavigationAPI
+import com.mapbox.navigation.base.internal.extensions.applyDefaultParams
+import com.mapbox.navigation.base.options.NavigationOptions
+import com.mapbox.navigation.base.trip.model.RouteProgress
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.directions.session.RoutesObserver
+import com.mapbox.navigation.core.directions.session.RoutesRequestCallback
+import com.mapbox.navigation.core.replay.MapboxReplayer
+import com.mapbox.navigation.core.replay.ReplayLocationEngine
+import com.mapbox.navigation.core.replay.route.ReplayProgressObserver
+import com.mapbox.navigation.core.replay.route.ReplayRouteMapper
+import com.mapbox.navigation.core.trip.session.LocationObserver
+import com.mapbox.navigation.core.trip.session.RouteProgressObserver
+import com.mapbox.navigation.qa_test_app.databinding.ActivityRecreatinNavigatorBinding
+import com.mapbox.navigation.qa_test_app.utils.Utils
+import com.mapbox.navigation.qa_test_app.utils.WaypointsController
+import com.mapbox.navigation.ui.base.model.Expected
+import com.mapbox.navigation.ui.maps.internal.route.line.MapboxRouteLineApiExtensions.findClosestRoute
+import com.mapbox.navigation.ui.maps.internal.route.line.MapboxRouteLineApiExtensions.setRoutes
+import com.mapbox.navigation.ui.maps.internal.route.line.MapboxRouteLineApiExtensions.updateToPrimaryRoute
+import com.mapbox.navigation.ui.maps.location.NavigationLocationProvider
+import com.mapbox.navigation.ui.maps.route.line.api.MapboxRouteLineApi
+import com.mapbox.navigation.ui.maps.route.line.api.MapboxRouteLineView
+import com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions
+import com.mapbox.navigation.ui.maps.route.line.model.RouteLine
+import com.mapbox.navigation.ui.maps.route.line.model.RouteLineResources
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+class ForceRecreatingNavigatorInstanceActivity: AppCompatActivity(), OnMapLongClickListener {
+
+    private val binding: ActivityRecreatinNavigatorBinding by lazy {
+        ActivityRecreatinNavigatorBinding.inflate(layoutInflater)
+    }
+
+    private val routeClickPadding = com.mapbox.android.gestures.Utils.dpToPx(30f)
+    private val navigationLocationProvider = NavigationLocationProvider()
+    private val replayRouteMapper = ReplayRouteMapper()
+    private val mapboxReplayer = MapboxReplayer()
+    private val replayProgressObserver = ReplayProgressObserver(mapboxReplayer)
+    private val localRouteProgress = object : RouteProgressObserver {
+        override fun onRouteProgressChanged(routeProgress: RouteProgress) {
+            binding.routeProgressText.text = "${routeProgress.durationRemaining} sec."
+        }
+    }
+    private val waypointsController = WaypointsController()
+
+    private val mapCamera: CameraAnimationsPlugin by lazy {
+        binding.mapView.camera
+    }
+
+    private val mapboxNavigation: MapboxNavigation by lazy {
+        MapboxNavigation(
+            NavigationOptions.Builder(this)
+                .accessToken(Utils.getMapboxAccessToken(this))
+                .locationEngine(ReplayLocationEngine(mapboxReplayer))
+                .build()
+        )
+    }
+
+    private val routeLineResources: RouteLineResources by lazy {
+        RouteLineResources.Builder().build()
+    }
+
+    private val options: MapboxRouteLineOptions by lazy {
+        MapboxRouteLineOptions.Builder(this)
+            .withRouteLineResources(routeLineResources)
+            .withRouteLineBelowLayerId("road-label")
+            .build()
+    }
+
+    private val routeLineView by lazy {
+        MapboxRouteLineView(options)
+    }
+
+    private val routeLineApi: MapboxRouteLineApi by lazy {
+        MapboxRouteLineApi(options)
+    }
+
+    private val locationObserver: LocationObserver = object : LocationObserver {
+        override fun onRawLocationChanged(rawLocation: Location) {
+            Log.d(TAG, "raw location $rawLocation")
+        }
+
+        override fun onEnhancedLocationChanged(
+            enhancedLocation: Location,
+            keyPoints: List<Location>
+        ) {
+            navigationLocationProvider.changePosition(enhancedLocation, keyPoints, null, null)
+            updateCamera(enhancedLocation)
+        }
+    }
+
+
+    private val mapClickListener = OnMapClickListener {
+        CoroutineScope(Dispatchers.Main).launch {
+            val result = routeLineApi.findClosestRoute(
+                it,
+                binding.mapView.getMapboxMap(),
+                routeClickPadding
+            )
+
+            val routeFound = (result as Expected.Success).value.route
+            if (routeFound != routeLineApi.getPrimaryRoute()) {
+                routeLineApi.updateToPrimaryRoute(routeFound)
+                mapboxNavigation.setRoutes(routeLineApi.getRoutes())
+            }
+        }
+        false
+    }
+
+    private val routesObserver = object : RoutesObserver {
+        override fun onRoutesChanged(routes: List<DirectionsRoute>) {
+            resetTextInfo()
+            val routelines = routes.map { RouteLine(it, null) }
+            CoroutineScope(Dispatchers.Main).launch {
+                routeLineApi.setRoutes(routelines).apply {
+                    routeLineView.renderRouteDrawData(
+                        binding.mapView.getMapboxMap().getStyle()!!,
+                        this
+                    )
+                }
+            }
+        }
+    }
+
+    private companion object {
+        private const val TAG = "RecreatingNavigatorAct"
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(binding.root)
+
+        initNavigation()
+        initStyle()
+        initListeners()
+    }
+
+    override fun onStart() {
+        super.onStart()
+        binding.mapView.onStart()
+    }
+
+    override fun onStop() {
+        super.onStop()
+        binding.mapView.onStop()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        binding.mapView.onDestroy()
+        mapboxNavigation.unregisterRouteProgressObserver(replayProgressObserver)
+        mapboxNavigation.unregisterLocationObserver(locationObserver)
+        mapboxNavigation.unregisterRoutesObserver(routesObserver)
+        mapboxNavigation.onDestroy()
+    }
+
+    override fun onLowMemory() {
+        super.onLowMemory()
+        binding.mapView.onLowMemory()
+    }
+
+    @OptIn(ExperimentalMapboxNavigationAPI::class)
+    @SuppressLint("MissingPermission")
+    private fun initListeners() {
+        binding.startNavigation.setOnClickListener {
+            mapboxNavigation.startTripSession()
+            binding.startNavigation.visibility = View.GONE
+            startSimulation(mapboxNavigation.getRoutes()[0])
+        }
+
+        binding.mapView.gestures.addOnMapClickListener(mapClickListener)
+
+        binding.recreateNavigator.setOnClickListener {
+            mapboxNavigation.recreateNavigatorInstance()
+        }
+    }
+
+    private fun initNavigation() {
+        binding.mapView.location.apply {
+            setLocationProvider(navigationLocationProvider)
+            enabled = true
+        }
+        mapboxNavigation.registerLocationObserver(locationObserver)
+        mapboxNavigation.registerRouteProgressObserver(replayProgressObserver)
+        mapboxNavigation.registerRouteProgressObserver(localRouteProgress)
+        mapboxNavigation.registerRoutesObserver(routesObserver)
+        mapboxReplayer.pushRealLocation(this, 0.0)
+        mapboxReplayer.playbackSpeed(1.5)
+        mapboxReplayer.play()
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun initStyle() {
+        binding.mapView.getMapboxMap().loadStyleUri(
+            Style.MAPBOX_STREETS
+        ) {
+            mapboxNavigation.navigationOptions.locationEngine.getLastLocation(object :
+                LocationEngineCallback<LocationEngineResult> {
+                override fun onSuccess(result: LocationEngineResult) {
+                    result.lastLocation?.let {
+                        locationObserver.onEnhancedLocationChanged(it, listOf())
+                    }
+                }
+
+                override fun onFailure(exception: Exception) {}
+            })
+            binding.mapView.gestures.addOnMapLongClickListener(this)
+        }
+    }
+
+    private fun startSimulation(route: DirectionsRoute) {
+        mapboxReplayer.stop()
+        mapboxReplayer.clearEvents()
+        val replayData = replayRouteMapper.mapDirectionsRouteGeometry(route)
+        mapboxReplayer.pushEvents(replayData)
+        mapboxReplayer.seekTo(replayData[0])
+        mapboxReplayer.play()
+    }
+
+    private fun updateCamera(location: Location) {
+        val mapAnimationOptionsBuilder = MapAnimationOptions.Builder()
+        mapAnimationOptionsBuilder.duration(1500L)
+        mapCamera.easeTo(
+            CameraOptions.Builder()
+                .center(Point.fromLngLat(location.longitude, location.latitude))
+                .bearing(location.bearing.toDouble())
+                .zoom(15.0)
+                .padding(EdgeInsets(1000.0, 0.0, 0.0, 0.0))
+                .build(),
+            mapAnimationOptionsBuilder.build()
+        )
+    }
+
+    override fun onMapLongClick(point: Point): Boolean {
+        waypointsController.add(point)
+        val currentLocation = navigationLocationProvider.lastLocation
+        if (currentLocation != null) {
+            val originPoint = Point.fromLngLat(
+                currentLocation.longitude,
+                currentLocation.latitude
+            )
+            findRoute(waypointsController.coordinates(originPoint))
+        }
+        return false
+    }
+
+    private fun resetTextInfo() {
+        binding.routeProgressText.text = null
+    }
+
+    private fun findRoute(coordinates: List<Point>) {
+        val useSilent = binding.useSilentWaypoints.isChecked.also {
+            binding.useSilentWaypoints.visibility = View.GONE
+        }
+        val routeOptions = RouteOptions.builder()
+            .applyDefaultParams()
+            .profile(DirectionsCriteria.PROFILE_DRIVING_TRAFFIC)
+            .accessToken(Utils.getMapboxAccessToken(this))
+            .coordinates(coordinates)
+            .apply {
+                if (useSilent){
+                    waypointIndicesList(listOf(0, coordinates.lastIndex))
+                }
+            }
+            .alternatives(true)
+            .build()
+        mapboxNavigation.requestRoutes(
+            routeOptions,
+            object : RoutesRequestCallback {
+                override fun onRoutesReady(routes: List<DirectionsRoute>) {
+                    mapboxNavigation.setRoutes(routes)
+                }
+
+                override fun onRoutesRequestFailure(
+                    throwable: Throwable,
+                    routeOptions: RouteOptions
+                ) {
+                    // no impl
+                }
+
+                override fun onRoutesRequestCanceled(routeOptions: RouteOptions) {
+                    // no impl
+                }
+            }
+        )
+    }
+}

--- a/qa-test-app/src/main/res/layout/activity_recreatin_navigator.xml
+++ b/qa-test-app/src/main/res/layout/activity_recreatin_navigator.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.mapbox.maps.MapView
+        android:id="@+id/mapView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+    </com.mapbox.maps.MapView>
+
+    <TextView
+        android:id="@+id/routeProgressLabel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/mapbox_dimen_16dp"
+        android:layout_marginTop="@dimen/mapbox_dimen_32dp"
+        android:text="Route Progress:"
+        android:textColor="@android:color/holo_red_dark"
+        android:textSize="16sp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/routeProgressText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/mapbox_dimen_8dp"
+        android:textColor="@android:color/holo_red_dark"
+        android:textSize="16sp"
+        app:layout_constraintBottom_toBottomOf="@+id/routeProgressLabel"
+        app:layout_constraintStart_toEndOf="@+id/routeProgressLabel"
+        app:layout_constraintTop_toTopOf="@+id/routeProgressLabel"
+        tools:text="RouteProgress text" />
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/startNavigation"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/primary"
+        android:text="Start Navigation"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <androidx.appcompat.widget.AppCompatCheckBox
+        android:id="@+id/useSilentWaypoints"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Use silent waypoint"
+        app:layout_constraintBottom_toTopOf="@+id/startNavigation"
+        android:layout_marginEnd="@dimen/mapbox_dimen_8dp"
+        android:layout_marginBottom="@dimen/mapbox_dimen_8dp"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/recreateNavigator"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Re-create navigator"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/qa-test-app/src/main/res/values/strings.xml
+++ b/qa-test-app/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <string name="app_name" tools:ignore="MissingTranslation">Kaizen</string>
     <string name="alternative_route_selection_description" tools:ignore="MissingTranslation">Tests the selecting of an alternative route line. \n\n1. Long press a point on the map in order to get a primary route and at least one alternative route. \n\n2. Select an alternative route by touching it. The touched route should appear as the primary route and the previous primary route should appear as an alternative. \n\n3. Click start navigation and make sure the puck follows the selected route.</string>
+    <string name="force_navigator_recreating_description" tools:ignore="MissingTranslation">Forcing recreating NavNative Navigator</string>
 </resources>


### PR DESCRIPTION
POC recreating NN Navigator on the fly, 
To run you need `qa-test-app` module, `Recreating Navigator` screen.

Closes https://github.com/mapbox/mapbox-navigation-android/issues/4330

I was running tests with 
- Android device: Samsun SM-G950U 
- API: `25`(Android 7.1).

On each re-creation on NN Navigator Native memory consumption grows about `100 mb`(sometime later GC collects this memory), it's not a problem for the scenario of very rare Navigator re-creating, but with tests you can get `OutOfTheMemory exception`. Would be great if the native team provide for SDK some destroyer function to clean resources that not needed anymore for legacy Navigator.

Also re-creating a few times in a row(for me it might happen each time) it might run in situations when a location fetched from NavigationStatus is not right and the camera jump. See the video 

https://user-images.githubusercontent.com/8738058/116405114-f6126380-a837-11eb-88a6-72b80c4a7dd3.mp4

The same for the simulation route(the same happens not so often).

https://user-images.githubusercontent.com/8738058/116405561-78028c80-a838-11eb-95fe-1fc96686785d.mp4

Seems that we can just skip NavigationStatus when re-creating NN Navigator. Any other thoughts? 

**Updated 04.29.21**
Added `null-island` check(latitude and longitude are not 0.0), camera is not "teleporting" anymore. Also before the check was added, SDK received non-valid `routeState`(from `NavigationStatus`), with the current check we skip them.

cc @LukasPaczos @Guardiola31337  @mskurydin @etl @SiarheiFedartsou 