### PR TITLE
Fix flaky instrumentation tests (#4726)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -357,6 +357,7 @@ commands:
               --device model=star2lte,version=28,locale=de,orientation=landscape \
               --device model=flame,version=30,locale=en,orientation=portrait \
               --use-orchestrator \
+              --directories-to-pull=/sdcard/Download/mapbox_test \
               --timeout 15m
 
   run-firebase-robo:

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/MapboxHistoryTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/MapboxHistoryTest.kt
@@ -71,16 +71,18 @@ class MapboxHistoryTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.j
     fun setup() {
         Espresso.onIdle()
 
-        mapboxNavigation = MapboxNavigationProvider.create(
-            NavigationOptions.Builder(activity)
-                .accessToken(getMapboxAccessTokenFromResources(activity))
-                .historyRecorderOptions(
-                    HistoryRecorderOptions.Builder()
-                        .build()
-                )
-                .build()
-        )
-        mapboxHistoryTestRule.historyRecorder = mapboxNavigation.historyRecorder
+        runOnMainSync {
+            mapboxNavigation = MapboxNavigationProvider.create(
+                NavigationOptions.Builder(activity)
+                    .accessToken(getMapboxAccessTokenFromResources(activity))
+                    .historyRecorderOptions(
+                        HistoryRecorderOptions.Builder()
+                            .build()
+                    )
+                    .build()
+            )
+            mapboxHistoryTestRule.historyRecorder = mapboxNavigation.historyRecorder
+        }
         routeCompleteIdlingResource = RouteProgressStateIdlingResource(
             mapboxNavigation,
             RouteProgressState.COMPLETE
@@ -139,7 +141,9 @@ class MapboxHistoryTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.j
         }
 
         // assert and clean up
-        Espresso.onIdle()
+        mapboxHistoryTestRule.stopRecordingOnCrash("no route complete") {
+            Espresso.onIdle()
+        }
         routeCompleteIdlingResource.unregister()
 
         runOnMainSync {

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/ui/routeline/AlternativeRouteSelectionTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/ui/routeline/AlternativeRouteSelectionTest.kt
@@ -40,11 +40,13 @@ class AlternativeRouteSelectionTest : BaseTest<BasicNavigationViewActivity>(
 
     @Before
     fun setUp() {
-        mapboxNavigation = MapboxNavigation(
-            NavigationOptions.Builder(activity)
-                .accessToken(getMapboxAccessTokenFromResources(activity))
-                .build()
-        )
+        runOnMainSync {
+            mapboxNavigation = MapboxNavigation(
+                NavigationOptions.Builder(activity)
+                    .accessToken(getMapboxAccessTokenFromResources(activity))
+                    .build()
+            )
+        }
     }
 
     @After

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/utils/http/MockDirectionsRequestHandler.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/utils/http/MockDirectionsRequestHandler.kt
@@ -16,11 +16,16 @@ import okhttp3.mockwebserver.RecordedRequest
 data class MockDirectionsRequestHandler(
     val profile: String,
     val jsonResponse: String,
-    val expectedCoordinates: List<Point>?
+    val expectedCoordinates: List<Point>?,
+    val relaxedExpectedCoordinates: Boolean = false,
 ) : MockRequestHandler {
     override fun handle(request: RecordedRequest): MockResponse? {
-        val prefix =
+        val prefix = if (relaxedExpectedCoordinates) {
+            """/directions/v5/mapbox/$profile"""
+        } else {
             """/directions/v5/mapbox/$profile/${expectedCoordinates.parseCoordinates()}"""
+        }
+
         return if (request.path!!.startsWith(prefix)) {
             MockResponse().setBody(jsonResponse)
         } else {


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

CP #4726

Fix flaky instrumentation tests
- pull / push history files from device to gcloud test bucket
- use mapbox history test rule and set /sdcard/Download/mapbox_test as directory to pull from
- add logs and relaxed expected coordinates
- capture exceptions and retrieve history files up to that point
- mapbox navigation creation (setup) run on main sync