### PR TITLE
Fixes audio focus not released

### DIFF
--- a/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/api/MapboxVoiceInstructionsPlayer.kt
+++ b/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/api/MapboxVoiceInstructionsPlayer.kt
@@ -93,7 +93,7 @@ class MapboxVoiceInstructionsPlayer @JvmOverloads constructor(
      * Clears any announcements queued.
      */
     fun clear() {
-        clean()
+        finalize()
         filePlayer.clear()
         textPlayer.clear()
     }
@@ -104,7 +104,7 @@ class MapboxVoiceInstructionsPlayer @JvmOverloads constructor(
      * the announcement should end immediately and any announcements queued should be cleared.
      */
     fun shutdown() {
-        clean()
+        finalize()
         filePlayer.shutdown()
         textPlayer.shutdown()
     }
@@ -123,8 +123,9 @@ class MapboxVoiceInstructionsPlayer @JvmOverloads constructor(
         }
     }
 
-    private fun clean() {
+    private fun finalize() {
         playCallbackQueue.clear()
+        audioFocusDelegate.abandonFocus()
     }
 
     private companion object {

--- a/libnavui-voice/src/test/java/com/mapbox/navigation/ui/voice/api/MapboxVoiceInstructionsPlayerTest.kt
+++ b/libnavui-voice/src/test/java/com/mapbox/navigation/ui/voice/api/MapboxVoiceInstructionsPlayerTest.kt
@@ -450,6 +450,9 @@ class MapboxVoiceInstructionsPlayerTest {
         verify(exactly = 1) {
             mockedTextPlayer.clear()
         }
+        verify(exactly = 1) {
+            mockedAudioFocusDelegate.abandonFocus()
+        }
     }
 
     @Test
@@ -489,6 +492,9 @@ class MapboxVoiceInstructionsPlayerTest {
         }
         verify(exactly = 1) {
             mockedTextPlayer.shutdown()
+        }
+        verify(exactly = 1) {
+            mockedAudioFocusDelegate.abandonFocus()
         }
     }
 


### PR DESCRIPTION
### Description
Closes #4763
Audio focus was not released when stopping MapboxVoiceInstructionsPlayer, because VoiceInstructionsPlayerCallback was not called in that event. Alternative solution was to invoke the callback, but that would change the API.

### Changelog
```
<changelog>Fixed the issue with music volume not restored after stopping voice instructions playback</changelog>
```

