### PR TITLE
Refactoring to clean up the MapboxTripNotification class.

### DIFF
--- a/libnavigation-base/api/current.txt
+++ b/libnavigation-base/api/current.txt
@@ -559,6 +559,28 @@ package com.mapbox.navigation.base.trip.model {
     method public com.mapbox.navigation.base.trip.model.RouteStepProgress.Builder stepPoints(java.util.List<com.mapbox.geojson.Point>? stepPoints);
   }
 
+  public abstract sealed class TripNotificationState {
+  }
+
+  public static final class TripNotificationState.TripNotificationData extends com.mapbox.navigation.base.trip.model.TripNotificationState {
+    method public com.mapbox.api.directions.v5.models.BannerInstructions? component1();
+    method public Double? component2();
+    method public Double? component3();
+    method public String? component4();
+    method public com.mapbox.navigation.base.trip.model.TripNotificationState.TripNotificationData copy(com.mapbox.api.directions.v5.models.BannerInstructions? bannerInstructions, Double? distanceRemaining, Double? durationRemaining, String? drivingSide);
+    method public com.mapbox.api.directions.v5.models.BannerInstructions? getBannerInstructions();
+    method public Double? getDistanceRemaining();
+    method public String? getDrivingSide();
+    method public Double? getDurationRemaining();
+    property public final com.mapbox.api.directions.v5.models.BannerInstructions? bannerInstructions;
+    property public final Double? distanceRemaining;
+    property public final String? drivingSide;
+    property public final Double? durationRemaining;
+  }
+
+  public static final class TripNotificationState.TripNotificationFreeState extends com.mapbox.navigation.base.trip.model.TripNotificationState {
+  }
+
 }
 
 package com.mapbox.navigation.base.trip.model.eh {
@@ -1126,7 +1148,7 @@ package com.mapbox.navigation.base.trip.notification {
     method public int getNotificationId();
     method public void onTripSessionStarted();
     method public void onTripSessionStopped();
-    method public void updateNotification(com.mapbox.navigation.base.trip.model.RouteProgress? routeProgress);
+    method public void updateNotification(com.mapbox.navigation.base.trip.model.TripNotificationState state);
   }
 
 }

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/factory/TripNotificationStateFactory.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/factory/TripNotificationStateFactory.kt
@@ -1,0 +1,34 @@
+package com.mapbox.navigation.base.internal.factory
+
+import com.mapbox.api.directions.v5.models.BannerInstructions
+import com.mapbox.navigation.base.trip.model.RouteProgress
+import com.mapbox.navigation.base.trip.model.TripNotificationState
+import com.mapbox.navigation.base.utils.ifNonNull
+
+object TripNotificationStateFactory {
+
+    fun buildTripNotificationState(
+        bannerInstructions: BannerInstructions?,
+        distanceRemaining: Double?,
+        durationRemaining: Double?,
+        drivingSide: String?
+    ): TripNotificationState {
+        return TripNotificationState.TripNotificationData(
+            bannerInstructions,
+            distanceRemaining,
+            durationRemaining,
+            drivingSide
+        )
+    }
+
+    fun buildTripNotificationState(routeProgress: RouteProgress?): TripNotificationState {
+        return ifNonNull(routeProgress) { progress ->
+            buildTripNotificationState(
+                progress.bannerInstructions,
+                progress.currentLegProgress?.currentStepProgress?.distanceRemaining?.toDouble(),
+                progress.currentLegProgress?.durationRemaining,
+                progress.currentLegProgress?.currentStepProgress?.step?.drivingSide()
+            )
+        } ?: TripNotificationState.TripNotificationFreeState()
+    }
+}

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/TripNotificationState.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/TripNotificationState.kt
@@ -1,0 +1,28 @@
+package com.mapbox.navigation.base.trip.model
+
+import com.mapbox.api.directions.v5.models.BannerInstructions
+
+/**
+ * Represents data used for trip notifications
+ */
+sealed class TripNotificationState {
+    /**
+     * Represents data related to trip notifications.
+     *
+     * @param bannerInstructions an optional [BannerInstructions]
+     * @param distanceRemaining an optional value representing the distance remaining
+     * @param durationRemaining an optional value representing the trip duration remaining
+     * @param drivingSide an optional value representing the driving side
+     */
+    data class TripNotificationData internal constructor(
+        val bannerInstructions: BannerInstructions?,
+        val distanceRemaining: Double?,
+        val durationRemaining: Double?,
+        val drivingSide: String?
+    ) : TripNotificationState()
+
+    /**
+     * Represents a data-less state.
+     */
+    class TripNotificationFreeState internal constructor() : TripNotificationState()
+}

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/notification/TripNotification.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/notification/TripNotification.kt
@@ -1,7 +1,7 @@
 package com.mapbox.navigation.base.trip.notification
 
 import android.app.Notification
-import com.mapbox.navigation.base.trip.model.RouteProgress
+import com.mapbox.navigation.base.trip.model.TripNotificationState
 
 /**
  * Defines a contract for [Notification] instance provider and manager.
@@ -28,15 +28,12 @@ interface TripNotification {
     fun getNotificationId(): Int
 
     /**
-     * If enabled, this method will be called every time a
-     * new [RouteProgress] is generated.
-     *
      * This method can serve as a cue to update a [Notification]
      * with a specific notification id.
      *
-     * @param routeProgress with the latest progress data
+     * @param state with the latest progress data
      */
