### PR TITLE
move zLevel to MapMatcherResult

### DIFF
--- a/libnavigation-base/api/current.txt
+++ b/libnavigation-base/api/current.txt
@@ -522,7 +522,6 @@ package com.mapbox.navigation.base.trip.model {
     method public java.util.List<com.mapbox.navigation.base.trip.model.roadobject.UpcomingRoadObject> getUpcomingRoadObjects();
     method public java.util.List<com.mapbox.geojson.Point>? getUpcomingStepPoints();
     method public com.mapbox.api.directions.v5.models.VoiceInstructions? getVoiceInstructions();
-    method public Integer? getZLevel();
     property public final com.mapbox.api.directions.v5.models.BannerInstructions? bannerInstructions;
     property public final com.mapbox.navigation.base.trip.model.RouteLegProgress? currentLegProgress;
     property public final com.mapbox.navigation.base.trip.model.RouteProgressState currentState;
@@ -537,7 +536,6 @@ package com.mapbox.navigation.base.trip.model {
     property public final java.util.List<com.mapbox.navigation.base.trip.model.roadobject.UpcomingRoadObject> upcomingRoadObjects;
     property public final java.util.List<com.mapbox.geojson.Point>? upcomingStepPoints;
     property public final com.mapbox.api.directions.v5.models.VoiceInstructions? voiceInstructions;
-    property public final Integer? zLevel;
   }
 
   public enum RouteProgressState {

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/factory/RouteProgressFactory.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/factory/RouteProgressFactory.kt
@@ -40,8 +40,6 @@ object RouteProgressFactory {
      * @param upcomingRoadObjects list of upcoming road objects.
      * @param stale `true` if there were no location updates for a significant amount which causes
      * a lack of confidence in the progress updates being sent.
-     * @param zLevel [Int] current Z-level.
-     * Can be used to build a route from a proper level of a road.
      */
     fun buildRouteProgressObject(
         route: DirectionsRoute,
@@ -58,7 +56,6 @@ object RouteProgressFactory {
         remainingWaypoints: Int,
         upcomingRoadObjects: List<UpcomingRoadObject>,
         stale: Boolean,
-        zLevel: Int?,
     ): RouteProgress {
         return RouteProgress(
             route = route,
@@ -75,7 +72,6 @@ object RouteProgressFactory {
             remainingWaypoints = remainingWaypoints,
             upcomingRoadObjects = upcomingRoadObjects,
             stale = stale,
-            zLevel = zLevel,
         )
     }
 }

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteProgress.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteProgress.kt
@@ -36,7 +36,6 @@ import com.mapbox.navigation.base.trip.model.roadobject.UpcomingRoadObject
  * @param upcomingRoadObjects list of upcoming road objects.
  * @param stale `true` if there were no location updates for a significant amount which causes
  * a lack of confidence in the progress updates being sent.
- * @param zLevel [Int] current Z-level. Can be used to build a route from a proper level of a road.
  */
 class RouteProgress internal constructor(
     val route: DirectionsRoute,
@@ -53,7 +52,6 @@ class RouteProgress internal constructor(
     val remainingWaypoints: Int,
     val upcomingRoadObjects: List<UpcomingRoadObject>,
     val stale: Boolean,
-    val zLevel: Int?,
 ) {
 
     /**
@@ -79,7 +77,6 @@ class RouteProgress internal constructor(
         if (remainingWaypoints != other.remainingWaypoints) return false
         if (upcomingRoadObjects != other.upcomingRoadObjects) return false
         if (stale != other.stale) return false
-        if (zLevel != other.zLevel) return false
 
         return true
     }
@@ -102,7 +99,6 @@ class RouteProgress internal constructor(
         result = 31 * result + remainingWaypoints
         result = 31 * result + upcomingRoadObjects.hashCode()
         result = 31 * result + stale.hashCode()
-        result = 31 * result + zLevel.hashCode()
         return result
     }
 
@@ -124,8 +120,7 @@ class RouteProgress internal constructor(
             "fractionTraveled=$fractionTraveled, " +
             "remainingWaypoints=$remainingWaypoints, " +
             "upcomingRoadObjects=$upcomingRoadObjects, " +
-            "stale=$stale, " +
-            "zLevel=$zLevel" +
+            "stale=$stale" +
             ")"
     }
 }

--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -494,7 +494,8 @@ package com.mapbox.navigation.core.routeoptions {
 
   public final class RouteOptionsUpdater {
     ctor public RouteOptionsUpdater();
-    method public com.mapbox.navigation.core.routeoptions.RouteOptionsUpdater.RouteOptionsResult update(com.mapbox.api.directions.v5.models.RouteOptions? routeOptions, com.mapbox.navigation.base.trip.model.RouteProgress? routeProgress, android.location.Location? location);
+    method @Deprecated public com.mapbox.navigation.core.routeoptions.RouteOptionsUpdater.RouteOptionsResult update(com.mapbox.api.directions.v5.models.RouteOptions? routeOptions, com.mapbox.navigation.base.trip.model.RouteProgress? routeProgress, android.location.Location? location);
+    method public com.mapbox.navigation.core.routeoptions.RouteOptionsUpdater.RouteOptionsResult update(com.mapbox.api.directions.v5.models.RouteOptions? routeOptions, com.mapbox.navigation.base.trip.model.RouteProgress? routeProgress, com.mapbox.navigation.core.trip.session.MapMatcherResult? mapMatcherResult);
   }
 
   public abstract static sealed class RouteOptionsUpdater.RouteOptionsResult {
@@ -644,6 +645,7 @@ package com.mapbox.navigation.core.trip.session {
     method public float getOffRoadProbability();
     method public float getRoadEdgeMatchProbability();
     method public com.mapbox.navigation.base.speed.model.SpeedLimit? getSpeedLimit();
+    method public Integer? getZLevel();
     method public boolean isOffRoad();
     method public boolean isTeleport();
     property public final android.location.Location enhancedLocation;
@@ -653,6 +655,7 @@ package com.mapbox.navigation.core.trip.session {
     property public final float offRoadProbability;
     property public final float roadEdgeMatchProbability;
     property public final com.mapbox.navigation.base.speed.model.SpeedLimit? speedLimit;
+    property public final Integer? zLevel;
   }
 
   public fun interface MapMatcherResultObserver {

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/navigator/NavigatorMapper.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/navigator/NavigatorMapper.kt
@@ -202,7 +202,6 @@ private fun NavigationStatus.getRouteProgress(
             remainingWaypoints,
             upcomingRouteAlerts.toUpcomingRoadObjects(),
             stale,
-            layer,
         )
     }
     return null
@@ -309,7 +308,8 @@ internal fun TripStatus.getMapMatcherResult(
         navigationStatus.offRoadProba,
         navigationStatus.mapMatcherOutput.isTeleport,
         navigationStatus.prepareSpeedLimit(),
-        navigationStatus.mapMatcherOutput.matches.firstOrNull()?.proba ?: 0f
+        navigationStatus.mapMatcherOutput.matches.firstOrNull()?.proba ?: 0f,
+        navigationStatus.layer,
     )
 }
 

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/reroute/MapboxRerouteController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/reroute/MapboxRerouteController.kt
@@ -64,7 +64,7 @@ internal class MapboxRerouteController(
         routeOptionsUpdater.update(
             directionsSession.getPrimaryRouteOptions(),
             tripSession.getRouteProgress(),
-            tripSession.getEnhancedLocation()
+            tripSession.mapMatcherResult,
         )
             .let { routeOptionsResult ->
                 when (routeOptionsResult) {

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesController.kt
@@ -75,7 +75,7 @@ internal class RouteAlternativesController(
         val routeOptionsResult = routeOptionsUpdater.update(
             directionsSession.getPrimaryRouteOptions(),
             tripSession.getRouteProgress(),
-            tripSession.getEnhancedLocation()
+            tripSession.mapMatcherResult,
         )
 
         when (routeOptionsResult) {

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapMatcherResult.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapMatcherResult.kt
@@ -21,6 +21,7 @@ import com.mapbox.navigation.base.speed.model.SpeedLimit
  * In order to receive the speed limit make sure you add annotationsList with
  * DirectionsCriteria.ANNOTATION_MAXSPEED annotation to the route request.
  * @param roadEdgeMatchProbability when map matcher snaps to a road, this is the confidence in the chosen edge from all nearest edges.
+ * @param zLevel [Int] current Z-level. Can be used to build a route from a proper level of a road.
  */
 class MapMatcherResult internal constructor(
     val enhancedLocation: Location,
@@ -29,7 +30,8 @@ class MapMatcherResult internal constructor(
     val offRoadProbability: Float,
     val isTeleport: Boolean,
     val speedLimit: SpeedLimit?,
-    val roadEdgeMatchProbability: Float
+    val roadEdgeMatchProbability: Float,
+    val zLevel: Int?,
 ) {
 
     /**

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
@@ -121,7 +121,6 @@ internal class MapboxTripSession(
         }
 
     private var rawLocation: Location? = null
-    private var enhancedLocation: Location? = null
     override var zLevel: Int? = null
         private set
     private var routeProgress: RouteProgress? = null
@@ -133,7 +132,9 @@ internal class MapboxTripSession(
             field = value
             roadObjectsOnRouteObservers.forEach { it.onNewRoadObjectsOnTheRoute(value) }
         }
-    private var mapMatcherResult: MapMatcherResult? = null
+
+    override var mapMatcherResult: MapMatcherResult? = null
+        private set
 
     private val nativeFallbackVersionsObserver =
         object : com.mapbox.navigator.FallbackVersionsObserver() {
@@ -169,11 +170,6 @@ internal class MapboxTripSession(
      * Return raw location
      */
     override fun getRawLocation() = rawLocation
-
-    /**
-     * Return enhanced location
-     */
-    override fun getEnhancedLocation() = enhancedLocation
 
     /**
      * Provide route progress
@@ -295,7 +291,6 @@ internal class MapboxTripSession(
     private fun reset() {
         mapMatcherResult = null
         rawLocation = null
-        enhancedLocation = null
         zLevel = null
         routeProgress = null
         isOffRoute = false
@@ -308,7 +303,9 @@ internal class MapboxTripSession(
     override fun registerLocationObserver(locationObserver: LocationObserver) {
         locationObservers.add(locationObserver)
         rawLocation?.let { locationObserver.onRawLocationChanged(it) }
-        enhancedLocation?.let { locationObserver.onEnhancedLocationChanged(it, emptyList()) }
+        mapMatcherResult?.let { matcherResult ->
+            locationObserver.onEnhancedLocationChanged(matcherResult.enhancedLocation, emptyList())
+        }
     }
 
     /**
@@ -561,7 +558,6 @@ internal class MapboxTripSession(
     }
 
     private fun updateEnhancedLocation(location: Location, keyPoints: List<Location>) {
-        enhancedLocation = location
         locationObservers.forEach { it.onEnhancedLocationChanged(location, keyPoints) }
     }
 

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/TripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/TripSession.kt
@@ -14,8 +14,8 @@ internal interface TripSession {
     fun setRoute(route: DirectionsRoute?, legIndex: Int)
 
     fun getRawLocation(): Location?
-    fun getEnhancedLocation(): Location?
     val zLevel: Int?
+    val mapMatcherResult: MapMatcherResult?
     fun getRouteProgress(): RouteProgress?
     fun getState(): TripSessionState
 

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
@@ -3,7 +3,6 @@ package com.mapbox.navigation.core
 import android.app.AlarmManager
 import android.app.NotificationManager
 import android.content.Context
-import android.location.Location
 import android.net.ConnectivityManager
 import com.mapbox.android.core.location.LocationEngine
 import com.mapbox.android.telemetry.MapboxTelemetryConstants.MAPBOX_SHARED_PREFERENCES
@@ -98,7 +97,6 @@ class MapboxNavigationTest {
     private val navigator: MapboxNativeNavigator = mockk(relaxUnitFun = true)
     private val tripService: TripService = mockk(relaxUnitFun = true)
     private val tripSession: TripSession = mockk(relaxUnitFun = true)
-    private val location: Location = mockk(relaxUnitFun = true)
     private val locationEngine: LocationEngine = mockk(relaxUnitFun = true)
     private val distanceFormatterOptions: DistanceFormatterOptions = mockk(relaxed = true)
     private val routingTilesOptions: RoutingTilesOptions = mockk(relaxed = true)
@@ -139,8 +137,6 @@ class MapboxNavigationTest {
     private lateinit var mapboxNavigation: MapboxNavigation
 
     companion object {
-        private const val DEFAULT_REROUTE_BEARING_ANGLE = 11f
-
         @BeforeClass
         @JvmStatic
         fun initialize() {
@@ -188,7 +184,6 @@ class MapboxNavigationTest {
 
         navigationOptions = provideNavigationOptions().build()
 
-        mockLocation()
         mockNativeNavigator()
         mockTripService()
         mockTripSession()
@@ -452,20 +447,6 @@ class MapboxNavigationTest {
         mapboxNavigation.onDestroy()
 
         verify(exactly = 1) { arrivalProgressObserver.unregisterAllObservers() }
-    }
-
-    @Test
-    fun routeAlternatives_noRouteOptions_noRequest() {
-        createMapboxNavigation()
-        every { directionsSession.getPrimaryRouteOptions() } returns null
-        verify(exactly = 0) { directionsSession.requestRoutes(any(), any()) }
-    }
-
-    @Test
-    fun routeAlternatives_noEnhancedLocation_noRequest() {
-        createMapboxNavigation()
-        every { tripSession.getEnhancedLocation() } returns null
-        verify(exactly = 0) { directionsSession.requestRoutes(any(), any()) }
     }
 
     @Test
@@ -1054,12 +1035,6 @@ class MapboxNavigationTest {
         mapboxNavigation = MapboxNavigation(navigationOptions)
     }
 
-    private fun mockLocation() {
-        every { location.longitude } returns -122.789876
-        every { location.latitude } returns 37.657483
-        every { location.bearing } returns DEFAULT_REROUTE_BEARING_ANGLE
-    }
-
     private fun mockNativeNavigator() {
         every {
             NavigationComponentProvider.createNativeNavigator(any(), any(), any(), any(), any())
@@ -1091,9 +1066,7 @@ class MapboxNavigationTest {
                 logger = logger,
             )
         } returns tripSession
-        every { tripSession.getEnhancedLocation() } returns location
         every { tripSession.getRouteProgress() } returns routeProgress
-        every { tripSession.getRawLocation() } returns location
     }
 
     private fun mockDirectionSession() {

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/navigator/NavigatorMapperTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/navigator/NavigatorMapperTest.kt
@@ -85,7 +85,6 @@ class NavigatorMapperTest {
             stale = true,
             remainingWaypoints = 1,
             upcomingRoadObjects = listOf(),
-            zLevel = 2,
         )
 
         val result = getRouteProgressFrom(
@@ -114,6 +113,7 @@ class NavigatorMapperTest {
                         }
                     )
                 }
+                every { layer } returns null
             }
         )
         val expected = MapMatcherResult(
@@ -127,7 +127,8 @@ class NavigatorMapperTest {
                 com.mapbox.navigation.base.speed.model.SpeedLimitUnit.KILOMETRES_PER_HOUR,
                 com.mapbox.navigation.base.speed.model.SpeedLimitSign.MUTCD
             ),
-            roadEdgeMatchProbability = 1f
+            roadEdgeMatchProbability = 1f,
+            zLevel = null,
         )
 
         val result = tripStatus.getMapMatcherResult(enhancedLocation, keyPoints)
@@ -150,6 +151,7 @@ class NavigatorMapperTest {
                         }
                     )
                 }
+                every { layer } returns null
             }
         )
         val expected = MapMatcherResult(
@@ -163,7 +165,8 @@ class NavigatorMapperTest {
                 com.mapbox.navigation.base.speed.model.SpeedLimitUnit.KILOMETRES_PER_HOUR,
                 com.mapbox.navigation.base.speed.model.SpeedLimitSign.MUTCD
             ),
-            roadEdgeMatchProbability = 1f
+            roadEdgeMatchProbability = 1f,
+            zLevel = null,
         )
 
         val result = tripStatus.getMapMatcherResult(enhancedLocation, keyPoints)
@@ -186,6 +189,7 @@ class NavigatorMapperTest {
                         }
                     )
                 }
+                every { layer } returns null
             }
         )
         val expected = MapMatcherResult(
@@ -199,7 +203,8 @@ class NavigatorMapperTest {
                 com.mapbox.navigation.base.speed.model.SpeedLimitUnit.KILOMETRES_PER_HOUR,
                 com.mapbox.navigation.base.speed.model.SpeedLimitSign.MUTCD
             ),
-            roadEdgeMatchProbability = 1f
+            roadEdgeMatchProbability = 1f,
+            zLevel = null,
         )
 
         val result = tripStatus.getMapMatcherResult(enhancedLocation, keyPoints)
@@ -222,6 +227,7 @@ class NavigatorMapperTest {
                         }
                     )
                 }
+                every { layer } returns null
             }
         )
         val expected = MapMatcherResult(
@@ -235,7 +241,8 @@ class NavigatorMapperTest {
                 com.mapbox.navigation.base.speed.model.SpeedLimitUnit.KILOMETRES_PER_HOUR,
                 com.mapbox.navigation.base.speed.model.SpeedLimitSign.MUTCD
             ),
-            roadEdgeMatchProbability = 1f
+            roadEdgeMatchProbability = 1f,
+            zLevel = null,
         )
 
         val result = tripStatus.getMapMatcherResult(enhancedLocation, keyPoints)
@@ -254,6 +261,7 @@ class NavigatorMapperTest {
                     every { isTeleport } returns false
                     every { matches } returns listOf()
                 }
+                every { layer } returns null
             }
         )
         val expected = MapMatcherResult(
@@ -267,7 +275,46 @@ class NavigatorMapperTest {
                 com.mapbox.navigation.base.speed.model.SpeedLimitUnit.KILOMETRES_PER_HOUR,
                 com.mapbox.navigation.base.speed.model.SpeedLimitSign.MUTCD
             ),
-            roadEdgeMatchProbability = 0f
+            roadEdgeMatchProbability = 0f,
+            zLevel = null,
+        )
+
+        val result = tripStatus.getMapMatcherResult(enhancedLocation, keyPoints)
+
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `map matcher result zLevel`() {
+        val tripStatus = TripStatus(
+            route,
+            mockk {
+                every { offRoadProba } returns 1f
+                every { speedLimit } returns createSpeedLimit()
+                every { mapMatcherOutput } returns mockk {
+                    every { isTeleport } returns false
+                    every { matches } returns listOf(
+                        mockk {
+                            every { proba } returns 1f
+                        }
+                    )
+                }
+                every { layer } returns 2
+            }
+        )
+        val expected = MapMatcherResult(
+            enhancedLocation,
+            keyPoints,
+            isOffRoad = true,
+            offRoadProbability = 1f,
+            isTeleport = false,
+            speedLimit = SpeedLimit(
+                10,
+                com.mapbox.navigation.base.speed.model.SpeedLimitUnit.KILOMETRES_PER_HOUR,
+                com.mapbox.navigation.base.speed.model.SpeedLimitSign.MUTCD
+            ),
+            roadEdgeMatchProbability = 1f,
+            zLevel = 2,
         )
 
         val result = tripStatus.getMapMatcherResult(enhancedLocation, keyPoints)
@@ -449,7 +496,6 @@ class NavigatorMapperTest {
         every { voiceInstruction } returns nativeVoiceInstructions
         every { inTunnel } returns true
         every { upcomingRouteAlerts } returns emptyList()
-        every { layer } returns 2
     }
 
     val routeAlertLocation: RouteAlertLocation = mockk()

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/reroute/MapboxRerouteControllerTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/reroute/MapboxRerouteControllerTest.kt
@@ -7,6 +7,7 @@ import com.mapbox.navigation.base.route.RouterCallback
 import com.mapbox.navigation.base.route.RouterOrigin
 import com.mapbox.navigation.core.directions.session.DirectionsSession
 import com.mapbox.navigation.core.routeoptions.RouteOptionsUpdater
+import com.mapbox.navigation.core.trip.session.MapMatcherResult
 import com.mapbox.navigation.core.trip.session.TripSession
 import com.mapbox.navigation.testing.MainCoroutineRule
 import com.mapbox.navigation.utils.internal.ThreadController
@@ -112,7 +113,7 @@ class MapboxRerouteControllerTest {
         routeRequestCallback.captured.onRoutesReady(mockk(), mockk())
 
         verify(exactly = 1) {
-            tripSession.getEnhancedLocation()
+            tripSession.mapMatcherResult
         }
         verify(exactly = 1) {
             tripSession.getRouteProgress()
@@ -346,7 +347,7 @@ class MapboxRerouteControllerTest {
             routeOptionsUpdater.update(
                 any(),
                 any(),
-                any()
+                any<MapMatcherResult>(),
             )
         } returns _routeOptionsResult
     }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesControllerTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesControllerTest.kt
@@ -7,6 +7,7 @@ import com.mapbox.navigation.base.route.RouterCallback
 import com.mapbox.navigation.base.route.RouterOrigin
 import com.mapbox.navigation.core.directions.session.DirectionsSession
 import com.mapbox.navigation.core.routeoptions.RouteOptionsUpdater
+import com.mapbox.navigation.core.trip.session.MapMatcherResult
 import com.mapbox.navigation.core.trip.session.TripSession
 import com.mapbox.navigation.core.trip.session.TripSessionState
 import com.mapbox.navigation.navigator.internal.MapboxNativeNavigator
@@ -94,10 +95,7 @@ class RouteAlternativesControllerTest {
                 every { duration() } returns 1727.228
             }
         )
-        every { tripSession.getEnhancedLocation() } returns mockk {
-            every { latitude } returns -33.874308
-            every { longitude } returns 151.206087
-        }
+        mockLocation()
 
         val controller = mockController()
         controller.register(routeAlternativesObserver)
@@ -118,10 +116,7 @@ class RouteAlternativesControllerTest {
                 every { duration() } returns 1727.228
             }
         )
-        every { tripSession.getEnhancedLocation() } returns mockk {
-            every { latitude } returns -33.874308
-            every { longitude } returns 151.206087
-        }
+        mockLocation()
 
         val controller = mockController(
             RouteAlternativesOptions.Builder()
@@ -146,10 +141,7 @@ class RouteAlternativesControllerTest {
                 every { duration() } returns 1727.228
             }
         )
-        every { tripSession.getEnhancedLocation() } returns mockk {
-            every { latitude } returns -33.874308
-            every { longitude } returns 151.206087
-        }
+        mockLocation()
 
         val controller = mockController(
             RouteAlternativesOptions.Builder()
@@ -179,10 +171,7 @@ class RouteAlternativesControllerTest {
                 every { duration() } returns 1727.228
             }
         )
-        every { tripSession.getEnhancedLocation() } returns mockk {
-            every { latitude } returns -33.874308
-            every { longitude } returns 151.206087
-        }
+        mockLocation()
 
         val controller = mockController(
             RouteAlternativesOptions.Builder()
@@ -208,10 +197,7 @@ class RouteAlternativesControllerTest {
                 every { duration() } returns 1727.228
             }
         )
-        every { tripSession.getEnhancedLocation() } returns mockk {
-            every { latitude } returns -33.874308
-            every { longitude } returns 151.206087
-        }
+        mockLocation()
 
         val controller = mockController(
             RouteAlternativesOptions.Builder()
@@ -241,10 +227,7 @@ class RouteAlternativesControllerTest {
                 every { duration() } returns 1727.228
             }
         )
-        every { tripSession.getEnhancedLocation() } returns mockk {
-            every { latitude } returns -33.874308
-            every { longitude } returns 151.206087
-        }
+        mockLocation()
 
         val controller = mockController(
             RouteAlternativesOptions.Builder()
@@ -279,10 +262,7 @@ class RouteAlternativesControllerTest {
         every { tripSession.getState() } returns TripSessionState.STARTED
         mockRouteOptionsProvider(routeOptionsResultSuccess)
         every { directionsSession.routes } returns emptyList()
-        every { tripSession.getEnhancedLocation() } returns mockk {
-            every { latitude } returns -33.874308
-            every { longitude } returns 151.206087
-        }
+        mockLocation()
 
         val controller = mockController()
         controller.register(routeAlternativesObserver)
@@ -303,10 +283,7 @@ class RouteAlternativesControllerTest {
                 every { duration() } returns 1727.228
             }
         )
-        every { tripSession.getEnhancedLocation() } returns mockk {
-            every { latitude } returns -33.874308
-            every { longitude } returns 151.206087
-        }
+        mockLocation()
 
         val controller = mockController()
         controller.register(routeAlternativesObserver)
@@ -328,10 +305,7 @@ class RouteAlternativesControllerTest {
                     every { duration() } returns 1727.228
                 }
             )
-            every { tripSession.getEnhancedLocation() } returns mockk {
-                every { latitude } returns -33.874308
-                every { longitude } returns 151.206087
-            }
+            mockLocation()
 
             val controller = mockController()
             controller.interrupt()
@@ -350,10 +324,7 @@ class RouteAlternativesControllerTest {
             every { routeIndex() } returns "0"
         }
         every { directionsSession.routes } returns listOf(currentRoute)
-        every { tripSession.getEnhancedLocation() } returns mockk {
-            every { latitude } returns -33.874308
-            every { longitude } returns 151.206087
-        }
+        mockLocation()
         every {
             directionsSession.requestRoutes(
                 any(),
@@ -389,10 +360,7 @@ class RouteAlternativesControllerTest {
             every { routeIndex() } returns "0"
         }
         every { directionsSession.routes } returns listOf(currentRoute)
-        every { tripSession.getEnhancedLocation() } returns mockk {
-            every { latitude } returns -33.874308
-            every { longitude } returns 151.206087
-        }
+        mockLocation()
         every {
             directionsSession.requestRoutes(
                 any(),
@@ -414,9 +382,20 @@ class RouteAlternativesControllerTest {
         coroutineRule.testDispatcher.cleanupTestCoroutines()
     }
 
+    private fun mockLocation() {
+        every { tripSession.mapMatcherResult } returns mockk {
+            every { enhancedLocation } returns mockk {
+                every { latitude } returns -33.874308
+                every { longitude } returns 151.206087
+            }
+        }
+    }
+
     private fun mockRouteOptionsProvider(
         routeOptionsResult: RouteOptionsUpdater.RouteOptionsResult
     ) {
-        every { routeOptionsUpdater.update(any(), any(), any()) } returns routeOptionsResult
+        every {
+            routeOptionsUpdater.update(any(), any(), any<MapMatcherResult>())
+        } returns routeOptionsResult
     }
 }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/routeoptions/RouteOptionsUpdaterParameterizedTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/routeoptions/RouteOptionsUpdaterParameterizedTest.kt
@@ -7,6 +7,7 @@ import com.mapbox.core.constants.Constants
 import com.mapbox.geojson.Point
 import com.mapbox.navigation.base.trip.model.RouteLegProgress
 import com.mapbox.navigation.base.trip.model.RouteProgress
+import com.mapbox.navigation.core.trip.session.MapMatcherResult
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.mockk
@@ -62,7 +63,7 @@ class RouteOptionsUpdaterParameterizedTest(
     }
 
     private lateinit var routeRefreshAdapter: RouteOptionsUpdater
-    private lateinit var location: Location
+    private lateinit var mapMatcherResult: MapMatcherResult
 
     @Before
     fun setup() {
@@ -85,7 +86,7 @@ class RouteOptionsUpdaterParameterizedTest(
         every { routeProgress.remainingWaypoints } returns remainingWaypoints
 
         val updatedRouteOptions =
-            routeRefreshAdapter.update(routeOptions, routeProgress, location)
+            routeRefreshAdapter.update(routeOptions, routeProgress, mapMatcherResult)
                 .let {
                     assertTrue(it is RouteOptionsUpdater.RouteOptionsResult.Success)
                     return@let it as RouteOptionsUpdater.RouteOptionsResult.Success
@@ -100,10 +101,14 @@ class RouteOptionsUpdaterParameterizedTest(
     }
 
     private fun mockLocation() {
-        location = mockk(relaxUnitFun = true)
+        val location = mockk<Location>(relaxUnitFun = true)
         every { location.longitude } returns -122.4232
         every { location.latitude } returns 23.54423
         every { location.bearing } returns 11f
+        mapMatcherResult = mockk {
+            every { enhancedLocation } returns location
+            every { zLevel } returns 2
+        }
     }
 
     private fun provideRouteOptionsWithCoordinates() =

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
@@ -117,7 +117,9 @@ class MapboxTripSessionTest {
 
     private val stateObserver: TripSessionStateObserver = mockk(relaxUnitFun = true)
 
-    private val mapMatcherResult: MapMatcherResult = mockk(relaxUnitFun = true)
+    private val mapMatcherResult: MapMatcherResult = mockk(relaxUnitFun = true) {
+        every { enhancedLocation } returns location
+    }
     private val eHorizonSubscriptionManager: EHorizonSubscriptionManager = mockk(relaxed = true)
     private val navigatorObserverImplSlot = slot<NavigatorObserver>()
     private val navigatorRecreationObserverImplSlot = slot<NativeNavigatorRecreationObserver>()
@@ -564,7 +566,7 @@ class MapboxTripSessionTest {
         updateLocationAndJoin()
 
         verify { observer.onEnhancedLocationChanged(location, keyPoints) }
-        assertEquals(location, tripSession.getEnhancedLocation())
+        assertEquals(location, tripSession.mapMatcherResult?.enhancedLocation)
         tripSession.stop()
     }
 
@@ -577,7 +579,7 @@ class MapboxTripSessionTest {
         tripSession.registerLocationObserver(observer)
 
         verify(exactly = 1) { observer.onEnhancedLocationChanged(location, emptyList()) }
-        assertEquals(location, tripSession.getEnhancedLocation())
+        assertEquals(location, tripSession.mapMatcherResult?.enhancedLocation)
         tripSession.stop()
     }
 


### PR DESCRIPTION
### Description
Closes #4812. 

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Moved `zLevel` from `RouteProgress` to `MapMatcherResult`</changelog>
```

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
