### PR TITLE
Bump `mapboxMapSdk` dependency versions to `10.0.0-rc.3`

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -16,7 +16,7 @@ ext {
   println("Navigation Native version: " + mapboxNavigatorVersion)
 
   version = [
-      mapboxMapSdk              : '10.0.0-rc.2',
+      mapboxMapSdk              : '10.0.0-rc.3',
       mapboxSdkServices         : '5.9.0-alpha.5',
       mapboxEvents              : '8.1.0',
       mapboxCore                : '5.0.0',

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/arrow/RouteArrowUtils.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/arrow/RouteArrowUtils.kt
@@ -4,7 +4,6 @@ import androidx.core.graphics.drawable.DrawableCompat
 import com.mapbox.geojson.FeatureCollection
 import com.mapbox.geojson.LineString
 import com.mapbox.geojson.Point
-import com.mapbox.maps.LayerPosition
 import com.mapbox.maps.Style
 import com.mapbox.maps.extension.style.expressions.generated.Expression
 import com.mapbox.maps.extension.style.layers.addLayerAbove

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/arrow/RouteArrowUtils.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/arrow/RouteArrowUtils.kt
@@ -4,6 +4,7 @@ import androidx.core.graphics.drawable.DrawableCompat
 import com.mapbox.geojson.FeatureCollection
 import com.mapbox.geojson.LineString
 import com.mapbox.geojson.Point
+import com.mapbox.maps.LayerPosition
 import com.mapbox.maps.Style
 import com.mapbox.maps.extension.style.expressions.generated.Expression
 import com.mapbox.maps.extension.style.layers.addLayerAbove

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/arrow/RouteArrowUtils.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/arrow/RouteArrowUtils.kt
@@ -69,17 +69,15 @@ internal object RouteArrowUtils {
         if (!style.styleSourceExists(RouteConstants.ARROW_SHAFT_SOURCE_ID)) {
             geoJsonSource(RouteConstants.ARROW_SHAFT_SOURCE_ID) {
                 maxzoom(16)
-                featureCollection(FeatureCollection.fromFeatures(listOf()))
                 tolerance(options.tolerance)
-            }.bindTo(style)
+            }.featureCollection(FeatureCollection.fromFeatures(listOf())).bindTo(style)
         }
 
         if (!style.styleSourceExists(RouteConstants.ARROW_HEAD_SOURCE_ID)) {
             geoJsonSource(RouteConstants.ARROW_HEAD_SOURCE_ID) {
                 maxzoom(16)
-                featureCollection(FeatureCollection.fromFeatures(listOf()))
                 tolerance(options.tolerance)
-            }.bindTo(style)
+            }.featureCollection(FeatureCollection.fromFeatures(listOf())).bindTo(style)
         }
 
         if (style.getStyleImage(RouteConstants.ARROW_HEAD_ICON_CASING) != null) {

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtilsTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtilsTest.kt
@@ -3,6 +3,7 @@ package com.mapbox.navigation.ui.maps.internal.route.line
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Color
+import android.os.HandlerThread
 import androidx.test.core.app.ApplicationProvider
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.bindgen.ExpectedFactory
@@ -16,6 +17,7 @@ import com.mapbox.maps.StyleObjectInfo
 import com.mapbox.maps.extension.style.layers.Layer
 import com.mapbox.maps.extension.style.layers.getLayer
 import com.mapbox.maps.extension.style.layers.properties.generated.Visibility
+import com.mapbox.maps.extension.style.sources.generated.GeoJsonSource
 import com.mapbox.maps.plugin.locationcomponent.LocationComponentConstants
 import com.mapbox.navigation.testing.FileUtils
 import com.mapbox.navigation.testing.FileUtils.loadJsonFixture
@@ -292,6 +294,11 @@ class MapboxRouteLineUtilsTest {
 
     @Test
     fun initializeLayers() {
+        GeoJsonSource.workerThread =
+            HandlerThread("STYLE_WORKER").apply {
+                priority = Thread.MAX_PRIORITY
+                start()
+            }
         mockkStatic("com.mapbox.maps.extension.style.layers.LayerKt")
         val options = MapboxRouteLineOptions.Builder(ctx)
             .withRouteLineBelowLayerId(LocationComponentConstants.MODEL_LAYER)

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/arrow/RouteArrowUtilsTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/arrow/RouteArrowUtilsTest.kt
@@ -3,6 +3,7 @@ package com.mapbox.navigation.ui.maps.route.arrow
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.drawable.Drawable
+import android.os.HandlerThread
 import androidx.test.core.app.ApplicationProvider
 import com.mapbox.bindgen.ExpectedFactory
 import com.mapbox.bindgen.Value
@@ -10,6 +11,7 @@ import com.mapbox.geojson.Point
 import com.mapbox.maps.Image
 import com.mapbox.maps.LayerPosition
 import com.mapbox.maps.Style
+import com.mapbox.maps.extension.style.sources.generated.GeoJsonSource
 import com.mapbox.navigation.base.trip.model.RouteLegProgress
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.base.trip.model.RouteStepProgress
@@ -197,6 +199,11 @@ class RouteArrowUtilsTest {
 
     @Test
     fun initializeLayers() {
+        GeoJsonSource.workerThread =
+            HandlerThread("STYLE_WORKER").apply {
+                priority = Thread.MAX_PRIORITY
+                start()
+            }
         mockkStatic("com.mapbox.maps.extension.style.layers.LayerKt")
         mockkStatic("com.mapbox.maps.extension.style.sources.SourceKt")
         val options = RouteArrowOptions.Builder(ctx).build()

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineViewTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineViewTest.kt
@@ -171,9 +171,15 @@ class MapboxRouteLineViewTest {
         val style = mockk<Style> {
             every { isFullyLoaded() } returns true
             every { fullyLoaded } returns true
-            every { getLayer(RouteLayerConstants.PRIMARY_ROUTE_TRAFFIC_LAYER_ID) } returns primaryRouteTrafficLayer
-            every { getLayer(RouteLayerConstants.PRIMARY_ROUTE_LAYER_ID) } returns primaryRouteLayer
-            every { getLayer(RouteLayerConstants.PRIMARY_ROUTE_CASING_LAYER_ID) } returns primaryRouteCasingLayer
+            every {
+                getLayer(RouteLayerConstants.PRIMARY_ROUTE_TRAFFIC_LAYER_ID)
+            } returns primaryRouteTrafficLayer
+            every {
+                getLayer(RouteLayerConstants.PRIMARY_ROUTE_LAYER_ID)
+            } returns primaryRouteLayer
+            every {
+                getLayer(RouteLayerConstants.PRIMARY_ROUTE_CASING_LAYER_ID)
+            } returns primaryRouteCasingLayer
         }.also {
             mockCheckForLayerInitialization(it)
         }
@@ -232,11 +238,21 @@ class MapboxRouteLineViewTest {
         val style = mockk<Style> {
             every { isFullyLoaded() } returns true
             every { fullyLoaded } returns true
-            every { getLayer(RouteLayerConstants.PRIMARY_ROUTE_TRAFFIC_LAYER_ID) } returns primaryRouteTrafficLayer
-            every { getLayer(RouteLayerConstants.PRIMARY_ROUTE_LAYER_ID) } returns primaryRouteLayer
-            every { getLayer(RouteLayerConstants.PRIMARY_ROUTE_CASING_LAYER_ID) } returns primaryRouteCasingLayer
-            every { getLayer(RouteLayerConstants.ALTERNATIVE_ROUTE1_TRAFFIC_LAYER_ID) } returns altRouteTrafficLayer1
-            every { getLayer(RouteLayerConstants.ALTERNATIVE_ROUTE2_TRAFFIC_LAYER_ID) } returns altRouteTrafficLayer2
+            every {
+                getLayer(RouteLayerConstants.PRIMARY_ROUTE_TRAFFIC_LAYER_ID)
+            } returns primaryRouteTrafficLayer
+            every {
+                getLayer(RouteLayerConstants.PRIMARY_ROUTE_LAYER_ID)
+            } returns primaryRouteLayer
+            every {
+                getLayer(RouteLayerConstants.PRIMARY_ROUTE_CASING_LAYER_ID)
+            } returns primaryRouteCasingLayer
+            every {
+                getLayer(RouteLayerConstants.ALTERNATIVE_ROUTE1_TRAFFIC_LAYER_ID)
+            } returns altRouteTrafficLayer1
+            every {
+                getLayer(RouteLayerConstants.ALTERNATIVE_ROUTE2_TRAFFIC_LAYER_ID)
+            } returns altRouteTrafficLayer2
             every { getSource(RouteConstants.PRIMARY_ROUTE_SOURCE_ID) } returns primaryRouteSource
             every { getSource(RouteConstants.ALTERNATIVE_ROUTE1_SOURCE_ID) } returns altRoute1Source
             every { getSource(RouteConstants.ALTERNATIVE_ROUTE2_SOURCE_ID) } returns altRoute2Source
@@ -275,9 +291,13 @@ class MapboxRouteLineViewTest {
         val style = mockk<Style> {
             every { isFullyLoaded() } returns true
             every { fullyLoaded } returns true
-            every { getLayer(RouteLayerConstants.PRIMARY_ROUTE_TRAFFIC_LAYER_ID) } returns primaryRouteTrafficLayer
+            every {
+                getLayer(RouteLayerConstants.PRIMARY_ROUTE_TRAFFIC_LAYER_ID)
+            } returns primaryRouteTrafficLayer
             every { getLayer(RouteLayerConstants.PRIMARY_ROUTE_LAYER_ID) } returns primaryRouteLayer
-            every { getLayer(RouteLayerConstants.PRIMARY_ROUTE_CASING_LAYER_ID) } returns primaryRouteCasingLayer
+            every {
+                getLayer(RouteLayerConstants.PRIMARY_ROUTE_CASING_LAYER_ID)
+            } returns primaryRouteCasingLayer
         }.also {
             mockCheckForLayerInitialization(it)
         }
@@ -374,7 +394,8 @@ class MapboxRouteLineViewTest {
     }
 
     @Test
-    fun hideAlternativeRoutes() {mockkStatic("com.mapbox.maps.extension.style.layers.LayerKt")
+    fun hideAlternativeRoutes() {
+        mockkStatic("com.mapbox.maps.extension.style.layers.LayerKt")
         mockkObject(MapboxRouteLineUtils)
         val options = MapboxRouteLineOptions.Builder(ctx).build()
         val altRoute1 = mockk<LineLayer>(relaxed = true)
@@ -383,7 +404,6 @@ class MapboxRouteLineViewTest {
         val altRoute2 = mockk<LineLayer>(relaxed = true)
         val altRouteCasing2 = mockk<LineLayer>(relaxed = true)
         val altRouteTraffic2 = mockk<LineLayer>(relaxed = true)
-
 
         val style = mockk<Style> {
             every { isFullyLoaded() } returns true

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineViewTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineViewTest.kt
@@ -4,12 +4,15 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import com.mapbox.bindgen.Expected
 import com.mapbox.bindgen.ExpectedFactory
-import com.mapbox.bindgen.Value
 import com.mapbox.geojson.Feature
 import com.mapbox.geojson.FeatureCollection
 import com.mapbox.maps.Style
 import com.mapbox.maps.extension.style.expressions.generated.Expression
+import com.mapbox.maps.extension.style.layers.generated.LineLayer
+import com.mapbox.maps.extension.style.layers.getLayer
 import com.mapbox.maps.extension.style.layers.properties.generated.Visibility
+import com.mapbox.maps.extension.style.sources.generated.GeoJsonSource
+import com.mapbox.maps.extension.style.sources.getSource
 import com.mapbox.navigation.ui.base.internal.model.route.RouteConstants
 import com.mapbox.navigation.ui.base.model.route.RouteLayerConstants
 import com.mapbox.navigation.ui.maps.internal.route.line.MapboxRouteLineUtils
@@ -22,8 +25,9 @@ import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
-import io.mockk.slot
+import io.mockk.mockkStatic
 import io.mockk.unmockkObject
+import io.mockk.unmockkStatic
 import io.mockk.verify
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -36,33 +40,6 @@ import java.util.UUID
 class MapboxRouteLineViewTest {
 
     lateinit var ctx: Context
-
-    private val layerTypeValue = mockk<Value> {
-        every { contents } returns "line"
-    }
-    private val sourceValue = mockk<Value> {
-        every { contents } returns "mapbox-navigation-route-source"
-    }
-    private val layerValue = mockk<Value> {
-        every { contents } returns HashMap<String, Value>().also {
-            it["type"] = layerTypeValue
-            it["source"] = sourceValue
-        }
-    }
-    private val layerPropertyExpected = mockk<Expected<String, Value>> {
-        every { value.hint(Value::class) } returns layerValue
-    }
-    private val geoJsonSourceTypeValue = mockk<Value> {
-        every { contents } returns "geojson"
-    }
-    private val geoJsonSourceValue = mockk<Value> {
-        every { contents } returns HashMap<String, Value>().also {
-            it["type"] = geoJsonSourceTypeValue
-        }
-    }
-    private val geoJsonSourceExpected = mockk<Expected<String, Value>> {
-        every { value.hint(Value::class) } returns geoJsonSourceValue
-    }
 
     @Before
     fun setUp() {
@@ -107,18 +84,6 @@ class MapboxRouteLineViewTest {
             every { isFullyLoaded() } returns true
             every { fullyLoaded } returns true
             every {
-                getStyleSourceProperties(RouteConstants.PRIMARY_ROUTE_SOURCE_ID)
-            } returns geoJsonSourceExpected
-            every {
-                getStyleSourceProperties(RouteConstants.ALTERNATIVE_ROUTE1_SOURCE_ID)
-            } returns geoJsonSourceExpected
-            every {
-                getStyleSourceProperties(RouteConstants.ALTERNATIVE_ROUTE2_SOURCE_ID)
-            } returns geoJsonSourceExpected
-            every {
-                getStyleSourceProperties(RouteConstants.WAYPOINT_SOURCE_ID)
-            } returns geoJsonSourceExpected
-            every {
                 setStyleSourceProperty(RouteConstants.PRIMARY_ROUTE_SOURCE_ID, any(), any())
             } returns ExpectedFactory.createNone()
             every {
@@ -142,40 +107,24 @@ class MapboxRouteLineViewTest {
 
     @Test
     fun renderClearRouteDataState() {
+        mockkStatic("com.mapbox.maps.extension.style.sources.SourceKt")
         mockkObject(MapboxRouteLineUtils)
         val options = MapboxRouteLineOptions.Builder(ctx).build()
         val primaryRouteFeatureCollection =
             FeatureCollection.fromFeatures(listOf(getEmptyFeature()))
         val altRoutesFeatureCollection = FeatureCollection.fromFeatures(listOf(getEmptyFeature()))
         val waypointsFeatureCollection = FeatureCollection.fromFeatures(listOf(getEmptyFeature()))
-        val slots = mutableListOf<Value>()
+        val primaryRouteSource = mockk<GeoJsonSource>(relaxed = true)
+        val altRoute1Source = mockk<GeoJsonSource>(relaxed = true)
+        val altRoute2Source = mockk<GeoJsonSource>(relaxed = true)
+        val wayPointSource = mockk<GeoJsonSource>(relaxed = true)
         val style = mockk<Style> {
             every { isFullyLoaded() } returns true
             every { fullyLoaded } returns true
-            every {
-                getStyleSourceProperties(RouteConstants.PRIMARY_ROUTE_SOURCE_ID)
-            } returns geoJsonSourceExpected
-            every {
-                getStyleSourceProperties(RouteConstants.ALTERNATIVE_ROUTE1_SOURCE_ID)
-            } returns geoJsonSourceExpected
-            every {
-                getStyleSourceProperties(RouteConstants.ALTERNATIVE_ROUTE2_SOURCE_ID)
-            } returns geoJsonSourceExpected
-            every {
-                getStyleSourceProperties(RouteConstants.WAYPOINT_SOURCE_ID)
-            } returns geoJsonSourceExpected
-            every {
-                setStyleSourceProperty(RouteConstants.PRIMARY_ROUTE_SOURCE_ID, any(), any())
-            } returns ExpectedFactory.createNone()
-            every {
-                setStyleSourceProperty(RouteConstants.ALTERNATIVE_ROUTE1_SOURCE_ID, any(), any())
-            } returns ExpectedFactory.createNone()
-            every {
-                setStyleSourceProperty(RouteConstants.ALTERNATIVE_ROUTE2_SOURCE_ID, any(), any())
-            } returns ExpectedFactory.createNone()
-            every {
-                setStyleSourceProperty(RouteConstants.WAYPOINT_SOURCE_ID, any(), any())
-            } returns ExpectedFactory.createNone()
+            every { getSource(RouteConstants.PRIMARY_ROUTE_SOURCE_ID) } returns primaryRouteSource
+            every { getSource(RouteConstants.ALTERNATIVE_ROUTE1_SOURCE_ID) } returns altRoute1Source
+            every { getSource(RouteConstants.ALTERNATIVE_ROUTE2_SOURCE_ID) } returns altRoute2Source
+            every { getSource(RouteConstants.WAYPOINT_SOURCE_ID) } returns wayPointSource
         }.also {
             mockCheckForLayerInitialization(it)
         }
@@ -191,56 +140,18 @@ class MapboxRouteLineViewTest {
 
         MapboxRouteLineView(options).renderClearRouteLineValue(style, state)
 
-        verify {
-            style.setStyleSourceProperty(
-                RouteConstants.PRIMARY_ROUTE_SOURCE_ID,
-                any(),
-                capture(slots)
-            )
-        }
-        assertEquals(
-            primaryRouteFeatureCollection.toJson(),
-            slots[0].contents as String
-        )
-        verify {
-            style.setStyleSourceProperty(
-                RouteConstants.ALTERNATIVE_ROUTE1_SOURCE_ID,
-                any(),
-                capture(slots)
-            )
-        }
-        assertEquals(
-            altRoutesFeatureCollection.toJson(),
-            slots[1].contents as String
-        )
-        verify {
-            style.setStyleSourceProperty(
-                RouteConstants.ALTERNATIVE_ROUTE2_SOURCE_ID,
-                any(),
-                capture(slots)
-            )
-        }
-        assertEquals(
-            altRoutesFeatureCollection.toJson(),
-            slots[2].contents as String
-        )
-        verify {
-            style.setStyleSourceProperty(
-                RouteConstants.WAYPOINT_SOURCE_ID,
-                any(),
-                capture(slots)
-            )
-        }
-        assertEquals(
-            waypointsFeatureCollection.toJson(),
-            slots[3].contents as String
-        )
+        verify { primaryRouteSource.featureCollection(primaryRouteFeatureCollection) }
+        verify { altRoute1Source.featureCollection(altRoutesFeatureCollection) }
+        verify { altRoute2Source.featureCollection(altRoutesFeatureCollection) }
+        verify { wayPointSource.featureCollection(waypointsFeatureCollection) }
         verify { MapboxRouteLineUtils.initializeLayers(style, options) }
         unmockkObject(MapboxRouteLineUtils)
+        unmockkStatic("com.mapbox.maps.extension.style.sources.SourceKt")
     }
 
     @Test
     fun renderTraveledRouteLineUpdate() {
+        mockkStatic("com.mapbox.maps.extension.style.layers.LayerKt")
         mockkObject(MapboxRouteLineUtils)
         val options = MapboxRouteLineOptions.Builder(ctx).build()
         val trafficLineExp = mockk<Expression>()
@@ -254,72 +165,33 @@ class MapboxRouteLineViewTest {
                     casingLineEx
                 )
             )
+        val primaryRouteTrafficLayer = mockk<LineLayer>(relaxed = true)
+        val primaryRouteLayer = mockk<LineLayer>(relaxed = true)
+        val primaryRouteCasingLayer = mockk<LineLayer>(relaxed = true)
         val style = mockk<Style> {
             every { isFullyLoaded() } returns true
             every { fullyLoaded } returns true
-            every {
-                getStyleLayerProperties(RouteLayerConstants.PRIMARY_ROUTE_TRAFFIC_LAYER_ID)
-            } returns layerPropertyExpected
-            every {
-                getStyleLayerProperties(RouteLayerConstants.PRIMARY_ROUTE_LAYER_ID)
-            } returns layerPropertyExpected
-            every {
-                getStyleLayerProperties(RouteLayerConstants.PRIMARY_ROUTE_CASING_LAYER_ID)
-            } returns layerPropertyExpected
-            every {
-                setStyleLayerProperty(
-                    RouteLayerConstants.PRIMARY_ROUTE_TRAFFIC_LAYER_ID,
-                    "line-gradient",
-                    trafficLineExp
-                )
-            } returns ExpectedFactory.createNone()
-            every {
-                setStyleLayerProperty(
-                    RouteLayerConstants.PRIMARY_ROUTE_LAYER_ID,
-                    "line-gradient",
-                    routeLineExp
-                )
-            } returns ExpectedFactory.createNone()
-            every {
-                setStyleLayerProperty(
-                    RouteLayerConstants.PRIMARY_ROUTE_CASING_LAYER_ID,
-                    "line-gradient",
-                    casingLineEx
-                )
-            } returns ExpectedFactory.createNone()
+            every { getLayer(RouteLayerConstants.PRIMARY_ROUTE_TRAFFIC_LAYER_ID) } returns primaryRouteTrafficLayer
+            every { getLayer(RouteLayerConstants.PRIMARY_ROUTE_LAYER_ID) } returns primaryRouteLayer
+            every { getLayer(RouteLayerConstants.PRIMARY_ROUTE_CASING_LAYER_ID) } returns primaryRouteCasingLayer
         }.also {
             mockCheckForLayerInitialization(it)
         }
 
         MapboxRouteLineView(options).renderVanishingRouteLineUpdateValue(style, state)
 
-        verify {
-            style.setStyleLayerProperty(
-                RouteLayerConstants.PRIMARY_ROUTE_TRAFFIC_LAYER_ID,
-                "line-gradient",
-                trafficLineExp
-            )
-        }
-        verify {
-            style.setStyleLayerProperty(
-                RouteLayerConstants.PRIMARY_ROUTE_LAYER_ID,
-                "line-gradient",
-                routeLineExp
-            )
-        }
-        verify {
-            style.setStyleLayerProperty(
-                RouteLayerConstants.PRIMARY_ROUTE_CASING_LAYER_ID,
-                "line-gradient",
-                casingLineEx
-            )
-        }
+        verify { primaryRouteTrafficLayer.lineGradient(trafficLineExp) }
+        verify { primaryRouteLayer.lineGradient(routeLineExp) }
+        verify { primaryRouteCasingLayer.lineGradient(casingLineEx) }
         verify { MapboxRouteLineUtils.initializeLayers(style, options) }
         unmockkObject(MapboxRouteLineUtils)
+        unmockkStatic("com.mapbox.maps.extension.style.layers.LayerKt")
     }
 
     @Test
     fun renderDrawRouteState() {
+        mockkStatic("com.mapbox.maps.extension.style.layers.LayerKt")
+        mockkStatic("com.mapbox.maps.extension.style.sources.SourceKt")
         mockkObject(MapboxRouteLineUtils)
         val options = MapboxRouteLineOptions.Builder(ctx).build()
         val primaryRouteFeatureCollection =
@@ -329,12 +201,21 @@ class MapboxRouteLineViewTest {
         val alternativeRoute2FeatureCollection =
             FeatureCollection.fromFeatures(listOf(getEmptyFeature()))
         val waypointsFeatureCollection = FeatureCollection.fromFeatures(listOf(getEmptyFeature()))
-        val slots = mutableListOf<Value>()
         val trafficLineExp = mockk<Expression>()
         val routeLineExp = mockk<Expression>()
         val casingLineEx = mockk<Expression>()
         val alternativeRoute1Expression = mockk<Expression>()
         val alternativeRoute2Expression = mockk<Expression>()
+        val primaryRouteTrafficLayer = mockk<LineLayer>(relaxed = true)
+        val primaryRouteLayer = mockk<LineLayer>(relaxed = true)
+        val primaryRouteCasingLayer = mockk<LineLayer>(relaxed = true)
+        val altRouteTrafficLayer1 = mockk<LineLayer>(relaxed = true)
+        val altRouteTrafficLayer2 = mockk<LineLayer>(relaxed = true)
+        val primaryRouteSource = mockk<GeoJsonSource>(relaxed = true)
+        val altRoute1Source = mockk<GeoJsonSource>(relaxed = true)
+        val altRoute2Source = mockk<GeoJsonSource>(relaxed = true)
+        val wayPointSource = mockk<GeoJsonSource>(relaxed = true)
+
         val state: Expected<RouteLineError, RouteSetValue> = ExpectedFactory.createValue(
             RouteSetValue(
                 primaryRouteFeatureCollection,
@@ -351,768 +232,238 @@ class MapboxRouteLineViewTest {
         val style = mockk<Style> {
             every { isFullyLoaded() } returns true
             every { fullyLoaded } returns true
-
-            every {
-                getStyleLayerProperties(RouteLayerConstants.PRIMARY_ROUTE_TRAFFIC_LAYER_ID)
-            } returns layerPropertyExpected
-            every {
-                getStyleLayerProperties(RouteLayerConstants.PRIMARY_ROUTE_LAYER_ID)
-            } returns layerPropertyExpected
-            every {
-                getStyleLayerProperties(RouteLayerConstants.PRIMARY_ROUTE_CASING_LAYER_ID)
-            } returns layerPropertyExpected
-            every {
-                setStyleLayerProperty(
-                    RouteLayerConstants.PRIMARY_ROUTE_TRAFFIC_LAYER_ID,
-                    "line-gradient",
-                    trafficLineExp
-                )
-            } returns ExpectedFactory.createNone()
-            every {
-                setStyleLayerProperty(
-                    RouteLayerConstants.PRIMARY_ROUTE_LAYER_ID,
-                    "line-gradient",
-                    routeLineExp
-                )
-            } returns ExpectedFactory.createNone()
-            every {
-                setStyleLayerProperty(
-                    RouteLayerConstants.PRIMARY_ROUTE_CASING_LAYER_ID,
-                    "line-gradient",
-                    casingLineEx
-                )
-            } returns ExpectedFactory.createNone()
-            every {
-                getStyleLayerProperties(RouteLayerConstants.ALTERNATIVE_ROUTE1_TRAFFIC_LAYER_ID)
-            } returns layerPropertyExpected
-            every {
-                getStyleLayerProperties(RouteLayerConstants.ALTERNATIVE_ROUTE2_TRAFFIC_LAYER_ID)
-            } returns layerPropertyExpected
-            every {
-                setStyleLayerProperty(
-                    RouteLayerConstants.ALTERNATIVE_ROUTE1_TRAFFIC_LAYER_ID,
-                    "line-gradient",
-                    alternativeRoute1Expression
-                )
-            } returns ExpectedFactory.createNone()
-            every {
-                setStyleLayerProperty(
-                    RouteLayerConstants.ALTERNATIVE_ROUTE2_TRAFFIC_LAYER_ID,
-                    "line-gradient",
-                    alternativeRoute2Expression
-                )
-            } returns ExpectedFactory.createNone()
-            every {
-                getStyleSourceProperties(RouteConstants.PRIMARY_ROUTE_SOURCE_ID)
-            } returns geoJsonSourceExpected
-            every {
-                getStyleSourceProperties(RouteConstants.ALTERNATIVE_ROUTE1_SOURCE_ID)
-            } returns geoJsonSourceExpected
-            every {
-                getStyleSourceProperties(RouteConstants.ALTERNATIVE_ROUTE2_SOURCE_ID)
-            } returns geoJsonSourceExpected
-            every {
-                getStyleSourceProperties(RouteConstants.WAYPOINT_SOURCE_ID)
-            } returns geoJsonSourceExpected
-            every {
-                setStyleSourceProperty(RouteConstants.PRIMARY_ROUTE_SOURCE_ID, any(), any())
-            } returns ExpectedFactory.createNone()
-            every {
-                setStyleSourceProperty(RouteConstants.ALTERNATIVE_ROUTE1_SOURCE_ID, any(), any())
-            } returns ExpectedFactory.createNone()
-            every {
-                setStyleSourceProperty(RouteConstants.ALTERNATIVE_ROUTE2_SOURCE_ID, any(), any())
-            } returns ExpectedFactory.createNone()
-            every {
-                setStyleSourceProperty(RouteConstants.WAYPOINT_SOURCE_ID, any(), any())
-            } returns ExpectedFactory.createNone()
+            every { getLayer(RouteLayerConstants.PRIMARY_ROUTE_TRAFFIC_LAYER_ID) } returns primaryRouteTrafficLayer
+            every { getLayer(RouteLayerConstants.PRIMARY_ROUTE_LAYER_ID) } returns primaryRouteLayer
+            every { getLayer(RouteLayerConstants.PRIMARY_ROUTE_CASING_LAYER_ID) } returns primaryRouteCasingLayer
+            every { getLayer(RouteLayerConstants.ALTERNATIVE_ROUTE1_TRAFFIC_LAYER_ID) } returns altRouteTrafficLayer1
+            every { getLayer(RouteLayerConstants.ALTERNATIVE_ROUTE2_TRAFFIC_LAYER_ID) } returns altRouteTrafficLayer2
+            every { getSource(RouteConstants.PRIMARY_ROUTE_SOURCE_ID) } returns primaryRouteSource
+            every { getSource(RouteConstants.ALTERNATIVE_ROUTE1_SOURCE_ID) } returns altRoute1Source
+            every { getSource(RouteConstants.ALTERNATIVE_ROUTE2_SOURCE_ID) } returns altRoute2Source
+            every { getSource(RouteConstants.WAYPOINT_SOURCE_ID) } returns wayPointSource
         }.also {
             mockCheckForLayerInitialization(it)
         }
 
         MapboxRouteLineView(options).renderRouteDrawData(style, state)
 
-        verify {
-            style.setStyleLayerProperty(
-                RouteLayerConstants.PRIMARY_ROUTE_TRAFFIC_LAYER_ID,
-                "line-gradient",
-                trafficLineExp
-            )
-        }
-        verify {
-            style.setStyleLayerProperty(
-                RouteLayerConstants.PRIMARY_ROUTE_LAYER_ID,
-                "line-gradient",
-                routeLineExp
-            )
-        }
-        verify {
-            style.setStyleLayerProperty(
-                RouteLayerConstants.PRIMARY_ROUTE_CASING_LAYER_ID,
-                "line-gradient",
-                casingLineEx
-            )
-        }
-        verify {
-            style.setStyleLayerProperty(
-                RouteLayerConstants.ALTERNATIVE_ROUTE1_TRAFFIC_LAYER_ID,
-                "line-gradient",
-                alternativeRoute1Expression
-            )
-        }
-        verify {
-            style.setStyleLayerProperty(
-                RouteLayerConstants.ALTERNATIVE_ROUTE2_TRAFFIC_LAYER_ID,
-                "line-gradient",
-                alternativeRoute2Expression
-            )
-        }
-        verify {
-            style.setStyleSourceProperty(
-                RouteConstants.PRIMARY_ROUTE_SOURCE_ID,
-                any(),
-                capture(slots)
-            )
-        }
-        assertEquals(
-            primaryRouteFeatureCollection.toJson(),
-            slots[0].contents as String
-        )
-        verify {
-            style.setStyleSourceProperty(
-                RouteConstants.ALTERNATIVE_ROUTE1_SOURCE_ID,
-                any(),
-                capture(slots)
-            )
-        }
-        assertEquals(
-            alternativeRoute1FeatureCollection.toJson(),
-            slots[1].contents as String
-        )
-        verify {
-            style.setStyleSourceProperty(
-                RouteConstants.ALTERNATIVE_ROUTE2_SOURCE_ID,
-                any(),
-                capture(slots)
-            )
-        }
-        assertEquals(
-            alternativeRoute2FeatureCollection.toJson(),
-            slots[2].contents as String
-        )
-        verify {
-            style.setStyleSourceProperty(
-                RouteConstants.ALTERNATIVE_ROUTE2_SOURCE_ID,
-                any(),
-                capture(slots)
-            )
-        }
-        assertEquals(
-            waypointsFeatureCollection.toJson(),
-            slots[3].contents as String
-        )
+        verify { primaryRouteTrafficLayer.lineGradient(trafficLineExp) }
+        verify { primaryRouteLayer.lineGradient(routeLineExp) }
+        verify { primaryRouteCasingLayer.lineGradient(casingLineEx) }
+        verify { altRouteTrafficLayer1.lineGradient(alternativeRoute1Expression) }
+        verify { altRouteTrafficLayer2.lineGradient(alternativeRoute2Expression) }
+        verify { primaryRouteSource.featureCollection(primaryRouteFeatureCollection) }
+        verify { altRoute1Source.featureCollection(alternativeRoute1FeatureCollection) }
+        verify { altRoute2Source.featureCollection(alternativeRoute2FeatureCollection) }
+        verify { wayPointSource.featureCollection(waypointsFeatureCollection) }
         verify { MapboxRouteLineUtils.initializeLayers(style, options) }
         unmockkObject(MapboxRouteLineUtils)
+        unmockkStatic("com.mapbox.maps.extension.style.layers.LayerKt")
+        unmockkStatic("com.mapbox.maps.extension.style.sources.SourceKt")
     }
 
     @Test
     fun showPrimaryRoute() {
+        mockkStatic("com.mapbox.maps.extension.style.layers.LayerKt")
+        mockkStatic("com.mapbox.maps.extension.style.sources.SourceKt")
         mockkObject(MapboxRouteLineUtils)
         val options = MapboxRouteLineOptions.Builder(ctx).build()
-        val primaryRouteValueSlot = slot<Value>()
-        val trafficValueSlot = slot<Value>()
-        val casingValueSlot = slot<Value>()
+        val primaryRouteTrafficLayer = mockk<LineLayer>(relaxed = true)
+        val primaryRouteLayer = mockk<LineLayer>(relaxed = true)
+        val primaryRouteCasingLayer = mockk<LineLayer>(relaxed = true)
+
         val style = mockk<Style> {
             every { isFullyLoaded() } returns true
             every { fullyLoaded } returns true
-            every {
-                getStyleLayerProperties(RouteLayerConstants.PRIMARY_ROUTE_LAYER_ID)
-            } returns layerPropertyExpected
-            every {
-                setStyleSourceProperty(RouteConstants.PRIMARY_ROUTE_SOURCE_ID, any(), any())
-            } returns ExpectedFactory.createNone()
-            every {
-                setStyleLayerProperty(
-                    RouteLayerConstants.PRIMARY_ROUTE_LAYER_ID,
-                    "visibility",
-                    any()
-                )
-            } returns ExpectedFactory.createNone()
-            every {
-                getStyleLayerProperties(RouteLayerConstants.PRIMARY_ROUTE_TRAFFIC_LAYER_ID)
-            } returns layerPropertyExpected
-            every {
-                setStyleSourceProperty(RouteConstants.PRIMARY_ROUTE_SOURCE_ID, any(), any())
-            } returns ExpectedFactory.createNone()
-            every {
-                setStyleLayerProperty(
-                    RouteLayerConstants.PRIMARY_ROUTE_TRAFFIC_LAYER_ID,
-                    "visibility",
-                    any()
-                )
-            } returns ExpectedFactory.createNone()
-            every {
-                getStyleLayerProperties(RouteLayerConstants.PRIMARY_ROUTE_CASING_LAYER_ID)
-            } returns layerPropertyExpected
-            every {
-                setStyleSourceProperty(RouteConstants.PRIMARY_ROUTE_SOURCE_ID, any(), any())
-            } returns ExpectedFactory.createNone()
-            every {
-                setStyleLayerProperty(
-                    RouteLayerConstants.PRIMARY_ROUTE_CASING_LAYER_ID,
-                    "visibility",
-                    any()
-                )
-            } returns ExpectedFactory.createNone()
+            every { getLayer(RouteLayerConstants.PRIMARY_ROUTE_TRAFFIC_LAYER_ID) } returns primaryRouteTrafficLayer
+            every { getLayer(RouteLayerConstants.PRIMARY_ROUTE_LAYER_ID) } returns primaryRouteLayer
+            every { getLayer(RouteLayerConstants.PRIMARY_ROUTE_CASING_LAYER_ID) } returns primaryRouteCasingLayer
         }.also {
             mockCheckForLayerInitialization(it)
         }
 
         MapboxRouteLineView(options).showPrimaryRoute(style)
 
-        verify {
-            style.setStyleLayerProperty(
-                RouteLayerConstants.PRIMARY_ROUTE_LAYER_ID,
-                "visibility",
-                capture(primaryRouteValueSlot)
-            )
-        }
-        verify {
-            style.setStyleLayerProperty(
-                RouteLayerConstants.PRIMARY_ROUTE_TRAFFIC_LAYER_ID,
-                "visibility",
-                capture(trafficValueSlot)
-            )
-        }
-        verify {
-            style.setStyleLayerProperty(
-                RouteLayerConstants.PRIMARY_ROUTE_CASING_LAYER_ID,
-                "visibility",
-                capture(casingValueSlot)
-            )
-        }
-        assertEquals(
-            Visibility.VISIBLE.value.toLowerCase(),
-            primaryRouteValueSlot.captured.contents.toString().toLowerCase()
-        )
-        assertEquals(
-            Visibility.VISIBLE.value.toLowerCase(),
-            trafficValueSlot.captured.contents.toString().toLowerCase()
-        )
-        assertEquals(
-            Visibility.VISIBLE.value.toLowerCase(),
-            casingValueSlot.captured.contents.toString().toLowerCase()
-        )
+        verify { primaryRouteTrafficLayer.visibility(Visibility.VISIBLE) }
+        verify { primaryRouteLayer.visibility(Visibility.VISIBLE) }
+        verify { primaryRouteCasingLayer.visibility(Visibility.VISIBLE) }
         unmockkObject(MapboxRouteLineUtils)
+        unmockkStatic("com.mapbox.maps.extension.style.layers.LayerKt")
+        unmockkStatic("com.mapbox.maps.extension.style.sources.SourceKt")
     }
 
     @Test
     fun hidePrimaryRoute() {
+        mockkStatic("com.mapbox.maps.extension.style.layers.LayerKt")
         mockkObject(MapboxRouteLineUtils)
         val options = MapboxRouteLineOptions.Builder(ctx).build()
-        val primaryRouteValueSlot = slot<Value>()
-        val trafficValueSlot = slot<Value>()
-        val casingValueSlot = slot<Value>()
+        val trafficLayer = mockk<LineLayer>(relaxed = true)
+        val routeLayer = mockk<LineLayer>(relaxed = true)
+        val casingLayer = mockk<LineLayer>(relaxed = true)
+
         val style = mockk<Style> {
             every { isFullyLoaded() } returns true
             every { fullyLoaded } returns true
             every {
-                getStyleLayerProperties(RouteLayerConstants.PRIMARY_ROUTE_LAYER_ID)
-            } returns layerPropertyExpected
+                getLayer(RouteLayerConstants.PRIMARY_ROUTE_TRAFFIC_LAYER_ID)
+            } returns trafficLayer
+            every { getLayer(RouteLayerConstants.PRIMARY_ROUTE_LAYER_ID) } returns routeLayer
             every {
-                setStyleSourceProperty(RouteConstants.PRIMARY_ROUTE_SOURCE_ID, any(), any())
-            } returns ExpectedFactory.createNone()
-            every {
-                setStyleLayerProperty(
-                    RouteLayerConstants.PRIMARY_ROUTE_LAYER_ID,
-                    "visibility",
-                    any()
-                )
-            } returns ExpectedFactory.createNone()
-            every {
-                getStyleLayerProperties(RouteLayerConstants.PRIMARY_ROUTE_TRAFFIC_LAYER_ID)
-            } returns layerPropertyExpected
-            every {
-                setStyleSourceProperty(RouteConstants.PRIMARY_ROUTE_SOURCE_ID, any(), any())
-            } returns ExpectedFactory.createNone()
-            every {
-                setStyleLayerProperty(
-                    RouteLayerConstants.PRIMARY_ROUTE_TRAFFIC_LAYER_ID,
-                    "visibility",
-                    any()
-                )
-            } returns ExpectedFactory.createNone()
-            every {
-                getStyleLayerProperties(RouteLayerConstants.PRIMARY_ROUTE_CASING_LAYER_ID)
-            } returns layerPropertyExpected
-            every {
-                setStyleSourceProperty(RouteConstants.PRIMARY_ROUTE_SOURCE_ID, any(), any())
-            } returns ExpectedFactory.createNone()
-            every {
-                setStyleLayerProperty(
-                    RouteLayerConstants.PRIMARY_ROUTE_CASING_LAYER_ID,
-                    "visibility",
-                    any()
-                )
-            } returns ExpectedFactory.createNone()
+                getLayer(RouteLayerConstants.PRIMARY_ROUTE_CASING_LAYER_ID)
+            } returns casingLayer
         }.also {
             mockCheckForLayerInitialization(it)
         }
 
         MapboxRouteLineView(options).hidePrimaryRoute(style)
 
-        verify {
-            style.setStyleLayerProperty(
-                RouteLayerConstants.PRIMARY_ROUTE_LAYER_ID,
-                "visibility",
-                capture(primaryRouteValueSlot)
-            )
-        }
-        verify {
-            style.setStyleLayerProperty(
-                RouteLayerConstants.PRIMARY_ROUTE_TRAFFIC_LAYER_ID,
-                "visibility",
-                capture(trafficValueSlot)
-            )
-        }
-        verify {
-            style.setStyleLayerProperty(
-                RouteLayerConstants.PRIMARY_ROUTE_CASING_LAYER_ID,
-                "visibility",
-                capture(casingValueSlot)
-            )
-        }
-        assertEquals(
-            Visibility.NONE.value.toLowerCase(),
-            primaryRouteValueSlot.captured.contents.toString().toLowerCase()
-        )
-        assertEquals(
-            Visibility.NONE.value.toLowerCase(),
-            trafficValueSlot.captured.contents.toString().toLowerCase()
-        )
-        assertEquals(
-            Visibility.NONE.value.toLowerCase(),
-            casingValueSlot.captured.contents.toString().toLowerCase()
-        )
+        verify { trafficLayer.visibility(Visibility.NONE) }
+        verify { routeLayer.visibility(Visibility.NONE) }
+        verify { casingLayer.visibility(Visibility.NONE) }
         unmockkObject(MapboxRouteLineUtils)
+        unmockkStatic("com.mapbox.maps.extension.style.layers.LayerKt")
     }
 
     @Test
     fun showAlternativeRoutes() {
+        mockkStatic("com.mapbox.maps.extension.style.layers.LayerKt")
         mockkObject(MapboxRouteLineUtils)
         val options = MapboxRouteLineOptions.Builder(ctx).build()
-        val alternativeRoute1ValueSlot = slot<Value>()
-        val alternativeRoute1TrafficValueSlot = slot<Value>()
-        val alternativeRoute1CasingValueSlot = slot<Value>()
-        val alternativeRoute2ValueSlot = slot<Value>()
-        val alternativeRoute2TrafficValueSlot = slot<Value>()
-        val alternativeRoute2CasingValueSlot = slot<Value>()
+        val altRoute1 = mockk<LineLayer>(relaxed = true)
+        val altRouteCasing1 = mockk<LineLayer>(relaxed = true)
+        val altRouteTraffic1 = mockk<LineLayer>(relaxed = true)
+        val altRoute2 = mockk<LineLayer>(relaxed = true)
+        val altRouteCasing2 = mockk<LineLayer>(relaxed = true)
+        val altRouteTraffic2 = mockk<LineLayer>(relaxed = true)
 
         val style = mockk<Style> {
             every { isFullyLoaded() } returns true
             every { fullyLoaded } returns true
-
             every {
-                getStyleLayerProperties(RouteLayerConstants.ALTERNATIVE_ROUTE1_LAYER_ID)
-            } returns layerPropertyExpected
+                getLayer(RouteLayerConstants.ALTERNATIVE_ROUTE1_LAYER_ID)
+            } returns altRoute1
             every {
-                setStyleSourceProperty(RouteConstants.ALTERNATIVE_ROUTE1_SOURCE_ID, any(), any())
-            } returns ExpectedFactory.createNone()
+                getLayer(RouteLayerConstants.ALTERNATIVE_ROUTE1_CASING_LAYER_ID)
+            } returns altRouteCasing1
             every {
-                setStyleLayerProperty(
-                    RouteLayerConstants.ALTERNATIVE_ROUTE1_LAYER_ID,
-                    "visibility",
-                    any()
-                )
-            } returns ExpectedFactory.createNone()
+                getLayer(RouteLayerConstants.ALTERNATIVE_ROUTE1_TRAFFIC_LAYER_ID)
+            } returns altRouteTraffic1
             every {
-                getStyleLayerProperties(RouteLayerConstants.ALTERNATIVE_ROUTE1_CASING_LAYER_ID)
-            } returns layerPropertyExpected
+                getLayer(RouteLayerConstants.ALTERNATIVE_ROUTE2_LAYER_ID)
+            } returns altRoute2
             every {
-                setStyleSourceProperty(RouteConstants.ALTERNATIVE_ROUTE1_SOURCE_ID, any(), any())
-            } returns ExpectedFactory.createNone()
+                getLayer(RouteLayerConstants.ALTERNATIVE_ROUTE2_CASING_LAYER_ID)
+            } returns altRouteCasing2
             every {
-                setStyleLayerProperty(
-                    RouteLayerConstants.ALTERNATIVE_ROUTE1_CASING_LAYER_ID,
-                    "visibility",
-                    any()
-                )
-            } returns ExpectedFactory.createNone()
-            every {
-                getStyleLayerProperties(RouteLayerConstants.ALTERNATIVE_ROUTE2_LAYER_ID)
-            } returns layerPropertyExpected
-            every {
-                setStyleSourceProperty(RouteConstants.ALTERNATIVE_ROUTE2_SOURCE_ID, any(), any())
-            } returns ExpectedFactory.createNone()
-            every {
-                setStyleLayerProperty(
-                    RouteLayerConstants.ALTERNATIVE_ROUTE2_LAYER_ID,
-                    "visibility",
-                    any()
-                )
-            } returns ExpectedFactory.createNone()
-            every {
-                getStyleLayerProperties(RouteLayerConstants.ALTERNATIVE_ROUTE2_CASING_LAYER_ID)
-            } returns layerPropertyExpected
-            every {
-                setStyleSourceProperty(RouteConstants.ALTERNATIVE_ROUTE2_SOURCE_ID, any(), any())
-            } returns ExpectedFactory.createNone()
-            every {
-                setStyleLayerProperty(
-                    RouteLayerConstants.ALTERNATIVE_ROUTE2_CASING_LAYER_ID,
-                    "visibility",
-                    any()
-                )
-            } returns ExpectedFactory.createNone()
-            every {
-                getStyleLayerProperties(RouteLayerConstants.ALTERNATIVE_ROUTE1_TRAFFIC_LAYER_ID)
-            } returns layerPropertyExpected
-            every {
-                setStyleSourceProperty(RouteConstants.ALTERNATIVE_ROUTE1_SOURCE_ID, any(), any())
-            } returns ExpectedFactory.createNone()
-            every {
-                setStyleLayerProperty(
-                    RouteLayerConstants.ALTERNATIVE_ROUTE1_TRAFFIC_LAYER_ID,
-                    "visibility",
-                    any()
-                )
-            } returns ExpectedFactory.createNone()
-            every {
-                getStyleLayerProperties(RouteLayerConstants.ALTERNATIVE_ROUTE2_TRAFFIC_LAYER_ID)
-            } returns layerPropertyExpected
-            every {
-                setStyleSourceProperty(RouteConstants.ALTERNATIVE_ROUTE2_SOURCE_ID, any(), any())
-            } returns ExpectedFactory.createNone()
-            every {
-                setStyleLayerProperty(
-                    RouteLayerConstants.ALTERNATIVE_ROUTE2_TRAFFIC_LAYER_ID,
-                    "visibility",
-                    any()
-                )
-            } returns ExpectedFactory.createNone()
+                getLayer(RouteLayerConstants.ALTERNATIVE_ROUTE2_TRAFFIC_LAYER_ID)
+            } returns altRouteTraffic2
         }.also {
             mockCheckForLayerInitialization(it)
         }
 
         MapboxRouteLineView(options).showAlternativeRoutes(style)
 
-        verify {
-            style.setStyleLayerProperty(
-                RouteLayerConstants.ALTERNATIVE_ROUTE1_LAYER_ID,
-                "visibility",
-                capture(alternativeRoute1ValueSlot)
-            )
-        }
-        verify {
-            style.setStyleLayerProperty(
-                RouteLayerConstants.ALTERNATIVE_ROUTE1_TRAFFIC_LAYER_ID,
-                "visibility",
-                capture(alternativeRoute1TrafficValueSlot)
-            )
-        }
-        verify {
-            style.setStyleLayerProperty(
-                RouteLayerConstants.ALTERNATIVE_ROUTE1_CASING_LAYER_ID,
-                "visibility",
-                capture(alternativeRoute1CasingValueSlot)
-            )
-        }
-        verify {
-            style.setStyleLayerProperty(
-                RouteLayerConstants.ALTERNATIVE_ROUTE2_LAYER_ID,
-                "visibility",
-                capture(alternativeRoute2ValueSlot)
-            )
-        }
-        verify {
-            style.setStyleLayerProperty(
-                RouteLayerConstants.ALTERNATIVE_ROUTE2_TRAFFIC_LAYER_ID,
-                "visibility",
-                capture(alternativeRoute2TrafficValueSlot)
-            )
-        }
-        verify {
-            style.setStyleLayerProperty(
-                RouteLayerConstants.ALTERNATIVE_ROUTE2_CASING_LAYER_ID,
-                "visibility",
-                capture(alternativeRoute2CasingValueSlot)
-            )
-        }
-        assertEquals(
-            Visibility.VISIBLE.value.toLowerCase(),
-            alternativeRoute1ValueSlot.captured.contents.toString().toLowerCase()
-        )
-        assertEquals(
-            Visibility.VISIBLE.value.toLowerCase(),
-            alternativeRoute1TrafficValueSlot.captured.contents.toString().toLowerCase()
-        )
-        assertEquals(
-            Visibility.VISIBLE.value.toLowerCase(),
-            alternativeRoute1CasingValueSlot.captured.contents.toString().toLowerCase()
-        )
-        assertEquals(
-            Visibility.VISIBLE.value.toLowerCase(),
-            alternativeRoute2ValueSlot.captured.contents.toString().toLowerCase()
-        )
-        assertEquals(
-            Visibility.VISIBLE.value.toLowerCase(),
-            alternativeRoute2TrafficValueSlot.captured.contents.toString().toLowerCase()
-        )
-        assertEquals(
-            Visibility.VISIBLE.value.toLowerCase(),
-            alternativeRoute2CasingValueSlot.captured.contents.toString().toLowerCase()
-        )
+        verify { altRoute1.visibility(Visibility.VISIBLE) }
+        verify { altRouteCasing1.visibility(Visibility.VISIBLE) }
+        verify { altRouteTraffic1.visibility(Visibility.VISIBLE) }
+        verify { altRoute2.visibility(Visibility.VISIBLE) }
+        verify { altRouteCasing2.visibility(Visibility.VISIBLE) }
+        verify { altRouteTraffic2.visibility(Visibility.VISIBLE) }
         unmockkObject(MapboxRouteLineUtils)
+        unmockkStatic("com.mapbox.maps.extension.style.layers.LayerKt")
     }
 
     @Test
-    fun hideAlternativeRoutes() {
+    fun hideAlternativeRoutes() {mockkStatic("com.mapbox.maps.extension.style.layers.LayerKt")
         mockkObject(MapboxRouteLineUtils)
         val options = MapboxRouteLineOptions.Builder(ctx).build()
-        val alternativeRoute1ValueSlot = slot<Value>()
-        val alternativeRoute1TrafficValueSlot = slot<Value>()
-        val alternativeRoute1CasingValueSlot = slot<Value>()
-        val alternativeRoute2ValueSlot = slot<Value>()
-        val alternativeRoute2TrafficValueSlot = slot<Value>()
-        val alternativeRoute2CasingValueSlot = slot<Value>()
+        val altRoute1 = mockk<LineLayer>(relaxed = true)
+        val altRouteCasing1 = mockk<LineLayer>(relaxed = true)
+        val altRouteTraffic1 = mockk<LineLayer>(relaxed = true)
+        val altRoute2 = mockk<LineLayer>(relaxed = true)
+        val altRouteCasing2 = mockk<LineLayer>(relaxed = true)
+        val altRouteTraffic2 = mockk<LineLayer>(relaxed = true)
+
 
         val style = mockk<Style> {
             every { isFullyLoaded() } returns true
             every { fullyLoaded } returns true
 
             every {
-                getStyleLayerProperties(RouteLayerConstants.ALTERNATIVE_ROUTE1_LAYER_ID)
-            } returns layerPropertyExpected
+                getLayer(RouteLayerConstants.ALTERNATIVE_ROUTE1_LAYER_ID)
+            } returns altRoute1
             every {
-                setStyleSourceProperty(RouteConstants.ALTERNATIVE_ROUTE1_SOURCE_ID, any(), any())
-            } returns ExpectedFactory.createNone()
+                getLayer(RouteLayerConstants.ALTERNATIVE_ROUTE1_CASING_LAYER_ID)
+            } returns altRouteCasing1
             every {
-                setStyleLayerProperty(
-                    RouteLayerConstants.ALTERNATIVE_ROUTE1_LAYER_ID,
-                    "visibility",
-                    any()
-                )
-            } returns ExpectedFactory.createNone()
+                getLayer(RouteLayerConstants.ALTERNATIVE_ROUTE1_TRAFFIC_LAYER_ID)
+            } returns altRouteTraffic1
             every {
-                getStyleLayerProperties(RouteLayerConstants.ALTERNATIVE_ROUTE1_CASING_LAYER_ID)
-            } returns layerPropertyExpected
+                getLayer(RouteLayerConstants.ALTERNATIVE_ROUTE2_LAYER_ID)
+            } returns altRoute2
             every {
-                setStyleSourceProperty(RouteConstants.ALTERNATIVE_ROUTE1_SOURCE_ID, any(), any())
-            } returns ExpectedFactory.createNone()
+                getLayer(RouteLayerConstants.ALTERNATIVE_ROUTE2_CASING_LAYER_ID)
+            } returns altRouteCasing2
             every {
-                setStyleLayerProperty(
-                    RouteLayerConstants.ALTERNATIVE_ROUTE1_CASING_LAYER_ID,
-                    "visibility",
-                    any()
-                )
-            } returns ExpectedFactory.createNone()
-            every {
-                getStyleLayerProperties(RouteLayerConstants.ALTERNATIVE_ROUTE2_LAYER_ID)
-            } returns layerPropertyExpected
-            every {
-                setStyleSourceProperty(RouteConstants.ALTERNATIVE_ROUTE2_SOURCE_ID, any(), any())
-            } returns ExpectedFactory.createNone()
-            every {
-                setStyleLayerProperty(
-                    RouteLayerConstants.ALTERNATIVE_ROUTE2_LAYER_ID,
-                    "visibility",
-                    any()
-                )
-            } returns ExpectedFactory.createNone()
-            every {
-                getStyleLayerProperties(RouteLayerConstants.ALTERNATIVE_ROUTE2_CASING_LAYER_ID)
-            } returns layerPropertyExpected
-            every {
-                setStyleSourceProperty(RouteConstants.ALTERNATIVE_ROUTE2_SOURCE_ID, any(), any())
-            } returns ExpectedFactory.createNone()
-            every {
-                setStyleLayerProperty(
-                    RouteLayerConstants.ALTERNATIVE_ROUTE2_CASING_LAYER_ID,
-                    "visibility",
-                    any()
-                )
-            } returns ExpectedFactory.createNone()
-            every {
-                getStyleLayerProperties(RouteLayerConstants.ALTERNATIVE_ROUTE1_TRAFFIC_LAYER_ID)
-            } returns layerPropertyExpected
-            every {
-                setStyleSourceProperty(RouteConstants.ALTERNATIVE_ROUTE1_SOURCE_ID, any(), any())
-            } returns ExpectedFactory.createNone()
-            every {
-                setStyleLayerProperty(
-                    RouteLayerConstants.ALTERNATIVE_ROUTE1_TRAFFIC_LAYER_ID,
-                    "visibility",
-                    any()
-                )
-            } returns ExpectedFactory.createNone()
-            every {
-                getStyleLayerProperties(RouteLayerConstants.ALTERNATIVE_ROUTE2_TRAFFIC_LAYER_ID)
-            } returns layerPropertyExpected
-            every {
-                setStyleSourceProperty(RouteConstants.ALTERNATIVE_ROUTE2_SOURCE_ID, any(), any())
-            } returns ExpectedFactory.createNone()
-            every {
-                setStyleLayerProperty(
-                    RouteLayerConstants.ALTERNATIVE_ROUTE2_TRAFFIC_LAYER_ID,
-                    "visibility",
-                    any()
-                )
-            } returns ExpectedFactory.createNone()
+                getLayer(RouteLayerConstants.ALTERNATIVE_ROUTE2_TRAFFIC_LAYER_ID)
+            } returns altRouteTraffic2
         }.also {
             mockCheckForLayerInitialization(it)
         }
 
         MapboxRouteLineView(options).hideAlternativeRoutes(style)
 
-        verify {
-            style.setStyleLayerProperty(
-                RouteLayerConstants.ALTERNATIVE_ROUTE1_LAYER_ID,
-                "visibility",
-                capture(alternativeRoute1ValueSlot)
-            )
-        }
-        verify {
-            style.setStyleLayerProperty(
-                RouteLayerConstants.ALTERNATIVE_ROUTE1_TRAFFIC_LAYER_ID,
-                "visibility",
-                capture(alternativeRoute1TrafficValueSlot)
-            )
-        }
-        verify {
-            style.setStyleLayerProperty(
-                RouteLayerConstants.ALTERNATIVE_ROUTE1_CASING_LAYER_ID,
-                "visibility",
-                capture(alternativeRoute1CasingValueSlot)
-            )
-        }
-        verify {
-            style.setStyleLayerProperty(
-                RouteLayerConstants.ALTERNATIVE_ROUTE2_LAYER_ID,
-                "visibility",
-                capture(alternativeRoute2ValueSlot)
-            )
-        }
-        verify {
-            style.setStyleLayerProperty(
-                RouteLayerConstants.ALTERNATIVE_ROUTE2_TRAFFIC_LAYER_ID,
-                "visibility",
-                capture(alternativeRoute2TrafficValueSlot)
-            )
-        }
-        verify {
-            style.setStyleLayerProperty(
-                RouteLayerConstants.ALTERNATIVE_ROUTE2_CASING_LAYER_ID,
-                "visibility",
-                capture(alternativeRoute2CasingValueSlot)
-            )
-        }
-        assertEquals(
-            Visibility.NONE.value.toLowerCase(),
-            alternativeRoute1ValueSlot.captured.contents.toString().toLowerCase()
-        )
-        assertEquals(
-            Visibility.NONE.value.toLowerCase(),
-            alternativeRoute1TrafficValueSlot.captured.contents.toString().toLowerCase()
-        )
-        assertEquals(
-            Visibility.NONE.value.toLowerCase(),
-            alternativeRoute1CasingValueSlot.captured.contents.toString().toLowerCase()
-        )
-        assertEquals(
-            Visibility.NONE.value.toLowerCase(),
-            alternativeRoute2ValueSlot.captured.contents.toString().toLowerCase()
-        )
-        assertEquals(
-            Visibility.NONE.value.toLowerCase(),
-            alternativeRoute2TrafficValueSlot.captured.contents.toString().toLowerCase()
-        )
-        assertEquals(
-            Visibility.NONE.value.toLowerCase(),
-            alternativeRoute2CasingValueSlot.captured.contents.toString().toLowerCase()
-        )
+        verify { altRoute1.visibility(Visibility.NONE) }
+        verify { altRouteCasing1.visibility(Visibility.NONE) }
+        verify { altRouteTraffic1.visibility(Visibility.NONE) }
+        verify { altRoute2.visibility(Visibility.NONE) }
+        verify { altRouteCasing2.visibility(Visibility.NONE) }
+        verify { altRouteTraffic2.visibility(Visibility.NONE) }
+
         unmockkObject(MapboxRouteLineUtils)
+        unmockkStatic("com.mapbox.maps.extension.style.layers.LayerKt")
     }
 
     @Test
     fun showOriginAndDestinationPoints() {
+        mockkStatic("com.mapbox.maps.extension.style.layers.LayerKt")
         mockkObject(MapboxRouteLineUtils)
         val options = MapboxRouteLineOptions.Builder(ctx).build()
-        val valueSlot = slot<Value>()
+        val waypointLayer = mockk<LineLayer>(relaxed = true)
         val style = mockk<Style> {
             every { isFullyLoaded() } returns true
             every { fullyLoaded } returns true
-            every {
-                getStyleLayerProperties(RouteLayerConstants.WAYPOINT_LAYER_ID)
-            } returns layerPropertyExpected
-            every {
-                setStyleSourceProperty(RouteConstants.WAYPOINT_SOURCE_ID, any(), any())
-            } returns ExpectedFactory.createNone()
-            every {
-                setStyleLayerProperty(
-                    RouteLayerConstants.WAYPOINT_LAYER_ID,
-                    "visibility",
-                    any()
-                )
-            } returns ExpectedFactory.createNone()
+            every { getLayer(RouteLayerConstants.WAYPOINT_LAYER_ID) } returns waypointLayer
         }.also {
             mockCheckForLayerInitialization(it)
         }
 
         MapboxRouteLineView(options).showOriginAndDestinationPoints(style)
 
-        verify {
-            style.setStyleLayerProperty(
-                RouteLayerConstants.WAYPOINT_LAYER_ID,
-                "visibility",
-                capture(valueSlot)
-            )
-        }
-        assertEquals(
-            Visibility.VISIBLE.value.toLowerCase(),
-            valueSlot.captured.contents.toString().toLowerCase()
-        )
+        verify { waypointLayer.visibility(Visibility.VISIBLE) }
         unmockkObject(MapboxRouteLineUtils)
+        unmockkStatic("com.mapbox.maps.extension.style.layers.LayerKt")
     }
 
     @Test
     fun hideOriginAndDestinationPoints() {
+        mockkStatic("com.mapbox.maps.extension.style.layers.LayerKt")
         mockkObject(MapboxRouteLineUtils)
+        val waypointLayer = mockk<LineLayer>(relaxed = true)
         val options = MapboxRouteLineOptions.Builder(ctx).build()
-        val valueSlot = slot<Value>()
         val style = mockk<Style> {
             every { isFullyLoaded() } returns true
             every { fullyLoaded } returns true
-            every {
-                getStyleLayerProperties(RouteLayerConstants.WAYPOINT_LAYER_ID)
-            } returns layerPropertyExpected
-            every {
-                setStyleSourceProperty(RouteConstants.WAYPOINT_SOURCE_ID, any(), any())
-            } returns ExpectedFactory.createNone()
-            every {
-                setStyleLayerProperty(
-                    RouteLayerConstants.WAYPOINT_LAYER_ID,
-                    "visibility",
-                    any()
-                )
-            } returns ExpectedFactory.createNone()
+            every { getLayer(RouteLayerConstants.WAYPOINT_LAYER_ID) } returns waypointLayer
         }.also {
             mockCheckForLayerInitialization(it)
         }
 
         MapboxRouteLineView(options).hideOriginAndDestinationPoints(style)
 
-        verify {
-            style.setStyleLayerProperty(
-                RouteLayerConstants.WAYPOINT_LAYER_ID,
-                "visibility",
-                capture(valueSlot)
-            )
-        }
-        assertEquals(
-            Visibility.NONE.value.toLowerCase(),
-            valueSlot.captured.contents.toString().toLowerCase()
-        )
+        verify { waypointLayer.visibility(Visibility.NONE) }
         unmockkObject(MapboxRouteLineUtils)
+        unmockkStatic("com.mapbox.maps.extension.style.layers.LayerKt")
     }
 
     @Test


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Bumps `mapboxMapSdk` ~and `mapboxCommonNative`~ dependency versions to `10.0.0-rc.3` ~and `14.2.0` respectively~

Refs. https://github.com/mapbox/mapbox-maps-android/releases/tag/android-v10.0.0-rc.3

cc @kiryldz @etl @mskurydin 