### PR TITLE
Fix route refresh race condition

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -311,9 +311,7 @@ class MapboxNavigation(
             tripSession,
             logger
         )
-        if (navigationOptions.routeRefreshOptions.enabled) {
-            routeRefreshController.start()
-        }
+        routeRefreshController.restart()
 
         defaultRerouteController = MapboxRerouteController(
             directionsSession,
@@ -439,6 +437,7 @@ class MapboxNavigation(
     fun setRoutes(routes: List<DirectionsRoute>) {
         rerouteController?.interrupt()
         routeAlternativesController.interrupt()
+        routeRefreshController.restart()
         directionsSession.routes = routes
     }
 

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
@@ -242,45 +242,51 @@ class MapboxNavigationTest {
     }
 
     @Test
-    fun init_routeRefreshController_start_called_when_isRouteRefresh_enabled() {
+    fun `restart the routeRefreshController during initialization`() {
         ThreadController.cancelAllUICoroutines()
-        val routeRefreshOptions = RouteRefreshOptions.Builder()
-            .enabled(true)
-            .build()
         every {
             RouteRefreshControllerProvider.createRouteRefreshController(
                 any(), any(), any(), any()
             )
         } returns routeRefreshController
-        every { routeRefreshController.start() } returns mockk()
-        val navigationOptions = provideNavigationOptions()
-            .routeRefreshOptions(routeRefreshOptions)
-            .build()
+        every { routeRefreshController.restart() } returns mockk()
 
-        mapboxNavigation = MapboxNavigation(navigationOptions)
+        mapboxNavigation = MapboxNavigation(
+            provideNavigationOptions()
+                .routeRefreshOptions(
+                    RouteRefreshOptions.Builder()
+                        .enabled(true)
+                        .build()
+                )
+                .build()
+        )
 
-        verify(exactly = 1) { routeRefreshController.start() }
+        verify(exactly = 1) { routeRefreshController.restart() }
     }
 
     @Test
-    fun init_routeRefreshController_start_not_called_when_isRouteRefresh_disabled() {
+    fun `restart the routeRefreshController if new route is set`() {
         ThreadController.cancelAllUICoroutines()
-        val routeRefreshOptions = RouteRefreshOptions.Builder()
-            .enabled(false)
-            .build()
         every {
             RouteRefreshControllerProvider.createRouteRefreshController(
                 any(), any(), any(), any()
             )
         } returns routeRefreshController
-        every { routeRefreshController.start() } returns mockk()
-        val navigationOptions = provideNavigationOptions()
-            .routeRefreshOptions(routeRefreshOptions)
-            .build()
+        every { routeRefreshController.restart() } returns mockk()
 
-        mapboxNavigation = MapboxNavigation(navigationOptions)
+        mapboxNavigation = MapboxNavigation(
+            provideNavigationOptions()
+                .routeRefreshOptions(
+                    RouteRefreshOptions.Builder()
+                        .enabled(true)
+                        .build()
+                )
+                .build()
+        )
+        val routes = listOf(mockk<DirectionsRoute>())
+        mapboxNavigation.setRoutes(routes)
 
-        verify(exactly = 0) { routeRefreshController.start() }
+        verify(exactly = 2) { routeRefreshController.restart() }
     }
 
     @Test

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesControllerTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesControllerTest.kt
@@ -1,12 +1,10 @@
-package com.mapbox.navigation.core.alternatives
+package com.mapbox.navigation.core.routealternatives
 
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.RouteOptions
 import com.mapbox.navigation.base.route.RouteAlternativesOptions
 import com.mapbox.navigation.core.directions.session.DirectionsSession
 import com.mapbox.navigation.core.directions.session.RoutesRequestCallback
-import com.mapbox.navigation.core.routealternatives.RouteAlternativesController
-import com.mapbox.navigation.core.routealternatives.RouteAlternativesObserver
 import com.mapbox.navigation.core.routeoptions.RouteOptionsUpdater
 import com.mapbox.navigation.core.trip.session.TripSession
 import com.mapbox.navigation.core.trip.session.TripSessionState


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Resolves https://github.com/mapbox/mapbox-navigation-android/issues/4409

It's unclear how often it is happening. Fixing the issue by adding multiple tests covering the issue, and then refactored the logic to pass the tests. See the screenshot section to see more details of the issue. 

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Fixing the race condition in RouteRefreshController where setRoute will not cancel old refresh requests</changelog>
```

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->

Below has a bubble diagram describing the issue. Horizontal is time, each channel is a functional stream. The issue happens when we set a new route, and there is a pending request

Before the fix, here is a description of the race condition
| ----o------o---------------| Set route events
| ----------1---------2-------| Refresh request events
| --------------1--------2----| Refresh response events
|------------xxx-------------| Race condition zone

After the fix, the flow looks like this
| ----o------o---------------| Set route events
| ----------1-x----2---------| Refresh request events
| ---------------------2------| Refresh response events
|-----------------------------| Race condition zone

The x in the response event, represents the request being canceled. A potential race condition in the response, is not being handled inside the `RouteRefreshController`. This class assumes that the upstream callback will will not be triggered after a cancel request has been submitted. 

### Other race conditions

The assumption that pending requests are canceled, is potentially inaccurate. This is because after a refresh has been canceled, the response will be called. But I'm considering these a separate issues. As you can see, the response is carried out regardless of whether the request containers have removed the requests. The time window when this can happen is much smaller than the one we're fixing here. These race conditions are thread local, rather than networking
https://github.com/mapbox/mapbox-navigation-android/blob/4c91e80f65bcb6d20baa5c567e88ccfb6dadb4eb/libnavigation-router/src/main/java/com/mapbox/navigation/route/internal/offboard/MapboxOffboardRouter.kt#L156
https://github.com/mapbox/mapbox-navigation-android/blob/4c91e80f65bcb6d20baa5c567e88ccfb6dadb4eb/libnavigation-router/src/main/java/com/mapbox/navigation/route/internal/onboard/MapboxOnboardRouter.kt#L72-L85


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