-    fun updateNotification(routeProgress: RouteProgress?)
+    fun updateNotification(state: TripNotificationState)
 
     /**
      * Callback for when trip session is started via [TripSession.start].

--- a/libnavigation-core/src/androidTest/java/com/mapbox/navigation/core/tests/activity/TripServiceActivity.kt
+++ b/libnavigation-core/src/androidTest/java/com/mapbox/navigation/core/tests/activity/TripServiceActivity.kt
@@ -11,6 +11,7 @@ import com.mapbox.common.module.provider.MapboxModuleProvider
 import com.mapbox.common.module.provider.ModuleProviderArgument
 import com.mapbox.navigation.base.TimeFormat.TWENTY_FOUR_HOURS
 import com.mapbox.navigation.base.formatter.DistanceFormatter
+import com.mapbox.navigation.base.internal.factory.TripNotificationStateFactory.buildTripNotificationState
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.trip.notification.TripNotification
 import com.mapbox.navigation.core.internal.formatter.MapboxDistanceFormatter
@@ -101,7 +102,7 @@ internal class TripServiceActivity : AppCompatActivity() {
     private fun changeText() {
         textUpdateJob = mainJobController.scope.launch {
             while (isActive) {
-                mapboxTripService.updateNotification(null)
+                mapboxTripService.updateNotification(buildTripNotificationState(null))
                 delay(1000L)
             }
         }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/service/MapboxTripService.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/service/MapboxTripService.kt
@@ -6,7 +6,7 @@ import android.content.Intent
 import android.os.Build
 import com.mapbox.base.common.logger.Logger
 import com.mapbox.base.common.logger.model.Message
-import com.mapbox.navigation.base.trip.model.RouteProgress
+import com.mapbox.navigation.base.trip.model.TripNotificationState
 import com.mapbox.navigation.base.trip.notification.TripNotification
 import com.mapbox.navigation.utils.internal.ifChannelException
 import kotlinx.coroutines.channels.Channel
@@ -130,8 +130,8 @@ internal class MapboxTripService(
     /**
      * Update the trip's information in the notification bar
      */
