### PR TITLE
Adding support for using the replay engine with NavigationView.

### DIFF
--- a/examples/src/main/AndroidManifest.xml
+++ b/examples/src/main/AndroidManifest.xml
@@ -97,8 +97,7 @@
 
     <activity
         android:name=".MapboxDropInActivity"
-        android:label="@string/title_drop_in"
-        android:screenOrientation="portrait">
+        android:label="@string/title_drop_in">
     </activity>
 
     <activity

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxDropInActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxDropInActivity.kt
@@ -2,10 +2,13 @@ package com.mapbox.navigation.examples.core
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import com.mapbox.navigation.dropin.MapboxNavigationViewApi
 import com.mapbox.navigation.dropin.ViewProvider
 import com.mapbox.navigation.examples.core.databinding.LayoutActivityDropInBinding
 
 class MapboxDropInActivity : AppCompatActivity() {
+
+    private lateinit var mapboxNavigationViewApi: MapboxNavigationViewApi
 
     private lateinit var binding: LayoutActivityDropInBinding
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -13,6 +16,17 @@ class MapboxDropInActivity : AppCompatActivity() {
         binding = LayoutActivityDropInBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        binding.navigationView.navigationViewApi.configureNavigationView(ViewProvider())
+        mapboxNavigationViewApi = binding.navigationView.navigationViewApi
+        mapboxNavigationViewApi.getOptions()
+            .toBuilder(this)
+            .useReplayEngine(true)
+            .build().apply {
+                mapboxNavigationViewApi.update(this)
+            }
+        mapboxNavigationViewApi.configureNavigationView(ViewProvider())
+
+        binding.tempStartNavigation.setOnClickListener {
+            mapboxNavigationViewApi.temporaryStartNavigation()
+        }
     }
 }

--- a/examples/src/main/res/layout/layout_activity_drop_in.xml
+++ b/examples/src/main/res/layout/layout_activity_drop_in.xml
@@ -14,4 +14,12 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:accessToken="@string/mapbox_access_token" />
 
+    <Button
+        android:id="@+id/tempStartNavigation"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="temporary start navigation"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"/>
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/MapboxNavigationViewApi.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/MapboxNavigationViewApi.kt
@@ -27,6 +27,8 @@ interface MapboxNavigationViewApi {
     fun update(navigationViewOptions: NavigationViewOptions)
     fun getMapView(): MapView
     fun configureNavigationView(viewProvider: ViewProvider)
+    fun getOptions(): NavigationViewOptions
+    fun temporaryStartNavigation()
 }
 
 internal class MapboxNavigationViewApiImpl(
@@ -98,5 +100,13 @@ internal class MapboxNavigationViewApiImpl(
 
     override fun configureNavigationView(viewProvider: ViewProvider) {
         navigationView.configure(viewProvider)
+    }
+
+    override fun temporaryStartNavigation() {
+        navigationView.temporaryStartNavigation()
+    }
+
+    override fun getOptions(): NavigationViewOptions {
+        return navigationView.navigationViewOptions
     }
 }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewOptions.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewOptions.kt
@@ -13,6 +13,7 @@ class NavigationViewOptions private constructor(
     val mapStyleUrlLightTheme: String,
     val darkTheme: DropInTheme,
     val lightTheme: DropInTheme,
+    val useReplayEngine: Boolean
 ) {
 
     fun toBuilder(context: Context): Builder = Builder(context).apply {
@@ -22,10 +23,14 @@ class NavigationViewOptions private constructor(
         mapStyleUrlLightTheme(mapStyleUrlLightTheme)
         darkTheme(darkTheme)
         lightTheme(lightTheme)
+        useReplayEngine(useReplayEngine)
     }
 
     class Builder(context: Context) {
-        private var mapboxRouteLineOptions = MapboxRouteLineOptions.Builder(context).build()
+        private var mapboxRouteLineOptions = MapboxRouteLineOptions.Builder(context)
+            .withRouteLineBelowLayerId("road-label")
+            .withVanishingRouteLineEnabled(true)
+            .build()
         private var routeArrowOptions = RouteArrowOptions.Builder(context).build()
         private var mapStyleUrlDarkTheme: String = Style.LIGHT
         private var mapStyleUrlLightTheme: String = Style.DARK
@@ -53,6 +58,7 @@ class NavigationViewOptions private constructor(
         )
         private var darkTheme: DropInTheme = DropInTheme.DarkTheme(darkColors, Typography())
         private var lightTheme: DropInTheme = DropInTheme.LightTheme(lightColors, Typography())
+        private var useReplayEngine = false
 
         fun mapboxRouteLineOptions(options: MapboxRouteLineOptions): Builder = apply {
             this.mapboxRouteLineOptions = options
@@ -86,13 +92,18 @@ class NavigationViewOptions private constructor(
             this.lightTheme = lightTheme
         }
 
+        fun useReplayEngine(useTheReplayEngine: Boolean): Builder = apply {
+            this.useReplayEngine = useTheReplayEngine
+        }
+
         fun build(): NavigationViewOptions = NavigationViewOptions(
             mapboxRouteLineOptions,
             routeArrowOptions,
             mapStyleUrlDarkTheme,
             mapStyleUrlLightTheme,
             darkTheme,
-            lightTheme
+            lightTheme,
+            useReplayEngine
         )
     }
 }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/viewmodel/RouteLineViewModel.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/viewmodel/RouteLineViewModel.kt
@@ -22,6 +22,17 @@ class RouteLineViewModel(
     private val _routeLineErrors: MutableSharedFlow<RouteLineError> = MutableSharedFlow()
     val routeLineErrors: Flow<RouteLineError> = _routeLineErrors
 
+    fun mapStyleUpdated(style: Style) {
+        routeLineView.initializeLayers(style)
+        routeLineApi.getRouteDrawData { result ->
+            routeLineView.renderRouteDrawData(style, result).also {
+                result.error?.let {
+                    viewModelScope.launch { _routeLineErrors.emit(it) }
+                }
+            }
+        }
+    }
+
     fun routesUpdated(update: RoutesUpdatedResult, style: Style) {
         update.routes.map {
             RouteLine(it, null)

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/MapboxNavigationViewApiTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/MapboxNavigationViewApiTest.kt
@@ -187,4 +187,14 @@ class MapboxNavigationViewApiTest {
 
         verify { navigationView.configure(viewProvider) }
     }
+
+    @Test
+    fun getOptionsTest() {
+        val navigationView = mockk<NavigationView>(relaxed = true)
+        val api = MapboxNavigationViewApiImpl(navigationView)
+
+        api.getOptions()
+
+        verify { navigationView.navigationViewOptions }
+    }
 }


### PR DESCRIPTION
### Description
Adding support for using the replay engine with NavigationView.
There is some temporary code included to facilitate starting navigation in order to facilitate further development.

The temporary code is commented or named in such a way that it will be easy to identify and remove in the near future. Having a basic implementation to draw a route line via a long press on the map and usage of the replay engine will allow for further development of the `NavigationView`.


### Screenshots or Gifs

