### PR TITLE
Bump `mapbox-navigation-native` dependency version to `48.0.7`

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -11,7 +11,7 @@ ext {
   // version which we should use in this build
   def mapboxNavigatorVersion = System.getenv("FORCE_MAPBOX_NAVIGATION_NATIVE_VERSION")
   if (mapboxNavigatorVersion == null || mapboxNavigatorVersion == '') {
-      mapboxNavigatorVersion = '48.0.6'
+      mapboxNavigatorVersion = '48.0.7'
   }
   println("Navigation Native version: " + mapboxNavigatorVersion)
 


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Bumps `mapbox-navigation-native` dependency version to `48.0.7`

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Added ability to restore from "backwards snapping" issue: set `noRouteLength` to 150m.</changelog>
```

cc @zugaldia @dudeuter @etl @mskurydin 
