### PR TITLE
removed RouteProgressState.ROUTE_INVALID state and renamed the states

### DIFF
--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/CoreRerouteTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/CoreRerouteTest.kt
@@ -52,7 +52,7 @@ class CoreRerouteTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.jav
         )
         locationTrackingIdlingResource = RouteProgressStateIdlingResource(
             mapboxNavigation,
-            RouteProgressState.LOCATION_TRACKING
+            RouteProgressState.TRACKING
         )
         offRouteIdlingResource = RouteProgressStateIdlingResource(
             mapboxNavigation,
@@ -92,11 +92,10 @@ class CoreRerouteTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.jav
         locationTrackingIdlingResource.register()
 
         val expectedStates = RouteProgressStateTransitionAssertion(mapboxNavigation) {
-            optionalState(RouteProgressState.ROUTE_INVALID)
-            requiredState(RouteProgressState.LOCATION_TRACKING)
+            requiredState(RouteProgressState.TRACKING)
             requiredState(RouteProgressState.OFF_ROUTE)
-            optionalState(RouteProgressState.ROUTE_INITIALIZED)
-            requiredState(RouteProgressState.LOCATION_TRACKING)
+            optionalState(RouteProgressState.INITIALIZED)
+            requiredState(RouteProgressState.TRACKING)
         }
 
         // start a route

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/SanityCoreRouteTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/SanityCoreRouteTest.kt
@@ -46,7 +46,7 @@ class SanityCoreRouteTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class
         )
         routeCompleteIdlingResource = RouteProgressStateIdlingResource(
             mapboxNavigation,
-            RouteProgressState.ROUTE_COMPLETE
+            RouteProgressState.COMPLETE
         )
     }
 
