### PR TITLE
Fix for soft gradient expression created with extremely small distanc…

### DIFF
--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtils.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtils.kt
@@ -53,6 +53,7 @@ import kotlin.reflect.KProperty1
 object MapboxRouteLineUtils {
 
     private val TAG = "MbxMapboxRouteLineUtils"
+    internal val VANISH_POINT_STOP_GAP = .00000000001
 
     /**
      * Creates an [Expression] that can be applied to the layer style changing the appearance of
@@ -115,7 +116,7 @@ object MapboxRouteLineUtils {
         softGradientStopGap: Double,
         routeLineExpressionData: List<RouteLineExpressionData>
     ): Expression {
-        val vanishPointStopGap = .00000000001
+        val vanishPointStopGap = VANISH_POINT_STOP_GAP
         val expressionBuilder = Expression.InterpolatorBuilder("interpolate")
         expressionBuilder.linear()
         expressionBuilder.lineProgress()
@@ -133,9 +134,11 @@ object MapboxRouteLineUtils {
                         color(lineStartColor)
                     }
 
-                    expressionBuilder.stop {
-                        literal(expressionData.offset - vanishPointStopGap)
-                        color(lineStartColor)
+                    if (expressionData.offset > vanishPointStopGap) {
+                        expressionBuilder.stop {
+                            literal(expressionData.offset - vanishPointStopGap)
+                            color(lineStartColor)
+                        }
                     }
                 }
 

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtilsTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtilsTest.kt
@@ -1955,6 +1955,76 @@ class MapboxRouteLineUtilsTest {
     }
 
     @Test
+    fun getTrafficLineExpressionSoftGradient_withExtremelySmallDistanceOffset() {
+        val expectedExpression = "[interpolate, [linear], [line-progress], 0.0, " +
+            // notice no stop added before the vanishing point
+            "[rgba, 0.0, 0.0, 0.0, 0.0], 1.0267342531733E-12, " +
+            "[rgba, 86.0, 168.0, 251.0, 1.0], 0.4532366552813495, " +
+            "[rgba, 86.0, 168.0, 251.0, 1.0], 0.468779750455607, " +
+            "[rgba, 255.0, 149.0, 0.0, 1.0], 0.4877423265682011, " +
+            "[rgba, 255.0, 149.0, 0.0, 1.0], 0.5032854217424586, " +
+            "[rgba, 86.0, 168.0, 251.0, 1.0], 0.8454666620037381, " +
+            "[rgba, 86.0, 168.0, 251.0, 1.0], 0.8610097571779957, " +
+            "[rgba, 255.0, 149.0, 0.0, 1.0], 0.8766305678281243, " +
+            "[rgba, 255.0, 149.0, 0.0, 1.0], 0.8921736630023819, " +
+            "[rgba, 86.0, 168.0, 251.0, 1.0]]"
+        val colorResources = RouteLineColorResources.Builder().build()
+        val route = loadRoute("route-with-restrictions.json")
+        val segments = MapboxRouteLineUtils.calculateRouteLineSegments(
+            route,
+            listOf(),
+            true,
+            colorResources
+        )
+        val stopGap = 20.0 / route.distance()
+
+        val result = MapboxRouteLineUtils.getTrafficLineExpressionSoftGradient(
+            0.0000000000010267342531733,
+            Color.TRANSPARENT,
+            colorResources.routeDefaultColor,
+            stopGap,
+            segments
+        )
+
+        assertEquals(expectedExpression, result.toString())
+    }
+
+    @Test
+    fun getTrafficLineExpressionSoftGradient_withOffsetEqualToVanishPointStopGap() {
+        val expectedExpression = "[interpolate, [linear], [line-progress], 0.0, " +
+            // notice no stop added before the vanishing point
+            "[rgba, 0.0, 0.0, 0.0, 0.0], 1.0E-11, " +
+            "[rgba, 86.0, 168.0, 251.0, 1.0], 0.4532366552813495, " +
+            "[rgba, 86.0, 168.0, 251.0, 1.0], 0.468779750455607, " +
+            "[rgba, 255.0, 149.0, 0.0, 1.0], 0.4877423265682011, " +
+            "[rgba, 255.0, 149.0, 0.0, 1.0], 0.5032854217424586, " +
+            "[rgba, 86.0, 168.0, 251.0, 1.0], 0.8454666620037381, " +
+            "[rgba, 86.0, 168.0, 251.0, 1.0], 0.8610097571779957, " +
+            "[rgba, 255.0, 149.0, 0.0, 1.0], 0.8766305678281243, " +
+            "[rgba, 255.0, 149.0, 0.0, 1.0], 0.8921736630023819, " +
+            "[rgba, 86.0, 168.0, 251.0, 1.0]]"
+        val colorResources = RouteLineColorResources.Builder().build()
+        val route = loadRoute("route-with-restrictions.json")
+        val segments = MapboxRouteLineUtils.calculateRouteLineSegments(
+            route,
+            listOf(),
+            true,
+            colorResources
+        )
+        val stopGap = 20.0 / route.distance()
+
+        val result = MapboxRouteLineUtils.getTrafficLineExpressionSoftGradient(
+            MapboxRouteLineUtils.VANISH_POINT_STOP_GAP,
+            Color.TRANSPARENT,
+            colorResources.routeDefaultColor,
+            stopGap,
+            segments
+        )
+
+        assertEquals(expectedExpression, result.toString())
+    }
+
+    @Test
     fun whenAnnotationIsCongestionNumericThenResolveLowCongestionNumeric() {
         val lowCongestionNumeric = 4
         val congestionResource = RouteLineColorResources.Builder().build()


### PR DESCRIPTION
### Description
Fixes #4857 by checking the distance offset value when creating soft gradient Expression objects. 

### Changelog
```
<changelog>Bug fix for traffic expressions using soft gradients.</changelog>
```

### Screenshots or Gifs

