### PR TITLE
Add method to cancel all MapboxRouteLineApi tasks

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxRouteLineAndArrowActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxRouteLineAndArrowActivity.kt
@@ -481,6 +481,7 @@ class MapboxRouteLineAndArrowActivity : AppCompatActivity(), OnMapLongClickListe
 
     override fun onDestroy() {
         super.onDestroy()
+        routeLineApi.cancel()
         mapboxNavigation.onDestroy()
     }
 

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MultiLegRouteExampleActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MultiLegRouteExampleActivity.kt
@@ -214,6 +214,7 @@ class MultiLegRouteExampleActivity : AppCompatActivity() {
 
     override fun onDestroy() {
         super.onDestroy()
+        routeLineApi.cancel()
         viewBinding.mapView.onDestroy()
         mapboxNavigation.onDestroy()
     }

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayHistoryActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayHistoryActivity.kt
@@ -115,6 +115,7 @@ class ReplayHistoryActivity : AppCompatActivity() {
 
     override fun onDestroy() {
         super.onDestroy()
+        routeLineApi.cancel()
         findViewById<MapView>(R.id.mapView).onDestroy()
         mapboxNavigation.onDestroy()
         if (::locationComponent.isInitialized) {

--- a/libnavui-maps/api/current.txt
+++ b/libnavui-maps/api/current.txt
@@ -710,6 +710,7 @@ package com.mapbox.navigation.ui.maps.route.line.api {
 
   public final class MapboxRouteLineApi {
     ctor public MapboxRouteLineApi(com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions routeLineOptions);
+    method public void cancel();
     method public void clearRouteLine(com.mapbox.navigation.ui.base.util.MapboxNavigationConsumer<com.mapbox.bindgen.Expected<com.mapbox.navigation.ui.maps.route.line.model.RouteLineError,com.mapbox.navigation.ui.maps.route.line.model.RouteLineClearValue>> consumer);
     method public void findClosestRoute(com.mapbox.geojson.Point target, com.mapbox.maps.MapboxMap mapboxMap, float padding, com.mapbox.navigation.ui.base.util.MapboxNavigationConsumer<com.mapbox.bindgen.Expected<com.mapbox.navigation.ui.maps.route.line.model.RouteNotFound,com.mapbox.navigation.ui.maps.route.line.model.ClosestRouteValue>> resultConsumer);
     method public com.mapbox.api.directions.v5.models.DirectionsRoute? getPrimaryRoute();

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApi.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApi.kt
@@ -670,6 +670,15 @@ class MapboxRouteLineApi(
         }
     }
 
+    /**
+     * Invoke the function to cancel any job invoked through this API.
+     */
+    fun cancel() {
+        jobControl.job.children.forEach {
+            it.cancel()
+        }
+    }
+
     private suspend fun findClosestRoute(
         target: Point,
         mapboxMap: MapboxMap,

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/InactiveRouteStylingActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/InactiveRouteStylingActivity.kt
@@ -113,6 +113,7 @@ class InactiveRouteStylingActivity : AppCompatActivity() {
     override fun onDestroy() {
         super.onDestroy()
         mapboxNavigation.onDestroy()
+        routeLineApi.cancel()
     }
 
     private fun initNavigation() {

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/InactiveRouteStylingWithRestrictionsActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/InactiveRouteStylingWithRestrictionsActivity.kt
@@ -123,6 +123,7 @@ class InactiveRouteStylingWithRestrictionsActivity : AppCompatActivity() {
     override fun onDestroy() {
         super.onDestroy()
         mapboxNavigation.onDestroy()
+        routeLineApi.cancel()
     }
 
     private fun initNavigation() {

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/MapboxRouteLineActivity.java
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/MapboxRouteLineActivity.java
@@ -299,6 +299,7 @@ public class MapboxRouteLineActivity extends AppCompatActivity implements OnMapL
   @Override
   protected void onDestroy() {
     super.onDestroy();
+    mapboxRouteLineApi.cancel();
     if (predictiveCacheController != null) {
       predictiveCacheController.onDestroy();
     }

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/RouteRestrictionsActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/RouteRestrictionsActivity.kt
@@ -135,6 +135,7 @@ class RouteRestrictionsActivity : AppCompatActivity() {
     override fun onDestroy() {
         super.onDestroy()
         mapboxNavigation.onDestroy()
+        routeLineApi.cancel()
     }
 
     private fun initStyle() {

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/RouteTrafficUpdateActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/RouteTrafficUpdateActivity.kt
@@ -76,6 +76,7 @@ class RouteTrafficUpdateActivity : AppCompatActivity() {
 
     override fun onDestroy() {
         super.onDestroy()
+        routeLineApi.cancel()
         binding.mapView.onDestroy()
     }
 

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/TrafficGradientActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/TrafficGradientActivity.kt
@@ -55,6 +55,11 @@ class TrafficGradientActivity : AppCompatActivity() {
         initStyle()
     }
 
+    override fun onDestroy() {
+        super.onDestroy()
+        routeLineApi.cancel()
+    }
+
     private fun initGradientSelector() {
         binding.gradientOptionHard.setOnClickListener {
             options = options.toBuilder(this)


### PR DESCRIPTION
### Description
`MapboxRouteLineApi` is leaking consumers and so needs ability to cancel running tasks.

### Changelog
```
<changelog>Add `MapboxRouteLineApi.cancel()` to cancel running tasks</changelog>
```
