### PR TITLE
start foreground service with actual notification

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/service/NotificationDataObserver.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/service/NotificationDataObserver.kt
@@ -1,0 +1,5 @@
+package com.mapbox.navigation.core.trip.service
+
+internal fun interface NotificationDataObserver {
+    fun onNotificationUpdated(notificationData: MapboxNotificationData)
+}


### PR DESCRIPTION
### Description
Fixed #2604. 
There was an issue with `MapboxTripService.notificationDataChannel`. By the time `NavigationNotificationService` is started, the data stored in the channel could become outdated. With my changes we retrieve `NotificationData` just before starting the service. 

### Changelog
```
<changelog>Fixed an issue where navigation notification could show partial data with a wrong icon</changelog>
```

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