-    override fun updateNotification(routeProgress: RouteProgress?) {
-        tripNotification.updateNotification(routeProgress)
+    override fun updateNotification(tripNotificationState: TripNotificationState) {
+        tripNotification.updateNotification(tripNotificationState)
     }
 
     /**

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/service/TripService.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/service/TripService.kt
@@ -1,6 +1,7 @@
 package com.mapbox.navigation.core.trip.service
 
 import com.mapbox.navigation.base.trip.model.RouteProgress
+import com.mapbox.navigation.base.trip.model.TripNotificationState
 import com.mapbox.navigation.core.trip.session.TripSession
 
 /**
@@ -21,7 +22,7 @@ internal interface TripService {
     /**
      * Update the trip's information in the notification bar
      */
-    fun updateNotification(routeProgress: RouteProgress?)
+    fun updateNotification(tripNotificationState: TripNotificationState)
 
     /**
      * Return *true* if service is started

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
@@ -10,6 +10,7 @@ import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.VoiceInstructions
 import com.mapbox.base.common.logger.Logger
 import com.mapbox.base.common.logger.model.Message
+import com.mapbox.navigation.base.internal.factory.TripNotificationStateFactory.buildTripNotificationState
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.trip.model.RouteLegProgress
 import com.mapbox.navigation.base.trip.model.RouteProgress
@@ -606,7 +607,7 @@ internal class MapboxTripSession(
 
     private fun updateRouteProgress(progress: RouteProgress?) {
         routeProgress = progress
-        tripService.updateNotification(progress)
+        tripService.updateNotification(buildTripNotificationState(progress))
         progress?.let { progress ->
             routeProgressObservers.forEach { it.onRouteProgressChanged(progress) }
             if (bannerInstructionEvent.isOccurring(progress)) {

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/service/MapboxTripServiceTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/service/MapboxTripServiceTest.kt
@@ -3,7 +3,9 @@ package com.mapbox.navigation.core.trip.service
 import android.app.Notification
 import com.mapbox.base.common.logger.Logger
 import com.mapbox.base.common.logger.model.Message
+import com.mapbox.navigation.base.internal.factory.TripNotificationStateFactory.buildTripNotificationState
 import com.mapbox.navigation.base.trip.model.RouteProgress
+import com.mapbox.navigation.base.trip.model.TripNotificationState
 import com.mapbox.navigation.base.trip.notification.TripNotification
 import io.mockk.every
 import io.mockk.mockk
@@ -122,11 +124,25 @@ class MapboxTripServiceTest {
 
     @Test
     fun tripNotification_updateNotificationWhenUpdateNotificationCalled() {
-        val routeProgress: RouteProgress = mockk()
+        val routeProgress: RouteProgress = mockk {
+            every { bannerInstructions } returns null
+            every { currentLegProgress } returns null
+        }
 
-        service.updateNotification(routeProgress)
+        service.updateNotification(buildTripNotificationState(routeProgress))
 
-        verify(exactly = 1) { tripNotification.updateNotification(routeProgress) }
+        verify(exactly = 1) { tripNotification.updateNotification(any<TripNotificationState>()) }
+    }
+
+    @Test
+    fun tripNotification_updateNotificationWhenUpdateNotificationCalledWhenRouteProgressNull() {
+        service.updateNotification(buildTripNotificationState(null))
+
+        verify(exactly = 1) {
+            tripNotification.updateNotification(
+                any<TripNotificationState.TripNotificationFreeState>()
+            )
+        }
     }
 
     @Test

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
@@ -353,6 +353,7 @@ class MapboxTripSessionTest {
 
     @Test
     fun routeProgressObserverSuccess() = coroutineRule.runBlockingTest {
+        every { routeProgress.currentLegProgress } returns null
         tripSession = buildTripSession()
         tripSession.start()
         val observer: RouteProgressObserver = mockk(relaxUnitFun = true)
@@ -421,6 +422,7 @@ class MapboxTripSessionTest {
 
     @Test
     fun routeProgressObserverDoubleRegister() = coroutineRule.runBlockingTest {
+        every { routeProgress.currentLegProgress } returns null
         tripSession = buildTripSession()
         tripSession.start()
         val observer: RouteProgressObserver = mockk(relaxUnitFun = true)
@@ -435,6 +437,7 @@ class MapboxTripSessionTest {
 
     @Test
     fun offRouteObserverCalledWhenStatusIsDifferentToCurrent() = coroutineRule.runBlockingTest {
+        every { routeProgress.currentLegProgress } returns null
         tripSession = buildTripSession()
         tripSession.start()
         val offRouteObserver: OffRouteObserver = mockk(relaxUnitFun = true)
@@ -468,6 +471,7 @@ class MapboxTripSessionTest {
 
     @Test
     fun isOffRouteIsSetToFalseWhenSettingARoute() = coroutineRule.runBlockingTest {
+        every { routeProgress.currentLegProgress } returns null
         tripSession = buildTripSession()
         tripSession.route = route
         tripSession.start()
@@ -491,6 +495,7 @@ class MapboxTripSessionTest {
 
     @Test
     fun isOffRouteIsSetToFalseWhenSettingANullRoute() = coroutineRule.runBlockingTest {
+        every { routeProgress.currentLegProgress } returns null
         tripSession = buildTripSession()
         tripSession.route = route
         tripSession.start()
@@ -765,6 +770,7 @@ class MapboxTripSessionTest {
 
     @Test
     fun unregisterAllBannerInstructionsObservers() = coroutineRule.runBlockingTest {
+        every { routeProgress.currentLegProgress } returns null
         val bannerInstructionsObserver: BannerInstructionsObserver = mockk(relaxUnitFun = true)
         val bannerInstructions: BannerInstructions = mockk()
 
@@ -793,6 +799,7 @@ class MapboxTripSessionTest {
 
     @Test
     fun unregisterAllVoiceInstructionsObservers() = coroutineRule.runBlockingTest {
+        every { routeProgress.currentLegProgress } returns null
         val voiceInstructionsObserver: VoiceInstructionsObserver = mockk(relaxUnitFun = true)
         val voiceInstructions: VoiceInstructions = mockk()
         every { routeProgress.bannerInstructions } returns null

--- a/libtrip-notification/src/main/java/com/mapbox/navigation/trip/notification/MapboxTripNotificationView.kt
+++ b/libtrip-notification/src/main/java/com/mapbox/navigation/trip/notification/MapboxTripNotificationView.kt
@@ -1,0 +1,236 @@
+package com.mapbox.navigation.trip.notification
+
+import android.app.PendingIntent
+import android.content.Context
+import android.graphics.Bitmap
+import android.text.SpannableString
+import android.view.View
+import android.widget.RemoteViews
+import androidx.core.content.ContextCompat
+import com.mapbox.navigation.utils.internal.SET_BACKGROUND_COLOR
+
+internal class MapboxTripNotificationView(
+    private val context: Context
+) {
+    var collapsedView: RemoteViews? = null
+        private set
+    var expandedView: RemoteViews? = null
+        private set
+
+    /**
+     * Rebuilds the view component references.
+     */
+    fun buildRemoteViews(pendingCloseIntent: PendingIntent?) {
+        val backgroundColor =
+            ContextCompat.getColor(context, R.color.mapbox_notification_blue)
+
+        collapsedView = createRemoteView(
+            backgroundColor,
+            R.layout.mapbox_notification_navigation_collapsed,
+            R.id.navigationCollapsedNotificationLayout
+        )
+
+        expandedView = createRemoteView(
+            backgroundColor,
+            R.layout.mapbox_notification_navigation_expanded,
+            R.id.navigationExpandedNotificationLayout
+        ).also {
+            it.setOnClickPendingIntent(R.id.endNavigationBtn, pendingCloseIntent)
+        }
+    }
+
+    /**
+     * Sets the visibility of the view components.
+     *
+     * @param visibility a View.VISIBLE or View.GONE
+     */
+    fun setVisibility(visibility: Int) {
+        updateViewVisibility(
+            collapsedView,
+            R.id.navigationIsStarting,
+            visibility
+        )
+        updateViewVisibility(
+            expandedView,
+            R.id.navigationIsStarting,
+            visibility
+        )
+    }
+
+    /**
+     * Sets the text for the expanded notification remote view.
+     *
+     * @param textResource the resource ID
+     */
+    fun setEndNavigationButtonText(textResource: Int) {
+        expandedView?.setTextViewText(
+            R.id.endNavigationBtnText,
+            context.getString(textResource)
+        )
+    }
+
+    /**
+     * Sets the instruction text for the collapsed and expanded views.
+     *
+     * @param primaryText the text resource ID
+     */
+    fun updateInstructionText(primaryText: String) {
+        collapsedView?.setTextViewText(
+            R.id.notificationInstructionText,
+            primaryText
+        )
+        expandedView?.setTextViewText(
+            R.id.notificationInstructionText,
+            primaryText
+        )
+    }
+
+    /**
+     * Updates the distance text for the collapsed and expanded views.
+     *
+     * @param currentDistanceText the text resource ID
+     */
+    fun updateDistanceText(currentDistanceText: SpannableString?) {
+        collapsedView?.setTextViewText(
+            R.id.notificationDistanceText,
+            currentDistanceText.toString()
+        )
+        expandedView?.setTextViewText(
+            R.id.notificationDistanceText,
+            currentDistanceText.toString()
+        )
+    }
+
+    /**
+     * Updates the arrival time for the collapsed and expanded views.
+     *
+     * @param time the time text
+     */
+    fun updateArrivalTime(time: String) {
+        collapsedView?.setTextViewText(R.id.notificationArrivalText, time)
+        expandedView?.setTextViewText(R.id.notificationArrivalText, time)
+    }
+
+    /**
+     * Updates the image for the collapsed and expanded views.
+     *
+     * @param bitmap the bitmap to apply
+     */
+    fun updateImage(bitmap: Bitmap) {
+        collapsedView?.setImageViewBitmap(R.id.maneuverImage, bitmap)
+        expandedView?.setImageViewBitmap(R.id.maneuverImage, bitmap)
+    }
+
+    /**
+     * Resets the text for the collapsed and expanded views to empty strings and resets the
+     * visibility.
+     */
+    fun resetView() {
+        collapsedView?.apply {
+            setTextViewText(R.id.notificationDistanceText, "")
+            setTextViewText(R.id.notificationArrivalText, "")
+            setTextViewText(R.id.notificationInstructionText, "")
+            setViewVisibility(R.id.etaContent, View.GONE)
+            setViewVisibility(R.id.notificationInstructionText, View.GONE)
+            setViewVisibility(R.id.freeDriveText, View.GONE)
+        }
+
+        expandedView?.apply {
+            setTextViewText(R.id.notificationDistanceText, "")
+            setTextViewText(R.id.notificationArrivalText, "")
+            setTextViewText(R.id.notificationInstructionText, "")
+            setTextViewText(R.id.endNavigationBtnText, "")
+            setViewVisibility(R.id.etaContent, View.GONE)
+            setViewVisibility(R.id.notificationInstructionText, View.GONE)
+            setViewVisibility(R.id.freeDriveText, View.GONE)
+        }
+    }
+
+    /**
+     * Updates the expanded and collapsed views visibility.
+     *
+     * @param isFreeDriveMode indicates if in free drive
+     */
+    fun setFreeDriveMode(isFreeDriveMode: Boolean) {
+        when (isFreeDriveMode) {
+            true -> {
+                updateViewVisibility(collapsedView, R.id.etaContent, View.GONE)
+                updateViewVisibility(expandedView, R.id.etaContent, View.GONE)
+                updateViewVisibility(
+                    collapsedView,
+                    R.id.notificationInstructionText,
+                    View.GONE
+                )
+                updateViewVisibility(
+                    expandedView,
+                    R.id.notificationInstructionText,
+                    View.GONE
+                )
+                updateViewVisibility(
+                    collapsedView,
+                    R.id.freeDriveText,
+                    View.VISIBLE
+                )
+                updateViewVisibility(
+                    expandedView,
+                    R.id.freeDriveText,
+                    View.VISIBLE
+                )
+                setImageViewResource(collapsedView)
+                setImageViewResource(expandedView)
+                setEndNavigationButtonText(R.string.mapbox_stop_session)
+            }
+            false -> {
+                updateViewVisibility(
+                    collapsedView,
+                    R.id.etaContent,
+                    View.VISIBLE
+                )
+                updateViewVisibility(expandedView, R.id.etaContent, View.VISIBLE)
+                updateViewVisibility(
+                    collapsedView,
+                    R.id.notificationInstructionText,
+                    View.VISIBLE
+                )
+                updateViewVisibility(
+                    expandedView,
+                    R.id.notificationInstructionText,
+                    View.VISIBLE
+                )
+                updateViewVisibility(
+                    collapsedView,
+                    R.id.freeDriveText,
+                    View.GONE
+                )
+                updateViewVisibility(
+                    expandedView,
+                    R.id.freeDriveText,
+                    View.GONE
+                )
+                setEndNavigationButtonText(R.string.mapbox_end_navigation)
+            }
+        }
+    }
+
+    private fun updateViewVisibility(remoteView: RemoteViews?, viewId: Int, visibility: Int) {
+        remoteView?.setViewVisibility(viewId, visibility)
+    }
+
+    private fun createRemoteView(
+        backgroundColor: Int,
+        layoutResource: Int,
+        layoutId: Int
+    ): RemoteViews {
+        return RemoteViewsProvider.createRemoteViews(context.packageName, layoutResource)
+            .also { remoteViews ->
+                remoteViews.setInt(layoutId, SET_BACKGROUND_COLOR, backgroundColor)
+            }
+    }
+
+    private fun setImageViewResource(remoteView: RemoteViews?) {
+        remoteView?.setImageViewResource(
+            R.id.maneuverImage,
+            R.drawable.mapbox_ic_navigation
+        )
+    }
+}

