### PR TITLE
add option to set custom text for map buttons

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxVoiceActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxVoiceActivity.kt
@@ -162,18 +162,6 @@ class MapboxVoiceActivity : AppCompatActivity(), OnMapLongClickListener {
 
     private val replayProgressObserver = ReplayProgressObserver(mapboxReplayer)
 
-    private val soundButtonCallback = MapboxNavigationConsumer<Boolean> { value ->
-        isMuted = value.also {
-            if (it) {
-                // This is used to set the speech volume to mute.
-                voiceInstructionsPlayer.volume(SpeechVolume(0.0f))
-            } else {
-                // This is used to set the speech volume to max
-                voiceInstructionsPlayer.volume(SpeechVolume(1.0f))
-            }
-        }
-    }
-
     private val locationObserver = object : LocationObserver {
         override fun onRawLocationChanged(rawLocation: Location) {}
         override fun onEnhancedLocationChanged(
@@ -269,13 +257,23 @@ class MapboxVoiceActivity : AppCompatActivity(), OnMapLongClickListener {
     }
 
     private fun soundButtonMake(mute: Boolean) {
-        if (mute) {
-            binding.soundButton
-                .muteAndExtend(SOUND_BUTTON_TEXT_APPEAR_DURATION, soundButtonCallback)
+        val muted = if (mute) {
+            binding.soundButton.muteAndExtend(SOUND_BUTTON_TEXT_APPEAR_DURATION)
         } else {
-            binding.soundButton
-                .unmuteAndExtend(SOUND_BUTTON_TEXT_APPEAR_DURATION, soundButtonCallback)
+            binding.soundButton.unmuteAndExtend(SOUND_BUTTON_TEXT_APPEAR_DURATION)
         }
+        handleSoundState(muted)
+    }
+
+    private fun handleSoundState(value: Boolean) {
+        if (value) {
+            // This is used to set the speech volume to mute.
+            voiceInstructionsPlayer.volume(SpeechVolume(0.0f))
+        } else {
+            // This is used to set the speech volume to max
+            voiceInstructionsPlayer.volume(SpeechVolume(1.0f))
+        }
+        isMuted = value
     }
 
     private fun getMapboxAccessTokenFromResources(): String {

--- a/libnavui-maps/api/current.txt
+++ b/libnavui-maps/api/current.txt
@@ -427,6 +427,7 @@ package com.mapbox.navigation.ui.maps.camera.view {
     ctor public MapboxRecenterButton(android.content.Context context);
     ctor public MapboxRecenterButton(android.content.Context context, android.util.AttributeSet? attrs);
     ctor public MapboxRecenterButton(android.content.Context context, android.util.AttributeSet? attrs, int defStyleAttr);
+    method public void showTextAndExtend(long duration, String text = context.getString(R.string.mapbox_recenter));
     method public void showTextAndExtend(long duration);
     method public void updateStyle(@StyleRes int style);
   }
@@ -435,6 +436,7 @@ package com.mapbox.navigation.ui.maps.camera.view {
     ctor public MapboxRouteOverviewButton(android.content.Context context);
     ctor public MapboxRouteOverviewButton(android.content.Context context, android.util.AttributeSet? attrs);
     ctor public MapboxRouteOverviewButton(android.content.Context context, android.util.AttributeSet? attrs, int defStyleAttr);
+    method public void showTextAndExtend(long duration, String text = context.getString(R.string.mapbox_route_overview));
     method public void showTextAndExtend(long duration);
     method public void updateStyle(@StyleRes int style);
   }

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/view/MapboxRecenterButton.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/view/MapboxRecenterButton.kt
@@ -85,11 +85,15 @@ class MapboxRecenterButton : ConstraintLayout {
     /**
      * Invoke the function to show optional text associated with the view.
      * @param duration for the view to be in the extended mode before it starts to shrink.
+     * @param text for the view to show in the extended mode.
      */
-    fun showTextAndExtend(duration: Long) {
+    @JvmOverloads
+    fun showTextAndExtend(
+        duration: Long,
+        text: String = context.getString(R.string.mapbox_recenter),
+    ) {
         if (!isAnimationRunning) {
             isAnimationRunning = true
-            val text = context.getString(R.string.mapbox_recenter)
             val extendedWidth = (binding.recenterText.measureTextWidth(text) + shrunkWidth)
                 .coerceAtLeast(MIN_EXTENDED_WIDTH * context.resources.displayMetrics.density)
             getAnimator(shrunkWidth, extendedWidth.toInt()).play(

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/view/MapboxRouteOverviewButton.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/view/MapboxRouteOverviewButton.kt
@@ -84,11 +84,15 @@ class MapboxRouteOverviewButton : ConstraintLayout {
     /**
      * Invoke the function to show optional text associated with the view.
      * @param duration for the view to be in the extended mode before it starts to shrink.
+     * @param text for the view to show in the extended mode.
      */
-    fun showTextAndExtend(duration: Long) {
+    @JvmOverloads
+    fun showTextAndExtend(
+        duration: Long,
+        text: String = context.getString(R.string.mapbox_route_overview),
+    ) {
         if (!isAnimationRunning) {
             isAnimationRunning = true
-            val text = context.getString(R.string.mapbox_route_overview)
             val extendedWidth = (binding.routeOverviewText.measureTextWidth(text) + shrunkWidth)
                 .coerceAtLeast(MIN_EXTENDED_WIDTH * context.resources.displayMetrics.density)
             getAnimator(shrunkWidth, extendedWidth.toInt()).play(

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/camera/view/MapboxRecenterButtonTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/camera/view/MapboxRecenterButtonTest.kt
@@ -18,6 +18,8 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.LooperMode
 import org.robolectric.shadows.ShadowLooper
 
+private const val customText = "custom text"
+
 @LooperMode(LooperMode.Mode.PAUSED)
 @ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
@@ -74,5 +76,16 @@ class MapboxRecenterButtonTest {
 
         assertTrue(recenterText.text.isEmpty())
         assertEquals(recenterText.visibility, View.INVISIBLE)
+    }
+
+    @Test
+    fun `recenter and extend with text`() {
+        val view = MapboxRecenterButton(ctx)
+        val recenterText = view.findViewById<AppCompatTextView>(R.id.recenterText)
+
+        view.showTextAndExtend(0, customText)
+
+        assertEquals(recenterText.text, customText)
+        assertEquals(recenterText.visibility, View.VISIBLE)
     }
 }

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/camera/view/MapboxRecenterButtonTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/camera/view/MapboxRecenterButtonTest.kt
@@ -1,11 +1,13 @@
 package com.mapbox.navigation.ui.maps.camera.view
 
 import android.content.Context
+import android.view.View
 import android.widget.ImageView
 import androidx.appcompat.widget.AppCompatTextView
 import androidx.test.core.app.ApplicationProvider
 import com.mapbox.navigation.ui.maps.R
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -13,8 +15,10 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.LooperMode
 import org.robolectric.shadows.ShadowLooper
 
+@LooperMode(LooperMode.Mode.PAUSED)
 @ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
 class MapboxRecenterButtonTest {
@@ -69,5 +73,6 @@ class MapboxRecenterButtonTest {
         ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
 
         assertTrue(recenterText.text.isEmpty())
+        assertEquals(recenterText.visibility, View.INVISIBLE)
     }
 }

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/camera/view/MapboxRouteOverviewButtonTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/camera/view/MapboxRouteOverviewButtonTest.kt
@@ -1,11 +1,13 @@
 package com.mapbox.navigation.ui.maps.camera.view
 
 import android.content.Context
+import android.view.View
 import android.widget.ImageView
 import androidx.appcompat.widget.AppCompatTextView
 import androidx.test.core.app.ApplicationProvider
 import com.mapbox.navigation.ui.maps.R
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -13,8 +15,10 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.LooperMode
 import org.robolectric.shadows.ShadowLooper
 
+@LooperMode(LooperMode.Mode.PAUSED)
 @ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
 class MapboxRouteOverviewButtonTest {
@@ -69,5 +73,6 @@ class MapboxRouteOverviewButtonTest {
         ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
 
         assertTrue(routeOverviewText.text.isEmpty())
+        assertEquals(routeOverviewText.visibility, View.INVISIBLE)
     }
 }

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/camera/view/MapboxRouteOverviewButtonTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/camera/view/MapboxRouteOverviewButtonTest.kt
@@ -18,6 +18,8 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.LooperMode
 import org.robolectric.shadows.ShadowLooper
 
+private const val customText = "custom text"
+
 @LooperMode(LooperMode.Mode.PAUSED)
 @ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
@@ -74,5 +76,16 @@ class MapboxRouteOverviewButtonTest {
 
         assertTrue(routeOverviewText.text.isEmpty())
         assertEquals(routeOverviewText.visibility, View.INVISIBLE)
+    }
+
+    @Test
+    fun `overview and extend with text`() {
+        val view = MapboxRouteOverviewButton(ctx)
+        val routeOverviewText = view.findViewById<AppCompatTextView>(R.id.routeOverviewText)
+
+        view.showTextAndExtend(2000L, customText)
+
+        assertEquals(routeOverviewText.text, customText)
+        assertEquals(routeOverviewText.visibility, View.VISIBLE)
     }
 }

--- a/libnavui-voice/api/current.txt
+++ b/libnavui-voice/api/current.txt
@@ -126,14 +126,10 @@ package com.mapbox.navigation.ui.voice.view {
     ctor public MapboxSoundButton(android.content.Context context);
     ctor public MapboxSoundButton(android.content.Context context, android.util.AttributeSet? attrs);
     ctor public MapboxSoundButton(android.content.Context context, android.util.AttributeSet? attrs, int defStyleAttr);
-    method public void mute(com.mapbox.navigation.ui.base.util.MapboxNavigationConsumer<java.lang.Boolean>? callback = null);
-    method public void mute();
-    method public void muteAndExtend(long duration, com.mapbox.navigation.ui.base.util.MapboxNavigationConsumer<java.lang.Boolean>? callback = null);
-    method public void muteAndExtend(long duration);
-    method public void unmute(com.mapbox.navigation.ui.base.util.MapboxNavigationConsumer<java.lang.Boolean>? callback = null);
-    method public void unmute();
-    method public void unmuteAndExtend(long duration, com.mapbox.navigation.ui.base.util.MapboxNavigationConsumer<java.lang.Boolean>? callback = null);
-    method public void unmuteAndExtend(long duration);
+    method public boolean mute();
+    method public boolean muteAndExtend(long duration);
+    method public boolean unmute();
+    method public boolean unmuteAndExtend(long duration);
     method public void updateStyle(@StyleRes int style);
   }
 

--- a/libnavui-voice/api/current.txt
+++ b/libnavui-voice/api/current.txt
@@ -127,8 +127,10 @@ package com.mapbox.navigation.ui.voice.view {
     ctor public MapboxSoundButton(android.content.Context context, android.util.AttributeSet? attrs);
     ctor public MapboxSoundButton(android.content.Context context, android.util.AttributeSet? attrs, int defStyleAttr);
     method public boolean mute();
+    method public boolean muteAndExtend(long duration, String text = context.getString(R.string.mapbox_muted));
     method public boolean muteAndExtend(long duration);
     method public boolean unmute();
+    method public boolean unmuteAndExtend(long duration, String text = context.getString(R.string.mapbox_unmuted));
     method public boolean unmuteAndExtend(long duration);
     method public void updateStyle(@StyleRes int style);
   }

--- a/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/view/MapboxSoundButton.kt
+++ b/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/view/MapboxSoundButton.kt
@@ -8,7 +8,6 @@ import android.os.Looper
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.View
-import androidx.annotation.StringRes
 import androidx.annotation.StyleRes
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
@@ -141,23 +140,32 @@ class MapboxSoundButton : ConstraintLayout {
     /**
      * Invoke the function to mute and show optional text associated with the action.
      * @param duration for the view to be in the extended mode before it starts to shrink.
+     * @param text for the view to show in the extended mode.
      * @return `true` representing that view is in muted state.
      */
-    fun muteAndExtend(duration: Long): Boolean {
-        return mute().also { showTextWithAnimation(R.string.mapbox_muted, duration) }
+    @JvmOverloads
+    fun muteAndExtend(
+        duration: Long,
+        text: String = context.getString(R.string.mapbox_muted),
+    ): Boolean {
+        return mute().also { showTextWithAnimation(text, duration) }
     }
 
     /**
      * Invoke the function to unmute and show optional text associated with the action.
      * @param duration for the view to be in the extended mode before it starts to shrink.
+     * @param text for the view to show in the extended mode.
      * @return `false` representing that view is in unmuted state.
      */
-    fun unmuteAndExtend(duration: Long): Boolean {
-        return unmute().also { showTextWithAnimation(R.string.mapbox_unmuted, duration) }
+    @JvmOverloads
+    fun unmuteAndExtend(
+        duration: Long,
+        text: String = context.getString(R.string.mapbox_unmuted),
+    ): Boolean {
+        return unmute().also { showTextWithAnimation(text, duration) }
     }
 
-    private fun showTextWithAnimation(@StringRes textId: Int, duration: Long) {
-        val text = context.getString(textId)
+    private fun showTextWithAnimation(text: String, duration: Long) {
         val extendedWidth = (binding.soundButtonText.measureTextWidth(text) + shrunkWidth)
             .coerceAtLeast(MIN_EXTENDED_WIDTH * context.resources.displayMetrics.density)
         mainHandler.removeCallbacksAndMessages(null)

--- a/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/view/MapboxSoundButton.kt
+++ b/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/view/MapboxSoundButton.kt
@@ -12,7 +12,6 @@ import androidx.annotation.StringRes
 import androidx.annotation.StyleRes
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
-import com.mapbox.navigation.ui.base.util.MapboxNavigationConsumer
 import com.mapbox.navigation.ui.utils.internal.extensions.afterMeasured
 import com.mapbox.navigation.ui.utils.internal.extensions.measureTextWidth
 import com.mapbox.navigation.ui.utils.internal.extensions.play
@@ -123,48 +122,38 @@ class MapboxSoundButton : ConstraintLayout {
 
     /**
      * Invoke the function to mute.
-     * @param callback MapboxNavigationConsumer<Boolean> invoked after the drawable has been set and
-     * returns true representing that view is in muted state.
+     * @return `true` representing that view is in muted state.
      */
-    @JvmOverloads
-    fun mute(callback: MapboxNavigationConsumer<Boolean>? = null) {
+    fun mute(): Boolean {
         binding.soundButtonIcon.setImageDrawable(muteDrawable)
-        callback?.accept(true)
+        return true
     }
 
     /**
      * Invoke the function to unmute.
-     * @param callback MapboxNavigationConsumer<Boolean> invoked after the drawable has been set and
-     * returns false representing that view is in unmuted state.
+     * @return `false` representing that view is in unmuted state.
      */
-    @JvmOverloads
-    fun unmute(callback: MapboxNavigationConsumer<Boolean>? = null) {
+    fun unmute(): Boolean {
         binding.soundButtonIcon.setImageDrawable(unmuteDrawable)
-        callback?.accept(false)
+        return false
     }
 
     /**
      * Invoke the function to mute and show optional text associated with the action.
      * @param duration for the view to be in the extended mode before it starts to shrink.
-     * @param callback MapboxNavigationConsumer<Boolean> invoked after the animation is finished and
-     * returns true representing that view is in muted state.
+     * @return `true` representing that view is in muted state.
      */
-    @JvmOverloads
-    fun muteAndExtend(duration: Long, callback: MapboxNavigationConsumer<Boolean>? = null) {
-        mute(callback)
-        showTextWithAnimation(R.string.mapbox_muted, duration)
+    fun muteAndExtend(duration: Long): Boolean {
+        return mute().also { showTextWithAnimation(R.string.mapbox_muted, duration) }
     }
 
     /**
      * Invoke the function to unmute and show optional text associated with the action.
      * @param duration for the view to be in the extended mode before it starts to shrink.
-     * @param callback MapboxNavigationConsumer<Boolean> invoked after the animation is finished and
-     * returns false representing that view is in unmuted state.
+     * @return `false` representing that view is in unmuted state.
      */
-    @JvmOverloads
-    fun unmuteAndExtend(duration: Long, callback: MapboxNavigationConsumer<Boolean>? = null) {
-        unmute(callback)
-        showTextWithAnimation(R.string.mapbox_unmuted, duration)
+    fun unmuteAndExtend(duration: Long): Boolean {
+        return unmute().also { showTextWithAnimation(R.string.mapbox_unmuted, duration) }
     }
 
     private fun showTextWithAnimation(@StringRes textId: Int, duration: Long) {

--- a/libnavui-voice/src/test/java/com/mapbox/navigation/ui/voice/view/MapboxSoundButtonTest.kt
+++ b/libnavui-voice/src/test/java/com/mapbox/navigation/ui/voice/view/MapboxSoundButtonTest.kt
@@ -20,6 +20,8 @@ import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import org.robolectric.shadows.ShadowLooper
 
+private const val customText = "custom text"
+
 @LooperMode(LooperMode.Mode.PAUSED)
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.P])
@@ -97,6 +99,17 @@ class MapboxSoundButtonTest {
     }
 
     @Test
+    fun `mute and extend with text`() {
+        val view = MapboxSoundButton(ctx)
+        val soundButtonText = view.findViewById<AppCompatTextView>(R.id.soundButtonText)
+
+        view.muteAndExtend(0, customText)
+
+        assertEquals(soundButtonText.text, customText)
+        assertEquals(soundButtonText.visibility, View.VISIBLE)
+    }
+
+    @Test
     fun `mute and unmute and extend multiple times is allowed`() {
         val view = MapboxSoundButton(ctx)
         val soundButtonText = view.findViewById<AppCompatTextView>(R.id.soundButtonText)
@@ -123,5 +136,16 @@ class MapboxSoundButtonTest {
 
         assertTrue(soundButtonText.text.isEmpty())
         assertEquals(soundButtonText.visibility, View.INVISIBLE)
+    }
+
+    @Test
+    fun `unmute and extend with text`() {
+        val view = MapboxSoundButton(ctx)
+        val soundButtonText = view.findViewById<AppCompatTextView>(R.id.soundButtonText)
+
+        view.unmuteAndExtend(0, customText)
+
+        assertEquals(soundButtonText.text, customText)
+        assertEquals(soundButtonText.visibility, View.VISIBLE)
     }
 }

--- a/libnavui-voice/src/test/java/com/mapbox/navigation/ui/voice/view/MapboxSoundButtonTest.kt
+++ b/libnavui-voice/src/test/java/com/mapbox/navigation/ui/voice/view/MapboxSoundButtonTest.kt
@@ -12,6 +12,7 @@ import io.mockk.Ordering
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -128,7 +129,8 @@ class MapboxSoundButtonTest {
 
         verify(exactly = 1) { consumer.accept(capture(messageSlot)) }
         assertTrue(messageSlot.captured)
-        assertTrue(soundButtonText.visibility == View.INVISIBLE)
+        assertTrue(soundButtonText.text.isEmpty())
+        assertEquals(soundButtonText.visibility, View.INVISIBLE)
     }
 
     @Test
@@ -154,8 +156,8 @@ class MapboxSoundButtonTest {
             consumer.accept(false)
             consumer.accept(false)
         }
-        assertTrue(soundButtonText.visibility == View.INVISIBLE)
-        assertTrue(soundButtonText.visibility == View.INVISIBLE)
+        assertTrue(soundButtonText.text.isEmpty())
+        assertEquals(soundButtonText.visibility, View.INVISIBLE)
     }
 
     @Test
@@ -169,6 +171,7 @@ class MapboxSoundButtonTest {
 
         verify(exactly = 1) { consumer.accept(capture(messageSlot)) }
         assertFalse(messageSlot.captured)
-        assertTrue(soundButtonText.visibility == View.INVISIBLE)
+        assertTrue(soundButtonText.text.isEmpty())
+        assertEquals(soundButtonText.visibility, View.INVISIBLE)
     }
 }

--- a/libnavui-voice/src/test/java/com/mapbox/navigation/ui/voice/view/MapboxSoundButtonTest.kt
+++ b/libnavui-voice/src/test/java/com/mapbox/navigation/ui/voice/view/MapboxSoundButtonTest.kt
@@ -6,12 +6,7 @@ import android.view.View
 import android.widget.ImageView
 import androidx.appcompat.widget.AppCompatTextView
 import androidx.test.core.app.ApplicationProvider
-import com.mapbox.navigation.ui.base.util.MapboxNavigationConsumer
 import com.mapbox.navigation.ui.voice.R
-import io.mockk.Ordering
-import io.mockk.mockk
-import io.mockk.slot
-import io.mockk.verify
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -31,7 +26,6 @@ import org.robolectric.shadows.ShadowLooper
 class MapboxSoundButtonTest {
 
     private lateinit var ctx: Context
-    private val consumer: MapboxNavigationConsumer<Boolean> = mockk(relaxed = true)
 
     @Before
     fun setUp() {
@@ -51,7 +45,7 @@ class MapboxSoundButtonTest {
         val view = MapboxSoundButton(ctx, null)
         val expectedDrawable = view.findViewById<ImageView>(R.id.soundButtonIcon)
 
-        view.unmute(null)
+        view.unmute()
 
         assertNotNull(expectedDrawable.drawable)
     }
@@ -61,7 +55,7 @@ class MapboxSoundButtonTest {
         val view = MapboxSoundButton(ctx, null, 0)
         val expectedDrawable = view.findViewById<ImageView>(R.id.soundButtonIcon)
 
-        view.mute(null)
+        view.mute()
 
         assertNotNull(expectedDrawable.drawable)
     }
@@ -77,58 +71,27 @@ class MapboxSoundButtonTest {
     }
 
     @Test
-    fun `mute callback not invoked`() {
+    fun `mute returns true`() {
         val view = MapboxSoundButton(ctx, null, 0)
-        val messageSlot = slot<Boolean>()
 
-        view.mute(null)
-
-        verify(exactly = 0) { consumer.accept(capture(messageSlot)) }
+        assertTrue(view.mute())
     }
 
     @Test
-    fun `mute callback invoked`() {
+    fun `unmute returns false`() {
         val view = MapboxSoundButton(ctx, null, 0)
-        val messageSlot = slot<Boolean>()
 
-        view.mute(consumer)
-
-        verify(exactly = 1) { consumer.accept(capture(messageSlot)) }
-        assertTrue(messageSlot.captured)
-    }
-
-    @Test
-    fun `unmute callback not invoked`() {
-        val view = MapboxSoundButton(ctx, null, 0)
-        val messageSlot = slot<Boolean>()
-
-        view.unmute(null)
-
-        verify(exactly = 0) { consumer.accept(capture(messageSlot)) }
-    }
-
-    @Test
-    fun `unmute callback invoked`() {
-        val view = MapboxSoundButton(ctx, null, 0)
-        val messageSlot = slot<Boolean>()
-
-        view.unmute(consumer)
-
-        verify(exactly = 1) { consumer.accept(capture(messageSlot)) }
-        assertFalse(messageSlot.captured)
+        assertFalse(view.unmute())
     }
 
     @Test
     fun `mute and extend`() {
         val view = MapboxSoundButton(ctx)
         val soundButtonText = view.findViewById<AppCompatTextView>(R.id.soundButtonText)
-        val messageSlot = slot<Boolean>()
 
-        view.muteAndExtend(0, consumer)
+        assertTrue(view.muteAndExtend(0))
         ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
 
-        verify(exactly = 1) { consumer.accept(capture(messageSlot)) }
-        assertTrue(messageSlot.captured)
         assertTrue(soundButtonText.text.isEmpty())
         assertEquals(soundButtonText.visibility, View.INVISIBLE)
     }
@@ -137,25 +100,15 @@ class MapboxSoundButtonTest {
     fun `mute and unmute and extend multiple times is allowed`() {
         val view = MapboxSoundButton(ctx)
         val soundButtonText = view.findViewById<AppCompatTextView>(R.id.soundButtonText)
-        val messageSlot = slot<Boolean>()
 
-        view.muteAndExtend(100, consumer)
-        view.muteAndExtend(100, consumer)
-        view.unmuteAndExtend(100, consumer)
-        view.muteAndExtend(100, consumer)
-        view.unmuteAndExtend(100, consumer)
-        view.unmuteAndExtend(100, consumer)
+        assertTrue(view.muteAndExtend(100))
+        assertTrue(view.muteAndExtend(100))
+        assertFalse(view.unmuteAndExtend(100))
+        assertTrue(view.muteAndExtend(100))
+        assertFalse(view.unmuteAndExtend(100))
+        assertFalse(view.unmuteAndExtend(100))
         ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
 
-        verify(exactly = 6) { consumer.accept(capture(messageSlot)) }
-        verify(ordering = Ordering.SEQUENCE) {
-            consumer.accept(true)
-            consumer.accept(true)
-            consumer.accept(false)
-            consumer.accept(true)
-            consumer.accept(false)
-            consumer.accept(false)
-        }
         assertTrue(soundButtonText.text.isEmpty())
         assertEquals(soundButtonText.visibility, View.INVISIBLE)
     }
@@ -164,13 +117,10 @@ class MapboxSoundButtonTest {
     fun `unmute and extend`() {
         val view = MapboxSoundButton(ctx)
         val soundButtonText = view.findViewById<AppCompatTextView>(R.id.soundButtonText)
-        val messageSlot = slot<Boolean>()
 
-        view.unmuteAndExtend(0, consumer)
+        assertFalse(view.unmuteAndExtend(0))
         ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
 
-        verify(exactly = 1) { consumer.accept(capture(messageSlot)) }
-        assertFalse(messageSlot.captured)
         assertTrue(soundButtonText.text.isEmpty())
         assertEquals(soundButtonText.visibility, View.INVISIBLE)
     }


### PR DESCRIPTION
### Description
Resolves #4524. Users can now change text of map buttons.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Added option to set custom text for `Recenter`, `Sound`, and `RouteOverview` buttons.</changelog>
```

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
