### PR TITLE
[Cherry-pick] Add PedingIntent Android 12 flags support (#5105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 Mapbox welcomes participation and contributions from everyone.
 
+## Mapbox Navigation SDK 2.0.2 - November 17, 2021
+
+For details on how v2 differs from v1 and guidance on migrating from v1 of the Mapbox Navigation SDK for Android to the v2 public preview, see [2.0 Navigation SDK Migration Guide](https://github.com/mapbox/mapbox-navigation-android/wiki/2.0-Navigation-SDK-Migration-Guide).
+
+### Changelog
+#### Bug fixes and improvements
+- Add PedingIntent Android 12 flags support. [#5121](https://github.com/mapbox/mapbox-navigation-android/pull/5121)
+
+### Mapbox dependencies
+This release depends, and has been tested with, the following Mapbox dependencies:
+- Mapbox Maps SDK `v10.0.0` ([release notes](https://github.com/mapbox/mapbox-maps-android/releases/tag/android-v10.0.0))
+- Mapbox Navigation Native `v69.0.3`
+- Mapbox Core Common `v20.0.0`
+- Mapbox Java `v6.0.0` ([release notes](https://github.com/mapbox/mapbox-java/releases/tag/v6.0.0))
+- Mapbox Android Core `v5.0.0`
+- Mapbox Android Telemetry `v8.1.0`
+
 ## Mapbox Navigation SDK 2.0.1 - November 10, 2021
 
 For details on how v2 differs from v1 and guidance on migrating from v1 of the Mapbox Navigation SDK for Android to the v2 public preview, see [2.0 Navigation SDK Migration Guide](https://github.com/mapbox/mapbox-navigation-android/wiki/2.0-Navigation-SDK-Migration-Guide).

--- a/libtrip-notification/src/main/java/com/mapbox/navigation/trip/notification/internal/MapboxTripNotification.kt
+++ b/libtrip-notification/src/main/java/com/mapbox/navigation/trip/notification/internal/MapboxTripNotification.kt
@@ -1,6 +1,5 @@
 package com.mapbox.navigation.trip.notification.internal
 
-import android.annotation.SuppressLint
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
@@ -89,6 +88,12 @@ class MapboxTripNotification constructor(
     )
 
     private var notificationView: MapboxTripNotificationView
+    private val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+    } else {
+        PendingIntent.FLAG_UPDATE_CURRENT
+    }
+
     init {
         applicationContext.getSystemService(Context.NOTIFICATION_SERVICE)
             ?.let { notificationService ->
@@ -212,12 +217,11 @@ class MapboxTripNotification constructor(
      * @param applicationContext the application's [Context]
      * @return [PendingIntent] to opening application
      */
-    @SuppressLint("UnspecifiedImmutableFlag")
     private fun createPendingOpenIntent(applicationContext: Context): PendingIntent? {
         val pm = applicationContext.packageManager
         val intent = pm.getLaunchIntentForPackage(applicationContext.packageName) ?: return null
         intent.setPackage(null)
-        return PendingIntent.getActivity(applicationContext, 0, intent, 0)
+        return PendingIntent.getActivity(applicationContext, 0, intent, flags)
     }
 
     /**
@@ -227,10 +231,9 @@ class MapboxTripNotification constructor(
      * @param applicationContext the application's [Context]
      * @return [PendingIntent] for stopping trip session
      */
-    @SuppressLint("UnspecifiedImmutableFlag")
     private fun createPendingCloseIntent(applicationContext: Context): PendingIntent? {
         val endNavigationBtn = Intent(END_NAVIGATION_ACTION)
-        return PendingIntent.getBroadcast(applicationContext, 0, endNavigationBtn, 0)
+        return PendingIntent.getBroadcast(applicationContext, 0, endNavigationBtn, flags)
     }
 
     private fun createNotificationChannel() {


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Cherry picking https://github.com/mapbox/mapbox-navigation-android/pull/5105

This is for a v2.0.2 release to support Android 12

## Mapbox Navigation SDK 2.0.2 - November 17, 2021

For details on how v2 differs from v1 and guidance on migrating from v1 of the Mapbox Navigation SDK for Android to the v2 public preview, see [2.0 Navigation SDK Migration Guide](https://github.com/mapbox/mapbox-navigation-android/wiki/2.0-Navigation-SDK-Migration-Guide).

### Changelog
#### Bug fixes and improvements
- Add PedingIntent Android 12 flags support. [#5121](https://github.com/mapbox/mapbox-navigation-android/pull/5121)

### Mapbox dependencies
This release depends, and has been tested with, the following Mapbox dependencies:
- Mapbox Maps SDK `v10.0.0` ([release notes](https://github.com/mapbox/mapbox-maps-android/releases/tag/android-v10.0.0))
- Mapbox Navigation Native `v69.0.3`
- Mapbox Core Common `v20.0.0`
- Mapbox Java `v6.0.0` ([release notes](https://github.com/mapbox/mapbox-java/releases/tag/v6.0.0))
- Mapbox Android Core `v5.0.0`
- Mapbox Android Telemetry `v8.1.0`
