### PR TITLE
RouteAlternativesController fix

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesController.kt
@@ -28,7 +28,9 @@ internal class RouteAlternativesController(
 ) {
     private val jobControl = ThreadController.getMainScopeAndRootJob()
 
-    private val mapboxTimer = MapboxTimer()
+    private val mapboxTimer = MapboxTimer().apply {
+        restartAfterMillis = options.intervalMillis
+    }
     private val observers = CopyOnWriteArraySet<RouteAlternativesObserver>()
     private var currentRequestId: Long? = null
 
@@ -36,7 +38,6 @@ internal class RouteAlternativesController(
         val needsToStartTimer = observers.isEmpty()
         observers.add(routeAlternativesObserver)
         if (needsToStartTimer) {
-            mapboxTimer.restartAfterMillis = options.intervalMillis
             restartTimer()
         }
     }
@@ -91,7 +92,9 @@ internal class RouteAlternativesController(
 
     fun interrupt() {
         currentRequestId?.let { directionsSession.cancelRouteRequest(it) }
-        restartTimer()
+        if (observers.isNotEmpty()) {
+            restartTimer()
+        }
     }
 
     private fun restartTimer() {


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
closes #4705 

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Fixed a bug when after `setRoutes()` is called `RouteAlternativesController` started to request alternative routes even with no observers.</changelog>
```

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
