### PR TITLE
move MapboxDistanceFormatter to a public package

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxCustomStyleActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxCustomStyleActivity.kt
@@ -30,7 +30,7 @@ import com.mapbox.navigation.base.route.RouterCallback
 import com.mapbox.navigation.base.route.RouterFailure
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesObserver
-import com.mapbox.navigation.core.internal.formatter.MapboxDistanceFormatter
+import com.mapbox.navigation.core.formatter.MapboxDistanceFormatter
 import com.mapbox.navigation.core.replay.MapboxReplayer
 import com.mapbox.navigation.core.replay.ReplayLocationEngine
 import com.mapbox.navigation.core.replay.route.ReplayProgressObserver

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxManeuverActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxManeuverActivity.kt
@@ -30,7 +30,7 @@ import com.mapbox.navigation.base.route.RouterCallback
 import com.mapbox.navigation.base.route.RouterFailure
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesObserver
-import com.mapbox.navigation.core.internal.formatter.MapboxDistanceFormatter
+import com.mapbox.navigation.core.formatter.MapboxDistanceFormatter
 import com.mapbox.navigation.core.replay.MapboxReplayer
 import com.mapbox.navigation.core.replay.ReplayLocationEngine
 import com.mapbox.navigation.core.replay.route.ReplayProgressObserver

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxNavigationActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxNavigationActivity.kt
@@ -34,7 +34,7 @@ import com.mapbox.navigation.base.route.RouterFailure
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesObserver
-import com.mapbox.navigation.core.internal.formatter.MapboxDistanceFormatter
+import com.mapbox.navigation.core.formatter.MapboxDistanceFormatter
 import com.mapbox.navigation.core.trip.session.LocationObserver
 import com.mapbox.navigation.core.trip.session.RouteProgressObserver
 import com.mapbox.navigation.core.trip.session.VoiceInstructionsObserver

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/formatter/DistanceFormatterOptions.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/formatter/DistanceFormatterOptions.kt
@@ -8,6 +8,8 @@ import java.util.Locale
 /**
  * Gives options to format the distance in the trip notification.
  *
+ * If not provided, the object will infer device language and unit type using the device locale from the context.
+ *
  * @param applicationContext from which to get localized strings from
  * @param locale the locale to use for localization of distance resources
  * @param unitType to use for voice and visual information.

--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -108,6 +108,17 @@ package com.mapbox.navigation.core.directions.session {
 
 }
 
+package com.mapbox.navigation.core.formatter {
+
+  public final class MapboxDistanceFormatter implements com.mapbox.navigation.base.formatter.DistanceFormatter {
+    ctor public MapboxDistanceFormatter(com.mapbox.navigation.base.formatter.DistanceFormatterOptions options);
+    method public android.text.SpannableString formatDistance(double distance);
+    method public com.mapbox.navigation.base.formatter.DistanceFormatterOptions getOptions();
+    property public final com.mapbox.navigation.base.formatter.DistanceFormatterOptions options;
+  }
+
+}
+
 package com.mapbox.navigation.core.history {
 
   public final class MapboxHistoryReader implements java.util.Iterator<com.mapbox.navigation.core.history.model.HistoryEvent> kotlin.jvm.internal.markers.KMappedMarker {

--- a/libnavigation-core/src/androidTest/java/com/mapbox/navigation/core/tests/activity/TripServiceActivity.kt
+++ b/libnavigation-core/src/androidTest/java/com/mapbox/navigation/core/tests/activity/TripServiceActivity.kt
@@ -14,7 +14,7 @@ import com.mapbox.navigation.base.formatter.DistanceFormatter
 import com.mapbox.navigation.base.internal.factory.TripNotificationStateFactory.buildTripNotificationState
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.trip.notification.TripNotification
-import com.mapbox.navigation.core.internal.formatter.MapboxDistanceFormatter
+import com.mapbox.navigation.core.formatter.MapboxDistanceFormatter
 import com.mapbox.navigation.core.test.R
 import com.mapbox.navigation.core.trip.service.MapboxTripService
 import com.mapbox.navigation.utils.internal.ThreadController

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -36,11 +36,11 @@ import com.mapbox.navigation.core.arrival.ArrivalProgressObserver
 import com.mapbox.navigation.core.arrival.AutoArrivalController
 import com.mapbox.navigation.core.directions.session.DirectionsSession
 import com.mapbox.navigation.core.directions.session.RoutesObserver
+import com.mapbox.navigation.core.formatter.MapboxDistanceFormatter
 import com.mapbox.navigation.core.history.MapboxHistoryReader
 import com.mapbox.navigation.core.history.MapboxHistoryRecorder
 import com.mapbox.navigation.core.internal.ReachabilityService
 import com.mapbox.navigation.core.internal.accounts.MapboxNavigationAccounts
-import com.mapbox.navigation.core.internal.formatter.MapboxDistanceFormatter
 import com.mapbox.navigation.core.internal.utils.InternalUtils
 import com.mapbox.navigation.core.navigator.TilesetDescriptorFactory
 import com.mapbox.navigation.core.reroute.MapboxRerouteController

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/formatter/MapboxDistanceFormatter.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/formatter/MapboxDistanceFormatter.kt
@@ -1,4 +1,4 @@
-package com.mapbox.navigation.core.internal.formatter
+package com.mapbox.navigation.core.formatter
 
 import android.content.Context
 import android.content.res.Configuration
@@ -19,10 +19,8 @@ import java.util.Locale
 import kotlin.math.roundToInt
 
 /**
- * Creates an instance of DistanceFormatter, which can format distances in meters
+ * Implementation of DistanceFormatter, which can format distances in meters
  * based on a language format and unit type.
- *
- * This constructor will infer device language and unit type using the device locale.
  *
  * @param options to build the [MapboxDistanceFormatter]
  */
