### PR TITLE
Fix route refresh

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/routerefresh/RouteRefreshController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/routerefresh/RouteRefreshController.kt
@@ -42,12 +42,12 @@ internal class RouteRefreshController(
      */
     fun restart() {
         stop()
-        val route = tripSession.route
-        if (route?.routeOptions()?.enableRefresh() == true) {
+        val routeOptions = directionsSession.getPrimaryRouteOptions()
+        if (routeOptions?.enableRefresh() == true) {
             routerRefreshTimer.startTimer {
                 refreshRoute()
             }
-        } else if (route != null && route.routeOptions() == null) {
+        } else if (routeOptions != null) {
             logger.w(
                 TAG,
                 Message(
@@ -73,7 +73,7 @@ internal class RouteRefreshController(
     }
 
     private fun refreshRoute() {
-        val route = tripSession.route
+        val route = directionsSession.routes.firstOrNull()
             ?.takeIf { it.routeOptions()?.enableRefresh() == true }
             ?.takeIf { it.isUuidValidForRefresh() }
         if (route != null) {


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Resolves https://github.com/mapbox/mapbox-navigation-android/issues/4829

I think [this change caused the test to start failing](https://github.com/mapbox/mapbox-navigation-android/commit/a13c2fd590ea7b268ae9c6ab935b7bd5b95eda39#diff-c8878cb5894580f0c3816fb56632f1577830691cb218173dfb0a14d49ecd0e0fR44). The tripSession.routes are null when the directionSession.routes are being set. This is because the TripSession routes are updated by a directionsSession route observer.

The tripSession.route and directionsSession.route should never be out of sync for any external observer. But considering these are internal observers, it could be acceptable (but still not ideal). 
