### PR TITLE
Bump Kotlin dependency version to `1.5.31`

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,5 +1,5 @@
 ext {
-  def kotlinVersion = "1.5.30"
+  def kotlinVersion = "1.5.31"
 
   androidVersions = [
       minSdkVersion           : 21,


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Bumps Kotlin dependency version to [`1.5.31`](https://github.com/JetBrains/kotlin/releases/tag/v1.5.31)