### PR TITLE
Fix route alternative thread issue

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -12,7 +12,7 @@ ext {
   // version which we should use in this build
   def mapboxNavigatorVersion = System.getenv("FORCE_MAPBOX_NAVIGATION_NATIVE_VERSION")
   if (mapboxNavigatorVersion == null || mapboxNavigatorVersion == '') {
-      mapboxNavigatorVersion = '79.0.2'
+      mapboxNavigatorVersion = '79.0.3'
   }
   println("Navigation Native version: " + mapboxNavigatorVersion)
 

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/RouteAlternativesTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/RouteAlternativesTest.kt
@@ -104,6 +104,7 @@ class RouteAlternativesTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::cla
             Espresso.onIdle()
         }
         firstAlternative.unregister()
+        assertTrue(firstAlternative.calledOnMainThread)
 
         runOnMainSync {
             val countDownLatch = CountDownLatch(1)

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/utils/idling/RouteAlternativesIdlingResource.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/utils/idling/RouteAlternativesIdlingResource.kt
@@ -1,5 +1,6 @@
 package com.mapbox.navigation.instrumentation_tests.utils.idling
 
+import android.os.Looper
 import androidx.test.espresso.IdlingResource
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.navigation.base.route.RouterOrigin
@@ -24,6 +25,7 @@ class RouteAlternativesIdlingResource(
         private set
     var alternatives: List<DirectionsRoute>? = null
         private set
+    var calledOnMainThread = true
 
     private var callback: IdlingResource.ResourceCallback? = null
 
@@ -47,6 +49,11 @@ class RouteAlternativesIdlingResource(
         alternatives: List<DirectionsRoute>,
         routerOrigin: RouterOrigin
     ) {
+        // Verify this happens on the main thread.
+        if (Looper.myLooper() != Looper.getMainLooper()) {
+            calledOnMainThread = false
+        }
+
         mapboxNavigation.unregisterRouteAlternativesObserver(this)
         this.routeProgress = routeProgress
         this.alternatives = alternatives

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -426,7 +426,8 @@ class MapboxNavigation @VisibleForTesting internal constructor(
         routeAlternativesController = RouteAlternativesControllerProvider.create(
             navigationOptions.routeAlternativesOptions,
             navigator,
-            tripSession
+            tripSession,
+            threadController,
         )
         routeRefreshController = RouteRefreshControllerProvider.createRouteRefreshController(
             navigationOptions.routeRefreshOptions,

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesController.kt
@@ -1,22 +1,29 @@
 package com.mapbox.navigation.core.routealternatives
 
-import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.base.common.logger.model.Message
 import com.mapbox.base.common.logger.model.Tag
 import com.mapbox.navigation.base.internal.utils.parseDirectionsResponse
 import com.mapbox.navigation.base.route.RouteAlternativesOptions
 import com.mapbox.navigation.base.route.RouterOrigin
+import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.trip.session.TripSession
 import com.mapbox.navigation.navigator.internal.MapboxNativeNavigator
+import com.mapbox.navigation.utils.internal.ThreadController
 import com.mapbox.navigation.utils.internal.logI
+import com.mapbox.navigator.RouteAlternative
+import kotlinx.coroutines.cancelChildren
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import java.util.concurrent.CopyOnWriteArraySet
 
 internal class RouteAlternativesController constructor(
     private val options: RouteAlternativesOptions,
     private val navigator: MapboxNativeNavigator,
-    private val tripSession: TripSession
+    private val tripSession: TripSession,
+    private val threadController: ThreadController
 ) {
+
+    private val mainJobControl by lazy { threadController.getMainScopeAndRootJob() }
 
     private val nativeRouteAlternativesController = navigator.createRouteAlternativesController()
         .apply {
@@ -44,6 +51,7 @@ internal class RouteAlternativesController constructor(
         observers.remove(routeAlternativesObserver)
         if (observers.isEmpty()) {
             nativeRouteAlternativesController.removeObserver(nativeObserver)
+            mainJobControl.job.cancelChildren()
         }
     }
 
@@ -58,16 +66,28 @@ internal class RouteAlternativesController constructor(
 
     private val nativeObserver = object : com.mapbox.navigator.RouteAlternativesObserver {
         override fun onRouteAlternativesChanged(
-            routeAlternatives: List<com.mapbox.navigator.RouteAlternative>
+            routeAlternatives: List<RouteAlternative>
         ): List<Int> {
             val routeProgress = tripSession.getRouteProgress()
                 ?: return emptyList()
 
-            // Map the alternatives from nav-native, add the existing RouteOptions.
+            onRouteAlternativesChanged(routeProgress, routeAlternatives)
 
-            // TODO make async
-            val alternatives: List<DirectionsRoute> = runBlocking {
-                routeAlternatives.map { routeAlternative ->
+            // This is supposed to be able to filter alternatives. If we want to provide
+            // a mechanism to let downstream developers edit the routes - we should remove
+            // the call to directionsSession.setRoutes
+            return emptyList()
+        }
+    }
+
+    private fun onRouteAlternativesChanged(
+        routeProgress: RouteProgress,
+        routeAlternatives: List<RouteAlternative>
+    ) {
+        // Map the alternatives from nav-native, add the existing RouteOptions.
+        val alternatives = runBlocking {
+            routeAlternatives
+                .map { routeAlternative ->
                     parseDirectionsResponse(
                         routeAlternative.route,
                         routeProgress.route.routeOptions()
@@ -75,19 +95,15 @@ internal class RouteAlternativesController constructor(
                         logI(TAG, Message("Response metadata: $it"))
                     }.first()
                 }
-            }
+        }
 
+        mainJobControl.scope.launch {
             // Notify the listeners.
             // TODO https://github.com/mapbox/mapbox-navigation-native/issues/4409
             // There is no way to determine if the route was Onboard or Offboard
             observers.forEach {
                 it.onRouteAlternatives(routeProgress, alternatives, RouterOrigin.Onboard)
             }
-
-            // This is supposed to be able to filter alternatives. If we want to provide
-            // a mechanism to let downstream developers edit the routes - we should remove
-            // the call to directionsSession.setRoutes
-            return emptyList()
         }
     }
 

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesControllerProvider.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesControllerProvider.kt
@@ -3,16 +3,19 @@ package com.mapbox.navigation.core.routealternatives
 import com.mapbox.navigation.base.route.RouteAlternativesOptions
 import com.mapbox.navigation.core.trip.session.TripSession
 import com.mapbox.navigation.navigator.internal.MapboxNativeNavigator
+import com.mapbox.navigation.utils.internal.ThreadController
 
 internal object RouteAlternativesControllerProvider {
 
     fun create(
         options: RouteAlternativesOptions,
         navigator: MapboxNativeNavigator,
-        tripSession: TripSession
+        tripSession: TripSession,
+        threadController: ThreadController
     ) = RouteAlternativesController(
         options,
         navigator,
-        tripSession
+        tripSession,
+        threadController
     )
 }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
@@ -180,7 +180,7 @@ class MapboxNavigationTest {
         } returns routeRefreshController
         mockkObject(RouteAlternativesControllerProvider)
         every {
-            RouteAlternativesControllerProvider.create(any(), any(), any())
+            RouteAlternativesControllerProvider.create(any(), any(), any(), any())
         } returns routeAlternativesController
 
         every { applicationContext.applicationContext } returns applicationContext

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesControllerTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesControllerTest.kt
@@ -8,6 +8,7 @@ import com.mapbox.navigation.core.trip.session.TripSession
 import com.mapbox.navigation.navigator.internal.MapboxNativeNavigator
 import com.mapbox.navigation.testing.FileUtils
 import com.mapbox.navigation.testing.MainCoroutineRule
+import com.mapbox.navigation.utils.internal.ThreadController
 import com.mapbox.navigator.RouteAlternativesControllerInterface
 import io.mockk.every
 import io.mockk.just
@@ -38,6 +39,7 @@ class RouteAlternativesControllerTest {
         options,
         navigator,
         tripSession,
+        ThreadController(),
     )
 
     @Test
@@ -102,7 +104,7 @@ class RouteAlternativesControllerTest {
     }
 
     @Test
-    fun `should broadcast alternative routes changes from nav-native`() {
+    fun `should broadcast alternative routes changes from nav-native`() = coroutineRule.runBlockingTest {
         val routeAlternativesController = routeAlternativesController()
         val nativeObserver = slot<com.mapbox.navigator.RouteAlternativesObserver>()
         every { controllerInterface.addObserver(capture(nativeObserver)) } just runs
@@ -130,7 +132,7 @@ class RouteAlternativesControllerTest {
     }
 
     @Test
-    fun `should broadcast current route with alternative`() {
+    fun `should broadcast current route with alternative`() = coroutineRule.runBlockingTest {
         val routeAlternativesController = routeAlternativesController()
         val nativeObserver = slot<com.mapbox.navigator.RouteAlternativesObserver>()
         every { controllerInterface.addObserver(capture(nativeObserver)) } just runs
@@ -169,7 +171,7 @@ class RouteAlternativesControllerTest {
     }
 
     @Test
-    fun `should set alternative RouteOptions to primary RouteOptions`() {
+    fun `should set alternative RouteOptions to primary RouteOptions`() = coroutineRule.runBlockingTest {
         val originalCoordinates = "-122.270375,37.801429;-122.271496, 37.799063"
         val routeAlternativesController = routeAlternativesController()
         val nativeObserver = slot<com.mapbox.navigator.RouteAlternativesObserver>()


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Addresses https://github.com/mapbox/mapbox-navigation-android/issues/5119

We also want this in 2.2 and the main branch. But it has conflicts with https://github.com/mapbox/mapbox-navigation-android/pull/5034 that we will resolve after that is merged.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Trigger RouteAlternativesObserver on main thread</changelog>
```

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
