### PR TITLE
update code to remove duplicate maneuvers

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxManeuverActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxManeuverActivity.kt
@@ -41,6 +41,7 @@ import com.mapbox.navigation.examples.core.databinding.LayoutActivityManeuverBin
 import com.mapbox.navigation.ui.maneuver.api.ManeuverCallback
 import com.mapbox.navigation.ui.maneuver.api.MapboxManeuverApi
 import com.mapbox.navigation.ui.maneuver.api.RoadShieldCallback
+import com.mapbox.navigation.ui.maneuver.view.MapboxManeuverView
 import com.mapbox.navigation.ui.maps.internal.route.line.MapboxRouteLineApiExtensions.setRoutes
 import com.mapbox.navigation.ui.maps.location.NavigationLocationProvider
 import com.mapbox.navigation.ui.maps.route.arrow.api.MapboxRouteArrowApi

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/utils/DirectionsRouteEx.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/utils/DirectionsRouteEx.kt
@@ -10,7 +10,9 @@ fun DirectionsRoute.isSameUuid(compare: DirectionsRoute?): Boolean =
     this.routeOptions()?.requestUuid() == compare?.routeOptions()?.requestUuid()
 
 /**
- * Compare routes as geometries(if exist) or as a names of [LegStep] of the [DirectionsRoute]
+ * Compare routes as geometries (if exist) or as a names of [LegStep] of the [DirectionsRoute].
+ *
+ * **This check does not compare route annotations!**
  */
 fun DirectionsRoute.isSameRoute(compare: DirectionsRoute?): Boolean {
     if (compare == null) return false

--- a/libnavui-maneuver/api/current.txt
+++ b/libnavui-maneuver/api/current.txt
@@ -14,6 +14,7 @@ package com.mapbox.navigation.ui.maneuver.api {
 
   public final class MapboxManeuverApi {
     ctor public MapboxManeuverApi(com.mapbox.navigation.base.formatter.DistanceFormatter formatter);
+    ctor public MapboxManeuverApi(com.mapbox.navigation.base.formatter.DistanceFormatter formatter, com.mapbox.navigation.ui.maneuver.model.ManeuverOptions maneuverOptions);
     method public void cancel();
     method public void getManeuvers(com.mapbox.api.directions.v5.models.DirectionsRoute route, com.mapbox.navigation.ui.maneuver.api.ManeuverCallback callback, com.mapbox.api.directions.v5.models.RouteLeg? routeLeg = null);
     method public void getManeuvers(com.mapbox.api.directions.v5.models.DirectionsRoute route, com.mapbox.navigation.ui.maneuver.api.ManeuverCallback callback);
@@ -127,6 +128,18 @@ package com.mapbox.navigation.ui.maneuver.model {
     method public Throwable? getThrowable();
     property public final String? errorMessage;
     property public final Throwable? throwable;
+  }
+
+  public final class ManeuverOptions {
+    method public boolean getFilterDuplicateManeuvers();
+    method public com.mapbox.navigation.ui.maneuver.model.ManeuverOptions.Builder toBuilder();
+    property public final boolean filterDuplicateManeuvers;
+  }
+
+  public static final class ManeuverOptions.Builder {
+    ctor public ManeuverOptions.Builder();
+    method public com.mapbox.navigation.ui.maneuver.model.ManeuverOptions build();
+    method public com.mapbox.navigation.ui.maneuver.model.ManeuverOptions.Builder filterDuplicateManeuvers(boolean filterDuplicateManeuvers);
   }
 
   public final class PrimaryManeuver {

--- a/libnavui-maneuver/api/current.txt
+++ b/libnavui-maneuver/api/current.txt
@@ -13,8 +13,8 @@ package com.mapbox.navigation.ui.maneuver.api {
   }
 
   public final class MapboxManeuverApi {
+    ctor public MapboxManeuverApi(com.mapbox.navigation.base.formatter.DistanceFormatter formatter, com.mapbox.navigation.ui.maneuver.model.ManeuverOptions maneuverOptions = ManeuverOptions.<init>().build());
     ctor public MapboxManeuverApi(com.mapbox.navigation.base.formatter.DistanceFormatter formatter);
-    ctor public MapboxManeuverApi(com.mapbox.navigation.base.formatter.DistanceFormatter formatter, com.mapbox.navigation.ui.maneuver.model.ManeuverOptions maneuverOptions);
     method public void cancel();
     method public void getManeuvers(com.mapbox.api.directions.v5.models.DirectionsRoute route, com.mapbox.navigation.ui.maneuver.api.ManeuverCallback callback, com.mapbox.api.directions.v5.models.RouteLeg? routeLeg = null);
     method public void getManeuvers(com.mapbox.api.directions.v5.models.DirectionsRoute route, com.mapbox.navigation.ui.maneuver.api.ManeuverCallback callback);

--- a/libnavui-maneuver/src/main/java/com/mapbox/navigation/ui/maneuver/ManeuverAction.kt
+++ b/libnavui-maneuver/src/main/java/com/mapbox/navigation/ui/maneuver/ManeuverAction.kt
@@ -4,12 +4,14 @@ import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.RouteLeg
 import com.mapbox.navigation.base.formatter.DistanceFormatter
 import com.mapbox.navigation.base.trip.model.RouteProgress
+import com.mapbox.navigation.ui.maneuver.model.ManeuverOptions
 
 internal sealed class ManeuverAction {
 
     data class GetManeuverList(
         val routeProgress: RouteProgress,
         val maneuverState: ManeuverState,
+        val maneuverOption: ManeuverOptions,
         val distanceFormatter: DistanceFormatter
     ) : ManeuverAction()
 
@@ -17,6 +19,7 @@ internal sealed class ManeuverAction {
         val route: DirectionsRoute,
         val routeLeg: RouteLeg? = null,
         val maneuverState: ManeuverState,
+        val maneuverOption: ManeuverOptions,
         val distanceFormatter: DistanceFormatter
     ) : ManeuverAction()
 }

--- a/libnavui-maneuver/src/main/java/com/mapbox/navigation/ui/maneuver/api/MapboxManeuverApi.kt
+++ b/libnavui-maneuver/src/main/java/com/mapbox/navigation/ui/maneuver/api/MapboxManeuverApi.kt
@@ -48,18 +48,11 @@ class MapboxManeuverApi internal constructor(
      * a [DirectionsRoute] (to get all maneuvers for the provided route)
      * or [RouteProgress] (to get remaining maneuvers for the provided route).
      */
-    constructor(formatter: DistanceFormatter) : this(
-        formatter,
-        ManeuverOptions.Builder().build(),
-        ManeuverProcessor
-    )
-
-    /**
-     * Mapbox Maneuver Api allows you to request [Maneuver] instructions given
-     * a [DirectionsRoute] (to get all maneuvers for the provided route)
-     * or [RouteProgress] (to get remaining maneuvers for the provided route).
-     */
-    constructor(formatter: DistanceFormatter, maneuverOptions: ManeuverOptions) : this(
+    @JvmOverloads
+    constructor(
+        formatter: DistanceFormatter,
+        maneuverOptions: ManeuverOptions = ManeuverOptions.Builder().build()
+    ) : this(
         formatter,
         maneuverOptions,
         ManeuverProcessor

--- a/libnavui-maneuver/src/main/java/com/mapbox/navigation/ui/maneuver/api/MapboxManeuverApi.kt
+++ b/libnavui-maneuver/src/main/java/com/mapbox/navigation/ui/maneuver/api/MapboxManeuverApi.kt
@@ -14,6 +14,7 @@ import com.mapbox.navigation.ui.maneuver.ManeuverState
 import com.mapbox.navigation.ui.maneuver.RoadShieldContentManager
 import com.mapbox.navigation.ui.maneuver.model.Maneuver
 import com.mapbox.navigation.ui.maneuver.model.ManeuverError
+import com.mapbox.navigation.ui.maneuver.model.ManeuverOptions
 import com.mapbox.navigation.ui.maneuver.model.PrimaryManeuver
 import com.mapbox.navigation.ui.maneuver.model.RoadShield
 import com.mapbox.navigation.ui.maneuver.model.RoadShieldComponentNode
@@ -34,6 +35,7 @@ import kotlinx.coroutines.launch
  */
 class MapboxManeuverApi internal constructor(
     private val distanceFormatter: DistanceFormatter,
+    private val maneuverOptions: ManeuverOptions,
     private val processor: ManeuverProcessor
 ) {
 
@@ -46,7 +48,22 @@ class MapboxManeuverApi internal constructor(
      * a [DirectionsRoute] (to get all maneuvers for the provided route)
      * or [RouteProgress] (to get remaining maneuvers for the provided route).
      */
-    constructor(formatter: DistanceFormatter) : this(formatter, ManeuverProcessor)
+    constructor(formatter: DistanceFormatter) : this(
+        formatter,
+        ManeuverOptions.Builder().build(),
+        ManeuverProcessor
+    )
+
+    /**
+     * Mapbox Maneuver Api allows you to request [Maneuver] instructions given
+     * a [DirectionsRoute] (to get all maneuvers for the provided route)
+     * or [RouteProgress] (to get remaining maneuvers for the provided route).
+     */
+    constructor(formatter: DistanceFormatter, maneuverOptions: ManeuverOptions) : this(
+        formatter,
+        maneuverOptions,
+        ManeuverProcessor
+    )
 
     /**
      * The function calls [ManeuverCallback] with a list of [Maneuver]s which are wrappers on top of [BannerInstructions] that are in the provided route.
@@ -71,6 +88,7 @@ class MapboxManeuverApi internal constructor(
             route,
             routeLeg,
             maneuverState,
+            maneuverOptions,
             distanceFormatter
         )
         when (val result = processor.process(action)) {
@@ -110,7 +128,12 @@ class MapboxManeuverApi internal constructor(
         routeProgress: RouteProgress,
         callback: ManeuverCallback
     ) {
-        val action = ManeuverAction.GetManeuverList(routeProgress, maneuverState, distanceFormatter)
+        val action = ManeuverAction.GetManeuverList(
+            routeProgress,
+            maneuverState,
+            maneuverOptions,
+            distanceFormatter
+        )
         when (
             val result = processor.process(action)
         ) {

--- a/libnavui-maneuver/src/main/java/com/mapbox/navigation/ui/maneuver/model/ManeuverOptions.kt
+++ b/libnavui-maneuver/src/main/java/com/mapbox/navigation/ui/maneuver/model/ManeuverOptions.kt
@@ -1,9 +1,21 @@
 package com.mapbox.navigation.ui.maneuver.model
 
+import com.mapbox.api.directions.v5.models.BannerInstructions
+import com.mapbox.navigation.ui.maneuver.api.MapboxManeuverApi
+
 /**
- * Gives options to filter duplicate maneuvers
+ * Specifies options for parsing [Maneuver] data in the [MapboxManeuverApi].
  *
- * @param filterDuplicateManeuvers filter duplicate maneuvers if true
+ * @param filterDuplicateManeuvers guidance instructions returned by the Mapbox Directions API
+ * often have instructions on a route duplicated to control
+ * the timing of when to notify the user about details of an upcoming maneuver.
+ * For example, there can a "left turn" [BannerInstructions] available 1000m and 300m before a turn, where only the latter also contains lane information.
+ * By setting this flag to `true`, you can filter out those duplicates which improves the presentation in, for example, a scrolling list.
+ *
+ * The [MapboxManeuverApi] will ensure that no information is lost and the current maneuver is always up-to-date.
+ * It's only the upcoming duplicates that are continuously filtered out.
+ *
+ * This option defaults to `true`.
  */
 class ManeuverOptions private constructor(
     val filterDuplicateManeuvers: Boolean
@@ -51,9 +63,18 @@ class ManeuverOptions private constructor(
         private var filterDuplicateManeuvers = true
 
         /**
-         * Set to true/false to filter duplicate maneuvers or not. Default value is true
+         * Guidance instructions returned by the Mapbox Directions API
+         * often have instructions on a route duplicated to control
+         * the timing of when to notify the user about details of an upcoming maneuver.
+         * For example, there can a "left turn" [BannerInstructions] available 1000m and 300m before a turn, where only the latter also contains lane information.
+         * By setting this flag to `true`, you can filter out those duplicates which improves the presentation in, for example, a scrolling list.
          *
-         * @param filterDuplicateManeuvers Boolean
+         * The [MapboxManeuverApi] will ensure that no information is lost and the current maneuver is always up-to-date.
+         * It's only the upcoming duplicates that are continuously filtered out.
+         *
+         * This option defaults to `true`.
+         *
+         * @param filterDuplicateManeuvers true/false to filter duplicate maneuvers or not
          * @return Builder
          */
         fun filterDuplicateManeuvers(filterDuplicateManeuvers: Boolean) = apply {

--- a/libnavui-maneuver/src/main/java/com/mapbox/navigation/ui/maneuver/model/ManeuverOptions.kt
+++ b/libnavui-maneuver/src/main/java/com/mapbox/navigation/ui/maneuver/model/ManeuverOptions.kt
@@ -1,0 +1,72 @@
+package com.mapbox.navigation.ui.maneuver.model
+
+/**
+ * Gives options to filter duplicate maneuvers
+ *
+ * @param filterDuplicateManeuvers filter duplicate maneuvers if true
+ */
+class ManeuverOptions private constructor(
+    val filterDuplicateManeuvers: Boolean
+) {
+
+    /**
+     * @return the [Builder] that created the [ManeuverOptions]
+     */
+    fun toBuilder() = Builder()
+        .filterDuplicateManeuvers(filterDuplicateManeuvers)
+
+    /**
+     * Regenerate whenever a change is made
+     */
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as ManeuverOptions
+
+        if (filterDuplicateManeuvers != other.filterDuplicateManeuvers) return false
+
+        return true
+    }
+
+    /**
+     * Regenerate whenever a change is made
+     */
+    override fun hashCode(): Int {
+        return filterDuplicateManeuvers.hashCode()
+    }
+
+    /**
+     * Regenerate whenever a change is made
+     */
+    override fun toString(): String {
+        return "ManeuverOptions(filterDuplicateManeuvers=$filterDuplicateManeuvers)"
+    }
+
+    /**
+     * Builder of [ManeuverOptions]
+     */
+    class Builder {
+
+        private var filterDuplicateManeuvers = true
+
+        /**
+         * Set to true/false to filter duplicate maneuvers or not. Default value is true
+         *
+         * @param filterDuplicateManeuvers Boolean
+         * @return Builder
+         */
+        fun filterDuplicateManeuvers(filterDuplicateManeuvers: Boolean) = apply {
+            this.filterDuplicateManeuvers = filterDuplicateManeuvers
+        }
+
+        /**
+         * Build a new instance of [ManeuverOptions]
+         *
+         * @return ManeuverOptions
+         */
+        fun build() = ManeuverOptions(
+            filterDuplicateManeuvers = filterDuplicateManeuvers
+        )
+    }
+}

--- a/libnavui-maneuver/src/test/java/com/mapbox/navigation/ui/maneuver/ManeuverProcessorTest.kt
+++ b/libnavui-maneuver/src/test/java/com/mapbox/navigation/ui/maneuver/ManeuverProcessorTest.kt
@@ -6,6 +6,7 @@ import com.mapbox.navigation.base.formatter.DistanceFormatter
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.testing.FileUtils
 import com.mapbox.navigation.testing.MainCoroutineRule
+import com.mapbox.navigation.ui.maneuver.model.ManeuverOptions
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -25,11 +26,13 @@ class ManeuverProcessorTest {
             FileUtils.loadJsonFixture("short_route_invalid_banner_instruction.json")
         )
         val maneuverState = ManeuverState()
+        val maneuverOptions = ManeuverOptions.Builder().build()
         val distanceFormatter = mockk<DistanceFormatter>()
         val maneuverAction = ManeuverAction.GetManeuverListWithRoute(
             route,
             null,
             maneuverState,
+            maneuverOptions,
             distanceFormatter
         )
         val expected = ManeuverResult.GetManeuverList.Failure(
@@ -48,10 +51,12 @@ class ManeuverProcessorTest {
         )
         val maneuverState = ManeuverState()
         val distanceFormatter = mockk<DistanceFormatter>()
+        val maneuverOptions = ManeuverOptions.Builder().build()
         val maneuverAction = ManeuverAction.GetManeuverListWithRoute(
             route,
             null,
             maneuverState,
+            maneuverOptions,
             distanceFormatter
         )
         val expected = ManeuverResult.GetManeuverList.Failure("RouteLeg should have valid steps")
@@ -68,10 +73,12 @@ class ManeuverProcessorTest {
         )
         val maneuverState = ManeuverState()
         val distanceFormatter = mockk<DistanceFormatter>()
+        val maneuverOptions = ManeuverOptions.Builder().build()
         val maneuverAction = ManeuverAction.GetManeuverListWithRoute(
             route,
             null,
             maneuverState,
+            maneuverOptions,
             distanceFormatter
         )
         val expected = ManeuverResult.GetManeuverList.Failure("Route should have valid legs")
@@ -89,10 +96,12 @@ class ManeuverProcessorTest {
         val routeLeg = null
         val maneuverState = ManeuverState()
         val distanceFormatter = mockk<DistanceFormatter>()
+        val maneuverOptions = ManeuverOptions.Builder().build()
         val maneuverAction = ManeuverAction.GetManeuverListWithRoute(
             route,
             routeLeg,
             maneuverState,
+            maneuverOptions,
             distanceFormatter
         )
         val expected = ManeuverResult.GetManeuverList.Failure(
@@ -122,10 +131,12 @@ class ManeuverProcessorTest {
         }
         val maneuverState = ManeuverState()
         val distanceFormatter = mockk<DistanceFormatter>()
+        val maneuverOptions = ManeuverOptions.Builder().build()
         val maneuverAction = ManeuverAction.GetManeuverListWithRoute(
             route,
             routeLeg,
             maneuverState,
+            maneuverOptions,
             distanceFormatter
         )
         val expected = ManeuverResult.GetManeuverList.Failure(
@@ -138,17 +149,43 @@ class ManeuverProcessorTest {
     }
 
     @Test
-    fun `when maneuver with direction route and is valid`() {
+    fun `when maneuver with direction route is valid and filter duplicate`() {
         val route = DirectionsRoute.fromJson(
             FileUtils.loadJsonFixture("short_route.json")
         )
         val routeLeg = null
         val maneuverState = ManeuverState()
         val distanceFormatter = mockk<DistanceFormatter>()
+        val maneuverOptions = ManeuverOptions.Builder().build()
         val maneuverAction = ManeuverAction.GetManeuverListWithRoute(
             route,
             routeLeg,
             maneuverState,
+            maneuverOptions,
+            distanceFormatter
+        )
+        val expected = 3
+
+        val actual = ManeuverProcessor.process(maneuverAction) as
+            ManeuverResult.GetManeuverList.Success
+
+        assertEquals(expected, actual.maneuvers.size)
+    }
+
+    @Test
+    fun `when maneuver with direction route and is valid and don't filter duplicate`() {
+        val route = DirectionsRoute.fromJson(
+            FileUtils.loadJsonFixture("short_route.json")
+        )
+        val routeLeg = null
+        val maneuverState = ManeuverState()
+        val distanceFormatter = mockk<DistanceFormatter>()
+        val maneuverOptions = ManeuverOptions.Builder().filterDuplicateManeuvers(false).build()
+        val maneuverAction = ManeuverAction.GetManeuverListWithRoute(
+            route,
+            routeLeg,
+            maneuverState,
+            maneuverOptions,
             distanceFormatter
         )
         val expected = 4
@@ -167,10 +204,12 @@ class ManeuverProcessorTest {
         val routeLeg = null
         val maneuverState = ManeuverState()
         val distanceFormatter = mockk<DistanceFormatter>()
+        val maneuverOptions = ManeuverOptions.Builder().build()
         val maneuverAction = ManeuverAction.GetManeuverListWithRoute(
             route,
             routeLeg,
             maneuverState,
+            maneuverOptions,
             distanceFormatter
         )
 
@@ -184,6 +223,7 @@ class ManeuverProcessorTest {
             route1,
             routeLeg1,
             maneuverState,
+            maneuverOptions,
             distanceFormatter
         )
 
@@ -207,9 +247,11 @@ class ManeuverProcessorTest {
         )
         val maneuverState = ManeuverState()
         val distanceFormatter = mockk<DistanceFormatter>()
+        val maneuverOptions = ManeuverOptions.Builder().build()
         val maneuverAction = ManeuverAction.GetManeuverList(
             routeProgress,
             maneuverState,
+            maneuverOptions,
             distanceFormatter
         )
         val expected = ManeuverResult.GetManeuverListWithProgress.Failure(
@@ -235,9 +277,11 @@ class ManeuverProcessorTest {
         )
         val maneuverState = ManeuverState()
         val distanceFormatter = mockk<DistanceFormatter>()
+        val maneuverOptions = ManeuverOptions.Builder().build()
         val maneuverAction = ManeuverAction.GetManeuverList(
             routeProgress,
             maneuverState,
+            maneuverOptions,
             distanceFormatter
         )
         val expected = ManeuverResult.GetManeuverListWithProgress.Failure(
@@ -263,9 +307,11 @@ class ManeuverProcessorTest {
         )
         val maneuverState = ManeuverState()
         val distanceFormatter = mockk<DistanceFormatter>()
+        val maneuverOptions = ManeuverOptions.Builder().build()
         val maneuverAction = ManeuverAction.GetManeuverList(
             routeProgress,
             maneuverState,
+            maneuverOptions,
             distanceFormatter
         )
         val expected = ManeuverResult.GetManeuverListWithProgress.Failure(
@@ -293,9 +339,11 @@ class ManeuverProcessorTest {
         every { legProgress?.routeLeg } returns RouteLeg.builder().build()
         val maneuverState = ManeuverState()
         val distanceFormatter = mockk<DistanceFormatter>()
+        val maneuverOptions = ManeuverOptions.Builder().build()
         val maneuverAction = ManeuverAction.GetManeuverList(
             routeProgress,
             maneuverState,
+            maneuverOptions,
             distanceFormatter
         )
         val expected = ManeuverResult.GetManeuverListWithProgress.Failure(
@@ -321,9 +369,11 @@ class ManeuverProcessorTest {
         )
         val maneuverState = ManeuverState()
         val distanceFormatter = mockk<DistanceFormatter>()
+        val maneuverOptions = ManeuverOptions.Builder().build()
         val maneuverAction = ManeuverAction.GetManeuverList(
             routeProgress,
             maneuverState,
+            maneuverOptions,
             distanceFormatter
         )
         val expected = ManeuverResult.GetManeuverListWithProgress.Failure(
@@ -336,7 +386,7 @@ class ManeuverProcessorTest {
     }
 
     @Test
-    fun `when maneuver with route progress valid`() {
+    fun `when maneuver with route progress is valid and filter duplicate`() {
         val route = DirectionsRoute.fromJson(
             FileUtils.loadJsonFixture("short_route.json")
         )
@@ -349,9 +399,41 @@ class ManeuverProcessorTest {
         )
         val maneuverState = ManeuverState()
         val distanceFormatter = mockk<DistanceFormatter>()
+        val maneuverOptions = ManeuverOptions.Builder().build()
         val maneuverAction = ManeuverAction.GetManeuverList(
             routeProgress,
             maneuverState,
+            maneuverOptions,
+            distanceFormatter
+        )
+        val expected = 3
+
+        val actual = ManeuverProcessor.process(maneuverAction) as
+            ManeuverResult.GetManeuverListWithProgress.Success
+
+        assertEquals(expected, actual.maneuvers.size)
+        assertEquals(15.0, actual.maneuvers[0].stepDistance.distanceRemaining)
+    }
+
+    @Test
+    fun `when maneuver with route progress is valid and don't filter duplicate`() {
+        val route = DirectionsRoute.fromJson(
+            FileUtils.loadJsonFixture("short_route.json")
+        )
+        val routeProgress = mockRouteProgress(
+            _route = route,
+            _distanceRemaining = 15f,
+            _routeLegIndex = 0,
+            _stepIndex = 0,
+            _instructionIndex = 0,
+        )
+        val maneuverState = ManeuverState()
+        val distanceFormatter = mockk<DistanceFormatter>()
+        val maneuverOptions = ManeuverOptions.Builder().filterDuplicateManeuvers(false).build()
+        val maneuverAction = ManeuverAction.GetManeuverList(
+            routeProgress,
+            maneuverState,
+            maneuverOptions,
             distanceFormatter
         )
         val expected = 4
@@ -377,9 +459,11 @@ class ManeuverProcessorTest {
         )
         val maneuverState = ManeuverState()
         val distanceFormatter = mockk<DistanceFormatter>()
+        val maneuverOptions = ManeuverOptions.Builder().build()
         val maneuverAction = ManeuverAction.GetManeuverList(
             routeProgress,
             maneuverState,
+            maneuverOptions,
             distanceFormatter
         )
 
@@ -395,13 +479,14 @@ class ManeuverProcessorTest {
         val maneuverAction1 = ManeuverAction.GetManeuverList(
             routeProgress1,
             maneuverState,
+            maneuverOptions,
             distanceFormatter
         )
 
         val actual1 = ManeuverProcessor.process(maneuverAction1) as
             ManeuverResult.GetManeuverListWithProgress.Success
 
-        assertEquals(4, actual1.maneuvers.size)
+        assertEquals(3, actual1.maneuvers.size)
         assertEquals(10.0, actual1.maneuvers[0].stepDistance.distanceRemaining)
     }
 

--- a/libnavui-maneuver/src/test/java/com/mapbox/navigation/ui/maneuver/api/MapboxManeuverApiTest.kt
+++ b/libnavui-maneuver/src/test/java/com/mapbox/navigation/ui/maneuver/api/MapboxManeuverApiTest.kt
@@ -12,6 +12,7 @@ import com.mapbox.navigation.ui.maneuver.ManeuverState
 import com.mapbox.navigation.ui.maneuver.RoadShieldContentManager
 import com.mapbox.navigation.ui.maneuver.model.Maneuver
 import com.mapbox.navigation.ui.maneuver.model.ManeuverError
+import com.mapbox.navigation.ui.maneuver.model.ManeuverOptions
 import com.mapbox.navigation.ui.maneuver.model.RoadShield
 import com.mapbox.navigation.ui.maneuver.model.RoadShieldError
 import com.mapbox.navigation.ui.maneuver.model.RoadShieldResult
@@ -33,6 +34,7 @@ class MapboxManeuverApiTest {
 
     @get:Rule
     var coroutineRule = MainCoroutineRule()
+    private val maneuverOptions = mockk<ManeuverOptions>()
     private val distanceFormatter = mockk<DistanceFormatter>()
     private val mapboxManeuverApi = MapboxManeuverApi(distanceFormatter)
 
@@ -54,6 +56,7 @@ class MapboxManeuverApiTest {
             route,
             null,
             maneuverState,
+            maneuverOptions,
             distanceFormatter
         )
         every { ManeuverProcessor.process(action) } returns
@@ -74,6 +77,7 @@ class MapboxManeuverApiTest {
             route,
             null,
             maneuverState,
+            maneuverOptions,
             distanceFormatter
         )
         every { ManeuverProcessor.process(action) } returns
@@ -94,6 +98,7 @@ class MapboxManeuverApiTest {
             route,
             null,
             maneuverState,
+            maneuverOptions,
             distanceFormatter
         )
         every { ManeuverProcessor.process(action) } returns
@@ -113,6 +118,7 @@ class MapboxManeuverApiTest {
         val action = ManeuverAction.GetManeuverList(
             routeProgress,
             maneuverState,
+            maneuverOptions,
             distanceFormatter
         )
         every { ManeuverProcessor.process(action) } returns
@@ -132,6 +138,7 @@ class MapboxManeuverApiTest {
         val action = ManeuverAction.GetManeuverList(
             routeProgress,
             maneuverState,
+            maneuverOptions,
             distanceFormatter
         )
         every { ManeuverProcessor.process(action) } returns
@@ -151,6 +158,7 @@ class MapboxManeuverApiTest {
         val action = ManeuverAction.GetManeuverList(
             routeProgress,
             maneuverState,
+            maneuverOptions,
             distanceFormatter
         )
         every { ManeuverProcessor.process(action) } returns

--- a/libnavui-maneuver/src/test/java/com/mapbox/navigation/ui/maneuver/model/ManeuverOptionsTest.kt
+++ b/libnavui-maneuver/src/test/java/com/mapbox/navigation/ui/maneuver/model/ManeuverOptionsTest.kt
@@ -1,0 +1,18 @@
+package com.mapbox.navigation.ui.maneuver.model
+
+import com.mapbox.navigation.testing.BuilderTest
+import kotlin.reflect.KClass
+
+class ManeuverOptionsTest : BuilderTest<ManeuverOptions, ManeuverOptions.Builder>() {
+
+    override fun getImplementationClass(): KClass<ManeuverOptions> = ManeuverOptions::class
+
+    override fun getFilledUpBuilder(): ManeuverOptions.Builder {
+        return ManeuverOptions.Builder()
+            .filterDuplicateManeuvers(false)
+    }
+
+    override fun trigger() {
+        // see comments
+    }
+}


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Fixes #4430 

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Exposed `ManeuverOptions#filterDuplicateManeuvers` which allows to filter out `Maneuver`s that point to the same actual turn from the presented lists. This parameter defaults to `true`.</changelog>
```

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->

| Before | After |
| ------- | ----- |
| <img width="250" src="https://user-images.githubusercontent.com/9770186/124891204-625ad180-dff6-11eb-9551-34e5dd5a8650.png"></br><img width="250" src="https://user-images.githubusercontent.com/9770186/124891215-65ee5880-dff6-11eb-8fd1-e0f32062db7f.png"> | <img width="250" src="https://user-images.githubusercontent.com/9770186/124891372-8cac8f00-dff6-11eb-9822-abc61c6244cf.png"> |
| <img width="250" src="https://user-images.githubusercontent.com/1668582/112864325-b6fcc100-9085-11eb-9317-62dc9a96d086.png"> | <img width="250" src="https://user-images.githubusercontent.com/9770186/124901634-cd5cd600-dfff-11eb-8e16-c13e11d3a7e0.png"> |

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
