### PR TITLE
Bump NN to 63.0.0 and mapbox-java to 6.0.0-alpha.3

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -265,8 +265,9 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 
 ===========================================================================
 
-Mapbox Navigation uses portions of the OkHttp Logging Interceptor.
-License: [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+Mapbox Navigation uses portions of the okhttp-logging-interceptor (Square’s meticulous HTTP client for Java and Kotlin.).
+URL: [https://square.github.io/okhttp/](https://square.github.io/okhttp/)
+License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
@@ -1945,18 +1946,21 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 
 ===========================================================================
 
-Mapbox Navigation uses portions of the OkHttp.
-License: [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+Mapbox Navigation uses portions of the okhttp (Square’s meticulous HTTP client for Java and Kotlin.).
+URL: [https://square.github.io/okhttp/](https://square.github.io/okhttp/)
+License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox Navigation uses portions of the OkHttp Logging Interceptor.
-License: [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+Mapbox Navigation uses portions of the okhttp-logging-interceptor (Square’s meticulous HTTP client for Java and Kotlin.).
+URL: [https://square.github.io/okhttp/](https://square.github.io/okhttp/)
+License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
-Mapbox Navigation uses portions of the Okio.
-License: [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+Mapbox Navigation uses portions of the Okio (A modern I/O API for Java).
+URL: [https://github.com/square/okio/](https://github.com/square/okio/)
+License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -12,13 +12,13 @@ ext {
   // version which we should use in this build
   def mapboxNavigatorVersion = System.getenv("FORCE_MAPBOX_NAVIGATION_NATIVE_VERSION")
   if (mapboxNavigatorVersion == null || mapboxNavigatorVersion == '') {
-      mapboxNavigatorVersion = '62.0.0'
+      mapboxNavigatorVersion = '63.0.0'
   }
   println("Navigation Native version: " + mapboxNavigatorVersion)
 
   version = [
       mapboxMapSdk              : '10.0.0-rc.6',
-      mapboxSdkServices         : '6.0.0-alpha.2',
+      mapboxSdkServices         : '6.0.0-alpha.3',
       mapboxEvents              : '8.1.0',
       mapboxCore                : '5.0.0',
       mapboxNavigator           : "${mapboxNavigatorVersion}",

--- a/libnavigation-base/api/current.txt
+++ b/libnavigation-base/api/current.txt
@@ -607,6 +607,7 @@ package com.mapbox.navigation.base.trip.model.eh {
     method public boolean getMotorway();
     method public java.util.List<com.mapbox.navigation.base.trip.model.eh.RoadName> getNames();
     method public boolean getRamp();
+    method public String getRoadSurface();
     method public double getSpeed();
     method public Double? getSpeedLimit();
     method public String? getStateCode();
@@ -628,6 +629,7 @@ package com.mapbox.navigation.base.trip.model.eh {
     property public final boolean motorway;
     property public final java.util.List<com.mapbox.navigation.base.trip.model.eh.RoadName> names;
     property public final boolean ramp;
+    property public final String roadSurface;
     property public final double speed;
     property public final Double? speedLimit;
     property public final String? stateCode;
@@ -703,6 +705,21 @@ package com.mapbox.navigation.base.trip.model.eh {
     method public boolean getShielded();
     property public final String name;
     property public final boolean shielded;
+  }
+
+  public final class RoadSurface {
+    field public static final String COMPACTED = "COMPACTED";
+    field public static final String DIRT = "DIRT";
+    field public static final String GRAVEL = "GRAVEL";
+    field public static final String IMPASSABLE = "IMPASSABLE";
+    field public static final com.mapbox.navigation.base.trip.model.eh.RoadSurface INSTANCE;
+    field public static final String PATH = "PATH";
+    field public static final String PAVED = "PAVED";
+    field public static final String PAVED_ROUGH = "PAVED_ROUGH";
+    field public static final String PAVED_SMOOTH = "PAVED_SMOOTH";
+  }
+
+  @StringDef({com.mapbox.navigation.base.trip.model.eh.RoadSurface.PAVED_SMOOTH, com.mapbox.navigation.base.trip.model.eh.RoadSurface.PAVED, com.mapbox.navigation.base.trip.model.eh.RoadSurface.PAVED_ROUGH, com.mapbox.navigation.base.trip.model.eh.RoadSurface.COMPACTED, com.mapbox.navigation.base.trip.model.eh.RoadSurface.DIRT, com.mapbox.navigation.base.trip.model.eh.RoadSurface.GRAVEL, com.mapbox.navigation.base.trip.model.eh.RoadSurface.PATH, com.mapbox.navigation.base.trip.model.eh.RoadSurface.IMPASSABLE}) @kotlin.annotation.Retention(kotlin.annotation.AnnotationRetention) public static @interface RoadSurface.Type {
   }
 
 }

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/eh/EHorizonEdgeMetadata.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/eh/EHorizonEdgeMetadata.kt
@@ -24,6 +24,7 @@ package com.mapbox.navigation.base.trip.model.eh
  * @param isRightHandTraffic true if in the current place/state right-hand traffic is used
  * @param isOneWay true if current edge is one-way.
  * false if left-hand.
+ * @param roadSurface type of the road surface.
  */
 class EHorizonEdgeMetadata internal constructor(
     val heading: Double,
@@ -45,6 +46,7 @@ class EHorizonEdgeMetadata internal constructor(
     val stateCode: String?,
     val isRightHandTraffic: Boolean,
     val isOneWay: Boolean,
+    @RoadSurface.Type val roadSurface: String
 ) {
 
     /**
@@ -75,6 +77,7 @@ class EHorizonEdgeMetadata internal constructor(
         if (stateCode != other.stateCode) return false
         if (isRightHandTraffic != other.isRightHandTraffic) return false
         if (isOneWay != other.isOneWay) return false
+        if (roadSurface != other.roadSurface) return false
 
         return true
     }
@@ -102,6 +105,7 @@ class EHorizonEdgeMetadata internal constructor(
         result = 31 * result + (stateCode?.hashCode() ?: 0)
         result = 31 * result + isRightHandTraffic.hashCode()
         result = 31 * result + isOneWay.hashCode()
+        result = 31 * result + roadSurface.hashCode()
         return result
     }
 
@@ -128,7 +132,8 @@ class EHorizonEdgeMetadata internal constructor(
             "countryCodeIso2=$countryCodeIso2, " +
             "stateCode=$stateCode, " +
             "isRightHandTraffic=$isRightHandTraffic, " +
-            "isOneWay=$isOneWay" +
+            "isOneWay=$isOneWay, " +
+            "roadSurface=$roadSurface" +
             ")"
     }
 }

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/eh/EHorizonMapper.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/eh/EHorizonMapper.kt
@@ -34,6 +34,7 @@ import com.mapbox.navigator.RoadObjectEnterExitInfo
 import com.mapbox.navigator.RoadObjectPassInfo
 import com.mapbox.navigator.RoadObjectProvider
 import com.mapbox.navigator.RoadObjectType
+import com.mapbox.navigator.RoadSurface
 
 private typealias SDKRoadObjectType =
     com.mapbox.navigation.base.trip.model.roadobject.RoadObjectType
@@ -58,6 +59,9 @@ internal typealias SDKOpenLRSideOfRoad =
 
 internal typealias SDKOpenLROrientation =
     com.mapbox.navigation.base.trip.model.roadobject.location.OpenLROrientation
+
+internal typealias SDKRoadSurface =
+    com.mapbox.navigation.base.trip.model.eh.RoadSurface
 
 /**
  * Map the ElectronicHorizonPosition.
@@ -289,6 +293,7 @@ internal fun EdgeMetadata.mapToEHorizonEdgeMetadata(): EHorizonEdgeMetadata {
         stateCode,
         isRightHandTraffic,
         isOneway,
+        surface.mapToRoadSurface()
     )
 }
 
@@ -417,3 +422,15 @@ private fun com.mapbox.navigator.Gate.mapToGate(): Gate {
         distance
     )
 }
+
+private fun RoadSurface.mapToRoadSurface(): String =
+    when (this) {
+        RoadSurface.PAVED_SMOOTH -> SDKRoadSurface.PAVED_SMOOTH
+        RoadSurface.PAVED -> SDKRoadSurface.PAVED
+        RoadSurface.PAVED_ROUGH -> SDKRoadSurface.PAVED_ROUGH
+        RoadSurface.COMPACTED -> SDKRoadSurface.COMPACTED
+        RoadSurface.DIRT -> SDKRoadSurface.DIRT
+        RoadSurface.GRAVEL -> SDKRoadSurface.GRAVEL
+        RoadSurface.PATH -> SDKRoadSurface.PATH
+        RoadSurface.IMPASSABLE -> SDKRoadSurface.IMPASSABLE
+    }

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/eh/RoadSurface.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/eh/RoadSurface.kt
@@ -1,0 +1,70 @@
+package com.mapbox.navigation.base.trip.model.eh
+
+import androidx.annotation.StringDef
+
+/**
+ * Surface type of the road.
+ * Check for details: https://wiki.openstreetmap.org/wiki/Key:surface
+ */
+object RoadSurface {
+
+    /**
+     * Paved smooth surface. The vehicle can traverse the route without significant risk of damage
+     * (e.g., to vehicle undercarriage/drivetrain) or injury (e.g., by falling).
+     */
+    const val PAVED_SMOOTH = "PAVED_SMOOTH"
+
+    /**
+     * A type that is predominantly paved, it is covered with paving stones, concrete or bitumen.
+     */
+    const val PAVED = "PAVED"
+
+    /**
+     * Heavily damaged paved roads that need maintenance: many potholes, some of them quite deep.
+     */
+    const val PAVED_ROUGH = "PAVED_ROUGH"
+
+    /**
+     * A stable surface, it's a mixture of larger (e.g., gravel) and smaller (e.g., sand) parts,
+     * compacted (e.g., with a roller).
+     */
+    const val COMPACTED = "COMPACTED"
+
+    /**
+     * No special surface, the ground itself has marks of human or animal usage.
+     * It is prone to erosion and therefore often uneven.
+     */
+    const val DIRT = "DIRT"
+
+    /**
+     * Used for cases ranging from huge gravel pieces like track ballast used as surface,
+     * through small pieces of gravel to compacted surface.
+     */
+    const val GRAVEL = "GRAVEL"
+
+    /**
+     * Grass or stepping stones surface. Used for pedestrian and bicycle routing only.
+     */
+    const val PATH = "PATH"
+
+    /**
+     * Road with such surface type can't be used for any routing.
+     */
+    const val IMPASSABLE = "IMPASSABLE"
+
+    /**
+     * Retention policy for the RoadSurface
+     */
+    @Retention(AnnotationRetention.BINARY)
+    @StringDef(
+        PAVED_SMOOTH,
+        PAVED,
+        PAVED_ROUGH,
+        COMPACTED,
+        DIRT,
+        GRAVEL,
+        PATH,
+        IMPASSABLE,
+    )
+    annotation class Type
+}


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Bump NN to 63.0.0 and mapbox-java to 6.0.0-alpha.3
Add new `roadSurface` property to `EHorizonEdgeMetadata`

mapper tests will be added in a separate PR when we will be unblocked.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Added new `roadSurface` property to `EHorizonEdgeMetadata`.</changelog>
```

