### PR TITLE
Add MapboxNavigationApp lifecycle

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -321,14 +321,26 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 
 ===========================================================================
 
-Mapbox Navigation uses portions of the Android Lifecycle Runtime.
+Mapbox Navigation uses portions of the Android Arch-Runtime.
 URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 
+Mapbox Navigation uses portions of the Android Lifecycle Kotlin Extensions (Kotlin extensions for 'lifecycle' artifact).
+URL: [https://developer.android.com/jetpack/androidx/releases/lifecycle#2.4.0](https://developer.android.com/jetpack/androidx/releases/lifecycle#2.4.0)
+License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+===========================================================================
+
+Mapbox Navigation uses portions of the Android Lifecycle Runtime.
+URL: [https://developer.android.com/jetpack/androidx/releases/lifecycle#2.4.0](https://developer.android.com/jetpack/androidx/releases/lifecycle#2.4.0)
+License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+===========================================================================
+
 Mapbox Navigation uses portions of the Android Lifecycle-Common.
-URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)
+URL: [https://developer.android.com/jetpack/androidx/releases/lifecycle#2.4.0](https://developer.android.com/jetpack/androidx/releases/lifecycle#2.4.0)
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -46,8 +46,6 @@ ext {
       commonsIO                 : '2.6',
       robolectric               : '4.3.1',
       mockwebserver             : '4.9.0',
-      lifecycle                 : '2.2.0',
-      lifecycleViewModelKtx     : '2.2.0',
       gmsLocation               : '17.0.0',
       ktlint                    : '0.41.0',
       kotlinStdLib              : kotlinVersion,
@@ -115,9 +113,6 @@ ext {
       androidXAppCompat         : "androidx.appcompat:appcompat:${version.androidXAppCompatVersion}",
       androidXCore              : "androidx.core:core:${version.androidXCoreVersion}",
       androidXCoreKtx           : "androidx.core:core-ktx:${version.androidXCoreVersion}",
-      androidXLifecycleRuntime  : "androidx.lifecycle:lifecycle-runtime-ktx:${version.androidXLifecycle}",
-      androidXLifecycleLivedata : "androidx.lifecycle:lifecycle-livedata-ktx:${version.androidXLifecycle}",
-      androidXLifecycleViewmodel: "androidx.lifecycle:lifecycle-viewmodel-ktx:${version.androidXLifecycle}",
       materialDesign            : "com.google.android.material:material:${version.materialDesignVersion}",
       androidXRecyclerView      : "androidx.recyclerview:recyclerview:${version.recyclerViewVersion}",
       androidXCardView          : "androidx.cardview:cardview:${version.cardViewVersion}",
@@ -125,10 +120,10 @@ ext {
       androidXPreference        : "androidx.preference:preference-ktx:${version.androidXPreferenceVersion}",
       androidStartup            : "androidx.startup:startup-runtime:${version.androidStartup}",
 
-      // architecture
-      lifecycleViewModelKtx     : "androidx.lifecycle:lifecycle-viewmodel-ktx:${version.lifecycleViewModelKtx}",
-      lifecycleExtensions       : "androidx.lifecycle:lifecycle-extensions:${version.lifecycle}",
-      lifecycleCompiler         : "androidx.lifecycle:lifecycle-compiler:${version.lifecycle}",
+      // lifecycle
+      androidXLifecycleRuntime  : "androidx.lifecycle:lifecycle-runtime-ktx:${version.androidXLifecycle}",
+      androidXLifecycleLivedata : "androidx.lifecycle:lifecycle-livedata-ktx:${version.androidXLifecycle}",
+      androidXLifecycleViewmodel: "androidx.lifecycle:lifecycle-viewmodel-ktx:${version.androidXLifecycle}",
 
       // square crew
       leakCanaryDebug           : "com.squareup.leakcanary:leakcanary-android:${version.leakCanaryVersion}",

--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -231,6 +231,29 @@ package com.mapbox.navigation.core.history.model {
 
 }
 
+package com.mapbox.navigation.core.lifecycle {
+
+  @com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI public final class MapboxNavigationApp {
+    method public com.mapbox.navigation.core.lifecycle.MapboxNavigationApp attach(androidx.lifecycle.LifecycleOwner lifecycleOwner);
+    method public com.mapbox.navigation.core.lifecycle.MapboxNavigationApp attachAllActivities();
+    method public com.mapbox.navigation.core.MapboxNavigation? current();
+    method public com.mapbox.navigation.core.lifecycle.MapboxNavigationApp detach(androidx.lifecycle.LifecycleOwner lifecycleOwner);
+    method public com.mapbox.navigation.core.lifecycle.MapboxNavigationApp disable();
+    method public androidx.lifecycle.LifecycleOwner getLifecycleOwner();
+    method public com.mapbox.navigation.core.lifecycle.MapboxNavigationApp registerObserver(com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver mapboxNavigationObserver);
+    method public com.mapbox.navigation.core.lifecycle.MapboxNavigationApp setup(com.mapbox.navigation.base.options.NavigationOptions navigationOptions);
+    method public com.mapbox.navigation.core.lifecycle.MapboxNavigationApp unregisterObserver(com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver mapboxNavigationObserver);
+    property public final androidx.lifecycle.LifecycleOwner lifecycleOwner;
+    field public static final com.mapbox.navigation.core.lifecycle.MapboxNavigationApp INSTANCE;
+  }
+
+  @com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI public interface MapboxNavigationObserver {
+    method public void onAttached(com.mapbox.navigation.core.MapboxNavigation mapboxNavigation);
+    method public void onDetached(com.mapbox.navigation.core.MapboxNavigation mapboxNavigation);
+  }
+
+}
+
 package com.mapbox.navigation.core.navigator {
 
   public final class LocationEx {

--- a/libnavigation-core/build.gradle
+++ b/libnavigation-core/build.gradle
@@ -54,6 +54,8 @@ dependencies {
     implementation dependenciesList.coroutinesAndroid
     implementation dependenciesList.androidStartup
 
+    api dependenciesList.androidXLifecycleRuntime
+
     testImplementation project(':libtesting-utils')
     apply from: "${rootDir}/gradle/unit-testing-dependencies.gradle"
     testImplementation dependenciesList.commonsIO

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/lifecycle/CarAppLifecycleOwner.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/lifecycle/CarAppLifecycleOwner.kt
@@ -1,0 +1,176 @@
+package com.mapbox.navigation.core.lifecycle
+
+import android.app.Activity
+import android.app.Application
+import android.os.Bundle
+import androidx.annotation.VisibleForTesting
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import com.mapbox.base.common.logger.model.Message
+import com.mapbox.base.common.logger.model.Tag
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.utils.internal.LoggerProvider.logger
+
+@ExperimentalPreviewMapboxNavigationAPI
+internal class CarAppLifecycleOwner : LifecycleOwner {
+
+    // Keeps track of the activities created and foregrounded
+    private var activitiesCreated = 0
+    private var activitiesForegrounded = 0
+
+    // Keeps track of the car session created and foregrounded
+    private var lifecycleCreated = 0
+    private var lifecycleForegrounded = 0
+
+    // Keeps track of the activities changing configurations
+    private var createdChangingConfiguration = 0
+    private var foregroundedChangingConfiguration = 0
+
+    private val lifecycleRegistry = LifecycleRegistry(this)
+        .apply { currentState = Lifecycle.State.INITIALIZED }
+
+    @VisibleForTesting
+    internal val startedReferenceCounter = object : DefaultLifecycleObserver {
+        override fun onCreate(owner: LifecycleOwner) {
+            lifecycleCreated++
+            logger.i(TAG, Message("LifecycleOwner ($owner) onCreate"))
+            if (activitiesCreated == 0 && lifecycleCreated > 0 && lifecycleForegrounded == 0) {
+                changeState(Lifecycle.State.STARTED)
+            }
+        }
+
+        override fun onStart(owner: LifecycleOwner) {
+            lifecycleForegrounded++
+            logger.i(TAG, Message("LifecycleOwner ($owner) onStart"))
+            if (activitiesCreated == 0 && lifecycleForegrounded > 0) {
+                changeState(Lifecycle.State.RESUMED)
+            }
+        }
+
+        override fun onStop(owner: LifecycleOwner) {
+            lifecycleForegrounded--
+            logger.i(TAG, Message("LifecycleOwner ($owner) onStop"))
+            if (activitiesForegrounded == 0 && lifecycleForegrounded == 0) {
+                changeState(Lifecycle.State.STARTED)
+            }
+        }
+
+        override fun onDestroy(owner: LifecycleOwner) {
+            lifecycleCreated--
+            logger.i(TAG, Message("LifecycleOwner ($owner) onDestroy"))
+            if (activitiesForegrounded == 0 && lifecycleForegrounded == 0) {
+                changeState(Lifecycle.State.CREATED)
+            }
+        }
+    }
+
+    @VisibleForTesting
+    internal val activityLifecycleCallbacks = object : Application.ActivityLifecycleCallbacks {
+        override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
+            if (createdChangingConfiguration > 0) {
+                createdChangingConfiguration--
+            } else {
+                activitiesCreated++
+                logger.i(TAG, Message("app onActivityCreated"))
+                if (lifecycleCreated == 0 && activitiesCreated == 1) {
+                    changeState(Lifecycle.State.STARTED)
+                }
+            }
+        }
+
+        override fun onActivityStarted(activity: Activity) {
+            if (foregroundedChangingConfiguration > 0) {
+                foregroundedChangingConfiguration--
+            } else {
+                activitiesForegrounded++
+                logger.i(TAG, Message("app onActivityStarted"))
+                if (lifecycleCreated == 0 && activitiesForegrounded == 1) {
+                    changeState(Lifecycle.State.RESUMED)
+                }
+            }
+        }
+
+        override fun onActivityResumed(activity: Activity) {
+            logger.i(TAG, Message("app onActivityResumed"))
+        }
+
+        override fun onActivityPaused(activity: Activity) {
+            logger.i(TAG, Message("app onActivityPaused"))
+        }
+
+        override fun onActivityStopped(activity: Activity) {
+            if (activity.isChangingConfigurations) {
+                foregroundedChangingConfiguration++
+            } else {
+                activitiesForegrounded--
+                logger.i(TAG, Message("app onActivityStopped"))
+                if (lifecycleCreated == 0 &&
+                    activitiesCreated == 0 &&
+                    activitiesForegrounded == 0
+                ) {
+                    check(activitiesCreated == 0 && activitiesForegrounded == 0) {
+                        "onActivityStopped when no activities exist"
+                    }
+                    changeState(Lifecycle.State.STARTED)
+                }
+            }
+        }
+
+        override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {
+            logger.i(TAG, Message("app onActivitySaveInstanceState"))
+        }
+
+        override fun onActivityDestroyed(activity: Activity) {
+            if (activity.isChangingConfigurations) {
+                createdChangingConfiguration++
+            } else {
+                activitiesCreated--
+                logger.i(TAG, Message("app onActivityDestroyed"))
+                if (lifecycleCreated == 0 && activitiesCreated == 0) {
+                    changeState(Lifecycle.State.CREATED)
+                }
+            }
+        }
+    }
+
+    private fun changeState(state: Lifecycle.State) {
+        if (lifecycleRegistry.currentState != state) {
+            lifecycleRegistry.currentState = state
+            logger.i(TAG, Message("changeState ${lifecycleRegistry.currentState}"))
+        }
+    }
+
+    override fun getLifecycle(): Lifecycle = lifecycleRegistry
+
+    internal fun attachAllActivities(application: Application) {
+        logger.i(TAG, Message("attachAllActivities"))
+        application.unregisterActivityLifecycleCallbacks(activityLifecycleCallbacks)
+        application.registerActivityLifecycleCallbacks(activityLifecycleCallbacks)
+    }
+
+    fun attach(lifecycleOwner: LifecycleOwner) {
+        logger.i(TAG, Message("attach"))
+        lifecycleOwner.lifecycle.addObserver(startedReferenceCounter)
+    }
+
+    fun detach(lifecycleOwner: LifecycleOwner) {
+        logger.i(TAG, Message("detach"))
+        lifecycleOwner.lifecycle.removeObserver(startedReferenceCounter)
+        val currentState = lifecycleOwner.lifecycle.currentState
+        if (currentState.isAtLeast(Lifecycle.State.RESUMED)) {
+            startedReferenceCounter.onPause(MapboxNavigationApp.lifecycleOwner)
+        }
+        if (currentState.isAtLeast(Lifecycle.State.STARTED)) {
+            startedReferenceCounter.onStop(MapboxNavigationApp.lifecycleOwner)
+        }
+        if (currentState.isAtLeast(Lifecycle.State.CREATED)) {
+            startedReferenceCounter.onDestroy(MapboxNavigationApp.lifecycleOwner)
+        }
+    }
+
+    private companion object {
+        private val TAG = Tag("MbxCarAppLifecycleOwner")
+    }
+}

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/lifecycle/MapboxNavigationApp.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/lifecycle/MapboxNavigationApp.kt
@@ -1,0 +1,138 @@
+package com.mapbox.navigation.core.lifecycle
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.base.options.NavigationOptions
+import com.mapbox.navigation.core.MapboxNavigation
+
+/**
+ * Manages a default lifecycle for [MapboxNavigation].
+ *
+ * 1. Call [MapboxNavigationApp.setup] to specify your [NavigationOptions].
+ * 2. Register and unregister your [MapboxNavigationObserver] instances with
+ * [MapboxNavigationApp.registerObserver] and [MapboxNavigationApp.unregisterObserver].
+ * 3. Attach and detach [LifecycleOwner]s to create instances of [MapboxNavigation].
+ *
+ * ## Examples
+ *
+ * Register and unregister individual [LifecycleOwner]s. Below is an example of creating a
+ * single activity that uses [MapboxNavigation].
+ *
+ * ```
+ * class MyActivity : ComponentActivity() {
+ *   override fun onCreate() {
+ *     MapboxNavigationApp
+ *       .setup(navigationOptions)
+ *       .attach(this)
+ *   }
+ *   override fun onResume() {
+ *     MapboxNavigationApp
+ *       .registerObserver(locationObserver)
+ *   }
+ *   override fun onPause() {
+ *     MapboxNavigationApp
+ *       .unregisterObserver(locationObserver)
+ *   }
+ * }
+ * ```
+ *
+ * Alternatively, you can enable an entire application by attaching all activities. This will
+ * make a [MapboxNavigation] instance available to any activity or fragment.
+ *
+ * ```
+ * class MyApplication : Application() {
+ *   override fun onCreate() {
+ *     MapboxNavigationApp.setup(this)
+ *       .attachAllActivities()
+ *       .registerObserver(locationObserver)
+ *   }
+ * }
+ * ```
+ */
+@ExperimentalPreviewMapboxNavigationAPI
+object MapboxNavigationApp {
+
+    // The singleton MapboxNavigationApp is not good for unit testing.
+    // See the unit tests in MapboxNavigationAppDelegateTest
+    private val mapboxNavigationAppDelegate by lazy { MapboxNavigationAppDelegate() }
+
+    /**
+     * Get the lifecycle of the car and app. It is started when either the car or
+     * app is in foreground. When both the car and app have been closed, the lifecycle
+     * is stopped. The lifecycle is never destroyed.
+     */
+    val lifecycleOwner: LifecycleOwner = mapboxNavigationAppDelegate.lifecycleOwner
+
+    /**
+     * Call [MapboxNavigationApp.setup] to provide the application with [NavigationOptions].
+     */
+    fun setup(navigationOptions: NavigationOptions) = apply {
+        mapboxNavigationAppDelegate.setup(navigationOptions)
+    }
+
+    /**
+     * Detect when any Activity is in the foreground. Use [attach] and [detach] for
+     * granular control of which lifecycle is used for creating [MapboxNavigation].
+     */
+    fun attachAllActivities() = apply {
+        mapboxNavigationAppDelegate.attachAllActivities()
+    }
+
+    /**
+     * Optional function to detach all observers and disable [MapboxNavigation] from being created.
+     * You can re-enable [MapboxNavigation] by calling [MapboxNavigationApp.setup].
+     */
+    fun disable() = apply {
+        mapboxNavigationAppDelegate.disable()
+    }
+
+    /**
+     * Individually attach a lifecycle onto the [MapboxNavigationApp].
+     * If the app has been [setup], then this lifecycle will cause
+     * [MapboxNavigation] to be created.
+     *
+     * It is not required to [detach] every lifecycle. Because when
+     * the [Lifecycle] reaches the terminal [Lifecycle.State.DESTROYED] state
+     * it will be removed from the observers automatically.
+     */
+    fun attach(lifecycleOwner: LifecycleOwner) = apply {
+        mapboxNavigationAppDelegate.attach(lifecycleOwner)
+    }
+
+    /**
+     * Individually detach lifecycles from [MapboxNavigationApp].
+     * When all LifecycleOwners have been detached, this will cause all
+     * [MapboxNavigationObserver.onDetached].
+     *
+     * Warning: The [CarAppLifecycleOwner] assumes all [detach] calls included an [attach].
+     * Detaching an owner that was never attached will create incorrect counters
+     * and will potentially cause [MapboxNavigation] to never be created.
+     */
+    fun detach(lifecycleOwner: LifecycleOwner) = apply {
+        mapboxNavigationAppDelegate.detach(lifecycleOwner)
+    }
+
+    /**
+     * Register an observer to receive the [MapboxNavigation] instance.
+     */
+    fun registerObserver(mapboxNavigationObserver: MapboxNavigationObserver) = apply {
+        mapboxNavigationAppDelegate.registerObserver(mapboxNavigationObserver)
+    }
+
+    /**
+     * Unregister the observer that was registered through [registerObserver].
+     */
+    fun unregisterObserver(mapboxNavigationObserver: MapboxNavigationObserver) = apply {
+        mapboxNavigationAppDelegate.unregisterObserver(mapboxNavigationObserver)
+    }
+
+    /**
+     * [MapboxNavigation] has functions that do not require observation streams. This function
+     * allows you to get the current instance to call those functions.
+     *
+     * For example, you do not need to [registerObserver] in order to call
+     * [MapboxNavigation.postUserFeedback] or [MapboxNavigation.setRoutes].
+     */
+    fun current(): MapboxNavigation? = mapboxNavigationAppDelegate.current()
+}

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/lifecycle/MapboxNavigationAppDelegate.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/lifecycle/MapboxNavigationAppDelegate.kt
@@ -1,0 +1,58 @@
+package com.mapbox.navigation.core.lifecycle
+
+import android.app.Application
+import androidx.lifecycle.LifecycleOwner
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.base.options.NavigationOptions
+import com.mapbox.navigation.core.MapboxNavigation
+
+/**
+ * This is a testable version of [MapboxNavigationApp]. Please refer to the singleton
+ * for documented functions and expected behaviors.
+ */
+@ExperimentalPreviewMapboxNavigationAPI
+internal class MapboxNavigationAppDelegate {
+    private val mapboxNavigationOwner = MapboxNavigationOwner()
+    private val carAppLifecycleOwner = CarAppLifecycleOwner()
+    private var isSetup = false
+
+    val lifecycleOwner: LifecycleOwner = carAppLifecycleOwner
+
+    fun setup(navigationOptions: NavigationOptions) = apply {
+        mapboxNavigationOwner.setup(navigationOptions)
+        if (isSetup) {
+            disable()
+        }
+        carAppLifecycleOwner.lifecycle.addObserver(mapboxNavigationOwner.carAppLifecycleObserver)
+        isSetup = true
+    }
+
+    fun attachAllActivities() {
+        val application = mapboxNavigationOwner.navigationOptions.applicationContext as Application
+        carAppLifecycleOwner.attachAllActivities(application)
+    }
+
+    fun disable() {
+        isSetup = false
+        carAppLifecycleOwner.lifecycle.removeObserver(mapboxNavigationOwner.carAppLifecycleObserver)
+        mapboxNavigationOwner.disable()
+    }
+
+    fun attach(lifecycleOwner: LifecycleOwner) {
+        carAppLifecycleOwner.attach(lifecycleOwner)
+    }
+
+    fun detach(lifecycleOwner: LifecycleOwner) {
+        carAppLifecycleOwner.detach(lifecycleOwner)
+    }
+
+    fun registerObserver(mapboxNavigationObserver: MapboxNavigationObserver) {
+        mapboxNavigationOwner.register(mapboxNavigationObserver)
+    }
+
+    fun unregisterObserver(mapboxNavigationObserver: MapboxNavigationObserver) {
+        mapboxNavigationOwner.unregister(mapboxNavigationObserver)
+    }
+
+    fun current(): MapboxNavigation? = mapboxNavigationOwner.current()
+}

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/lifecycle/MapboxNavigationObserver.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/lifecycle/MapboxNavigationObserver.kt
@@ -1,0 +1,80 @@
+package com.mapbox.navigation.core.lifecycle
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.core.MapboxNavigation
+/**
+ * Defines an object that needs to interact with or observe [MapboxNavigation]. Use the
+ * [MapboxNavigationApp] singleton to register and unregister observers with
+ * [MapboxNavigationApp.registerObserver] and [MapboxNavigationApp.unregisterObserver].
+ *
+ * Example of observing locations with a view model
+ * ```
+ * class MyViewModel : ViewModel() {
+ *   private val locationObserver = MyLocationObserver()
+ *
+ *   val location: LiveData<Location> = locationObserver.location.asLiveData()
+ *
+ *   init {
+ *     MapboxNavigationApp.register(locationObserver)
+ *   }
+ *
+ *   override fun onCleared() {
+ *     MapboxNavigationApp.unregister(locationObserver)
+ *   }
+ * }
+ *
+ * class MyLocationObserver : MapboxNavigationObserver {
+ *   private val mutableLocation = MutableStateFlow<LocationMatcherResult?>(null)
+ *   val locationFlow: Flow<LocationMatcherResult?> = mutableLocation
+ *
+ *   private val locationObserver = object : LocationObserver {
+ *     override fun onNewLocationMatcherResult(locationMatcherResult: LocationMatcherResult) {
+ *       mutableLocation.value = locationMatcherResult
+ *     }
+ *
+ *     override fun onNewRawLocation(rawLocation: Location) {
+ *       // no op
+ *     }
+ *   }
+ *
+ *   override fun onAttached(mapboxNavigation: MapboxNavigation) {
+ *     mapboxNavigation.registerLocationObserver(locationObserver)
+ *   }
+ *
+ *   override fun onDetached(mapboxNavigation: MapboxNavigation) {
+ *     mapboxNavigation.unregisterLocationObserver(locationObserver)
+ *   }
+ * }
+ * ```
+ */
+@ExperimentalPreviewMapboxNavigationAPI
+interface MapboxNavigationObserver {
+    /**
+     * Signals that the [mapboxNavigation] instance is ready for use. Use this function to
+     * register [mapboxNavigation] observers, such as [MapboxNavigation.registerRoutesObserver].
+     *
+     * After you have registered an observer through [MapboxNavigationApp.registerObserver],
+     * the onAttached will be called when at least one [LifecycleOwner] that has been attached to
+     * [MapboxNavigationApp.attach] and is at least in the [Lifecycle.State.STARTED] state.
+     *
+     * @param mapboxNavigation instance that is being attached.
+     */
+    fun onAttached(mapboxNavigation: MapboxNavigation)
+
+    /**
+     * Signals that the [mapboxNavigation] instance is being detached. Use this function to
+     * unregister [mapboxNavigation] observers that were registered in [onAttached].
+     *
+     * [onDetached] is called when [onAttached] was called at some time in the past and:
+     * - All [LifecycleOwner]s that have been attached with [MapboxNavigationApp.attach] have
+     * moved to the [Lifecycle.State.CREATED] or [Lifecycle.State.DESTROYED] states.
+     * - The last [LifecycleOwner]s is detached [MapboxNavigationApp.detach].
+     * - This observer is unregistered with [MapboxNavigationApp.unregisterObserver].
+     * - [MapboxNavigationApp.disable] is called.
+     *
+     * @param mapboxNavigation instance that is being detached.
+     */
+    fun onDetached(mapboxNavigation: MapboxNavigation)
+}

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/lifecycle/MapboxNavigationOwner.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/lifecycle/MapboxNavigationOwner.kt
@@ -1,0 +1,72 @@
+package com.mapbox.navigation.core.lifecycle
+
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import com.mapbox.base.common.logger.model.Message
+import com.mapbox.base.common.logger.model.Tag
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.base.options.NavigationOptions
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.MapboxNavigationProvider
+import com.mapbox.navigation.utils.internal.logI
+import java.util.concurrent.CopyOnWriteArraySet
+
+@ExperimentalPreviewMapboxNavigationAPI
+internal class MapboxNavigationOwner {
+    internal lateinit var navigationOptions: NavigationOptions
+        private set
+
+    private val services = CopyOnWriteArraySet<MapboxNavigationObserver>()
+    private var mapboxNavigation: MapboxNavigation? = null
+    private var attached = false
+
+    internal val carAppLifecycleObserver = object : DefaultLifecycleObserver {
+
+        override fun onStart(owner: LifecycleOwner) {
+            logI(TAG, Message("onStart"))
+            check(!MapboxNavigationProvider.isCreated()) {
+                "MapboxNavigation should only be created by the MapboxNavigationOwner"
+            }
+            val mapboxNavigation = MapboxNavigationProvider.create(navigationOptions)
+            this@MapboxNavigationOwner.mapboxNavigation = mapboxNavigation
+            attached = true
+            services.forEach { it.onAttached(mapboxNavigation) }
+        }
+
+        override fun onStop(owner: LifecycleOwner) {
+            logI(TAG, Message("onStop"))
+            attached = false
+            services.forEach { it.onDetached(mapboxNavigation!!) }
+            MapboxNavigationProvider.destroy()
+            mapboxNavigation = null
+        }
+    }
+
+    fun setup(navigationOptions: NavigationOptions) {
+        this.navigationOptions = navigationOptions
+    }
+
+    fun register(mapboxNavigationObserver: MapboxNavigationObserver) = apply {
+        mapboxNavigation?.let { mapboxNavigationObserver.onAttached(it) }
+        services.add(mapboxNavigationObserver)
+    }
+
+    fun unregister(mapboxNavigationObserver: MapboxNavigationObserver) {
+        mapboxNavigation?.let { mapboxNavigationObserver.onDetached(it) }
+        services.remove(mapboxNavigationObserver)
+    }
+
+    fun disable() {
+        if (attached) {
+            attached = false
+            services.forEach { it.onDetached(mapboxNavigation!!) }
+            MapboxNavigationProvider.destroy()
+        }
+    }
+
+    fun current(): MapboxNavigation? = mapboxNavigation
+
+    private companion object {
+        private val TAG = Tag("MbxNavigationOwner")
+    }
+}

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/lifecycle/CarAppLifecycleOwnerTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/lifecycle/CarAppLifecycleOwnerTest.kt
@@ -1,0 +1,306 @@
+@file:Suppress("NoMockkVerifyImport")
+
+package com.mapbox.navigation.core.lifecycle
+
+import android.app.Activity
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.verifyOrder
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@ExperimentalPreviewMapboxNavigationAPI
+@RunWith(RobolectricTestRunner::class)
+class CarAppLifecycleOwnerTest {
+
+    private val testLifecycleObserver: DefaultLifecycleObserver = mockk(relaxUnitFun = true)
+    private val carAppLifecycleOwner = CarAppLifecycleOwner()
+
+    @Before
+    fun setup() {
+        carAppLifecycleOwner.lifecycle.addObserver(testLifecycleObserver)
+    }
+
+    @Test
+    fun `verify order when the app is started without the car`() {
+        carAppLifecycleOwner.activityLifecycleCallbacks.apply {
+            val activity: Activity = mockActivity()
+            onActivityCreated(activity, mockk())
+            onActivityStarted(activity)
+        }
+
+        verifyOrder {
+            testLifecycleObserver.onCreate(any())
+            testLifecycleObserver.onStart(any())
+            testLifecycleObserver.onResume(any())
+        }
+    }
+
+    @Test
+    fun `verify order when the car is started without the app`() {
+        carAppLifecycleOwner.startedReferenceCounter.apply {
+            onCreate(carAppLifecycleOwner)
+            onStart(carAppLifecycleOwner)
+            onResume(carAppLifecycleOwner)
+        }
+
+        verifyOrder {
+            testLifecycleObserver.onCreate(any())
+            testLifecycleObserver.onStart(any())
+            testLifecycleObserver.onResume(any())
+        }
+    }
+
+    @Test
+    fun `verify the lifecycle is not stopped when the activities are destroyed`() {
+        carAppLifecycleOwner.startedReferenceCounter.apply {
+            onCreate(carAppLifecycleOwner)
+            onStart(carAppLifecycleOwner)
+        }
+        carAppLifecycleOwner.activityLifecycleCallbacks.apply {
+            val activity: Activity = mockActivity()
+            onActivityCreated(activity, mockk())
+            onActivityStarted(activity)
+            onActivityStopped(activity)
+            onActivityDestroyed(activity)
+        }
+
+        verify(exactly = 1) { testLifecycleObserver.onCreate(any()) }
+        verify(exactly = 1) { testLifecycleObserver.onStart(any()) }
+        verify(exactly = 1) { testLifecycleObserver.onResume(any()) }
+        verify(exactly = 0) { testLifecycleObserver.onStop(any()) }
+        verify(exactly = 0) { testLifecycleObserver.onDestroy(any()) }
+    }
+
+    @Test
+    fun `verify the lifecycle is not stopped when the car session is destroyed`() {
+        carAppLifecycleOwner.activityLifecycleCallbacks.apply {
+            val activity: Activity = mockActivity()
+            onActivityCreated(activity, mockk())
+            onActivityStarted(activity)
+            onActivityResumed(activity)
+        }
+        carAppLifecycleOwner.startedReferenceCounter.apply {
+            onCreate(carAppLifecycleOwner)
+            onStart(carAppLifecycleOwner)
+            onResume(carAppLifecycleOwner)
+            onPause(carAppLifecycleOwner)
+            onStop(carAppLifecycleOwner)
+            onDestroy(carAppLifecycleOwner)
+        }
+
+        verify(exactly = 1) { testLifecycleObserver.onCreate(any()) }
+        verify(exactly = 1) { testLifecycleObserver.onStart(any()) }
+        verify(exactly = 1) { testLifecycleObserver.onResume(any()) }
+        verify(exactly = 0) { testLifecycleObserver.onStop(any()) }
+        verify(exactly = 0) { testLifecycleObserver.onDestroy(any()) }
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `verify activity switching does not stop the app lifecycle`() {
+        /**
+         * https://developer.android.com/guide/components/activities/activity-lifecycle#coordinating-activities
+         *
+         * Activity A's onPause() method executes.
+         * Activity B's onCreate(), onStart(), and onResume() methods execute in sequence. (Activity B now has user focus.)
+         * Then, if Activity A is no longer visible on screen, its onStop() method executes.
+         */
+        carAppLifecycleOwner.activityLifecycleCallbacks.apply {
+            val activityA: Activity = mockActivity()
+            onActivityCreated(activityA, mockk())
+            onActivityStarted(activityA)
+            onActivityResumed(activityA)
+            onActivityPaused(activityA)
+            val activityB: Activity = mockActivity()
+            onActivityCreated(activityB, mockk())
+            onActivityStarted(activityB)
+            onActivityResumed(activityB)
+            onActivityStopped(activityA)
+            onActivityDestroyed(activityA)
+        }
+
+        verify(exactly = 1) { testLifecycleObserver.onCreate(any()) }
+        verify(exactly = 1) { testLifecycleObserver.onStart(any()) }
+        verify(exactly = 1) { testLifecycleObserver.onResume(any()) }
+        verify(exactly = 0) { testLifecycleObserver.onStop(any()) }
+        verify(exactly = 0) { testLifecycleObserver.onDestroy(any()) }
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `verify orientation switching does not stop the app lifecycle`() {
+        carAppLifecycleOwner.activityLifecycleCallbacks.apply {
+            val activityA: Activity = mockActivity()
+            every { activityA.isChangingConfigurations } returns false
+            onActivityCreated(activityA, mockk())
+            onActivityStarted(activityA)
+            onActivityResumed(activityA)
+            every { activityA.isChangingConfigurations } returns true
+            onActivityPaused(activityA)
+            onActivityStopped(activityA)
+            onActivityDestroyed(activityA)
+            val activityB: Activity = mockActivity()
+            every { activityB.isChangingConfigurations } returns false
+            onActivityCreated(activityB, mockk())
+            onActivityStarted(activityB)
+            onActivityResumed(activityB)
+        }
+
+        verify(exactly = 1) { testLifecycleObserver.onCreate(any()) }
+        verify(exactly = 1) { testLifecycleObserver.onStart(any()) }
+        verify(exactly = 1) { testLifecycleObserver.onResume(any()) }
+        verify(exactly = 0) { testLifecycleObserver.onStop(any()) }
+        verify(exactly = 0) { testLifecycleObserver.onDestroy(any()) }
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `verify backgrounded orientation switching does not stop the app lifecycle`() {
+        carAppLifecycleOwner.activityLifecycleCallbacks.apply {
+            val activityA: Activity = mockActivity()
+            every { activityA.isChangingConfigurations } returns false
+            onActivityCreated(activityA, mockk())
+            every { activityA.isChangingConfigurations } returns true
+            onActivityDestroyed(activityA)
+            val activityB: Activity = mockActivity()
+            every { activityB.isChangingConfigurations } returns false
+            onActivityCreated(activityB, mockk())
+        }
+
+        verify(exactly = 1) { testLifecycleObserver.onCreate(any()) }
+        verify(exactly = 1) { testLifecycleObserver.onStart(any()) }
+        verify(exactly = 0) { testLifecycleObserver.onResume(any()) }
+        verify(exactly = 0) { testLifecycleObserver.onStop(any()) }
+        verify(exactly = 0) { testLifecycleObserver.onDestroy(any()) }
+    }
+
+    @Test
+    fun `verify app can restart after everything is destroyed`() {
+        carAppLifecycleOwner.activityLifecycleCallbacks.apply {
+            val activity: Activity = mockActivity()
+            onActivityCreated(activity, mockk())
+            onActivityStarted(activity)
+            onActivityResumed(activity)
+        }
+        carAppLifecycleOwner.startedReferenceCounter.apply {
+            onCreate(carAppLifecycleOwner)
+            onStart(carAppLifecycleOwner)
+            onResume(carAppLifecycleOwner)
+        }
+        carAppLifecycleOwner.activityLifecycleCallbacks.apply {
+            val activity: Activity = mockActivity()
+            onActivityPaused(activity)
+            onActivityStopped(activity)
+            onActivityDestroyed(activity)
+        }
+        carAppLifecycleOwner.startedReferenceCounter.apply {
+            onPause(carAppLifecycleOwner)
+            onStop(carAppLifecycleOwner)
+            onDestroy(carAppLifecycleOwner)
+            onCreate(carAppLifecycleOwner)
+            onStart(carAppLifecycleOwner)
+            onResume(carAppLifecycleOwner)
+        }
+
+        verifyOrder {
+            testLifecycleObserver.onCreate(any())
+            testLifecycleObserver.onStart(any())
+            testLifecycleObserver.onResume(any())
+            testLifecycleObserver.onStop(any())
+            testLifecycleObserver.onStart(any())
+            testLifecycleObserver.onResume(any())
+        }
+        verify(exactly = 1) { testLifecycleObserver.onCreate(any()) }
+        verify(exactly = 2) { testLifecycleObserver.onStart(any()) }
+        verify(exactly = 2) { testLifecycleObserver.onResume(any()) }
+        verify(exactly = 1) { testLifecycleObserver.onStop(any()) }
+        verify(exactly = 0) { testLifecycleObserver.onDestroy(any()) }
+    }
+
+    @Test
+    fun `verify a single LifecycleOwner calls all events except destroy`() {
+        val testLifecycleOwner = TestLifecycleOwner()
+        carAppLifecycleOwner.attach(testLifecycleOwner)
+
+        testLifecycleOwner.lifecycleRegistry.currentState = Lifecycle.State.RESUMED
+        testLifecycleOwner.lifecycleRegistry.currentState = Lifecycle.State.DESTROYED
+
+        verify(exactly = 1) { testLifecycleObserver.onCreate(any()) }
+        verify(exactly = 1) { testLifecycleObserver.onStart(any()) }
+        verify(exactly = 1) { testLifecycleObserver.onResume(any()) }
+        verify(exactly = 1) { testLifecycleObserver.onStop(any()) }
+        verify(exactly = 0) { testLifecycleObserver.onDestroy(any()) }
+    }
+
+    @Test
+    fun `verify multiple LifecycleOwner will call events once`() {
+        val testLifecycleOwnerA = TestLifecycleOwner()
+        val testLifecycleOwnerB = TestLifecycleOwner()
+        carAppLifecycleOwner.attach(testLifecycleOwnerA)
+        carAppLifecycleOwner.attach(testLifecycleOwnerB)
+
+        testLifecycleOwnerA.lifecycleRegistry.currentState = Lifecycle.State.RESUMED
+        testLifecycleOwnerB.lifecycleRegistry.currentState = Lifecycle.State.RESUMED
+        testLifecycleOwnerA.lifecycleRegistry.currentState = Lifecycle.State.DESTROYED
+        testLifecycleOwnerB.lifecycleRegistry.currentState = Lifecycle.State.DESTROYED
+
+        verify(exactly = 1) { testLifecycleObserver.onCreate(any()) }
+        verify(exactly = 1) { testLifecycleObserver.onStart(any()) }
+        verify(exactly = 1) { testLifecycleObserver.onResume(any()) }
+        verify(exactly = 1) { testLifecycleObserver.onStop(any()) }
+        verify(exactly = 0) { testLifecycleObserver.onDestroy(any()) }
+    }
+
+    @Test
+    fun `verify multiple LifecycleOwner started will call events once`() {
+        val testLifecycleOwnerA = TestLifecycleOwner()
+        val testLifecycleOwnerB = TestLifecycleOwner()
+        carAppLifecycleOwner.attach(testLifecycleOwnerA)
+        carAppLifecycleOwner.attach(testLifecycleOwnerB)
+
+        testLifecycleOwnerA.lifecycleRegistry.currentState = Lifecycle.State.RESUMED
+        testLifecycleOwnerB.lifecycleRegistry.currentState = Lifecycle.State.STARTED
+        testLifecycleOwnerA.lifecycleRegistry.currentState = Lifecycle.State.DESTROYED
+        testLifecycleOwnerB.lifecycleRegistry.currentState = Lifecycle.State.DESTROYED
+
+        verify(exactly = 1) { testLifecycleObserver.onCreate(any()) }
+        verify(exactly = 1) { testLifecycleObserver.onStart(any()) }
+        verify(exactly = 1) { testLifecycleObserver.onResume(any()) }
+        verify(exactly = 1) { testLifecycleObserver.onStop(any()) }
+        verify(exactly = 0) { testLifecycleObserver.onDestroy(any()) }
+    }
+
+    @Test
+    fun `verify detach will cause destruction states`() {
+        val testLifecycleOwner = TestLifecycleOwner()
+
+        carAppLifecycleOwner.attach(testLifecycleOwner)
+        testLifecycleOwner.lifecycleRegistry.currentState = Lifecycle.State.RESUMED
+        carAppLifecycleOwner.detach(testLifecycleOwner)
+
+        verify(exactly = 1) { testLifecycleObserver.onCreate(any()) }
+        verify(exactly = 1) { testLifecycleObserver.onStart(any()) }
+        verify(exactly = 1) { testLifecycleObserver.onResume(any()) }
+        verify(exactly = 1) { testLifecycleObserver.onStop(any()) }
+        verify(exactly = 0) { testLifecycleObserver.onDestroy(any()) }
+    }
+
+    class TestLifecycleOwner : LifecycleOwner {
+        val lifecycleRegistry = LifecycleRegistry(this)
+            .also { it.currentState = Lifecycle.State.INITIALIZED }
+        override fun getLifecycle(): Lifecycle = lifecycleRegistry
+    }
+
+    private fun mockActivity(isChangingConfig: Boolean = false): Activity = mockk {
+        every { isChangingConfigurations } returns isChangingConfig
+    }
+}

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/lifecycle/MapboxNavigationAppDelegateTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/lifecycle/MapboxNavigationAppDelegateTest.kt
@@ -1,0 +1,214 @@
+@file:Suppress("NoMockkVerifyImport")
+
+package com.mapbox.navigation.core.lifecycle
+
+import androidx.lifecycle.Lifecycle
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.base.options.NavigationOptions
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.MapboxNavigationProvider
+import com.mapbox.navigation.utils.internal.LoggerProvider
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import io.mockk.verifyOrder
+import junit.framework.Assert.assertNotNull
+import junit.framework.Assert.assertNull
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@ExperimentalPreviewMapboxNavigationAPI
+@RunWith(RobolectricTestRunner::class)
+class MapboxNavigationAppDelegateTest {
+
+    private val mapboxNavigation: MapboxNavigation = mockk()
+    private val navigationOptions: NavigationOptions = mockk {
+        every { accessToken } returns "test_access_token"
+    }
+
+    private val mapboxNavigationApp = MapboxNavigationAppDelegate()
+
+    @Before
+    fun setup() {
+        mockkStatic(MapboxNavigationProvider::class)
+        mockkObject(LoggerProvider)
+        every { LoggerProvider.logger } returns mockk(relaxUnitFun = true)
+        every { MapboxNavigationProvider.create(navigationOptions) } returns mapboxNavigation
+        every { MapboxNavigationProvider.retrieve() } returns mapboxNavigation
+    }
+
+    @After
+    fun teardown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `verify onAttached and onDetached when multiple lifecycles have started`() {
+        mapboxNavigationApp.setup(navigationOptions)
+
+        val testLifecycleOwnerA = CarAppLifecycleOwnerTest.TestLifecycleOwner()
+        val testLifecycleOwnerB = CarAppLifecycleOwnerTest.TestLifecycleOwner()
+        mapboxNavigationApp.attach(testLifecycleOwnerA)
+        mapboxNavigationApp.attach(testLifecycleOwnerB)
+
+        testLifecycleOwnerA.lifecycleRegistry.currentState = Lifecycle.State.RESUMED
+        testLifecycleOwnerB.lifecycleRegistry.currentState = Lifecycle.State.RESUMED
+
+        val observer = mockk<MapboxNavigationObserver>(relaxUnitFun = true)
+        mapboxNavigationApp.registerObserver(observer)
+        mapboxNavigationApp.unregisterObserver(observer)
+
+        verifyOrder {
+            observer.onAttached(any())
+            observer.onDetached(any())
+        }
+    }
+
+    @Test
+    fun `verify onAttached is called when LifecycleOwner is started`() {
+        mapboxNavigationApp.setup(navigationOptions)
+
+        val firstObserver = mockk<MapboxNavigationObserver>(relaxUnitFun = true)
+        val secondObserver = mockk<MapboxNavigationObserver>(relaxUnitFun = true)
+        mapboxNavigationApp.registerObserver(firstObserver)
+        mapboxNavigationApp.registerObserver(secondObserver)
+
+        val testLifecycleOwner = CarAppLifecycleOwnerTest.TestLifecycleOwner()
+        mapboxNavigationApp.attach(testLifecycleOwner)
+
+        testLifecycleOwner.lifecycleRegistry.currentState = Lifecycle.State.RESUMED
+
+        verify(exactly = 1) { firstObserver.onAttached(any()) }
+        verify(exactly = 1) { secondObserver.onAttached(any()) }
+        verify(exactly = 0) { firstObserver.onDetached(any()) }
+        verify(exactly = 0) { secondObserver.onDetached(any()) }
+    }
+
+    @Test
+    fun `verify setup can be called after LifecycleOwner is started`() {
+        val firstObserver = mockk<MapboxNavigationObserver>(relaxUnitFun = true)
+        val secondObserver = mockk<MapboxNavigationObserver>(relaxUnitFun = true)
+        mapboxNavigationApp.registerObserver(firstObserver)
+        mapboxNavigationApp.registerObserver(secondObserver)
+
+        val testLifecycleOwner = CarAppLifecycleOwnerTest.TestLifecycleOwner()
+        mapboxNavigationApp.attach(testLifecycleOwner)
+
+        testLifecycleOwner.lifecycleRegistry.currentState = Lifecycle.State.RESUMED
+        mapboxNavigationApp.setup(navigationOptions)
+
+        verify(exactly = 1) { firstObserver.onAttached(any()) }
+        verify(exactly = 1) { secondObserver.onAttached(any()) }
+        verify(exactly = 0) { firstObserver.onDetached(any()) }
+        verify(exactly = 0) { secondObserver.onDetached(any()) }
+    }
+
+    @Test
+    fun `verify detaching all LifecycleOwners detaches all observers`() {
+        mapboxNavigationApp.setup(navigationOptions)
+
+        val testLifecycleOwnerA = CarAppLifecycleOwnerTest.TestLifecycleOwner()
+        val testLifecycleOwnerB = CarAppLifecycleOwnerTest.TestLifecycleOwner()
+        mapboxNavigationApp.attach(testLifecycleOwnerA)
+        mapboxNavigationApp.attach(testLifecycleOwnerB)
+
+        testLifecycleOwnerA.lifecycleRegistry.currentState = Lifecycle.State.RESUMED
+        testLifecycleOwnerB.lifecycleRegistry.currentState = Lifecycle.State.RESUMED
+
+        val firstObserver = mockk<MapboxNavigationObserver>(relaxUnitFun = true)
+        val secondObserver = mockk<MapboxNavigationObserver>(relaxUnitFun = true)
+        mapboxNavigationApp.registerObserver(firstObserver)
+        mapboxNavigationApp.registerObserver(secondObserver)
+
+        mapboxNavigationApp.detach(testLifecycleOwnerA)
+        mapboxNavigationApp.detach(testLifecycleOwnerB)
+
+        verifyOrder {
+            firstObserver.onAttached(any())
+            secondObserver.onAttached(any())
+            firstObserver.onDetached(any())
+            secondObserver.onDetached(any())
+        }
+    }
+
+    @Test
+    fun `verify disable will call observers onDetached`() {
+        mapboxNavigationApp.setup(navigationOptions)
+
+        val testLifecycleOwnerA = CarAppLifecycleOwnerTest.TestLifecycleOwner()
+        val testLifecycleOwnerB = CarAppLifecycleOwnerTest.TestLifecycleOwner()
+        mapboxNavigationApp.attach(testLifecycleOwnerA)
+        mapboxNavigationApp.attach(testLifecycleOwnerB)
+
+        testLifecycleOwnerA.lifecycleRegistry.currentState = Lifecycle.State.RESUMED
+        testLifecycleOwnerB.lifecycleRegistry.currentState = Lifecycle.State.RESUMED
+
+        val firstObserver = mockk<MapboxNavigationObserver>(relaxUnitFun = true)
+        val secondObserver = mockk<MapboxNavigationObserver>(relaxUnitFun = true)
+        mapboxNavigationApp.registerObserver(firstObserver)
+        mapboxNavigationApp.registerObserver(secondObserver)
+
+        mapboxNavigationApp.disable()
+
+        verifyOrder {
+            firstObserver.onAttached(any())
+            secondObserver.onAttached(any())
+            firstObserver.onDetached(any())
+            secondObserver.onDetached(any())
+        }
+    }
+
+    @Test
+    fun `verify disable will prevent mapboxNavigation from restarting`() {
+        mapboxNavigationApp.setup(navigationOptions)
+
+        val testLifecycleOwner = CarAppLifecycleOwnerTest.TestLifecycleOwner()
+        mapboxNavigationApp.attach(testLifecycleOwner)
+        testLifecycleOwner.lifecycleRegistry.currentState = Lifecycle.State.RESUMED
+
+        val observer = mockk<MapboxNavigationObserver>(relaxUnitFun = true)
+        mapboxNavigationApp.registerObserver(observer)
+
+        mapboxNavigationApp.disable()
+        mapboxNavigationApp.detach(testLifecycleOwner)
+        mapboxNavigationApp.attach(testLifecycleOwner)
+
+        verify(exactly = 1) { observer.onAttached(any()) }
+        verify(exactly = 1) { observer.onAttached(any()) }
+    }
+
+    @Test
+    fun `verify current is null when all lifecycle owners are destroyed`() {
+        mapboxNavigationApp.setup(navigationOptions)
+
+        val testLifecycleOwner = CarAppLifecycleOwnerTest.TestLifecycleOwner()
+        mapboxNavigationApp.attach(testLifecycleOwner)
+        val observer = mockk<MapboxNavigationObserver>(relaxUnitFun = true)
+        mapboxNavigationApp.registerObserver(observer)
+
+        testLifecycleOwner.lifecycleRegistry.currentState = Lifecycle.State.RESUMED
+        testLifecycleOwner.lifecycleRegistry.currentState = Lifecycle.State.DESTROYED
+
+        assertNull(mapboxNavigationApp.current())
+    }
+
+    @Test
+    fun `verify current is set after LifecycleOwner is created`() {
+        mapboxNavigationApp.setup(navigationOptions)
+
+        val testLifecycleOwner = CarAppLifecycleOwnerTest.TestLifecycleOwner()
+        mapboxNavigationApp.attach(testLifecycleOwner)
+        val observer = mockk<MapboxNavigationObserver>(relaxUnitFun = true)
+        mapboxNavigationApp.registerObserver(observer)
+
+        assertNull(mapboxNavigationApp.current())
+        testLifecycleOwner.lifecycleRegistry.currentState = Lifecycle.State.CREATED
+        assertNotNull(mapboxNavigationApp.current())
+    }
+}

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/lifecycle/MapboxNavigationOwnerTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/lifecycle/MapboxNavigationOwnerTest.kt
@@ -1,0 +1,144 @@
+@file:Suppress("NoMockkVerifyImport")
+
+package com.mapbox.navigation.core.lifecycle
+
+import androidx.lifecycle.LifecycleOwner
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.base.options.NavigationOptions
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.MapboxNavigationProvider
+import com.mapbox.navigation.utils.internal.LoggerProvider
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import io.mockk.verifyOrder
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@ExperimentalPreviewMapboxNavigationAPI
+class MapboxNavigationOwnerTest {
+
+    private val mapboxNavigation: MapboxNavigation = mockk()
+    private val navigationOptions: NavigationOptions = mockk {
+        every { accessToken } returns "test_access_token"
+    }
+
+    private val mapboxNavigationOwner = MapboxNavigationOwner()
+
+    @Before
+    fun setup() {
+        mockkStatic(MapboxNavigationProvider::class)
+        mockkObject(LoggerProvider)
+        every { LoggerProvider.logger } returns mockk(relaxUnitFun = true)
+        every { MapboxNavigationProvider.create(navigationOptions) } returns mapboxNavigation
+        every { MapboxNavigationProvider.retrieve() } returns mapboxNavigation
+    }
+
+    @After
+    fun teardown() {
+        unmockkAll()
+    }
+
+    @Test(expected = Throwable::class)
+    fun `crashes when navigationOptions have not been setup`() {
+        val mapboxNavigationObserver = mockk<MapboxNavigationObserver>(relaxUnitFun = true)
+        mapboxNavigationOwner.register(mapboxNavigationObserver)
+
+        val lifecycleOwner: LifecycleOwner = mockk()
+        mapboxNavigationOwner.carAppLifecycleObserver.onCreate(lifecycleOwner)
+        mapboxNavigationOwner.carAppLifecycleObserver.onStart(lifecycleOwner)
+        mapboxNavigationOwner.carAppLifecycleObserver.onResume(lifecycleOwner)
+    }
+
+    @Test
+    fun `full lifecycle will attach and detach MapboxNavigation`() {
+        mapboxNavigationOwner.setup(navigationOptions)
+        val mapboxNavigationObserver = mockk<MapboxNavigationObserver>(relaxUnitFun = true)
+        mapboxNavigationOwner.register(mapboxNavigationObserver)
+
+        val lifecycleOwner: LifecycleOwner = mockk()
+        mapboxNavigationOwner.carAppLifecycleObserver.onCreate(lifecycleOwner)
+        mapboxNavigationOwner.carAppLifecycleObserver.onStart(lifecycleOwner)
+        mapboxNavigationOwner.carAppLifecycleObserver.onResume(lifecycleOwner)
+        mapboxNavigationOwner.carAppLifecycleObserver.onPause(lifecycleOwner)
+        mapboxNavigationOwner.carAppLifecycleObserver.onStop(lifecycleOwner)
+        mapboxNavigationOwner.carAppLifecycleObserver.onDestroy(lifecycleOwner)
+
+        verifyOrder {
+            mapboxNavigationObserver.onAttached(any())
+            mapboxNavigationObserver.onDetached(any())
+        }
+    }
+
+    @Test
+    fun `attach and detach multiple times`() {
+        mapboxNavigationOwner.setup(navigationOptions)
+        val mapboxNavigationObserver = mockk<MapboxNavigationObserver>(relaxUnitFun = true)
+        mapboxNavigationOwner.register(mapboxNavigationObserver)
+
+        val lifecycleOwner: LifecycleOwner = mockk()
+        mapboxNavigationOwner.carAppLifecycleObserver.onStart(lifecycleOwner)
+        mapboxNavigationOwner.carAppLifecycleObserver.onStop(lifecycleOwner)
+        mapboxNavigationOwner.carAppLifecycleObserver.onStart(lifecycleOwner)
+        mapboxNavigationOwner.carAppLifecycleObserver.onStop(lifecycleOwner)
+
+        verifyOrder {
+            mapboxNavigationObserver.onAttached(any())
+            mapboxNavigationObserver.onDetached(any())
+            mapboxNavigationObserver.onAttached(any())
+            mapboxNavigationObserver.onDetached(any())
+        }
+    }
+
+    @Test
+    fun `notify multiple observers in the order they were registered`() {
+        mapboxNavigationOwner.setup(navigationOptions)
+        val firstObserver = mockk<MapboxNavigationObserver>(relaxUnitFun = true)
+        val secondObserver = mockk<MapboxNavigationObserver>(relaxUnitFun = true)
+        mapboxNavigationOwner.register(firstObserver)
+        mapboxNavigationOwner.register(secondObserver)
+
+        val lifecycleOwner: LifecycleOwner = mockk()
+        mapboxNavigationOwner.carAppLifecycleObserver.onStart(lifecycleOwner)
+        mapboxNavigationOwner.carAppLifecycleObserver.onStop(lifecycleOwner)
+
+        verifyOrder {
+            firstObserver.onAttached(any())
+            secondObserver.onAttached(any())
+            firstObserver.onDetached(any())
+            secondObserver.onDetached(any())
+        }
+    }
+
+    @Test
+    fun `attach and detach observer when navigation is started`() {
+        mapboxNavigationOwner.setup(navigationOptions)
+        val lifecycleOwner: LifecycleOwner = mockk()
+        mapboxNavigationOwner.carAppLifecycleObserver.onStart(lifecycleOwner)
+
+        val observer = mockk<MapboxNavigationObserver>(relaxUnitFun = true)
+        mapboxNavigationOwner.register(observer)
+        mapboxNavigationOwner.unregister(observer)
+
+        verifyOrder {
+            observer.onAttached(any())
+            observer.onDetached(any())
+        }
+    }
+
+    @Test
+    fun `do not attach and detach when navigation is not started`() {
+        mapboxNavigationOwner.setup(navigationOptions)
+
+        val observer = mockk<MapboxNavigationObserver>(relaxUnitFun = true)
+        mapboxNavigationOwner.register(observer)
+        mapboxNavigationOwner.unregister(observer)
+
+        verify(exactly = 0) { observer.onAttached(any()) }
+        verify(exactly = 0) { observer.onDetached(any()) }
+    }
+}

--- a/qa-test-app/src/main/AndroidManifest.xml
+++ b/qa-test-app/src/main/AndroidManifest.xml
@@ -20,6 +20,7 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity android:name=".view.AppLifecycleActivity"/>
         <activity android:name=".view.AlternativeRouteActivity"/>
         <activity android:name=".view.MapboxRouteLineActivity"/>
         <activity android:name=".view.util.RouteDrawingActivity"/>

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/domain/TestActivitySuite.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/domain/TestActivitySuite.kt
@@ -5,6 +5,7 @@ import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.qa_test_app.R
 import com.mapbox.navigation.qa_test_app.utils.startActivity
 import com.mapbox.navigation.qa_test_app.view.AlternativeRouteActivity
+import com.mapbox.navigation.qa_test_app.view.AppLifecycleActivity
 import com.mapbox.navigation.qa_test_app.view.FeedbackActivity
 import com.mapbox.navigation.qa_test_app.view.InactiveRouteStylingActivity
 import com.mapbox.navigation.qa_test_app.view.InactiveRouteStylingWithRestrictionsActivity
@@ -20,6 +21,12 @@ object TestActivitySuite {
 
     @OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
     val testActivities = listOf(
+        TestActivityDescription(
+            "MapboxNavigation Lifecycle",
+            R.string.mapbox_navigation_app_lifecycle_description
+        ) { activity ->
+            activity.startActivity<AppLifecycleActivity>()
+        },
         TestActivityDescription(
             "Alternative Route Selection",
             R.string.alternative_route_selection_description

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/AppLifecycleActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/AppLifecycleActivity.kt
@@ -1,0 +1,382 @@
+package com.mapbox.navigation.qa_test_app.view
+
+import android.annotation.SuppressLint
+import android.location.Location
+import android.os.Build
+import android.os.Bundle
+import android.os.VibrationEffect
+import android.os.Vibrator
+import android.util.Log
+import android.view.View
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.MutableLiveData
+import com.mapbox.android.core.location.LocationEngineCallback
+import com.mapbox.android.core.location.LocationEngineResult
+import com.mapbox.android.gestures.Utils
+import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.api.directions.v5.models.RouteOptions
+import com.mapbox.geojson.Point
+import com.mapbox.maps.CameraOptions
+import com.mapbox.maps.EdgeInsets
+import com.mapbox.maps.MapView
+import com.mapbox.maps.plugin.animation.CameraAnimationsPlugin
+import com.mapbox.maps.plugin.animation.MapAnimationOptions
+import com.mapbox.maps.plugin.animation.camera
+import com.mapbox.maps.plugin.gestures.OnMapClickListener
+import com.mapbox.maps.plugin.gestures.OnMapLongClickListener
+import com.mapbox.maps.plugin.gestures.gestures
+import com.mapbox.maps.plugin.locationcomponent.location
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.base.extensions.applyDefaultNavigationOptions
+import com.mapbox.navigation.base.extensions.applyLanguageAndVoiceUnitOptions
+import com.mapbox.navigation.base.options.NavigationOptions
+import com.mapbox.navigation.base.route.RouterCallback
+import com.mapbox.navigation.base.route.RouterFailure
+import com.mapbox.navigation.base.route.RouterOrigin
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.directions.session.RoutesObserver
+import com.mapbox.navigation.core.lifecycle.MapboxNavigationApp
+import com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver
+import com.mapbox.navigation.core.replay.route.ReplayProgressObserver
+import com.mapbox.navigation.core.replay.route.ReplayRouteMapper
+import com.mapbox.navigation.core.routealternatives.RouteAlternativesObserver
+import com.mapbox.navigation.core.trip.session.LocationMatcherResult
+import com.mapbox.navigation.core.trip.session.LocationObserver
+import com.mapbox.navigation.qa_test_app.databinding.AppLifecycleActivityLayoutBinding
+import com.mapbox.navigation.qa_test_app.utils.Utils.getMapboxAccessToken
+import com.mapbox.navigation.ui.maps.NavigationStyles
+import com.mapbox.navigation.ui.maps.location.NavigationLocationProvider
+import com.mapbox.navigation.ui.maps.route.line.MapboxRouteLineApiExtensions.findClosestRoute
+import com.mapbox.navigation.ui.maps.route.line.MapboxRouteLineApiExtensions.setRoutes
+import com.mapbox.navigation.ui.maps.route.line.api.MapboxRouteLineApi
+import com.mapbox.navigation.ui.maps.route.line.api.MapboxRouteLineView
+import com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions
+import com.mapbox.navigation.ui.maps.route.line.model.RouteLine
+import com.mapbox.navigation.ui.maps.route.line.model.RouteLineResources
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+private const val TAG = "AlternativeRouteActiv"
+
+@OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
+class AppLifecycleActivity : AppCompatActivity(), OnMapLongClickListener {
+
+    private val binding: AppLifecycleActivityLayoutBinding by lazy {
+        AppLifecycleActivityLayoutBinding.inflate(layoutInflater)
+    }
+
+    private val mapCamera: CameraAnimationsPlugin by lazy { binding.mapView.camera }
+
+    private val replayInteractor = ReplayInteractor()
+    private val locationInteractor = LocationInteractor()
+    private val continuousRoutesInteractor = ContinuousRoutesInteractor()
+    private lateinit var routesInteractor: RoutesInteractor
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(binding.root)
+
+        setupNavigation()
+        setupMap()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        routesInteractor = RoutesInteractor(binding.mapView)
+        MapboxNavigationApp.registerObserver(routesInteractor)
+    }
+
+    override fun onPause() {
+        super.onPause()
+        MapboxNavigationApp.unregisterObserver(routesInteractor)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        // Detach and unregister the listeners.
+        MapboxNavigationApp.detach(this)
+            .unregisterObserver(replayInteractor)
+            .unregisterObserver(locationInteractor)
+            .unregisterObserver(continuousRoutesInteractor)
+    }
+
+    private fun setupNavigation() {
+        // 1. MapboxNavigationApp.setup with your NavigationOptions
+        // 2. MapboxNavigationApp.attach with the LifecycleOwner
+        // 3. Register MapboxNavigationObservers to observe data streams
+        val navigationOptions = NavigationOptions.Builder(this)
+            .accessToken(getMapboxAccessToken(this))
+            .build()
+        MapboxNavigationApp.setup(navigationOptions)
+            .attach(this)
+            .registerObserver(locationInteractor)
+            .registerObserver(continuousRoutesInteractor)
+            .registerObserver(replayInteractor)
+
+        locationInteractor.locationLiveData.observe(this) {
+            updateCamera(it)
+        }
+    }
+
+    private fun updateCamera(location: Location) {
+        val mapAnimationOptionsBuilder = MapAnimationOptions.Builder()
+        mapAnimationOptionsBuilder.duration(1500L)
+        mapCamera.easeTo(
+            CameraOptions.Builder()
+                .center(Point.fromLngLat(location.longitude, location.latitude))
+                .bearing(location.bearing.toDouble())
+                .zoom(15.0)
+                .padding(EdgeInsets(1000.0, 0.0, 0.0, 0.0))
+                .build(),
+            mapAnimationOptionsBuilder.build()
+        )
+    }
+
+    private fun setupMap() {
+        binding.mapView.getMapboxMap().loadStyleUri(
+            NavigationStyles.NAVIGATION_DAY_STYLE
+        ) {
+            binding.mapView.gestures.addOnMapLongClickListener(this)
+        }
+
+        binding.mapView.location.apply {
+            setLocationProvider(locationInteractor.navigationLocationProvider)
+            enabled = true
+        }
+
+        binding.startNavigation.setOnClickListener {
+            binding.startNavigation.visibility = View.GONE
+            replayInteractor.startSimulation()
+        }
+
+        binding.mapView.gestures.addOnMapClickListener(mapClickListener)
+    }
+
+    override fun onMapLongClick(point: Point): Boolean {
+        vibrate()
+        val currentLocation = locationInteractor.navigationLocationProvider.lastLocation
+        if (currentLocation != null) {
+            val originPoint = Point.fromLngLat(
+                currentLocation.longitude,
+                currentLocation.latitude
+            )
+            routesInteractor.findRoute(originPoint, point)
+        }
+        return false
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun vibrate() {
+        val vibrator = getSystemService(VIBRATOR_SERVICE) as Vibrator
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            vibrator.vibrate(VibrationEffect.createOneShot(100L, VibrationEffect.DEFAULT_AMPLITUDE))
+        } else {
+            vibrator.vibrate(100L)
+        }
+    }
+
+    private val mapClickListener = OnMapClickListener {
+        routesInteractor.selectRoute(it)
+        false
+    }
+}
+
+@OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
+private class ReplayInteractor : MapboxNavigationObserver {
+    private val replayRouteMapper = ReplayRouteMapper()
+    private lateinit var replayProgressObserver: ReplayProgressObserver
+
+    override fun onAttached(mapboxNavigation: MapboxNavigation) {
+        replayProgressObserver = ReplayProgressObserver(mapboxNavigation.mapboxReplayer)
+        mapboxNavigation.registerRouteProgressObserver(replayProgressObserver)
+        mapboxNavigation.mapboxReplayer.pushRealLocation(
+            mapboxNavigation.navigationOptions.applicationContext,
+            0.0
+        )
+        mapboxNavigation.mapboxReplayer.playbackSpeed(1.5)
+        mapboxNavigation.mapboxReplayer.play()
+    }
+
+    fun startSimulation() = MapboxNavigationApp.current()?.apply {
+        val route = MapboxNavigationApp.current()?.getRoutes()?.get(0)
+        checkNotNull(route) { "Current route should not be null" }
+        mapboxReplayer.stop()
+        mapboxReplayer.clearEvents()
+        val replayData = replayRouteMapper.mapDirectionsRouteGeometry(route)
+        mapboxReplayer.pushEvents(replayData)
+        mapboxReplayer.seekTo(replayData[0])
+        mapboxReplayer.play()
+        startReplayTripSession()
+    }
+
+    override fun onDetached(mapboxNavigation: MapboxNavigation) {
+        mapboxNavigation.unregisterRouteProgressObserver(replayProgressObserver)
+        mapboxNavigation.mapboxReplayer.finish()
+    }
+}
+
+@SuppressLint("MissingPermission")
+@OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
+private class LocationInteractor : MapboxNavigationObserver {
+    val navigationLocationProvider = NavigationLocationProvider()
+
+    val locationLiveData = MutableLiveData<Location>()
+
+    private val locationObserver: LocationObserver = object : LocationObserver {
+        override fun onNewRawLocation(rawLocation: Location) {
+            Log.d(TAG, "raw location $rawLocation")
+        }
+
+        override fun onNewLocationMatcherResult(locationMatcherResult: LocationMatcherResult) {
+            navigationLocationProvider.changePosition(
+                locationMatcherResult.enhancedLocation,
+                locationMatcherResult.keyPoints
+            )
+            locationLiveData.value = locationMatcherResult.enhancedLocation
+        }
+    }
+
+    override fun onAttached(mapboxNavigation: MapboxNavigation) {
+        val locationEngine = mapboxNavigation.navigationOptions.locationEngine
+        locationEngine.getLastLocation(object : LocationEngineCallback<LocationEngineResult> {
+            override fun onSuccess(result: LocationEngineResult) {
+                result.lastLocation?.let {
+                    navigationLocationProvider.changePosition(it, emptyList())
+                    locationLiveData.value = it
+                }
+            }
+            override fun onFailure(exception: Exception) {}
+        })
+
+        mapboxNavigation.registerLocationObserver(locationObserver)
+    }
+
+    override fun onDetached(mapboxNavigation: MapboxNavigation) {
+        mapboxNavigation.unregisterLocationObserver(locationObserver)
+    }
+}
+
+@OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
+private class RoutesInteractor(val mapView: MapView) : MapboxNavigationObserver {
+    private val routeClickPadding = Utils.dpToPx(30f)
+
+    private val routeLineResources: RouteLineResources by lazy {
+        RouteLineResources.Builder().build()
+    }
+
+    private val options: MapboxRouteLineOptions by lazy {
+        MapboxRouteLineOptions.Builder(mapView.context)
+            .withRouteLineResources(routeLineResources)
+            .withRouteLineBelowLayerId("road-label-navigation")
+            .build()
+    }
+
+    private val routeLineView by lazy {
+        MapboxRouteLineView(options)
+    }
+
+    private val routeLineApi: MapboxRouteLineApi by lazy {
+        MapboxRouteLineApi(options)
+    }
+
+    private val routesObserver = RoutesObserver { result ->
+        val routelines = result.routes.map { RouteLine(it, null) }
+        CoroutineScope(Dispatchers.Main).launch {
+            routeLineApi.setRoutes(routelines).apply {
+                routeLineView.renderRouteDrawData(
+                    mapView.getMapboxMap().getStyle()!!,
+                    this
+                )
+            }
+        }
+    }
+
+    override fun onAttached(mapboxNavigation: MapboxNavigation) {
+        mapboxNavigation.registerRoutesObserver(routesObserver)
+    }
+
+    override fun onDetached(mapboxNavigation: MapboxNavigation) {
+        mapboxNavigation.unregisterRoutesObserver(routesObserver)
+        routeLineApi.cancel()
+        routeLineView.cancel()
+    }
+
+    fun selectRoute(point: Point) {
+        CoroutineScope(Dispatchers.Main).launch {
+            val result = routeLineApi.findClosestRoute(
+                point,
+                mapView.getMapboxMap(),
+                routeClickPadding
+            )
+
+            val routeFound = result.value?.route
+            if (routeFound != null && routeFound != routeLineApi.getPrimaryRoute()) {
+                val reOrderedRoutes = routeLineApi.getRoutes()
+                    .filter { it != routeFound }
+                    .toMutableList()
+                    .also {
+                        it.add(0, routeFound)
+                    }
+                MapboxNavigationApp.current()?.setRoutes(reOrderedRoutes)
+            }
+        }
+    }
+
+    fun findRoute(origin: Point?, destination: Point) {
+        val mapboxNavigation: MapboxNavigation = MapboxNavigationApp.current() ?: return
+        val routeOptions = RouteOptions.builder()
+            .applyDefaultNavigationOptions()
+            .applyLanguageAndVoiceUnitOptions(mapView.context)
+            .coordinatesList(listOf(origin, destination))
+            .layersList(listOf(mapboxNavigation.getZLevel(), null))
+            .alternatives(true)
+            .build()
+        mapboxNavigation.requestRoutes(
+            routeOptions,
+            object : RouterCallback {
+                override fun onRoutesReady(
+                    routes: List<DirectionsRoute>,
+                    routerOrigin: RouterOrigin
+                ) {
+                    mapboxNavigation.setRoutes(routes.reversed())
+                }
+
+                override fun onFailure(
+                    reasons: List<RouterFailure>,
+                    routeOptions: RouteOptions
+                ) {
+                    // no impl
+                }
+
+                override fun onCanceled(routeOptions: RouteOptions, routerOrigin: RouterOrigin) {
+                    // no impl
+                }
+            }
+        )
+    }
+}
+
+@OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
+private class ContinuousRoutesInteractor : MapboxNavigationObserver {
+
+    private val routeAlternativesObserver =
+        RouteAlternativesObserver { routeProgress, alternatives, _ ->
+            val updatedRoutes = mutableListOf<DirectionsRoute>()
+            updatedRoutes.add(routeProgress.route)
+            updatedRoutes.addAll(alternatives)
+
+            MapboxNavigationApp.current()?.apply {
+                setRoutes(updatedRoutes)
+                requestAlternativeRoutes()
+            }
+        }
+
+    override fun onAttached(mapboxNavigation: MapboxNavigation) {
+        mapboxNavigation.registerRouteAlternativesObserver(routeAlternativesObserver)
+    }
+
+    override fun onDetached(mapboxNavigation: MapboxNavigation) {
+        mapboxNavigation.unregisterRouteAlternativesObserver(routeAlternativesObserver)
+    }
+}

--- a/qa-test-app/src/main/res/layout/app_lifecycle_activity_layout.xml
+++ b/qa-test-app/src/main/res/layout/app_lifecycle_activity_layout.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <com.mapbox.maps.MapView
+        android:id="@+id/mapView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/startNavigation"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:text="Start Navigation"
+        android:background="@color/primary"/>
+
+    <ProgressBar
+        android:id="@+id/routeLoadingProgressBar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:visibility="invisible"
+        />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/qa-test-app/src/main/res/values/strings.xml
+++ b/qa-test-app/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <string name="app_name" tools:ignore="MissingTranslation">Kaizen</string>
+    <string name="mapbox_navigation_app_lifecycle_description" tools:ignore="MissingTranslation">Test the usage of MapboxNavigationApp which can manage lifecycles between a car and app.</string>
     <string name="alternative_route_selection_description" tools:ignore="MissingTranslation">Tests the selecting of an alternative route line. \n\n1. Long press a point on the map in order to get a primary route and at least one alternative route. \n\n2. Select an alternative route by touching it. The touched route should appear as the primary route and the previous primary route should appear as an alternative. \n\n3. Click start navigation and make sure the puck follows the selected route.</string>
     <string name="routeline_activity" translatable="false">Internal Development Activity</string>
     <string name="label_start_navigation" translatable="false">Start Navigation</string>


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Resolves https://github.com/mapbox/mapbox-navigation-android/issues/5109

- [x] ~Create `:libnavigation-lifecycle:` module~ We decided to put this in libnativation-core
- [x] Port over `MapboxNavigationApp` `CarAppLifecycleOwner` `MapboxNavigationOwner` `MapboxNavigationObserver`
- [x] Port over tests

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Introduce `MapboxNavigationApp` and `MapboxNavigationObserver` to handle `MapboxNavigation` lifecycles. [#5112](https://github.com/mapbox/mapbox-navigation-android/pull/5112)</changelog>
```
