### PR TITLE
Added error handling to deprecated onError listener

### DIFF
--- a/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/api/VoiceInstructionsTextPlayer.kt
+++ b/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/api/VoiceInstructionsTextPlayer.kt
@@ -108,7 +108,9 @@ internal class VoiceInstructionsTextPlayer(
             }
 
             override fun onError(utteranceId: String?) {
-                // Intentionally empty as deprecated
+                // Deprecated, may be called due to https://issuetracker.google.com/issues/138321382
+                LoggerProvider.logger.e(Tag(TAG), Message("Unexpected TextToSpeech error"))
+                donePlaying()
             }
 
             override fun onError(utteranceId: String?, errorCode: Int) {


### PR DESCRIPTION
### Description
Closes #4702
Because of Android SDK issue mentioned in the comment (see code), deprecated onError method was called instead of the new one. Copied error handling logic to the deprecated method.

### Changelog
```
<changelog>Fixed stuck TTS queue when deprecated onError is called</changelog>
```
