### PR TITLE
Extrude all buildings with a highlighted one

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxBuildingHighlightActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxBuildingHighlightActivity.kt
@@ -25,7 +25,6 @@ import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.route.RouterCallback
 import com.mapbox.navigation.base.route.RouterFailure
 import com.mapbox.navigation.base.route.RouterOrigin
-import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesObserver
 import com.mapbox.navigation.core.replay.MapboxReplayer
@@ -111,11 +110,9 @@ class MapboxBuildingHighlightActivity : AppCompatActivity(), OnMapLongClickListe
 
     private val replayProgressObserver = ReplayProgressObserver(mapboxReplayer)
 
-    private val routeProgressObserver = object : RouteProgressObserver {
-        override fun onRouteProgressChanged(routeProgress: RouteProgress) {
-            routeArrowApi.addUpcomingManeuverArrow(routeProgress).apply {
-                routeArrowView.renderManeuverUpdate(mapboxMap.getStyle()!!, this)
-            }
+    private val routeProgressObserver = RouteProgressObserver { routeProgress ->
+        routeArrowApi.addUpcomingManeuverArrow(routeProgress).apply {
+            routeArrowView.renderManeuverUpdate(mapboxMap.getStyle()!!, this)
         }
     }
 
@@ -133,18 +130,16 @@ class MapboxBuildingHighlightActivity : AppCompatActivity(), OnMapLongClickListe
         }
     }
 
