### PR TITLE
Reset offRoute on setRoute before NN method completes

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
@@ -73,10 +73,12 @@ internal class MapboxTripSession(
     override fun setRoute(route: DirectionsRoute?, legIndex: Int) {
         val isSameUuid = route?.isSameUuid(this.route) ?: false
         val isSameRoute = route?.isSameRoute(this.route) ?: false
-        if (route == null) {
-            roadObjects = emptyList()
-            routeProgress = null
-        }
+
+        isOffRoute = false
+        invalidateLatestBannerInstructionEvent()
+        roadObjects = emptyList()
+        routeProgress = null
+
         updateRouteJob = threadController.getMainScopeAndRootJob().scope.launch {
             when {
                 isSameUuid && isSameRoute && route != null -> {
@@ -92,8 +94,6 @@ internal class MapboxTripSession(
         mainJobController.scope.launch {
             updateRouteJob?.join()
             this@MapboxTripSession.route = route
-            isOffRoute = false
-            invalidateLatestBannerInstructionEvent()
         }
     }
 
@@ -227,6 +227,13 @@ internal class MapboxTripSession(
                 tripStatus.getMapMatcherResult(enhancedLocation, keyPoints)
             )
             zLevel = status.layer
+
+            // we should skip RouteProgress, BannerInstructions, isOffRoute state updates while
+            // setting a new route
+            if (updateRouteJob?.isActive == true) {
+                return
+            }
+
             val remainingWaypoints =
                 ifNonNull(tripStatus.route?.routeOptions()?.coordinatesList()?.size) {
                     it - tripStatus.navigationStatus.nextWaypointIndex
@@ -612,10 +619,6 @@ internal class MapboxTripSession(
         progress: RouteProgress?,
         shouldTriggerBannerInstructionsObserver: Boolean
     ) {
-        if (updateRouteJob?.isActive == true) {
-            return
-        }
-
         routeProgress = progress
         if (tripService.hasServiceStarted()) {
             tripService.updateNotification(buildTripNotificationState(progress))


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Fixed: reset offRoute, BannerInstructions immediately on setRoute, don't wait for NN method completion.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Fixed an issue where `offRoute` and `BannerInstructions` states were not immediately reset after setting a new route.</changelog>
```

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
