### PR TITLE
Bump nav-native dependency version to `66.0.3`

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -12,7 +12,7 @@ ext {
   // version which we should use in this build
   def mapboxNavigatorVersion = System.getenv("FORCE_MAPBOX_NAVIGATION_NATIVE_VERSION")
   if (mapboxNavigatorVersion == null || mapboxNavigatorVersion == '') {
-      mapboxNavigatorVersion = '66.0.2'
+      mapboxNavigatorVersion = '66.0.3'
   }
   println("Navigation Native version: " + mapboxNavigatorVersion)
 


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Bumps nav-native dependency version to `66.0.3`

cc @SiarheiFedartsou @mskurydin @truburt @zugaldia @etl @scottpietka 
