### PR TITLE
Integrate navigator observer

### DIFF
--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/CoreRerouteTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/CoreRerouteTest.kt
@@ -28,6 +28,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
+// TODO: Refactor https://github.com/mapbox/mapbox-navigation-android/issues/4429
 class CoreRerouteTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.java) {
 
     @get:Rule

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/RouteAlternativesTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/RouteAlternativesTest.kt
@@ -31,6 +31,7 @@ import java.util.concurrent.TimeUnit
  * This test ensures that alternative route recommendations
  * are given during active guidance.
  */
+// TODO: Refactor https://github.com/mapbox/mapbox-navigation-android/issues/4429
 class RouteAlternativesTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.java) {
 
     @get:Rule

--- a/libnavigation-base/api/current.txt
+++ b/libnavigation-base/api/current.txt
@@ -249,7 +249,7 @@ package com.mapbox.navigation.base.options {
   }
 
   public final class NavigationOptionsKt {
-    field public static final long DEFAULT_NAVIGATOR_PREDICTION_MILLIS = 1100L; // 0x44cL
+    field public static final long DEFAULT_NAVIGATOR_PREDICTION_MILLIS = 1000L; // 0x3e8L
   }
 
   public final class PredictiveCacheLocationOptions {

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/NavigationOptions.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/NavigationOptions.kt
@@ -16,7 +16,7 @@ import com.mapbox.navigation.base.route.RouteRefreshOptions
  * in such a way as to project the location forward along the current trajectory so as to
  * appear more in sync with the users ground-truth location
  */
-const val DEFAULT_NAVIGATOR_PREDICTION_MILLIS = 1100L
+const val DEFAULT_NAVIGATOR_PREDICTION_MILLIS = 1000L
 
 /**
  * This value will be used to offset the time at which the current location was calculated

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -42,6 +42,7 @@ import com.mapbox.navigation.core.history.MapboxHistoryRecorder
 import com.mapbox.navigation.core.internal.ReachabilityService
 import com.mapbox.navigation.core.internal.accounts.MapboxNavigationAccounts
 import com.mapbox.navigation.core.internal.formatter.MapboxDistanceFormatter
+import com.mapbox.navigation.core.internal.utils.InternalUtils
 import com.mapbox.navigation.core.navigator.TilesetDescriptorFactory
 import com.mapbox.navigation.core.reroute.MapboxRerouteController
 import com.mapbox.navigation.core.reroute.RerouteController
@@ -84,6 +85,7 @@ import com.mapbox.navigator.ElectronicHorizonOptions
 import com.mapbox.navigator.FallbackVersionsObserver
 import com.mapbox.navigator.IncidentsOptions
 import com.mapbox.navigator.NavigatorConfig
+import com.mapbox.navigator.PollingConfig
 import com.mapbox.navigator.TileEndpointConfiguration
 import com.mapbox.navigator.TilesConfig
 import kotlinx.coroutines.channels.Channel
@@ -209,12 +211,18 @@ class MapboxNavigation(
         }
     }
 
+    private val pollingConfig = PollingConfig(
+        navigationOptions.navigatorPredictionMillis / ONE_SECOND_IN_MILLIS,
+        InternalUtils.UNCONDITIONAL_POLLING_PATIENCE_MILLISECONDS / ONE_SECOND_IN_MILLIS,
+        InternalUtils.UNCONDITIONAL_POLLING_INTERVAL_MILLISECONDS / ONE_SECOND_IN_MILLIS
+    )
+
     private val navigatorConfig = NavigatorConfig(
         null,
         electronicHorizonOptions,
-        null,
+        pollingConfig,
         incidentsOptions,
-        false
+        null
     )
 
     private var notificationChannelField: Field? = null
@@ -1071,5 +1079,6 @@ class MapboxNavigation(
         private val TAG = Tag("MbxNavigation")
         private const val USER_AGENT: String = "MapboxNavigationNative"
         private const val THREADS_COUNT = 2
+        private const val ONE_SECOND_IN_MILLIS = 1000.0
     }
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/utils/InternalUtils.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/utils/InternalUtils.kt
@@ -1,27 +1,31 @@
 package com.mapbox.navigation.core.internal.utils
 
-import com.mapbox.navigation.core.trip.session.MapboxTripSession
+object InternalUtils {
 
-/**
- * Internal API used for testing. Sets the static unconditional polling patience value for all
- * instances in the process.
- *
- * Pass `null` to reset to default.
- *
- * Do not use in a production environment.
- */
-fun setUnconditionalPollingPatience(patience: Long?) {
-    MapboxTripSession.UNCONDITIONAL_STATUS_POLLING_PATIENCE = patience ?: 2000L
-}
+    internal var UNCONDITIONAL_POLLING_PATIENCE_MILLISECONDS = 2000L
+    internal var UNCONDITIONAL_POLLING_INTERVAL_MILLISECONDS = 1000L
 
-/**
- * Internal API used for testing. Sets the static unconditional polling interval value for all
- * instances in the process.
- *
- * Pass `null` to reset to default.
- *
- * Do not use in a production environment.
- */
-fun setUnconditionalPollingInterval(interval: Long?) {
-    MapboxTripSession.UNCONDITIONAL_STATUS_POLLING_INTERVAL = interval ?: 1000L
+    /**
+     * Internal API used for testing. Sets the static unconditional polling patience value for all
+     * instances in the process. Needs to be set prior to [MapboxNavigation] creation.
+     *
+     * Pass `null` to reset to default.
+     *
+     * Do not use in a production environment.
+     */
+    fun setUnconditionalPollingPatience(patienceInMillis: Long?) {
+        UNCONDITIONAL_POLLING_PATIENCE_MILLISECONDS = patienceInMillis ?: 2000L
+    }
+
+    /**
+     * Internal API used for testing. Sets the static unconditional polling interval value for all
+     * instances in the process. Needs to be set prior to [MapboxNavigation] creation.
+     *
+     * Pass `null` to reset to default.
+     *
+     * Do not use in a production environment.
+     */
+    fun setUnconditionalPollingInterval(intervalInMillis: Long?) {
+        UNCONDITIONAL_POLLING_INTERVAL_MILLISECONDS = intervalInMillis ?: 1000L
+    }
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/navigator/NavigatorMapper.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/navigator/NavigatorMapper.kt
@@ -62,6 +62,14 @@ internal fun getRouteProgressFrom(
     return status.getRouteProgress(directionsRoute, remainingWaypoints)
 }
 
+internal fun NavigationStatus.getTripStatusFrom(
+    route: DirectionsRoute?,
+): TripStatus =
+    TripStatus(
+        route,
+        this
+    )
+
 private fun NavigationStatus.getRouteProgress(
     route: DirectionsRoute?,
     remainingWaypoints: Int

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigator.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigator.kt
@@ -17,6 +17,7 @@ import com.mapbox.navigator.GraphAccessor
 import com.mapbox.navigator.HistoryRecorderHandle
 import com.mapbox.navigator.NavigationStatus
 import com.mapbox.navigator.NavigatorConfig
+import com.mapbox.navigator.NavigatorObserver
 import com.mapbox.navigator.PredictiveCacheController
 import com.mapbox.navigator.RoadObjectMatcher
 import com.mapbox.navigator.RoadObjectsStore
@@ -86,21 +87,9 @@ interface MapboxNativeNavigator {
      */
     fun updateSensorData(sensorData: SensorData): Boolean
 
-    /**
-     * Gets the status as an offset in time from the last fixed location. This
-     * allows the caller to get predicted statuses in the future along the route if
-     * the device is unable to get fixed locations. Poor reception would be one reason.
-     *
-     * This method uses previous fixes to snap the user's location to the route
-     * and verify that the user is still on the route. This method also determines
-     * if an instruction needs to be called out for the user.
-     *
-     * @param navigatorPredictionMillis millis for navigation status predictions.
-     *
-     * @return the last [TripStatus] as a result of fixed location updates. If the timestamp
-     * is earlier than a previous call, the last status will be returned. The function does not support re-winding time.
-     */
-    suspend fun getStatus(navigatorPredictionMillis: Long): TripStatus
+    fun addNavigatorObserver(navigatorObserver: NavigatorObserver)
+
+    fun removeNavigatorObserver(navigatorObserver: NavigatorObserver)
 
     // Routing
 

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigatorImpl.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigatorImpl.kt
@@ -1,6 +1,5 @@
 package com.mapbox.navigation.navigator.internal
 
-import android.os.SystemClock
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.base.common.logger.Logger
 import com.mapbox.base.common.logger.model.Message
@@ -22,6 +21,7 @@ import com.mapbox.navigator.HistoryRecorderHandle
 import com.mapbox.navigator.NavigationStatus
 import com.mapbox.navigator.Navigator
 import com.mapbox.navigator.NavigatorConfig
+import com.mapbox.navigator.NavigatorObserver
 import com.mapbox.navigator.PredictiveCacheController
 import com.mapbox.navigator.PredictiveCacheControllerOptions
 import com.mapbox.navigator.PredictiveLocationTrackerOptions
@@ -40,7 +40,6 @@ import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.withContext
 import java.util.concurrent.CopyOnWriteArraySet
 import java.util.concurrent.Executors
-import java.util.concurrent.TimeUnit
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 
@@ -149,31 +148,11 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
         return navigator!!.updateSensorData(sensorData)
     }
 
-    /**
-     * Gets the status as an offset in time from the last fixed location. This
-     * allows the caller to get predicted statuses in the future along the route if
-     * the device is unable to get fixed locations. Poor reception would be one reason.
-     *
-     * This method uses previous fixes to snap the user's location to the route
-     * and verify that the user is still on the route. This method also determines
-     * if an instruction needs to be called out for the user.
-     *
-     * @param navigatorPredictionMillis millis for navigation status predictions.
-     *
-     * @return the last [TripStatus] as a result of fixed location updates. If the timestamp
-     * is earlier than a previous call, the last status will be returned. The function does not support re-winding time.
-     */
-    override suspend fun getStatus(navigatorPredictionMillis: Long): TripStatus =
-        withContext(NavigatorDispatcher) {
-            val nanos = SystemClock.elapsedRealtimeNanos() + TimeUnit.MILLISECONDS.toNanos(
-                navigatorPredictionMillis
-            )
-            val status = navigator!!.getStatus(nanos)
-            TripStatus(
-                route,
-                status
-            )
-        }
+    override fun addNavigatorObserver(navigatorObserver: NavigatorObserver) =
+        navigator!!.addObserver(navigatorObserver)
+
+    override fun removeNavigatorObserver(navigatorObserver: NavigatorObserver) =
+        navigator!!.removeObserver(navigatorObserver)
 
     // Routing
 

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/TripStatus.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/TripStatus.kt
@@ -8,8 +8,6 @@ import com.mapbox.navigator.NavigationStatus
  *
  * @param route
  * @param navigationStatus
- *
- * @see [MapboxNativeNavigator.getStatus]
  */
 data class TripStatus(
     val route: DirectionsRoute?,


### PR DESCRIPTION
### Description
Supersedes https://github.com/mapbox/mapbox-navigation-android/pull/4354

This builds on top of https://github.com/mapbox/mapbox-navigation-android/pull/4417

- Now `NavigatorObserver` [`onStatus`](https://github.com/mapbox/mapbox-navigation-native/blob/cf2fcee5bf9b768b68eb49919711bd28b06d1b71/bindings/generated/cpp/mapbox/navigation/navigator_observer.hpp#L22) callback returns `NavigationStatusOrigin` in addition to `NavigationStatus`. This is an `enum` including information about where this status is coming from (`LOCATION_UPDATE`, `LEG_CHANGE`, `SET_ROUTE` and `UNCONDITIONAL`). Is that correct @DmitryAk? How can we use this extra information for our benefit from the SDK side? Should we expose it to developers? Could you talk more about why you added this in the first place? Currently, we're just ignoring this value.

**TO-DO**

- [x] Expose  `NavigatorConfig` `PollingConfig` through `NavigationOptions`?
- [x] Fix `MapboxTripSession` `@Ignore`d tests
- [x] Extensive field testing
- [x] @DmitryAk Any other things that we need to think about? Please, feel free to add any checks here or as a comment.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Migrated to callback-based native getStatus approach.</changelog>
<changelog>Removed `routeGeometryWithBuffer` from `RouteProgress`.</changelog>
<changelog>:warning: Internal `setUnconditionalPollingPatience` and `setUnconditionalPollingInterval` have been moved to `InternalUtils` `object` and have to be called _before_ `MapboxNavigation` is instantiated to actually take effect.</changelog>
```

cc @etl @mskurydin @SiarheiFedartsou @truburt @zugaldia 