### PR TITLE
pass LocationMatcherResult to RouteOptionsUpdater

### DIFF
--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -513,7 +513,7 @@ package com.mapbox.navigation.core.routeoptions {
 
   public final class RouteOptionsUpdater {
     ctor public RouteOptionsUpdater();
-    method public com.mapbox.navigation.core.routeoptions.RouteOptionsUpdater.RouteOptionsResult update(com.mapbox.api.directions.v5.models.RouteOptions? routeOptions, com.mapbox.navigation.base.trip.model.RouteProgress? routeProgress, android.location.Location? location);
+    method public com.mapbox.navigation.core.routeoptions.RouteOptionsUpdater.RouteOptionsResult update(com.mapbox.api.directions.v5.models.RouteOptions? routeOptions, com.mapbox.navigation.base.trip.model.RouteProgress? routeProgress, com.mapbox.navigation.core.trip.session.LocationMatcherResult? locationMatcherResult);
   }
 
   public abstract static sealed class RouteOptionsUpdater.RouteOptionsResult {

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/reroute/MapboxRerouteController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/reroute/MapboxRerouteController.kt
@@ -64,7 +64,7 @@ internal class MapboxRerouteController(
         routeOptionsUpdater.update(
             directionsSession.getPrimaryRouteOptions(),
             tripSession.getRouteProgress(),
-            tripSession.locationMatcherResult?.enhancedLocation,
+            tripSession.locationMatcherResult,
         )
             .let { routeOptionsResult ->
                 when (routeOptionsResult) {

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesController.kt
@@ -76,7 +76,7 @@ internal class RouteAlternativesController(
         val routeOptionsResult = routeOptionsUpdater.update(
             directionsSession.getPrimaryRouteOptions(),
             tripSession.getRouteProgress(),
-            tripSession.locationMatcherResult?.enhancedLocation,
+            tripSession.locationMatcherResult,
         )
 
         when (routeOptionsResult) {

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/routeoptions/RouteOptionsUpdaterParameterizedTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/routeoptions/RouteOptionsUpdaterParameterizedTest.kt
@@ -7,6 +7,7 @@ import com.mapbox.core.constants.Constants
 import com.mapbox.geojson.Point
 import com.mapbox.navigation.base.trip.model.RouteLegProgress
 import com.mapbox.navigation.base.trip.model.RouteProgress
+import com.mapbox.navigation.core.trip.session.LocationMatcherResult
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.mockk
@@ -62,7 +63,7 @@ class RouteOptionsUpdaterParameterizedTest(
     }
 
     private lateinit var routeRefreshAdapter: RouteOptionsUpdater
-    private lateinit var location: Location
+    private lateinit var locationMatcherResult: LocationMatcherResult
 
     @Before
     fun setup() {
@@ -85,7 +86,7 @@ class RouteOptionsUpdaterParameterizedTest(
         every { routeProgress.remainingWaypoints } returns remainingWaypoints
 
         val updatedRouteOptions =
-            routeRefreshAdapter.update(routeOptions, routeProgress, location)
+            routeRefreshAdapter.update(routeOptions, routeProgress, locationMatcherResult)
                 .let {
                     assertTrue(it is RouteOptionsUpdater.RouteOptionsResult.Success)
                     return@let it as RouteOptionsUpdater.RouteOptionsResult.Success
@@ -100,10 +101,13 @@ class RouteOptionsUpdaterParameterizedTest(
     }
 
     private fun mockLocation() {
-        location = mockk(relaxUnitFun = true)
+        val location = mockk<Location>(relaxUnitFun = true)
         every { location.longitude } returns -122.4232
         every { location.latitude } returns 23.54423
         every { location.bearing } returns 11f
+        locationMatcherResult = mockk {
+            every { enhancedLocation } returns location
+        }
     }
 
     private fun provideRouteOptionsWithCoordinates() =

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/routeoptions/RouteOptionsUpdaterTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/routeoptions/RouteOptionsUpdaterTest.kt
@@ -7,6 +7,7 @@ import com.mapbox.api.directions.v5.models.RouteOptions
 import com.mapbox.core.constants.Constants
 import com.mapbox.geojson.Point
 import com.mapbox.navigation.base.trip.model.RouteProgress
+import com.mapbox.navigation.core.trip.session.LocationMatcherResult
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.mockk
@@ -21,7 +22,7 @@ import org.junit.runners.Parameterized
 class RouteOptionsUpdaterTest {
 
     private lateinit var routeRefreshAdapter: RouteOptionsUpdater
-    private lateinit var location: Location
+    private lateinit var locationMatcherResult: LocationMatcherResult
 
     companion object {
         private const val DEFAULT_REROUTE_BEARING_ANGLE = 11f
@@ -114,7 +115,7 @@ class RouteOptionsUpdaterTest {
         }
 
         val newRouteOptions =
-            routeRefreshAdapter.update(routeOptions, routeProgress, location)
+            routeRefreshAdapter.update(routeOptions, routeProgress, locationMatcherResult)
                 .let {
                     assertTrue(it is RouteOptionsUpdater.RouteOptionsResult.Success)
                     return@let it as RouteOptionsUpdater.RouteOptionsResult.Success
@@ -142,7 +143,7 @@ class RouteOptionsUpdaterTest {
         }
 
         val newRouteOptions =
-            routeRefreshAdapter.update(routeOptions, routeProgress, location)
+            routeRefreshAdapter.update(routeOptions, routeProgress, locationMatcherResult)
                 .let {
                     assertTrue(it is RouteOptionsUpdater.RouteOptionsResult.Success)
                     return@let it as RouteOptionsUpdater.RouteOptionsResult.Success
@@ -173,26 +174,28 @@ class RouteOptionsUpdaterTest {
         }
 
         val newRouteOptions =
-            routeRefreshAdapter.update(routeOptions, routeProgress, location)
+            routeRefreshAdapter.update(routeOptions, routeProgress, locationMatcherResult)
 
         assertTrue(newRouteOptions is RouteOptionsUpdater.RouteOptionsResult.Error)
     }
 
     @Test
     fun no_options_on_invalid_input() {
-        val invalidInput = mutableListOf<Triple<RouteOptions?, RouteProgress?, Location?>>()
-        invalidInput.add(Triple(null, mockk(), mockk()))
-        invalidInput.add(Triple(mockk(), null, null))
-        invalidInput.add(Triple(mockk(), mockk(), null))
+        val invalidInput = listOf<Triple<RouteOptions?, RouteProgress?, LocationMatcherResult?>>(
+            Triple(null, mockk(), mockk()),
+            Triple(mockk(), null, null),
+            Triple(mockk(), mockk(), null),
+        )
 
-        invalidInput.forEach { (routeOptions, routeProgress, location) ->
+        invalidInput.forEach { (routeOptions, routeProgress, locationMatcherResult) ->
             val message =
                 "routeOptions is ${routeOptions.isNullToString()}; routeProgress is " +
-                    "${routeProgress.isNullToString()}; location is ${location.isNullToString()}"
+                    "${routeProgress.isNullToString()}; locationMatcherResult is " +
+                    locationMatcherResult.isNullToString()
 
             assertTrue(
                 message,
-                routeRefreshAdapter.update(routeOptions, routeProgress, location)
+                routeRefreshAdapter.update(routeOptions, routeProgress, locationMatcherResult)
                 is RouteOptionsUpdater.RouteOptionsResult.Error
             )
         }
@@ -206,7 +209,7 @@ class RouteOptionsUpdaterTest {
         }
 
         val newRouteOptions =
-            routeRefreshAdapter.update(routeOptions, routeProgress, location)
+            routeRefreshAdapter.update(routeOptions, routeProgress, locationMatcherResult)
                 .let {
                     assertTrue(it is RouteOptionsUpdater.RouteOptionsResult.Success)
                     return@let it as RouteOptionsUpdater.RouteOptionsResult.Success
@@ -219,10 +222,13 @@ class RouteOptionsUpdaterTest {
     }
 
     private fun mockLocation() {
-        location = mockk(relaxUnitFun = true)
+        val location = mockk<Location>(relaxUnitFun = true)
         every { location.longitude } returns -122.4232
         every { location.latitude } returns 23.54423
         every { location.bearing } returns DEFAULT_REROUTE_BEARING_ANGLE
+        locationMatcherResult = mockk {
+            every { enhancedLocation } returns location
+        }
     }
 
     @RunWith(Parameterized::class)
@@ -233,7 +239,7 @@ class RouteOptionsUpdaterTest {
     ) {
 
         private lateinit var routeRefreshAdapter: RouteOptionsUpdater
-        private lateinit var location: Location
+        private lateinit var locationMatcherResult: LocationMatcherResult
 
         companion object {
             @JvmStatic
@@ -339,7 +345,7 @@ class RouteOptionsUpdaterTest {
             }
 
             val newRouteOptions =
-                routeRefreshAdapter.update(routeOptions, routeProgress, location)
+                routeRefreshAdapter.update(routeOptions, routeProgress, locationMatcherResult)
                     .let {
                         assertTrue(it is RouteOptionsUpdater.RouteOptionsResult.Success)
                         return@let it as RouteOptionsUpdater.RouteOptionsResult.Success
@@ -353,10 +359,13 @@ class RouteOptionsUpdaterTest {
         }
 
         private fun mockLocation() {
-            location = mockk(relaxUnitFun = true)
+            val location = mockk<Location>(relaxUnitFun = true)
             every { location.longitude } returns -122.4232
             every { location.latitude } returns 23.54423
             every { location.bearing } returns DEFAULT_REROUTE_BEARING_ANGLE
+            locationMatcherResult = mockk {
+                every { enhancedLocation } returns location
+            }
         }
     }
 
@@ -369,7 +378,7 @@ class RouteOptionsUpdaterTest {
     ) {
 
         private lateinit var routeRefreshAdapter: RouteOptionsUpdater
-        private lateinit var location: Location
+        private lateinit var locationMatcherResult: LocationMatcherResult
 
         companion object {
             @JvmStatic
@@ -436,7 +445,7 @@ class RouteOptionsUpdaterTest {
             }
 
             val newRouteOptions =
-                routeRefreshAdapter.update(routeOptions, routeProgress, location)
+                routeRefreshAdapter.update(routeOptions, routeProgress, locationMatcherResult)
                     .let {
                         assertTrue(it is RouteOptionsUpdater.RouteOptionsResult.Success)
                         return@let it as RouteOptionsUpdater.RouteOptionsResult.Success
@@ -450,10 +459,13 @@ class RouteOptionsUpdaterTest {
         }
 
         private fun mockLocation() {
-            location = mockk(relaxUnitFun = true)
+            val location = mockk<Location>(relaxUnitFun = true)
             every { location.longitude } returns -122.4232
             every { location.latitude } returns 23.54423
             every { location.bearing } returns DEFAULT_REROUTE_BEARING_ANGLE
+            locationMatcherResult = mockk {
+                every { enhancedLocation } returns location
+            }
         }
     }
 }


### PR DESCRIPTION
### Description
Refs #4970. This aligns `RouteOptionsUpdater` API with `main` branch, so that deprecating would not be required for 2.1. 
The changes are mostly from #4849, but excluding z-level stuff. 

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Changed `RouteOptionsUpdater.update` signature to accept `LocationMatcherResult`</changelog>
```

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
