### PR TITLE
pass null to `avoidManeuverRadius` when there should be no avoidance

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/reroute/MapboxRerouteController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/reroute/MapboxRerouteController.kt
@@ -75,19 +75,11 @@ internal class MapboxRerouteController(
                 return this
             }
 
-            val avoidManeuverRadius = rerouteOptions.avoidManeuverSeconds.let { seconds ->
-                if (seconds == 0) {
-                    0
-                } else {
-                    (speed / seconds).toInt()
-                }
-            }.let { meters ->
-                if (meters > MAX_DANGEROUS_MANEUVERS_RADIUS) {
-                    MAX_DANGEROUS_MANEUVERS_RADIUS
-                } else {
-                    meters
-                }
-            }
+            val avoidManeuverRadius = rerouteOptions.avoidManeuverSeconds
+                .takeIf { it != 0 }
+                ?.let { speed / it }?.toInt()
+                ?.takeIf { it >= 1 }
+                ?.coerceAtMost(MAX_DANGEROUS_MANEUVERS_RADIUS)
 
             return toBuilder().avoidManeuverRadius(avoidManeuverRadius).build()
         }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/reroute/MapboxRerouteControllerTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/reroute/MapboxRerouteControllerTest.kt
@@ -337,10 +337,10 @@ class MapboxRerouteControllerTest {
 
         listOf(
             Triple(200f, 1, 200),
-            Triple(0f, 1, 0),
+            Triple(0f, 1, null),
             Triple(1000f, 1, 1000),
             Triple(5000f, 1, 1000),
-            Triple(200f, 0, 0),
+            Triple(200f, 0, null),
         ).forEach { (speed, secondsRadius, expectedMetersRadius) ->
             val mockRo = mockk<RouteOptions>()
             val mockRoBuilder = mockk<RouteOptions.Builder>()


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-navigation-android/issues/5135. Follow up to https://github.com/mapbox/mapbox-navigation-android/pull/5056. Fixing up a case where avoidance would result in `0` and changing it to `null` because `0` is not a valid API parameter and results in:
```
{"message":"should be >= 1","code":"InvalidInput"}
```