### PR TITLE
do not reset MapboxNavigationViewportDataSource state when the same route is provided twice

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/utils/DirectionsRouteEx.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/utils/DirectionsRouteEx.kt
@@ -13,7 +13,13 @@ fun DirectionsRoute.isSameUuid(compare: DirectionsRoute?): Boolean =
  * Compare routes as geometries(if exist) or as a names of [LegStep] of the [DirectionsRoute]
  */
 fun DirectionsRoute.isSameRoute(compare: DirectionsRoute?): Boolean {
-    if (compare == null) return false
+    if (this === compare) {
+        return true
+    }
+
+    if (compare == null) {
+        return false
+    }
 
     ifNonNull(this.geometry(), compare.geometry()) { g1, g2 ->
         return g1 == g2

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/internal/utils/DirectionsRouteExTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/internal/utils/DirectionsRouteExTest.kt
@@ -3,6 +3,7 @@ package com.mapbox.navigation.core.internal.utils
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.LegStep
 import com.mapbox.api.directions.v5.models.RouteLeg
+import io.mockk.every
 import io.mockk.mockk
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -12,6 +13,14 @@ class DirectionsRouteExTest {
 
     @Test
     fun isRouteTheSame() {
+        val mockkRoute = mockk<DirectionsRoute> {
+            every { geometry() } throws AssertionError(
+                "we should check reference first"
+            )
+            every { legs() } throws AssertionError(
+                "we should check reference first"
+            )
+        }
         val comparing = listOf<Triple<DirectionsRoute, DirectionsRoute?, Boolean>>(
             Triple(
                 getDirectionRouteBuilder().geometry("geomery").build(),
@@ -57,6 +66,11 @@ class DirectionsRouteExTest {
                     )
                 ).build(),
                 false
+            ),
+            Triple(
+                mockkRoute,
+                mockkRoute,
+                true
             )
         )
 

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/MapboxNavigationViewportDataSource.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/MapboxNavigationViewportDataSource.kt
@@ -391,33 +391,35 @@ class MapboxNavigationViewportDataSource(
      * @see [evaluate]
      */
     fun onRouteChanged(route: DirectionsRoute) {
-        clearRouteData()
-        this.route = route
-        completeRoutePoints = processRoutePoints(route)
-        simplifiedCompleteRoutePoints = simplifyCompleteRoutePoints(
-            options.overviewFrameOptions.geometrySimplification.enabled,
-            options.overviewFrameOptions.geometrySimplification.simplificationFactor,
-            completeRoutePoints
-        )
-        simplifiedRemainingPointsOnRoute = simplifiedCompleteRoutePoints.flatten().flatten()
-
-        options.followingFrameOptions.intersectionDensityCalculation.run {
-            averageIntersectionDistancesOnRoute = processRouteIntersections(
-                enabled,
-                minimumDistanceBetweenIntersections,
-                route,
+        if (!route.isSameRoute(this.route)) {
+            clearRouteData()
+            this.route = route
+            completeRoutePoints = processRoutePoints(route)
+            simplifiedCompleteRoutePoints = simplifyCompleteRoutePoints(
+                options.overviewFrameOptions.geometrySimplification.enabled,
+                options.overviewFrameOptions.geometrySimplification.simplificationFactor,
                 completeRoutePoints
             )
-        }
+            simplifiedRemainingPointsOnRoute = simplifiedCompleteRoutePoints.flatten().flatten()
 
-        options.followingFrameOptions.frameGeometryAfterManeuver.run {
-            postManeuverFramingPoints = processRouteForPostManeuverFramingGeometry(
-                enabled,
-                distanceToCoalesceCompoundManeuvers,
-                distanceToFrameAfterManeuver,
-                route,
-                completeRoutePoints
-            )
+            options.followingFrameOptions.intersectionDensityCalculation.run {
+                averageIntersectionDistancesOnRoute = processRouteIntersections(
+                    enabled,
+                    minimumDistanceBetweenIntersections,
+                    route,
+                    completeRoutePoints
+                )
+            }
+
+            options.followingFrameOptions.frameGeometryAfterManeuver.run {
+                postManeuverFramingPoints = processRouteForPostManeuverFramingGeometry(
+                    enabled,
+                    distanceToCoalesceCompoundManeuvers,
+                    distanceToFrameAfterManeuver,
+                    route,
+                    completeRoutePoints
+                )
+            }
         }
     }
 


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
This ensures that the camera doesn't behave unexpectedly when same route is provided twice. By the same route we mean a route that has the same geometry, so this resolves an issue that could most commonly be caused by a route refresh running in the background.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Fixed an issue where the `MapboxNavigationViewportDataSource` could produce an unexpected update when the same route was provided more than once, for example, during a route refresh update.</changelog>
```

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->
Visualization of an issue where the same route is provided every 5 seconds, whenever a light-blue line disappears and the camera unexpectedly changes perspective is when the route was reset because we were also clearing the progress state:

https://user-images.githubusercontent.com/16925074/124942168-af956e00-e00b-11eb-8826-617186f022f1.mp4


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
