### PR TITLE
text appearance for upcoming maneuver

### DIFF
--- a/libnavui-maneuver/api/current.txt
+++ b/libnavui-maneuver/api/current.txt
@@ -612,7 +612,10 @@ package com.mapbox.navigation.ui.maneuver.view {
     method public void updateSubManeuverViewVisibility(int visibility);
     method public void updateTurnIconResources(com.mapbox.navigation.ui.maneuver.model.TurnIconResources turnIconResources);
     method public void updateTurnIconStyle(@StyleRes int style);
+    method public void updateUpcomingManeuverStepDistanceTextAppearance(@StyleRes int style);
     method public void updateUpcomingManeuversVisibility(int visibility);
+    method public void updateUpcomingPrimaryManeuverTextAppearance(@StyleRes int style);
+    method public void updateUpcomingSecondaryManeuverTextAppearance(@StyleRes int style);
   }
 
   public final class MapboxPrimaryManeuver extends androidx.appcompat.widget.AppCompatTextView {
@@ -659,6 +662,9 @@ package com.mapbox.navigation.ui.maneuver.view {
     method public int getItemCount();
     method public void onBindViewHolder(com.mapbox.navigation.ui.maneuver.view.MapboxUpcomingManeuverAdapter.MapboxUpcomingManeuverViewHolder holder, int position);
     method public com.mapbox.navigation.ui.maneuver.view.MapboxUpcomingManeuverAdapter.MapboxUpcomingManeuverViewHolder onCreateViewHolder(android.view.ViewGroup parent, int viewType);
+    method public void updateUpcomingManeuverStepDistanceTextAppearance(@StyleRes int style);
+    method public void updateUpcomingPrimaryManeuverTextAppearance(@StyleRes int style);
+    method public void updateUpcomingSecondaryManeuverTextAppearance(@StyleRes int style);
   }
 
   public final class MapboxUpcomingManeuverAdapter.MapboxUpcomingManeuverViewHolder extends androidx.recyclerview.widget.RecyclerView.ViewHolder {

--- a/libnavui-maneuver/src/main/java/com/mapbox/navigation/ui/maneuver/view/MapboxManeuverView.kt
+++ b/libnavui-maneuver/src/main/java/com/mapbox/navigation/ui/maneuver/view/MapboxManeuverView.kt
@@ -141,6 +141,7 @@ class MapboxManeuverView : ConstraintLayout {
 
     /**
      * Allows you to change the text appearance of primary maneuver text.
+     * @see [TextViewCompat.setTextAppearance]
      * @param style Int
      */
     fun updatePrimaryManeuverTextAppearance(@StyleRes style: Int) {
@@ -149,6 +150,7 @@ class MapboxManeuverView : ConstraintLayout {
 
     /**
      * Allows you to change the text appearance of secondary maneuver text.
+     * @see [TextViewCompat.setTextAppearance]
      * @param style Int
      */
     fun updateSecondaryManeuverTextAppearance(@StyleRes style: Int) {
@@ -157,6 +159,7 @@ class MapboxManeuverView : ConstraintLayout {
 
     /**
      * Allows you to change the text appearance of sub maneuver text.
+     * @see [TextViewCompat.setTextAppearance]
      * @param style Int
      */
     fun updateSubManeuverTextAppearance(@StyleRes style: Int) {
@@ -165,10 +168,38 @@ class MapboxManeuverView : ConstraintLayout {
 
     /**
      * Allows you to change the text appearance of step distance text.
+     * @see [TextViewCompat.setTextAppearance]
      * @param style Int
      */
     fun updateStepDistanceTextAppearance(@StyleRes style: Int) {
         TextViewCompat.setTextAppearance(mainLayoutBinding.stepDistance, style)
+    }
+
+    /**
+     * Allows you to change the text appearance of primary maneuver text in upcoming maneuver list.
+     * @see [TextViewCompat.setTextAppearance]
+     * @param style Int
+     */
+    fun updateUpcomingPrimaryManeuverTextAppearance(@StyleRes style: Int) {
+        upcomingManeuverAdapter.updateUpcomingPrimaryManeuverTextAppearance(style)
+    }
+
+    /**
+     * Allows you to change the text appearance of secondary maneuver text in upcoming maneuver list.
+     * @see [TextViewCompat.setTextAppearance]
+     * @param style Int
+     */
+    fun updateUpcomingSecondaryManeuverTextAppearance(@StyleRes style: Int) {
+        upcomingManeuverAdapter.updateUpcomingSecondaryManeuverTextAppearance(style)
+    }
+
+    /**
+     * Allows you to change the text appearance of step distance text in upcoming maneuver list.
+     * @see [TextViewCompat.setTextAppearance]
+     * @param style Int
+     */
+    fun updateUpcomingManeuverStepDistanceTextAppearance(@StyleRes style: Int) {
+        upcomingManeuverAdapter.updateUpcomingManeuverStepDistanceTextAppearance(style)
     }
 
     /**

--- a/libnavui-maneuver/src/main/java/com/mapbox/navigation/ui/maneuver/view/MapboxUpcomingManeuverAdapter.kt
+++ b/libnavui-maneuver/src/main/java/com/mapbox/navigation/ui/maneuver/view/MapboxUpcomingManeuverAdapter.kt
@@ -5,7 +5,9 @@ import android.view.LayoutInflater
 import android.view.View.GONE
 import android.view.View.VISIBLE
 import android.view.ViewGroup
+import androidx.annotation.StyleRes
 import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.widget.TextViewCompat
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.mapbox.navigation.base.formatter.DistanceFormatterOptions
@@ -18,6 +20,7 @@ import com.mapbox.navigation.ui.maneuver.model.SecondaryManeuver
 import com.mapbox.navigation.ui.maneuver.model.StepDistance
 import com.mapbox.navigation.ui.maneuver.model.TotalManeuverDistance
 import com.mapbox.navigation.ui.maneuver.view.MapboxUpcomingManeuverAdapter.MapboxUpcomingManeuverViewHolder
+import com.mapbox.navigation.utils.internal.ifNonNull
 
 /**
  * Default recycler adapter to render upcoming maneuvers for the [RouteLeg].
@@ -30,6 +33,9 @@ class MapboxUpcomingManeuverAdapter(
     private val context: Context
 ) : RecyclerView.Adapter<MapboxUpcomingManeuverViewHolder>() {
 
+    @StyleRes private var stepDistanceAppearance: Int? = null
+    @StyleRes private var primaryManeuverAppearance: Int? = null
+    @StyleRes private var secondaryManeuverAppearance: Int? = null
     private val inflater = LayoutInflater.from(context)
     private val upcomingManeuverList = mutableListOf<Maneuver>()
 
@@ -67,6 +73,33 @@ class MapboxUpcomingManeuverAdapter(
     }
 
     /**
+     * Allows you to change the text appearance of step distance text in upcoming maneuver list.
+     * @see [TextViewCompat.setTextAppearance]
+     * @param style Int
+     */
+    fun updateUpcomingManeuverStepDistanceTextAppearance(@StyleRes style: Int) {
+        stepDistanceAppearance = style
+    }
+
+    /**
+     * Allows you to change the text appearance of primary maneuver text in upcoming maneuver list.
+     * @see [TextViewCompat.setTextAppearance]
+     * @param style Int
+     */
+    fun updateUpcomingPrimaryManeuverTextAppearance(@StyleRes style: Int) {
+        primaryManeuverAppearance = style
+    }
+
+    /**
+     * Allows you to change the text appearance of secondary maneuver text in upcoming maneuver list.
+     * @see [TextViewCompat.setTextAppearance]
+     * @param style Int
+     */
+    fun updateUpcomingSecondaryManeuverTextAppearance(@StyleRes style: Int) {
+        secondaryManeuverAppearance = style
+    }
+
+    /**
      * Invoke to add all upcoming maneuvers to the recycler view.
      * @param upcomingManeuvers List<Maneuver>
      */
@@ -98,6 +131,27 @@ class MapboxUpcomingManeuverAdapter(
             drawSecondaryManeuver(secondary)
             drawPrimaryManeuver(primary)
             drawTotalStepDistance(totalStepDistance)
+            updateStepDistanceTextAppearance()
+            updateUpcomingPrimaryManeuverTextAppearance()
+            updateUpcomingSecondaryManeuverTextAppearance()
+        }
+
+        private fun updateUpcomingPrimaryManeuverTextAppearance() {
+            ifNonNull(primaryManeuverAppearance) { appearance ->
+                TextViewCompat.setTextAppearance(viewBinding.primaryManeuverText, appearance)
+            }
+        }
+
+        private fun updateUpcomingSecondaryManeuverTextAppearance() {
+            ifNonNull(secondaryManeuverAppearance) { appearance ->
+                TextViewCompat.setTextAppearance(viewBinding.secondaryManeuverText, appearance)
+            }
+        }
+
+        private fun updateStepDistanceTextAppearance() {
+            ifNonNull(stepDistanceAppearance) { appearance ->
+                TextViewCompat.setTextAppearance(viewBinding.stepDistance, appearance)
+            }
         }
 
         private fun drawPrimaryManeuver(primary: PrimaryManeuver) {


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Fixes #4309
### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Add ability to change the text appearance for primary, secondary and total step distance of upcoming maneuver instructions.</changelog>
```

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->

![Screen Shot 2021-05-11 at 3 37 21 PM](https://user-images.githubusercontent.com/9770186/117798455-ccf9c600-b26e-11eb-9474-e241265574e3.png)

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
