### PR TITLE
render route arrow below location puck

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxBuildingHighlightActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxBuildingHighlightActivity.kt
@@ -230,9 +230,8 @@ class MapboxBuildingHighlightActivity : AppCompatActivity(), OnMapLongClickListe
 
     @SuppressLint("MissingPermission")
     private fun initStyle() {
-        mapboxMap.loadStyleUri(
-            MAPBOX_STREETS
-        ) {
+        mapboxMap.loadStyleUri(MAPBOX_STREETS) { style ->
+            routeLineView.initializeLayers(style)
             binding.mapView.gestures.addOnMapLongClickListener(this)
         }
     }

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxCustomStyleActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxCustomStyleActivity.kt
@@ -14,7 +14,7 @@ import com.mapbox.geojson.Point
 import com.mapbox.maps.CameraOptions
 import com.mapbox.maps.EdgeInsets
 import com.mapbox.maps.MapboxMap
-import com.mapbox.maps.Style
+import com.mapbox.maps.Style.Companion.MAPBOX_STREETS
 import com.mapbox.maps.plugin.animation.MapAnimationOptions
 import com.mapbox.maps.plugin.animation.camera
 import com.mapbox.maps.plugin.gestures.OnMapLongClickListener
@@ -210,9 +210,8 @@ class MapboxCustomStyleActivity : AppCompatActivity(), OnMapLongClickListener {
 
     @SuppressLint("MissingPermission")
     private fun initStyle() {
-        mapboxMap.loadStyleUri(
-            Style.MAPBOX_STREETS
-        ) {
+        mapboxMap.loadStyleUri(MAPBOX_STREETS) { style ->
+            routeLineView.initializeLayers(style)
             binding.mapView.gestures.addOnMapLongClickListener(this)
         }
     }

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxJunctionActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxJunctionActivity.kt
@@ -13,7 +13,6 @@ import com.mapbox.geojson.Point
 import com.mapbox.maps.CameraOptions
 import com.mapbox.maps.EdgeInsets
 import com.mapbox.maps.MapboxMap
-import com.mapbox.maps.Style
 import com.mapbox.maps.Style.Companion.MAPBOX_STREETS
 import com.mapbox.maps.plugin.animation.MapAnimationOptions
 import com.mapbox.maps.plugin.animation.camera
@@ -194,14 +193,10 @@ class MapboxJunctionActivity : AppCompatActivity(), OnMapLongClickListener {
 
     @SuppressLint("MissingPermission")
     private fun initStyle() {
-        mapboxMap.loadStyleUri(
-            MAPBOX_STREETS,
-            object : Style.OnStyleLoaded {
-                override fun onStyleLoaded(style: Style) {
-                    binding.mapView.gestures.addOnMapLongClickListener(this@MapboxJunctionActivity)
-                }
-            }
-        )
+        mapboxMap.loadStyleUri(MAPBOX_STREETS) { style ->
+            routeLineView.initializeLayers(style)
+            binding.mapView.gestures.addOnMapLongClickListener(this)
+        }
     }
 
     private fun startSimulation(route: DirectionsRoute) {

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxManeuverActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxManeuverActivity.kt
@@ -221,9 +221,8 @@ class MapboxManeuverActivity : AppCompatActivity(), OnMapLongClickListener {
 
     @SuppressLint("MissingPermission")
     private fun initStyle() {
-        mapboxMap.loadStyleUri(
-            MAPBOX_STREETS
-        ) {
+        mapboxMap.loadStyleUri(MAPBOX_STREETS) { style ->
+            routeLineView.initializeLayers(style)
             binding.mapView.gestures.addOnMapLongClickListener(this)
         }
     }

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxNavigationActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxNavigationActivity.kt
@@ -18,7 +18,7 @@ import com.mapbox.geojson.Point
 import com.mapbox.maps.CameraOptions
 import com.mapbox.maps.EdgeInsets
 import com.mapbox.maps.MapboxMap
-import com.mapbox.maps.Style
+import com.mapbox.maps.Style.Companion.MAPBOX_STREETS
 import com.mapbox.maps.plugin.LocationPuck2D
 import com.mapbox.maps.plugin.animation.camera
 import com.mapbox.maps.plugin.gestures.gestures
@@ -405,9 +405,8 @@ class MapboxNavigationActivity : AppCompatActivity() {
         routeArrowView = MapboxRouteArrowView(routeArrowOptions)
 
         // load map style
-        mapboxMap.loadStyleUri(
-            Style.MAPBOX_STREETS
-        ) {
+        mapboxMap.loadStyleUri(MAPBOX_STREETS) { style ->
+            routeLineView.initializeLayers(style)
             // add long click listener that search for a route to the clicked destination
             binding.mapView.gestures.addOnMapLongClickListener { point ->
                 findRoute(point)

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxSignboardActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxSignboardActivity.kt
@@ -14,7 +14,6 @@ import com.mapbox.geojson.Point
 import com.mapbox.maps.CameraOptions
 import com.mapbox.maps.EdgeInsets
 import com.mapbox.maps.MapboxMap
-import com.mapbox.maps.Style
 import com.mapbox.maps.Style.Companion.MAPBOX_STREETS
 import com.mapbox.maps.plugin.animation.MapAnimationOptions
 import com.mapbox.maps.plugin.animation.camera
@@ -200,14 +199,10 @@ class MapboxSignboardActivity : AppCompatActivity(), OnMapLongClickListener {
 
     @SuppressLint("MissingPermission")
     private fun initStyle() {
-        mapboxMap.loadStyleUri(
-            MAPBOX_STREETS,
-            object : Style.OnStyleLoaded {
-                override fun onStyleLoaded(style: Style) {
-                    binding.mapView.gestures.addOnMapLongClickListener(this@MapboxSignboardActivity)
-                }
-            }
-        )
+        mapboxMap.loadStyleUri(MAPBOX_STREETS) { style ->
+            routeLineView.initializeLayers(style)
+            binding.mapView.gestures.addOnMapLongClickListener(this)
+        }
     }
 
     private fun startSimulation(route: DirectionsRoute) {

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxTripProgressActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxTripProgressActivity.kt
@@ -202,9 +202,8 @@ class MapboxTripProgressActivity : AppCompatActivity(), OnMapLongClickListener {
 
     @SuppressLint("MissingPermission")
     private fun initStyle() {
-        mapboxMap.loadStyleUri(
-            MAPBOX_STREETS
-        ) {
+        mapboxMap.loadStyleUri(MAPBOX_STREETS) { style ->
+            routeLineView.initializeLayers(style)
             binding.mapView.gestures.addOnMapLongClickListener(this)
         }
     }

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxVoiceActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxVoiceActivity.kt
@@ -232,12 +232,9 @@ class MapboxVoiceActivity : AppCompatActivity(), OnMapLongClickListener {
     }
 
     private fun initStyle() {
-        mapboxMap.loadStyleUri(
-            MAPBOX_STREETS
-        ) {
-            binding.mapView.gestures.addOnMapLongClickListener(
-                this@MapboxVoiceActivity
-            )
+        mapboxMap.loadStyleUri(MAPBOX_STREETS) { style ->
+            routeLineView.initializeLayers(style)
+            binding.mapView.gestures.addOnMapLongClickListener(this)
         }
     }
 


### PR DESCRIPTION
### Description
Closes #4725. 
By default, a route arrow is rendered on top of the layer with a route line. But if the route line itself isn't rendered at this point, then the route arrow will be rendered above everything else including location puck. This is exactly what happens in our examples, since the route line is rendered asynchronously inside a coroutine which is started in a routes observer. 
I considered adding a new route arrow option like `withBelowLayerId`, but that led to crashes, since [mapbox-gl-native-internal](https://github.com/mapbox/mapbox-gl-native-internal/blob/d8449cd6bf1c8252e0f0fb84e687f2f93e74311b/internal/src/mapbox/maps/style_manager_impl.cpp#L34-L40) doesn't allow to specify both aboveLayer and belowLayer. 
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
