### PR TITLE
Created option for route arrow scaling

### DIFF
--- a/libnavui-maps/api/current.txt
+++ b/libnavui-maps/api/current.txt
@@ -647,15 +647,23 @@ package com.mapbox.navigation.ui.maps.route.arrow.model {
     method public String getAboveLayerId();
     method public int getArrowCasingColor();
     method public int getArrowColor();
+    method public com.mapbox.maps.extension.style.expressions.generated.Expression getArrowHeadCasingScaleExpression();
     method public android.graphics.drawable.Drawable getArrowHeadIcon();
     method public android.graphics.drawable.Drawable getArrowHeadIconCasing();
+    method public com.mapbox.maps.extension.style.expressions.generated.Expression getArrowHeadScaleExpression();
+    method public com.mapbox.maps.extension.style.expressions.generated.Expression getArrowShaftCasingScaleExpression();
+    method public com.mapbox.maps.extension.style.expressions.generated.Expression getArrowShaftScaleExpression();
     method public double getTolerance();
     method public com.mapbox.navigation.ui.maps.route.arrow.model.RouteArrowOptions.Builder toBuilder(android.content.Context context);
     property public final String aboveLayerId;
     property public final int arrowCasingColor;
     property public final int arrowColor;
+    property public final com.mapbox.maps.extension.style.expressions.generated.Expression arrowHeadCasingScaleExpression;
     property public final android.graphics.drawable.Drawable arrowHeadIcon;
     property public final android.graphics.drawable.Drawable arrowHeadIconCasing;
+    property public final com.mapbox.maps.extension.style.expressions.generated.Expression arrowHeadScaleExpression;
+    property public final com.mapbox.maps.extension.style.expressions.generated.Expression arrowShaftCasingScaleExpression;
+    property public final com.mapbox.maps.extension.style.expressions.generated.Expression arrowShaftScaleExpression;
     property public final double tolerance;
   }
 
@@ -667,6 +675,10 @@ package com.mapbox.navigation.ui.maps.route.arrow.model {
     method public com.mapbox.navigation.ui.maps.route.arrow.model.RouteArrowOptions.Builder withArrowColor(@ColorInt int color);
     method public com.mapbox.navigation.ui.maps.route.arrow.model.RouteArrowOptions.Builder withArrowHeadIconCasingDrawable(@DrawableRes int drawable);
     method public com.mapbox.navigation.ui.maps.route.arrow.model.RouteArrowOptions.Builder withArrowHeadIconDrawable(@DrawableRes int drawable);
+    method public com.mapbox.navigation.ui.maps.route.arrow.model.RouteArrowOptions.Builder withArrowShaftCasingScalingExpression(com.mapbox.maps.extension.style.expressions.generated.Expression expression);
+    method public com.mapbox.navigation.ui.maps.route.arrow.model.RouteArrowOptions.Builder withArrowShaftScalingExpression(com.mapbox.maps.extension.style.expressions.generated.Expression expression);
+    method public com.mapbox.navigation.ui.maps.route.arrow.model.RouteArrowOptions.Builder withArrowheadCasingScalingExpression(com.mapbox.maps.extension.style.expressions.generated.Expression expression);
+    method public com.mapbox.navigation.ui.maps.route.arrow.model.RouteArrowOptions.Builder withArrowheadScalingExpression(com.mapbox.maps.extension.style.expressions.generated.Expression expression);
     method public com.mapbox.navigation.ui.maps.route.arrow.model.RouteArrowOptions.Builder withTolerance(double tolerance);
   }
 

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/arrow/RouteArrowUtils.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/arrow/RouteArrowUtils.kt
@@ -130,20 +130,7 @@ internal object RouteArrowUtils {
                     options.arrowCasingColor
                 )
             )
