### PR TITLE
Pull in the latest translations from Transifex

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -20,3 +20,21 @@ file_filter = libnavigation-base/src/main/res/values-<lang>/strings.xml
 source_file = libnavigation-base/src/main/res/values/strings.xml
 source_lang = en
 type = ANDROID
+
+[mapbox-navigation-sdk-for-android.libnavui-maps-strings-file]
+file_filter = libnavui-maps/src/main/res/values-<lang>/strings.xml
+source_file = libnavui-maps/src/main/res/values/strings.xml
+source_lang = en
+type = ANDROID
+
+[mapbox-navigation-sdk-for-android.libnavui-speedlimit-strings-file]
+file_filter = libnavui-speedlimit/src/main/res/values-<lang>/strings.xml
+source_file = libnavui-speedlimit/src/main/res/values/strings.xml
+source_lang = en
+type = ANDROID
+
+[mapbox-navigation-sdk-for-android.libnavui-voice-strings-file]
+file_filter = libnavui-voice/src/main/res/values-<lang>/strings.xml
+source_file = libnavui-voice/src/main/res/values/strings.xml
+source_lang = en
+type = ANDROID

--- a/libnavigation-base/src/main/res/values-ca/strings.xml
+++ b/libnavigation-base/src/main/res/values-ca/strings.xml
@@ -1,0 +1,12 @@
+<resources>
+
+    <!-- Time formatting -->
+    <plurals name="mapbox_number_of_days">
+        <item quantity="one">dies</item>
+        <item quantity="other">dies</item>
+    </plurals>
+    <!-- Hour -->
+    <string name="mapbox_unit_hr">h</string>
+    <!-- Minute -->
+    <string name="mapbox_unit_min">min</string>
+</resources>

--- a/libnavigation-util/src/main/res/values-ca/strings.xml
+++ b/libnavigation-util/src/main/res/values-ca/strings.xml
@@ -1,0 +1,6 @@
+<resources>
+    <string name="mapbox_unit_kilometers">km</string>
+    <string name="mapbox_unit_meters">m</string>
+    <string name="mapbox_unit_miles">mi</string>
+    <string name="mapbox_unit_feet">ft</string>
+</resources>

--- a/libnavui-maps/src/main/res/values-ca/strings.xml
+++ b/libnavui-maps/src/main/res/values-ca/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="mapbox_route_overview">Visió General</string>
+</resources>

--- a/libnavui-maps/src/main/res/values-cs/strings.xml
+++ b/libnavui-maps/src/main/res/values-cs/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="mapbox_recenter">Znovu vycentrovat</string>
+    <string name="mapbox_route_overview">Přehled</string>
+</resources>

--- a/libnavui-maps/src/main/res/values-de/strings.xml
+++ b/libnavui-maps/src/main/res/values-de/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="mapbox_route_overview">Übersicht</string>
+</resources>

--- a/libnavui-maps/src/main/res/values-el/strings.xml
+++ b/libnavui-maps/src/main/res/values-el/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="mapbox_route_overview">Επισκόπηση</string>
+</resources>

--- a/libnavui-maps/src/main/res/values-es-rES/strings.xml
+++ b/libnavui-maps/src/main/res/values-es-rES/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="mapbox_route_overview">Vista previa</string>
+</resources>

--- a/libnavui-maps/src/main/res/values-es/strings.xml
+++ b/libnavui-maps/src/main/res/values-es/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="mapbox_route_overview">Vista previa</string>
+</resources>

--- a/libnavui-maps/src/main/res/values-fr/strings.xml
+++ b/libnavui-maps/src/main/res/values-fr/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="mapbox_route_overview">Aperçu</string>
+</resources>

--- a/libnavui-maps/src/main/res/values-hu/strings.xml
+++ b/libnavui-maps/src/main/res/values-hu/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="mapbox_route_overview">Áttekintés</string>
+</resources>

--- a/libnavui-maps/src/main/res/values-ja/strings.xml
+++ b/libnavui-maps/src/main/res/values-ja/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="mapbox_route_overview">全体を見る</string>
+</resources>

--- a/libnavui-maps/src/main/res/values-pt-rPT/strings.xml
+++ b/libnavui-maps/src/main/res/values-pt-rPT/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="mapbox_route_overview">Vista geral</string>
+</resources>

--- a/libnavui-maps/src/main/res/values-ru/strings.xml
+++ b/libnavui-maps/src/main/res/values-ru/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="mapbox_route_overview">Обзор</string>
+</resources>

--- a/libnavui-maps/src/main/res/values-sv/strings.xml
+++ b/libnavui-maps/src/main/res/values-sv/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="mapbox_route_overview">Översikt</string>
+</resources>

