### PR TITLE
upgrade telemetry to v8.1.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -18,7 +18,7 @@ ext {
   version = [
       mapboxMapSdk              : '10.0.0-rc.2',
       mapboxSdkServices         : '5.9.0-alpha.5',
-      mapboxEvents              : '8.0.0',
+      mapboxEvents              : '8.1.0',
       mapboxCore                : '5.0.0',
       mapboxNavigator           : "${mapboxNavigatorVersion}",
       mapboxCommonNative        : '14.0.1',


### PR DESCRIPTION
Refs https://github.com/mapbox/mapbox-events-android/releases/tag/telem-8.1.0-core-5.0.0.