-            .lineWidth(
-                Expression.interpolate {
-                    linear()
-                    zoom()
-                    stop {
-                        literal(RouteConstants.MIN_ARROW_ZOOM)
-                        literal(RouteConstants.MIN_ZOOM_ARROW_SHAFT_CASING_SCALE)
-                    }
-                    stop {
-                        literal(RouteConstants.MAX_ARROW_ZOOM)
-                        literal(RouteConstants.MAX_ZOOM_ARROW_SHAFT_CASING_SCALE)
-                    }
-                }
-            )
+            .lineWidth(options.arrowShaftCasingScaleExpression)
             .lineCap(LineCap.ROUND)
             .lineJoin(LineJoin.ROUND)
             .visibility(Visibility.VISIBLE)
@@ -169,20 +156,7 @@ internal object RouteArrowUtils {
             .iconImage(RouteConstants.ARROW_HEAD_ICON_CASING)
             .iconAllowOverlap(true)
             .iconIgnorePlacement(true)
-            .iconSize(
-                Expression.interpolate {
-                    linear()
-                    zoom()
-                    stop {
-                        literal(RouteConstants.MIN_ARROW_ZOOM)
-                        literal(RouteConstants.MIN_ZOOM_ARROW_HEAD_CASING_SCALE)
-                    }
-                    stop {
-                        literal(RouteConstants.MAX_ARROW_ZOOM)
-                        literal(RouteConstants.MAX_ZOOM_ARROW_HEAD_CASING_SCALE)
-                    }
-                }
-            )
+            .iconSize(options.arrowHeadCasingScaleExpression)
             .iconOffset(RouteConstants.ARROW_HEAD_OFFSET.toList())
             .iconRotationAlignment(IconRotationAlignment.MAP)
             .iconRotate(
@@ -215,20 +189,7 @@ internal object RouteArrowUtils {
             .lineColor(
                 Expression.color(options.arrowColor)
             )
-            .lineWidth(
-                Expression.interpolate {
-                    linear()
-                    zoom()
-                    stop {
-                        literal(RouteConstants.MIN_ARROW_ZOOM)
-                        literal(RouteConstants.MIN_ZOOM_ARROW_SHAFT_SCALE)
-                    }
-                    stop {
-                        literal(RouteConstants.MAX_ARROW_ZOOM)
-                        literal(RouteConstants.MAX_ZOOM_ARROW_SHAFT_SCALE)
-                    }
-                }
-            )
+            .lineWidth(options.arrowShaftScaleExpression)
             .lineCap(LineCap.ROUND)
             .lineJoin(LineJoin.ROUND)
             .visibility(Visibility.VISIBLE)
@@ -254,20 +215,7 @@ internal object RouteArrowUtils {
             .iconImage(RouteConstants.ARROW_HEAD_ICON)
             .iconAllowOverlap(true)
             .iconIgnorePlacement(true)
-            .iconSize(
-                Expression.interpolate {
-                    linear()
-                    zoom()
-                    stop {
-                        literal(RouteConstants.MIN_ARROW_ZOOM)
-                        literal(RouteConstants.MIN_ZOOM_ARROW_HEAD_SCALE)
-                    }
-                    stop {
-                        literal(RouteConstants.MAX_ARROW_ZOOM)
-                        literal(RouteConstants.MAX_ZOOM_ARROW_HEAD_SCALE)
-                    }
-                }
-            )
+            .iconSize(options.arrowHeadScaleExpression)
             .iconOffset(RouteConstants.ARROW_HEAD_CASING_OFFSET.toList())
             .iconRotationAlignment(IconRotationAlignment.MAP)
             .iconRotate(

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/arrow/model/RouteArrowOptions.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/arrow/model/RouteArrowOptions.kt
@@ -5,6 +5,7 @@ import android.graphics.drawable.Drawable
 import androidx.annotation.ColorInt
 import androidx.annotation.DrawableRes
 import androidx.appcompat.content.res.AppCompatResources
+import com.mapbox.maps.extension.style.expressions.generated.Expression
 import com.mapbox.navigation.ui.base.internal.model.route.RouteConstants
 import com.mapbox.navigation.ui.base.model.route.RouteLayerConstants.PRIMARY_ROUTE_TRAFFIC_LAYER_ID
 
@@ -17,6 +18,10 @@ import com.mapbox.navigation.ui.base.model.route.RouteLayerConstants.PRIMARY_ROU
  * @param arrowHeadIconCasing the drawable to represent the arrow head border
  * @param aboveLayerId indicates the maneuver arrow map layers appear above this layer on the map
  * @param tolerance the tolerance value used when configuring the underlying map source
+ * @param arrowShaftScaleExpression an [Expression] governing the scaling of the maneuver arrow shaft
+ * @param arrowShaftCasingScaleExpression an [Expression] governing the scaling of the maneuver arrow shaft casing
+ * @param arrowHeadScaleExpression an [Expression] governing the scaling of the maneuver arrow head
+ * @param arrowHeadCasingScaleExpression an [Expression] governing the scaling of the maneuver arrow head casing
  */
 class RouteArrowOptions private constructor(
     @ColorInt val arrowColor: Int,
@@ -26,7 +31,11 @@ class RouteArrowOptions private constructor(
     val arrowHeadIcon: Drawable,
     val arrowHeadIconCasing: Drawable,
     val aboveLayerId: String,
-    val tolerance: Double
+    val tolerance: Double,
+    val arrowShaftScaleExpression: Expression,
+    val arrowShaftCasingScaleExpression: Expression,
+    val arrowHeadScaleExpression: Expression,
+    val arrowHeadCasingScaleExpression: Expression
 ) {
 
     /**
@@ -42,7 +51,11 @@ class RouteArrowOptions private constructor(
             arrowHeadIconDrawable,
             arrowHeadIconCasingDrawable,
             aboveLayerId,
-            tolerance
+            tolerance,
+            arrowShaftScaleExpression,
+            arrowShaftCasingScaleExpression,
+            arrowHeadScaleExpression,
+            arrowHeadCasingScaleExpression
         )
     }
 
@@ -63,6 +76,10 @@ class RouteArrowOptions private constructor(
         if (arrowHeadIconCasing != other.arrowHeadIconCasing) return false
         if (aboveLayerId != other.aboveLayerId) return false
         if (tolerance != other.tolerance) return false
+        if (arrowShaftScaleExpression != other.arrowShaftScaleExpression) return false
+        if (arrowShaftCasingScaleExpression != other.arrowShaftCasingScaleExpression) return false
+        if (arrowHeadScaleExpression != other.arrowHeadScaleExpression) return false
+        if (arrowHeadCasingScaleExpression != other.arrowHeadCasingScaleExpression) return false
 
         return true
     }
@@ -79,6 +96,10 @@ class RouteArrowOptions private constructor(
         result = 31 * result + arrowHeadIconCasing.hashCode()
         result = 31 * result + aboveLayerId.hashCode()
         result = 31 * result + (tolerance.hashCode())
+        result = 31 * result + arrowShaftScaleExpression.hashCode()
+        result = 31 * result + arrowShaftCasingScaleExpression.hashCode()
+        result = 31 * result + arrowHeadScaleExpression.hashCode()
+        result = 31 * result + arrowHeadCasingScaleExpression.hashCode()
         return result
     }
 
@@ -93,7 +114,12 @@ class RouteArrowOptions private constructor(
             "arrowHeadIcon=$arrowHeadIcon, " +
             "arrowHeadIconCasing=$arrowHeadIconCasing, " +
             "aboveLayerId='$aboveLayerId', " +
-            "tolerance=$tolerance)"
+            "tolerance=$tolerance, " +
+            "arrowShaftScaleExpression=$arrowShaftScaleExpression, " +
+            "arrowShaftCasingScaleExpression=$arrowShaftCasingScaleExpression, " +
+            "arrowHeadScaleExpression=$arrowHeadScaleExpression, " +
+            "arrowHeadCasingScaleExpression=$arrowHeadCasingScaleExpression" +
+            ")"
     }
 
     /**
@@ -106,7 +132,11 @@ class RouteArrowOptions private constructor(
         private var arrowHeadIconDrawable: Int,
         private var arrowHeadIconCasingDrawable: Int,
         private var aboveLayerId: String?,
-        private var tolerance: Double
+        private var tolerance: Double,
+        private var arrowShaftScaleExpression: Expression?,
+        private var arrowShaftCasingScaleExpression: Expression?,
+        private var arrowHeadScaleExpression: Expression?,
+        private var arrowHeadCasingScaleExpression: Expression?
     ) {
 
         /**
@@ -119,7 +149,11 @@ class RouteArrowOptions private constructor(
             RouteConstants.MANEUVER_ARROWHEAD_ICON_DRAWABLE,
             RouteConstants.MANEUVER_ARROWHEAD_ICON_CASING_DRAWABLE,
             null,
-            RouteConstants.DEFAULT_ROUTE_SOURCES_TOLERANCE
+            RouteConstants.DEFAULT_ROUTE_SOURCES_TOLERANCE,
+            null,
+            null,
+            null,
+            null
         )
 
         /**
@@ -178,6 +212,46 @@ class RouteArrowOptions private constructor(
         }
 
         /**
+         * An expression that will define the scaling behavior of the maneuver arrow shafts.
+         *
+         * @param expression the expression governing the scaling of the maneuver arrow shafts
+         *
+         * @return the builder
+         */
+        fun withArrowShaftScalingExpression(expression: Expression): Builder =
+            apply { this.arrowShaftScaleExpression = expression }
+
+        /**
+         * An expression that will define the scaling behavior of the maneuver arrow shaft casing.
+         *
+         * @param expression the expression governing the scaling of the maneuver arrow shaft casing
+         *
+         * @return the builder
+         */
+        fun withArrowShaftCasingScalingExpression(expression: Expression): Builder =
+            apply { this.arrowShaftCasingScaleExpression = expression }
+
+        /**
+         * An expression that will define the scaling behavior of the maneuver arrow head.
+         *
+         * @param expression the expression governing the scaling of the maneuver arrow head
+         *
+         * @return the builder
+         */
+        fun withArrowheadScalingExpression(expression: Expression): Builder =
+            apply { this.arrowHeadScaleExpression = expression }
+
+        /**
+         * An expression that will define the scaling behavior of the maneuver arrow head casing.
+         *
+         * @param expression the expression governing the scaling of the maneuver arrow head casing
+         *
+         * @return the builder
+         */
+        fun withArrowheadCasingScalingExpression(expression: Expression): Builder =
+            apply { this.arrowHeadCasingScaleExpression = expression }
+
+        /**
          * Applies the supplied parameters and instantiates a RouteArrowOptions
          *
          * @return a RouteArrowOptions object
@@ -193,6 +267,62 @@ class RouteArrowOptions private constructor(
             )
             val routeArrowAboveLayerId: String = aboveLayerId ?: PRIMARY_ROUTE_TRAFFIC_LAYER_ID
 
+            val arrowShaftScalingExpression: Expression = arrowShaftScaleExpression
+                ?: Expression.interpolate {
+                    linear()
+                    zoom()
+                    stop {
+                        literal(RouteConstants.MIN_ARROW_ZOOM)
+                        literal(RouteConstants.MIN_ZOOM_ARROW_SHAFT_SCALE)
+                    }
+                    stop {
+                        literal(RouteConstants.MAX_ARROW_ZOOM)
+                        literal(RouteConstants.MAX_ZOOM_ARROW_SHAFT_SCALE)
+                    }
+                }
+
+            val arrowShaftCasingScaleExpression: Expression = arrowShaftCasingScaleExpression
+                ?: Expression.interpolate {
+                    linear()
+                    zoom()
+                    stop {
+                        literal(RouteConstants.MIN_ARROW_ZOOM)
+                        literal(RouteConstants.MIN_ZOOM_ARROW_SHAFT_CASING_SCALE)
+                    }
+                    stop {
+                        literal(RouteConstants.MAX_ARROW_ZOOM)
+                        literal(RouteConstants.MAX_ZOOM_ARROW_SHAFT_CASING_SCALE)
+                    }
+                }
+
+            val arrowHeadScalingExpression: Expression = arrowHeadScaleExpression
+                ?: Expression.interpolate {
+                    linear()
+                    zoom()
+                    stop {
+                        literal(RouteConstants.MIN_ARROW_ZOOM)
+                        literal(RouteConstants.MIN_ZOOM_ARROW_HEAD_SCALE)
+                    }
+                    stop {
+                        literal(RouteConstants.MAX_ARROW_ZOOM)
+                        literal(RouteConstants.MAX_ZOOM_ARROW_HEAD_SCALE)
+                    }
+                }
+
+            val arrowHeadCasingScalingExpression: Expression = arrowHeadCasingScaleExpression
+                ?: Expression.interpolate {
+                    linear()
+                    zoom()
+                    stop {
+                        literal(RouteConstants.MIN_ARROW_ZOOM)
+                        literal(RouteConstants.MIN_ZOOM_ARROW_HEAD_CASING_SCALE)
+                    }
+                    stop {
+                        literal(RouteConstants.MAX_ARROW_ZOOM)
+                        literal(RouteConstants.MAX_ZOOM_ARROW_HEAD_CASING_SCALE)
+                    }
+                }
+
             return RouteArrowOptions(
                 arrowColor,
                 arrowCasingColor,
@@ -201,7 +331,11 @@ class RouteArrowOptions private constructor(
                 arrowHeadIcon!!,
                 arrowHeadCasingIcon!!,
                 routeArrowAboveLayerId,
-                tolerance
+                tolerance,
+                arrowShaftScalingExpression,
+                arrowShaftCasingScaleExpression,
+                arrowHeadScalingExpression,
+                arrowHeadCasingScalingExpression
             )
         }
     }

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/arrow/RouteArrowUtilsTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/arrow/RouteArrowUtilsTest.kt
@@ -419,6 +419,14 @@ class RouteArrowUtilsTest {
                 every { intrinsicHeight } returns 0
                 every { intrinsicWidth } returns 1
             }
+            every {
+                arrowShaftCasingScaleExpression
+            } returns options.arrowShaftCasingScaleExpression
+            every {
+                arrowHeadCasingScaleExpression
+            } returns options.arrowHeadCasingScaleExpression
+            every { arrowShaftScaleExpression } returns options.arrowShaftScaleExpression
+            every { arrowHeadScaleExpression } returns options.arrowHeadScaleExpression
         }
         val style = getFullMockedStyle()
 
@@ -441,6 +449,14 @@ class RouteArrowUtilsTest {
                 every { intrinsicHeight } returns 1
                 every { intrinsicWidth } returns 0
             }
+            every {
+                arrowShaftCasingScaleExpression
+            } returns options.arrowShaftCasingScaleExpression
+            every {
+                arrowHeadCasingScaleExpression
+            } returns options.arrowHeadCasingScaleExpression
+            every { arrowShaftScaleExpression } returns options.arrowShaftScaleExpression
+            every { arrowHeadScaleExpression } returns options.arrowHeadScaleExpression
         }
         val style = getFullMockedStyle()
 
@@ -463,6 +479,14 @@ class RouteArrowUtilsTest {
                 every { intrinsicHeight } returns 0
                 every { intrinsicWidth } returns 1
             }
+            every {
+                arrowShaftCasingScaleExpression
+            } returns options.arrowShaftCasingScaleExpression
+            every {
+                arrowHeadCasingScaleExpression
+            } returns options.arrowHeadCasingScaleExpression
+            every { arrowShaftScaleExpression } returns options.arrowShaftScaleExpression
+            every { arrowHeadScaleExpression } returns options.arrowHeadScaleExpression
         }
         val style = getFullMockedStyle()
 
@@ -485,6 +509,14 @@ class RouteArrowUtilsTest {
                 every { intrinsicHeight } returns 0
                 every { intrinsicWidth } returns 1
             }
+            every {
+                arrowShaftCasingScaleExpression
+            } returns options.arrowShaftCasingScaleExpression
+            every {
+                arrowHeadCasingScaleExpression
+            } returns options.arrowHeadCasingScaleExpression
+            every { arrowShaftScaleExpression } returns options.arrowShaftScaleExpression
+            every { arrowHeadScaleExpression } returns options.arrowHeadScaleExpression
         }
         val style = getFullMockedStyle()
 

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/arrow/model/RouteArrowOptionsTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/arrow/model/RouteArrowOptionsTest.kt
@@ -2,7 +2,9 @@ package com.mapbox.navigation.ui.maps.route.arrow.model
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
+import com.mapbox.maps.extension.style.expressions.generated.Expression
 import com.mapbox.navigation.ui.base.internal.model.route.RouteConstants
+import io.mockk.mockk
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Before
@@ -67,7 +69,136 @@ class RouteArrowOptionsTest {
     }
 
     @Test
+    fun withArrowShaftScalingExpressionTest() {
+        val expression = mockk<Expression>()
+
+        val options = RouteArrowOptions.Builder(ctx)
+            .withArrowShaftScalingExpression(expression)
+            .build()
+
+        assertEquals(expression, options.arrowShaftScaleExpression)
+    }
+
+    @Test
+    fun withArrowShaftCasingScalingExpressionTest() {
+        val expression = mockk<Expression>()
+
+        val options = RouteArrowOptions.Builder(ctx)
+            .withArrowShaftCasingScalingExpression(expression)
+            .build()
+
+        assertEquals(expression, options.arrowShaftCasingScaleExpression)
+    }
+
+    @Test
+    fun withArrowheadScalingExpressionTest() {
+        val expression = mockk<Expression>()
+
+        val options = RouteArrowOptions.Builder(ctx)
+            .withArrowheadScalingExpression(expression)
+            .build()
+
+        assertEquals(expression, options.arrowHeadScaleExpression)
+    }
+
+    @Test
+    fun withArrowheadCasingScalingExpressionTest() {
+        val expression = mockk<Expression>()
+
+        val options = RouteArrowOptions.Builder(ctx)
+            .withArrowheadCasingScalingExpression(expression)
+            .build()
+
+        assertEquals(expression, options.arrowHeadCasingScaleExpression)
+    }
+
+    @Test
+    fun defaultShaftScaleExpression() {
+        val expression = Expression.interpolate {
+            linear()
+            zoom()
+            stop {
+                literal(RouteConstants.MIN_ARROW_ZOOM)
+                literal(RouteConstants.MIN_ZOOM_ARROW_SHAFT_SCALE)
+            }
+            stop {
+                literal(RouteConstants.MAX_ARROW_ZOOM)
+                literal(RouteConstants.MAX_ZOOM_ARROW_SHAFT_SCALE)
+            }
+        }
+
+        val options = RouteArrowOptions.Builder(ctx).build()
+
+        assertEquals(expression, options.arrowShaftScaleExpression)
+    }
+
+    @Test
+    fun defaultShaftCasingScaleExpression() {
+        val expression = Expression.interpolate {
+            linear()
+            zoom()
+            stop {
+                literal(RouteConstants.MIN_ARROW_ZOOM)
+                literal(RouteConstants.MIN_ZOOM_ARROW_SHAFT_CASING_SCALE)
+            }
+            stop {
+                literal(RouteConstants.MAX_ARROW_ZOOM)
+                literal(RouteConstants.MAX_ZOOM_ARROW_SHAFT_CASING_SCALE)
+            }
+        }
+
+        val options = RouteArrowOptions.Builder(ctx).build()
+
+        assertEquals(expression, options.arrowShaftCasingScaleExpression)
+    }
+
+    @Test
+    fun defaultHeadScaleExpression() {
+        val expression = Expression.interpolate {
+            linear()
+            zoom()
+            stop {
+                literal(RouteConstants.MIN_ARROW_ZOOM)
+                literal(RouteConstants.MIN_ZOOM_ARROW_HEAD_SCALE)
+            }
+            stop {
+                literal(RouteConstants.MAX_ARROW_ZOOM)
+                literal(RouteConstants.MAX_ZOOM_ARROW_HEAD_SCALE)
+            }
+        }
+
+        val options = RouteArrowOptions.Builder(ctx).build()
+
+        assertEquals(expression, options.arrowHeadScaleExpression)
+    }
+
+    @Test
+    fun defaultHeadCasingScaleExpression() {
+        val expression = Expression.interpolate {
+            linear()
+            zoom()
+            stop {
+                literal(RouteConstants.MIN_ARROW_ZOOM)
+                literal(RouteConstants.MIN_ZOOM_ARROW_HEAD_CASING_SCALE)
+            }
+            stop {
+                literal(RouteConstants.MAX_ARROW_ZOOM)
+                literal(RouteConstants.MAX_ZOOM_ARROW_HEAD_CASING_SCALE)
+            }
+        }
+
+        val options = RouteArrowOptions.Builder(ctx).build()
+
+        assertEquals(expression, options.arrowHeadCasingScaleExpression)
+    }
+
+    @Test
     fun toBuilder() {
+        val shaftExpression = mockk<Expression>()
+        val shaftCasingExpression = mockk<Expression>()
+        val headExpression = mockk<Expression>()
+        val headCasingExpression = mockk<Expression>()
+
         val options = RouteArrowOptions.Builder(ctx)
             .withArrowColor(1)
             .withAboveLayerId("someLayerId")
@@ -75,6 +206,10 @@ class RouteArrowOptionsTest {
             .withArrowHeadIconDrawable(RouteConstants.MANEUVER_ARROWHEAD_ICON_DRAWABLE)
             .withArrowHeadIconCasingDrawable(RouteConstants.MANEUVER_ARROWHEAD_ICON_DRAWABLE)
             .withTolerance(.111)
+            .withArrowShaftScalingExpression(shaftExpression)
+            .withArrowShaftCasingScalingExpression(shaftCasingExpression)
+            .withArrowheadScalingExpression(headExpression)
+            .withArrowheadCasingScalingExpression(headCasingExpression)
             .build()
             .toBuilder(ctx)
             .build()
@@ -85,5 +220,9 @@ class RouteArrowOptionsTest {
         assertNotNull(options.arrowHeadIcon)
         assertNotNull(options.arrowHeadIconCasing)
         assertEquals(.111, options.tolerance, 0.0)
+        assertEquals(shaftExpression, options.arrowShaftScaleExpression)
+        assertEquals(shaftCasingExpression, options.arrowShaftCasingScaleExpression)
+        assertEquals(headExpression, options.arrowHeadScaleExpression)
+        assertEquals(headCasingExpression, options.arrowHeadCasingScaleExpression)
     }
 }


### PR DESCRIPTION
### Description
Resolves #4487 by adding options to change the scaling expressions used for the maneuver arrows.

### Changelog
```
<changelog>Added options to the `RouteArrowOptions` class for customizing the scaling expressions used for maneuver arrows.</changelog>
```

### Screenshots or Gifs

