### PR TITLE
Fix large timestamp replay example issue

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayHistoryActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayHistoryActivity.kt
@@ -30,7 +30,6 @@ import com.mapbox.navigation.core.replay.ReplayLocationEngine
 import com.mapbox.navigation.core.replay.history.ReplayEventBase
 import com.mapbox.navigation.core.replay.history.ReplayEventsObserver
 import com.mapbox.navigation.core.replay.history.ReplaySetRoute
-import com.mapbox.navigation.core.replay.route.ReplayProgressObserver
 import com.mapbox.navigation.core.trip.session.LocationObserver
 import com.mapbox.navigation.examples.core.databinding.ActivityReplayHistoryLayoutBinding
 import com.mapbox.navigation.examples.core.replay.HistoryFileLoader
@@ -52,7 +51,6 @@ class ReplayHistoryActivity : AppCompatActivity() {
     private var loadNavigationJob: Job? = null
     private val mapboxReplayer = MapboxReplayer()
     private val historyFileLoader = HistoryFileLoader()
-    private val replayProgressObserver = ReplayProgressObserver(mapboxReplayer)
     private val navigationLocationProvider = NavigationLocationProvider()
     private val locationEngineCallback = MyLocationEngineCallback(this)
     private lateinit var mapboxNavigation: MapboxNavigation
@@ -84,7 +82,6 @@ class ReplayHistoryActivity : AppCompatActivity() {
         binding.mapView.onStart()
         if (::mapboxNavigation.isInitialized) {
             mapboxNavigation.registerLocationObserver(locationObserver)
-            mapboxNavigation.registerRouteProgressObserver(replayProgressObserver)
         }
     }
 
@@ -92,7 +89,6 @@ class ReplayHistoryActivity : AppCompatActivity() {
         super.onStop()
         if (::mapboxNavigation.isInitialized) {
             mapboxNavigation.unregisterLocationObserver(locationObserver)
-            mapboxNavigation.unregisterRouteProgressObserver(replayProgressObserver)
         }
         binding.mapView.onStop()
     }


### PR DESCRIPTION


### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Fix ReplayHistoryActivty issue with large durations and skipping to different routes.

The explanation for this issue is:
1. History event timestamps are real timestamps, e.g., 1585549464.255122 seconds
2. Simulated routes have simulated timestamps, e.g., 0.0 to 2000.0 seconds

The `ReplayProgressObserver` is used for simulating routes but not for historical files. Mixing history files with simulated would have a few issues to resolve. The ReplayHistoryActivty is not for simulating routes, but for replaying history files. So we don't want to use `ReplayProgressObserver` here.

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->

| Before | After |
| -- | -- |
| <img width="371" alt="Screen Shot 2021-07-19 at 12 57 46 PM" src="https://user-images.githubusercontent.com/3021882/126219640-67a99a49-0124-4c8c-be81-91c944b7c9a1.png"> | <img width="387" alt="Screen Shot 2021-07-19 at 1 06 48 PM" src="https://user-images.githubusercontent.com/3021882/126220507-dbc0bca1-68ce-4aef-a624-dd5d476c61c0.png">|

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
