### PR TITLE
Add `PedingIntent` Android 12 flags support

### DIFF
--- a/libtrip-notification/src/main/java/com/mapbox/navigation/trip/notification/internal/MapboxTripNotification.kt
+++ b/libtrip-notification/src/main/java/com/mapbox/navigation/trip/notification/internal/MapboxTripNotification.kt
@@ -1,6 +1,5 @@
 package com.mapbox.navigation.trip.notification.internal
 
-import android.annotation.SuppressLint
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
@@ -89,6 +88,12 @@ class MapboxTripNotification constructor(
     )
 
     private var notificationView: MapboxTripNotificationView
+    private val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+    } else {
+        PendingIntent.FLAG_UPDATE_CURRENT
+    }
+
     init {
         applicationContext.getSystemService(Context.NOTIFICATION_SERVICE)
             ?.let { notificationService ->
@@ -212,12 +217,11 @@ class MapboxTripNotification constructor(
      * @param applicationContext the application's [Context]
      * @return [PendingIntent] to opening application
      */
-    @SuppressLint("UnspecifiedImmutableFlag")
     private fun createPendingOpenIntent(applicationContext: Context): PendingIntent? {
         val pm = applicationContext.packageManager
         val intent = pm.getLaunchIntentForPackage(applicationContext.packageName) ?: return null
         intent.setPackage(null)
-        return PendingIntent.getActivity(applicationContext, 0, intent, 0)
+        return PendingIntent.getActivity(applicationContext, 0, intent, flags)
     }
 
     /**
@@ -227,10 +231,9 @@ class MapboxTripNotification constructor(
      * @param applicationContext the application's [Context]
      * @return [PendingIntent] for stopping trip session
      */
-    @SuppressLint("UnspecifiedImmutableFlag")
     private fun createPendingCloseIntent(applicationContext: Context): PendingIntent? {
         val endNavigationBtn = Intent(END_NAVIGATION_ACTION)
-        return PendingIntent.getBroadcast(applicationContext, 0, endNavigationBtn, 0)
+        return PendingIntent.getBroadcast(applicationContext, 0, endNavigationBtn, flags)
     }
 
     private fun createNotificationChannel() {


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Adds `PedingIntent` Android 12 flags support.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Added `PedingIntent` Android 12 flags support.</changelog>
```

Refs. #5102 