-    private val routesObserver = object : RoutesObserver {
-        override fun onRoutesChanged(routes: List<DirectionsRoute>) {
-            if (routes.isNotEmpty()) {
-                CoroutineScope(Dispatchers.Main).launch {
-                    routeLineApi.setRoutes(
-                        listOf(RouteLine(routes[0], null))
-                    ).apply {
-                        routeLineView.renderRouteDrawData(mapboxMap.getStyle()!!, this)
-                    }
+    private val routesObserver = RoutesObserver { routes ->
+        if (routes.isNotEmpty()) {
+            CoroutineScope(Dispatchers.Main).launch {
+                routeLineApi.setRoutes(
+                    listOf(RouteLine(routes[0], null))
+                ).apply {
+                    routeLineView.renderRouteDrawData(mapboxMap.getStyle()!!, this)
                 }
-                startSimulation(routes[0])
             }
+            startSimulation(routes[0])
         }
     }
 
@@ -279,6 +274,14 @@ class MapboxBuildingHighlightActivity : AppCompatActivity(), OnMapLongClickListe
          * building arrival api. It will select a building upon arrival
          */
         buildingsArrivalApi.buildingHighlightApi(buildingHighlightApi)
+
+        /**
+         * Showing all buildings is disabled by default. But this function
+         * allows you to show all buildings in 3D with the highlighted one.
+         */
+        binding.toggleBuildings.setOnCheckedChangeListener { _, isChecked ->
+            buildingHighlightApi.extrudeBuildings(isChecked)
+        }
 
         locationComponent = binding.mapView.location.apply {
             setLocationProvider(navigationLocationProvider)

--- a/examples/src/main/res/layout/layout_activity_building_highlight.xml
+++ b/examples/src/main/res/layout/layout_activity_building_highlight.xml
@@ -8,9 +8,30 @@
         android:id="@+id/mapView"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintBottom_toTopOf="@id/exampleActions"
+        />
+
+    <androidx.appcompat.widget.LinearLayoutCompat
+        android:id="@+id/exampleActions"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="@dimen/mapbox_dimen_8dp"
+        android:orientation="horizontal"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent">
+
+        <androidx.appcompat.widget.SwitchCompat
+            android:id="@+id/toggleBuildings"
+            android:text="Show buildings"
+            android:layout_width="wrap_content"
+            android:background="@color/cardview_light_background"
+            android:layout_height="wrap_content"
+            />
+
+    </androidx.appcompat.widget.LinearLayoutCompat>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/libnavui-maps/api/current.txt
+++ b/libnavui-maps/api/current.txt
@@ -21,17 +21,35 @@ package com.mapbox.navigation.ui.maps {
 
 package com.mapbox.navigation.ui.maps.arrival.api {
 
+  public fun interface BuildingHighlightObserver {
+    method public void onBuildingHighlight(java.util.List<com.mapbox.maps.QueriedFeature> features);
+  }
+
   public final class MapboxBuildingArrivalApi {
     ctor public MapboxBuildingArrivalApi();
     method public com.mapbox.navigation.ui.maps.arrival.api.MapboxBuildingArrivalApi buildingHighlightApi(com.mapbox.navigation.ui.maps.arrival.api.MapboxBuildingHighlightApi? mapboxBuildingHighlightApi);
+    method public void clearBuildingHighlightObservers();
     method public void disable();
     method public void enable(com.mapbox.navigation.core.MapboxNavigation mapboxNavigation);
+    method public com.mapbox.navigation.ui.maps.arrival.api.MapboxBuildingArrivalApi registerBuildingHighlightObserver(com.mapbox.navigation.ui.maps.arrival.api.BuildingHighlightObserver observer);
+    method public void unregisterBuildingHighlightObserver(com.mapbox.navigation.ui.maps.arrival.api.BuildingHighlightObserver observer);
   }
 
   public final class MapboxBuildingHighlightApi {
     ctor public MapboxBuildingHighlightApi(com.mapbox.maps.MapboxMap mapboxMap, com.mapbox.navigation.ui.maps.arrival.model.MapboxBuildingHighlightOptions options = MapboxBuildingHighlightOptions.default);
     method public void clear();
-    method public void highlightBuilding(com.mapbox.geojson.Point? point);
+    method public com.mapbox.maps.extension.style.expressions.generated.Expression getBuildingHeightExpression();
+    method public java.util.List<com.mapbox.maps.QueriedFeature> getHighlightedBuildings();
+    method public void highlightBuilding(com.mapbox.geojson.Point? point, com.mapbox.navigation.ui.maps.arrival.api.BuildingHighlightObserver callback);
+    property public final com.mapbox.maps.extension.style.expressions.generated.Expression buildingHeightExpression;
+    property public final java.util.List<com.mapbox.maps.QueriedFeature> highlightedBuildings;
+    field public static final String BUILDING_LAYER_ID = "building";
+    field public static final String COMPOSITE_SOURCE_ID = "composite";
+    field public static final com.mapbox.navigation.ui.maps.arrival.api.MapboxBuildingHighlightApi.Companion Companion;
+    field public static final String HIGHLIGHT_BUILDING_LAYER_ID = "mapbox-building-highlight-layer";
+  }
+
+  public static final class MapboxBuildingHighlightApi.Companion {
   }
 
 }

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/arrival/api/BuildingHighlightObserver.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/arrival/api/BuildingHighlightObserver.kt
@@ -1,0 +1,16 @@
+package com.mapbox.navigation.ui.maps.arrival.api
+
+import com.mapbox.maps.QueriedFeature
+
+/**
+ * Observer used to surface the features queried by [MapboxBuildingHighlightApi].
+ * This observer can also be used to observe building highlighted upon arrival
+ * from the [MapboxBuildingArrivalApi]
+ */
+fun interface BuildingHighlightObserver {
+    /**
+     * Called when buildings have been queried. The list is empty when there
+     * were no buildings found.
+     */
+    fun onBuildingHighlight(features: List<QueriedFeature>)
+}

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/arrival/api/MapboxBuildingHighlightApi.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/arrival/api/MapboxBuildingHighlightApi.kt
@@ -1,5 +1,7 @@
 package com.mapbox.navigation.ui.maps.arrival.api
 
+import com.mapbox.base.common.logger.model.Message
+import com.mapbox.base.common.logger.model.Tag
 import com.mapbox.geojson.Point
 import com.mapbox.maps.MapboxMap
 import com.mapbox.maps.QueriedFeature
@@ -12,11 +14,15 @@ import com.mapbox.maps.extension.style.expressions.generated.Expression.Companio
 import com.mapbox.maps.extension.style.expressions.generated.Expression.Companion.inExpression
 import com.mapbox.maps.extension.style.expressions.generated.Expression.Companion.interpolate
 import com.mapbox.maps.extension.style.expressions.generated.Expression.Companion.linear
+import com.mapbox.maps.extension.style.expressions.generated.Expression.Companion.not
 import com.mapbox.maps.extension.style.expressions.generated.Expression.Companion.zoom
 import com.mapbox.maps.extension.style.layers.addLayer
 import com.mapbox.maps.extension.style.layers.generated.FillExtrusionLayer
+import com.mapbox.maps.extension.style.layers.generated.FillLayer
 import com.mapbox.maps.extension.style.layers.getLayer
+import com.mapbox.maps.extension.style.layers.getLayerAs
 import com.mapbox.navigation.ui.maps.arrival.model.MapboxBuildingHighlightOptions
+import com.mapbox.navigation.utils.internal.LoggerProvider.logger
 
 /**
  * Map layer to highlight a single building.
@@ -27,19 +33,34 @@ class MapboxBuildingHighlightApi(
         MapboxBuildingHighlightOptions.default
 ) {
     /**
+     * Access the currently highlighted buildings.
+     */
+    var highlightedBuildings: List<QueriedFeature> = emptyList()
+        private set
+
+    /**
+     * Access the current state of the extruded buildings layer.
+     */
+    var extrudeBuildings: Boolean = false
+        private set
+
+    /**
      * Highlight a building whose feature geometry that contains the [point]. If
      * no building contains this point, a building is not highlighted.
      *
      * @param point for finding a building to highlight,
      *   null will clear any highlighted building
+     * @param callback optional callback with the queried feature results.
      */
     fun highlightBuilding(
-        point: Point?
+        point: Point?,
+        callback: (List<QueriedFeature>) -> Unit = { }
     ) {
         mapboxMap.getStyle { style ->
-
             if (point == null) {
-                updateBuildingLayer(style, emptyList())
+                highlightedBuildings = emptyList()
+                updateBuildingsLayer(style)
+                callback(highlightedBuildings)
                 return@getStyle
             }
 
@@ -47,9 +68,20 @@ class MapboxBuildingHighlightApi(
 
             val queryOptions = RenderedQueryOptions(listOf(BUILDING_LAYER_ID), null)
             mapboxMap.queryRenderedFeatures(screenCoordinate, queryOptions) { expected ->
-                val queriedFeature: List<QueriedFeature> = expected.value ?: emptyList()
-                updateBuildingLayer(style, queriedFeature)
+                highlightedBuildings = expected.value ?: emptyList()
+                updateBuildingsLayer(style)
+                callback(highlightedBuildings)
             }
+        }
+    }
+
+    /**
+     * Show all buildings on the map.
+     */
+    fun extrudeBuildings(extrudeBuildings: Boolean) = also {
+        this.extrudeBuildings = extrudeBuildings
+        mapboxMap.getStyle { style ->
+            updateBuildingsLayer(style)
         }
     }
 
@@ -62,14 +94,14 @@ class MapboxBuildingHighlightApi(
         }
     }
 
-    private fun updateBuildingLayer(
-        style: Style,
-        queriedFeature: List<QueriedFeature>
-    ) {
+    private fun updateBuildingsLayer(style: Style) {
+        updateHighlightBuildingLayer(style)
+        updateFillBuildingsLayer(style)
+    }
+
+    private fun updateHighlightBuildingLayer(style: Style) {
         val layerId = HIGHLIGHT_BUILDING_LAYER_ID
-
-        val ids = queriedFeature.mapNotNull { it.feature.id()?.toLong() }
-
+        val ids = highlightedBuildings.mapNotNull { it.feature.id()?.toLong() }
         val selectedBuilding = inExpression(id(), literal(ids))
         if (!style.styleLayerExists(layerId)) {
             style.addLayer(
@@ -82,8 +114,47 @@ class MapboxBuildingHighlightApi(
                     .fillExtrusionHeight(heightExpression())
             )
         } else {
-            (style.getLayer(layerId) as FillExtrusionLayer)
+            style.getLayerAs<FillExtrusionLayer>(layerId)
                 .filter(selectedBuilding)
+        }
+    }
+
+    private fun updateFillBuildingsLayer(style: Style) {
+        val layerId = EXTRUDE_BUILDING_LAYER_ID
+        if (!extrudeBuildings) {
+            style.removeStyleLayer(layerId)
+            return
+        }
+        val buildingFillColorExpression = buildingFillColor(style) ?: return
+
+        val ids = highlightedBuildings.mapNotNull { it.feature.id()?.toLong() }
+        val notSelectedBuildings = not(inExpression(id(), literal(ids)))
+        if (!style.styleLayerExists(layerId)) {
+            style.addLayer(
+                FillExtrusionLayer(layerId, COMPOSITE_SOURCE_ID)
+                    .sourceLayer(BUILDING_LAYER_ID)
+                    .filter(notSelectedBuildings)
+                    .fillExtrusionColor(buildingFillColorExpression)
+                    .fillExtrusionOpacity(literal(0.6))
+                    .fillExtrusionBase(get("min-height"))
+                    .fillExtrusionHeight(heightExpression())
+            )
+        } else {
+            style.getLayerAs<FillExtrusionLayer>(layerId)
+                .filter(notSelectedBuildings)
+        }
+    }
+
+    private fun buildingFillColor(style: Style): Expression? {
+        return when (val buildingLayer = style.getLayer(BUILDING_LAYER_ID)) {
+            is FillLayer -> buildingLayer.fillColorAsExpression
+            else -> {
+                logger.e(
+                    tag = TAG,
+                    msg = Message("$BUILDING_LAYER_ID has unsupported type $buildingLayer")
+                )
+                null
+            }
         }
     }
 
@@ -95,7 +166,10 @@ class MapboxBuildingHighlightApi(
         )
 
     private companion object {
+        private val TAG = Tag("MapboxBuildingHighlightApi")
+
         private const val HIGHLIGHT_BUILDING_LAYER_ID = "mapbox-building-highlight-layer"
+        private const val EXTRUDE_BUILDING_LAYER_ID = "mapbox-building-extrude-layer"
         private const val BUILDING_LAYER_ID = "building"
         private const val COMPOSITE_SOURCE_ID = "composite"
     }

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/arrival/api/MapboxBuildingArrivalApiTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/arrival/api/MapboxBuildingArrivalApiTest.kt
@@ -23,7 +23,7 @@ class MapboxBuildingArrivalApiTest {
     }
 
     private val buildingHighlightApi = mockk<MapboxBuildingHighlightApi> {
-        every { highlightBuilding(any()) } returns Unit
+        every { highlightBuilding(any(), any()) } returns Unit
     }
     private val buildingArrivalApi = MapboxBuildingArrivalApi()
 
@@ -72,7 +72,7 @@ class MapboxBuildingArrivalApiTest {
         buildingArrivalApi.enable(mapboxNavigation)
         arrivalSlot.captured.onFinalDestinationArrival(mockFinalDestinationRouteProgress())
 
-        verify { buildingHighlightApi.highlightBuilding(any()) }
+        verify { buildingHighlightApi.highlightBuilding(any(), any()) }
     }
 
     @Test
@@ -84,7 +84,7 @@ class MapboxBuildingArrivalApiTest {
         buildingArrivalApi.enable(mapboxNavigation)
         arrivalSlot.captured.onWaypointArrival(mockWaypointRouteProgress())
 
-        verify { buildingHighlightApi.highlightBuilding(any()) }
+        verify { buildingHighlightApi.highlightBuilding(any(), any()) }
     }
 
     @Test
@@ -97,7 +97,7 @@ class MapboxBuildingArrivalApiTest {
         arrivalSlot.captured.onWaypointArrival(mockWaypointRouteProgress())
         arrivalSlot.captured.onNextRouteLegStart(mockk())
 
-        verify { buildingHighlightApi.highlightBuilding(null) }
+        verify { buildingHighlightApi.highlightBuilding(null, any()) }
     }
 
     private fun mockFinalDestinationRouteProgress() = mockk<RouteProgress> {

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/arrival/api/MapboxBuildingHighlightApiTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/arrival/api/MapboxBuildingHighlightApiTest.kt
@@ -27,6 +27,7 @@ class MapboxBuildingHighlightApiTest {
     private val style: Style = mockk {
         every { styleLayerExists(any()) } returns false
         every { addStyleLayer(any(), any()) } returns expected
+        every { removeStyleLayer(any()) } returns mockk()
     }
 
     /** Mock querying features **/

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/arrival/api/MapboxBuildingHighlightApiTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/arrival/api/MapboxBuildingHighlightApiTest.kt
@@ -12,7 +12,9 @@ import com.mapbox.maps.ScreenCoordinate
 import com.mapbox.maps.Style
 import com.mapbox.navigation.testing.FileUtils
 import io.mockk.CapturingSlot
+import io.mockk.Runs
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.Assert.assertTrue
@@ -45,11 +47,17 @@ class MapboxBuildingHighlightApiTest {
         }
     }
 
+    private val buildings = mutableListOf<List<QueriedFeature>>()
+    private val buildingHighlightObserver = mockk<BuildingHighlightObserver> {
+        every { onBuildingHighlight(capture(buildings)) } just Runs
+    }
     private val buildingHighlightApi = MapboxBuildingHighlightApi(mapboxMap)
 
     @Test
     fun `highlight null point is a no-op`() {
-        buildingHighlightApi.highlightBuilding(null)
+        buildingHighlightApi.highlightBuilding(null, buildingHighlightObserver)
+
+        verify(exactly = 0) { buildingHighlightObserver.onBuildingHighlight(any()) }
     }
 
     @Test
@@ -63,7 +71,7 @@ class MapboxBuildingHighlightApiTest {
         }
 
         val testPoint = Point.fromLngLat(-122.431969, 37.777663)
-        buildingHighlightApi.highlightBuilding(testPoint)
+        buildingHighlightApi.highlightBuilding(testPoint, buildingHighlightObserver)
         onStyleLoadedSlot.captured.onStyleLoaded(style)
 
         val propertySlot = CapturingSlot<Value>()


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

One issue with highlighting a single building, is that it will break any layer that is attempting to extrude the rest of the buildings. This is because the two layers in 3d will be in conflict, causing a classic z-fighting issue (as shown in the before screenshot below). 

Extruding all buildings is outside of the navigation domain, so this is showing it as part of the example. But this pull request shows the interfaces needed to build this type of experience.

We also had developer requests for identifying routes that have a building highlighted. Exposing these variables makes this possible.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Add example showing extrude all building along with a highlighted one. Expose the map data used to highlight a building.</changelog>
```

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->

| Before | After |
| -- | -- |
| ![overlap-issue](https://user-images.githubusercontent.com/3021882/118894912-014a3380-b8ba-11eb-88b9-7c7235916910.png) | ![screen](https://user-images.githubusercontent.com/3021882/118895069-4ec6a080-b8ba-11eb-9ebb-adcd132ce292.png) |


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
