### PR TITLE
Test the time to split core and ui tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,10 @@ workflows:
       - static-analysis:
           requires:
             - prepare-and-assemble
-      - unit-tests:
+      - unit-tests-core:
+          requires:
+            - prepare-and-assemble
+      - unit-tests-ui:
           requires:
             - prepare-and-assemble
       - ui-robo-tests:
@@ -448,11 +451,16 @@ jobs:
           module_target: "libnavigation-core"
       - write-workspace
 
-  unit-tests:
+  unit-tests-core:
     executor: ndk-r21e-latest-executor
     steps:
       - read-workspace
       - unit-tests-core
+
+  unit-tests-ui:
+    executor: ndk-r21e-latest-executor
+    steps:
+      - read-workspace
       - unit-tests-ui
 # Disabling Codecov (for now) due to https://about.codecov.io/security-update/
 #      - codecov


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Test parallelizing core and ui tests, because the unit test job is the circle-ci bottleneck

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->

Reason I'm testing this one is because, after prepare-and-assemble, the unit tests take the most time. The idea is we can potentially cut that job in half and save ourselves ~10 minutes.
![Screen Shot 2021-06-16 at 8 19 33 AM](https://user-images.githubusercontent.com/3021882/122246687-9f122d80-ce7b-11eb-966e-fb35c2a9a1e1.png)

After, it makes it so unit tests are no longer the bottleneck
![Screen Shot 2021-06-16 at 9 38 24 AM](https://user-images.githubusercontent.com/3021882/122259093-a12db980-ce86-11eb-9403-550665d15654.png)

This is the test that keeps failing for the screenshots :) https://github.com/mapbox/mapbox-navigation-android/issues/4510
<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
