### PR TITLE
use waypoint target and coordinates as fallback

### DIFF
--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/building/api/MapboxBuildingsApi.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/building/api/MapboxBuildingsApi.kt
@@ -1,5 +1,6 @@
 package com.mapbox.navigation.ui.maps.building.api
 
+import com.mapbox.api.directions.v5.models.RouteOptions
 import com.mapbox.bindgen.Expected
 import com.mapbox.bindgen.ExpectedFactory
 import com.mapbox.geojson.Point
@@ -40,13 +41,11 @@ class MapboxBuildingsApi internal constructor(
      * Note:
      *
      * There are two kind of points that can be used here to query a building.
-     * - A point you can obtain that lives on a building also known as location point
-     * - A point you would route to on the road also known as routable point
+     * - A point you can obtain where the actual building is also known as location point
+     * - A point on a road snapped from the address also known as routable point
      *
-     * For this method to work, your route's original request should be a "location point" and not a
-     * "routing point", otherwise, nothing will be returned. If the coordinate is a routing point
-     * (which is the correct way to do it), you should define a "waypoint_targets" in the original
-     * request, for each of the waypoints, and for the final destination.
+     * For this method to work, the [point] passed to this API should be a "location point" and not a
+     * "routing point".
      */
     fun queryBuildingToHighlight(
         point: Point,
@@ -69,13 +68,45 @@ class MapboxBuildingsApi internal constructor(
      * Note:
      *
      * There are two kind of points that can be used here to query a building.
-     * - A point you can obtain that lives on a building also known as location point
-     * - A point you would route to on the road also known as routable point
+     * - A point you can obtain where the actual building is also known as location point
+     * - A point on a road snapped from the address also known as routable point
      *
      * For this method to work, your route's original request should be a "location point" and not a
      * "routing point", otherwise, nothing will be returned. If the coordinate is a routing point
      * (which is the correct way to do it), you should define a "waypoint_targets" in the original
      * request, for each of the waypoints, and for the final destination.
+     *
+     * For example when making a route request, you can specify the [RouteOptions] as follows if you
+     * choose the coordinate to be a routing point:
+     *
+     * ```
+     * val routeOptions = RouteOptions.builder()
+     *   .applyDefaultNavigationOptions()
+     *   .applyLanguageAndVoiceUnitOptions(this)
+     *   .coordinatesList(
+     *     listOf(
+     *       Point.fromLngLat(-122.4192, 37.7627), // origin
+     *       Point.fromLngLat(-122.4182, 37.7651), // waypoint destination
+     *       Point.fromLngLat(-122.4145, 37.7653)  // final destination
+     *     )
+     *   )
+     *   .waypointTargetsList(
+     *     listOf(
+     *       Point.fromLngLat(-122.4192, 37.7627), // origin
+     *       Point.fromLngLat(-122.4183, 37.7653), // waypoint destination
+     *       Point.fromLngLat(-122.4146, 37.7655)  // final destination
+     *     )
+     *   )
+     *   .build()
+     * ```
+     *
+     * In this case the points mentioned in the [RouteOptions.coordinatesList] are routing points
+     * where you would want the router to route you to whereas the points mentioned in the
+     * [RouteOptions.waypointTargetsList] are the location points that would be highlighted when you
+     * reach your waypoint or final destination. In case you don't specify the
+     * [RouteOptions.waypointTargetsList] the logic will fallback to [RouteOptions.coordinatesList]
+     * and would try to highlight these points. However the highlight will only work if they are
+     * location points.
      */
     fun queryBuildingOnWaypoint(
         progress: RouteProgress,
@@ -106,13 +137,42 @@ class MapboxBuildingsApi internal constructor(
      * Note:
      *
      * There are two kind of points that can be used here to query a building.
-     * - A point you can obtain that lives on a building also known as location point
-     * - A point you would route to on the road also known as routable point
+     * - A point you can obtain where the actual building is also known as location point
+     * - A point on a road snapped from the address also known as routable point
      *
      * For this method to work, your route's original request should be a "location point" and not a
      * "routing point", otherwise, nothing will be returned. If the coordinate is a routing point
      * (which is the correct way to do it), you should define a "waypoint_targets" in the original
      * request, for each of the waypoints, and for the final destination.
+     *
+     * For example when making a route request, you can specify the [RouteOptions] as follows if you
+     * choose the coordinate to be a routing point:
+     *
+     * ```
+     * val routeOptions = RouteOptions.builder()
+     *   .applyDefaultNavigationOptions()
+     *   .applyLanguageAndVoiceUnitOptions(this)
+     *   .coordinatesList(
+     *     listOf(
+     *       Point.fromLngLat(-122.4192, 37.7627), // origin
+     *       Point.fromLngLat(-122.4145, 37.7653)  // final destination
+     *     )
+     *   )
+     *   .waypointTargetsList(
+     *     listOf(
+     *       Point.fromLngLat(-122.4192, 37.7627), // origin
+     *       Point.fromLngLat(-122.4146, 37.7655)  // final destination
+     *     )
+     *   )
+     *   .build()
+     * ```
+     *
+     * In this case the points mentioned in the [RouteOptions.coordinatesList] are routing points
+     * where you would want the router to route you to whereas the points mentioned in the
+     * [RouteOptions.waypointTargetsList] are the location points that would be highlighted when you
+     * reach your final destination. In case you don't specify the [RouteOptions.waypointTargetsList]
+     * the logic will fallback to [RouteOptions.coordinatesList] and would try to highlight these
+     * points. However the highlight will only work if they are location points.
      */
     fun queryBuildingOnFinalDestination(
         progress: RouteProgress,

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/building/BuildingProcessorTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/building/BuildingProcessorTest.kt
@@ -13,10 +13,114 @@ import org.junit.Test
 class BuildingProcessorTest {
 
     @Test
-    fun `map query on waypoint arrival no point`() {
-        val mockOrigin = Point.fromLngLat(-123.4567, 37.8765)
+    fun `map query on waypoint arrival with waypoint targets`() {
+        val mockOriginForWaypointTarget = Point.fromLngLat(-122.4192, 37.7627)
+        val mockWaypointForWaypointTarget = Point.fromLngLat(-122.4183, 37.7653)
+        val mockFinalForWaypointTarget = Point.fromLngLat(-122.4146, 37.7655)
+        val mockOriginForCoordinates = Point.fromLngLat(-122.4192, 37.7627)
+        val mockWaypointForCoordinates = Point.fromLngLat(-122.4182, 37.7651)
+        val mockFinalForCoordinates = Point.fromLngLat(-122.4145, 37.7653)
         val mockRouteOptions = mockk<RouteOptions>(relaxed = true) {
-            every { coordinatesList() } returns listOf(mockOrigin, null)
+            every { coordinatesList() } returns listOf(
+                mockOriginForCoordinates,
+                mockWaypointForCoordinates,
+                mockFinalForCoordinates
+            )
+            every { waypointTargetsList() } returns listOf(
+                mockOriginForWaypointTarget,
+                mockWaypointForWaypointTarget,
+                mockFinalForWaypointTarget
+            )
+        }
+        val mockRoute = mockk<DirectionsRoute>(relaxed = true) {
+            every { routeOptions() } returns mockRouteOptions
+        }
+        val mockRouteLegProgress = mockk<RouteLegProgress>(relaxed = true) {
+            every { legIndex } returns 0
+        }
+        val mockRouteProgress = mockk<RouteProgress>(relaxed = true) {
+            every { currentLegProgress } returns mockRouteLegProgress
+            every { route } returns mockRoute
+        }
+        val mockAction = BuildingAction.QueryBuildingOnWaypoint(mockRouteProgress)
+
+        val result = BuildingProcessor.queryBuildingOnWaypoint(mockAction)
+
+        assertEquals(result.point, mockWaypointForWaypointTarget)
+    }
+
+    @Test
+    fun `map query on waypoint arrival with some waypoint targets`() {
+        val mockOriginForWaypointTarget = Point.fromLngLat(-122.4192, 37.7627)
+        val mockWaypointForWaypointTarget = null
+        val mockFinalForWaypointTarget = Point.fromLngLat(-122.4146, 37.7655)
+        val mockOriginForCoordinates = Point.fromLngLat(-122.4192, 37.7627)
+        val mockWaypointForCoordinates = Point.fromLngLat(-122.4182, 37.7651)
+        val mockFinalForCoordinates = Point.fromLngLat(-122.4145, 37.7653)
+        val mockRouteOptions = mockk<RouteOptions>(relaxed = true) {
+            every { coordinatesList() } returns listOf(
+                mockOriginForCoordinates,
+                mockWaypointForCoordinates,
+                mockFinalForCoordinates
+            )
+            every { waypointTargetsList() } returns listOf(
+                mockOriginForWaypointTarget,
+                mockWaypointForWaypointTarget,
+                mockFinalForWaypointTarget
+            )
+        }
+        val mockRoute = mockk<DirectionsRoute>(relaxed = true) {
+            every { routeOptions() } returns mockRouteOptions
+        }
+        val mockRouteLegProgress = mockk<RouteLegProgress>(relaxed = true) {
+            every { legIndex } returns 0
+        }
+        val mockRouteProgress = mockk<RouteProgress>(relaxed = true) {
+            every { currentLegProgress } returns mockRouteLegProgress
+            every { route } returns mockRoute
+        }
+        val mockAction = BuildingAction.QueryBuildingOnWaypoint(mockRouteProgress)
+
+        val result = BuildingProcessor.queryBuildingOnWaypoint(mockAction)
+
+        assertEquals(result.point, mockWaypointForCoordinates)
+    }
+
+    @Test
+    fun `map query on waypoint arrival without waypoint targets`() {
+        val mockOriginForCoordinates = Point.fromLngLat(-122.4192, 37.7627)
+        val mockWaypointForCoordinates = Point.fromLngLat(-122.4182, 37.7651)
+        val mockFinalForCoordinates = Point.fromLngLat(-122.4145, 37.7653)
+        val mockRouteOptions = mockk<RouteOptions>(relaxed = true) {
+            every { coordinatesList() } returns listOf(
+                mockOriginForCoordinates,
+                mockWaypointForCoordinates,
+                mockFinalForCoordinates
+            )
+            every { waypointTargetsList() } returns null
+        }
+        val mockRoute = mockk<DirectionsRoute>(relaxed = true) {
+            every { routeOptions() } returns mockRouteOptions
+        }
+        val mockRouteLegProgress = mockk<RouteLegProgress>(relaxed = true) {
+            every { legIndex } returns 0
+        }
+        val mockRouteProgress = mockk<RouteProgress>(relaxed = true) {
+            every { currentLegProgress } returns mockRouteLegProgress
+            every { route } returns mockRoute
+        }
+        val mockAction = BuildingAction.QueryBuildingOnWaypoint(mockRouteProgress)
+
+        val result = BuildingProcessor.queryBuildingOnWaypoint(mockAction)
+
+        assertEquals(result.point, mockWaypointForCoordinates)
+    }
+
+    @Test
+    fun `map query on waypoint arrival without waypoint targets or coordinates`() {
+        val mockRouteOptions = mockk<RouteOptions>(relaxed = true) {
+            every { coordinatesList() } returns listOf()
+            every { waypointTargetsList() } returns null
         }
         val mockRoute = mockk<DirectionsRoute>(relaxed = true) {
             every { routeOptions() } returns mockRouteOptions
@@ -36,11 +140,24 @@ class BuildingProcessorTest {
     }
 
     @Test
-    fun `map query on waypoint arrival valid point`() {
-        val mockOrigin = Point.fromLngLat(-123.4567, 37.8765)
-        val mockWaypoint = Point.fromLngLat(-123.4567, 37.8765)
+    fun `map query on final destination arrival with waypoint targets`() {
+        val mockOriginForWaypointTarget = Point.fromLngLat(-122.4192, 37.7627)
+        val mockWaypointForWaypointTarget = Point.fromLngLat(-122.4183, 37.7653)
+        val mockFinalForWaypointTarget = Point.fromLngLat(-122.4146, 37.7655)
+        val mockOriginForCoordinates = Point.fromLngLat(-122.4192, 37.7627)
+        val mockWaypointForCoordinates = Point.fromLngLat(-122.4182, 37.7651)
+        val mockFinalForCoordinates = Point.fromLngLat(-122.4145, 37.7653)
         val mockRouteOptions = mockk<RouteOptions>(relaxed = true) {
-            every { coordinatesList() } returns listOf(mockOrigin, mockWaypoint)
+            every { coordinatesList() } returns listOf(
+                mockOriginForCoordinates,
+                mockWaypointForCoordinates,
+                mockFinalForCoordinates
+            )
+            every { waypointTargetsList() } returns listOf(
+                mockOriginForWaypointTarget,
+                mockWaypointForWaypointTarget,
+                mockFinalForWaypointTarget
+            )
         }
         val mockRoute = mockk<DirectionsRoute>(relaxed = true) {
             every { routeOptions() } returns mockRouteOptions
@@ -52,49 +169,40 @@ class BuildingProcessorTest {
             every { currentLegProgress } returns mockRouteLegProgress
             every { route } returns mockRoute
         }
-        val mockAction = BuildingAction.QueryBuildingOnWaypoint(mockRouteProgress)
+        val mockAction = BuildingAction.QueryBuildingOnFinalDestination(mockRouteProgress)
 
-        val result = BuildingProcessor.queryBuildingOnWaypoint(mockAction)
+        val result = BuildingProcessor.queryBuildingOnFinalDestination(mockAction)
 
-        assertEquals(result.point, mockWaypoint)
+        assertEquals(result.point, mockFinalForWaypointTarget)
     }
 
     @Test
-    fun `map query on final destination arrival no point`() {
-        val mockOrigin = Point.fromLngLat(-123.4567, 37.8765)
+    fun `map query on final destination arrival without waypoint targets`() {
+        val mockOriginForCoordinates = Point.fromLngLat(-122.4192, 37.7627)
+        val mockWaypointForCoordinates = Point.fromLngLat(-122.4182, 37.7651)
+        val mockFinalForCoordinates = Point.fromLngLat(-122.4145, 37.7653)
         val mockRouteOptions = mockk<RouteOptions>(relaxed = true) {
-            every { coordinatesList() } returns listOf(mockOrigin, null)
+            every { coordinatesList() } returns listOf(
+                mockOriginForCoordinates,
+                mockWaypointForCoordinates,
+                mockFinalForCoordinates
+            )
+            every { waypointTargetsList() } returns null
         }
         val mockRoute = mockk<DirectionsRoute>(relaxed = true) {
             every { routeOptions() } returns mockRouteOptions
         }
+        val mockRouteLegProgress = mockk<RouteLegProgress>(relaxed = true) {
+            every { legIndex } returns 0
+        }
         val mockRouteProgress = mockk<RouteProgress>(relaxed = true) {
+            every { currentLegProgress } returns mockRouteLegProgress
             every { route } returns mockRoute
         }
         val mockAction = BuildingAction.QueryBuildingOnFinalDestination(mockRouteProgress)
 
         val result = BuildingProcessor.queryBuildingOnFinalDestination(mockAction)
 
-        assertEquals(result.point, null)
-    }
-
-    @Test
-    fun `map query on final destination arrival valid point`() {
-        val mockOrigin = Point.fromLngLat(-123.4567, 37.8765)
-        val mockWaypoint = Point.fromLngLat(-123.4567, 37.8765)
-        val mockRouteOptions = mockk<RouteOptions>(relaxed = true) {
-            every { coordinatesList() } returns listOf(mockOrigin, mockWaypoint)
-        }
-        val mockRoute = mockk<DirectionsRoute>(relaxed = true) {
-            every { routeOptions() } returns mockRouteOptions
-        }
-        val mockRouteProgress = mockk<RouteProgress>(relaxed = true) {
-            every { route } returns mockRoute
-        }
-        val mockAction = BuildingAction.QueryBuildingOnFinalDestination(mockRouteProgress)
-
-        val result = BuildingProcessor.queryBuildingOnFinalDestination(mockAction)
-
-        assertEquals(result.point, mockWaypoint)
+        assertEquals(result.point, mockFinalForCoordinates)
     }
 }


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Refactored the internal logic in `BuildingProcessor` to read the location point from waypoint target. If not available it fallbacks to the points in the coordinates list.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Refactored the internal logic in `BuildingProcessor` to read the location point from waypoint target. If not available it fallbacks to the points in the coordinates list.</changelog>
```

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
