### PR TITLE
Add mapbox history test rule

### DIFF
--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/utils/history/MapboxHistoryTestRule.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/utils/history/MapboxHistoryTestRule.kt
@@ -1,0 +1,51 @@
+package com.mapbox.navigation.instrumentation_tests.utils.history
+
+import android.os.Environment
+import com.mapbox.navigation.core.history.MapboxHistoryRecorder
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+import java.io.File
+
+/**
+ * Add this TestRule to your test and the directory will be saved
+ * to external storage. This allows you to then pull the file and
+ * debug potential issues in instrumentation tests.
+ *
+ * Adding rule to your test, example:
+ * @get:Rule
+ * val historyTestRule = MapboxHistoryTestRule()
+ *
+ * @Before
+ * fun setup() {
+ *     mapboxNavigation = MapboxNavigation(..)
+ *     historyTestRule.historyRecorder = mapboxNavigation.historyRecorder
+ * }
+ *
+ * Download files, example:
+ * View the results on the device
+ *   adb shell "cd sdcard/Download/mapbox_test && ls"
+ * Pull the results onto your desktop
+ *   adb pull sdcard/Download/mapbox_test my-local-folder
+ */
+class MapboxHistoryTestRule : TestWatcher() {
+
+    private val directory: File =
+        File(
+            Environment.getExternalStoragePublicDirectory(
+                Environment.DIRECTORY_DOWNLOADS
+            ),
+            "mapbox_test"
+        )
+
+    lateinit var historyRecorder: MapboxHistoryRecorder
+
+    override fun finished(description: Description) {
+        val filePath = historyRecorder.fileDirectory()!!
+        val file = File(filePath)
+        file.walk().filterNot { it.isDirectory }.forEach {
+            val path = description.methodName + File.separator + it.name
+            val target = File(directory, path)
+            it.copyTo(target)
+        }
+    }
+}

--- a/instrumentation-tests/src/main/AndroidManifest.xml
+++ b/instrumentation-tests/src/main/AndroidManifest.xml
@@ -5,6 +5,9 @@
 
     <uses-permission android:name="android.permission.ACCESS_MOCK_LOCATION"
         tools:ignore="MockLocation,ProtectedPermissions" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        tools:ignore="ScopedStorage" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 
     <!-- usesCleartextTraffic is a workaround for Android security requirement when using mocked
     web server and local host possible to resolve with and additional keystore and key generator
@@ -15,6 +18,7 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
+        android:requestLegacyExternalStorage="true"
         android:usesCleartextTraffic="true">
         <activity android:name=".activity.EmptyTestActivity" />
         <activity android:name=".activity.BasicNavigationViewActivity" />

