### PR TITLE
catch more `MapboxRouteOptionsUpdater` exceptions and print additional data

### DIFF
--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -416,7 +416,7 @@ package com.mapbox.navigation.core.reroute {
 package com.mapbox.navigation.core.routeoptions {
 
   public final class MapboxRouteOptionsUpdater implements com.mapbox.navigation.core.routeoptions.RouteOptionsUpdater {
-    ctor public MapboxRouteOptionsUpdater(com.mapbox.base.common.logger.Logger? logger = null);
+    ctor public MapboxRouteOptionsUpdater();
     method public com.mapbox.navigation.core.routeoptions.RouteOptionsUpdater.RouteOptionsResult update(com.mapbox.api.directions.v5.models.RouteOptions? routeOptions, com.mapbox.navigation.base.trip.model.RouteProgress? routeProgress, android.location.Location? location);
   }
 

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -275,7 +275,7 @@ class MapboxNavigation(
             )
         }
 
-        val routeOptionsProvider = MapboxRouteOptionsUpdater(logger)
+        val routeOptionsProvider = MapboxRouteOptionsUpdater()
 
         fasterRouteController = FasterRouteController(
             directionsSession,

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/routeoptions/MapboxRouteOptionsUpdater.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/routeoptions/MapboxRouteOptionsUpdater.kt
@@ -2,11 +2,11 @@ package com.mapbox.navigation.core.routeoptions
 
 import android.location.Location
 import com.mapbox.api.directions.v5.models.RouteOptions
-import com.mapbox.base.common.logger.Logger
 import com.mapbox.base.common.logger.model.Message
 import com.mapbox.base.common.logger.model.Tag
 import com.mapbox.geojson.Point
 import com.mapbox.navigation.base.trip.model.RouteProgress
+import com.mapbox.navigation.utils.internal.LoggerProvider
 import kotlin.math.min
 
 private const val DEFAULT_REROUTE_BEARING_TOLERANCE = 90.0
@@ -15,9 +15,7 @@ private const val TAG = "MbxRouteOptionsProvider"
 /**
  * Default implementation of [RouteOptionsUpdater].
  */
-class MapboxRouteOptionsUpdater(
-    private val logger: Logger? = null
-) : RouteOptionsUpdater {
+class MapboxRouteOptionsUpdater : RouteOptionsUpdater {
 
     /**
      * Provides a new [RouteOptions] instance based on the original request options and the current route progress.
@@ -33,7 +31,7 @@ class MapboxRouteOptionsUpdater(
         if (routeOptions == null || routeProgress == null || location == null) {
             val msg = "Cannot combine RouteOptions, invalid inputs. routeOptions, " +
                 "routeProgress, and location mustn't be null"
-            logger?.e(
+            LoggerProvider.logger.e(
                 Tag(TAG),
                 Message(msg)
             )
@@ -48,10 +46,10 @@ class MapboxRouteOptionsUpdater(
             val msg = """
                 Reroute failed. There are no remaining waypoints on the route.
                 routeOptions=$routeOptions
-                routeProgress=$routeProgress
                 location=$location
+                routeProgress=$routeProgress
             """.trimIndent()
-            logger?.e(
+            LoggerProvider.logger.e(
                 Tag(TAG),
                 Message(msg)
             )
@@ -118,14 +116,20 @@ class MapboxRouteOptionsUpdater(
                         )
                     )
             }
-        } catch (e: IndexOutOfBoundsException) {
-            throw RuntimeException(
-                "${e.localizedMessage}\n" +
-                    "routeOptions=[$routeOptions]\n" +
-                    "routeProgress=[$routeProgress]\n" +
-                    "location=[$location]",
-                e
+        } catch (e: Exception) {
+            LoggerProvider.logger.e(
+                Tag(TAG),
+                Message("routeOptions=[$routeOptions]")
             )
+            LoggerProvider.logger.e(
+                Tag(TAG),
+                Message("location=[$location]")
+            )
+            LoggerProvider.logger.e(
+                Tag(TAG),
+                Message("routeProgress=[$routeProgress]")
+            )
+            throw e
         }
 
         return RouteOptionsUpdater.RouteOptionsResult.Success(optionsBuilder.build())

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/routeoptions/MapboxRouteOptionsUpdaterParameterizedTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/routeoptions/MapboxRouteOptionsUpdaterParameterizedTest.kt
@@ -4,14 +4,12 @@ import android.location.Location
 import com.mapbox.api.directions.v5.DirectionsCriteria
 import com.mapbox.api.directions.v5.WalkingOptions
 import com.mapbox.api.directions.v5.models.RouteOptions
-import com.mapbox.base.common.logger.Logger
 import com.mapbox.core.constants.Constants
 import com.mapbox.geojson.Point
 import com.mapbox.navigation.base.trip.model.RouteLegProgress
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import io.mockk.MockKAnnotations
 import io.mockk.every
-import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -64,9 +62,6 @@ class MapboxRouteOptionsUpdaterParameterizedTest(
         )
     }
 
-    @MockK
-    private lateinit var logger: Logger
-
     private val accessToken = "pk.1234pplffd"
 
     private lateinit var routeRefreshAdapter: MapboxRouteOptionsUpdater
@@ -77,7 +72,7 @@ class MapboxRouteOptionsUpdaterParameterizedTest(
         MockKAnnotations.init(this, relaxUnitFun = true, relaxed = true)
         mockLocation()
 
-        routeRefreshAdapter = MapboxRouteOptionsUpdater(logger)
+        routeRefreshAdapter = MapboxRouteOptionsUpdater()
     }
 
     @Test

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/routeoptions/MapboxRouteOptionsUpdaterTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/routeoptions/MapboxRouteOptionsUpdaterTest.kt
@@ -4,13 +4,11 @@ import android.location.Location
 import com.mapbox.api.directions.v5.DirectionsCriteria
 import com.mapbox.api.directions.v5.WalkingOptions
 import com.mapbox.api.directions.v5.models.RouteOptions
-import com.mapbox.base.common.logger.Logger
 import com.mapbox.core.constants.Constants
 import com.mapbox.geojson.Point
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import io.mockk.MockKAnnotations
 import io.mockk.every
-import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -20,9 +18,6 @@ import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 class MapboxRouteOptionsUpdaterTest {
-
-    @MockK
-    private lateinit var logger: Logger
 
     private lateinit var routeRefreshAdapter: MapboxRouteOptionsUpdater
     private lateinit var location: Location
@@ -94,7 +89,7 @@ class MapboxRouteOptionsUpdaterTest {
         MockKAnnotations.init(this, relaxUnitFun = true, relaxed = true)
         mockLocation()
 
-        routeRefreshAdapter = MapboxRouteOptionsUpdater(logger)
+        routeRefreshAdapter = MapboxRouteOptionsUpdater()
     }
 
     @Test
@@ -177,8 +172,7 @@ class MapboxRouteOptionsUpdaterTest {
 
             assertTrue(
                 message,
-                routeRefreshAdapter
-                    .update(routeOptions, routeProgress, location)
+                routeRefreshAdapter.update(routeOptions, routeProgress, location)
                 is RouteOptionsUpdater.RouteOptionsResult.Error
             )
         }
@@ -197,8 +191,6 @@ class MapboxRouteOptionsUpdaterTest {
         val remainingWaypointsParameter: Int,
         val expectedBearings: List<List<Double>?>
     ) {
-        @MockK
-        private lateinit var logger: Logger
 
         private lateinit var routeRefreshAdapter: MapboxRouteOptionsUpdater
         private lateinit var location: Location
@@ -277,7 +269,7 @@ class MapboxRouteOptionsUpdaterTest {
             MockKAnnotations.init(this, relaxUnitFun = true, relaxed = true)
             mockLocation()
 
-            routeRefreshAdapter = MapboxRouteOptionsUpdater(logger)
+            routeRefreshAdapter = MapboxRouteOptionsUpdater()
         }
 
         @Test

--- a/libnavigation-util/src/main/java/com/mapbox/navigation/utils/internal/LoggerProvider.kt
+++ b/libnavigation-util/src/main/java/com/mapbox/navigation/utils/internal/LoggerProvider.kt
@@ -3,7 +3,6 @@ package com.mapbox.navigation.utils.internal
 import com.mapbox.annotation.module.MapboxModuleType
 import com.mapbox.base.common.logger.Logger
 import com.mapbox.common.module.provider.MapboxModuleProvider
-import com.mapbox.common.module.provider.ModuleProviderArgument
 
 /**
  * Singleton provider of [Logger].
@@ -11,11 +10,8 @@ import com.mapbox.common.module.provider.ModuleProviderArgument
 object LoggerProvider {
 
     val logger = MapboxModuleProvider.createModule<Logger>(
-        MapboxModuleType.CommonLogger,
-        LoggerProvider::paramsProvider
-    )
-
-    private fun paramsProvider(type: MapboxModuleType): Array<ModuleProviderArgument> {
-        return arrayOf()
+        MapboxModuleType.CommonLogger
+    ) {
+        arrayOf()
     }
 }


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Refs https://github.com/mapbox/mapbox-navigation-android/issues/4179. Tries to catch (and re-throw) more errors in the `MapboxRouteOptionsUpdater` while printing additional debug data.

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
