### PR TITLE
RouteAlternativesTest wait for location warm-up

### DIFF
--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/utils/idling/FirstLocationIdlingResource.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/utils/idling/FirstLocationIdlingResource.kt
@@ -1,0 +1,70 @@
+package com.mapbox.navigation.instrumentation_tests.utils.idling
+
+import android.location.Location
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.IdlingRegistry
+import androidx.test.espresso.IdlingResource
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.trip.session.LocationObserver
+
+/**
+ * Idling resource for testing situations that require a valid location.
+ *
+ * @param mapboxNavigation the navigation interface used to register a [LocationObserver].
+ */
+class FirstLocationIdlingResource(
+    private val mapboxNavigation: MapboxNavigation
+) {
+
+    var firstLocation: Location? = null
+        private set
+    private lateinit var callback: IdlingResource.ResourceCallback
+
+    /**
+     * This will block the execution of a test while waiting for the first
+     * enhanced location from the navigator.
+     *
+     * If this fails due to timeout, locations are not being sent to the navigator.
+     */
+    fun firstLocationSync(): Location {
+        IdlingRegistry.getInstance().register(idlingResource)
+        mapboxNavigation.registerLocationObserver(locationObserver)
+        Espresso.onIdle()
+        mapboxNavigation.unregisterLocationObserver(locationObserver)
+        IdlingRegistry.getInstance().unregister(idlingResource)
+        return firstLocation!!
+    }
+
+    /** Used to communicate with the [IdlingRegistry] **/
+    private val idlingResource = object : IdlingResource {
+        override fun getName() = "FirstLocationIdlingResource"
+
+        override fun isIdleNow(): Boolean = firstLocation != null
+
+        override fun registerIdleTransitionCallback(
+            resourceCallback: IdlingResource.ResourceCallback
+        ) {
+            callback = resourceCallback
+            if (isIdleNow) {
+                callback.onTransitionToIdle()
+            }
+        }
+    }
+
+    /** Used to communicate with [MapboxNavigation.registerLocationObserver] **/
+    private val locationObserver = object : LocationObserver {
+        override fun onRawLocationChanged(rawLocation: Location) {
+            // Do nothing
+        }
+
+        override fun onEnhancedLocationChanged(
+            enhancedLocation: Location,
+            keyPoints: List<Location>
+        ) {
+            if (firstLocation == null) {
+                firstLocation = enhancedLocation
+                callback.onTransitionToIdle()
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

When updating the status polling mechanism to be push based from nav-native, we found that `RouteAlternativesTest` will fail because a current location has not been established. https://github.com/mapbox/mapbox-navigation-android/pull/4419. 

In real life scenarios, a couple GPS locations will be provided to the navigator. This PR is introducing a `FirstLocationIdlingResource` for instrumentation tests to deterministically wait for the navigator to establish a current location. And then we can test the active guidance behavior

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
