### PR TITLE
add code to trigger route alternatives

### DIFF
--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -34,6 +34,7 @@ package com.mapbox.navigation.core {
     method public void registerRoutesObserver(com.mapbox.navigation.core.directions.session.RoutesObserver routesObserver);
     method public void registerTripSessionStateObserver(com.mapbox.navigation.core.trip.session.TripSessionStateObserver tripSessionStateObserver);
     method public void registerVoiceInstructionsObserver(com.mapbox.navigation.core.trip.session.VoiceInstructionsObserver voiceInstructionsObserver);
+    method public void requestAlternativeRoutes();
     method public long requestRoutes(com.mapbox.api.directions.v5.models.RouteOptions routeOptions, com.mapbox.navigation.base.route.RouterCallback routesRequestCallback);
     method public void resetTripSession();
     method public String? retrieveSsmlAnnouncementInstruction(int index);

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -535,6 +535,15 @@ class MapboxNavigation(
     fun getRoutes(): List<DirectionsRoute> = directionsSession.routes
 
     /**
+     * Requests an alternative route using the original [RouteOptions] associated with
+     * [MapboxNavigation.setRoutes()] call and [Router] implementation.
+     * @see [registerRouteAlternativesObserver]
+     */
+    fun requestAlternativeRoutes() {
+        routeAlternativesController.triggerAlternativeRequest()
+    }
+
+    /**
      * Call this method whenever this instance of the [MapboxNavigation] is not going to be used anymore and should release all of its resources.
      */
     fun onDestroy() {

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesController.kt
@@ -34,6 +34,11 @@ internal class RouteAlternativesController(
     private val observers = CopyOnWriteArraySet<RouteAlternativesObserver>()
     private var currentRequestId: Long? = null
 
+    fun triggerAlternativeRequest() {
+        interrupt()
+        requestRouteAlternatives()
+    }
+
     fun register(routeAlternativesObserver: RouteAlternativesObserver) {
         val needsToStartTimer = observers.isEmpty()
         observers.add(routeAlternativesObserver)


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Fixes https://github.com/mapbox/navigation-sdks/issues/1110

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Added a new API that would allow you to request alternative routes upon request by a user using `MapboxNavigation`.</changelog>
```

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
