### PR TITLE
do not cancel job that calls setRoute

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
@@ -83,9 +83,6 @@ internal class MapboxTripSession(
                     }
                 }
             }
-        }
-        mainJobController.scope.launch {
-            updateRouteJob?.join()
             this@MapboxTripSession.route = route
         }
     }


### PR DESCRIPTION
### Description
Fixes #4361. The problem was that in `MapboxTripSession.stop` we cancel the job that updates `MapboxTripSession.route` and thus after setting the same route we didn't call `navigator.setRoute`, because for us it looked like the route didn't change. 
In my opinion we also shouldn't cancel jobs, that are started in `nativeFallbackVersionsObserver`, since the observer is set forever instead of only when the session is started, but that's not related to this bug. 

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Fixed an issue where banner instructions were missing after restarting trip session with the same route</changelog>
```

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
