### PR TITLE
Trigger documentation publishing on a new tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,11 @@ workflows:
       - publish-documentation:
           requires:
             - release
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
   default:
     jobs:
       - prepare-and-assemble


### PR DESCRIPTION
### Description
Circle CI documentation [says](https://circleci.com/docs/2.0/workflows/#executing-workflows-for-a-git-tag)
> CircleCI does not run workflows for tags unless you explicitly specify tag filters.