### PR TITLE
Bump `compileSdkVersion` and targetSdkVersion and CI `android-ndk` image to `30` and `r21e` respectively

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,9 @@ parameters:
 #---------- EXECUTORS ----------
 #-------------------------------
 executors:
-  ndk-r21-latest-executor:
+  ndk-r21e-latest-executor:
     docker:
-      - image: mbgl/android-ndk-r21:latest
+      - image: mbgl/android-ndk-r21e:latest
     working_directory: ~/code
     environment:
       FORCE_MAPBOX_NAVIGATION_NATIVE_VERSION: << pipeline.parameters.mapbox_navigation_native_snapshot >>
@@ -414,7 +414,7 @@ commands:
 #--------------------------
 jobs:
   prepare-and-assemble:
-    executor: ndk-r21-latest-executor
+    executor: ndk-r21e-latest-executor
     steps:
       - checkout
       - restore-gradle-cache
@@ -436,7 +436,7 @@ jobs:
       - write-workspace
 
   unit-tests:
-    executor: ndk-r21-latest-executor
+    executor: ndk-r21e-latest-executor
     steps:
       - read-workspace
       - unit-tests-core
@@ -445,7 +445,7 @@ jobs:
 #      - codecov
 
   static-analysis:
-    executor: ndk-r21-latest-executor
+    executor: ndk-r21e-latest-executor
     steps:
       - read-workspace
       - verify-codestyle
@@ -456,13 +456,13 @@ jobs:
       - check-public-documentation
 
   changelog-verification:
-    executor: ndk-r21-latest-executor
+    executor: ndk-r21e-latest-executor
     steps:
       - checkout
       - verify-changelog
 
   ui-robo-tests:
-    executor: ndk-r21-latest-executor
+    executor: ndk-r21e-latest-executor
     environment:
       JVM_OPTS: -Xmx3200m
       BUILDTYPE: Debug
@@ -482,7 +482,7 @@ jobs:
           variant: "release"
 
   internal-instrumentation-tests:
-    executor: ndk-r21-latest-executor
+    executor: ndk-r21e-latest-executor
     environment:
       JVM_OPTS: -Xmx3200m
       BUILDTYPE: Debug
@@ -496,7 +496,7 @@ jobs:
           variant: "debug"
 
   instrumentation-tests:
-    executor: ndk-r21-latest-executor
+    executor: ndk-r21e-latest-executor
     environment:
       JVM_OPTS: -Xmx3200m
       BUILDTYPE: Debug
@@ -508,13 +508,13 @@ jobs:
           variant: "debug"
 
   mobile-metrics-benchmarks:
-    executor: ndk-r21-latest-executor
+    executor: ndk-r21e-latest-executor
     steps:
       - checkout
       - trigger-mobile-metrics
 
   release-snapshot:
-    executor: ndk-r21-latest-executor
+    executor: ndk-r21e-latest-executor
     steps:
       - checkout
       - generate-version-name
@@ -529,7 +529,7 @@ jobs:
 #      - trigger-mobile-metrics
 
   release:
-    executor: ndk-r21-latest-executor
+    executor: ndk-r21e-latest-executor
     steps:
       - checkout
       - generate-version-name

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -2,8 +2,8 @@ ext {
 
   androidVersions = [
       minSdkVersion           : 21,
-      targetSdkVersion        : 29,
-      compileSdkVersion       : 29
+      targetSdkVersion        : 30,
+      compileSdkVersion       : 30
   ]
 
   // Navigation Native CI can run SDK CI downstream with forced Navigation Native version

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/ApplicationLifecycleMonitor.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/ApplicationLifecycleMonitor.kt
@@ -29,8 +29,8 @@ internal class ApplicationLifecycleMonitor(
         initCurrentOrientation(application)
     }
 
-    override fun onActivityStarted(activity: Activity?) {
-        activity?.let {
+    override fun onActivityStarted(activity: Activity) {
+        activity.let {
             val newOrientation = it.resources.configuration.orientation
             // If a new orientation is found, set it to the current
             if (!currentOrientation.compareAndSet(newOrientation, newOrientation)) {
@@ -50,16 +50,16 @@ internal class ApplicationLifecycleMonitor(
         }
     }
 
-    override fun onActivityResumed(activity: Activity?) {
+    override fun onActivityResumed(activity: Activity) {
         resumes.add(System.currentTimeMillis())
     }
 
-    override fun onActivityPaused(activity: Activity?) {
+    override fun onActivityPaused(activity: Activity) {
         pauses.add(System.currentTimeMillis())
     }
 
-    override fun onActivityDestroyed(activity: Activity?) {
-        activity?.let {
+    override fun onActivityDestroyed(activity: Activity) {
+        activity.let {
             if (it.isFinishing) {
                 it.application.unregisterActivityLifecycleCallbacks(this)
             }
@@ -68,13 +68,13 @@ internal class ApplicationLifecycleMonitor(
 
     //region Unused Lifecycle Methods
 
-    override fun onActivityCreated(activity: Activity?, bundle: Bundle?) {
+    override fun onActivityCreated(activity: Activity, bundle: Bundle?) {
     }
 
-    override fun onActivityStopped(activity: Activity?) {
+    override fun onActivityStopped(activity: Activity) {
     }
 
-    override fun onActivitySaveInstanceState(activity: Activity?, bundle: Bundle?) {
+    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {
     }
 
     //endregion

--- a/libnavigation-util/src/main/java/com/mapbox/navigation/utils/internal/NetworkStatusService.kt
+++ b/libnavigation-util/src/main/java/com/mapbox/navigation/utils/internal/NetworkStatusService.kt
@@ -34,12 +34,12 @@ class NetworkStatusService(private val applicationContext: Context) {
 
             val callback: ConnectivityManager.NetworkCallback =
                 object : ConnectivityManager.NetworkCallback() {
-                    override fun onAvailable(network: Network?) {
+                    override fun onAvailable(network: Network) {
                         super.onAvailable(network)
                         networkStatusChannel.offer(NetworkStatus(true))
                     }
 
-                    override fun onLost(network: Network?) {
+                    override fun onLost(network: Network) {
                         super.onLost(network)
                         networkStatusChannel.offer(NetworkStatus(false))
                     }


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Bumps `compileSdkVersion` and targetSdkVersion and CI `android-ndk` image to `30` and `r21e` respectively

cc @tobrun 