### PR TITLE
Bump `mapbox-navigation-native` version to `48.0.5`

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -11,7 +11,7 @@ ext {
   // version which we should use in this build
   def mapboxNavigatorVersion = System.getenv("FORCE_MAPBOX_NAVIGATION_NATIVE_VERSION")
   if (mapboxNavigatorVersion == null || mapboxNavigatorVersion == '') {
-      mapboxNavigatorVersion = '48.0.4'
+      mapboxNavigatorVersion = '48.0.5'
   }
   println("Navigation Native version: " + mapboxNavigatorVersion)
 


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Bumps `mapbox-navigation-native` version to `48.0.5`

cc @etl @truburt 