@@ -58,9 +58,8 @@ class SanityCoreRouteTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class
         routeCompleteIdlingResource.register()
 
         val expectedStates = RouteProgressStateTransitionAssertion(mapboxNavigation) {
-            optionalState(RouteProgressState.ROUTE_INVALID)
-            requiredState(RouteProgressState.LOCATION_TRACKING)
-            requiredState(RouteProgressState.ROUTE_COMPLETE)
+            requiredState(RouteProgressState.TRACKING)
+            requiredState(RouteProgressState.COMPLETE)
         }
 
         // execute

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/ui/routeline/AlternativeRouteSelectionTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/ui/routeline/AlternativeRouteSelectionTest.kt
@@ -78,7 +78,7 @@ class AlternativeRouteSelectionTest : BaseTest<BasicNavigationViewActivity>(
 
         routeProgressIdlingResource = RouteProgressStateIdlingResource(
             mapboxNavigation,
-            RouteProgressState.LOCATION_TRACKING
+            RouteProgressState.TRACKING
         )
 
         runOnMainSync {

--- a/libnavigation-base/api/current.txt
+++ b/libnavigation-base/api/current.txt
@@ -444,6 +444,7 @@ package com.mapbox.navigation.base.trip.model {
     method public int getRemainingWaypoints();
     method public com.mapbox.api.directions.v5.models.DirectionsRoute getRoute();
     method public com.mapbox.geojson.Geometry? getRouteGeometryWithBuffer();
+    method public boolean getStale();
     method public java.util.List<com.mapbox.navigation.base.trip.model.roadobject.UpcomingRoadObject> getUpcomingRoadObjects();
     method public java.util.List<com.mapbox.geojson.Point>? getUpcomingStepPoints();
     method public com.mapbox.api.directions.v5.models.VoiceInstructions? getVoiceInstructions();
@@ -459,6 +460,7 @@ package com.mapbox.navigation.base.trip.model {
     property public final int remainingWaypoints;
     property public final com.mapbox.api.directions.v5.models.DirectionsRoute route;
     property public final com.mapbox.geojson.Geometry? routeGeometryWithBuffer;
+    property public final boolean stale;
     property public final java.util.List<com.mapbox.navigation.base.trip.model.roadobject.UpcomingRoadObject> upcomingRoadObjects;
     property public final java.util.List<com.mapbox.geojson.Point>? upcomingStepPoints;
     property public final com.mapbox.api.directions.v5.models.VoiceInstructions? voiceInstructions;
@@ -477,6 +479,7 @@ package com.mapbox.navigation.base.trip.model {
     method public com.mapbox.navigation.base.trip.model.RouteProgress.Builder inTunnel(boolean inTunnel);
     method public com.mapbox.navigation.base.trip.model.RouteProgress.Builder remainingWaypoints(int remainingWaypoints);
     method public com.mapbox.navigation.base.trip.model.RouteProgress.Builder routeGeometryWithBuffer(com.mapbox.geojson.Geometry? routeGeometryWithBuffer);
+    method public com.mapbox.navigation.base.trip.model.RouteProgress.Builder stale(boolean stale);
     method public com.mapbox.navigation.base.trip.model.RouteProgress.Builder upcomingRoadObjects(java.util.List<com.mapbox.navigation.base.trip.model.roadobject.UpcomingRoadObject> upcomingRoadObjects);
     method public com.mapbox.navigation.base.trip.model.RouteProgress.Builder upcomingStepPoints(java.util.List<com.mapbox.geojson.Point>? upcomingStepPoints);
     method public com.mapbox.navigation.base.trip.model.RouteProgress.Builder voiceInstructions(com.mapbox.api.directions.v5.models.VoiceInstructions? voiceInstructions);
@@ -485,7 +488,6 @@ package com.mapbox.navigation.base.trip.model {
   public enum RouteProgressState {
     enum_constant public static final com.mapbox.navigation.base.trip.model.RouteProgressState COMPLETE;
     enum_constant public static final com.mapbox.navigation.base.trip.model.RouteProgressState INITIALIZED;
-    enum_constant public static final com.mapbox.navigation.base.trip.model.RouteProgressState LOCATION_STALE;
     enum_constant public static final com.mapbox.navigation.base.trip.model.RouteProgressState OFF_ROUTE;
     enum_constant public static final com.mapbox.navigation.base.trip.model.RouteProgressState TRACKING;
     enum_constant public static final com.mapbox.navigation.base.trip.model.RouteProgressState UNCERTAIN;

--- a/libnavigation-base/api/current.txt
+++ b/libnavigation-base/api/current.txt
@@ -483,13 +483,12 @@ package com.mapbox.navigation.base.trip.model {
   }
 
   public enum RouteProgressState {
+    enum_constant public static final com.mapbox.navigation.base.trip.model.RouteProgressState COMPLETE;
+    enum_constant public static final com.mapbox.navigation.base.trip.model.RouteProgressState INITIALIZED;
     enum_constant public static final com.mapbox.navigation.base.trip.model.RouteProgressState LOCATION_STALE;
-    enum_constant public static final com.mapbox.navigation.base.trip.model.RouteProgressState LOCATION_TRACKING;
     enum_constant public static final com.mapbox.navigation.base.trip.model.RouteProgressState OFF_ROUTE;
-    enum_constant public static final com.mapbox.navigation.base.trip.model.RouteProgressState ROUTE_COMPLETE;
-    enum_constant public static final com.mapbox.navigation.base.trip.model.RouteProgressState ROUTE_INITIALIZED;
-    enum_constant public static final com.mapbox.navigation.base.trip.model.RouteProgressState ROUTE_INVALID;
-    enum_constant public static final com.mapbox.navigation.base.trip.model.RouteProgressState ROUTE_UNCERTAIN;
+    enum_constant public static final com.mapbox.navigation.base.trip.model.RouteProgressState TRACKING;
+    enum_constant public static final com.mapbox.navigation.base.trip.model.RouteProgressState UNCERTAIN;
   }
 
   public final class RouteStepProgress {

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteProgress.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteProgress.kt
@@ -153,7 +153,7 @@ class RouteProgress private constructor(
         private var routeGeometryWithBuffer: Geometry? = null
         private var bannerInstructions: BannerInstructions? = null
         private var voiceInstructions: VoiceInstructions? = null
-        private var currentState: RouteProgressState = RouteProgressState.ROUTE_INVALID
+        private var currentState: RouteProgressState = RouteProgressState.INITIALIZED
         private var currentLegProgress: RouteLegProgress? = null
         private var upcomingStepPoints: List<Point>? = null
         private var inTunnel: Boolean = false

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteProgress.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteProgress.kt
@@ -38,6 +38,8 @@ import com.mapbox.navigation.base.trip.model.roadobject.UpcomingRoadObject
  * between 0 and 1 and isn't guaranteed to reach 1 before the user reaches the end of the route.
  * @param remainingWaypoints [Int] number of waypoints remaining on the current route.
  * @param upcomingRoadObjects list of upcoming road objects.
+ * @param stale `true` if there were no location updates for a significant amount which causes
+ * a lack of confidence in the progress updates being sent.
  */
 class RouteProgress private constructor(
     val route: DirectionsRoute,
@@ -53,7 +55,8 @@ class RouteProgress private constructor(
     val durationRemaining: Double,
     val fractionTraveled: Float,
     val remainingWaypoints: Int,
-    val upcomingRoadObjects: List<UpcomingRoadObject>
+    val upcomingRoadObjects: List<UpcomingRoadObject>,
+    val stale: Boolean
 ) {
 
     /**
@@ -73,6 +76,7 @@ class RouteProgress private constructor(
         .fractionTraveled(fractionTraveled)
         .remainingWaypoints(remainingWaypoints)
         .upcomingRoadObjects(upcomingRoadObjects)
+        .stale(stale)
 
     /**
      * Indicates whether some other object is "equal to" this one.
@@ -97,6 +101,7 @@ class RouteProgress private constructor(
         if (fractionTraveled != other.fractionTraveled) return false
         if (remainingWaypoints != other.remainingWaypoints) return false
         if (upcomingRoadObjects != other.upcomingRoadObjects) return false
+        if (stale != other.stale) return false
 
         return true
     }
@@ -119,6 +124,7 @@ class RouteProgress private constructor(
         result = 31 * result + fractionTraveled.hashCode()
         result = 31 * result + remainingWaypoints
         result = 31 * result + upcomingRoadObjects.hashCode()
+        result = 31 * result + stale.hashCode()
         return result
     }
 
@@ -140,7 +146,8 @@ class RouteProgress private constructor(
             "durationRemaining=$durationRemaining, " +
             "fractionTraveled=$fractionTraveled, " +
             "remainingWaypoints=$remainingWaypoints, " +
-            "upcomingRoadObjects=$upcomingRoadObjects" +
+            "upcomingRoadObjects=$upcomingRoadObjects, " +
+            "stale=$stale" +
             ")"
     }
 
@@ -163,6 +170,7 @@ class RouteProgress private constructor(
         private var fractionTraveled: Float = 0f
         private var remainingWaypoints: Int = 0
         private var upcomingRoadObjects: List<UpcomingRoadObject> = emptyList()
+        private var stale: Boolean = false
 
         /**
          * Current [DirectionsRoute] geometry with a buffer
@@ -193,7 +201,7 @@ class RouteProgress private constructor(
             apply { this.voiceInstructions = voiceInstructions }
 
         /**
-         * The current state of progress along the route.  Provides route and location tracking
+         * The current state of progress along the route. Provides route and location tracking
          * information.
          *
          * @return Builder
@@ -275,6 +283,15 @@ class RouteProgress private constructor(
             apply { this.upcomingRoadObjects = upcomingRoadObjects }
 
         /**
+         * True if there were no location updates for a significant amount of time which causes
+         * a lack of confidence in the progress updates being sent.
+         *
+         * @return Builder
+         */
+        fun stale(stale: Boolean): Builder =
+            apply { this.stale = stale }
+
+        /**
          * Build new instance of [RouteProgress]
          *
          * @return RouteProgress
@@ -295,7 +312,8 @@ class RouteProgress private constructor(
                 durationRemaining,
                 fractionTraveled,
                 remainingWaypoints,
-                upcomingRoadObjects
+                upcomingRoadObjects,
+                stale
             )
         }
     }

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteProgressState.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteProgressState.kt
@@ -21,18 +21,12 @@ enum class RouteProgressState {
     COMPLETE,
 
     /**
-     * We've gone of route: all [RouteProgress] fields are invalid.
+     * We've gone off route: all [RouteProgress] fields are invalid.
      */
     OFF_ROUTE,
 
     /**
      * We are probably about to go off-route: all [RouteProgress] fields are valid.
      */
-    UNCERTAIN,
-
-    /**
-     * A lack of [android.location.Location] updates has caused a lack of confidence in the
-     * progress updates being sent.
-     */
-    LOCATION_STALE
+    UNCERTAIN
 }

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteProgressState.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteProgressState.kt
@@ -1,54 +1,38 @@
 package com.mapbox.navigation.base.trip.model
 
-import com.mapbox.api.directions.v5.models.DirectionsRoute
-
 /**
  * Contains the various progress states that can occur while navigating.
  */
 enum class RouteProgressState {
 
     /**
-     * The [com.mapbox.api.directions.v5.models.DirectionsRoute] provided
-     * via [com.mapbox.navigation.core.MapboxNavigation.setRoutes]
-     * when in `Active Guidance` is not valid.
+     * We have initialized route, but haven't started route tracking yet: all [RouteProgress] fields are valid.
      */
-    ROUTE_INVALID,
+    INITIALIZED,
 
     /**
-     * The [DirectionsRoute] is valid
-     * and [com.mapbox.navigation.core.MapboxNavigation] is waiting for
-     * sufficient [android.location.Location] updates
-     * from the [com.mapbox.android.core.location.LocationEngine].
+     * We are on the route: all [RouteProgress] fields are valid.
      */
-    ROUTE_INITIALIZED,
+    TRACKING,
 
     /**
-     * The user has arrived at the destination of the given [com.mapbox.api.directions.v5.models.RouteLeg].
+     * We've approached to the end of route's leg: all [RouteProgress] fields are valid.
      */
-    ROUTE_COMPLETE,
+    COMPLETE,
 
     /**
-     * [com.mapbox.navigation.core.MapboxNavigation] is now confidently tracking the
-     * location updates and processing them against the route.
+     * We've gone of route: all [RouteProgress] fields are invalid.
      */
-    LOCATION_TRACKING,
+    OFF_ROUTE,
+
+    /**
+     * We are probably about to go off-route: all [RouteProgress] fields are valid.
+     */
+    UNCERTAIN,
 
     /**
      * A lack of [android.location.Location] updates has caused a lack of confidence in the
      * progress updates being sent.
      */
-    LOCATION_STALE,
-
-    /**
-     * State when we detect an off-route.
-     */
-    OFF_ROUTE,
-
-    /**
-     * State when we start following a route.
-     *
-     * After a certain number of tracking points, we gain confidence and switch to tracking state.
-     * We do map-matching rather than route line snapping during this state.
-     */
-    ROUTE_UNCERTAIN
+    LOCATION_STALE
 }

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/trip/model/RouteProgressTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/trip/model/RouteProgressTest.kt
@@ -23,6 +23,7 @@ class RouteProgressTest : BuilderTest<RouteProgress, RouteProgress.Builder>() {
             .fractionTraveled(101112f)
             .remainingWaypoints(131415)
             .upcomingRoadObjects(mockk(relaxed = true))
+            .stale(true)
     }
 
     @Test

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/arrival/ArrivalProgressObserver.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/arrival/ArrivalProgressObserver.kt
@@ -60,10 +60,13 @@ internal class ArrivalProgressObserver(
             }
             RouteProgressState.INITIALIZED,
             RouteProgressState.OFF_ROUTE,
-            RouteProgressState.UNCERTAIN,
-            RouteProgressState.LOCATION_STALE -> {
+            RouteProgressState.UNCERTAIN -> {
                 return
             }
+        }
+
+        if (routeProgress.stale) {
+            return
         }
 
         val arrivalOptions = arrivalController.arrivalOptions()

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/arrival/ArrivalProgressObserver.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/arrival/ArrivalProgressObserver.kt
@@ -54,14 +54,13 @@ internal class ArrivalProgressObserver(
             ?: return
 
         when (routeProgress.currentState) {
-            RouteProgressState.LOCATION_TRACKING,
-            RouteProgressState.ROUTE_COMPLETE -> {
+            RouteProgressState.TRACKING,
+            RouteProgressState.COMPLETE -> {
                 // continue
             }
-            RouteProgressState.ROUTE_INVALID,
-            RouteProgressState.ROUTE_INITIALIZED,
+            RouteProgressState.INITIALIZED,
             RouteProgressState.OFF_ROUTE,
-            RouteProgressState.ROUTE_UNCERTAIN,
+            RouteProgressState.UNCERTAIN,
             RouteProgressState.LOCATION_STALE -> {
                 return
             }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/navigator/NavigatorMapper.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/navigator/NavigatorMapper.kt
@@ -69,6 +69,9 @@ private fun NavigationStatus.getRouteProgress(
     routeBufferGeoJson: Geometry?,
     remainingWaypoints: Int
 ): RouteProgress? {
+    if (routeState == RouteState.INVALID) {
+        return null
+    }
     route?.let {
         val upcomingStepIndex = stepIndex + ONE_INDEX
 
@@ -145,7 +148,7 @@ private fun NavigationStatus.getRouteProgress(
 
                         var bannerInstructions =
                             bannerInstruction?.mapToDirectionsApi(currentStep)
-                        if (it == RouteProgressState.ROUTE_INITIALIZED) {
+                        if (it == RouteProgressState.INITIALIZED) {
                             bannerInstructions =
                                 MapboxNativeNavigatorImpl.getBannerInstruction(
                                     FIRST_BANNER_INSTRUCTION
@@ -246,12 +249,13 @@ private fun VoiceInstruction.mapToDirectionsApi(): VoiceInstructions? {
 
 private fun RouteState.convertState(): RouteProgressState {
     return when (this) {
-        RouteState.INVALID -> RouteProgressState.ROUTE_INVALID
-        RouteState.INITIALIZED -> RouteProgressState.ROUTE_INITIALIZED
-        RouteState.TRACKING -> RouteProgressState.LOCATION_TRACKING
-        RouteState.COMPLETE -> RouteProgressState.ROUTE_COMPLETE
+        RouteState.INVALID ->
+            throw IllegalArgumentException("invalid route progress state not supported")
+        RouteState.INITIALIZED -> RouteProgressState.INITIALIZED
+        RouteState.TRACKING -> RouteProgressState.TRACKING
+        RouteState.COMPLETE -> RouteProgressState.COMPLETE
         RouteState.OFF_ROUTE -> RouteProgressState.OFF_ROUTE
-        RouteState.UNCERTAIN -> RouteProgressState.ROUTE_UNCERTAIN
+        RouteState.UNCERTAIN -> RouteProgressState.UNCERTAIN
     }
 }
 

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/navigator/NavigatorMapper.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/navigator/NavigatorMapper.kt
@@ -140,11 +140,7 @@ private fun NavigationStatus.getRouteProgress(
                     )
 
                     routeState.convertState().let {
-                        if (stale) {
-                            routeProgressBuilder.currentState(RouteProgressState.LOCATION_STALE)
-                        } else {
-                            routeProgressBuilder.currentState(it)
-                        }
+                        routeProgressBuilder.currentState(it)
 
                         var bannerInstructions =
                             bannerInstruction?.mapToDirectionsApi(currentStep)
@@ -194,6 +190,8 @@ private fun NavigationStatus.getRouteProgress(
         routeProgressBuilder.voiceInstructions(voiceInstruction?.mapToDirectionsApi())
 
         routeProgressBuilder.upcomingRoadObjects(upcomingRouteAlerts.toUpcomingRoadObjects())
+
+        routeProgressBuilder.stale(stale)
 
         return routeProgressBuilder.build()
     }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/arrival/ArrivalProgressObserverTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/arrival/ArrivalProgressObserverTest.kt
@@ -36,6 +36,7 @@ class ArrivalProgressObserverTest {
     @Test
     fun `should not crash with null route progress values`() {
         val routeProgress: RouteProgress = mockk {
+            every { stale } returns false
             every { currentState } returns RouteProgressState.TRACKING
             every { route } returns mockk {
                 mockMultipleLegs()
@@ -55,6 +56,7 @@ class ArrivalProgressObserverTest {
     @Test
     fun `should do nothing when currentLegProgress is null`() {
         val routeProgress: RouteProgress = mockk {
+            every { stale } returns false
             every { currentState } returns RouteProgressState.TRACKING
             every { route } returns mockk {
                 every { currentLegProgress } returns null
@@ -70,6 +72,7 @@ class ArrivalProgressObserverTest {
     @Test
     fun `should not navigateNextRouteLeg when currentLegProgress is null`() {
         every { tripSession.getRouteProgress() } returns mockk {
+            every { stale } returns false
             every { currentState } returns RouteProgressState.TRACKING
             every { route } returns mockk {
                 mockMultipleLegs()
@@ -83,6 +86,7 @@ class ArrivalProgressObserverTest {
     @Test
     fun `should not navigateNextRouteLeg when route legs is empty`() {
         every { tripSession.getRouteProgress() } returns mockk {
+            every { stale } returns false
             every { currentState } returns RouteProgressState.TRACKING
             every { route } returns mockk {
                 every { legs() } returns emptyList()
@@ -110,6 +114,7 @@ class ArrivalProgressObserverTest {
         arrivalProgressObserver.attach(customArrivalController)
         arrivalProgressObserver.onRouteProgressChanged(
             mockk {
+                every { stale } returns false
                 every { currentState } returns RouteProgressState.COMPLETE
                 every { route } returns mockk {
                     mockMultipleLegs()
@@ -145,6 +150,7 @@ class ArrivalProgressObserverTest {
         arrivalProgressObserver.attach(customArrivalController)
         arrivalProgressObserver.onRouteProgressChanged(
             mockk {
+                every { stale } returns false
                 every { currentState } returns RouteProgressState.COMPLETE
                 every { route } returns mockk {
                     mockMultipleLegs()
@@ -179,6 +185,7 @@ class ArrivalProgressObserverTest {
             arrivalObserver.onFinalDestinationArrival(capture(onFinalDestinationArrivalCalls))
         } returns Unit
         val routeProgress: RouteProgress = mockk {
+            every { stale } returns false
             every { currentState } returns RouteProgressState.COMPLETE
             every { route } returns mockk {
                 mockMultipleLegs()
@@ -217,6 +224,7 @@ class ArrivalProgressObserverTest {
         arrivalProgressObserver.attach(customArrivalController)
         arrivalProgressObserver.onRouteProgressChanged(
             mockk {
+                every { stale } returns false
                 every { currentState } returns RouteProgressState.TRACKING
                 every { currentLegProgress } returns mockk {
                     every { routeLeg } returns mockk()
@@ -248,6 +256,7 @@ class ArrivalProgressObserverTest {
         arrivalProgressObserver.attach(customArrivalController)
         arrivalProgressObserver.onRouteProgressChanged(
             mockk {
+                every { stale } returns false
                 every { currentState } returns RouteProgressState.TRACKING
                 every { currentLegProgress } returns mockk {
                     every { durationRemaining } returns 2.0
@@ -276,6 +285,7 @@ class ArrivalProgressObserverTest {
             }
         }
         val routeProgress: RouteProgress = mockk {
+            every { stale } returns false
             every { currentState } returns RouteProgressState.TRACKING
             every { currentLegProgress } returns mockk {
                 every { routeLeg } returns mockk()
@@ -310,6 +320,7 @@ class ArrivalProgressObserverTest {
             arrivalObserver.onWaypointArrival(capture(onWaypointArrivalCalls))
         } returns Unit
         val routeProgress: RouteProgress = mockk {
+            every { stale } returns false
             every { currentState } returns RouteProgressState.TRACKING
             every { route } returns mockk {
                 mockMultipleLegs()
@@ -345,6 +356,7 @@ class ArrivalProgressObserverTest {
         arrivalProgressObserver.attach(customArrivalController)
         arrivalProgressObserver.onRouteProgressChanged(
             mockk {
+                every { stale } returns false
                 every { currentState } returns RouteProgressState.TRACKING
                 every { currentLegProgress } returns mockk {
                     every { routeLeg } returns mockk()
@@ -365,6 +377,7 @@ class ArrivalProgressObserverTest {
     fun `should navigate to next waypoint automatically using options`() {
         val testNavigateNextRouteLeg = true
         val routeProgress: RouteProgress = mockk {
+            every { stale } returns false
             every { currentState } returns RouteProgressState.TRACKING
             every { route } returns mockk {
                 mockMultipleLegs()
@@ -397,6 +410,7 @@ class ArrivalProgressObserverTest {
     fun `should not navigate to next waypoint automatically using options`() {
         val testNavigateNextRouteLeg = false
         every { tripSession.getRouteProgress() } returns mockk {
+            every { stale } returns false
             every { currentState } returns RouteProgressState.TRACKING
             every { route } returns mockk {
                 mockMultipleLegs()
@@ -424,6 +438,7 @@ class ArrivalProgressObserverTest {
     @Test
     fun `navigateNextRouteLeg should return true when route leg is updated`() {
         every { tripSession.getRouteProgress() } returns mockk {
+            every { stale } returns false
             every { currentState } returns RouteProgressState.TRACKING
             every { route } returns mockk {
                 mockMultipleLegs()
@@ -443,6 +458,7 @@ class ArrivalProgressObserverTest {
     @Test
     fun `navigateNextRouteLeg should return false when route leg is not updated`() {
         every { tripSession.getRouteProgress() } returns mockk {
+            every { stale } returns false
             every { currentState } returns RouteProgressState.TRACKING
             every { route } returns mockk {
                 mockMultipleLegs()
@@ -470,6 +486,7 @@ class ArrivalProgressObserverTest {
             arrivalObserver.onFinalDestinationArrival(capture(onFinalDestinationArrivalCalls))
         } returns Unit
         every { tripSession.getRouteProgress() } returns mockk {
+            every { stale } returns false
             every { currentState } returns RouteProgressState.TRACKING
             every { route } returns mockk {
                 mockMultipleLegs()

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/arrival/ArrivalProgressObserverTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/arrival/ArrivalProgressObserverTest.kt
@@ -36,7 +36,7 @@ class ArrivalProgressObserverTest {
     @Test
     fun `should not crash with null route progress values`() {
         val routeProgress: RouteProgress = mockk {
-            every { currentState } returns RouteProgressState.LOCATION_TRACKING
+            every { currentState } returns RouteProgressState.TRACKING
             every { route } returns mockk {
                 mockMultipleLegs()
                 every { routeIndex() } returns null
@@ -55,7 +55,7 @@ class ArrivalProgressObserverTest {
     @Test
     fun `should do nothing when currentLegProgress is null`() {
         val routeProgress: RouteProgress = mockk {
-            every { currentState } returns RouteProgressState.LOCATION_TRACKING
+            every { currentState } returns RouteProgressState.TRACKING
             every { route } returns mockk {
                 every { currentLegProgress } returns null
             }
@@ -70,7 +70,7 @@ class ArrivalProgressObserverTest {
     @Test
     fun `should not navigateNextRouteLeg when currentLegProgress is null`() {
         every { tripSession.getRouteProgress() } returns mockk {
-            every { currentState } returns RouteProgressState.LOCATION_TRACKING
+            every { currentState } returns RouteProgressState.TRACKING
             every { route } returns mockk {
                 mockMultipleLegs()
                 every { currentLegProgress } returns null
@@ -83,7 +83,7 @@ class ArrivalProgressObserverTest {
     @Test
     fun `should not navigateNextRouteLeg when route legs is empty`() {
         every { tripSession.getRouteProgress() } returns mockk {
-            every { currentState } returns RouteProgressState.LOCATION_TRACKING
+            every { currentState } returns RouteProgressState.TRACKING
             every { route } returns mockk {
                 every { legs() } returns emptyList()
                 every { currentLegProgress } returns mockk {
@@ -110,7 +110,7 @@ class ArrivalProgressObserverTest {
         arrivalProgressObserver.attach(customArrivalController)
         arrivalProgressObserver.onRouteProgressChanged(
             mockk {
-                every { currentState } returns RouteProgressState.ROUTE_COMPLETE
+                every { currentState } returns RouteProgressState.COMPLETE
                 every { route } returns mockk {
                     mockMultipleLegs()
                 }
@@ -145,7 +145,7 @@ class ArrivalProgressObserverTest {
         arrivalProgressObserver.attach(customArrivalController)
         arrivalProgressObserver.onRouteProgressChanged(
             mockk {
-                every { currentState } returns RouteProgressState.ROUTE_COMPLETE
+                every { currentState } returns RouteProgressState.COMPLETE
                 every { route } returns mockk {
                     mockMultipleLegs()
                     every { durationRemaining } returns 2.0
@@ -179,7 +179,7 @@ class ArrivalProgressObserverTest {
             arrivalObserver.onFinalDestinationArrival(capture(onFinalDestinationArrivalCalls))
         } returns Unit
         val routeProgress: RouteProgress = mockk {
-            every { currentState } returns RouteProgressState.ROUTE_COMPLETE
+            every { currentState } returns RouteProgressState.COMPLETE
             every { route } returns mockk {
                 mockMultipleLegs()
                 every { durationRemaining } returns 2.0
@@ -217,7 +217,7 @@ class ArrivalProgressObserverTest {
         arrivalProgressObserver.attach(customArrivalController)
         arrivalProgressObserver.onRouteProgressChanged(
             mockk {
-                every { currentState } returns RouteProgressState.LOCATION_TRACKING
+                every { currentState } returns RouteProgressState.TRACKING
                 every { currentLegProgress } returns mockk {
                     every { routeLeg } returns mockk()
                     every { durationRemaining } returns 1.0
@@ -248,7 +248,7 @@ class ArrivalProgressObserverTest {
         arrivalProgressObserver.attach(customArrivalController)
         arrivalProgressObserver.onRouteProgressChanged(
             mockk {
-                every { currentState } returns RouteProgressState.LOCATION_TRACKING
+                every { currentState } returns RouteProgressState.TRACKING
                 every { currentLegProgress } returns mockk {
                     every { durationRemaining } returns 2.0
                     every { distanceRemaining } returns 8.0f
@@ -276,7 +276,7 @@ class ArrivalProgressObserverTest {
             }
         }
         val routeProgress: RouteProgress = mockk {
-            every { currentState } returns RouteProgressState.LOCATION_TRACKING
+            every { currentState } returns RouteProgressState.TRACKING
             every { currentLegProgress } returns mockk {
                 every { routeLeg } returns mockk()
                 every { durationRemaining } returns 1.0
@@ -310,7 +310,7 @@ class ArrivalProgressObserverTest {
             arrivalObserver.onWaypointArrival(capture(onWaypointArrivalCalls))
         } returns Unit
         val routeProgress: RouteProgress = mockk {
-            every { currentState } returns RouteProgressState.LOCATION_TRACKING
+            every { currentState } returns RouteProgressState.TRACKING
             every { route } returns mockk {
                 mockMultipleLegs()
             }
@@ -345,7 +345,7 @@ class ArrivalProgressObserverTest {
         arrivalProgressObserver.attach(customArrivalController)
         arrivalProgressObserver.onRouteProgressChanged(
             mockk {
-                every { currentState } returns RouteProgressState.LOCATION_TRACKING
+                every { currentState } returns RouteProgressState.TRACKING
                 every { currentLegProgress } returns mockk {
                     every { routeLeg } returns mockk()
                     every { durationRemaining } returns 360.0
@@ -365,7 +365,7 @@ class ArrivalProgressObserverTest {
     fun `should navigate to next waypoint automatically using options`() {
         val testNavigateNextRouteLeg = true
         val routeProgress: RouteProgress = mockk {
-            every { currentState } returns RouteProgressState.LOCATION_TRACKING
+            every { currentState } returns RouteProgressState.TRACKING
             every { route } returns mockk {
                 mockMultipleLegs()
                 every { routeIndex() } returns "0"
@@ -397,7 +397,7 @@ class ArrivalProgressObserverTest {
     fun `should not navigate to next waypoint automatically using options`() {
         val testNavigateNextRouteLeg = false
         every { tripSession.getRouteProgress() } returns mockk {
-            every { currentState } returns RouteProgressState.LOCATION_TRACKING
+            every { currentState } returns RouteProgressState.TRACKING
             every { route } returns mockk {
                 mockMultipleLegs()
                 every { routeIndex() } returns "0"
@@ -424,7 +424,7 @@ class ArrivalProgressObserverTest {
     @Test
     fun `navigateNextRouteLeg should return true when route leg is updated`() {
         every { tripSession.getRouteProgress() } returns mockk {
-            every { currentState } returns RouteProgressState.LOCATION_TRACKING
+            every { currentState } returns RouteProgressState.TRACKING
             every { route } returns mockk {
                 mockMultipleLegs()
                 every { routeIndex() } returns "0"
@@ -443,7 +443,7 @@ class ArrivalProgressObserverTest {
     @Test
     fun `navigateNextRouteLeg should return false when route leg is not updated`() {
         every { tripSession.getRouteProgress() } returns mockk {
-            every { currentState } returns RouteProgressState.LOCATION_TRACKING
+            every { currentState } returns RouteProgressState.TRACKING
             every { route } returns mockk {
                 mockMultipleLegs()
                 every { routeIndex() } returns "0"
@@ -470,7 +470,7 @@ class ArrivalProgressObserverTest {
             arrivalObserver.onFinalDestinationArrival(capture(onFinalDestinationArrivalCalls))
         } returns Unit
         every { tripSession.getRouteProgress() } returns mockk {
-            every { currentState } returns RouteProgressState.LOCATION_TRACKING
+            every { currentState } returns RouteProgressState.TRACKING
             every { route } returns mockk {
                 mockMultipleLegs()
                 every { routeIndex() } returns "0"

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/arrival/RouteStateObserverParametrizedTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/arrival/RouteStateObserverParametrizedTest.kt
@@ -27,13 +27,12 @@ class RouteStateObserverParametrizedTest(
         @JvmStatic
         @Parameterized.Parameters(name = "{0}")
         fun data() = listOf(
-            arrayOf(RouteProgressState.ROUTE_INVALID, false, false),
-            arrayOf(RouteProgressState.ROUTE_UNCERTAIN, false, false),
+            arrayOf(RouteProgressState.UNCERTAIN, false, false),
             arrayOf(RouteProgressState.OFF_ROUTE, false, false),
-            arrayOf(RouteProgressState.ROUTE_INITIALIZED, false, false),
+            arrayOf(RouteProgressState.INITIALIZED, false, false),
             arrayOf(RouteProgressState.LOCATION_STALE, false, false),
-            arrayOf(RouteProgressState.ROUTE_COMPLETE, true, true),
-            arrayOf(RouteProgressState.LOCATION_TRACKING, true, true)
+            arrayOf(RouteProgressState.COMPLETE, true, true),
+            arrayOf(RouteProgressState.TRACKING, true, true)
         )
     }
 

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/arrival/RouteStateObserverParametrizedTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/arrival/RouteStateObserverParametrizedTest.kt
@@ -18,6 +18,7 @@ import org.junit.runners.Parameterized
 @RunWith(Parameterized::class)
 class RouteStateObserverParametrizedTest(
     private val routeProgressState: RouteProgressState,
+    private val isStale: Boolean,
     private val nextLegStart: Boolean,
     private val finalDestinationArrival: Boolean
 ) {
@@ -27,12 +28,42 @@ class RouteStateObserverParametrizedTest(
         @JvmStatic
         @Parameterized.Parameters(name = "{0}")
         fun data() = listOf(
-            arrayOf(RouteProgressState.UNCERTAIN, false, false),
-            arrayOf(RouteProgressState.OFF_ROUTE, false, false),
-            arrayOf(RouteProgressState.INITIALIZED, false, false),
-            arrayOf(RouteProgressState.LOCATION_STALE, false, false),
-            arrayOf(RouteProgressState.COMPLETE, true, true),
-            arrayOf(RouteProgressState.TRACKING, true, true)
+            arrayOf(
+                /*routeProgressState*/ RouteProgressState.UNCERTAIN,
+                /*isStale*/ false,
+                /*nextLegStart*/ false,
+                /*finalDestinationArrival*/ false
+            ),
+            arrayOf(
+                /*routeProgressState*/ RouteProgressState.OFF_ROUTE,
+                /*isStale*/ false,
+                /*nextLegStart*/ false,
+                /*finalDestinationArrival*/ false
+            ),
+            arrayOf(
+                /*routeProgressState*/ RouteProgressState.INITIALIZED,
+                /*isStale*/ false,
+                /*nextLegStart*/ false,
+                /*finalDestinationArrival*/ false
+            ),
+            arrayOf(
+                /*routeProgressState*/ RouteProgressState.COMPLETE,
+                /*isStale*/ true,
+                /*nextLegStart*/ false,
+                /*finalDestinationArrival*/ false
+            ),
+            arrayOf(
+                /*routeProgressState*/ RouteProgressState.COMPLETE,
+                /*isStale*/ false,
+                /*nextLegStart*/ true,
+                /*finalDestinationArrival*/ true
+            ),
+            arrayOf(
+                /*routeProgressState*/ RouteProgressState.TRACKING,
+                /*isStale*/ false,
+                /*nextLegStart*/ true,
+                /*finalDestinationArrival*/ true
+            )
         )
     }
 
@@ -66,6 +97,7 @@ class RouteStateObserverParametrizedTest(
         arrivalProgressObserver.onRouteProgressChanged(
             mockk {
                 every { currentState } returns routeProgressState
+                every { stale } returns isStale
                 every { route } returns mockk {
                     mockMultipleLegs()
                 }
@@ -101,6 +133,7 @@ class RouteStateObserverParametrizedTest(
         arrivalProgressObserver.onRouteProgressChanged(
             mockk {
                 every { currentState } returns routeProgressState
+                every { stale } returns isStale
                 every { route } returns mockk {
                     mockMultipleLegs()
                     every { durationRemaining } returns 2.0

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/navigator/NavigatorMapperTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/navigator/NavigatorMapperTest.kt
@@ -6,7 +6,6 @@ import com.mapbox.geojson.Geometry
 import com.mapbox.geojson.Point
 import com.mapbox.geojson.utils.PolylineUtils
 import com.mapbox.navigation.base.speed.model.SpeedLimit
-import com.mapbox.navigation.base.trip.model.RouteProgressState
 import com.mapbox.navigation.base.trip.model.RouteStepProgress
 import com.mapbox.navigation.base.trip.model.roadobject.RoadObjectType
 import com.mapbox.navigation.core.trip.session.MapMatcherResult
@@ -26,8 +25,10 @@ import com.mapbox.navigator.UpcomingRouteAlert
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class NavigatorMapperTest {
@@ -262,7 +263,7 @@ class NavigatorMapperTest {
     }
 
     @Test
-    fun `route progress state location stale`() {
+    fun `route progress state stale`() {
         every { navigationStatus.stale } returns true
         val routeProgress = getRouteProgressFrom(
             directionsRoute,
@@ -271,7 +272,20 @@ class NavigatorMapperTest {
             mockk(relaxed = true)
         )
 
-        assertEquals(RouteProgressState.LOCATION_STALE, routeProgress!!.currentState)
+        assertTrue(routeProgress!!.stale)
+    }
+
+    @Test
+    fun `route progress state not stale`() {
+        every { navigationStatus.stale } returns false
+        val routeProgress = getRouteProgressFrom(
+            directionsRoute,
+            null,
+            navigationStatus,
+            mockk(relaxed = true)
+        )
+
+        assertFalse(routeProgress!!.stale)
     }
 
     @Test

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/navigator/NavigatorMapperTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/navigator/NavigatorMapperTest.kt
@@ -221,10 +221,26 @@ class NavigatorMapperTest {
 
     @Test
     fun `route progress is null when route is null`() {
-        val navigationStatus: NavigationStatus = mockk()
+        val navigationStatus: NavigationStatus = mockk {
+            every { routeState } returns RouteState.TRACKING
+        }
 
         val routeProgress = getRouteProgressFrom(
             null,
+            null,
+            navigationStatus,
+            mockk(relaxed = true)
+        )
+
+        assertNull(routeProgress)
+    }
+
+    @Test
+    fun `route progress is null when status is invalid`() {
+        every { navigationStatus.routeState } returns RouteState.INVALID
+
+        val routeProgress = getRouteProgressFrom(
+            directionsRoute,
             null,
             navigationStatus,
             mockk(relaxed = true)

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetryTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetryTest.kt
@@ -19,7 +19,7 @@ import com.mapbox.navigation.base.metrics.MetricEvent
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.trip.model.RouteLegProgress
 import com.mapbox.navigation.base.trip.model.RouteProgress
-import com.mapbox.navigation.base.trip.model.RouteProgressState.LOCATION_TRACKING
+import com.mapbox.navigation.base.trip.model.RouteProgressState.TRACKING
 import com.mapbox.navigation.base.trip.model.RouteStepProgress
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.NavigationSession
@@ -1003,7 +1003,7 @@ class MapboxNavigationTelemetryTest {
 
     private fun mockRouteProgress() {
         every { routeProgress.route } returns originalRoute
-        every { routeProgress.currentState } returns LOCATION_TRACKING
+        every { routeProgress.currentState } returns TRACKING
         every { routeProgress.currentLegProgress } returns legProgress
         every { routeProgress.distanceRemaining } returns ROUTE_PROGRESS_DISTANCE_REMAINING
         every { routeProgress.durationRemaining } returns ROUTE_PROGRESS_DURATION_REMAINING

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/VanishingRouteLine.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/VanishingRouteLine.kt
@@ -95,8 +95,8 @@ internal class VanishingRouteLine {
      */
     fun updateVanishingPointState(routeProgressState: RouteProgressState) {
         vanishingPointState = when (routeProgressState) {
-            RouteProgressState.LOCATION_TRACKING -> VanishingPointState.ENABLED
-            RouteProgressState.ROUTE_COMPLETE -> VanishingPointState.ONLY_INCREASE_PROGRESS
+            RouteProgressState.TRACKING -> VanishingPointState.ENABLED
+            RouteProgressState.COMPLETE -> VanishingPointState.ONLY_INCREASE_PROGRESS
             else -> VanishingPointState.DISABLED
         }
     }

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/arrow/api/MapboxRouteArrowApiTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/arrow/api/MapboxRouteArrowApiTest.kt
@@ -49,7 +49,7 @@ class MapboxRouteArrowApiTest {
                     every { stepIndex } returns 2
                 }
             }
-            every { currentState } returns RouteProgressState.LOCATION_TRACKING
+            every { currentState } returns RouteProgressState.TRACKING
             every { upcomingStepPoints } returns upcomingPoints
         }
 
@@ -360,7 +360,7 @@ class MapboxRouteArrowApiTest {
                     every { stepIndex } returns 2
                 }
             }
-            every { currentState } returns RouteProgressState.LOCATION_TRACKING
+            every { currentState } returns RouteProgressState.TRACKING
             every { upcomingStepPoints } returns upcomingPoints
         }
         val api = MapboxRouteArrowApi()

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApiTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApiTest.kt
@@ -495,7 +495,7 @@ class MapboxRouteLineApiTest {
             }
         }
 
-        api.updateVanishingPointState(RouteProgressState.LOCATION_TRACKING)
+        api.updateVanishingPointState(RouteProgressState.TRACKING)
         api.setRoutes(listOf(RouteLine(route, null)))
         api.updateUpcomingRoutePointIndex(routeProgress)
 
@@ -536,7 +536,7 @@ class MapboxRouteLineApiTest {
                 }
             }
         }
-        api.updateVanishingPointState(RouteProgressState.LOCATION_TRACKING)
+        api.updateVanishingPointState(RouteProgressState.TRACKING)
         api.setRoutes(listOf(RouteLine(route, null)))
 
         api.updateUpcomingRoutePointIndex(routeProgress)
@@ -574,7 +574,7 @@ class MapboxRouteLineApiTest {
                     }
                 }
             }
-            api.updateVanishingPointState(RouteProgressState.LOCATION_TRACKING)
+            api.updateVanishingPointState(RouteProgressState.TRACKING)
             api.setRoutes(listOf(RouteLine(route, null)))
 
             api.updateUpcomingRoutePointIndex(routeProgress)
@@ -602,7 +602,7 @@ class MapboxRouteLineApiTest {
                     every { currentStepProgress } returns null
                 }
             }
-            api.updateVanishingPointState(RouteProgressState.LOCATION_TRACKING)
+            api.updateVanishingPointState(RouteProgressState.TRACKING)
             api.setRoutes(listOf(RouteLine(route, null)))
 
             api.updateUpcomingRoutePointIndex(routeProgress)
@@ -627,7 +627,7 @@ class MapboxRouteLineApiTest {
             val routeProgress = mockk<RouteProgress> {
                 every { currentLegProgress } returns null
             }
-            api.updateVanishingPointState(RouteProgressState.LOCATION_TRACKING)
+            api.updateVanishingPointState(RouteProgressState.TRACKING)
             api.setRoutes(listOf(RouteLine(route, null)))
 
             api.updateUpcomingRoutePointIndex(routeProgress)
@@ -663,16 +663,16 @@ class MapboxRouteLineApiTest {
                     every { stepIndex } returns 2
                 }
             }
-            every { currentState } returns RouteProgressState.LOCATION_TRACKING
+            every { currentState } returns RouteProgressState.TRACKING
         }
-        api.updateVanishingPointState(RouteProgressState.LOCATION_TRACKING)
+        api.updateVanishingPointState(RouteProgressState.TRACKING)
         api.setRoutes(listOf(RouteLine(route, null)))
 
         api.updateWithRouteProgress(routeProgress)
 
         verify { mockVanishingRouteLine.primaryRouteRemainingDistancesIndex = null }
         verify {
-            mockVanishingRouteLine.updateVanishingPointState(RouteProgressState.LOCATION_TRACKING)
+            mockVanishingRouteLine.updateVanishingPointState(RouteProgressState.TRACKING)
         }
     }
 
@@ -696,7 +696,7 @@ class MapboxRouteLineApiTest {
         val route = getRoute()
         val api = MapboxRouteLineApi(options)
 
-        api.updateVanishingPointState(RouteProgressState.LOCATION_TRACKING)
+        api.updateVanishingPointState(RouteProgressState.TRACKING)
         api.setRoutes(listOf(RouteLine(route, null)))
 
         val result = api.updateTraveledRouteLine(Point.fromLngLat(-122.4727051, 37.7577627))
@@ -711,7 +711,7 @@ class MapboxRouteLineApiTest {
             .build()
 
         MapboxRouteLineApi(options).updateVanishingPointState(
-            RouteProgressState.LOCATION_TRACKING
+            RouteProgressState.TRACKING
         )
 
         assertEquals(

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/VanishingRouteLineTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/VanishingRouteLineTest.kt
@@ -97,7 +97,7 @@ class VanishingRouteLineTest {
     @Test
     fun updateVanishingPointState_when_LOCATION_TRACKING() {
         val vanishingRouteLine = VanishingRouteLine().also {
-            it.updateVanishingPointState(RouteProgressState.LOCATION_TRACKING)
+            it.updateVanishingPointState(RouteProgressState.TRACKING)
         }
 
         assertEquals(VanishingPointState.ENABLED, vanishingRouteLine.vanishingPointState)
@@ -106,7 +106,7 @@ class VanishingRouteLineTest {
     @Test
     fun updateVanishingPointState_when_ROUTE_COMPLETE() {
         val vanishingRouteLine = VanishingRouteLine().also {
-            it.updateVanishingPointState(RouteProgressState.ROUTE_COMPLETE)
+            it.updateVanishingPointState(RouteProgressState.COMPLETE)
         }
 
         assertEquals(

--- a/libnavui-tripprogress/src/main/java/com/mapbox/navigation/ui/tripprogress/TripProgressProcessor.kt
+++ b/libnavui-tripprogress/src/main/java/com/mapbox/navigation/ui/tripprogress/TripProgressProcessor.kt
@@ -13,7 +13,7 @@ internal class TripProgressProcessor {
     private fun calculateTripProgress(
         action: TripProgressAction.CalculateTripProgress
     ): TripProgressResult.RouteProgressCalculation {
-        val eta = if (action.routeProgress.currentState == RouteProgressState.ROUTE_COMPLETE) {
+        val eta = if (action.routeProgress.currentState == RouteProgressState.COMPLETE) {
             Calendar.getInstance()
         } else {
             Calendar.getInstance().also {
@@ -23,7 +23,7 @@ internal class TripProgressProcessor {
         val percentRouteTraveled = getPercentDistanceTraveled(action.routeProgress)
 
         return when (action.routeProgress.currentState) {
-            RouteProgressState.ROUTE_COMPLETE -> TripProgressResult.RouteProgressCalculation(
+            RouteProgressState.COMPLETE -> TripProgressResult.RouteProgressCalculation(
                 Calendar.getInstance().timeInMillis,
                 0.0,
                 0.0,

--- a/libnavui-tripprogress/src/test/java/com/mapbox/navigation/ui/tripprogress/TripProgressProcessorTest.kt
+++ b/libnavui-tripprogress/src/test/java/com/mapbox/navigation/ui/tripprogress/TripProgressProcessorTest.kt
@@ -21,7 +21,7 @@ class TripProgressProcessorTest {
             }
             every { distanceTraveled } returns 50f
             every { route } returns mockk {
-                every { currentState } returns RouteProgressState.LOCATION_TRACKING
+                every { currentState } returns RouteProgressState.TRACKING
             }
         }
         val expectedEta = Calendar.getInstance().also {

--- a/libnavui-tripprogress/src/test/java/com/mapbox/navigation/ui/tripprogress/api/MapboxTripProgressApiTest.kt
+++ b/libnavui-tripprogress/src/test/java/com/mapbox/navigation/ui/tripprogress/api/MapboxTripProgressApiTest.kt
@@ -28,7 +28,7 @@ class MapboxTripProgressApiTest {
             }
             every { distanceTraveled } returns 50f
             every { route } returns mockk<DirectionsRoute> {
-                every { currentState } returns RouteProgressState.LOCATION_TRACKING
+                every { currentState } returns RouteProgressState.TRACKING
             }
         }
 


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

We already aren't reporting any route progress state when there's no route object, so we also shouldn't report any route progress for other calculation failures - missing route being one of them but also missing location updates, etc.

@mapbox/navnative is there any scenario where we would actually like to deliver `RouteState#INVALID` to developers that we are missing?

This closes https://github.com/mapbox/mapbox-navigation-android/issues/4379 by not emitting a `ROUTE_INVALID` state which defaults to
```
distanceRemaining == 0
durationRemaining == 0
```
https://github.com/mapbox/mapbox-navigation-android/blob/bc1dce0cb8cba9ea8c8efc40bd8d65d5350a9d23/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteProgress.kt#L160-L162

and was triggering arrival observer: https://github.com/mapbox/mapbox-navigation-android/blob/bc1dce0cb8cba9ea8c8efc40bd8d65d5350a9d23/libnavigation-core/src/main/java/com/mapbox/navigation/core/arrival/ArrivalProgressObserver.kt#L98-L109

We were ending up emitting the `ROUTE_INVALID` because the status updater was started by https://github.com/mapbox/mapbox-navigation-android/blob/bc1dce0cb8cba9ea8c8efc40bd8d65d5350a9d23/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt#L100

before there were any location updates available.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Removed `RouteProgressState.ROUTE_INVALID`. `RouteProgress` will never be delivered with an invalid update, besides `RouteProgressState.OFF_ROUTE`.</changelog>
<changelog>Removed the `ROUTE_` prefix from `RouteProgressState` values and updated the documentation.</changelog>
<changelog>Moved the `RouteProgressState.LOCATION_STALE` to `RouteProgress.stale`.</changelog>
```

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
