### PR TITLE
PredictiveCacheController for multiple map instances with sources filter

### DIFF
--- a/libnavigation-base/api/current.txt
+++ b/libnavigation-base/api/current.txt
@@ -200,7 +200,6 @@ package com.mapbox.navigation.base.options {
     method public com.mapbox.android.core.location.LocationEngine getLocationEngine();
     method public com.mapbox.android.core.location.LocationEngineRequest getLocationEngineRequest();
     method public long getNavigatorPredictionMillis();
-    method public com.mapbox.navigation.base.options.PredictiveCacheLocationOptions getPredictiveCacheLocationOptions();
     method public com.mapbox.navigation.base.route.RouteAlternativesOptions getRouteAlternativesOptions();
     method public com.mapbox.navigation.base.route.RouteRefreshOptions getRouteRefreshOptions();
     method public com.mapbox.navigation.base.options.RoutingTilesOptions getRoutingTilesOptions();
@@ -220,7 +219,6 @@ package com.mapbox.navigation.base.options {
     property public final com.mapbox.android.core.location.LocationEngine locationEngine;
     property public final com.mapbox.android.core.location.LocationEngineRequest locationEngineRequest;
     property public final long navigatorPredictionMillis;
-    property public final com.mapbox.navigation.base.options.PredictiveCacheLocationOptions predictiveCacheLocationOptions;
     property public final com.mapbox.navigation.base.route.RouteAlternativesOptions routeAlternativesOptions;
     property public final com.mapbox.navigation.base.route.RouteRefreshOptions routeRefreshOptions;
     property public final com.mapbox.navigation.base.options.RoutingTilesOptions routingTilesOptions;
@@ -241,7 +239,6 @@ package com.mapbox.navigation.base.options {
     method public com.mapbox.navigation.base.options.NavigationOptions.Builder locationEngine(com.mapbox.android.core.location.LocationEngine locationEngine);
     method public com.mapbox.navigation.base.options.NavigationOptions.Builder locationEngineRequest(com.mapbox.android.core.location.LocationEngineRequest locationEngineRequest);
     method public com.mapbox.navigation.base.options.NavigationOptions.Builder navigatorPredictionMillis(long predictionMillis);
-    method public com.mapbox.navigation.base.options.NavigationOptions.Builder predictiveCacheLocationOptions(com.mapbox.navigation.base.options.PredictiveCacheLocationOptions predictiveCacheLocationOptions);
     method public com.mapbox.navigation.base.options.NavigationOptions.Builder routeAlternativesOptions(com.mapbox.navigation.base.route.RouteAlternativesOptions routeAlternativesOptions);
     method public com.mapbox.navigation.base.options.NavigationOptions.Builder routeRefreshOptions(com.mapbox.navigation.base.route.RouteRefreshOptions routeRefreshOptions);
     method public com.mapbox.navigation.base.options.NavigationOptions.Builder routingTilesOptions(com.mapbox.navigation.base.options.RoutingTilesOptions routingTilesOptions);

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/NavigationOptions.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/NavigationOptions.kt
@@ -31,7 +31,6 @@ const val DEFAULT_NAVIGATOR_PREDICTION_MILLIS = 1000L
  * @param navigatorPredictionMillis defines approximate navigator prediction in milliseconds
  * @param distanceFormatterOptions [DistanceFormatterOptions] options to format distances showing in notification during navigation
  * @param routingTilesOptions [RoutingTilesOptions] defines routing tiles endpoint and storage configuration.
- * @param predictiveCacheLocationOptions [PredictiveCacheLocationOptions] defines location configuration for predictive caching
  * @param isFromNavigationUi Boolean *true* if is called from UI, otherwise *false*
  * @param isDebugLoggingEnabled Boolean
  * @param deviceProfile [DeviceProfile] defines how navigation data should be interpretation
@@ -50,7 +49,6 @@ class NavigationOptions private constructor(
     val navigatorPredictionMillis: Long,
     val distanceFormatterOptions: DistanceFormatterOptions,
     val routingTilesOptions: RoutingTilesOptions,
-    val predictiveCacheLocationOptions: PredictiveCacheLocationOptions,
     val isFromNavigationUi: Boolean,
     val isDebugLoggingEnabled: Boolean,
     val deviceProfile: DeviceProfile,
@@ -72,7 +70,6 @@ class NavigationOptions private constructor(
         navigatorPredictionMillis(navigatorPredictionMillis)
         distanceFormatterOptions(distanceFormatterOptions)
         routingTilesOptions(routingTilesOptions)
-        predictiveCacheLocationOptions(predictiveCacheLocationOptions)
         isFromNavigationUi(isFromNavigationUi)
         isDebugLoggingEnabled(isDebugLoggingEnabled)
         deviceProfile(deviceProfile)
@@ -100,7 +97,6 @@ class NavigationOptions private constructor(
         if (navigatorPredictionMillis != other.navigatorPredictionMillis) return false
         if (distanceFormatterOptions != other.distanceFormatterOptions) return false
         if (routingTilesOptions != other.routingTilesOptions) return false
-        if (predictiveCacheLocationOptions != other.predictiveCacheLocationOptions) return false
         if (isFromNavigationUi != other.isFromNavigationUi) return false
         if (isDebugLoggingEnabled != other.isDebugLoggingEnabled) return false
         if (deviceProfile != other.deviceProfile) return false
@@ -125,7 +121,6 @@ class NavigationOptions private constructor(
         result = 31 * result + navigatorPredictionMillis.hashCode()
         result = 31 * result + distanceFormatterOptions.hashCode()
         result = 31 * result + routingTilesOptions.hashCode()
-        result = 31 * result + predictiveCacheLocationOptions.hashCode()
         result = 31 * result + isFromNavigationUi.hashCode()
         result = 31 * result + isDebugLoggingEnabled.hashCode()
         result = 31 * result + deviceProfile.hashCode()
@@ -150,7 +145,6 @@ class NavigationOptions private constructor(
             "navigatorPredictionMillis=$navigatorPredictionMillis, " +
             "distanceFormatterOptions=$distanceFormatterOptions, " +
             "routingTilesOptions=$routingTilesOptions, " +
-            "predictiveCacheLocationOptions=$predictiveCacheLocationOptions, " +
             "isFromNavigationUi=$isFromNavigationUi, " +
             "isDebugLoggingEnabled=$isDebugLoggingEnabled, " +
             "deviceProfile=$deviceProfile, " +
@@ -181,8 +175,6 @@ class NavigationOptions private constructor(
             DistanceFormatterOptions.Builder(applicationContext).build()
         private var routingTilesOptions: RoutingTilesOptions =
             RoutingTilesOptions.Builder().build()
-        private var predictiveCacheLocationOptions: PredictiveCacheLocationOptions =
-            PredictiveCacheLocationOptions.Builder().build()
         private var isFromNavigationUi: Boolean = false
         private var isDebugLoggingEnabled: Boolean = false
         private var deviceProfile: DeviceProfile = DeviceProfile.Builder().build()
@@ -243,14 +235,6 @@ class NavigationOptions private constructor(
             apply { this.routingTilesOptions = routingTilesOptions }
 
         /**
-         * Defines location configuration for predictive caching
-         */
-        fun predictiveCacheLocationOptions(
-            predictiveCacheLocationOptions: PredictiveCacheLocationOptions
-        ): Builder =
-            apply { this.predictiveCacheLocationOptions = predictiveCacheLocationOptions }
-
-        /**
          * Defines if the builder instance is created from the Navigation UI
          */
         fun isFromNavigationUi(flag: Boolean): Builder =
@@ -307,7 +291,6 @@ class NavigationOptions private constructor(
                 navigatorPredictionMillis = navigatorPredictionMillis,
                 distanceFormatterOptions = distanceFormatterOptions,
                 routingTilesOptions = routingTilesOptions,
-                predictiveCacheLocationOptions = predictiveCacheLocationOptions,
                 isFromNavigationUi = isFromNavigationUi,
                 isDebugLoggingEnabled = isDebugLoggingEnabled,
                 deviceProfile = deviceProfile,

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/options/NavigationOptionsTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/options/NavigationOptionsTest.kt
@@ -64,7 +64,6 @@ class NavigationOptionsTest : BuilderTest<NavigationOptions, NavigationOptions.B
             )
             .navigatorPredictionMillis(1)
             .routingTilesOptions(mockk())
-            .predictiveCacheLocationOptions(mockk())
             .timeFormatType(1)
             .eHorizonOptions(mockk())
             .routeRefreshOptions(mockk())

--- a/libnavui-maps/api/current.txt
+++ b/libnavui-maps/api/current.txt
@@ -2,11 +2,12 @@
 package com.mapbox.navigation.ui.maps {
 
   public final class PredictiveCacheController {
-    ctor public PredictiveCacheController(com.mapbox.navigation.core.MapboxNavigation navigation, com.mapbox.navigation.ui.maps.PredictiveCacheControllerErrorHandler? predictiveCacheControllerErrorHandler = null);
-    ctor public PredictiveCacheController(com.mapbox.navigation.core.MapboxNavigation navigation);
+    ctor public PredictiveCacheController(com.mapbox.navigation.base.options.PredictiveCacheLocationOptions predictiveCacheLocationOptions = PredictiveCacheLocationOptions.<init>().build(), com.mapbox.navigation.ui.maps.PredictiveCacheControllerErrorHandler? predictiveCacheControllerErrorHandler = null);
+    ctor public PredictiveCacheController(com.mapbox.navigation.base.options.PredictiveCacheLocationOptions predictiveCacheLocationOptions = PredictiveCacheLocationOptions.<init>().build());
+    method public void createMapControllers(com.mapbox.maps.MapboxMap map, java.util.List<java.lang.String> sourceIdsToCache = emptyList());
+    method public void createMapControllers(com.mapbox.maps.MapboxMap map);
     method public void onDestroy();
-    method public void removeMapInstance();
-    method public void setMapInstance(com.mapbox.maps.MapboxMap map);
+    method public void removeMapControllers(com.mapbox.maps.MapboxMap map);
   }
 
   public fun interface PredictiveCacheControllerErrorHandler {

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/PredictiveCacheControllerTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/PredictiveCacheControllerTest.kt
@@ -7,7 +7,7 @@ import com.mapbox.maps.MapboxMap
 import com.mapbox.maps.Style
 import com.mapbox.maps.StyleObjectInfo
 import com.mapbox.maps.plugin.delegates.listeners.OnStyleLoadedListener
-import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.base.options.PredictiveCacheLocationOptions
 import com.mapbox.navigation.core.internal.PredictiveCache
 import io.mockk.Runs
 import io.mockk.every
@@ -49,20 +49,15 @@ class PredictiveCacheControllerTest {
 
     @Test
     fun `initialize creates Navigation Predictive Cache Controller`() {
-        val mockedMapboxNavigation = mockk<MapboxNavigation>(relaxed = true)
+        val mockedLocationOptions: PredictiveCacheLocationOptions = mockk()
         every {
             PredictiveCache.createNavigationController(any())
         } just Runs
 
-        PredictiveCacheController(
-            mockedMapboxNavigation,
-            errorHandler
-        )
+        PredictiveCacheController(mockedLocationOptions, errorHandler)
 
         verify {
-            PredictiveCache.createNavigationController(
-                mockedMapboxNavigation.navigationOptions.predictiveCacheLocationOptions
-            )
+            PredictiveCache.createNavigationController(mockedLocationOptions)
         }
 
         verify(exactly = 0) { errorHandler.onError(any()) }
@@ -70,7 +65,7 @@ class PredictiveCacheControllerTest {
 
     @Test
     fun `null tileStore creates error message and does not initialize Predictive Cache Controllers`() {
-        val mockedMapboxNavigation = mockk<MapboxNavigation>(relaxed = true)
+        val mockedLocationOptions: PredictiveCacheLocationOptions = mockk()
         every {
             PredictiveCache.createNavigationController(any())
         } just Runs
@@ -95,18 +90,18 @@ class PredictiveCacheControllerTest {
         every { style.styleSources } returns styleSources
 
         val predictiveCacheController = PredictiveCacheController(
-            mockedMapboxNavigation,
+            mockedLocationOptions,
             errorHandler
         )
 
-        predictiveCacheController.setMapInstance(mockedMapboxMap)
+        predictiveCacheController.createMapControllers(mockedMapboxMap)
 
         verify { errorHandler.onError(any()) }
     }
 
     @Test
     fun `non-null tileStore initializes Maps Predictive Cache Controllers`() {
-        val mockedMapboxNavigation = mockk<MapboxNavigation>(relaxed = true)
+        val mockedLocationOptions: PredictiveCacheLocationOptions = mockk()
         every {
             PredictiveCache.createNavigationController(any())
         } just Runs
@@ -152,19 +147,25 @@ class PredictiveCacheControllerTest {
         every { style.getStyleSourceProperties(mockedIds[2]) } returns mockedPropertiesRaster
 
         val predictiveCacheController = PredictiveCacheController(
-            mockedMapboxNavigation,
+            mockedLocationOptions,
             errorHandler
         )
 
         val slotIds = mutableListOf<String>()
         every {
-            PredictiveCache.createMapsController(mockedTileStore, capture(slotIds))
+            PredictiveCache.createMapsController(
+                mockedMapboxMap,
+                mockedTileStore,
+                capture(slotIds),
+                mockedLocationOptions
+            )
         } just Runs
 
-        predictiveCacheController.setMapInstance(mockedMapboxMap)
+        predictiveCacheController.createMapControllers(mockedMapboxMap)
 
         verify(exactly = 2) {
             PredictiveCache.createMapsController(
+                mockedMapboxMap,
                 mockedTileStore,
                 any(),
                 any()
@@ -181,8 +182,111 @@ class PredictiveCacheControllerTest {
     }
 
     @Test
+    fun `Maps Predictive Cache Controllers initialized for passed sources`() {
+        val mockedLocationOptions: PredictiveCacheLocationOptions = mockk()
+        every {
+            PredictiveCache.createNavigationController(any())
+        } just Runs
+        val mockedTileStore = mockk<TileStore>()
+        every { TileStore.create(any()) } returns mockedTileStore
+        val mockedMapboxMap = mockk<MapboxMap>(relaxed = true) {
+            every { getResourceOptions().tileStore } returns mockedTileStore
+        }
+        val style = mockk<Style>()
+        every {
+            mockedMapboxMap.getStyle()
+        } returns style
+        val mockedIds: List<String> = listOf(
+            "composite",
+            "mapbox-navigation-waypoint-source",
+            "mapbox://mapbox.satellite",
+            "mapbox://mapbox.mapbox-terrain-v2",
+            "mapbox://mapbox.transit-v2",
+        )
+        val styleSources: List<StyleObjectInfo> = listOf(
+            StyleObjectInfo(mockedIds[0], "vector"),
+            StyleObjectInfo(mockedIds[1], "geojson"),
+            StyleObjectInfo(mockedIds[2], "raster"),
+            StyleObjectInfo(mockedIds[3], "vector"),
+            StyleObjectInfo(mockedIds[4], "vector"),
+        )
+        every { style.styleSources } returns styleSources
+
+        val mockedPropertiesVector = mockk<Expected<String, Value>>(relaxed = true)
+        val contentsVector = mutableMapOf<String, Value>()
+        contentsVector["type"] = Value("vector")
+        contentsVector["url"] = Value("mapbox://mapbox.mapbox-streets-v8,mapbox.mapbox-terrain-v2")
+        every { mockedPropertiesVector.value?.contents } returns contentsVector
+        every { style.getStyleSourceProperties(mockedIds[0]) } returns mockedPropertiesVector
+
+        val mockedPropertiesGeojson = mockk<Expected<String, Value>>(relaxed = true)
+        val contentsGeojson = mutableMapOf<String, Value>()
+        contentsGeojson["type"] = Value("geojson")
+        every { mockedPropertiesGeojson.value?.contents } returns contentsGeojson
+        every { style.getStyleSourceProperties(mockedIds[1]) } returns mockedPropertiesGeojson
+
+        val mockedPropertiesRaster = mockk<Expected<String, Value>>(relaxed = true)
+        val contentsRaster = mutableMapOf<String, Value>()
+        contentsRaster["type"] = Value("raster")
+        contentsRaster["url"] = Value("mapbox://mapbox.satellite")
+        every { mockedPropertiesRaster.value?.contents } returns contentsRaster
+        every { style.getStyleSourceProperties(mockedIds[2]) } returns mockedPropertiesRaster
+
+        val mockedPropertiesVectorSecond = mockk<Expected<String, Value>>(relaxed = true)
+        val contentsVectorSecond = mutableMapOf<String, Value>()
+        contentsVectorSecond["type"] = Value("vector")
+        contentsVectorSecond["url"] = Value("mapbox://mapbox.mapbox-terrain-v2")
+        every { mockedPropertiesVectorSecond.value?.contents } returns contentsVectorSecond
+        every { style.getStyleSourceProperties(mockedIds[3]) } returns mockedPropertiesVectorSecond
+
+        val mockedPropertiesVectorThird = mockk<Expected<String, Value>>(relaxed = true)
+        val contentsVectorThird = mutableMapOf<String, Value>()
+        contentsVectorThird["type"] = Value("vector")
+        contentsVectorThird["url"] = Value("mapbox://mapbox.transit-v2")
+        every { mockedPropertiesVectorThird.value?.contents } returns contentsVectorThird
+        every { style.getStyleSourceProperties(mockedIds[4]) } returns mockedPropertiesVectorThird
+
+        val predictiveCacheController = PredictiveCacheController(
+            mockedLocationOptions,
+            errorHandler
+        )
+
+        val slotIds = mutableListOf<String>()
+        every {
+            PredictiveCache.createMapsController(
+                mockedMapboxMap,
+                mockedTileStore,
+                capture(slotIds),
+                mockedLocationOptions
+            )
+        } just Runs
+
+        predictiveCacheController.createMapControllers(
+            mockedMapboxMap,
+            listOf(
+                "mapbox://mapbox.satellite",
+                "mapbox://mapbox.transit-v2",
+            )
+        )
+
+        verify(exactly = 2) {
+            PredictiveCache.createMapsController(
+                mockedMapboxMap,
+                mockedTileStore,
+                any(),
+                any()
+            )
+        }
+        assertEquals(
+            listOf("mapbox.satellite", "mapbox.transit-v2"),
+            slotIds
+        )
+        verify(exactly = 0) { errorHandler.onError(any()) }
+    }
+
+    @Test
     fun `style change triggers Maps Predictive Cache Controllers update`() {
-        val mockedMapboxNavigation = mockk<MapboxNavigation>(relaxed = true)
+        val mockedLocationOptions: PredictiveCacheLocationOptions = mockk()
         every {
             PredictiveCache.createNavigationController(any())
         } just Runs
@@ -228,25 +332,31 @@ class PredictiveCacheControllerTest {
         every { style.getStyleSourceProperties(mockedIds[2]) } returns mockedPropertiesRaster
 
         val predictiveCacheController = PredictiveCacheController(
-            mockedMapboxNavigation,
+            mockedLocationOptions,
             errorHandler
         )
         val slotIds = mutableListOf<String>()
         every {
-            PredictiveCache.createMapsController(mockedTileStore, capture(slotIds))
+            PredictiveCache.createMapsController(
+                mockedMapboxMap,
+                mockedTileStore,
+                capture(slotIds),
+                mockedLocationOptions
+            )
         } just Runs
 
-        predictiveCacheController.setMapInstance(mockedMapboxMap)
+        predictiveCacheController.createMapControllers(mockedMapboxMap)
 
         verify(exactly = 2) {
             PredictiveCache.createMapsController(
+                mockedMapboxMap,
                 mockedTileStore,
                 any(),
                 any()
             )
         }
         every {
-            PredictiveCache.currentMapsPredictiveCacheControllers()
+            PredictiveCache.currentMapsPredictiveCacheControllers(mockedMapboxMap)
         } returns listOf("mapbox.satellite")
 
         val newStyle = mockk<Style>()
@@ -272,12 +382,17 @@ class PredictiveCacheControllerTest {
 
         val removeSlotIds = mutableListOf<String>()
         every {
-            PredictiveCache.removeMapsController(capture(removeSlotIds))
+            PredictiveCache.removeMapControllers(mockedMapboxMap, capture(removeSlotIds))
         } just Runs
 
         val addSlotIds = mutableListOf<String>()
         every {
-            PredictiveCache.createMapsController(mockedTileStore, capture(addSlotIds))
+            PredictiveCache.createMapsController(
+                mockedMapboxMap,
+                mockedTileStore,
+                capture(addSlotIds),
+                mockedLocationOptions
+            )
         } just Runs
 
         val mapChangedListenerSlot = slot<OnStyleLoadedListener>()
@@ -287,5 +402,101 @@ class PredictiveCacheControllerTest {
         assertEquals(listOf("mapbox.satellite"), removeSlotIds)
         assertEquals(listOf("mapbox.mapbox-streets-v9"), addSlotIds)
         verify(exactly = 0) { errorHandler.onError(any()) }
+    }
+
+    @Test
+    fun `cache controllers are removed when map added twice`() {
+        val mockedLocationOptions: PredictiveCacheLocationOptions = mockk()
+        every {
+            PredictiveCache.createNavigationController(any())
+        } just Runs
+        val mockedTileStore = mockk<TileStore>()
+        every { TileStore.create(any()) } returns mockedTileStore
+        val mockedMapboxMap = mockk<MapboxMap>(relaxed = true) {
+            every { getResourceOptions().tileStore } returns mockedTileStore
+        }
+        val style = mockk<Style>()
+        every {
+            mockedMapboxMap.getStyle()
+        } returns style
+        val mockedIds: List<String> = listOf("mapbox://mapbox.satellite")
+        val styleSources: List<StyleObjectInfo> = listOf(StyleObjectInfo(mockedIds[0], "raster"))
+        every { style.styleSources } returns styleSources
+
+        val mockedPropertiesRaster = mockk<Expected<String, Value>>(relaxed = true)
+        val contentsRaster = mutableMapOf<String, Value>()
+        contentsRaster["type"] = Value("raster")
+        contentsRaster["url"] = Value("mapbox://mapbox.satellite")
+        every { mockedPropertiesRaster.value?.contents } returns contentsRaster
+        every { style.getStyleSourceProperties(mockedIds[0]) } returns mockedPropertiesRaster
+
+        val predictiveCacheController = PredictiveCacheController(
+            mockedLocationOptions,
+            errorHandler
+        )
+
+        val slotIds = mutableListOf<String>()
+        every {
+            PredictiveCache.createMapsController(
+                mockedMapboxMap,
+                mockedTileStore,
+                capture(slotIds),
+                mockedLocationOptions
+            )
+        } just Runs
+
+        predictiveCacheController.createMapControllers(mockedMapboxMap)
+        predictiveCacheController.createMapControllers(mockedMapboxMap)
+
+        assertEquals(listOf("mapbox.satellite", "mapbox.satellite"), slotIds)
+
+        verify(exactly = 2) {
+            PredictiveCache.createMapsController(
+                mockedMapboxMap,
+                mockedTileStore,
+                any(),
+                any()
+            )
+        }
+        verify(exactly = 1) { PredictiveCache.removeAllMapControllers(mockedMapboxMap) }
+        verify(exactly = 0) { errorHandler.onError(any()) }
+    }
+
+    @Test
+    fun `error style source properties create error message and does not initialize Predictive Cache Controllers`() {
+        val mockedLocationOptions: PredictiveCacheLocationOptions = mockk()
+        every {
+            PredictiveCache.createNavigationController(any())
+        } just Runs
+        val mockedTileStore = mockk<TileStore>()
+        every { TileStore.create(any()) } returns mockedTileStore
+        val mockedMapboxMap = mockk<MapboxMap>(relaxed = true) {
+            every { getResourceOptions().tileStore } returns mockedTileStore
+        }
+        val style = mockk<Style>()
+        every {
+            mockedMapboxMap.getStyle()
+        } returns style
+        val mockedIds: List<String> = listOf("mapbox://mapbox.mapbox-terrain-v2")
+        val styleSources: List<StyleObjectInfo> = listOf(StyleObjectInfo(mockedIds[0], "vector"))
+        every { style.styleSources } returns styleSources
+
+        val mockedPropertiesVector = mockk<Expected<String, Value>>(relaxed = true)
+        every { mockedPropertiesVector.isError } returns true
+        val error = "style source property error"
+        every { mockedPropertiesVector.error } returns error
+        every { style.getStyleSourceProperties(mockedIds[0]) } returns mockedPropertiesVector
+
+        val predictiveCacheController = PredictiveCacheController(
+            mockedLocationOptions,
+            errorHandler
+        )
+
+        predictiveCacheController.createMapControllers(mockedMapboxMap)
+
+        verify(exactly = 1) { errorHandler.onError(error) }
+        verify(exactly = 0) {
+            PredictiveCache.createMapsController(any(), any(), any(), any())
+        }
     }
 }

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/MapboxRouteLineActivity.java
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/MapboxRouteLineActivity.java
@@ -171,7 +171,7 @@ public class MapboxRouteLineActivity extends AppCompatActivity implements OnMapL
     predictiveCacheController = new PredictiveCacheController(mapboxNavigation, message -> {
       Log.e(TAG, "predictive cache error: " + message);
     });
-    predictiveCacheController.setMapInstance(mapboxMap);
+    predictiveCacheController.createMapControllers(mapboxMap);
   }
 
   @SuppressLint("MissingPermission")

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/MapboxRouteLineActivity.java
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/MapboxRouteLineActivity.java
@@ -42,6 +42,7 @@ import com.mapbox.maps.plugin.locationcomponent.LocationComponentPluginImpl;
 import com.mapbox.maps.plugin.locationcomponent.OnIndicatorPositionChangedListener;
 import com.mapbox.navigation.base.extensions.RouteOptionsExtensions;
 import com.mapbox.navigation.base.options.NavigationOptions;
+import com.mapbox.navigation.base.options.PredictiveCacheLocationOptions;
 import com.mapbox.navigation.base.options.RoutingTilesOptions;
 import com.mapbox.navigation.base.trip.model.RouteProgress;
 import com.mapbox.navigation.core.MapboxNavigation;
@@ -168,9 +169,11 @@ public class MapboxRouteLineActivity extends AppCompatActivity implements OnMapL
         .build();
     routeArrowView = new MapboxRouteArrowView(routeArrowOptions);
 
-    predictiveCacheController = new PredictiveCacheController(mapboxNavigation, message -> {
-      Log.e(TAG, "predictive cache error: " + message);
-    });
+    predictiveCacheController = new PredictiveCacheController(
+        new PredictiveCacheLocationOptions.Builder().build(),
+        message -> {
+           Log.e(TAG, "predictive cache error: " + message);
+        });
     predictiveCacheController.createMapControllers(mapboxMap);
   }
 

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/util/RouteDrawingActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/util/RouteDrawingActivity.kt
@@ -79,13 +79,11 @@ class RouteDrawingActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.layout_route_drawing_activity)
-        val tileStore = TileStore.getInstance()
+        val tileStore = TileStore.create()
         val mapboxMapOptions = MapInitOptions(this)
         val resourceOptions = ResourceOptions.Builder()
             .accessToken(getMapboxAccessTokenFromResources())
             .assetPath(filesDir.absolutePath)
-            .cachePath(filesDir.absolutePath + "/mbx.db")
-            .cacheSize(100000000L) // 100 MB
             .tileStore(tileStore)
             .build()
         mapboxMapOptions.resourceOptions = resourceOptions


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Improve PredictiveCacheController to handle multiple map instances, add ability to filter sources to cache.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Improve PredictiveCacheController to handle multiple map instances, add ability to filter sources to cache.
`fun setMapInstance(map: MapboxMap)` replaced with `fun addMapInstance(map: MapboxMap,  sourceIdsToCache: List<String>)`,
`fun removeMapInstance()` replaced with `fun removeMapInstance(map: MapboxMap)` 
`predictiveCacheLocationOptions: PredictiveCacheLocationOptions` removed from `NavigationOptions`
map instance has to be configured with the same [TileStore] instance that was provided to [RoutingTilesOptions.tileStore].
</changelog>
```

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
