### PR TITLE
avoid maneuver radius: how to add param to reroute flow

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ allprojects {
     // we allow access to snapshots repo if ALLOW_SNAPSHOT_REPOSITORY is set, what means we are running on CI 
     // with Navigation Native forced to be some snapshot version
     // if you need to use snapshots while development, just set `addSnapshotsRepo` to true manually
-    def addSnapshotsRepo = System.getenv("ALLOW_SNAPSHOT_REPOSITORY")?.toBoolean() ?: false
+    def addSnapshotsRepo = project.hasProperty('ALLOW_SNAPSHOT_REPOSITORY') ? project.property('ALLOW_SNAPSHOT_REPOSITORY') : (System.getenv("ALLOW_SNAPSHOT_REPOSITORY")?.toBoolean() ?: false)
     if (addSnapshotsRepo) {
       println("Snapshot repository reference added.")
       maven {

--- a/libnavigation-base/api/current.txt
+++ b/libnavigation-base/api/current.txt
@@ -216,6 +216,7 @@ package com.mapbox.navigation.base.options {
     method public com.mapbox.android.core.location.LocationEngine getLocationEngine();
     method public com.mapbox.android.core.location.LocationEngineRequest getLocationEngineRequest();
     method public long getNavigatorPredictionMillis();
+    method public com.mapbox.navigation.base.options.RerouteOptions getRerouteOptions();
     method public com.mapbox.navigation.base.route.RouteAlternativesOptions getRouteAlternativesOptions();
     method public com.mapbox.navigation.base.route.RouteRefreshOptions getRouteRefreshOptions();
     method public com.mapbox.navigation.base.options.RoutingTilesOptions getRoutingTilesOptions();
@@ -234,6 +235,7 @@ package com.mapbox.navigation.base.options {
     property public final com.mapbox.android.core.location.LocationEngine locationEngine;
     property public final com.mapbox.android.core.location.LocationEngineRequest locationEngineRequest;
     property public final long navigatorPredictionMillis;
+    property public final com.mapbox.navigation.base.options.RerouteOptions rerouteOptions;
     property public final com.mapbox.navigation.base.route.RouteAlternativesOptions routeAlternativesOptions;
     property public final com.mapbox.navigation.base.route.RouteRefreshOptions routeRefreshOptions;
     property public final com.mapbox.navigation.base.options.RoutingTilesOptions routingTilesOptions;
@@ -254,6 +256,7 @@ package com.mapbox.navigation.base.options {
     method public com.mapbox.navigation.base.options.NavigationOptions.Builder locationEngine(com.mapbox.android.core.location.LocationEngine locationEngine);
     method public com.mapbox.navigation.base.options.NavigationOptions.Builder locationEngineRequest(com.mapbox.android.core.location.LocationEngineRequest locationEngineRequest);
     method public com.mapbox.navigation.base.options.NavigationOptions.Builder navigatorPredictionMillis(long predictionMillis);
+    method public com.mapbox.navigation.base.options.NavigationOptions.Builder rerouteOptions(com.mapbox.navigation.base.options.RerouteOptions rerouteOptions);
     method public com.mapbox.navigation.base.options.NavigationOptions.Builder routeAlternativesOptions(com.mapbox.navigation.base.route.RouteAlternativesOptions routeAlternativesOptions);
     method public com.mapbox.navigation.base.options.NavigationOptions.Builder routeRefreshOptions(com.mapbox.navigation.base.route.RouteRefreshOptions routeRefreshOptions);
     method public com.mapbox.navigation.base.options.NavigationOptions.Builder routingTilesOptions(com.mapbox.navigation.base.options.RoutingTilesOptions routingTilesOptions);
@@ -280,6 +283,18 @@ package com.mapbox.navigation.base.options {
     method public com.mapbox.navigation.base.options.PredictiveCacheLocationOptions.Builder currentLocationRadiusInMeters(int radiusInMeters);
     method public com.mapbox.navigation.base.options.PredictiveCacheLocationOptions.Builder destinationLocationRadiusInMeters(int radiusInMeters);
     method public com.mapbox.navigation.base.options.PredictiveCacheLocationOptions.Builder routeBufferRadiusInMeters(int radiusInMeters);
+  }
+
+  public final class RerouteOptions {
+    method public int getAvoidManeuverSeconds();
+    method public com.mapbox.navigation.base.options.RerouteOptions.Builder toBuilder();
+    property public final int avoidManeuverSeconds;
+  }
+
+  public static final class RerouteOptions.Builder {
+    ctor public RerouteOptions.Builder();
+    method public com.mapbox.navigation.base.options.RerouteOptions.Builder avoidManeuverSeconds(int avoidManeuverSeconds);
+    method public com.mapbox.navigation.base.options.RerouteOptions build();
   }
 
   public final class RoutingTilesOptions {

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/NavigationOptions.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/NavigationOptions.kt
@@ -35,6 +35,7 @@ const val DEFAULT_NAVIGATOR_PREDICTION_MILLIS = 1000L
  * @param deviceProfile [DeviceProfile] defines how navigation data should be interpreted
  * @param eHorizonOptions [EHorizonOptions] defines configuration for the Electronic Horizon
  * @param routeRefreshOptions defines configuration for refreshing routes
+ * @param rerouteOptions defines configuration for reroute
  * @param routeAlternativesOptions defines configuration for observing alternatives while navigating
  * @param incidentsOptions defines configuration for live incidents
  * @param historyRecorderOptions defines configuration for recording navigation events
@@ -53,6 +54,7 @@ class NavigationOptions private constructor(
     val deviceProfile: DeviceProfile,
     val eHorizonOptions: EHorizonOptions,
     val routeRefreshOptions: RouteRefreshOptions,
+    val rerouteOptions: RerouteOptions,
     val routeAlternativesOptions: RouteAlternativesOptions,
     val incidentsOptions: IncidentsOptions,
     val historyRecorderOptions: HistoryRecorderOptions,
@@ -74,6 +76,7 @@ class NavigationOptions private constructor(
         deviceProfile(deviceProfile)
         eHorizonOptions(eHorizonOptions)
         routeRefreshOptions(routeRefreshOptions)
+        rerouteOptions(rerouteOptions)
         routeAlternativesOptions(routeAlternativesOptions)
         incidentsOptions(incidentsOptions)
         historyRecorderOptions(historyRecorderOptions)
@@ -101,6 +104,7 @@ class NavigationOptions private constructor(
         if (deviceProfile != other.deviceProfile) return false
         if (eHorizonOptions != other.eHorizonOptions) return false
         if (routeRefreshOptions != other.routeRefreshOptions) return false
+        if (rerouteOptions != other.rerouteOptions) return false
         if (routeAlternativesOptions != other.routeAlternativesOptions) return false
         if (incidentsOptions != other.incidentsOptions) return false
         if (historyRecorderOptions != other.historyRecorderOptions) return false
@@ -125,6 +129,7 @@ class NavigationOptions private constructor(
         result = 31 * result + deviceProfile.hashCode()
         result = 31 * result + eHorizonOptions.hashCode()
         result = 31 * result + routeRefreshOptions.hashCode()
+        result = 31 * result + rerouteOptions.hashCode()
         result = 31 * result + routeAlternativesOptions.hashCode()
         result = 31 * result + incidentsOptions.hashCode()
         result = 31 * result + historyRecorderOptions.hashCode()
@@ -149,6 +154,7 @@ class NavigationOptions private constructor(
             "deviceProfile=$deviceProfile, " +
             "eHorizonOptions=$eHorizonOptions, " +
             "routeRefreshOptions=$routeRefreshOptions, " +
+            "rerouteOptions=$rerouteOptions, " +
             "routeAlternativesOptions=$routeAlternativesOptions, " +
             "incidentsOptions=$incidentsOptions, " +
             "historyRecorderOptions=$historyRecorderOptions, " +
@@ -179,6 +185,7 @@ class NavigationOptions private constructor(
         private var deviceProfile: DeviceProfile = DeviceProfile.Builder().build()
         private var eHorizonOptions: EHorizonOptions = EHorizonOptions.Builder().build()
         private var routeRefreshOptions: RouteRefreshOptions = RouteRefreshOptions.Builder().build()
+        private var rerouteOptions: RerouteOptions = RerouteOptions.Builder().build()
         private var routeAlternativesOptions: RouteAlternativesOptions =
             RouteAlternativesOptions.Builder().build()
         private var incidentsOptions: IncidentsOptions = IncidentsOptions.Builder().build()
@@ -253,6 +260,12 @@ class NavigationOptions private constructor(
             apply { this.routeRefreshOptions = routeRefreshOptions }
 
         /**
+         * Defines configuration for reroute
+         */
+        fun rerouteOptions(rerouteOptions: RerouteOptions): Builder =
+            apply { this.rerouteOptions = rerouteOptions }
+
+        /**
          * Defines configuration for route refresh
          */
         fun routeAlternativesOptions(routeAlternativesOptions: RouteAlternativesOptions): Builder =
@@ -295,6 +308,7 @@ class NavigationOptions private constructor(
                 deviceProfile = deviceProfile,
                 eHorizonOptions = eHorizonOptions,
                 routeRefreshOptions = routeRefreshOptions,
+                rerouteOptions = rerouteOptions,
                 routeAlternativesOptions = routeAlternativesOptions,
                 incidentsOptions = incidentsOptions,
                 historyRecorderOptions = historyRecorderOptions,

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/RerouteOptions.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/RerouteOptions.kt
@@ -1,0 +1,80 @@
+package com.mapbox.navigation.base.options
+
+import com.mapbox.api.directions.v5.models.RouteOptions
+
+/**
+ * Reroute options
+ *
+ * @param avoidManeuverSeconds a radius in seconds around reroute origin point where need to
+ * avoid any significant maneuvers. Unit is seconds.
+ */
+class RerouteOptions private constructor(
+    val avoidManeuverSeconds: Int
+) {
+
+    /**
+     * @return the builder that created the [RerouteOptions]
+     */
+    fun toBuilder(): Builder = Builder().apply {
+        avoidManeuverSeconds(avoidManeuverSeconds)
+    }
+
+    /**
+     * Regenerate whenever a change is made
+     */
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as RerouteOptions
+
+        if (avoidManeuverSeconds != other.avoidManeuverSeconds) return false
+
+        return true
+    }
+
+    /**
+     * Regenerate whenever a change is made
+     */
+    override fun hashCode(): Int {
+        return avoidManeuverSeconds.hashCode()
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    override fun toString(): String = "RerouteOptions(" +
+        "avoidManeuverSeconds=$avoidManeuverSeconds" +
+        ")"
+
+    /**
+     * Builder for [RerouteOptions].
+     */
+    class Builder {
+        private var avoidManeuverSeconds = 8
+
+        /**
+         * Avoid maneuver second. A radius in seconds around reroute origin point where need to
+         * avoid any significant maneuvers. Unit is seconds.
+         *
+         * Default value is **8**.
+         *
+         * Note: value is mapped to _meters_ at a re-route moment (based on speed), if meters result
+         * is more than 1000, it's restricted to 1000 meters.
+         *
+         * @throws IllegalStateException if provided value is less than **0**
+         * @see RouteOptions.avoidManeuverRadius
+         */
+        fun avoidManeuverSeconds(avoidManeuverSeconds: Int): Builder = apply {
+            check(avoidManeuverSeconds >= 0) {
+                "avoidManeuverSeconds must be >= 0"
+            }
+            this.avoidManeuverSeconds = avoidManeuverSeconds
+        }
+
+        /**
+         * Build the [RerouteOptions]
+         */
+        fun build(): RerouteOptions = RerouteOptions(avoidManeuverSeconds)
+    }
+}

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/options/NavigationOptionsTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/options/NavigationOptionsTest.kt
@@ -66,6 +66,7 @@ class NavigationOptionsTest : BuilderTest<NavigationOptions, NavigationOptions.B
             .timeFormatType(1)
             .eHorizonOptions(mockk())
             .routeRefreshOptions(mockk())
+            .rerouteOptions(mockk())
             .routeAlternativesOptions(mockk())
             .incidentsOptions(mockk())
             .historyRecorderOptions(

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/options/RerouteOptionsTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/options/RerouteOptionsTest.kt
@@ -1,0 +1,33 @@
+package com.mapbox.navigation.base.options
+
+import com.mapbox.navigation.testing.BuilderTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.lang.IllegalStateException
+import kotlin.reflect.KClass
+
+class RerouteOptionsTest : BuilderTest<RerouteOptions, RerouteOptions.Builder>() {
+
+    override fun getImplementationClass(): KClass<RerouteOptions> =
+        RerouteOptions::class
+
+    override fun getFilledUpBuilder(): RerouteOptions.Builder = RerouteOptions.Builder()
+        .avoidManeuverSeconds(10)
+
+    @Test
+    override fun trigger() {
+        // trigger, see KDoc
+    }
+
+    @Test
+    fun test_default_value_is_8() {
+        val rerouteOptions = RerouteOptions.Builder().build()
+
+        assertEquals(8, rerouteOptions.avoidManeuverSeconds)
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun set_negative_maneuver_seconds_trow_exception() {
+        RerouteOptions.Builder().avoidManeuverSeconds(-1).build()
+    }
+}

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -440,6 +440,7 @@ class MapboxNavigation @VisibleForTesting internal constructor(
             directionsSession,
             tripSession,
             routeOptionsProvider,
+            navigationOptions.rerouteOptions,
             threadController,
             logger
         )


### PR DESCRIPTION
### Description

adapt `avoid maneuver radius` for re-route scenario

mapbox-java introduced `avoidManeuverRadius` param https://github.com/mapbox/mapbox-java/pull/1310 ~(draft)~

### Changelog
```
<changelog>Added `RerouteOptions` to define reroute params for default `RereouteController`</changelog>
```

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
