### PR TITLE
updated telemetry to 7.0.1 and location core to 4.0.1

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -218,12 +218,6 @@ License: [BSD](https://opensource.org/licenses/BSD-2-Clause)
 
 ===========================================================================
 
-Mapbox Navigation uses portions of the Mapbox Android Core Library.
-URL: [https://github.com/mapbox/mapbox-events-android](https://github.com/mapbox/mapbox-events-android)
-License: [The MIT License](https://opensource.org/licenses/MIT)
-
-===========================================================================
-
 Mapbox Navigation uses portions of the Mapbox Annotations (Artifact that provides Mapbox module and plugin annotations).
 URL: [https://github.com/mapbox/mapbox-base-android](https://github.com/mapbox/mapbox-base-android)
 License: [BSD](https://opensource.org/licenses/BSD-2-Clause)
@@ -256,6 +250,11 @@ License: [BSD](https://opensource.org/licenses/BSD-2-Clause)
 
 Mapbox Navigation uses portions of the Mapbox Navigation Native (Common multi-platform navigation logic).
 URL: [https://github.com/mapbox/mapbox-navigation-native](https://github.com/mapbox/mapbox-navigation-native)
+License: [Mapbox Terms of Service](https://www.mapbox.com/tos)
+
+===========================================================================
+
+Mapbox Navigation uses portions of the mapbox-android-core.
 License: [Mapbox Terms of Service](https://www.mapbox.com/tos)
 
 ===========================================================================
@@ -568,9 +567,8 @@ License: [The Apache Software License, Version 2.0](https://www.apache.org/licen
 
 ===========================================================================
 
-Mapbox Navigation uses portions of the Mapbox Android Telemetry Library.
-URL: [https://github.com/mapbox/mapbox-events-android](https://github.com/mapbox/mapbox-events-android)
-License: [The MIT License](https://opensource.org/licenses/MIT)
+Mapbox Navigation uses portions of the mapbox-android-telemetry.
+License: [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -18,8 +18,8 @@ ext {
   version = [
       mapboxMapSdk              : '10.0.0-beta.19',
       mapboxSdkServices         : '5.9.0-alpha.5',
-      mapboxEvents              : '6.2.2',
-      mapboxCore                : '3.1.1',
+      mapboxEvents              : '7.0.1',
+      mapboxCore                : '4.0.1',
       mapboxNavigator           : "${mapboxNavigatorVersion}",
       mapboxCommonNative        : '11.0.2',
       mapboxCrashMonitor        : '2.0.0',


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
One of the changes coming in with the upgrade is a change to the fused location engine to not push duplicate location samples - https://github.com/mapbox/mapbox-events-android/pull/520.