### PR TITLE
support more styling options for map buttons

### DIFF
--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/view/MapboxRecenterButton.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/view/MapboxRecenterButton.kt
@@ -132,6 +132,17 @@ class MapboxRecenterButton : ConstraintLayout {
         typedArray.getDrawable(
             R.styleable.MapboxRecenterButton_recenterButtonDrawable
         ).also { binding.recenterIcon.setImageDrawable(it) }
+
+        typedArray.getDrawable(
+            R.styleable.MapboxRecenterButton_recenterButtonBackground,
+        )?.let { background ->
+            binding.recenterIcon.background = background
+            binding.recenterText.background = background
+        }
+
+        typedArray.getColorStateList(
+            R.styleable.MapboxRecenterButton_recenterButtonTextColor,
+        )?.let { binding.recenterText.setTextColor(it) }
     }
 
     private fun getAnimator(from: Int, to: Int) =

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/view/MapboxRouteOverviewButton.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/view/MapboxRouteOverviewButton.kt
@@ -132,6 +132,17 @@ class MapboxRouteOverviewButton : ConstraintLayout {
         typedArray.getDrawable(
             R.styleable.MapboxRouteOverviewButton_overviewButtonDrawable
         ).also { binding.routeOverviewIcon.setImageDrawable(it) }
+
+        typedArray.getDrawable(
+            R.styleable.MapboxRouteOverviewButton_overviewButtonBackground,
+        )?.let { background ->
+            binding.routeOverviewIcon.background = background
+            binding.routeOverviewText.background = background
+        }
+
+        typedArray.getColorStateList(
+            R.styleable.MapboxRouteOverviewButton_overviewButtonTextColor,
+        )?.let { binding.routeOverviewText.setTextColor(it) }
     }
 
     private fun getAnimator(from: Int, to: Int) =

--- a/libnavui-maps/src/main/res/values/attrs.xml
+++ b/libnavui-maps/src/main/res/values/attrs.xml
@@ -3,10 +3,18 @@
     <declare-styleable name="MapboxRouteOverviewButton">
         <!-- Defines the drawable representing route overview. -->
         <attr name="overviewButtonDrawable" format="reference" />
+        <!-- Defines the background of route overview button. -->
+        <attr name="overviewButtonBackground" format="reference|color" />
+        <!-- Defines the text color of route overview button. -->
+        <attr name="overviewButtonTextColor" format="color" />
     </declare-styleable>
 
     <declare-styleable name="MapboxRecenterButton">
         <!-- Defines the drawable representing recenter. -->
         <attr name="recenterButtonDrawable" format="reference" />
+        <!-- Defines the background of recenter button. -->
+        <attr name="recenterButtonBackground" format="reference|color" />
+        <!-- Defines the text color of recenter button. -->
+        <attr name="recenterButtonTextColor" format="color" />
     </declare-styleable>
 </resources>

--- a/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/view/MapboxSoundButton.kt
+++ b/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/view/MapboxSoundButton.kt
@@ -90,6 +90,15 @@ class MapboxSoundButton : ConstraintLayout {
                 R.drawable.mapbox_ic_sound_on
             )
         )
+
+        val background = typedArray.getDrawable(R.styleable.MapboxSoundButton_soundButtonBackground)
+        if (background != null) {
+            binding.soundButtonIcon.background = background
+            binding.soundButtonText.background = background
+        }
+
+        typedArray.getColorStateList(R.styleable.MapboxSoundButton_soundButtonTextColor)
+            ?.let { binding.soundButtonText.setTextColor(it) }
     }
 
     override fun onFinishInflate() {

--- a/libnavui-voice/src/main/res/values/attrs.xml
+++ b/libnavui-voice/src/main/res/values/attrs.xml
@@ -5,5 +5,9 @@
         <attr name="soundButtonMuteDrawable" format="reference" />
         <!-- Defines the drawable representing sound button unmute state. -->
         <attr name="soundButtonUnmuteDrawable" format="reference" />
+        <!-- Defines the background of sound button. -->
+        <attr name="soundButtonBackground" format="reference|color" />
+        <!-- Defines the text color of sound button. -->
+        <attr name="soundButtonTextColor" format="color" />
     </declare-styleable>
 </resources>


### PR DESCRIPTION
### Description
Resolves #4685. Users can now change background and text color of map buttons. 

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Added option to set custom background and text color for `Recenter` and `RouteOverview` buttons.</changelog>
```

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
