### PR TITLE
improved the behavior of maximizeViewableGeometryWhenPitchZero flag

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/camera/MapboxCameraAnimationsActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/camera/MapboxCameraAnimationsActivity.kt
@@ -125,7 +125,7 @@ class MapboxCameraAnimationsActivity :
         )
     }
 
-    private var followingEdgeInsets = notPaddedEdgeInsets
+    private var followingEdgeInsets = paddedFollowingEdgeInsets
         set(value) {
             field = value
             viewportDataSource.followingPadding = value
@@ -484,11 +484,7 @@ class MapboxCameraAnimationsActivity :
     override fun onButtonClicked(animationType: AnimationType) {
         when (animationType) {
             AnimationType.Following, AnimationType.FastFollowing -> {
-                followingEdgeInsets = if (followingEdgeInsets == paddedFollowingEdgeInsets) {
-                    notPaddedEdgeInsets
-                } else {
-                    paddedFollowingEdgeInsets
-                }
+                followingEdgeInsets = paddedFollowingEdgeInsets
                 viewportDataSource.options.followingFrameOptions.zoomUpdatesAllowed = true
                 viewportDataSource.followingPadding = followingEdgeInsets
                 viewportDataSource.evaluate()

--- a/libnavui-maps/api/current.txt
+++ b/libnavui-maps/api/current.txt
@@ -98,7 +98,7 @@ package com.mapbox.navigation.ui.maps.camera.data {
     method public com.mapbox.navigation.ui.maps.camera.data.FollowingFrameOptions.FrameGeometryAfterManeuver getFrameGeometryAfterManeuver();
     method public com.mapbox.navigation.ui.maps.camera.data.FollowingFrameOptions.IntersectionDensityCalculation getIntersectionDensityCalculation();
     method public double getMaxZoom();
-    method public boolean getMaximizeViewableRouteGeometryWhenPitchZero();
+    method public boolean getMaximizeViewableGeometryWhenPitchZero();
     method public double getMinZoom();
     method public boolean getPaddingUpdatesAllowed();
     method public com.mapbox.navigation.ui.maps.camera.data.FollowingFrameOptions.PitchNearManeuvers getPitchNearManeuvers();
@@ -108,7 +108,7 @@ package com.mapbox.navigation.ui.maps.camera.data {
     method public void setCenterUpdatesAllowed(boolean p);
     method public void setDefaultPitch(double p);
     method public void setMaxZoom(double p);
-    method public void setMaximizeViewableRouteGeometryWhenPitchZero(boolean p);
+    method public void setMaximizeViewableGeometryWhenPitchZero(boolean p);
     method public void setMinZoom(double p);
     method public void setPaddingUpdatesAllowed(boolean p);
     method public void setPitchUpdatesAllowed(boolean p);
@@ -120,7 +120,7 @@ package com.mapbox.navigation.ui.maps.camera.data {
     property public final com.mapbox.navigation.ui.maps.camera.data.FollowingFrameOptions.FrameGeometryAfterManeuver frameGeometryAfterManeuver;
     property public final com.mapbox.navigation.ui.maps.camera.data.FollowingFrameOptions.IntersectionDensityCalculation intersectionDensityCalculation;
     property public final double maxZoom;
-    property public final boolean maximizeViewableRouteGeometryWhenPitchZero;
+    property public final boolean maximizeViewableGeometryWhenPitchZero;
     property public final double minZoom;
     property public final boolean paddingUpdatesAllowed;
     property public final com.mapbox.navigation.ui.maps.camera.data.FollowingFrameOptions.PitchNearManeuvers pitchNearManeuvers;

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/MapboxNavigationViewportDataSource.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/MapboxNavigationViewportDataSource.kt
@@ -96,7 +96,7 @@ import kotlin.math.min
  *
  * **When following frame is used, the first point of the framed geometry list will be placed at the bottom edge of this padding, centered horizontally.**
  * This typically refers to the user's location provided via [onLocationChanged], if available.
- * This can be influenced with [FollowingFrameOptions.maximizeViewableRouteGeometryWhenPitchZero].
+ * This can be influenced by [FollowingFrameOptions.maximizeViewableGeometryWhenPitchZero] when there are at least 2 points available for framing.
  *
  * **The geometries that are below the bottom edge of the following padding on screen (based on camera's bearing) are ignored and not being framed.**
  * It's impossible to find a zoom level that would fit geometries that are below the vanishing point of the camera,
@@ -255,7 +255,7 @@ class MapboxNavigationViewportDataSource(
      *
      * **When following frame is used, the first point of the framed geometry list will be placed at the bottom edge of this padding, centered horizontally.**
      * This typically refers to the user's location provided via [onLocationChanged], if available.
-     * This can be influenced with [FollowingFrameOptions.maximizeViewableRouteGeometryWhenPitchZero].
+     * This can be influenced by [FollowingFrameOptions.maximizeViewableGeometryWhenPitchZero] when there are at least 2 points available for framing.
      *
      * The frame will contain the remaining portion of the current [LegStep] of the route provided via [onRouteChanged]
      * based on [onRouteProgressChanged].
@@ -717,7 +717,8 @@ class MapboxNavigationViewportDataSource(
         }
 
         val cameraFrame =
-            if (options.followingFrameOptions.maximizeViewableRouteGeometryWhenPitchZero &&
+            if (pointsForFollowing.size > 1 &&
+                options.followingFrameOptions.maximizeViewableGeometryWhenPitchZero &&
                 followingPitchProperty.get() == ZERO_PITCH
             ) {
                 mapboxMap.cameraForCoordinates(

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/MapboxNavigationViewportDataSourceOptions.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/MapboxNavigationViewportDataSourceOptions.kt
@@ -44,13 +44,14 @@ class FollowingFrameOptions internal constructor() {
     var maxZoom = 16.35
 
     /**
-     * When a produced **following frame** has pitch `0`,
+     * When a produced **following frame** has pitch `0` and there are at least 2 points available for framing,
      * the puck will not be tied to the bottom edge of the [MapboxNavigationViewportDataSource.followingPadding] and instead move
-     * around the centroid of the maneuver's geometry to maximize the view of the maneuver's geometry within the [MapboxNavigationViewportDataSource.followingPadding].
+     * around the centroid of the framed geometry (user location plus additional points to frame together or maneuver if route is available)
+     * to maximize the view of that geometry within the [MapboxNavigationViewportDataSource.followingPadding].
      *
      * Defaults to `true`.
      */
-    var maximizeViewableRouteGeometryWhenPitchZero = true
+    var maximizeViewableGeometryWhenPitchZero = true
 
     /**
      * Options that modify the framed route geometries based on the intersection density.

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/camera/data/MapboxNavigationViewportDataSourceTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/camera/data/MapboxNavigationViewportDataSourceTest.kt
@@ -52,7 +52,7 @@ class MapboxNavigationViewportDataSourceTest {
         .anchor(null)
         .build()
     private val mapSize = Size(1000f, 1000f)
-    private val maxPitchEdgeInsets = EdgeInsets(1.0, 2.0, 3.0, 4.0)
+    private val singlePixelEdgeInsets = EdgeInsets(1.0, 2.0, 3.0, 4.0)
     private val followingScreenBox = ScreenBox(
         ScreenCoordinate(1.0, 2.0),
         ScreenCoordinate(3.0, 4.0)
@@ -125,7 +125,7 @@ class MapboxNavigationViewportDataSourceTest {
         viewportDataSource = MapboxNavigationViewportDataSource(mapboxMap)
 
         mockkObject(ViewportDataSourceProcessor)
-        every { getMapAnchoredPaddingFromUserPadding(mapSize, any()) } returns maxPitchEdgeInsets
+        every { getMapAnchoredPaddingFromUserPadding(mapSize, any()) } returns singlePixelEdgeInsets
         every { getScreenBoxForFraming(mapSize, any()) } returns followingScreenBox
         every {
             getSmootherBearingForMap(
@@ -249,7 +249,7 @@ class MapboxNavigationViewportDataSourceTest {
             bearing(smoothedBearing)
             pitch(viewportDataSource.options.followingFrameOptions.defaultPitch)
             zoom(viewportDataSource.options.followingFrameOptions.minZoom)
-            padding(maxPitchEdgeInsets)
+            padding(singlePixelEdgeInsets)
         }
 
         // overview mocks
@@ -295,7 +295,7 @@ class MapboxNavigationViewportDataSourceTest {
             bearing(smoothedBearing)
             pitch(viewportDataSource.options.followingFrameOptions.defaultPitch)
             zoom(viewportDataSource.options.followingFrameOptions.minZoom)
-            padding(maxPitchEdgeInsets)
+            padding(singlePixelEdgeInsets)
         }
 
         // overview mocks
@@ -417,7 +417,7 @@ class MapboxNavigationViewportDataSourceTest {
             bearing(smoothedBearing)
             pitch(viewportDataSource.options.followingFrameOptions.defaultPitch)
             zoom(mapboxMap.getCameraOptions().zoom)
-            padding(maxPitchEdgeInsets)
+            padding(singlePixelEdgeInsets)
         }
         val followingZoom = 16.0
         val followingCameraOptions = fallbackOptions.toBuilder()
@@ -489,7 +489,7 @@ class MapboxNavigationViewportDataSourceTest {
             bearing(smoothedBearing)
             pitch(viewportDataSource.options.followingFrameOptions.defaultPitch)
             zoom(mapboxMap.getCameraOptions().zoom)
-            padding(maxPitchEdgeInsets)
+            padding(singlePixelEdgeInsets)
         }
         val followingZoom = 16.0
         val followingCameraOptions = fallbackOptions.toBuilder()
@@ -640,7 +640,7 @@ class MapboxNavigationViewportDataSourceTest {
             bearing(smoothedBearing)
             pitch(ZERO_PITCH)
             zoom(mapboxMap.getCameraOptions().zoom)
-            padding(maxPitchEdgeInsets)
+            padding(singlePixelEdgeInsets)
         }
         val followingZoom = 16.0
         val followingCameraOptions = fallbackOptions.toBuilder()
@@ -677,7 +677,7 @@ class MapboxNavigationViewportDataSourceTest {
 
         // run
         viewportDataSource.options.followingFrameOptions
-            .maximizeViewableRouteGeometryWhenPitchZero = false
+            .maximizeViewableGeometryWhenPitchZero = false
         viewportDataSource.onLocationChanged(location)
         viewportDataSource.onRouteChanged(route)
         viewportDataSource.onRouteProgressChanged(routeProgress)
@@ -715,7 +715,7 @@ class MapboxNavigationViewportDataSourceTest {
             bearing(smoothedBearing)
             pitch(viewportDataSource.options.followingFrameOptions.defaultPitch)
             zoom(viewportDataSource.options.followingFrameOptions.minZoom)
-            padding(maxPitchEdgeInsets)
+            padding(singlePixelEdgeInsets)
         }
         val pointsForInitialFollowingFrame = mutableListOf<Point>().apply {
             add(location.toPoint())
@@ -810,19 +810,8 @@ class MapboxNavigationViewportDataSourceTest {
             bearing(smoothedBearing)
             pitch(ZERO_PITCH)
             zoom(viewportDataSource.options.followingFrameOptions.minZoom)
-            padding(EMPTY_EDGE_INSETS)
+            padding(singlePixelEdgeInsets)
         }
-        val pointsForFinalFollowingFrame = mutableListOf<Point>().apply {
-            add(location.toPoint())
-        }
-        every {
-            mapboxMap.cameraForCoordinates(
-                pointsForFinalFollowingFrame,
-                EMPTY_EDGE_INSETS,
-                smoothedBearing,
-                ZERO_PITCH
-            )
-        } returns followingCameraOptions
 
         // overview mocks
         val pointsForInitialOverviewFrame = mutableListOf<Point>().apply {
@@ -898,7 +887,7 @@ class MapboxNavigationViewportDataSourceTest {
             bearing(smoothedBearing)
             pitch(viewportDataSource.options.followingFrameOptions.defaultPitch)
             zoom(mapboxMap.getCameraOptions().zoom)
-            padding(maxPitchEdgeInsets)
+            padding(singlePixelEdgeInsets)
         }
         val followingZoom = 16.0
         val followingCameraOptions = fallbackOptions.toBuilder()
@@ -984,7 +973,7 @@ class MapboxNavigationViewportDataSourceTest {
             bearing(smoothedBearing)
             pitch(viewportDataSource.options.followingFrameOptions.defaultPitch)
             zoom(viewportDataSource.options.followingFrameOptions.minZoom)
-            padding(maxPitchEdgeInsets)
+            padding(singlePixelEdgeInsets)
         }
 
         // overview mocks
@@ -1056,7 +1045,7 @@ class MapboxNavigationViewportDataSourceTest {
             bearing(smoothedBearing)
             pitch(viewportDataSource.options.followingFrameOptions.defaultPitch)
             zoom(viewportDataSource.options.followingFrameOptions.minZoom)
-            padding(maxPitchEdgeInsets)
+            padding(singlePixelEdgeInsets)
         }
 
         // overview mocks
@@ -1121,7 +1110,7 @@ class MapboxNavigationViewportDataSourceTest {
             bearing(followingBearing)
             pitch(followingPitch)
             zoom(followingZoom)
-            padding(maxPitchEdgeInsets)
+            padding(singlePixelEdgeInsets)
         }
 
         // overview mocks


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Closes https://github.com/mapbox/mapbox-navigation-android/issues/4339. The flag is now only considered if there are at least 2 points for framing. This has the effect of correctly keeping the user location at the bottom edge of the padding in free-drive when the pitch is zero instead of moving it to the center of the padding.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Fixed an issue where the user location was incorrectly positioned in the center of the screen in the following state when the pitch was zero, `maximizeViewableRouteGeometryWhenPitchZero` was set, and no other points were available for framing. Now the user location is correctly tied to the bottom edge of the padding if that's the only geometry to frame. The flag was also renamed to `maximizeViewableGeometryWhenPitchZero`.</changelog>
```

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->
Before:

https://user-images.githubusercontent.com/16925074/116581693-e3219100-a914-11eb-85e0-d790f4658de0.mp4

After:

https://user-images.githubusercontent.com/16925074/116581710-e6b51800-a914-11eb-8458-89c8b4184bab.mp4



<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
