### PR TITLE
Bump Kotlin version to `1.5.30` and coroutines version to `1.5.1`

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,5 +1,5 @@
 ext {
-  def kotlinVersion = "1.5.20"
+  def kotlinVersion = "1.5.30"
 
   androidVersions = [
       minSdkVersion           : 21,
@@ -52,7 +52,7 @@ ext {
       firebaseCrashlytics       : '17.3.1',
       multidex                  : '2.0.1',
       json                      : '20180813',
-      coroutinesAndroid         : '1.5.0',
+      coroutinesAndroid         : '1.5.1',
       okhttp                    : '4.9.0',
       okio                      : '2.10.0',
       androidxTestJunit         : '1.1.1',


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Bumps Kotlin version to `1.5.30` https://blog.jetbrains.com/kotlin/2021/08/kotlin-1-5-30-released/ and coroutines version to `1.5.1` https://github.com/Kotlin/kotlinx.coroutines/releases/tag/1.5.1

