### PR TITLE
Changed the text `border` to `casing` in route arrow options

### DIFF
--- a/libnavui-base/api/current.txt
+++ b/libnavui-base/api/current.txt
@@ -24,7 +24,7 @@ package com.mapbox.navigation.ui.base.internal.model.route {
     method public int getDESTINATION_WAYPOINT_ICON();
     method public int getMANEUVER_ARROWHEAD_ICON_CASING_DRAWABLE();
     method public int getMANEUVER_ARROWHEAD_ICON_DRAWABLE();
-    method public int getMANEUVER_ARROW_BORDER_COLOR();
+    method public int getMANEUVER_ARROW_CASING_COLOR();
     method public int getMANEUVER_ARROW_COLOR();
     method public int getORIGIN_WAYPOINT_ICON();
     method public int getRESTRICTED_ROAD_COLOR();
@@ -54,7 +54,7 @@ package com.mapbox.navigation.ui.base.internal.model.route {
     property public final int DESTINATION_WAYPOINT_ICON;
     property public final int MANEUVER_ARROWHEAD_ICON_CASING_DRAWABLE;
     property public final int MANEUVER_ARROWHEAD_ICON_DRAWABLE;
-    property public final int MANEUVER_ARROW_BORDER_COLOR;
+    property public final int MANEUVER_ARROW_CASING_COLOR;
     property public final int MANEUVER_ARROW_COLOR;
     property public final int ORIGIN_WAYPOINT_ICON;
     property public final int RESTRICTED_ROAD_COLOR;

--- a/libnavui-base/src/main/java/com/mapbox/navigation/ui/base/internal/model/route/RouteConstants.kt
+++ b/libnavui-base/src/main/java/com/mapbox/navigation/ui/base/internal/model/route/RouteConstants.kt
@@ -120,7 +120,7 @@ object RouteConstants {
     val MANEUVER_ARROW_COLOR = Color.parseColor("#FFFFFF")
 
     @ColorInt
-    val MANEUVER_ARROW_BORDER_COLOR = Color.parseColor("#2D3F53")
+    val MANEUVER_ARROW_CASING_COLOR = Color.parseColor("#2D3F53")
 
     @ColorInt
     val ROUTE_CLOSURE_COLOR = Color.parseColor("#000000")

--- a/libnavui-maps/api/current.txt
+++ b/libnavui-maps/api/current.txt
@@ -646,17 +646,17 @@ package com.mapbox.navigation.ui.maps.route.arrow.model {
 
   public final class RouteArrowOptions {
     method public String getAboveLayerId();
-    method public int getArrowBorderColor();
+    method public int getArrowCasingColor();
     method public int getArrowColor();
     method public android.graphics.drawable.Drawable getArrowHeadIcon();
-    method public android.graphics.drawable.Drawable getArrowHeadIconBorder();
+    method public android.graphics.drawable.Drawable getArrowHeadIconCasing();
     method public double getTolerance();
     method public com.mapbox.navigation.ui.maps.route.arrow.model.RouteArrowOptions.Builder toBuilder(android.content.Context context);
     property public final String aboveLayerId;
-    property public final int arrowBorderColor;
+    property public final int arrowCasingColor;
     property public final int arrowColor;
     property public final android.graphics.drawable.Drawable arrowHeadIcon;
-    property public final android.graphics.drawable.Drawable arrowHeadIconBorder;
+    property public final android.graphics.drawable.Drawable arrowHeadIconCasing;
     property public final double tolerance;
   }
 
@@ -664,7 +664,7 @@ package com.mapbox.navigation.ui.maps.route.arrow.model {
     ctor public RouteArrowOptions.Builder(android.content.Context context);
     method public com.mapbox.navigation.ui.maps.route.arrow.model.RouteArrowOptions build();
     method public com.mapbox.navigation.ui.maps.route.arrow.model.RouteArrowOptions.Builder withAboveLayerId(String layerId);
-    method public com.mapbox.navigation.ui.maps.route.arrow.model.RouteArrowOptions.Builder withArrowBorderColor(@ColorInt int color);
+    method public com.mapbox.navigation.ui.maps.route.arrow.model.RouteArrowOptions.Builder withArrowCasingColor(@ColorInt int color);
     method public com.mapbox.navigation.ui.maps.route.arrow.model.RouteArrowOptions.Builder withArrowColor(@ColorInt int color);
     method public com.mapbox.navigation.ui.maps.route.arrow.model.RouteArrowOptions.Builder withArrowHeadIconCasingDrawable(@DrawableRes int drawable);
     method public com.mapbox.navigation.ui.maps.route.arrow.model.RouteArrowOptions.Builder withArrowHeadIconDrawable(@DrawableRes int drawable);

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/arrow/RouteArrowUtils.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/arrow/RouteArrowUtils.kt
@@ -87,15 +87,15 @@ internal object RouteArrowUtils {
         }
 
         if (
-            options.arrowHeadIconBorder.intrinsicHeight > 0 &&
-            options.arrowHeadIconBorder.intrinsicWidth > 0
+            options.arrowHeadIconCasing.intrinsicHeight > 0 &&
+            options.arrowHeadIconCasing.intrinsicWidth > 0
         ) {
             val arrowHeadCasingDrawable = DrawableCompat.wrap(
-                options.arrowHeadIconBorder
+                options.arrowHeadIconCasing
             )
             DrawableCompat.setTint(
                 arrowHeadCasingDrawable.mutate(),
-                options.arrowBorderColor
+                options.arrowCasingColor
             )
             val arrowHeadCasingBitmap = arrowHeadCasingDrawable.getBitmap()
             style.addImage(RouteConstants.ARROW_HEAD_ICON_CASING, arrowHeadCasingBitmap)
@@ -127,7 +127,7 @@ internal object RouteArrowUtils {
         )
             .lineColor(
                 Expression.color(
-                    options.arrowBorderColor
+                    options.arrowCasingColor
                 )
             )
             .lineWidth(

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/arrow/model/RouteArrowOptions.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/arrow/model/RouteArrowOptions.kt
@@ -12,19 +12,19 @@ import com.mapbox.navigation.ui.base.model.route.RouteLayerConstants.PRIMARY_ROU
  * Options for determining the appearance of maneuver arrow(s)
  *
  * @param arrowColor the color of the arrow shaft
- * @param arrowBorderColor the color of the arrow shaft border
+ * @param arrowCasingColor the color of the arrow shaft border
  * @param arrowHeadIcon the drawable to represent the arrow head
- * @param arrowHeadIconBorder the drawable to represent the arrow head border
+ * @param arrowHeadIconCasing the drawable to represent the arrow head border
  * @param aboveLayerId indicates the maneuver arrow map layers appear above this layer on the map
  * @param tolerance the tolerance value used when configuring the underlying map source
  */
 class RouteArrowOptions private constructor(
     @ColorInt val arrowColor: Int,
-    @ColorInt val arrowBorderColor: Int,
+    @ColorInt val arrowCasingColor: Int,
     private val arrowHeadIconDrawable: Int,
     private val arrowHeadIconCasingDrawable: Int,
     val arrowHeadIcon: Drawable,
-    val arrowHeadIconBorder: Drawable,
+    val arrowHeadIconCasing: Drawable,
     val aboveLayerId: String,
     val tolerance: Double
 ) {
@@ -38,7 +38,7 @@ class RouteArrowOptions private constructor(
         return Builder(
             context,
             arrowColor,
-            arrowBorderColor,
+            arrowCasingColor,
             arrowHeadIconDrawable,
             arrowHeadIconCasingDrawable,
             aboveLayerId,
@@ -56,11 +56,11 @@ class RouteArrowOptions private constructor(
         other as RouteArrowOptions
 
         if (arrowColor != other.arrowColor) return false
-        if (arrowBorderColor != other.arrowBorderColor) return false
+        if (arrowCasingColor != other.arrowCasingColor) return false
         if (arrowHeadIconDrawable != other.arrowHeadIconDrawable) return false
         if (arrowHeadIconCasingDrawable != other.arrowHeadIconCasingDrawable) return false
         if (arrowHeadIcon != other.arrowHeadIcon) return false
-        if (arrowHeadIconBorder != other.arrowHeadIconBorder) return false
+        if (arrowHeadIconCasing != other.arrowHeadIconCasing) return false
         if (aboveLayerId != other.aboveLayerId) return false
         if (tolerance != other.tolerance) return false
 
@@ -72,11 +72,11 @@ class RouteArrowOptions private constructor(
      */
     override fun hashCode(): Int {
         var result = arrowColor
-        result = 31 * result + arrowBorderColor
+        result = 31 * result + arrowCasingColor
         result = 31 * result + arrowHeadIconDrawable
         result = 31 * result + arrowHeadIconCasingDrawable
         result = 31 * result + arrowHeadIcon.hashCode()
-        result = 31 * result + arrowHeadIconBorder.hashCode()
+        result = 31 * result + arrowHeadIconCasing.hashCode()
         result = 31 * result + aboveLayerId.hashCode()
         result = 31 * result + (tolerance.hashCode())
         return result
@@ -87,11 +87,11 @@ class RouteArrowOptions private constructor(
      */
     override fun toString(): String {
         return "RouteArrowOptions(arrowColor=$arrowColor, " +
-            "arrowBorderColor=$arrowBorderColor, " +
+            "arrowCasingColor=$arrowCasingColor, " +
             "arrowHeadIconDrawable=$arrowHeadIconDrawable, " +
             "arrowHeadIconCasingDrawable=$arrowHeadIconCasingDrawable, " +
             "arrowHeadIcon=$arrowHeadIcon, " +
-            "arrowHeadIconBorder=$arrowHeadIconBorder, " +
+            "arrowHeadIconCasing=$arrowHeadIconCasing, " +
             "aboveLayerId='$aboveLayerId', " +
             "tolerance=$tolerance)"
     }
@@ -102,7 +102,7 @@ class RouteArrowOptions private constructor(
     class Builder internal constructor(
         private val context: Context,
         private var arrowColor: Int,
-        private var arrowBorderColor: Int,
+        private var arrowCasingColor: Int,
         private var arrowHeadIconDrawable: Int,
         private var arrowHeadIconCasingDrawable: Int,
         private var aboveLayerId: String?,
@@ -115,7 +115,7 @@ class RouteArrowOptions private constructor(
         constructor(context: Context) : this(
             context,
             RouteConstants.MANEUVER_ARROW_COLOR,
-            RouteConstants.MANEUVER_ARROW_BORDER_COLOR,
+            RouteConstants.MANEUVER_ARROW_CASING_COLOR,
             RouteConstants.MANEUVER_ARROWHEAD_ICON_DRAWABLE,
             RouteConstants.MANEUVER_ARROWHEAD_ICON_CASING_DRAWABLE,
             null,
@@ -135,8 +135,8 @@ class RouteArrowOptions private constructor(
          *
          * @param color the color to be used
          */
-        fun withArrowBorderColor(@ColorInt color: Int): Builder =
-            apply { this.arrowBorderColor = color }
+        fun withArrowCasingColor(@ColorInt color: Int): Builder =
+            apply { this.arrowCasingColor = color }
 
         /**
          * Indicates the drawable of the arrow head.
@@ -195,7 +195,7 @@ class RouteArrowOptions private constructor(
 
             return RouteArrowOptions(
                 arrowColor,
-                arrowBorderColor,
+                arrowCasingColor,
                 arrowHeadIconDrawable,
                 arrowHeadIconCasingDrawable,
                 arrowHeadIcon!!,

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/arrow/RouteArrowUtilsTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/arrow/RouteArrowUtilsTest.kt
@@ -412,9 +412,9 @@ class RouteArrowUtilsTest {
         val mockOptions = mockk<RouteArrowOptions> {
             every { aboveLayerId } returns options.aboveLayerId
             every { tolerance } returns options.tolerance
-            every { arrowBorderColor } returns options.arrowBorderColor
+            every { arrowCasingColor } returns options.arrowCasingColor
             every { arrowColor } returns options.arrowColor
-            every { arrowHeadIconBorder } returns options.arrowHeadIconBorder
+            every { arrowHeadIconCasing } returns options.arrowHeadIconCasing
             every { arrowHeadIcon } returns mockk<Drawable> {
                 every { intrinsicHeight } returns 0
                 every { intrinsicWidth } returns 1
@@ -434,9 +434,9 @@ class RouteArrowUtilsTest {
         val mockOptions = mockk<RouteArrowOptions> {
             every { aboveLayerId } returns options.aboveLayerId
             every { tolerance } returns options.tolerance
-            every { arrowBorderColor } returns options.arrowBorderColor
+            every { arrowCasingColor } returns options.arrowCasingColor
             every { arrowColor } returns options.arrowColor
-            every { arrowHeadIconBorder } returns options.arrowHeadIconBorder
+            every { arrowHeadIconCasing } returns options.arrowHeadIconCasing
             every { arrowHeadIcon } returns mockk<Drawable> {
                 every { intrinsicHeight } returns 1
                 every { intrinsicWidth } returns 0
@@ -456,10 +456,10 @@ class RouteArrowUtilsTest {
         val mockOptions = mockk<RouteArrowOptions> {
             every { aboveLayerId } returns options.aboveLayerId
             every { tolerance } returns options.tolerance
-            every { arrowBorderColor } returns options.arrowBorderColor
+            every { arrowCasingColor } returns options.arrowCasingColor
             every { arrowColor } returns options.arrowColor
             every { arrowHeadIcon } returns options.arrowHeadIcon
-            every { arrowHeadIconBorder } returns mockk<Drawable> {
+            every { arrowHeadIconCasing } returns mockk<Drawable> {
                 every { intrinsicHeight } returns 0
                 every { intrinsicWidth } returns 1
             }
@@ -478,10 +478,10 @@ class RouteArrowUtilsTest {
         val mockOptions = mockk<RouteArrowOptions> {
             every { aboveLayerId } returns options.aboveLayerId
             every { tolerance } returns options.tolerance
-            every { arrowBorderColor } returns options.arrowBorderColor
+            every { arrowCasingColor } returns options.arrowCasingColor
             every { arrowColor } returns options.arrowColor
             every { arrowHeadIcon } returns options.arrowHeadIcon
-            every { arrowHeadIconBorder } returns mockk<Drawable> {
+            every { arrowHeadIconCasing } returns mockk<Drawable> {
                 every { intrinsicHeight } returns 0
                 every { intrinsicWidth } returns 1
             }

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/arrow/model/RouteArrowOptionsTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/arrow/model/RouteArrowOptionsTest.kt
@@ -28,10 +28,10 @@ class RouteArrowOptionsTest {
     }
 
     @Test
-    fun withArrowBorderColorTest() {
-        val options = RouteArrowOptions.Builder(ctx).withArrowBorderColor(5).build()
+    fun withArrowCasingColorTest() {
+        val options = RouteArrowOptions.Builder(ctx).withArrowCasingColor(5).build()
 
-        assertEquals(5, options.arrowBorderColor)
+        assertEquals(5, options.arrowCasingColor)
     }
 
     @Test
@@ -49,7 +49,7 @@ class RouteArrowOptionsTest {
             .withArrowHeadIconCasingDrawable(RouteConstants.MANEUVER_ARROWHEAD_ICON_DRAWABLE)
             .build()
 
-        assertNotNull(options.arrowHeadIconBorder)
+        assertNotNull(options.arrowHeadIconCasing)
     }
 
     @Test
@@ -71,7 +71,7 @@ class RouteArrowOptionsTest {
         val options = RouteArrowOptions.Builder(ctx)
             .withArrowColor(1)
             .withAboveLayerId("someLayerId")
-            .withArrowBorderColor(2)
+            .withArrowCasingColor(2)
             .withArrowHeadIconDrawable(RouteConstants.MANEUVER_ARROWHEAD_ICON_DRAWABLE)
             .withArrowHeadIconCasingDrawable(RouteConstants.MANEUVER_ARROWHEAD_ICON_DRAWABLE)
             .withTolerance(.111)
@@ -80,10 +80,10 @@ class RouteArrowOptionsTest {
             .build()
 
         assertEquals(1, options.arrowColor)
-        assertEquals(2, options.arrowBorderColor)
+        assertEquals(2, options.arrowCasingColor)
         assertEquals("someLayerId", options.aboveLayerId)
         assertNotNull(options.arrowHeadIcon)
-        assertNotNull(options.arrowHeadIconBorder)
+        assertNotNull(options.arrowHeadIconCasing)
         assertEquals(.111, options.tolerance, 0.0)
     }
 }


### PR DESCRIPTION
### Description
Changed the text `border` to `casing` in route arrow options for correctness and consistency. 


### Changelog
```
<changelog>Changed terminology used for route arrow border for correctness and consistency.</changelog>
```

### Screenshots or Gifs
