### PR TITLE
Added workaround for staging docs publishing

### DIFF
--- a/scripts/publish_api_docs_android.sh
+++ b/scripts/publish_api_docs_android.sh
@@ -106,6 +106,10 @@ pushDocsToStaging() {
     git commit -m "Docs ${TAG}"
     git push origin HEAD --set-upstream
 
+    # workaround for https://github.com/mapbox/documentation/issues/668
+    git commit --allow-empty -m "trigger publisher"
+    git push origin HEAD
+
     popd > /dev/null
 }
 


### PR DESCRIPTION
### Description
Push an empty commit to trigger staging docs publishing for sure. Notification mechanism could not work because of big commits.
