### PR TITLE
Modification to the waypoint icon layer so that iconKeepUpright is tr…

### DIFF
--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/MapboxRouteLayerProvider.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/MapboxRouteLayerProvider.kt
@@ -269,6 +269,7 @@ internal class MapboxRouteLayerProvider(
             .iconPitchAlignment(IconPitchAlignment.MAP)
             .iconAllowOverlap(true)
             .iconIgnorePlacement(true)
+            .iconKeepUpright(true)
     }
 
     private fun initializeRouteLayer(


### PR DESCRIPTION
### Description
Resolves #5004 by setting the iconKeepUpright option to true for the waypoints symbol layer. 

### Changelog
```
<changelog>The iconKeepUpright parameter for the layer hosting the waypoints is set to true to address issue with some custom icons that may be intended to appear like 3D pins.</changelog>
```

### Screenshots or Gifs

