### PR TITLE
removed a workaround for a missing banner instruction that was fixed upstream

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
@@ -226,20 +226,10 @@ internal class MapboxTripSession(
                             val currentStep = steps[tripStatus.navigationStatus.stepIndex]
                             val state = tripStatus.navigationStatus.routeState.convertState()
                             val nativeBannerInstruction: BannerInstruction? =
-                                if (state == RouteProgressState.INITIALIZED) {
-                                    MapboxNativeNavigatorImpl.getBannerInstruction(0)
-                                } else {
-                                    tripStatus.navigationStatus.bannerInstruction
-                                }.let {
-                                    // workaround for
-                                    // github.com/mapbox/mapbox-navigation-native/issues/3466
-                                    // there are cases where first status update with a new route
-                                    // does not provide banner instructions so we need to
-                                    // backfill them
-                                    if (
-                                        it == null &&
-                                        bannerInstructionEvent.latestBannerInstructions == null
-                                    ) {
+                                tripStatus.navigationStatus.bannerInstruction.let {
+                                    if (it == null && state == RouteProgressState.INITIALIZED) {
+                                        // workaround for a remaining issue in
+                                        // github.com/mapbox/mapbox-navigation-native/issues/3466
                                         MapboxNativeNavigatorImpl.getBannerInstruction(0)
                                     } else {
                                         it


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
This change removes the workaround for part of a problem with missing banner instructions which also resolves a crash where the workaround was supplying banner instructions for steps that correctly did not have any. This sometimes resulted in `ArrayindexOutOfBounds` exceptions.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Fixed an issue with an occasional `ArrayindexOutOfBoundsException` being thrown when setting a new route.</changelog>
```

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
