### PR TITLE
MapboxSpeechFileProvider: ensure cacheDirectory exists each time

### DIFF
--- a/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/api/MapboxSpeechFileProvider.kt
+++ b/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/api/MapboxSpeechFileProvider.kt
@@ -13,6 +13,8 @@ internal class MapboxSpeechFileProvider(private val cacheDirectory: File) {
 
     suspend fun generateVoiceFileFrom(data: ResponseBody): File =
         withContext(ThreadController.IODispatcher) {
+            // OS can delete folders and files in the cache even while app is running.
+            cacheDirectory.mkdirs()
             File(cacheDirectory, "${retrieveUniqueId()}$MP3_EXTENSION")
                 .apply { outputStream().use { data.byteStream().copyTo(it) } }
         }

--- a/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/api/VoiceApiProvider.kt
+++ b/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/api/VoiceApiProvider.kt
@@ -25,7 +25,7 @@ internal object VoiceApiProvider {
             File(
                 context.applicationContext.cacheDir,
                 MAPBOX_INSTRUCTIONS_CACHE
-            ).also { it.mkdirs() }
+            )
         )
     )
 }


### PR DESCRIPTION
### Description
We have a crash report in Crashlytics:
```
Fatal Exception: java.io.FileNotFoundException: /data/user/0/com.mapbox.nav.gm/cache/mapbox_instructions_cache/1.mp3 (No such file or directory)
       at java.io.FileOutputStream.open0(FileOutputStream.java)
       at java.io.FileOutputStream.open(FileOutputStream.java:308)
       at java.io.FileOutputStream.<init>(FileOutputStream.java:238)
       at java.io.FileOutputStream.<init>(FileOutputStream.java:180)
       at com.mapbox.navigation.ui.voice.api.MapboxSpeechFileProvider$generateVoiceFileFrom$2.invokeSuspend(MapboxSpeechFileProvider.kt:17)
       at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
       at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
       at java.lang.Thread.run(Thread.java:764)
```
The OS may delete folders and files in the cache while the application is running, this may be the cause of the crash.

### Changelog
```
<changelog>Fixed a crash in MapboxSpeechFileProvider when OS clears the cache directory while an app is running.</changelog>
```

