### PR TITLE
Sb 1000 hide inactive route legs

### DIFF
--- a/examples/src/main/AndroidManifest.xml
+++ b/examples/src/main/AndroidManifest.xml
@@ -98,6 +98,11 @@
     </activity>
 
     <activity
+        android:name=".MultiLegRouteExampleActivity"
+        android:label="@string/title_multileg_route">
+    </activity>
+
+    <activity
         android:name="com.mapbox.navigation.examples.MainActivity"
         android:screenOrientation="portrait">
       <intent-filter>

--- a/examples/src/main/java/com/mapbox/navigation/examples/MainActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/MainActivity.kt
@@ -22,6 +22,7 @@ import com.mapbox.navigation.examples.core.MapboxSignboardActivity
 import com.mapbox.navigation.examples.core.MapboxSnapshotActivity
 import com.mapbox.navigation.examples.core.MapboxTripProgressActivity
 import com.mapbox.navigation.examples.core.MapboxVoiceActivity
+import com.mapbox.navigation.examples.core.MultiLegRouteExampleActivity
 import com.mapbox.navigation.examples.core.R
 import com.mapbox.navigation.examples.core.ReplayHistoryActivity
 import com.mapbox.navigation.examples.core.camera.MapboxCameraAnimationsActivity
@@ -125,11 +126,6 @@ class MainActivity : AppCompatActivity(), PermissionsListener {
                 MapboxMultipleArrowActivity::class.java
             ),
             SampleItem(
-                getString(R.string.title_draw_utility),
-                getString(R.string.description_draw_utility),
-                RouteDrawingActivity::class.java
-            ),
-            SampleItem(
                 getString(R.string.title_independent_route),
                 getString(R.string.description_independent_route),
                 IndependentRouteGenerationActivity::class.java
@@ -138,6 +134,16 @@ class MainActivity : AppCompatActivity(), PermissionsListener {
                 getString(R.string.title_building_highlight),
                 getString(R.string.description_building_highlight),
                 MapboxBuildingHighlightActivity::class.java
+            ),
+            SampleItem(
+                getString(R.string.title_multileg_route),
+                getString(R.string.description_multileg_route),
+                MultiLegRouteExampleActivity::class.java
+            ),
+            SampleItem(
+                getString(R.string.title_draw_utility),
+                getString(R.string.description_draw_utility),
+                RouteDrawingActivity::class.java
             )
         )
     }

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxRouteLineAndArrowActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxRouteLineAndArrowActivity.kt
@@ -228,14 +228,18 @@ class MapboxRouteLineAndArrowActivity : AppCompatActivity(), OnMapLongClickListe
         val result = routeLineApi.updateTraveledRouteLine(point)
         mapboxMap.getStyle()?.apply {
             // Render the result to update the map.
-            routeLineView.renderVanishingRouteLineUpdateValue(this, result)
+            routeLineView.renderRouteLineUpdate(this, result)
         }
     }
 
     private val routeProgressObserver = RouteProgressObserver { routeProgress ->
         // RouteLine: This line is only necessary if the vanishing route line feature
         // is enabled.
-        routeLineApi.updateWithRouteProgress(routeProgress)
+        routeLineApi.updateWithRouteProgress(routeProgress) { result ->
+            mapboxMap.getStyle()?.apply {
+                routeLineView.renderRouteLineUpdate(this, result)
+            }
+        }
 
         // RouteArrow: The next maneuver arrows are driven by route progress events.
         // Generate the next maneuver arrow update data and pass it to the view class

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MultiLegRouteExampleActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MultiLegRouteExampleActivity.kt
@@ -1,0 +1,342 @@
+package com.mapbox.navigation.examples.core
+
+import android.annotation.SuppressLint
+import android.graphics.Color
+import android.location.Location
+import android.os.Bundle
+import android.util.Log
+import android.view.View
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
+import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.api.directions.v5.models.RouteOptions
+import com.mapbox.geojson.Point
+import com.mapbox.maps.CameraOptions
+import com.mapbox.maps.EdgeInsets
+import com.mapbox.maps.MapboxMap
+import com.mapbox.maps.Style
+import com.mapbox.maps.plugin.LocationPuck2D
+import com.mapbox.maps.plugin.animation.MapAnimationOptions
+import com.mapbox.maps.plugin.animation.camera
+import com.mapbox.maps.plugin.delegates.listeners.OnMapLoadErrorListener
+import com.mapbox.maps.plugin.delegates.listeners.eventdata.MapLoadErrorType
+import com.mapbox.maps.plugin.locationcomponent.location
+import com.mapbox.navigation.base.extensions.applyDefaultNavigationOptions
+import com.mapbox.navigation.base.extensions.applyLanguageAndVoiceUnitOptions
+import com.mapbox.navigation.base.options.NavigationOptions
+import com.mapbox.navigation.base.route.RouterCallback
+import com.mapbox.navigation.base.route.RouterFailure
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.directions.session.RoutesObserver
+import com.mapbox.navigation.core.replay.MapboxReplayer
+import com.mapbox.navigation.core.replay.ReplayLocationEngine
+import com.mapbox.navigation.core.replay.history.ReplayEventBase
+import com.mapbox.navigation.core.replay.route.ReplayProgressObserver
+import com.mapbox.navigation.core.replay.route.ReplayRouteMapper
+import com.mapbox.navigation.core.trip.session.LocationObserver
+import com.mapbox.navigation.core.trip.session.RouteProgressObserver
+import com.mapbox.navigation.examples.core.databinding.MultilegRouteExampleLayoutBinding
+import com.mapbox.navigation.ui.maps.location.NavigationLocationProvider
+import com.mapbox.navigation.ui.maps.route.arrow.api.MapboxRouteArrowApi
+import com.mapbox.navigation.ui.maps.route.arrow.api.MapboxRouteArrowView
+import com.mapbox.navigation.ui.maps.route.arrow.model.RouteArrowOptions
+import com.mapbox.navigation.ui.maps.route.line.api.MapboxRouteLineApi
+import com.mapbox.navigation.ui.maps.route.line.api.MapboxRouteLineView
+import com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions
+import com.mapbox.navigation.ui.maps.route.line.model.RouteLine
+import com.mapbox.navigation.ui.maps.route.line.model.RouteLineColorResources
+import com.mapbox.navigation.ui.maps.route.line.model.RouteLineResources
+
+/**
+ * This example demonstrates hiding inactive route legs. There are two specific use cases to
+ * take notice of that effect the implementation.
+ *
+ * It's important to take note of the code in the [RouteProgressObserver] below.
+ */
+class MultiLegRouteExampleActivity : AppCompatActivity() {
+
+    private val mapboxReplayer = MapboxReplayer()
+    private val replayRouteMapper = ReplayRouteMapper()
+
+    private val mapboxMap: MapboxMap by lazy {
+        viewBinding.mapView.getMapboxMap()
+    }
+
+    private val navigationLocationProvider by lazy {
+        NavigationLocationProvider()
+    }
+
+    private val viewBinding: MultilegRouteExampleLayoutBinding by lazy {
+        MultilegRouteExampleLayoutBinding.inflate(layoutInflater)
+    }
+
+    private val locationComponent by lazy {
+        viewBinding.mapView.location.apply {
+            setLocationProvider(navigationLocationProvider)
+            enabled = true
+        }
+    }
+
+    private val mapboxNavigation by lazy {
+        MapboxNavigation(
+            NavigationOptions.Builder(this)
+                .accessToken(getMapboxAccessTokenFromResources())
+                .locationEngine(ReplayLocationEngine(mapboxReplayer))
+                .build()
+        )
+    }
+
+    private val mapCamera by lazy {
+        viewBinding.mapView.camera
+    }
+
+    private val routeColorResources: RouteLineColorResources by lazy {
+        // This options is transparent by default.
+        RouteLineColorResources.Builder().inActiveRouteLegsColor(Color.GRAY).build()
+    }
+
+    private val routeLineResources: RouteLineResources by lazy {
+        RouteLineResources.Builder().routeLineColorResources(routeColorResources).build()
+    }
+
+    private val options: MapboxRouteLineOptions by lazy {
+        MapboxRouteLineOptions.Builder(this)
+            .withRouteLineResources(routeLineResources)
+            .withRouteLineBelowLayerId("road-label")
+            .styleInactiveRouteLegsIndependently(true) // This is the relevant option for this example
+            .build()
+    }
+
+    private val routeLineView by lazy {
+        MapboxRouteLineView(options)
+    }
+
+    private val routeLineApi: MapboxRouteLineApi by lazy {
+        MapboxRouteLineApi(options)
+    }
+
+    private val routeArrowApi: MapboxRouteArrowApi by lazy {
+        MapboxRouteArrowApi()
+    }
+
+    private val routeArrowView: MapboxRouteArrowView by lazy {
+        MapboxRouteArrowView(RouteArrowOptions.Builder(this).build())
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(viewBinding.root)
+        init()
+    }
+
+    private fun init() {
+        initNavigation()
+        initStyle()
+        initListeners()
+        locationComponent.locationPuck = LocationPuck2D(
+            null,
+            ContextCompat.getDrawable(
+                this@MultiLegRouteExampleActivity,
+                R.drawable.mapbox_navigation_puck_icon
+            ),
+            null,
+            null
+        )
+    }
+
+    private fun initNavigation() {
+        mapboxNavigation.registerLocationObserver(locationObserver)
+        mapboxNavigation.registerRouteProgressObserver(replayProgressObserver)
+        mapboxNavigation.registerRoutesObserver(routesObserver)
+
+        // The lines below are related to the navigation simulator.
+        mapboxReplayer.pushRealLocation(this, 0.0)
+        mapboxReplayer.playbackSpeed(1.5)
+        mapboxReplayer.play()
+    }
+
+    private val locationObserver = object : LocationObserver {
+        override fun onRawLocationChanged(rawLocation: Location) {}
+        override fun onEnhancedLocationChanged(
+            enhancedLocation: Location,
+            keyPoints: List<Location>
+        ) {
+            navigationLocationProvider.changePosition(
+                enhancedLocation,
+                keyPoints,
+            )
+            updateCamera(enhancedLocation)
+        }
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun initListeners() {
+        viewBinding.startNavigation.setOnClickListener {
+            val route = mapboxNavigation.getRoutes().firstOrNull()
+            if (route != null) {
+                mapboxNavigation.registerRouteProgressObserver(routeProgressObserver)
+                mapboxNavigation.startTripSession()
+                viewBinding.startNavigation.visibility = View.INVISIBLE
+
+                startSimulation(route)
+            }
+        }
+    }
+
+    // Starts the navigation simulator
+    private fun startSimulation(route: DirectionsRoute) {
+        mapboxReplayer.stop()
+        mapboxReplayer.clearEvents()
+        val replayData: List<ReplayEventBase> = replayRouteMapper.mapDirectionsRouteGeometry(route)
+        mapboxReplayer.pushEvents(replayData)
+        mapboxReplayer.seekTo(replayData[0])
+        mapboxReplayer.play()
+    }
+
+    override fun onStart() {
+        super.onStart()
+        mapboxNavigation.registerLocationObserver(locationObserver)
+        mapboxNavigation.registerRouteProgressObserver(replayProgressObserver)
+        mapboxNavigation.registerRouteProgressObserver(routeProgressObserver)
+        mapboxNavigation.registerRoutesObserver(routesObserver)
+        viewBinding.mapView.onStart()
+    }
+
+    override fun onStop() {
+        super.onStop()
+        mapboxNavigation.unregisterRouteProgressObserver(replayProgressObserver)
+        mapboxNavigation.unregisterRouteProgressObserver(routeProgressObserver)
+        mapboxNavigation.unregisterLocationObserver(locationObserver)
+        mapboxNavigation.unregisterRoutesObserver(routesObserver)
+        viewBinding.mapView.onStop()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        viewBinding.mapView.onDestroy()
+        mapboxNavigation.onDestroy()
+    }
+
+    override fun onLowMemory() {
+        super.onLowMemory()
+        viewBinding.mapView.onLowMemory()
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun initStyle() {
+        mapboxMap.loadStyleUri(
+            Style.MAPBOX_STREETS,
+            { style: Style ->
+
+                // Hard coding a location and a route for this example.
+                val location = Location("").also {
+                    it.latitude = 37.974972
+                    it.longitude = -122.523179
+                }
+                val point = Point.fromLngLat(-122.523179, 37.974972)
+                val cameraOptions = CameraOptions.Builder().center(point).zoom(13.0).build()
+                mapboxMap.setCamera(cameraOptions)
+                navigationLocationProvider.changePosition(
+                    location,
+                    listOf(),
+                    null,
+                    null
+                )
+                getRoute()
+                //
+            },
+            object : OnMapLoadErrorListener {
+                override fun onMapLoadError(mapLoadError: MapLoadErrorType, message: String) {
+                    Log.e(
+                        MapboxRouteLineAndArrowActivity::class.java.simpleName,
+                        "Error loading map: " + mapLoadError.name
+                    )
+                }
+            }
+        )
+    }
+
+    private fun getRoute() {
+        val routeOptions = RouteOptions.builder()
+            .applyDefaultNavigationOptions()
+            .applyLanguageAndVoiceUnitOptions(this)
+            .accessToken(getMapboxAccessTokenFromResources())
+            .coordinates(
+                listOf(
+                    Point.fromLngLat(-122.523179, 37.974972),
+                    Point.fromLngLat(-122.524257, 37.970785),
+                    Point.fromLngLat(-122.518925, 37.970548),
+                )
+            )
+            .alternatives(false)
+            .build()
+        mapboxNavigation.requestRoutes(
+            routeOptions,
+            routesReqCallback
+        )
+    }
+
+    private val routesReqCallback: RouterCallback = object : RouterCallback {
+        override fun onRoutesReady(routes: List<DirectionsRoute>) {
+            mapboxNavigation.setRoutes(routes)
+            if (routes.isNotEmpty()) {
+                viewBinding.routeLoadingProgressBar.visibility = View.INVISIBLE
+                viewBinding.startNavigation.visibility = View.VISIBLE
+            }
+        }
+
+        override fun onCanceled(routeOptions: RouteOptions) {
+            viewBinding.routeLoadingProgressBar.visibility = View.INVISIBLE
+        }
+
+        override fun onFailure(reasons: List<RouterFailure>, routeOptions: RouteOptions) {
+            viewBinding.routeLoadingProgressBar.visibility = View.INVISIBLE
+        }
+    }
+
+    private fun updateCamera(location: Location) {
+        val mapAnimationOptionsBuilder = MapAnimationOptions.Builder()
+        mapCamera.easeTo(
+            CameraOptions.Builder()
+                .center(Point.fromLngLat(location.longitude, location.latitude))
+                .bearing(location.bearing.toDouble())
+                .pitch(45.0)
+                .zoom(17.0)
+                .padding(EdgeInsets(1000.0, 0.0, 0.0, 0.0))
+                .build(),
+            mapAnimationOptionsBuilder.build()
+        )
+    }
+
+    private val replayProgressObserver = ReplayProgressObserver(mapboxReplayer)
+
+    private val routeProgressObserver = RouteProgressObserver { routeProgress ->
+
+        // This is the most important part of this example. The route progress will be used to
+        // determine the active leg and adjust the route line visibility accordingly.
+        routeLineApi.updateWithRouteProgress(routeProgress) { result ->
+            mapboxMap.getStyle()?.apply {
+                routeLineView.renderRouteLineUpdate(this, result)
+            }
+        }
+
+        routeArrowApi.addUpcomingManeuverArrow(routeProgress).apply {
+            routeArrowView.renderManeuverUpdate(mapboxMap.getStyle()!!, this)
+        }
+    }
+
+    private val routesObserver: RoutesObserver = RoutesObserver { routes ->
+        val routeLines = routes.map { RouteLine(it, null) }
+        routeLineApi.setRoutes(
+            routeLines
+        ) { value ->
+            mapboxMap.getStyle()?.apply {
+                routeLineView.renderRouteDrawData(this, value)
+            }
+        }
+    }
+
+    private fun getMapboxAccessTokenFromResources(): String {
+        return getString(this.resources.getIdentifier("mapbox_access_token", "string", packageName))
+    }
+}

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayHistoryActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayHistoryActivity.kt
@@ -234,7 +234,11 @@ class ReplayHistoryActivity : AppCompatActivity() {
     }
 
     private val routeProgressObserver = RouteProgressObserver { routeProgress ->
-        routeLineApi.updateWithRouteProgress(routeProgress)
+        routeLineApi.updateWithRouteProgress(routeProgress) { result ->
+            binding.mapView.getMapboxMap().getStyle()?.apply {
+                routeLineView.renderRouteLineUpdate(this, result)
+            }
+        }
         val arrowUpdate = routeArrowApi.addUpcomingManeuverArrow(routeProgress)
         binding.mapView.getMapboxMap().getStyle()?.apply {
             routeArrowView.renderManeuverUpdate(this, arrowUpdate)
@@ -245,7 +249,7 @@ class ReplayHistoryActivity : AppCompatActivity() {
         val result = routeLineApi.updateTraveledRouteLine(point)
         binding.mapView.getMapboxMap().getStyle()?.apply {
             // Render the result to update the map.
-            routeLineView.renderVanishingRouteLineUpdateValue(this, result)
+            routeLineView.renderRouteLineUpdate(this, result)
         }
     }
 

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/camera/MapboxCameraAnimationsActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/camera/MapboxCameraAnimationsActivity.kt
@@ -182,7 +182,11 @@ class MapboxCameraAnimationsActivity :
         viewportDataSource.onRouteProgressChanged(routeProgress)
         viewportDataSource.evaluate()
 
-        routeLineAPI?.updateWithRouteProgress(routeProgress)
+        routeLineAPI?.updateWithRouteProgress(routeProgress) { result ->
+            mapboxMap.getStyle()?.apply {
+                routeLineView?.renderRouteLineUpdate(this, result)
+            }
+        }
 
         routeArrowAPI.addUpcomingManeuverArrow(routeProgress).apply {
             ifNonNull(routeArrowView, mapboxMap.getStyle()) { view, style ->
@@ -227,7 +231,7 @@ class MapboxCameraAnimationsActivity :
         OnIndicatorPositionChangedListener { point ->
             routeLineAPI?.updateTraveledRouteLine(point)?.apply {
                 ifNonNull(routeLineView, mapboxMap.getStyle()) { view, style ->
-                    view.renderVanishingRouteLineUpdateValue(style, this)
+                    view.renderRouteLineUpdate(style, this)
                 }
             }
         }

--- a/examples/src/main/java/com/mapbox/navigation/examples/util/RouteLineUtil.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/util/RouteLineUtil.kt
@@ -70,7 +70,7 @@ class RouteLineUtil(private val activity: AppCompatActivity) : LifecycleObserver
 
     private val onIndicatorPositionChangedListener = OnIndicatorPositionChangedListener { point ->
         routeLineApi.updateTraveledRouteLine(point).apply {
-            routeLineView.renderVanishingRouteLineUpdateValue(style, this)
+            routeLineView.renderRouteLineUpdate(style, this)
         }
     }
 
@@ -86,7 +86,10 @@ class RouteLineUtil(private val activity: AppCompatActivity) : LifecycleObserver
 
     private val routeProgressObserver: RouteProgressObserver = object : RouteProgressObserver {
         override fun onRouteProgressChanged(routeProgress: RouteProgress) {
-            routeLineApi.updateWithRouteProgress(routeProgress)
+            routeLineApi.updateWithRouteProgress(routeProgress) { result ->
+                routeLineView.renderRouteLineUpdate(style, result)
+            }
+
             routeArrowApi.addUpcomingManeuverArrow(routeProgress).apply {
                 routeArrowView.renderManeuverUpdate(style, this)
             }

--- a/examples/src/main/res/layout/multileg_route_example_layout.xml
+++ b/examples/src/main/res/layout/multileg_route_example_layout.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.mapbox.maps.MapView
+        android:id="@+id/mapView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/startNavigation"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:background="@color/colorPrimary"
+        android:text="@string/label_start_navigation"
+        android:textColor="@android:color/white"
+        android:visibility="gone" />
+
+    <ProgressBar
+        android:id="@+id/routeLoadingProgressBar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:visibility="invisible"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/examples/src/main/res/values/strings.xml
+++ b/examples/src/main/res/values/strings.xml
@@ -26,6 +26,9 @@
     <string name="title_custom_style" translatable="false">Custom Style Example</string>
     <string name="description_custom_style" translatable="false">Demonstrates the use of custom styling.</string>
 
+    <string name="title_multileg_route" translatable="false">Hide inactive route legs.</string>
+    <string name="description_multileg_route" translatable="false">Demonstrates hiding inactive route legs.</string>
+
     <string name="title_multiple_arrows" translatable="false">Multiple Arrow Example</string>
     <string name="description_multiple_arrows" translatable="false">Demonstrates adding multiple arrows.</string>
 

--- a/libnavui-base/api/current.txt
+++ b/libnavui-base/api/current.txt
@@ -22,6 +22,7 @@ package com.mapbox.navigation.ui.base.internal.model.route {
     method public Double![] getARROW_HEAD_CASING_OFFSET();
     method public Double![] getARROW_HEAD_OFFSET();
     method public int getDESTINATION_WAYPOINT_ICON();
+    method public int getIN_ACTIVE_ROUTE_LEG_COLOR();
     method public int getMANEUVER_ARROWHEAD_ICON_CASING_DRAWABLE();
     method public int getMANEUVER_ARROWHEAD_ICON_DRAWABLE();
     method public int getMANEUVER_ARROW_CASING_COLOR();
@@ -39,7 +40,6 @@ package com.mapbox.navigation.ui.base.internal.model.route {
     method public int getROUTE_SEVERE_TRAFFIC_COLOR();
     method public int getROUTE_UNKNOWN_TRAFFIC_COLOR();
     method public java.util.List<java.lang.String> getTRAFFIC_BACKFILL_ROAD_CLASSES();
-    method public int getTRANSPARENT_COLOR();
     property public final int ALTERNATE_RESTRICTED_ROAD_COLOR;
     property public final int ALTERNATE_ROUTE_CASING_COLOR;
     property public final int ALTERNATE_ROUTE_DEFAULT_COLOR;
@@ -52,6 +52,7 @@ package com.mapbox.navigation.ui.base.internal.model.route {
     property public final Double![] ARROW_HEAD_CASING_OFFSET;
     property public final Double![] ARROW_HEAD_OFFSET;
     property public final int DESTINATION_WAYPOINT_ICON;
+    property public final int IN_ACTIVE_ROUTE_LEG_COLOR;
     property public final int MANEUVER_ARROWHEAD_ICON_CASING_DRAWABLE;
     property public final int MANEUVER_ARROWHEAD_ICON_DRAWABLE;
     property public final int MANEUVER_ARROW_CASING_COLOR;
@@ -69,7 +70,6 @@ package com.mapbox.navigation.ui.base.internal.model.route {
     property public final int ROUTE_SEVERE_TRAFFIC_COLOR;
     property public final int ROUTE_UNKNOWN_TRAFFIC_COLOR;
     property public final java.util.List<java.lang.String> TRAFFIC_BACKFILL_ROAD_CLASSES;
-    property public final int TRANSPARENT_COLOR;
     field public static final String ALTERNATIVE_ROUTE1_SOURCE_ID = "mapbox-navigation-alt-route1-source";
     field public static final String ALTERNATIVE_ROUTE2_SOURCE_ID = "mapbox-navigation-alt-route2-source";
     field public static final String ARROW_BEARING = "mapbox-navigation-arrow-bearing";

--- a/libnavui-base/src/main/java/com/mapbox/navigation/ui/base/internal/model/route/RouteConstants.kt
+++ b/libnavui-base/src/main/java/com/mapbox/navigation/ui/base/internal/model/route/RouteConstants.kt
@@ -54,10 +54,10 @@ object RouteConstants {
     val TRAFFIC_BACKFILL_ROAD_CLASSES = emptyList<String>()
 
     @ColorInt
-    val ROUTE_LINE_TRAVELED_COLOR = Color.parseColor("#00000000")
+    val ROUTE_LINE_TRAVELED_COLOR = Color.TRANSPARENT
 
     @ColorInt
-    val ROUTE_LINE_TRAVELED_CASING_COLOR = Color.parseColor("#00000000")
+    val ROUTE_LINE_TRAVELED_CASING_COLOR = Color.TRANSPARENT
 
     @ColorInt
     val ROUTE_DEFAULT_COLOR = Color.parseColor("#56A8FB")
@@ -107,9 +107,6 @@ object RouteConstants {
     @ColorInt
     val ALTERNATE_RESTRICTED_ROAD_COLOR = Color.parseColor("#333333")
 
-    @ColorInt
-    val TRANSPARENT_COLOR = Color.parseColor("#00000000")
-
     @DrawableRes
     val ORIGIN_WAYPOINT_ICON: Int = R.drawable.mapbox_ic_route_origin
 
@@ -127,6 +124,9 @@ object RouteConstants {
 
     @ColorInt
     val ALTERNATIVE_ROUTE_CLOSURE_COLOR = Color.parseColor("#333333")
+
+    @ColorInt
+    val IN_ACTIVE_ROUTE_LEG_COLOR = Color.TRANSPARENT
 
     @DrawableRes
     val MANEUVER_ARROWHEAD_ICON_DRAWABLE: Int = R.drawable.mapbox_ic_arrow_head

--- a/libnavui-maps/api/current.txt
+++ b/libnavui-maps/api/current.txt
@@ -546,6 +546,7 @@ package com.mapbox.navigation.ui.maps.internal.route.line {
     method public suspend Object? findClosestRoute(com.mapbox.navigation.ui.maps.route.line.api.MapboxRouteLineApi, com.mapbox.geojson.Point target, com.mapbox.maps.MapboxMap mapboxMap, float padding, kotlin.coroutines.Continuation<? super com.mapbox.bindgen.Expected<com.mapbox.navigation.ui.maps.route.line.model.RouteNotFound,com.mapbox.navigation.ui.maps.route.line.model.ClosestRouteValue>> p);
     method public suspend Object? getRouteDrawData(com.mapbox.navigation.ui.maps.route.line.api.MapboxRouteLineApi, kotlin.coroutines.Continuation<? super com.mapbox.bindgen.Expected<com.mapbox.navigation.ui.maps.route.line.model.RouteLineError,com.mapbox.navigation.ui.maps.route.line.model.RouteSetValue>> p);
     method public suspend Object? setRoutes(com.mapbox.navigation.ui.maps.route.line.api.MapboxRouteLineApi, java.util.List<com.mapbox.navigation.ui.maps.route.line.model.RouteLine> newRoutes, kotlin.coroutines.Continuation<? super com.mapbox.bindgen.Expected<com.mapbox.navigation.ui.maps.route.line.model.RouteLineError,com.mapbox.navigation.ui.maps.route.line.model.RouteSetValue>> p);
+    method public suspend Object? showRouteWithLegIndexHighlighted(com.mapbox.navigation.ui.maps.route.line.api.MapboxRouteLineApi, int legIndex, kotlin.coroutines.Continuation<? super com.mapbox.bindgen.Expected<com.mapbox.navigation.ui.maps.route.line.model.RouteLineError,com.mapbox.navigation.ui.maps.route.line.model.RouteLineUpdateValue>> p);
     field public static final com.mapbox.navigation.ui.maps.internal.route.line.MapboxRouteLineApiExtensions INSTANCE;
   }
 
@@ -705,9 +706,14 @@ package com.mapbox.navigation.ui.maps.route.line.api {
     method public java.util.List<com.mapbox.api.directions.v5.models.DirectionsRoute> getRoutes();
     method public double getVanishPointOffset();
     method public void setRoutes(java.util.List<com.mapbox.navigation.ui.maps.route.line.model.RouteLine> newRoutes, com.mapbox.navigation.ui.base.util.MapboxNavigationConsumer<com.mapbox.bindgen.Expected<com.mapbox.navigation.ui.maps.route.line.model.RouteLineError,com.mapbox.navigation.ui.maps.route.line.model.RouteSetValue>> consumer);
-    method public com.mapbox.bindgen.Expected<com.mapbox.navigation.ui.maps.route.line.model.RouteLineError,com.mapbox.navigation.ui.maps.route.line.model.VanishingRouteLineUpdateValue> setVanishingOffset(double offset);
-    method public com.mapbox.bindgen.Expected<com.mapbox.navigation.ui.maps.route.line.model.RouteLineError,com.mapbox.navigation.ui.maps.route.line.model.VanishingRouteLineUpdateValue> updateTraveledRouteLine(com.mapbox.geojson.Point point);
-    method public void updateWithRouteProgress(com.mapbox.navigation.base.trip.model.RouteProgress routeProgress);
+    method public com.mapbox.bindgen.Expected<com.mapbox.navigation.ui.maps.route.line.model.RouteLineError,com.mapbox.navigation.ui.maps.route.line.model.RouteLineUpdateValue> setVanishingOffset(double offset);
+    method public void showRouteWithLegIndexHighlighted(int legIndexToHighlight, com.mapbox.navigation.ui.base.util.MapboxNavigationConsumer<com.mapbox.bindgen.Expected<com.mapbox.navigation.ui.maps.route.line.model.RouteLineError,com.mapbox.navigation.ui.maps.route.line.model.RouteLineUpdateValue>> consumer);
+    method public com.mapbox.bindgen.Expected<com.mapbox.navigation.ui.maps.route.line.model.RouteLineError,com.mapbox.navigation.ui.maps.route.line.model.RouteLineUpdateValue> updateTraveledRouteLine(com.mapbox.geojson.Point point);
+    method public void updateWithRouteProgress(com.mapbox.navigation.base.trip.model.RouteProgress routeProgress, com.mapbox.navigation.ui.base.util.MapboxNavigationConsumer<com.mapbox.bindgen.Expected<com.mapbox.navigation.ui.maps.route.line.model.RouteLineError,com.mapbox.navigation.ui.maps.route.line.model.RouteLineUpdateValue>> consumer);
+    field public static final com.mapbox.navigation.ui.maps.route.line.api.MapboxRouteLineApi.Companion Companion;
+  }
+
+  public static final class MapboxRouteLineApi.Companion {
   }
 
   public final class MapboxRouteLineView {
@@ -721,7 +727,7 @@ package com.mapbox.navigation.ui.maps.route.line.api {
     method public void initializeLayers(com.mapbox.maps.Style style);
     method public void renderClearRouteLineValue(com.mapbox.maps.Style style, com.mapbox.bindgen.Expected<com.mapbox.navigation.ui.maps.route.line.model.RouteLineError,com.mapbox.navigation.ui.maps.route.line.model.RouteLineClearValue> clearRouteLineValue);
     method public void renderRouteDrawData(com.mapbox.maps.Style style, com.mapbox.bindgen.Expected<com.mapbox.navigation.ui.maps.route.line.model.RouteLineError,com.mapbox.navigation.ui.maps.route.line.model.RouteSetValue> routeDrawData);
-    method public void renderVanishingRouteLineUpdateValue(com.mapbox.maps.Style style, com.mapbox.bindgen.Expected<com.mapbox.navigation.ui.maps.route.line.model.RouteLineError,com.mapbox.navigation.ui.maps.route.line.model.VanishingRouteLineUpdateValue> update);
+    method public void renderRouteLineUpdate(com.mapbox.maps.Style style, com.mapbox.bindgen.Expected<com.mapbox.navigation.ui.maps.route.line.model.RouteLineError,com.mapbox.navigation.ui.maps.route.line.model.RouteLineUpdateValue> update);
     method public void setOptions(com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions p);
     method public void showAlternativeRoutes(com.mapbox.maps.Style style);
     method public void showOriginAndDestinationPoints(com.mapbox.maps.Style style);
@@ -744,6 +750,7 @@ package com.mapbox.navigation.ui.maps.route.line.model {
     method public android.graphics.drawable.Drawable getOriginIcon();
     method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineResources getResourceProvider();
     method public String? getRouteLineBelowLayerId();
+    method public boolean getStyleInactiveRouteLegsIndependently();
     method public double getTolerance();
     method public com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions.Builder toBuilder(android.content.Context context);
     property public final android.graphics.drawable.Drawable destinationIcon;
@@ -751,6 +758,7 @@ package com.mapbox.navigation.ui.maps.route.line.model {
     property public final android.graphics.drawable.Drawable originIcon;
     property public final com.mapbox.navigation.ui.maps.route.line.model.RouteLineResources resourceProvider;
     property public final String? routeLineBelowLayerId;
+    property public final boolean styleInactiveRouteLegsIndependently;
     property public final double tolerance;
   }
 
@@ -758,6 +766,7 @@ package com.mapbox.navigation.ui.maps.route.line.model {
     ctor public MapboxRouteLineOptions.Builder(android.content.Context context);
     method public com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions build();
     method public com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions.Builder displayRestrictedRoadSections(boolean displayRestrictedRoadSections);
+    method public com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions.Builder styleInactiveRouteLegsIndependently(boolean enable);
     method public com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions.Builder withRouteLineBelowLayerId(String layerId);
     method public com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions.Builder withRouteLineResources(com.mapbox.navigation.ui.maps.route.line.model.RouteLineResources resourceProvider);
     method public com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions.Builder withRouteStyleDescriptors(java.util.List<com.mapbox.navigation.ui.maps.route.line.model.RouteStyleDescriptor> routeStyleDescriptors);
@@ -811,6 +820,7 @@ package com.mapbox.navigation.ui.maps.route.line.model {
     method public int getAlternativeRouteRestrictedRoadColor();
     method public int getAlternativeRouteSevereColor();
     method public int getAlternativeRouteUnknownTrafficColor();
+    method public int getInActiveRouteLegsColor();
     method public int getRestrictedRoadColor();
     method public int getRouteCasingColor();
     method public int getRouteClosureColor();
@@ -832,6 +842,7 @@ package com.mapbox.navigation.ui.maps.route.line.model {
     property public final int alternativeRouteRestrictedRoadColor;
     property public final int alternativeRouteSevereColor;
     property public final int alternativeRouteUnknownTrafficColor;
+    property public final int inActiveRouteLegsColor;
     property public final int restrictedRoadColor;
     property public final int routeCasingColor;
     property public final int routeClosureColor;
@@ -857,6 +868,7 @@ package com.mapbox.navigation.ui.maps.route.line.model {
     method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineColorResources.Builder alternativeRouteSevereColor(@ColorInt int color);
     method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineColorResources.Builder alternativeRouteUnknownTrafficColor(@ColorInt int color);
     method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineColorResources build();
+    method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineColorResources.Builder inActiveRouteLegsColor(@ColorInt int color);
     method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineColorResources.Builder restrictedRoadColor(@ColorInt int color);
     method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineColorResources.Builder routeCasingColor(@ColorInt int color);
     method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineColorResources.Builder routeClosureColor(@ColorInt int color);
@@ -889,12 +901,15 @@ package com.mapbox.navigation.ui.maps.route.line.model {
   }
 
   public final class RouteLineExpressionData {
-    ctor public RouteLineExpressionData(double offset, @ColorInt int segmentColor);
+    ctor public RouteLineExpressionData(double offset, @ColorInt int segmentColor, int legIndex);
     method public double component1();
     method public int component2();
-    method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineExpressionData copy(double offset, int segmentColor);
+    method public int component3();
+    method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineExpressionData copy(double offset, int segmentColor, int legIndex);
+    method public int getLegIndex();
     method public double getOffset();
     method public int getSegmentColor();
+    property public final int legIndex;
     property public final double offset;
     property public final int segmentColor;
   }
@@ -967,6 +982,15 @@ package com.mapbox.navigation.ui.maps.route.line.model {
     property public final float scale;
     property public final float scaleMultiplier;
     property public final float scaleStop;
+  }
+
+  public final class RouteLineUpdateValue {
+    method public com.mapbox.maps.extension.style.expressions.generated.Expression getCasingLineExpression();
+    method public com.mapbox.maps.extension.style.expressions.generated.Expression getRouteLineExpression();
+    method public com.mapbox.maps.extension.style.expressions.generated.Expression getTrafficLineExpression();
+    property public final com.mapbox.maps.extension.style.expressions.generated.Expression casingLineExpression;
+    property public final com.mapbox.maps.extension.style.expressions.generated.Expression routeLineExpression;
+    property public final com.mapbox.maps.extension.style.expressions.generated.Expression trafficLineExpression;
   }
 
   public final class RouteNotFound {
@@ -1061,15 +1085,6 @@ package com.mapbox.navigation.ui.maps.route.line.model {
     enum_constant public static final com.mapbox.navigation.ui.maps.route.line.model.VanishingPointState DISABLED;
     enum_constant public static final com.mapbox.navigation.ui.maps.route.line.model.VanishingPointState ENABLED;
     enum_constant public static final com.mapbox.navigation.ui.maps.route.line.model.VanishingPointState ONLY_INCREASE_PROGRESS;
-  }
-
-  public final class VanishingRouteLineUpdateValue {
-    method public com.mapbox.maps.extension.style.expressions.generated.Expression getCasingLineExpression();
-    method public com.mapbox.maps.extension.style.expressions.generated.Expression getRouteLineExpression();
-    method public com.mapbox.maps.extension.style.expressions.generated.Expression getTrafficLineExpression();
-    property public final com.mapbox.maps.extension.style.expressions.generated.Expression casingLineExpression;
-    property public final com.mapbox.maps.extension.style.expressions.generated.Expression routeLineExpression;
-    property public final com.mapbox.maps.extension.style.expressions.generated.Expression trafficLineExpression;
   }
 
 }

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineApiExtensions.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineApiExtensions.kt
@@ -9,6 +9,7 @@ import com.mapbox.navigation.ui.maps.route.line.model.ClosestRouteValue
 import com.mapbox.navigation.ui.maps.route.line.model.RouteLine
 import com.mapbox.navigation.ui.maps.route.line.model.RouteLineClearValue
 import com.mapbox.navigation.ui.maps.route.line.model.RouteLineError
+import com.mapbox.navigation.ui.maps.route.line.model.RouteLineUpdateValue
 import com.mapbox.navigation.ui.maps.route.line.model.RouteNotFound
 import com.mapbox.navigation.ui.maps.route.line.model.RouteSetValue
 import kotlin.coroutines.resume
@@ -84,6 +85,29 @@ object MapboxRouteLineApiExtensions {
     suspend fun MapboxRouteLineApi.clearRouteLine(): Expected<RouteLineError, RouteLineClearValue> {
         return suspendCoroutine { continuation ->
             this.clearRouteLine { value -> continuation.resume(value) }
+        }
+    }
+
+    /**
+     * If successful this method returns a [RouteLineUpdateValue] that when rendered will
+     * display the route line with the route leg indicated by the provided leg index highlighted.
+     * All the other legs will only show a simple line with
+     * [RouteLineColorResources.inActiveRouteLegsColor].
+     *
+     * This is intended to be used with routes that have multiple waypoints.
+     * In addition, calling this method does not change the state of the route line.
+     *
+     * This method can be useful for showing a route overview with a specific route leg highlighted.
+     *
+     * @param legIndex the route leg index that should appear most prominent.
+     * @return a [RouteLineUpdateValue] for rendering or an error
+     */
+    suspend fun MapboxRouteLineApi.showRouteWithLegIndexHighlighted(legIndex: Int):
+        Expected<RouteLineError, RouteLineUpdateValue> {
+        return suspendCoroutine { continuation ->
+            this.showRouteWithLegIndexHighlighted(legIndex) { value ->
+                continuation.resume(value)
+            }
         }
     }
 }

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineView.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineView.kt
@@ -18,8 +18,8 @@ import com.mapbox.navigation.ui.maps.internal.route.line.MapboxRouteLineUtils.in
 import com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions
 import com.mapbox.navigation.ui.maps.route.line.model.RouteLineClearValue
 import com.mapbox.navigation.ui.maps.route.line.model.RouteLineError
+import com.mapbox.navigation.ui.maps.route.line.model.RouteLineUpdateValue
 import com.mapbox.navigation.ui.maps.route.line.model.RouteSetValue
-import com.mapbox.navigation.ui.maps.route.line.model.VanishingRouteLineUpdateValue
 import com.mapbox.navigation.utils.internal.ThreadController
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
@@ -165,9 +165,9 @@ class MapboxRouteLineView(var options: MapboxRouteLineOptions) {
      * @param style an instance of the Style
      * @param update an instance of VanishingRouteLineUpdateState
      */
-    fun renderVanishingRouteLineUpdateValue(
+    fun renderRouteLineUpdate(
         style: Style,
-        update: Expected<RouteLineError, VanishingRouteLineUpdateValue>
+        update: Expected<RouteLineError, RouteLineUpdateValue>
     ) {
         initializeLayers(style, options)
         jobControl.scope.launch {

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/VanishingRouteLine.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/VanishingRouteLine.kt
@@ -1,5 +1,6 @@
 package com.mapbox.navigation.ui.maps.route.line.api
 
+import android.graphics.Color
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.base.common.logger.model.Message
 import com.mapbox.base.common.logger.model.Tag
@@ -105,6 +106,7 @@ internal class VanishingRouteLine {
         point: Point,
         routeLineExpressionData: List<RouteLineExpressionData>,
         routeResourceProvider: RouteLineResources,
+        activeLegIndex: Int,
     ): VanishingRouteLineExpressions? {
         ifNonNull(
             primaryRouteLineGranularDistances,
@@ -170,21 +172,31 @@ internal class VanishingRouteLine {
                 return null
             }
             vanishPointOffset = offset
+
             val trafficLineExpression = MapboxRouteLineUtils.getTrafficLineExpression(
                 offset,
-                routeLineExpressionData,
-                routeResourceProvider.routeLineColorResources.routeUnknownTrafficColor
-            )
-            val routeLineExpression = MapboxRouteLineUtils.getVanishingRouteLineExpression(
-                offset,
                 routeResourceProvider.routeLineColorResources.routeLineTraveledColor,
-                routeResourceProvider.routeLineColorResources.routeDefaultColor
+                routeResourceProvider.routeLineColorResources.routeUnknownTrafficColor,
+                routeLineExpressionData
             )
-            val routeLineCasingExpression = MapboxRouteLineUtils.getVanishingRouteLineExpression(
+
+            val routeLineExpression = MapboxRouteLineUtils.getRouteLineExpression(
                 offset,
-                routeResourceProvider.routeLineColorResources.routeLineTraveledCasingColor,
-                routeResourceProvider.routeLineColorResources.routeCasingColor
+                routeLineExpressionData,
+                routeResourceProvider.routeLineColorResources.routeLineTraveledColor,
+                routeResourceProvider.routeLineColorResources.routeDefaultColor,
+                routeResourceProvider.routeLineColorResources.inActiveRouteLegsColor,
+                activeLegIndex
             )
+            val routeLineCasingExpression = MapboxRouteLineUtils.getRouteLineExpression(
+                offset,
+                routeLineExpressionData,
+                routeResourceProvider.routeLineColorResources.routeLineTraveledCasingColor,
+                routeResourceProvider.routeLineColorResources.routeCasingColor,
+                Color.TRANSPARENT,
+                activeLegIndex
+            )
+
             return VanishingRouteLineExpressions(
                 trafficLineExpression,
                 routeLineExpression,

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/MapboxRouteLineOptions.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/MapboxRouteLineOptions.kt
@@ -20,6 +20,9 @@ import com.mapbox.navigation.ui.maps.route.line.api.VanishingRouteLine
  * @param tolerance the tolerance value used when configuring the underlying map source
  * @param displayRestrictedRoadSections indicates if the route line will display restricted
  * road sections with a dashed line
+ * @param styleInactiveRouteLegsIndependently enabling this feature will change the color of the route
+ * legs that aren't currently being navigated. See [RouteLineColorResources] to specify the color
+ * used.
  */
 class MapboxRouteLineOptions private constructor(
     val resourceProvider: RouteLineResources,
@@ -29,7 +32,8 @@ class MapboxRouteLineOptions private constructor(
     val routeLineBelowLayerId: String?,
     internal var vanishingRouteLine: VanishingRouteLine? = null,
     val tolerance: Double,
-    val displayRestrictedRoadSections: Boolean = false
+    val displayRestrictedRoadSections: Boolean = false,
+    val styleInactiveRouteLegsIndependently: Boolean = false
 ) {
 
     /**
@@ -46,7 +50,8 @@ class MapboxRouteLineOptions private constructor(
             routeLayerProvider.routeStyleDescriptors,
             vanishingRouteLineEnabled,
             tolerance,
-            displayRestrictedRoadSections
+            displayRestrictedRoadSections,
+            styleInactiveRouteLegsIndependently
         )
     }
 
@@ -67,6 +72,8 @@ class MapboxRouteLineOptions private constructor(
         if (vanishingRouteLine != other.vanishingRouteLine) return false
         if (tolerance != other.tolerance) return false
         if (displayRestrictedRoadSections != other.displayRestrictedRoadSections) return false
+        if (styleInactiveRouteLegsIndependently != other.styleInactiveRouteLegsIndependently)
+            return false
 
         return true
     }
@@ -83,6 +90,7 @@ class MapboxRouteLineOptions private constructor(
         result = 31 * result + (vanishingRouteLine?.hashCode() ?: 0)
         result = 31 * result + (tolerance.hashCode())
         result = 31 * result + (displayRestrictedRoadSections.hashCode())
+        result = 31 * result + (styleInactiveRouteLegsIndependently.hashCode())
         return result
     }
 
@@ -97,7 +105,8 @@ class MapboxRouteLineOptions private constructor(
             "routeLineBelowLayerId=$routeLineBelowLayerId, " +
             "vanishingRouteLine=$vanishingRouteLine, " +
             "tolerance=$tolerance, " +
-            "displayRestrictedRoadSections=$displayRestrictedRoadSections" +
+            "displayRestrictedRoadSections=$displayRestrictedRoadSections, " +
+            "styleInactiveRouteLegsIndependently=$styleInactiveRouteLegsIndependently" +
             ")"
     }
 
@@ -111,6 +120,9 @@ class MapboxRouteLineOptions private constructor(
      * @param vanishingRouteLineEnabled indicates if the vanishing route line feature is enabled
      * @param displayRestrictedRoadSections indicates if the route line will display restricted
      * road sections with a dashed line
+     * @param styleInactiveRouteLegsIndependently enabling this feature will change the color of the route
+     * legs that aren't currently being navigated. See [RouteLineColorResources] to specify the color
+     * used.
      */
     class Builder internal constructor(
         private val context: Context,
@@ -119,7 +131,8 @@ class MapboxRouteLineOptions private constructor(
         private var routeStyleDescriptors: List<RouteStyleDescriptor>,
         private var vanishingRouteLineEnabled: Boolean,
         private var tolerance: Double,
-        private var displayRestrictedRoadSections: Boolean
+        private var displayRestrictedRoadSections: Boolean,
+        private var styleInactiveRouteLegsIndependently: Boolean
     ) {
 
         /**
@@ -134,6 +147,7 @@ class MapboxRouteLineOptions private constructor(
             listOf(),
             false,
             DEFAULT_ROUTE_SOURCES_TOLERANCE,
+            false,
             false
         )
 
@@ -198,6 +212,14 @@ class MapboxRouteLineOptions private constructor(
             apply { this.displayRestrictedRoadSections = displayRestrictedRoadSections }
 
         /**
+         * Enabling this feature will result in route legs that aren't currently being navigated
+         * to be color differently than the active leg. See [RouteLineColorResources] for the
+         * color option.
+         */
+        fun styleInactiveRouteLegsIndependently(enable: Boolean): Builder =
+            apply { this.styleInactiveRouteLegsIndependently = enable }
+
+        /**
          * @return an instance of [MapboxRouteLineOptions]
          */
         fun build(): MapboxRouteLineOptions {
@@ -238,7 +260,8 @@ class MapboxRouteLineOptions private constructor(
                 routeLineBelowLayerId,
                 vanishingRouteLine,
                 tolerance,
-                displayRestrictedRoadSections
+                displayRestrictedRoadSections,
+                styleInactiveRouteLegsIndependently
             )
         }
     }

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineColorResources.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineColorResources.kt
@@ -37,6 +37,8 @@ import com.mapbox.navigation.ui.base.internal.model.route.RouteConstants
  * alternative routes.
  * @param routeClosureColor the color used for the route closure line
  * @param alternativeRouteClosureColor the color used for the alternative route closure line(s)
+ * @param inActiveRouteLegsColor the color used for route legs that aren't currently
+ * being navigated.
  */
 class RouteLineColorResources private constructor(
     @ColorInt val routeLineTraveledColor: Int,
@@ -58,7 +60,8 @@ class RouteLineColorResources private constructor(
     @ColorInt val restrictedRoadColor: Int,
     @ColorInt val alternativeRouteRestrictedRoadColor: Int,
     @ColorInt val routeClosureColor: Int,
-    @ColorInt val alternativeRouteClosureColor: Int
+    @ColorInt val alternativeRouteClosureColor: Int,
+    @ColorInt val inActiveRouteLegsColor: Int,
 ) {
 
     /**
@@ -86,6 +89,7 @@ class RouteLineColorResources private constructor(
             .alternativeRouteRestrictedRoadColor(alternativeRouteRestrictedRoadColor)
             .routeClosureColor(routeClosureColor)
             .alternativeRouteClosureColor(alternativeRouteClosureColor)
+            .inActiveRouteLegsColor(inActiveRouteLegsColor)
     }
 
     /**
@@ -112,7 +116,8 @@ class RouteLineColorResources private constructor(
             "restrictedRoadColor=$restrictedRoadColor, " +
             "alternativeRouteRestrictedRoadColor=$alternativeRouteRestrictedRoadColor, " +
             "routeClosureColor=$routeClosureColor, " +
-            "alternativeRouteClosureColor=$alternativeRouteClosureColor" +
+            "alternativeRouteClosureColor=$alternativeRouteClosureColor, " +
+            "inActiveRouteLegsColor=$inActiveRouteLegsColor" +
             ")"
     }
 
@@ -147,6 +152,8 @@ class RouteLineColorResources private constructor(
             return false
         if (routeClosureColor != other.routeClosureColor) return false
         if (alternativeRouteClosureColor != other.alternativeRouteClosureColor) return false
+        if (inActiveRouteLegsColor != other.inActiveRouteLegsColor)
+            return false
 
         return true
     }
@@ -175,6 +182,7 @@ class RouteLineColorResources private constructor(
         result = 31 * result + alternativeRouteRestrictedRoadColor
         result = 31 * result + routeClosureColor
         result = 31 * result + alternativeRouteClosureColor
+        result = 31 * result + inActiveRouteLegsColor
         return result
     }
 
@@ -209,6 +217,8 @@ class RouteLineColorResources private constructor(
         private var routeClosureColor: Int = RouteConstants.ROUTE_CLOSURE_COLOR
         private var alternativeRouteClosureColor: Int =
             RouteConstants.ALTERNATIVE_ROUTE_CLOSURE_COLOR
+        private var inActiveRouteLegsColor: Int =
+            RouteConstants.IN_ACTIVE_ROUTE_LEG_COLOR
 
         /**
          * The color of the section of route line behind the puck representing the section
@@ -416,6 +426,16 @@ class RouteLineColorResources private constructor(
             apply { this.alternativeRouteClosureColor = color }
 
         /**
+         * The color used for route legs that aren't currently being navigated.
+         *
+         * @param color the color to be used
+         *
+         * @return the builder
+         */
+        fun inActiveRouteLegsColor(@ColorInt color: Int): Builder =
+            apply { this.inActiveRouteLegsColor = color }
+
+        /**
          * Creates a instance of RouteLineResources
          *
          * @return the instance
@@ -441,7 +461,8 @@ class RouteLineColorResources private constructor(
                 restrictedRoadColor,
                 alternativeRouteRestrictedRoadColor,
                 routeClosureColor,
-                alternativeRouteClosureColor
+                alternativeRouteClosureColor,
+                inActiveRouteLegsColor
             )
         }
     }

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineExpressionData.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineExpressionData.kt
@@ -5,7 +5,12 @@ import androidx.annotation.ColorInt
 /**
  * Contains data related to a route distance traveled and a traffic congestion color.
  *
- * @param offset
- * @param segmentColor
+ * @param offset a distance offset value
+ * @param segmentColor a color for a segment of a route line
+ * @param legIndex the route leg index for this data
  */
-data class RouteLineExpressionData(val offset: Double, @ColorInt val segmentColor: Int)
+data class RouteLineExpressionData(
+    val offset: Double,
+    @ColorInt val segmentColor: Int,
+    val legIndex: Int
+)

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineTrafficExpressionData.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineTrafficExpressionData.kt
@@ -6,10 +6,13 @@ package com.mapbox.navigation.ui.maps.route.line.model
  * @param distanceFromOrigin the distance from the route origin
  * @param trafficCongestionIdentifier a string indicating the level of traffic congestion
  * @param roadClass an optional road class for route section
+ * @param legIndex indicates the leg index within the route that this data originates from
  */
 internal data class RouteLineTrafficExpressionData(
     val distanceFromOrigin: Double,
     val trafficCongestionIdentifier: String,
     val roadClass: String?,
-    val isInRestrictedSection: Boolean
+    val isInRestrictedSection: Boolean,
+    val legIndex: Int = 0,
+    val isLegOrigin: Boolean = false
 )

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineUpdateValue.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineUpdateValue.kt
@@ -9,7 +9,7 @@ import com.mapbox.maps.extension.style.expressions.generated.Expression
  * @param routeLineExpression the expression for the primary route line
  * @param casingLineExpression the expression for the primary route casing line
  */
-class VanishingRouteLineUpdateValue internal constructor(
+class RouteLineUpdateValue internal constructor(
     val trafficLineExpression: Expression,
     val routeLineExpression: Expression,
     val casingLineExpression: Expression

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/util/CacheResultUtils.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/util/CacheResultUtils.kt
@@ -12,6 +12,11 @@ internal object CacheResultUtils {
         override fun invoke(f: (P1) -> R) = f(p1)
     }
 
+    private data class CacheResultKey2<out P1, P2, R>(val p1: P1, val p2: P2) :
+        CacheResultCall<(P1, P2) -> R, R> {
+        override fun invoke(f: (P1, P2) -> R) = f(p1, p2)
+    }
+
     fun <P1, R> ((P1) -> R).cacheResult(maxSize: Int): (P1) -> R {
         return object : (P1) -> R {
             private val handler =
@@ -20,6 +25,17 @@ internal object CacheResultUtils {
                     maxSize
                 )
             override fun invoke(p1: P1) = handler(CacheResultKey1(p1))
+        }
+    }
+
+    fun <P1, P2, R> ((P1, P2) -> R).cacheResult(maxSize: Int): (P1, P2) -> R {
+        return object : (P1, P2) -> R {
+            private val handler =
+                CacheResultHandler<((P1, P2) -> R), CacheResultKey2<P1, P2, R>, R>(
+                    this@cacheResult,
+                    maxSize
+                )
+            override fun invoke(p1: P1, p2: P2) = handler(CacheResultKey2(p1, p2))
         }
     }
 

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApiTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApiTest.kt
@@ -20,17 +20,22 @@ import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.base.trip.model.RouteProgressState
 import com.mapbox.navigation.testing.FileUtils.loadJsonFixture
 import com.mapbox.navigation.testing.MainCoroutineRule
+import com.mapbox.navigation.ui.base.internal.model.route.RouteConstants
 import com.mapbox.navigation.ui.base.model.route.RouteLayerConstants.ALTERNATIVE_ROUTE1_LAYER_ID
 import com.mapbox.navigation.ui.base.util.MapboxNavigationConsumer
 import com.mapbox.navigation.ui.maps.internal.route.line.MapboxRouteLineApiExtensions.clearRouteLine
 import com.mapbox.navigation.ui.maps.internal.route.line.MapboxRouteLineApiExtensions.findClosestRoute
 import com.mapbox.navigation.ui.maps.internal.route.line.MapboxRouteLineApiExtensions.getRouteDrawData
 import com.mapbox.navigation.ui.maps.internal.route.line.MapboxRouteLineApiExtensions.setRoutes
+import com.mapbox.navigation.ui.maps.internal.route.line.MapboxRouteLineApiExtensions.showRouteWithLegIndexHighlighted
+import com.mapbox.navigation.ui.maps.internal.route.line.MapboxRouteLineUtils
 import com.mapbox.navigation.ui.maps.internal.route.line.MapboxRouteLineUtils.parseRoutePoints
 import com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions
 import com.mapbox.navigation.ui.maps.route.line.model.RouteLine
+import com.mapbox.navigation.ui.maps.route.line.model.RouteLineColorResources
 import com.mapbox.navigation.ui.maps.route.line.model.RouteLineError
 import com.mapbox.navigation.ui.maps.route.line.model.RouteLineGranularDistances
+import com.mapbox.navigation.ui.maps.route.line.model.RouteLineResources
 import com.mapbox.navigation.ui.maps.route.line.model.RouteSetValue
 import com.mapbox.navigation.ui.maps.route.line.model.RouteStyleDescriptor
 import com.mapbox.navigation.ui.maps.route.line.model.VanishingPointState
@@ -154,6 +159,9 @@ class MapboxRouteLineApiTest {
         every { options.resourceProvider } returns realOptions.resourceProvider
         every { options.vanishingRouteLine } returns vanishingRouteLine
         every { options.displayRestrictedRoadSections } returns false
+        every {
+            options.styleInactiveRouteLegsIndependently
+        } returns realOptions.styleInactiveRouteLegsIndependently
 
         val api = MapboxRouteLineApi(options)
         val route = getRoute()
@@ -174,6 +182,9 @@ class MapboxRouteLineApiTest {
             every { options.resourceProvider } returns realOptions.resourceProvider
             every { options.vanishingRouteLine } returns vanishingRouteLine
             every { options.displayRestrictedRoadSections } returns false
+            every {
+                options.styleInactiveRouteLegsIndependently
+            } returns realOptions.styleInactiveRouteLegsIndependently
 
             val api = MapboxRouteLineApi(options)
             val route = getRoute()
@@ -195,6 +206,9 @@ class MapboxRouteLineApiTest {
             every { options.resourceProvider } returns realOptions.resourceProvider
             every { options.vanishingRouteLine } returns vanishingRouteLine
             every { options.displayRestrictedRoadSections } returns false
+            every {
+                options.styleInactiveRouteLegsIndependently
+            } returns realOptions.styleInactiveRouteLegsIndependently
 
             val api = MapboxRouteLineApi(options)
             val route = getRoute()
@@ -458,6 +472,9 @@ class MapboxRouteLineApiTest {
             every { options.resourceProvider } returns realOptions.resourceProvider
             every { options.vanishingRouteLine } returns vanishingRouteLine
             every { options.displayRestrictedRoadSections } returns false
+            every {
+                options.styleInactiveRouteLegsIndependently
+            } returns realOptions.styleInactiveRouteLegsIndependently
 
             val api = MapboxRouteLineApi(options)
             val route = getRoute()
@@ -480,6 +497,9 @@ class MapboxRouteLineApiTest {
             every { options.resourceProvider } returns realOptions.resourceProvider
             every { options.vanishingRouteLine } returns vanishingRouteLine
             every { options.displayRestrictedRoadSections } returns false
+            every {
+                options.styleInactiveRouteLegsIndependently
+            } returns realOptions.styleInactiveRouteLegsIndependently
 
             val api = MapboxRouteLineApi(options)
             val route = getRoute()
@@ -545,16 +565,13 @@ class MapboxRouteLineApiTest {
             .withVanishingRouteLineEnabled(true)
             .build()
         val api = MapboxRouteLineApi(options)
-        val expectedCasingExpression =
-            "[step, [line-progress], [rgba, 0.0, 0.0, 0.0, 0.0], 0.3240769449298392, " +
-                "[rgba, 47.0, 122.0, 198.0, 1.0]]"
-        val expectedRouteExpression =
-            "[step, [line-progress], [rgba, 0.0, 0.0, 0.0, 0.0], 0.3240769449298392," +
-                " [rgba, 86.0, 168.0, 251.0, 1.0]]"
-        val expectedTrafficExpression =
-            "[step, [line-progress], [rgba, 0.0, 0.0, 0.0, 0.0], 0.3240769449298392, " +
-                "[rgba, 86.0, 168.0, 251.0, 1.0], 0.9429639111009005, " +
-                "[rgba, 255.0, 149.0, 0.0, 1.0]]"
+        val expectedCasingExpression = "[step, [line-progress], [rgba, 0.0, 0.0, 0.0, 0.0], " +
+            "0.3240769449298392, [rgba, 47.0, 122.0, 198.0, 1.0]]"
+        val expectedRouteExpression = "[step, [line-progress], [rgba, 0.0, 0.0, 0.0, 0.0], " +
+            "0.3240769449298392, [rgba, 86.0, 168.0, 251.0, 1.0]]"
+        val expectedTrafficExpression = "[step, [line-progress], [rgba, 0.0, 0.0, 0.0, 0.0], " +
+            "0.3240769449298392, [rgba, 86.0, 168.0, 251.0, 1.0], 0.9429639111009005, " +
+            "[rgba, 255.0, 149.0, 0.0, 1.0]]"
         val route = getRoute()
         val lineString = LineString.fromPolyline(route.geometry() ?: "", Constants.PRECISION_6)
         val routeProgress = mockk<RouteProgress> {
@@ -598,6 +615,9 @@ class MapboxRouteLineApiTest {
             every { vanishingRouteLine } returns mockVanishingRouteLine
             every { resourceProvider } returns realOptions.resourceProvider
             every { displayRestrictedRoadSections } returns false
+            every {
+                styleInactiveRouteLegsIndependently
+            } returns realOptions.styleInactiveRouteLegsIndependently
         }
         val api = MapboxRouteLineApi(options)
         val routeProgress = mockk<RouteProgress> {
@@ -638,6 +658,9 @@ class MapboxRouteLineApiTest {
                 every { vanishingRouteLine } returns mockVanishingRouteLine
                 every { resourceProvider } returns realOptions.resourceProvider
                 every { displayRestrictedRoadSections } returns false
+                every {
+                    styleInactiveRouteLegsIndependently
+                } returns realOptions.styleInactiveRouteLegsIndependently
             }
             val api = MapboxRouteLineApi(options)
             val routeProgress = mockk<RouteProgress> {
@@ -678,6 +701,9 @@ class MapboxRouteLineApiTest {
                 every { vanishingRouteLine } returns mockVanishingRouteLine
                 every { resourceProvider } returns realOptions.resourceProvider
                 every { displayRestrictedRoadSections } returns false
+                every {
+                    styleInactiveRouteLegsIndependently
+                } returns realOptions.styleInactiveRouteLegsIndependently
             }
             val api = MapboxRouteLineApi(options)
             val routeProgress = mockk<RouteProgress> {
@@ -708,6 +734,9 @@ class MapboxRouteLineApiTest {
                 every { vanishingRouteLine } returns mockVanishingRouteLine
                 every { resourceProvider } returns realOptions.resourceProvider
                 every { displayRestrictedRoadSections } returns false
+                every {
+                    styleInactiveRouteLegsIndependently
+                } returns realOptions.styleInactiveRouteLegsIndependently
             }
             val api = MapboxRouteLineApi(options)
             val routeProgress = mockk<RouteProgress> {
@@ -734,6 +763,9 @@ class MapboxRouteLineApiTest {
             every { vanishingRouteLine } returns mockVanishingRouteLine
             every { resourceProvider } returns realOptions.resourceProvider
             every { displayRestrictedRoadSections } returns false
+            every {
+                styleInactiveRouteLegsIndependently
+            } returns realOptions.styleInactiveRouteLegsIndependently
         }
         val api = MapboxRouteLineApi(options)
         val routeProgress = mockk<RouteProgress> {
@@ -756,12 +788,228 @@ class MapboxRouteLineApiTest {
         api.updateVanishingPointState(RouteProgressState.TRACKING)
         api.setRoutes(listOf(RouteLine(route, null)))
 
-        api.updateWithRouteProgress(routeProgress)
+        api.updateWithRouteProgress(routeProgress) {}
 
         verify { mockVanishingRouteLine.primaryRouteRemainingDistancesIndex = null }
         verify {
             mockVanishingRouteLine.updateVanishingPointState(RouteProgressState.TRACKING)
         }
+    }
+
+    @Test
+    fun updateWithRouteProgress_whenDeEmphasizeInactiveLegSegments() =
+        coroutineRule.runBlockingTest {
+            val expectedTrafficExp = "[step, [line-progress], [rgba, 0.0, 0.0, 0.0, 0.0], 0.0," +
+                " [rgba, 86.0, 168.0, 251.0, 1.0], 0.10338667841237215, " +
+                "[rgba, 255.0, 149.0, 0.0, 1.0], 0.1235746096999951, " +
+                "[rgba, 86.0, 168.0, 251.0, 1.0], 0.27090572440007177, " +
+                "[rgba, 255.0, 149.0, 0.0, 1.0], 0.32147751186805656, " +
+                "[rgba, 86.0, 168.0, 251.0, 1.0], 0.48807892461540975, [rgba, 0.0, 0.0, 0.0, 0.0]]"
+            val realOptions = MapboxRouteLineOptions.Builder(ctx)
+                .styleInactiveRouteLegsIndependently(true)
+                .build()
+            val route = getMultilegWithTwoLegs()
+            val mockVanishingRouteLine = mockk<VanishingRouteLine>(relaxUnitFun = true) {
+                every { primaryRoutePoints } returns null
+                every { vanishPointOffset } returns 0.0
+                every { primaryRouteLineGranularDistances } returns null
+            }
+            val options = mockk<MapboxRouteLineOptions> {
+                every { vanishingRouteLine } returns mockVanishingRouteLine
+                every { resourceProvider } returns realOptions.resourceProvider
+                every {
+                    styleInactiveRouteLegsIndependently
+                } returns realOptions.styleInactiveRouteLegsIndependently
+                every { displayRestrictedRoadSections } returns false
+            }
+            val api = MapboxRouteLineApi(options)
+            val routeProgress = mockk<RouteProgress> {
+                every { currentLegProgress } returns mockk {
+                    every { legIndex } returns 0
+                    every { currentStepProgress } returns mockk {
+                        every { stepPoints } returns PolylineUtils.decode(
+                            route.legs()!![0].steps()!![0].geometry()!!,
+                            6
+                        )
+                        every { distanceTraveled } returns 0f
+                        every { step } returns mockk {
+                            every { distance() } returns route.legs()!![0].steps()!![0].distance()
+                        }
+                        every { stepIndex } returns 0
+                    }
+                }
+                every { currentState } returns RouteProgressState.TRACKING
+            }
+            api.updateVanishingPointState(RouteProgressState.TRACKING)
+            api.setRoutes(listOf(RouteLine(route, null)))
+            api.updateWithRouteProgress(routeProgress) {}
+
+            val result = api.setVanishingOffset(0.0).value!!
+
+            assertEquals(expectedTrafficExp, result.trafficLineExpression.toString())
+        }
+
+    @Test
+    fun updateWithRouteProgress_whenDeEmphasizeInactiveLegSegments_vanishingRouteLineDisabled() =
+        coroutineRule.runBlockingTest {
+            val expectedTrafficExp = "[step, [line-progress], [rgba, 0.0, 0.0, 0.0, 0.0], 0.0, " +
+                "[rgba, 0.0, 0.0, 0.0, 0.0]]"
+            val realOptions = MapboxRouteLineOptions.Builder(ctx)
+                .styleInactiveRouteLegsIndependently(true)
+                .build()
+            val route = getMultilegWithTwoLegs()
+            val options = mockk<MapboxRouteLineOptions> {
+                every { vanishingRouteLine } returns null
+                every { resourceProvider } returns realOptions.resourceProvider
+                every {
+                    styleInactiveRouteLegsIndependently
+                } returns realOptions.styleInactiveRouteLegsIndependently
+                every { displayRestrictedRoadSections } returns false
+            }
+            val api = MapboxRouteLineApi(options)
+            val routeProgress = mockk<RouteProgress> {
+                every { currentLegProgress } returns mockk {
+                    every { legIndex } returns 0
+                    every { currentStepProgress } returns mockk {
+                        every { stepPoints } returns PolylineUtils.decode(
+                            route.legs()!![0].steps()!![0].geometry()!!,
+                            6
+                        )
+                        every { distanceTraveled } returns 0f
+                        every { step } returns mockk {
+                            every { distance() } returns route.legs()!![0].steps()!![0].distance()
+                        }
+                        every { stepIndex } returns 0
+                    }
+                }
+                every { currentState } returns RouteProgressState.TRACKING
+            }
+            api.updateVanishingPointState(RouteProgressState.TRACKING)
+            api.setRoutes(listOf(RouteLine(route, null)))
+            api.updateWithRouteProgress(routeProgress) {}
+
+            val result = api.setVanishingOffset(0.0).value!!
+
+            assertEquals(expectedTrafficExp, result.trafficLineExpression.toString())
+            assertEquals(-1, api.activeLegIndex)
+        }
+
+    @Test
+    fun updateWithRouteProgress_whenDeEmphasizeInactiveLegSegments_setsActiveLegIndex() =
+        coroutineRule.runBlockingTest {
+            val realOptions = MapboxRouteLineOptions.Builder(ctx)
+                .styleInactiveRouteLegsIndependently(true)
+                .build()
+            val route = getMultilegWithTwoLegs()
+            val mockVanishingRouteLine = mockk<VanishingRouteLine>(relaxUnitFun = true) {
+                every { primaryRoutePoints } returns null
+                every { vanishPointOffset } returns 0.0
+                every { primaryRouteLineGranularDistances } returns null
+            }
+            val options = mockk<MapboxRouteLineOptions> {
+                every { vanishingRouteLine } returns mockVanishingRouteLine
+                every { resourceProvider } returns realOptions.resourceProvider
+                every {
+                    styleInactiveRouteLegsIndependently
+                } returns realOptions.styleInactiveRouteLegsIndependently
+                every { displayRestrictedRoadSections } returns false
+            }
+            val api = MapboxRouteLineApi(options)
+            val routeProgress = mockk<RouteProgress> {
+                every { currentLegProgress } returns mockk {
+                    every { legIndex } returns 0
+                    every { currentStepProgress } returns mockk {
+                        every { stepPoints } returns PolylineUtils.decode(
+                            route.legs()!![0].steps()!![0].geometry()!!,
+                            6
+                        )
+                        every { distanceTraveled } returns 0f
+                        every { step } returns mockk {
+                            every { distance() } returns route.legs()!![0].steps()!![0].distance()
+                        }
+                        every { stepIndex } returns 0
+                    }
+                }
+                every { currentState } returns RouteProgressState.TRACKING
+            }
+            api.updateVanishingPointState(RouteProgressState.TRACKING)
+            api.setRoutes(listOf(RouteLine(route, null)))
+
+            api.updateWithRouteProgress(routeProgress) {}
+
+            assertEquals(0, api.activeLegIndex)
+        }
+
+    @Test
+    fun highlightActiveLeg() = coroutineRule.runBlockingTest {
+        var callbackCalled = false
+        val expectedTrafficExp = "[step, [line-progress], [rgba, 0.0, 0.0, 0.0, 0.0], 0.0, " +
+            "[rgba, 0.0, 0.0, 0.0, 0.0], 0.48807892461540975, [rgba, 143.0, 36.0, 71.0, 1.0]," +
+            " 0.48811448630642584, [rgba, 255.0, 149.0, 0.0, 1.0], 0.5403176217572488, " +
+            "[rgba, 86.0, 168.0, 251.0, 1.0], 0.5691720892036999, [rgba, 255.0, 149.0, 0.0, 1.0]," +
+            " 0.589665898238105, [rgba, 86.0, 168.0, 251.0, 1.0], 0.883716372144694, " +
+            "[rgba, 255.0, 149.0, 0.0, 1.0], 0.939080244312266, [rgba, 86.0, 168.0, 251.0, 1.0]]"
+        val expectedRouteLineExp = "[step, [line-progress], [rgba, 86.0, 168.0, 251.0, 1.0], 0.0," +
+            " [rgba, 0.0, 0.0, 0.0, 0.0], 0.48807892461540975, [rgba, 86.0, 168.0, 251.0, 1.0]]"
+        val expectedCasingExp = "[step, [line-progress], [rgba, 47.0, 122.0, 198.0, 1.0], 0.0," +
+            " [rgba, 0.0, 0.0, 0.0, 0.0], 0.48807892461540975, [rgba, 47.0, 122.0, 198.0, 1.0]]"
+        val route = getMultilegWithTwoLegs()
+        val options = MapboxRouteLineOptions.Builder(ctx)
+            .styleInactiveRouteLegsIndependently(true)
+            .build()
+        val api = MapboxRouteLineApi(options)
+        val routeProgress = mockk<RouteProgress> {
+            every { currentLegProgress } returns mockk {
+                every { legIndex } returns 1
+                every { currentStepProgress } returns mockk {
+                    every { stepPoints } returns PolylineUtils.decode(
+                        route.legs()!![0].steps()!![0].geometry()!!,
+                        6
+                    )
+                    every { distanceTraveled } returns 0f
+                    every { step } returns mockk {
+                        every { distance() } returns route.legs()!![0].steps()!![0].distance()
+                    }
+                    every { stepIndex } returns 0
+                }
+                every { currentState } returns RouteProgressState.UNCERTAIN
+            }
+        }
+        api.setRoutes(listOf(RouteLine(route, null)))
+
+        api.updateWithRouteProgress(routeProgress) { result ->
+            assertEquals(expectedTrafficExp, result.value!!.trafficLineExpression.toString())
+            assertEquals(expectedRouteLineExp, result.value!!.routeLineExpression.toString())
+            assertEquals(expectedCasingExp, result.value!!.casingLineExpression.toString())
+            callbackCalled = true
+        }
+        assertTrue(callbackCalled)
+    }
+
+    @Test
+    fun showRouteWithLegIndexHighlighted() = coroutineRule.runBlockingTest {
+        val expectedTrafficExp = "[step, [line-progress], [rgba, 0.0, 0.0, 0.0, 0.0], 0.0, " +
+            "[rgba, 0.0, 0.0, 0.0, 0.0], 0.48807892461540975, [rgba, 143.0, 36.0, 71.0, 1.0]," +
+            " 0.48811448630642584, [rgba, 255.0, 149.0, 0.0, 1.0], 0.5403176217572488, " +
+            "[rgba, 86.0, 168.0, 251.0, 1.0], 0.5691720892036999, [rgba, 255.0, 149.0, 0.0, 1.0]," +
+            " 0.589665898238105, [rgba, 86.0, 168.0, 251.0, 1.0], 0.883716372144694, " +
+            "[rgba, 255.0, 149.0, 0.0, 1.0], 0.939080244312266, [rgba, 86.0, 168.0, 251.0, 1.0]]"
+        val expectedRouteLineExp = "[step, [line-progress], [rgba, 86.0, 168.0, 251.0, 1.0], 0.0," +
+            " [rgba, 0.0, 0.0, 0.0, 0.0], 0.48807892461540975, [rgba, 86.0, 168.0, 251.0, 1.0]]"
+        val expectedCasingExp = "[step, [line-progress], [rgba, 47.0, 122.0, 198.0, 1.0], 0.0," +
+            " [rgba, 0.0, 0.0, 0.0, 0.0], 0.48807892461540975, [rgba, 47.0, 122.0, 198.0, 1.0]]"
+        val route = getMultilegWithTwoLegs()
+        val options = MapboxRouteLineOptions.Builder(ctx)
+            .styleInactiveRouteLegsIndependently(true)
+            .build()
+        val api = MapboxRouteLineApi(options)
+        api.setRoutes(listOf(RouteLine(route, null)))
+
+        val result = api.showRouteWithLegIndexHighlighted(1).value!!
+
+        assertEquals(expectedTrafficExp, result.trafficLineExpression.toString())
+        assertEquals(expectedRouteLineExp, result.routeLineExpression.toString())
+        assertEquals(expectedCasingExp, result.casingLineExpression.toString())
     }
 
     @Test
@@ -1013,6 +1261,35 @@ class MapboxRouteLineApiTest {
         assertEquals(625, longRouteDef.await())
     }
 
+    @Test
+    fun deEmphasizeSegmentsNotInLeg() = coroutineRule.runBlockingTest {
+        val colorOptions = RouteLineColorResources.Builder()
+            .inActiveRouteLegsColor(Color.YELLOW)
+            .build()
+        val resources = RouteLineResources.Builder().routeLineColorResources(colorOptions).build()
+        val options = MapboxRouteLineOptions.Builder(ctx).withRouteLineResources(resources).build()
+        val route = getMultilegWithTwoLegs()
+        val segments = MapboxRouteLineUtils.calculateRouteLineSegments(
+            route,
+            listOf(),
+            true,
+            options.resourceProvider.routeLineColorResources,
+            RouteConstants.RESTRICTED_ROAD_SECTION_SCALE,
+            false
+        )
+        val api = MapboxRouteLineApi(options)
+
+        val result = api.alternativelyStyleSegmentsNotInLeg(1, segments)
+
+        assertEquals(12, result.size)
+        assertEquals(-256, result.first().segmentColor)
+        assertEquals(0, result.first().legIndex)
+        assertEquals(-256, result[4].segmentColor)
+        assertEquals(0, result[4].legIndex)
+        assertEquals(-7396281, result[5].segmentColor)
+        assertEquals(1, result[5].legIndex)
+    }
+
     private fun getRoute(): DirectionsRoute {
         val routeAsJson = loadJsonFixture("short_route.json")
         return DirectionsRoute.fromJson(routeAsJson)
@@ -1030,6 +1307,11 @@ class MapboxRouteLineApiTest {
 
     private fun getVeryLongRoute(): DirectionsRoute {
         val routeAsJson = loadJsonFixture("cross-country-route.json")
+        return DirectionsRoute.fromJson(routeAsJson)
+    }
+
+    private fun getMultilegWithTwoLegs(): DirectionsRoute {
+        val routeAsJson = loadJsonFixture("multileg-route-two-legs.json")
         return DirectionsRoute.fromJson(routeAsJson)
     }
 

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineViewTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineViewTest.kt
@@ -21,8 +21,8 @@ import com.mapbox.navigation.ui.maps.internal.route.line.MapboxRouteLineUtils
 import com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions
 import com.mapbox.navigation.ui.maps.route.line.model.RouteLineClearValue
 import com.mapbox.navigation.ui.maps.route.line.model.RouteLineError
+import com.mapbox.navigation.ui.maps.route.line.model.RouteLineUpdateValue
 import com.mapbox.navigation.ui.maps.route.line.model.RouteSetValue
-import com.mapbox.navigation.ui.maps.route.line.model.VanishingRouteLineUpdateValue
 import com.mapbox.navigation.utils.internal.JobControl
 import com.mapbox.navigation.utils.internal.ThreadController
 import io.mockk.MockKAnnotations
@@ -181,9 +181,9 @@ class MapboxRouteLineViewTest {
         val trafficLineExp = mockk<Expression>()
         val routeLineExp = mockk<Expression>()
         val casingLineEx = mockk<Expression>()
-        val state: Expected<RouteLineError, VanishingRouteLineUpdateValue> =
+        val state: Expected<RouteLineError, RouteLineUpdateValue> =
             ExpectedFactory.createValue(
-                VanishingRouteLineUpdateValue(
+                RouteLineUpdateValue(
                     trafficLineExp,
                     routeLineExp,
                     casingLineEx
@@ -209,7 +209,7 @@ class MapboxRouteLineViewTest {
         }
 
         pauseDispatcher {
-            MapboxRouteLineView(options).renderVanishingRouteLineUpdateValue(style, state)
+            MapboxRouteLineView(options).renderRouteLineUpdate(style, state)
             verify { MapboxRouteLineUtils.initializeLayers(style, options) }
         }
 

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/model/MapboxRouteLineOptionsTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/model/MapboxRouteLineOptionsTest.kt
@@ -71,6 +71,15 @@ class MapboxRouteLineOptionsTest {
     }
 
     @Test
+    fun styleInactiveRouteLegsIndependently() {
+        val options = MapboxRouteLineOptions.Builder(ctx)
+            .styleInactiveRouteLegsIndependently(true)
+            .build()
+
+        assertTrue(options.styleInactiveRouteLegsIndependently)
+    }
+
+    @Test
     fun toBuilder() {
         val routeLineResources = RouteLineResources.Builder().build()
         val routeStyleDescriptors =
@@ -83,6 +92,7 @@ class MapboxRouteLineOptionsTest {
             .withTolerance(.111)
             .withRouteStyleDescriptors(routeStyleDescriptors)
             .displayRestrictedRoadSections(true)
+            .styleInactiveRouteLegsIndependently(true)
             .build()
             .toBuilder(ctx)
             .build()
@@ -93,5 +103,6 @@ class MapboxRouteLineOptionsTest {
         assertEquals(.111, options.tolerance, 0.0)
         assertEquals(routeStyleDescriptors, options.routeLayerProvider.routeStyleDescriptors)
         assertTrue(options.displayRestrictedRoadSections)
+        assertTrue(options.styleInactiveRouteLegsIndependently)
     }
 }

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineColorResourcesTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineColorResourcesTest.kt
@@ -33,6 +33,7 @@ class RouteLineColorResourcesTest :
             .alternativeRouteRestrictedRoadColor(18)
             .routeClosureColor(19)
             .alternativeRouteClosureColor(20)
+            .inActiveRouteLegsColor(21)
     }
 
     override fun trigger() {
@@ -192,6 +193,14 @@ class RouteLineColorResourcesTest :
     }
 
     @Test
+    fun inActiveRouteLegsColor() {
+        val resources =
+            RouteLineColorResources.Builder().inActiveRouteLegsColor(5).build()
+
+        assertEquals(5, resources.inActiveRouteLegsColor)
+    }
+
+    @Test
     fun toBuilder() {
         val routeLineColorResources = RouteLineColorResources.Builder()
             .routeLineTraveledColor(1)
@@ -214,6 +223,7 @@ class RouteLineColorResourcesTest :
             .alternativeRouteRestrictedRoadColor(18)
             .routeClosureColor(19)
             .alternativeRouteClosureColor(20)
+            .inActiveRouteLegsColor(21)
             .build()
 
         val result = routeLineColorResources.toBuilder().build()
@@ -238,5 +248,6 @@ class RouteLineColorResourcesTest :
         assertEquals(18, result.alternativeRouteRestrictedRoadColor)
         assertEquals(19, result.routeClosureColor)
         assertEquals(20, result.alternativeRouteClosureColor)
+        assertEquals(21, result.inActiveRouteLegsColor)
     }
 }

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/util/CacheResultUtilsTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/util/CacheResultUtilsTest.kt
@@ -26,6 +26,23 @@ class CacheResultUtilsTest {
     }
 
     @Test
+    fun cacheResult2() {
+        var counter = 0
+        val testFun: (a: Int, b: Int) -> Int = { a: Int, b: Int ->
+            counter += 1
+            a + b + counter
+        }.cacheResult(1)
+
+        testFun(5, 0)
+        testFun(5, 0)
+
+        val result = testFun(5, 0)
+
+        assertEquals(6, result)
+        assertEquals(1, counter)
+    }
+
+    @Test
     fun cacheMaxSize() {
         var counter = 0
         val testFun: (a: Int) -> Int = { a: Int ->

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/MapboxRouteLineActivity.java
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/MapboxRouteLineActivity.java
@@ -75,7 +75,7 @@ import com.mapbox.navigation.ui.maps.route.line.model.RouteLine;
 import com.mapbox.navigation.ui.maps.route.line.model.RouteLineError;
 import com.mapbox.navigation.ui.maps.route.line.model.RouteLineResources;
 import com.mapbox.navigation.ui.maps.route.line.model.RouteNotFound;
-import com.mapbox.navigation.ui.maps.route.line.model.VanishingRouteLineUpdateValue;
+import com.mapbox.navigation.ui.maps.route.line.model.RouteLineUpdateValue;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -440,9 +440,9 @@ public class MapboxRouteLineActivity extends AppCompatActivity implements OnMapL
   private ReplayProgressObserver replayProgressObserver = new ReplayProgressObserver(mapboxReplayer);
 
   private OnIndicatorPositionChangedListener onIndicatorPositionChangedListener = point -> {
-    Expected<RouteLineError, VanishingRouteLineUpdateValue> vanishingRouteLineData = mapboxRouteLineApi.updateTraveledRouteLine(point);
+    Expected<RouteLineError, RouteLineUpdateValue> vanishingRouteLineData = mapboxRouteLineApi.updateTraveledRouteLine(point);
     if (vanishingRouteLineData != null && mapboxMap.getStyle() != null) {
-      mapboxRouteLineView.renderVanishingRouteLineUpdateValue(mapboxMap.getStyle(), vanishingRouteLineData);
+      mapboxRouteLineView.renderRouteLineUpdate(mapboxMap.getStyle(), vanishingRouteLineData);
     }
   };
 
@@ -452,7 +452,9 @@ public class MapboxRouteLineActivity extends AppCompatActivity implements OnMapL
       if (mapboxMap.getStyle() == null) {
         return;
       }
-      mapboxRouteLineApi.updateWithRouteProgress(routeProgress);
+      mapboxRouteLineApi.updateWithRouteProgress(routeProgress, value -> {
+        mapboxRouteLineView.renderRouteLineUpdate(mapboxMap.getStyle(), value);
+      });
 
       Expected<InvalidPointError, UpdateManeuverArrowValue> updateArrowState = routeArrow.addUpcomingManeuverArrow(routeProgress);
       routeArrowView.renderManeuverUpdate(mapboxMap.getStyle(), updateArrowState);


### PR DESCRIPTION
### Description
Implements #4303 by adding an option to de-emphasize inactive routes for multi-leg routes.  
There are also modifications to fix #4483.

There are two use cases supported.

1. Hide inactive legs with the vanishing route line feature **disabled**.
2. Hide inactive legs with the vanishing route line feature **enabled**.

With the vanishing route line feature **enabled** the developer needs only to enable the option for deEmphasizing inactive routes  to use the feature.

With the vanishing route line feature **disabled** it's necessary to add a route progress observer and call `MapboxRouteLineApi::showOnlyActiveLeg` and render the result. An example activity was added.

### Changelog
```
<changelog>Added option to MapboxRouteLineOptions to visually differentiate inactive route legs for multi-leg routes. A callback was added to `MapboxRouteLineApi::updateWithRouteProgress`. The result of the callback should be rendered by the `MapboxRouteLineView` class.</changelog>
```

### Screenshots or Gifs
![Screenshot_20210610-104133](https://user-images.githubusercontent.com/2249818/121572333-e8c0cb00-c9d8-11eb-9d79-242e0c1ac9b7.png)
