### PR TITLE
verify if the native route response is valid

### DIFF
--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/utils/DirectionsResponseUtils.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/utils/DirectionsResponseUtils.kt
@@ -3,65 +3,97 @@ package com.mapbox.navigation.base.internal.utils
 import com.mapbox.api.directions.v5.models.DirectionsResponse
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.RouteOptions
-import kotlinx.coroutines.Dispatchers
+import com.mapbox.bindgen.Expected
+import com.mapbox.bindgen.ExpectedFactory
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
+import org.json.JSONException
 import org.json.JSONObject
 
 suspend fun parseDirectionsResponse(
+    dispatcher: CoroutineDispatcher,
     json: String,
     options: RouteOptions?,
     onMetadata: (String) -> Unit,
-): List<DirectionsRoute> =
-    withContext(Dispatchers.IO) {
-        val jsonObject = JSONObject(json)
-        val uuid: String? = if (jsonObject.has(UUID)) {
-            jsonObject.getString(UUID)
-        } else {
-            null
+): Expected<Throwable, List<DirectionsRoute>> =
+    withContext(dispatcher) {
+        return@withContext try {
+            val jsonObject = JSONObject(json)
+            val uuid: String? = if (jsonObject.has(UUID)) {
+                jsonObject.getString(UUID)
+            } else {
+                null
+            }
+
+            // TODO remove after https://github.com/mapbox/navigation-sdks/issues/1229
+            if (jsonObject.has(METADATA)) {
+                onMetadata(jsonObject.getString(METADATA))
+            }
+
+            check(jsonObject.has("routes")) {
+                """route response should contain "routes" array"""
+            }
+            // TODO simplify when https://github.com/mapbox/mapbox-java/issues/1292 is finished
+            val response = DirectionsResponse.fromJson(json, options, uuid)
+            val routes = response.routes()
+            check(routes.size > 0) {
+                "route response should contain at least one route"
+            }
+            ExpectedFactory.createValue(routes)
+        } catch (ex: Exception) {
+            when (ex) {
+                is JSONException,
+                is IllegalStateException,
+                is NullPointerException -> ExpectedFactory.createError(ex)
+                else -> throw ex
+            }
         }
-
-        // TODO remove after https://github.com/mapbox/navigation-sdks/issues/1229
-        if (jsonObject.has(METADATA)) {
-            onMetadata(jsonObject.getString(METADATA))
-        }
-
-        // TODO simplify when https://github.com/mapbox/mapbox-java/issues/1292 is finished
-        val response = DirectionsResponse.fromJson(json, options, uuid)
-
-        response.routes()
     }
 
 suspend fun parseNativeDirectionsAlternative(
+    dispatcher: CoroutineDispatcher,
     json: String,
     options: RouteOptions?,
-): DirectionsRoute? =
-    withContext(Dispatchers.IO) {
-        val jsonObject = JSONObject(json)
-        val uuid: String? = if (jsonObject.has(UUID)) {
-            jsonObject.getString(UUID)
-        } else {
-            null
-        }
+): Expected<Throwable, DirectionsRoute> =
+    withContext(dispatcher) {
+        return@withContext try {
+            val jsonObject = JSONObject(json)
+            val uuid: String? = if (jsonObject.has(UUID)) {
+                jsonObject.getString(UUID)
+            } else {
+                null
+            }
 
-        val jsonRoutes = jsonObject.getJSONArray("routes")
-        val jsonRoute: DirectionsRoute = jsonRoutes.let { routesArray ->
-            for (i in 0 until routesArray.length()) {
-                if (!routesArray.isNull(i)) {
-                    // TODO simplify after https://github.com/mapbox/mapbox-java/issues/1292
-                    return@let DirectionsRoute.fromJson(
-                        routesArray.getJSONObject(i).toString(),
-                        options,
-                        uuid
-                    ).run {
-                        toBuilder()
-                            .routeIndex(i.toString())
-                            .build()
+            val jsonRoutes = jsonObject.getJSONArray("routes")
+            check(jsonRoutes.length() > 0) {
+                "route alternatives response should contain at least one route"
+            }
+            val jsonRoute: DirectionsRoute = jsonRoutes.let { routesArray ->
+                for (i in 0 until routesArray.length()) {
+                    if (!routesArray.isNull(i)) {
+                        // TODO simplify after https://github.com/mapbox/mapbox-java/issues/1292
+                        return@let DirectionsRoute.fromJson(
+                            routesArray.getJSONObject(i).toString(),
+                            options,
+                            uuid
+                        ).run {
+                            toBuilder()
+                                .routeIndex(i.toString())
+                                .build()
+                        }
                     }
                 }
+                throw IllegalArgumentException("all alternative routes are null")
             }
-            return@withContext null
+            ExpectedFactory.createValue(jsonRoute)
+        } catch (ex: Exception) {
+            when (ex) {
+                is JSONException,
+                is IllegalStateException,
+                is IllegalArgumentException -> ExpectedFactory.createError(ex)
+                else -> throw ex
+            }
         }
-        return@withContext jsonRoute
     }
 
 private const val UUID = "uuid"

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesController.kt
@@ -120,14 +120,26 @@ internal class RouteAlternativesController constructor(
     ) {
         val alternatives: List<DirectionsRoute> = runBlocking {
             routeAlternatives.mapIndexedNotNull { index, routeAlternative ->
-                val alternative = parseNativeDirectionsAlternative(
+                val expected = parseNativeDirectionsAlternative(
+                    ThreadController.IODispatcher,
                     routeAlternative.routeResponse,
                     routeProgress.route.routeOptions()
                 )
-                if (alternative == null) {
-                    logE(TAG, Message("null alternative at index $index"))
+                if (expected.isValue) {
+                    expected.value
+                } else {
+                    logE(
+                        TAG,
+                        Message(
+                            """
+                                    |unable to parse alternative at index $index;
+                                    |failure for response: ${routeAlternative.routeResponse}
+                                """.trimMargin()
+                        ),
+                        expected.error
+                    )
+                    null
                 }
-                alternative
             }
         }
         logI(TAG, Message("${alternatives.size} alternatives available"))


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Refs https://github.com/mapbox/mapbox-navigation-android/issues/5066. In case of invalid request parameters Nav Native seems to be returning an error body as a success which leads to the parsing error. Discussing internally in https://github.com/mapbox/mapbox-navigation-native/pull/4721#issuecomment-974046088.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Fixed an issue where route request failure (due to incorrect parameters) led to a parsing error and runtime crash instead of failure callback.</changelog>
```

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
