### PR TITLE
Make setup location required for instrumenation tests

### DIFF
--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/MapboxHistoryTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/MapboxHistoryTest.kt
@@ -1,5 +1,6 @@
 package com.mapbox.navigation.instrumentation_tests.core
 
+import android.location.Location
 import androidx.test.espresso.Espresso
 import com.mapbox.api.directions.v5.DirectionsCriteria
 import com.mapbox.api.directions.v5.models.DirectionsRoute
@@ -52,6 +53,11 @@ class MapboxHistoryTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.j
     private lateinit var routeCompleteIdlingResource: RouteProgressStateIdlingResource
     private lateinit var testDirectory: File
 
+    override fun setupMockLocation(): Location = mockLocationUpdatesRule.generateLocationUpdate {
+        latitude = 38.894721
+        longitude = -77.031991
+    }
+
     @Before
     fun createTestDirectory() {
         testDirectory = File(activity.filesDir, "mapbox_history_test_directory")
@@ -65,11 +71,6 @@ class MapboxHistoryTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.j
 
     @Before
     fun setup() {
-        mockLocationUpdatesRule.pushLocationUpdate {
-            latitude = 38.894721
-            longitude = -77.031991
-        }
-
         Espresso.onIdle()
 
         runOnMainSync {
@@ -100,11 +101,6 @@ class MapboxHistoryTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.j
         runOnMainSync {
             mapboxNavigation.historyRecorder.startRecording()
             mapboxNavigation.historyRecorder.pushHistory(CUSTOM_EVENT_TYPE, CUSTOM_EVENT_PROPERTIES)
-
-            mockLocationUpdatesRule.pushLocationUpdate {
-                latitude = mockRoute.routeWaypoints.first().latitude()
-                longitude = mockRoute.routeWaypoints.first().longitude()
-            }
         }
         runOnMainSync {
             mapboxNavigation.startTripSession()

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/RouteAlternativesTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/RouteAlternativesTest.kt
@@ -1,5 +1,6 @@
 package com.mapbox.navigation.instrumentation_tests.core
 
+import android.location.Location
 import androidx.test.espresso.Espresso
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.RouteOptions
@@ -48,6 +49,15 @@ class RouteAlternativesTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::cla
     val mapboxHistoryTestRule = MapboxHistoryTestRule()
 
     private lateinit var mapboxNavigation: MapboxNavigation
+    private val coordinates = listOf(
+        Point.fromLngLat(-121.46685, 38.56301),
+        Point.fromLngLat(-121.445697, 38.56707)
+    )
+
+    override fun setupMockLocation(): Location = mockLocationUpdatesRule.generateLocationUpdate {
+        latitude = coordinates[0].latitude()
+        longitude = coordinates[0].longitude()
+    }
 
     @Before
     fun setup() {
@@ -68,10 +78,7 @@ class RouteAlternativesTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::cla
     @Test
     fun expect_faster_route_alternatives() {
         // Prepare with a slow alternative route.
-        val coordinates = listOf(
-            Point.fromLngLat(-121.46685, 38.56301),
-            Point.fromLngLat(-121.445697, 38.56707)
-        )
+
         setupMockRequestHandlers(coordinates)
         val routes = requestDirectionsRouteSync(coordinates).reversed()
 

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/RouteRefreshTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/RouteRefreshTest.kt
@@ -1,5 +1,6 @@
 package com.mapbox.navigation.instrumentation_tests.core
 
+import android.location.Location
 import com.mapbox.api.directions.v5.DirectionsCriteria
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.RouteOptions
@@ -40,6 +41,15 @@ class RouteRefreshTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.ja
     val idlingPolicyRule = IdlingPolicyTimeoutRule(35, TimeUnit.SECONDS)
 
     private lateinit var mapboxNavigation: MapboxNavigation
+    private val coordinates = listOf(
+        Point.fromLngLat(-121.495975, 38.57774),
+        Point.fromLngLat(-121.480279, 38.57674)
+    )
+
+    override fun setupMockLocation(): Location = mockLocationUpdatesRule.generateLocationUpdate {
+        latitude = coordinates[0].latitude()
+        longitude = coordinates[0].longitude()
+    }
 
     @Before
     fun setup() {
@@ -58,10 +68,6 @@ class RouteRefreshTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.ja
     @Test
     fun expect_route_refresh_to_update_traffic_annotations() {
         // Request a route.
-        val coordinates = listOf(
-            Point.fromLngLat(-121.495975, 38.57774),
-            Point.fromLngLat(-121.480279, 38.57674)
-        )
         setupMockRequestHandlers(coordinates)
         val routes = requestDirectionsRouteSync(coordinates).reversed()
 

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/SanityCoreRouteTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/SanityCoreRouteTest.kt
@@ -1,5 +1,6 @@
 package com.mapbox.navigation.instrumentation_tests.core
 
+import android.location.Location
 import androidx.test.espresso.Espresso
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.RouteOptions
@@ -38,8 +39,15 @@ class SanityCoreRouteTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class
     val mapboxHistoryTestRule = MapboxHistoryTestRule()
 
     private lateinit var mapboxNavigation: MapboxNavigation
-
     private lateinit var routeCompleteIdlingResource: RouteProgressStateIdlingResource
+
+    override fun setupMockLocation(): Location {
+        val mockRoute = MockRoutesProvider.dc_very_short(activity)
+        return mockLocationUpdatesRule.generateLocationUpdate {
+            latitude = mockRoute.routeWaypoints.first().latitude()
+            longitude = mockRoute.routeWaypoints.first().longitude()
+        }
+    }
 
     @Before
     fun setup() {
@@ -74,10 +82,6 @@ class SanityCoreRouteTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class
         // execute
         runOnMainSync {
             mapboxNavigation.historyRecorder.startRecording()
-            mockLocationUpdatesRule.pushLocationUpdate {
-                latitude = mockRoute.routeWaypoints.first().latitude()
-                longitude = mockRoute.routeWaypoints.first().longitude()
-            }
         }
         runOnMainSync {
             mapboxNavigation.startTripSession()

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/ui/SimpleMapViewNavigationTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/ui/SimpleMapViewNavigationTest.kt
@@ -58,6 +58,12 @@ abstract class SimpleMapViewNavigationTest :
     protected lateinit var navigationLocationProvider: NavigationLocationProvider
     protected lateinit var locationPlugin: LocationComponentPlugin
 
+    override fun setupMockLocation(): Location = mockLocationUpdatesRule.generateLocationUpdate {
+        val mockRoute = getRoute(activity)
+        latitude = mockRoute.routeWaypoints.first().latitude()
+        longitude = mockRoute.routeWaypoints.first().longitude()
+    }
+
     @Before
     fun setup() {
         initIdlingResource = MapStyleInitIdlingResource(activity.binding.mapView)
@@ -70,10 +76,6 @@ abstract class SimpleMapViewNavigationTest :
         val route = mockRoute.routeResponse.routes()[0]
 
         runOnMainSync {
-            mockLocationUpdatesRule.pushLocationUpdate {
-                latitude = mockRoute.routeWaypoints.first().latitude()
-                longitude = mockRoute.routeWaypoints.first().longitude()
-            }
             mockLocationReplayerRule.playRoute(route)
 
             mapboxNavigation = MapboxNavigation(

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/ui/routeline/AlternativeRouteSelectionTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/ui/routeline/AlternativeRouteSelectionTest.kt
@@ -1,5 +1,6 @@
 package com.mapbox.navigation.instrumentation_tests.ui.routeline
 
+import android.location.Location
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.core.MapboxNavigation
@@ -37,6 +38,17 @@ class AlternativeRouteSelectionTest : BaseTest<BasicNavigationViewActivity>(
     private lateinit var mapboxNavigation: MapboxNavigation
     private lateinit var routeLineApi: MapboxRouteLineApi
     private lateinit var routeLineView: MapboxRouteLineView
+
+    override fun setupMockLocation(): Location {
+        val directionsResponse = MockRoutesProvider
+            .loadDirectionsResponse(activity, R.raw.multiple_routes)
+        val origin = directionsResponse.waypoints()!!.map { it.location()!! }
+            .first()
+        return mockLocationUpdatesRule.generateLocationUpdate {
+            latitude = origin.latitude()
+            longitude = origin.longitude()
+        }
+    }
 
     @Before
     fun setUp() {
@@ -105,14 +117,8 @@ class AlternativeRouteSelectionTest : BaseTest<BasicNavigationViewActivity>(
     private fun setupRouteWithAlternatives() {
         val directionsResponse = MockRoutesProvider
             .loadDirectionsResponse(activity, R.raw.multiple_routes)
-        val origin = directionsResponse.waypoints()!!.map { it.location()!! }
-            .first()
         val route = directionsResponse.routes()[0]
         runOnMainSync {
-            mockLocationUpdatesRule.pushLocationUpdate {
-                latitude = origin.latitude()
-                longitude = origin.longitude()
-            }
             mapboxNavigation.setRoutes(directionsResponse.routes())
             mockLocationReplayerRule.playRoute(route)
         }

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/ui/routeline/SetRouteOrderTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/ui/routeline/SetRouteOrderTest.kt
@@ -1,6 +1,7 @@
 package com.mapbox.navigation.instrumentation_tests.ui.routeline
 
 import android.content.Context
+import android.location.Location
 import androidx.annotation.IntegerRes
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.IdlingRegistry
@@ -41,6 +42,15 @@ class SetRouteOrderTest : BaseTest<BasicNavigationViewActivity>(
     }
     private val myResourceIdler =
         CountingIdlingResource("MultipleRouteSetTestResource")
+
+    override fun setupMockLocation(): Location {
+        val shortRoute = getRoute(activity, R.raw.short_route)
+        val origin = shortRoute.routeOptions()!!.coordinatesList().first()
+        return mockLocationUpdatesRule.generateLocationUpdate {
+            latitude = origin.latitude()
+            longitude = origin.longitude()
+        }
+    }
 
     @Before
     fun setUp() {

--- a/libnavigation-core/src/androidTest/java/com/mapbox/navigation/core/trip/service/TripServiceTest.kt
+++ b/libnavigation-core/src/androidTest/java/com/mapbox/navigation/core/trip/service/TripServiceTest.kt
@@ -28,7 +28,6 @@ internal class TripServiceTest :
             clickOn(it)
         }
         uiDevice.run {
-            mockLocationUpdatesRule.pushLocationUpdate()
             val etaContent =
                 By.res("com.mapbox.navigation.core.test:id/etaContent")
             val freeDriveText =

--- a/libtesting-ui/src/main/java/com/mapbox/navigation/testing/ui/BaseTest.kt
+++ b/libtesting-ui/src/main/java/com/mapbox/navigation/testing/ui/BaseTest.kt
@@ -1,6 +1,7 @@
 package com.mapbox.navigation.testing.ui
 
 import android.Manifest
+import android.location.Location
 import androidx.appcompat.app.AppCompatActivity
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.ActivityTestRule
@@ -10,10 +11,11 @@ import com.mapbox.navigation.testing.ui.http.MockWebServerRule
 import com.schibsted.spain.barista.rule.cleardata.ClearDatabaseRule
 import com.schibsted.spain.barista.rule.cleardata.ClearFilesRule
 import com.schibsted.spain.barista.rule.cleardata.ClearPreferencesRule
+import org.junit.Before
 import org.junit.ClassRule
 import org.junit.Rule
 
-open class BaseTest<A : AppCompatActivity>(activityClass: Class<A>) {
+abstract class BaseTest<A : AppCompatActivity>(activityClass: Class<A>) {
 
     companion object {
         @ClassRule
@@ -54,4 +56,17 @@ open class BaseTest<A : AppCompatActivity>(activityClass: Class<A>) {
 
     val activity: A
         get() = activityRule.activity
+
+    @Before
+    fun runSetupMockLocation() {
+        mockLocationUpdatesRule.pushLocationUpdate(setupMockLocation())
+    }
+
+    // The MockLocationUpdatesRule will uses the system's GPS provider.
+    // Considering that any device, at any location, can run a test;
+    // the initial location is ambiguous if it is not specified.
+    //
+    // It is required to specify real location in the tests.
+    // Do not return Location(0,0) unless the test is explicitly testing initialization.
+    abstract fun setupMockLocation(): Location
 }

--- a/libtesting-ui/src/main/java/com/mapbox/navigation/testing/ui/NotificationTest.kt
+++ b/libtesting-ui/src/main/java/com/mapbox/navigation/testing/ui/NotificationTest.kt
@@ -1,6 +1,7 @@
 package com.mapbox.navigation.testing.ui
 
 import android.graphics.Point
+import android.location.Location
 import androidx.appcompat.app.AppCompatActivity
 import androidx.test.uiautomator.BySelector
 import androidx.test.uiautomator.UiDevice
@@ -54,4 +55,6 @@ open class NotificationTest<A : AppCompatActivity>(activityClass: Class<A>) :
             100
         )
     }
+
+    override fun setupMockLocation(): Location = mockLocationUpdatesRule.generateLocationUpdate()
 }


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Resolves https://github.com/mapbox/mapbox-navigation-android/issues/4510

We've had issues with flaky instrumentation tests because automated devices can run at any location, but our instrumentation tests are attempting to simulate _specified_ locations. For example, a test is simulating a route in San Francisco but the initial location is in Washington DC. This is because the device is in Washington DC, and the route is in San Francisco.

For this reason we are forcing all our navigation-sdk instrumentation tests to specify the initial location of the test.

For example, this should never happen (thanks for image @Guardiola31337)
<p align="center">
<img width="400" alt="Screen Shot 2021-10-05 at 2 02 36 PM" src="https://user-images.githubusercontent.com/3021882/136078799-cd0aa7d9-ff84-4cc1-b226-572c3e032dd2.png">
</p