### PR TITLE
Handle EHorizon SubgraphLocation

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -12,7 +12,7 @@ ext {
   // version which we should use in this build
   def mapboxNavigatorVersion = System.getenv("FORCE_MAPBOX_NAVIGATION_NATIVE_VERSION")
   if (mapboxNavigatorVersion == null || mapboxNavigatorVersion == '') {
-      mapboxNavigatorVersion = '63.0.0'
+      mapboxNavigatorVersion = '63.1.0'
   }
   println("Navigation Native version: " + mapboxNavigatorVersion)
 

--- a/libnavigation-base/api/current.txt
+++ b/libnavigation-base/api/current.txt
@@ -1097,12 +1097,35 @@ package com.mapbox.navigation.base.trip.model.roadobject.location {
     field public static final int POLYGON = 4; // 0x4
     field public static final int POLYLINE = 5; // 0x5
     field public static final int ROUTE_ALERT = 6; // 0x6
+    field public static final int SUBGRAPH = 7; // 0x7
   }
 
-  @IntDef({com.mapbox.navigation.base.trip.model.roadobject.location.RoadObjectLocationType.GANTRY, com.mapbox.navigation.base.trip.model.roadobject.location.RoadObjectLocationType.OPEN_LR_LINE, com.mapbox.navigation.base.trip.model.roadobject.location.RoadObjectLocationType.OPEN_LR_POINT, com.mapbox.navigation.base.trip.model.roadobject.location.RoadObjectLocationType.POINT, com.mapbox.navigation.base.trip.model.roadobject.location.RoadObjectLocationType.POLYGON, com.mapbox.navigation.base.trip.model.roadobject.location.RoadObjectLocationType.POLYLINE, com.mapbox.navigation.base.trip.model.roadobject.location.RoadObjectLocationType.ROUTE_ALERT}) @kotlin.annotation.Retention(kotlin.annotation.AnnotationRetention) public static @interface RoadObjectLocationType.Type {
+  @IntDef({com.mapbox.navigation.base.trip.model.roadobject.location.RoadObjectLocationType.GANTRY, com.mapbox.navigation.base.trip.model.roadobject.location.RoadObjectLocationType.OPEN_LR_LINE, com.mapbox.navigation.base.trip.model.roadobject.location.RoadObjectLocationType.OPEN_LR_POINT, com.mapbox.navigation.base.trip.model.roadobject.location.RoadObjectLocationType.POINT, com.mapbox.navigation.base.trip.model.roadobject.location.RoadObjectLocationType.POLYGON, com.mapbox.navigation.base.trip.model.roadobject.location.RoadObjectLocationType.POLYLINE, com.mapbox.navigation.base.trip.model.roadobject.location.RoadObjectLocationType.ROUTE_ALERT, com.mapbox.navigation.base.trip.model.roadobject.location.RoadObjectLocationType.SUBGRAPH}) @kotlin.annotation.Retention(kotlin.annotation.AnnotationRetention) public static @interface RoadObjectLocationType.Type {
   }
 
   public final class RouteAlertLocation extends com.mapbox.navigation.base.trip.model.roadobject.location.RoadObjectLocation {
+  }
+
+  public final class SubgraphEdge {
+    method public long getId();
+    method public java.util.List<java.lang.Long> getInnerEdgeIds();
+    method public double getLength();
+    method public java.util.List<java.lang.Long> getOuterEdgeIds();
+    method public com.mapbox.geojson.Geometry getShape();
+    property public final long id;
+    property public final java.util.List<java.lang.Long> innerEdgeIds;
+    property public final double length;
+    property public final java.util.List<java.lang.Long> outerEdgeIds;
+    property public final com.mapbox.geojson.Geometry shape;
+  }
+
+  public final class SubgraphLocation extends com.mapbox.navigation.base.trip.model.roadobject.location.RoadObjectLocation {
+    method public java.util.Map<java.lang.Long,com.mapbox.navigation.base.trip.model.roadobject.location.SubgraphEdge> getEdges();
+    method public java.util.List<com.mapbox.navigation.base.trip.model.roadobject.RoadObjectPosition> getEntries();
+    method public java.util.List<com.mapbox.navigation.base.trip.model.roadobject.RoadObjectPosition> getExits();
+    property public final java.util.Map<java.lang.Long,com.mapbox.navigation.base.trip.model.roadobject.location.SubgraphEdge> edges;
+    property public final java.util.List<com.mapbox.navigation.base.trip.model.roadobject.RoadObjectPosition> entries;
+    property public final java.util.List<com.mapbox.navigation.base.trip.model.roadobject.RoadObjectPosition> exits;
   }
 
 }

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/eh/EHorizonMapper.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/eh/EHorizonMapper.kt
@@ -15,6 +15,7 @@ import com.mapbox.navigation.base.trip.model.roadobject.location.PolygonLocation
 import com.mapbox.navigation.base.trip.model.roadobject.location.PolylineLocation
 import com.mapbox.navigation.base.trip.model.roadobject.location.RoadObjectLocation
 import com.mapbox.navigation.base.trip.model.roadobject.location.RouteAlertLocation
+import com.mapbox.navigation.base.trip.model.roadobject.location.SubgraphLocation
 import com.mapbox.navigator.EdgeMetadata
 import com.mapbox.navigator.ElectronicHorizon
 import com.mapbox.navigator.ElectronicHorizonEdge
@@ -35,6 +36,7 @@ import com.mapbox.navigator.RoadObjectPassInfo
 import com.mapbox.navigator.RoadObjectProvider
 import com.mapbox.navigator.RoadObjectType
 import com.mapbox.navigator.RoadSurface
+import com.mapbox.navigator.SubgraphEdge
 
 private typealias SDKRoadObjectType =
     com.mapbox.navigation.base.trip.model.roadobject.RoadObjectType
@@ -62,6 +64,9 @@ internal typealias SDKOpenLROrientation =
 
 internal typealias SDKRoadSurface =
     com.mapbox.navigation.base.trip.model.eh.RoadSurface
+
+internal typealias SDKSubgraphEdge =
+    com.mapbox.navigation.base.trip.model.roadobject.location.SubgraphEdge
 
 /**
  * Map the ElectronicHorizonPosition.
@@ -200,6 +205,14 @@ internal fun MatchedRoadObjectLocation.mapToRoadObjectLocation(): RoadObjectLoca
         isRouteAlertLocation -> {
             RouteAlertLocation(routeAlertLocation.shape)
         }
+        isMatchedSubgraphLocation -> {
+            SubgraphLocation(
+                matchedSubgraphLocation.enters.mapToRoadObjectPositions(),
+                matchedSubgraphLocation.exits.mapToRoadObjectPositions(),
+                matchedSubgraphLocation.edges.mapToSubgraphEdges(),
+                matchedSubgraphLocation.shape
+            )
+        }
         else -> throw IllegalArgumentException("Unsupported object location type.")
     }
 }
@@ -213,6 +226,24 @@ internal fun Position.mapToRoadObjectPosition(): RoadObjectPosition {
         coordinate
     )
 }
+
+internal fun Map<Long, SubgraphEdge>.mapToSubgraphEdges(): Map<Long, SDKSubgraphEdge> {
+    val edges = mutableMapOf<Long, SDKSubgraphEdge>()
+    this.forEach {
+        edges[it.key] = it.value.mapToSubgraphEdge()
+    }
+
+    return edges
+}
+
+internal fun SubgraphEdge.mapToSubgraphEdge() =
+    SDKSubgraphEdge(
+        id,
+        innerEdgeIds,
+        outerEdgeIds,
+        shape,
+        length
+    )
 
 /**
  * Map the RoadObjectType.

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/roadobject/location/RoadObjectLocationType.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/roadobject/location/RoadObjectLocationType.kt
@@ -58,6 +58,11 @@ object RoadObjectLocationType {
     const val ROUTE_ALERT = 6
 
     /**
+     * Location of an object represented as a subgraph.
+     */
+    const val SUBGRAPH = 7
+
+    /**
      * Retention policy for the RoadObjectLocationType
      */
     @Retention(AnnotationRetention.BINARY)
@@ -69,6 +74,7 @@ object RoadObjectLocationType {
         POLYGON,
         POLYLINE,
         ROUTE_ALERT,
+        SUBGRAPH,
     )
     annotation class Type
 }

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/roadobject/location/SubgraphEdge.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/roadobject/location/SubgraphEdge.kt
@@ -1,0 +1,69 @@
+package com.mapbox.navigation.base.trip.model.roadobject.location
+
+import com.mapbox.geojson.Geometry
+
+/**
+ * SubgraphEdge represents an edge in the complex object which might be considered as a
+ * directed graph. The graph might contain loops.
+ * `innerEdgeIds` and `outerEdgeIds` properties contain edge ids, which allows to traverse the
+ * graph, obtain geometry and calculate different distances inside it.
+ *
+ * @param id unique identifier of the edge.
+ * @param innerEdgeIds the identifiers of edges in the subgraph from which the user could transition
+ * to this edge.
+ * @param outerEdgeIds the identifiers of edges in the subgraph to which the user could transition
+ * from this edge.
+ * @param shape the edge shape geometry.
+ * @param length the length of the edge measured in meters.
+ */
+class SubgraphEdge internal constructor(
+    val id: Long,
+    val innerEdgeIds: List<Long>,
+    val outerEdgeIds: List<Long>,
+    val shape: Geometry,
+    val length: Double,
+) {
+
+    /**
+     * Indicates whether some other object is "equal to" this one.
+     */
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as SubgraphEdge
+
+        if (id != other.id) return false
+        if (innerEdgeIds != other.innerEdgeIds) return false
+        if (outerEdgeIds != other.outerEdgeIds) return false
+        if (shape != other.shape) return false
+        if (length != other.length) return false
+
+        return true
+    }
+
+    /**
+     * Returns a hash code value for the object.
+     */
+    override fun hashCode(): Int {
+        var result = id.hashCode()
+        result = 31 * result + innerEdgeIds.hashCode()
+        result = 31 * result + outerEdgeIds.hashCode()
+        result = 31 * result + shape.hashCode()
+        result = 31 * result + length.hashCode()
+        return result
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    override fun toString(): String {
+        return "SubgraphEdge(" +
+            "id=$id, " +
+            "innerEdgeIds=$innerEdgeIds, " +
+            "outerEdgeIds=$outerEdgeIds, " +
+            "shape=$shape, " +
+            "length=$length" +
+            ")"
+    }
+}

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/roadobject/location/SubgraphLocation.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/roadobject/location/SubgraphLocation.kt
@@ -1,0 +1,58 @@
+package com.mapbox.navigation.base.trip.model.roadobject.location
+
+import com.mapbox.geojson.Geometry
+import com.mapbox.navigation.base.trip.model.roadobject.RoadObjectPosition
+
+/**
+ * Location of an object represented as a subgraph.
+ *
+ * @param entries positions of the subgraph entries.
+ * @param exits positions of the subgraph exits.
+ * @param edges edges of the subgraph associated by id.
+ */
+class SubgraphLocation internal constructor(
+    val entries: List<RoadObjectPosition>,
+    val exits: List<RoadObjectPosition>,
+    val edges: Map<Long, SubgraphEdge>,
+    shape: Geometry,
+) : RoadObjectLocation(RoadObjectLocationType.SUBGRAPH, shape) {
+
+    /**
+     * Indicates whether some other object is "equal to" this one.
+     */
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        if (!super.equals(other)) return false
+
+        other as SubgraphLocation
+
+        if (entries != other.entries) return false
+        if (exits != other.exits) return false
+        if (edges != other.edges) return false
+
+        return true
+    }
+
+    /**
+     * Returns a hash code value for the object.
+     */
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+        result = 31 * result + entries.hashCode()
+        result = 31 * result + exits.hashCode()
+        result = 31 * result + edges.hashCode()
+        return result
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    override fun toString(): String {
+        return "SubgraphLocation(" +
+            "entries=$entries, " +
+            "exits=$exits, " +
+            "edges=$edges" +
+            ")"
+    }
+}


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Bump NN to 63.1.0

closes #4721 

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>
Fixed a bug when NavSDK crashed on EHorizon SubgraphLocation.
Expose a new RoadObject SubgraphLocation.
</changelog>
```