### PR TITLE
Bump `SNAPSHOT` version name to `2.1.0-SNAPSHOT`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ POM_LICENCE_DIST=repo
 POM_DEVELOPER_ID=mapbox
 POM_DEVELOPER_NAME=Mapbox
 
-POM_SNAPSHOT_VERSION_NAME=2.0.0-SNAPSHOT
+POM_SNAPSHOT_VERSION_NAME=2.1.0-SNAPSHOT
 
 # IDE (e.g. Android Studio) users:
 # Gradle settings configured through the IDE *will override*


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
After [Mapbox Navigation SDK `2.0.0-rc.1`](https://github.com/mapbox/mapbox-navigation-android/releases/tag/v2.0.0-rc.1) and https://github.com/mapbox/mapbox-navigation-android/tree/release-v2.0 we should bump the `POM_SNAPSHOT_VERSION_NAME` in preparation for the next minor release.