### PR TITLE
update logic to check if modifier contains left or right indicators

### DIFF
--- a/libnavui-maneuver/src/main/java/com/mapbox/navigation/ui/maneuver/LaneIconProcessor.kt
+++ b/libnavui-maneuver/src/main/java/com/mapbox/navigation/ui/maneuver/LaneIconProcessor.kt
@@ -68,6 +68,12 @@ internal object LaneIconProcessor {
             R.drawable.mapbox_ic_turn_slight_right,
     )
 
+    /**
+     * Often the primary banner's modifier property might have a different turn indication than what
+     * is included in the sub banner components directions array. To cover the edge case, the logic
+     * below checks if [activeDirection] contains any string that contains "left" or "right" instead
+     * of checking for string equality.
+     */
     @DrawableRes
     fun getDrawableFrom(laneIndicator: LaneIndicator, activeDirection: String?): Int? {
         return when {
@@ -76,11 +82,11 @@ internal object LaneIconProcessor {
                 laneIndicator.directions.contains(STRAIGHT) &&
                 laneIndicator.directions.contains(RIGHT) -> {
                 activeDirection?.let {
-                    when (it) {
-                        LEFT -> {
+                    when {
+                        it.contains(LEFT, ignoreCase = true) -> {
                             laneIcon[LaneTurns.LANE_LEFT_STRAIGHT_RIGHT_LEFT_ONLY]
                         }
-                        RIGHT -> {
+                        it.contains(RIGHT, ignoreCase = true) -> {
                             laneIcon[LaneTurns.LANE_LEFT_STRAIGHT_RIGHT_RIGHT_ONLY]
                         }
                         else -> {
@@ -94,12 +100,20 @@ internal object LaneIconProcessor {
                 laneIndicator.directions.contains(STRAIGHT) &&
                 laneIndicator.directions.contains(SLIGHT_RIGHT) -> {
                 activeDirection?.let {
-                    if (it == LEFT || it == SLIGHT_LEFT) {
-                        laneIcon[LaneTurns.LANE_SLIGHT_LEFT_STRAIGHT_SLIGHT_RIGHT_SLIGHT_LEFT_ONLY]
-                    } else if (it == RIGHT || it == SLIGHT_RIGHT) {
-                        laneIcon[LaneTurns.LANE_SLIGHT_LEFT_STRAIGHT_SLIGHT_RIGHT_SLIGHT_RIGHT_ONLY]
-                    } else {
-                        laneIcon[LaneTurns.LANE_SLIGHT_LEFT_STRAIGHT_SLIGHT_RIGHT_STRAIGHT_ONLY]
+                    when {
+                        it.contains(LEFT, ignoreCase = true) -> {
+                            laneIcon[
+                                LaneTurns.LANE_SLIGHT_LEFT_STRAIGHT_SLIGHT_RIGHT_SLIGHT_LEFT_ONLY
+                            ]
+                        }
+                        it.contains(RIGHT, ignoreCase = true) -> {
+                            laneIcon[
+                                LaneTurns.LANE_SLIGHT_LEFT_STRAIGHT_SLIGHT_RIGHT_SLIGHT_RIGHT_ONLY
+                            ]
+                        }
+                        else -> {
+                            laneIcon[LaneTurns.LANE_SLIGHT_LEFT_STRAIGHT_SLIGHT_RIGHT_STRAIGHT_ONLY]
+                        }
                     }
                 }
             }
@@ -107,7 +121,7 @@ internal object LaneIconProcessor {
                 laneIndicator.directions.contains(LEFT) &&
                 laneIndicator.directions.contains(RIGHT) -> {
                 activeDirection?.let {
-                    if (it == LEFT) {
+                    if (it.contains(LEFT, ignoreCase = true)) {
                         laneIcon[LaneTurns.LANE_LEFT_RIGHT_LEFT_ONLY]
                     } else {
                         laneIcon[LaneTurns.LANE_LEFT_RIGHT_RIGHT_ONLY]
@@ -162,9 +176,9 @@ internal object LaneIconProcessor {
                 laneIndicator.directions.contains(SLIGHT_LEFT) &&
                 laneIndicator.directions.contains(SLIGHT_RIGHT) -> {
                 activeDirection?.let {
-                    if (it == SLIGHT_LEFT || it == LEFT) {
+                    if (it.contains(LEFT, ignoreCase = true)) {
                         laneIcon[LaneTurns.LANE_SLIGHT_LEFT_SLIGHT_RIGHT_SLIGHT_LEFT_ONLY]
-                    } else if (it == SLIGHT_RIGHT || it == RIGHT) {
+                    } else if (it.contains(RIGHT, ignoreCase = true)) {
                         laneIcon[LaneTurns.LANE_SLIGHT_LEFT_SLIGHT_RIGHT_SLIGHT_RIGHT_ONLY]
                     } else {
                         laneIcon[LaneTurns.LANE_STRAIGHT]


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Fix on top of #4815. Refactors the logic when a turn lane is either left or right, but modifier in the primary banner text is slight left, sharp left or slight right, sharp right.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Updated logic to check if modifier contains left or right indicators.</changelog>
```

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
