### PR TITLE
set @mapbox/docs as a code owner for the publisher branch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @mapbox/docs


### PR DESCRIPTION
Code owners will be assigner automatically when somebody opens a PR to publisher-production branch. 