### PR TITLE
Predictive cache with descriptors

### DIFF
--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/internal/cache/PredictiveCacheTests.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/internal/cache/PredictiveCacheTests.kt
@@ -32,7 +32,11 @@ class PredictiveCacheTests {
         } returns mockk()
 
         every {
-            MapboxNativeNavigatorImpl.createMapsPredictiveCacheController(any(), any(), any())
+            MapboxNativeNavigatorImpl.createMapsPredictiveCacheControllerTileVariant(
+                any(),
+                any(),
+                any()
+            )
         } returns mockk()
 
         every {
@@ -81,7 +85,7 @@ class PredictiveCacheTests {
         PredictiveCache.removeMapControllers(map, TILE_VARIANT_4)
 
         assertEquals(1, PredictiveCache.currentMapsPredictiveCacheControllers(map).size)
-        assertEquals(1, PredictiveCache.cachedMapsPredictiveCacheControllers[map]?.size)
+        assertEquals(1, PredictiveCache.cachedMapsPredictiveCacheControllersTileVariant[map]?.size)
         assertEquals(TILE_VARIANT_3, PredictiveCache.currentMapsPredictiveCacheControllers(map)[0])
     }
 
@@ -93,7 +97,7 @@ class PredictiveCacheTests {
         PredictiveCache.createMapsController(map, tileStore, TILE_VARIANT_2, mockk())
         PredictiveCache.createMapsController(map, tileStore, TILE_VARIANT_3, mockk())
 
-        PredictiveCache.removeAllMapControllers(map)
+        PredictiveCache.removeAllMapControllersFromTileVariants(map)
 
         assertEquals(0, PredictiveCache.currentMapsPredictiveCacheControllers(map).size)
         assertEquals(null, PredictiveCache.mapsPredictiveCacheLocationOptions[map])
@@ -133,55 +137,55 @@ class PredictiveCacheTests {
         val callback = navigatorRecreationCallbackSlot.captured
         callback.onNativeNavigatorRecreated()
 
-        assertEquals(2, PredictiveCache.cachedMapsPredictiveCacheControllers.size)
+        assertEquals(2, PredictiveCache.cachedMapsPredictiveCacheControllersTileVariant.size)
         assertEquals(3, PredictiveCache.currentMapsPredictiveCacheControllers(map1).size)
         assertEquals(4, PredictiveCache.currentMapsPredictiveCacheControllers(map2).size)
 
-        assertEquals(2, PredictiveCache.mapsPredictiveCacheLocationOptions.size)
-        assertEquals(3, PredictiveCache.mapsPredictiveCacheLocationOptions[map1]?.size)
-        assertEquals(4, PredictiveCache.mapsPredictiveCacheLocationOptions[map2]?.size)
+        assertEquals(2, PredictiveCache.mapsPredictiveCacheLocationOptionsTileVariant.size)
+        assertEquals(3, PredictiveCache.mapsPredictiveCacheLocationOptionsTileVariant[map1]?.size)
+        assertEquals(4, PredictiveCache.mapsPredictiveCacheLocationOptionsTileVariant[map2]?.size)
 
         assertEquals(2, PredictiveCache.cachedNavigationPredictiveCacheControllers.size)
         assertEquals(2, PredictiveCache.navPredictiveCacheLocationOptions.size)
 
         verify(exactly = 2) {
-            MapboxNativeNavigatorImpl.createMapsPredictiveCacheController(
+            MapboxNativeNavigatorImpl.createMapsPredictiveCacheControllerTileVariant(
                 tileStore, TILE_VARIANT_1, any()
             )
         }
 
         verify(exactly = 2) {
-            MapboxNativeNavigatorImpl.createMapsPredictiveCacheController(
+            MapboxNativeNavigatorImpl.createMapsPredictiveCacheControllerTileVariant(
                 tileStore, TILE_VARIANT_2, any()
             )
         }
 
         verify(exactly = 2) {
-            MapboxNativeNavigatorImpl.createMapsPredictiveCacheController(
+            MapboxNativeNavigatorImpl.createMapsPredictiveCacheControllerTileVariant(
                 tileStore, TILE_VARIANT_3, any()
             )
         }
 
         verify(exactly = 2) {
-            MapboxNativeNavigatorImpl.createMapsPredictiveCacheController(
+            MapboxNativeNavigatorImpl.createMapsPredictiveCacheControllerTileVariant(
                 tileStore, TILE_VARIANT_4, any()
             )
         }
 
         verify(exactly = 2) {
-            MapboxNativeNavigatorImpl.createMapsPredictiveCacheController(
+            MapboxNativeNavigatorImpl.createMapsPredictiveCacheControllerTileVariant(
                 tileStore, TILE_VARIANT_5, any()
             )
         }
 
         verify(exactly = 2) {
-            MapboxNativeNavigatorImpl.createMapsPredictiveCacheController(
+            MapboxNativeNavigatorImpl.createMapsPredictiveCacheControllerTileVariant(
                 tileStore, TILE_VARIANT_6, any()
             )
         }
 
         verify(exactly = 2) {
-            MapboxNativeNavigatorImpl.createMapsPredictiveCacheController(
+            MapboxNativeNavigatorImpl.createMapsPredictiveCacheControllerTileVariant(
                 tileStore, TILE_VARIANT_7, any()
             )
         }

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigator.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigator.kt
@@ -4,6 +4,7 @@ import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.base.common.logger.Logger
 import com.mapbox.bindgen.Expected
 import com.mapbox.common.TileStore
+import com.mapbox.common.TilesetDescriptor
 import com.mapbox.navigation.base.options.DeviceProfile
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.options.PredictiveCacheLocationOptions
@@ -196,9 +197,29 @@ interface MapboxNativeNavigator {
      *
      * @return [PredictiveCacheController]
      */
-    fun createMapsPredictiveCacheController(
+    @Deprecated(
+        "Use createMapsController(" +
+            "mapboxMap, tileStore, tilesetDescriptor, predictiveCacheLocationOptions" +
+            ") instead."
+    )
+    fun createMapsPredictiveCacheControllerTileVariant(
         tileStore: TileStore,
         tileVariant: String,
+        predictiveCacheLocationOptions: PredictiveCacheLocationOptions
+    ): PredictiveCacheController
+
+    /**
+     * Creates a Maps [PredictiveCacheController].
+     *
+     * @param tileStore Maps [TileStore]
+     * @param tilesetDescriptor Maps tilesetDescriptor
+     * @param predictiveCacheLocationOptions [PredictiveCacheLocationOptions]
+     *
+     * @return [PredictiveCacheController]
+     */
+    fun createMapsPredictiveCacheController(
+        tileStore: TileStore,
+        tilesetDescriptor: TilesetDescriptor,
         predictiveCacheLocationOptions: PredictiveCacheLocationOptions
     ): PredictiveCacheController
 

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigatorImpl.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigatorImpl.kt
@@ -9,6 +9,7 @@ import com.mapbox.base.common.logger.model.Message
 import com.mapbox.base.common.logger.model.Tag
 import com.mapbox.bindgen.Expected
 import com.mapbox.common.TileStore
+import com.mapbox.common.TilesetDescriptor
 import com.mapbox.navigation.base.options.DeviceProfile
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.options.PredictiveCacheLocationOptions
@@ -369,7 +370,12 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
      *
      * @return [PredictiveCacheController]
      */
-    override fun createMapsPredictiveCacheController(
+    @Deprecated(
+        "Use createMapsController(" +
+            "mapboxMap, tileStore, tilesetDescriptor, predictiveCacheLocationOptions" +
+            ") instead."
+    )
+    override fun createMapsPredictiveCacheControllerTileVariant(
         tileStore: TileStore,
         tileVariant: String,
         predictiveCacheLocationOptions: PredictiveCacheLocationOptions
@@ -377,6 +383,26 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
         navigator!!.createPredictiveCacheController(
             tileStore,
             createDefaultMapsPredictiveCacheControllerOptions(tileVariant),
+            predictiveCacheLocationOptions.toPredictiveLocationTrackerOptions()
+        )
+
+    /**
+     * Creates a Maps [PredictiveCacheController].
+     *
+     * @param tileStore Maps [TileStore]
+     * @param tilesetDescriptor Maps tilesetDescriptor
+     * @param predictiveCacheLocationOptions [PredictiveCacheLocationOptions]
+     *
+     * @return [PredictiveCacheController]
+     */
+    override fun createMapsPredictiveCacheController(
+        tileStore: TileStore,
+        tilesetDescriptor: TilesetDescriptor,
+        predictiveCacheLocationOptions: PredictiveCacheLocationOptions
+    ): PredictiveCacheController =
+        navigator!!.createPredictiveCacheController(
+            tileStore,
+            listOf(tilesetDescriptor),
             predictiveCacheLocationOptions.toPredictiveLocationTrackerOptions()
         )
 

--- a/libnavui-maps/api/current.txt
+++ b/libnavui-maps/api/current.txt
@@ -4,8 +4,11 @@ package com.mapbox.navigation.ui.maps {
   public final class PredictiveCacheController {
     ctor public PredictiveCacheController(com.mapbox.navigation.base.options.PredictiveCacheLocationOptions predictiveCacheLocationOptions = PredictiveCacheLocationOptions.<init>().build(), com.mapbox.navigation.ui.maps.PredictiveCacheControllerErrorHandler? predictiveCacheControllerErrorHandler = null);
     ctor public PredictiveCacheController(com.mapbox.navigation.base.options.PredictiveCacheLocationOptions predictiveCacheLocationOptions = PredictiveCacheLocationOptions.<init>().build());
-    method public void createMapControllers(com.mapbox.maps.MapboxMap map, java.util.List<java.lang.String> sourceIdsToCache = emptyList());
-    method public void createMapControllers(com.mapbox.maps.MapboxMap map);
+    method @Deprecated public void createMapControllers(com.mapbox.maps.MapboxMap map, java.util.List<java.lang.String> sourceIdsToCache = emptyList());
+    method @Deprecated public void createMapControllers(com.mapbox.maps.MapboxMap map);
+    method public void createStyleMapControllers(com.mapbox.maps.MapboxMap map, boolean cacheCurrentMapStyle = true, java.util.List<java.lang.String> styles = emptyList());
+    method public void createStyleMapControllers(com.mapbox.maps.MapboxMap map, boolean cacheCurrentMapStyle = true);
+    method public void createStyleMapControllers(com.mapbox.maps.MapboxMap map);
     method public void onDestroy();
     method public void removeMapControllers(com.mapbox.maps.MapboxMap map);
   }

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/PredictiveCacheControllerTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/PredictiveCacheControllerTest.kt
@@ -167,7 +167,7 @@ class PredictiveCacheControllerTest {
             PredictiveCache.createMapsController(
                 mockedMapboxMap,
                 mockedTileStore,
-                any(),
+                any<String>(),
                 any()
             )
         }
@@ -273,7 +273,7 @@ class PredictiveCacheControllerTest {
             PredictiveCache.createMapsController(
                 mockedMapboxMap,
                 mockedTileStore,
-                any(),
+                any<String>(),
                 any()
             )
         }
@@ -351,7 +351,7 @@ class PredictiveCacheControllerTest {
             PredictiveCache.createMapsController(
                 mockedMapboxMap,
                 mockedTileStore,
-                any(),
+                any<String>(),
                 any()
             )
         }
@@ -454,11 +454,13 @@ class PredictiveCacheControllerTest {
             PredictiveCache.createMapsController(
                 mockedMapboxMap,
                 mockedTileStore,
-                any(),
+                any<String>(),
                 any()
             )
         }
-        verify(exactly = 1) { PredictiveCache.removeAllMapControllers(mockedMapboxMap) }
+        verify(exactly = 1) {
+            PredictiveCache.removeAllMapControllersFromTileVariants(mockedMapboxMap)
+        }
         verify(exactly = 0) { errorHandler.onError(any()) }
     }
 
@@ -496,7 +498,7 @@ class PredictiveCacheControllerTest {
 
         verify(exactly = 1) { errorHandler.onError(error) }
         verify(exactly = 0) {
-            PredictiveCache.createMapsController(any(), any(), any(), any())
+            PredictiveCache.createMapsController(any(), any(), any<String>(), any())
         }
     }
 }

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/MapboxRouteLineActivity.java
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/MapboxRouteLineActivity.java
@@ -185,7 +185,7 @@ public class MapboxRouteLineActivity extends AppCompatActivity implements OnMapL
         message -> {
           Log.e(TAG, "predictive cache error: " + message);
         });
-    predictiveCacheController.createMapControllers(mapboxMap);
+    predictiveCacheController.createStyleMapControllers(mapboxMap);
   }
 
   @SuppressLint("MissingPermission")


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Predictive cache with `TilesetDescriptor`.

Fixes https://github.com/mapbox/mapbox-navigation-android/issues/4707

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Implemented predictive cache with `TilesetDescriptor` so that volatile sources are not loaded unexpectedly.</changelog>
```

Opening this as a `Draft` because we're still missing:
- [ ] Add tests for new logic
- [x] Check traffic / verify that `volatile` sources are not loaded https://github.com/mapbox/mapbox-navigation-android/pull/5068#issuecomment-960650128