### PR TITLE
Add MapboxSpeechApiExtension for generation files

### DIFF
--- a/libnavui-voice/api/current.txt
+++ b/libnavui-voice/api/current.txt
@@ -14,6 +14,11 @@ package com.mapbox.navigation.ui.voice.api {
     method public void generate(com.mapbox.api.directions.v5.models.VoiceInstructions voiceInstruction, com.mapbox.navigation.ui.base.util.MapboxNavigationConsumer<com.mapbox.navigation.ui.base.model.Expected<com.mapbox.navigation.ui.voice.model.SpeechValue,com.mapbox.navigation.ui.voice.model.SpeechError>> consumer);
   }
 
+  public final class MapboxSpeechApiExtension {
+    method public suspend Object? generate(com.mapbox.navigation.ui.voice.api.MapboxSpeechApi, com.mapbox.api.directions.v5.models.VoiceInstructions voiceInstruction, kotlin.jvm.functions.Function1<? super com.mapbox.navigation.ui.base.model.Expected<com.mapbox.navigation.ui.voice.model.SpeechValue,com.mapbox.navigation.ui.voice.model.SpeechError>,kotlin.Unit> block, kotlin.coroutines.Continuation<? super kotlin.Unit> p);
+    field public static final com.mapbox.navigation.ui.voice.api.MapboxSpeechApiExtension INSTANCE;
+  }
+
   @UiThread public final class MapboxVoiceInstructionsPlayer {
     ctor public MapboxVoiceInstructionsPlayer(android.content.Context context, String accessToken, String language, com.mapbox.navigation.ui.voice.options.VoiceInstructionsPlayerOptions options = VoiceInstructionsPlayerOptions.<init>().build(), com.mapbox.navigation.ui.voice.api.AudioFocusDelegate audioFocusDelegate = buildAndroidAudioFocus(context, options));
     ctor public MapboxVoiceInstructionsPlayer(android.content.Context context, String accessToken, String language, com.mapbox.navigation.ui.voice.options.VoiceInstructionsPlayerOptions options = VoiceInstructionsPlayerOptions.<init>().build());

--- a/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/api/MapboxSpeechApi.kt
+++ b/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/api/MapboxSpeechApi.kt
@@ -77,7 +77,7 @@ class MapboxSpeechApi @JvmOverloads constructor(
         voiceAPI.clean(announcement)
     }
 
-    private suspend fun retrieveVoiceFile(
+    internal suspend fun retrieveVoiceFile(
         voiceInstruction: VoiceInstructions,
         consumer: MapboxNavigationConsumer<Expected<SpeechValue, SpeechError>>
     ) {

--- a/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/api/MapboxSpeechApiExtension.kt
+++ b/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/api/MapboxSpeechApiExtension.kt
@@ -1,0 +1,36 @@
+package com.mapbox.navigation.ui.voice.api
+
+import com.mapbox.api.directions.v5.models.VoiceInstructions
+import com.mapbox.navigation.ui.base.model.Expected
+import com.mapbox.navigation.ui.base.util.MapboxNavigationConsumer
+import com.mapbox.navigation.ui.voice.model.SpeechError
+import com.mapbox.navigation.ui.voice.model.SpeechValue
+
+/**
+ * Extension functions for [MapboxSpeechApi] calls that are implemented as callbacks. This offers
+ * an alternative to those callbacks by providing Kotlin oriented suspend functions.
+ */
+object MapboxSpeechApiExtension {
+
+    /**
+     * Given [VoiceInstructions] the method will try to generate the
+     * voice instruction [SpeechAnnouncement] including the synthesized speech mp3 file
+     * from Mapbox's API Voice.
+     * @param voiceInstruction VoiceInstructions object representing [VoiceInstructions]
+     * @return a state which contains the side effects to be played when the
+     * announcement is ready or the error information and a fallback
+     * with the raw announcement (without file) that can be played with a text-to-speech engine.
+     */
+    suspend fun MapboxSpeechApi.generate(
+        voiceInstruction: VoiceInstructions,
+        block: (Expected<SpeechValue, SpeechError>) -> Unit,
+    ) {
+        retrieveVoiceFile(
+            voiceInstruction,
+            object : MapboxNavigationConsumer<Expected<SpeechValue, SpeechError>> {
+                override fun accept(value: Expected<SpeechValue, SpeechError>) {
+                    block(value)
+                }
+            })
+    }
+}


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
As a user, I want to manage file uploads.

In the current implementation, there is no way to download multiple files at the same time.

The extension allows you to start the generation process without interrupting the current tasks

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Add MapboxSpeechApiExtension for generation files</changelog>
```

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
