### PR TITLE
Clear `VoiceInstructionsTextPlayer` `currentPlay` when `shutdown`

### DIFF
--- a/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/api/BundleProvider.kt
+++ b/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/api/BundleProvider.kt
@@ -1,0 +1,10 @@
+package com.mapbox.navigation.ui.voice.api
+
+import android.os.Bundle
+
+internal object BundleProvider {
+
+    fun retrieveBundle(): Bundle {
+        return Bundle()
+    }
+}

--- a/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/api/FileInputStreamProvider.kt
+++ b/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/api/FileInputStreamProvider.kt
@@ -1,0 +1,11 @@
+package com.mapbox.navigation.ui.voice.api
+
+import java.io.File
+import java.io.FileInputStream
+
+internal object FileInputStreamProvider {
+
+    fun retrieveFileInputStream(file: File): FileInputStream {
+        return FileInputStream(file)
+    }
+}

--- a/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/api/MediaPlayerProvider.kt
+++ b/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/api/MediaPlayerProvider.kt
@@ -1,0 +1,10 @@
+package com.mapbox.navigation.ui.voice.api
+
+import android.media.MediaPlayer
+
+internal object MediaPlayerProvider {
+
+    fun retrieveMediaPlayer(): MediaPlayer {
+        return MediaPlayer()
+    }
+}

--- a/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/api/VoiceInstructionsFilePlayer.kt
+++ b/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/api/VoiceInstructionsFilePlayer.kt
@@ -2,13 +2,13 @@ package com.mapbox.navigation.ui.voice.api
 
 import android.content.Context
 import android.media.MediaPlayer
+import androidx.annotation.VisibleForTesting
 import com.mapbox.base.common.logger.model.Message
 import com.mapbox.base.common.logger.model.Tag
 import com.mapbox.navigation.ui.voice.model.SpeechAnnouncement
 import com.mapbox.navigation.ui.voice.model.SpeechVolume
 import com.mapbox.navigation.utils.internal.LoggerProvider
 import java.io.File
-import java.io.FileInputStream
 import java.io.FileNotFoundException
 import java.io.IOException
 
