### PR TITLE
Fix stop session button no longer working when in Replay mode (#4953)

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -486,16 +486,7 @@ class MapboxNavigation(
     @RequiresPermission(anyOf = [ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION])
     @JvmOverloads
     fun startTripSession(withForegroundService: Boolean = true) {
-        runIfNotDestroyed {
-            tripSession.start(
-                withTripService = withForegroundService,
-                withReplayEnabled = false
-            )
-            restoreTripSessionRoute()
-            notificationChannelField?.let {
-                monitorNotificationActionButton(it.get(null) as ReceiveChannel<NotificationAction>)
-            }
-        }
+        startSession(withForegroundService, false)
     }
 
     /**
@@ -523,13 +514,7 @@ class MapboxNavigation(
      */
     @ExperimentalPreviewMapboxNavigationAPI
     fun startReplayTripSession(withForegroundService: Boolean = true) {
-        runIfNotDestroyed {
-            tripSession.start(
-                withTripService = withForegroundService,
-                withReplayEnabled = true
-            )
-            restoreTripSessionRoute()
-        }
+        startSession(withForegroundService, true)
     }
 
     /**
@@ -1108,6 +1093,19 @@ class MapboxNavigation(
         navigationSessionStateObserver: NavigationSessionStateObserver
     ) {
         navigationSession.unregisterNavigationSessionStateObserver(navigationSessionStateObserver)
+    }
+
+    private fun startSession(withTripService: Boolean, withReplayEnabled: Boolean) {
+        runIfNotDestroyed {
+            tripSession.start(
+                withTripService = withTripService,
+                withReplayEnabled = withReplayEnabled
+            )
+            restoreTripSessionRoute()
+            notificationChannelField?.let {
+                monitorNotificationActionButton(it.get(null) as ReceiveChannel<NotificationAction>)
+            }
+        }
     }
 
     private fun restoreTripSessionRoute() {


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
CP: https://github.com/mapbox/mapbox-navigation-android/pull/4953

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Fixed stop session button no longer working when in Replay mode.</changelog>
```