### PR TITLE
Start a new session for each leg of a route

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -362,14 +362,17 @@ class MapboxNavigation(
         )
         tripSession.registerStateObserver(navigationSession)
 
+        arrivalProgressObserver = NavigationComponentProvider.createArrivalProgressObserver(
+            tripSession
+        )
+        setArrivalController()
+
         billingController = NavigationComponentProvider.createBillingController(
             navigationOptions.accessToken,
             navigationSession,
-            tripSession
+            tripSession,
+            arrivalProgressObserver
         )
-
-        arrivalProgressObserver = ArrivalProgressObserver(tripSession)
-        setArrivalController()
 
         ifNonNull(accessToken) { token ->
             logger.d(
@@ -620,6 +623,7 @@ class MapboxNavigation(
         resetTripSession()
         navigator.unregisterAllObservers()
         navigationVersionSwitchObservers.clear()
+        arrivalProgressObserver.unregisterAllObservers()
 
         navigationSession.unregisterAllNavigationSessionStateObservers()
         MapboxNavigationTelemetry.destroy(this@MapboxNavigation)

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/NavigationComponentProvider.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/NavigationComponentProvider.kt
@@ -7,6 +7,7 @@ import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.route.Router
 import com.mapbox.navigation.base.trip.notification.TripNotification
 import com.mapbox.navigation.core.accounts.BillingController
+import com.mapbox.navigation.core.arrival.ArrivalProgressObserver
 import com.mapbox.navigation.core.directions.session.DirectionsSession
 import com.mapbox.navigation.core.directions.session.MapboxDirectionsSession
 import com.mapbox.navigation.core.trip.service.MapboxTripService
@@ -67,6 +68,16 @@ internal object NavigationComponentProvider {
     fun createBillingController(
         accessToken: String?,
         navigationSession: NavigationSession,
+        tripSession: TripSession,
+        arrivalProgressObserver: ArrivalProgressObserver
+    ): BillingController = BillingController(
+        navigationSession,
+        arrivalProgressObserver,
+        accessToken.toString(),
+        tripSession
+    )
+
+    fun createArrivalProgressObserver(
         tripSession: TripSession
-    ): BillingController = BillingController(accessToken.toString(), navigationSession, tripSession)
+    ): ArrivalProgressObserver = ArrivalProgressObserver(tripSession)
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/arrival/ArrivalProgressObserver.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/arrival/ArrivalProgressObserver.kt
@@ -30,6 +30,10 @@ internal class ArrivalProgressObserver(
         arrivalObservers.remove(arrivalObserver)
     }
 
+    fun unregisterAllObservers() {
+        arrivalObservers.clear()
+    }
+
     fun navigateNextRouteLeg(): Boolean {
         val routeProgress = tripSession.getRouteProgress()
         val numberOfLegs = routeProgress?.route?.legs()?.size

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
@@ -111,6 +111,7 @@ class MapboxNavigationTest {
     private val logger: Logger = mockk(relaxUnitFun = true)
     private val rerouteController: RerouteController = mockk(relaxUnitFun = true)
     private lateinit var navigationOptions: NavigationOptions
+    private val arrivalProgressObserver: ArrivalProgressObserver = mockk(relaxUnitFun = true)
 
     private val applicationContext: Context = mockk(relaxed = true) {
         every { inferDeviceLocale() } returns Locale.US
@@ -194,8 +195,11 @@ class MapboxNavigationTest {
         mockNavigationSession()
         mockNavTelemetry()
         every {
-            NavigationComponentProvider.createBillingController(any(), any(), any())
+            NavigationComponentProvider.createBillingController(any(), any(), any(), any())
         } returns billingController
+        every {
+            NavigationComponentProvider.createArrivalProgressObserver(tripSession)
+        } returns arrivalProgressObserver
 
         every { navigator.create(any(), any(), any(), any(), any()) } returns navigator
     }
@@ -476,6 +480,14 @@ class MapboxNavigationTest {
             tripSession.stop()
             MapboxNavigationTelemetry.destroy(mapboxNavigation)
         }
+    }
+
+    @Test
+    fun unregisterAllArrivalObservers() {
+        createMapboxNavigation()
+        mapboxNavigation.onDestroy()
+
+        verify(exactly = 1) { arrivalProgressObserver.unregisterAllObservers() }
     }
 
     @Test

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/arrival/ArrivalProgressObserverTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/arrival/ArrivalProgressObserverTest.kt
@@ -97,6 +97,7 @@ class ArrivalProgressObserverTest {
         }
 
         assertFalse(arrivalProgressObserver.navigateNextRouteLeg())
+        verify { arrivalObserver wasNot Called }
     }
 
     @Test
@@ -311,6 +312,7 @@ class ArrivalProgressObserverTest {
         )
 
         assertFalse(onArrivalCalls.isCaptured)
+        verify { arrivalObserver wasNot Called }
     }
 
     @Test
@@ -365,6 +367,7 @@ class ArrivalProgressObserverTest {
         arrivalProgressObserver.attach(customArrivalController)
 
         verify(exactly = 0) { tripSession.updateLegIndex(any()) }
+        verify { arrivalObserver wasNot Called }
     }
 
     @Test
@@ -385,6 +388,7 @@ class ArrivalProgressObserverTest {
         val didNavigate = arrivalProgressObserver.navigateNextRouteLeg()
 
         assertTrue(didNavigate)
+        verify(exactly = 1) { arrivalObserver.onNextRouteLegStart(any()) }
     }
 
     @Test
@@ -405,6 +409,7 @@ class ArrivalProgressObserverTest {
         val didNavigate = arrivalProgressObserver.navigateNextRouteLeg()
 
         assertFalse(didNavigate)
+        verify { arrivalObserver wasNot Called }
     }
 
     @Test


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Whenever the `ArrivalObserver#onNextRouteLegStart` triggers, we're now starting a new billing session.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Fixed an issue where separate legs of a route were not counted as separate trips.</changelog>
```