### PR TITLE
Add `snappingClosures` to `RouteOptionsUpdater`

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/routeoptions/MapboxRouteOptionsUpdater.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/routeoptions/MapboxRouteOptionsUpdater.kt
@@ -95,6 +95,17 @@ class MapboxRouteOptionsUpdater : RouteOptionsUpdater {
                             }
                         }
                     )
+                    .snappingClosures(
+                        let snappingClosures@{
+                            val snappingClosures = routeOptions.snappingClosuresList()
+                            if (snappingClosures.isNullOrEmpty()) {
+                                return@snappingClosures emptyList<Boolean>()
+                            }
+                            mutableListOf<Boolean>().also {
+                                it.addAll(snappingClosures.subList(index, coordinates.size))
+                            }
+                        }
+                    )
                     .waypointNamesList(
                         getUpdatedWaypointsList(
                             routeOptions.waypointNamesList(),


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Adds `snappingClosures` to `RouteOptionsUpdater`
Fixes #4469 

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Fixed a bug in `RouteOptionsUpdater` where `snappingClosures` were not taken into account when making a reroute request.</changelog>
```