### PR TITLE
[Cherry pick] Fix route alternative thread issue

### DIFF
--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/RouteAlternativesTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/RouteAlternativesTest.kt
@@ -104,6 +104,7 @@ class RouteAlternativesTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::cla
             Espresso.onIdle()
         }
         firstAlternative.unregister()
+        assertTrue(firstAlternative.calledOnMainThread)
 
         runOnMainSync {
             val countDownLatch = CountDownLatch(1)

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/utils/idling/RouteAlternativesIdlingResource.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/utils/idling/RouteAlternativesIdlingResource.kt
@@ -1,5 +1,6 @@
 package com.mapbox.navigation.instrumentation_tests.utils.idling
 
+import android.os.Looper
 import androidx.test.espresso.IdlingResource
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.navigation.base.route.RouterOrigin
@@ -25,6 +26,7 @@ class RouteAlternativesIdlingResource(
         private set
     var alternatives: List<DirectionsRoute>? = null
         private set
+    var calledOnMainThread = true
 
     private var callback: IdlingResource.ResourceCallback? = null
 
@@ -50,6 +52,11 @@ class RouteAlternativesIdlingResource(
         alternatives: List<DirectionsRoute>,
         routerOrigin: RouterOrigin
     ) {
+        // Verify this happens on the main thread.
+        if (Looper.myLooper() != Looper.getMainLooper()) {
+            calledOnMainThread = false
+        }
+
         mapboxNavigation.unregisterRouteAlternativesObserver(this)
         this.routeProgress = routeProgress
         this.alternatives = alternatives

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -426,7 +426,8 @@ class MapboxNavigation @VisibleForTesting internal constructor(
         routeAlternativesController = RouteAlternativesControllerProvider.create(
             navigationOptions.routeAlternativesOptions,
             navigator,
-            tripSession
+            tripSession,
+            threadController,
         )
         routeRefreshController = RouteRefreshControllerProvider.createRouteRefreshController(
             navigationOptions.routeRefreshOptions,

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesController.kt
@@ -6,20 +6,25 @@ import com.mapbox.base.common.logger.model.Tag
 import com.mapbox.navigation.base.internal.utils.parseNativeDirectionsAlternative
 import com.mapbox.navigation.base.route.RouteAlternativesOptions
 import com.mapbox.navigation.base.route.RouterOrigin
+import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.trip.NativeRouteProcessingListener
 import com.mapbox.navigation.core.trip.session.TripSession
 import com.mapbox.navigation.navigator.internal.MapboxNativeNavigator
+import com.mapbox.navigation.utils.internal.ThreadController
 import com.mapbox.navigation.utils.internal.logD
 import com.mapbox.navigation.utils.internal.logE
 import com.mapbox.navigation.utils.internal.logI
+import com.mapbox.navigator.RouteAlternative
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import java.util.concurrent.CopyOnWriteArraySet
 
 internal class RouteAlternativesController constructor(
     private val options: RouteAlternativesOptions,
     private val navigator: MapboxNativeNavigator,
-    private val tripSession: TripSession
+    private val tripSession: TripSession,
+    private val threadController: ThreadController
 ) {
 
     /**
@@ -34,6 +39,8 @@ internal class RouteAlternativesController constructor(
      * after setting a route.
      */
     private var inhibitNextUpdate = false
+
+    private val mainJobControl by lazy { threadController.getMainScopeAndRootJob() }
 
     private val nativeRouteAlternativesController = navigator.createRouteAlternativesController()
         .apply {
@@ -84,7 +91,7 @@ internal class RouteAlternativesController constructor(
 
     private val nativeObserver = object : com.mapbox.navigator.RouteAlternativesObserver {
         override fun onRouteAlternativesChanged(
-            routeAlternatives: List<com.mapbox.navigator.RouteAlternative>
+            routeAlternatives: List<RouteAlternative>
         ): List<Int> {
             if (inhibitNextUpdate) {
                 logD(TAG, Message("update skipped because alternatives were reset with #setRoutes"))
@@ -95,27 +102,7 @@ internal class RouteAlternativesController constructor(
             val routeProgress = tripSession.getRouteProgress()
                 ?: return emptyList()
 
-            // TODO make async
-            val alternatives: List<DirectionsRoute> = runBlocking {
-                routeAlternatives.mapIndexedNotNull { index, routeAlternative ->
-                    val alternative = parseNativeDirectionsAlternative(
-                        routeAlternative.routeResponse,
-                        routeProgress.route.routeOptions()
-                    )
-                    if (alternative == null) {
-                        logE(TAG, Message("null alternative at index $index"))
-                    }
-                    alternative
-                }
-            }
-            logI(TAG, Message("${alternatives.size} alternatives available"))
-
-            // Notify the listeners.
-            // TODO https://github.com/mapbox/mapbox-navigation-native/issues/4409
-            // There is no way to determine if the route was Onboard or Offboard
-            observers.forEach {
-                it.onRouteAlternatives(routeProgress, alternatives, RouterOrigin.Onboard)
-            }
+            onRouteAlternativesChanged(routeProgress, routeAlternatives)
 
             // This is supposed to be able to filter alternatives
             // but at this point we're not filtering anything.
@@ -124,6 +111,34 @@ internal class RouteAlternativesController constructor(
 
         override fun onError(message: String) {
             logE(TAG, Message("Error: $message"))
+        }
+    }
+
+    private fun onRouteAlternativesChanged(
+        routeProgress: RouteProgress,
+        routeAlternatives: List<RouteAlternative>
+    ) {
+        val alternatives: List<DirectionsRoute> = runBlocking {
+            routeAlternatives.mapIndexedNotNull { index, routeAlternative ->
+                val alternative = parseNativeDirectionsAlternative(
+                    routeAlternative.routeResponse,
+                    routeProgress.route.routeOptions()
+                )
+                if (alternative == null) {
+                    logE(TAG, Message("null alternative at index $index"))
+                }
+                alternative
+            }
+        }
+        logI(TAG, Message("${alternatives.size} alternatives available"))
+
+        mainJobControl.scope.launch {
+            // Notify the listeners.
+            // TODO https://github.com/mapbox/mapbox-navigation-native/issues/4409
+            // There is no way to determine if the route was Onboard or Offboard
+            observers.forEach {
+                it.onRouteAlternatives(routeProgress, alternatives, RouterOrigin.Onboard)
+            }
         }
     }
 

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesControllerProvider.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesControllerProvider.kt
@@ -3,16 +3,19 @@ package com.mapbox.navigation.core.routealternatives
 import com.mapbox.navigation.base.route.RouteAlternativesOptions
 import com.mapbox.navigation.core.trip.session.TripSession
 import com.mapbox.navigation.navigator.internal.MapboxNativeNavigator
+import com.mapbox.navigation.utils.internal.ThreadController
 
 internal object RouteAlternativesControllerProvider {
 
     fun create(
         options: RouteAlternativesOptions,
         navigator: MapboxNativeNavigator,
-        tripSession: TripSession
+        tripSession: TripSession,
+        threadController: ThreadController
     ) = RouteAlternativesController(
         options,
         navigator,
-        tripSession
+        tripSession,
+        threadController
     )
 }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
@@ -180,7 +180,7 @@ class MapboxNavigationTest {
         } returns routeRefreshController
         mockkObject(RouteAlternativesControllerProvider)
         every {
-            RouteAlternativesControllerProvider.create(any(), any(), any())
+            RouteAlternativesControllerProvider.create(any(), any(), any(), any())
         } returns routeAlternativesController
 
         every { applicationContext.applicationContext } returns applicationContext

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesControllerTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesControllerTest.kt
@@ -9,6 +9,7 @@ import com.mapbox.navigation.core.trip.session.TripSession
 import com.mapbox.navigation.navigator.internal.MapboxNativeNavigator
 import com.mapbox.navigation.testing.FileUtils
 import com.mapbox.navigation.testing.MainCoroutineRule
+import com.mapbox.navigation.utils.internal.ThreadController
 import com.mapbox.navigator.RouteAlternativesControllerInterface
 import io.mockk.Runs
 import io.mockk.every
@@ -44,6 +45,7 @@ class RouteAlternativesControllerTest {
         options,
         navigator,
         tripSession,
+        ThreadController(),
     )
 
     @Test
@@ -108,7 +110,7 @@ class RouteAlternativesControllerTest {
     }
 
     @Test
-    fun `should broadcast alternative routes changes from nav-native`() {
+    fun `should broadcast alternative routes changes from nav-native`() = coroutineRule.runBlockingTest {
         val routeAlternativesController = createRouteAlternativesController()
         val nativeObserver = slot<com.mapbox.navigator.RouteAlternativesObserver>()
         every { controllerInterface.addObserver(capture(nativeObserver)) } just runs
@@ -145,7 +147,7 @@ class RouteAlternativesControllerTest {
     }
 
     @Test
-    fun `should not broadcast current route with alternative`() {
+    fun `should not broadcast current route with alternative`() = coroutineRule.runBlockingTest {
         val routeAlternativesController = createRouteAlternativesController()
         val nativeObserver = slot<com.mapbox.navigator.RouteAlternativesObserver>()
         every { controllerInterface.addObserver(capture(nativeObserver)) } just runs
@@ -185,7 +187,7 @@ class RouteAlternativesControllerTest {
     }
 
     @Test
-    fun `should set RouteOptions to alternative routes`() {
+    fun `should set RouteOptions to alternative routes`() = coroutineRule.runBlockingTest {
         val originalCoordinates = "-122.270375,37.801429;-122.271496, 37.799063"
         val routeAlternativesController = createRouteAlternativesController()
         val nativeObserver = slot<com.mapbox.navigator.RouteAlternativesObserver>()


### PR DESCRIPTION
EDIT: reproducing the issue blocking this on `main` branch https://github.com/mapbox/mapbox-navigation-android/issues/5135

Resolves https://github.com/mapbox/mapbox-navigation-android/issues/5119

### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

This is a cherry-pick from the v2.1 release because there was conflicts to resolve on the `main` branch as the route alternatives diverge. https://github.com/mapbox/mapbox-navigation-android/pull/5120

