### PR TITLE
Fix NavigationCamera infinite recursion on animation cancel and update device farm config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,16 +20,16 @@ executors:
       MBX_CI_DOMAIN: o619qyc20d.execute-api.us-east-1.amazonaws.com
       FORCE_MAPBOX_NAVIGATION_NATIVE_VERSION: << pipeline.parameters.mapbox_navigation_native_snapshot >>
       ALLOW_SNAPSHOT_REPOSITORY: << pipeline.parameters.mapbox_navigation_native_upstream >>
-      
+
 #-------------------------------
 #---------- WORKFLOWS ----------
 #-------------------------------
 workflows:
   version: 2
   release-workflow:
-    when: 
+    when:
       not: << pipeline.parameters.mapbox_navigation_native_upstream >>
-    jobs: 
+    jobs:
       - release-snapshot:
           filters:
             branches:
@@ -292,7 +292,7 @@ commands:
     steps:
       - run:
           name: Generate google services json for the test app
-          command:  |
+          command: |
             echo "${EXAMPLES_GOOGLE_SERVICES_JSON}" > /root/code/examples/google-services.json
 
   download-native-libs:
@@ -333,9 +333,9 @@ commands:
             gcloud firebase test android run --type instrumentation \
               --app << parameters.module_wrapper >>/build/outputs/apk/<< parameters.variant >>/<< parameters.module_wrapper >>-<< parameters.variant >>.apk \
               --test << parameters.module_target >>/build/outputs/apk/androidTest/<< parameters.variant >>/<< parameters.module_target >>-<< parameters.variant >>-androidTest.apk \
-              --device model=athene,version=23,locale=fr,orientation=landscape \
-              --device model=sailfish,version=26,locale=es,orientation=portrait \
-              --device model=walleye,version=28,locale=de,orientation=landscape \
+              --device model=hammerhead,version=23,locale=fr,orientation=portrait \
+              --device model=star2lte,version=28,locale=de,orientation=landscape \
+              --device model=flame,version=30,locale=en,orientation=portrait \
               --use-orchestrator \
               --timeout 10m
 
@@ -353,9 +353,9 @@ commands:
             gcloud firebase test android run --type instrumentation \
               --app instrumentation-tests/build/outputs/apk/<< parameters.variant >>/instrumentation-tests-<< parameters.variant >>.apk \
               --test instrumentation-tests/build/outputs/apk/androidTest/<< parameters.variant >>/instrumentation-tests-<< parameters.variant >>-androidTest.apk \
-              --device model=athene,version=23,locale=fr,orientation=landscape \
-              --device model=sailfish,version=26,locale=es,orientation=portrait \
-              --device model=walleye,version=28,locale=de,orientation=landscape \
+              --device model=hammerhead,version=23,locale=fr,orientation=portrait \
+              --device model=star2lte,version=28,locale=de,orientation=landscape \
+              --device model=flame,version=30,locale=en,orientation=portrait \
               --use-orchestrator \
               --timeout 15m
 
@@ -374,10 +374,10 @@ commands:
           command: |
             gcloud firebase test android run --type robo \
               --app << parameters.module_target >>/build/outputs/apk/<< parameters.variant >>/<< parameters.module_target >>-<< parameters.variant >>.apk \
-              --device model=hammerhead,version=21,locale=en,orientation=portrait  \
-              --device model=athene,version=23,locale=fr,orientation=landscape \
-              --device model=sailfish,version=26,locale=es,orientation=portrait \
-              --device model=walleye,version=28,locale=de,orientation=landscape \
+              --device model=hammerhead,version=21,locale=es,orientation=portrait  \
+              --device model=hammerhead,version=23,locale=fr,orientation=landscape \
+              --device model=star2lte,version=28,locale=de,orientation=landscape \
+              --device model=flame,version=30,locale=en,orientation=portrait \
               --timeout 5m
 
   publish-artifacts:
@@ -462,8 +462,8 @@ jobs:
     steps:
       - read-workspace
       - unit-tests-ui
-# Disabling Codecov (for now) due to https://about.codecov.io/security-update/
-#      - codecov
+  # Disabling Codecov (for now) due to https://about.codecov.io/security-update/
+  #      - codecov
 
   static-analysis:
     executor: ndk-r21e-latest-executor

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/ui/SanityUiRouteTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/ui/SanityUiRouteTest.kt
@@ -2,7 +2,6 @@ package com.mapbox.navigation.instrumentation_tests.ui
 
 import androidx.test.espresso.Espresso
 import com.mapbox.navigation.instrumentation_tests.utils.idling.ArrivalIdlingResource
