### PR TITLE
Fix camera bouncing

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/camera/MapboxCameraAnimationsActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/camera/MapboxCameraAnimationsActivity.kt
@@ -108,10 +108,10 @@ class MapboxCameraAnimationsActivity :
     }
 
     private val paddedFollowingEdgeInsets = EdgeInsets(
-        0.0 * pixelDensity,
-        0.0 * pixelDensity,
+        0.0,
+        0.0,
         120.0 * pixelDensity,
-        0.0 * pixelDensity
+        0.0
     )
 
     private val notPaddedEdgeInsets: EdgeInsets by lazy {

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/camera/MapboxCameraAnimationsActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/camera/MapboxCameraAnimationsActivity.kt
@@ -109,9 +109,9 @@ class MapboxCameraAnimationsActivity :
 
     private val paddedFollowingEdgeInsets = EdgeInsets(
         0.0 * pixelDensity,
-        40.0 * pixelDensity,
+        0.0 * pixelDensity,
         120.0 * pixelDensity,
-        40.0 * pixelDensity
+        0.0 * pixelDensity
     )
 
     private val notPaddedEdgeInsets: EdgeInsets by lazy {

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/ViewportDataSourceProcessor.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/ViewportDataSourceProcessor.kt
@@ -216,7 +216,8 @@ internal object ViewportDataSourceProcessor {
      * the first edge's bearing.
      */
     fun slicePointsAtAngle(
-        points: List<Point>, maxAngleDifference: Double
+        points: List<Point>,
+        maxAngleDifference: Double
     ): List<Point> {
         if (points.size < 2) return points
         val outputCoordinates: MutableList<Point> = emptyList<Point>().toMutableList()

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/ViewportDataSourceProcessor.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/ViewportDataSourceProcessor.kt
@@ -25,6 +25,8 @@ internal object ViewportDataSourceProcessor {
 
     private const val TAG = "MbxViewportDataSource"
 
+    private const val maxAngleDifferenceForGeometrySlicing: Double = 100.0
+
     /**
      * Returns complete route points in nested arrays of points for all steps in all legs arranged as \[legs]\[steps]\[points].
      */
@@ -199,7 +201,10 @@ internal object ViewportDataSourceProcessor {
                 lookaheadDistanceForZoom,
                 TurfConstants.UNIT_KILOMETERS
             ).coordinates()
-            slicePointsAtAngle(lineSliceCoordinatesForLookaheadDistance, 100.0)
+            slicePointsAtAngle(
+                lineSliceCoordinatesForLookaheadDistance,
+                maxAngleDifferenceForGeometrySlicing
+            )
         } catch (e: TurfException) {
             LoggerProvider.logger.e(Tag(TAG), Message(e.message.toString()))
             emptyList()
@@ -207,7 +212,8 @@ internal object ViewportDataSourceProcessor {
     }
 
     /**
-     * Returns route geometry sliced at the point where it exceeds a certain angle difference from the first edge's bearing.
+     * Returns route geometry sliced at the point where it exceeds a certain angle difference from
+     * the first edge's bearing.
      */
     fun slicePointsAtAngle(
         points: List<Point>, maxAngleDifference: Double
@@ -220,9 +226,10 @@ internal object ViewportDataSourceProcessor {
             if (index == 0) {
                 continue
             }
-            val coord = points[index-1]?.let {
+            val coord = points[index - 1]?.let {
                 val thisEdgeBearing = TurfMeasurement.bearing(it, points[index])
-                if (abs(shortestRotationDiff(thisEdgeBearing, firstEdgeBearing)) < maxAngleDifference) {
+                val rotationDiff = shortestRotationDiff(thisEdgeBearing, firstEdgeBearing)
+                if (abs(rotationDiff) < maxAngleDifference) {
                     points[index]
                 } else {
                     null

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/camera/data/ViewportDataSourceProcessorTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/camera/data/ViewportDataSourceProcessorTest.kt
@@ -373,6 +373,43 @@ class ViewportDataSourceProcessorTest {
     }
 
     @Test
+    fun `test getPointsToFrameOnCurrentStep, intersections disabled, cloverleaf`() {
+        val stepProgress: RouteStepProgress = mockk {
+            every { distanceTraveled } returns 0f
+            every { distanceRemaining } returns 20000000f
+            every { stepPoints } returns listOf(
+                Point.fromLngLat(20.0, 11.0),
+                Point.fromLngLat(20.0, 12.0),
+                Point.fromLngLat(21.0, 12.0),
+                Point.fromLngLat(21.0, 9.0),
+                Point.fromLngLat(19.0, 9.0),
+                Point.fromLngLat(19.0, 13.0),
+                Point.fromLngLat(22.0, 13.0)
+            )
+            every { stepIndex } returns 0
+        }
+        val legProgress: RouteLegProgress = mockk {
+            every { currentStepProgress } returns stepProgress
+            every { legIndex } returns 0
+        }
+        val expected: List<Point> = listOf(
+            Point.fromLngLat(20.0, 11.0),
+            Point.fromLngLat(20.0, 12.0),
+            Point.fromLngLat(21.0, 12.0)
+        )
+
+        val actual = getPointsToFrameOnCurrentStep(
+            intersectionDensityCalculationEnabled = false,
+            intersectionDensityAverageDistanceMultiplier = 7.0,
+            averageIntersectionDistancesOnRoute = averageIntersectionDistancesOnRoute,
+            currentLegProgress = legProgress,
+            currentStepProgress = stepProgress
+        )
+
+        assertArrays1(expected, actual, pointAdapter)
+    }
+
+    @Test
     fun `test getPitchFallbackFromRouteProgress - pitch near maneuver disabled`() {
         val expected = 45.0
 


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Closes https://github.com/mapbox/mapbox-navigation-android/issues/4382.

Line slicing for lookahead distance stops at the first edge with an angle that exceeds 100º difference from the direction of the first edge of the line.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>When traversing routes that wrap around behind the vehicle (e.g.: cloverleafs and circular on-ramps) the zoom level is now held constant.</changelog>
```

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


https://user-images.githubusercontent.com/30373159/121577299-3c81e300-c9de-11eb-9055-ba2ee2a64eb9.mov


https://user-images.githubusercontent.com/30373159/121577319-40156a00-c9de-11eb-8aab-53b0c28627cd.mov



<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