--- a/libnavui-maps/src/main/res/values-uk/strings.xml
+++ b/libnavui-maps/src/main/res/values-uk/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="mapbox_route_overview">Огляд</string>
+</resources>

--- a/libnavui-maps/src/main/res/values-vi/strings.xml
+++ b/libnavui-maps/src/main/res/values-vi/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="mapbox_route_overview">Tóm tắt</string>
+</resources>

--- a/libnavui-maps/src/main/res/values-yo/strings.xml
+++ b/libnavui-maps/src/main/res/values-yo/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="mapbox_route_overview">Akopọ</string>
+</resources>

--- a/libnavui-voice/src/main/res/values-ar/strings.xml
+++ b/libnavui-voice/src/main/res/values-ar/strings.xml
@@ -5,5 +5,4 @@
 
     <!-- Indicates voice instructions are unmuted -->
     <string name="mapbox_unmuted">غير صامت</string>
-
 </resources>

--- a/libnavui-voice/src/main/res/values-id/strings.xml
+++ b/libnavui-voice/src/main/res/values-id/strings.xml
@@ -5,5 +5,4 @@
 
     <!-- Indicates voice instructions are unmuted -->
     <string name="mapbox_unmuted">Suara Dinyalakan</string>
-
 </resources>

--- a/libtrip-notification/src/main/res/values-ca/strings.xml
+++ b/libtrip-notification/src/main/res/values-ca/strings.xml
@@ -1,4 +1,8 @@
 <resources>
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Aturar navegació</string>
-    </resources>
+    <string name="mapbox_navigation_is_starting">Comença la navegació...</string>
+    <string name="mapbox_stop_session">Aturar sessió</string>
+    <string name="mapbox_free_drive_session">Sessió de conducció gratuïta</string>
+    <string name="mapbox_eta_format">%s ETA</string>
+</resources>

--- a/libtrip-notification/src/main/res/values-es/strings.xml
+++ b/libtrip-notification/src/main/res/values-es/strings.xml
@@ -1,6 +1,7 @@
 <resources>
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Salir de la navegación</string>
+    <string name="mapbox_navigation_is_starting">Empezando la navegación…</string>
     <string name="mapbox_stop_session">Parar la sesión</string>
     <string name="mapbox_free_drive_session">Sesión de manejar libremente</string>
     <string name="mapbox_eta_format">%s ETA</string>

--- a/libtrip-notification/src/main/res/values-ru/strings.xml
+++ b/libtrip-notification/src/main/res/values-ru/strings.xml
@@ -1,5 +1,8 @@
 <resources>
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Завершить</string>
+    <string name="mapbox_navigation_is_starting">Навигация запущена...</string>
+    <string name="mapbox_stop_session">Остановить сессию</string>
+    <string name="mapbox_free_drive_session">Освободить сессию</string>
     <string name="mapbox_eta_format">Ожидаемое прибытие %s</string>
 </resources>

--- a/libtrip-notification/src/main/res/values-uk/strings.xml
+++ b/libtrip-notification/src/main/res/values-uk/strings.xml
@@ -1,6 +1,8 @@
 <resources>
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Закінчити навігацію</string>
+    <string name="mapbox_navigation_is_starting">Початок навігації…</string>
     <string name="mapbox_stop_session">Призупинити сесію</string>
-    <string name="mapbox_eta_format">До прибуття %s</string>
+    <string name="mapbox_free_drive_session">Вільна драйв-сесія</string>
+    <string name="mapbox_eta_format">Прибуття: %s</string>
 </resources>

--- a/libtrip-notification/src/main/res/values-vi/strings.xml
+++ b/libtrip-notification/src/main/res/values-vi/strings.xml
@@ -1,6 +1,7 @@
 <resources>
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Kết thúc Điều hướng</string>
+    <string name="mapbox_navigation_is_starting">Đang bắt đầu điều hướng…</string>
     <string name="mapbox_stop_session">Ngừng phiên điều hướng</string>
     <string name="mapbox_free_drive_session">Phiên Lái xe Tự do</string>
     <string name="mapbox_eta_format">Đến %s</string>


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Fixes https://github.com/mapbox/mapbox-navigation-android/issues/3944

Force-pulls translations from Transifex in all languages, since it has been a while since translations were last pulled in https://github.com/mapbox/mapbox-navigation-android/pull/3856

This also sets up `libnavui-maps`, `libnavui-speedlimit` and `libnavui-voice` resources i.e. https://github.com/mapbox/mapbox-navigation-android/issues/3944

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Updated assets and resources translations.</changelog>
```

cc @1ec5 @zugaldia 