### PR TITLE
cache MapboxRouteLineView's layers instead of always fetching them from native

### DIFF
--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtils.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtils.kt
@@ -18,6 +18,7 @@ import com.mapbox.maps.Style
 import com.mapbox.maps.extension.style.expressions.dsl.generated.color
 import com.mapbox.maps.extension.style.expressions.dsl.generated.eq
 import com.mapbox.maps.extension.style.expressions.generated.Expression
+import com.mapbox.maps.extension.style.layers.Layer
 import com.mapbox.maps.extension.style.layers.getLayer
 import com.mapbox.maps.extension.style.layers.properties.generated.Visibility
 import com.mapbox.maps.extension.style.sources.generated.geoJsonSource
@@ -729,10 +730,11 @@ object MapboxRouteLineUtils {
         return expressions.plus(color(defaultColor))
     }
 
-    internal fun initializeLayers(style: Style, options: MapboxRouteLineOptions) {
-        if (!style.fullyLoaded || layersAreInitialized(style)) {
-            return
-        }
+    internal fun initializeLayers(
+        style: Style,
+        options: MapboxRouteLineOptions
+    ): HashMap<String, Layer> {
+        val map = hashMapOf<String, Layer>()
 
         val belowLayerIdToUse: String? =
             getBelowLayerIdToUse(
@@ -780,6 +782,7 @@ object MapboxRouteLineUtils {
             options.resourceProvider.routeLineColorResources.alternativeRouteCasingColor
         ).forEach {
             it.bindTo(style, LayerPosition(null, belowLayerIdToUse, null))
+            map[it.layerId] = it
         }
 
         options.routeLayerProvider.buildAlternativeRouteLayers(
@@ -788,6 +791,7 @@ object MapboxRouteLineUtils {
             options.resourceProvider.routeLineColorResources.alternativeRouteDefaultColor
         ).forEach {
             it.bindTo(style, LayerPosition(null, belowLayerIdToUse, null))
+            map[it.layerId] = it
         }
 
         options.routeLayerProvider.buildAlternativeRouteTrafficLayers(
@@ -796,30 +800,45 @@ object MapboxRouteLineUtils {
             options.resourceProvider.routeLineColorResources.alternativeRouteDefaultColor
         ).forEach {
             it.bindTo(style, LayerPosition(null, belowLayerIdToUse, null))
+            map[it.layerId] = it
         }
 
         options.routeLayerProvider.buildPrimaryRouteCasingLayer(
             style,
             options.resourceProvider.routeLineColorResources.routeCasingColor
-        ).bindTo(style, LayerPosition(null, belowLayerIdToUse, null))
+        ).apply {
+            bindTo(style, LayerPosition(null, belowLayerIdToUse, null))
+            map[layerId] = this
+        }
 
         options.routeLayerProvider.buildPrimaryRouteLayer(
             style,
             options.resourceProvider.roundedLineCap,
             options.resourceProvider.routeLineColorResources.routeDefaultColor
-        ).bindTo(style, LayerPosition(null, belowLayerIdToUse, null))
+        ).apply {
+            bindTo(style, LayerPosition(null, belowLayerIdToUse, null))
+            map[layerId] = this
+        }
 
         options.routeLayerProvider.buildPrimaryRouteTrafficLayer(
             style,
             options.resourceProvider.roundedLineCap,
             options.resourceProvider.routeLineColorResources.routeDefaultColor
-        ).bindTo(style, LayerPosition(null, belowLayerIdToUse, null))
+        ).apply {
+            bindTo(style, LayerPosition(null, belowLayerIdToUse, null))
+            map[layerId] = this
+        }
 
         options.routeLayerProvider.buildWayPointLayer(
             style,
             options.originIcon,
             options.destinationIcon
-        ).bindTo(style, LayerPosition(null, belowLayerIdToUse, null))
+        ).apply {
+            bindTo(style, LayerPosition(null, belowLayerIdToUse, null))
+            map[layerId] = this
+        }
+
+        return map
     }
 
     internal fun layersAreInitialized(style: Style): Boolean {


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Each call to `getLayer` internally wires to Map's native implementation and going through that boundary was consuming a significant amount of resources given how frequently it was called on each location puck position change.

By caching the layers, the percentage of time blocking the main thread when updating the route line view's gradient was reduced from ~24% to ~3%.

Before:
![Screenshot from 2021-05-20 16-26-03](https://user-images.githubusercontent.com/16925074/119005067-6a4fab00-b98f-11eb-9a18-a102ea372df9.png)

After:
![Screenshot from 2021-05-20 16-28-12](https://user-images.githubusercontent.com/16925074/119005082-6d4a9b80-b98f-11eb-8ad6-0867db6fc38c.png)

Cutting a draft since this still needs tests.
### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Improved performance of the vanishing point update in the `MapboxRouteLineView`.</changelog>
```
