### PR TITLE
fixes a regression that appended wrong distance traveled value to `RouteProgress`

### DIFF
--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/factory/RouteLegProgressFactory.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/factory/RouteLegProgressFactory.kt
@@ -30,24 +30,24 @@ object RouteLegProgressFactory {
      * on the last leg, this will return null since a next step doesn't exist
      */
     fun buildRouteLegProgressObject(
-        legIndex: Int = 0,
-        routeLeg: RouteLeg? = null,
-        distanceTraveled: Float = 0f,
-        distanceRemaining: Float = 0f,
-        durationRemaining: Double = 0.0,
-        fractionTraveled: Float = 0f,
-        currentStepProgress: RouteStepProgress? = null,
-        upcomingStep: LegStep? = null
+        legIndex: Int,
+        routeLeg: RouteLeg?,
+        distanceTraveled: Float,
+        distanceRemaining: Float,
+        durationRemaining: Double,
+        fractionTraveled: Float,
+        currentStepProgress: RouteStepProgress?,
+        upcomingStep: LegStep?
     ): RouteLegProgress {
         return RouteLegProgress(
-            legIndex,
-            routeLeg,
-            distanceTraveled,
-            distanceRemaining,
-            durationRemaining,
-            fractionTraveled,
-            currentStepProgress,
-            upcomingStep
+            legIndex = legIndex,
+            routeLeg = routeLeg,
+            distanceTraveled = distanceTraveled,
+            distanceRemaining = distanceRemaining,
+            durationRemaining = durationRemaining,
+            fractionTraveled = fractionTraveled,
+            currentStepProgress = currentStepProgress,
+            upcomingStep = upcomingStep
         )
     }
 }

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/factory/RouteProgressFactory.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/factory/RouteProgressFactory.kt
@@ -43,35 +43,35 @@ object RouteProgressFactory {
      */
     fun buildRouteProgressObject(
         route: DirectionsRoute,
-        bannerInstructions: BannerInstructions? = null,
-        voiceInstructions: VoiceInstructions? = null,
-        currentState: RouteProgressState = RouteProgressState.INITIALIZED,
-        currentLegProgress: RouteLegProgress? = null,
-        upcomingStepPoints: List<Point>? = null,
-        inTunnel: Boolean = false,
-        distanceRemaining: Float = 0f,
-        distanceTraveled: Float = 0f,
-        durationRemaining: Double = 0.0,
-        fractionTraveled: Float = 0f,
-        remainingWaypoints: Int = 0,
-        upcomingRoadObjects: List<UpcomingRoadObject> = emptyList(),
-        stale: Boolean = false
+        bannerInstructions: BannerInstructions?,
+        voiceInstructions: VoiceInstructions?,
+        currentState: RouteProgressState,
+        currentLegProgress: RouteLegProgress?,
+        upcomingStepPoints: List<Point>?,
+        inTunnel: Boolean,
+        distanceRemaining: Float,
+        distanceTraveled: Float,
+        durationRemaining: Double,
+        fractionTraveled: Float,
+        remainingWaypoints: Int,
+        upcomingRoadObjects: List<UpcomingRoadObject>,
+        stale: Boolean
     ): RouteProgress {
         return RouteProgress(
-            route,
-            bannerInstructions,
-            voiceInstructions,
-            currentState,
-            currentLegProgress,
-            upcomingStepPoints,
-            inTunnel,
-            distanceRemaining,
-            distanceTraveled,
-            durationRemaining,
-            fractionTraveled,
-            remainingWaypoints,
-            upcomingRoadObjects,
-            stale
+            route = route,
+            bannerInstructions = bannerInstructions,
+            voiceInstructions = voiceInstructions,
+            currentState = currentState,
+            currentLegProgress = currentLegProgress,
+            upcomingStepPoints = upcomingStepPoints,
+            inTunnel = inTunnel,
+            distanceRemaining = distanceRemaining,
+            distanceTraveled = distanceTraveled,
+            durationRemaining = durationRemaining,
+            fractionTraveled = fractionTraveled,
+            remainingWaypoints = remainingWaypoints,
+            upcomingRoadObjects = upcomingRoadObjects,
+            stale = stale
         )
     }
 }

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/factory/RouteStepProgressFactory.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/factory/RouteStepProgressFactory.kt
@@ -27,26 +27,26 @@ object RouteStepProgressFactory {
      * @param durationRemaining [Double] The duration remaining in seconds until the user reaches the end of the current step
      */
     fun buildRouteStepProgressObject(
-        stepIndex: Int = 0,
-        intersectionIndex: Int = 0,
-        instructionIndex: Int? = null,
-        step: LegStep? = null,
-        stepPoints: List<Point>? = null,
-        distanceRemaining: Float = 0f,
-        distanceTraveled: Float = 0f,
-        fractionTraveled: Float = 0f,
-        durationRemaining: Double = 0.0
+        stepIndex: Int,
+        intersectionIndex: Int,
+        instructionIndex: Int?,
+        step: LegStep?,
+        stepPoints: List<Point>?,
+        distanceRemaining: Float,
+        distanceTraveled: Float,
+        fractionTraveled: Float,
+        durationRemaining: Double
     ): RouteStepProgress {
         return RouteStepProgress(
-            stepIndex,
-            intersectionIndex,
-            instructionIndex,
-            step,
-            stepPoints,
-            distanceRemaining,
-            distanceTraveled,
-            fractionTraveled,
-            durationRemaining
+            stepIndex = stepIndex,
+            intersectionIndex = intersectionIndex,
+            instructionIndex = instructionIndex,
+            step = step,
+            stepPoints = stepPoints,
+            distanceRemaining = distanceRemaining,
+            distanceTraveled = distanceTraveled,
+            fractionTraveled = fractionTraveled,
+            durationRemaining = durationRemaining
         )
     }
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/navigator/NavigatorMapper.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/navigator/NavigatorMapper.kt
@@ -99,18 +99,18 @@ private fun NavigationStatus.getRouteProgress(
         var stepDurationRemaining = 0.0
 
         var currentLeg: RouteLeg? = null
-        var routeLegProgressDistanceRemaining: Float = 0f
-        var routeLegProgressDistanceTraveled: Float = 0f
-        var routeLegProgressDurationRemaining: Double = 0.0
-        var routeLegProgressFractionTraveled: Float = 0f
+        var routeLegProgressDistanceRemaining = 0f
+        var routeLegProgressDistanceTraveled = 0f
+        var routeLegProgressDurationRemaining = 0.0
+        var routeLegProgressFractionTraveled = 0f
         var routeLegProgressUpcomingStep: LegStep? = null
 
         var routeProgressCurrentState: RouteProgressState = RouteProgressState.INITIALIZED
         var routeProgressUpcomingStepPoints: List<Point>? = null
-        var routeProgressDistanceRemaining: Float = 0f
-        var routeProgressDistanceTraveled: Float = 0f
-        var routeProgressDurationRemaining: Double = 0.0
-        var routeProgressFractionTraveled: Float = 0f
+        var routeProgressDistanceRemaining = 0f
+        var routeProgressDistanceTraveled = 0f
+        var routeProgressDurationRemaining = 0.0
+        var routeProgressFractionTraveled = 0f
 
         ifNonNull(route.legs(), activeGuidanceInfo) { legs, activeGuidanceInfo ->
             if (legIndex < legs.size) {
@@ -254,7 +254,7 @@ private fun MutableList<BannerComponent>.mapToDirectionsApi(): MutableList<Banne
     return components
 }
 
-private fun VoiceInstruction.mapToDirectionsApi(): VoiceInstructions? {
+internal fun VoiceInstruction.mapToDirectionsApi(): VoiceInstructions? {
     return VoiceInstructions.builder()
         .announcement(this.announcement)
         .distanceAlongGeometry(this.remainingStepDistance.toDouble())

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/navigator/NavigatorMapper.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/navigator/NavigatorMapper.kt
@@ -100,6 +100,7 @@ private fun NavigationStatus.getRouteProgress(
 
         var currentLeg: RouteLeg? = null
         var routeLegProgressDistanceRemaining: Float = 0f
+        var routeLegProgressDistanceTraveled: Float = 0f
         var routeLegProgressDurationRemaining: Double = 0.0
         var routeLegProgressFractionTraveled: Float = 0f
         var routeLegProgressUpcomingStep: LegStep? = null
@@ -115,16 +116,17 @@ private fun NavigationStatus.getRouteProgress(
             if (legIndex < legs.size) {
                 currentLeg = legs[legIndex]
 
-                routeProgressDistanceTraveled =
+                routeLegProgressDistanceTraveled =
                     activeGuidanceInfo.legProgress.distanceTraveled.toFloat()
                 routeLegProgressFractionTraveled =
                     activeGuidanceInfo.legProgress.fractionTraveled.toFloat()
-
                 routeLegProgressDistanceRemaining =
                     activeGuidanceInfo.legProgress.remainingDistance.toFloat()
                 routeLegProgressDurationRemaining =
                     activeGuidanceInfo.legProgress.remainingDuration / ONE_SECOND_IN_MILLISECONDS
 
+                routeProgressDistanceTraveled =
+                    activeGuidanceInfo.routeProgress.distanceTraveled.toFloat()
                 routeProgressDistanceRemaining =
                     activeGuidanceInfo.routeProgress.remainingDistance.toFloat()
                 routeProgressDurationRemaining =
@@ -185,7 +187,7 @@ private fun NavigationStatus.getRouteProgress(
         val routeLegProgress = buildRouteLegProgressObject(
             legIndex,
             currentLeg,
-            routeProgressDistanceTraveled,
+            routeLegProgressDistanceTraveled,
             routeLegProgressDistanceRemaining,
             routeLegProgressDurationRemaining,
             routeLegProgressFractionTraveled,


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Fixes a regression from https://github.com/mapbox/mapbox-navigation-android/pull/4509 where `RouteProgress#distanceTraveled` was reported incorrectly for multi-leg routes.

At some point in time, we unnecessarily commented out a lot of tests that probably would've caught the issue. This PR reintroduces and extends these tests while leaving only the actually blocked cases ignored.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Fixed an issue where `RouteProgress#distanceTraveled` was reported incorrectly for multi-leg routes.</changelog>
```
