### PR TITLE
utils module: removed dokka

### DIFF
--- a/libnavigation-util/build.gradle
+++ b/libnavigation-util/build.gradle
@@ -1,9 +1,7 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-parcelize'
-apply plugin: 'org.jetbrains.dokka'
 apply from: "${rootDir}/gradle/ktlint.gradle"
-apply from: "${rootDir}/gradle/kdoc-settings.gradle"
 
 android {
     compileSdkVersion androidVersions.compileSdkVersion
@@ -37,21 +35,6 @@ dependencies {
 
     apply from: "${rootDir}/gradle/unit-testing-dependencies.gradle"
     testImplementation project(':libtesting-utils')
-}
-
-dokkaHtml {
-    outputDirectory.set(kdocPath)
-    moduleName.set("Utils")
-    dokkaSourceSets {
-        configureEach {
-            reportUndocumented.set(true)
-
-            perPackageOption {
-                matchingRegex.set("com.mapbox.navigation.utils.internal.*")
-                suppress.set(true)
-            }
-        }
-    }
 }
 
 apply from: "${rootDir}/gradle/track-public-apis.gradle"


### PR DESCRIPTION
### Description

`libnavigation-util module`: removed dokka 

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