--- a/libtrip-notification/src/test/java/com/mapbox/navigation/trip/notification/MapboxTripNotificationViewTest.kt
+++ b/libtrip-notification/src/test/java/com/mapbox/navigation/trip/notification/MapboxTripNotificationViewTest.kt
@@ -1,0 +1,255 @@
+package com.mapbox.navigation.trip.notification
+
+import android.app.PendingIntent
+import android.content.Context
+import android.content.pm.PackageManager
+import android.content.res.Configuration
+import android.content.res.Resources
+import android.graphics.Bitmap
+import android.text.SpannableString
+import android.view.View
+import android.widget.RemoteViews
+import com.mapbox.navigation.trip.notification.internal.END_NAVIGATION
+import com.mapbox.navigation.trip.notification.internal.STOP_SESSION
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.verify
+import junit.framework.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+import java.util.Locale
+
+class MapboxTripNotificationViewTest {
+
+    private lateinit var mockedContext: Context
+    private lateinit var collapsedViews: RemoteViews
+    private lateinit var expandedViews: RemoteViews
+
+    @Before
+    fun setUp() {
+        mockedContext = createContext()
+        every { mockedContext.applicationContext } returns mockedContext
+        mockRemoteViews()
+    }
+
+    private fun mockRemoteViews() {
+        mockkObject(RemoteViewsProvider)
+        collapsedViews = mockk(relaxUnitFun = true)
+        expandedViews = mockk(relaxUnitFun = true)
+        every {
+            RemoteViewsProvider.createRemoteViews(
+                any(),
+                R.layout.mapbox_notification_navigation_collapsed
+            )
+        } returns collapsedViews
+        every {
+            RemoteViewsProvider.createRemoteViews(
+                any(),
+                R.layout.mapbox_notification_navigation_expanded
+            )
+        } returns expandedViews
+    }
+
+    @Test
+    fun buildRemoteViews() {
+        val pendingIntent = createPendingOpenIntent(mockedContext)
+
+        val view = MapboxTripNotificationView(mockedContext).also {
+            it.buildRemoteViews(pendingIntent)
+        }
+
+        assertNotNull(view.collapsedView)
+        assertNotNull(view.expandedView)
+        verify { view.expandedView!!.setOnClickPendingIntent(R.id.endNavigationBtn, pendingIntent) }
+    }
+
+    @Test
+    fun setVisibility() {
+        val pendingIntent = createPendingOpenIntent(mockedContext)
+
+        val view = MapboxTripNotificationView(mockedContext).also {
+            it.buildRemoteViews(pendingIntent)
+            it.setVisibility(View.VISIBLE)
+        }
+
+        verify { view.collapsedView!!.setViewVisibility(R.id.navigationIsStarting, View.VISIBLE) }
+        verify { view.expandedView!!.setViewVisibility(R.id.navigationIsStarting, View.VISIBLE) }
+    }
+
+    @Test
+    fun setEndNavigationButtonText() {
+        val pendingIntent = createPendingOpenIntent(mockedContext)
+
+        val view = MapboxTripNotificationView(mockedContext).also {
+            it.buildRemoteViews(pendingIntent)
+            it.setEndNavigationButtonText(R.string.mapbox_stop_session)
+        }
+
+        verify { view.expandedView!!.setTextViewText(R.id.endNavigationBtnText, STOP_SESSION) }
+    }
+
+    @Test
+    fun updateInstructionText() {
+        val pendingIntent = createPendingOpenIntent(mockedContext)
+
+        val view = MapboxTripNotificationView(mockedContext).also {
+            it.buildRemoteViews(pendingIntent)
+            it.updateInstructionText("foobar")
+        }
+
+        verify { view.collapsedView!!.setTextViewText(R.id.notificationInstructionText, "foobar") }
+        verify { view.expandedView!!.setTextViewText(R.id.notificationInstructionText, "foobar") }
+    }
+
+    @Test
+    fun updateDistanceText() {
+        val pendingIntent = createPendingOpenIntent(mockedContext)
+        val text = mockk<SpannableString>()
+
+        val view = MapboxTripNotificationView(mockedContext).also {
+            it.buildRemoteViews(pendingIntent)
+            it.updateDistanceText(text)
+        }
+
+        verify {
+            view.collapsedView!!.setTextViewText(R.id.notificationDistanceText, text.toString())
+        }
+        verify {
+            view.expandedView!!.setTextViewText(R.id.notificationDistanceText, text.toString())
+        }
+    }
+
+    @Test
+    fun updateArrivalTime() {
+        val pendingIntent = createPendingOpenIntent(mockedContext)
+
+        val view = MapboxTripNotificationView(mockedContext).also {
+            it.buildRemoteViews(pendingIntent)
+            it.updateArrivalTime("foobar")
+        }
+
+        verify { view.collapsedView!!.setTextViewText(R.id.notificationArrivalText, "foobar") }
+        verify { view.expandedView!!.setTextViewText(R.id.notificationArrivalText, "foobar") }
+    }
+
+    @Test
+    fun updateImage() {
+        val pendingIntent = createPendingOpenIntent(mockedContext)
+        val bitmap = mockk<Bitmap>()
+
+        val view = MapboxTripNotificationView(mockedContext).also {
+            it.buildRemoteViews(pendingIntent)
+            it.updateImage(bitmap)
+        }
+
+        verify { view.collapsedView!!.setImageViewBitmap(R.id.maneuverImage, bitmap) }
+        verify { view.expandedView!!.setImageViewBitmap(R.id.maneuverImage, bitmap) }
+    }
+
+    @Test
+    fun resetView() {
+        val pendingIntent = createPendingOpenIntent(mockedContext)
+
+        val view = MapboxTripNotificationView(mockedContext).also {
+            it.buildRemoteViews(pendingIntent)
+            it.resetView()
+        }
+
+        verify { view.collapsedView!!.setTextViewText(R.id.notificationDistanceText, "") }
+        verify { view.collapsedView!!.setTextViewText(R.id.notificationArrivalText, "") }
+        verify { view.collapsedView!!.setTextViewText(R.id.notificationInstructionText, "") }
+        verify { view.collapsedView!!.setViewVisibility(R.id.etaContent, View.GONE) }
+        verify { view.collapsedView!!.setViewVisibility(R.id.freeDriveText, View.GONE) }
+        verify {
+            view.collapsedView!!.setViewVisibility(R.id.notificationInstructionText, View.GONE)
+        }
+
+        verify { view.expandedView!!.setTextViewText(R.id.notificationDistanceText, "") }
+        verify { view.expandedView!!.setTextViewText(R.id.notificationArrivalText, "") }
+        verify { view.expandedView!!.setTextViewText(R.id.notificationInstructionText, "") }
+        verify { view.expandedView!!.setViewVisibility(R.id.etaContent, View.GONE) }
+        verify { view.expandedView!!.setViewVisibility(R.id.freeDriveText, View.GONE) }
+        verify {
+            view.expandedView!!.setViewVisibility(R.id.notificationInstructionText, View.GONE)
+        }
+    }
+
+    @Test
+    fun setFreeDriveMode_true() {
+        val pendingIntent = createPendingOpenIntent(mockedContext)
+
+        val view = MapboxTripNotificationView(mockedContext).also {
+            it.buildRemoteViews(pendingIntent)
+            it.setFreeDriveMode(true)
+        }
+
+        verify { view.collapsedView!!.setViewVisibility(R.id.etaContent, View.GONE) }
+        verify { view.collapsedView!!.setViewVisibility(R.id.freeDriveText, View.VISIBLE) }
+        verify {
+            view.collapsedView!!.setViewVisibility(R.id.notificationInstructionText, View.GONE)
+        }
+        verify {
+            view.collapsedView!!.setImageViewResource(
+                R.id.maneuverImage,
+                R.drawable.mapbox_ic_navigation
+            )
+        }
+        verify { view.expandedView!!.setViewVisibility(R.id.etaContent, View.GONE) }
+        verify { view.expandedView!!.setViewVisibility(R.id.freeDriveText, View.VISIBLE) }
+        verify {
+            view.expandedView!!.setViewVisibility(R.id.notificationInstructionText, View.GONE)
+        }
+        verify {
+            view.expandedView!!.setImageViewResource(
+                R.id.maneuverImage,
+                R.drawable.mapbox_ic_navigation
+            )
+        }
+        verify { view.expandedView!!.setTextViewText(R.id.endNavigationBtnText, STOP_SESSION) }
+    }
+
+    @Test
+    fun setFreeDriveMode_false() {
+        val pendingIntent = createPendingOpenIntent(mockedContext)
+
+        val view = MapboxTripNotificationView(mockedContext).also {
+            it.buildRemoteViews(pendingIntent)
+            it.setFreeDriveMode(false)
+        }
+
+        verify { view.collapsedView!!.setViewVisibility(R.id.etaContent, View.VISIBLE) }
+        verify { view.collapsedView!!.setViewVisibility(R.id.freeDriveText, View.GONE) }
+        verify {
+            view.collapsedView!!.setViewVisibility(R.id.notificationInstructionText, View.VISIBLE)
+        }
+        verify { view.expandedView!!.setViewVisibility(R.id.etaContent, View.VISIBLE) }
+        verify { view.expandedView!!.setViewVisibility(R.id.freeDriveText, View.GONE) }
+        verify {
+            view.expandedView!!.setViewVisibility(R.id.notificationInstructionText, View.VISIBLE)
+        }
+        verify { view.expandedView!!.setTextViewText(R.id.endNavigationBtnText, END_NAVIGATION) }
+    }
+
+    private fun createContext(): Context {
+        val mockedContext = mockk<Context>()
+        val mockedConfiguration = Configuration()
+        mockedConfiguration.locale = Locale("en")
+        val mockedResources = mockk<Resources>(relaxed = true)
+        every { mockedResources.configuration } returns (mockedConfiguration)
+        every { mockedContext.resources } returns (mockedResources)
+        val mockedPackageManager = mockk<PackageManager>(relaxed = true)
+        every { mockedContext.packageManager } returns (mockedPackageManager)
+        every { mockedContext.packageName } returns ("com.mapbox.navigation.trip.notification")
+        every { mockedContext.getString(R.string.mapbox_stop_session) } returns STOP_SESSION
+        every { mockedContext.getString(R.string.mapbox_end_navigation) } returns END_NAVIGATION
+        return mockedContext
+    }
+
+    private fun createPendingOpenIntent(applicationContext: Context): PendingIntent? {
+        val pm = applicationContext.packageManager
+        val intent = pm.getLaunchIntentForPackage(applicationContext.packageName) ?: return null
+        intent.setPackage(null)
+        return PendingIntent.getActivity(applicationContext, 0, intent, 0)
+    }
+}

