### PR TITLE
Bump Maps SDK and NN dependency versions to `10.0.0-rc.6` and `62.0.0` respectively

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -12,17 +12,17 @@ ext {
   // version which we should use in this build
   def mapboxNavigatorVersion = System.getenv("FORCE_MAPBOX_NAVIGATION_NATIVE_VERSION")
   if (mapboxNavigatorVersion == null || mapboxNavigatorVersion == '') {
-      mapboxNavigatorVersion = '61.0.0'
+      mapboxNavigatorVersion = '62.0.0'
   }
   println("Navigation Native version: " + mapboxNavigatorVersion)
 
   version = [
-      mapboxMapSdk              : '10.0.0-rc.5',
+      mapboxMapSdk              : '10.0.0-rc.6',
       mapboxSdkServices         : '6.0.0-alpha.2',
       mapboxEvents              : '8.1.0',
       mapboxCore                : '5.0.0',
       mapboxNavigator           : "${mapboxNavigatorVersion}",
-      mapboxCommonNative        : '16.0.0',
+      mapboxCommonNative        : '16.2.0',
       mapboxCrashMonitor        : '2.0.0',
       mapboxAnnotationPlugin    : '0.8.0',
       mapboxBaseAndroid         : '0.5.0',

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/navigator/NavigatorMapperTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/navigator/NavigatorMapperTest.kt
@@ -321,7 +321,7 @@ class NavigatorMapperTest {
 
     @Test
     fun `alerts are present in the route init info is they are delivered from native`() {
-        val routeInfo = RouteInfo(listOf(tunnel.toUpcomingRouteAlert()))
+        val routeInfo = RouteInfo(1, listOf(tunnel.toUpcomingRouteAlert()))
 
         val result = getRouteInitInfo(routeInfo)!!
 

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/NavigatorLoader.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/NavigatorLoader.kt
@@ -18,7 +18,6 @@ import com.mapbox.navigator.ProfileApplication
 import com.mapbox.navigator.ProfilePlatform
 import com.mapbox.navigator.RoadObjectMatcher
 import com.mapbox.navigator.Router
-import com.mapbox.navigator.RunLoopExecutorFactory
 import com.mapbox.navigator.SettingsProfile
 import com.mapbox.navigator.TilesConfig
 
@@ -40,11 +39,9 @@ internal object NavigatorLoader {
             deviceProfile.customConfig
         )
         val historyRecorder = buildHistoryRecorder(historyDir, config)
-        val runLoopExecutor = RunLoopExecutorFactory.build()
         val cache = CacheFactory.build(tilesConfig, config, historyRecorder)
         val navigator = Navigator(
             config,
-            runLoopExecutor,
             cache,
             historyRecorder
         )

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/MapboxRouteLineActivity.java
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/MapboxRouteLineActivity.java
@@ -31,8 +31,9 @@ import com.mapbox.maps.MapboxMap;
 import com.mapbox.maps.Style;
 import com.mapbox.maps.extension.style.layers.properties.generated.Visibility;
 import com.mapbox.maps.plugin.LocationPuck2D;
+import com.mapbox.maps.plugin.Plugin;
 import com.mapbox.maps.plugin.animation.CameraAnimationsPlugin;
-import com.mapbox.maps.plugin.animation.CameraAnimationsPluginImplKt;
+import com.mapbox.maps.plugin.animation.CameraAnimationsUtils;
 import com.mapbox.maps.plugin.animation.MapAnimationOptions;
 import com.mapbox.maps.plugin.gestures.GesturesPluginImpl;
 import com.mapbox.maps.plugin.gestures.OnMapClickListener;
@@ -340,7 +341,7 @@ public class MapboxRouteLineActivity extends AppCompatActivity implements OnMapL
   private RouterCallback routesReqCallback = new RouterCallback() {
     @Override
     public void onRoutesReady(
-      @NotNull List<? extends DirectionsRoute> routes, @NonNull RouterOrigin routerOrigin
+        @NotNull List<? extends DirectionsRoute> routes, @NonNull RouterOrigin routerOrigin
     ) {
       mapboxNavigation.setRoutes(routes);
       if (!routes.isEmpty()) {
@@ -428,15 +429,15 @@ public class MapboxRouteLineActivity extends AppCompatActivity implements OnMapL
   }
 
   private LocationComponentPluginImpl getLocationComponent() {
-    return mapView.getPlugin(LocationComponentPluginImpl.class);
+    return mapView.getPlugin(Plugin.MAPBOX_LOCATION_COMPONENT_PLUGIN_ID);
   }
 
   private CameraAnimationsPlugin getMapCamera() {
-    return CameraAnimationsPluginImplKt.getCamera(mapView);
+    return CameraAnimationsUtils.getCamera(mapView);
   }
 
   private GesturesPluginImpl getGesturePlugin() {
-    return mapView.getPlugin(GesturesPluginImpl.class);
+    return mapView.getPlugin(Plugin.MAPBOX_GESTURES_PLUGIN_ID);
   }
 
   private ReplayProgressObserver replayProgressObserver = new ReplayProgressObserver(mapboxReplayer);


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Bumps Maps SDK and NN dependency versions to `10.0.0-rc.6` and `62.0.0` respectively and reverts `common` dependency version back to `16.2.0`

~~Still missing latest NN version integrating `common` `16.2.0`.~~

cc @truburt @zugaldia @etl 