@@ -25,10 +25,15 @@ internal class VoiceInstructionsFilePlayer(
     private val playerAttributes: VoiceInstructionsPlayerAttributes,
 ) : VoiceInstructionsPlayer {
 
-    private var mediaPlayer: MediaPlayer? = null
-    private var volumeLevel: Float = DEFAULT_VOLUME_LEVEL
+    @VisibleForTesting
+    internal var mediaPlayer: MediaPlayer? = null
+
+    @VisibleForTesting
+    internal var volumeLevel: Float = DEFAULT_VOLUME_LEVEL
     private var clientCallback: VoiceInstructionsPlayerCallback? = null
-    private var currentPlay: SpeechAnnouncement? = null
+
+    @VisibleForTesting
+    internal var currentPlay: SpeechAnnouncement? = null
 
     /**
      * Given [SpeechAnnouncement] the method will play the voice instruction.
@@ -88,9 +93,13 @@ internal class VoiceInstructionsFilePlayer(
 
     private fun play(instruction: File) {
         try {
-            FileInputStream(instruction).use { fis ->
-                mediaPlayer = MediaPlayer().apply {
-                    setDataSource(fis.fd)
+            val currentFileInputStream = FileInputStreamProvider.retrieveFileInputStream(
+                instruction
+            )
+            currentFileInputStream.use { fis ->
+                val currentMediaPlayer = MediaPlayerProvider.retrieveMediaPlayer()
+                mediaPlayer = currentMediaPlayer!!.apply {
+                    setDataSource(fis!!.fd)
                     playerAttributes.applyOn(this)
                     prepareAsync()
                 }

--- a/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/api/VoiceInstructionsTextPlayer.kt
+++ b/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/api/VoiceInstructionsTextPlayer.kt
@@ -1,9 +1,9 @@
 package com.mapbox.navigation.ui.voice.api
 
 import android.content.Context
-import android.os.Bundle
 import android.speech.tts.TextToSpeech
 import android.speech.tts.UtteranceProgressListener
+import androidx.annotation.VisibleForTesting
 import com.mapbox.base.common.logger.model.Message
 import com.mapbox.base.common.logger.model.Tag
 import com.mapbox.navigation.ui.voice.model.SpeechAnnouncement
@@ -23,15 +23,22 @@ internal class VoiceInstructionsTextPlayer(
     private val playerAttributes: VoiceInstructionsPlayerAttributes,
 ) : VoiceInstructionsPlayer {
 
-    private var isLanguageSupported: Boolean = false
-    private val textToSpeech = TextToSpeech(context.applicationContext) { status ->
+    @VisibleForTesting
+    internal var isLanguageSupported: Boolean = false
+
+    @VisibleForTesting
+    internal var textToSpeech = TextToSpeech(context.applicationContext) { status ->
         if (status == TextToSpeech.SUCCESS) {
             initializeWithLanguage(Locale(language))
         }
     }
-    private var volumeLevel: Float = DEFAULT_VOLUME_LEVEL
+
+    @VisibleForTesting
+    internal var volumeLevel: Float = DEFAULT_VOLUME_LEVEL
     private var clientCallback: VoiceInstructionsPlayerCallback? = null
-    private var currentPlay: SpeechAnnouncement? = null
+
+    @VisibleForTesting
+    internal var currentPlay: SpeechAnnouncement? = null
 
     /**
      * Given [SpeechAnnouncement] the method will play the voice instruction.
@@ -91,6 +98,7 @@ internal class VoiceInstructionsTextPlayer(
     override fun shutdown() {
         textToSpeech.setOnUtteranceProgressListener(null)
         textToSpeech.shutdown()
+        currentPlay = null
         volumeLevel = DEFAULT_VOLUME_LEVEL
     }
 
@@ -136,7 +144,8 @@ internal class VoiceInstructionsTextPlayer(
     }
 
     private fun play(announcement: String) {
-        val bundle = Bundle().apply {
+        val currentBundle = BundleProvider.retrieveBundle()
+        val bundle = currentBundle.apply {
             putFloat(TextToSpeech.Engine.KEY_PARAM_VOLUME, volumeLevel)
         }
         playerAttributes.applyOn(textToSpeech, bundle)

--- a/libnavui-voice/src/test/java/com/mapbox/navigation/ui/voice/api/VoiceInstructionsFilePlayerTest.kt
+++ b/libnavui-voice/src/test/java/com/mapbox/navigation/ui/voice/api/VoiceInstructionsFilePlayerTest.kt
@@ -1,0 +1,477 @@
+package com.mapbox.navigation.ui.voice.api
+
+import android.content.Context
+import android.media.MediaPlayer
+import com.mapbox.navigation.ui.voice.model.SpeechAnnouncement
+import com.mapbox.navigation.ui.voice.model.SpeechVolume
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.verify
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+import java.io.FileDescriptor
+import java.io.FileInputStream
+
+class VoiceInstructionsFilePlayerTest {
+
+    private val mockedMediaPlayer: MediaPlayer = mockk(relaxUnitFun = true)
+    private val mockedFileInputStream: FileInputStream = mockk(relaxUnitFun = true)
+
+    @Before
+    fun setUp() {
+        mockkObject(MediaPlayerProvider)
+        every { MediaPlayerProvider.retrieveMediaPlayer() } returns mockedMediaPlayer
+        mockkObject(FileInputStreamProvider)
+        every {
+            FileInputStreamProvider.retrieveFileInputStream(any())
+        } returns mockedFileInputStream
+    }
+
+    @After
+    fun tearDown() {
+        unmockkObject(MediaPlayerProvider)
+        unmockkObject(FileInputStreamProvider)
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `only one announcement can be played at a time`() {
+        val anyContext = mockk<Context>()
+        val anyAccessToken = "pk.1234"
+        val anyPlayerAttributes = mockk<VoiceInstructionsPlayerAttributes>()
+        val filePlayer =
+            VoiceInstructionsFilePlayer(anyContext, anyAccessToken, anyPlayerAttributes)
+        val anyAnnouncement = mockk<SpeechAnnouncement>(relaxed = true)
+        val anyVoiceInstructionsPlayerCallback =
+            mockk<VoiceInstructionsPlayerCallback>(relaxUnitFun = true)
+
+        filePlayer.currentPlay = anyAnnouncement
+
+        filePlayer.play(anyAnnouncement, anyVoiceInstructionsPlayerCallback)
+    }
+
+    @Test
+    fun `announcement file from state can't be null media player is released`() {
+        val anyContext = mockk<Context>()
+        val anyAccessToken = "pk.1234"
+        val anyPlayerAttributes = mockk<VoiceInstructionsPlayerAttributes>()
+        val filePlayer =
+            VoiceInstructionsFilePlayer(anyContext, anyAccessToken, anyPlayerAttributes)
+        val announcementWithNullFile = mockk<SpeechAnnouncement>(relaxed = true)
+        every { announcementWithNullFile.file } returns null
+        val anyVoiceInstructionsPlayerCallback =
+            mockk<VoiceInstructionsPlayerCallback>(relaxUnitFun = true)
+        filePlayer.mediaPlayer = mockedMediaPlayer
+
+        filePlayer.play(announcementWithNullFile, anyVoiceInstructionsPlayerCallback)
+
+        verify {
+            mockedMediaPlayer.release()
+        }
+    }
+
+    @Test
+    fun `announcement file from state can't be null media player is null`() {
+        val anyContext = mockk<Context>()
+        val anyAccessToken = "pk.1234"
+        val anyPlayerAttributes = mockk<VoiceInstructionsPlayerAttributes>()
+        val filePlayer =
+            VoiceInstructionsFilePlayer(anyContext, anyAccessToken, anyPlayerAttributes)
+        val announcementWithNullFile = mockk<SpeechAnnouncement>(relaxed = true)
+        every { announcementWithNullFile.file } returns null
+        val anyVoiceInstructionsPlayerCallback =
+            mockk<VoiceInstructionsPlayerCallback>(relaxUnitFun = true)
+
+        filePlayer.play(announcementWithNullFile, anyVoiceInstructionsPlayerCallback)
+
+        assertEquals(null, filePlayer.mediaPlayer)
+    }
+
+    @Test
+    fun `announcement file from state can't be null current play is null`() {
+        val anyContext = mockk<Context>()
+        val anyAccessToken = "pk.1234"
+        val anyPlayerAttributes = mockk<VoiceInstructionsPlayerAttributes>()
+        val filePlayer =
+            VoiceInstructionsFilePlayer(anyContext, anyAccessToken, anyPlayerAttributes)
+        val announcementWithNullFile = mockk<SpeechAnnouncement>(relaxed = true)
+        every { announcementWithNullFile.file } returns null
+        val anyVoiceInstructionsPlayerCallback =
+            mockk<VoiceInstructionsPlayerCallback>(relaxUnitFun = true)
+
+        filePlayer.play(announcementWithNullFile, anyVoiceInstructionsPlayerCallback)
+
+        assertEquals(null, filePlayer.currentPlay)
+    }
+
+    @Test
+    fun `announcement file from state can't be null onDone is called`() {
+        val anyContext = mockk<Context>()
+        val anyAccessToken = "pk.1234"
+        val anyPlayerAttributes = mockk<VoiceInstructionsPlayerAttributes>()
+        val filePlayer =
+            VoiceInstructionsFilePlayer(anyContext, anyAccessToken, anyPlayerAttributes)
+        val announcementWithNullFile = mockk<SpeechAnnouncement>(relaxed = true)
+        every { announcementWithNullFile.file } returns null
+        val anyVoiceInstructionsPlayerCallback =
+            mockk<VoiceInstructionsPlayerCallback>(relaxUnitFun = true)
+
+        filePlayer.play(announcementWithNullFile, anyVoiceInstructionsPlayerCallback)
+
+        verify {
+            anyVoiceInstructionsPlayerCallback.onDone(announcementWithNullFile)
+        }
+    }
+
+    @Test
+    fun `announcement file from state needs to be accessible media player is released`() {
+        val anyContext = mockk<Context>()
+        val anyAccessToken = "pk.1234"
+        val anyPlayerAttributes = mockk<VoiceInstructionsPlayerAttributes>()
+        val filePlayer =
+            VoiceInstructionsFilePlayer(anyContext, anyAccessToken, anyPlayerAttributes)
+        val announcementWithNullFile = mockk<SpeechAnnouncement>(relaxed = true)
+        val mockedFile = mockk<File>()
+        every { mockedFile.canRead() } returns false
+        every { announcementWithNullFile.file } returns mockedFile
+        val anyVoiceInstructionsPlayerCallback =
+            mockk<VoiceInstructionsPlayerCallback>(relaxUnitFun = true)
+        filePlayer.mediaPlayer = mockedMediaPlayer
+
+        filePlayer.play(announcementWithNullFile, anyVoiceInstructionsPlayerCallback)
+
+        verify {
+            mockedMediaPlayer.release()
+        }
+    }
+
+    @Test
+    fun `announcement file from state needs to be accessible media player is null`() {
+        val anyContext = mockk<Context>()
+        val anyAccessToken = "pk.1234"
+        val anyPlayerAttributes = mockk<VoiceInstructionsPlayerAttributes>()
+        val filePlayer =
+            VoiceInstructionsFilePlayer(anyContext, anyAccessToken, anyPlayerAttributes)
+        val announcementWithNullFile = mockk<SpeechAnnouncement>(relaxed = true)
+        val mockedFile = mockk<File>()
+        every { mockedFile.canRead() } returns false
+        every { announcementWithNullFile.file } returns mockedFile
+        val anyVoiceInstructionsPlayerCallback =
+            mockk<VoiceInstructionsPlayerCallback>(relaxUnitFun = true)
+
+        filePlayer.play(announcementWithNullFile, anyVoiceInstructionsPlayerCallback)
+
+        assertEquals(null, filePlayer.mediaPlayer)
+    }
+
+    @Test
+    fun `announcement file from state needs to be accessible current play is null`() {
+        val anyContext = mockk<Context>()
+        val anyAccessToken = "pk.1234"
+        val anyPlayerAttributes = mockk<VoiceInstructionsPlayerAttributes>()
+        val filePlayer =
+            VoiceInstructionsFilePlayer(anyContext, anyAccessToken, anyPlayerAttributes)
+        val announcementWithNullFile = mockk<SpeechAnnouncement>(relaxed = true)
+        val mockedFile = mockk<File>()
+        every { mockedFile.canRead() } returns false
+        every { announcementWithNullFile.file } returns mockedFile
+        val anyVoiceInstructionsPlayerCallback =
+            mockk<VoiceInstructionsPlayerCallback>(relaxUnitFun = true)
+
+        filePlayer.play(announcementWithNullFile, anyVoiceInstructionsPlayerCallback)
+
+        assertEquals(null, filePlayer.currentPlay)
+    }
+
+    @Test
+    fun `announcement file from state needs to be accessible onDone is called`() {
+        val anyContext = mockk<Context>()
+        val anyAccessToken = "pk.1234"
+        val anyPlayerAttributes = mockk<VoiceInstructionsPlayerAttributes>()
+        val filePlayer =
+            VoiceInstructionsFilePlayer(anyContext, anyAccessToken, anyPlayerAttributes)
+        val announcementWithNullFile = mockk<SpeechAnnouncement>(relaxed = true)
+        val mockedFile = mockk<File>()
+        every { mockedFile.canRead() } returns false
+        every { announcementWithNullFile.file } returns mockedFile
+        val anyVoiceInstructionsPlayerCallback =
+            mockk<VoiceInstructionsPlayerCallback>(relaxUnitFun = true)
+
+        filePlayer.play(announcementWithNullFile, anyVoiceInstructionsPlayerCallback)
+
+        verify {
+            anyVoiceInstructionsPlayerCallback.onDone(announcementWithNullFile)
+        }
+    }
+
+    @Test
+    fun `player attributes applyOn media player is called when play`() {
+        val anyContext = mockk<Context>()
+        val anyAccessToken = "pk.1234"
+        val anyPlayerAttributes = mockk<VoiceInstructionsPlayerAttributes>(relaxUnitFun = true)
+        val filePlayer =
+            VoiceInstructionsFilePlayer(anyContext, anyAccessToken, anyPlayerAttributes)
+        val announcementWithNullFile = mockk<SpeechAnnouncement>(relaxed = true)
+        val mockedFile = mockk<File>(relaxed = true)
+        every { mockedFile.canRead() } returns true
+        every { announcementWithNullFile.file } returns mockedFile
+        val anyVoiceInstructionsPlayerCallback =
+            mockk<VoiceInstructionsPlayerCallback>(relaxUnitFun = true)
+        val mockedFileDescriptor = mockk<FileDescriptor>()
+        every { mockedFileInputStream.fd } returns mockedFileDescriptor
+
+        filePlayer.play(announcementWithNullFile, anyVoiceInstructionsPlayerCallback)
+
+        verify {
+            anyPlayerAttributes.applyOn(filePlayer.mediaPlayer!!)
+        }
+    }
+
+    @Test
+    fun `media player prepareAsync is called when play`() {
+        val anyContext = mockk<Context>()
+        val anyAccessToken = "pk.1234"
+        val anyPlayerAttributes = mockk<VoiceInstructionsPlayerAttributes>(relaxUnitFun = true)
+        val filePlayer =
+            VoiceInstructionsFilePlayer(anyContext, anyAccessToken, anyPlayerAttributes)
+        val announcementWithNullFile = mockk<SpeechAnnouncement>(relaxed = true)
+        val mockedFile = mockk<File>(relaxed = true)
+        every { mockedFile.canRead() } returns true
+        every { announcementWithNullFile.file } returns mockedFile
+        val anyVoiceInstructionsPlayerCallback =
+            mockk<VoiceInstructionsPlayerCallback>(relaxUnitFun = true)
+        val mockedFileDescriptor = mockk<FileDescriptor>()
+        every { mockedFileInputStream.fd } returns mockedFileDescriptor
+
+        filePlayer.play(announcementWithNullFile, anyVoiceInstructionsPlayerCallback)
+
+        verify {
+            filePlayer.mediaPlayer!!.prepareAsync()
+        }
+    }
+
+    @Test
+    fun `media player setVolume with default level is called when play`() {
+        val anyContext = mockk<Context>()
+        val anyAccessToken = "pk.1234"
+        val anyPlayerAttributes = mockk<VoiceInstructionsPlayerAttributes>(relaxUnitFun = true)
+        val filePlayer =
+            VoiceInstructionsFilePlayer(anyContext, anyAccessToken, anyPlayerAttributes)
+        val announcementWithNullFile = mockk<SpeechAnnouncement>(relaxed = true)
+        val mockedFile = mockk<File>(relaxed = true)
+        every { mockedFile.canRead() } returns true
+        every { announcementWithNullFile.file } returns mockedFile
+        val anyVoiceInstructionsPlayerCallback =
+            mockk<VoiceInstructionsPlayerCallback>(relaxUnitFun = true)
+        val mockedFileDescriptor = mockk<FileDescriptor>()
+        every { mockedFileInputStream.fd } returns mockedFileDescriptor
+
+        filePlayer.play(announcementWithNullFile, anyVoiceInstructionsPlayerCallback)
+
+        verify {
+            filePlayer.mediaPlayer!!.setVolume(1.0f, 1.0f)
+        }
+    }
+
+    @Test
+    fun `media player setOnErrorListener is added when play`() {
+        val anyContext = mockk<Context>()
+        val anyAccessToken = "pk.1234"
+        val anyPlayerAttributes = mockk<VoiceInstructionsPlayerAttributes>(relaxUnitFun = true)
+        val filePlayer =
+            VoiceInstructionsFilePlayer(anyContext, anyAccessToken, anyPlayerAttributes)
+        val announcementWithNullFile = mockk<SpeechAnnouncement>(relaxed = true)
+        val mockedFile = mockk<File>(relaxed = true)
+        every { mockedFile.canRead() } returns true
+        every { announcementWithNullFile.file } returns mockedFile
+        val anyVoiceInstructionsPlayerCallback =
+            mockk<VoiceInstructionsPlayerCallback>(relaxUnitFun = true)
+        val mockedFileDescriptor = mockk<FileDescriptor>()
+        every { mockedFileInputStream.fd } returns mockedFileDescriptor
+
+        filePlayer.play(announcementWithNullFile, anyVoiceInstructionsPlayerCallback)
+
+        verify {
+            filePlayer.mediaPlayer!!.setOnErrorListener(any())
+        }
+    }
+
+    @Test
+    fun `media player setOnPreparedListener is added when play`() {
+        val anyContext = mockk<Context>()
+        val anyAccessToken = "pk.1234"
+        val anyPlayerAttributes = mockk<VoiceInstructionsPlayerAttributes>(relaxUnitFun = true)
+        val filePlayer =
+            VoiceInstructionsFilePlayer(anyContext, anyAccessToken, anyPlayerAttributes)
+        val announcementWithNullFile = mockk<SpeechAnnouncement>(relaxed = true)
+        val mockedFile = mockk<File>(relaxed = true)
+        every { mockedFile.canRead() } returns true
+        every { announcementWithNullFile.file } returns mockedFile
+        val anyVoiceInstructionsPlayerCallback =
+            mockk<VoiceInstructionsPlayerCallback>(relaxUnitFun = true)
+        val mockedFileDescriptor = mockk<FileDescriptor>()
+        every { mockedFileInputStream.fd } returns mockedFileDescriptor
+
+        filePlayer.play(announcementWithNullFile, anyVoiceInstructionsPlayerCallback)
+
+        verify {
+            filePlayer.mediaPlayer!!.setOnPreparedListener(any())
+        }
+    }
+
+    @Test
+    fun `media player setOnCompletionListener is added when play`() {
+        val anyContext = mockk<Context>()
+        val anyAccessToken = "pk.1234"
+        val anyPlayerAttributes = mockk<VoiceInstructionsPlayerAttributes>(relaxUnitFun = true)
+        val filePlayer =
+            VoiceInstructionsFilePlayer(anyContext, anyAccessToken, anyPlayerAttributes)
+        val announcementWithAnyFile = mockk<SpeechAnnouncement>(relaxed = true)
+        val mockedFile = mockk<File>(relaxed = true)
+        every { mockedFile.canRead() } returns true
+        every { announcementWithAnyFile.file } returns mockedFile
+        val anyVoiceInstructionsPlayerCallback =
+            mockk<VoiceInstructionsPlayerCallback>(relaxUnitFun = true)
+        val mockedFileDescriptor = mockk<FileDescriptor>()
+        every { mockedFileInputStream.fd } returns mockedFileDescriptor
+
+        filePlayer.play(announcementWithAnyFile, anyVoiceInstructionsPlayerCallback)
+
+        verify {
+            filePlayer.mediaPlayer!!.setOnCompletionListener(any())
+        }
+    }
+
+    @Test
+    fun `volume level is updated when volume`() {
+        val anyContext = mockk<Context>()
+        val anyAccessToken = "pk.1234"
+        val anyPlayerAttributes = mockk<VoiceInstructionsPlayerAttributes>(relaxUnitFun = true)
+        val filePlayer =
+            VoiceInstructionsFilePlayer(anyContext, anyAccessToken, anyPlayerAttributes)
+        val aSpeechVolume = SpeechVolume(0.5f)
+
+        filePlayer.volume(aSpeechVolume)
+
+        assertEquals(0.5f, filePlayer.volumeLevel)
+    }
+
+    @Test
+    fun `media player setVolume is called when volume`() {
+        val anyContext = mockk<Context>()
+        val anyAccessToken = "pk.1234"
+        val anyPlayerAttributes = mockk<VoiceInstructionsPlayerAttributes>(relaxUnitFun = true)
+        val filePlayer =
+            VoiceInstructionsFilePlayer(anyContext, anyAccessToken, anyPlayerAttributes)
+        val aSpeechVolume = SpeechVolume(0.5f)
+        filePlayer.mediaPlayer = mockedMediaPlayer
+
+        filePlayer.volume(aSpeechVolume)
+
+        verify {
+            mockedMediaPlayer.setVolume(0.5f, 0.5f)
+        }
+    }
+
+    @Test
+    fun `media player release is called when clear`() {
+        val anyContext = mockk<Context>()
+        val anyAccessToken = "pk.1234"
+        val anyPlayerAttributes = mockk<VoiceInstructionsPlayerAttributes>(relaxUnitFun = true)
+        val filePlayer =
+            VoiceInstructionsFilePlayer(anyContext, anyAccessToken, anyPlayerAttributes)
+        filePlayer.mediaPlayer = mockedMediaPlayer
+
+        filePlayer.clear()
+
+        verify {
+            mockedMediaPlayer.release()
+        }
+    }
+
+    @Test
+    fun `media player is null after clear`() {
+        val anyContext = mockk<Context>()
+        val anyAccessToken = "pk.1234"
+        val anyPlayerAttributes = mockk<VoiceInstructionsPlayerAttributes>(relaxUnitFun = true)
+        val filePlayer =
+            VoiceInstructionsFilePlayer(anyContext, anyAccessToken, anyPlayerAttributes)
+
+        filePlayer.clear()
+
+        assertEquals(null, filePlayer.mediaPlayer)
+    }
+
+    @Test
+    fun `current play is null after clear`() {
+        val anyContext = mockk<Context>()
+        val anyAccessToken = "pk.1234"
+        val anyPlayerAttributes = mockk<VoiceInstructionsPlayerAttributes>(relaxUnitFun = true)
+        val filePlayer =
+            VoiceInstructionsFilePlayer(anyContext, anyAccessToken, anyPlayerAttributes)
+
+        filePlayer.clear()
+
+        assertEquals(null, filePlayer.currentPlay)
+    }
+
+    @Test
+    fun `media player release is called when shutdown`() {
+        val anyContext = mockk<Context>()
+        val anyAccessToken = "pk.1234"
+        val anyPlayerAttributes = mockk<VoiceInstructionsPlayerAttributes>(relaxUnitFun = true)
+        val filePlayer =
+            VoiceInstructionsFilePlayer(anyContext, anyAccessToken, anyPlayerAttributes)
+        filePlayer.mediaPlayer = mockedMediaPlayer
+
+        filePlayer.shutdown()
+
+        verify {
+            mockedMediaPlayer.release()
+        }
+    }
+
+    @Test
+    fun `media player is null after shutdown`() {
+        val anyContext = mockk<Context>()
+        val anyAccessToken = "pk.1234"
+        val anyPlayerAttributes = mockk<VoiceInstructionsPlayerAttributes>(relaxUnitFun = true)
+        val filePlayer =
+            VoiceInstructionsFilePlayer(anyContext, anyAccessToken, anyPlayerAttributes)
+
+        filePlayer.shutdown()
+
+        assertEquals(null, filePlayer.mediaPlayer)
+    }
+
+    @Test
+    fun `current play is null after shutdown`() {
+        val anyContext = mockk<Context>()
+        val anyAccessToken = "pk.1234"
+        val anyPlayerAttributes = mockk<VoiceInstructionsPlayerAttributes>(relaxUnitFun = true)
+        val filePlayer =
+            VoiceInstructionsFilePlayer(anyContext, anyAccessToken, anyPlayerAttributes)
+
+        filePlayer.shutdown()
+
+        assertEquals(null, filePlayer.currentPlay)
+    }
+
+    @Test
+    fun `volume level is reset to default after shutdown`() {
+        val anyContext = mockk<Context>()
+        val anyAccessToken = "pk.1234"
+        val anyPlayerAttributes = mockk<VoiceInstructionsPlayerAttributes>(relaxUnitFun = true)
+        val filePlayer =
+            VoiceInstructionsFilePlayer(anyContext, anyAccessToken, anyPlayerAttributes)
+        filePlayer.volumeLevel = 0.5f
+
+        filePlayer.shutdown()
+
+        assertEquals(1.0f, filePlayer.volumeLevel)
+    }
+}

--- a/libnavui-voice/src/test/java/com/mapbox/navigation/ui/voice/api/VoiceInstructionsTextPlayerTest.kt
+++ b/libnavui-voice/src/test/java/com/mapbox/navigation/ui/voice/api/VoiceInstructionsTextPlayerTest.kt
@@ -1,0 +1,316 @@
+package com.mapbox.navigation.ui.voice.api
+
+import android.content.Context
+import android.os.Bundle
+import android.speech.tts.TextToSpeech
+import com.mapbox.navigation.ui.voice.model.SpeechAnnouncement
+import com.mapbox.navigation.ui.voice.model.SpeechVolume
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.verify
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class VoiceInstructionsTextPlayerTest {
+
+    private val mockedBundle: Bundle = mockk(relaxUnitFun = true)
+
+    @Before
+    fun setUp() {
+        mockkObject(BundleProvider)
+        every { BundleProvider.retrieveBundle() } returns mockedBundle
+    }
+
+    @After
+    fun tearDown() {
+        unmockkObject(BundleProvider)
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `only one announcement can be played at a time`() {
+        val anyContext = mockk<Context>(relaxed = true)
+        val anyAccessToken = "pk.1234"
+        val anyPlayerAttributes = mockk<VoiceInstructionsPlayerAttributes>()
+        val textPlayer =
+            VoiceInstructionsTextPlayer(anyContext, anyAccessToken, anyPlayerAttributes)
+        val anyAnnouncement = mockk<SpeechAnnouncement>(relaxed = true)
+        val anyVoiceInstructionsPlayerCallback =
+            mockk<VoiceInstructionsPlayerCallback>(relaxUnitFun = true)
+
+        textPlayer.currentPlay = anyAnnouncement
+
+        textPlayer.play(anyAnnouncement, anyVoiceInstructionsPlayerCallback)
+    }
+
+    @Test
+    fun `language is not supported current play is null`() {
+        val anyContext = mockk<Context>(relaxed = true)
+        val anyAccessToken = "pk.1234"
+        val anyPlayerAttributes = mockk<VoiceInstructionsPlayerAttributes>()
+        val textPlayer =
+            VoiceInstructionsTextPlayer(anyContext, anyAccessToken, anyPlayerAttributes)
+        val anyAnnouncement = mockk<SpeechAnnouncement>(relaxed = true)
+        val anyVoiceInstructionsPlayerCallback =
+            mockk<VoiceInstructionsPlayerCallback>(relaxUnitFun = true)
+        textPlayer.isLanguageSupported = false
+
+        textPlayer.play(anyAnnouncement, anyVoiceInstructionsPlayerCallback)
+
+        assertEquals(null, textPlayer.currentPlay)
+    }
+
+    @Test
+    fun `language is not supported onDone is called`() {
+        val anyContext = mockk<Context>(relaxed = true)
+        val anyAccessToken = "pk.1234"
+        val anyPlayerAttributes = mockk<VoiceInstructionsPlayerAttributes>()
+        val textPlayer =
+            VoiceInstructionsTextPlayer(anyContext, anyAccessToken, anyPlayerAttributes)
+        val anyAnnouncement = mockk<SpeechAnnouncement>(relaxed = true)
+        val anyVoiceInstructionsPlayerCallback =
+            mockk<VoiceInstructionsPlayerCallback>(relaxUnitFun = true)
+        textPlayer.isLanguageSupported = false
+
+        textPlayer.play(anyAnnouncement, anyVoiceInstructionsPlayerCallback)
+
+        verify {
+            anyVoiceInstructionsPlayerCallback.onDone(anyAnnouncement)
+        }
+    }
+
+    @Test
+    fun `announcement from state is blank current play is null`() {
+        val anyContext = mockk<Context>(relaxed = true)
+        val anyAccessToken = "pk.1234"
+        val anyPlayerAttributes = mockk<VoiceInstructionsPlayerAttributes>()
+        val textPlayer =
+            VoiceInstructionsTextPlayer(anyContext, anyAccessToken, anyPlayerAttributes)
+        val blankAnnouncement = mockk<SpeechAnnouncement>()
+        every { blankAnnouncement.announcement } returns "   "
+        val anyVoiceInstructionsPlayerCallback =
+            mockk<VoiceInstructionsPlayerCallback>(relaxUnitFun = true)
+        textPlayer.isLanguageSupported = true
+
+        textPlayer.play(blankAnnouncement, anyVoiceInstructionsPlayerCallback)
+
+        assertEquals(null, textPlayer.currentPlay)
+    }
+
+    @Test
+    fun `announcement from state is blank onDone is called`() {
+        val anyContext = mockk<Context>(relaxed = true)
+        val anyAccessToken = "pk.1234"
+        val anyPlayerAttributes = mockk<VoiceInstructionsPlayerAttributes>()
+        val textPlayer =
+            VoiceInstructionsTextPlayer(anyContext, anyAccessToken, anyPlayerAttributes)
+        val blankAnnouncement = mockk<SpeechAnnouncement>()
+        every { blankAnnouncement.announcement } returns "   "
+        val anyVoiceInstructionsPlayerCallback =
+            mockk<VoiceInstructionsPlayerCallback>(relaxUnitFun = true)
+        textPlayer.isLanguageSupported = false
+
+        textPlayer.play(blankAnnouncement, anyVoiceInstructionsPlayerCallback)
+
+        verify {
+            anyVoiceInstructionsPlayerCallback.onDone(blankAnnouncement)
+        }
+    }
+
+    @Test
+    fun `putFloat with volume level is called when play`() {
+        val anyContext = mockk<Context>(relaxed = true)
+        val anyAccessToken = "pk.1234"
+        val anyPlayerAttributes = mockk<VoiceInstructionsPlayerAttributes>(relaxUnitFun = true)
+        val textPlayer =
+            VoiceInstructionsTextPlayer(anyContext, anyAccessToken, anyPlayerAttributes)
+        val anyNonBlankAnnouncement = mockk<SpeechAnnouncement>()
+        every { anyNonBlankAnnouncement.announcement } returns "Turn right."
+        val anyVoiceInstructionsPlayerCallback =
+            mockk<VoiceInstructionsPlayerCallback>(relaxUnitFun = true)
+        textPlayer.isLanguageSupported = true
+
+        textPlayer.play(anyNonBlankAnnouncement, anyVoiceInstructionsPlayerCallback)
+
+        verify { mockedBundle.putFloat(TextToSpeech.Engine.KEY_PARAM_VOLUME, 1.0f) }
+    }
+
+    @Test
+    fun `player attributes applyOn with text to speech and bundle is called when play`() {
+        val anyContext = mockk<Context>(relaxed = true)
+        val anyAccessToken = "pk.1234"
+        val anyPlayerAttributes = mockk<VoiceInstructionsPlayerAttributes>(relaxUnitFun = true)
+        val textPlayer =
+            VoiceInstructionsTextPlayer(anyContext, anyAccessToken, anyPlayerAttributes)
+        val anyNonBlankAnnouncement = mockk<SpeechAnnouncement>()
+        every { anyNonBlankAnnouncement.announcement } returns "Turn right."
+        val anyVoiceInstructionsPlayerCallback =
+            mockk<VoiceInstructionsPlayerCallback>(relaxUnitFun = true)
+        textPlayer.isLanguageSupported = true
+        val mockedTextToSpeech = mockk<TextToSpeech>(relaxed = true)
+        textPlayer.textToSpeech = mockedTextToSpeech
+
+        textPlayer.play(anyNonBlankAnnouncement, anyVoiceInstructionsPlayerCallback)
+
+        verify { anyPlayerAttributes.applyOn(mockedTextToSpeech, mockedBundle) }
+    }
+
+    @Test
+    fun `text to speech speak with announcement and bundle is called when play`() {
+        val anyContext = mockk<Context>(relaxed = true)
+        val anyAccessToken = "pk.1234"
+        val anyPlayerAttributes = mockk<VoiceInstructionsPlayerAttributes>(relaxUnitFun = true)
+        val textPlayer =
+            VoiceInstructionsTextPlayer(anyContext, anyAccessToken, anyPlayerAttributes)
+        val turnRightAnnouncement = "Turn right."
+        val anyNonBlankAnnouncement = mockk<SpeechAnnouncement>()
+        every { anyNonBlankAnnouncement.announcement } returns turnRightAnnouncement
+        val anyVoiceInstructionsPlayerCallback =
+            mockk<VoiceInstructionsPlayerCallback>(relaxUnitFun = true)
+        textPlayer.isLanguageSupported = true
+        val mockedTextToSpeech = mockk<TextToSpeech>(relaxed = true)
+        textPlayer.textToSpeech = mockedTextToSpeech
+
+        textPlayer.play(anyNonBlankAnnouncement, anyVoiceInstructionsPlayerCallback)
+
+        verify {
+            textPlayer.textToSpeech.speak(
+                turnRightAnnouncement,
+                TextToSpeech.QUEUE_FLUSH,
+                mockedBundle,
+                "default_id"
+            )
+        }
+    }
+
+    @Test
+    fun `volume level is updated when volume`() {
+        val anyContext = mockk<Context>(relaxed = true)
+        val anyAccessToken = "pk.1234"
+        val anyPlayerAttributes = mockk<VoiceInstructionsPlayerAttributes>()
+        val textPlayer =
+            VoiceInstructionsTextPlayer(anyContext, anyAccessToken, anyPlayerAttributes)
+        val aSpeechVolume = SpeechVolume(0.5f)
+
+        textPlayer.volume(aSpeechVolume)
+
+        assertEquals(0.5f, textPlayer.volumeLevel)
+    }
+
+    @Test
+    fun `if announcing and volume is muted text to speech stop is called when volume`() {
+        val anyContext = mockk<Context>(relaxed = true)
+        val anyAccessToken = "pk.1234"
+        val anyPlayerAttributes = mockk<VoiceInstructionsPlayerAttributes>()
+        val textPlayer =
+            VoiceInstructionsTextPlayer(anyContext, anyAccessToken, anyPlayerAttributes)
+        val mute = SpeechVolume(0.0f)
+        val mockedTextToSpeech = mockk<TextToSpeech>(relaxed = true)
+        every { mockedTextToSpeech.isSpeaking } returns true
+        textPlayer.textToSpeech = mockedTextToSpeech
+
+        textPlayer.volume(mute)
+
+        verify { textPlayer.textToSpeech.stop() }
+    }
+
+    @Test
+    fun `text to speech stop is called is called when clear`() {
+        val anyContext = mockk<Context>(relaxed = true)
+        val anyAccessToken = "pk.1234"
+        val anyPlayerAttributes = mockk<VoiceInstructionsPlayerAttributes>()
+        val textPlayer =
+            VoiceInstructionsTextPlayer(anyContext, anyAccessToken, anyPlayerAttributes)
+        val mockedTextToSpeech = mockk<TextToSpeech>(relaxed = true)
+        textPlayer.textToSpeech = mockedTextToSpeech
+
+        textPlayer.clear()
+
+        verify {
+            textPlayer.textToSpeech.stop()
+        }
+    }
+
+    @Test
+    fun `current play null after clear`() {
+        val anyContext = mockk<Context>(relaxed = true)
+        val anyAccessToken = "pk.1234"
+        val anyPlayerAttributes = mockk<VoiceInstructionsPlayerAttributes>()
+        val textPlayer =
+            VoiceInstructionsTextPlayer(anyContext, anyAccessToken, anyPlayerAttributes)
+        val mockedTextToSpeech = mockk<TextToSpeech>(relaxed = true)
+        textPlayer.textToSpeech = mockedTextToSpeech
+
+        textPlayer.clear()
+
+        assertEquals(null, textPlayer.currentPlay)
+    }
+
+    @Test
+    fun `text to speech setOnUtteranceProgressListener with null is called when shutdown`() {
+        val anyContext = mockk<Context>(relaxed = true)
+        val anyAccessToken = "pk.1234"
+        val anyPlayerAttributes = mockk<VoiceInstructionsPlayerAttributes>()
+        val textPlayer =
+            VoiceInstructionsTextPlayer(anyContext, anyAccessToken, anyPlayerAttributes)
+        val mockedTextToSpeech = mockk<TextToSpeech>(relaxed = true)
+        textPlayer.textToSpeech = mockedTextToSpeech
+
+        textPlayer.shutdown()
+
+        verify {
+            textPlayer.textToSpeech.setOnUtteranceProgressListener(null)
+        }
+    }
+
+    @Test
+    fun `text to speech shutdown is called when shutdown`() {
+        val anyContext = mockk<Context>(relaxed = true)
+        val anyAccessToken = "pk.1234"
+        val anyPlayerAttributes = mockk<VoiceInstructionsPlayerAttributes>()
+        val textPlayer =
+            VoiceInstructionsTextPlayer(anyContext, anyAccessToken, anyPlayerAttributes)
+        val mockedTextToSpeech = mockk<TextToSpeech>(relaxed = true)
+        textPlayer.textToSpeech = mockedTextToSpeech
+
+        textPlayer.shutdown()
+
+        verify {
+            textPlayer.textToSpeech.shutdown()
+        }
+    }
+
+    @Test
+    fun `current play is null after shutdown`() {
+        val anyContext = mockk<Context>(relaxed = true)
+        val anyAccessToken = "pk.1234"
+        val anyPlayerAttributes = mockk<VoiceInstructionsPlayerAttributes>()
+        val textPlayer =
+            VoiceInstructionsTextPlayer(anyContext, anyAccessToken, anyPlayerAttributes)
+        val mockedTextToSpeech = mockk<TextToSpeech>(relaxed = true)
+        textPlayer.textToSpeech = mockedTextToSpeech
+
+        textPlayer.shutdown()
+
+        assertEquals(null, textPlayer.currentPlay)
+    }
+
+    @Test
+    fun `volume level is reset to default after shutdown`() {
+        val anyContext = mockk<Context>(relaxed = true)
+        val anyAccessToken = "pk.1234"
+        val anyPlayerAttributes = mockk<VoiceInstructionsPlayerAttributes>()
+        val textPlayer =
+            VoiceInstructionsTextPlayer(anyContext, anyAccessToken, anyPlayerAttributes)
+        textPlayer.volumeLevel = 0.5f
+        val mockedTextToSpeech = mockk<TextToSpeech>(relaxed = true)
+        textPlayer.textToSpeech = mockedTextToSpeech
+
+        textPlayer.shutdown()
+
+        assertEquals(1.0f, textPlayer.volumeLevel)
+    }
+}


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Clears `VoiceInstructionsTextPlayer` `currentPlay` when `shutdown`

Fixes #5018 

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Clear `VoiceInstructionsTextPlayer` `currentPlay` when `shutdown`.</changelog>
```

cc @VitaminPSG @zeac 