--- a/libtrip-notification/src/test/java/com/mapbox/navigation/trip/notification/internal/MapboxTripNotificationTest.kt
+++ b/libtrip-notification/src/test/java/com/mapbox/navigation/trip/notification/internal/MapboxTripNotificationTest.kt
@@ -16,10 +16,11 @@ import android.widget.RemoteViews
 import com.mapbox.api.directions.v5.models.BannerInstructions
 import com.mapbox.api.directions.v5.models.BannerText
 import com.mapbox.navigation.base.formatter.DistanceFormatter
+import com.mapbox.navigation.base.internal.factory.TripNotificationStateFactory
+import com.mapbox.navigation.base.internal.factory.TripNotificationStateFactory.buildTripNotificationState
 import com.mapbox.navigation.base.internal.time.TimeFormatter
 import com.mapbox.navigation.base.options.NavigationOptions
-import com.mapbox.navigation.base.trip.model.RouteLegProgress
-import com.mapbox.navigation.base.trip.model.RouteProgress
+import com.mapbox.navigation.base.trip.model.TripNotificationState
 import com.mapbox.navigation.trip.notification.NavigationNotificationProvider
 import com.mapbox.navigation.trip.notification.R
 import com.mapbox.navigation.trip.notification.RemoteViewsProvider