@@ -40,7 +38,7 @@ class MapboxDistanceFormatter(
         UnitType.METRIC -> TurfConstants.UNIT_KILOMETERS
     }
 
-    companion object {
+    private companion object {
         private const val smallDistanceUpperThresholdInMeters = 400.0
         private const val mediumDistanceUpperThresholdInMeters = 10000.0
     }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/formatter/MapboxDistanceFormatterTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/formatter/MapboxDistanceFormatterTest.kt
@@ -1,4 +1,4 @@
-package com.mapbox.navigation.core.internal.formatter
+package com.mapbox.navigation.core.formatter
 
 import android.content.Context
 import android.graphics.Typeface

--- a/libnavui-maneuver/src/test/java/com/mapbox/navigation/ui/maneuver/view/MapboxUpcomingManeuverAdapterTest.kt
+++ b/libnavui-maneuver/src/test/java/com/mapbox/navigation/ui/maneuver/view/MapboxUpcomingManeuverAdapterTest.kt
@@ -9,7 +9,7 @@ import com.mapbox.api.directions.v5.models.BannerComponents
 import com.mapbox.api.directions.v5.models.ManeuverModifier
 import com.mapbox.api.directions.v5.models.StepManeuver
 import com.mapbox.navigation.base.formatter.DistanceFormatterOptions
-import com.mapbox.navigation.core.internal.formatter.MapboxDistanceFormatter
+import com.mapbox.navigation.core.formatter.MapboxDistanceFormatter
 import com.mapbox.navigation.ui.maneuver.model.Component
 import com.mapbox.navigation.ui.maneuver.model.Maneuver
 import com.mapbox.navigation.ui.maneuver.model.PrimaryManeuver

--- a/libnavui-tripprogress/src/main/java/com/mapbox/navigation/ui/tripprogress/model/DistanceRemainingFormatter.kt
+++ b/libnavui-tripprogress/src/main/java/com/mapbox/navigation/ui/tripprogress/model/DistanceRemainingFormatter.kt
@@ -2,7 +2,7 @@ package com.mapbox.navigation.ui.tripprogress.model
 
 import android.text.SpannableString
 import com.mapbox.navigation.base.formatter.DistanceFormatterOptions
-import com.mapbox.navigation.core.internal.formatter.MapboxDistanceFormatter
+import com.mapbox.navigation.core.formatter.MapboxDistanceFormatter
 import com.mapbox.navigation.ui.base.formatter.ValueFormatter
 
 /**


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Moves the `MapboxDistanceFormatter` into a public package. We're advertising using this implementation to developers, so we should maintain it in a public package.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Changed `MapboxDistanceFormatter`'s package from `com.mapbox.navigation.core.internal.formatter` to `com.mapbox.navigation.core.formatter`, making it stable.</changelog>
```

