### PR TITLE
Workaround for disappearing route line layers

### DIFF
--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/MapboxRouteLayerProvider.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/MapboxRouteLayerProvider.kt
@@ -1,5 +1,6 @@
 package com.mapbox.navigation.ui.maps.route.line
 
+import android.graphics.Color
 import android.graphics.drawable.Drawable
 import com.mapbox.maps.Style
 import com.mapbox.maps.extension.style.expressions.dsl.generated.interpolate
@@ -279,6 +280,23 @@ internal class MapboxRouteLayerProvider(
             .lineWidth(lineWidthExpression)
             .lineColor(
                 switchCase(*colorExpressions.toTypedArray())
-            )
+            ).apply {
+                // fixme workaround
+                // until https://github.com/mapbox/mapbox-gl-native-internal/pull/2180 is available.
+                // We're initializing some of the layers with a non-default gradient value
+                // which was causing a problem (just using transparent).
+                // All of the listed layers will later have gradient updated in
+                // MapboxRouteLineView#renderRouteDrawData so they won't remain transparent forever.
+                val workaroundLayerIds = listOf(
+                    RouteLayerConstants.PRIMARY_ROUTE_TRAFFIC_LAYER_ID,
+                    RouteLayerConstants.ALTERNATIVE_ROUTE1_TRAFFIC_LAYER_ID,
+                    RouteLayerConstants.ALTERNATIVE_ROUTE2_TRAFFIC_LAYER_ID,
+                    RouteLayerConstants.PRIMARY_ROUTE_LAYER_ID,
+                    RouteLayerConstants.PRIMARY_ROUTE_CASING_LAYER_ID
+                )
+                if (workaroundLayerIds.contains(layerId)) {
+                    lineGradient(Expression.color(Color.TRANSPARENT))
+                }
+            }
     }
 }


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Initializes some vulnerable route line layers with a non-default gradient value so that they do not disappear once loaded.

Before:

https://user-images.githubusercontent.com/16925074/132016034-6bf2fe92-b5c4-49df-86ed-000109d93181.mp4

After:

https://user-images.githubusercontent.com/16925074/132016358-3461c594-0724-4238-98db-6a6689f6e91c.mp4

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Fixed an issue where traffic line, or the whole route line, could sometimes disappear and required a significant camera zoom level change to show up again.</changelog>
```

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
