### PR TITLE
RouteProgress#voiceInstructions property doesn't become null

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/navigator/NavigatorMapper.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/navigator/NavigatorMapper.kt
@@ -63,7 +63,7 @@ internal fun getRouteProgressFrom(
     remainingWaypoints: Int,
     bannerInstructions: BannerInstructions?,
     instructionIndex: Int?,
-    lastVoiceInstruction: VoiceInstructions?
+    lastVoiceInstruction: VoiceInstructions?,
 ): RouteProgress? {
     return status.getRouteProgress(
         directionsRoute,

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/navigator/NavigatorMapper.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/navigator/NavigatorMapper.kt
@@ -62,13 +62,15 @@ internal fun getRouteProgressFrom(
     status: NavigationStatus,
     remainingWaypoints: Int,
     bannerInstructions: BannerInstructions?,
-    instructionIndex: Int?
+    instructionIndex: Int?,
+    lastVoiceInstruction: VoiceInstructions?
 ): RouteProgress? {
     return status.getRouteProgress(
         directionsRoute,
         remainingWaypoints,
         bannerInstructions,
-        instructionIndex
+        instructionIndex,
+        lastVoiceInstruction,
     )
 }
 
@@ -86,7 +88,8 @@ private fun NavigationStatus.getRouteProgress(
     route: DirectionsRoute?,
     remainingWaypoints: Int,
     bannerInstructions: BannerInstructions?,
-    instructionIndex: Int?
+    instructionIndex: Int?,
+    lastVoiceInstruction: VoiceInstructions?
 ): RouteProgress? {
     if (routeState == RouteState.INVALID) {
         return null
@@ -192,7 +195,7 @@ private fun NavigationStatus.getRouteProgress(
         return buildRouteProgressObject(
             route,
             bannerInstructions,
-            voiceInstruction?.mapToDirectionsApi(),
+            voiceInstruction?.mapToDirectionsApi() ?: lastVoiceInstruction,
             routeProgressCurrentState,
             routeLegProgress,
             routeProgressUpcomingStepPoints,

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/navigator/NavigatorMapper.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/navigator/NavigatorMapper.kt
@@ -89,7 +89,7 @@ private fun NavigationStatus.getRouteProgress(
     remainingWaypoints: Int,
     bannerInstructions: BannerInstructions?,
     instructionIndex: Int?,
-    lastVoiceInstruction: VoiceInstructions?
+    lastVoiceInstruction: VoiceInstructions?,
 ): RouteProgress? {
     if (routeState == RouteState.INVALID) {
         return null

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
@@ -313,7 +313,7 @@ internal class MapboxTripSession(
                     lastVoiceInstruction
                 )
                 updateRouteProgress(routeProgress, triggerObserver)
-
+                triggerVoiceInstructionEvent(routeProgress, status)
                 isOffRoute = tripStatus.navigationStatus.routeState == RouteState.OFF_ROUTE
             }
         }
@@ -622,13 +622,14 @@ internal class MapboxTripSession(
                     }
                 }
             }
-            triggerVoiceInstructionEvent(progress)
         }
     }
 
-    private fun triggerVoiceInstructionEvent(progress: RouteProgress) {
+    private fun triggerVoiceInstructionEvent(progress: RouteProgress?, status: NavigationStatus) {
+        if (progress == null) return
         val voiceInstructions = progress.voiceInstructions
-        if (voiceInstructions != null && lastVoiceInstruction != voiceInstructions) {
+        val navigatorTriggeredNewInstruction = status.voiceInstruction != null
+        if (voiceInstructions != null && navigatorTriggeredNewInstruction) {
             voiceInstructionsObservers.forEach {
                 it.onNewVoiceInstructions(voiceInstructions)
             }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
@@ -626,8 +626,7 @@ internal class MapboxTripSession(
     }
 
     private fun triggerVoiceInstructionEvent(progress: RouteProgress?, status: NavigationStatus) {
-        if (progress == null) return
-        val voiceInstructions = progress.voiceInstructions
+        val voiceInstructions = progress?.voiceInstructions
         val navigatorTriggeredNewInstruction = status.voiceInstruction != null
         if (voiceInstructions != null && navigatorTriggeredNewInstruction) {
             voiceInstructionsObservers.forEach {

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/infra/TestLocationEngine.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/infra/TestLocationEngine.kt
@@ -1,0 +1,57 @@
+package com.mapbox.navigation.core.infra
+
+import android.app.PendingIntent
+import android.location.Location
+import android.os.Looper
+import com.mapbox.android.core.location.LocationEngine
+import com.mapbox.android.core.location.LocationEngineCallback
+import com.mapbox.android.core.location.LocationEngineRequest
+import com.mapbox.android.core.location.LocationEngineResult
+import com.mapbox.navigation.core.infra.factories.createLocation
+
+class TestLocationEngine private constructor() : LocationEngine {
+
+    companion object {
+
+        fun create() = TestLocationEngine()
+    }
+
+    private val locationUpdateCallbacks =
+        mutableListOf<LocationEngineCallback<LocationEngineResult>>()
+    private var currentLocation = LocationEngineResult.create(createLocation())
+
+    override fun getLastLocation(p0: LocationEngineCallback<LocationEngineResult>) {
+        p0.onSuccess(currentLocation)
+    }
+
+    override fun requestLocationUpdates(
+        p0: LocationEngineRequest,
+        p1: LocationEngineCallback<LocationEngineResult>,
+        p2: Looper?
+    ) {
+        locationUpdateCallbacks.add(p1)
+    }
+
+    override fun removeLocationUpdates(p0: LocationEngineCallback<LocationEngineResult>) {
+        locationUpdateCallbacks.remove(p0)
+    }
+
+    override fun requestLocationUpdates(p0: LocationEngineRequest, p1: PendingIntent?) {
+        TODO(
+            "requestLocationUpdates for PendingIntent isn't supported yet." +
+                "Implement if you need it"
+        )
+    }
+
+    override fun removeLocationUpdates(p0: PendingIntent?) {
+        TODO(
+            "removeLocationUpdates for PendingIntent isn't supported yet." +
+                "Implement if you need it"
+        )
+    }
+
+    fun updateLocation(location: Location) {
+        currentLocation = LocationEngineResult.create(location)
+        locationUpdateCallbacks.forEach { it.onSuccess(currentLocation) }
+    }
+}

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/infra/factories/Android.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/infra/factories/Android.kt
@@ -1,0 +1,8 @@
+package com.mapbox.navigation.core.infra.factories
+
+import android.location.Location
+
+fun createLocation(longitude: Double = 0.0, latitude: Double = 0.0) = Location("").apply {
+    setLatitude(latitude)
+    setLongitude(longitude)
+}

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/infra/factories/DirectionsResponseFactories.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/infra/factories/DirectionsResponseFactories.kt
@@ -1,0 +1,10 @@
+package com.mapbox.navigation.core.infra.factories
+
+import com.mapbox.api.directions.v5.models.DirectionsRoute
+
+fun createDirectionsRoute(): DirectionsRoute {
+    return DirectionsRoute.builder()
+        .distance(5.0)
+        .duration(9.0)
+        .build()
+}

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/infra/factories/NativeFactories.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/infra/factories/NativeFactories.kt
@@ -1,0 +1,118 @@
+package com.mapbox.navigation.core.infra.factories
+
+import com.mapbox.geojson.Point
+import com.mapbox.navigator.ActiveGuidanceInfo
+import com.mapbox.navigator.BannerInstruction
+import com.mapbox.navigator.BannerSection
+import com.mapbox.navigator.FixLocation
+import com.mapbox.navigator.MapMatcherOutput
+import com.mapbox.navigator.NavigationStatus
+import com.mapbox.navigator.RouteState
+import com.mapbox.navigator.SpeedLimit
+import com.mapbox.navigator.UpcomingRouteAlert
+import com.mapbox.navigator.VoiceInstruction
+import java.time.Instant
+import java.util.Date
+
+fun createNavigationStatus(
+    routeState: RouteState = RouteState.TRACKING,
+    stale: Boolean = false,
+    location: FixLocation = createFixedLocation(),
+    routeSequenceNumber: Int = 0,
+    routeIndex: Int = 0,
+    legIndex: Int = 0,
+    stepIndex: Int = 0,
+    isFallback: Boolean = false,
+    isTunnel: Boolean = false,
+    predicted: Long = 0,
+    shapeIndex: Int = 0,
+    intersectionIndex: Int = 0,
+    roadName: String = "test road name",
+    shieldName: String = "test shield name",
+    voiceInstruction: VoiceInstruction? = null,
+    // default banner instruction workarounds the direct usage of the MapboxNativeNavigatorImpl
+    bannerInstruction: BannerInstruction? = createBannerInstruction(),
+    speedLimit: SpeedLimit? = null,
+    keyPoints: List<FixLocation> = emptyList(),
+    mapMatcherOutput: MapMatcherOutput = createMapMatcherOutput(),
+    offRoadProba: Float = 0f,
+    activeGuidanceInfo: ActiveGuidanceInfo? = null,
+    upcomingRouteAlerts: List<UpcomingRouteAlert> = emptyList(),
+    nextWaypointIndex: Int = 0,
+    layer: Int = 0
+): NavigationStatus {
+    return NavigationStatus(
+        routeState,
+        stale,
+        location,
+        routeSequenceNumber,
+        routeIndex,
+        legIndex,
+        stepIndex,
+        isFallback,
+        isTunnel,
+        predicted,
+        shapeIndex,
+        intersectionIndex,
+        roadName,
+        shieldName,
+        voiceInstruction,
+        bannerInstruction,
+        speedLimit,
+        keyPoints,
+        mapMatcherOutput,
+        offRoadProba,
+        activeGuidanceInfo,
+        upcomingRouteAlerts,
+        nextWaypointIndex,
+        layer
+    )
+}
+
+fun createVoiceInstruction(
+    announcement: String = "test"
+): VoiceInstruction {
+    return VoiceInstruction("test", announcement, 0f, 0)
+}
+
+fun createBannerInstruction(): BannerInstruction {
+    return BannerInstruction(
+        createBannerSection(),
+        null,
+        null,
+        null,
+        0f,
+        0
+    )
+}
+
+fun createBannerSection(): BannerSection {
+    return BannerSection(
+        "test",
+        null,
+        null,
+        null,
+        null,
+        null
+    )
+}
+
+// Add default parameters if you define properties
+fun createFixedLocation() = FixLocation(
+    Point.fromLngLat(0.0, 0.0),
+    0,
+    Date.from(Instant.ofEpochMilli(20)),
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    HashMap(),
+    true
+)
+
+// Add default parameters if you define properties
+fun createMapMatcherOutput() = MapMatcherOutput(emptyList(), false)

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/infra/factories/NativeFactories.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/infra/factories/NativeFactories.kt
@@ -86,9 +86,11 @@ fun createBannerInstruction(): BannerInstruction {
     )
 }
 
-fun createBannerSection(): BannerSection {
+fun createBannerSection(
+    text: String = "testText",
+): BannerSection {
     return BannerSection(
-        "test",
+        text,
         null,
         null,
         null,
@@ -97,9 +99,12 @@ fun createBannerSection(): BannerSection {
     )
 }
 
-// Add default parameters if you define properties
-fun createFixedLocation() = FixLocation(
-    Point.fromLngLat(0.0, 0.0),
+// Add more default parameters if you define properties
+fun createFixedLocation(
+    longitude: Double = 0.0,
+    latitude: Double = 0.0,
+) = FixLocation(
+    Point.fromLngLat(longitude, latitude),
     0,
     Date.from(Instant.ofEpochMilli(20)),
     null,

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/infra/recorders/RouteProgressObserverRecorder.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/infra/recorders/RouteProgressObserverRecorder.kt
@@ -1,0 +1,13 @@
+package com.mapbox.navigation.core.infra.recorders
+
+import com.mapbox.navigation.base.trip.model.RouteProgress
+import com.mapbox.navigation.core.trip.session.RouteProgressObserver
+
+class RouteProgressObserverRecorder : RouteProgressObserver {
+
+    private val _records = mutableListOf<RouteProgress>()
+    val records: List<RouteProgress> get() = _records
+    override fun onRouteProgressChanged(routeProgress: RouteProgress) {
+        _records.add(routeProgress)
+    }
+}

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/infra/recorders/VoiceInstructionsObserverRecorder.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/infra/recorders/VoiceInstructionsObserverRecorder.kt
@@ -1,0 +1,14 @@
+package com.mapbox.navigation.core.infra.recorders
+
+import com.mapbox.api.directions.v5.models.VoiceInstructions
+import com.mapbox.navigation.core.trip.session.VoiceInstructionsObserver
+
+class VoiceInstructionsObserverRecorder : VoiceInstructionsObserver {
+
+    private val _records = mutableListOf<VoiceInstructions>()
+    val records: List<VoiceInstructions> get() = _records
+
+    override fun onNewVoiceInstructions(voiceInstructions: VoiceInstructions) {
+        _records.add(voiceInstructions)
+    }
+}

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/navigator/NavigatorMapperTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/navigator/NavigatorMapperTest.kt
@@ -428,7 +428,7 @@ class NavigatorMapperTest {
             mockk(relaxed = true),
             mockk(relaxed = true),
             0,
-            lastVoiceInstruction = mockk(relaxed = true)
+            lastVoiceInstruction = mockk(relaxed = true),
         )
 
         assertFalse(routeProgress!!.stale)

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/navigator/NavigatorMapperTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/navigator/NavigatorMapperTest.kt
@@ -94,7 +94,8 @@ class NavigatorMapperTest {
             navigationStatus,
             remainingWaypoints = 1,
             bannerInstructions,
-            instructionIndex = 1
+            instructionIndex = 1,
+            lastVoiceInstruction = null
         )
 
         assertEquals(expected, result)
@@ -366,7 +367,8 @@ class NavigatorMapperTest {
             navigationStatus,
             mockk(relaxed = true),
             mockk(relaxed = true),
-            0
+            0,
+            mockk(relaxed = true),
         )
 
         assertNull(routeProgress)
@@ -381,7 +383,8 @@ class NavigatorMapperTest {
             navigationStatus,
             mockk(relaxed = true),
             mockk(relaxed = true),
-            0
+            0,
+            mockk(relaxed = true),
         )
 
         assertNull(routeProgress)
@@ -394,7 +397,8 @@ class NavigatorMapperTest {
             navigationStatus,
             mockk(relaxed = true),
             mockk(relaxed = true),
-            0
+            0,
+            mockk(relaxed = true),
         )
 
         assertNotNull(routeProgress)
@@ -408,7 +412,8 @@ class NavigatorMapperTest {
             navigationStatus,
             mockk(relaxed = true),
             mockk(relaxed = true),
-            0
+            0,
+            lastVoiceInstruction = mockk(relaxed = true),
         )
 
         assertTrue(routeProgress!!.stale)
@@ -422,7 +427,8 @@ class NavigatorMapperTest {
             navigationStatus,
             mockk(relaxed = true),
             mockk(relaxed = true),
-            0
+            0,
+            lastVoiceInstruction = mockk(relaxed = true)
         )
 
         assertFalse(routeProgress!!.stale)
@@ -459,7 +465,8 @@ class NavigatorMapperTest {
             navigationStatus,
             mockk(relaxed = true),
             mockk(relaxed = true),
-            0
+            0,
+            mockk(relaxed = true),
         )
         val upcomingRouteAlerts = routeProgress!!.upcomingRoadObjects
 

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/navigator/NavigatorMapperTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/navigator/NavigatorMapperTest.kt
@@ -95,7 +95,7 @@ class NavigatorMapperTest {
             remainingWaypoints = 1,
             bannerInstructions,
             instructionIndex = 1,
-            lastVoiceInstruction = null
+            lastVoiceInstruction = null,
         )
 
         assertEquals(expected, result)

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionNoSetupTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionNoSetupTest.kt
@@ -1,0 +1,303 @@
+package com.mapbox.navigation.core.trip.session
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.mapbox.android.core.location.LocationEngine
+import com.mapbox.navigation.base.options.NavigationOptions
+import com.mapbox.navigation.core.directions.session.RoutesExtra
+import com.mapbox.navigation.core.directions.session.RoutesExtra.ROUTES_UPDATE_REASON_NEW
+import com.mapbox.navigation.core.infra.TestLocationEngine
+import com.mapbox.navigation.core.infra.factories.createDirectionsRoute
+import com.mapbox.navigation.core.infra.factories.createLocation
+import com.mapbox.navigation.core.infra.factories.createNavigationStatus
+import com.mapbox.navigation.core.infra.factories.createVoiceInstruction
+import com.mapbox.navigation.core.infra.recorders.RouteProgressObserverRecorder
+import com.mapbox.navigation.core.infra.recorders.VoiceInstructionsObserverRecorder
+import com.mapbox.navigation.core.trip.service.TripService
+import com.mapbox.navigation.core.trip.session.StatusWithVoiceInstructionUpdateUtil.Companion.LONGITUDE_FOR_VOICE_INSTRUCTION_1
+import com.mapbox.navigation.core.trip.session.StatusWithVoiceInstructionUpdateUtil.Companion.LONGITUDE_FOR_VOICE_INSTRUCTION_2
+import com.mapbox.navigation.core.trip.session.StatusWithVoiceInstructionUpdateUtil.Companion.LONGITUDE_FOR_VOICE_INSTRUCTION_NULL
+import com.mapbox.navigation.navigator.internal.MapboxNativeNavigator
+import com.mapbox.navigation.utils.internal.JobControl
+import com.mapbox.navigation.utils.internal.ThreadController
+import com.mapbox.navigator.NavigationStatusOrigin
+import com.mapbox.navigator.NavigatorObserver
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.spyk
+import junit.framework.Assert.assertEquals
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class MapboxTripSessionNoSetupTest {
+
+    @Test
+    fun voiceInstructionsFallbacksToPreviousValue() {
+        // arrange
+        val voiceInstructionsObserver = VoiceInstructionsObserverRecorder()
+        val routeProgressObserver = RouteProgressObserverRecorder()
+        val nativeNavigator = mockk<MapboxNativeNavigator>(relaxed = true)
+        StatusWithVoiceInstructionUpdateUtil.triggerStatusUpdatesOnLocationUpdate(nativeNavigator)
+        val locationEngine = TestLocationEngine.create()
+        val tripSession = buildTripSession(
+            nativeNavigator = nativeNavigator,
+            locationEngine = locationEngine
+        )
+        tripSession.start(true)
+        tripSession.registerVoiceInstructionsObserver(voiceInstructionsObserver)
+        tripSession.registerRouteProgressObserver(routeProgressObserver)
+        tripSession.setRoutes(
+            listOf(createDirectionsRoute()),
+            0,
+            RoutesExtra.ROUTES_UPDATE_REASON_NEW
+        )
+        // act
+        locationEngine.updateLocation(createLocation(longitude = LONGITUDE_FOR_VOICE_INSTRUCTION_1))
+        locationEngine.updateLocation(
+            createLocation(longitude = LONGITUDE_FOR_VOICE_INSTRUCTION_NULL)
+        )
+        locationEngine.updateLocation(createLocation(longitude = LONGITUDE_FOR_VOICE_INSTRUCTION_2))
+        // assert
+        val announcementsFromVoiceInstructionObserver = voiceInstructionsObserver.records
+            .takeLast(3) // take only events triggered by location updates
+            .map { it.announcement() }
+        assertEquals(listOf("1", "2"), announcementsFromVoiceInstructionObserver)
+        val announcementsFromRouteProgress = routeProgressObserver.records
+            .takeLast(3) // take only events triggered by location updates
+            .map { it.voiceInstructions?.announcement() }
+        assertEquals(listOf("1", "1", "2"), announcementsFromRouteProgress)
+    }
+
+    @Test
+    fun addingVoiceInstructionsObserversInTheMiddleOfNavigation() {
+        // arrange
+        val nativeNavigator = mockk<MapboxNativeNavigator>(relaxed = true)
+        StatusWithVoiceInstructionUpdateUtil.triggerStatusUpdatesOnLocationUpdate(nativeNavigator)
+        val locationEngine = TestLocationEngine.create()
+        val tripSession = buildTripSession(
+            nativeNavigator = nativeNavigator,
+            locationEngine = locationEngine
+        )
+        tripSession.start(true)
+        tripSession.setRoutes(
+            listOf(createDirectionsRoute()),
+            0,
+            RoutesExtra.ROUTES_UPDATE_REASON_NEW
+        )
+        locationEngine.updateLocation(createLocation(longitude = LONGITUDE_FOR_VOICE_INSTRUCTION_1))
+        val routeProgressObserver = RouteProgressObserverRecorder()
+        tripSession.registerRouteProgressObserver(routeProgressObserver)
+        // act
+        val voiceInstructionsObserver = VoiceInstructionsObserverRecorder()
+        tripSession.registerVoiceInstructionsObserver(voiceInstructionsObserver)
+        locationEngine.updateLocation(
+            createLocation(longitude = LONGITUDE_FOR_VOICE_INSTRUCTION_NULL)
+        )
+        locationEngine.updateLocation(createLocation(longitude = LONGITUDE_FOR_VOICE_INSTRUCTION_2))
+        // assert
+        val voiceInstructionsAnnouncements = voiceInstructionsObserver.records
+            .takeLast(2) // take only events triggered by location updates
+            .map { it.announcement() }
+        assertEquals(listOf("1", "2"), voiceInstructionsAnnouncements)
+    }
+
+    @Test
+    fun noVoiceInstructionFallbackForFreshRoute() {
+        // arrange
+        val nativeNavigator = mockk<MapboxNativeNavigator>(relaxed = true)
+        StatusWithVoiceInstructionUpdateUtil.triggerStatusUpdatesOnLocationUpdate(nativeNavigator)
+        val locationEngine = TestLocationEngine.create()
+        val tripSession = buildTripSession(
+            nativeNavigator = nativeNavigator,
+            locationEngine = locationEngine
+        )
+        val routeProgressObserver = RouteProgressObserverRecorder()
+        tripSession.registerRouteProgressObserver(routeProgressObserver)
+        tripSession.start(true)
+        tripSession.setRoutes(
+            listOf(createDirectionsRoute()),
+            0,
+            ROUTES_UPDATE_REASON_NEW
+        )
+        locationEngine.updateLocation(createLocation(longitude = LONGITUDE_FOR_VOICE_INSTRUCTION_1))
+        // act
+        tripSession.setRoutes(
+            listOf(createDirectionsRoute()),
+            0,
+            ROUTES_UPDATE_REASON_NEW
+        )
+        locationEngine.updateLocation(
+            createLocation(longitude = LONGITUDE_FOR_VOICE_INSTRUCTION_NULL)
+        )
+        locationEngine.updateLocation(createLocation(longitude = LONGITUDE_FOR_VOICE_INSTRUCTION_2))
+        // assert
+        val voiceInstructionsAnnouncements = routeProgressObserver.records
+            .takeLast(2) // take only events triggered by location updates
+            .map { it.voiceInstructions?.announcement() }
+        assertEquals(listOf(null, "2"), voiceInstructionsAnnouncements)
+    }
+
+    @Test
+    fun noVoiceInstructionFallbackAfterLegIndexUpdate() {
+        // arrange
+        val nativeNavigator = mockk<MapboxNativeNavigator>(relaxed = true)
+        StatusWithVoiceInstructionUpdateUtil.triggerStatusUpdatesOnLocationUpdate(nativeNavigator)
+        coEvery { nativeNavigator.updateLegIndex(any()) } returns true
+        val locationEngine = TestLocationEngine.create()
+        val tripSession = buildTripSession(
+            nativeNavigator = nativeNavigator,
+            locationEngine = locationEngine
+        )
+        val routeProgressObserver = RouteProgressObserverRecorder()
+        tripSession.registerRouteProgressObserver(routeProgressObserver)
+        tripSession.start(true)
+        tripSession.setRoutes(
+            listOf(createDirectionsRoute()),
+            0,
+            ROUTES_UPDATE_REASON_NEW
+        )
+        locationEngine.updateLocation(createLocation(longitude = LONGITUDE_FOR_VOICE_INSTRUCTION_1))
+        // act
+        tripSession.updateLegIndex(1) { }
+        locationEngine.updateLocation(
+            createLocation(longitude = LONGITUDE_FOR_VOICE_INSTRUCTION_NULL)
+        )
+        locationEngine.updateLocation(createLocation(longitude = LONGITUDE_FOR_VOICE_INSTRUCTION_2))
+        // assert
+        val voiceInstructionsAnnouncements = routeProgressObserver.records
+            .takeLast(2) // take only events triggered by location updates
+            .map { it.voiceInstructions?.announcement() }
+        assertEquals(listOf(null, "2"), voiceInstructionsAnnouncements)
+    }
+
+    @Test
+    fun voiceInstructionFallbackAfterUnsuccessfulLegIndexUpdate() {
+        // arrange
+        val nativeNavigator = mockk<MapboxNativeNavigator>(relaxed = true)
+        coEvery { nativeNavigator.updateLegIndex(any()) } returns false
+        StatusWithVoiceInstructionUpdateUtil.triggerStatusUpdatesOnLocationUpdate(nativeNavigator)
+        val locationEngine = TestLocationEngine.create()
+        val tripSession = buildTripSession(
+            nativeNavigator = nativeNavigator,
+            locationEngine = locationEngine
+        )
+        val routeProgressObserver = RouteProgressObserverRecorder()
+        tripSession.registerRouteProgressObserver(routeProgressObserver)
+        tripSession.start(true)
+        tripSession.setRoutes(
+            listOf(createDirectionsRoute()),
+            0,
+            ROUTES_UPDATE_REASON_NEW
+        )
+        locationEngine.updateLocation(createLocation(longitude = LONGITUDE_FOR_VOICE_INSTRUCTION_1))
+        // act
+        tripSession.updateLegIndex(1) { }
+        locationEngine.updateLocation(
+            createLocation(longitude = LONGITUDE_FOR_VOICE_INSTRUCTION_NULL)
+        )
+        locationEngine.updateLocation(createLocation(longitude = LONGITUDE_FOR_VOICE_INSTRUCTION_2))
+        // assert
+        val voiceInstructionsAnnouncements = routeProgressObserver.records
+            .takeLast(2) // take only events triggered by location updates
+            .map { it.voiceInstructions?.announcement() }
+        assertEquals(listOf("1", "2"), voiceInstructionsAnnouncements)
+    }
+}
+
+private fun buildTripSession(
+    nativeNavigator: MapboxNativeNavigator = mockk(relaxed = true),
+    locationEngine: LocationEngine = TestLocationEngine.create()
+): MapboxTripSession {
+    val context: Context = ApplicationProvider.getApplicationContext()
+    val navigationOptions = NavigationOptions.Builder(context)
+        .locationEngine(locationEngine)
+        .build()
+
+    val tripService: TripService = mockk(relaxUnitFun = true) {
+        every { hasServiceStarted() } returns false
+    }
+
+    val parentJob = SupervisorJob()
+    val testScope = CoroutineScope(parentJob + TestCoroutineDispatcher())
+    val threadController = spyk<ThreadController>()
+    every { threadController.getMainScopeAndRootJob() } returns JobControl(parentJob, testScope)
+
+    return MapboxTripSession(
+        tripService,
+        TripSessionLocationEngine(navigationOptions),
+        nativeNavigator,
+        threadController,
+        logger = mockk(relaxed = true),
+        eHorizonSubscriptionManager = mockk(relaxed = true),
+    )
+}
+
+class StatusWithVoiceInstructionUpdateUtil {
+    companion object {
+
+        const val LONGITUDE_FOR_VOICE_INSTRUCTION_1 = 1.0
+        const val LONGITUDE_FOR_VOICE_INSTRUCTION_NULL = 1.5
+        const val LONGITUDE_FOR_VOICE_INSTRUCTION_2 = 2.0
+
+        fun triggerStatusUpdatesOnLocationUpdate(nativeNavigator: MapboxNativeNavigator) {
+            coEvery {
+                nativeNavigator.setRoute(any(), any())
+            } returns null
+            val navigatorObserverImplSlot = slot<NavigatorObserver>()
+            every {
+                nativeNavigator.addNavigatorObserver(capture(navigatorObserverImplSlot))
+            } returns Unit
+            coEvery {
+                nativeNavigator.updateLocation(
+                    match { it.coordinate.longitude() == LONGITUDE_FOR_VOICE_INSTRUCTION_1 }
+                )
+            } answers {
+                navigatorObserverImplSlot.captured.onStatus(
+                    NavigationStatusOrigin.LOCATION_UPDATE,
+                    createNavigationStatus(
+                        location = firstArg(),
+                        voiceInstruction = createVoiceInstruction("1")
+                    )
+                )
+                true
+            }
+            coEvery {
+                nativeNavigator.updateLocation(
+                    match { it.coordinate.longitude() == LONGITUDE_FOR_VOICE_INSTRUCTION_NULL }
+                )
+            } answers {
+                navigatorObserverImplSlot.captured.onStatus(
+                    NavigationStatusOrigin.LOCATION_UPDATE,
+                    createNavigationStatus(
+                        location = firstArg(),
+                        voiceInstruction = null
+                    )
+                )
+                true
+            }
+            coEvery {
+                nativeNavigator.updateLocation(
+                    match { it.coordinate.longitude() == LONGITUDE_FOR_VOICE_INSTRUCTION_2 }
+                )
+            } answers {
+                navigatorObserverImplSlot.captured.onStatus(
+                    NavigationStatusOrigin.LOCATION_UPDATE,
+                    createNavigationStatus(
+                        location = firstArg(),
+                        voiceInstruction = createVoiceInstruction("2")
+                    )
+                )
+                true
+            }
+        }
+    }
+}

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
@@ -776,28 +776,6 @@ class MapboxTripSessionTest {
     }
 
     @Test
-    fun voiceInstructionsFollowRouteProgress() = coroutineRule.runBlockingTest {
-        val voiceInstructionsObserver: VoiceInstructionsObserver = mockk(relaxUnitFun = true)
-        val voiceInstructions: VoiceInstructions = mockk()
-        val routeProgressObserver: RouteProgressObserver = mockk(relaxUnitFun = true)
-        every { routeProgress.voiceInstructions } returns voiceInstructions
-
-        tripSession = buildTripSession()
-        tripSession.start(true)
-        tripSession.registerVoiceInstructionsObserver(voiceInstructionsObserver)
-        tripSession.registerRouteProgressObserver(routeProgressObserver)
-
-        navigatorObserverImplSlot.captured.onStatus(navigationStatusOrigin, navigationStatus)
-
-        every { routeProgress.voiceInstructions } returns null
-
-        navigatorObserverImplSlot.captured.onStatus(navigationStatusOrigin, navigationStatus)
-
-        verify(exactly = 1) { voiceInstructionsObserver.onNewVoiceInstructions(any()) }
-        verify(exactly = 2) { routeProgressObserver.onRouteProgressChanged(any()) }
-    }
-
-    @Test
     fun `road objects observer gets successfully called`() = coroutineRule.runBlockingTest {
         val roadObjectsObserver: RoadObjectsOnRouteObserver = mockk(relaxUnitFun = true)
         val roadObjects: List<UpcomingRoadObject> = listOf(mockk())

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
@@ -158,7 +158,9 @@ class MapboxTripSessionTest {
         every { routeProgress.bannerInstructions } returns null
         every { routeProgress.voiceInstructions } returns null
         every { routeProgress.currentLegProgress } returns mockk(relaxed = true)
-        every { getRouteProgressFrom(any(), any(), any(), any(), any()) } returns routeProgress
+        every {
+            getRouteProgressFrom(any(), any(), any(), any(), any(), any())
+        } returns routeProgress
         every { routes[0].requestUuid() } returns "uuid"
 
         every {
@@ -353,7 +355,7 @@ class MapboxTripSessionTest {
 
     @Test
     fun routeProgressObserverNotCalledWhenInFreeDrive() = coroutineRule.runBlockingTest {
-        every { getRouteProgressFrom(any(), any(), any(), any(), any()) } returns null
+        every { getRouteProgressFrom(any(), any(), any(), any(), any(), any()) } returns null
         tripSession = buildTripSession()
         tripSession.start(true)
         val observer: RouteProgressObserver = mockk(relaxUnitFun = true)
@@ -537,7 +539,7 @@ class MapboxTripSessionTest {
         every { navigationStatus.bannerInstruction } returns null
         navigatorObserverImplSlot.captured.onStatus(navigationStatusOrigin, navigationStatus)
 
-        verify { getRouteProgressFrom(routes[0], navigationStatus, any(), banner, 0) }
+        verify { getRouteProgressFrom(routes[0], navigationStatus, any(), banner, 0, any()) }
         tripSession.stop()
     }
 
@@ -771,6 +773,28 @@ class MapboxTripSessionTest {
         verify(exactly = 1) { voiceInstructionsObserver.onNewVoiceInstructions(any()) }
 
         tripSession.stop()
+    }
+
+    @Test
+    fun voiceInstructionsFollowRouteProgress() = coroutineRule.runBlockingTest {
+        val voiceInstructionsObserver: VoiceInstructionsObserver = mockk(relaxUnitFun = true)
+        val voiceInstructions: VoiceInstructions = mockk()
+        val routeProgressObserver: RouteProgressObserver = mockk(relaxUnitFun = true)
+        every { routeProgress.voiceInstructions } returns voiceInstructions
+
+        tripSession = buildTripSession()
+        tripSession.start(true)
+        tripSession.registerVoiceInstructionsObserver(voiceInstructionsObserver)
+        tripSession.registerRouteProgressObserver(routeProgressObserver)
+
+        navigatorObserverImplSlot.captured.onStatus(navigationStatusOrigin, navigationStatus)
+
+        every { routeProgress.voiceInstructions } returns null
+
+        navigatorObserverImplSlot.captured.onStatus(navigationStatusOrigin, navigationStatus)
+
+        verify(exactly = 1) { voiceInstructionsObserver.onNewVoiceInstructions(any()) }
+        verify(exactly = 2) { routeProgressObserver.onRouteProgressChanged(any()) }
     }
 
     @Test


### PR DESCRIPTION
### Description
The`RouteProgress#voiceInstructions` should not become null just like the `RouteProgress.bannerInstructions`. See #5017

I was trying to implement the feature using TDD. But I had problems with this. When I added `voiceInstructionsFollowRouteProgress` test to the `MapboxTripSessionTest` I realised a few things.

I don't trust the added tests. I wasn't sure that everything works when I saw a green color. Why? I mocked so many implementation details so that the code that I run in tests deviate from what our users run in their app. Green tests don't make me confident that the feature works in the app.

I can't refactor. I want to write a test, then write shitty implementation, then refactor it and make the implementation beautiful. The current approach forces me to setup many implementation details using `mockk`. When I refactor and change implementation details tests are breading and I have to rewrite them. I don't trust the test I've just rewritten. I have think a lot to avoid errors when I'm rewriting tests. I lost the main advantage that TDD gives me: easy refactoring.

In this PR I added a new test class `MapboxTripSessionNewTest` where I wrote tests as I usually do it. I considered `MapboxTripSession` as a unit and mocked only dependencies that are passed in constructor. I didn't consider static utils functions like `getRouteProgressFrom` as an external dependency, in my implementation it's considered as an implementation detail that can be changed without breaking the tests.

I used fake instead of a mock for `MapboxNativeNavigator`. The idea is to have reusable fake with different implemented scenario. It should behave very similar to a real one. So that when you use fake in tests you're confident that the code works with real navigator too. When the real navigator changes behaviour you just change one fake and run tests to see if other code still works. 
### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>
The `RouteProgress.voiceInstructions` property always keeps the last value and don't become `null`.
</changelog>
```

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->