### PR TITLE
Fix route refresh not starting

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -408,7 +408,6 @@ class MapboxNavigation(
             tripSession,
             logger
         )
-        routeRefreshController.restart()
 
         defaultRerouteController = MapboxRerouteController(
             directionsSession,
@@ -576,7 +575,6 @@ class MapboxNavigation(
         rerouteController?.interrupt()
         routeAlternativesController.interrupt()
         directionsSession.setRoutes(routes, initialLegIndex)
-        routeRefreshController.restart()
     }
 
     /**
@@ -1008,6 +1006,11 @@ class MapboxNavigation(
 
     private fun createInternalRoutesObserver() = RoutesObserver { routes ->
         tripSession.setRoute(routes.firstOrNull(), directionsSession.initialLegIndex)
+        if (routes.isNotEmpty()) {
+            routeRefreshController.restart(routes.first())
+        } else {
+            routeRefreshController.stop()
+        }
     }
 
     private fun createInternalOffRouteObserver() = OffRouteObserver { offRoute ->

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -1070,7 +1070,7 @@ class MapboxNavigation(
                 logger
             )
             historyRecorder.historyRecorderHandle = navigator.getHistoryRecorderHandle()
-            tripSession.route?.let {
+            directionsSession.routes.firstOrNull()?.let {
                 navigator.setRoute(
                     it,
                     tripSession.getRouteProgress()?.currentLegProgress?.legIndex ?: 0

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/routerefresh/RouteRefreshController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/routerefresh/RouteRefreshController.kt
@@ -16,7 +16,7 @@ import com.mapbox.navigation.utils.internal.MapboxTimer
  * This class is responsible for refreshing the current direction route's traffic.
  * This does not support alternative routes.
  *
- * If the route is successfully refreshed, this class will update the [TripSession.route]
+ * If the route is successfully refreshed, this class will update the [DirectionsSession].
  */
 internal class RouteRefreshController(
     private val routeRefreshOptions: RouteRefreshOptions,

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/routerefresh/RouteRefreshController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/routerefresh/RouteRefreshController.kt
@@ -40,14 +40,13 @@ internal class RouteRefreshController(
      * If route refresh is enabled, attach a refresh poller.
      * Cancel old timers, and cancel pending requests.
      */
-    fun restart() {
+    fun restart(route: DirectionsRoute) {
         stop()
-        val route = tripSession.route
-        if (route?.routeOptions()?.enableRefresh() == true) {
+        if (route.routeOptions()?.enableRefresh() == true) {
             routerRefreshTimer.startTimer {
-                refreshRoute()
+                refreshRoute(route)
             }
-        } else if (route != null && route.routeOptions() == null) {
+        } else if (route.routeOptions() == null) {
             logger.w(
                 TAG,
                 Message(
@@ -72,11 +71,9 @@ internal class RouteRefreshController(
         }
     }
 
-    private fun refreshRoute() {
-        val route = tripSession.route
-            ?.takeIf { it.routeOptions()?.enableRefresh() == true }
-            ?.takeIf { it.isUuidValidForRefresh() }
-        if (route != null) {
+    private fun refreshRoute(route: DirectionsRoute) {
+        val isValid = route.routeOptions()?.enableRefresh() == true && route.isUuidValidForRefresh()
+        if (isValid) {
             val legIndex = tripSession.getRouteProgress()?.currentLegProgress?.legIndex ?: 0
             currentRequestId?.let { directionsSession.cancelRouteRefreshRequest(it) }
             currentRequestId = directionsSession.requestRouteRefresh(
@@ -92,7 +89,7 @@ internal class RouteRefreshController(
                         The route is not qualified for route refresh feature.
                         See com.mapbox.navigation.base.extensions.supportsRouteRefresh
                         extension for details.
-                        ${route?.routeOptions()}
+                        ${route.routeOptions()}
                     """.trimIndent()
                 )
             )

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
@@ -3,6 +3,7 @@ package com.mapbox.navigation.core.trip.session
 import android.hardware.SensorEvent
 import android.location.Location
 import android.os.Looper
+import androidx.annotation.VisibleForTesting
 import com.mapbox.android.core.location.LocationEngineCallback
 import com.mapbox.android.core.location.LocationEngineResult
 import com.mapbox.api.directions.v5.models.BannerInstructions
@@ -53,8 +54,6 @@ import java.util.concurrent.CopyOnWriteArraySet
  * @param navigator Native navigator
  * @param threadController controller for main/io jobs
  * @param logger interface for logging any events
- *
- * @property route should be set to start routing
  */
 internal class MapboxTripSession(
     override val tripService: TripService,
@@ -67,8 +66,8 @@ internal class MapboxTripSession(
 
     private var updateRouteJob: Job? = null
 
-    override var route: DirectionsRoute? = null
-        private set
+    @VisibleForTesting
+    internal var route: DirectionsRoute? = null
 
     override fun setRoute(route: DirectionsRoute?, legIndex: Int) {
         val isSameUuid = route?.isSameUuid(this.route) ?: false

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/TripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/TripSession.kt
@@ -11,7 +11,6 @@ import com.mapbox.navigator.FallbackVersionsObserver
 internal interface TripSession {
 
     val tripService: TripService
-    val route: DirectionsRoute?
     fun setRoute(route: DirectionsRoute?, legIndex: Int)
 
     fun getRawLocation(): Location?

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
@@ -19,7 +19,6 @@ import com.mapbox.navigation.base.internal.extensions.inferDeviceLocale
 import com.mapbox.navigation.base.options.IncidentsOptions
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.options.RoutingTilesOptions
-import com.mapbox.navigation.base.route.RouteRefreshOptions
 import com.mapbox.navigation.base.route.Router
 import com.mapbox.navigation.base.route.RouterCallback
 import com.mapbox.navigation.base.route.RouterOrigin
@@ -299,43 +298,6 @@ class MapboxNavigationTest {
     }
 
     @Test
-    fun `restart the routeRefreshController during initialization`() {
-        createMapboxNavigation()
-        ThreadController.cancelAllUICoroutines()
-        verify(exactly = 1) { routeRefreshController.restart() }
-    }
-
-    @Test
-    fun `restart the routeRefreshController if new route is set`() {
-        ThreadController.cancelAllUICoroutines()
-
-        mapboxNavigation = MapboxNavigation(
-            provideNavigationOptions()
-                .routeRefreshOptions(
-                    RouteRefreshOptions.Builder()
-                        .build()
-                )
-                .build()
-        )
-        val route: DirectionsRoute = mockk()
-        val routeOptions: RouteOptions = mockk()
-        every { route.routeOptions() } returns routeOptions
-        every { route.geometry() } returns "geometry"
-        every { route.legs() } returns emptyList()
-        every { routeOptions.overview() } returns "full"
-        every { routeOptions.annotationsList() } returns emptyList()
-        every { routeOptions.enableRefresh() } returns true
-        mapboxNavigation.setRoutes(listOf(route))
-
-        // the sequence needs to be kept because routeRefreshController uses the route stored
-        // in the trip session, which has to be set first via directionsSession
-        verifyOrder {
-            directionsSession.setRoutes(listOf(route))
-            routeRefreshController.restart()
-        }
-    }
-
-    @Test
     fun registerMapMatcherResultObserver() {
         createMapboxNavigation()
         val observer: MapMatcherResultObserver = mockk()
@@ -570,6 +532,7 @@ class MapboxNavigationTest {
         }
 
         verify { tripSession.setRoute(primary, initialLegIndex) }
+        verify { routeRefreshController.restart(primary) }
     }
 
     @Test
@@ -586,6 +549,7 @@ class MapboxNavigationTest {
         }
 
         verify { tripSession.setRoute(null, initialLegIndex) }
+        verify { routeRefreshController.stop() }
     }
 
     @Test

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
@@ -863,7 +863,7 @@ class MapboxNavigationTest {
         every {
             tripSession.registerFallbackVersionsObserver(capture(fallbackObserverSlot))
         } just Runs
-        every { tripSession.route } returns null
+        every { directionsSession.routes } returns emptyList()
         every { tripSession.getRouteProgress() } returns mockk()
 
         mapboxNavigation = MapboxNavigation(navigationOptions)
@@ -897,7 +897,7 @@ class MapboxNavigationTest {
         every {
             tripSession.registerFallbackVersionsObserver(capture(fallbackObserverSlot))
         } just Runs
-        every { tripSession.route } returns null
+        every { directionsSession.routes } returns emptyList()
         every { tripSession.getRouteProgress() } returns mockk()
 
         mapboxNavigation = MapboxNavigation(navigationOptions)
@@ -931,7 +931,7 @@ class MapboxNavigationTest {
         val routeProgress: RouteProgress = mockk()
         val legProgress: RouteLegProgress = mockk()
         val index = 137
-        every { tripSession.route } returns route
+        every { directionsSession.routes } returns listOf(route)
         every { tripSession.getRouteProgress() } returns routeProgress
         every { routeProgress.currentLegProgress } returns legProgress
         every { legProgress.legIndex } returns index

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/routerefresh/RouteRefreshControllerTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/routerefresh/RouteRefreshControllerTest.kt
@@ -89,7 +89,7 @@ class RouteRefreshControllerTest {
     fun `should refresh route every 5 minutes by default`() = coroutineRule.runBlockingTest {
         every { routeOptions.enableRefresh() } returns true
 
-        routeRefreshController.restart()
+        routeRefreshController.restart(validRoute)
         coroutineRule.testDispatcher.advanceTimeBy(TimeUnit.MINUTES.toMillis(15))
         routeRefreshController.stop()
 
@@ -108,7 +108,7 @@ class RouteRefreshControllerTest {
         )
         every { routeOptions.enableRefresh() } returns true
 
-        routeRefreshController.restart()
+        routeRefreshController.restart(validRoute)
         coroutineRule.testDispatcher.advanceTimeBy(TimeUnit.MINUTES.toMillis(15))
         routeRefreshController.stop()
 
@@ -119,7 +119,7 @@ class RouteRefreshControllerTest {
     fun `should refresh route with correct properties`() = coroutineRule.runBlockingTest {
         every { routeOptions.enableRefresh() } returns true
 
-        routeRefreshController.restart()
+        routeRefreshController.restart(validRoute)
         coroutineRule.testDispatcher.advanceTimeBy(TimeUnit.MINUTES.toMillis(6))
         routeRefreshController.stop()
 
@@ -131,7 +131,7 @@ class RouteRefreshControllerTest {
         coroutineRule.runBlockingTest {
             every { routeOptions.enableRefresh() } returns true
 
-            routeRefreshController.restart()
+            routeRefreshController.restart(validRoute)
             coroutineRule.testDispatcher.advanceTimeBy(TimeUnit.MINUTES.toMillis(6))
             routeRefreshController.stop()
 
@@ -143,7 +143,7 @@ class RouteRefreshControllerTest {
         every { routeOptions.enableRefresh() } returns true
         every { validRoute.requestUuid() } returns null
 
-        routeRefreshController.restart()
+        routeRefreshController.restart(validRoute)
         coroutineRule.testDispatcher.advanceTimeBy(TimeUnit.MINUTES.toMillis(6))
         routeRefreshController.stop()
 
@@ -164,7 +164,7 @@ class RouteRefreshControllerTest {
     fun `cancel request when stopped`() = coroutineRule.runBlockingTest {
         every { routeOptions.enableRefresh() } returns true
 
-        routeRefreshController.restart()
+        routeRefreshController.restart(validRoute)
         coroutineRule.testDispatcher.advanceTimeBy(TimeUnit.MINUTES.toMillis(6))
         routeRefreshController.stop()
 
@@ -175,7 +175,7 @@ class RouteRefreshControllerTest {
     fun `do not send a request when route options is null`() {
         every { validRoute.routeOptions() } returns null
 
-        routeRefreshController.restart()
+        routeRefreshController.restart(validRoute)
         coroutineRule.testDispatcher.advanceTimeBy(routeRefreshOptions.intervalMillis * 2)
         routeRefreshController.stop()
 
@@ -187,7 +187,7 @@ class RouteRefreshControllerTest {
         every { routeOptions.enableRefresh() } returns true
         every { validRoute.requestUuid() } returns ""
 
-        routeRefreshController.restart()
+        routeRefreshController.restart(validRoute)
         coroutineRule.testDispatcher.advanceTimeBy(routeRefreshOptions.intervalMillis * 2)
         routeRefreshController.stop()
 
@@ -199,7 +199,7 @@ class RouteRefreshControllerTest {
         every { routeOptions.enableRefresh() } returns true
         every { validRoute.requestUuid() } returns OFFLINE_UUID
 
-        routeRefreshController.restart()
+        routeRefreshController.restart(validRoute)
         coroutineRule.testDispatcher.advanceTimeBy(routeRefreshOptions.intervalMillis * 2)
         routeRefreshController.stop()
 
@@ -216,13 +216,13 @@ class RouteRefreshControllerTest {
         val countDownLatch = CountDownLatch(2)
         every { directionsSession.requestRouteRefresh(any(), any(), any()) } answers {
             if (countDownLatch.count == 1L) {
-                routeRefreshController.restart()
+                routeRefreshController.restart(validRoute)
             }
             countDownLatch.countDown()
             countDownLatch.count
         }
 
-        routeRefreshController.restart()
+        routeRefreshController.restart(validRoute)
         coroutineRule.testDispatcher.advanceTimeBy(routeRefreshOptions.intervalMillis * 2)
         countDownLatch.await()
         routeRefreshController.stop()
@@ -243,11 +243,11 @@ class RouteRefreshControllerTest {
             countDownLatch.count
         }
 
-        routeRefreshController.restart()
+        routeRefreshController.restart(validRoute)
         coroutineRule.testDispatcher.advanceTimeBy(
             (routeRefreshOptions.intervalMillis * 1.9).toLong()
         )
-        routeRefreshController.restart()
+        routeRefreshController.restart(validRoute)
         coroutineRule.testDispatcher.advanceTimeBy(
             (routeRefreshOptions.intervalMillis * 1.9).toLong()
         )
@@ -266,7 +266,7 @@ class RouteRefreshControllerTest {
         every { routeOptions.enableRefresh() } returns true
         every { routeDiffProvider.buildRouteDiffs(validRoute, any(), 0) } returns emptyList()
 
-        routeRefreshController.restart()
+        routeRefreshController.restart(validRoute)
         coroutineRule.testDispatcher.advanceTimeBy(routeRefreshOptions.intervalMillis)
         routeRefreshCallbackSlot.captured.onRefresh(
             mockk {
@@ -283,7 +283,7 @@ class RouteRefreshControllerTest {
     fun `clear the request when there is a failure response`() {
         every { routeOptions.enableRefresh() } returns true
 
-        routeRefreshController.restart()
+        routeRefreshController.restart(validRoute)
         coroutineRule.testDispatcher.advanceTimeBy(routeRefreshOptions.intervalMillis)
         routeRefreshCallbackSlot.captured.onError(
             mockk {
@@ -301,7 +301,7 @@ class RouteRefreshControllerTest {
     fun `should log warning when route options are null`() = coroutineRule.runBlockingTest {
         every { validRoute.routeOptions() } returns null
 
-        routeRefreshController.restart()
+        routeRefreshController.restart(validRoute)
         coroutineRule.testDispatcher.advanceTimeBy(TimeUnit.MINUTES.toMillis(6))
         routeRefreshController.stop()
 
@@ -328,7 +328,7 @@ class RouteRefreshControllerTest {
         every { routeOptions.enableRefresh() } returns true
         every { routeDiffProvider.buildRouteDiffs(validRoute, newRoute, 0) } returns routeDiffs
 
-        routeRefreshController.restart()
+        routeRefreshController.restart(validRoute)
         coroutineRule.testDispatcher.advanceTimeBy(routeRefreshOptions.intervalMillis)
         routeRefreshCallbackSlot.captured.onRefresh(newRoute)
         routeRefreshController.stop()
@@ -346,7 +346,7 @@ class RouteRefreshControllerTest {
         every { routeOptions.enableRefresh() } returns true
         every { routeDiffProvider.buildRouteDiffs(validRoute, newRoute, 0) } returns emptyList()
 
-        routeRefreshController.restart()
+        routeRefreshController.restart(validRoute)
         coroutineRule.testDispatcher.advanceTimeBy(routeRefreshOptions.intervalMillis)
         routeRefreshCallbackSlot.captured.onRefresh(newRoute)
         routeRefreshController.stop()

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/routerefresh/RouteRefreshControllerTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/routerefresh/RouteRefreshControllerTest.kt
@@ -79,7 +79,6 @@ class RouteRefreshControllerTest {
                 every { legIndex } returns 0
             }
         }
-        every { tripSession.route } returns validRoute
         every {
             directionsSession.requestRouteRefresh(any(), any(), capture(routeRefreshCallbackSlot))
         } returns requestId

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
@@ -87,7 +87,7 @@ class MapboxTripSessionTest {
     @get:Rule
     var coroutineRule = MainCoroutineRule()
 
-    private lateinit var tripSession: TripSession
+    private lateinit var tripSession: MapboxTripSession
 
     private val tripService: TripService = mockk(relaxUnitFun = true) {
         every { hasServiceStarted() } returns false
@@ -179,7 +179,7 @@ class MapboxTripSessionTest {
         } answers {}
     }
 
-    private fun buildTripSession(): TripSession {
+    private fun buildTripSession(): MapboxTripSession {
         return MapboxTripSession(
             tripService,
             navigationOptions,
@@ -638,12 +638,6 @@ class MapboxTripSessionTest {
     @Test
     fun getTripService() {
         assertEquals(tripService, tripSession.tripService)
-    }
-
-    @Test
-    fun getRoute() {
-        tripSession.setRoute(route, legIndex)
-        assertEquals(route, tripSession.route)
     }
 
     @Test


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Closes https://github.com/mapbox/mapbox-navigation-android/issues/4829. Fixes a regression potentially from https://github.com/mapbox/mapbox-navigation-android/pull/4755.

A route is not set synchronously in the `MapboxTripSession` anymore, so we cannot use a synchronous getter for it in the `RouteRefreshController`.

We could potentially use a synchronous getter from `MapboxDirectionsSession` instead as https://github.com/mapbox/mapbox-navigation-android/pull/4830 proposes but it's exposed to the same risk as the previous `MapboxTripSession` getter - route setting is run on a callback (`RoutesObserver`) and we don't guarantee that the route setting process is synchronous. We could change `MapboxDirectionsSession` to work asynchronously in the future and run into the same exact regression.

This PR instead uses the `RoutesObserver` to restart the refresh timer.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Fixed an issue where the route was never refreshed because of an internal timer not starting when a new route was set.</changelog>
```

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
