### PR TITLE
when rerouting add layers and avoid maneuvers parameters only for driving profiles

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/reroute/MapboxRerouteController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/reroute/MapboxRerouteController.kt
@@ -1,6 +1,7 @@
 package com.mapbox.navigation.core.reroute
 
 import androidx.annotation.MainThread
+import com.mapbox.api.directions.v5.DirectionsCriteria
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.RouteOptions
 import com.mapbox.base.common.logger.Logger
@@ -75,13 +76,21 @@ internal class MapboxRerouteController(
                 return this
             }
 
-            val avoidManeuverRadius = rerouteOptions.avoidManeuverSeconds
-                .takeIf { it != 0 }
-                ?.let { speed / it }?.toInt()
-                ?.takeIf { it >= 1 }
-                ?.coerceAtMost(MAX_DANGEROUS_MANEUVERS_RADIUS)
+            val builder = toBuilder()
 
-            return toBuilder().avoidManeuverRadius(avoidManeuverRadius).build()
+            if (this.profile() == DirectionsCriteria.PROFILE_DRIVING ||
+                this.profile() == DirectionsCriteria.PROFILE_DRIVING_TRAFFIC
+            ) {
+                val avoidManeuverRadius = rerouteOptions.avoidManeuverSeconds
+                    .takeIf { it != 0 }
+                    ?.let { speed / it }?.toInt()
+                    ?.takeIf { it >= 1 }
+                    ?.coerceAtMost(MAX_DANGEROUS_MANEUVERS_RADIUS)
+
+                builder.avoidManeuverRadius(avoidManeuverRadius)
+            }
+
+            return builder.build()
         }
     }
 

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/routeoptions/RouteOptionsUpdater.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/routeoptions/RouteOptionsUpdater.kt
@@ -1,5 +1,6 @@
 package com.mapbox.navigation.core.routeoptions
 
+import com.mapbox.api.directions.v5.DirectionsCriteria
 import com.mapbox.api.directions.v5.models.Bearing
 import com.mapbox.api.directions.v5.models.RouteOptions
 import com.mapbox.base.common.logger.model.Message
@@ -134,16 +135,22 @@ class RouteOptionsUpdater {
                             coordinatesList.size - remainingWaypoints - 1
                         )
                     )
-                    .layersList(
-                        mutableListOf(locationMatcherResult.zLevel).apply {
-                            val legacyLayerList = routeOptions.layersList()
-                            if (legacyLayerList != null) {
-                                addAll(legacyLayerList.takeLast(remainingWaypoints))
-                            } else {
-                                repeat(remainingWaypoints) { add(null) }
-                            }
+            }
+
+            if (
+                routeOptions.profile() == DirectionsCriteria.PROFILE_DRIVING ||
+                routeOptions.profile() == DirectionsCriteria.PROFILE_DRIVING_TRAFFIC
+            ) {
+                optionsBuilder.layersList(
+                    mutableListOf(locationMatcherResult.zLevel).apply {
+                        val legacyLayerList = routeOptions.layersList()
+                        if (legacyLayerList != null) {
+                            addAll(legacyLayerList.takeLast(remainingWaypoints))
+                        } else {
+                            repeat(remainingWaypoints) { add(null) }
                         }
-                    )
+                    }
+                )
             }
 
             optionsBuilder.arriveBy(null)


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Closes https://github.com/mapbox/mapbox-navigation-android/issues/5066 by adding `driving` and `driving-traffic` request parameters during reroute only if these profiles are actually used.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Fixed an issue where reroute controller attempted to add request parameters unsuitable for the selected profile.</changelog>
```

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
