### PR TITLE
Adding check for route with insufficient geometry coordinates to rend…

### DIFF
--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApi.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApi.kt
@@ -603,6 +603,15 @@ class MapboxRouteLineApi(
             featureDataProvider()
         }
         val routeFeatureDataResult = routeFeatureDataDef.await()
+        if (routeFeatureDataResult.count { it.lineString.coordinates().size < 2 } > 0) {
+            return ExpectedFactory.createError(
+                RouteLineError(
+                    "The route geometry contained less than two coordinates. " +
+                        "At least two coordinates are required to render a route line.",
+                    null
+                )
+            )
+        }
         routeFeatureData.clear()
         routeFeatureData.addAll(routeFeatureDataResult)
 

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApiTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApiTest.kt
@@ -54,6 +54,7 @@ import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -124,6 +125,24 @@ class MapboxRouteLineApiTest {
 
         assertEquals(result.size, routes.size)
         assertEquals(result[0], routes[0].route)
+    }
+
+    @Test
+    fun setRoutes_whenRouteCoordinatesAreEmpty() = coroutineRule.runBlockingTest {
+        val options = MapboxRouteLineOptions.Builder(ctx).build()
+        val api = MapboxRouteLineApi(options)
+        val route = getRoute()
+        val augmentedLineString =
+            LineString.fromJson("{\"type\":\"LineString\",\"coordinates\":[]}")
+                .toPolyline(Constants.PRECISION_6)
+        val augmentedRouteJson = route.toJson()
+            .replace("etylgAl`guhFpJrBh@kHbC{[nAZ", augmentedLineString)
+        val augmentedRoute = DirectionsRoute.fromJson(augmentedRouteJson)
+
+        val result = api.setRoutes(listOf(RouteLine(augmentedRoute, null)))
+
+        assertNotNull(result.error)
+        assertNull(result.value)
     }
 
     @Test


### PR DESCRIPTION
### Description
Fixes #4562 by checking for routes that have less than 2 coordinates which result in an invalid `FeatureCollection` and hence a crash. 

### Changelog
```
<changelog>Bug fix for invalid FeatureCollection objects derived from routes that have less than two coordinates.</changelog>
```

