### PR TITLE
Fixed strings comparison in the docs release script

### DIFF
--- a/scripts/publish_api_docs_android.sh
+++ b/scripts/publish_api_docs_android.sh
@@ -47,7 +47,7 @@ checkIfGithubTokensAreProvided() {
 
 checkIfTagExist() {
     pushd "${NAVIGATION_GIT_REPO}"
-    if [ $(git tag --points-at HEAD) = TAG ]; then
+    if [ "$(git tag --points-at HEAD)" = "$TAG" ]; then
         echo "tag ${TAG} exist"
     else
         echo "current commit is not point at tag ${TAG}"


### PR DESCRIPTION
### Description
Fixed strings comparison in the bash script to avoid [the error](https://app.circleci.com/pipelines/github/mapbox/mapbox-navigation-android/14648/workflows/291bf18c-a70d-4098-ba60-80771cdf64c7/jobs/62136)
