### PR TITLE
Remove unused `accessToken` from `MapboxTripSession` and some cleanup

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -250,7 +250,6 @@ class MapboxNavigation(
             navigationOptions = navigationOptions,
             navigator = navigator,
             logger = logger,
-            accessToken = accessToken
         )
         tripSession.registerStateObserver(navigationSession)
 

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/NavigationComponentProvider.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/NavigationComponentProvider.kt
@@ -47,13 +47,11 @@ internal object NavigationComponentProvider {
         navigationOptions: NavigationOptions,
         navigator: MapboxNativeNavigator,
         logger: Logger,
-        accessToken: String?
     ): TripSession = MapboxTripSession(
         tripService,
         navigationOptions,
         navigator = navigator,
         logger = logger,
-        accessToken = accessToken,
         eHorizonSubscriptionManager = EHorizonSubscriptionManagerImpl(navigator),
     )
 

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
@@ -58,7 +58,6 @@ internal class MapboxTripSession(
     private val navigator: MapboxNativeNavigator = MapboxNativeNavigatorImpl,
     private val threadController: ThreadController = ThreadController,
     private val logger: Logger,
-    private val accessToken: String?,
     private val eHorizonSubscriptionManager: EHorizonSubscriptionManager,
 ) : TripSession {
 

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
@@ -7,12 +7,10 @@ import android.location.Location
 import com.mapbox.android.core.location.LocationEngine
 import com.mapbox.android.telemetry.MapboxTelemetryConstants.MAPBOX_SHARED_PREFERENCES
 import com.mapbox.annotation.module.MapboxModuleType
-import com.mapbox.api.directions.v5.DirectionsCriteria
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.RouteOptions
 import com.mapbox.base.common.logger.Logger
 import com.mapbox.common.module.provider.MapboxModuleProvider
-import com.mapbox.core.constants.Constants
 import com.mapbox.navigation.base.TimeFormat.NONE_SPECIFIED
 import com.mapbox.navigation.base.formatter.DistanceFormatterOptions
 import com.mapbox.navigation.base.internal.extensions.inferDeviceLocale
@@ -83,10 +81,7 @@ class MapboxNavigationTest {
     private val locationEngine: LocationEngine = mockk(relaxUnitFun = true)
     private val distanceFormatterOptions: DistanceFormatterOptions = mockk(relaxed = true)
     private val routingTilesOptions: RoutingTilesOptions = mockk(relaxed = true)
-    private val fasterRouteRequestCallback: RoutesRequestCallback = mockk(relaxed = true)
     private val routeRefreshController: RouteRefreshController = mockk(relaxUnitFun = true)
-    private val routeOptions: RouteOptions = provideDefaultRouteOptionsBuilder().build()
-    private val routes: List<DirectionsRoute> = listOf(mockk())
     private val routeProgress: RouteProgress = mockk(relaxed = true)
     private val navigationSession: NavigationSession = mockk(relaxUnitFun = true)
     private val logger: Logger = mockk(relaxUnitFun = true)
@@ -781,7 +776,6 @@ class MapboxNavigationTest {
                 navigationOptions = navigationOptions,
                 navigator = navigator,
                 logger = logger,
-                accessToken = "pk.1234"
             )
         } returns tripSession
         every { tripSession.getEnhancedLocation() } returns location
@@ -802,16 +796,6 @@ class MapboxNavigationTest {
             navigationSession
         }
     }
-
-    private fun provideDefaultRouteOptionsBuilder() =
-        RouteOptions.builder()
-            .accessToken(accessToken)
-            .baseUrl(Constants.BASE_API_URL)
-            .user(Constants.MAPBOX_USER)
-            .profile(DirectionsCriteria.PROFILE_DRIVING)
-            .coordinates(emptyList())
-            .geometries("")
-            .requestUuid("")
 
     private fun provideNavigationOptions() =
         NavigationOptions

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
@@ -7,7 +7,6 @@ import androidx.test.core.app.ApplicationProvider
 import com.mapbox.android.core.location.LocationEngine
 import com.mapbox.android.core.location.LocationEngineCallback
 import com.mapbox.android.core.location.LocationEngineResult
-import com.mapbox.api.directions.v5.models.BannerComponents
 import com.mapbox.api.directions.v5.models.BannerInstructions
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.VoiceInstructions
@@ -154,14 +153,13 @@ class MapboxTripSessionTest {
         every { locationEngineResult.locations } returns listOf(location)
     }
 
-    private fun buildTripSession(accessToken: String? = "pk.1234"): TripSession {
+    private fun buildTripSession(): TripSession {
         return MapboxTripSession(
             tripService,
             navigationOptions,
             navigator,
             ThreadController,
             logger,
-            accessToken,
             eHorizonSubscriptionManager,
         )
     }
@@ -1027,14 +1025,4 @@ class MapboxTripSessionTest {
         locationCallbackSlot.captured.onSuccess(locationEngineResult)
         parentJob.cancelAndJoin()
     }
-
-    private fun getBannerComponent() =
-        BannerComponents.builder()
-            .text("some text")
-            .type("guidance-view")
-            .imageUrl(
-                "https://api.mapbox.com/guidance-views/v1/1580515200/" +
-                    "jct/CB211101?arrow_ids=CB21110A"
-            )
-            .build()
 }


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Fixes https://github.com/mapbox/mapbox-navigation-android/issues/4377

Removes unused `accessToken` from `MapboxTripSession` and some cleanup

