### PR TITLE
improve notification on android 12

### DIFF
--- a/libtrip-notification/src/main/java/com/mapbox/navigation/trip/notification/MapboxTripNotificationView.kt
+++ b/libtrip-notification/src/main/java/com/mapbox/navigation/trip/notification/MapboxTripNotificationView.kt
@@ -66,7 +66,7 @@ internal class MapboxTripNotificationView(
      */
     fun setEndNavigationButtonText(textResource: Int) {
         expandedView?.setTextViewText(
-            R.id.endNavigationBtnText,
+            R.id.endNavigationBtn,
             context.getString(textResource)
         )
     }
@@ -145,7 +145,7 @@ internal class MapboxTripNotificationView(
             setTextViewText(R.id.notificationDistanceText, "")
             setTextViewText(R.id.notificationArrivalText, "")
             setTextViewText(R.id.notificationInstructionText, "")
-            setTextViewText(R.id.endNavigationBtnText, "")
+            setTextViewText(R.id.endNavigationBtn, "")
             setViewVisibility(R.id.etaContent, View.GONE)
             setViewVisibility(R.id.notificationInstructionText, View.GONE)
             setViewVisibility(R.id.freeDriveText, View.GONE)

--- a/libtrip-notification/src/main/res/layout/mapbox_notification_navigation_collapsed.xml
+++ b/libtrip-notification/src/main/res/layout/mapbox_notification_navigation_collapsed.xml
@@ -3,8 +3,9 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/navigationCollapsedNotificationLayout"
     android:layout_width="match_parent"
-    android:layout_height="64dp"
-    android:background="@color/mapbox_notification_blue">
+    android:layout_height="wrap_content"
+    android:background="@color/mapbox_notification_blue"
+    android:padding="@dimen/mapbox_notification_padding">
 
     <ImageView
         android:id="@+id/maneuverImage"
@@ -13,10 +14,8 @@
         android:layout_alignParentStart="true"
         android:layout_alignParentLeft="true"
         android:layout_centerVertical="true"
-        android:layout_marginStart="8dp"
-        android:layout_marginLeft="8dp"
         android:layout_marginEnd="8dp"
-        android:layout_marginRight="8dp"
+        android:contentDescription="@null"
         android:cropToPadding="true"
         android:padding="8dp" />
 

--- a/libtrip-notification/src/main/res/layout/mapbox_notification_navigation_expanded.xml
+++ b/libtrip-notification/src/main/res/layout/mapbox_notification_navigation_expanded.xml
@@ -11,33 +11,21 @@
 
     <include layout="@layout/mapbox_notification_navigation_collapsed" />
 
-    <LinearLayout
+    <TextView
         android:id="@+id/endNavigationBtn"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="56dp"
         android:layout_marginLeft="56dp"
+        android:layout_marginTop="8dp"
         android:gravity="center_vertical"
-        android:orientation="horizontal"
-        android:padding="8dp">
-
-        <ImageView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:layout_marginEnd="8dp"
-            android:layout_marginRight="8dp"
-            android:src="@drawable/mapbox_ic_close" />
-
-        <TextView
-            android:id="@+id/endNavigationBtnText"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="@android:color/transparent"
-            tools:text="@string/mapbox_end_navigation"
-            android:textAllCaps="true"
-            android:textColor="@android:color/white" />
-
-    </LinearLayout>
+        android:paddingBottom="@dimen/mapbox_notification_padding"
+        android:paddingEnd="@dimen/mapbox_notification_padding"
+        android:paddingStart="@dimen/mapbox_notification_padding"
+        android:drawablePadding="8dp"
+        android:drawableStart="@drawable/mapbox_ic_close"
+        android:textAllCaps="true"
+        android:textColor="@android:color/white"
+        tools:text="@string/mapbox_end_navigation" />
 
 </LinearLayout>

--- a/libtrip-notification/src/main/res/values-v31/dimens.xml
+++ b/libtrip-notification/src/main/res/values-v31/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="mapbox_notification_padding">0dp</dimen>
+</resources>

--- a/libtrip-notification/src/main/res/values/dimens.xml
+++ b/libtrip-notification/src/main/res/values/dimens.xml
@@ -2,4 +2,5 @@
 <resources>
     <dimen name="mapbox_notification_maneuver_image_width">48dp</dimen>
     <dimen name="mapbox_notification_maneuver_image_height">48dp</dimen>
+    <dimen name="mapbox_notification_padding">8dp</dimen>
 </resources>

--- a/libtrip-notification/src/test/java/com/mapbox/navigation/trip/notification/MapboxTripNotificationViewTest.kt
+++ b/libtrip-notification/src/test/java/com/mapbox/navigation/trip/notification/MapboxTripNotificationViewTest.kt
@@ -15,7 +15,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.verify
-import junit.framework.Assert.assertNotNull
+import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
 import java.util.Locale
@@ -86,7 +86,7 @@ class MapboxTripNotificationViewTest {
             it.setEndNavigationButtonText(R.string.mapbox_stop_session)
         }
 
-        verify { view.expandedView!!.setTextViewText(R.id.endNavigationBtnText, STOP_SESSION) }
+        verify { view.expandedView!!.setTextViewText(R.id.endNavigationBtn, STOP_SESSION) }
     }
 
     @Test
@@ -206,7 +206,7 @@ class MapboxTripNotificationViewTest {
                 R.drawable.mapbox_ic_navigation
             )
         }
-        verify { view.expandedView!!.setTextViewText(R.id.endNavigationBtnText, STOP_SESSION) }
+        verify { view.expandedView!!.setTextViewText(R.id.endNavigationBtn, STOP_SESSION) }
     }
 
     @Test
@@ -228,7 +228,7 @@ class MapboxTripNotificationViewTest {
         verify {
             view.expandedView!!.setViewVisibility(R.id.notificationInstructionText, View.VISIBLE)
         }
-        verify { view.expandedView!!.setTextViewText(R.id.endNavigationBtnText, END_NAVIGATION) }
+        verify { view.expandedView!!.setTextViewText(R.id.endNavigationBtn, END_NAVIGATION) }
     }
 
     private fun createContext(): Context {


### PR DESCRIPTION
### Description
With Android 12 we can no longer customize the whole notification area: https://developer.android.com/about/versions/12/behavior-changes-12#custom-notifications. But we can use `setColorized` to apply background color to the rest on the notification. 
Also with Android 12 it is no longer possible to set only those attributes to `RemoteViews` that changed since the last notification. Since we are creating a new `RemoteViews` instance every time, we have to set all attributes. 
I would appreciate if someone tested this in long trips, as I'm worried about possible performance degradation. 

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Fixed notification appearance on Android 12</changelog>
```

### Screenshots or Gifs
![3](https://user-images.githubusercontent.com/2395284/143407815-bf003fbf-dd47-425e-b123-e67805d38226.png) ![4](https://user-images.githubusercontent.com/2395284/143407823-81db19d5-53ef-4cbf-80a1-3a12d5c888d8.png)



<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
