### PR TITLE
Recreate Navigator

### DIFF
--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -23,6 +23,7 @@ package com.mapbox.navigation.core {
     method public void registerEHorizonObserver(com.mapbox.navigation.core.trip.session.eh.EHorizonObserver eHorizonObserver);
     method public void registerLocationObserver(com.mapbox.navigation.core.trip.session.LocationObserver locationObserver);
     method public void registerMapMatcherResultObserver(com.mapbox.navigation.core.trip.session.MapMatcherResultObserver mapMatcherResultObserver);
+    method public void registerNavigationVersionSwitchObserver(com.mapbox.navigation.core.NavigationVersionSwitchObserver observer);
     method public void registerOffRouteObserver(com.mapbox.navigation.core.trip.session.OffRouteObserver offRouteObserver);
     method public void registerRoadObjectsOnRouteObserver(com.mapbox.navigation.core.trip.session.RoadObjectsOnRouteObserver roadObjectsOnRouteObserver);
     method public void registerRouteAlternativesObserver(com.mapbox.navigation.core.routealternatives.RouteAlternativesObserver routeAlternativesObserver);
@@ -47,6 +48,7 @@ package com.mapbox.navigation.core {
     method public void unregisterEHorizonObserver(com.mapbox.navigation.core.trip.session.eh.EHorizonObserver eHorizonObserver);
     method public void unregisterLocationObserver(com.mapbox.navigation.core.trip.session.LocationObserver locationObserver);
     method public void unregisterMapMatcherResultObserver(com.mapbox.navigation.core.trip.session.MapMatcherResultObserver mapMatcherResultObserver);
+    method public void unregisterNavigationVersionSwitchObserver(com.mapbox.navigation.core.NavigationVersionSwitchObserver observer);
     method public void unregisterOffRouteObserver(com.mapbox.navigation.core.trip.session.OffRouteObserver offRouteObserver);
     method public void unregisterRoadObjectsOnRouteObserver(com.mapbox.navigation.core.trip.session.RoadObjectsOnRouteObserver roadObjectsOnRouteObserver);
     method public void unregisterRouteAlternativesObserver(com.mapbox.navigation.core.routealternatives.RouteAlternativesObserver routeAlternativesObserver);
@@ -71,6 +73,11 @@ package com.mapbox.navigation.core {
     method public static boolean isCreated();
     method public static com.mapbox.navigation.core.MapboxNavigation retrieve();
     field public static final com.mapbox.navigation.core.MapboxNavigationProvider INSTANCE;
+  }
+
+  public interface NavigationVersionSwitchObserver {
+    method public void onSwitchToFallbackVersion(String? tilesVersion);
+    method public void onSwitchToTargetVersion(String? tilesVersion);
   }
 
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/NavigationVersionSwitchObserver.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/NavigationVersionSwitchObserver.kt
@@ -1,0 +1,32 @@
+package com.mapbox.navigation.core
+
+import com.mapbox.common.TileStore
+import com.mapbox.navigation.base.options.RoutingTilesOptions
+
+/**
+ *  An interface which enables listening to navigation tiles version switch.
+ *  Navigator might be switched to a fallback tiles version when there are no enough tiles of the
+ *  current version to navigate on. It might happen when network is not available and tiles can't
+ *  be loaded. When connection is restored, navigator will switch back to the target version
+ *  specified in [RoutingTilesOptions] (the latest available version if no version is specified).
+ *  To create additional fallback tiles versions, use the [TileStore] to create and download
+ *  offline regions. Otherwise, fallback candidates will only be the tiles versions from the ambient
+ *  cache.
+ */
+interface NavigationVersionSwitchObserver {
+
+    /**
+     * Invoked as soon as navigation switched to a fallback tiles version.
+     *
+     * @param tilesVersion tiles version used for navigation.
+     */
+    fun onSwitchToFallbackVersion(tilesVersion: String?)
+
+    /**
+     * Invoked as soon as navigation switched to a tiles version specified in [RoutingTilesOptions]
+     * (the latest available version if no version is specified).
+     *
+     * @param tilesVersion tiles version used for navigation.
+     */
+    fun onSwitchToTargetVersion(tilesVersion: String?)
+}

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/TripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/TripSession.kt
@@ -6,6 +6,7 @@ import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.trip.service.TripService
 import com.mapbox.navigation.core.trip.session.eh.EHorizonObserver
+import com.mapbox.navigator.FallbackVersionsObserver
 
 internal interface TripSession {
 
@@ -62,4 +63,8 @@ internal interface TripSession {
     fun registerMapMatcherResultObserver(mapMatcherResultObserver: MapMatcherResultObserver)
     fun unregisterMapMatcherResultObserver(mapMatcherResultObserver: MapMatcherResultObserver)
     fun unregisterAllMapMatcherResultObservers()
+
+    fun registerFallbackVersionsObserver(fallbackVersionsObserver: FallbackVersionsObserver)
+    fun unregisterFallbackVersionsObserver(fallbackVersionsObserver: FallbackVersionsObserver)
+    fun unregisterAllFallbackVersionsObservers()
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/eh/EHorizonSubscriptionManagerImpl.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/eh/EHorizonSubscriptionManagerImpl.kt
@@ -85,10 +85,10 @@ internal class EHorizonSubscriptionManagerImpl(
             }
         }
 
-    private fun notifyAllObservers(action: suspend EHorizonObserver.() -> Unit) {
-        mainJobController.scope.launch {
-            eHorizonObservers.forEach {
-                it.action()
+    init {
+        navigator.setNativeNavigatorRecreationObserver {
+            if (eHorizonObservers.isNotEmpty()) {
+                setNavigatorObservers()
             }
         }
     }
@@ -132,6 +132,14 @@ internal class EHorizonSubscriptionManagerImpl(
         navigator.run {
             setElectronicHorizonObserver(null)
             setRoadObjectsStoreObserver(null)
+        }
+    }
+
+    private fun notifyAllObservers(action: suspend EHorizonObserver.() -> Unit) {
+        mainJobController.scope.launch {
+            eHorizonObservers.forEach {
+                it.action()
+            }
         }
     }
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/eh/RoadObjectMatcher.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/eh/RoadObjectMatcher.kt
@@ -28,6 +28,14 @@ class RoadObjectMatcher internal constructor(
 
     private val roadObjectMatcherObservers = CopyOnWriteArraySet<RoadObjectMatcherObserver>()
 
+    init {
+        navigator.setNativeNavigatorRecreationObserver {
+            if (roadObjectMatcherObservers.isNotEmpty()) {
+                navigator.roadObjectMatcher?.setListener(roadObjectMatcherListener)
+            }
+        }
+    }
+
     /**
      * Register road object matcher observer. It needs to be registered before any of the other
      * methods are called. Otherwise, the results are lost.

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigator.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigator.kt
@@ -12,6 +12,7 @@ import com.mapbox.navigation.base.options.RoutingTilesOptions
 import com.mapbox.navigator.BannerInstruction
 import com.mapbox.navigator.CacheHandle
 import com.mapbox.navigator.ElectronicHorizonObserver
+import com.mapbox.navigator.FallbackVersionsObserver
 import com.mapbox.navigator.FixLocation
 import com.mapbox.navigator.GraphAccessor
 import com.mapbox.navigator.NavigationStatus
@@ -48,6 +49,16 @@ interface MapboxNativeNavigator {
         tilesConfig: TilesConfig,
         logger: Logger
     ): MapboxNativeNavigator
+
+    /**
+     * Reinitialize the navigator with a device profile
+     */
+    fun recreate(
+        deviceProfile: DeviceProfile,
+        navigatorConfig: NavigatorConfig,
+        tilesConfig: TilesConfig,
+        logger: Logger
+    )
 
     /**
      * Reset the navigator state with the same configuration. The location becomes unknown,
@@ -262,6 +273,17 @@ interface MapboxNativeNavigator {
      * @param roadObjectsStoreObserver
      */
     fun setRoadObjectsStoreObserver(roadObjectsStoreObserver: RoadObjectsStoreObserver?)
+
+    fun setFallbackVersionsObserver(fallbackVersionsObserver: FallbackVersionsObserver?)
+
+    fun setNativeNavigatorRecreationObserver(
+        nativeNavigatorRecreationObserver: NativeNavigatorRecreationObserver
+    )
+
+    /**
+     * Unregister native observers
+     */
+    fun unregisterAllObservers()
 
     // Predictive cache
 

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/NativeNavigatorRecreationObserver.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/NativeNavigatorRecreationObserver.kt
@@ -1,0 +1,6 @@
+package com.mapbox.navigation.navigator.internal
+
+fun interface NativeNavigatorRecreationObserver {
+
+    fun onNativeNavigatorRecreated()
+}


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

When NN detects that there are no tiles to navigate, it scans for tiles with a different version. If there are valid tiles, sdk is notified with `onFallbackVersionsFound` method
```
public abstract class FallbackVersionsObserver {
    
    public abstract void onFallbackVersionsFound(@NonNull List<String> versions);
    
    public abstract void onCanReturnToLatest();
}
```
To switch navigator to another tiles version, we need to recreate it. It's implemented in `MapboxNavigation::recreateNavigatorInstance`.

When recreation is finished, `internal` listeners are notified with
```
fun interface NativeNavigatorRecreationObserver {

    fun onNativeNavigatorRecreated()
}
```

Right now we have the next listeners:
- TripSession
- EHorizonSubscriptionManager
- RoadObjectMatcher
They ^^ resubscribe internal observers to a new `navigator` instance. 

`PredictiveCache` also listens for a recreation event. We need to recreate all controllers with a new `navigator` instance. 
To make it possible, we cache all options used to create controllers and iterate on the options when we need.
(No way to shutdown old controllers on sdk side, might be implemented on NN side)

Open questions:
- If you add `EHorizon` custom objects to the `RoadObjectStore` they will be missed, because with a new `navigator` instance we get a new objectsStore instance. Should NN try to fix it? Or it's enough to explain it in the docs?
- should we expose a callback when we recreate the navigator? How we should call it? 

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Recreate Navigator to switch tiles version</changelog>
```

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
