### PR TITLE
Removes the hardcoded layer reference from the MapboxNavigationViewportDataSourceDebugger

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/camera/MapboxCameraAnimationsActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/camera/MapboxCameraAnimationsActivity.kt
@@ -257,8 +257,9 @@ class MapboxCameraAnimationsActivity :
         initNavigation()
 
         val debugger = MapboxNavigationViewportDataSourceDebugger(
-            this,
-            binding.mapView
+            context = this,
+            mapView = binding.mapView,
+            layerAbove = "road-label"
         ).apply {
             enabled = true
         }

--- a/libnavui-maps/api/current.txt
+++ b/libnavui-maps/api/current.txt
@@ -263,6 +263,7 @@ package com.mapbox.navigation.ui.maps.camera.data {
 package com.mapbox.navigation.ui.maps.camera.data.debugger {
 
   @com.mapbox.navigation.base.ExperimentalMapboxNavigationAPI public final class MapboxNavigationViewportDataSourceDebugger {
+    ctor public MapboxNavigationViewportDataSourceDebugger(android.content.Context context, com.mapbox.maps.MapView mapView, String? layerAbove = null);
     ctor public MapboxNavigationViewportDataSourceDebugger(android.content.Context context, com.mapbox.maps.MapView mapView);
     method public boolean getEnabled();
     method public void setEnabled(boolean value);

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/debugger/MapboxNavigationViewportDataSourceDebugger.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/debugger/MapboxNavigationViewportDataSourceDebugger.kt
@@ -11,6 +11,7 @@ import com.mapbox.geojson.LineString
 import com.mapbox.geojson.Point
 import com.mapbox.maps.EdgeInsets
 import com.mapbox.maps.MapView
+import com.mapbox.maps.extension.style.layers.addLayer
 import com.mapbox.maps.extension.style.layers.addLayerAbove
 import com.mapbox.maps.extension.style.layers.generated.LineLayer
 import com.mapbox.maps.extension.style.sources.addSource
@@ -55,11 +56,14 @@ import com.mapbox.navigation.ui.maps.camera.state.NavigationCameraState
  * )
  * navigationCamera.debugger = debugger
  * ```
+ *
+ * @param layerAbove layer in the current map style above which the debug layer with framed geometries should be placed
  */
 @ExperimentalMapboxNavigationAPI
-class MapboxNavigationViewportDataSourceDebugger(
+class MapboxNavigationViewportDataSourceDebugger @JvmOverloads constructor(
     private val context: Context,
-    private val mapView: MapView
+    private val mapView: MapView,
+    private val layerAbove: String? = null
 ) {
     private val pointsSourceId = "mbx_viewport_data_source_points_source"
     private val pointsLayerId = "mbx_viewport_data_source_points_layer"
@@ -248,7 +252,11 @@ class MapboxNavigationViewportDataSourceDebugger(
                     lineColor(Color.CYAN)
                     lineWidth(5.0)
                 }
-                style.addLayerAbove(layer, "road-label")
+                if (layerAbove != null && style.styleLayerExists(layerAbove)) {
+                    style.addLayerAbove(layer, layerAbove)
+                } else {
+                    style.addLayer(layer)
+                }
             }
 
             val source = style.getSource(pointsSourceId) as GeoJsonSource


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Changed where the `MapboxNavigationViewportDataSourceDebugger`'s debug layer is positioned on the map. By default, the layer will be placed on top of the stack unless a reference ID is provided. This prevents a crash that was occurring if the previously hardcoded layer ID wasn't present in the style.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Changed where the `MapboxNavigationViewportDataSourceDebugger`'s debug layer is positioned on the map. By default, the layer will be placed on top of the stack unless a reference ID is provided. This prevents a crash that was occurring if the previously hardcoded layer ID wasn't present in the style.</changelog>
```

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