-import com.mapbox.navigation.instrumentation_tests.utils.runOnMainSync
 import org.junit.Test
 
 class SanityUiRouteTest : SimpleMapViewNavigationTest() {

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/ui/SanityUiRouteTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/ui/SanityUiRouteTest.kt
@@ -2,6 +2,7 @@ package com.mapbox.navigation.instrumentation_tests.ui
 
 import androidx.test.espresso.Espresso
 import com.mapbox.navigation.instrumentation_tests.utils.idling.ArrivalIdlingResource
+import com.mapbox.navigation.instrumentation_tests.utils.runOnMainSync
 import org.junit.Test
 
 class SanityUiRouteTest : SimpleMapViewNavigationTest() {

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/ui/camera/NavigationCameraTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/ui/camera/NavigationCameraTest.kt
@@ -1,0 +1,33 @@
+package com.mapbox.navigation.instrumentation_tests.ui.camera
+
+import com.mapbox.navigation.instrumentation_tests.ui.SimpleMapViewNavigationTest
+import com.mapbox.navigation.instrumentation_tests.utils.runOnMainSync
+import org.junit.Test
+
+class NavigationCameraTest : SimpleMapViewNavigationTest() {
+
+    /**
+     * https://github.com/mapbox/mapbox-navigation-android/issues/4453
+     * https://github.com/mapbox/mapbox-navigation-android/pull/4575
+     * https://cs.android.com/android/_/android/platform/frameworks/base/+/3dbaae1ef4f221b3626810f4ba19eec068dd6304
+     *
+     * Checks for an issue where Android Animators where running into a cancellation loop
+     * on some API levels (definitely 21-24, maybe later) and caused stack overflow.
+     */
+    @Test
+    fun navigation_camera_mode_changes_completes() {
+        addNavigationCamera()
+
+        runOnMainSync {
+            navigationCamera.requestNavigationCameraToFollowing()
+        }
+
+        runOnMainSync {
+            navigationCamera.requestNavigationCameraToOverview()
+        }
+
+        runOnMainSync {
+            navigationCamera.requestNavigationCameraToFollowing()
+        }
+    }
+}

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/NavigationCamera.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/NavigationCamera.kt
@@ -431,13 +431,11 @@ class NavigationCamera(
 
         override fun onAnimationEnd(animation: Animator?) {
             if (isCanceled) {
-                requestNavigationCameraToIdle()
+                this@NavigationCamera.frameTransitionOptions = DEFAULT_FRAME_TRANSITION_OPT
+                state = IDLE
             } else {
-                state = finalState
-            }
-
-            if (!isCanceled) {
                 this@NavigationCamera.frameTransitionOptions = frameTransitionOptions
+                state = finalState
             }
 
             finishAnimation(animation as AnimatorSet)

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/NavigationCamera.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/NavigationCamera.kt
@@ -314,9 +314,8 @@ class NavigationCamera(
      */
     fun requestNavigationCameraToIdle() {
         if (state != IDLE) {
-            this@NavigationCamera.frameTransitionOptions = DEFAULT_FRAME_TRANSITION_OPT
             cancelAnimation()
-            state = IDLE
+            setIdleProperties()
         }
     }
 
@@ -379,6 +378,11 @@ class NavigationCamera(
         navigationCameraStateChangedObservers.remove(navigationCameraStateChangedObserver)
     }
 
+    private fun setIdleProperties() {
+        this@NavigationCamera.frameTransitionOptions = DEFAULT_FRAME_TRANSITION_OPT
+        state = IDLE
+    }
+
     private fun cancelAnimation() {
         runningAnimation?.let { set ->
             set.cancel()
@@ -431,8 +435,7 @@ class NavigationCamera(
 
         override fun onAnimationEnd(animation: Animator?) {
             if (isCanceled) {
-                this@NavigationCamera.frameTransitionOptions = DEFAULT_FRAME_TRANSITION_OPT
-                state = IDLE
+                setIdleProperties()
             } else {
                 this@NavigationCamera.frameTransitionOptions = frameTransitionOptions
                 state = finalState


### PR DESCRIPTION
### Description
Switching between camera states during animation can cause a StackOverflow crash. Here is the test and the fix for it.

### Changelog
```
<changelog>Fixed stack overflow error that could happen when `NavigationCamera` state transitions were canceled while running on some Android API levels (definitely 21-24 and maybe more).</changelog>
```

Fixes https://github.com/mapbox/mapbox-navigation-android/issues/4453.