### PR TITLE
Fix stop session button no longer working when in Replay mode

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -486,16 +486,7 @@ class MapboxNavigation(
     @RequiresPermission(anyOf = [ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION])
     @JvmOverloads
     fun startTripSession(withForegroundService: Boolean = true) {
-        runIfNotDestroyed {
-            tripSession.start(
-                withTripService = withForegroundService,
-                withReplayEnabled = false
-            )
-            restoreTripSessionRoute()
-            notificationChannelField?.let {
-                monitorNotificationActionButton(it.get(null) as ReceiveChannel<NotificationAction>)
-            }
-        }
+        startSession(withForegroundService, false)
     }
 
     /**
@@ -523,13 +514,7 @@ class MapboxNavigation(
      */
     @ExperimentalPreviewMapboxNavigationAPI
     fun startReplayTripSession(withForegroundService: Boolean = true) {
-        runIfNotDestroyed {
-            tripSession.start(
-                withTripService = withForegroundService,
-                withReplayEnabled = true
-            )
-            restoreTripSessionRoute()
-        }
+        startSession(withForegroundService, true)
     }
 
     /**
@@ -1115,6 +1100,19 @@ class MapboxNavigation(
         navigationSessionStateObserver: NavigationSessionStateObserver
     ) {
         navigationSession.unregisterNavigationSessionStateObserver(navigationSessionStateObserver)
+    }
+
+    private fun startSession(withTripService: Boolean, withReplayEnabled: Boolean) {
+        runIfNotDestroyed {
+            tripSession.start(
+                withTripService = withTripService,
+                withReplayEnabled = withReplayEnabled
+            )
+            restoreTripSessionRoute()
+            notificationChannelField?.let {
+                monitorNotificationActionButton(it.get(null) as ReceiveChannel<NotificationAction>)
+            }
+        }
     }
 
     private fun restoreTripSessionRoute() {


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Fixes stop session button no longer working when in Replay mode.

Regression from https://github.com/mapbox/mapbox-navigation-android/pull/4825

```kotling
notificationChannelField?.let {
                monitorNotificationActionButton(it.get(null) as ReceiveChannel<NotificationAction>)
}
```

Is not included as part of `startReplayTripSession` and therefore the notification action is never executed. @kmadsen any reason why not including this as part of `startReplayTripSession` or was this an overlook?

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Fixed stop session button no longer working when in Replay mode.</changelog>
```

cc @zugaldia 