### PR TITLE
Fix `verify_history_files_are_recorded_and_readable` `MapboxHistoryTest`

### DIFF
--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/MapboxHistoryTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/MapboxHistoryTest.kt
@@ -180,8 +180,9 @@ class MapboxHistoryTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.j
         assertEquals(firstLocation.location.latitude, 38.894721, 0.00001)
 
         // Verify the set route event
-        val setRouteEvent = historyEvents
-            .find { it is HistoryEventSetRoute } as HistoryEventSetRoute
+        val setRouteEvent = historyEvents.find {
+            it is HistoryEventSetRoute && it.directionsRoute != null
+        } as HistoryEventSetRoute
         assertEquals(24.001, setRouteEvent.directionsRoute!!.duration(), 0.001)
         assertEquals(setRouteEvent.legIndex, 0)
         assertEquals(setRouteEvent.routeIndex, 0)
@@ -244,6 +245,8 @@ class MapboxHistoryTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.j
 
     private companion object {
         private const val CUSTOM_EVENT_TYPE = "custom_event_type"
-        private const val CUSTOM_EVENT_PROPERTIES = "custom_event_properties"
+        private const val CUSTOM_EVENT_PROPERTIES = """
+            {"name":"John", "age":30, "car":null}
+        """
     }
 }

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/RouteAlternativesTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/RouteAlternativesTest.kt
@@ -99,7 +99,7 @@ class RouteAlternativesTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::cla
         runOnMainSync {
             val countDownLatch = CountDownLatch(1)
             mapboxNavigation.historyRecorder.stopRecording {
-                logE(Tag("DEBUG"), Message("history path=$it"))
+                logE(Tag("RouteAlternativesTest"), Message("history path=$it"))
                 countDownLatch.countDown()
             }
             countDownLatch.await()

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/RouteAlternativesTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/RouteAlternativesTest.kt
@@ -3,6 +3,8 @@ package com.mapbox.navigation.instrumentation_tests.core
 import androidx.test.espresso.Espresso
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.RouteOptions
+import com.mapbox.base.common.logger.model.Message
+import com.mapbox.base.common.logger.model.Tag
 import com.mapbox.geojson.Point
 import com.mapbox.navigation.base.extensions.applyDefaultNavigationOptions
 import com.mapbox.navigation.base.options.NavigationOptions
@@ -22,10 +24,12 @@ import com.mapbox.navigation.instrumentation_tests.utils.readRawFileText
 import com.mapbox.navigation.instrumentation_tests.utils.runOnMainSync
 import com.mapbox.navigation.testing.ui.BaseTest
 import com.mapbox.navigation.testing.ui.utils.getMapboxAccessTokenFromResources
+import com.mapbox.navigation.utils.internal.logE
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
 /**
@@ -90,6 +94,15 @@ class RouteAlternativesTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::cla
         alternativesIdlingResource.register()
         mapboxHistoryTestRule.stopRecordingOnCrash("no route alternatives") {
             Espresso.onIdle()
+        }
+
+        runOnMainSync {
+            val countDownLatch = CountDownLatch(1)
+            mapboxNavigation.historyRecorder.stopRecording {
+                logE(Tag("DEBUG"), Message("history path=$it"))
+                countDownLatch.countDown()
+            }
+            countDownLatch.await()
         }
 
         // Verify faster alternatives are found.


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Regression from https://github.com/mapbox/mapbox-navigation-android/pull/4915 caught in https://github.com/mapbox/mapbox-navigation-android/pull/4913#issuecomment-932541016

After https://github.com/mapbox/mapbox-navigation-android/pull/4915 2 `setRoute` history files events are generated 👀 

```
2021-10-01 17:47:48.391 15934-16027/com.mapbox.navigation.instrumentation_tests E/DEBUG: request=/directions/v5/mapbox/driving-traffic/-77.031991,38.894721;-77.030923,38.895433?access_token=pk.eyJ&geometries=polyline6&overview=full&steps=true&continue_straight=true&annotations=congestion_numeric%2Cmaxspeed%2Cspeed%2Cduration%2Cdistance%2Cclosure&language=en&roundabout_exits=true&voice_instructions=true&banner_instructions=true&voice_units=imperial&enable_refresh=true&sku=10bcWffIWLZJX
2021-10-01 17:47:48.393 15934-15934/com.mapbox.navigation.instrumentation_tests E/DEBUG: setRoute=null
2021-10-01 17:47:48.395 15934-15934/com.mapbox.navigation.instrumentation_tests W/LocationUpdateReceiver: LocationEngineResult == null
2021-10-01 17:47:48.398 15934-16011/com.mapbox.navigation.instrumentation_tests E/nav-native: setRoute request URI parse error: Should be at least 3 url's path parts.. Use default directions options
2021-10-01 17:47:48.398 15934-16008/com.mapbox.navigation.instrumentation_tests W/nav-native: Location at timestamp 358386505477709ns was filtered out.
2021-10-01 17:47:48.398 15934-16008/com.mapbox.navigation.instrumentation_tests W/nav-native: Got location timestamp from the past: 358387505477709ns <= 358387505477709ns. No status will be produced.
2021-10-01 17:47:48.405 15934-15934/com.mapbox.navigation.instrumentation_tests I/MbxOffboardRouter: Successful directions response. Metadata: null
2021-10-01 17:47:48.406 15934-15934/com.mapbox.navigation.instrumentation_tests D/MbxNavigationTelemetry: session state is ActiveGuidance(sessionId=e89c6eb0-db7a-4ff9-926a-c64637ecd9f5)
2021-10-01 17:47:48.406 15934-15934/com.mapbox.navigation.instrumentation_tests D/MbxNavigationTelemetry: trackFreeDrive STOP
2021-10-01 17:47:48.406 15934-15934/com.mapbox.navigation.instrumentation_tests D/MbxNavigationTelemetry: createFreeDriveEvent STOP
2021-10-01 17:47:48.410 15934-15934/com.mapbox.navigation.instrumentation_tests W/TelemetryUtils: java.lang.SecurityException: getDataNetworkTypeForSubscriber
2021-10-01 17:47:48.412 15934-15934/com.mapbox.navigation.instrumentation_tests D/MbxNavigationTelemetry: populateFreeDriveEvent
2021-10-01 17:47:48.413 15934-15934/com.mapbox.navigation.instrumentation_tests D/MbxNavigationTelemetry: class com.mapbox.navigation.core.telemetry.events.NavigationFreeDriveEvent event sent
2021-10-01 17:47:48.414 15934-15934/com.mapbox.navigation.instrumentation_tests D/MbxNavigationTelemetry: onRoutesChanged. size = 1
2021-10-01 17:47:48.414 15934-15934/com.mapbox.navigation.instrumentation_tests D/MbxNavigationTelemetry: handle a new route
2021-10-01 17:47:48.414 15934-15934/com.mapbox.navigation.instrumentation_tests D/MbxNavigationTelemetry: resetOriginalRoute
2021-10-01 17:47:48.414 15934-15934/com.mapbox.navigation.instrumentation_tests D/MbxNavigationTelemetry: resetRouteProgress
2021-10-01 17:47:48.419 15934-15934/com.mapbox.navigation.instrumentation_tests E/DEBUG: setRoute=DirectionsRoute{routeIndex=0, distance=174.33, duration=24.001, durationTypical=24.001, geometry=ag}diA``t|qCkf@E_E?B{K?u^?oU, weight=34.907, weightName=auto, legs=[RouteLeg{distance=174.33, duration=24.001, durationTypical=24.001, summary=14th Street Northwest, Pennsylvania Avenue Northwest, admins=[Admin{countryCode=US, countryCodeAlpha3=USA}], steps=[LegStep{distance=81.33, duration=8.879, durationTypical=8.879, speedLimitUnit=mph, speedLimitSign=mutcd, geometry=ag}diA``t|qCkf@E_E?, name=14th Street Northwest, ref=null, destinations=null, mode=driving, pronunciation=null, rotaryName=null, rotaryPronunciation=null, maneuver=StepManeuver{rawLocation=[-77.031953, 38.894721], bearingBefore=0.0, bearingAfter=0.0, instruction=Drive north on 14th Street Northwest., type=depart, modifier=null, exit=null}, voiceInstructions=[VoiceInstructions{distanceAlongGeometry=81.33, announcement=Drive north on 14th Street Northwest. Then Turn right onto Pennsylvania Avenue Northwest., ssmlAnnouncement=<speak><amazon:effect name="drc"><prosody rate="1.08">Drive north on 14th Street Northwest. Then Turn right onto Pennsylvania Avenue Northwest.</prosody></amazon:effect></speak>}], bannerInstructions=[BannerInstructions{distanceAlongGeometry=81.33, primary=BannerText{text=Pennsylvania Avenue Northwest, components=[BannerComponents{text=Pennsylvania Avenue Northwest, type=text, subType=null, abbreviation=null, abbreviationPriority=null, imageBaseUrl=null, imageUrl=null, directions=null, active=null, activeDirection=null}], type=turn, modifier=right, degrees=null, drivingSide=null}, secondary=null, sub=null, view=null}], drivingSide=right, weight=12.677, intersections=[StepIntersection{rawLocation=[-77.031953, 38.894721], bearings=[0], classes=null, entry=[true], in=null, out=0, lanes=null, geometryIndex=0, isUrban=true, adminIndex=0, restStop=null, tollCollection=null, mapboxStreetsV8=MapboxStreetsV8{roadClass=secondary}, tunnelName=null}, StepIntersection{rawLocation=[-77.03195, 38.895351], bearings=[0, 180], classes=null, entry=[true, false], in=1, out=0, lanes=[IntersectionLanes{valid=false, active=false, validIndication=null, indications=[left]}, IntersectionLanes{valid=true, active=false, validIndication=straight, indications=[straight]}, IntersectionLanes{valid=true, active=false, validIndication=straight, indications=[straight]}, IntersectionLanes{valid=true, active=true, validIndication=straight, indications=[straight]}], geometryIndex=1, isUrban=true, adminIndex=0, restStop=null, tollCollection=null, mapboxStreetsV8=MapboxStreetsV8{roadClass=secondary}, tunnelName=null}], exits=null}, LegStep{distance=93.0, duration=15.122, durationTypical=15.122, speedLimitUnit=mph, speedLimitSign=mutcd, geometry=mt~diAz_t|qCB{K?u^?oU, name=Pennsylvania Avenue Northwest, ref=null, destinations=null, mode=driving, pronunciation=null, rotaryName=null, rotaryPronunciation=null, maneuver=StepManeuver{rawLocation=[-77.03195, 38.895447], bearingBefore=0.0, bearingAfter=91.0, instruction=Turn right onto Pennsylvania Avenue Northwest., type=turn, modifier=right, exit=null}, voiceInstructions=[VoiceInstructions{distanceAlongGeometry=79.167, announcement=You have arrived at your destination., ssmlAnnouncement=<speak><amazon:effect name="drc"><prosody rate="1.08">You have arrived at your destination.</prosody></amazon:effect></speak>}], bannerInstructions=[BannerInstructions{distanceAlongGeometry=93.0, primary=BannerText{text=You will arrive at your destination, components=[BannerComponents{text=You will arrive at your destination, type=text, subType=null, abbreviation=null, abbreviationPriority=null, imageBaseUrl=null, imageUrl=null, directions=null, active=null, activeDirection=null}], type=arrive, modifier=straight, degrees=null, drivingSide=null}, secondary=null, sub=null, view=null}, BannerInstructions{distanceAlongGeometry=79.167, primary=BannerText{text=You have arrived at your destination, components=[BannerComponents{text=You have arrived at your destination, type=text, subTyp
2021-10-01 17:47:48.419 15934-15934/com.mapbox.navigation.instrumentation_tests E/DEBUG: e=null, abbreviation=null, abbreviationPriority=null, imageBaseUrl=null, imageUrl=null, directions=null, active=null, activeDirection=null}], type=arrive, modifier=straight, degrees=null, drivingSide=null}, secondary=null, sub=null, view=null}], drivingSide=right, weight=22.23, intersections=[StepIntersection{rawLocation=[-77.03195, 38.895447], bearings=[91, 180], classes=null, entry=[true, false], in=1, out=0, lanes=null, geometryIndex=2, isUrban=true, adminIndex=0, restStop=null, tollCollection=null, mapboxStreetsV8=MapboxStreetsV8{roadClass=primary}, tunnelName=null}, StepIntersection{rawLocation=[-77.031744, 38.895445], bearings=[90, 271], classes=null, entry=[true, false], in=1, out=0, lanes=null, geometryIndex=3, isUrban=true, adminIndex=0, restStop=null, tollCollection=null, mapboxStreetsV8=MapboxStreetsV8{roadClass=primary}, tunnelName=null}, StepIntersection{rawLocation=[-77.031237, 38.895445], bearings=[90, 270], classes=null, entry=[true, false], in=1, out=0, lanes=null, geometryIndex=4, isUrban=true, adminIndex=0, restStop=null, tollCollection=null, mapboxStreetsV8=MapboxStreetsV8{roadClass=primary}, tunnelName=null}], exits=null}, LegStep{distance=0.0, duration=0.0, durationTypical=0.0, speedLimitUnit=mph, speedLimitSign=mutcd, geometry=it~diAx|q|qC??, name=Pennsylvania Avenue Northwest, ref=null, destinations=null, mode=driving, pronunciation=null, rotaryName=null, rotaryPronunciation=null, maneuver=StepManeuver{rawLocation=[-77.030877, 38.895445], bearingBefore=90.0, bearingAfter=0.0, instruction=You have arrived at your destination., type=arrive, modifier=null, exit=null}, voiceInstructions=[], bannerInstructions=[], drivingSide=right, weight=0.0, intersections=[StepIntersection{rawLocation=[-77.030877, 38.895445], bearings=[270], classes=null, entry=[true], in=0, out=null, lanes=null, geometryIndex=5, isUrban=null, adminIndex=0, restStop=null, tollCollection=null, mapboxStreetsV8=null, tunnelName=null}], exits=null}], incidents=null, annotation=LegAnnotation{distance=[70.1, 10.7, 17.8, 43.9, 31.2], duration=[7.652, 1.166, 2.073, 5.101, 3.622], speed=[9.2, 9.2, 8.6, 8.6, 8.6], maxspeed=[MaxSpeed{speed=null, unit=null, unknown=true, none=null}, MaxSpeed{speed=null, unit=null, unknown=true, none=null}, MaxSpeed{speed=null, unit=null, unknown=true, none=null}, MaxSpeed{speed=null, unit=null, unknown=true, none=null}, MaxSpeed{speed=null, unit=null, unknown=true, none=null}], congestion=[low, low, low, low, low], congestionNumeric=null}, closures=null}], routeOptions=RouteOptions{baseUrl=http://localhost:42775/, user=mapbox, profile=driving-traffic, coordinates=-77.031991,38.894721;-77.030923,38.895433, alternatives=null, language=en, radiuses=null, bearings=null, layers=null, continueStraight=true, roundaboutExits=true, geometries=polyline6, overview=full, steps=true, annotations=congestion_numeric,maxspeed,speed,duration,distance,closure, exclude=null, include=null, voiceInstructions=true, bannerInstructions=true, voiceUnits=imperial, approaches=null, waypointIndices=null, waypointNames=null, waypointTargets=null, alleyBias=null, walkingSpeed=null, walkwayBias=null, snappingIncludeClosures=null, arriveBy=null, departAt=null, maxHeight=null, maxWidth=null, enableRefresh=true, metadata=null}, voiceLanguage=en-US, requestUuid=}
2021-10-01 17:47:48.437 668-668/? E/SELinux: avc:  denied  { find } for pid=6218 uid=10218 name=tethering scontext=u:r:permissioncontroller_app:s0:c218,c256,c512,c768 tcontext=u:object_r:tethering_service:s0 tclass=service_manager permissive=0
```

We were checking for the first `HistoryEventSetRoute` event which was `null` and caused the 💥 

```
10-01 12:58:31.931: W/System.err(32432): java.lang.NullPointerException
10-01 12:58:31.931: W/System.err(32432): 	at com.mapbox.navigation.instrumentation_tests.core.MapboxHistoryTest.verifyHistoryEvents(MapboxHistoryTest.kt:185)
10-01 12:58:31.931: W/System.err(32432): 	at com.mapbox.navigation.instrumentation_tests.core.MapboxHistoryTest.access$verifyHistoryEvents(MapboxHistoryTest.kt:44)
10-01 12:58:31.932: W/System.err(32432): 	at com.mapbox.navigation.instrumentation_tests.core.MapboxHistoryTest$verify_history_files_are_recorded_and_readable$4.invoke$lambda-0(MapboxHistoryTest.kt:153)
10-01 12:58:31.932: W/System.err(32432): 	at com.mapbox.navigation.instrumentation_tests.core.MapboxHistoryTest$verify_history_files_are_recorded_and_readable$4.lambda$qhSbnW71L7pKLzT9MNDLBiyQjE4(Unknown Source:0)
10-01 12:58:31.932: W/System.err(32432): 	at com.mapbox.navigation.instrumentation_tests.core.-$$Lambda$MapboxHistoryTest$verify_history_files_are_recorded_and_readable$4$qhSbnW71L7pKLzT9MNDLBiyQjE4.onSaved(Unknown Source:4)
10-01 12:58:31.932: W/System.err(32432): 	at com.mapbox.navigation.core.history.MapboxHistoryRecorder.stopRecording$lambda-2$lambda-1(MapboxHistoryRecorder.kt:66)
10-01 12:58:31.932: W/System.err(32432): 	at com.mapbox.navigation.core.history.MapboxHistoryRecorder.lambda$zuWriAVaqYkp03VeNQNrWCYRggA(Unknown Source:0)
10-01 12:58:31.932: W/System.err(32432): 	at com.mapbox.navigation.core.history.-$$Lambda$MapboxHistoryRecorder$zuWriAVaqYkp03VeNQNrWCYRggA.run(Unknown Source:2)
```

![NPE from setRouteEvent.directionsRoute!!](https://user-images.githubusercontent.com/1668582/135685046-c5e0bed3-dc7e-447a-aa33-e3bc71b1d52e.png)

Getting the last (`findLast`) solves the issue.

Also went ahead and fixed the following `nav-native-viz` error reproducible when trying to load the history files generated by `verify_history_files_are_recorded_and_readable` `MapboxHistoryTest` cc @mskurydin 

![verify_history_files_are_recorded_and_readable history file viz error](https://user-images.githubusercontent.com/1668582/134426850-f68fe088-8f64-4aec-a330-1698a9abd3bb.png)

> It fails because custom event is not a proper JSON.