### PR TITLE
Kyv router origin

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/IndependentRouteGenerationActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/IndependentRouteGenerationActivity.kt
@@ -33,6 +33,7 @@ import com.mapbox.navigation.base.formatter.DistanceFormatterOptions
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.route.RouterCallback
 import com.mapbox.navigation.base.route.RouterFailure
+import com.mapbox.navigation.base.route.RouterOrigin
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesObserver
 import com.mapbox.navigation.core.replay.MapboxReplayer
@@ -217,7 +218,10 @@ class IndependentRouteGenerationActivity : AppCompatActivity() {
         routeRequestId = mapboxNavigation.requestRoutes(
             routeOptions,
             object : RouterCallback {
-                override fun onRoutesReady(routes: List<DirectionsRoute>) {
+                override fun onRoutesReady(
+                    routes: List<DirectionsRoute>,
+                    routerOrigin: RouterOrigin
+                ) {
                     lineManager.create(
                         PolylineAnnotationOptions.fromFeature(
                             Feature.fromGeometry(
@@ -250,7 +254,7 @@ class IndependentRouteGenerationActivity : AppCompatActivity() {
                     clearRouteSelectionUi()
                 }
 
-                override fun onCanceled(routeOptions: RouteOptions) {
+                override fun onCanceled(routeOptions: RouteOptions, routerOrigin: RouterOrigin) {
                     Toast.makeText(
                         this@IndependentRouteGenerationActivity,
                         """Route request "$routeRequestId" canceled.""",

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxBuildingHighlightActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxBuildingHighlightActivity.kt
@@ -24,6 +24,7 @@ import com.mapbox.navigation.base.extensions.applyLanguageAndVoiceUnitOptions
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.route.RouterCallback
 import com.mapbox.navigation.base.route.RouterFailure
+import com.mapbox.navigation.base.route.RouterOrigin
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesObserver
@@ -233,7 +234,10 @@ class MapboxBuildingHighlightActivity : AppCompatActivity(), OnMapLongClickListe
         mapboxNavigation.requestRoutes(
             routeOptions,
             object : RouterCallback {
-                override fun onRoutesReady(routes: List<DirectionsRoute>) {
+                override fun onRoutesReady(
+                    routes: List<DirectionsRoute>,
+                    routerOrigin: RouterOrigin
+                ) {
                     mapboxNavigation.setRoutes(routes)
                 }
 
@@ -244,7 +248,7 @@ class MapboxBuildingHighlightActivity : AppCompatActivity(), OnMapLongClickListe
                     // no impl
                 }
 
-                override fun onCanceled(routeOptions: RouteOptions) {
+                override fun onCanceled(routeOptions: RouteOptions, routerOrigin: RouterOrigin) {
                     // no impl
                 }
             }

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxCustomStyleActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxCustomStyleActivity.kt
@@ -27,6 +27,7 @@ import com.mapbox.navigation.base.formatter.DistanceFormatterOptions
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.route.RouterCallback
 import com.mapbox.navigation.base.route.RouterFailure
+import com.mapbox.navigation.base.route.RouterOrigin
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesObserver
 import com.mapbox.navigation.core.formatter.MapboxDistanceFormatter
@@ -238,7 +239,10 @@ class MapboxCustomStyleActivity : AppCompatActivity(), OnMapLongClickListener {
                 .annotationsList(Collections.singletonList(DirectionsCriteria.ANNOTATION_MAXSPEED))
                 .build(),
             object : RouterCallback {
-                override fun onRoutesReady(routes: List<DirectionsRoute>) {
+                override fun onRoutesReady(
+                    routes: List<DirectionsRoute>,
+                    routerOrigin: RouterOrigin
+                ) {
                     mapboxNavigation.setRoutes(routes)
                 }
 
@@ -249,7 +253,7 @@ class MapboxCustomStyleActivity : AppCompatActivity(), OnMapLongClickListener {
                     // no impl
                 }
 
-                override fun onCanceled(routeOptions: RouteOptions) {
+                override fun onCanceled(routeOptions: RouteOptions, routerOrigin: RouterOrigin) {
                     // no impl
                 }
             }

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxJunctionActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxJunctionActivity.kt
@@ -26,6 +26,7 @@ import com.mapbox.navigation.base.extensions.applyLanguageAndVoiceUnitOptions
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.route.RouterCallback
 import com.mapbox.navigation.base.route.RouterFailure
+import com.mapbox.navigation.base.route.RouterOrigin
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesObserver
@@ -223,7 +224,10 @@ class MapboxJunctionActivity : AppCompatActivity(), OnMapLongClickListener {
                 .alternatives(true)
                 .build(),
             object : RouterCallback {
-                override fun onRoutesReady(routes: List<DirectionsRoute>) {
+                override fun onRoutesReady(
+                    routes: List<DirectionsRoute>,
+                    routerOrigin: RouterOrigin
+                ) {
                     mapboxNavigation.setRoutes(routes)
                 }
 
@@ -234,7 +238,7 @@ class MapboxJunctionActivity : AppCompatActivity(), OnMapLongClickListener {
                     // no impl
                 }
 
-                override fun onCanceled(routeOptions: RouteOptions) {
+                override fun onCanceled(routeOptions: RouteOptions, routerOrigin: RouterOrigin) {
                     // no impl
                 }
             }

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxManeuverActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxManeuverActivity.kt
@@ -29,6 +29,7 @@ import com.mapbox.navigation.base.formatter.DistanceFormatterOptions
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.route.RouterCallback
 import com.mapbox.navigation.base.route.RouterFailure
+import com.mapbox.navigation.base.route.RouterOrigin
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesObserver
 import com.mapbox.navigation.core.formatter.MapboxDistanceFormatter
@@ -251,7 +252,10 @@ class MapboxManeuverActivity : AppCompatActivity(), OnMapLongClickListener {
         mapboxNavigation.requestRoutes(
             routeOptions,
             object : RouterCallback {
-                override fun onRoutesReady(routes: List<DirectionsRoute>) {
+                override fun onRoutesReady(
+                    routes: List<DirectionsRoute>,
+                    routerOrigin: RouterOrigin
+                ) {
                     mapboxNavigation.setRoutes(routes)
                 }
 
@@ -262,7 +266,7 @@ class MapboxManeuverActivity : AppCompatActivity(), OnMapLongClickListener {
                     // no impl
                 }
 
-                override fun onCanceled(routeOptions: RouteOptions) {
+                override fun onCanceled(routeOptions: RouteOptions, routerOrigin: RouterOrigin) {
                     // no impl
                 }
             }

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxNavigationActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxNavigationActivity.kt
@@ -31,6 +31,7 @@ import com.mapbox.navigation.base.formatter.DistanceFormatterOptions
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.route.RouterCallback
 import com.mapbox.navigation.base.route.RouterFailure
+import com.mapbox.navigation.base.route.RouterOrigin
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesObserver
@@ -483,8 +484,11 @@ class MapboxNavigationActivity : AppCompatActivity() {
                 .coordinates(listOf(origin, destination))
                 .build(),
             object : RouterCallback {
-                override fun onRoutesReady(routes: List<DirectionsRoute>) {
-                    setRouteAndStartNavigation(routes.first())
+                override fun onRoutesReady(
+                    routes: List<DirectionsRoute>,
+                    routerOrigin: RouterOrigin
+                ) {
+                    setRouteAndStartNavigation(routes.first(), routerOrigin)
                 }
 
                 override fun onFailure(
@@ -494,14 +498,14 @@ class MapboxNavigationActivity : AppCompatActivity() {
                     // no impl
                 }
 
-                override fun onCanceled(routeOptions: RouteOptions) {
+                override fun onCanceled(routeOptions: RouteOptions, routerOrigin: RouterOrigin) {
                     // no impl
                 }
             }
         )
     }
 
-    private fun setRouteAndStartNavigation(route: DirectionsRoute) {
+    private fun setRouteAndStartNavigation(route: DirectionsRoute, routerOrigin: RouterOrigin) {
         // set route
         mapboxNavigation.setRoutes(listOf(route))
 

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxRouteLineAndArrowActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxRouteLineAndArrowActivity.kt
@@ -36,6 +36,7 @@ import com.mapbox.navigation.base.extensions.applyLanguageAndVoiceUnitOptions
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.route.RouterCallback
 import com.mapbox.navigation.base.route.RouterFailure
+import com.mapbox.navigation.base.route.RouterOrigin
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesObserver
 import com.mapbox.navigation.core.replay.MapboxReplayer
@@ -208,6 +209,7 @@ class MapboxRouteLineAndArrowActivity : AppCompatActivity(), OnMapLongClickListe
         // to the MapboxRouteLineApi to generate the data necessary to draw the route(s)
         // on the map.
         val routeLines = routes.map { RouteLine(it, null) }
+
         routeLineApi.setRoutes(
             routeLines
         ) { value ->
@@ -380,7 +382,7 @@ class MapboxRouteLineAndArrowActivity : AppCompatActivity(), OnMapLongClickListe
     }
 
     private val routesReqCallback: RouterCallback = object : RouterCallback {
-        override fun onRoutesReady(routes: List<DirectionsRoute>) {
+        override fun onRoutesReady(routes: List<DirectionsRoute>, routerOrigin: RouterOrigin) {
             mapboxNavigation.setRoutes(routes)
             if (routes.isNotEmpty()) {
                 viewBinding.routeLoadingProgressBar.visibility = View.INVISIBLE
@@ -388,7 +390,7 @@ class MapboxRouteLineAndArrowActivity : AppCompatActivity(), OnMapLongClickListe
             }
         }
 
-        override fun onCanceled(routeOptions: RouteOptions) {
+        override fun onCanceled(routeOptions: RouteOptions, routerOrigin: RouterOrigin) {
             viewBinding.routeLoadingProgressBar.visibility = View.INVISIBLE
         }
 

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxSignboardActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxSignboardActivity.kt
@@ -27,6 +27,7 @@ import com.mapbox.navigation.base.extensions.applyLanguageAndVoiceUnitOptions
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.route.RouterCallback
 import com.mapbox.navigation.base.route.RouterFailure
+import com.mapbox.navigation.base.route.RouterOrigin
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesObserver
@@ -228,7 +229,10 @@ class MapboxSignboardActivity : AppCompatActivity(), OnMapLongClickListener {
                 .coordinates(listOf(origin, destination))
                 .build(),
             object : RouterCallback {
-                override fun onRoutesReady(routes: List<DirectionsRoute>) {
+                override fun onRoutesReady(
+                    routes: List<DirectionsRoute>,
+                    routerOrigin: RouterOrigin
+                ) {
                     mapboxNavigation.setRoutes(routes)
                 }
 
@@ -239,7 +243,7 @@ class MapboxSignboardActivity : AppCompatActivity(), OnMapLongClickListener {
                     // no impl
                 }
 
-                override fun onCanceled(routeOptions: RouteOptions) {
+                override fun onCanceled(routeOptions: RouteOptions, routerOrigin: RouterOrigin) {
                     // no impl
                 }
             }

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxSnapshotActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxSnapshotActivity.kt
@@ -25,6 +25,7 @@ import com.mapbox.navigation.base.extensions.applyLanguageAndVoiceUnitOptions
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.route.RouterCallback
 import com.mapbox.navigation.base.route.RouterFailure
+import com.mapbox.navigation.base.route.RouterOrigin
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesObserver
@@ -223,7 +224,10 @@ class MapboxSnapshotActivity : AppCompatActivity(), OnMapLongClickListener {
                 .coordinates(listOf(origin, destination))
                 .build(),
             object : RouterCallback {
-                override fun onRoutesReady(routes: List<DirectionsRoute>) {
+                override fun onRoutesReady(
+                    routes: List<DirectionsRoute>,
+                    routerOrigin: RouterOrigin
+                ) {
                     mapboxNavigation.setRoutes(routes)
                 }
 
@@ -234,7 +238,7 @@ class MapboxSnapshotActivity : AppCompatActivity(), OnMapLongClickListener {
                     // no impl
                 }
 
-                override fun onCanceled(routeOptions: RouteOptions) {
+                override fun onCanceled(routeOptions: RouteOptions, routerOrigin: RouterOrigin) {
                     // no impl
                 }
             }

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxTripProgressActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxTripProgressActivity.kt
@@ -24,6 +24,7 @@ import com.mapbox.navigation.base.formatter.DistanceFormatterOptions
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.route.RouterCallback
 import com.mapbox.navigation.base.route.RouterFailure
+import com.mapbox.navigation.base.route.RouterOrigin
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesObserver
@@ -248,7 +249,10 @@ class MapboxTripProgressActivity : AppCompatActivity(), OnMapLongClickListener {
         mapboxNavigation.requestRoutes(
             routeOptions,
             object : RouterCallback {
-                override fun onRoutesReady(routes: List<DirectionsRoute>) {
+                override fun onRoutesReady(
+                    routes: List<DirectionsRoute>,
+                    routerOrigin: RouterOrigin
+                ) {
                     mapboxNavigation.setRoutes(routes)
                 }
 
@@ -259,7 +263,7 @@ class MapboxTripProgressActivity : AppCompatActivity(), OnMapLongClickListener {
                     // no impl
                 }
 
-                override fun onCanceled(routeOptions: RouteOptions) {
+                override fun onCanceled(routeOptions: RouteOptions, routerOrigin: RouterOrigin) {
                     // no impl
                 }
             }

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxVoiceActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxVoiceActivity.kt
@@ -24,6 +24,7 @@ import com.mapbox.navigation.base.extensions.applyLanguageAndVoiceUnitOptions
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.route.RouterCallback
 import com.mapbox.navigation.base.route.RouterFailure
+import com.mapbox.navigation.base.route.RouterOrigin
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesObserver
@@ -316,7 +317,10 @@ class MapboxVoiceActivity : AppCompatActivity(), OnMapLongClickListener {
         mapboxNavigation.requestRoutes(
             routeOptions,
             object : RouterCallback {
-                override fun onRoutesReady(routes: List<DirectionsRoute>) {
+                override fun onRoutesReady(
+                    routes: List<DirectionsRoute>,
+                    routerOrigin: RouterOrigin
+                ) {
                     mapboxNavigation.setRoutes(routes)
                 }
 
@@ -327,7 +331,7 @@ class MapboxVoiceActivity : AppCompatActivity(), OnMapLongClickListener {
                     // no impl
                 }
 
-                override fun onCanceled(routeOptions: RouteOptions) {
+                override fun onCanceled(routeOptions: RouteOptions, routerOrigin: RouterOrigin) {
                     // no impl
                 }
             }

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/camera/MapboxCameraAnimationsActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/camera/MapboxCameraAnimationsActivity.kt
@@ -41,6 +41,7 @@ import com.mapbox.navigation.base.extensions.applyLanguageAndVoiceUnitOptions
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.route.RouterCallback
 import com.mapbox.navigation.base.route.RouterFailure
+import com.mapbox.navigation.base.route.RouterOrigin
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesObserver
 import com.mapbox.navigation.core.replay.MapboxReplayer
@@ -563,7 +564,10 @@ class MapboxCameraAnimationsActivity :
         mapboxNavigation.requestRoutes(
             routeOptions,
             object : RouterCallback {
-                override fun onRoutesReady(routes: List<DirectionsRoute>) {
+                override fun onRoutesReady(
+                    routes: List<DirectionsRoute>,
+                    routerOrigin: RouterOrigin
+                ) {
                     mapboxNavigation.setRoutes(routes)
                 }
 
@@ -574,7 +578,7 @@ class MapboxCameraAnimationsActivity :
                     // no impl
                 }
 
-                override fun onCanceled(routeOptions: RouteOptions) {
+                override fun onCanceled(routeOptions: RouteOptions, routerOrigin: RouterOrigin) {
                     // no impl
                 }
             }

--- a/examples/src/main/java/com/mapbox/navigation/examples/util/RouteDrawingActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/util/RouteDrawingActivity.kt
@@ -26,6 +26,7 @@ import com.mapbox.maps.plugin.locationcomponent.LocationComponentPlugin
 import com.mapbox.maps.plugin.locationcomponent.location
 import com.mapbox.navigation.base.route.RouterCallback
 import com.mapbox.navigation.base.route.RouterFailure
+import com.mapbox.navigation.base.route.RouterOrigin
 import com.mapbox.navigation.examples.core.R
 import com.mapbox.navigation.ui.maps.internal.route.line.MapboxRouteLineApiExtensions.clearRouteLine
 import com.mapbox.navigation.ui.maps.internal.route.line.MapboxRouteLineApiExtensions.setRoutes
@@ -145,7 +146,7 @@ class RouteDrawingActivity : AppCompatActivity() {
     }
 
     private val routeRequestCallback: RouterCallback = object : RouterCallback {
-        override fun onRoutesReady(routes: List<DirectionsRoute>) {
+        override fun onRoutesReady(routes: List<DirectionsRoute>, routerOrigin: RouterOrigin) {
             val routeLines = routes.map { RouteLine(it, null) }
             CoroutineScope(Dispatchers.Main).launch {
                 routeLineApi.setRoutes(routeLines).apply {
@@ -162,7 +163,7 @@ class RouteDrawingActivity : AppCompatActivity() {
             ).show()
         }
 
-        override fun onCanceled(routeOptions: RouteOptions) {
+        override fun onCanceled(routeOptions: RouteOptions, routerOrigin: RouterOrigin) {
             Toast.makeText(
                 this@RouteDrawingActivity,
                 "Fetch Route Cancelled",

--- a/examples/src/main/java/com/mapbox/navigation/examples/util/RouteDrawingUtil.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/util/RouteDrawingUtil.kt
@@ -23,6 +23,7 @@ import com.mapbox.maps.plugin.gestures.OnMapLongClickListener
 import com.mapbox.maps.plugin.gestures.addOnMapLongClickListener
 import com.mapbox.maps.plugin.gestures.removeOnMapLongClickListener
 import com.mapbox.navigation.base.route.RouterCallback
+import com.mapbox.navigation.base.route.RouterOrigin
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
@@ -225,7 +226,7 @@ class RouteDrawingUtil(private val mapView: MapView) {
                         enable()
                     } else {
                         val route = response.body()?.matchings()?.get(0)?.toDirectionRoute()!!
-                        routeReadyCallback.onRoutesReady(listOf(route))
+                        routeReadyCallback.onRoutesReady(listOf(route), RouterOrigin.Offboard)
                     }
                 }
             }

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/CoreRerouteTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/CoreRerouteTest.kt
@@ -10,6 +10,7 @@ import com.mapbox.navigation.base.extensions.applyLanguageAndVoiceUnitOptions
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.route.RouterCallback
 import com.mapbox.navigation.base.route.RouterFailure
+import com.mapbox.navigation.base.route.RouterOrigin
 import com.mapbox.navigation.base.trip.model.RouteProgressState
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.MapboxNavigationProvider
@@ -112,7 +113,10 @@ class CoreRerouteTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.jav
                     .accessToken(getMapboxAccessTokenFromResources(activity))
                     .coordinates(mockRoute.routeWaypoints).build(),
                 object : RouterCallback {
-                    override fun onRoutesReady(routes: List<DirectionsRoute>) {
+                    override fun onRoutesReady(
+                        routes: List<DirectionsRoute>,
+                        routerOrigin: RouterOrigin
+                    ) {
                         mapboxNavigation.setRoutes(routes)
                     }
 
@@ -123,7 +127,10 @@ class CoreRerouteTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.jav
                         // no impl
                     }
 
-                    override fun onCanceled(routeOptions: RouteOptions) {
+                    override fun onCanceled(
+                        routeOptions: RouteOptions,
+                        routerOrigin: RouterOrigin
+                    ) {
                         // no impl
                     }
                 }

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/MapboxHistoryTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/MapboxHistoryTest.kt
@@ -10,6 +10,7 @@ import com.mapbox.navigation.base.options.HistoryRecorderOptions
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.route.RouterCallback
 import com.mapbox.navigation.base.route.RouterFailure
+import com.mapbox.navigation.base.route.RouterOrigin
 import com.mapbox.navigation.base.trip.model.RouteProgressState
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.MapboxNavigationProvider
@@ -97,7 +98,10 @@ class MapboxHistoryTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.j
                     .accessToken(getMapboxAccessTokenFromResources(activity))
                     .coordinates(mockRoute.routeWaypoints).build(),
                 object : RouterCallback {
-                    override fun onRoutesReady(routes: List<DirectionsRoute>) {
+                    override fun onRoutesReady(
+                        routes: List<DirectionsRoute>,
+                        routerOrigin: RouterOrigin
+                    ) {
                         mapboxNavigation.setRoutes(routes)
                         mockLocationReplayerRule.playRoute(routes[0])
                     }
@@ -109,7 +113,10 @@ class MapboxHistoryTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.j
                         // no impl
                     }
 
-                    override fun onCanceled(routeOptions: RouteOptions) {
+                    override fun onCanceled(
+                        routeOptions: RouteOptions,
+                        routerOrigin: RouterOrigin
+                    ) {
                         // no impl
                     }
                 }

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/SanityCoreRouteTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/SanityCoreRouteTest.kt
@@ -8,6 +8,7 @@ import com.mapbox.navigation.base.extensions.applyLanguageAndVoiceUnitOptions
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.route.RouterCallback
 import com.mapbox.navigation.base.route.RouterFailure
+import com.mapbox.navigation.base.route.RouterOrigin
 import com.mapbox.navigation.base.trip.model.RouteProgressState
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.MapboxNavigationProvider
@@ -80,7 +81,10 @@ class SanityCoreRouteTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class
                     .accessToken(getMapboxAccessTokenFromResources(activity))
                     .coordinates(mockRoute.routeWaypoints).build(),
                 object : RouterCallback {
-                    override fun onRoutesReady(routes: List<DirectionsRoute>) {
+                    override fun onRoutesReady(
+                        routes: List<DirectionsRoute>,
+                        routerOrigin: RouterOrigin
+                    ) {
                         mapboxNavigation.setRoutes(routes)
                         mockLocationReplayerRule.playRoute(routes[0])
                     }
@@ -92,7 +96,10 @@ class SanityCoreRouteTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class
                         // no impl
                     }
 
-                    override fun onCanceled(routeOptions: RouteOptions) {
+                    override fun onCanceled(
+                        routeOptions: RouteOptions,
+                        routerOrigin: RouterOrigin
+                    ) {
                         // no impl
                     }
                 }

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/utils/idling/RouteAlternativesIdlingResource.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/utils/idling/RouteAlternativesIdlingResource.kt
@@ -2,6 +2,7 @@ package com.mapbox.navigation.instrumentation_tests.utils.idling
 
 import androidx.test.espresso.IdlingResource
 import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.navigation.base.route.RouterOrigin
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.routealternatives.RouteAlternativesObserver
@@ -43,7 +44,8 @@ class RouteAlternativesIdlingResource(
 
     override fun onRouteAlternatives(
         routeProgress: RouteProgress,
-        alternatives: List<DirectionsRoute>
+        alternatives: List<DirectionsRoute>,
+        routerOrigin: RouterOrigin
     ) {
         mapboxNavigation.unregisterRouteAlternativesObserver(this)
         this.routeProgress = routeProgress

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/utils/idling/RouteRequestIdlingResource.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/utils/idling/RouteRequestIdlingResource.kt
@@ -7,6 +7,7 @@ import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.RouteOptions
 import com.mapbox.navigation.base.route.RouterCallback
 import com.mapbox.navigation.base.route.RouterFailure
+import com.mapbox.navigation.base.route.RouterOrigin
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.testing.ui.http.MockWebServerRule
 import org.junit.Assert.fail
@@ -62,7 +63,7 @@ class RouteRequestIdlingResource(
 
     /** Used to communicate with [MapboxNavigation.requestRoutes] **/
     private val routesRequestCallback = object : RouterCallback {
-        override fun onRoutesReady(routes: List<DirectionsRoute>) {
+        override fun onRoutesReady(routes: List<DirectionsRoute>, routerOrigin: RouterOrigin) {
             directionsRoutes = routes
             callback.onTransitionToIdle()
         }
@@ -71,7 +72,7 @@ class RouteRequestIdlingResource(
             fail()
         }
 
-        override fun onCanceled(routeOptions: RouteOptions) {
+        override fun onCanceled(routeOptions: RouteOptions, routerOrigin: RouterOrigin) {
             fail("onRoutesRequestCanceled")
         }
     }

--- a/libnavigation-base/api/current.txt
+++ b/libnavigation-base/api/current.txt
@@ -385,28 +385,50 @@ package com.mapbox.navigation.base.route {
   }
 
   public interface RouterCallback {
-    method public void onCanceled(com.mapbox.api.directions.v5.models.RouteOptions routeOptions);
+    method public void onCanceled(com.mapbox.api.directions.v5.models.RouteOptions routeOptions, com.mapbox.navigation.base.route.RouterOrigin routerOrigin);
     method public void onFailure(java.util.List<com.mapbox.navigation.base.route.RouterFailure> reasons, com.mapbox.api.directions.v5.models.RouteOptions routeOptions);
-    method public void onRoutesReady(java.util.List<? extends com.mapbox.api.directions.v5.models.DirectionsRoute> routes);
+    method public void onRoutesReady(java.util.List<? extends com.mapbox.api.directions.v5.models.DirectionsRoute> routes, com.mapbox.navigation.base.route.RouterOrigin routerOrigin);
   }
 
   public final class RouterFailure {
-    ctor public RouterFailure(java.net.URL url, String message, Integer? code = null, Throwable? throwable = null);
-    ctor public RouterFailure(java.net.URL url, String message, Integer? code = null);
-    ctor public RouterFailure(java.net.URL url, String message);
+    ctor public RouterFailure(java.net.URL url, com.mapbox.navigation.base.route.RouterOrigin routerOrigin, String message, Integer? code = null, Throwable? throwable = null);
+    ctor public RouterFailure(java.net.URL url, com.mapbox.navigation.base.route.RouterOrigin routerOrigin, String message, Integer? code = null);
+    ctor public RouterFailure(java.net.URL url, com.mapbox.navigation.base.route.RouterOrigin routerOrigin, String message);
     method public java.net.URL component1();
-    method public String component2();
-    method public Integer? component3();
-    method public Throwable? component4();
-    method public com.mapbox.navigation.base.route.RouterFailure copy(java.net.URL url, String message, Integer? code, Throwable? throwable);
+    method public com.mapbox.navigation.base.route.RouterOrigin component2();
+    method public String component3();
+    method public Integer? component4();
+    method public Throwable? component5();
+    method public com.mapbox.navigation.base.route.RouterFailure copy(java.net.URL url, com.mapbox.navigation.base.route.RouterOrigin routerOrigin, String message, Integer? code, Throwable? throwable);
     method public Integer? getCode();
     method public String getMessage();
+    method public com.mapbox.navigation.base.route.RouterOrigin getRouterOrigin();
     method public Throwable? getThrowable();
     method public java.net.URL getUrl();
     property public final Integer? code;
     property public final String message;
+    property public final com.mapbox.navigation.base.route.RouterOrigin routerOrigin;
     property public final Throwable? throwable;
     property public final java.net.URL url;
+  }
+
+  public abstract sealed class RouterOrigin {
+  }
+
+  public static final class RouterOrigin.Custom extends com.mapbox.navigation.base.route.RouterOrigin {
+    ctor public RouterOrigin.Custom(Object? obj = null);
+    method public Object? component1();
+    method public com.mapbox.navigation.base.route.RouterOrigin.Custom copy(Object? obj);
+    method public Object? getObj();
+    property public final Object? obj;
+  }
+
+  public static final class RouterOrigin.Offboard extends com.mapbox.navigation.base.route.RouterOrigin {
+    field public static final com.mapbox.navigation.base.route.RouterOrigin.Offboard INSTANCE;
+  }
+
+  public static final class RouterOrigin.Onboard extends com.mapbox.navigation.base.route.RouterOrigin {
+    field public static final com.mapbox.navigation.base.route.RouterOrigin.Onboard INSTANCE;
   }
 
 }

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/route/Router.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/route/Router.kt
@@ -66,6 +66,7 @@ interface Router {
  * Describes a reason for a route request failure.
  *
  * @param url original request URL
+ * @param routerOrigin router that failed to generate a route
  * @param message message attached to the error code
  * @param code if present, can be either be the HTTP code for offboard requests
  * or an internal error code for onboard requests
@@ -73,6 +74,7 @@ interface Router {
  */
 data class RouterFailure @JvmOverloads constructor(
     val url: URL,
+    val routerOrigin: RouterOrigin,
     val message: String,
     val code: Int? = null,
     val throwable: Throwable? = null

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/route/RouterCallback.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/route/RouterCallback.kt
@@ -13,8 +13,9 @@ interface RouterCallback {
      *
      * @param routes the most optimal route has index 0. If requested, alternative routes are available on higher indices.
      * At least one route is always available in a successful response.
+     * @param routerOrigin route origin
      */
-    fun onRoutesReady(routes: List<DirectionsRoute>)
+    fun onRoutesReady(routes: List<DirectionsRoute>, routerOrigin: RouterOrigin)
 
     /**
      * Called whenever router fails.
@@ -31,5 +32,5 @@ interface RouterCallback {
      *
      * @param routeOptions the original request options
      */
-    fun onCanceled(routeOptions: RouteOptions)
+    fun onCanceled(routeOptions: RouteOptions, routerOrigin: RouterOrigin)
 }

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/route/RouterOrigin.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/route/RouterOrigin.kt
@@ -1,0 +1,26 @@
+package com.mapbox.navigation.base.route
+
+/**
+ * Describes which kind of router presents response.
+ */
+sealed class RouterOrigin {
+    /**
+     * Router based on Directions API.
+     *
+     * See also [https://docs.mapbox.com/help/glossary/directions-api/]
+     */
+    object Offboard : RouterOrigin()
+
+    /**
+     * Router based on embedded offline library and local navigation tiles.
+     */
+    object Onboard : RouterOrigin()
+
+    /**
+     * Can be used as a router origin of custom routes source, different from [Offboard] and [Onboard]. The
+     * SDK doesn't operate with [obj], it might be used to spread any additional data.
+     *
+     * @param obj is used to provide additional data with [Custom] router origin
+     */
+    data class Custom @JvmOverloads constructor(val obj: Any? = null) : RouterOrigin()
+}

--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -457,7 +457,11 @@ package com.mapbox.navigation.core.reroute {
   }
 
   public static final class RerouteState.RouteFetched extends com.mapbox.navigation.core.reroute.RerouteState {
-    field public static final com.mapbox.navigation.core.reroute.RerouteState.RouteFetched INSTANCE;
+    ctor public RerouteState.RouteFetched(com.mapbox.navigation.base.route.RouterOrigin routerOrigin);
+    method public com.mapbox.navigation.base.route.RouterOrigin component1();
+    method public com.mapbox.navigation.core.reroute.RerouteState.RouteFetched copy(com.mapbox.navigation.base.route.RouterOrigin routerOrigin);
+    method public com.mapbox.navigation.base.route.RouterOrigin getRouterOrigin();
+    property public final com.mapbox.navigation.base.route.RouterOrigin routerOrigin;
   }
 
 }
@@ -465,7 +469,7 @@ package com.mapbox.navigation.core.reroute {
 package com.mapbox.navigation.core.routealternatives {
 
   public interface RouteAlternativesObserver {
-    method public void onRouteAlternatives(com.mapbox.navigation.base.trip.model.RouteProgress routeProgress, java.util.List<? extends com.mapbox.api.directions.v5.models.DirectionsRoute> alternatives);
+    method public void onRouteAlternatives(com.mapbox.navigation.base.trip.model.RouteProgress routeProgress, java.util.List<? extends com.mapbox.api.directions.v5.models.DirectionsRoute> alternatives, com.mapbox.navigation.base.route.RouterOrigin routerOrigin);
   }
 
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/NavigationSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/NavigationSession.kt
@@ -6,9 +6,7 @@ import com.mapbox.navigation.core.trip.session.TripSessionState
 import com.mapbox.navigation.core.trip.session.TripSessionStateObserver
 import java.util.concurrent.CopyOnWriteArraySet
 
-internal class NavigationSession :
-    RoutesObserver,
-    TripSessionStateObserver {
+internal class NavigationSession : RoutesObserver, TripSessionStateObserver {
 
     private val stateObservers = CopyOnWriteArraySet<NavigationSessionStateObserver>()
 

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/MapboxDirectionsSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/MapboxDirectionsSession.kt
@@ -6,6 +6,7 @@ import com.mapbox.navigation.base.route.RouteRefreshCallback
 import com.mapbox.navigation.base.route.Router
 import com.mapbox.navigation.base.route.RouterCallback
 import com.mapbox.navigation.base.route.RouterFailure
+import com.mapbox.navigation.base.route.RouterOrigin
 import java.util.concurrent.CopyOnWriteArraySet
 
 /**
@@ -89,16 +90,19 @@ internal class MapboxDirectionsSession(
         return router.getRoute(
             routeOptions,
             object : RouterCallback {
-                override fun onRoutesReady(routes: List<DirectionsRoute>) {
-                    routerCallback.onRoutesReady(routes)
+                override fun onRoutesReady(
+                    routes: List<DirectionsRoute>,
+                    routerOrigin: RouterOrigin
+                ) {
+                    routerCallback.onRoutesReady(routes, routerOrigin)
                 }
 
                 override fun onFailure(reasons: List<RouterFailure>, routeOptions: RouteOptions) {
                     routerCallback.onFailure(reasons, routeOptions)
                 }
 
-                override fun onCanceled(routeOptions: RouteOptions) {
-                    routerCallback.onCanceled(routeOptions)
+                override fun onCanceled(routeOptions: RouteOptions, routerOrigin: RouterOrigin) {
+                    routerCallback.onCanceled(routeOptions, routerOrigin)
                 }
             }
         )

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/reroute/RerouteController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/reroute/RerouteController.kt
@@ -2,6 +2,7 @@ package com.mapbox.navigation.core.reroute
 
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.navigation.base.route.RouterFailure
+import com.mapbox.navigation.base.route.RouterOrigin
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.routeoptions.MapboxRouteOptionsUpdater
 import com.mapbox.navigation.core.trip.session.OffRouteObserver
@@ -115,6 +116,8 @@ sealed class RerouteState {
 
     /**
      * Route has been fetched.
+     *
+     * @param routerOrigin which router was used to fetch the route
      */
-    object RouteFetched : RerouteState()
+    data class RouteFetched(val routerOrigin: RouterOrigin) : RerouteState()
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesController.kt
@@ -6,6 +6,7 @@ import com.mapbox.base.common.logger.model.Message
 import com.mapbox.navigation.base.route.RouteAlternativesOptions
 import com.mapbox.navigation.base.route.RouterCallback
 import com.mapbox.navigation.base.route.RouterFailure
+import com.mapbox.navigation.base.route.RouterOrigin
 import com.mapbox.navigation.core.directions.session.DirectionsSession
 import com.mapbox.navigation.core.routeoptions.RouteOptionsUpdater
 import com.mapbox.navigation.core.trip.session.TripSession
@@ -101,7 +102,7 @@ internal class RouteAlternativesController(
     }
 
     private val routesRequestCallback = object : RouterCallback {
-        override fun onRoutesReady(routes: List<DirectionsRoute>) {
+        override fun onRoutesReady(routes: List<DirectionsRoute>, routerOrigin: RouterOrigin) {
             val routeProgress = tripSession.getRouteProgress()
                 ?: return
             jobControl.scope.launch {
@@ -109,7 +110,9 @@ internal class RouteAlternativesController(
                     tripSession.getState() == TripSessionState.STARTED
                 ) {
                     val alternatives = routes.filter { navigator.isDifferentRoute(it) }
-                    observers.forEach { it.onRouteAlternatives(routeProgress, alternatives) }
+                    observers.forEach {
+                        it.onRouteAlternatives(routeProgress, alternatives, routerOrigin)
+                    }
                 }
             }
         }
@@ -120,7 +123,7 @@ internal class RouteAlternativesController(
             )
         }
 
-        override fun onCanceled(routeOptions: RouteOptions) {
+        override fun onCanceled(routeOptions: RouteOptions, routerOrigin: RouterOrigin) {
             logger.w(msg = Message("Route alternatives request canceled"))
         }
     }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesObserver.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesObserver.kt
@@ -2,6 +2,7 @@ package com.mapbox.navigation.core.routealternatives
 
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.navigation.base.route.RouteAlternativesOptions
+import com.mapbox.navigation.base.route.RouterOrigin
 import com.mapbox.navigation.base.trip.model.RouteProgress
 
 /**
@@ -20,6 +21,7 @@ interface RouteAlternativesObserver {
      */
     fun onRouteAlternatives(
         routeProgress: RouteProgress,
-        alternatives: List<DirectionsRoute>
+        alternatives: List<DirectionsRoute>,
+        routerOrigin: RouterOrigin
     )
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetry.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetry.kt
@@ -100,7 +100,7 @@ internal object MapboxNavigationTelemetry {
     private const val MOCK_PROVIDER = "com.mapbox.navigation.core.replay.ReplayLocationEngine"
     private const val EVENT_VERSION = 7
 
-    private lateinit var context: Context // Must be context.getApplicationContext
+    private lateinit var applicationContext: Context // Must be context.getApplicationContext
     private lateinit var metricsReporter: MetricsReporter
     private lateinit var navigationOptions: NavigationOptions
     private var lifecycleMonitor: ApplicationLifecycleMonitor? = null
@@ -220,7 +220,7 @@ internal object MapboxNavigationTelemetry {
         this.logger = logger
         this.locationsCollector = locationsCollector
         navigationOptions = options
-        context = options.applicationContext
+        applicationContext = options.applicationContext
         locationEngineNameExternal = options.locationEngine.javaClass.name
         sdkIdentifier = if (options.isFromNavigationUi) {
             "mapbox-navigation-ui-android"
@@ -321,7 +321,7 @@ internal object MapboxNavigationTelemetry {
         if (dynamicValues.sessionStarted && dataInitialized()) {
             log("collect post event locations for user feedback")
             val feedbackEvent = NavigationFeedbackEvent(
-                PhoneState(context),
+                PhoneState(applicationContext),
                 MetricsRouteProgress(routeProgress)
             ).apply {
                 this.feedbackType = feedbackType
@@ -400,7 +400,7 @@ internal object MapboxNavigationTelemetry {
     ) {
         log("createFreeDriveEvent $type")
         if (sessionId != null && sessionStartTime != null) {
-            val freeDriveEvent = NavigationFreeDriveEvent(PhoneState(context)).apply {
+            val freeDriveEvent = NavigationFreeDriveEvent(PhoneState(applicationContext)).apply {
                 populate(type, sessionId, sessionStartTime)
             }
             sendEvent(freeDriveEvent)
@@ -437,7 +437,8 @@ internal object MapboxNavigationTelemetry {
                 sessionStarted = true
             }
 
-            val departEvent = NavigationDepartEvent(PhoneState(context)).apply { populate() }
+            val departEvent =
+                NavigationDepartEvent(PhoneState(applicationContext)).apply { populate() }
             sendMetricEvent(departEvent)
         }
     }
@@ -480,7 +481,7 @@ internal object MapboxNavigationTelemetry {
             }
 
             val navigationRerouteEvent = NavigationRerouteEvent(
-                PhoneState(context),
+                PhoneState(applicationContext),
                 MetricsRouteProgress(routeProgress)
             ).apply {
                 secondsSinceLastReroute = dynamicValues.timeSinceLastReroute / ONE_SECOND
@@ -506,7 +507,8 @@ internal object MapboxNavigationTelemetry {
             log("handleSessionCanceled")
             locationsCollector.flushBuffers()
 
-            val cancelEvent = NavigationCancelEvent(PhoneState(context)).apply { populate() }
+            val cancelEvent =
+                NavigationCancelEvent(PhoneState(applicationContext)).apply { populate() }
             ifNonNull(dynamicValues.sessionArrivalTime) {
                 cancelEvent.arrivalTimestamp = generateCreateDateFormatted(it)
             }
@@ -528,7 +530,8 @@ internal object MapboxNavigationTelemetry {
             log("you have arrived")
             dynamicValues.sessionArrivalTime = Date()
 
-            val arriveEvent = NavigationArriveEvent(PhoneState(context)).apply { populate() }
+            val arriveEvent =
+                NavigationArriveEvent(PhoneState(applicationContext)).apply { populate() }
             sendMetricEvent(arriveEvent)
         }
     }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
@@ -22,6 +22,7 @@ import com.mapbox.navigation.base.options.RoutingTilesOptions
 import com.mapbox.navigation.base.route.RouteRefreshOptions
 import com.mapbox.navigation.base.route.Router
 import com.mapbox.navigation.base.route.RouterCallback
+import com.mapbox.navigation.base.route.RouterOrigin
 import com.mapbox.navigation.base.trip.model.RouteLegProgress
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.base.trip.notification.TripNotification
@@ -786,11 +787,12 @@ class MapboxNavigationTest {
         val routes = listOf(mockk<DirectionsRoute>())
         val options = mockk<RouteOptions>()
         val possibleInternalCallbackSlot = slot<RouterCallback>()
+        val origin = mockk<RouterOrigin>()
         every { directionsSession.requestRoutes(options, any()) } returns 1L
 
         mapboxNavigation.requestRoutes(options, mockk(relaxUnitFun = true))
         verify { directionsSession.requestRoutes(options, capture(possibleInternalCallbackSlot)) }
-        possibleInternalCallbackSlot.captured.onRoutesReady(routes)
+        possibleInternalCallbackSlot.captured.onRoutesReady(routes, origin)
 
         verify(exactly = 0) { directionsSession.routes = routes }
     }

--- a/libnavigation-router/src/main/java/com/mapbox/navigation/route/internal/hybrid/MapboxHybridRouter.kt
+++ b/libnavigation-router/src/main/java/com/mapbox/navigation/route/internal/hybrid/MapboxHybridRouter.kt
@@ -11,6 +11,7 @@ import com.mapbox.navigation.base.route.RouteRefreshError
 import com.mapbox.navigation.base.route.Router
 import com.mapbox.navigation.base.route.RouterCallback
 import com.mapbox.navigation.base.route.RouterFailure
+import com.mapbox.navigation.base.route.RouterOrigin
 import com.mapbox.navigation.navigator.internal.MapboxNativeNavigator
 import com.mapbox.navigation.route.internal.offboard.MapboxOffboardRouter
 import com.mapbox.navigation.route.internal.onboard.MapboxOnboardRouter
@@ -92,9 +93,12 @@ class MapboxHybridRouter(
         routerHandler.getRoute(
             routeOptions,
             object : RouterCallback {
-                override fun onRoutesReady(routes: List<DirectionsRoute>) {
+                override fun onRoutesReady(
+                    routes: List<DirectionsRoute>,
+                    routerOrigin: RouterOrigin
+                ) {
                     directionRequests.remove(id)
-                    callback.onRoutesReady(routes)
+                    callback.onRoutesReady(routes, routerOrigin)
                 }
 
                 override fun onFailure(reasons: List<RouterFailure>, routeOptions: RouteOptions) {
@@ -102,9 +106,9 @@ class MapboxHybridRouter(
                     callback.onFailure(reasons, routeOptions)
                 }
 
-                override fun onCanceled(routeOptions: RouteOptions) {
+                override fun onCanceled(routeOptions: RouteOptions, routerOrigin: RouterOrigin) {
                     directionRequests.remove(id)
-                    callback.onCanceled(routeOptions)
+                    callback.onCanceled(routeOptions, routerOrigin)
                 }
             }
         )

--- a/libnavigation-router/src/test/java/com/mapbox/navigation/route/internal/offboard/MapboxOffboardRouterTest.kt
+++ b/libnavigation-router/src/test/java/com/mapbox/navigation/route/internal/offboard/MapboxOffboardRouterTest.kt
@@ -13,6 +13,7 @@ import com.mapbox.navigation.base.route.RouteRefreshCallback
 import com.mapbox.navigation.base.route.RouteRefreshError
 import com.mapbox.navigation.base.route.RouterCallback
 import com.mapbox.navigation.base.route.RouterFailure
+import com.mapbox.navigation.base.route.RouterOrigin
 import com.mapbox.navigation.route.internal.util.ACCESS_TOKEN_QUERY_PARAM
 import com.mapbox.navigation.route.internal.util.redactQueryParam
 import com.mapbox.navigation.route.offboard.RouteBuilderProvider
@@ -50,6 +51,7 @@ class MapboxOffboardRouterTest : BaseTest() {
     private lateinit var routeCallback: Callback<DirectionsResponse>
     private lateinit var refreshCallback: Callback<DirectionsRefreshResponse>
     private val routeOptions: RouteOptions = mockk(relaxed = true)
+    private val routerOrigin = RouterOrigin.Offboard
     private val mockSkuTokenProvider = mockk<UrlSkuTokenProvider>(relaxed = true)
     private val routeCall: Call<DirectionsResponse> = mockk()
     private val refreshCall: Call<DirectionsRefreshResponse> = mockk()
@@ -182,7 +184,7 @@ class MapboxOffboardRouterTest : BaseTest() {
 
         routeCallback.onResponse(routeCall, response)
 
-        verify { routerCallback.onRoutesReady(listOf(route)) }
+        verify { routerCallback.onRoutesReady(listOf(route), routerOrigin) }
     }
 
     @Test
@@ -233,6 +235,7 @@ class MapboxOffboardRouterTest : BaseTest() {
         val expected = listOf(
             RouterFailure(
                 url = url.redactQueryParam(ACCESS_TOKEN_QUERY_PARAM).toUrl(),
+                routerOrigin = routerOrigin,
                 message = "msg",
                 code = null,
                 throwable = throwable
@@ -252,7 +255,7 @@ class MapboxOffboardRouterTest : BaseTest() {
 
         routeCallback.onFailure(call, throwable)
 
-        verify { routerCallback.onCanceled(routeOptions) }
+        verify { routerCallback.onCanceled(routeOptions, routerOrigin) }
     }
 
     @Test
@@ -266,7 +269,7 @@ class MapboxOffboardRouterTest : BaseTest() {
 
         routeCallback.onResponse(routeCall, response)
 
-        verify { routerCallback.onCanceled(routeOptions) }
+        verify { routerCallback.onCanceled(routeOptions, routerOrigin) }
     }
 
     @Test

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/AlternativeRouteActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/AlternativeRouteActivity.kt
@@ -30,6 +30,7 @@ import com.mapbox.navigation.base.extensions.applyLanguageAndVoiceUnitOptions
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.route.RouterCallback
 import com.mapbox.navigation.base.route.RouterFailure
+import com.mapbox.navigation.base.route.RouterOrigin
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesObserver
 import com.mapbox.navigation.core.replay.MapboxReplayer
@@ -216,7 +217,10 @@ class AlternativeRouteActivity : AppCompatActivity(), OnMapLongClickListener {
         mapboxNavigation.requestRoutes(
             routeOptions,
             object : RouterCallback {
-                override fun onRoutesReady(routes: List<DirectionsRoute>) {
+                override fun onRoutesReady(
+                    routes: List<DirectionsRoute>,
+                    routerOrigin: RouterOrigin
+                ) {
                     mapboxNavigation.setRoutes(routes)
                 }
 
@@ -227,7 +231,7 @@ class AlternativeRouteActivity : AppCompatActivity(), OnMapLongClickListener {
                     // no impl
                 }
 
-                override fun onCanceled(routeOptions: RouteOptions) {
+                override fun onCanceled(routeOptions: RouteOptions, routerOrigin: RouterOrigin) {
                     // no impl
                 }
             }

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/MapboxRouteLineActivity.java
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/MapboxRouteLineActivity.java
@@ -46,6 +46,7 @@ import com.mapbox.navigation.base.options.PredictiveCacheLocationOptions;
 import com.mapbox.navigation.base.options.RoutingTilesOptions;
 import com.mapbox.navigation.base.route.RouterCallback;
 import com.mapbox.navigation.base.route.RouterFailure;
+import com.mapbox.navigation.base.route.RouterOrigin;
 import com.mapbox.navigation.base.trip.model.RouteProgress;
 import com.mapbox.navigation.core.MapboxNavigation;
 import com.mapbox.navigation.core.directions.session.RoutesObserver;
@@ -339,7 +340,9 @@ public class MapboxRouteLineActivity extends AppCompatActivity implements OnMapL
 
   private RouterCallback routesReqCallback = new RouterCallback() {
     @Override
-    public void onRoutesReady(@NotNull List<? extends DirectionsRoute> routes) {
+    public void onRoutesReady(
+      @NotNull List<? extends DirectionsRoute> routes, @NonNull RouterOrigin routerOrigin
+    ) {
       mapboxNavigation.setRoutes(routes);
       if (!routes.isEmpty()) {
         routeLoading.setVisibility(View.INVISIBLE);
@@ -353,7 +356,7 @@ public class MapboxRouteLineActivity extends AppCompatActivity implements OnMapL
     }
 
     @Override
-    public void onCanceled(@NonNull RouteOptions routeOptions) {
+    public void onCanceled(@NonNull RouteOptions routeOptions, @NonNull RouterOrigin routerOrigin) {
       Log.d(TAG, "route request canceled");
       routeLoading.setVisibility(View.INVISIBLE);
 

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/util/RouteDrawingActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/util/RouteDrawingActivity.kt
@@ -26,6 +26,7 @@ import com.mapbox.maps.plugin.locationcomponent.LocationComponentPlugin
 import com.mapbox.maps.plugin.locationcomponent.location
 import com.mapbox.navigation.base.route.RouterCallback
 import com.mapbox.navigation.base.route.RouterFailure
+import com.mapbox.navigation.base.route.RouterOrigin
 import com.mapbox.navigation.qa_test_app.R
 import com.mapbox.navigation.ui.maps.internal.route.line.MapboxRouteLineApiExtensions.clearRouteLine
 import com.mapbox.navigation.ui.maps.internal.route.line.MapboxRouteLineApiExtensions.setRoutes
@@ -144,7 +145,7 @@ class RouteDrawingActivity : AppCompatActivity() {
     }
 
     private val routeRequestCallback: RouterCallback = object : RouterCallback {
-        override fun onRoutesReady(routes: List<DirectionsRoute>) {
+        override fun onRoutesReady(routes: List<DirectionsRoute>, routerOrigin: RouterOrigin) {
             val routeLines = routes.map { RouteLine(it, null) }
             CoroutineScope(Dispatchers.Main).launch {
                 routeLineApi.setRoutes(routeLines).apply {
@@ -161,7 +162,7 @@ class RouteDrawingActivity : AppCompatActivity() {
             ).show()
         }
 
-        override fun onCanceled(routeOptions: RouteOptions) {
+        override fun onCanceled(routeOptions: RouteOptions, routerOrigin: RouterOrigin) {
             Toast.makeText(
                 this@RouteDrawingActivity,
                 "Fetch Route Cancelled",

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/util/RouteDrawingUtil.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/util/RouteDrawingUtil.kt
@@ -23,6 +23,7 @@ import com.mapbox.maps.plugin.gestures.OnMapLongClickListener
 import com.mapbox.maps.plugin.gestures.addOnMapLongClickListener
 import com.mapbox.maps.plugin.gestures.removeOnMapLongClickListener
 import com.mapbox.navigation.base.route.RouterCallback
+import com.mapbox.navigation.base.route.RouterOrigin
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
@@ -223,7 +224,7 @@ class RouteDrawingUtil(private val mapView: MapView) {
                         enable()
                     } else {
                         val route = response.body()?.matchings()?.get(0)?.toDirectionRoute()!!
-                        routeReadyCallback.onRoutesReady(listOf(route))
+                        routeReadyCallback.onRoutesReady(listOf(route), RouterOrigin.Offboard)
                     }
                 }
             }


### PR DESCRIPTION
### Description
Added `RouterOrigin`

```
<changelog>
Added `RouterOrigin` which indicates where a route was fetched from.
Added `RouterOrigin` param to:
  - `RouterCallback#onRoutesReady` method;
  - `RouterCallback#onCanceled` method;
  - `RouterFailure` class;
  - `RerouteState.RouteFetched` class;
  - `RouteAlternativesObserver#onRouteAlternatives` method.
</changelog>
```

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
