### PR TITLE
fix IndexOutOfBoundsException in MapboxRouteLineUtils

### DIFF
--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtils.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtils.kt
@@ -522,9 +522,9 @@ object MapboxRouteLineUtils {
                 val isInAClosure = closureRanges.any { it.contains(index) }
                 val congestionValue: String = when {
                     isInAClosure -> RouteConstants.CLOSURE_CONGESTION_VALUE
-                    trafficCongestion?.isEmpty() ?: true -> RouteConstants.UNKNOWN_CONGESTION_VALUE
-                    index > trafficCongestion?.size ?: 0 -> RouteConstants.UNKNOWN_CONGESTION_VALUE
-                    else -> trafficCongestion?.get(index) ?: RouteConstants.UNKNOWN_CONGESTION_VALUE
+                    trafficCongestion.isNullOrEmpty() -> RouteConstants.UNKNOWN_CONGESTION_VALUE
+                    index >= trafficCongestion.size -> RouteConstants.UNKNOWN_CONGESTION_VALUE
+                    else -> trafficCongestion[index]
                 }
                 val roadClass = getRoadClassForIndex(roadClassArray, index)
 

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtilsTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtilsTest.kt
@@ -2219,6 +2219,38 @@ class MapboxRouteLineUtilsTest {
         verify(exactly = 1) { route.legs() }
     }
 
+    @Test
+    fun `extractRouteData with null congestion provider`() {
+        val route = loadRoute("short_route.json")
+        for (data in MapboxRouteLineUtils.extractRouteData(route) { null }) {
+            assertEquals(RouteConstants.UNKNOWN_CONGESTION_VALUE, data.trafficCongestionIdentifier)
+        }
+    }
+
+    @Test
+    fun `extractRouteData with empty congestion provider`() {
+        val route = loadRoute("short_route.json")
+        for (data in MapboxRouteLineUtils.extractRouteData(route) { emptyList() }) {
+            assertEquals(RouteConstants.UNKNOWN_CONGESTION_VALUE, data.trafficCongestionIdentifier)
+        }
+    }
+
+    @Test
+    fun `extractRouteData with short congestion provider`() {
+        val route = loadRoute("short_route.json")
+        val extractedData = MapboxRouteLineUtils.extractRouteData(route) { leg ->
+            val distance = requireNotNull(leg.annotation()?.distance()?.takeIf { it.size > 1 })
+            List(distance.size - 1) { "low" }
+        }
+        for (index in 0 until extractedData.lastIndex) {
+            assertEquals("low", extractedData[index].trafficCongestionIdentifier)
+        }
+        assertEquals(
+            RouteConstants.UNKNOWN_CONGESTION_VALUE,
+            extractedData.last().trafficCongestionIdentifier,
+        )
+    }
+
     private fun getMultilegRoute(): DirectionsRoute {
         return loadRoute("multileg_route.json")
     }


### PR DESCRIPTION
### Description
Fixes #4833. The problem was in the check `index > trafficCongestion.size`. It should be `index >= trafficCongestion.size`. Also simplified code a bit using kotlin smart casts. 

### Changelog
```
<changelog>Fixed `IndexOutOfBoundsException` in `MapboxRouteLineUtils`</changelog>
```

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
