### PR TITLE
Add expirmental annotation to startReplayTripSession

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayHistoryActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayHistoryActivity.kt
@@ -22,6 +22,7 @@ import com.mapbox.maps.plugin.delegates.listeners.eventdata.MapLoadErrorType
 import com.mapbox.maps.plugin.locationcomponent.LocationComponentPlugin
 import com.mapbox.maps.plugin.locationcomponent.OnIndicatorPositionChangedListener
 import com.mapbox.maps.plugin.locationcomponent.location
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesObserver
@@ -256,6 +257,14 @@ class ReplayHistoryActivity : AppCompatActivity() {
                 .build()
         )
         mapboxReplayer = mapboxNavigation.mapboxReplayer
+        startReplayTripSession()
+    }
+
+    /**
+     * This is showcasing a new way to replay rides at runtime.
+     */
+    @OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
+    private fun startReplayTripSession() {
         mapboxNavigation.startReplayTripSession()
     }
 

--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -46,7 +46,7 @@ package com.mapbox.navigation.core {
     method public void setRerouteController();
     method public void setRoutes(java.util.List<? extends com.mapbox.api.directions.v5.models.DirectionsRoute> routes, int initialLegIndex = 0);
     method public void setRoutes(java.util.List<? extends com.mapbox.api.directions.v5.models.DirectionsRoute> routes);
-    method public void startReplayTripSession(boolean withForegroundService = true);
+    method @com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI public void startReplayTripSession(boolean withForegroundService = true);
     method @RequiresPermission(anyOf={android.Manifest.permission.ACCESS_COARSE_LOCATION, android.Manifest.permission.ACCESS_FINE_LOCATION}) public void startTripSession(boolean withForegroundService = true);
     method @RequiresPermission(anyOf={android.Manifest.permission.ACCESS_COARSE_LOCATION, android.Manifest.permission.ACCESS_FINE_LOCATION}) public void startTripSession();
     method public void stopTripSession();

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -489,6 +489,7 @@ class MapboxNavigation(
      *
      * This allows you to simulate navigation routes or replay history from the [historyRecorder].
      */
+    @ExperimentalPreviewMapboxNavigationAPI
     fun startReplayTripSession(withForegroundService: Boolean = true) {
         runIfNotDestroyed {
             tripSession.start(


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

https://github.com/mapbox/mapbox-navigation-android/pull/4843

For backporting to 2.0.0-rc, it makes sense to have the `@ExperimentalPreviewMapboxNavigationAPI`

We also discussed that it is confusing there are 2 ways to enable replay (through the construction of MapboxNavigation, or by startReplayTripSession). These two ways are also, not meant to work together but independently. Adding the annotation here may make this more clear. Also our public documentation recommends the construction way.