### PR TITLE
use banner instruction as is from nav native

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/navigator/NavigatorMapper.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/navigator/NavigatorMapper.kt
@@ -6,6 +6,7 @@ import android.location.Location
 import com.mapbox.api.directions.v5.models.BannerComponents
 import com.mapbox.api.directions.v5.models.BannerInstructions
 import com.mapbox.api.directions.v5.models.BannerText
+import com.mapbox.api.directions.v5.models.BannerView
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.LegStep
 import com.mapbox.api.directions.v5.models.RouteLeg
@@ -215,13 +216,13 @@ private fun NavigationStatus.getRouteProgress(
     return null
 }
 
-internal fun BannerInstruction.mapToDirectionsApi(currentStep: LegStep): BannerInstructions {
+internal fun BannerInstruction.mapToDirectionsApi(): BannerInstructions {
     return BannerInstructions.builder()
         .distanceAlongGeometry(this.remainingStepDistance.toDouble())
         .primary(this.primary.mapToDirectionsApi())
         .secondary(this.secondary?.mapToDirectionsApi())
         .sub(this.sub?.mapToDirectionsApi())
-        .view(currentStep.bannerInstructions()?.get(this.index)?.view())
+        .view(this.view?.mapViewToDirectionsApi())
         .build()
 }
 
@@ -236,6 +237,16 @@ private fun BannerSection.mapToDirectionsApi(): BannerText {
         .build()
 }
 
+private fun BannerSection.mapViewToDirectionsApi(): BannerView {
+    val view = BannerView.builder()
+        .components(this.components?.mapToDirectionsApi())
+        .text(this.text)
+        .type(this.type)
+        .modifier(this.modifier)
+        .build()
+    return view
+}
+
 private fun MutableList<BannerComponent>.mapToDirectionsApi(): MutableList<BannerComponents>? {
     val components = mutableListOf<BannerComponents>()
     this.forEach {
@@ -246,8 +257,10 @@ private fun MutableList<BannerComponent>.mapToDirectionsApi(): MutableList<Banne
                 .active(it.active)
                 .directions(it.directions)
                 .imageBaseUrl(it.imageBaseurl)
+                .imageUrl(it.imageURL)
                 .text(it.text)
                 .type(it.type)
+                .subType(it.subType?.name?.lowercase())
                 .build()
         )
     }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
@@ -235,7 +235,6 @@ internal class MapboxTripSession(
                     ifNonNull(route.legs()) { legs ->
                         val currentLeg = legs[tripStatus.navigationStatus.legIndex]
                         ifNonNull(currentLeg?.steps()) { steps ->
-                            val currentStep = steps[tripStatus.navigationStatus.stepIndex]
                             val nativeBannerInstruction: BannerInstruction? =
                                 tripStatus.navigationStatus.bannerInstruction.let {
                                     if (it == null &&
@@ -253,7 +252,7 @@ internal class MapboxTripSession(
                                     }
                                 }
                             val bannerInstructions: BannerInstructions? =
-                                nativeBannerInstruction?.mapToDirectionsApi(currentStep)
+                                nativeBannerInstruction?.mapToDirectionsApi()
                             triggerObserver = bannerInstructionEvent.isOccurring(
                                 bannerInstructions,
                                 nativeBannerInstruction?.index

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/navigator/NavigatorMapperTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/navigator/NavigatorMapperTest.kt
@@ -47,9 +47,7 @@ class NavigatorMapperTest {
     @OptIn(ExperimentalMapboxNavigationAPI::class)
     @Test
     fun `route progress result sanity`() {
-        val bannerInstructions = nativeBannerInstructions.mapToDirectionsApi(
-            directionsRoute.legs()!!.first().steps()!![1]
-        )
+        val bannerInstructions = nativeBannerInstructions.mapToDirectionsApi()
         val expected = RouteProgressFactory.buildRouteProgressObject(
             route = directionsRoute,
             bannerInstructions = bannerInstructions,
@@ -423,6 +421,7 @@ class NavigatorMapperTest {
         }
         every { secondary } returns null
         every { sub } returns null
+        every { view } returns null
         every { index } returns 0
     }
     private val nativeVoiceInstructions = mockk<VoiceInstruction> {

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
@@ -560,7 +560,7 @@ class MapboxTripSessionTest {
                 )
             }
         )
-        every { nativeBanner.mapToDirectionsApi(step) } returns banner
+        every { nativeBanner.mapToDirectionsApi() } returns banner
         every { MapboxNativeNavigatorImpl.getBannerInstruction(1) } returns nativeBanner
         val bannerInstructionsObserver: BannerInstructionsObserver = mockk(relaxUnitFun = true)
 


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Fixes https://github.com/mapbox/mapbox-navigation-native/issues/4008

##### What is happening?
```
33125 09-03 09:56:12.900 28121 28121 W System.err: java.lang.IndexOutOfBoundsException: Index: 1, Size: 1
33126 09-03 09:56:12.900 28121 28121 W System.err:    at java.util.ArrayList.get(ArrayList.java:437)
33127 09-03 09:56:12.900 28121 28121 W System.err:    at e.o.g.b.n.b.g(NavigatorMapper.kt:222)
33128 09-03 09:56:12.900 28121 28121 W System.err:    at e.o.g.b.t.b.g$c.onStatus(MapboxTripSession.kt:242)
33129 09-03 09:56:12.900 28121 28121 W System.err:    at android.os.MessageQueue.nativePollOnce(Native Method)
33130 09-03 09:56:12.900 28121 28121 W System.err:    at android.os.MessageQueue.next(MessageQueue.java:335)
33131 09-03 09:56:12.900 28121 28121 W System.err:    at android.os.Looper.loop(Looper.java:206)
33132 09-03 09:56:12.900 28121 28121 W System.err:    at android.app.ActivityThread.main(ActivityThread.java:8512)
33133 09-03 09:56:12.900 28121 28121 W System.err:    at java.lang.reflect.Method.invoke(Native Method)
33134 09-03 09:56:12.900 28121 28121 W System.err:    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:602)
33135 09-03 09:56:12.900 28121 28121 W System.err:    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1130)
```

##### What did I do to find the problem?

The customer mentioned that they are using `v2.0.0-beta.23`. I did the following in both `v2.0.0-beta.23` and `v2.0.0-beta.25`
I tried reproducing the crash with the route attached here 
https://github.com/mapbox/mapbox-navigation-native/issues/4008#issue-987731597 
> The Directions API response in the scenario is picked up from log server and uploaded here. Unfortunately, just using the route did not reproduce the issue.

I wasn't able to reproduce the crash and with no history file attached to the original ticket, the only thing I could look for was this crash log. 

##### What did I change?

When looking at the crash log and hence the [code](https://github.com/mapbox/mapbox-navigation-android/blob/v2.0.0-beta.23/libnavigation-core/src/main/java/com/mapbox/navigation/core/navigator/NavigatorMapper.kt#L222) I saw that we are using `index` to query the `bannerInstruction.view()` whereas we are not doing so for the others. This was an easy fix to remove any references to `index` and do the same thing that `primary`, `secondary` and `sub` are doing. 

Hence instead of 
```
return BannerInstructions.builder()
        .distanceAlongGeometry(this.remainingStepDistance.toDouble())
        .primary(this.primary.mapToDirectionsApi())
        .secondary(this.secondary?.mapToDirectionsApi())
        .sub(this.sub?.mapToDirectionsApi())
        .view(currentStep.bannerInstructions()?.get(this.index)?.view())
        .build()
```

all we need to do is

```
return BannerInstructions.builder()
        .distanceAlongGeometry(this.remainingStepDistance.toDouble())
        .primary(this.primary.mapToDirectionsApi())
        .secondary(this.secondary?.mapToDirectionsApi())
        .sub(this.sub?.mapToDirectionsApi())
        .view(this.view?.mapToDirectionsApi())
        .build()
```

This way we are using the `view` as coming from `Native` rather than using it from the `currentStep`.

This was also brought up by @mskurydin [here](https://github.com/mapbox/mapbox-navigation-native/issues/4008#issuecomment-912574862)

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Referenced `BannerView` from native implementation rather than doing it from current step using index from nav native.</changelog>
```

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
