### PR TITLE
LoggerProvider: added aliases to simplify call

### DIFF
--- a/libnavigation-util/src/main/java/com/mapbox/navigation/utils/internal/LoggerProvider.kt
+++ b/libnavigation-util/src/main/java/com/mapbox/navigation/utils/internal/LoggerProvider.kt
@@ -2,6 +2,8 @@ package com.mapbox.navigation.utils.internal
 
 import com.mapbox.annotation.module.MapboxModuleType
 import com.mapbox.base.common.logger.Logger
+import com.mapbox.base.common.logger.model.Message
+import com.mapbox.base.common.logger.model.Tag
 import com.mapbox.common.module.provider.MapboxModuleProvider
 
 /**
@@ -14,4 +16,39 @@ object LoggerProvider {
     ) {
         arrayOf()
     }
+}
+
+/**
+ * Alias of [LoggerProvider.logger]#v
+ */
+fun logV(tag: Tag? = null, msg: Message, tr: Throwable? = null) {
+    LoggerProvider.logger.v(tag, msg, tr)
+}
+
+/**
+ * Alias of [LoggerProvider.logger]#d
+ */
+fun logD(tag: Tag? = null, msg: Message, tr: Throwable? = null) {
+    LoggerProvider.logger.d(tag, msg, tr)
+}
+
+/**
+ * Alias of [LoggerProvider.logger]#i
+ */
+fun logI(tag: Tag? = null, msg: Message, tr: Throwable? = null) {
+    LoggerProvider.logger.i(tag, msg, tr)
+}
+
+/**
+ * Alias of [LoggerProvider.logger]#w
+ */
+fun logW(tag: Tag? = null, msg: Message, tr: Throwable? = null) {
+    LoggerProvider.logger.w(tag, msg, tr)
+}
+
+/**
+ * Alias of [LoggerProvider.logger]#e
+ */
+fun logE(tag: Tag? = null, msg: Message, tr: Throwable? = null) {
+    LoggerProvider.logger.e(tag, msg, tr)
 }

--- a/libnavigation-util/src/test/java/com/mapbox/navigation/utils/internal/LoggerProviderTest.kt
+++ b/libnavigation-util/src/test/java/com/mapbox/navigation/utils/internal/LoggerProviderTest.kt
@@ -1,0 +1,73 @@
+package com.mapbox.navigation.utils.internal
+
+import com.mapbox.base.common.logger.Logger
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.verify
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+class LoggerProviderTest {
+
+    private lateinit var mockkLogger: Logger
+
+    @Before
+    fun setup() {
+        mockkLogger = mockk(relaxUnitFun = true)
+        mockkObject(LoggerProvider)
+        every { LoggerProvider.logger } returns mockkLogger
+    }
+
+    @After
+    fun reset() {
+        unmockkObject(LoggerProvider)
+    }
+
+    @Test
+    fun `alias log V`() {
+        logV(mockk(), mockk(), mockk())
+
+        verify(exactly = 1) {
+            mockkLogger.v(any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `alias log D`() {
+        logD(mockk(), mockk(), mockk())
+
+        verify(exactly = 1) {
+            mockkLogger.d(any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `alias log I`() {
+        logI(mockk(), mockk(), mockk())
+
+        verify(exactly = 1) {
+            mockkLogger.i(any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `alias log W`() {
+        logW(mockk(), mockk(), mockk())
+
+        verify(exactly = 1) {
+            mockkLogger.w(any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `alias log E`() {
+        logE(mockk(), mockk(), mockk())
+
+        verify(exactly = 1) {
+            mockkLogger.e(any(), any(), any())
+        }
+    }
+}

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/NavigatorLoader.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/NavigatorLoader.kt
@@ -5,7 +5,7 @@ import com.mapbox.base.common.logger.model.Tag
 import com.mapbox.navigation.base.options.DeviceProfile
 import com.mapbox.navigation.base.options.DeviceType
 import com.mapbox.navigation.navigator.internal.NavigatorLoader.customConfig
-import com.mapbox.navigation.utils.internal.LoggerProvider
+import com.mapbox.navigation.utils.internal.logE
 import com.mapbox.navigator.CacheFactory
 import com.mapbox.navigator.CacheHandle
 import com.mapbox.navigator.ConfigFactory
@@ -66,7 +66,7 @@ internal object NavigatorLoader {
         return if (historyDir != null) {
             val historyRecorderHandle = HistoryRecorderHandle.build(historyDir, config)
             if (historyRecorderHandle == null) {
-                LoggerProvider.logger.e(
+                logE(
                     Tag("MbxHistoryRecorder"),
                     Message("Could not create directory directory to write events")
                 )


### PR DESCRIPTION
### Description
Util. 
LoggerProvider: added aliases to simplify call

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
