### PR TITLE
Rename `mapbox-access-token` to `mapbox_access_token` in docs.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ If you want to contribute code:
 
 2. Add an `SDK_REGISTRY_TOKEN` gradle property or env variable with a **secret token**. The token needs to have the `DOWNLOADS:READ` scope. You can obtain the token from your [Mapbox Account page](https://account.mapbox.com/access-tokens/).
 
-3. Add your **public token** to `examples/src/main/res/values/mapbox-access-token.xml` to be able to run the test app. You can obtain the token from your [Mapbox Account page](https://account.mapbox.com/access-tokens/).
+3. Add your **public token** to `examples/src/main/res/values/mapbox_access_token.xml` to be able to run the test app. The file will be automatically generated when you sync the project with gradle. You can obtain the token from your [Mapbox Account page](https://account.mapbox.com/access-tokens/).
 
 4. Pull requests are gladly accepted. If there are any changes that developers should be aware of, please update the [change log](CHANGELOG.md)
 


### PR DESCRIPTION
### Description
Small clarification in the CONTRIBUTING.md file, so the developers will be able to find the `mapbox_access_token.xml` file when they try to build samples for the first time.
