### PR TITLE
always update notification view fully

### DIFF
--- a/libtrip-notification/src/test/java/com/mapbox/navigation/trip/notification/internal/MapboxTripNotificationTest.kt
+++ b/libtrip-notification/src/test/java/com/mapbox/navigation/trip/notification/internal/MapboxTripNotificationTest.kt
@@ -257,7 +257,7 @@ class MapboxTripNotificationTest {
     }
 
     @Test
-    fun whenUpdateNotificationCalledTwiceWithSameDataThenRemoteViewAreNotUpdatedTwice() {
+    fun whenUpdateNotificationCalledTwiceWithSameDataThenRemoteViewAreUpdatedTwice() {
         val state = mockk<TripNotificationState.TripNotificationData>(relaxed = true)
         val primaryText = { "Primary Text" }
         val bannerText = mockBannerText(state, primaryText)
@@ -272,8 +272,8 @@ class MapboxTripNotificationTest {
         notification.updateNotification(state)
 
         verify(exactly = 2) { bannerText.text() }
-        verify(exactly = 1) { collapsedViews.setTextViewText(any(), primaryText()) }
-        verify(exactly = 1) { expandedViews.setTextViewText(any(), primaryText()) }
+        verify(exactly = 2) { collapsedViews.setTextViewText(any(), primaryText()) }
+        verify(exactly = 2) { expandedViews.setTextViewText(any(), primaryText()) }
         assertEquals(notification.currentManeuverType, MANEUVER_TYPE)
         assertEquals(notification.currentManeuverModifier, MANEUVER_MODIFIER)
     }


### PR DESCRIPTION
### Description
Attempts to fix #2604. 

Sometimes notification views are not updated after calling `MapboxTripNotificationView`'s functions. 
I couldn't find a reason for that, but it is somehow related to `NotificationManager.cancel` call and stopping of `NavigationNotificationService`. Both actions occur in `MapboxTripService.stopService` (which is called before starting each route in 1tap), also `NavigationNotificationService` can be restarted by the system at any time. 
So I suggest a workaround to update the notification views fully every time, even when nothing changes. I measured `MapboxTripNotification.updateNotificationViews` duration on my phone, it went from 1-3 to 2-5 milliseconds. 