### PR TITLE
Bump `mapboxEvents` and `mapboxCore` dependencies version to `7.0.2` and `4.0.2`

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -18,8 +18,8 @@ ext {
   version = [
       mapboxMapSdk              : '10.0.0-beta.20',
       mapboxSdkServices         : '5.9.0-alpha.5',
-      mapboxEvents              : '7.0.1',
-      mapboxCore                : '4.0.1',
+      mapboxEvents              : '7.0.2',
+      mapboxCore                : '4.0.2',
       mapboxNavigator           : "${mapboxNavigatorVersion}",
       mapboxCommonNative        : '12.0.0',
       mapboxCrashMonitor        : '2.0.0',


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Bumps `mapboxEvents` and `mapboxCore` dependencies version to `7.0.2` and `4.0.2` respectively

Refs. https://github.com/mapbox/mapbox-events-android/releases/tag/telem-7.0.2-core-4.0.2

cc @tarigo @mr1sunshine 