### PR TITLE
workaround for the missing instruction if the route is set while the trip session is stopped

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
@@ -14,11 +14,9 @@ import com.mapbox.navigation.base.internal.factory.TripNotificationStateFactory.
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.trip.model.RouteLegProgress
 import com.mapbox.navigation.base.trip.model.RouteProgress
-import com.mapbox.navigation.base.trip.model.RouteProgressState
 import com.mapbox.navigation.base.trip.model.roadobject.UpcomingRoadObject
 import com.mapbox.navigation.core.internal.utils.isSameRoute
 import com.mapbox.navigation.core.internal.utils.isSameUuid
-import com.mapbox.navigation.core.navigator.convertState
 import com.mapbox.navigation.core.navigator.getMapMatcherResult
 import com.mapbox.navigation.core.navigator.getRouteInitInfo
 import com.mapbox.navigation.core.navigator.getRouteProgressFrom
@@ -224,13 +222,18 @@ internal class MapboxTripSession(
                         val currentLeg = legs[tripStatus.navigationStatus.legIndex]
                         ifNonNull(currentLeg?.steps()) { steps ->
                             val currentStep = steps[tripStatus.navigationStatus.stepIndex]
-                            val state = tripStatus.navigationStatus.routeState.convertState()
                             val nativeBannerInstruction: BannerInstruction? =
                                 tripStatus.navigationStatus.bannerInstruction.let {
-                                    if (it == null && state == RouteProgressState.INITIALIZED) {
-                                        // workaround for a remaining issue in
+                                    if (it == null &&
+                                        bannerInstructionEvent.latestBannerInstructions == null
+                                    ) {
+                                        // workaround for a remaining issues in
                                         // github.com/mapbox/mapbox-navigation-native/issues/3466
-                                        MapboxNativeNavigatorImpl.getBannerInstruction(0)
+                                        // and
+                                        // github.com/mapbox/mapbox-navigation-android/issues/4727
+                                        MapboxNativeNavigatorImpl.getBannerInstruction(
+                                            status.stepIndex
+                                        )
                                     } else {
                                         it
                                     }


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Workaround for https://github.com/mapbox/mapbox-navigation-android/issues/4727 that ensures that even if we drop some events while the trip session is stopped, we can recover the banner instruction information.

This problem was caught by @Zayankovsky after the previous workaround was removed in https://github.com/mapbox/mapbox-navigation-android/pull/4714.

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
