### PR TITLE
upgrade Maps SDK to v10.0.0-rc.8 and Nav Native to v66.0.0

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -119,7 +119,7 @@ License: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 #### Navigation Base SDK module
 Mapbox Navigation uses portions of the Android App Startup Runtime.
-URL: [https://developer.android.com/jetpack/androidx/releases/startup#1.0.0](https://developer.android.com/jetpack/androidx/releases/startup#1.0.0)
+URL: [https://developer.android.com/jetpack/androidx/releases/startup#1.1.0](https://developer.android.com/jetpack/androidx/releases/startup#1.1.0)
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
@@ -298,7 +298,7 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 
 #### Navigation Core SDK module
 Mapbox Navigation uses portions of the Android App Startup Runtime.
-URL: [https://developer.android.com/jetpack/androidx/releases/startup#1.0.0](https://developer.android.com/jetpack/androidx/releases/startup#1.0.0)
+URL: [https://developer.android.com/jetpack/androidx/releases/startup#1.1.0](https://developer.android.com/jetpack/androidx/releases/startup#1.1.0)
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
@@ -601,7 +601,7 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 
 #### Navigator SDK module
 Mapbox Navigation uses portions of the Android App Startup Runtime.
-URL: [https://developer.android.com/jetpack/androidx/releases/startup#1.0.0](https://developer.android.com/jetpack/androidx/releases/startup#1.0.0)
+URL: [https://developer.android.com/jetpack/androidx/releases/startup#1.1.0](https://developer.android.com/jetpack/androidx/releases/startup#1.1.0)
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
@@ -944,7 +944,7 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 ===========================================================================
 
 Mapbox Navigation uses portions of the Android App Startup Runtime.
-URL: [https://developer.android.com/jetpack/androidx/releases/startup#1.0.0](https://developer.android.com/jetpack/androidx/releases/startup#1.0.0)
+URL: [https://developer.android.com/jetpack/androidx/releases/startup#1.1.0](https://developer.android.com/jetpack/androidx/releases/startup#1.1.0)
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -12,17 +12,17 @@ ext {
   // version which we should use in this build
   def mapboxNavigatorVersion = System.getenv("FORCE_MAPBOX_NAVIGATION_NATIVE_VERSION")
   if (mapboxNavigatorVersion == null || mapboxNavigatorVersion == '') {
-      mapboxNavigatorVersion = '65.0.2'
+      mapboxNavigatorVersion = '66.0.1'
   }
   println("Navigation Native version: " + mapboxNavigatorVersion)
 
   version = [
-      mapboxMapSdk              : '10.0.0-rc.7',
+      mapboxMapSdk              : '10.0.0-rc.8',
       mapboxSdkServices         : '6.0.0-alpha.5',
       mapboxEvents              : '8.1.0',
       mapboxCore                : '5.0.0',
       mapboxNavigator           : "${mapboxNavigatorVersion}",
-      mapboxCommonNative        : '17.1.0',
+      mapboxCommonNative        : '18.0.0',
       mapboxCrashMonitor        : '2.0.0',
       mapboxAnnotationPlugin    : '0.8.0',
       mapboxBaseAndroid         : '0.5.0',

--- a/libnavigation-base/api/current.txt
+++ b/libnavigation-base/api/current.txt
@@ -697,6 +697,45 @@ package com.mapbox.navigation.base.trip.model.eh {
   @StringDef({com.mapbox.navigation.base.trip.model.eh.EHorizonResultType.INITIAL, com.mapbox.navigation.base.trip.model.eh.EHorizonResultType.UPDATE}) @kotlin.annotation.Retention(kotlin.annotation.AnnotationRetention) public static @interface EHorizonResultType.Type {
   }
 
+  public final class MatchableGeometry {
+    ctor public MatchableGeometry(String roadObjectId, java.util.List<com.mapbox.geojson.Point> coordinates);
+    method public String component1();
+    method public java.util.List<com.mapbox.geojson.Point> component2();
+    method public com.mapbox.navigation.base.trip.model.eh.MatchableGeometry copy(String roadObjectId, java.util.List<com.mapbox.geojson.Point> coordinates);
+    method public java.util.List<com.mapbox.geojson.Point> getCoordinates();
+    method public String getRoadObjectId();
+    property public final java.util.List<com.mapbox.geojson.Point> coordinates;
+    property public final String roadObjectId;
+  }
+
+  public final class MatchableOpenLr {
+    ctor public MatchableOpenLr(String roadObjectId, String openLRLocation, @com.mapbox.navigation.base.trip.model.eh.OpenLRStandard.Type String openLRStandard);
+    method public String component1();
+    method public String component2();
+    method public String component3();
+    method public com.mapbox.navigation.base.trip.model.eh.MatchableOpenLr copy(String roadObjectId, String openLRLocation, String openLRStandard);
+    method public String getOpenLRLocation();
+    method public String getOpenLRStandard();
+    method public String getRoadObjectId();
+    property public final String openLRLocation;
+    property public final String openLRStandard;
+    property public final String roadObjectId;
+  }
+
+  public final class MatchablePoint {
+    ctor public MatchablePoint(String roadObjectId, com.mapbox.geojson.Point point, Double? bearing = null);
+    method public String component1();
+    method public com.mapbox.geojson.Point component2();
+    method public Double? component3();
+    method public com.mapbox.navigation.base.trip.model.eh.MatchablePoint copy(String roadObjectId, com.mapbox.geojson.Point point, Double? bearing);
+    method public Double? getBearing();
+    method public com.mapbox.geojson.Point getPoint();
+    method public String getRoadObjectId();
+    property public final Double? bearing;
+    property public final com.mapbox.geojson.Point point;
+    property public final String roadObjectId;
+  }
+
   public final class OpenLRStandard {
     field public static final com.mapbox.navigation.base.trip.model.eh.OpenLRStandard INSTANCE;
     field public static final String TOM_TOM = "TOM_TOM";

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/factory/EHorizonFactory.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/factory/EHorizonFactory.kt
@@ -2,11 +2,16 @@ package com.mapbox.navigation.base.internal.factory
 
 import com.mapbox.navigation.base.trip.model.eh.EHorizonGraphPath
 import com.mapbox.navigation.base.trip.model.eh.EHorizonGraphPosition
+import com.mapbox.navigation.base.trip.model.eh.MatchableGeometry
+import com.mapbox.navigation.base.trip.model.eh.MatchableOpenLr
+import com.mapbox.navigation.base.trip.model.eh.MatchablePoint
 import com.mapbox.navigation.base.trip.model.eh.mapToEHorizonEdgeMetadata
 import com.mapbox.navigation.base.trip.model.eh.mapToEHorizonPosition
 import com.mapbox.navigation.base.trip.model.eh.mapToNativeGraphPath
 import com.mapbox.navigation.base.trip.model.eh.mapToNativeGraphPosition
-import com.mapbox.navigation.base.trip.model.eh.mapToOpenLRStandard
+import com.mapbox.navigation.base.trip.model.eh.mapToNativeMatchableGeometry
+import com.mapbox.navigation.base.trip.model.eh.mapToNativeMatchableOpenLr
+import com.mapbox.navigation.base.trip.model.eh.mapToNativeMatchablePoint
 import com.mapbox.navigation.base.trip.model.eh.mapToRoadObjectDistance
 import com.mapbox.navigation.base.trip.model.eh.mapToRoadObjectEdgeLocation
 import com.mapbox.navigation.base.trip.model.eh.mapToRoadObjectEnterExitInfo
@@ -55,11 +60,6 @@ object EHorizonFactory {
         edgeLocation.mapToRoadObjectEdgeLocation()
 
     /**
-     * Build OpenLRStandard
-     */
-    fun buildOpenLRStandard(openLRStandard: String) = openLRStandard.mapToOpenLRStandard()
-
-    /**
      * Build native GraphPath
      */
     fun buildNativeGraphPath(graphPath: EHorizonGraphPath) = graphPath.mapToNativeGraphPath()
@@ -69,4 +69,16 @@ object EHorizonFactory {
      */
     fun buildNativeGraphPosition(graphPosition: EHorizonGraphPosition) =
         graphPosition.mapToNativeGraphPosition()
+
+    fun buildNativeMatchableOpenLr(
+        matchable: MatchableOpenLr
+    ) = matchable.mapToNativeMatchableOpenLr()
+
+    fun buildNativeMatchableGeometry(
+        matchable: MatchableGeometry
+    ) = matchable.mapToNativeMatchableGeometry()
+
+    fun buildNativeMatchablePoint(
+        matchable: MatchablePoint
+    ) = matchable.mapToNativeMatchablePoint()
 }

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/eh/EHorizonMapper.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/eh/EHorizonMapper.kt
@@ -24,6 +24,9 @@ import com.mapbox.navigator.ElectronicHorizonResultType
 import com.mapbox.navigator.FunctionalRoadClass
 import com.mapbox.navigator.GraphPath
 import com.mapbox.navigator.GraphPosition
+import com.mapbox.navigator.MatchableGeometry
+import com.mapbox.navigator.MatchableOpenLr
+import com.mapbox.navigator.MatchablePoint
 import com.mapbox.navigator.MatchedRoadObjectLocation
 import com.mapbox.navigator.OpenLROrientation
 import com.mapbox.navigator.OpenLRSideOfRoad
@@ -67,6 +70,15 @@ internal typealias SDKRoadSurface =
 
 internal typealias SDKSubgraphEdge =
     com.mapbox.navigation.base.trip.model.roadobject.location.SubgraphEdge
+
+internal typealias SDKMatchableOpenLr =
+    com.mapbox.navigation.base.trip.model.eh.MatchableOpenLr
+
+internal typealias SDKMatchableGeometry =
+    com.mapbox.navigation.base.trip.model.eh.MatchableGeometry
+
+internal typealias SDKMatchablePoint =
+    com.mapbox.navigation.base.trip.model.eh.MatchablePoint
 
 /**
  * Map the ElectronicHorizonPosition.
@@ -355,6 +367,29 @@ internal fun EHorizonGraphPosition.mapToNativeGraphPosition(): GraphPosition {
     return GraphPosition(
         edgeId,
         percentAlong
+    )
+}
+
+internal fun SDKMatchableOpenLr.mapToNativeMatchableOpenLr(): MatchableOpenLr {
+    return MatchableOpenLr(
+        openLRLocation,
+        openLRStandard.mapToOpenLRStandard(),
+        roadObjectId
+    )
+}
+
+internal fun SDKMatchableGeometry.mapToNativeMatchableGeometry(): MatchableGeometry {
+    return MatchableGeometry(
+        roadObjectId,
+        coordinates
+    )
+}
+
+internal fun SDKMatchablePoint.mapToNativeMatchablePoint(): MatchablePoint {
+    return MatchablePoint(
+        roadObjectId,
+        point,
+        bearing
     )
 }
 

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/eh/MatchableTypes.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/eh/MatchableTypes.kt
@@ -1,0 +1,45 @@
+package com.mapbox.navigation.base.trip.model.eh
+
+import com.mapbox.geojson.Point
+
+/**
+ * The record represents a piece of data which is required to match one OpenLR.
+ *
+ * @param roadObjectId unique id of the object
+ * @param openLRLocation road object location
+ * @param openLRStandard standard used to encode openLRLocation
+ */
+data class MatchableOpenLr(
+    val roadObjectId: String,
+    val openLRLocation: String,
+    @OpenLRStandard.Type val openLRStandard: String
+)
+
+/**
+ * The record represents the raw data which could be matched to the road graph.
+ * Might be used to match:
+ * - gantries, with exactly two coordinates
+ * - lines, with two or more coordinates
+ * - polygons, with three or more coordinates
+ *
+ * @param roadObjectId unique id of the object
+ * @param coordinates list of points representing the geometry
+ */
+data class MatchableGeometry(
+    val roadObjectId: String,
+    val coordinates: List<Point>
+)
+
+/**
+ * The record represents a raw point which could be matched to the road graph.
+ *
+ * @param roadObjectId unique id of the object
+ * @param point point representing the object
+ * @param bearing optional bearing in degrees from the North.
+ * Describes the direction of riding for the edge where provided point is going to be matched.
+ */
+data class MatchablePoint(
+    val roadObjectId: String,
+    val point: Point,
+    val bearing: Double? = null
+)

--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -39,7 +39,6 @@ package com.mapbox.navigation.core {
     method public void requestAlternativeRoutes();
     method public long requestRoutes(com.mapbox.api.directions.v5.models.RouteOptions routeOptions, com.mapbox.navigation.base.route.RouterCallback routesRequestCallback);
     method public void resetTripSession();
-    method public String? retrieveSsmlAnnouncementInstruction(int index);
     method public void setArrivalController(com.mapbox.navigation.core.arrival.ArrivalController? arrivalController = com.mapbox.navigation.core.arrival.AutoArrivalController());
     method public void setArrivalController();
     method public void setRerouteController(com.mapbox.navigation.core.reroute.RerouteController? rerouteController = com.mapbox.navigation.core.MapboxNavigation.defaultRerouteController);
@@ -739,11 +738,21 @@ package com.mapbox.navigation.core.trip.session.eh {
   public final class RoadObjectMatcher {
     method public void cancel(java.util.List<java.lang.String> roadObjectIds);
     method public void cancelAll();
-    method public void matchGantryObject(String roadObjectId, java.util.List<com.mapbox.geojson.Point> gantry);
-    method public void matchOpenLRObject(String roadObjectId, String openLRLocation, @com.mapbox.navigation.base.trip.model.eh.OpenLRStandard.Type String openLRStandard);
-    method public void matchPointObject(String roadObjectId, com.mapbox.geojson.Point point);
-    method public void matchPolygonObject(String roadObjectId, java.util.List<com.mapbox.geojson.Point> polygon);
-    method public void matchPolylineObject(String roadObjectId, java.util.List<com.mapbox.geojson.Point> polyline);
+    method @Deprecated public void matchGantryObject(String roadObjectId, java.util.List<com.mapbox.geojson.Point> gantry);
+    method public void matchGantryObjects(java.util.List<com.mapbox.navigation.base.trip.model.eh.MatchableGeometry> matchableGeometries, boolean useOnlyPreloadedTiles = false);
+    method public void matchGantryObjects(java.util.List<com.mapbox.navigation.base.trip.model.eh.MatchableGeometry> matchableGeometries);
+    method @Deprecated public void matchOpenLRObject(String roadObjectId, String openLRLocation, @com.mapbox.navigation.base.trip.model.eh.OpenLRStandard.Type String openLRStandard);
+    method public void matchOpenLRObjects(java.util.List<com.mapbox.navigation.base.trip.model.eh.MatchableOpenLr> matchableOpenLrs, boolean useOnlyPreloadedTiles = false);
+    method public void matchOpenLRObjects(java.util.List<com.mapbox.navigation.base.trip.model.eh.MatchableOpenLr> matchableOpenLrs);
+    method @Deprecated public void matchPointObject(String roadObjectId, com.mapbox.geojson.Point point);
+    method public void matchPointObjects(java.util.List<com.mapbox.navigation.base.trip.model.eh.MatchablePoint> matchablePoints, boolean useOnlyPreloadedTiles = false);
+    method public void matchPointObjects(java.util.List<com.mapbox.navigation.base.trip.model.eh.MatchablePoint> matchablePoints);
+    method @Deprecated public void matchPolygonObject(String roadObjectId, java.util.List<com.mapbox.geojson.Point> polygon);
+    method public void matchPolygonObjects(java.util.List<com.mapbox.navigation.base.trip.model.eh.MatchableGeometry> matchableGeometries, boolean useOnlyPreloadedTiles = false);
+    method public void matchPolygonObjects(java.util.List<com.mapbox.navigation.base.trip.model.eh.MatchableGeometry> matchableGeometries);
+    method @Deprecated public void matchPolylineObject(String roadObjectId, java.util.List<com.mapbox.geojson.Point> polyline);
+    method public void matchPolylineObjects(java.util.List<com.mapbox.navigation.base.trip.model.eh.MatchableGeometry> matchableGeometries, boolean useOnlyPreloadedTiles = false);
+    method public void matchPolylineObjects(java.util.List<com.mapbox.navigation.base.trip.model.eh.MatchableGeometry> matchableGeometries);
     method public void registerRoadObjectMatcherObserver(com.mapbox.navigation.core.trip.session.eh.RoadObjectMatcherObserver roadObjectMatcherObserver);
   }
 

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -635,14 +635,6 @@ class MapboxNavigation(
     }
 
     /**
-     * API used to retrieve the SSML announcement for voice instructions.
-     *
-     * @return SSML voice instruction announcement string
-     */
-    fun retrieveSsmlAnnouncementInstruction(index: Int): String? =
-        MapboxNativeNavigatorImpl.getVoiceInstruction(index)?.ssmlAnnouncement
-
-    /**
      * Registers [LocationObserver]. The updates are available whenever the trip session is started.
      *
      * @see [startTripSession]

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/eh/EHorizonSubscriptionManagerImpl.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/eh/EHorizonSubscriptionManagerImpl.kt
@@ -124,14 +124,14 @@ internal class EHorizonSubscriptionManagerImpl(
     private fun setNavigatorObservers() {
         navigator.run {
             setElectronicHorizonObserver(electronicHorizonObserver)
-            setRoadObjectsStoreObserver(roadObjectsStoreObserver)
+            addRoadObjectsStoreObserver(roadObjectsStoreObserver)
         }
     }
 
     private fun removeNavigatorObservers() {
         navigator.run {
             setElectronicHorizonObserver(null)
-            setRoadObjectsStoreObserver(null)
+            removeRoadObjectsStoreObserver(roadObjectsStoreObserver)
         }
     }
 

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/EHorizonSubscriptionManagerTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/EHorizonSubscriptionManagerTest.kt
@@ -79,7 +79,7 @@ class EHorizonSubscriptionManagerTest {
         subscriptionManager.registerObserver(mockk())
 
         verify(exactly = 1) { navigator.setElectronicHorizonObserver(any()) }
-        verify(exactly = 1) { navigator.setRoadObjectsStoreObserver(any()) }
+        verify(exactly = 1) { navigator.addRoadObjectsStoreObserver(any()) }
     }
 
     @Test
@@ -88,7 +88,7 @@ class EHorizonSubscriptionManagerTest {
         subscriptionManager.registerObserver(mockk())
 
         verify(exactly = 1) { navigator.setElectronicHorizonObserver(any()) }
-        verify(exactly = 1) { navigator.setRoadObjectsStoreObserver(any()) }
+        verify(exactly = 1) { navigator.addRoadObjectsStoreObserver(any()) }
     }
 
     @Test
@@ -96,7 +96,7 @@ class EHorizonSubscriptionManagerTest {
         subscriptionManager.unregisterAllObservers()
 
         verify(exactly = 1) { navigator.setElectronicHorizonObserver(null) }
-        verify(exactly = 1) { navigator.setRoadObjectsStoreObserver(null) }
+        verify(exactly = 1) { navigator.removeRoadObjectsStoreObserver(any()) }
     }
 
     @Test
@@ -104,7 +104,7 @@ class EHorizonSubscriptionManagerTest {
         val eHorizonObserverSlot = CapturingSlot<ElectronicHorizonObserver>()
         val roadObjectsStoreObserverSlot = CapturingSlot<RoadObjectsStoreObserver>()
         every { navigator.setElectronicHorizonObserver(capture(eHorizonObserverSlot)) } just Runs
-        every { navigator.setRoadObjectsStoreObserver(capture(roadObjectsStoreObserverSlot)) } just
+        every { navigator.addRoadObjectsStoreObserver(capture(roadObjectsStoreObserverSlot)) } just
             Runs
         val observer: EHorizonObserver = mockk(relaxed = true)
 
@@ -115,10 +115,12 @@ class EHorizonSubscriptionManagerTest {
             navigator.setElectronicHorizonObserver(eHorizonObserverSlot.captured)
         }
         verify(exactly = 1) {
-            navigator.setRoadObjectsStoreObserver(roadObjectsStoreObserverSlot.captured)
+            navigator.addRoadObjectsStoreObserver(roadObjectsStoreObserverSlot.captured)
         }
         verify(exactly = 1) { navigator.setElectronicHorizonObserver(null) }
-        verify(exactly = 1) { navigator.setRoadObjectsStoreObserver(null) }
+        verify(exactly = 1) {
+            navigator.removeRoadObjectsStoreObserver(roadObjectsStoreObserverSlot.captured)
+        }
     }
 
     @Test
@@ -183,7 +185,7 @@ class EHorizonSubscriptionManagerTest {
     @Test
     fun `onRoadObjectAdded is called for all observers`() = runBlockingTest {
         val roadObjectsStoreObserver = CapturingSlot<RoadObjectsStoreObserver>()
-        every { navigator.setRoadObjectsStoreObserver(capture(roadObjectsStoreObserver)) } just Runs
+        every { navigator.addRoadObjectsStoreObserver(capture(roadObjectsStoreObserver)) } just Runs
         val firstObserver: EHorizonObserver = mockk(relaxed = true)
         val secondObserver: EHorizonObserver = mockk(relaxed = true)
 
@@ -199,7 +201,7 @@ class EHorizonSubscriptionManagerTest {
     @Test
     fun `onRoadObjectUpdated is called for all observers`() = runBlockingTest {
         val roadObjectsStoreObserver = CapturingSlot<RoadObjectsStoreObserver>()
-        every { navigator.setRoadObjectsStoreObserver(capture(roadObjectsStoreObserver)) } just Runs
+        every { navigator.addRoadObjectsStoreObserver(capture(roadObjectsStoreObserver)) } just Runs
         val firstObserver: EHorizonObserver = mockk(relaxed = true)
         val secondObserver: EHorizonObserver = mockk(relaxed = true)
 
@@ -215,7 +217,7 @@ class EHorizonSubscriptionManagerTest {
     @Test
     fun `onRoadObjectRemoved is called for all observers`() = runBlockingTest {
         val roadObjectsStoreObserver = CapturingSlot<RoadObjectsStoreObserver>()
-        every { navigator.setRoadObjectsStoreObserver(capture(roadObjectsStoreObserver)) } just Runs
+        every { navigator.addRoadObjectsStoreObserver(capture(roadObjectsStoreObserver)) } just Runs
         val firstObserver: EHorizonObserver = mockk(relaxed = true)
         val secondObserver: EHorizonObserver = mockk(relaxed = true)
 

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
@@ -561,7 +561,7 @@ class MapboxTripSessionTest {
             }
         )
         every { nativeBanner.mapToDirectionsApi() } returns banner
-        every { MapboxNativeNavigatorImpl.getBannerInstruction(1) } returns nativeBanner
+        every { MapboxNativeNavigatorImpl.getCurrentBannerInstruction() } returns nativeBanner
         val bannerInstructionsObserver: BannerInstructionsObserver = mockk(relaxUnitFun = true)
 
         tripSession = buildTripSession()

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigator.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigator.kt
@@ -27,7 +27,6 @@ import com.mapbox.navigator.RouteInfo
 import com.mapbox.navigator.RouterError
 import com.mapbox.navigator.SensorData
 import com.mapbox.navigator.TilesConfig
-import com.mapbox.navigator.VoiceInstruction
 
 /**
  * Provides API to work with native Navigator class. Exposed for internal usage only.
@@ -111,14 +110,12 @@ interface MapboxNativeNavigator {
     suspend fun updateAnnotations(route: DirectionsRoute)
 
     /**
-     * Gets the banner at a specific step index in the route. If there is no
-     * banner at the specified index method return *null*.
-     *
-     * @param index Which step you want to get [BannerInstruction] for
+     * Gets the current banner. If there is no
+     * banner, the method returns *null*.
      *
      * @return [BannerInstruction] for step index you passed
      */
-    fun getBannerInstruction(index: Int): BannerInstruction?
+    fun getCurrentBannerInstruction(): BannerInstruction?
 
     /**
      * Follows a new leg of the already loaded directions.
@@ -154,16 +151,6 @@ interface MapboxNativeNavigator {
     // Other
 
     /**
-     * Gets the voice instruction at a specific step index in the route. If there is no
-     * voice instruction at the specified index, *null* is returned.
-     *
-     * @param index Which step you want to get [VoiceInstruction] for
-     *
-     * @return [VoiceInstruction] for step index you passed
-     */
-    fun getVoiceInstruction(index: Int): VoiceInstruction?
-
-    /**
      * Compare given route with current route.
      * Routes are considered the same if one of the routes is a suffix of another
      * without the first and last intersection.
@@ -186,12 +173,9 @@ interface MapboxNativeNavigator {
      */
     fun setElectronicHorizonObserver(eHorizonObserver: ElectronicHorizonObserver?)
 
-    /**
-     * Sets the Road objects store observer
-     *
-     * @param roadObjectsStoreObserver
-     */
-    fun setRoadObjectsStoreObserver(roadObjectsStoreObserver: RoadObjectsStoreObserver?)
+    fun addRoadObjectsStoreObserver(roadObjectsStoreObserver: RoadObjectsStoreObserver)
+
+    fun removeRoadObjectsStoreObserver(roadObjectsStoreObserver: RoadObjectsStoreObserver)
 
     fun setFallbackVersionsObserver(fallbackVersionsObserver: FallbackVersionsObserver?)
 

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigatorImpl.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigatorImpl.kt
@@ -34,7 +34,6 @@ import com.mapbox.navigator.Router
 import com.mapbox.navigator.RouterError
 import com.mapbox.navigator.SensorData
 import com.mapbox.navigator.TilesConfig
-import com.mapbox.navigator.VoiceInstruction
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.withContext
@@ -208,15 +207,12 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
         }
 
     /**
-     * Gets the banner at a specific step index in the route. If there is no
-     * banner at the specified index method return *null*.
-     *
-     * @param index Which step you want to get [BannerInstruction] for
+     * Gets the current banner. If there is no
+     * banner, the method returns *null*.
      *
      * @return [BannerInstruction] for step index you passed
      */
-    override fun getBannerInstruction(index: Int): BannerInstruction? =
-        navigator!!.getBannerInstruction(index)
+    override fun getCurrentBannerInstruction(): BannerInstruction? = navigator!!.bannerInstruction
 
     /**
      * Follows a new leg of the already loaded directions.
@@ -255,17 +251,6 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
     // Other
 
     /**
-     * Gets the voice instruction at a specific step index in the route. If there is no
-     * voice instruction at the specified index, *null* is returned.
-     *
-     * @param index Which step you want to get [VoiceInstruction] for
-     *
-     * @return [VoiceInstruction] for step index you passed
-     */
-    override fun getVoiceInstruction(index: Int): VoiceInstruction? =
-        navigator!!.getVoiceInstruction(index)
-
-    /**
      * Compare given route with current route.
      * Routes are considered the same if one of the routes is a suffix of another
      * without the first and last intersection.
@@ -297,13 +282,14 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
         navigator!!.setElectronicHorizonObserver(eHorizonObserver)
     }
 
-    /**
-     * Sets the Road objects store observer
-     *
-     * @param roadObjectsStoreObserver
-     */
-    override fun setRoadObjectsStoreObserver(roadObjectsStoreObserver: RoadObjectsStoreObserver?) {
-        roadObjectsStore?.setObserver(roadObjectsStoreObserver)
+    override fun addRoadObjectsStoreObserver(roadObjectsStoreObserver: RoadObjectsStoreObserver) {
+        roadObjectsStore?.addObserver(roadObjectsStoreObserver)
+    }
+
+    override fun removeRoadObjectsStoreObserver(
+        roadObjectsStoreObserver: RoadObjectsStoreObserver
+    ) {
+        roadObjectsStore?.removeObserver(roadObjectsStoreObserver)
     }
 
     override fun setFallbackVersionsObserver(fallbackVersionsObserver: FallbackVersionsObserver?) {
@@ -319,7 +305,7 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
     override fun unregisterAllObservers() {
         navigator!!.setElectronicHorizonObserver(null)
         navigator!!.setFallbackVersionsObserver(null)
-        roadObjectsStore?.setObserver(null)
+        roadObjectsStore?.removeAllCustomRoadObjects()
         nativeNavigatorRecreationObservers.clear()
     }
 


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Next to the changes listed below, make sure to check out https://github.com/mapbox/mapbox-maps-android/releases/tag/android-v10.0.0-rc.8.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
### Bug fixes
<changelog>Fixed an issue when occasionally there would be an off-route event emitted when leaving a tunnel.</changelog>
<changelog>Fixed an issue when location could be map-matched to a wrong, nearby road near intersections.</changelog>
<changelog>Fixed an issue where location and progress updates could be skipped faster resetting the session with `MapboxNavigation#resetTripSession`.</changelog>
<changelog>Fixed an issue with the wrong speed limit being returned around an off-route event.</changelog>
<changelog>Fixed an issue where EHorizon would sometimes report road objects that were already passed.</changelog>

### Improvements
<changelog>When downloading critical tiles, the Map tiles are preferred over Routing tiles to ensure that the map is visible as soon as possible.</changelog>
<changelog>:warning: Deprecated all matching methods that accept a single object in the `RoadObjectMatcher` in favor of methods that accept a list of matchable objects.</changelog>

### Other changes
<changelog>:warning: Removed `MapboxNavigation#retrieveSsmlAnnouncementInstruction`. It did not work correctly and if you plan to introduce a voice cache manually, look for `LegStep#voiceInstructions` in the `RouteLeg` of a `DirectionsRoute`.</changelog>
```

