### PR TITLE
Added a thread pool factory for components that need the functionality of ThreadController without being tied to MaboxNavigation.

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxBuildingHighlightActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxBuildingHighlightActivity.kt
@@ -335,6 +335,8 @@ class MapboxBuildingHighlightActivity : AppCompatActivity(), OnMapLongClickListe
 
     override fun onDestroy() {
         super.onDestroy()
+        routeLineApi.cancel()
+        routeLineView.cancel()
         mapboxNavigation.onDestroy()
     }
 

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxCustomStyleActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxCustomStyleActivity.kt
@@ -314,6 +314,8 @@ class MapboxCustomStyleActivity : AppCompatActivity(), OnMapLongClickListener {
 
     override fun onDestroy() {
         super.onDestroy()
+        routeLineApi.cancel()
+        routeLineView.cancel()
         mapboxNavigation.onDestroy()
     }
 

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxJunctionActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxJunctionActivity.kt
@@ -303,6 +303,8 @@ class MapboxJunctionActivity : AppCompatActivity(), OnMapLongClickListener {
 
     override fun onDestroy() {
         super.onDestroy()
+        routeLineApi.cancel()
+        routeLineView.cancel()
         mapboxNavigation.onDestroy()
     }
 

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxManeuverActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxManeuverActivity.kt
@@ -324,6 +324,8 @@ class MapboxManeuverActivity : AppCompatActivity(), OnMapLongClickListener {
 
     override fun onDestroy() {
         super.onDestroy()
+        routeLineApi.cancel()
+        routeLineView.cancel()
         mapboxNavigation.onDestroy()
     }
 

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxNavigationActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxNavigationActivity.kt
@@ -459,6 +459,8 @@ class MapboxNavigationActivity : AppCompatActivity() {
 
     override fun onDestroy() {
         super.onDestroy()
+        routeLineAPI.cancel()
+        routeLineView.cancel()
         mapboxNavigation.onDestroy()
         speechAPI.cancel()
         voiceInstructionsPlayer.shutdown()

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxRouteLineAndArrowActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxRouteLineAndArrowActivity.kt
@@ -478,6 +478,8 @@ class MapboxRouteLineAndArrowActivity : AppCompatActivity(), OnMapLongClickListe
 
     override fun onDestroy() {
         super.onDestroy()
+        routeLineApi.cancel()
+        routeLineView.cancel()
         mapboxNavigation.onDestroy()
     }
 

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxSignboardActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxSignboardActivity.kt
@@ -308,6 +308,8 @@ class MapboxSignboardActivity : AppCompatActivity(), OnMapLongClickListener {
 
     override fun onDestroy() {
         super.onDestroy()
+        routeLineApi.cancel()
+        routeLineView.cancel()
         mapboxNavigation.onDestroy()
     }
 

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxTripProgressActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxTripProgressActivity.kt
@@ -298,6 +298,8 @@ class MapboxTripProgressActivity : AppCompatActivity(), OnMapLongClickListener {
 
     override fun onDestroy() {
         super.onDestroy()
+        routeLineApi.cancel()
+        routeLineView.cancel()
         mapboxNavigation.onDestroy()
     }
 

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxVoiceActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxVoiceActivity.kt
@@ -365,6 +365,8 @@ class MapboxVoiceActivity : AppCompatActivity(), OnMapLongClickListener {
 
     override fun onDestroy() {
         super.onDestroy()
+        routeLineApi.cancel()
+        routeLineView.cancel()
         mapboxNavigation.onDestroy()
         speechApi.cancel()
         voiceInstructionsPlayer.shutdown()

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MultiLegRouteExampleActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MultiLegRouteExampleActivity.kt
@@ -210,6 +210,8 @@ class MultiLegRouteExampleActivity : AppCompatActivity() {
 
     override fun onDestroy() {
         super.onDestroy()
+        routeLineApi.cancel()
+        routeLineView.cancel()
         mapboxNavigation.onDestroy()
     }
 

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayHistoryActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayHistoryActivity.kt
@@ -108,6 +108,8 @@ class ReplayHistoryActivity : AppCompatActivity() {
 
     override fun onDestroy() {
         super.onDestroy()
+        routeLineApi.cancel()
+        routeLineView.cancel()
         mapboxNavigation.onDestroy()
         if (::locationComponent.isInitialized) {
             locationComponent.removeOnIndicatorPositionChangedListener(onPositionChangedListener)

--- a/examples/src/main/java/com/mapbox/navigation/examples/util/RouteLineUtil.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/util/RouteLineUtil.kt
@@ -131,6 +131,8 @@ class RouteLineUtil(private val activity: AppCompatActivity) : LifecycleObserver
 
     @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
     private fun onStop() {
+        routeLineApi.cancel()
+        routeLineView.cancel()
         mapView.location.removeOnIndicatorPositionChangedListener(
             onIndicatorPositionChangedListener
         )

--- a/libnavui-maps/api/current.txt
+++ b/libnavui-maps/api/current.txt
@@ -710,6 +710,7 @@ package com.mapbox.navigation.ui.maps.route.line.api {
 
   public final class MapboxRouteLineApi {
     ctor public MapboxRouteLineApi(com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions routeLineOptions);
+    method public void cancel();
     method public void clearRouteLine(com.mapbox.navigation.ui.base.util.MapboxNavigationConsumer<com.mapbox.bindgen.Expected<com.mapbox.navigation.ui.maps.route.line.model.RouteLineError,com.mapbox.navigation.ui.maps.route.line.model.RouteLineClearValue>> consumer);
     method public void findClosestRoute(com.mapbox.geojson.Point target, com.mapbox.maps.MapboxMap mapboxMap, float padding, com.mapbox.navigation.ui.base.util.MapboxNavigationConsumer<com.mapbox.bindgen.Expected<com.mapbox.navigation.ui.maps.route.line.model.RouteNotFound,com.mapbox.navigation.ui.maps.route.line.model.ClosestRouteValue>> resultConsumer);
     method public com.mapbox.api.directions.v5.models.DirectionsRoute? getPrimaryRoute();
@@ -729,6 +730,7 @@ package com.mapbox.navigation.ui.maps.route.line.api {
 
   public final class MapboxRouteLineView {
     ctor public MapboxRouteLineView(com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions options);
+    method public void cancel();
     method public com.mapbox.maps.extension.style.layers.properties.generated.Visibility? getAlternativeRoutesVisibility(com.mapbox.maps.Style style);
     method public com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions getOptions();
     method public com.mapbox.maps.extension.style.layers.properties.generated.Visibility? getPrimaryRouteVisibility(com.mapbox.maps.Style style);

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/util/InternalJobControlFactory.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/util/InternalJobControlFactory.kt
@@ -1,0 +1,19 @@
+package com.mapbox.navigation.ui.maps.util
+
+import com.mapbox.navigation.utils.internal.JobControl
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+
+internal object InternalJobControlFactory {
+
+    /**
+     * Creates a [JobControl] using the default dispatcher. This is similar to [ThreadController] but the
+     * resources created here aren't shared. It is your responsibility to cancel child jobs as
+     * necessary.
+     */
+    fun createJobControl(): JobControl {
+        val parentJob = SupervisorJob()
+        return JobControl(parentJob, CoroutineScope(parentJob + Dispatchers.Default))
+    }
+}

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/domain/TestActivitySuite.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/domain/TestActivitySuite.kt
@@ -1,6 +1,7 @@
 package com.mapbox.navigation.qa_test_app.domain
 
 import android.app.Activity
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.qa_test_app.R
 import com.mapbox.navigation.qa_test_app.utils.startActivity
 import com.mapbox.navigation.qa_test_app.view.AlternativeRouteActivity
@@ -17,6 +18,7 @@ typealias LaunchActivityFun = (Activity) -> Unit
 
 object TestActivitySuite {
 
+    @OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
     val testActivities = listOf(
         TestActivityDescription(
             "Alternative Route Selection",

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/AlternativeRouteActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/AlternativeRouteActivity.kt
@@ -115,6 +115,13 @@ class AlternativeRouteActivity : AppCompatActivity(), OnMapLongClickListener {
         mapboxNavigation.unregisterRoutesObserver(routesObserver)
     }
 
+    override fun onDestroy() {
+        super.onDestroy()
+        routeLineApi.cancel()
+        routeLineView.cancel()
+        mapboxNavigation.onDestroy()
+    }
+
     private fun initNavigation() {
         binding.mapView.location.apply {
             setLocationProvider(navigationLocationProvider)

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/InactiveRouteStylingActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/InactiveRouteStylingActivity.kt
@@ -113,6 +113,8 @@ class InactiveRouteStylingActivity : AppCompatActivity() {
 
     override fun onDestroy() {
         super.onDestroy()
+        routeLineApi.cancel()
+        routeLineView.cancel()
         mapboxNavigation.onDestroy()
     }
 

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/InactiveRouteStylingWithRestrictionsActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/InactiveRouteStylingWithRestrictionsActivity.kt
@@ -123,6 +123,8 @@ class InactiveRouteStylingWithRestrictionsActivity : AppCompatActivity() {
 
     override fun onDestroy() {
         super.onDestroy()
+        routeLineApi.cancel()
+        routeLineView.cancel()
         mapboxNavigation.onDestroy()
     }
 

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/MapboxRouteLineActivity.java
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/MapboxRouteLineActivity.java
@@ -294,6 +294,8 @@ public class MapboxRouteLineActivity extends AppCompatActivity implements OnMapL
   @Override
   protected void onDestroy() {
     super.onDestroy();
+    mapboxRouteLineApi.cancel();
+    mapboxRouteLineView.cancel();
     if (predictiveCacheController != null) {
       predictiveCacheController.onDestroy();
     }

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/RouteRestrictionsActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/RouteRestrictionsActivity.kt
@@ -135,6 +135,8 @@ class RouteRestrictionsActivity : AppCompatActivity() {
 
     override fun onDestroy() {
         super.onDestroy()
+        routeLineApi.cancel()
+        routeLineView.cancel()
         mapboxNavigation.onDestroy()
     }
 

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/RouteTrafficUpdateActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/RouteTrafficUpdateActivity.kt
@@ -68,6 +68,12 @@ class RouteTrafficUpdateActivity : AppCompatActivity() {
         job.cancel()
     }
 
+    override fun onDestroy() {
+        super.onDestroy()
+        routeLineApi.cancel()
+        routeLineView.cancel()
+    }
+
     private fun initStyle() {
         binding.mapView.getMapboxMap().loadStyleUri(
             Style.MAPBOX_STREETS

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/TrafficGradientActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/TrafficGradientActivity.kt
@@ -55,6 +55,12 @@ class TrafficGradientActivity : AppCompatActivity() {
         initStyle()
     }
 
+    override fun onDestroy() {
+        super.onDestroy()
+        routeLineApi.cancel()
+        routeLineView.cancel()
+    }
+
     private fun initGradientSelector() {
         binding.gradientOptionHard.setOnClickListener {
             options = options.toBuilder(this)


### PR DESCRIPTION
### Description
Expanding on the issue brought up in [this pull request](https://github.com/mapbox/mapbox-navigation-android/pull/4816) and based on the ideas expressed in #4853, the work in this pull request implements a factory for creating JobControl objects that are independent of ThreadController. The route line api related classes use their own thread pools and have a cancel method for cancelling the background tasks.

### Changelog
```
<changelog>Added a cancel method to the MapboxRouteLineApi and MapboxRouteLineView classes for cancelling the background tasks.</changelog>
```

