### PR TITLE
Remove automatic `setRoutes` from `RouteAlternativesController`

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -426,7 +426,6 @@ class MapboxNavigation @VisibleForTesting internal constructor(
         routeAlternativesController = RouteAlternativesControllerProvider.create(
             navigationOptions.routeAlternativesOptions,
             navigator,
-            directionsSession,
             tripSession
         )
         routeRefreshController = RouteRefreshControllerProvider.createRouteRefreshController(
@@ -621,9 +620,13 @@ class MapboxNavigation @VisibleForTesting internal constructor(
         }
         rerouteController?.interrupt()
 
+        // Telemetry uses this field to determine what type of event should be triggered.
         @RoutesExtra.RoutesUpdateReason val reason = when {
             routes.isEmpty() -> {
                 RoutesExtra.ROUTES_UPDATE_REASON_CLEAN_UP
+            }
+            routes.first() == directionsSession.routes.firstOrNull() -> {
+                RoutesExtra.ROUTES_UPDATE_REASON_ALTERNATIVE
             }
             else -> {
                 RoutesExtra.ROUTES_UPDATE_REASON_NEW

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesControllerProvider.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesControllerProvider.kt
@@ -1,7 +1,6 @@
 package com.mapbox.navigation.core.routealternatives
 
 import com.mapbox.navigation.base.route.RouteAlternativesOptions
-import com.mapbox.navigation.core.directions.session.DirectionsSession
 import com.mapbox.navigation.core.trip.session.TripSession
 import com.mapbox.navigation.navigator.internal.MapboxNativeNavigator
 
@@ -10,12 +9,10 @@ internal object RouteAlternativesControllerProvider {
     fun create(
         options: RouteAlternativesOptions,
         navigator: MapboxNativeNavigator,
-        directionsSession: DirectionsSession,
         tripSession: TripSession
     ) = RouteAlternativesController(
         options,
         navigator,
-        directionsSession,
         tripSession
     )
 }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
@@ -104,8 +104,7 @@ class MapboxNavigationTest {
     private val distanceFormatterOptions: DistanceFormatterOptions = mockk(relaxed = true)
     private val routingTilesOptions: RoutingTilesOptions = mockk(relaxed = true)
     private val routeRefreshController: RouteRefreshController = mockk(relaxUnitFun = true)
-    private val routeAlternativesController: RouteAlternativesController =
-        mockk(relaxUnitFun = true)
+    private val routeAlternativesController: RouteAlternativesController = mockk(relaxed = true)
     private val routeProgress: RouteProgress = mockk(relaxed = true)
     private val navigationSession: NavigationSession = mockk(relaxed = true)
     private val billingController: BillingController = mockk(relaxUnitFun = true)
@@ -181,7 +180,7 @@ class MapboxNavigationTest {
         } returns routeRefreshController
         mockkObject(RouteAlternativesControllerProvider)
         every {
-            RouteAlternativesControllerProvider.create(any(), any(), any(), any())
+            RouteAlternativesControllerProvider.create(any(), any(), any())
         } returns routeAlternativesController
 
         every { applicationContext.applicationContext } returns applicationContext
@@ -1071,6 +1070,22 @@ class MapboxNavigationTest {
             directionsSession.setRoutes(
                 routes, 0, RoutesExtra.ROUTES_UPDATE_REASON_NEW
             )
+        }
+    }
+
+    @Test
+    fun `adding or removing alternative routes creates alternative reason`() {
+        createMapboxNavigation()
+        val primaryRoute = mockk<DirectionsRoute>()
+        val alternativeRoute = mockk<DirectionsRoute>()
+        every { directionsSession.routes } returns listOf(primaryRoute)
+
+        mapboxNavigation.setRoutes(listOf(primaryRoute, alternativeRoute))
+        mapboxNavigation.setRoutes(listOf(primaryRoute))
+
+        verifyOrder {
+            directionsSession.setRoutes(any(), any(), RoutesExtra.ROUTES_UPDATE_REASON_ALTERNATIVE)
+            directionsSession.setRoutes(any(), any(), RoutesExtra.ROUTES_UPDATE_REASON_ALTERNATIVE)
         }
     }
 

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/AlternativeRouteActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/AlternativeRouteActivity.kt
@@ -115,7 +115,7 @@ class AlternativeRouteActivity : AppCompatActivity(), OnMapLongClickListener {
         mapboxNavigation.unregisterRouteProgressObserver(replayProgressObserver)
         mapboxNavigation.unregisterLocationObserver(locationObserver)
         mapboxNavigation.unregisterRoutesObserver(routesObserver)
-        mapboxNavigation.unregisterRouteAlternativesObserver(requestAlternativesObserver)
+        mapboxNavigation.unregisterRouteAlternativesObserver(routeAlternativesObserver)
     }
 
     override fun onDestroy() {
@@ -134,7 +134,7 @@ class AlternativeRouteActivity : AppCompatActivity(), OnMapLongClickListener {
         mapboxNavigation.registerLocationObserver(locationObserver)
         mapboxNavigation.registerRouteProgressObserver(replayProgressObserver)
         mapboxNavigation.registerRoutesObserver(routesObserver)
-        mapboxNavigation.registerRouteAlternativesObserver(requestAlternativesObserver)
+        mapboxNavigation.registerRouteAlternativesObserver(routeAlternativesObserver)
         mapboxReplayer.pushRealLocation(this, 0.0)
         mapboxReplayer.playbackSpeed(1.5)
         mapboxReplayer.play()
@@ -201,10 +201,17 @@ class AlternativeRouteActivity : AppCompatActivity(), OnMapLongClickListener {
     }
 
     /**
-     * Whenever alternatives have changed, request a new set of alternatives.
+     * Example of how to handle route alternatives during navigation.
      */
-    private val requestAlternativesObserver =
-        RouteAlternativesObserver { _, _, _ ->
+    private val routeAlternativesObserver =
+        RouteAlternativesObserver { routeProgress, alternatives, _ ->
+            // Set the alternatives suggested
+            val updatedRoutes = mutableListOf<DirectionsRoute>()
+            updatedRoutes.add(routeProgress.route)
+            updatedRoutes.addAll(alternatives)
+            mapboxNavigation.setRoutes(updatedRoutes)
+
+            // Request new alternatives instead of waiting for the interval.
             mapboxNavigation.requestAlternativeRoutes()
         }
 
@@ -222,7 +229,7 @@ class AlternativeRouteActivity : AppCompatActivity(), OnMapLongClickListener {
                     routes: List<DirectionsRoute>,
                     routerOrigin: RouterOrigin
                 ) {
-                    mapboxNavigation.setRoutes(routes)
+                    mapboxNavigation.setRoutes(routes.reversed())
                 }
 
                 override fun onFailure(


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Following discussion from here https://github.com/mapbox/mapbox-navigation-android/pull/4892
We also waited for the Native Router to merge https://github.com/mapbox/mapbox-navigation-android/pull/4791

There are a few known issues where we are not ready to automatically set the route inside the alternative route controller
- Route alternatives breaks route refresh if you set the route from nav-native
- Nav-native's RouteAlternativesObserver does not provide the RouterOrigin
- Taking an alternative route still triggers a reroute
- The alternative is not removed when the fork is at the origin

These need to be fixed by Nav-Native in order to be able to update the routes continuously.

If we remove the `directionsSession.setRoutes(` call. Nav-native will only be notifying the SDK of route alternative changes. And then the [RouteAlternativesObserver](https://github.com/mapbox/mapbox-navigation-android/blob/fa0ca5802cc16474f37f7fcf6594f0f992978e16/libnavigation-core/src/main/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesObserver.kt#L15-L26) will allow downstream developers decide how they want to select the routes suggested.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Remove automatic setRoute from route alternatives controller</changelog>
```