### PR TITLE
Backport mapbox-java bump 6.0.0-alpha.7

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -18,7 +18,7 @@ ext {
 
   version = [
       mapboxMapSdk              : '10.0.0-rc.8',
-      mapboxSdkServices         : '6.0.0-alpha.6',
+      mapboxSdkServices         : '6.0.0-alpha.7',
       mapboxEvents              : '8.1.0',
       mapboxCore                : '5.0.0',
       mapboxNavigator           : "${mapboxNavigatorVersion}",

--- a/libnavigation-base/api/current.txt
+++ b/libnavigation-base/api/current.txt
@@ -361,7 +361,6 @@ package com.mapbox.navigation.base.route {
   }
 
   public final class RouteExclusions {
-    method public static com.mapbox.api.directions.v5.models.RouteOptions.Builder exclude(com.mapbox.api.directions.v5.models.RouteOptions.Builder, java.lang.String... exclusionCriteria);
     method public static java.util.List<com.mapbox.navigation.base.route.ExclusionViolation> exclusionViolations(com.mapbox.api.directions.v5.models.DirectionsRoute);
   }
 

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/route/RouteExclusions.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/route/RouteExclusions.kt
@@ -7,18 +7,9 @@ import com.mapbox.api.directions.v5.models.LegStep
 import com.mapbox.api.directions.v5.models.RouteLeg
 import com.mapbox.api.directions.v5.models.RouteOptions
 import com.mapbox.api.directions.v5.models.StepIntersection
-import com.mapbox.api.directions.v5.utils.FormatUtils
 import com.mapbox.api.directions.v5.utils.ParseUtils
 
 private const val COMMA_DELIMETER = ","
-
-/**
- * Exclude certain road types from routing.
- * See [RouteOptions.Builder.exclude] for possible combinations.
- * @param exclusionCriteria see [RouteOptions.Builder.exclude] for possible types.
- */
-fun RouteOptions.Builder.exclude(vararg exclusionCriteria: String): RouteOptions.Builder =
-    this.exclude(FormatUtils.join(COMMA_DELIMETER, exclusionCriteria.asList()).toString())
 
 /**
  * Violated road type.

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/route/RouteExclusionsJavaTest.java
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/route/RouteExclusionsJavaTest.java
@@ -1,12 +1,10 @@
 package com.mapbox.navigation.base.route;
 
-import com.mapbox.api.directions.v5.DirectionsCriteria;
 import com.mapbox.api.directions.v5.models.DirectionsRoute;
 import com.mapbox.api.directions.v5.models.RouteOptions;
 import com.mapbox.geojson.Point;
 import com.mapbox.navigation.base.extensions.RouteOptionsExtensions;
 import com.mapbox.navigation.testing.FileUtils;
-
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -18,28 +16,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class RouteExclusionsJavaTest {
-
-  @Test
-  public void routeOptionsBuilderExcludeParsing() {
-    Point origin = Point.fromLngLat(14.75513115258181, 55.19464648744247);
-    Point destination = Point.fromLngLat(12.54071010365584, 55.68521471271404);
-    List<Point> coordinates = new ArrayList<>();
-    coordinates.add(origin);
-    coordinates.add(destination);
-    RouteOptions.Builder routeOptionsBuilder =
-        RouteOptionsExtensions.applyDefaultNavigationOptions(
-            RouteOptions.builder()
-                .coordinatesList(coordinates)
-        );
-
-    RouteOptions routeOptionsWithExclusions = RouteExclusions.exclude(
-        routeOptionsBuilder,
-        DirectionsCriteria.EXCLUDE_TOLL,
-        DirectionsCriteria.EXCLUDE_FERRY
-    ).build();
-
-    assertEquals("toll,ferry", routeOptionsWithExclusions.exclude());
-  }
 
   @Test
   public void emptyExclusionViolationsIfNoExcludeRouteOptionsAdded() {

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/route/RouteExclusionsTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/route/RouteExclusionsTest.kt
@@ -1,6 +1,5 @@
 package com.mapbox.navigation.base.route
 
-import com.mapbox.api.directions.v5.DirectionsCriteria
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.RouteOptions
 import com.mapbox.geojson.Point
@@ -11,22 +10,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class RouteExclusionsTest {
-
-    @Test
-    fun `RouteOptions Builder exclude parsing`() {
-        val origin = Point.fromLngLat(14.75513115258181, 55.19464648744247)
-        val destination = Point.fromLngLat(12.54071010365584, 55.68521471271404)
-        val routeOptionsBuilder = RouteOptions.builder()
-            .applyDefaultNavigationOptions()
-            .coordinatesList(listOf(origin, destination))
-
-        val routeOptionsWithExclusions = routeOptionsBuilder.exclude(
-            DirectionsCriteria.EXCLUDE_TOLL,
-            DirectionsCriteria.EXCLUDE_FERRY
-        ).build()
-
-        assertEquals("toll,ferry", routeOptionsWithExclusions.exclude())
-    }
 
     @Test
     fun `empty exclusion violations if no exclude RouteOptions added`() {


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Backporting https://github.com/mapbox/mapbox-navigation-android/pull/4893

Bumps `mapbox-java` dependency version to `6.0.0-alpha.7`

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Exposed include-hov/hot parameters in `RouteOptions`.</changelog>
<changelog>Added `exclude` list option.</changelog>
<changelog>Removed unnecessary `RouteExclusions` `exclude` extension.</changelog>
```
