### PR TITLE
fixes missing argument for tripSession.start in unit test

### DIFF
--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
@@ -562,7 +562,7 @@ class MapboxTripSessionTest {
         tripSession = buildTripSession()
         tripSession.registerBannerInstructionsObserver(bannerInstructionsObserver)
         tripSession.route = route
-        tripSession.start()
+        tripSession.start(true)
         every { navigationStatus.routeState } returns RouteState.TRACKING
         every { navigationStatus.bannerInstruction } returns null
         navigatorObserverImplSlot.captured.onStatus(navigationStatusOrigin, navigationStatus)


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Fixes a merge conflict after https://github.com/mapbox/mapbox-navigation-android/commit/0546af088b9ac641fede57407bca7ca35672b706 landed.
