### PR TITLE
removed style loaded checks

### DIFF
--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/debugger/MapboxNavigationViewportDataSourceDebugger.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/debugger/MapboxNavigationViewportDataSourceDebugger.kt
@@ -238,7 +238,7 @@ class MapboxNavigationViewportDataSourceDebugger @JvmOverloads constructor(
         }
 
         val style = mapboxMap.getStyle()
-        if (enabled && style != null && style.isStyleLoaded) {
+        if (enabled && style != null) {
             if (!style.styleSourceExists(pointsSourceId)) {
                 val source = geoJsonSource(pointsSourceId) { }.featureCollection(featureCollection)
                 style.addSource(source)

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtils.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtils.kt
@@ -824,11 +824,7 @@ object MapboxRouteLineUtils {
     }
 
     internal fun getLayerVisibility(style: Style, layerId: String): Visibility? {
-        return if (style.isStyleLoaded) {
-            style.getLayer(layerId)?.visibility
-        } else {
-            null
-        }
+        return style.getLayer(layerId)?.visibility
     }
 
     /**
@@ -940,7 +936,7 @@ object MapboxRouteLineUtils {
 
     @OptIn(MapboxExperimental::class)
     internal fun initializeLayers(style: Style, options: MapboxRouteLineOptions) {
-        if (!style.isStyleLoaded || layersAreInitialized(style, options)) {
+        if (layersAreInitialized(style, options)) {
             return
         }
         val belowLayerIdToUse: String? =
@@ -1061,8 +1057,7 @@ object MapboxRouteLineUtils {
     }
 
     internal fun layersAreInitialized(style: Style, options: MapboxRouteLineOptions): Boolean {
-        return style.isStyleLoaded &&
-            style.styleSourceExists(RouteLayerConstants.PRIMARY_ROUTE_SOURCE_ID) &&
+        return style.styleSourceExists(RouteLayerConstants.PRIMARY_ROUTE_SOURCE_ID) &&
             style.styleSourceExists(RouteLayerConstants.ALTERNATIVE_ROUTE1_SOURCE_ID) &&
             style.styleSourceExists(RouteLayerConstants.ALTERNATIVE_ROUTE2_SOURCE_ID) &&
             style.styleLayerExists(RouteLayerConstants.PRIMARY_ROUTE_LAYER_ID) &&

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/arrow/RouteArrowUtils.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/arrow/RouteArrowUtils.kt
@@ -58,7 +58,7 @@ internal object RouteArrowUtils {
 
     @OptIn(MapboxExperimental::class)
     fun initializeLayers(style: Style, options: RouteArrowOptions) {
-        if (!style.isStyleLoaded || layersAreInitialized(style)) {
+        if (layersAreInitialized(style)) {
             return
         }
 
@@ -256,8 +256,7 @@ internal object RouteArrowUtils {
     }
 
     internal fun layersAreInitialized(style: Style): Boolean {
-        return style.isStyleLoaded &&
-            style.styleSourceExists(RouteLayerConstants.ARROW_SHAFT_SOURCE_ID) &&
+        return style.styleSourceExists(RouteLayerConstants.ARROW_SHAFT_SOURCE_ID) &&
             style.styleSourceExists(RouteLayerConstants.ARROW_HEAD_SOURCE_ID) &&
             style.styleLayerExists(RouteLayerConstants.ARROW_SHAFT_CASING_LINE_LAYER_ID) &&
             style.styleLayerExists(RouteLayerConstants.ARROW_HEAD_CASING_LAYER_ID) &&

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/arrow/api/MapboxRouteArrowView.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/arrow/api/MapboxRouteArrowView.kt
@@ -178,19 +178,17 @@ class MapboxRouteArrowView(private val options: RouteArrowOptions) {
     }
 
     private fun updateLayerVisibility(style: Style, layerId: String, visibility: Visibility) {
-        if (style.isStyleLoaded) {
-            style.getLayer(layerId)?.visibility(visibility)
-        }
+        style.getLayer(layerId)?.visibility(visibility)
     }
 
     private fun updateSource(style: Style, sourceId: String, feature: Feature) {
-        if (style.isStyleLoaded && style.styleSourceExists(sourceId)) {
+        if (style.styleSourceExists(sourceId)) {
             style.getSourceAs<GeoJsonSource>(sourceId)?.feature(feature)
         }
     }
 
     private fun updateSource(style: Style, sourceId: String, featureCollection: FeatureCollection) {
-        if (style.isStyleLoaded && style.styleSourceExists(sourceId)) {
+        if (style.styleSourceExists(sourceId)) {
             style.getSourceAs<GeoJsonSource>(sourceId)?.featureCollection(featureCollection)
         }
     }

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineView.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineView.kt
@@ -448,16 +448,12 @@ class MapboxRouteLineView(var options: MapboxRouteLineOptions) {
     }
 
     private fun updateLayerVisibility(style: Style, layerId: String, visibility: Visibility) {
-        if (style.isStyleLoaded) {
-            style.getLayer(layerId)?.visibility(visibility)
-        }
+        style.getLayer(layerId)?.visibility(visibility)
     }
 
     private fun updateSource(style: Style, sourceId: String, featureCollection: FeatureCollection) {
-        if (style.isStyleLoaded) {
-            style.getSource(sourceId)?.let {
-                (it as GeoJsonSource).featureCollection(featureCollection)
-            }
+        style.getSource(sourceId)?.let {
+            (it as GeoJsonSource).featureCollection(featureCollection)
         }
     }
 
@@ -492,10 +488,8 @@ class MapboxRouteLineView(var options: MapboxRouteLineOptions) {
     }
 
     private fun updateLineGradient(style: Style, layerId: String, expression: Expression) {
-        if (style.isStyleLoaded) {
-            style.getLayer(layerId)?.let {
-                (it as LineLayer).lineGradient(expression)
-            }
+        style.getLayer(layerId)?.let {
+            (it as LineLayer).lineGradient(expression)
         }
     }
 }

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtilsTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtilsTest.kt
@@ -290,7 +290,6 @@ class MapboxRouteLineUtilsTest {
             every { displayRestrictedRoadSections } returns true
         }
         val style = mockk<Style> {
-            every { isStyleLoaded } returns true
             every { styleSourceExists(PRIMARY_ROUTE_SOURCE_ID) } returns true
             every { styleSourceExists(ALTERNATIVE_ROUTE1_SOURCE_ID) } returns true
             every { styleSourceExists(ALTERNATIVE_ROUTE2_SOURCE_ID) } returns true
@@ -326,7 +325,6 @@ class MapboxRouteLineUtilsTest {
         val result = MapboxRouteLineUtils.layersAreInitialized(style, options)
 
         assertTrue(result)
-        verify { style.isStyleLoaded }
         verify { style.styleSourceExists(PRIMARY_ROUTE_SOURCE_ID) }
         verify { style.styleSourceExists(ALTERNATIVE_ROUTE1_SOURCE_ID) }
         verify { style.styleSourceExists(ALTERNATIVE_ROUTE2_SOURCE_ID) }
@@ -348,7 +346,6 @@ class MapboxRouteLineUtilsTest {
             every { displayRestrictedRoadSections } returns false
         }
         val style = mockk<Style> {
-            every { isStyleLoaded } returns true
             every { styleSourceExists(PRIMARY_ROUTE_SOURCE_ID) } returns true
             every { styleSourceExists(ALTERNATIVE_ROUTE1_SOURCE_ID) } returns true
             every { styleSourceExists(ALTERNATIVE_ROUTE2_SOURCE_ID) } returns true
@@ -384,7 +381,6 @@ class MapboxRouteLineUtilsTest {
         val result = MapboxRouteLineUtils.layersAreInitialized(style, options)
 
         assertTrue(result)
-        verify { style.isStyleLoaded }
         verify { style.styleSourceExists(PRIMARY_ROUTE_SOURCE_ID) }
         verify { style.styleSourceExists(ALTERNATIVE_ROUTE1_SOURCE_ID) }
         verify { style.styleSourceExists(ALTERNATIVE_ROUTE2_SOURCE_ID) }
@@ -403,23 +399,10 @@ class MapboxRouteLineUtilsTest {
     }
 
     @Test
-    fun initializeLayers_whenStyleNotLoaded() {
-        val options = MapboxRouteLineOptions.Builder(ctx).build()
-        val style = mockk<Style> {
-            every { isStyleLoaded } returns false
-        }
-
-        MapboxRouteLineUtils.initializeLayers(style, options)
-
-        verify(exactly = 0) { style.styleSourceExists(any()) }
-    }
-
-    @Test
     fun initializeLayers_whenLayersAreInitialized() {
         val options = MapboxRouteLineOptions.Builder(ctx).build()
         val style = mockk<Style> {
             every { styleLayers } returns listOf()
-            every { isStyleLoaded } returns true
             every { styleSourceExists(PRIMARY_ROUTE_SOURCE_ID) } returns true
             every { styleSourceExists(ALTERNATIVE_ROUTE1_SOURCE_ID) } returns true
             every { styleSourceExists(ALTERNATIVE_ROUTE2_SOURCE_ID) } returns true
@@ -482,7 +465,6 @@ class MapboxRouteLineUtilsTest {
             every { id } returns LocationComponentConstants.MODEL_LAYER
         }
         val style = mockk<Style> {
-            every { isStyleLoaded } returns true
             every { styleLayers } returns listOf(mockLayer)
             every { styleSourceExists(PRIMARY_ROUTE_SOURCE_ID) } returns false
             every { styleSourceExists(ALTERNATIVE_ROUTE1_SOURCE_ID) } returns false
@@ -1790,7 +1772,6 @@ class MapboxRouteLineUtilsTest {
         }
 
         val style = mockk<Style> {
-            every { isStyleLoaded } returns true
             every { getLayer("foobar") } returns layer
         }
 
@@ -1801,21 +1782,9 @@ class MapboxRouteLineUtilsTest {
     }
 
     @Test
-    fun getLayerVisibility_whenStyleNotLoaded() {
-        val style = mockk<Style> {
-            every { isStyleLoaded } returns false
-        }
-
-        val result = MapboxRouteLineUtils.getLayerVisibility(style, "foobar")
-
-        assertNull(result)
-    }
-
-    @Test
     fun getLayerVisibility_whenLayerNotFound() {
         mockkStatic("com.mapbox.maps.extension.style.layers.LayerUtils")
         val style = mockk<Style> {
-            every { isStyleLoaded } returns true
             every { getLayer("foobar") } returns null
         }
 

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/arrow/RouteArrowUtilsTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/arrow/RouteArrowUtilsTest.kt
@@ -150,7 +150,6 @@ class RouteArrowUtilsTest {
     @Test
     fun layersAreInitialized() {
         val style = mockk<Style> {
-            every { isStyleLoaded } returns true
             every { styleSourceExists(ARROW_SHAFT_SOURCE_ID) } returns true
             every { styleSourceExists(ARROW_HEAD_SOURCE_ID) } returns true
             every {
@@ -164,7 +163,6 @@ class RouteArrowUtilsTest {
         val result = RouteArrowUtils.layersAreInitialized(style)
 
         assertTrue(result)
-        verify { style.isStyleLoaded }
         verify { style.styleSourceExists(ARROW_SHAFT_SOURCE_ID) }
         verify { style.styleSourceExists(ARROW_HEAD_SOURCE_ID) }
         verify { style.styleLayerExists(ARROW_SHAFT_CASING_LINE_LAYER_ID) }
@@ -174,23 +172,10 @@ class RouteArrowUtilsTest {
     }
 
     @Test
-    fun initializeLayers_whenStyleNotLoaded() {
-        val options = RouteArrowOptions.Builder(ctx).build()
-        val style = mockk<Style> {
-            every { isStyleLoaded } returns false
-        }
-
-        RouteArrowUtils.initializeLayers(style, options)
-
-        verify(exactly = 0) { style.styleSourceExists(any()) }
-    }
-
-    @Test
     fun initializeLayers_whenLayersAreInitialized() {
         val options = RouteArrowOptions.Builder(ctx).build()
         val style = mockk<Style> {
             every { styleLayers } returns listOf()
-            every { isStyleLoaded } returns true
             every { styleSourceExists(ARROW_SHAFT_SOURCE_ID) } returns true
             every { styleSourceExists(ARROW_HEAD_SOURCE_ID) } returns true
             every {
@@ -224,7 +209,6 @@ class RouteArrowUtilsTest {
         val mockImage = mockk<Image>(relaxed = true)
 
         val style = mockk<Style>(relaxed = true) {
-            every { isStyleLoaded } returns true
             every { styleLayers } returns listOf()
             every { styleSourceExists(ARROW_SHAFT_SOURCE_ID) } returns false
             every { styleSourceExists(ARROW_HEAD_SOURCE_ID) } returns false
@@ -363,7 +347,6 @@ class RouteArrowUtilsTest {
         val mockImage = mockk<Image>(relaxed = true)
 
         val style = mockk<Style>(relaxed = true) {
-            every { isStyleLoaded } returns true
             every { styleLayers } returns listOf()
             every { styleSourceExists(ARROW_SHAFT_SOURCE_ID) } returns false
             every { styleSourceExists(ARROW_HEAD_SOURCE_ID) } returns false
@@ -437,7 +420,6 @@ class RouteArrowUtilsTest {
         val addStyleLayerSlots = mutableListOf<Value>()
         val addStyleLayerPositionSlots = mutableListOf<LayerPosition>()
         val style = mockk<Style>(relaxed = true) {
-            every { isStyleLoaded } returns true
             every { styleLayers } returns listOf()
             every { styleSourceExists(ARROW_SHAFT_SOURCE_ID) } returns false
             every { styleSourceExists(ARROW_HEAD_SOURCE_ID) } returns false
@@ -582,7 +564,6 @@ class RouteArrowUtilsTest {
             every { arrowHeadScaleExpression } returns options.arrowHeadScaleExpression
         }
         val style = mockk<Style>(relaxed = true) {
-            every { isStyleLoaded } returns true
             every { styleLayers } returns listOf()
             every { styleSourceExists(ARROW_SHAFT_SOURCE_ID) } returns true
             every { styleSourceExists(ARROW_HEAD_SOURCE_ID) } returns true
@@ -633,7 +614,6 @@ class RouteArrowUtilsTest {
             every { arrowHeadScaleExpression } returns options.arrowHeadScaleExpression
         }
         val style = mockk<Style>(relaxed = true) {
-            every { isStyleLoaded } returns true
             every { styleLayers } returns listOf()
             every { styleSourceExists(ARROW_SHAFT_SOURCE_ID) } returns true
             every { styleSourceExists(ARROW_HEAD_SOURCE_ID) } returns true
@@ -684,7 +664,6 @@ class RouteArrowUtilsTest {
             every { arrowHeadScaleExpression } returns options.arrowHeadScaleExpression
         }
         val style = mockk<Style>(relaxed = true) {
-            every { isStyleLoaded } returns true
             every { styleLayers } returns listOf()
             every { styleSourceExists(ARROW_SHAFT_SOURCE_ID) } returns true
             every { styleSourceExists(ARROW_HEAD_SOURCE_ID) } returns true
@@ -735,7 +714,6 @@ class RouteArrowUtilsTest {
             every { arrowHeadScaleExpression } returns options.arrowHeadScaleExpression
         }
         val style = mockk<Style>(relaxed = true) {
-            every { isStyleLoaded } returns true
             every { styleLayers } returns listOf()
             every { styleSourceExists(ARROW_SHAFT_SOURCE_ID) } returns true
             every { styleSourceExists(ARROW_HEAD_SOURCE_ID) } returns true

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/arrow/api/MapboxRouteArrowViewTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/arrow/api/MapboxRouteArrowViewTest.kt
@@ -64,7 +64,6 @@ class MapboxRouteArrowViewTest {
             listOf(Pair(ARROW_SHAFT_LINE_LAYER_ID, Visibility.NONE))
         )
         val style = mockk<Style> {
-            every { isStyleLoaded } returns true
             every { getLayer(ARROW_SHAFT_LINE_LAYER_ID) } returns arrowLayer
         }.also {
             mockCheckForLayerInitialization(it)
@@ -99,7 +98,6 @@ class MapboxRouteArrowViewTest {
             arrowHeadFeature
         )
         val style = mockk<Style> {
-            every { isStyleLoaded } returns true
             every { getSource(ARROW_HEAD_SOURCE_ID) } returns arrowHeadSource
             every { getSource(ARROW_SHAFT_SOURCE_ID) } returns arrowShaftSource
             every { getLayer(ARROW_SHAFT_LINE_LAYER_ID) } returns arrowLayer
@@ -129,7 +127,6 @@ class MapboxRouteArrowViewTest {
         val arrowShaftSource = mockk<GeoJsonSource>(relaxed = true)
         val arrowHeadSource = mockk<GeoJsonSource>(relaxed = true)
         val style = mockk<Style> {
-            every { isStyleLoaded } returns true
             every { getSource(ARROW_HEAD_SOURCE_ID) } returns arrowHeadSource
             every { getSource(ARROW_SHAFT_SOURCE_ID) } returns arrowShaftSource
         }.also {
@@ -157,7 +154,6 @@ class MapboxRouteArrowViewTest {
         val arrowShaftSource = mockk<GeoJsonSource>(relaxed = true)
         val arrowHeadSource = mockk<GeoJsonSource>(relaxed = true)
         val style = mockk<Style> {
-            every { isStyleLoaded } returns true
             every { getSource(ARROW_HEAD_SOURCE_ID) } returns arrowHeadSource
             every { getSource(ARROW_SHAFT_SOURCE_ID) } returns arrowShaftSource
         }.also {
@@ -190,7 +186,6 @@ class MapboxRouteArrowViewTest {
         val arrowHeadSource = mockk<GeoJsonSource>(relaxed = true)
         val options = RouteArrowOptions.Builder(ctx).build()
         val style = mockk<Style> {
-            every { isStyleLoaded } returns true
             every { getSource(ARROW_HEAD_SOURCE_ID) } returns arrowHeadSource
             every { getSource(ARROW_SHAFT_SOURCE_ID) } returns arrowShaftSource
         }.also {
@@ -226,7 +221,6 @@ class MapboxRouteArrowViewTest {
         val arrowHeadSource = mockk<GeoJsonSource>(relaxed = true)
         val options = RouteArrowOptions.Builder(ctx).build()
         val style = mockk<Style> {
-            every { isStyleLoaded } returns true
             every { getSource(ARROW_HEAD_SOURCE_ID) } returns arrowHeadSource
             every { getSource(ARROW_SHAFT_SOURCE_ID) } returns arrowShaftSource
         }.also {
@@ -260,7 +254,6 @@ class MapboxRouteArrowViewTest {
         val arrowShaftSource = mockk<GeoJsonSource>(relaxed = true)
         val arrowHeadSource = mockk<GeoJsonSource>(relaxed = true)
         val style = mockk<Style> {
-            every { isStyleLoaded } returns true
             every { getSource(ARROW_HEAD_SOURCE_ID) } returns arrowHeadSource
             every { getSource(ARROW_SHAFT_SOURCE_ID) } returns arrowShaftSource
         }.also {

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineViewTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineViewTest.kt
@@ -127,7 +127,6 @@ class MapboxRouteLineViewTest {
         mockkObject(MapboxRouteLineUtils)
         val options = MapboxRouteLineOptions.Builder(ctx).build()
         val style = mockk<Style> {
-            every { isStyleLoaded } returns true
             every {
                 setStyleSourceProperty(PRIMARY_ROUTE_SOURCE_ID, any(), any())
             } returns ExpectedFactory.createNone()
@@ -164,7 +163,6 @@ class MapboxRouteLineViewTest {
         val altRoute2Source = mockk<GeoJsonSource>(relaxed = true)
         val wayPointSource = mockk<GeoJsonSource>(relaxed = true)
         val style = mockk<Style> {
-            every { isStyleLoaded } returns true
             every { getSource(PRIMARY_ROUTE_SOURCE_ID) } returns primaryRouteSource
             every { getSource(ALTERNATIVE_ROUTE1_SOURCE_ID) } returns altRoute1Source
             every { getSource(ALTERNATIVE_ROUTE2_SOURCE_ID) } returns altRoute2Source
@@ -235,7 +233,6 @@ class MapboxRouteLineViewTest {
         val restrictedLineLayer = mockk<LineLayer>(relaxed = true)
         val topLevelLayer = mockk<LineLayer>(relaxed = true)
         val style = mockk<Style> {
-            every { isStyleLoaded } returns true
             every {
                 getLayer(PRIMARY_ROUTE_TRAFFIC_LAYER_ID)
             } returns primaryRouteTrafficLayer
@@ -334,7 +331,6 @@ class MapboxRouteLineViewTest {
             )
         )
         val style = mockk<Style>(relaxed = true) {
-            every { isStyleLoaded } returns true
             every {
                 getLayer(PRIMARY_ROUTE_TRAFFIC_LAYER_ID)
             } returns primaryRouteTrafficLayer
@@ -398,7 +394,6 @@ class MapboxRouteLineViewTest {
         val primaryRouteCasingLayer = mockk<LineLayer>(relaxed = true)
 
         val style = mockk<Style> {
-            every { isStyleLoaded } returns true
             every {
                 getLayer(PRIMARY_ROUTE_TRAFFIC_LAYER_ID)
             } returns primaryRouteTrafficLayer
@@ -430,7 +425,6 @@ class MapboxRouteLineViewTest {
         val casingLayer = mockk<LineLayer>(relaxed = true)
 
         val style = mockk<Style> {
-            every { isStyleLoaded } returns true
             every {
                 getLayer(PRIMARY_ROUTE_TRAFFIC_LAYER_ID)
             } returns trafficLayer
@@ -464,7 +458,6 @@ class MapboxRouteLineViewTest {
         val altRouteTraffic2 = mockk<LineLayer>(relaxed = true)
 
         val style = mockk<Style> {
-            every { isStyleLoaded } returns true
             every {
                 getLayer(ALTERNATIVE_ROUTE1_LAYER_ID)
             } returns altRoute1
@@ -512,8 +505,6 @@ class MapboxRouteLineViewTest {
         val altRouteTraffic2 = mockk<LineLayer>(relaxed = true)
 
         val style = mockk<Style> {
-            every { isStyleLoaded } returns true
-
             every {
                 getLayer(ALTERNATIVE_ROUTE1_LAYER_ID)
             } returns altRoute1
@@ -556,7 +547,6 @@ class MapboxRouteLineViewTest {
         val options = MapboxRouteLineOptions.Builder(ctx).build()
         val waypointLayer = mockk<LineLayer>(relaxed = true)
         val style = mockk<Style> {
-            every { isStyleLoaded } returns true
             every { getLayer(WAYPOINT_LAYER_ID) } returns waypointLayer
         }.also {
             mockCheckForLayerInitialization(it)
@@ -576,7 +566,6 @@ class MapboxRouteLineViewTest {
         val waypointLayer = mockk<LineLayer>(relaxed = true)
         val options = MapboxRouteLineOptions.Builder(ctx).build()
         val style = mockk<Style> {
-            every { isStyleLoaded } returns true
             every { getLayer(WAYPOINT_LAYER_ID) } returns waypointLayer
         }.also {
             mockCheckForLayerInitialization(it)

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/MapboxRouteLineActivity.java
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/MapboxRouteLineActivity.java
@@ -201,7 +201,7 @@ public class MapboxRouteLineActivity extends AppCompatActivity implements OnMapL
     ((FloatingActionButton) findViewById(R.id.fabToggleStyle)).setOnClickListener(new View.OnClickListener() {
       @Override
       public void onClick(View view) {
-        if (mapboxMap.getStyle() == null || !mapboxMap.getStyle().isStyleLoaded()) {
+        if (mapboxMap.getStyle() == null) {
           return;
         }
 
@@ -502,7 +502,7 @@ public class MapboxRouteLineActivity extends AppCompatActivity implements OnMapL
   private final OnMapClickListener mapClickListener = new OnMapClickListener() {
     @Override
     public boolean onMapClick(@NotNull Point point) {
-      if (mapboxMap.getStyle() != null && mapboxMap.getStyle().isStyleLoaded()) {
+      if (mapboxMap.getStyle() != null) {
         Visibility primaryLineVisibility = mapboxRouteLineView.getPrimaryRouteVisibility(mapboxMap.getStyle());
         Visibility alternativeRouteLinesVisibility = mapboxRouteLineView.getAlternativeRoutesVisibility(mapboxMap.getStyle());
         if (primaryLineVisibility == Visibility.VISIBLE && alternativeRouteLinesVisibility == Visibility.VISIBLE) {


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Refs https://github.com/mapbox/mapbox-maps-android/issues/748. With the recent changes to async GeoJSON source parsing in GL-Native it surfaced that the style loaded checks that we used across the codebase did not behave as we expected them to. It turns out that we can safely remove all of them as all `Style` object instances point to same underlying native instance and the methods are safe to use regardless of whether the style is reloading or not.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Fixed an issue where the route line's elements (the primary route, alternatives, or the destination symbol) might intermittently not render or not update.</changelog>
```

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->
Example of the issue:

https://user-images.githubusercontent.com/16925074/137479992-fb89737c-7f33-4fa7-8f69-8cc038db33a4.mp4

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
