### PR TITLE
Add TileStore param to RoutingTilesOptions

### DIFF
--- a/libnavigation-base/api/current.txt
+++ b/libnavigation-base/api/current.txt
@@ -252,6 +252,7 @@ package com.mapbox.navigation.base.options {
   public final class RoutingTilesOptions {
     method public String? getFilePath();
     method public int getMinDaysBetweenServerAndLocalTilesVersion();
+    method public com.mapbox.common.TileStore getTileStore();
     method public java.net.URI getTilesBaseUri();
     method public String getTilesDataset();
     method public String getTilesProfile();
@@ -259,6 +260,7 @@ package com.mapbox.navigation.base.options {
     method public com.mapbox.navigation.base.options.RoutingTilesOptions.Builder toBuilder();
     property public final String? filePath;
     property public final int minDaysBetweenServerAndLocalTilesVersion;
+    property public final com.mapbox.common.TileStore tileStore;
     property public final java.net.URI tilesBaseUri;
     property public final String tilesDataset;
     property public final String tilesProfile;
@@ -270,6 +272,7 @@ package com.mapbox.navigation.base.options {
     method public com.mapbox.navigation.base.options.RoutingTilesOptions build();
     method public com.mapbox.navigation.base.options.RoutingTilesOptions.Builder filePath(String? filePath);
     method public com.mapbox.navigation.base.options.RoutingTilesOptions.Builder minDaysBetweenServerAndLocalTilesVersion(int minDaysBetweenServerAndLocalTilesVersion);
+    method public com.mapbox.navigation.base.options.RoutingTilesOptions.Builder tileStore(com.mapbox.common.TileStore tileStore);
     method public com.mapbox.navigation.base.options.RoutingTilesOptions.Builder tilesBaseUri(java.net.URI tilesBaseUri);
     method public com.mapbox.navigation.base.options.RoutingTilesOptions.Builder tilesDataset(String tilesDataset);
     method public com.mapbox.navigation.base.options.RoutingTilesOptions.Builder tilesProfile(String tilesProfile);

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/tilestore/TileStoreProvider.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/tilestore/TileStoreProvider.kt
@@ -1,0 +1,10 @@
+package com.mapbox.navigation.base.internal.tilestore
+
+import com.mapbox.common.TileStore
+
+object TileStoreProvider {
+
+    fun getDefaultTileStoreInstance() = TileStore.getInstance()
+
+    fun getTileStoreInstance(path: String) = TileStore.getInstance(path)
+}

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/options/NavigationOptionsTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/options/NavigationOptionsTest.kt
@@ -7,11 +7,14 @@ import com.mapbox.android.core.location.LocationEngineRequest
 import com.mapbox.navigation.base.TimeFormat.NONE_SPECIFIED
 import com.mapbox.navigation.base.TimeFormat.TWELVE_HOURS
 import com.mapbox.navigation.base.TimeFormat.TWENTY_FOUR_HOURS
+import com.mapbox.navigation.base.internal.tilestore.TileStoreProvider
 import com.mapbox.navigation.base.route.RouteRefreshOptions
 import com.mapbox.navigation.testing.BuilderTest
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
 import io.mockk.mockkStatic
+import io.mockk.unmockkObject
 import io.mockk.unmockkStatic
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -34,11 +37,16 @@ class NavigationOptionsTest : BuilderTest<NavigationOptions, NavigationOptions.B
     fun setup() {
         mockkStatic(LocationEngineProvider::class)
         every { LocationEngineProvider.getBestLocationEngine(any()) } returns mockk()
+
+        mockkObject(TileStoreProvider)
+        every { TileStoreProvider.getDefaultTileStoreInstance() } returns mockk()
+        every { TileStoreProvider.getTileStoreInstance(any()) } returns mockk()
     }
 
     @After
     fun teardown() {
         unmockkStatic(LocationEngineProvider::class)
+        unmockkObject(TileStoreProvider)
     }
 
     override fun getImplementationClass(): KClass<NavigationOptions> = NavigationOptions::class

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/options/RoutingTilesOptionsTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/options/RoutingTilesOptionsTest.kt
@@ -1,6 +1,14 @@
 package com.mapbox.navigation.base.options
 
+import com.mapbox.navigation.base.internal.tilestore.TileStoreProvider
 import com.mapbox.navigation.testing.BuilderTest
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import junit.framework.TestCase.assertEquals
+import org.junit.After
+import org.junit.Before
 import org.junit.Test
 import java.net.URI
 import java.net.URISyntaxException
@@ -18,7 +26,20 @@ class RoutingTilesOptionsTest : BuilderTest<RoutingTilesOptions, RoutingTilesOpt
             .tilesProfile("driving")
             .tilesVersion("456")
             .filePath("123")
+            .tileStore(TileStoreProvider.getTileStoreInstance("tile_store_path"))
             .minDaysBetweenServerAndLocalTilesVersion(0)
+    }
+
+    @Before
+    fun setup() {
+        mockkObject(TileStoreProvider)
+        every { TileStoreProvider.getDefaultTileStoreInstance() } returns mockk()
+        every { TileStoreProvider.getTileStoreInstance(any()) } returns mockk()
+    }
+
+    @After
+    fun teardown() {
+        unmockkObject(TileStoreProvider)
     }
 
     @Test
@@ -69,5 +90,22 @@ class RoutingTilesOptionsTest : BuilderTest<RoutingTilesOptions, RoutingTilesOpt
         RoutingTilesOptions.Builder()
             .minDaysBetweenServerAndLocalTilesVersion(-1)
             .build()
+    }
+
+    @Test
+    fun `default TileStore instance is used by default`() {
+        val defaultOptions = RoutingTilesOptions.Builder().build()
+
+        assertEquals(TileStoreProvider.getDefaultTileStoreInstance(), defaultOptions.tileStore)
+    }
+
+    @Test
+    fun `custom TileStore instance overrides a default one`() {
+        val customTileStore = TileStoreProvider.getTileStoreInstance("custom_tile_store_path")
+        val options = RoutingTilesOptions.Builder()
+            .tileStore(customTileStore)
+            .build()
+
+        assertEquals(customTileStore, options.tileStore)
     }
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -948,9 +948,7 @@ class MapboxNavigation(
 
         return TilesConfig(
             offlineFilesPath,
-            // TODO use TileStore from the options
-            // we pass null, so NavNative will use TileStore.getInstance(offlineFilesPath)
-            null,
+            navigationOptions.routingTilesOptions.tileStore,
             null,
             null,
             null,

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
@@ -14,6 +14,7 @@ import com.mapbox.common.module.provider.MapboxModuleProvider
 import com.mapbox.navigation.base.TimeFormat.NONE_SPECIFIED
 import com.mapbox.navigation.base.formatter.DistanceFormatterOptions
 import com.mapbox.navigation.base.internal.extensions.inferDeviceLocale
+import com.mapbox.navigation.base.internal.tilestore.TileStoreProvider
 import com.mapbox.navigation.base.options.IncidentsOptions
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.options.RoutingTilesOptions
@@ -123,6 +124,9 @@ class MapboxNavigationTest {
     @Before
     fun setUp() {
         mockkObject(MapboxModuleProvider)
+        mockkObject(TileStoreProvider)
+        every { TileStoreProvider.getDefaultTileStoreInstance() } returns mockk()
+
         val hybridRouter: Router = mockk(relaxUnitFun = true)
         every {
             MapboxModuleProvider.createModule<Router>(
@@ -163,6 +167,7 @@ class MapboxNavigationTest {
     @After
     fun tearDown() {
         unmockkObject(MapboxModuleProvider)
+        unmockkObject(TileStoreProvider)
         unmockkObject(LoggerProvider)
         unmockkObject(NavigationComponentProvider)
 

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
@@ -12,6 +12,7 @@ import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.VoiceInstructions
 import com.mapbox.base.common.logger.Logger
 import com.mapbox.geojson.Geometry
+import com.mapbox.navigation.base.internal.tilestore.TileStoreProvider
 import com.mapbox.navigation.base.options.DEFAULT_NAVIGATOR_PREDICTION_MILLIS
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.trip.model.RouteProgress
@@ -114,6 +115,9 @@ class MapboxTripSessionTest {
         mockkStatic("com.mapbox.navigation.core.navigator.NavigatorMapper")
         mockkStatic("com.mapbox.navigation.core.internal.utils.DirectionsRouteEx")
         mockkStatic("com.mapbox.navigation.core.navigator.LocationEx")
+        mockkObject(TileStoreProvider)
+        every { TileStoreProvider.getDefaultTileStoreInstance() } returns mockk()
+        every { TileStoreProvider.getTileStoreInstance(any()) } returns mockk()
         every { location.toFixLocation() } returns fixLocation
         every { fixLocation.toLocation() } returns location
         every { keyFixPoints.toLocations() } returns keyPoints
@@ -1021,6 +1025,7 @@ class MapboxTripSessionTest {
         unmockkStatic("com.mapbox.navigation.core.navigator.NavigatorMapper")
         unmockkStatic("com.mapbox.navigation.core.internal.utils.DirectionsRouteEx")
         unmockkStatic("com.mapbox.navigation.core.navigator.LocationEx")
+        unmockkObject(TileStoreProvider)
     }
 
     private suspend fun updateLocationAndJoin() {


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Add `TileStore` to the `RoutingTilesOptions`.
A default `TileStore` instance is used by default (`TileStore.getInstance()`).

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Add `TileStore` to the `RoutingTilesOptions`</changelog>
```

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
