### PR TITLE
Fix PredictiveCache crash

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/PredictiveCache.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/PredictiveCache.kt
@@ -7,26 +7,28 @@ import com.mapbox.navigator.PredictiveCacheController
 
 object PredictiveCache {
 
-    private val cachedNavigationPredictiveCacheControllers =
-        mutableListOf<PredictiveCacheController>()
-    private val cachedMapsPredictiveCacheControllers =
+    internal val cachedNavigationPredictiveCacheControllers =
+        mutableSetOf<PredictiveCacheController>()
+    internal val cachedMapsPredictiveCacheControllers =
         mutableMapOf<Any, MutableMap<String, PredictiveCacheController>>()
 
-    private val navPredictiveCacheLocationOptions =
-        mutableListOf<PredictiveCacheLocationOptions>()
-    private val mapsPredictiveCacheLocationOptions =
+    internal val navPredictiveCacheLocationOptions =
+        mutableSetOf<PredictiveCacheLocationOptions>()
+    internal val mapsPredictiveCacheLocationOptions =
         mutableMapOf<Any, MutableMap<String, Pair<TileStore, PredictiveCacheLocationOptions>>>()
 
-    init {
+    fun init() {
         // recreate controllers with the same options but with a new navigator instance
         MapboxNativeNavigatorImpl.setNativeNavigatorRecreationObserver {
-            cachedNavigationPredictiveCacheControllers.clear()
-            cachedMapsPredictiveCacheControllers.clear()
+            val navOptions = navPredictiveCacheLocationOptions.toSet()
+            val mapsOptions = mapsPredictiveCacheLocationOptions.toMap()
 
-            navPredictiveCacheLocationOptions.forEach {
+            clean()
+
+            navOptions.forEach {
                 createNavigationController(it)
             }
-            mapsPredictiveCacheLocationOptions.forEach { entry ->
+            mapsOptions.forEach { entry ->
                 entry.value.forEach {
                     createMapsController(
                         mapboxMap = entry.key,

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/internal/cache/PredictiveCacheTests.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/internal/cache/PredictiveCacheTests.kt
@@ -1,0 +1,220 @@
+package com.mapbox.navigation.core.internal.cache
+
+import com.mapbox.common.TileStore
+import com.mapbox.navigation.base.options.PredictiveCacheLocationOptions
+import com.mapbox.navigation.core.internal.PredictiveCache
+import com.mapbox.navigation.navigator.internal.MapboxNativeNavigatorImpl
+import com.mapbox.navigation.navigator.internal.NativeNavigatorRecreationObserver
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.slot
+import io.mockk.unmockkObject
+import io.mockk.verify
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class PredictiveCacheTests {
+
+    private val tileStore: TileStore = mockk()
+    private val navigatorRecreationCallbackSlot = slot<NativeNavigatorRecreationObserver>()
+
+    @Before
+    fun setUp() {
+        mockkObject(MapboxNativeNavigatorImpl)
+
+        every {
+            MapboxNativeNavigatorImpl.createNavigationPredictiveCacheController(any())
+        } returns mockk()
+
+        every {
+            MapboxNativeNavigatorImpl.createMapsPredictiveCacheController(any(), any(), any())
+        } returns mockk()
+
+        every {
+            MapboxNativeNavigatorImpl.setNativeNavigatorRecreationObserver(
+                capture(navigatorRecreationCallbackSlot)
+            )
+        } just Runs
+
+        PredictiveCache.clean()
+    }
+
+    @After
+    fun cleanUp() {
+        unmockkObject(MapboxNativeNavigatorImpl)
+    }
+
+    @Test
+    fun `size of map controllers is correct`() {
+        val map1 = mockk<Any>()
+        val map2 = mockk<Any>()
+
+        PredictiveCache.createMapsController(map1, tileStore, TILE_VARIANT_1, mockk())
+        PredictiveCache.createMapsController(map1, tileStore, TILE_VARIANT_2, mockk())
+        PredictiveCache.createMapsController(map1, tileStore, TILE_VARIANT_3, mockk())
+
+        PredictiveCache.createMapsController(map2, tileStore, TILE_VARIANT_4, mockk())
+        PredictiveCache.createMapsController(map2, tileStore, TILE_VARIANT_5, mockk())
+        PredictiveCache.createMapsController(map2, tileStore, TILE_VARIANT_6, mockk())
+        PredictiveCache.createMapsController(map2, tileStore, TILE_VARIANT_7, mockk())
+
+        assertEquals(3, PredictiveCache.currentMapsPredictiveCacheControllers(map1).size)
+        assertEquals(4, PredictiveCache.currentMapsPredictiveCacheControllers(map2).size)
+    }
+
+    @Test
+    fun `size of map controllers is correct after removing`() {
+        val map = mockk<Any>()
+
+        PredictiveCache.createMapsController(map, tileStore, TILE_VARIANT_1, mockk())
+        PredictiveCache.createMapsController(map, tileStore, TILE_VARIANT_2, mockk())
+        PredictiveCache.createMapsController(map, tileStore, TILE_VARIANT_3, mockk())
+        PredictiveCache.createMapsController(map, tileStore, TILE_VARIANT_4, mockk())
+
+        PredictiveCache.removeMapControllers(map, TILE_VARIANT_2)
+        PredictiveCache.removeMapControllers(map, TILE_VARIANT_1)
+        PredictiveCache.removeMapControllers(map, TILE_VARIANT_4)
+
+        assertEquals(1, PredictiveCache.currentMapsPredictiveCacheControllers(map).size)
+        assertEquals(1, PredictiveCache.cachedMapsPredictiveCacheControllers[map]?.size)
+        assertEquals(TILE_VARIANT_3, PredictiveCache.currentMapsPredictiveCacheControllers(map)[0])
+    }
+
+    @Test
+    fun `map controllers are empty after removing all`() {
+        val map = mockk<Any>()
+
+        PredictiveCache.createMapsController(map, tileStore, TILE_VARIANT_1, mockk())
+        PredictiveCache.createMapsController(map, tileStore, TILE_VARIANT_2, mockk())
+        PredictiveCache.createMapsController(map, tileStore, TILE_VARIANT_3, mockk())
+
+        PredictiveCache.removeAllMapControllers(map)
+
+        assertEquals(0, PredictiveCache.currentMapsPredictiveCacheControllers(map).size)
+        assertEquals(null, PredictiveCache.mapsPredictiveCacheLocationOptions[map])
+        assertEquals(null, PredictiveCache.cachedMapsPredictiveCacheControllers[map])
+    }
+
+    @Test
+    fun `controllers are recreated when navigator is recreated`() {
+        val navLocationOptions1: PredictiveCacheLocationOptions = mockk()
+        val navLocationOptions2: PredictiveCacheLocationOptions = mockk()
+
+        every {
+            MapboxNativeNavigatorImpl.createNavigationPredictiveCacheController(navLocationOptions1)
+        } returns mockk()
+
+        every {
+            MapboxNativeNavigatorImpl.createNavigationPredictiveCacheController(navLocationOptions2)
+        } returns mockk()
+
+        val map1 = mockk<Any>()
+        val map2 = mockk<Any>()
+
+        PredictiveCache.init()
+
+        PredictiveCache.createMapsController(map1, tileStore, TILE_VARIANT_1, mockk())
+        PredictiveCache.createMapsController(map1, tileStore, TILE_VARIANT_2, mockk())
+        PredictiveCache.createMapsController(map1, tileStore, TILE_VARIANT_3, mockk())
+
+        PredictiveCache.createMapsController(map2, tileStore, TILE_VARIANT_4, mockk())
+        PredictiveCache.createMapsController(map2, tileStore, TILE_VARIANT_5, mockk())
+        PredictiveCache.createMapsController(map2, tileStore, TILE_VARIANT_6, mockk())
+        PredictiveCache.createMapsController(map2, tileStore, TILE_VARIANT_7, mockk())
+
+        PredictiveCache.createNavigationController(navLocationOptions1)
+        PredictiveCache.createNavigationController(navLocationOptions2)
+
+        val callback = navigatorRecreationCallbackSlot.captured
+        callback.onNativeNavigatorRecreated()
+
+        assertEquals(2, PredictiveCache.cachedMapsPredictiveCacheControllers.size)
+        assertEquals(3, PredictiveCache.currentMapsPredictiveCacheControllers(map1).size)
+        assertEquals(4, PredictiveCache.currentMapsPredictiveCacheControllers(map2).size)
+
+        assertEquals(2, PredictiveCache.mapsPredictiveCacheLocationOptions.size)
+        assertEquals(3, PredictiveCache.mapsPredictiveCacheLocationOptions[map1]?.size)
+        assertEquals(4, PredictiveCache.mapsPredictiveCacheLocationOptions[map2]?.size)
+
+        assertEquals(2, PredictiveCache.cachedNavigationPredictiveCacheControllers.size)
+        assertEquals(2, PredictiveCache.navPredictiveCacheLocationOptions.size)
+
+        verify(exactly = 2) {
+            MapboxNativeNavigatorImpl.createMapsPredictiveCacheController(
+                tileStore, TILE_VARIANT_1, any()
+            )
+        }
+
+        verify(exactly = 2) {
+            MapboxNativeNavigatorImpl.createMapsPredictiveCacheController(
+                tileStore, TILE_VARIANT_2, any()
+            )
+        }
+
+        verify(exactly = 2) {
+            MapboxNativeNavigatorImpl.createMapsPredictiveCacheController(
+                tileStore, TILE_VARIANT_3, any()
+            )
+        }
+
+        verify(exactly = 2) {
+            MapboxNativeNavigatorImpl.createMapsPredictiveCacheController(
+                tileStore, TILE_VARIANT_4, any()
+            )
+        }
+
+        verify(exactly = 2) {
+            MapboxNativeNavigatorImpl.createMapsPredictiveCacheController(
+                tileStore, TILE_VARIANT_5, any()
+            )
+        }
+
+        verify(exactly = 2) {
+            MapboxNativeNavigatorImpl.createMapsPredictiveCacheController(
+                tileStore, TILE_VARIANT_6, any()
+            )
+        }
+
+        verify(exactly = 2) {
+            MapboxNativeNavigatorImpl.createMapsPredictiveCacheController(
+                tileStore, TILE_VARIANT_7, any()
+            )
+        }
+
+        verify(exactly = 2) {
+            MapboxNativeNavigatorImpl.createNavigationPredictiveCacheController(navLocationOptions1)
+        }
+
+        verify(exactly = 2) {
+            MapboxNativeNavigatorImpl.createNavigationPredictiveCacheController(navLocationOptions2)
+        }
+    }
+
+    @Test
+    fun `caches are empty after clean`() {
+        PredictiveCache.createMapsController(mockk(), tileStore, TILE_VARIANT_1, mockk())
+        PredictiveCache.createNavigationController(mockk())
+
+        PredictiveCache.clean()
+
+        assertEquals(0, PredictiveCache.cachedNavigationPredictiveCacheControllers.size)
+        assertEquals(0, PredictiveCache.cachedMapsPredictiveCacheControllers.size)
+        assertEquals(0, PredictiveCache.navPredictiveCacheLocationOptions.size)
+        assertEquals(0, PredictiveCache.mapsPredictiveCacheLocationOptions.size)
+    }
+
+    private companion object {
+        private const val TILE_VARIANT_1 = "tile_variant_1"
+        private const val TILE_VARIANT_2 = "tile_variant_2"
+        private const val TILE_VARIANT_3 = "tile_variant_3"
+        private const val TILE_VARIANT_4 = "tile_variant_4"
+        private const val TILE_VARIANT_5 = "tile_variant_5"
+        private const val TILE_VARIANT_6 = "tile_variant_6"
+        private const val TILE_VARIANT_7 = "tile_variant_7"
+    }
+}

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/PredictiveCacheController.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/PredictiveCacheController.kt
@@ -64,6 +64,7 @@ class PredictiveCacheController @JvmOverloads constructor(
     private var mapListeners = mutableMapOf<MapboxMap, OnStyleLoadedListener>()
 
     init {
+        PredictiveCache.init()
         PredictiveCache.createNavigationController(predictiveCacheLocationOptions)
     }
 


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Fix PredictiveCache crash
closes #4603 

`ArrayList`s were used to store nav controllers and options. Lists do not allow to iterate and modify the content.
At the same time we should prevent duplicates in the list.
It's enough to replace lists with sets.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Fixed PredictiveCache ConcurrentModificationException crash, covered it with tests</changelog>
```

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
