### PR TITLE
Changing log level since error is not useful for developers and has be…

### DIFF
--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/VanishingRouteLine.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/VanishingRouteLine.kt
@@ -118,15 +118,9 @@ internal class VanishingRouteLine {
         ) { granularDistances, index ->
             val upcomingIndex = granularDistances.distancesArray[index]
             if (upcomingIndex == null) {
-                LoggerProvider.logger.e(
+                LoggerProvider.logger.d(
                     Tag("MbxVanishingRouteLine"),
-                    Message(
-                        """
-                       Upcoming route line index is null.
-                       primaryRouteLineGranularDistances: $primaryRouteLineGranularDistances
-                       primaryRouteRemainingDistancesIndex: $primaryRouteRemainingDistancesIndex
-                        """.trimIndent()
-                    )
+                    Message("Upcoming route line index is null.")
                 )
                 return null
             }


### PR DESCRIPTION
### Description
Partially addresses #4882 by changing the log level of the error reporting. The error isn't useful for developers and has been reported to cause ANR's under some conditions because of the error string construction.

### Changelog
```
<changelog>Removed logging message that under some conditions could cause an ANR due to the construction of the logging message.</changelog>
```
