### PR TITLE
CP: fix legacy `route update reason` for new subscribers of RoutesObserver

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/MapboxDirectionsSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/MapboxDirectionsSession.kt
@@ -46,6 +46,7 @@ internal class MapboxDirectionsSession(
             return
         }
         this.routes = routes
+        this.routesUpdateReason = routesUpdateReason
         if (routes.isNotEmpty()) {
             primaryRouteOptions = routes[0].routeOptions()
         }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/directions/session/MapboxDirectionsSessionTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/directions/session/MapboxDirectionsSessionTest.kt
@@ -200,6 +200,19 @@ class MapboxDirectionsSessionTest {
     }
 
     @Test
+    fun `observer notified on subscribe with actual route data`() {
+        session.setRoutes(routes, 0, RoutesExtra.ROUTES_UPDATE_REASON_NEW)
+        val slot = slot<RoutesUpdatedResult>()
+        every { observer.onRoutesChanged(capture(slot)) } just runs
+
+        session.registerRoutesObserver(observer)
+
+        verify(exactly = 1) { observer.onRoutesChanged(slot.captured) }
+        assertEquals(slot.captured.reason, RoutesExtra.ROUTES_UPDATE_REASON_NEW)
+        assertEquals(slot.captured.routes, routes)
+    }
+
+    @Test
     fun `when route cleared, observer notified`() {
         val slot = mutableListOf<RoutesUpdatedResult>()
         every { observer.onRoutesChanged(capture(slot)) } just runs


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Legacy "route update reason" for new subscribers of `RoutesObserver`

CP https://github.com/mapbox/mapbox-navigation-android/pull/5006

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Fixed spread legacy `reason` when subscribing on routes updated via `RoutesObserver`</changelog>
```


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
