### PR TITLE
fixed a regression and restored the vanishing point update distance threshold to 3 meters

### DIFF
--- a/libnavui-base/api/current.txt
+++ b/libnavui-base/api/current.txt
@@ -116,7 +116,7 @@ package com.mapbox.navigation.ui.base.internal.model.route {
     field public static final double RESTRICTED_ROAD_LINE_WIDTH = 7.0;
     field public static final double RESTRICTED_ROAD_SECTION_SCALE = 10.0;
     field public static final boolean ROUNDED_LINE_CAP = true;
-    field public static final double ROUTE_LINE_UPDATE_MAX_DISTANCE_THRESHOLD_IN_METERS = 1.0;
+    field public static final double ROUTE_LINE_UPDATE_MAX_DISTANCE_THRESHOLD_IN_METERS = 3.0;
     field public static final String SEVERE_CONGESTION_VALUE = "severe";
     field public static final double SOFT_GRADIENT_STOP_GAP_METERS = 30.0;
     field public static final int THIRTY = 30; // 0x1e

--- a/libnavui-base/src/main/java/com/mapbox/navigation/ui/base/internal/model/route/RouteConstants.kt
+++ b/libnavui-base/src/main/java/com/mapbox/navigation/ui/base/internal/model/route/RouteConstants.kt
@@ -46,7 +46,7 @@ object RouteConstants {
     const val RESTRICTED_CONGESTION_VALUE = "restricted"
     const val ORIGIN_MARKER_NAME = "originMarker"
     const val DESTINATION_MARKER_NAME = "destinationMarker"
-    const val ROUTE_LINE_UPDATE_MAX_DISTANCE_THRESHOLD_IN_METERS = 1.0
+    const val ROUTE_LINE_UPDATE_MAX_DISTANCE_THRESHOLD_IN_METERS = 3.0
     const val DEFAULT_ROUTE_DESCRIPTOR_PLACEHOLDER = "mapboxDescriptorPlaceHolderUnused"
     const val MAX_ELAPSED_SINCE_INDEX_UPDATE_NANO = 1500000000.0 // 1.5s
     const val DEFAULT_ROUTE_SOURCES_TOLERANCE = 0.375


### PR DESCRIPTION

### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
In https://github.com/mapbox/mapbox-navigation-android/pull/3803 we changed the maximum distance of the location point from the route to keep updating the vanishing point to 3 meters. Somewhere when building a new version of the Route Line APIs this patch was lost (https://github.com/mapbox/mapbox-navigation-android/pull/3930, https://github.com/mapbox/mapbox-navigation-android-internal/pull/5/) and we ended up with a threshold of 1 meter.

This restores the original threshold.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Increased location tolerance for vanishing route line updates. This resolves rare occasions where the vanishing route line portion would briefly stop updating.</changelog>
```

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