--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -5,6 +5,7 @@ package com.mapbox.navigation.core {
     ctor public MapboxNavigation(com.mapbox.navigation.base.options.NavigationOptions navigationOptions);
     method public void cancelRouteRequest(long requestId);
     method public com.mapbox.navigation.core.trip.session.eh.GraphAccessor getGraphAccessor();
+    method public com.mapbox.navigation.core.history.MapboxHistoryRecorder getHistoryRecorder();
     method public com.mapbox.navigation.base.options.NavigationOptions getNavigationOptions();
     method public com.mapbox.navigation.core.reroute.RerouteController? getRerouteController();
     method public com.mapbox.navigation.core.trip.session.eh.RoadObjectMatcher getRoadObjectMatcher();
@@ -12,7 +13,6 @@ package com.mapbox.navigation.core {
     method public java.util.List<com.mapbox.api.directions.v5.models.DirectionsRoute> getRoutes();
     method public com.mapbox.navigation.core.navigator.TilesetDescriptorFactory getTilesetDescriptorFactory();
     method public com.mapbox.navigation.core.trip.session.TripSessionState getTripSessionState();
-    method public com.mapbox.navigation.core.history.MapboxHistoryRecorder historyRecorder();
     method public boolean navigateNextRouteLeg();
     method public void onDestroy();
     method public void postUserFeedback(@com.mapbox.navigation.core.telemetry.events.FeedbackEvent.Type String feedbackType, String description, @com.mapbox.navigation.core.telemetry.events.FeedbackEvent.Source String feedbackSource, String? screenshot, String![]? feedbackSubType = emptyArray(), com.mapbox.navigation.core.telemetry.events.AppMetadata? appMetadata = null);
@@ -56,6 +56,7 @@ package com.mapbox.navigation.core {
     method public void unregisterVoiceInstructionsObserver(com.mapbox.navigation.core.trip.session.VoiceInstructionsObserver voiceInstructionsObserver);
     method public void updateSensorEvent(android.hardware.SensorEvent sensorEvent);
     property public final com.mapbox.navigation.core.trip.session.eh.GraphAccessor graphAccessor;
+    property public final com.mapbox.navigation.core.history.MapboxHistoryRecorder historyRecorder;
     property public final com.mapbox.navigation.base.options.NavigationOptions navigationOptions;
     property public final com.mapbox.navigation.core.trip.session.eh.RoadObjectMatcher roadObjectMatcher;
     property public final com.mapbox.navigation.core.trip.session.eh.RoadObjectsStore roadObjectsStore;

--- a/libnavigation-core/src/androidTest/AndroidManifest.xml
+++ b/libnavigation-core/src/androidTest/AndroidManifest.xml
@@ -1,7 +1,12 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.mapbox.navigation.core">
 
-    <uses-permission android:name="android.permission.ACCESS_MOCK_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_MOCK_LOCATION"
+        tools:ignore="MockLocation,ProtectedPermissions" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        tools:ignore="ScopedStorage" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 
     <application>
         <activity

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -203,8 +203,6 @@ class MapboxNavigation(
         }
     }
 
-    private val mapboxHistoryRecorder = MapboxHistoryRecorder(navigationOptions, logger)
-
     private val navigatorConfig = NavigatorConfig(
         null,
         electronicHorizonOptions,
@@ -252,6 +250,14 @@ class MapboxNavigation(
      */
     val roadObjectMatcher: RoadObjectMatcher
 
+    /**
+     * Use the history recorder to save history files.
+     *
+     * @see [HistoryRecorderOptions] to enable and customize the directory
+     * @see [MapboxHistoryReader] to read the files
+     */
+    val historyRecorder = MapboxHistoryRecorder(navigationOptions, logger)
+
     init {
         ThreadController.init()
         navigator = NavigationComponentProvider.createNativeNavigator(
@@ -261,10 +267,10 @@ class MapboxNavigation(
                 isFallback = false,
                 tilesVersion = navigationOptions.routingTilesOptions.tilesVersion
             ),
-            mapboxHistoryRecorder.fileDirectory(),
+            historyRecorder.fileDirectory(),
             logger
         )
-        mapboxHistoryRecorder.historyRecorderHandle = navigator.getHistoryRecorderHandle()
+        historyRecorder.historyRecorderHandle = navigator.getHistoryRecorderHandle()
         navigationSession = NavigationComponentProvider.createNavigationSession()
         directionsSession = NavigationComponentProvider.createDirectionsSession(
             MapboxModuleProvider.createModule(MapboxModuleType.NavigationRouter, ::paramsProvider),
@@ -501,14 +507,6 @@ class MapboxNavigation(
         ThreadController.cancelAllNonUICoroutines()
         ThreadController.cancelAllUICoroutines()
     }
-
-    /**
-     * Use the history recorder to save history files.
-     *
-     * @see [HistoryRecorderOptions] to enable and customize the directory
-     * @see [MapboxHistoryReader] to read the files
-     */
-    fun historyRecorder(): MapboxHistoryRecorder = mapboxHistoryRecorder
 
     /**
      * API used to retrieve the SSML announcement for voice instructions.
@@ -931,10 +929,10 @@ class MapboxNavigation(
                 navigationOptions.deviceProfile,
                 navigatorConfig,
                 createTilesConfig(isFallback, tilesVersion),
-                mapboxHistoryRecorder.fileDirectory(),
+                historyRecorder.fileDirectory(),
                 logger
             )
-            mapboxHistoryRecorder.historyRecorderHandle = navigator.getHistoryRecorderHandle()
+            historyRecorder.historyRecorderHandle = navigator.getHistoryRecorderHandle()
             tripSession.route?.let {
                 navigator.setRoute(
                     it,

--- a/libtesting-ui/src/main/java/com/mapbox/navigation/testing/ui/BaseTest.kt
+++ b/libtesting-ui/src/main/java/com/mapbox/navigation/testing/ui/BaseTest.kt
@@ -23,7 +23,9 @@ open class BaseTest<A : AppCompatActivity>(activityClass: Class<A>) {
 
     @get:Rule
     val permissionsRule: GrantPermissionRule = GrantPermissionRule.grant(
-        Manifest.permission.ACCESS_FINE_LOCATION
+        Manifest.permission.ACCESS_FINE_LOCATION,
+        Manifest.permission.READ_EXTERNAL_STORAGE,
+        Manifest.permission.WRITE_EXTERNAL_STORAGE
     )
 
     @get:Rule


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Addressing https://github.com/mapbox/mapbox-navigation-android/issues/4506

Add a debugging utility that allows us to capture the history files from instrumentation tests. I'm opening it here as a debugging tool first, and then we can look into adding it to circleci artifacts. If we add it to all tests, we will also want to think about how we should clean up the files from local development environments.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Change the MapboxNavigation.historyRecorder() function to an immutable `val`</changelog>
```

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->

The MapboxHistoryTestRule saves the history files to a `sdcard/Download/mapbox_test` folder. Each test will have its own history file. There will be 1 in the future, right now there is 2 because of a separate bug.

![Screen Shot 2021-06-15 at 11 14 47 AM](https://user-images.githubusercontent.com/3021882/122104192-45065f00-cdcc-11eb-8254-4028f953aaf0.png)



<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
