### PR TITLE
CP: NavTelemetry fix: cancel event send in idle state

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetry.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetry.kt
@@ -208,7 +208,7 @@ internal object MapboxNavigationTelemetry {
             reason == RoutesExtra.ROUTES_UPDATE_REASON_CLEAN_UP || routes.isEmpty() -> Unit
             reason == RoutesExtra.ROUTES_UPDATE_REASON_NEW -> {
                 log("handle a new route")
-                if (routeData.originalRoute != null) {
+                if (routeData.originalRoute != null && sessionState is ActiveGuidance) {
                     handleCancelNavigation()
                 }
                 resetLocalVariables()

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetryTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetryTest.kt
@@ -293,6 +293,21 @@ class MapboxNavigationTelemetryTest {
     @Test
     fun departEvent_sent_on_active_guidance_when_route_and_routeProgress_available() {
         baseMock()
+        mockAnotherRoute()
+
+        initTelemetry()
+        updateSessionState(Idle)
+        updateRoute(originalRoute)
+        updateRoute(anotherRoute)
+        updateRoute(originalRoute)
+
+        val events = captureAndVerifyMetricsReporter(exactly = 1)
+        assertTrue(events[0] is NavigationAppUserTurnstileEvent)
+    }
+
+    @Test
+    fun active_guidance_events_are_not_sent_in_idle() {
+        baseMock()
 
         baseInitialization()
 


### PR DESCRIPTION
### Description

NavTelemetry: fix `cancel` events are sent when trip session is not started

cherry-pick https://github.com/mapbox/mapbox-navigation-android/pull/5016


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
