### PR TITLE
Modified the restricted road implementation

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/util/RouteDrawingActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/util/RouteDrawingActivity.kt
@@ -56,9 +56,7 @@ class RouteDrawingActivity : AppCompatActivity() {
 
     private val routeLineResources: RouteLineResources by lazy {
         RouteLineResources.Builder()
-            .restrictedRoadLineWidth(7.0)
-            .restrictedRoadOpacity(1.0)
-            .restrictedRoadDashArray(listOf(.5, 2.0))
+            .restrictedRoadSectionScale(7.0)
             .routeLineColorResources(routeColorResources)
             .build()
     }
@@ -75,7 +73,6 @@ class RouteDrawingActivity : AppCompatActivity() {
         MapboxRouteLineOptions.Builder(this)
             .withRouteLineResources(routeLineResources)
             .withRouteLineBelowLayerId("road-label")
-            .withRestrictedRoadLayerEnabled(true)
             .build()
     }
 

--- a/libnavui-base/api/current.txt
+++ b/libnavui-base/api/current.txt
@@ -21,6 +21,7 @@ package com.mapbox.navigation.ui.base.formatter {
 package com.mapbox.navigation.ui.base.internal.model.route {
 
   public final class RouteConstants {
+    method public int getALTERNATE_RESTRICTED_ROAD_COLOR();
     method public int getALTERNATE_ROUTE_CASING_COLOR();
     method public int getALTERNATE_ROUTE_DEFAULT_COLOR();
     method public int getALTERNATE_ROUTE_HEAVY_TRAFFIC_COLOR();
@@ -38,7 +39,6 @@ package com.mapbox.navigation.ui.base.internal.model.route {
     method public int getMANEUVER_ARROW_COLOR();
     method public int getORIGIN_WAYPOINT_ICON();
     method public int getRESTRICTED_ROAD_COLOR();
-    method public java.util.List<java.lang.Double> getRESTRICTED_ROAD_DASH_ARRAY();
     method public int getROUTE_CASING_COLOR();
     method public int getROUTE_CLOSURE_COLOR();
     method public int getROUTE_DEFAULT_COLOR();
@@ -50,6 +50,8 @@ package com.mapbox.navigation.ui.base.internal.model.route {
     method public int getROUTE_SEVERE_TRAFFIC_COLOR();
     method public int getROUTE_UNKNOWN_TRAFFIC_COLOR();
     method public java.util.List<java.lang.String> getTRAFFIC_BACKFILL_ROAD_CLASSES();
+    method public int getTRANSPARENT_COLOR();
+    property public final int ALTERNATE_RESTRICTED_ROAD_COLOR;
     property public final int ALTERNATE_ROUTE_CASING_COLOR;
     property public final int ALTERNATE_ROUTE_DEFAULT_COLOR;
     property public final int ALTERNATE_ROUTE_HEAVY_TRAFFIC_COLOR;
@@ -67,7 +69,6 @@ package com.mapbox.navigation.ui.base.internal.model.route {
     property public final int MANEUVER_ARROW_COLOR;
     property public final int ORIGIN_WAYPOINT_ICON;
     property public final int RESTRICTED_ROAD_COLOR;
-    property public final java.util.List<java.lang.Double> RESTRICTED_ROAD_DASH_ARRAY;
     property public final int ROUTE_CASING_COLOR;
     property public final int ROUTE_CLOSURE_COLOR;
     property public final int ROUTE_DEFAULT_COLOR;
@@ -79,6 +80,7 @@ package com.mapbox.navigation.ui.base.internal.model.route {
     property public final int ROUTE_SEVERE_TRAFFIC_COLOR;
     property public final int ROUTE_UNKNOWN_TRAFFIC_COLOR;
     property public final java.util.List<java.lang.String> TRAFFIC_BACKFILL_ROAD_CLASSES;
+    property public final int TRANSPARENT_COLOR;
     field public static final String ALTERNATIVE_ROUTE1_SOURCE_ID = "mapbox-navigation-alt-route1-source";
     field public static final String ALTERNATIVE_ROUTE2_SOURCE_ID = "mapbox-navigation-alt-route2-source";
     field public static final String ARROW_BEARING = "mapbox-navigation-arrow-bearing";
@@ -87,7 +89,7 @@ package com.mapbox.navigation.ui.base.internal.model.route {
     field public static final String ARROW_HEAD_SOURCE_ID = "mapbox-navigation-arrow-head-source";
     field public static final double ARROW_HIDDEN_ZOOM_LEVEL = 14.0;
     field public static final String ARROW_SHAFT_SOURCE_ID = "mapbox-navigation-arrow-shaft-source";
-    field public static final String ClOSURE_CONGESTION_VALUE = "closed";
+    field public static final String CLOSURE_CONGESTION_VALUE = "closed";
     field public static final String DEFAULT_ROUTE_DESCRIPTOR_PLACEHOLDER = "mapboxDescriptorPlaceHolderUnused";
     field public static final double DEFAULT_ROUTE_SOURCES_TOLERANCE = 0.375;
     field public static final String DESTINATION_MARKER_NAME = "destinationMarker";
@@ -110,9 +112,8 @@ package com.mapbox.navigation.ui.base.internal.model.route {
     field public static final double OPAQUE = 0.0;
     field public static final String ORIGIN_MARKER_NAME = "originMarker";
     field public static final String PRIMARY_ROUTE_SOURCE_ID = "mapbox-navigation-route-source";
-    field public static final double RESTRICTED_ROAD_LINE_OPACITY = 1.0;
-    field public static final double RESTRICTED_ROAD_LINE_WIDTH = 7.0;
-    field public static final String RESTRICTED_ROAD_SOURCE_ID = "mapbox-restricted-road-source";
+    field public static final String RESTRICTED_CONGESTION_VALUE = "restricted";
+    field public static final double RESTRICTED_ROAD_SECTION_SCALE = 10.0;
     field public static final boolean ROUNDED_LINE_CAP = true;
     field public static final double ROUTE_LINE_UPDATE_MAX_DISTANCE_THRESHOLD_IN_METERS = 1.0;
     field public static final String SEVERE_CONGESTION_VALUE = "severe";

--- a/libnavui-base/src/main/java/com/mapbox/navigation/ui/base/internal/model/route/RouteConstants.kt
+++ b/libnavui-base/src/main/java/com/mapbox/navigation/ui/base/internal/model/route/RouteConstants.kt
@@ -9,7 +9,6 @@ object RouteConstants {
     const val PRIMARY_ROUTE_SOURCE_ID = "mapbox-navigation-route-source"
     const val ALTERNATIVE_ROUTE1_SOURCE_ID = "mapbox-navigation-alt-route1-source"
     const val ALTERNATIVE_ROUTE2_SOURCE_ID = "mapbox-navigation-alt-route2-source"
-    const val RESTRICTED_ROAD_SOURCE_ID = "mapbox-restricted-road-source"
     const val WAYPOINT_SOURCE_ID = "mapbox-navigation-waypoint-source"
     const val TWO_POINTS = 2
     const val THIRTY = 30
@@ -42,7 +41,8 @@ object RouteConstants {
     const val HEAVY_CONGESTION_VALUE = "heavy"
     const val SEVERE_CONGESTION_VALUE = "severe"
     const val UNKNOWN_CONGESTION_VALUE = "unknown"
-    const val ClOSURE_CONGESTION_VALUE = "closed"
+    const val CLOSURE_CONGESTION_VALUE = "closed"
+    const val RESTRICTED_CONGESTION_VALUE = "restricted"
     const val ORIGIN_MARKER_NAME = "originMarker"
     const val DESTINATION_MARKER_NAME = "destinationMarker"
     const val ROUTE_LINE_UPDATE_MAX_DISTANCE_THRESHOLD_IN_METERS = 1.0
@@ -50,9 +50,7 @@ object RouteConstants {
     const val MAX_ELAPSED_SINCE_INDEX_UPDATE_NANO = 1500000000.0 // 1.5s
     const val DEFAULT_ROUTE_SOURCES_TOLERANCE = 0.375
     const val ROUNDED_LINE_CAP = true
-    const val RESTRICTED_ROAD_LINE_OPACITY = 1.0
-    const val RESTRICTED_ROAD_LINE_WIDTH = 7.0
-    val RESTRICTED_ROAD_DASH_ARRAY = listOf(.5, 2.0)
+    const val RESTRICTED_ROAD_SECTION_SCALE = 10.0
     val TRAFFIC_BACKFILL_ROAD_CLASSES = emptyList<String>()
 
     @ColorInt
@@ -105,6 +103,12 @@ object RouteConstants {
 
     @ColorInt
     val RESTRICTED_ROAD_COLOR = Color.parseColor("#000000")
+
+    @ColorInt
+    val ALTERNATE_RESTRICTED_ROAD_COLOR = Color.parseColor("#333333")
+
+    @ColorInt
+    val TRANSPARENT_COLOR = Color.parseColor("#00000000")
 
     @DrawableRes
     val ORIGIN_WAYPOINT_ICON: Int = R.drawable.mapbox_ic_route_origin

--- a/libnavui-maps/api/current.txt
+++ b/libnavui-maps/api/current.txt
@@ -538,9 +538,8 @@ package com.mapbox.navigation.ui.maps.internal.route.line {
   }
 
   public final class MapboxRouteLineUtils {
-    method public java.util.List<com.mapbox.navigation.ui.maps.route.line.model.RouteLineExpressionData> calculateRouteLineSegments(com.mapbox.api.directions.v5.models.DirectionsRoute route, java.util.List<java.lang.String> trafficBackfillRoadClasses, boolean isPrimaryRoute, com.mapbox.navigation.ui.maps.route.line.model.RouteLineColorResources routeLineColorResources);
+    method public java.util.List<com.mapbox.navigation.ui.maps.route.line.model.RouteLineExpressionData> calculateRouteLineSegments(com.mapbox.api.directions.v5.models.DirectionsRoute route, java.util.List<java.lang.String> trafficBackfillRoadClasses, boolean isPrimaryRoute, com.mapbox.navigation.ui.maps.route.line.model.RouteLineColorResources routeLineColorResources, double restrictedRoadSectionScale);
     method public static String? getBelowLayerIdToUse(String? belowLayerId, com.mapbox.maps.Style style);
-    method public java.util.List<java.util.List<com.mapbox.geojson.Point>> getRestrictedRouteSections(com.mapbox.api.directions.v5.models.DirectionsRoute route);
     method @ColorInt public int getRouteColorForCongestion(String congestionValue, boolean isPrimaryRoute, com.mapbox.navigation.ui.maps.route.line.model.RouteLineColorResources routeLineColorResources);
     method public kotlin.jvm.functions.Function0<java.util.List<com.mapbox.navigation.ui.maps.route.line.model.RouteFeatureData>> getRouteFeatureDataProvider(java.util.List<? extends com.mapbox.api.directions.v5.models.DirectionsRoute> directionsRoutes);
     method public kotlin.jvm.functions.Function0<java.util.List<com.mapbox.navigation.ui.maps.route.line.model.RouteFeatureData>> getRouteLineFeatureDataProvider(java.util.List<com.mapbox.navigation.ui.maps.route.line.model.RouteLine> directionsRoutes);
@@ -718,14 +717,12 @@ package com.mapbox.navigation.ui.maps.route.line.model {
 
   public final class MapboxRouteLineOptions {
     method public android.graphics.drawable.Drawable getDestinationIcon();
-    method public boolean getEnableRestrictedRoadLayer();
     method public android.graphics.drawable.Drawable getOriginIcon();
     method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineResources getResourceProvider();
     method public String? getRouteLineBelowLayerId();
     method public double getTolerance();
     method public com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions.Builder toBuilder(android.content.Context context);
     property public final android.graphics.drawable.Drawable destinationIcon;
-    property public final boolean enableRestrictedRoadLayer;
     property public final android.graphics.drawable.Drawable originIcon;
     property public final com.mapbox.navigation.ui.maps.route.line.model.RouteLineResources resourceProvider;
     property public final String? routeLineBelowLayerId;
@@ -735,7 +732,6 @@ package com.mapbox.navigation.ui.maps.route.line.model {
   public static final class MapboxRouteLineOptions.Builder {
     ctor public MapboxRouteLineOptions.Builder(android.content.Context context);
     method public com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions build();
-    method public com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions.Builder withRestrictedRoadLayerEnabled(boolean enabled);
     method public com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions.Builder withRouteLineBelowLayerId(String layerId);
     method public com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions.Builder withRouteLineResources(com.mapbox.navigation.ui.maps.route.line.model.RouteLineResources resourceProvider);
     method public com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions.Builder withRouteStyleDescriptors(java.util.List<com.mapbox.navigation.ui.maps.route.line.model.RouteStyleDescriptor> routeStyleDescriptors);
@@ -772,12 +768,10 @@ package com.mapbox.navigation.ui.maps.route.line.model {
     method public com.mapbox.geojson.FeatureCollection getAltRoute1Source();
     method public com.mapbox.geojson.FeatureCollection getAltRoute2Source();
     method public com.mapbox.geojson.FeatureCollection getPrimaryRouteSource();
-    method public com.mapbox.geojson.FeatureCollection getRestrictedRoadSource();
     method public com.mapbox.geojson.FeatureCollection getWaypointsSource();
     property public final com.mapbox.geojson.FeatureCollection altRoute1Source;
     property public final com.mapbox.geojson.FeatureCollection altRoute2Source;
     property public final com.mapbox.geojson.FeatureCollection primaryRouteSource;
-    property public final com.mapbox.geojson.FeatureCollection restrictedRoadSource;
     property public final com.mapbox.geojson.FeatureCollection waypointsSource;
   }
 
@@ -788,6 +782,7 @@ package com.mapbox.navigation.ui.maps.route.line.model {
     method public int getAlternativeRouteHeavyColor();
     method public int getAlternativeRouteLowColor();
     method public int getAlternativeRouteModerateColor();
+    method public int getAlternativeRouteRestrictedRoadColor();
     method public int getAlternativeRouteSevereColor();
     method public int getAlternativeRouteUnknownTrafficColor();
     method public int getRestrictedRoadColor();
@@ -808,6 +803,7 @@ package com.mapbox.navigation.ui.maps.route.line.model {
     property public final int alternativeRouteHeavyColor;
     property public final int alternativeRouteLowColor;
     property public final int alternativeRouteModerateColor;
+    property public final int alternativeRouteRestrictedRoadColor;
     property public final int alternativeRouteSevereColor;
     property public final int alternativeRouteUnknownTrafficColor;
     property public final int restrictedRoadColor;
@@ -831,6 +827,7 @@ package com.mapbox.navigation.ui.maps.route.line.model {
     method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineColorResources.Builder alternativeRouteHeavyColor(@ColorInt int color);
     method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineColorResources.Builder alternativeRouteLowColor(@ColorInt int color);
     method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineColorResources.Builder alternativeRouteModerateColor(@ColorInt int color);
+    method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineColorResources.Builder alternativeRouteRestrictedRoadColor(@ColorInt int color);
     method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineColorResources.Builder alternativeRouteSevereColor(@ColorInt int color);
     method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineColorResources.Builder alternativeRouteUnknownTrafficColor(@ColorInt int color);
     method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineColorResources build();
@@ -893,9 +890,7 @@ package com.mapbox.navigation.ui.maps.route.line.model {
     method public com.mapbox.maps.extension.style.expressions.generated.Expression getAlternativeRouteTrafficLineScaleExpression();
     method public int getDestinationWaypointIcon();
     method public int getOriginWaypointIcon();
-    method public java.util.List<java.lang.Double> getRestrictedRoadDashArray();
-    method public double getRestrictedRoadLineWidth();
-    method public double getRestrictedRoadOpacity();
+    method public double getRestrictedRoadSectionScale();
     method public boolean getRoundedLineCap();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression getRouteCasingLineScaleExpression();
     method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineColorResources getRouteLineColorResources();
@@ -908,9 +903,7 @@ package com.mapbox.navigation.ui.maps.route.line.model {
     property public final com.mapbox.maps.extension.style.expressions.generated.Expression alternativeRouteTrafficLineScaleExpression;
     property public final int destinationWaypointIcon;
     property public final int originWaypointIcon;
-    property public final java.util.List<java.lang.Double> restrictedRoadDashArray;
-    property public final double restrictedRoadLineWidth;
-    property public final double restrictedRoadOpacity;
+    property public final double restrictedRoadSectionScale;
     property public final boolean roundedLineCap;
     property public final com.mapbox.maps.extension.style.expressions.generated.Expression routeCasingLineScaleExpression;
     property public final com.mapbox.navigation.ui.maps.route.line.model.RouteLineColorResources routeLineColorResources;
@@ -927,9 +920,7 @@ package com.mapbox.navigation.ui.maps.route.line.model {
     method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineResources build();
     method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineResources.Builder destinationWaypointIcon(@DrawableRes int resource);
     method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineResources.Builder originWaypointIcon(@DrawableRes int resource);
-    method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineResources.Builder restrictedRoadDashArray(java.util.List<java.lang.Double> dashArray);
-    method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineResources.Builder restrictedRoadLineWidth(double width);
-    method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineResources.Builder restrictedRoadOpacity(double opacity);
+    method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineResources.Builder restrictedRoadSectionScale(double scaleValue);
     method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineResources.Builder roundedLineCap(boolean roundLineCap);
     method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineResources.Builder routeCasingLineScaleExpression(com.mapbox.maps.extension.style.expressions.generated.Expression expression);
     method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineResources.Builder routeLineColorResources(com.mapbox.navigation.ui.maps.route.line.model.RouteLineColorResources routeLineColorResources);
@@ -977,7 +968,6 @@ package com.mapbox.navigation.ui.maps.route.line.model {
     method public com.mapbox.geojson.FeatureCollection getAlternativeRoute2Source();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression getCasingLineExpression();
     method public com.mapbox.geojson.FeatureCollection getPrimaryRouteSource();
-    method public com.mapbox.geojson.FeatureCollection getRestrictedRoadSource();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression getRouteLineExpression();
     method public com.mapbox.maps.extension.style.expressions.generated.Expression getTrafficLineExpression();
     method public com.mapbox.geojson.FeatureCollection getWaypointsSource();
@@ -987,7 +977,6 @@ package com.mapbox.navigation.ui.maps.route.line.model {
     property public final com.mapbox.geojson.FeatureCollection alternativeRoute2Source;
     property public final com.mapbox.maps.extension.style.expressions.generated.Expression casingLineExpression;
     property public final com.mapbox.geojson.FeatureCollection primaryRouteSource;
-    property public final com.mapbox.geojson.FeatureCollection restrictedRoadSource;
     property public final com.mapbox.maps.extension.style.expressions.generated.Expression routeLineExpression;
     property public final com.mapbox.maps.extension.style.expressions.generated.Expression trafficLineExpression;
     property public final com.mapbox.geojson.FeatureCollection waypointsSource;

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/MapboxRouteLayerProvider.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/MapboxRouteLayerProvider.kt
@@ -1,7 +1,6 @@
 package com.mapbox.navigation.ui.maps.route.line
 
 import android.graphics.drawable.Drawable
-import androidx.annotation.ColorInt
 import com.mapbox.maps.Style
 import com.mapbox.maps.extension.style.expressions.dsl.generated.interpolate
 import com.mapbox.maps.extension.style.expressions.dsl.generated.match
@@ -27,24 +26,6 @@ internal class MapboxRouteLayerProvider(
     private val alternativeRouteCasingLineScaleExpression: Expression,
     private val alternativeRouteTrafficLineScaleExpression: Expression
 ) {
-
-    fun buildAccessRestrictionsLayer(
-        lineDashArray: List<Double>,
-        lineOpacity: Double,
-        @ColorInt color: Int,
-        lineWidth: Double
-    ): LineLayer {
-        return LineLayer(
-            RouteLayerConstants.RESTRICTED_ROAD_LAYER_ID,
-            RouteConstants.RESTRICTED_ROAD_SOURCE_ID
-        )
-            .lineWidth(lineWidth)
-            .lineJoin(LineJoin.ROUND)
-            .lineOpacity(lineOpacity)
-            .lineColor(color)
-            .lineDasharray(lineDashArray)
-            .lineCap(LineCap.ROUND)
-    }
 
     fun buildPrimaryRouteLayer(
         style: Style,

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineView.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineView.kt
@@ -97,11 +97,6 @@ class MapboxRouteLineView(var options: MapboxRouteLineOptions) {
                     RouteConstants.WAYPOINT_SOURCE_ID,
                     routeDrawData.value.waypointsSource
                 )
-                updateSource(
-                    style,
-                    RouteConstants.RESTRICTED_ROAD_SOURCE_ID,
-                    routeDrawData.value.restrictedRoadSource
-                )
             }
             is Expected.Failure -> { }
         }
@@ -175,11 +170,6 @@ class MapboxRouteLineView(var options: MapboxRouteLineOptions) {
                     style,
                     RouteConstants.WAYPOINT_SOURCE_ID,
                     clearRouteLineValue.value.waypointsSource
-                )
-                updateSource(
-                    style,
-                    RouteConstants.RESTRICTED_ROAD_SOURCE_ID,
-                    clearRouteLineValue.value.restrictedRoadSource
                 )
             }
         }

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/MapboxRouteLineOptions.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/MapboxRouteLineOptions.kt
@@ -18,7 +18,6 @@ import com.mapbox.navigation.ui.maps.route.line.api.VanishingRouteLine
  * @param routeLineBelowLayerId determines the elevation of the route layers
  * @param vanishingRouteLine an instance of the VanishingRouteLine
  * @param tolerance the tolerance value used when configuring the underlying map source
- * @param enableRestrictedRoadLayer whether or not the restricted road layer should be enabled
  */
 class MapboxRouteLineOptions private constructor(
     val resourceProvider: RouteLineResources,
@@ -27,8 +26,7 @@ class MapboxRouteLineOptions private constructor(
     val destinationIcon: Drawable,
     val routeLineBelowLayerId: String?,
     internal var vanishingRouteLine: VanishingRouteLine? = null,
-    val tolerance: Double,
-    val enableRestrictedRoadLayer: Boolean = false
+    val tolerance: Double
 ) {
 
     /**
@@ -44,8 +42,7 @@ class MapboxRouteLineOptions private constructor(
             routeLineBelowLayerId,
             routeLayerProvider.routeStyleDescriptors,
             vanishingRouteLineEnabled,
-            tolerance,
-            enableRestrictedRoadLayer
+            tolerance
         )
     }
 
@@ -65,7 +62,6 @@ class MapboxRouteLineOptions private constructor(
         if (routeLineBelowLayerId != other.routeLineBelowLayerId) return false
         if (vanishingRouteLine != other.vanishingRouteLine) return false
         if (tolerance != other.tolerance) return false
-        if (enableRestrictedRoadLayer != other.enableRestrictedRoadLayer) return false
 
         return true
     }
@@ -81,7 +77,6 @@ class MapboxRouteLineOptions private constructor(
         result = 31 * result + (routeLineBelowLayerId?.hashCode() ?: 0)
         result = 31 * result + (vanishingRouteLine?.hashCode() ?: 0)
         result = 31 * result + (tolerance.hashCode())
-        result = 31 * result + (enableRestrictedRoadLayer.hashCode())
         return result
     }
 
@@ -95,8 +90,7 @@ class MapboxRouteLineOptions private constructor(
             "destinationIcon=$destinationIcon, " +
             "routeLineBelowLayerId=$routeLineBelowLayerId, " +
             "vanishingRouteLine=$vanishingRouteLine, " +
-            "tolerance=$tolerance, " +
-            "enableRestrictedRoadLayer=$enableRestrictedRoadLayer)"
+            "tolerance=$tolerance)"
     }
 
     /**
@@ -114,8 +108,7 @@ class MapboxRouteLineOptions private constructor(
         private var routeLineBelowLayerId: String?,
         private var routeStyleDescriptors: List<RouteStyleDescriptor>,
         private var vanishingRouteLineEnabled: Boolean,
-        private var tolerance: Double,
-        private var enableRestrictedRoadLayer: Boolean
+        private var tolerance: Double
     ) {
 
         /**
@@ -129,8 +122,7 @@ class MapboxRouteLineOptions private constructor(
             null,
             listOf(),
             false,
-            DEFAULT_ROUTE_SOURCES_TOLERANCE,
-            false
+            DEFAULT_ROUTE_SOURCES_TOLERANCE
         )
 
         /**
@@ -174,14 +166,6 @@ class MapboxRouteLineOptions private constructor(
             this.tolerance = tolerance
             return this
         }
-
-        /**
-         * Determines if the restricted road layer is enabled
-         *
-         * @param enabled
-         */
-        fun withRestrictedRoadLayerEnabled(enabled: Boolean): Builder =
-            apply { this.enableRestrictedRoadLayer = enabled }
 
         /**
          * [RouteStyleDescriptor] is an override of an alternative route line coloring based on
@@ -234,8 +218,7 @@ class MapboxRouteLineOptions private constructor(
                 destinationIcon!!,
                 routeLineBelowLayerId,
                 vanishingRouteLine,
-                tolerance,
-                enableRestrictedRoadLayer
+                tolerance
             )
         }
     }

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineClearValue.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineClearValue.kt
@@ -9,12 +9,10 @@ import com.mapbox.geojson.FeatureCollection
  * @param altRoute1Source a feature collection representing an alternative route
  * @param altRoute2Source a feature collection representing an alternative route
  * @param waypointsSource a feature collection representing the origin and destination icons
- * @param restrictedRoadSource a feature collection representing the restricted roads
  */
 class RouteLineClearValue internal constructor(
     val primaryRouteSource: FeatureCollection,
     val altRoute1Source: FeatureCollection,
     val altRoute2Source: FeatureCollection,
-    val waypointsSource: FeatureCollection,
-    val restrictedRoadSource: FeatureCollection
+    val waypointsSource: FeatureCollection
 )

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineColorResources.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineColorResources.kt
@@ -33,6 +33,8 @@ import com.mapbox.navigation.ui.base.internal.model.route.RouteConstants
  * @param alternativeRouteCasingColor the color used for the alternative route casing line(s) which
  * is positioned below the route line giving the line the appearance of a boarder
  * @param restrictedRoadColor the color for the restricted road indicator(s)
+ * @param alternativeRouteRestrictedRoadColor the color for the restricted road indicator(s) for
+ * alternative routes.
  * @param routeClosureColor the color used for the route closure line
  * @param alternativeRouteClosureColor the color used for the alternative route closure line(s)
  */
@@ -54,6 +56,7 @@ class RouteLineColorResources private constructor(
     @ColorInt val alternativeRouteSevereColor: Int,
     @ColorInt val alternativeRouteCasingColor: Int,
     @ColorInt val restrictedRoadColor: Int,
+    @ColorInt val alternativeRouteRestrictedRoadColor: Int,
     @ColorInt val routeClosureColor: Int,
     @ColorInt val alternativeRouteClosureColor: Int
 ) {
@@ -80,6 +83,7 @@ class RouteLineColorResources private constructor(
             .alternativeRouteSevereColor(alternativeRouteSevereColor)
             .alternativeRouteCasingColor(alternativeRouteCasingColor)
             .restrictedRoadColor(restrictedRoadColor)
+            .alternativeRouteRestrictedRoadColor(alternativeRouteRestrictedRoadColor)
             .routeClosureColor(routeClosureColor)
             .alternativeRouteClosureColor(alternativeRouteClosureColor)
     }
@@ -106,6 +110,7 @@ class RouteLineColorResources private constructor(
             "alternativeRouteSevereColor=$alternativeRouteSevereColor, " +
             "alternativeRouteCasingColor=$alternativeRouteCasingColor, " +
             "restrictedRoadColor=$restrictedRoadColor, " +
+            "alternativeRouteRestrictedRoadColor=$alternativeRouteRestrictedRoadColor, " +
             "routeClosureColor=$routeClosureColor, " +
             "alternativeRouteClosureColor=$alternativeRouteClosureColor" +
             ")"
@@ -138,6 +143,8 @@ class RouteLineColorResources private constructor(
         if (alternativeRouteUnknownTrafficColor != other.alternativeRouteUnknownTrafficColor)
             return false
         if (restrictedRoadColor != other.restrictedRoadColor) return false
+        if (alternativeRouteRestrictedRoadColor != other.alternativeRouteRestrictedRoadColor)
+            return false
         if (routeClosureColor != other.routeClosureColor) return false
         if (alternativeRouteClosureColor != other.alternativeRouteClosureColor) return false
 
@@ -165,6 +172,7 @@ class RouteLineColorResources private constructor(
         result = 31 * result + alternativeRouteSevereColor
         result = 31 * result + alternativeRouteCasingColor
         result = 31 * result + restrictedRoadColor
+        result = 31 * result + alternativeRouteRestrictedRoadColor
         result = 31 * result + routeClosureColor
         result = 31 * result + alternativeRouteClosureColor
         return result
@@ -196,6 +204,8 @@ class RouteLineColorResources private constructor(
         private var routeLineTraveledCasingColor: Int =
             RouteConstants.ROUTE_LINE_TRAVELED_CASING_COLOR
         private var restrictedRoadColor: Int = RouteConstants.RESTRICTED_ROAD_COLOR
+        private var alternativeRouteRestrictedRoadColor: Int =
+            RouteConstants.ALTERNATE_RESTRICTED_ROAD_COLOR
         private var routeClosureColor: Int = RouteConstants.ROUTE_CLOSURE_COLOR
         private var alternativeRouteClosureColor: Int =
             RouteConstants.ALTERNATIVE_ROUTE_CLOSURE_COLOR
@@ -376,9 +386,21 @@ class RouteLineColorResources private constructor(
             apply { this.restrictedRoadColor = color }
 
         /**
+         * The color used for the alternative route restricted road representation.
+         *
+         * @param color the color to be used
+         *
+         * @return the builder
+         */
+        fun alternativeRouteRestrictedRoadColor(@ColorInt color: Int): Builder =
+            apply { this.alternativeRouteRestrictedRoadColor = color }
+
+        /**
          * The color used for road closure sections of a route.
          *
          * @param color the color to be used
+         *
+         * @return the builder
          */
         fun routeClosureColor(@ColorInt color: Int): Builder =
             apply { this.routeClosureColor = color }
@@ -387,6 +409,8 @@ class RouteLineColorResources private constructor(
          * The color used for road closure sections of an alternative route(s).
          *
          * @param color the color to be used
+         *
+         * @return the builder
          */
         fun alternativeRouteClosureColor(@ColorInt color: Int): Builder =
             apply { this.alternativeRouteClosureColor = color }
@@ -415,6 +439,7 @@ class RouteLineColorResources private constructor(
                 alternativeRouteSevereColor,
                 alternativeRouteCasingColor,
                 restrictedRoadColor,
+                alternativeRouteRestrictedRoadColor,
                 routeClosureColor,
                 alternativeRouteClosureColor
             )

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineResources.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineResources.kt
@@ -4,9 +4,7 @@ import androidx.annotation.DrawableRes
 import com.mapbox.maps.extension.style.expressions.generated.Expression
 import com.mapbox.navigation.ui.base.internal.model.route.RouteConstants.DESTINATION_WAYPOINT_ICON
 import com.mapbox.navigation.ui.base.internal.model.route.RouteConstants.ORIGIN_WAYPOINT_ICON
-import com.mapbox.navigation.ui.base.internal.model.route.RouteConstants.RESTRICTED_ROAD_DASH_ARRAY
-import com.mapbox.navigation.ui.base.internal.model.route.RouteConstants.RESTRICTED_ROAD_LINE_OPACITY
-import com.mapbox.navigation.ui.base.internal.model.route.RouteConstants.RESTRICTED_ROAD_LINE_WIDTH
+import com.mapbox.navigation.ui.base.internal.model.route.RouteConstants.RESTRICTED_ROAD_SECTION_SCALE
 import com.mapbox.navigation.ui.base.internal.model.route.RouteConstants.ROUNDED_LINE_CAP
 import com.mapbox.navigation.ui.base.internal.model.route.RouteConstants.TRAFFIC_BACKFILL_ROAD_CLASSES
 import com.mapbox.navigation.ui.maps.internal.route.line.MapboxRouteLineUtils.buildScalingExpression
@@ -32,10 +30,7 @@ import com.mapbox.navigation.ui.maps.internal.route.line.MapboxRouteLineUtils.bu
  * alternative route casing line scaling
  * @param alternativeRouteTrafficLineScaleExpression an expression governing the behavior of
  * alternative route traffic line scaling
- * @param restrictedRoadDashArray a list of values for configuring the dashed line representing
- * restricted sections of a route line
- * @param restrictedRoadOpacity the opacity of the restricted road dashed line
- * @param restrictedRoadLineWidth the width of the restricted road dashed line
+ * @param restrictedRoadSectionScale the width of the restricted road dashed line
  */
 class RouteLineResources private constructor(
     val routeLineColorResources: RouteLineColorResources,
@@ -49,9 +44,7 @@ class RouteLineResources private constructor(
     val alternativeRouteLineScaleExpression: Expression,
     val alternativeRouteCasingLineScaleExpression: Expression,
     val alternativeRouteTrafficLineScaleExpression: Expression,
-    val restrictedRoadDashArray: List<Double>,
-    val restrictedRoadOpacity: Double,
-    val restrictedRoadLineWidth: Double
+    val restrictedRoadSectionScale: Double
 ) {
 
     /**
@@ -70,9 +63,7 @@ class RouteLineResources private constructor(
             .alternativeRouteLineScaleExpression(alternativeRouteLineScaleExpression)
             .alternativeRouteCasingLineScaleExpression(alternativeRouteCasingLineScaleExpression)
             .alternativeRouteTrafficLineScaleExpression(alternativeRouteTrafficLineScaleExpression)
-            .restrictedRoadDashArray(restrictedRoadDashArray)
-            .restrictedRoadOpacity(restrictedRoadOpacity)
-            .restrictedRoadLineWidth(restrictedRoadLineWidth)
+            .restrictedRoadSectionScale(restrictedRoadSectionScale)
     }
 
     /**
@@ -101,9 +92,7 @@ class RouteLineResources private constructor(
             "routeCasingLineScaleExpression=$routeCasingLineScaleExpression, " +
             "routeTrafficLineScaleExpression=$routeTrafficLineScaleExpression, " +
             "trafficBackfillRoadClasses=$trafficBackfillRoadClasses, " +
-            "restrictedRoadDashArray=$restrictedRoadDashArray, " +
-            "restrictedRoadOpacity=$restrictedRoadOpacity, " +
-            "restrictedRoadLineWidth=$restrictedRoadLineWidth)"
+            "restrictedRoadSectionScale=$restrictedRoadSectionScale)"
     }
 
     /**
@@ -133,9 +122,7 @@ class RouteLineResources private constructor(
             alternativeRouteTrafficLineScaleExpression !=
             other.alternativeRouteTrafficLineScaleExpression
         ) return false
-        if (restrictedRoadDashArray != other.restrictedRoadDashArray) return false
-        if (restrictedRoadOpacity != other.restrictedRoadOpacity) return false
-        if (restrictedRoadLineWidth != other.restrictedRoadLineWidth) return false
+        if (restrictedRoadSectionScale != other.restrictedRoadSectionScale) return false
 
         return true
     }
@@ -155,9 +142,7 @@ class RouteLineResources private constructor(
         result = 31 * result + alternativeRouteLineScaleExpression.hashCode()
         result = 31 * result + alternativeRouteCasingLineScaleExpression.hashCode()
         result = 31 * result + alternativeRouteTrafficLineScaleExpression.hashCode()
-        result = 31 * result + restrictedRoadDashArray.hashCode()
-        result = 31 * result + restrictedRoadOpacity.hashCode()
-        result = 31 * result + restrictedRoadLineWidth.hashCode()
+        result = 31 * result + restrictedRoadSectionScale.hashCode()
         return result
     }
 
@@ -228,9 +213,7 @@ class RouteLineResources private constructor(
                 RouteLineScaleValue(22f, 18f, 1f)
             )
         )
-        private var restrictedRoadDashArray: List<Double> = RESTRICTED_ROAD_DASH_ARRAY
-        private var restrictedRoadOpacity: Double = RESTRICTED_ROAD_LINE_OPACITY
-        private var restrictedRoadLineWidth: Double = RESTRICTED_ROAD_LINE_WIDTH
+        private var restrictedRoadSectionScale: Double = RESTRICTED_ROAD_SECTION_SCALE
 
         /**
          * The route line color resources to use.
@@ -347,30 +330,16 @@ class RouteLineResources private constructor(
             apply { this.alternativeRouteTrafficLineScaleExpression = expression }
 
         /**
-         * The dash array parameter for the restricted road layer.
-         * See [LineLayer] LineDasharray for more information. An empty list will show a
-         * solid line.
+         * A restricted road or section of road is represented by a dashed line. The dashed line
+         * alternates between a length of color and a transparent section of equal length. The
+         * lengths of the colored and transparent parts of the dashed line is determined
+         * by this value. A larger value will result in longer colored sections and longer
+         * transparent sections between the colored sections.
          *
-         * @param dashArray value of lineDasharray
+         * @param scaleValue the scaleValue of the line segments
          */
-        fun restrictedRoadDashArray(dashArray: List<Double>): Builder =
-            apply { this.restrictedRoadDashArray = dashArray }
-
-        /**
-         * The opacity for the restricted road line.
-         *
-         * @param opacity the opacity value
-         */
-        fun restrictedRoadOpacity(opacity: Double): Builder =
-            apply { this.restrictedRoadOpacity = opacity }
-
-        /**
-         * The width of the restricted road line
-         *
-         * @param width the width of the line
-         */
-        fun restrictedRoadLineWidth(width: Double): Builder =
-            apply { this.restrictedRoadLineWidth = width }
+        fun restrictedRoadSectionScale(scaleValue: Double): Builder =
+            apply { this.restrictedRoadSectionScale = scaleValue }
 
         /**
          * Creates a instance of RouteLineResources
@@ -393,9 +362,7 @@ class RouteLineResources private constructor(
                 alternativeRouteLineScaleExpression,
                 alternativeRouteCasingLineScaleExpression,
                 alternativeRouteTrafficLineScaleExpression,
-                restrictedRoadDashArray,
-                restrictedRoadOpacity,
-                restrictedRoadLineWidth
+                restrictedRoadSectionScale
             )
         }
     }

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/RouteSetValue.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/RouteSetValue.kt
@@ -15,7 +15,6 @@ import com.mapbox.maps.extension.style.expressions.generated.Expression
  * @param alternativeRoute1Source the feature collection for an alternative route line
  * @param alternativeRoute2Source the feature collection for an alternative route line
  * @param waypointsSource the feature collection for the origin and destination icons
- * @param restrictedRoadSource the feature collection for the restricted road indicator(s)
  */
 class RouteSetValue internal constructor(
     val primaryRouteSource: FeatureCollection,
@@ -26,6 +25,5 @@ class RouteSetValue internal constructor(
     val altRoute2TrafficExpression: Expression,
     val alternativeRoute1Source: FeatureCollection,
     val alternativeRoute2Source: FeatureCollection,
-    val waypointsSource: FeatureCollection,
-    val restrictedRoadSource: FeatureCollection
+    val waypointsSource: FeatureCollection
 )

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApiTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApiTest.kt
@@ -184,7 +184,6 @@ class MapboxRouteLineApiTest {
         every { options.routeLayerProvider } returns realOptions.routeLayerProvider
         every { options.resourceProvider } returns realOptions.resourceProvider
         every { options.vanishingRouteLine } returns vanishingRouteLine
-        every { options.enableRestrictedRoadLayer } returns false
 
         val api = MapboxRouteLineApi(options)
         val route = getRoute()
@@ -258,10 +257,6 @@ class MapboxRouteLineApiTest {
         assertEquals(
             expectedWaypointFeature1,
             result.value.waypointsSource.features()!![1].geometry().toString()
-        )
-        assertEquals(
-            "{\"type\":\"FeatureCollection\",\"features\":[]}",
-            result.value.restrictedRoadSource.toJson()
         )
     }
 
@@ -420,28 +415,6 @@ class MapboxRouteLineApiTest {
     }
 
     @Test
-    fun setRoutes_calculatesRestrictedRoadSections() = coroutineRule.runBlockingTest {
-        val expectedFeatureCollections = "{\"type\":\"FeatureCollection\",\"features\":[{\"type\"" +
-            ":\"Feature\",\"geometry\":{\"type\":\"LineString\",\"coordinates\":" +
-            "[[-122.526159,37.971947],[-122.52645,37.971984]]},\"properties\":{}}," +
-            "{\"type\":\"Feature\",\"geometry\":{\"type\":\"LineString\",\"coordinates\"" +
-            ":[[-122.526951,37.972037],[-122.527206,37.972061]]},\"properties\":{}}]}"
-        val options = MapboxRouteLineOptions.Builder(ctx)
-            .withRestrictedRoadLayerEnabled(true)
-            .build()
-        val api = MapboxRouteLineApi(options)
-        val route = getRouteWithNoRoadRestrictions()
-        val routes = listOf(RouteLine(route, null))
-
-        val result = api.setRoutes(routes) as Expected.Success
-
-        assertEquals(
-            expectedFeatureCollections,
-            result.value.restrictedRoadSource.toJson()
-        )
-    }
-
-    @Test
     fun getRouteDrawData() = coroutineRule.runBlockingTest {
         val options = MapboxRouteLineOptions.Builder(ctx).build()
         val api = MapboxRouteLineApi(options)
@@ -545,7 +518,6 @@ class MapboxRouteLineApiTest {
         val options = mockk<MapboxRouteLineOptions> {
             every { vanishingRouteLine } returns mockVanishingRouteLine
             every { resourceProvider } returns realOptions.resourceProvider
-            every { enableRestrictedRoadLayer } returns false
         }
         val api = MapboxRouteLineApi(options)
         val routeProgress = mockk<RouteProgress> {
@@ -584,7 +556,6 @@ class MapboxRouteLineApiTest {
             val options = mockk<MapboxRouteLineOptions> {
                 every { vanishingRouteLine } returns mockVanishingRouteLine
                 every { resourceProvider } returns realOptions.resourceProvider
-                every { enableRestrictedRoadLayer } returns false
             }
             val api = MapboxRouteLineApi(options)
             val routeProgress = mockk<RouteProgress> {
@@ -623,7 +594,6 @@ class MapboxRouteLineApiTest {
             val options = mockk<MapboxRouteLineOptions> {
                 every { vanishingRouteLine } returns mockVanishingRouteLine
                 every { resourceProvider } returns realOptions.resourceProvider
-                every { enableRestrictedRoadLayer } returns false
             }
             val api = MapboxRouteLineApi(options)
             val routeProgress = mockk<RouteProgress> {
@@ -652,7 +622,6 @@ class MapboxRouteLineApiTest {
             val options = mockk<MapboxRouteLineOptions> {
                 every { vanishingRouteLine } returns mockVanishingRouteLine
                 every { resourceProvider } returns realOptions.resourceProvider
-                every { enableRestrictedRoadLayer } returns false
             }
             val api = MapboxRouteLineApi(options)
             val routeProgress = mockk<RouteProgress> {
@@ -677,7 +646,6 @@ class MapboxRouteLineApiTest {
         val options = mockk<MapboxRouteLineOptions> {
             every { vanishingRouteLine } returns mockVanishingRouteLine
             every { resourceProvider } returns realOptions.resourceProvider
-            every { enableRestrictedRoadLayer } returns false
         }
         val api = MapboxRouteLineApi(options)
         val routeProgress = mockk<RouteProgress> {
@@ -763,7 +731,6 @@ class MapboxRouteLineApiTest {
         assertTrue(result.value.altRoute2Source.features()!!.isEmpty())
         assertTrue(result.value.primaryRouteSource.features()!!.isEmpty())
         assertTrue(result.value.waypointsSource.features()!!.isEmpty())
-        assertTrue(result.value.restrictedRoadSource.features()!!.isEmpty())
     }
 
     @Test

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineViewTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineViewTest.kt
@@ -150,7 +150,6 @@ class MapboxRouteLineViewTest {
             FeatureCollection.fromFeatures(listOf(getEmptyFeature()))
         val altRoutesFeatureCollection = FeatureCollection.fromFeatures(listOf(getEmptyFeature()))
         val waypointsFeatureCollection = FeatureCollection.fromFeatures(listOf(getEmptyFeature()))
-        val restrictedFeatureCollection = FeatureCollection.fromFeatures(listOf(getEmptyFeature()))
         val slots = mutableListOf<Value>()
         val style = mockk<Style> {
             every { isFullyLoaded() } returns true
@@ -168,9 +167,6 @@ class MapboxRouteLineViewTest {
                 getStyleSourceProperties(RouteConstants.WAYPOINT_SOURCE_ID)
             } returns geoJsonSourceExpected
             every {
-                getStyleSourceProperties(RouteConstants.RESTRICTED_ROAD_SOURCE_ID)
-            } returns geoJsonSourceExpected
-            every {
                 setStyleSourceProperty(RouteConstants.PRIMARY_ROUTE_SOURCE_ID, any(), any())
             } returns ExpectedFactory.createValue()
             every {
@@ -182,9 +178,6 @@ class MapboxRouteLineViewTest {
             every {
                 setStyleSourceProperty(RouteConstants.WAYPOINT_SOURCE_ID, any(), any())
             } returns ExpectedFactory.createValue()
-            every {
-                setStyleSourceProperty(RouteConstants.RESTRICTED_ROAD_SOURCE_ID, any(), any())
-            } returns ExpectedFactory.createValue()
         }.also {
             mockCheckForLayerInitialization(it)
         }
@@ -194,8 +187,7 @@ class MapboxRouteLineViewTest {
                 primaryRouteFeatureCollection,
                 altRoutesFeatureCollection,
                 altRoutesFeatureCollection,
-                waypointsFeatureCollection,
-                restrictedFeatureCollection
+                waypointsFeatureCollection
             )
         )
 
@@ -244,17 +236,6 @@ class MapboxRouteLineViewTest {
         assertEquals(
             waypointsFeatureCollection.toJson(),
             slots[3].contents as String
-        )
-        verify {
-            style.setStyleSourceProperty(
-                RouteConstants.RESTRICTED_ROAD_SOURCE_ID,
-                any(),
-                capture(slots)
-            )
-        }
-        assertEquals(
-            restrictedFeatureCollection.toJson(),
-            slots[4].contents as String
         )
         verify { MapboxRouteLineUtils.initializeLayers(style, options) }
         unmockkObject(MapboxRouteLineUtils)
@@ -349,8 +330,6 @@ class MapboxRouteLineViewTest {
         val alternativeRoute2FeatureCollection =
             FeatureCollection.fromFeatures(listOf(getEmptyFeature()))
         val waypointsFeatureCollection = FeatureCollection.fromFeatures(listOf(getEmptyFeature()))
-        val restrictedRoadsFeatureCollection =
-            FeatureCollection.fromFeatures(listOf(getEmptyFeature()))
         val slots = mutableListOf<Value>()
         val trafficLineExp = mockk<Expression>()
         val routeLineExp = mockk<Expression>()
@@ -367,8 +346,7 @@ class MapboxRouteLineViewTest {
                 alternativeRoute2Expression,
                 alternativeRoute1FeatureCollection,
                 alternativeRoute2FeatureCollection,
-                waypointsFeatureCollection,
-                restrictedRoadsFeatureCollection
+                waypointsFeatureCollection
             )
         )
         val style = mockk<Style> {
@@ -438,9 +416,6 @@ class MapboxRouteLineViewTest {
                 getStyleSourceProperties(RouteConstants.WAYPOINT_SOURCE_ID)
             } returns geoJsonSourceExpected
             every {
-                getStyleSourceProperties(RouteConstants.RESTRICTED_ROAD_SOURCE_ID)
-            } returns geoJsonSourceExpected
-            every {
                 setStyleSourceProperty(RouteConstants.PRIMARY_ROUTE_SOURCE_ID, any(), any())
             } returns ExpectedFactory.createValue()
             every {
@@ -451,9 +426,6 @@ class MapboxRouteLineViewTest {
             } returns ExpectedFactory.createValue()
             every {
                 setStyleSourceProperty(RouteConstants.WAYPOINT_SOURCE_ID, any(), any())
-            } returns ExpectedFactory.createValue()
-            every {
-                setStyleSourceProperty(RouteConstants.RESTRICTED_ROAD_SOURCE_ID, any(), any())
             } returns ExpectedFactory.createValue()
         }.also {
             mockCheckForLayerInitialization(it)
@@ -539,17 +511,6 @@ class MapboxRouteLineViewTest {
         assertEquals(
             waypointsFeatureCollection.toJson(),
             slots[3].contents as String
-        )
-        verify {
-            style.setStyleSourceProperty(
-                RouteConstants.RESTRICTED_ROAD_SOURCE_ID,
-                any(),
-                capture(slots)
-            )
-        }
-        assertEquals(
-            restrictedRoadsFeatureCollection.toJson(),
-            slots[4].contents as String
         )
         verify { MapboxRouteLineUtils.initializeLayers(style, options) }
         unmockkObject(MapboxRouteLineUtils)

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/VanishingRouteLineTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/VanishingRouteLineTest.kt
@@ -6,6 +6,7 @@ import com.mapbox.geojson.LineString
 import com.mapbox.navigation.base.trip.model.RouteProgressState
 import com.mapbox.navigation.testing.FileUtils.loadJsonFixture
 import com.mapbox.navigation.testing.MainCoroutineRule
+import com.mapbox.navigation.ui.base.internal.model.route.RouteConstants
 import com.mapbox.navigation.ui.maps.internal.route.line.MapboxRouteLineUtils
 import com.mapbox.navigation.ui.maps.route.line.model.RouteLineColorResources
 import com.mapbox.navigation.ui.maps.route.line.model.RouteLineExpressionData
@@ -161,7 +162,8 @@ class VanishingRouteLineTest {
                 getRoute(),
                 listOf(),
                 true,
-                colorResources
+                colorResources,
+                RouteConstants.RESTRICTED_ROAD_SECTION_SCALE
             )
 
         val result = vanishingRouteLine.getTraveledRouteLineExpressions(

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/model/MapboxRouteLineOptionsTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/model/MapboxRouteLineOptionsTest.kt
@@ -5,7 +5,6 @@ import android.graphics.Color
 import androidx.test.core.app.ApplicationProvider
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -51,15 +50,6 @@ class MapboxRouteLineOptionsTest {
     }
 
     @Test
-    fun enableRestrictedRoadLayer() {
-        val options = MapboxRouteLineOptions.Builder(ctx)
-            .withRestrictedRoadLayerEnabled(true)
-            .build()
-
-        assertTrue(options.enableRestrictedRoadLayer)
-    }
-
-    @Test
     fun withRouteStyleDescriptors() {
         val routeStyleDescriptors =
             listOf(RouteStyleDescriptor("foobar", Color.CYAN, Color.YELLOW))
@@ -82,7 +72,6 @@ class MapboxRouteLineOptionsTest {
             .withRouteLineBelowLayerId("someLayerId")
             .withTolerance(.111)
             .withRouteStyleDescriptors(routeStyleDescriptors)
-            .withRestrictedRoadLayerEnabled(true)
             .build()
             .toBuilder(ctx)
             .build()
@@ -92,6 +81,5 @@ class MapboxRouteLineOptionsTest {
         assertNotNull(options.vanishingRouteLine)
         assertEquals(.111, options.tolerance, 0.0)
         assertEquals(routeStyleDescriptors, options.routeLayerProvider.routeStyleDescriptors)
-        assertTrue(options.enableRestrictedRoadLayer)
     }
 }

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineColorResourcesTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineColorResourcesTest.kt
@@ -30,8 +30,9 @@ class RouteLineColorResourcesTest :
             .alternativeRouteSevereColor(15)
             .alternativeRouteCasingColor(16)
             .restrictedRoadColor(17)
-            .routeClosureColor(17)
-            .alternativeRouteClosureColor(18)
+            .alternativeRouteRestrictedRoadColor(18)
+            .routeClosureColor(19)
+            .alternativeRouteClosureColor(20)
     }
 
     override fun trigger() {
@@ -167,6 +168,14 @@ class RouteLineColorResourcesTest :
     }
 
     @Test
+    fun withAlternateRouteRestrictedRoadColor() {
+        val resources =
+            RouteLineColorResources.Builder().alternativeRouteRestrictedRoadColor(5).build()
+
+        assertEquals(5, resources.alternativeRouteRestrictedRoadColor)
+    }
+
+    @Test
     fun withRoadClosure() {
         val resources =
             RouteLineColorResources.Builder().routeClosureColor(5).build()
@@ -202,8 +211,9 @@ class RouteLineColorResourcesTest :
             .alternativeRouteSevereColor(15)
             .alternativeRouteCasingColor(16)
             .restrictedRoadColor(17)
-            .routeClosureColor(17)
-            .alternativeRouteClosureColor(18)
+            .alternativeRouteRestrictedRoadColor(18)
+            .routeClosureColor(19)
+            .alternativeRouteClosureColor(20)
             .build()
 
         val result = routeLineColorResources.toBuilder().build()
@@ -225,7 +235,8 @@ class RouteLineColorResourcesTest :
         assertEquals(15, result.alternativeRouteSevereColor)
         assertEquals(16, result.alternativeRouteCasingColor)
         assertEquals(17, result.restrictedRoadColor)
-        assertEquals(17, result.routeClosureColor)
-        assertEquals(18, result.alternativeRouteClosureColor)
+        assertEquals(18, result.alternativeRouteRestrictedRoadColor)
+        assertEquals(19, result.routeClosureColor)
+        assertEquals(20, result.alternativeRouteClosureColor)
     }
 }

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineResourcesTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineResourcesTest.kt
@@ -50,9 +50,7 @@ class RouteLineResourcesTest : BuilderTest<RouteLineResources, RouteLineResource
             .alternativeRouteLineScaleExpression(routeCasingExpression)
             .alternativeRouteCasingLineScaleExpression(routeCasingExpression)
             .alternativeRouteTrafficLineScaleExpression(routeCasingExpression)
-            .restrictedRoadDashArray(restrictedRoadDashArray)
-            .restrictedRoadLineWidth(2.0)
-            .restrictedRoadOpacity(.5)
+            .restrictedRoadSectionScale(2.0)
     }
 
     override fun trigger() {
@@ -60,26 +58,10 @@ class RouteLineResourcesTest : BuilderTest<RouteLineResources, RouteLineResource
     }
 
     @Test
-    fun restrictedRoadDashArray() {
-        val resources =
-            RouteLineResources.Builder().restrictedRoadDashArray(listOf(.5, 2.0)).build()
-
-        assertEquals(resources.restrictedRoadDashArray[0], .5, 0.0)
-        assertEquals(resources.restrictedRoadDashArray[1], 2.0, 0.0)
-    }
-
-    @Test
     fun restrictedRoadLineWidth() {
-        val resources = RouteLineResources.Builder().restrictedRoadLineWidth(2.0).build()
+        val resources = RouteLineResources.Builder().restrictedRoadSectionScale(2.0).build()
 
-        assertEquals(resources.restrictedRoadLineWidth, 2.0, 0.0)
-    }
-
-    @Test
-    fun restrictedRoadOpacity() {
-        val resources = RouteLineResources.Builder().restrictedRoadOpacity(.3).build()
-
-        assertEquals(resources.restrictedRoadOpacity, .3, 0.0)
+        assertEquals(resources.restrictedRoadSectionScale, 2.0, 0.0)
     }
 
     @Test
@@ -171,9 +153,7 @@ class RouteLineResourcesTest : BuilderTest<RouteLineResources, RouteLineResource
             .alternativeRouteLineScaleExpression(trafficExpression)
             .alternativeRouteCasingLineScaleExpression(trafficExpression)
             .alternativeRouteTrafficLineScaleExpression(trafficExpression)
-            .restrictedRoadDashArray(listOf(1.0, 2.0))
-            .restrictedRoadLineWidth(3.0)
-            .restrictedRoadOpacity(.6)
+            .restrictedRoadSectionScale(3.0)
             .build()
             .toBuilder()
             .build()
@@ -185,9 +165,6 @@ class RouteLineResourcesTest : BuilderTest<RouteLineResources, RouteLineResource
         assertEquals(routeLineExpression, result.routeLineScaleExpression)
         assertEquals(routeCasingExpression, result.routeCasingLineScaleExpression)
         assertEquals(trafficExpression, result.routeTrafficLineScaleExpression)
-        assertEquals(3.0, result.restrictedRoadLineWidth, 0.0)
-        assertEquals(.6, result.restrictedRoadOpacity, 0.0)
-        assertEquals(1.0, result.restrictedRoadDashArray[0], 0.0)
-        assertEquals(2.0, result.restrictedRoadDashArray[1], 0.0)
+        assertEquals(3.0, result.restrictedRoadSectionScale, 0.0)
     }
 }


### PR DESCRIPTION
### Description
Fixes #4359 by representing restricted roads as part of the traffic line.

### Changelog
```
<changelog>Restricted roads are represented as part of the traffic line and will vanish along with the rest of the line when the vanishing route line feature is enabled.</changelog>
```

### Screenshots or Gifs
![20210504_162953](https://user-images.githubusercontent.com/2249818/117082067-19388980-acf6-11eb-8daf-2fa2fc0ca4e8.gif)
