### PR TITLE
expose link to navigation styles

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/IndependentRouteGenerationActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/IndependentRouteGenerationActivity.kt
@@ -12,7 +12,6 @@ import com.mapbox.geojson.Feature
 import com.mapbox.geojson.Point
 import com.mapbox.maps.CameraOptions
 import com.mapbox.maps.MapboxMap
-import com.mapbox.maps.Style
 import com.mapbox.maps.plugin.animation.MapAnimationOptions
 import com.mapbox.maps.plugin.animation.camera
 import com.mapbox.maps.plugin.annotation.annotations
@@ -47,6 +46,7 @@ import com.mapbox.navigation.core.trip.session.RouteProgressObserver
 import com.mapbox.navigation.examples.core.databinding.LayoutActivityIndependentRouteGenerationBinding
 import com.mapbox.navigation.examples.util.RouteLineUtil
 import com.mapbox.navigation.examples.util.Utils
+import com.mapbox.navigation.ui.maps.NavigationStyles
 import com.mapbox.navigation.ui.maps.location.NavigationLocationProvider
 import com.mapbox.navigation.ui.tripprogress.api.MapboxTripProgressApi
 import com.mapbox.navigation.ui.tripprogress.model.DistanceRemainingFormatter
@@ -103,7 +103,7 @@ class IndependentRouteGenerationActivity : AppCompatActivity() {
 
     private fun initStyle() {
         mapboxMap.loadStyleUri(
-            Style.MAPBOX_STREETS
+            NavigationStyles.NAVIGATION_DAY_STYLE
         ) {
             binding.mapView.gestures.addOnMapLongClickListener(
                 mapLongClickListener

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxMultipleArrowActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxMultipleArrowActivity.kt
@@ -10,6 +10,7 @@ import com.mapbox.maps.CameraOptions
 import com.mapbox.maps.MapboxMap
 import com.mapbox.maps.Style
 import com.mapbox.navigation.examples.core.databinding.LayoutActivityMultipleManeuverArrowBinding
+import com.mapbox.navigation.ui.maps.NavigationStyles
 import com.mapbox.navigation.ui.maps.location.NavigationLocationProvider
 import com.mapbox.navigation.ui.maps.route.arrow.api.MapboxRouteArrowApi
 import com.mapbox.navigation.ui.maps.route.arrow.api.MapboxRouteArrowView
@@ -114,7 +115,7 @@ class MapboxMultipleArrowActivity : AppCompatActivity() {
 
     private fun initStyle() {
         mapboxMap.loadStyleUri(
-            Style.MAPBOX_STREETS,
+            NavigationStyles.NAVIGATION_DAY_STYLE,
             object : Style.OnStyleLoaded {
                 override fun onStyleLoaded(style: Style) {
                     initListeners(style)

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxRouteLineAndArrowActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxRouteLineAndArrowActivity.kt
@@ -48,6 +48,7 @@ import com.mapbox.navigation.core.trip.session.LocationMatcherResult
 import com.mapbox.navigation.core.trip.session.LocationObserver
 import com.mapbox.navigation.core.trip.session.RouteProgressObserver
 import com.mapbox.navigation.examples.core.databinding.LayoutActivityRoutelineExampleBinding
+import com.mapbox.navigation.ui.maps.NavigationStyles
 import com.mapbox.navigation.ui.maps.location.NavigationLocationProvider
 import com.mapbox.navigation.ui.maps.route.RouteLayerConstants.TOP_LEVEL_ROUTE_LINE_LAYER_ID
 import com.mapbox.navigation.ui.maps.route.arrow.api.MapboxRouteArrowApi
@@ -347,7 +348,7 @@ class MapboxRouteLineAndArrowActivity : AppCompatActivity(), OnMapLongClickListe
     @SuppressLint("MissingPermission")
     private fun initStyle() {
         mapboxMap.loadStyleUri(
-            Style.MAPBOX_STREETS,
+            NavigationStyles.NAVIGATION_DAY_STYLE,
             { style: Style ->
                 // Get the last known location and move the map to that location.
                 mapboxNavigation.navigationOptions.locationEngine.getLastLocation(

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxRouteLineAndArrowActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxRouteLineAndArrowActivity.kt
@@ -143,7 +143,7 @@ class MapboxRouteLineAndArrowActivity : AppCompatActivity(), OnMapLongClickListe
     private val options: MapboxRouteLineOptions by lazy {
         MapboxRouteLineOptions.Builder(this)
             .withRouteLineResources(routeLineResources)
-            .withRouteLineBelowLayerId("road-label")
+            .withRouteLineBelowLayerId("road-label-navigation")
             .withVanishingRouteLineEnabled(true)
             .displaySoftGradientForTraffic(trafficGradientSoft)
             .build()

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MultiLegRouteExampleActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MultiLegRouteExampleActivity.kt
@@ -38,6 +38,7 @@ import com.mapbox.navigation.core.trip.session.LocationMatcherResult
 import com.mapbox.navigation.core.trip.session.LocationObserver
 import com.mapbox.navigation.core.trip.session.RouteProgressObserver
 import com.mapbox.navigation.examples.core.databinding.MultilegRouteExampleLayoutBinding
+import com.mapbox.navigation.ui.maps.NavigationStyles
 import com.mapbox.navigation.ui.maps.location.NavigationLocationProvider
 import com.mapbox.navigation.ui.maps.route.arrow.api.MapboxRouteArrowApi
 import com.mapbox.navigation.ui.maps.route.arrow.api.MapboxRouteArrowView
@@ -219,7 +220,7 @@ class MultiLegRouteExampleActivity : AppCompatActivity() {
     @SuppressLint("MissingPermission")
     private fun initStyle() {
         mapboxMap.loadStyleUri(
-            Style.MAPBOX_STREETS,
+            NavigationStyles.NAVIGATION_DAY_STYLE,
             { style: Style ->
 
                 // Hard coding a location and a route for this example.

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MultiLegRouteExampleActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MultiLegRouteExampleActivity.kt
@@ -105,7 +105,7 @@ class MultiLegRouteExampleActivity : AppCompatActivity() {
     private val options: MapboxRouteLineOptions by lazy {
         MapboxRouteLineOptions.Builder(this)
             .withRouteLineResources(routeLineResources)
-            .withRouteLineBelowLayerId("road-label")
+            .withRouteLineBelowLayerId("road-label-navigation")
             .styleInactiveRouteLegsIndependently(true) // This is the relevant option for this example
             .build()
     }

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayHistoryActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayHistoryActivity.kt
@@ -191,7 +191,7 @@ class ReplayHistoryActivity : AppCompatActivity() {
                     )
                     .build()
             )
-            .withRouteLineBelowLayerId("road-label")
+            .withRouteLineBelowLayerId("road-label-navigation")
             .withVanishingRouteLineEnabled(true)
             .build()
     }

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayHistoryActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayHistoryActivity.kt
@@ -36,6 +36,7 @@ import com.mapbox.navigation.examples.core.databinding.ActivityReplayHistoryLayo
 import com.mapbox.navigation.examples.core.replay.HistoryFileLoader
 import com.mapbox.navigation.examples.core.replay.HistoryFilesActivity
 import com.mapbox.navigation.examples.util.Utils
+import com.mapbox.navigation.ui.maps.NavigationStyles
 import com.mapbox.navigation.ui.maps.camera.NavigationCamera
 import com.mapbox.navigation.ui.maps.camera.data.MapboxNavigationViewportDataSource
 import com.mapbox.navigation.ui.maps.location.NavigationLocationProvider
@@ -124,7 +125,7 @@ class ReplayHistoryActivity : AppCompatActivity() {
             binding.mapView.getMapboxMap()
         )
         binding.mapView.getMapboxMap().loadStyleUri(
-            Style.MAPBOX_STREETS,
+            NavigationStyles.NAVIGATION_DAY_STYLE,
             { style: Style ->
                 locationComponent = binding.mapView.location.apply {
                     this.locationPuck = LocationPuck2D(

--- a/examples/src/main/java/com/mapbox/navigation/examples/util/RouteDrawingActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/util/RouteDrawingActivity.kt
@@ -73,7 +73,7 @@ class RouteDrawingActivity : AppCompatActivity() {
     private val options: MapboxRouteLineOptions by lazy {
         MapboxRouteLineOptions.Builder(this)
             .withRouteLineResources(routeLineResources)
-            .withRouteLineBelowLayerId("road-label")
+            .withRouteLineBelowLayerId("road-label-navigation")
             .build()
     }
 

--- a/examples/src/main/java/com/mapbox/navigation/examples/util/RouteDrawingActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/util/RouteDrawingActivity.kt
@@ -19,7 +19,6 @@ import com.mapbox.maps.CameraOptions
 import com.mapbox.maps.MapInitOptions
 import com.mapbox.maps.MapView
 import com.mapbox.maps.ResourceOptions
-import com.mapbox.maps.Style
 import com.mapbox.maps.plugin.animation.CameraAnimationsPlugin
 import com.mapbox.maps.plugin.animation.camera
 import com.mapbox.maps.plugin.locationcomponent.LocationComponentPlugin
@@ -28,6 +27,7 @@ import com.mapbox.navigation.base.route.RouterCallback
 import com.mapbox.navigation.base.route.RouterFailure
 import com.mapbox.navigation.base.route.RouterOrigin
 import com.mapbox.navigation.examples.core.R
+import com.mapbox.navigation.ui.maps.NavigationStyles
 import com.mapbox.navigation.ui.maps.location.NavigationLocationProvider
 import com.mapbox.navigation.ui.maps.route.line.MapboxRouteLineApiExtensions.clearRouteLine
 import com.mapbox.navigation.ui.maps.route.line.MapboxRouteLineApiExtensions.setRoutes
@@ -216,7 +216,7 @@ class RouteDrawingActivity : AppCompatActivity() {
     @SuppressLint("MissingPermission")
     private fun initStyle() {
         mapView.getMapboxMap().loadStyleUri(
-            Style.MAPBOX_STREETS
+            NavigationStyles.NAVIGATION_DAY_STYLE
         ) {
             routeDrawingUtil = RouteDrawingUtil(mapView)
             initListeners()

--- a/examples/src/main/java/com/mapbox/navigation/examples/util/RouteLineUtil.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/util/RouteLineUtil.kt
@@ -38,7 +38,7 @@ class RouteLineUtil(private val activity: AppCompatActivity) : LifecycleObserver
     private val options: MapboxRouteLineOptions by lazy {
         MapboxRouteLineOptions.Builder(activity)
             .withRouteLineResources(routeLineResources)
-            .withRouteLineBelowLayerId("road-label")
+            .withRouteLineBelowLayerId("road-label-navigation")
             .build()
     }
 

--- a/libnavui-maps/api/current.txt
+++ b/libnavui-maps/api/current.txt
@@ -1,6 +1,14 @@
 // Signature format: 3.0
 package com.mapbox.navigation.ui.maps {
 
+  public final class NavigationStyles {
+    method public String getNAVIGATION_DAY_STYLE();
+    method public String getNAVIGATION_NIGHT_STYLE();
+    property public final String NAVIGATION_DAY_STYLE;
+    property public final String NAVIGATION_NIGHT_STYLE;
+    field public static final com.mapbox.navigation.ui.maps.NavigationStyles INSTANCE;
+  }
+
   public final class PredictiveCacheController {
     ctor public PredictiveCacheController(com.mapbox.navigation.base.options.PredictiveCacheLocationOptions predictiveCacheLocationOptions = PredictiveCacheLocationOptions.<init>().build(), com.mapbox.navigation.ui.maps.PredictiveCacheControllerErrorHandler? predictiveCacheControllerErrorHandler = null);
     ctor public PredictiveCacheController(com.mapbox.navigation.base.options.PredictiveCacheLocationOptions predictiveCacheLocationOptions = PredictiveCacheLocationOptions.<init>().build());

--- a/libnavui-maps/api/current.txt
+++ b/libnavui-maps/api/current.txt
@@ -2,11 +2,9 @@
 package com.mapbox.navigation.ui.maps {
 
   public final class NavigationStyles {
-    method public String getNAVIGATION_DAY_STYLE();
-    method public String getNAVIGATION_NIGHT_STYLE();
-    property public final String NAVIGATION_DAY_STYLE;
-    property public final String NAVIGATION_NIGHT_STYLE;
     field public static final com.mapbox.navigation.ui.maps.NavigationStyles INSTANCE;
+    field public static final String NAVIGATION_DAY_STYLE = "mapbox://styles/mapbox/navigation-day-v1";
+    field public static final String NAVIGATION_NIGHT_STYLE = "mapbox://styles/mapbox/navigation-night-v1";
   }
 
   public final class PredictiveCacheController {

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/NavigationStyles.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/NavigationStyles.kt
@@ -5,6 +5,13 @@ package com.mapbox.navigation.ui.maps
  * We recommend using these map styles for an optimized map appearance for navigation use-cases.
  */
 object NavigationStyles {
+    /**
+     * Default navigation style for day mode
+     */
     const val NAVIGATION_DAY_STYLE = "mapbox://styles/mapbox/navigation-day-v1"
+
+    /**
+     * Default navigation sty;e for night mode
+     */
     const val NAVIGATION_NIGHT_STYLE = "mapbox://styles/mapbox/navigation-night-v1"
 }

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/NavigationStyles.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/NavigationStyles.kt
@@ -1,7 +1,8 @@
 package com.mapbox.navigation.ui.maps
 
 /**
- * An object that exposes default navigation styles for day and night mode
+ * An object that links to default navigation styles.
+ * We recommend using these map styles for an optimized map appearance for navigation use-cases.
  */
 object NavigationStyles {
     const val NAVIGATION_DAY_STYLE = "mapbox://styles/mapbox/navigation-day-v1"

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/NavigationStyles.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/NavigationStyles.kt
@@ -1,0 +1,9 @@
+package com.mapbox.navigation.ui.maps
+
+/**
+ * An object that exposes default navigation styles for day and night mode
+ */
+object NavigationStyles {
+    const val NAVIGATION_DAY_STYLE = "mapbox://styles/mapbox/navigation-day-v1"
+    const val NAVIGATION_NIGHT_STYLE = "mapbox://styles/mapbox/navigation-night-v1"
+}

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/AlternativeRouteActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/AlternativeRouteActivity.kt
@@ -17,7 +17,6 @@ import com.mapbox.api.directions.v5.models.RouteOptions
 import com.mapbox.geojson.Point
 import com.mapbox.maps.CameraOptions
 import com.mapbox.maps.EdgeInsets
-import com.mapbox.maps.Style
 import com.mapbox.maps.plugin.animation.CameraAnimationsPlugin
 import com.mapbox.maps.plugin.animation.MapAnimationOptions
 import com.mapbox.maps.plugin.animation.camera
@@ -43,6 +42,7 @@ import com.mapbox.navigation.core.trip.session.LocationMatcherResult
 import com.mapbox.navigation.core.trip.session.LocationObserver
 import com.mapbox.navigation.qa_test_app.databinding.AlternativeRouteActivityLayoutBinding
 import com.mapbox.navigation.qa_test_app.utils.Utils.getMapboxAccessToken
+import com.mapbox.navigation.ui.maps.NavigationStyles
 import com.mapbox.navigation.ui.maps.location.NavigationLocationProvider
 import com.mapbox.navigation.ui.maps.route.line.MapboxRouteLineApiExtensions.findClosestRoute
 import com.mapbox.navigation.ui.maps.route.line.MapboxRouteLineApiExtensions.setRoutes
@@ -170,7 +170,7 @@ class AlternativeRouteActivity : AppCompatActivity(), OnMapLongClickListener {
     @SuppressLint("MissingPermission")
     private fun initStyle() {
         binding.mapView.getMapboxMap().loadStyleUri(
-            Style.MAPBOX_STREETS
+            NavigationStyles.NAVIGATION_DAY_STYLE
         ) {
             mapboxNavigation.navigationOptions.locationEngine.getLastLocation(object :
                     LocationEngineCallback<LocationEngineResult> {

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/AlternativeRouteActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/AlternativeRouteActivity.kt
@@ -89,7 +89,7 @@ class AlternativeRouteActivity : AppCompatActivity(), OnMapLongClickListener {
     private val options: MapboxRouteLineOptions by lazy {
         MapboxRouteLineOptions.Builder(this)
             .withRouteLineResources(routeLineResources)
-            .withRouteLineBelowLayerId("road-label")
+            .withRouteLineBelowLayerId("road-label-navigation")
             .build()
     }
 

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/FeedbackActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/FeedbackActivity.kt
@@ -89,7 +89,7 @@ class FeedbackActivity : AppCompatActivity() {
     private val options: MapboxRouteLineOptions by lazy {
         MapboxRouteLineOptions.Builder(this)
             .withRouteLineResources(routeLineResources)
-            .withRouteLineBelowLayerId("road-label")
+            .withRouteLineBelowLayerId("road-label-navigation")
             .build()
     }
 

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/FeedbackActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/FeedbackActivity.kt
@@ -15,7 +15,6 @@ import com.mapbox.api.directions.v5.models.RouteOptions
 import com.mapbox.geojson.Point
 import com.mapbox.maps.CameraOptions
 import com.mapbox.maps.EdgeInsets
-import com.mapbox.maps.Style
 import com.mapbox.maps.plugin.animation.CameraAnimationsPlugin
 import com.mapbox.maps.plugin.animation.MapAnimationOptions
 import com.mapbox.maps.plugin.animation.camera
@@ -40,6 +39,7 @@ import com.mapbox.navigation.core.trip.session.LocationObserver
 import com.mapbox.navigation.core.trip.session.TripSessionState
 import com.mapbox.navigation.qa_test_app.databinding.FeedbackActivityBinding
 import com.mapbox.navigation.qa_test_app.utils.Utils
+import com.mapbox.navigation.ui.maps.NavigationStyles
 import com.mapbox.navigation.ui.maps.location.NavigationLocationProvider
 import com.mapbox.navigation.ui.maps.route.line.MapboxRouteLineApiExtensions.setRoutes
 import com.mapbox.navigation.ui.maps.route.line.api.MapboxRouteLineApi
@@ -160,7 +160,7 @@ class FeedbackActivity : AppCompatActivity() {
 
     @SuppressLint("MissingPermission")
     private fun initStyle() {
-        binding.mapView.getMapboxMap().loadStyleUri(Style.MAPBOX_STREETS) {
+        binding.mapView.getMapboxMap().loadStyleUri(NavigationStyles.NAVIGATION_DAY_STYLE) {
             mapboxNavigation.navigationOptions.locationEngine.getLastLocation(
                 object : LocationEngineCallback<LocationEngineResult> {
                     override fun onSuccess(result: LocationEngineResult) {

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/InactiveRouteStylingActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/InactiveRouteStylingActivity.kt
@@ -81,7 +81,7 @@ class InactiveRouteStylingActivity : AppCompatActivity() {
     private val options: MapboxRouteLineOptions by lazy {
         MapboxRouteLineOptions.Builder(this)
             .withRouteLineResources(routeLineResources)
-            .withRouteLineBelowLayerId("road-label")
+            .withRouteLineBelowLayerId("road-label-navigation")
             .styleInactiveRouteLegsIndependently(true)
             .displayRestrictedRoadSections(true)
             .build()

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/InactiveRouteStylingActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/InactiveRouteStylingActivity.kt
@@ -11,7 +11,6 @@ import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.geojson.Point
 import com.mapbox.maps.CameraOptions
 import com.mapbox.maps.EdgeInsets
-import com.mapbox.maps.Style
 import com.mapbox.maps.plugin.animation.CameraAnimationsPlugin
 import com.mapbox.maps.plugin.animation.MapAnimationOptions
 import com.mapbox.maps.plugin.animation.camera
@@ -29,6 +28,7 @@ import com.mapbox.navigation.core.trip.session.RouteProgressObserver
 import com.mapbox.navigation.qa_test_app.R
 import com.mapbox.navigation.qa_test_app.databinding.InactiveRouteActivityLayoutBinding
 import com.mapbox.navigation.qa_test_app.utils.Utils
+import com.mapbox.navigation.ui.maps.NavigationStyles
 import com.mapbox.navigation.ui.maps.location.NavigationLocationProvider
 import com.mapbox.navigation.ui.maps.route.line.api.MapboxRouteLineApi
 import com.mapbox.navigation.ui.maps.route.line.api.MapboxRouteLineView
@@ -135,7 +135,7 @@ class InactiveRouteStylingActivity : AppCompatActivity() {
 
     private fun initStyle() {
         binding.mapView.getMapboxMap().loadStyleUri(
-            Style.MAPBOX_STREETS
+            NavigationStyles.NAVIGATION_DAY_STYLE
         ) { style ->
 
             val route = getRoute()

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/InactiveRouteStylingWithRestrictionsActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/InactiveRouteStylingWithRestrictionsActivity.kt
@@ -89,7 +89,7 @@ class InactiveRouteStylingWithRestrictionsActivity : AppCompatActivity() {
     private val options: MapboxRouteLineOptions by lazy {
         MapboxRouteLineOptions.Builder(this)
             .withRouteLineResources(routeLineResources)
-            .withRouteLineBelowLayerId("road-label")
+            .withRouteLineBelowLayerId("road-label-navigation")
             .styleInactiveRouteLegsIndependently(true)
             .displayRestrictedRoadSections(true)
             .withVanishingRouteLineEnabled(true)

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/InactiveRouteStylingWithRestrictionsActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/InactiveRouteStylingWithRestrictionsActivity.kt
@@ -11,7 +11,6 @@ import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.geojson.Point
 import com.mapbox.maps.CameraOptions
 import com.mapbox.maps.EdgeInsets
-import com.mapbox.maps.Style
 import com.mapbox.maps.plugin.animation.CameraAnimationsPlugin
 import com.mapbox.maps.plugin.animation.MapAnimationOptions
 import com.mapbox.maps.plugin.animation.camera
@@ -30,6 +29,7 @@ import com.mapbox.navigation.core.trip.session.RouteProgressObserver
 import com.mapbox.navigation.qa_test_app.R
 import com.mapbox.navigation.qa_test_app.databinding.InactiveRouteWithRestrictionsLayoutBinding
 import com.mapbox.navigation.qa_test_app.utils.Utils
+import com.mapbox.navigation.ui.maps.NavigationStyles
 import com.mapbox.navigation.ui.maps.location.NavigationLocationProvider
 import com.mapbox.navigation.ui.maps.route.line.api.MapboxRouteLineApi
 import com.mapbox.navigation.ui.maps.route.line.api.MapboxRouteLineView
@@ -145,7 +145,7 @@ class InactiveRouteStylingWithRestrictionsActivity : AppCompatActivity() {
 
     private fun initStyle() {
         binding.mapView.getMapboxMap().loadStyleUri(
-            Style.MAPBOX_STREETS
+            NavigationStyles.NAVIGATION_DAY_STYLE
         ) { style ->
 
             val route = getRoute()

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/MapboxRouteLineActivity.java
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/MapboxRouteLineActivity.java
@@ -111,7 +111,7 @@ public class MapboxRouteLineActivity extends AppCompatActivity implements OnMapL
   private Button startNavigation;
   private ProgressBar routeLoading;
   private final List<String> mapStyles = Arrays.asList(
-      NavigationStyles.INSTANCE.getNAVIGATION_DAY_STYLE(),
+      NavigationStyles.NAVIGATION_DAY_STYLE,
       Style.OUTDOORS,
       Style.LIGHT,
       Style.SATELLITE_STREETS

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/MapboxRouteLineActivity.java
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/MapboxRouteLineActivity.java
@@ -66,6 +66,7 @@ import com.mapbox.navigation.core.trip.session.LocationObserver;
 import com.mapbox.navigation.core.trip.session.RouteProgressObserver;
 import com.mapbox.navigation.qa_test_app.R;
 import com.mapbox.navigation.ui.base.util.MapboxNavigationConsumer;
+import com.mapbox.navigation.ui.maps.NavigationStyles;
 import com.mapbox.navigation.ui.maps.PredictiveCacheController;
 import com.mapbox.navigation.ui.maps.location.NavigationLocationProvider;
 import com.mapbox.navigation.ui.maps.route.arrow.api.MapboxRouteArrowApi;
@@ -110,7 +111,7 @@ public class MapboxRouteLineActivity extends AppCompatActivity implements OnMapL
   private Button startNavigation;
   private ProgressBar routeLoading;
   private final List<String> mapStyles = Arrays.asList(
-      Style.MAPBOX_STREETS,
+      NavigationStyles.INSTANCE.getNAVIGATION_DAY_STYLE(),
       Style.OUTDOORS,
       Style.LIGHT,
       Style.SATELLITE_STREETS

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/RouteRestrictionsActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/RouteRestrictionsActivity.kt
@@ -11,7 +11,6 @@ import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.geojson.Point
 import com.mapbox.maps.CameraOptions
 import com.mapbox.maps.EdgeInsets
-import com.mapbox.maps.Style
 import com.mapbox.maps.plugin.animation.CameraAnimationsPlugin
 import com.mapbox.maps.plugin.animation.MapAnimationOptions
 import com.mapbox.maps.plugin.animation.camera
@@ -31,6 +30,7 @@ import com.mapbox.navigation.qa_test_app.R
 import com.mapbox.navigation.qa_test_app.databinding.RouteRestrictionsActivityLayoutBinding
 import com.mapbox.navigation.qa_test_app.utils.Utils
 import com.mapbox.navigation.qa_test_app.utils.Utils.getRouteOriginPoint
+import com.mapbox.navigation.ui.maps.NavigationStyles
 import com.mapbox.navigation.ui.maps.location.NavigationLocationProvider
 import com.mapbox.navigation.ui.maps.route.RouteLayerConstants
 import com.mapbox.navigation.ui.maps.route.arrow.api.MapboxRouteArrowApi
@@ -144,7 +144,7 @@ class RouteRestrictionsActivity : AppCompatActivity() {
 
     private fun initStyle() {
         binding.mapView.getMapboxMap().loadStyleUri(
-            Style.MAPBOX_STREETS
+            NavigationStyles.NAVIGATION_DAY_STYLE
         ) { style ->
 
             val route = getRoute()

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/RouteRestrictionsActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/RouteRestrictionsActivity.kt
@@ -90,7 +90,7 @@ class RouteRestrictionsActivity : AppCompatActivity() {
     private val options: MapboxRouteLineOptions by lazy {
         MapboxRouteLineOptions.Builder(this)
             .withRouteLineResources(routeLineResources)
-            .withRouteLineBelowLayerId("road-label")
+            .withRouteLineBelowLayerId("road-label-navigation")
             .displayRestrictedRoadSections(true)
             .withVanishingRouteLineEnabled(true)
             .build()

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/RouteTrafficUpdateActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/RouteTrafficUpdateActivity.kt
@@ -6,10 +6,10 @@ import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.maps.CameraOptions
-import com.mapbox.maps.Style
 import com.mapbox.navigation.qa_test_app.R
 import com.mapbox.navigation.qa_test_app.databinding.RouteTrafficUpdateActivityLayoutBinding
 import com.mapbox.navigation.qa_test_app.utils.Utils
+import com.mapbox.navigation.ui.maps.NavigationStyles
 import com.mapbox.navigation.ui.maps.route.line.api.MapboxRouteLineApi
 import com.mapbox.navigation.ui.maps.route.line.api.MapboxRouteLineView
 import com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions
@@ -76,7 +76,7 @@ class RouteTrafficUpdateActivity : AppCompatActivity() {
 
     private fun initStyle() {
         binding.mapView.getMapboxMap().loadStyleUri(
-            Style.MAPBOX_STREETS
+            NavigationStyles.NAVIGATION_DAY_STYLE
         ) { style ->
 
             val route = getRoute()

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/RouteTrafficUpdateActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/RouteTrafficUpdateActivity.kt
@@ -44,7 +44,7 @@ class RouteTrafficUpdateActivity : AppCompatActivity() {
     private val options: MapboxRouteLineOptions by lazy {
         MapboxRouteLineOptions.Builder(this)
             .withRouteLineResources(routeLineResources)
-            .withRouteLineBelowLayerId("road-label")
+            .withRouteLineBelowLayerId("road-label-navigation")
             .withVanishingRouteLineEnabled(true)
             .build()
     }

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/TrafficGradientActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/TrafficGradientActivity.kt
@@ -48,7 +48,7 @@ class TrafficGradientActivity : AppCompatActivity() {
         setContentView(binding.root)
         options = MapboxRouteLineOptions.Builder(this)
             .withRouteLineResources(routeLineResources)
-            .withRouteLineBelowLayerId("road-label")
+            .withRouteLineBelowLayerId("road-label-navigation")
             .build()
         routeLineApi = MapboxRouteLineApi(options)
         initGradientSelector()

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/TrafficGradientActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/TrafficGradientActivity.kt
@@ -5,10 +5,10 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.maps.CameraOptions
-import com.mapbox.maps.Style
 import com.mapbox.navigation.qa_test_app.R
 import com.mapbox.navigation.qa_test_app.databinding.TrafficGradientActivityLayoutBinding
 import com.mapbox.navigation.qa_test_app.utils.Utils
+import com.mapbox.navigation.ui.maps.NavigationStyles
 import com.mapbox.navigation.ui.maps.route.line.api.MapboxRouteLineApi
 import com.mapbox.navigation.ui.maps.route.line.api.MapboxRouteLineView
 import com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions
@@ -88,7 +88,7 @@ class TrafficGradientActivity : AppCompatActivity() {
 
     private fun initStyle() {
         binding.mapView.getMapboxMap().loadStyleUri(
-            Style.MAPBOX_STREETS
+            NavigationStyles.NAVIGATION_DAY_STYLE
         ) { style ->
 
             val route = getRoute()

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/util/RouteDrawingActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/util/RouteDrawingActivity.kt
@@ -73,7 +73,7 @@ class RouteDrawingActivity : AppCompatActivity() {
     private val options: MapboxRouteLineOptions by lazy {
         MapboxRouteLineOptions.Builder(this)
             .withRouteLineResources(routeLineResources)
-            .withRouteLineBelowLayerId("road-label")
+            .withRouteLineBelowLayerId("road-label-navigation")
             .build()
     }
 

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/util/RouteDrawingActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/util/RouteDrawingActivity.kt
@@ -19,7 +19,6 @@ import com.mapbox.maps.CameraOptions
 import com.mapbox.maps.MapInitOptions
 import com.mapbox.maps.MapView
 import com.mapbox.maps.ResourceOptions
-import com.mapbox.maps.Style
 import com.mapbox.maps.plugin.animation.CameraAnimationsPlugin
 import com.mapbox.maps.plugin.animation.camera
 import com.mapbox.maps.plugin.locationcomponent.LocationComponentPlugin
@@ -28,6 +27,7 @@ import com.mapbox.navigation.base.route.RouterCallback
 import com.mapbox.navigation.base.route.RouterFailure
 import com.mapbox.navigation.base.route.RouterOrigin
 import com.mapbox.navigation.qa_test_app.R
+import com.mapbox.navigation.ui.maps.NavigationStyles
 import com.mapbox.navigation.ui.maps.location.NavigationLocationProvider
 import com.mapbox.navigation.ui.maps.route.line.MapboxRouteLineApiExtensions.clearRouteLine
 import com.mapbox.navigation.ui.maps.route.line.MapboxRouteLineApiExtensions.setRoutes
@@ -215,7 +215,7 @@ class RouteDrawingActivity : AppCompatActivity() {
     @SuppressLint("MissingPermission")
     private fun initStyle() {
         mapView.getMapboxMap().loadStyleUri(
-            Style.MAPBOX_STREETS
+            NavigationStyles.NAVIGATION_DAY_STYLE
         ) {
             routeDrawingUtil = RouteDrawingUtil(mapView)
             initListeners()


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Fixes https://github.com/mapbox/navigation-sdks/issues/1280

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Added a new object `NavigationStyles` that exposes links to default navigation day and night styles</changelog>
```

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->

Note: 
I have modified the examples in the examples repository to use the new default navigation styles.

#### Before (Style.MAPBOX_STREETS)

<img src="https://user-images.githubusercontent.com/9770186/142904293-5d3b5c9b-acfd-4e78-a67d-df4d1c9265a5.png" width="200px">

#### After (NavigationStyle.NAVIGATION_DAY_V1)

<img src="https://user-images.githubusercontent.com/9770186/142904340-53ba7768-5101-48c2-b6a5-42b9e91e5ac0.png" width="200px">

cc @cafesilencio Can I request you to fix the layer id for route line and puck