### PR TITLE
Enable replay per trip session

### DIFF
--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -7,6 +7,7 @@ package com.mapbox.navigation.core {
     method public com.mapbox.navigator.Experimental getExperimental();
     method public com.mapbox.navigation.core.trip.session.eh.GraphAccessor getGraphAccessor();
     method public com.mapbox.navigation.core.history.MapboxHistoryRecorder getHistoryRecorder();
+    method public com.mapbox.navigation.core.replay.MapboxReplayer getMapboxReplayer();
     method public com.mapbox.navigation.base.options.NavigationOptions getNavigationOptions();
     method public com.mapbox.navigation.core.trip.session.NavigationSessionState getNavigationSessionState();
     method public com.mapbox.navigation.core.reroute.RerouteController? getRerouteController();
@@ -45,6 +46,7 @@ package com.mapbox.navigation.core {
     method public void setRerouteController();
     method public void setRoutes(java.util.List<? extends com.mapbox.api.directions.v5.models.DirectionsRoute> routes, int initialLegIndex = 0);
     method public void setRoutes(java.util.List<? extends com.mapbox.api.directions.v5.models.DirectionsRoute> routes);
+    method public void startReplayTripSession(boolean withForegroundService = true);
     method @RequiresPermission(anyOf={android.Manifest.permission.ACCESS_COARSE_LOCATION, android.Manifest.permission.ACCESS_FINE_LOCATION}) public void startTripSession(boolean withForegroundService = true);
     method @RequiresPermission(anyOf={android.Manifest.permission.ACCESS_COARSE_LOCATION, android.Manifest.permission.ACCESS_FINE_LOCATION}) public void startTripSession();
     method public void stopTripSession();
@@ -67,6 +69,7 @@ package com.mapbox.navigation.core {
     property public final com.mapbox.navigation.core.trip.session.eh.GraphAccessor graphAccessor;
     property public final com.mapbox.navigation.core.history.MapboxHistoryRecorder historyRecorder;
     property public final boolean isDestroyed;
+    property public final com.mapbox.navigation.core.replay.MapboxReplayer mapboxReplayer;
     property public final com.mapbox.navigation.base.options.NavigationOptions navigationOptions;
     property public final com.mapbox.navigation.core.trip.session.eh.RoadObjectMatcher roadObjectMatcher;
     property public final com.mapbox.navigation.core.trip.session.eh.RoadObjectsStore roadObjectsStore;

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/NavigationComponentProvider.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/NavigationComponentProvider.kt
@@ -15,6 +15,7 @@ import com.mapbox.navigation.core.trip.service.TripService
 import com.mapbox.navigation.core.trip.session.MapboxTripSession
 import com.mapbox.navigation.core.trip.session.NavigationSession
 import com.mapbox.navigation.core.trip.session.TripSession
+import com.mapbox.navigation.core.trip.session.TripSessionLocationEngine
 import com.mapbox.navigation.core.trip.session.eh.EHorizonSubscriptionManagerImpl
 import com.mapbox.navigation.navigator.internal.MapboxNativeNavigator
 import com.mapbox.navigation.navigator.internal.MapboxNativeNavigatorImpl
@@ -50,14 +51,18 @@ internal object NavigationComponentProvider {
         logger
     )
 
+    fun createTripSessionLocationEngine(
+        navigationOptions: NavigationOptions
+    ): TripSessionLocationEngine = TripSessionLocationEngine(navigationOptions)
+
     fun createTripSession(
         tripService: TripService,
-        navigationOptions: NavigationOptions,
+        tripSessionLocationEngine: TripSessionLocationEngine,
         navigator: MapboxNativeNavigator,
         logger: Logger,
     ): TripSession = MapboxTripSession(
         tripService,
-        navigationOptions,
+        tripSessionLocationEngine,
         navigator = navigator,
         logger = logger,
         eHorizonSubscriptionManager = EHorizonSubscriptionManagerImpl(navigator),

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
@@ -1,21 +1,15 @@
 package com.mapbox.navigation.core.trip.session
 
-import android.annotation.SuppressLint
 import android.hardware.SensorEvent
 import android.location.Location
-import android.os.Looper
 import androidx.annotation.VisibleForTesting
-import com.mapbox.android.core.location.LocationEngineCallback
-import com.mapbox.android.core.location.LocationEngineResult
 import com.mapbox.api.directions.v5.models.BannerInstructions
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.VoiceInstructions
 import com.mapbox.base.common.logger.Logger
-import com.mapbox.base.common.logger.model.Message
 import com.mapbox.navigation.base.internal.factory.TripNotificationStateFactory.buildTripNotificationState
 import com.mapbox.navigation.base.internal.utils.isSameRoute
 import com.mapbox.navigation.base.internal.utils.isSameUuid
-import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.trip.model.RouteLegProgress
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.base.trip.model.roadobject.UpcomingRoadObject
@@ -46,19 +40,18 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.launch
 import java.util.concurrent.CopyOnWriteArraySet
-
 /**
  * Default implementation of [TripSession]
  *
  * @param tripService TripService
- * @param navigationOptions the navigator options
+ * @param tripSessionLocationEngine the location engine
  * @param navigator Native navigator
  * @param threadController controller for main/io jobs
  * @param logger interface for logging any events
  */
 internal class MapboxTripSession(
     override val tripService: TripService,
-    private val navigationOptions: NavigationOptions,
+    private val tripSessionLocationEngine: TripSessionLocationEngine,
     private val navigator: MapboxNativeNavigator = MapboxNativeNavigatorImpl,
     private val threadController: ThreadController = ThreadController,
     private val logger: Logger,
@@ -198,7 +191,7 @@ internal class MapboxTripSession(
     /**
      * Start MapboxTripSession
      */
-    override fun start(withTripService: Boolean) {
+    override fun start(withTripService: Boolean, withReplayEnabled: Boolean) {
         if (state == TripSessionState.STARTED) {
             return
         }
@@ -206,8 +199,20 @@ internal class MapboxTripSession(
         if (withTripService) {
             tripService.startService()
         }
-        startLocationUpdates()
+        tripSessionLocationEngine.startLocationUpdates(withReplayEnabled) {
+            updateRawLocation(it)
+        }
         state = TripSessionState.STARTED
+    }
+
+    private fun updateRawLocation(rawLocation: Location) {
+        if (state != TripSessionState.STARTED) return
+
+        this.rawLocation = rawLocation
+        locationObservers.forEach { it.onRawLocationChanged(rawLocation) }
+        mainJobController.scope.launch {
+            navigator.updateLocation(rawLocation.toFixLocation())
+        }
     }
 
     /**
@@ -275,16 +280,6 @@ internal class MapboxTripSession(
         }
     }
 
-    @SuppressLint("MissingPermission")
-    private fun startLocationUpdates() {
-        navigationOptions.locationEngine.requestLocationUpdates(
-            navigationOptions.locationEngineRequest,
-            locationEngineCallback,
-            Looper.getMainLooper()
-        )
-        navigationOptions.locationEngine.getLastLocation(locationEngineCallback)
-    }
-
     /**
      * Stop MapboxTripSession
      */
@@ -294,14 +289,10 @@ internal class MapboxTripSession(
         }
         navigator.removeNavigatorObserver(navigatorObserver)
         tripService.stopService()
-        stopLocationUpdates()
+        tripSessionLocationEngine.stopLocationUpdates()
         mainJobController.job.cancelChildren()
         reset()
         state = TripSessionState.STOPPED
-    }
-
-    private fun stopLocationUpdates() {
-        navigationOptions.locationEngine.removeLocationUpdates(locationEngineCallback)
     }
 
     private fun reset() {
@@ -570,31 +561,6 @@ internal class MapboxTripSession(
     override fun unregisterAllFallbackVersionsObservers() {
         fallbackVersionsObservers.clear()
         navigator.setFallbackVersionsObserver(null)
-    }
-
-    private var locationEngineCallback = object : LocationEngineCallback<LocationEngineResult> {
-        override fun onSuccess(result: LocationEngineResult?) {
-            result?.locations?.lastOrNull()?.let {
-                updateRawLocation(it)
-            }
-        }
-
-        override fun onFailure(exception: Exception) {
-            logger.d(
-                msg = Message("location on failure"),
-                tr = exception
-            )
-        }
-    }
-
-    private fun updateRawLocation(rawLocation: Location) {
-        if (state != TripSessionState.STARTED) return
-
-        this.rawLocation = rawLocation
-        locationObservers.forEach { it.onRawLocationChanged(rawLocation) }
-        mainJobController.scope.launch {
-            navigator.updateLocation(rawLocation.toFixLocation())
-        }
     }
 
     private fun updateEnhancedLocation(location: Location, keyPoints: List<Location>) {

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/TripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/TripSession.kt
@@ -19,7 +19,7 @@ internal interface TripSession {
     fun getRouteProgress(): RouteProgress?
     fun getState(): TripSessionState
 
-    fun start(withTripService: Boolean)
+    fun start(withTripService: Boolean, withReplayEnabled: Boolean = false)
     fun stop()
     fun isRunningWithForegroundService(): Boolean
 

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/TripSessionLocationEngine.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/TripSessionLocationEngine.kt
@@ -1,0 +1,70 @@
+package com.mapbox.navigation.core.trip.session
+
+import android.annotation.SuppressLint
+import android.location.Location
+import android.os.Looper
+import com.mapbox.android.core.location.LocationEngine
+import com.mapbox.android.core.location.LocationEngineCallback
+import com.mapbox.android.core.location.LocationEngineResult
+import com.mapbox.base.common.logger.model.Message
+import com.mapbox.navigation.base.options.NavigationOptions
+import com.mapbox.navigation.core.replay.MapboxReplayer
+import com.mapbox.navigation.core.replay.ReplayLocationEngine
+import com.mapbox.navigation.utils.internal.LoggerProvider
+
+/**
+ * This class is only intended to be used by the [MapboxTripSession].
+ *
+ * Trip locations can come from the device, from an external location engine, or from a replay
+ * simulator. This class is responsible for determining which LocationEngine is used.
+ *
+ * When a trip session is started with replay, use the [ReplayLocationEngine]. If the
+ * trip session is not using replay, use the [NavigationOptions.locationEngine].
+ */
+internal class TripSessionLocationEngine constructor(
+    val navigationOptions: NavigationOptions
+) {
+    val mapboxReplayer: MapboxReplayer by lazy { MapboxReplayer() }
+
+    private val replayLocationEngine: ReplayLocationEngine by lazy {
+        ReplayLocationEngine(mapboxReplayer)
+    }
+    private var locationEngine: LocationEngine = navigationOptions.locationEngine
+    private var onRawLocationUpdate: (Location) -> Unit = { }
+
+    @SuppressLint("MissingPermission")
+    fun startLocationUpdates(isReplayEnabled: Boolean, onRawLocationUpdate: (Location) -> Unit) {
+        this.onRawLocationUpdate = onRawLocationUpdate
+        val locationEngine = if (isReplayEnabled) {
+            replayLocationEngine
+        } else {
+            navigationOptions.locationEngine
+        }
+        locationEngine.requestLocationUpdates(
+            navigationOptions.locationEngineRequest,
+            locationEngineCallback,
+            Looper.getMainLooper()
+        )
+        locationEngine.getLastLocation(locationEngineCallback)
+    }
+
+    fun stopLocationUpdates() {
+        onRawLocationUpdate = { }
+        locationEngine.removeLocationUpdates(locationEngineCallback)
+    }
+
+    private var locationEngineCallback = object : LocationEngineCallback<LocationEngineResult> {
+        override fun onSuccess(result: LocationEngineResult?) {
+            result?.locations?.lastOrNull()?.let {
+                onRawLocationUpdate(it)
+            }
+        }
+
+        override fun onFailure(exception: Exception) {
+            LoggerProvider.logger.d(
+                msg = Message("location on failure"),
+                tr = exception
+            )
+        }
+    }
+}

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
@@ -43,6 +43,7 @@ import com.mapbox.navigation.core.trip.session.NavigationSession
 import com.mapbox.navigation.core.trip.session.OffRouteObserver
 import com.mapbox.navigation.core.trip.session.RoadObjectsOnRouteObserver
 import com.mapbox.navigation.core.trip.session.TripSession
+import com.mapbox.navigation.core.trip.session.TripSessionLocationEngine
 import com.mapbox.navigation.navigator.internal.MapboxNativeNavigator
 import com.mapbox.navigation.testing.MainCoroutineRule
 import com.mapbox.navigation.utils.internal.LoggerProvider
@@ -109,6 +110,7 @@ class MapboxNavigationTest {
     private val billingController: BillingController = mockk(relaxUnitFun = true)
     private val logger: Logger = mockk(relaxUnitFun = true)
     private val rerouteController: RerouteController = mockk(relaxUnitFun = true)
+    private val tripSessionLocationEngine: TripSessionLocationEngine = mockk(relaxUnitFun = true)
     private lateinit var navigationOptions: NavigationOptions
     private val arrivalProgressObserver: ArrivalProgressObserver = mockk(relaxUnitFun = true)
 
@@ -955,7 +957,10 @@ class MapboxNavigationTest {
 
             verifyOrder {
                 tripSession.registerStateObserver(navigationSession)
-                tripSession.start(true)
+                tripSession.start(
+                    withTripService = true,
+                    withReplayEnabled = false
+                )
                 tripSession.stop()
                 tripSession.unregisterAllStateObservers()
             }
@@ -1073,9 +1078,15 @@ class MapboxNavigationTest {
 
     private fun mockTripSession() {
         every {
+            NavigationComponentProvider.createTripSessionLocationEngine(
+                navigationOptions = navigationOptions
+            )
+        } returns tripSessionLocationEngine
+
+        every {
             NavigationComponentProvider.createTripSession(
-                tripService,
-                navigationOptions = navigationOptions,
+                tripService = tripService,
+                tripSessionLocationEngine = tripSessionLocationEngine,
                 navigator = navigator,
                 logger = logger,
             )

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
@@ -2,11 +2,7 @@ package com.mapbox.navigation.core.trip.session
 
 import android.content.Context
 import android.location.Location
-import android.os.Looper
 import androidx.test.core.app.ApplicationProvider
-import com.mapbox.android.core.location.LocationEngine
-import com.mapbox.android.core.location.LocationEngineCallback
-import com.mapbox.android.core.location.LocationEngineResult
 import com.mapbox.api.directions.v5.models.BannerInstructions
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.LegStep
@@ -93,15 +89,18 @@ class MapboxTripSessionTest {
     private val tripService: TripService = mockk(relaxUnitFun = true) {
         every { hasServiceStarted() } returns false
     }
+    private lateinit var locationUpdateAnswers: (Location) -> Unit
+    private val tripSessionLocationEngine: TripSessionLocationEngine = mockk(relaxUnitFun = true) {
+        every { startLocationUpdates(any(), captureLambda()) } answers {
+            locationUpdateAnswers = secondArg()
+        }
+    }
     private val route: DirectionsRoute = mockk(relaxed = true)
     private val legIndex = 2
 
     private val context: Context = ApplicationProvider.getApplicationContext()
-    private val locationEngine: LocationEngine = mockk(relaxUnitFun = true)
     private lateinit var navigationOptions: NavigationOptions
-    private val locationCallbackSlot = slot<LocationEngineCallback<LocationEngineResult>>()
-    private val locationEngineResult: LocationEngineResult = mockk(relaxUnitFun = true)
-    private val location: Location = mockk(relaxed = true)
+    private val location: Location = mockLocation()
     private val fixLocation: FixLocation = mockk(relaxed = true)
     private val keyPoints: List<Location> = listOf(mockk(relaxUnitFun = true))
     private val keyFixPoints: List<FixLocation> = listOf(mockk(relaxed = true))
@@ -111,7 +110,6 @@ class MapboxTripSessionTest {
     private val navigationStatusOrigin: NavigationStatusOrigin = mockk()
     private val navigationStatus: NavigationStatus = mockk(relaxed = true)
     private val logger: Logger = mockk(relaxUnitFun = true)
-
     private val routeProgress: RouteProgress = mockk()
 
     private val parentJob = SupervisorJob()
@@ -135,9 +133,7 @@ class MapboxTripSessionTest {
         every { fixLocation.toLocation() } returns location
         every { keyFixPoints.toLocations() } returns keyPoints
         every { ThreadController.getMainScopeAndRootJob() } returns JobControl(parentJob, testScope)
-        navigationOptions = NavigationOptions.Builder(context)
-            .locationEngine(locationEngine)
-            .build()
+        navigationOptions = NavigationOptions.Builder(context).build()
         tripSession = buildTripSession()
 
         coEvery { navigator.updateLocation(any()) } returns false
@@ -163,14 +159,6 @@ class MapboxTripSessionTest {
         every { route.requestUuid() } returns "uuid"
 
         every {
-            locationEngine.requestLocationUpdates(
-                any(),
-                capture(locationCallbackSlot),
-                any()
-            )
-        } answers {}
-        every { locationEngineResult.locations } returns listOf(location)
-        every {
             navigator.addNavigatorObserver(capture(navigatorObserverImplSlot))
         } answers {}
         every {
@@ -183,7 +171,7 @@ class MapboxTripSessionTest {
     private fun buildTripSession(): MapboxTripSession {
         return MapboxTripSession(
             tripService,
-            navigationOptions,
+            tripSessionLocationEngine,
             navigator,
             ThreadController,
             logger,
@@ -199,13 +187,7 @@ class MapboxTripSessionTest {
 
         assertTrue(tripSession.isRunningWithForegroundService())
         verify { tripService.startService() }
-        verify {
-            locationEngine.requestLocationUpdates(
-                any(),
-                any(),
-                Looper.getMainLooper()
-            )
-        }
+        verify { tripSessionLocationEngine.startLocationUpdates(any(), any()) }
 
         tripSession.stop()
     }
@@ -218,13 +200,7 @@ class MapboxTripSessionTest {
 
         assertFalse(tripSession.isRunningWithForegroundService())
         verify(exactly = 0) { tripService.startService() }
-        verify {
-            locationEngine.requestLocationUpdates(
-                any(),
-                any(),
-                Looper.getMainLooper()
-            )
-        }
+        verify { tripSessionLocationEngine.startLocationUpdates(any(), any()) }
 
         tripSession.stop()
     }
@@ -239,13 +215,7 @@ class MapboxTripSessionTest {
 
         assertTrue(tripSession.isRunningWithForegroundService())
         verify(exactly = 1) { tripService.startService() }
-        verify(exactly = 1) {
-            locationEngine.requestLocationUpdates(
-                any(),
-                any(),
-                Looper.getMainLooper()
-            )
-        }
+        verify(exactly = 1) { tripSessionLocationEngine.startLocationUpdates(any(), any()) }
 
         tripSession.stop()
     }
@@ -262,11 +232,11 @@ class MapboxTripSessionTest {
     @Test
     fun stopSessionCallsLocationEngineRemoveLocationUpdates() {
         tripSession.start(true)
-        locationCallbackSlot.captured.onSuccess(locationEngineResult)
+        locationUpdateAnswers.invoke(location)
 
         tripSession.stop()
 
-        verify { locationEngine.removeLocationUpdates(locationCallbackSlot.captured) }
+        verify { tripSessionLocationEngine.stopLocationUpdates() }
     }
 
     @Test
@@ -307,26 +277,13 @@ class MapboxTripSessionTest {
 
     @Test
     fun locationObserverSuccessWhenMultipleSamples() = coroutineRule.runBlockingTest {
-        every { locationEngineResult.locations } returns listOf(mockk(), location)
         tripSession.start(true)
         val observer: LocationObserver = mockk(relaxUnitFun = true)
         tripSession.registerLocationObserver(observer)
-
+        locationUpdateAnswers.invoke(mockLocation())
         updateLocationAndJoin()
-
         verify { observer.onRawLocationChanged(location) }
         assertEquals(location, tripSession.getRawLocation())
-
-        tripSession.stop()
-    }
-
-    @Test
-    fun locationObserverOnFailure() {
-        tripSession.start(true)
-
-        locationCallbackSlot.captured.onFailure(Exception("location failure"))
-
-        verify(exactly = 0) { locationEngine.removeLocationUpdates(locationCallbackSlot.captured) }
 
         tripSession.stop()
     }
@@ -366,8 +323,9 @@ class MapboxTripSessionTest {
 
     @Test
     fun locationPushWhenMultipleSamples() = coroutineRule.runBlockingTest {
-        every { locationEngineResult.locations } returns listOf(mockk(), location)
         tripSession.start(true)
+        locationUpdateAnswers.invoke(mockLocation())
+        locationUpdateAnswers.invoke(mockLocation())
         updateLocationAndJoin()
         coVerify { navigator.updateLocation(fixLocation) }
         tripSession.stop()
@@ -501,7 +459,7 @@ class MapboxTripSessionTest {
         val offRouteObserver: OffRouteObserver = mockk(relaxUnitFun = true)
         tripSession.registerOffRouteObserver(offRouteObserver)
         every { navigationStatus.routeState } returns RouteState.OFF_ROUTE
-        locationCallbackSlot.captured.onSuccess(locationEngineResult)
+        locationUpdateAnswers.invoke(mockLocation())
         navigatorObserverImplSlot.captured.onStatus(navigationStatusOrigin, navigationStatus)
 
         tripSession.setRoute(route, legIndex)
@@ -527,7 +485,7 @@ class MapboxTripSessionTest {
         val offRouteObserver: OffRouteObserver = mockk(relaxUnitFun = true)
         tripSession.registerOffRouteObserver(offRouteObserver)
         every { navigationStatus.routeState } returns RouteState.OFF_ROUTE
-        locationCallbackSlot.captured.onSuccess(locationEngineResult)
+        locationUpdateAnswers.invoke(mockLocation())
         navigatorObserverImplSlot.captured.onStatus(navigationStatusOrigin, navigationStatus)
 
         tripSession.setRoute(null, 0)
@@ -1307,8 +1265,10 @@ class MapboxTripSessionTest {
         unmockkStatic("com.mapbox.navigation.core.navigator.LocationEx")
     }
 
+    private fun mockLocation(): Location = mockk(relaxed = true)
+
     private suspend fun updateLocationAndJoin() {
-        locationCallbackSlot.captured.onSuccess(locationEngineResult)
+        locationUpdateAnswers.invoke(location)
         navigatorObserverImplSlot.captured.onStatus(navigationStatusOrigin, navigationStatus)
         parentJob.cancelAndJoin()
     }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/TripSessionLocationEngineTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/TripSessionLocationEngineTest.kt
@@ -1,0 +1,87 @@
+package com.mapbox.navigation.core.trip.session
+
+import android.content.Context
+import android.location.Location
+import android.os.Looper
+import androidx.test.core.app.ApplicationProvider
+import com.mapbox.android.core.location.LocationEngine
+import com.mapbox.android.core.location.LocationEngineCallback
+import com.mapbox.android.core.location.LocationEngineResult
+import com.mapbox.navigation.base.options.NavigationOptions
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class TripSessionLocationEngineTest {
+
+    private val locationCallbackSlot = slot<LocationEngineCallback<LocationEngineResult>>()
+    private val locationEngine: LocationEngine = mockk(relaxUnitFun = true)
+    private val locationEngineResult: LocationEngineResult = mockk(relaxUnitFun = true)
+    private val location: Location = mockk(relaxed = true)
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val navigationOptions = NavigationOptions.Builder(context)
+        .locationEngine(locationEngine)
+        .build()
+    private val tripSessionLocationEngine = TripSessionLocationEngine(navigationOptions)
+
+    @Before
+    fun setup() {
+        every {
+            locationEngine.requestLocationUpdates(
+                any(),
+                capture(locationCallbackSlot),
+                any()
+            )
+        } answers {}
+        every { locationEngineResult.locations } returns listOf(location)
+    }
+
+    @Test
+    fun `should request location updates from navigation options when replay is disabled`() {
+        tripSessionLocationEngine.startLocationUpdates(false) {
+            // This test is not verifying the callback
+        }
+
+        verify(exactly = 1) {
+            navigationOptions.locationEngine.requestLocationUpdates(
+                any(),
+                any(),
+                Looper.getMainLooper()
+            )
+        }
+    }
+
+    @Test
+    fun `should stop location updates from navigation options when replay is disabled`() {
+        tripSessionLocationEngine.startLocationUpdates(false) {
+            // This test is not verifying the callback
+        }
+        tripSessionLocationEngine.stopLocationUpdates()
+
+        verify(exactly = 1) {
+            navigationOptions.locationEngine.removeLocationUpdates(
+                any<LocationEngineCallback<LocationEngineResult>>()
+            )
+        }
+    }
+
+    @Test
+    fun `should not request location updates from navigation options when replay is enabled`() {
+        tripSessionLocationEngine.startLocationUpdates(true) {
+            // This test is not verifying the callback
+        }
+
+        verify(exactly = 0) {
+            navigationOptions.locationEngine.requestLocationUpdates(any(), any(), any())
+        }
+    }
+}


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Resolves https://github.com/mapbox/mapbox-navigation-android/issues/4766

This introduces a new way to enable route and history replay. It also does not break the old way, of creating MapboxNavigation with replay enabled.

Opening it up for comments. All existing examples are using the old way, and then the `ReplayHistoryActivity` is using the new way. There should be no functional change in this pull request. Tests need to be updated.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Add `MapboxNavigation.startReplayTripSession` which allows you to use MapboxReplayer after `MapboxNavigation` has been created.</changelog>
```
