### PR TITLE
Added mutability to route line related result classes.

### DIFF
--- a/libnavui-maps/api/current.txt
+++ b/libnavui-maps/api/current.txt
@@ -874,6 +874,20 @@ package com.mapbox.navigation.ui.maps.route.line.model {
     method public java.util.List<com.mapbox.geojson.FeatureCollection> getAlternativeRouteSourceSources();
     method public com.mapbox.geojson.FeatureCollection getPrimaryRouteSource();
     method public com.mapbox.geojson.FeatureCollection getWaypointsSource();
+    method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineClearValue.MutableRouteLineClearValue toMutableValue();
+    property public final java.util.List<com.mapbox.geojson.FeatureCollection> alternativeRouteSourceSources;
+    property public final com.mapbox.geojson.FeatureCollection primaryRouteSource;
+    property public final com.mapbox.geojson.FeatureCollection waypointsSource;
+  }
+
+  public static final class RouteLineClearValue.MutableRouteLineClearValue {
+    method public java.util.List<com.mapbox.geojson.FeatureCollection> getAlternativeRouteSourceSources();
+    method public com.mapbox.geojson.FeatureCollection getPrimaryRouteSource();
+    method public com.mapbox.geojson.FeatureCollection getWaypointsSource();
+    method public void setAlternativeRouteSourceSources(java.util.List<com.mapbox.geojson.FeatureCollection> p);
+    method public void setPrimaryRouteSource(com.mapbox.geojson.FeatureCollection p);
+    method public void setWaypointsSource(com.mapbox.geojson.FeatureCollection p);
+    method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineClearValue toImmutableValue();
     property public final java.util.List<com.mapbox.geojson.FeatureCollection> alternativeRouteSourceSources;
     property public final com.mapbox.geojson.FeatureCollection primaryRouteSource;
     property public final com.mapbox.geojson.FeatureCollection waypointsSource;
@@ -966,6 +980,17 @@ package com.mapbox.navigation.ui.maps.route.line.model {
   public final class RouteLineData {
     method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineDynamicData getDynamicData();
     method public com.mapbox.geojson.FeatureCollection getFeatureCollection();
+    method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineData.MutableRouteLineData toMutableValue();
+    property public final com.mapbox.navigation.ui.maps.route.line.model.RouteLineDynamicData dynamicData;
+    property public final com.mapbox.geojson.FeatureCollection featureCollection;
+  }
+
+  public static final class RouteLineData.MutableRouteLineData {
+    method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineDynamicData getDynamicData();
+    method public com.mapbox.geojson.FeatureCollection getFeatureCollection();
+    method public void setDynamicData(com.mapbox.navigation.ui.maps.route.line.model.RouteLineDynamicData p);
+    method public void setFeatureCollection(com.mapbox.geojson.FeatureCollection p);
+    method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineData toImmutableValue();
     property public final com.mapbox.navigation.ui.maps.route.line.model.RouteLineDynamicData dynamicData;
     property public final com.mapbox.geojson.FeatureCollection featureCollection;
   }
@@ -986,6 +1011,23 @@ package com.mapbox.navigation.ui.maps.route.line.model {
     method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineExpressionProvider getCasingExpressionProvider();
     method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineExpressionProvider? getRestrictedSectionExpressionProvider();
     method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineExpressionProvider? getTrafficExpressionProvider();
+    method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineDynamicData.MutableRouteLineDynamicData toMutableValue();
+    property public final com.mapbox.navigation.ui.maps.route.line.model.RouteLineExpressionProvider baseExpressionProvider;
+    property public final com.mapbox.navigation.ui.maps.route.line.model.RouteLineExpressionProvider casingExpressionProvider;
+    property public final com.mapbox.navigation.ui.maps.route.line.model.RouteLineExpressionProvider? restrictedSectionExpressionProvider;
+    property public final com.mapbox.navigation.ui.maps.route.line.model.RouteLineExpressionProvider? trafficExpressionProvider;
+  }
+
+  public static final class RouteLineDynamicData.MutableRouteLineDynamicData {
+    method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineExpressionProvider getBaseExpressionProvider();
+    method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineExpressionProvider getCasingExpressionProvider();
+    method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineExpressionProvider? getRestrictedSectionExpressionProvider();
+    method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineExpressionProvider? getTrafficExpressionProvider();
+    method public void setBaseExpressionProvider(com.mapbox.navigation.ui.maps.route.line.model.RouteLineExpressionProvider p);
+    method public void setCasingExpressionProvider(com.mapbox.navigation.ui.maps.route.line.model.RouteLineExpressionProvider p);
+    method public void setRestrictedSectionExpressionProvider(com.mapbox.navigation.ui.maps.route.line.model.RouteLineExpressionProvider? p);
+    method public void setTrafficExpressionProvider(com.mapbox.navigation.ui.maps.route.line.model.RouteLineExpressionProvider? p);
+    method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineDynamicData toImmutableValue();
     property public final com.mapbox.navigation.ui.maps.route.line.model.RouteLineExpressionProvider baseExpressionProvider;
     property public final com.mapbox.navigation.ui.maps.route.line.model.RouteLineExpressionProvider casingExpressionProvider;
     property public final com.mapbox.navigation.ui.maps.route.line.model.RouteLineExpressionProvider? restrictedSectionExpressionProvider;
@@ -995,6 +1037,17 @@ package com.mapbox.navigation.ui.maps.route.line.model {
   public final class RouteLineError {
     method public String getErrorMessage();
     method public Throwable? getThrowable();
+    method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineError.MutableRouteLineError toMutableValue();
+    property public final String errorMessage;
+    property public final Throwable? throwable;
+  }
+
+  public static final class RouteLineError.MutableRouteLineError {
+    method public String getErrorMessage();
+    method public Throwable? getThrowable();
+    method public void setErrorMessage(String p);
+    method public void setThrowable(Throwable? p);
+    method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineError toImmutableValue();
     property public final String errorMessage;
     property public final Throwable? throwable;
   }
@@ -1096,6 +1149,17 @@ package com.mapbox.navigation.ui.maps.route.line.model {
   public final class RouteLineUpdateValue {
     method public java.util.List<com.mapbox.navigation.ui.maps.route.line.model.RouteLineDynamicData> getAlternativeRouteLinesDynamicData();
     method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineDynamicData getPrimaryRouteLineDynamicData();
+    method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineUpdateValue.MutableRouteLineUpdateValue toMutableValue();
+    property public final java.util.List<com.mapbox.navigation.ui.maps.route.line.model.RouteLineDynamicData> alternativeRouteLinesDynamicData;
+    property public final com.mapbox.navigation.ui.maps.route.line.model.RouteLineDynamicData primaryRouteLineDynamicData;
+  }
+
+  public static final class RouteLineUpdateValue.MutableRouteLineUpdateValue {
+    method public java.util.List<com.mapbox.navigation.ui.maps.route.line.model.RouteLineDynamicData> getAlternativeRouteLinesDynamicData();
+    method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineDynamicData getPrimaryRouteLineDynamicData();
+    method public void setAlternativeRouteLinesDynamicData(java.util.List<com.mapbox.navigation.ui.maps.route.line.model.RouteLineDynamicData> p);
+    method public void setPrimaryRouteLineDynamicData(com.mapbox.navigation.ui.maps.route.line.model.RouteLineDynamicData p);
+    method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineUpdateValue toImmutableValue();
     property public final java.util.List<com.mapbox.navigation.ui.maps.route.line.model.RouteLineDynamicData> alternativeRouteLinesDynamicData;
     property public final com.mapbox.navigation.ui.maps.route.line.model.RouteLineDynamicData primaryRouteLineDynamicData;
   }

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineClearValue.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineClearValue.kt
@@ -13,4 +13,37 @@ class RouteLineClearValue internal constructor(
     val primaryRouteSource: FeatureCollection,
     val alternativeRouteSourceSources: List<FeatureCollection>,
     val waypointsSource: FeatureCollection,
-)
+) {
+
+    /**
+     * @return a class with mutable values for replacing.
+     */
+    fun toMutableValue() = MutableRouteLineClearValue(
+        primaryRouteSource,
+        alternativeRouteSourceSources,
+        waypointsSource
+    )
+
+    /**
+     * Represents mutable data used to remove the route line(s) from the map.
+     *
+     * @param primaryRouteSource a feature collection representing the primary route
+     * @param alternativeRouteSourceSources feature collections representing alternative routes
+     * @param waypointsSource a feature collection representing the origin and destination icons
+     */
+    class MutableRouteLineClearValue internal constructor(
+        var primaryRouteSource: FeatureCollection,
+        var alternativeRouteSourceSources: List<FeatureCollection>,
+        var waypointsSource: FeatureCollection,
+    ) {
+
+        /**
+         * @return a RouteLineClearValue
+         */
+        fun toImmutableValue() = RouteLineClearValue(
+            primaryRouteSource,
+            alternativeRouteSourceSources,
+            waypointsSource
+        )
+    }
+}

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineData.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineData.kt
@@ -14,6 +14,34 @@ class RouteLineData internal constructor(
 ) {
 
     /**
+     * @return a class with mutable values for replacing.
+     */
+    fun toMutableValue() = MutableRouteLineData(
+        featureCollection,
+        dynamicData
+    )
+
+    /**
+     * Provides mutable information needed to draw a route.
+     *
+     * @param featureCollection the routes geometry
+     * @param dynamicData dynamic data to style the route line
+     */
+    class MutableRouteLineData internal constructor(
+        var featureCollection: FeatureCollection,
+        var dynamicData: RouteLineDynamicData
+    ) {
+
+        /**
+         * @return a RouteLineData
+         */
+        fun toImmutableValue() = RouteLineData(
+            featureCollection,
+            dynamicData
+        )
+    }
+
+    /**
      * Indicates whether some other object is "equal to" this one.
      */
     override fun equals(other: Any?): Boolean {

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineDynamicData.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineDynamicData.kt
@@ -16,6 +16,42 @@ class RouteLineDynamicData internal constructor(
 ) {
 
     /**
+     * @return a class with mutable values for replacing.
+     */
+    fun toMutableValue() = MutableRouteLineDynamicData(
+        baseExpressionProvider,
+        casingExpressionProvider,
+        trafficExpressionProvider,
+        restrictedSectionExpressionProvider
+    )
+
+    /**
+     * Provides a mutable representation of information needed to draw a route.
+     *
+     * @param baseExpressionProvider expression used to style the base of the line
+     * @param casingExpressionProvider expression used to style the case of the line
+     * @param trafficExpressionProvider expression used to style the congestion colors on the line
+     * @param restrictedSectionExpressionProvider expression used to style the restricted sections on the line
+     */
+    class MutableRouteLineDynamicData internal constructor(
+        var baseExpressionProvider: RouteLineExpressionProvider,
+        var casingExpressionProvider: RouteLineExpressionProvider,
+        var trafficExpressionProvider: RouteLineExpressionProvider?,
+        var restrictedSectionExpressionProvider: RouteLineExpressionProvider?
+    ) {
+
+        /**
+         * @return a RouteLineDynamicData
+         */
+        fun toImmutableValue() = RouteLineDynamicData(
+            baseExpressionProvider,
+            casingExpressionProvider,
+            trafficExpressionProvider,
+            restrictedSectionExpressionProvider
+        )
+    }
+
+    /**
      * Indicates whether some other object is "equal to" this one.
      */
     override fun equals(other: Any?): Boolean {

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineError.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineError.kt
@@ -9,4 +9,33 @@ package com.mapbox.navigation.ui.maps.route.line.model
 class RouteLineError internal constructor(
     val errorMessage: String,
     val throwable: Throwable?
-)
+) {
+
+    /**
+     * @return a class with mutable values for replacing.
+     */
+    fun toMutableValue() = MutableRouteLineError(
+        errorMessage,
+        throwable
+    )
+
+    /**
+     * Represents a mutable error value for route line related updates.
+     *
+     * @param errorMessage an error message
+     * @param throwable an optional throwable value expressing the error
+     */
+    class MutableRouteLineError internal constructor(
+        var errorMessage: String,
+        var throwable: Throwable?
+    ) {
+
+        /**
+         * @return a RouteLineError
+         */
+        fun toImmutableValue() = RouteLineError(
+            errorMessage,
+            throwable
+        )
+    }
+}

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineUpdateValue.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineUpdateValue.kt
@@ -12,6 +12,34 @@ class RouteLineUpdateValue internal constructor(
 ) {
 
     /**
+     * @return a class with mutable values for replacing.
+     */
+    fun toMutableValue() = MutableRouteLineUpdateValue(
+        primaryRouteLineDynamicData,
+        alternativeRouteLinesDynamicData
+    )
+
+    /**
+     * Represents the mutable data for updating the appearance of the route lines.
+     *
+     * @param primaryRouteLineDynamicData the data describing the primary route line
+     * @param alternativeRouteLinesDynamicData the data describing alternative route lines
+     */
+    class MutableRouteLineUpdateValue internal constructor(
+        var primaryRouteLineDynamicData: RouteLineDynamicData,
+        var alternativeRouteLinesDynamicData: List<RouteLineDynamicData>
+    ) {
+
+        /**
+         * @return a RouteLineUpdateValue
+         */
+        fun toImmutableValue() = RouteLineUpdateValue(
+            primaryRouteLineDynamicData,
+            alternativeRouteLinesDynamicData
+        )
+    }
+
+    /**
      * Indicates whether some other object is "equal to" this one.
      */
     override fun equals(other: Any?): Boolean {

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineClearValueTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineClearValueTest.kt
@@ -1,0 +1,46 @@
+package com.mapbox.navigation.ui.maps.route.line.model
+
+import com.mapbox.geojson.FeatureCollection
+import io.mockk.mockk
+import junit.framework.TestCase.assertEquals
+import org.junit.Test
+
+class RouteLineClearValueTest {
+
+    @Test
+    fun toMutableValue() {
+        val original = RouteLineClearValue(
+            mockk(),
+            listOf(),
+            mockk()
+        )
+
+        val result = original.toMutableValue()
+
+        assertEquals(original.primaryRouteSource, result.primaryRouteSource)
+        assertEquals(original.alternativeRouteSourceSources, result.alternativeRouteSourceSources)
+        assertEquals(original.waypointsSource, result.waypointsSource)
+    }
+
+    @Test
+    fun toImmutableValue() {
+        val original = RouteLineClearValue(
+            mockk(),
+            listOf(),
+            mockk()
+        )
+        val replacementPrimary = mockk<FeatureCollection>()
+        val replacementList = listOf<FeatureCollection>()
+        val replacementWaypointSource = mockk<FeatureCollection>()
+        val mutable = original.toMutableValue()
+
+        mutable.primaryRouteSource = replacementPrimary
+        mutable.alternativeRouteSourceSources = replacementList
+        mutable.waypointsSource = replacementWaypointSource
+        val result = mutable.toImmutableValue()
+
+        assertEquals(replacementPrimary, result.primaryRouteSource)
+        assertEquals(replacementList, result.alternativeRouteSourceSources)
+        assertEquals(replacementWaypointSource, result.waypointsSource)
+    }
+}

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineDataTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineDataTest.kt
@@ -1,0 +1,40 @@
+package com.mapbox.navigation.ui.maps.route.line.model
+
+import com.mapbox.geojson.FeatureCollection
+import io.mockk.mockk
+import junit.framework.TestCase.assertEquals
+import org.junit.Test
+
+class RouteLineDataTest {
+
+    @Test
+    fun toMutableValue() {
+        val original = RouteLineData(
+            mockk(),
+            RouteLineDynamicData(mockk(), mockk(), mockk(), mockk())
+        )
+
+        val result = original.toMutableValue()
+
+        assertEquals(original.featureCollection, result.featureCollection)
+        assertEquals(original.dynamicData, result.dynamicData)
+    }
+
+    @Test
+    fun toImmutableValue() {
+        val original = RouteLineData(
+            mockk(),
+            RouteLineDynamicData(mockk(), mockk(), mockk(), mockk())
+        )
+        val replacementFeatureCollection = mockk<FeatureCollection>()
+        val replacementDynamicData = RouteLineDynamicData(mockk(), mockk(), mockk(), mockk())
+        val mutable = original.toMutableValue()
+
+        mutable.featureCollection = replacementFeatureCollection
+        mutable.dynamicData = replacementDynamicData
+        val result = mutable.toImmutableValue()
+
+        assertEquals(replacementFeatureCollection, result.featureCollection)
+        assertEquals(replacementDynamicData, result.dynamicData)
+    }
+}

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineDynamicDataTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineDynamicDataTest.kt
@@ -1,0 +1,54 @@
+package com.mapbox.navigation.ui.maps.route.line.model
+
+import io.mockk.mockk
+import junit.framework.TestCase.assertEquals
+import org.junit.Test
+
+class RouteLineDynamicDataTest {
+
+    @Test
+    fun toMutableValue() {
+        val original = RouteLineDynamicData(
+            mockk(),
+            mockk(),
+            mockk(),
+            mockk()
+        )
+
+        val result = original.toMutableValue()
+
+        assertEquals(original.baseExpressionProvider, result.baseExpressionProvider)
+        assertEquals(original.casingExpressionProvider, result.casingExpressionProvider)
+        assertEquals(
+            original.restrictedSectionExpressionProvider,
+            result.restrictedSectionExpressionProvider
+        )
+        assertEquals(original.trafficExpressionProvider, result.trafficExpressionProvider)
+    }
+
+    @Test
+    fun toImmutableValue() {
+        val original = RouteLineDynamicData(
+            mockk(),
+            mockk(),
+            mockk(),
+            mockk()
+        )
+        val replacementBaseProvider = mockk<RouteLineExpressionProvider>()
+        val replacementCasingProvider = mockk<RouteLineExpressionProvider>()
+        val replacementTrafficProvider = mockk<RouteLineExpressionProvider>()
+        val replacementSectionProvider = mockk<RouteLineExpressionProvider>()
+        val mutable = original.toMutableValue()
+
+        mutable.baseExpressionProvider = replacementBaseProvider
+        mutable.casingExpressionProvider = replacementCasingProvider
+        mutable.trafficExpressionProvider = replacementTrafficProvider
+        mutable.restrictedSectionExpressionProvider = replacementSectionProvider
+        val result = mutable.toImmutableValue()
+
+        assertEquals(replacementBaseProvider, result.baseExpressionProvider)
+        assertEquals(replacementCasingProvider, result.casingExpressionProvider)
+        assertEquals(replacementTrafficProvider, result.trafficExpressionProvider)
+        assertEquals(replacementSectionProvider, result.restrictedSectionExpressionProvider)
+    }
+}

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineErrorTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineErrorTest.kt
@@ -1,0 +1,39 @@
+package com.mapbox.navigation.ui.maps.route.line.model
+
+import junit.framework.TestCase.assertEquals
+import org.junit.Test
+import java.lang.RuntimeException
+
+class RouteLineErrorTest {
+
+    @Test
+    fun toMutableValue() {
+        val original = RouteLineError(
+            "foobar",
+            RuntimeException()
+        )
+
+        val result = original.toMutableValue()
+
+        assertEquals(original.errorMessage, result.errorMessage)
+        assertEquals(original.throwable, result.throwable)
+    }
+
+    @Test
+    fun toImmutableValue() {
+        val original = RouteLineError(
+            "foobar",
+            RuntimeException()
+        )
+        val replacementMessage = "doodle"
+        val replacementThrowable = RuntimeException()
+        val mutable = original.toMutableValue()
+
+        mutable.errorMessage = replacementMessage
+        mutable.throwable = replacementThrowable
+        val result = mutable.toImmutableValue()
+
+        assertEquals(replacementMessage, result.errorMessage)
+        assertEquals(replacementThrowable, result.throwable)
+    }
+}

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineUpdateValueTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineUpdateValueTest.kt
@@ -1,0 +1,43 @@
+package com.mapbox.navigation.ui.maps.route.line.model
+
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class RouteLineUpdateValueTest {
+
+    @Test
+    fun toMutableValue() {
+        val original = RouteLineUpdateValue(
+            RouteLineDynamicData(mockk(), mockk(), mockk(), mockk()),
+            listOf()
+        )
+
+        val result = original.toMutableValue()
+
+        assertEquals(original.primaryRouteLineDynamicData, result.primaryRouteLineDynamicData)
+        assertEquals(
+            original.alternativeRouteLinesDynamicData,
+            result.alternativeRouteLinesDynamicData
+        )
+    }
+
+    @Test
+    fun toImmutableValue() {
+        val original = RouteLineUpdateValue(
+            RouteLineDynamicData(mockk(), mockk(), mockk(), mockk()),
+            listOf()
+        )
+        val replacementPrimaryRouteLineDynamicData =
+            RouteLineDynamicData(mockk(), mockk(), mockk(), mockk())
+        val replacementList = listOf<RouteLineDynamicData>()
+        val mutable = original.toMutableValue()
+
+        mutable.primaryRouteLineDynamicData = replacementPrimaryRouteLineDynamicData
+        mutable.alternativeRouteLinesDynamicData = replacementList
+        val result = mutable.toImmutableValue()
+
+        assertEquals(replacementPrimaryRouteLineDynamicData, result.primaryRouteLineDynamicData)
+        assertEquals(replacementList, result.alternativeRouteLinesDynamicData)
+    }
+}


### PR DESCRIPTION
### Description
Resolves #5059. Methods were added to existing classes but no existing methods were changed or removed so this shouldn't impact `semver` in a negative way.

### Changelog
```
<changelog>Added missing mutability methods to results returned by the route line API.</changelog>
```

### Screenshots or Gifs

