### PR TITLE
Fix FirstLocationIdlingResource race condition

### DIFF
--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/utils/idling/FirstLocationIdlingResource.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/utils/idling/FirstLocationIdlingResource.kt
@@ -19,7 +19,7 @@ class FirstLocationIdlingResource(
 
     var firstLocation: Location? = null
         private set
-    private lateinit var callback: IdlingResource.ResourceCallback
+    private var callback: IdlingResource.ResourceCallback? = null
 
     /**
      * This will block the execution of a test while waiting for the first
@@ -47,7 +47,7 @@ class FirstLocationIdlingResource(
         ) {
             callback = resourceCallback
             if (isIdleNow) {
-                callback.onTransitionToIdle()
+                callback?.onTransitionToIdle()
             }
         }
     }
@@ -61,7 +61,7 @@ class FirstLocationIdlingResource(
         override fun onNewLocationMatcherResult(locationMatcherResult: LocationMatcherResult) {
             if (firstLocation == null) {
                 firstLocation = locationMatcherResult.enhancedLocation
-                callback.onTransitionToIdle()
+                callback?.onTransitionToIdle()
             }
         }
     }


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Discovered over here https://github.com/mapbox/mapbox-navigation-android/pull/4984

There's a race-condition in `FirstLocationIdlingResource`

1. IdlingRegistry.getInstance().register(idlingResource)
2. mapboxNavigation.registerLocationObserver(locationObserver)

These two paths are off to race, but their callbacks are on the same thread.

```
2021-10-15 13:28:19.338 4028-4028/com.mapbox.navigation.instrumentation_tests I/kyle_debug: registerIdleTransitionCallback threadid=2
2021-10-15 13:28:19.343 4028-4028/com.mapbox.navigation.instrumentation_tests I/kyle_debug: onNewLocationMatcherResult threadid=2
```

The test will fail if onNewLocationMatcherResult is faster than registerIdleTransitionCallback

This fixes it because registerIdleTransitionCallback will transition to idle if it comes after
```
registerIdleTransitionCallback
if (isIdleNow) {
    callback?.onTransitionToIdle()
}
```