### PR TITLE
check route state before triggering arrival

### DIFF
--- a/gradle/jacoco.gradle
+++ b/gradle/jacoco.gradle
@@ -5,5 +5,6 @@ jacoco {
 }
 
 tasks.withType(Test) {
+  // needed to capture coverage from Robolectric tests
   jacoco.includeNoLocationClasses = true
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/arrival/ArrivalObserver.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/arrival/ArrivalObserver.kt
@@ -2,6 +2,7 @@ package com.mapbox.navigation.core.arrival
 
 import com.mapbox.navigation.base.trip.model.RouteLegProgress
 import com.mapbox.navigation.base.trip.model.RouteProgress
+import com.mapbox.navigation.base.trip.model.RouteProgressState
 import com.mapbox.navigation.core.MapboxNavigation
 
 /**
@@ -13,6 +14,9 @@ interface ArrivalObserver {
     /**
      * Called once the [ArrivalOptions] conditions have been met
      * and the route progress has reached a waypoint on the route.
+     *
+     * [RouteProgress.currentState] has to be one of [RouteProgressState.LOCATION_TRACKING] or [RouteProgressState.ROUTE_COMPLETE]
+     * to trigger this event.
      */
     fun onWaypointArrival(routeProgress: RouteProgress)
 
@@ -25,6 +29,9 @@ interface ArrivalObserver {
     /**
      * Called once the [ArrivalOptions] conditions have been met
      * and the route progress has reached the final destination on the route.
+     *
+     * [RouteProgress.currentState] has to be one of [RouteProgressState.LOCATION_TRACKING] or [RouteProgressState.ROUTE_COMPLETE]
+     * to trigger this event.
      */
     fun onFinalDestinationArrival(routeProgress: RouteProgress)
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/arrival/ArrivalProgressObserver.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/arrival/ArrivalProgressObserver.kt
@@ -4,6 +4,7 @@ import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.RouteLeg
 import com.mapbox.navigation.base.trip.model.RouteLegProgress
 import com.mapbox.navigation.base.trip.model.RouteProgress
+import com.mapbox.navigation.base.trip.model.RouteProgressState
 import com.mapbox.navigation.core.trip.session.RouteProgressObserver
 import com.mapbox.navigation.core.trip.session.TripSession
 import java.util.concurrent.CopyOnWriteArraySet
@@ -51,6 +52,20 @@ internal class ArrivalProgressObserver(
     override fun onRouteProgressChanged(routeProgress: RouteProgress) {
         val routeLegProgress = routeProgress.currentLegProgress
             ?: return
+
+        when (routeProgress.currentState) {
+            RouteProgressState.LOCATION_TRACKING,
+            RouteProgressState.ROUTE_COMPLETE -> {
+                // continue
+            }
+            RouteProgressState.ROUTE_INVALID,
+            RouteProgressState.ROUTE_INITIALIZED,
+            RouteProgressState.OFF_ROUTE,
+            RouteProgressState.ROUTE_UNCERTAIN,
+            RouteProgressState.LOCATION_STALE -> {
+                return
+            }
+        }
 
         val arrivalOptions = arrivalController.arrivalOptions()
         val hasMoreLegs = hasMoreLegs(routeProgress)

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/arrival/ArrivalProgressObserverTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/arrival/ArrivalProgressObserverTest.kt
@@ -17,7 +17,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
-internal class ArrivalProgressObserverTest {
+class ArrivalProgressObserverTest {
 
     private val tripSession: TripSession = mockk()
     private val arrivalObserver: ArrivalObserver = mockk {

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/arrival/RouteStateObserverParametrizedTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/arrival/RouteStateObserverParametrizedTest.kt
@@ -1,0 +1,138 @@
+package com.mapbox.navigation.core.arrival
+
+import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.geojson.Point
+import com.mapbox.navigation.base.trip.model.RouteLegProgress
+import com.mapbox.navigation.base.trip.model.RouteProgress
+import com.mapbox.navigation.base.trip.model.RouteProgressState
+import com.mapbox.navigation.core.trip.session.TripSession
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+class RouteStateObserverParametrizedTest(
+    private val routeProgressState: RouteProgressState,
+    private val nextLegStart: Boolean,
+    private val finalDestinationArrival: Boolean
+) {
+
+    companion object {
+
+        @JvmStatic
+        @Parameterized.Parameters(name = "{0}")
+        fun data() = listOf(
+            arrayOf(RouteProgressState.ROUTE_INVALID, false, false),
+            arrayOf(RouteProgressState.ROUTE_UNCERTAIN, false, false),
+            arrayOf(RouteProgressState.OFF_ROUTE, false, false),
+            arrayOf(RouteProgressState.ROUTE_INITIALIZED, false, false),
+            arrayOf(RouteProgressState.LOCATION_STALE, false, false),
+            arrayOf(RouteProgressState.ROUTE_COMPLETE, true, true),
+            arrayOf(RouteProgressState.LOCATION_TRACKING, true, true)
+        )
+    }
+
+    private val tripSession: TripSession = mockk()
+    private val arrivalObserver: ArrivalObserver = mockk {
+        every { onWaypointArrival(any()) } returns Unit
+        every { onNextRouteLegStart(any()) } returns Unit
+        every { onFinalDestinationArrival(any()) } returns Unit
+    }
+    private val arrivalProgressObserver = ArrivalProgressObserver(tripSession)
+
+    @Before
+    fun setup() {
+        every { tripSession.getRouteProgress() } returns null
+        arrivalProgressObserver.registerObserver(arrivalObserver)
+    }
+
+    @Test
+    fun `next leg start triggered`() {
+        val onNextRouteLegStartCalls = slot<RouteLegProgress>()
+        val onFinalDestinationArrivalCalls = slot<RouteProgress>()
+        val customArrivalController: ArrivalController = mockk {
+            every { navigateNextRouteLeg(capture(onNextRouteLegStartCalls)) } returns false
+            every { arrivalOptions() } returns mockk {
+                every { arrivalInSeconds } returns null
+                every { arrivalInMeters } returns 10.0
+            }
+        }
+
+        arrivalProgressObserver.attach(customArrivalController)
+        arrivalProgressObserver.onRouteProgressChanged(
+            mockk {
+                every { currentState } returns routeProgressState
+                every { route } returns mockk {
+                    mockMultipleLegs()
+                }
+                every { currentLegProgress } returns mockk {
+                    every { routeLeg } returns mockk()
+                    every { legIndex } returns 1
+                    every { durationRemaining } returns 2.0
+                    every { distanceRemaining } returns 8.0f
+                }
+            }
+        )
+
+        Assert.assertEquals(nextLegStart, onNextRouteLegStartCalls.isCaptured)
+        Assert.assertFalse(onFinalDestinationArrivalCalls.isCaptured)
+    }
+
+    @Test
+    fun `final destination arrival triggered`() {
+        val onNextRouteLegStartCalls = slot<RouteLegProgress>()
+        val onFinalDestinationArrivalCalls = slot<RouteProgress>()
+        val customArrivalController: ArrivalController = mockk {
+            every { navigateNextRouteLeg(capture(onNextRouteLegStartCalls)) } returns false
+            every { arrivalOptions() } returns mockk {
+                every { arrivalInSeconds } returns null
+                every { arrivalInMeters } returns 10.0
+            }
+        }
+        every {
+            arrivalObserver.onFinalDestinationArrival(capture(onFinalDestinationArrivalCalls))
+        } returns Unit
+
+        arrivalProgressObserver.attach(customArrivalController)
+        arrivalProgressObserver.onRouteProgressChanged(
+            mockk {
+                every { currentState } returns routeProgressState
+                every { route } returns mockk {
+                    mockMultipleLegs()
+                    every { durationRemaining } returns 2.0
+                    every { distanceRemaining } returns 8.0f
+                }
+                every { currentLegProgress } returns mockk {
+                    every { routeLeg } returns mockk()
+                    every { legIndex } returns 2
+                    every { durationRemaining } returns 2.0
+                    every { distanceRemaining } returns 8.0f
+                }
+            }
+        )
+
+        Assert.assertFalse(onNextRouteLegStartCalls.isCaptured)
+        Assert.assertEquals(finalDestinationArrival, onFinalDestinationArrivalCalls.isCaptured)
+    }
+
+    private fun DirectionsRoute.mockMultipleLegs() {
+        every { routeOptions() } returns mockk {
+            every { coordinates() } returns listOf(
+                Point.fromLngLat(-122.444359, 37.736351),
+                Point.fromLngLat(-122.444481, 37.735916),
+                Point.fromLngLat(-122.444275, 37.735595),
+                Point.fromLngLat(-122.444375, 37.736141)
+            )
+        }
+        every { legs() } returns listOf(
+            mockk(),
+            mockk(),
+            mockk() // This route has three legs
+        )
+    }
+}


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Refs https://github.com/mapbox/mapbox-navigation-android/issues/4379 and builds on top of https://github.com/mapbox/mapbox-navigation-android/pull/4391. This makes sure to only trigger arrival events when `RouteProgressState` is `ROUTE_COMPLETE` or `LOCATION_TRACKING` to avoid cases where we are uncertain/stale/rerouting but still reporting arrival.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Hardened arrival events to trigger only when `RouteProgressState` is `ROUTE_COMPLETE` or `LOCATION_TRACKING` to avoid cases where we are uncertain/stale/rerouting but still reporting arrival.</changelog>
```