@@ -40,12 +41,12 @@ import org.junit.Before
 import org.junit.Test
 import java.util.Locale
 
-private const val STOP_SESSION = "Stop session"
-private const val END_NAVIGATION = "End Navigation"
-private const val FORMAT_STRING = "%s 454545 ETA"
-private const val MANEUVER_TYPE = "MANEUVER TYPE"
-private const val MANEUVER_MODIFIER = "MANEUVER MODIFIER"
-private const val NAVIGATION_IS_STARTING = "Navigation is starting…"
+internal const val STOP_SESSION = "Stop session"
+internal const val END_NAVIGATION = "End Navigation"
+internal const val FORMAT_STRING = "%s 454545 ETA"
+internal const val MANEUVER_TYPE = "MANEUVER TYPE"
+internal const val MANEUVER_MODIFIER = "MANEUVER MODIFIER"
+internal const val NAVIGATION_IS_STARTING = "Navigation is starting…"
 
 class MapboxTripNotificationTest {
 
@@ -187,12 +188,12 @@ class MapboxTripNotificationTest {
 
     @Test
     fun whenUpdateNotificationCalledThenPrimaryTextIsSetToRemoteViews() {
-        val routeProgress = mockk<RouteProgress>(relaxed = true)
+        val state = mockk<TripNotificationState.TripNotificationData>(relaxed = true)
         val primaryText = { "Primary Text" }
-        val bannerText = mockBannerText(routeProgress, primaryText)
+        val bannerText = mockBannerText(state, primaryText)
         mockUpdateNotificationAndroidInteractions()
 
-        notification.updateNotification(routeProgress)
+        notification.updateNotification(state)
 
         verify(exactly = 1) { bannerText.text() }
         verify(exactly = 1) {
@@ -209,14 +210,16 @@ class MapboxTripNotificationTest {
 
     @Test
     fun whenUpdateNotificationCalledThenDistanceTextIsSetToRemoteViews() {
-        val routeProgress = mockk<RouteProgress>(relaxed = true)
-        val distance = 30f
+        val distance = 30.0
         val duration = 112.4
         val distanceText = distanceSpannable.toString()
-        mockLegProgress(routeProgress, distance, duration)
+        val state = mockk<TripNotificationState.TripNotificationData>(relaxed = true) {
+            every { distanceRemaining } returns distance
+            every { durationRemaining } returns duration
+        }
         mockUpdateNotificationAndroidInteractions()
 
-        notification.updateNotification(routeProgress)
+        notification.updateNotification(state)
 
         verify(exactly = 1) {
             collapsedViews.setTextViewText(
@@ -234,16 +237,20 @@ class MapboxTripNotificationTest {
 
     @Test
     fun whenUpdateNotificationCalledThenArrivalTimeIsSetToRemoteViews() {
-        val routeProgress = mockk<RouteProgress>(relaxed = true)
-        val distance = 30f
+        val distance = 30.0
         val duration = 112.4
-        mockLegProgress(routeProgress, distance, duration)
         mockUpdateNotificationAndroidInteractions()
         val suffix = "this is nice formatting"
         mockTimeFormatter(suffix)
         val result = String.format(FORMAT_STRING, suffix + duration.toDouble().toString())
+        val state = TripNotificationStateFactory.buildTripNotificationState(
+            null,
+            distance,
+            duration,
+            null
+        )
 
-        notification.updateNotification(routeProgress)
+        notification.updateNotification(state)
 
         verify(exactly = 1) { collapsedViews.setTextViewText(any(), result) }
         verify(exactly = 1) { expandedViews.setTextViewText(any(), result) }
@@ -251,18 +258,18 @@ class MapboxTripNotificationTest {
 
     @Test
     fun whenUpdateNotificationCalledTwiceWithSameDataThenRemoteViewAreNotUpdatedTwice() {
-        val routeProgress = mockk<RouteProgress>(relaxed = true)
+        val state = mockk<TripNotificationState.TripNotificationData>(relaxed = true)
         val primaryText = { "Primary Text" }
-        val bannerText = mockBannerText(routeProgress, primaryText)
+        val bannerText = mockBannerText(state, primaryText)
         mockUpdateNotificationAndroidInteractions()
 
-        notification.updateNotification(routeProgress)
+        notification.updateNotification(state)
 
         verify(exactly = 1) { bannerText.text() }
         verify(exactly = 1) { collapsedViews.setTextViewText(any(), primaryText()) }
         verify(exactly = 1) { expandedViews.setTextViewText(any(), primaryText()) }
 
-        notification.updateNotification(routeProgress)
+        notification.updateNotification(state)
 
         verify(exactly = 2) { bannerText.text() }
         verify(exactly = 1) { collapsedViews.setTextViewText(any(), primaryText()) }
@@ -273,17 +280,17 @@ class MapboxTripNotificationTest {
 
     @Test
     fun whenUpdateNotificationCalledTwiceWithDifferentDataThenRemoteViewUpdatedTwice() {
-        val routeProgress = mockk<RouteProgress>(relaxed = true)
+        val state = mockk<TripNotificationState.TripNotificationData>(relaxed = true)
         val initialPrimaryText = "Primary Text"
         val changedPrimaryText = "Changed Primary Text"
         var primaryText = initialPrimaryText
         val primaryTextLambda = { primaryText }
-        val bannerText = mockBannerText(routeProgress, primaryTextLambda)
+        val bannerText = mockBannerText(state, primaryTextLambda)
         mockUpdateNotificationAndroidInteractions()
 
-        notification.updateNotification(routeProgress)
+        notification.updateNotification(state)
         primaryText = changedPrimaryText
-        notification.updateNotification(routeProgress)
+        notification.updateNotification(state)
 
         verify(exactly = 2) { bannerText.text() }
         verify(exactly = 1) { collapsedViews.setTextViewText(any(), initialPrimaryText) }
@@ -296,13 +303,13 @@ class MapboxTripNotificationTest {
 
     @Test
     fun whenGoThroughStartUpdateStopCycleThenNotificationCacheDropped() {
-        val routeProgress = mockk<RouteProgress>(relaxed = true)
+        val state = mockk<TripNotificationState.TripNotificationData>(relaxed = true)
         val primaryText = { "Primary Text" }
-        val bannerText = mockBannerText(routeProgress, primaryText)
+        val bannerText = mockBannerText(state, primaryText)
         mockUpdateNotificationAndroidInteractions()
 
         notification.onTripSessionStarted()
-        notification.updateNotification(routeProgress)
+        notification.updateNotification(state)
         notification.onTripSessionStopped()
         notification.onTripSessionStarted()
 
@@ -312,7 +319,7 @@ class MapboxTripNotificationTest {
         assertNull(notification.currentManeuverType)
         assertNull(notification.currentManeuverModifier)
 
-        notification.updateNotification(routeProgress)
+        notification.updateNotification(state)
 
         verify(exactly = 2) { bannerText.text() }
         verify(exactly = 2) { collapsedViews.setTextViewText(any(), primaryText()) }
@@ -323,14 +330,14 @@ class MapboxTripNotificationTest {
 
     @Test
     fun whenGoThroughStartUpdateStopCycleThenStartStopSessionDontAffectRemoteViews() {
-        val routeProgress = mockk<RouteProgress>(relaxed = true)
+        val state = mockk<TripNotificationState.TripNotificationData>(relaxed = true)
         val primaryText = { "Primary Text" }
-        val bannerText = mockBannerText(routeProgress, primaryText)
+        val bannerText = mockBannerText(state, primaryText)
         mockUpdateNotificationAndroidInteractions()
 
         notification.onTripSessionStarted()
 
-        notification.updateNotification(routeProgress)
+        notification.updateNotification(state)
 
         verify(exactly = 1) { bannerText.text() }
         verify(exactly = 1) { collapsedViews.setTextViewText(any(), primaryText()) }
@@ -415,7 +422,7 @@ class MapboxTripNotificationTest {
         mockUpdateNotificationAndroidInteractions()
 
         notification.onTripSessionStarted()
-        notification.updateNotification(nullRouteProgress)
+        notification.updateNotification(buildTripNotificationState(nullRouteProgress))
 
         verify(ordering = Ordering.ORDERED) {
             collapsedViews.setViewVisibility(R.id.navigationIsStarting, View.VISIBLE)
@@ -450,32 +457,19 @@ class MapboxTripNotificationTest {
     }
 
     private fun mockBannerText(
-        routeProgress: RouteProgress,
+        state: TripNotificationState.TripNotificationData,
         primaryText: () -> String,
         primaryType: () -> String = { MANEUVER_TYPE },
         primaryModifier: () -> String = { MANEUVER_MODIFIER }
     ): BannerText {
         val bannerText = mockk<BannerText>()
         val bannerInstructions = mockk<BannerInstructions>()
-        every { routeProgress.bannerInstructions } returns bannerInstructions
+        every { state.bannerInstructions } returns bannerInstructions
         every { bannerInstructions.primary() } returns bannerText
         every { bannerText.text() } answers { primaryText() }
         every { bannerText.type() } answers { primaryType() }
         every { bannerText.modifier() } answers { primaryModifier() }
         return bannerText
-    }
-
-    @Suppress("SameParameterValue")
-    private fun mockLegProgress(
-        routeProgress: RouteProgress,
-        distance: Float,
-        duration: Double
-    ): RouteLegProgress {
-        val currentLegProgress = mockk<RouteLegProgress>(relaxed = true)
-        every { routeProgress.currentLegProgress } returns currentLegProgress
-        every { currentLegProgress.currentStepProgress?.distanceRemaining } returns distance
-        every { currentLegProgress.durationRemaining } returns duration
-        return currentLegProgress
     }
 
     private fun mockTimeFormatter(@Suppress("SameParameterValue") suffix: String) {


### PR DESCRIPTION
### Description
Partially addresses #4163 by refactoring the `MapboxTripNotification` by focussing on the points outline in the initial issue comment.  Removes the dependency on the RouteProgress. Moves much of the code related to updating the views in order to clean up the class.

### Screenshots or Gifs

