### PR TITLE
The initialization of the route line related layers is always a synchronous call.

### DIFF
--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineView.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineView.kt
@@ -52,11 +52,7 @@ class MapboxRouteLineView(var options: MapboxRouteLineOptions) {
      * @param style a valid [Style] instance
      */
     fun initializeLayers(style: Style) {
-        jobControl.scope.launch {
-            mutex.withLock {
-                initializeLayers(style, options)
-            }
-        }
+        initializeLayers(style, options)
     }
 
     /**
@@ -66,6 +62,7 @@ class MapboxRouteLineView(var options: MapboxRouteLineOptions) {
      * @param routeDrawData a [Expected<RouteLineError, RouteSetValue>]
      */
     fun renderRouteDrawData(style: Style, routeDrawData: Expected<RouteLineError, RouteSetValue>) {
+        initializeLayers(style, options)
         routeDrawData.fold(
             { error ->
                 Log.e(TAG, error.errorMessage)
@@ -73,8 +70,6 @@ class MapboxRouteLineView(var options: MapboxRouteLineOptions) {
             { value ->
                 jobControl.scope.launch {
                     mutex.withLock {
-                        initializeLayers(style, options)
-
                         updateLineGradient(
                             style,
                             RouteLayerConstants.PRIMARY_ROUTE_TRAFFIC_LAYER_ID,
@@ -174,11 +169,10 @@ class MapboxRouteLineView(var options: MapboxRouteLineOptions) {
         style: Style,
         update: Expected<RouteLineError, VanishingRouteLineUpdateValue>
     ) {
+        initializeLayers(style, options)
         jobControl.scope.launch {
             mutex.withLock {
                 update.onValue {
-                    initializeLayers(style, options)
-
                     updateLineGradient(
                         style,
                         RouteLayerConstants.PRIMARY_ROUTE_TRAFFIC_LAYER_ID,
@@ -209,11 +203,10 @@ class MapboxRouteLineView(var options: MapboxRouteLineOptions) {
         style: Style,
         clearRouteLineValue: Expected<RouteLineError, RouteLineClearValue>
     ) {
+        initializeLayers(style, options)
         jobControl.scope.launch {
             mutex.withLock {
                 clearRouteLineValue.onValue {
-                    initializeLayers(style, options)
-
                     updateSource(
                         style,
                         RouteConstants.PRIMARY_ROUTE_SOURCE_ID,

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineViewTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineViewTest.kt
@@ -127,7 +127,7 @@ class MapboxRouteLineViewTest {
     }
 
     @Test
-    fun renderClearRouteDataState() {
+    fun renderClearRouteDataState() = coroutineRule.runBlockingTest {
         mockkStatic("com.mapbox.maps.extension.style.sources.SourceKt")
         mockkObject(MapboxRouteLineUtils)
         val options = MapboxRouteLineOptions.Builder(ctx).build()
@@ -159,7 +159,10 @@ class MapboxRouteLineViewTest {
             )
         )
 
-        MapboxRouteLineView(options).renderClearRouteLineValue(style, state)
+        pauseDispatcher {
+            MapboxRouteLineView(options).renderClearRouteLineValue(style, state)
+            verify { MapboxRouteLineUtils.initializeLayers(style, options) }
+        }
 
         verify { primaryRouteSource.featureCollection(primaryRouteFeatureCollection) }
         verify { altRoute1Source.featureCollection(altRoutesFeatureCollection) }
@@ -171,7 +174,7 @@ class MapboxRouteLineViewTest {
     }
 
     @Test
-    fun renderTraveledRouteLineUpdate() {
+    fun renderTraveledRouteLineUpdate() = coroutineRule.runBlockingTest {
         mockkStatic("com.mapbox.maps.extension.style.layers.LayerKt")
         mockkObject(MapboxRouteLineUtils)
         val options = MapboxRouteLineOptions.Builder(ctx).build()
@@ -205,12 +208,14 @@ class MapboxRouteLineViewTest {
             mockCheckForLayerInitialization(it)
         }
 
-        MapboxRouteLineView(options).renderVanishingRouteLineUpdateValue(style, state)
+        pauseDispatcher {
+            MapboxRouteLineView(options).renderVanishingRouteLineUpdateValue(style, state)
+            verify { MapboxRouteLineUtils.initializeLayers(style, options) }
+        }
 
         verify { primaryRouteTrafficLayer.lineGradient(trafficLineExp) }
         verify { primaryRouteLayer.lineGradient(routeLineExp) }
         verify { primaryRouteCasingLayer.lineGradient(casingLineEx) }
-        verify { MapboxRouteLineUtils.initializeLayers(style, options) }
         unmockkObject(MapboxRouteLineUtils)
         unmockkStatic("com.mapbox.maps.extension.style.layers.LayerKt")
     }
@@ -282,7 +287,10 @@ class MapboxRouteLineViewTest {
             mockCheckForLayerInitialization(it)
         }
 
-        MapboxRouteLineView(options).renderRouteDrawData(style, state)
+        pauseDispatcher {
+            MapboxRouteLineView(options).renderRouteDrawData(style, state)
+            verify { MapboxRouteLineUtils.initializeLayers(style, options) }
+        }
 
         verify { primaryRouteTrafficLayer.lineGradient(Expression.color(Color.TRANSPARENT)) }
         verify { altRouteTrafficLayer1.lineGradient(Expression.color(Color.TRANSPARENT)) }
@@ -296,7 +304,6 @@ class MapboxRouteLineViewTest {
         verify { altRoute1Source.featureCollection(alternativeRoute1FeatureCollection) }
         verify { altRoute2Source.featureCollection(alternativeRoute2FeatureCollection) }
         verify { wayPointSource.featureCollection(waypointsFeatureCollection) }
-        verify { MapboxRouteLineUtils.initializeLayers(style, options) }
         unmockkObject(MapboxRouteLineUtils)
         unmockkStatic("com.mapbox.maps.extension.style.layers.LayerKt")
         unmockkStatic("com.mapbox.maps.extension.style.sources.SourceKt")


### PR DESCRIPTION
### Description
Resolves #4627 by making the initialization of the route line related layers always a synchronous call.

### Changelog
```
<changelog>The initialization of the route line related layers is always a synchronous call.</changelog>
```

### Screenshots or Gifs

