### PR TITLE
added additional checks to the reroute instrumentation checks

### DIFF
--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/CoreRerouteTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/CoreRerouteTest.kt
@@ -192,5 +192,14 @@ class CoreRerouteTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.jav
 
         // assert results
         expectedStates.assert()
+
+        runOnMainSync {
+            val newWaypoints =
+                mapboxNavigation.getRoutes().first().routeOptions()!!.coordinatesList()
+            check(newWaypoints.size == 2) {
+                "Expected 2 waypoints in the route after reroute but was ${newWaypoints.size}"
+            }
+            check(newWaypoints[1] == mockRoute.routeWaypoints.last())
+        }
     }
 }


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Adds a regression test in case the number of remaining waypoints is reported incorrectly which would break rerouting. 
