### PR TITLE
add option to select a leg when starting navigation

### DIFF
--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -41,6 +41,7 @@ package com.mapbox.navigation.core {
     method public void setArrivalController();
     method public void setRerouteController(com.mapbox.navigation.core.reroute.RerouteController? rerouteController = com.mapbox.navigation.core.MapboxNavigation.defaultRerouteController);
     method public void setRerouteController();
+    method public void setRoutes(java.util.List<? extends com.mapbox.api.directions.v5.models.DirectionsRoute> routes, int initialLegIndex = 0);
     method public void setRoutes(java.util.List<? extends com.mapbox.api.directions.v5.models.DirectionsRoute> routes);
     method @RequiresPermission(anyOf={android.Manifest.permission.ACCESS_COARSE_LOCATION, android.Manifest.permission.ACCESS_FINE_LOCATION}) public void startTripSession(boolean withForegroundService = true);
     method @RequiresPermission(anyOf={android.Manifest.permission.ACCESS_COARSE_LOCATION, android.Manifest.permission.ACCESS_FINE_LOCATION}) public void startTripSession();

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -515,12 +515,14 @@ class MapboxNavigation(
      * Use [RoutesObserver] and [MapboxNavigation.registerRoutesObserver] to observe whenever the routes list reference managed by the SDK changes, regardless of a source.
      *
      * @param routes a list of [DirectionsRoute]s
+     * @param initialLegIndex starting leg to follow. By default the first leg is used.
      * @see [requestRoutes]
      */
-    fun setRoutes(routes: List<DirectionsRoute>) {
+    @JvmOverloads
+    fun setRoutes(routes: List<DirectionsRoute>, initialLegIndex: Int = 0) {
         rerouteController?.interrupt()
         routeAlternativesController.interrupt()
-        directionsSession.routes = routes
+        directionsSession.setRoutes(routes, initialLegIndex)
         routeRefreshController.restart()
     }
 
@@ -554,7 +556,7 @@ class MapboxNavigation(
         tripSession.unregisterAllFallbackVersionsObservers()
         routeAlternativesController.unregisterAll()
         routeRefreshController.stop()
-        directionsSession.routes = emptyList()
+        directionsSession.setRoutes(emptyList())
         resetTripSession()
         navigator.unregisterAllObservers()
         navigationVersionSwitchObservers.clear()
@@ -935,11 +937,7 @@ class MapboxNavigation(
     }
 
     private fun createInternalRoutesObserver() = RoutesObserver { routes ->
-        if (routes.isNotEmpty()) {
-            tripSession.route = routes[0]
-        } else {
-            tripSession.route = null
-        }
+        tripSession.setRoute(routes.firstOrNull(), directionsSession.initialLegIndex)
     }
 
     private fun createInternalOffRouteObserver() = OffRouteObserver { offRoute ->

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/DirectionsSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/DirectionsSession.kt
@@ -14,7 +14,11 @@ internal interface DirectionsSession {
      *
      * @see [registerRoutesObserver]
      */
-    var routes: List<DirectionsRoute>
+    val routes: List<DirectionsRoute>
+
+    val initialLegIndex: Int
+
+    fun setRoutes(routes: List<DirectionsRoute>, initialLegIndex: Int = 0)
 
     /**
      * Provide route options for current primary route.

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/MapboxDirectionsSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/MapboxDirectionsSession.kt
@@ -29,16 +29,22 @@ internal class MapboxDirectionsSession(
      * @see [registerRoutesObserver]
      */
     override var routes: List<DirectionsRoute> = emptyList()
-        set(value) {
-            if (routes.isEmpty() && value.isEmpty()) {
-                return
-            }
-            field = value
-            if (routes.isNotEmpty()) {
-                this.primaryRouteOptions = routes[0].routeOptions()
-            }
-            routesObservers.forEach { it.onRoutesChanged(value) }
+        private set
+
+    override var initialLegIndex = 0
+        private set
+
+    override fun setRoutes(routes: List<DirectionsRoute>, initialLegIndex: Int) {
+        this.initialLegIndex = initialLegIndex
+        if (this.routes.isEmpty() && routes.isEmpty()) {
+            return
         }
+        this.routes = routes
+        if (routes.isNotEmpty()) {
+            primaryRouteOptions = routes[0].routeOptions()
+        }
+        routesObservers.forEach { it.onRoutesChanged(routes) }
+    }
 
     /**
      * Provide route options for current primary route.

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/routerefresh/RouteRefreshController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/routerefresh/RouteRefreshController.kt
@@ -121,7 +121,7 @@ internal class RouteRefreshController(
             val directionsSessionRoutes = directionsSession.routes.toMutableList()
             if (directionsSessionRoutes.isNotEmpty()) {
                 directionsSessionRoutes[0] = directionsRoute
-                directionsSession.routes = directionsSessionRoutes
+                directionsSession.setRoutes(directionsSessionRoutes)
             }
             currentRequestId = null
         }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/TripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/TripSession.kt
@@ -11,7 +11,8 @@ import com.mapbox.navigator.FallbackVersionsObserver
 internal interface TripSession {
 
     val tripService: TripService
-    var route: DirectionsRoute?
+    val route: DirectionsRoute?
+    fun setRoute(route: DirectionsRoute?, legIndex: Int)
 
     fun getRawLocation(): Location?
     fun getEnhancedLocation(): Location?

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/directions/session/MapboxDirectionsSessionTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/directions/session/MapboxDirectionsSessionTest.kt
@@ -144,8 +144,15 @@ class MapboxDirectionsSessionTest {
 
     @Test
     fun getRouteOptions() {
-        session.routes = routes
+        session.setRoutes(routes)
         assertEquals(routeOptions, session.getPrimaryRouteOptions())
+    }
+
+    @Test
+    fun getInitialLegIndex() {
+        val initialLegIndex = 2
+        session.setRoutes(routes, initialLegIndex)
+        assertEquals(initialLegIndex, session.initialLegIndex)
     }
 
     @Test
@@ -175,32 +182,32 @@ class MapboxDirectionsSessionTest {
     @Test
     fun `when route set, observer notified`() {
         session.registerRoutesObserver(observer)
-        session.routes = routes
+        session.setRoutes(routes)
         verify(exactly = 1) { observer.onRoutesChanged(routes) }
     }
 
     @Test
     fun `when route cleared, observer notified`() {
         session.registerRoutesObserver(observer)
-        session.routes = routes
-        session.routes = emptyList()
+        session.setRoutes(routes)
+        session.setRoutes(emptyList())
         verify(exactly = 1) { observer.onRoutesChanged(emptyList()) }
     }
 
     @Test
     fun `when new route available, observer notified`() {
         session.registerRoutesObserver(observer)
-        session.routes = routes
+        session.setRoutes(routes)
         val newRoutes: List<DirectionsRoute> = listOf(mockk())
         every { newRoutes[0].routeOptions() } returns routeOptions
-        session.routes = newRoutes
+        session.setRoutes(newRoutes)
         verify(exactly = 1) { observer.onRoutesChanged(newRoutes) }
     }
 
     @Test
     fun `setting a route does not impact ongoing route request`() {
         session.requestRoutes(routeOptions, routerCallback)
-        session.routes = routes
+        session.setRoutes(routes)
         verify(exactly = 0) { router.cancelAll() }
     }
 
@@ -208,7 +215,7 @@ class MapboxDirectionsSessionTest {
     fun unregisterAllRouteObservers() {
         session.registerRoutesObserver(observer)
         session.unregisterAllRoutesObservers()
-        session.routes = routes
+        session.setRoutes(routes)
 
         verify(exactly = 0) { observer.onRoutesChanged(any()) }
     }

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigator.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigator.kt
@@ -34,10 +34,6 @@ import com.mapbox.navigator.VoiceInstruction
  */
 interface MapboxNativeNavigator {
 
-    private companion object {
-        private const val INDEX_FIRST_LEG = 0
-    }
-
     /**
      * Initialize the navigator with a device profile
      */
@@ -104,10 +100,7 @@ interface MapboxNativeNavigator {
      * @return a [RouteInfo] route state if no errors occurred.
      * Otherwise, it returns null.
      */
-    suspend fun setRoute(
-        route: DirectionsRoute?,
-        legIndex: Int = INDEX_FIRST_LEG
-    ): RouteInfo?
+    suspend fun setRoute(route: DirectionsRoute?, legIndex: Int): RouteInfo?
 
     /**
      * Updates annotations so that subsequent calls to getStatus will


### PR DESCRIPTION
### Description
Closes #4681. 
Maybe we also need to trigger `onNextRouteLegStart` callback in this method, but I'm not sure. 

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Added option to select a leg when starting navigation</changelog>
```
