### PR TITLE
Add road object

### DIFF
--- a/libnavigation-base/api/current.txt
+++ b/libnavigation-base/api/current.txt
@@ -317,6 +317,19 @@ package com.mapbox.navigation.base.options {
 
 }
 
+package com.mapbox.navigation.base.road.model {
+
+  public final class Road {
+    method public String? getName();
+    method public String? getShieldName();
+    method public String? getShieldUrl();
+    property public final String? name;
+    property public final String? shieldName;
+    property public final String? shieldUrl;
+  }
+
+}
+
 package com.mapbox.navigation.base.route {
 
   public final class ExclusionViolation {

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/factory/RoadFactory.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/factory/RoadFactory.kt
@@ -1,0 +1,15 @@
+package com.mapbox.navigation.base.internal.factory
+
+import com.mapbox.navigation.base.ExperimentalMapboxNavigationAPI
+import com.mapbox.navigation.base.road.model.Road
+import com.mapbox.navigator.NavigationStatus
+
+/**
+ * Internal factory to build [Road] objects
+ */
+@ExperimentalMapboxNavigationAPI
+object RoadFactory {
+
+    fun buildRoadObject(navigationStatus: NavigationStatus): Road =
+        Road(navigationStatus.roadName, null, navigationStatus.shieldName)
+}

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/road/model/Road.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/road/model/Road.kt
@@ -1,0 +1,47 @@
+package com.mapbox.navigation.base.road.model
+
+/**
+ * Object that holds road properties
+ * @property name of the road if available otherwise null
+ * @property shieldUrl url for the route shield if available otherwise null
+ * @property shieldName name of the route shield if available otherwise null
+ */
+class Road internal constructor(
+    val name: String? = null,
+    val shieldUrl: String? = null,
+    val shieldName: String? = null,
+) {
+
+    /**
+     * Indicates whether some other object is "equal to" this one.
+     */
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as Road
+
+        if (name != other.name) return false
+        if (shieldUrl != other.shieldUrl) return false
+        if (shieldName != other.shieldName) return false
+
+        return true
+    }
+
+    /**
+     * Returns a hash code value for the object.
+     */
+    override fun hashCode(): Int {
+        var result = name?.hashCode() ?: 0
+        result = 31 * result + (shieldUrl?.hashCode() ?: 0)
+        result = 31 * result + (shieldName?.hashCode() ?: 0)
+        return result
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    override fun toString(): String {
+        return "Road(name=$name, shieldUrl=$shieldUrl, shieldName=$shieldName)"
+    }
+}

--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -698,6 +698,7 @@ package com.mapbox.navigation.core.trip.session {
     method public android.location.Location getEnhancedLocation();
     method public java.util.List<android.location.Location> getKeyPoints();
     method public float getOffRoadProbability();
+    method public com.mapbox.navigation.base.road.model.Road getRoad();
     method public float getRoadEdgeMatchProbability();
     method public com.mapbox.navigation.base.speed.model.SpeedLimit? getSpeedLimit();
     method public Integer? getZLevel();
@@ -708,6 +709,7 @@ package com.mapbox.navigation.core.trip.session {
     property public final boolean isTeleport;
     property public final java.util.List<android.location.Location> keyPoints;
     property public final float offRoadProbability;
+    property public final com.mapbox.navigation.base.road.model.Road road;
     property public final float roadEdgeMatchProbability;
     property public final com.mapbox.navigation.base.speed.model.SpeedLimit? speedLimit;
     property public final Integer? zLevel;

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/navigator/NavigatorMapper.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/navigator/NavigatorMapper.kt
@@ -17,6 +17,7 @@ import com.mapbox.navigation.base.internal.factory.RoadObjectFactory
 import com.mapbox.navigation.base.internal.factory.RouteLegProgressFactory.buildRouteLegProgressObject
 import com.mapbox.navigation.base.internal.factory.RouteProgressFactory.buildRouteProgressObject
 import com.mapbox.navigation.base.internal.factory.RouteStepProgressFactory.buildRouteStepProgressObject
+import com.mapbox.navigation.base.road.model.Road
 import com.mapbox.navigation.base.speed.model.SpeedLimit
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.base.trip.model.RouteProgressState
@@ -296,9 +297,11 @@ private fun List<com.mapbox.navigator.UpcomingRouteAlert>.toUpcomingRoadObjects(
         }
 }
 
+@OptIn(ExperimentalMapboxNavigationAPI::class)
 internal fun TripStatus.getLocationMatcherResult(
     enhancedLocation: Location,
-    keyPoints: List<Location>
+    keyPoints: List<Location>,
+    road: Road
 ): LocationMatcherResult {
     return LocationMatcherResult(
         enhancedLocation,
@@ -309,6 +312,7 @@ internal fun TripStatus.getLocationMatcherResult(
         navigationStatus.prepareSpeedLimit(),
         navigationStatus.mapMatcherOutput.matches.firstOrNull()?.proba ?: 0f,
         navigationStatus.layer,
+        road
     )
 }
 

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/LocationMatcherResult.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/LocationMatcherResult.kt
@@ -1,6 +1,7 @@
 package com.mapbox.navigation.core.trip.session
 
 import android.location.Location
+import com.mapbox.navigation.base.road.model.Road
 import com.mapbox.navigation.base.speed.model.SpeedLimit
 
 /**
@@ -20,6 +21,7 @@ import com.mapbox.navigation.base.speed.model.SpeedLimit
  * DirectionsCriteria.ANNOTATION_MAXSPEED annotation to the route request.
  * @param roadEdgeMatchProbability when map matcher snaps to a road, this is the confidence in the chosen edge from all nearest edges.
  * @param zLevel [Int] current Z-level. Can be used to build a route from a proper level of a road.
+ * @param road Road can be used to get information about the [Road] including name, shield name and shield url.
  */
 class LocationMatcherResult internal constructor(
     val enhancedLocation: Location,
@@ -30,6 +32,7 @@ class LocationMatcherResult internal constructor(
     val speedLimit: SpeedLimit?,
     val roadEdgeMatchProbability: Float,
     val zLevel: Int?,
+    val road: Road,
 ) {
 
     /**
@@ -48,6 +51,7 @@ class LocationMatcherResult internal constructor(
         if (isTeleport != other.isTeleport) return false
         if (speedLimit != other.speedLimit) return false
         if (roadEdgeMatchProbability != other.roadEdgeMatchProbability) return false
+        if (road != other.road) return false
 
         return true
     }
@@ -63,6 +67,7 @@ class LocationMatcherResult internal constructor(
         result = 31 * result + isTeleport.hashCode()
         result = 31 * result + speedLimit.hashCode()
         result = 31 * result + roadEdgeMatchProbability.hashCode()
+        result = 31 * result + road.hashCode()
         return result
     }
 
@@ -73,6 +78,6 @@ class LocationMatcherResult internal constructor(
         return "LocationMatcherResult(enhancedLocation=$enhancedLocation, " +
             "keyPoints=$keyPoints, isOffRoad=$isOffRoad, offRoadProbability=$offRoadProbability, " +
             "isTeleport=$isTeleport, speedLimit=$speedLimit, " +
-            "roadEdgeMatchProbability=$roadEdgeMatchProbability)"
+            "roadEdgeMatchProbability=$roadEdgeMatchProbability, road=$road)"
     }
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
@@ -9,6 +9,8 @@ import com.mapbox.api.directions.v5.models.VoiceInstructions
 import com.mapbox.base.common.logger.Logger
 import com.mapbox.base.common.logger.model.Message
 import com.mapbox.base.common.logger.model.Tag
+import com.mapbox.navigation.base.ExperimentalMapboxNavigationAPI
+import com.mapbox.navigation.base.internal.factory.RoadFactory
 import com.mapbox.navigation.base.internal.factory.TripNotificationStateFactory.buildTripNotificationState
 import com.mapbox.navigation.base.trip.model.RouteLegProgress
 import com.mapbox.navigation.base.trip.model.RouteProgress
@@ -246,13 +248,15 @@ internal class MapboxTripSession(
         return tripService.hasServiceStarted()
     }
 
+    @OptIn(ExperimentalMapboxNavigationAPI::class)
     private val navigatorObserver = object : NavigatorObserver {
         override fun onStatus(origin: NavigationStatusOrigin, status: NavigationStatus) {
             val tripStatus = status.getTripStatusFrom(route)
             val enhancedLocation = tripStatus.navigationStatus.location.toLocation()
             val keyPoints = tripStatus.navigationStatus.keyPoints.toLocations()
+            val road = RoadFactory.buildRoadObject(tripStatus.navigationStatus)
             updateLocationMatcherResult(
-                tripStatus.getLocationMatcherResult(enhancedLocation, keyPoints),
+                tripStatus.getLocationMatcherResult(enhancedLocation, keyPoints, road)
             )
             zLevel = status.layer
 

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/navigator/NavigatorMapperTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/navigator/NavigatorMapperTest.kt
@@ -4,9 +4,11 @@ import android.location.Location
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.geojson.utils.PolylineUtils
 import com.mapbox.navigation.base.ExperimentalMapboxNavigationAPI
+import com.mapbox.navigation.base.internal.factory.RoadFactory
 import com.mapbox.navigation.base.internal.factory.RouteLegProgressFactory
 import com.mapbox.navigation.base.internal.factory.RouteProgressFactory
 import com.mapbox.navigation.base.internal.factory.RouteStepProgressFactory.buildRouteStepProgressObject
+import com.mapbox.navigation.base.road.model.Road
 import com.mapbox.navigation.base.speed.model.SpeedLimit
 import com.mapbox.navigation.base.trip.model.roadobject.RoadObjectType
 import com.mapbox.navigation.core.trip.session.LocationMatcherResult
@@ -98,8 +100,10 @@ class NavigatorMapperTest {
         assertEquals(expected, result)
     }
 
+    @OptIn(ExperimentalMapboxNavigationAPI::class)
     @Test
     fun `location matcher result sanity`() {
+        val road: Road = RoadFactory.buildRoadObject(navigationStatus)
         val tripStatus = TripStatus(
             route,
             mockk {
@@ -114,6 +118,8 @@ class NavigatorMapperTest {
                     )
                 }
                 every { layer } returns null
+                every { roadName } returns "Central Avenue"
+                every { shieldName } returns "I880"
             }
         )
         val expected = LocationMatcherResult(
@@ -129,15 +135,18 @@ class NavigatorMapperTest {
             ),
             roadEdgeMatchProbability = 1f,
             zLevel = null,
+            road = road
         )
 
-        val result = tripStatus.getLocationMatcherResult(enhancedLocation, keyPoints)
+        val result = tripStatus.getLocationMatcherResult(enhancedLocation, keyPoints, road)
 
         assertEquals(expected, result)
     }
 
+    @OptIn(ExperimentalMapboxNavigationAPI::class)
     @Test
     fun `location matcher result when close to being off road`() {
+        val road: Road = RoadFactory.buildRoadObject(navigationStatus)
         val tripStatus = TripStatus(
             route,
             mockk {
@@ -152,6 +161,8 @@ class NavigatorMapperTest {
                     )
                 }
                 every { layer } returns null
+                every { roadName } returns "Central Avenue"
+                every { shieldName } returns "I880"
             }
         )
         val expected = LocationMatcherResult(
@@ -167,15 +178,18 @@ class NavigatorMapperTest {
             ),
             roadEdgeMatchProbability = 1f,
             zLevel = null,
+            road = road
         )
 
-        val result = tripStatus.getLocationMatcherResult(enhancedLocation, keyPoints)
+        val result = tripStatus.getLocationMatcherResult(enhancedLocation, keyPoints, road)
 
         assertEquals(expected, result)
     }
 
+    @OptIn(ExperimentalMapboxNavigationAPI::class)
     @Test
     fun `location matcher result when off road`() {
+        val road: Road = RoadFactory.buildRoadObject(navigationStatus)
         val tripStatus = TripStatus(
             route,
             mockk {
@@ -190,6 +204,8 @@ class NavigatorMapperTest {
                     )
                 }
                 every { layer } returns null
+                every { roadName } returns "Central Avenue"
+                every { shieldName } returns "I880"
             }
         )
         val expected = LocationMatcherResult(
@@ -205,15 +221,18 @@ class NavigatorMapperTest {
             ),
             roadEdgeMatchProbability = 1f,
             zLevel = null,
+            road = road
         )
 
-        val result = tripStatus.getLocationMatcherResult(enhancedLocation, keyPoints)
+        val result = tripStatus.getLocationMatcherResult(enhancedLocation, keyPoints, road)
 
         assertEquals(expected, result)
     }
 
+    @OptIn(ExperimentalMapboxNavigationAPI::class)
     @Test
     fun `location matcher result teleport`() {
+        val road: Road = RoadFactory.buildRoadObject(navigationStatus)
         val tripStatus = TripStatus(
             route,
             mockk {
@@ -228,6 +247,8 @@ class NavigatorMapperTest {
                     )
                 }
                 every { layer } returns null
+                every { roadName } returns "Central Avenue"
+                every { shieldName } returns "I880"
             }
         )
         val expected = LocationMatcherResult(
@@ -243,26 +264,32 @@ class NavigatorMapperTest {
             ),
             roadEdgeMatchProbability = 1f,
             zLevel = null,
+            road = road
         )
 
-        val result = tripStatus.getLocationMatcherResult(enhancedLocation, keyPoints)
+        val result = tripStatus.getLocationMatcherResult(enhancedLocation, keyPoints, road)
 
         assertEquals(expected, result)
     }
 
+    @OptIn(ExperimentalMapboxNavigationAPI::class)
     @Test
     fun `location matcher result no edge matches`() {
+        val navigationStatus = mockk<NavigationStatus> {
+            every { offRoadProba } returns 1f
+            every { speedLimit } returns createSpeedLimit()
+            every { mapMatcherOutput } returns mockk {
+                every { isTeleport } returns false
+                every { matches } returns listOf()
+            }
+            every { layer } returns null
+            every { roadName } returns navigationStatus.roadName
+            every { shieldName } returns navigationStatus.shieldName
+        }
+        val road: Road = RoadFactory.buildRoadObject(navigationStatus)
         val tripStatus = TripStatus(
             route,
-            mockk {
-                every { offRoadProba } returns 1f
-                every { speedLimit } returns createSpeedLimit()
-                every { mapMatcherOutput } returns mockk {
-                    every { isTeleport } returns false
-                    every { matches } returns listOf()
-                }
-                every { layer } returns null
-            }
+            navigationStatus
         )
         val expected = LocationMatcherResult(
             enhancedLocation,
@@ -277,15 +304,18 @@ class NavigatorMapperTest {
             ),
             roadEdgeMatchProbability = 0f,
             zLevel = null,
+            road = road
         )
 
-        val result = tripStatus.getLocationMatcherResult(enhancedLocation, keyPoints)
+        val result = tripStatus.getLocationMatcherResult(enhancedLocation, keyPoints, road)
 
         assertEquals(expected, result)
     }
 
+    @OptIn(ExperimentalMapboxNavigationAPI::class)
     @Test
     fun `location matcher result zLevel`() {
+        val road: Road = RoadFactory.buildRoadObject(navigationStatus)
         val tripStatus = TripStatus(
             route,
             mockk {
@@ -300,6 +330,8 @@ class NavigatorMapperTest {
                     )
                 }
                 every { layer } returns 2
+                every { roadName } returns "Central Avenue"
+                every { shieldName } returns "I880"
             }
         )
         val expected = LocationMatcherResult(
@@ -315,9 +347,10 @@ class NavigatorMapperTest {
             ),
             roadEdgeMatchProbability = 1f,
             zLevel = 2,
+            road = road
         )
 
-        val result = tripStatus.getLocationMatcherResult(enhancedLocation, keyPoints)
+        val result = tripStatus.getLocationMatcherResult(enhancedLocation, keyPoints, road)
 
         assertEquals(expected, result)
     }
@@ -496,6 +529,8 @@ class NavigatorMapperTest {
         every { voiceInstruction } returns nativeVoiceInstructions
         every { inTunnel } returns true
         every { upcomingRouteAlerts } returns emptyList()
+        every { roadName } returns "Central Avenue"
+        every { shieldName } returns "I880"
     }
 
     val routeAlertLocation: RouteAlertLocation = mockk()

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
@@ -150,7 +150,9 @@ class MapboxTripSessionTest {
         every { tripStatus.navigationStatus } returns navigationStatus
         every { tripStatus.route } returns route
 
-        every { tripStatus.getLocationMatcherResult(any(), any()) } returns locationMatcherResult
+        every {
+            tripStatus.getLocationMatcherResult(any(), any(), any())
+        } returns locationMatcherResult
         every { routeProgress.bannerInstructions } returns null
         every { routeProgress.voiceInstructions } returns null
         every { routeProgress.currentLegProgress } returns mockk(relaxed = true)


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Fixed #4971 
The PR introduces a `Road` object that is created using the road data derived from `NavigationStatus`. The data includes `roadName`, `shieldName` and `shieldUrl`. At the moment `NavigationStatus` doesn't report `shieldUrl` and hence this value is always null. `NavigationStatus.roadName` and `NavigationStatus.shieldName`, both are `@NonNullable`, but in the `Road` object all are `@Nullable` in case these informations are not present in the free drive mode. The information about the `Road` is now available through `LocationMatcherResult`. This makes the interface to extract this data very easy on the UI and helps avoiding `EHorizonObserver` which is chargeable in free drive mode and hence cannot be used in Drop-In UI.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Added a new `Road` object that can be obtained thorough `LocationMatcherResult`.</changelog>
```

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
