### PR TITLE
Bump `mapbox-navigation-native` dependency version to `61.0.0` and `maps` dependency version to `10.0.0-rc.5`

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -925,7 +925,7 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 
 #### Navigation UI Maps SDK module
 Mapbox Navigation uses portions of the Activity (Provides the base Activity subclass and the relevant hooks to build a composable structure on top.).
-URL: [https://developer.android.com/jetpack/androidx](https://developer.android.com/jetpack/androidx)
+URL: [https://developer.android.com/jetpack/androidx/releases/activity#1.2.3](https://developer.android.com/jetpack/androidx/releases/activity#1.2.3)
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
@@ -936,8 +936,8 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 
 ===========================================================================
 
-Mapbox Navigation uses portions of the Android AppCompat Library v7 (The Support Library is a static library that you can add to your Android application in order to use APIs that are either not available for older platform versions or utility APIs that aren't a part of the framework APIs. Compatible on devices running API 14 or later.).
-URL: [https://developer.android.com/jetpack/androidx](https://developer.android.com/jetpack/androidx)
+Mapbox Navigation uses portions of the Android AppCompat Library (The Support Library is a static library that you can add to your Android application in order to use APIs that are either not available for older platform versions or utility APIs that aren't a part of the framework APIs. Compatible on devices running API 14 or later.).
+URL: [https://developer.android.com/jetpack/androidx/releases/appcompat#1.3.0](https://developer.android.com/jetpack/androidx/releases/appcompat#1.3.0)
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
@@ -973,31 +973,37 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 ===========================================================================
 
 Mapbox Navigation uses portions of the Android Lifecycle LiveData Core.
-URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)
+URL: [https://developer.android.com/jetpack/androidx/releases/lifecycle#2.3.1](https://developer.android.com/jetpack/androidx/releases/lifecycle#2.3.1)
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
 Mapbox Navigation uses portions of the Android Lifecycle Runtime.
-URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)
+URL: [https://developer.android.com/jetpack/androidx/releases/lifecycle#2.3.1](https://developer.android.com/jetpack/androidx/releases/lifecycle#2.3.1)
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
 Mapbox Navigation uses portions of the Android Lifecycle ViewModel.
-URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)
+URL: [https://developer.android.com/jetpack/androidx/releases/lifecycle#2.3.1](https://developer.android.com/jetpack/androidx/releases/lifecycle#2.3.1)
+License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+===========================================================================
+
+Mapbox Navigation uses portions of the Android Lifecycle ViewModel with SavedState (Android Lifecycle ViewModel).
+URL: [https://developer.android.com/jetpack/androidx/releases/lifecycle#2.3.1](https://developer.android.com/jetpack/androidx/releases/lifecycle#2.3.1)
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
 Mapbox Navigation uses portions of the Android Lifecycle-Common.
-URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)
+URL: [https://developer.android.com/jetpack/androidx/releases/lifecycle#2.3.1](https://developer.android.com/jetpack/androidx/releases/lifecycle#2.3.1)
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
 Mapbox Navigation uses portions of the Android Resources Library (The Resources Library is a static library that you can add to your Android application in order to use resource APIs that backport the latest APIs to older versions of the platform. Compatible on devices running API 14 or later.).
-URL: [https://developer.android.com/jetpack/androidx](https://developer.android.com/jetpack/androidx)
+URL: [https://developer.android.com/jetpack/androidx/releases/appcompat#1.3.0](https://developer.android.com/jetpack/androidx/releases/appcompat#1.3.0)
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
@@ -1069,7 +1075,7 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 ===========================================================================
 
 Mapbox Navigation uses portions of the Android Support Library fragment (The Support Library is a static library that you can add to your Android application in order to use APIs that are either not available for older platform versions or utility APIs that aren't a part of the framework APIs. Compatible on devices running API 14 or later.).
-URL: [https://developer.android.com/jetpack/androidx](https://developer.android.com/jetpack/androidx)
+URL: [https://developer.android.com/jetpack/androidx/releases/fragment#1.3.4](https://developer.android.com/jetpack/androidx/releases/fragment#1.3.4)
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
@@ -1135,6 +1141,12 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 ===========================================================================
 
 Mapbox Navigation uses portions of the Core Kotlin Extensions (Kotlin extensions for 'core' artifact).
+URL: [https://developer.android.com/jetpack/androidx](https://developer.android.com/jetpack/androidx)
+License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+===========================================================================
+
+Mapbox Navigation uses portions of the Experimental annotation (Java annotation for use on unstable Android API surfaces. When used in conjunction with the Experimental annotation lint checks, this annotation provides functional parity with Kotlin's Experimental annotation.).
 URL: [https://developer.android.com/jetpack/androidx](https://developer.android.com/jetpack/androidx)
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -1324,6 +1336,12 @@ License: [BSD](https://opensource.org/licenses/BSD-2-Clause)
 ===========================================================================
 
 Mapbox Navigation uses portions of the The logo module for the Mapbox Maps SDK for Android.
+URL: [https://github.com/mapbox/mapbox-maps-android](https://github.com/mapbox/mapbox-maps-android)
+License: [BSD](https://opensource.org/licenses/BSD-2-Clause)
+
+===========================================================================
+
+Mapbox Navigation uses portions of the The map lifecycle module for the Mapbox Maps SDK for Android.
 URL: [https://github.com/mapbox/mapbox-maps-android](https://github.com/mapbox/mapbox-maps-android)
 License: [BSD](https://opensource.org/licenses/BSD-2-Clause)
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -12,17 +12,17 @@ ext {
   // version which we should use in this build
   def mapboxNavigatorVersion = System.getenv("FORCE_MAPBOX_NAVIGATION_NATIVE_VERSION")
   if (mapboxNavigatorVersion == null || mapboxNavigatorVersion == '') {
-      mapboxNavigatorVersion = '59.0.0'
+      mapboxNavigatorVersion = '61.0.0'
   }
   println("Navigation Native version: " + mapboxNavigatorVersion)
 
   version = [
-      mapboxMapSdk              : '10.0.0-rc.4',
+      mapboxMapSdk              : '10.0.0-rc.5',
       mapboxSdkServices         : '6.0.0-alpha.2',
       mapboxEvents              : '8.1.0',
       mapboxCore                : '5.0.0',
       mapboxNavigator           : "${mapboxNavigatorVersion}",
-      mapboxCommonNative        : '16.1.0',
+      mapboxCommonNative        : '16.0.0',
       mapboxCrashMonitor        : '2.0.0',
       mapboxAnnotationPlugin    : '0.8.0',
       mapboxBaseAndroid         : '0.5.0',

--- a/libnavigation-base/api/current.txt
+++ b/libnavigation-base/api/current.txt
@@ -836,10 +836,10 @@ package com.mapbox.navigation.base.trip.model.roadobject {
 
   public final class UpcomingRoadObject {
     method public com.mapbox.navigation.base.trip.model.roadobject.distanceinfo.RoadObjectDistanceInfo? getDistanceInfo();
-    method public double getDistanceToStart();
+    method public Double? getDistanceToStart();
     method public com.mapbox.navigation.base.trip.model.roadobject.RoadObject getRoadObject();
     property public final com.mapbox.navigation.base.trip.model.roadobject.distanceinfo.RoadObjectDistanceInfo? distanceInfo;
-    property public final double distanceToStart;
+    property public final Double? distanceToStart;
     property public final com.mapbox.navigation.base.trip.model.roadobject.RoadObject roadObject;
   }
 
@@ -885,48 +885,59 @@ package com.mapbox.navigation.base.trip.model.roadobject.custom {
 package com.mapbox.navigation.base.trip.model.roadobject.distanceinfo {
 
   public final class GantryDistanceInfo extends com.mapbox.navigation.base.trip.model.roadobject.distanceinfo.RoadObjectDistanceInfo {
-    method public double getDistanceToStart();
-    property public double distanceToStart;
+    method public Double getDistanceToStart();
+    property public Double distanceToStart;
+  }
+
+  public final class Gate {
+    method public double getDistance();
+    method public int getId();
+    method public com.mapbox.navigation.base.trip.model.roadobject.RoadObjectPosition getPosition();
+    method public double getProbability();
+    property public final double distance;
+    property public final int id;
+    property public final com.mapbox.navigation.base.trip.model.roadobject.RoadObjectPosition position;
+    property public final double probability;
   }
 
   public final class LineDistanceInfo extends com.mapbox.navigation.base.trip.model.roadobject.distanceinfo.RoadObjectDistanceInfo {
     method public double getDistanceToEnd();
     method public double getDistanceToEntry();
     method public double getDistanceToExit();
-    method public double getDistanceToStart();
+    method public Double getDistanceToStart();
     method public boolean getEntryFromStart();
     method public double getLength();
     property public final double distanceToEnd;
     property public final double distanceToEntry;
     property public final double distanceToExit;
-    property public double distanceToStart;
+    property public Double distanceToStart;
     property public final boolean entryFromStart;
     property public final double length;
   }
 
   public final class PointDistanceInfo extends com.mapbox.navigation.base.trip.model.roadobject.distanceinfo.RoadObjectDistanceInfo {
-    method public double getDistanceToStart();
-    property public double distanceToStart;
+    method public Double getDistanceToStart();
+    property public Double distanceToStart;
   }
 
   public final class PolygonDistanceInfo extends com.mapbox.navigation.base.trip.model.roadobject.distanceinfo.RoadObjectDistanceInfo {
-    method public double getDistanceToNearestEntry();
-    method public double getDistanceToNearestExit();
-    method public double getDistanceToStart();
+    method public Double? getDistanceToStart();
+    method public java.util.List<com.mapbox.navigation.base.trip.model.roadobject.distanceinfo.Gate> getEntrances();
+    method public java.util.List<com.mapbox.navigation.base.trip.model.roadobject.distanceinfo.Gate> getExits();
     method public boolean getInside();
-    property public final double distanceToNearestEntry;
-    property public final double distanceToNearestExit;
-    property public double distanceToStart;
+    property public Double? distanceToStart;
+    property public final java.util.List<com.mapbox.navigation.base.trip.model.roadobject.distanceinfo.Gate> entrances;
+    property public final java.util.List<com.mapbox.navigation.base.trip.model.roadobject.distanceinfo.Gate> exits;
     property public final boolean inside;
   }
 
   public abstract class RoadObjectDistanceInfo {
     method public final int getDistanceInfoType();
-    method public abstract double getDistanceToStart();
+    method public abstract Double? getDistanceToStart();
     method public final String getRoadObjectId();
     method public final int getRoadObjectType();
     property public final int distanceInfoType;
-    property public abstract double distanceToStart;
+    property public abstract Double? distanceToStart;
     property public final String roadObjectId;
     property public final int roadObjectType;
   }
@@ -944,13 +955,13 @@ package com.mapbox.navigation.base.trip.model.roadobject.distanceinfo {
   }
 
   public final class SubGraphDistanceInfo extends com.mapbox.navigation.base.trip.model.roadobject.distanceinfo.RoadObjectDistanceInfo {
-    method public double getDistanceToNearestEntry();
-    method public double getDistanceToNearestExit();
-    method public double getDistanceToStart();
+    method public Double? getDistanceToStart();
+    method public java.util.List<com.mapbox.navigation.base.trip.model.roadobject.distanceinfo.Gate> getEntrances();
+    method public java.util.List<com.mapbox.navigation.base.trip.model.roadobject.distanceinfo.Gate> getExits();
     method public boolean getInside();
-    property public final double distanceToNearestEntry;
-    property public final double distanceToNearestExit;
-    property public double distanceToStart;
+    property public Double? distanceToStart;
+    property public final java.util.List<com.mapbox.navigation.base.trip.model.roadobject.distanceinfo.Gate> entrances;
+    property public final java.util.List<com.mapbox.navigation.base.trip.model.roadobject.distanceinfo.Gate> exits;
     property public final boolean inside;
   }
 

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/factory/RoadObjectInstanceFactory.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/factory/RoadObjectInstanceFactory.kt
@@ -43,7 +43,7 @@ object RoadObjectInstanceFactory {
      */
     fun buildUpcomingRoadObject(
         roadObject: RoadObject,
-        distanceToStart: Double,
+        distanceToStart: Double?,
         distanceInfo: RoadObjectDistanceInfo?
     ) =
         UpcomingRoadObject(roadObject, distanceToStart, distanceInfo)

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/eh/EHorizonMapper.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/eh/EHorizonMapper.kt
@@ -2,6 +2,7 @@ package com.mapbox.navigation.base.trip.model.eh
 
 import com.mapbox.navigation.base.trip.model.roadobject.RoadObjectPosition
 import com.mapbox.navigation.base.trip.model.roadobject.distanceinfo.GantryDistanceInfo
+import com.mapbox.navigation.base.trip.model.roadobject.distanceinfo.Gate
 import com.mapbox.navigation.base.trip.model.roadobject.distanceinfo.LineDistanceInfo
 import com.mapbox.navigation.base.trip.model.roadobject.distanceinfo.PointDistanceInfo
 import com.mapbox.navigation.base.trip.model.roadobject.distanceinfo.PolygonDistanceInfo
@@ -128,20 +129,24 @@ internal fun RoadObjectDistanceInfo.mapToRoadObjectDistanceInfo(
             pointDistanceInfo.distance
         )
         isPolygonDistanceInfo -> with(polygonDistanceInfo) {
+            val entrances = mapToGates(entrances)
+            val exits = mapToGates(exits)
             PolygonDistanceInfo(
                 roadObjectId,
                 roadObjectType,
-                distanceToNearestEntry,
-                distanceToNearestExit,
+                entrances,
+                exits,
                 inside,
             )
         }
         isSubGraphDistanceInfo -> with(subGraphDistanceInfo) {
+            val entrances = mapToGates(entrances)
+            val exits = mapToGates(exits)
             SubGraphDistanceInfo(
                 roadObjectId,
                 roadObjectType,
-                distanceToNearestEntry,
-                distanceToNearestExit,
+                entrances,
+                exits,
                 inside,
             )
         }
@@ -397,5 +402,18 @@ private fun GraphPath.mapToEHorizonGraphPath(): EHorizonGraphPath {
         percentAlongBegin,
         percentAlongEnd,
         length
+    )
+}
+
+private fun mapToGates(gates: List<com.mapbox.navigator.Gate>): List<Gate> {
+    return gates.map { it.mapToGate() }.toList()
+}
+
+private fun com.mapbox.navigator.Gate.mapToGate(): Gate {
+    return Gate(
+        id,
+        position.mapToRoadObjectPosition(),
+        probability,
+        distance
     )
 }

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/roadobject/UpcomingRoadObject.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/roadobject/UpcomingRoadObject.kt
@@ -19,14 +19,14 @@ import com.mapbox.navigation.base.trip.model.roadobject.distanceinfo.RoadObjectD
  * @param distanceToStart remaining distance to the start of the object.
  * This value will be negative after passing the start of the object and until we cross the finish
  * point of the [RoadObject]s geometry for objects that are on the actively navigated route,
- * but it will be zero for [EHorizon] objects.
+ * but it will be zero for [EHorizon] objects. It will be null if couldn't be determined.
  * @param distanceInfo provides extra distance details for the road objects. It will be non-null
  * for objects coming from the electronic horizon and null for objects that are on the current route
  * that we are actively navigating on.
  */
 class UpcomingRoadObject internal constructor(
     val roadObject: RoadObject,
-    val distanceToStart: Double,
+    val distanceToStart: Double?,
     val distanceInfo: RoadObjectDistanceInfo?,
 ) {
 

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/roadobject/distanceinfo/Gate.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/roadobject/distanceinfo/Gate.kt
@@ -1,0 +1,64 @@
+package com.mapbox.navigation.base.trip.model.roadobject.distanceinfo
+
+import com.mapbox.navigation.base.trip.model.roadobject.RoadObjectPosition
+
+/**
+ * Gate represents information about a particular exit or entrance.
+ *
+ * @param id of the [Gate], persistent to the same gate.
+ * @param position on the road graph with coordinates
+ * @param probability to enter/exit this gate, value in range [0, 1].
+ * Warning: currently this field contains 1.0 for all gates, would be improved in the future.
+ * @param distance distance to the gate in meters:
+ * - if represents entrance outside the object - positive
+ * - if represents entrance inside the object - negative
+ * - if represents exit outside the object - zero
+ * - if represents exit inside the object - positive
+ */
+class Gate internal constructor(
+    val id: Int,
+    val position: RoadObjectPosition,
+    val probability: Double,
+    val distance: Double,
+) {
+
+    /**
+     * Regenerate whenever a change is made
+     */
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as Gate
+
+        if (id != other.id) return false
+        if (position != other.position) return false
+        if (probability != other.probability) return false
+        if (distance != other.distance) return false
+
+        return true
+    }
+
+    /**
+     * Regenerate whenever a change is made
+     */
+    override fun hashCode(): Int {
+        var result = id.hashCode()
+        result = 31 * result + position.hashCode()
+        result = 31 * result + probability.hashCode()
+        result = 31 * result + distance.hashCode()
+        return result
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    override fun toString(): String {
+        return "Gate(" +
+            "id=$id, " +
+            "position=$position, " +
+            "probability=$probability, " +
+            "distance=$distance" +
+            ")"
+    }
+}

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/roadobject/distanceinfo/PolygonDistanceInfo.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/roadobject/distanceinfo/PolygonDistanceInfo.kt
@@ -6,22 +6,24 @@ import com.mapbox.navigation.base.trip.model.roadobject.RoadObjectType
  * PolygonDistanceInfo contains information about distance to the road object represented as
  * polygon.
  *
- * @param distanceToNearestEntry distance to the nearest entry
- * @param distanceToNearestExit distance to the nearest exit
+ * @param entrances distances to particular entrances, sorted by probability.
+ * Might be empty in the case when the polygon is very large and no entry could be detected using most likely path.
+ * @param exits distances to particular exits, sorted by probability.
+ * Might be empty in the case when the polygon is very large and no exit could be detected using most probable path.
  * @param inside true if inside the object
  */
 class PolygonDistanceInfo internal constructor(
     roadObjectId: String,
     @RoadObjectType.Type roadObjectType: Int,
-    val distanceToNearestEntry: Double,
-    val distanceToNearestExit: Double,
+    val entrances: List<Gate>,
+    val exits: List<Gate>,
     val inside: Boolean,
 ) : RoadObjectDistanceInfo(roadObjectId, roadObjectType, RoadObjectDistanceInfoType.POLYGON) {
 
     /**
-     * distance to start of the object
+     * distance to start of the object or null if couldn't be determined.
      */
-    override val distanceToStart: Double = distanceToNearestEntry
+    override val distanceToStart: Double? = entrances.firstOrNull()?.distance
 
     /**
      * Indicates whether some other object is "equal to" this one.
@@ -33,8 +35,8 @@ class PolygonDistanceInfo internal constructor(
 
         other as PolygonDistanceInfo
 
-        if (distanceToNearestEntry != other.distanceToNearestEntry) return false
-        if (distanceToNearestExit != other.distanceToNearestExit) return false
+        if (entrances != other.entrances) return false
+        if (exits != other.exits) return false
         if (inside != other.inside) return false
         if (distanceToStart != other.distanceToStart) return false
 
@@ -46,8 +48,8 @@ class PolygonDistanceInfo internal constructor(
      */
     override fun hashCode(): Int {
         var result = super.hashCode()
-        result = 31 * result + distanceToNearestEntry.hashCode()
-        result = 31 * result + distanceToNearestExit.hashCode()
+        result = 31 * result + entrances.hashCode()
+        result = 31 * result + exits.hashCode()
         result = 31 * result + inside.hashCode()
         result = 31 * result + distanceToStart.hashCode()
         return result
@@ -58,8 +60,8 @@ class PolygonDistanceInfo internal constructor(
      */
     override fun toString(): String {
         return "PolygonDistanceInfo(" +
-            "distanceToNearestEntry=$distanceToNearestEntry, " +
-            "distanceToNearestExit=$distanceToNearestExit, " +
+            "entrances=$entrances, " +
+            "exits=$exits, " +
             "inside=$inside, " +
             "distanceToStart=$distanceToStart" +
             "), ${super.toString()}"

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/roadobject/distanceinfo/RoadObjectDistanceInfo.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/roadobject/distanceinfo/RoadObjectDistanceInfo.kt
@@ -24,9 +24,9 @@ abstract class RoadObjectDistanceInfo internal constructor(
 ) {
 
     /**
-     * Distance to start of the object from current location
+     * Distance to start of the object from current location or null if couldn't be determined.
      */
-    abstract val distanceToStart: Double
+    abstract val distanceToStart: Double?
 
     /**
      * Indicates whether some other object is "equal to" this one.

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/roadobject/distanceinfo/SubGraphDistanceInfo.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/roadobject/distanceinfo/SubGraphDistanceInfo.kt
@@ -6,22 +6,24 @@ import com.mapbox.navigation.base.trip.model.roadobject.RoadObjectType
  * SubGraphDistanceInfo contains information about distance to the road object represented as
  * sub-graph.
  *
- * @param distanceToNearestEntry distance to the nearest entry
- * @param distanceToNearestExit distance to the nearest exit
+ * @param entrances distances to particular entrances, sorted by probability.
+ * Might be empty in the case when the subgraph is very large and no entry could be detected using most likely path.
+ * @param exits distances to particular exits, sorted by probability.
+ * Might be empty in the case when the subgraph is very large and no exit could be detected using most probable path.
  * @param inside true if inside the object
  */
 class SubGraphDistanceInfo internal constructor(
     roadObjectId: String,
     @RoadObjectType.Type roadObjectType: Int,
-    val distanceToNearestEntry: Double,
-    val distanceToNearestExit: Double,
+    val entrances: List<Gate>,
+    val exits: List<Gate>,
     val inside: Boolean,
 ) : RoadObjectDistanceInfo(roadObjectId, roadObjectType, RoadObjectDistanceInfoType.SUB_GRAPH) {
 
     /**
-     * distance to start of the object
+     * distance to start of the object or null if couldn't be determined.
      */
-    override val distanceToStart: Double = distanceToNearestEntry
+    override val distanceToStart: Double? = entrances.firstOrNull()?.distance
 
     /**
      * Indicates whether some other object is "equal to" this one.
@@ -33,8 +35,8 @@ class SubGraphDistanceInfo internal constructor(
 
         other as SubGraphDistanceInfo
 
-        if (distanceToNearestEntry != other.distanceToNearestEntry) return false
-        if (distanceToNearestExit != other.distanceToNearestExit) return false
+        if (entrances != other.entrances) return false
+        if (exits != other.exits) return false
         if (inside != other.inside) return false
         if (distanceToStart != other.distanceToStart) return false
 
@@ -46,8 +48,8 @@ class SubGraphDistanceInfo internal constructor(
      */
     override fun hashCode(): Int {
         var result = super.hashCode()
-        result = 31 * result + distanceToNearestEntry.hashCode()
-        result = 31 * result + distanceToNearestExit.hashCode()
+        result = 31 * result + entrances.hashCode()
+        result = 31 * result + exits.hashCode()
         result = 31 * result + inside.hashCode()
         result = 31 * result + distanceToStart.hashCode()
         return result
@@ -58,8 +60,8 @@ class SubGraphDistanceInfo internal constructor(
      */
     override fun toString(): String {
         return "SubGraphDistanceInfo(" +
-            "distanceToNearestEntry=$distanceToNearestEntry, " +
-            "distanceToNearestExit=$distanceToNearestExit, " +
+            "entrances=$entrances, " +
+            "exits=$exits, " +
             "inside=$inside, " +
             "distanceToStart=$distanceToStart" +
             "), ${super.toString()}"

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/navigator/NavigatorMapperTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/navigator/NavigatorMapperTest.kt
@@ -349,12 +349,12 @@ class NavigatorMapperTest {
 
         assertEquals(
             firstEntrance.distanceToStart,
-            upcomingRouteAlerts[0].distanceToStart,
+            upcomingRouteAlerts[0].distanceToStart!!,
             .0001
         )
         assertEquals(
             secondEntrance.distanceToStart,
-            upcomingRouteAlerts[1].distanceToStart,
+            upcomingRouteAlerts[1].distanceToStart!!,
             .0001
         )
     }


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Bumps `mapbox-navigation-native` dependency version to `61.0.0`, `maps` dependency version to `10.0.0-rc.5` and downgrades `common` dependency version to `16.0.0`

Opening this as a `Draft` until we figure what we want to do with EHorizon `PolygonDistanceInfo` and `SubGraphDistanceInfo` (`entrances` and `exits`).

### Changelog
```
<changelog>Added `Gate` object that represents information about a particular exit or entrance.</changelog>
<changelog>Updated `PolygonDistanceInfo` and `SubGraphDistanceInfo` to include `entrances` and `exits`.</changelog>
<changelog>Made `RoadObjectDistanceInfo.distanceToStart` nullable.</changelog>
```

cc @etl @mskurydin @SiarheiFedartsou 
