### PR TITLE
removes unused isFromNavigationUi option

### DIFF
--- a/libnavigation-base/api/current.txt
+++ b/libnavigation-base/api/current.txt
@@ -221,7 +221,6 @@ package com.mapbox.navigation.base.options {
     method public com.mapbox.navigation.base.options.RoutingTilesOptions getRoutingTilesOptions();
     method public int getTimeFormatType();
     method public boolean isDebugLoggingEnabled();
-    method public boolean isFromNavigationUi();
     method public com.mapbox.navigation.base.options.NavigationOptions.Builder toBuilder();
     property public final String? accessToken;
     property public final android.content.Context applicationContext;
@@ -232,7 +231,6 @@ package com.mapbox.navigation.base.options {
     property public final com.mapbox.navigation.base.options.HistoryRecorderOptions historyRecorderOptions;
     property public final com.mapbox.navigation.base.options.IncidentsOptions incidentsOptions;
     property public final boolean isDebugLoggingEnabled;
-    property public final boolean isFromNavigationUi;
     property public final com.mapbox.android.core.location.LocationEngine locationEngine;
     property public final com.mapbox.android.core.location.LocationEngineRequest locationEngineRequest;
     property public final long navigatorPredictionMillis;
@@ -253,7 +251,6 @@ package com.mapbox.navigation.base.options {
     method public com.mapbox.navigation.base.options.NavigationOptions.Builder historyRecorderOptions(com.mapbox.navigation.base.options.HistoryRecorderOptions historyRecorderOptions);
     method public com.mapbox.navigation.base.options.NavigationOptions.Builder incidentsOptions(com.mapbox.navigation.base.options.IncidentsOptions incidentsOptions);
     method public com.mapbox.navigation.base.options.NavigationOptions.Builder isDebugLoggingEnabled(boolean flag);
-    method public com.mapbox.navigation.base.options.NavigationOptions.Builder isFromNavigationUi(boolean flag);
     method public com.mapbox.navigation.base.options.NavigationOptions.Builder locationEngine(com.mapbox.android.core.location.LocationEngine locationEngine);
     method public com.mapbox.navigation.base.options.NavigationOptions.Builder locationEngineRequest(com.mapbox.android.core.location.LocationEngineRequest locationEngineRequest);
     method public com.mapbox.navigation.base.options.NavigationOptions.Builder navigatorPredictionMillis(long predictionMillis);

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/NavigationOptions.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/NavigationOptions.kt
@@ -31,7 +31,6 @@ const val DEFAULT_NAVIGATOR_PREDICTION_MILLIS = 1000L
  * @param navigatorPredictionMillis defines approximate navigator prediction in milliseconds
  * @param distanceFormatterOptions [DistanceFormatterOptions] options to format distances showing in notification during navigation
  * @param routingTilesOptions [RoutingTilesOptions] defines routing tiles endpoint and storage configuration.
- * @param isFromNavigationUi Boolean *true* if is called from UI, otherwise *false*
  * @param isDebugLoggingEnabled Boolean
  * @param deviceProfile [DeviceProfile] defines how navigation data should be interpreted
  * @param eHorizonOptions [EHorizonOptions] defines configuration for the Electronic Horizon
@@ -50,7 +49,6 @@ class NavigationOptions private constructor(
     val navigatorPredictionMillis: Long,
     val distanceFormatterOptions: DistanceFormatterOptions,
     val routingTilesOptions: RoutingTilesOptions,
-    val isFromNavigationUi: Boolean,
     val isDebugLoggingEnabled: Boolean,
     val deviceProfile: DeviceProfile,
     val eHorizonOptions: EHorizonOptions,
@@ -72,7 +70,6 @@ class NavigationOptions private constructor(
         navigatorPredictionMillis(navigatorPredictionMillis)
         distanceFormatterOptions(distanceFormatterOptions)
         routingTilesOptions(routingTilesOptions)
-        isFromNavigationUi(isFromNavigationUi)
         isDebugLoggingEnabled(isDebugLoggingEnabled)
         deviceProfile(deviceProfile)
         eHorizonOptions(eHorizonOptions)
@@ -100,7 +97,6 @@ class NavigationOptions private constructor(
         if (navigatorPredictionMillis != other.navigatorPredictionMillis) return false
         if (distanceFormatterOptions != other.distanceFormatterOptions) return false
         if (routingTilesOptions != other.routingTilesOptions) return false
-        if (isFromNavigationUi != other.isFromNavigationUi) return false
         if (isDebugLoggingEnabled != other.isDebugLoggingEnabled) return false
         if (deviceProfile != other.deviceProfile) return false
         if (eHorizonOptions != other.eHorizonOptions) return false
@@ -125,7 +121,6 @@ class NavigationOptions private constructor(
         result = 31 * result + navigatorPredictionMillis.hashCode()
         result = 31 * result + distanceFormatterOptions.hashCode()
         result = 31 * result + routingTilesOptions.hashCode()
-        result = 31 * result + isFromNavigationUi.hashCode()
         result = 31 * result + isDebugLoggingEnabled.hashCode()
         result = 31 * result + deviceProfile.hashCode()
         result = 31 * result + eHorizonOptions.hashCode()
@@ -150,7 +145,6 @@ class NavigationOptions private constructor(
             "navigatorPredictionMillis=$navigatorPredictionMillis, " +
             "distanceFormatterOptions=$distanceFormatterOptions, " +
             "routingTilesOptions=$routingTilesOptions, " +
-            "isFromNavigationUi=$isFromNavigationUi, " +
             "isDebugLoggingEnabled=$isDebugLoggingEnabled, " +
             "deviceProfile=$deviceProfile, " +
             "eHorizonOptions=$eHorizonOptions, " +
@@ -181,7 +175,6 @@ class NavigationOptions private constructor(
             DistanceFormatterOptions.Builder(applicationContext).build()
         private var routingTilesOptions: RoutingTilesOptions =
             RoutingTilesOptions.Builder().build()
-        private var isFromNavigationUi: Boolean = false
         private var isDebugLoggingEnabled: Boolean = false
         private var deviceProfile: DeviceProfile = DeviceProfile.Builder().build()
         private var eHorizonOptions: EHorizonOptions = EHorizonOptions.Builder().build()
@@ -242,12 +235,6 @@ class NavigationOptions private constructor(
             apply { this.routingTilesOptions = routingTilesOptions }
 
         /**
-         * Defines if the builder instance is created from the Navigation UI
-         */
-        fun isFromNavigationUi(flag: Boolean): Builder =
-            apply { this.isFromNavigationUi = flag }
-
-        /**
          * Defines if debug logging is enabled
          */
         fun isDebugLoggingEnabled(flag: Boolean): Builder =
@@ -304,7 +291,6 @@ class NavigationOptions private constructor(
                 navigatorPredictionMillis = navigatorPredictionMillis,
                 distanceFormatterOptions = distanceFormatterOptions,
                 routingTilesOptions = routingTilesOptions,
-                isFromNavigationUi = isFromNavigationUi,
                 isDebugLoggingEnabled = isDebugLoggingEnabled,
                 deviceProfile = deviceProfile,
                 eHorizonOptions = eHorizonOptions,

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/options/NavigationOptionsTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/options/NavigationOptionsTest.kt
@@ -52,7 +52,6 @@ class NavigationOptionsTest : BuilderTest<NavigationOptions, NavigationOptions.B
             .deviceProfile(mockk())
             .distanceFormatterOptions(mockk())
             .isDebugLoggingEnabled(true)
-            .isFromNavigationUi(true)
             .locationEngine(mockk())
             .locationEngineRequest(
                 LocationEngineRequest.Builder(1234L)

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -112,7 +112,6 @@ import java.lang.reflect.Field
 import java.util.Locale
 
 private const val MAPBOX_NAVIGATION_USER_AGENT_BASE = "mapbox-navigation-android"
-private const val MAPBOX_NAVIGATION_UI_USER_AGENT_BASE = "mapbox-navigation-ui-android"
 private const val MAPBOX_NAVIGATION_TOKEN_EXCEPTION_ROUTER =
     "You need to provide an access token in NavigationOptions in order to use the default " +
         "Router."
@@ -411,7 +410,7 @@ class MapboxNavigation(
             MapboxMetricsReporter.init(
                 navigationOptions.applicationContext,
                 token,
-                obtainUserAgent(navigationOptions.isFromNavigationUi)
+                obtainUserAgent()
             )
             MapboxMetricsReporter.toggleLogging(navigationOptions.isDebugLoggingEnabled)
             MapboxNavigationTelemetry.initialize(
@@ -1227,12 +1226,8 @@ class MapboxNavigation(
         }
     }
 
-    private fun obtainUserAgent(isFromNavigationUi: Boolean): String {
-        return if (isFromNavigationUi) {
-            "$MAPBOX_NAVIGATION_UI_USER_AGENT_BASE/${BuildConfig.MAPBOX_NAVIGATION_VERSION_NAME}"
-        } else {
-            "$MAPBOX_NAVIGATION_USER_AGENT_BASE/${BuildConfig.MAPBOX_NAVIGATION_VERSION_NAME}"
-        }
+    private fun obtainUserAgent(): String {
+        return "$MAPBOX_NAVIGATION_USER_AGENT_BASE/${BuildConfig.MAPBOX_NAVIGATION_VERSION_NAME}"
     }
 
     private fun monitorNotificationActionButton(channel: ReceiveChannel<NotificationAction>) {

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetry.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetry.kt
@@ -118,6 +118,7 @@ private enum class TelemetryNavSessionState {
 
 private const val LOG_TELEMETRY_IS_NOT_RUNNING = "Telemetry is not running"
 private const val LOG_TELEMETRY_NO_ROUTE_OR_ROUTE_PROGRESS = "no route or route progress"
+private const val SDK_IDENTIFIER = "mapbox-navigation-android"
 
 /**
  * The one and only Telemetry class. This class handles all telemetry events.
@@ -318,11 +319,7 @@ internal object MapboxNavigationTelemetry {
         navigationOptions = options
         applicationContext = options.applicationContext
         locationEngineNameExternal = options.locationEngine.javaClass.name
-        sdkIdentifier = if (options.isFromNavigationUi) {
-            "mapbox-navigation-ui-android"
-        } else {
-            "mapbox-navigation-android"
-        }
+        sdkIdentifier = SDK_IDENTIFIER
         metricsReporter = reporter
         feedbackEventCacheMap.clear()
         postTurnstileEvent()


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Removed unused `NavigationOptions#isFromNavigationUi`.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Removed unused `NavigationOption#isFromNavigationUi` option.</changelog>
```
