### PR TITLE
Testing the tests for mock locations

### DIFF
--- a/instrumentation-tests/src/debug/AndroidManifest.xml
+++ b/instrumentation-tests/src/debug/AndroidManifest.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:tools="http://schemas.android.com/tools"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.ACCESS_MOCK_LOCATION"
+        tools:ignore="ProtectedPermissions" />
+</manifest>

--- a/libtesting-ui/src/main/java/com/mapbox/navigation/testing/ui/MockLocationUpdatesRule.kt
+++ b/libtesting-ui/src/main/java/com/mapbox/navigation/testing/ui/MockLocationUpdatesRule.kt
@@ -54,7 +54,7 @@ class MockLocationUpdatesRule : ExternalResource() {
             )
         } catch (ex: Exception) {
             // unstable
-            Log.w("MockLocationUpdatesRule", "addTestProvider failed")
+            Log.w("MockLocationUpdatesRule", "addTestProvider failed", ex)
         }
         locationManager.setTestProviderEnabled(mockProviderName, true)
     }


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Investigating https://github.com/mapbox/mapbox-navigation-android/issues/5116

The `CoreRerouteTest` fails because mock locations are not allowed. Adding a couple checks to see if we can figure it out
