### PR TITLE
use ANNOTATION_CONGESTION_NUMERIC in `RouteOptions.Builder.applyDefaultNavigationOptions`

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/util/RouteDrawingUtil.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/util/RouteDrawingUtil.kt
@@ -194,7 +194,7 @@ class RouteDrawingUtil(private val mapView: MapView) {
             .profile(DirectionsCriteria.PROFILE_DRIVING_TRAFFIC)
             .geometries(DirectionsCriteria.GEOMETRY_POLYLINE6)
             .annotations(
-                DirectionsCriteria.ANNOTATION_CONGESTION,
+                DirectionsCriteria.ANNOTATION_CONGESTION_NUMERIC,
                 DirectionsCriteria.ANNOTATION_DISTANCE
             )
             .overview("full")

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/extensions/RouteOptionsEx.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/extensions/RouteOptionsEx.kt
@@ -22,7 +22,7 @@ fun RouteOptions.Builder.applyDefaultNavigationOptions(): RouteOptions.Builder =
     roundaboutExits(true)
     annotationsList(
         listOf(
-            DirectionsCriteria.ANNOTATION_CONGESTION,
+            DirectionsCriteria.ANNOTATION_CONGESTION_NUMERIC,
             DirectionsCriteria.ANNOTATION_MAXSPEED,
             DirectionsCriteria.ANNOTATION_SPEED,
             DirectionsCriteria.ANNOTATION_DURATION,

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/routeoptions/MapboxRouteOptionsUpdaterParameterizedTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/routeoptions/MapboxRouteOptionsUpdaterParameterizedTest.kt
@@ -129,7 +129,7 @@ class MapboxRouteOptionsUpdaterParameterizedTest(
             .annotationsList(
                 listOf(
                     DirectionsCriteria.ANNOTATION_SPEED,
-                    DirectionsCriteria.ANNOTATION_CONGESTION
+                    DirectionsCriteria.ANNOTATION_CONGESTION_NUMERIC
                 )
             )
             .alternatives(true)

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/routeoptions/MapboxRouteOptionsUpdaterTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/routeoptions/MapboxRouteOptionsUpdaterTest.kt
@@ -83,7 +83,7 @@ class MapboxRouteOptionsUpdaterTest {
                 .annotationsList(
                     listOf(
                         DirectionsCriteria.ANNOTATION_SPEED,
-                        DirectionsCriteria.ANNOTATION_CONGESTION
+                        DirectionsCriteria.ANNOTATION_CONGESTION_NUMERIC
                     )
                 )
                 .coordinatesList(emptyList())

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApi.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApi.kt
@@ -106,7 +106,7 @@ import kotlin.coroutines.suspendCoroutine
  *      .steps(true)
  *      .annotationsList(
  *          listOf(
- *              DirectionsCriteria.ANNOTATION_CONGESTION,
+ *              DirectionsCriteria.ANNOTATION_CONGESTION_NUMERIC,
  *              DirectionsCriteria.ANNOTATION_DURATION,
  *              DirectionsCriteria.ANNOTATION_DISTANCE,
  *          )
@@ -117,10 +117,7 @@ import kotlin.coroutines.suspendCoroutine
  *      .build()
  * ```
  * A good starting point might be RouteOptions.Builder.applyDefaultNavigationOptions() which will
- * include the options above. Additionally, instead of specifying
- * `DirectionCriteria.ANNOTATION_CONGESTION` you can also use
- * `DirectionCriteria.ANNOTATION_CONGESTION_NUMERIC`. Using any one of these will return the other
- * as null. You can also request both.
+ * include the options above.
  *
  *
  * Vanishing Route Line:

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtilsTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtilsTest.kt
@@ -1385,7 +1385,9 @@ class MapboxRouteLineUtilsTest {
     fun calculateRouteLineSegments_whenNoTrafficExpressionData() {
         val colorResources = RouteLineColorResources.Builder().build()
         val routeOptions = mockk<RouteOptions>(relaxed = true) {
-            every { annotationsList() } returns listOf(DirectionsCriteria.ANNOTATION_CONGESTION)
+            every {
+                annotationsList()
+            } returns listOf(DirectionsCriteria.ANNOTATION_CONGESTION_NUMERIC)
         }
         val route = mockk<DirectionsRoute> {
             every { legs() } returns listOf()

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/util/RouteDrawingUtil.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/util/RouteDrawingUtil.kt
@@ -192,7 +192,7 @@ class RouteDrawingUtil(private val mapView: MapView) {
             .profile(DirectionsCriteria.PROFILE_DRIVING_TRAFFIC)
             .geometries(DirectionsCriteria.GEOMETRY_POLYLINE6)
             .annotations(
-                DirectionsCriteria.ANNOTATION_CONGESTION,
+                DirectionsCriteria.ANNOTATION_CONGESTION_NUMERIC,
                 DirectionsCriteria.ANNOTATION_DISTANCE
             )
             .overview("full")


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
https://github.com/mapbox/mapbox-navigation-android/pull/4778 follow up, refactors the `RouteOptions.Builder.applyDefaultNavigationOptions` extension to use `ANNOTATION_CONGESTION_NUMERIC` by default.  

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>:warning: `RouteOptions.Builder.applyDefaultNavigationOptions` extension now uses `ANNOTATION_CONGESTION_NUMERIC` by default, instead of `ANNOTATION_CONGESTION`.</changelog>
```

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
