### PR TITLE
Removed a workaround in connectivity handler.

### DIFF
--- a/libnavigation-util/src/main/java/com/mapbox/navigation/utils/internal/ConnectivityHandler.kt
+++ b/libnavigation-util/src/main/java/com/mapbox/navigation/utils/internal/ConnectivityHandler.kt
@@ -1,11 +1,8 @@
 package com.mapbox.navigation.utils.internal
 
-import android.content.Context
-import android.net.ConnectivityManager
 import com.mapbox.base.common.logger.Logger
 import com.mapbox.base.common.logger.model.Message
 import com.mapbox.base.common.logger.model.Tag
-import com.mapbox.common.MapboxSDKCommon.getContext
 import com.mapbox.common.NetworkStatus
 import com.mapbox.common.ReachabilityChanged
 import kotlinx.coroutines.channels.Channel
@@ -15,8 +12,6 @@ class ConnectivityHandler(
     private val logger: Logger,
     private val networkStatusChannel: Channel<Boolean>
 ) : ReachabilityChanged {
-    private val cm =
-        getContext().getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
 
     fun getNetworkStatusChannel(): ReceiveChannel<Boolean> = networkStatusChannel
 
@@ -29,15 +24,8 @@ class ConnectivityHandler(
             NetworkStatus.REACHABLE_VIA_WI_FI,
             NetworkStatus.REACHABLE_VIA_ETHERNET,
             NetworkStatus.REACHABLE_VIA_WWAN -> {
-                // TODO: Remove workaround when fix from Common is available
-                val activeNetwork = cm.activeNetworkInfo
-                if (activeNetwork == null) {
-                    logger.d(Tag(TAG), Message("NetworkStatus=${NetworkStatus.NOT_REACHABLE}"))
-                    networkStatusChannel.trySend(false).isSuccess
-                } else {
-                    logger.d(Tag(TAG), Message("NetworkStatus=$status"))
-                    networkStatusChannel.trySend(true).isSuccess
-                }
+                logger.d(Tag(TAG), Message("NetworkStatus=$status"))
+                networkStatusChannel.trySend(true).isSuccess
             }
         }
     }

--- a/libnavigation-util/src/test/java/com/mapbox/navigation/utils/internal/ConnectivityHandlerTest.kt
+++ b/libnavigation-util/src/test/java/com/mapbox/navigation/utils/internal/ConnectivityHandlerTest.kt
@@ -1,38 +1,15 @@
 package com.mapbox.navigation.utils.internal
 
-import android.content.Context
-import android.net.ConnectivityManager
 import com.mapbox.base.common.logger.Logger
 import com.mapbox.base.common.logger.model.Message
 import com.mapbox.base.common.logger.model.Tag
-import com.mapbox.common.MapboxSDKCommon
 import com.mapbox.common.NetworkStatus
-import io.mockk.every
 import io.mockk.mockk
-import io.mockk.mockkObject
-import io.mockk.unmockkObject
 import io.mockk.verify
 import kotlinx.coroutines.channels.Channel
-import org.junit.After
-import org.junit.Before
 import org.junit.Test
 
 class ConnectivityHandlerTest {
-
-    private var mockedConnectivityManager: ConnectivityManager = mockk()
-
-    @Before
-    fun setup() {
-        mockkObject(MapboxSDKCommon)
-        every {
-            MapboxSDKCommon.getContext().getSystemService(Context.CONNECTIVITY_SERVICE)
-        } returns mockedConnectivityManager
-    }
-
-    @After
-    fun teardown() {
-        unmockkObject(MapboxSDKCommon)
-    }
 
     @Test
     fun `not reachable network status channel sends false`() {
@@ -47,7 +24,6 @@ class ConnectivityHandlerTest {
 
     @Test
     fun `reachable via wifi network status channel sends true`() {
-        every { mockedConnectivityManager.activeNetworkInfo } returns mockk()
         val mockedLogger: Logger = mockk(relaxUnitFun = true)
         val mockedNetworkStatusChannel: Channel<Boolean> = mockk(relaxed = true)
         val connectivityHandler = ConnectivityHandler(mockedLogger, mockedNetworkStatusChannel)
@@ -55,23 +31,10 @@ class ConnectivityHandlerTest {
         connectivityHandler.run(NetworkStatus.REACHABLE_VIA_WI_FI)
 
         verify { mockedNetworkStatusChannel.trySend(true).isSuccess }
-    }
-
-    @Test
-    fun `reachable via wifi but activeNetwork null network status channel sends false`() {
-        every { mockedConnectivityManager.activeNetworkInfo } returns null
-        val mockedLogger: Logger = mockk(relaxUnitFun = true)
-        val mockedNetworkStatusChannel: Channel<Boolean> = mockk(relaxed = true)
-        val connectivityHandler = ConnectivityHandler(mockedLogger, mockedNetworkStatusChannel)
-
-        connectivityHandler.run(NetworkStatus.REACHABLE_VIA_WI_FI)
-
-        verify { mockedNetworkStatusChannel.trySend(false).isSuccess }
     }
 
     @Test
     fun `reachable via ethernet network status channel sends true`() {
-        every { mockedConnectivityManager.activeNetworkInfo } returns mockk()
         val mockedLogger: Logger = mockk(relaxUnitFun = true)
         val mockedNetworkStatusChannel: Channel<Boolean> = mockk(relaxed = true)
         val connectivityHandler = ConnectivityHandler(mockedLogger, mockedNetworkStatusChannel)
@@ -79,23 +42,10 @@ class ConnectivityHandlerTest {
         connectivityHandler.run(NetworkStatus.REACHABLE_VIA_ETHERNET)
 
         verify { mockedNetworkStatusChannel.trySend(true).isSuccess }
-    }
-
-    @Test
-    fun `reachable via ethernet but activeNetwork null network status channel sends false`() {
-        every { mockedConnectivityManager.activeNetworkInfo } returns null
-        val mockedLogger: Logger = mockk(relaxUnitFun = true)
-        val mockedNetworkStatusChannel: Channel<Boolean> = mockk(relaxed = true)
-        val connectivityHandler = ConnectivityHandler(mockedLogger, mockedNetworkStatusChannel)
-
-        connectivityHandler.run(NetworkStatus.REACHABLE_VIA_ETHERNET)
-
-        verify { mockedNetworkStatusChannel.trySend(false).isSuccess }
     }
 
     @Test
     fun `reachable via wwan network status channel sends true`() {
-        every { mockedConnectivityManager.activeNetworkInfo } returns mockk()
         val mockedLogger: Logger = mockk(relaxUnitFun = true)
         val mockedNetworkStatusChannel: Channel<Boolean> = mockk(relaxed = true)
         val connectivityHandler = ConnectivityHandler(mockedLogger, mockedNetworkStatusChannel)
@@ -103,18 +53,6 @@ class ConnectivityHandlerTest {
         connectivityHandler.run(NetworkStatus.REACHABLE_VIA_WWAN)
 
         verify { mockedNetworkStatusChannel.trySend(true).isSuccess }
-    }
-
-    @Test
-    fun `reachable via wwan but activeNetwork null network status channel sends false`() {
-        every { mockedConnectivityManager.activeNetworkInfo } returns null
-        val mockedLogger: Logger = mockk(relaxUnitFun = true)
-        val mockedNetworkStatusChannel: Channel<Boolean> = mockk(relaxed = true)
-        val connectivityHandler = ConnectivityHandler(mockedLogger, mockedNetworkStatusChannel)
-
-        connectivityHandler.run(NetworkStatus.REACHABLE_VIA_WWAN)
-
-        verify { mockedNetworkStatusChannel.trySend(false).isSuccess }
     }
 
     @Test
@@ -135,7 +73,6 @@ class ConnectivityHandlerTest {
 
     @Test
     fun `reachable via wifi logger prints out reachable via wifi`() {
-        every { mockedConnectivityManager.activeNetworkInfo } returns mockk()
         val mockedLogger: Logger = mockk(relaxUnitFun = true)
         val mockedNetworkStatusChannel: Channel<Boolean> = mockk(relaxed = true)
         val connectivityHandler = ConnectivityHandler(mockedLogger, mockedNetworkStatusChannel)
@@ -151,25 +88,7 @@ class ConnectivityHandlerTest {
     }
 
     @Test
-    fun `reachable via wifi but activeNetwork null logger prints out not reachable`() {
-        every { mockedConnectivityManager.activeNetworkInfo } returns null
-        val mockedLogger: Logger = mockk(relaxUnitFun = true)
-        val mockedNetworkStatusChannel: Channel<Boolean> = mockk(relaxed = true)
-        val connectivityHandler = ConnectivityHandler(mockedLogger, mockedNetworkStatusChannel)
-
-        connectivityHandler.run(NetworkStatus.REACHABLE_VIA_WI_FI)
-
-        verify {
-            mockedLogger.d(
-                Tag("MbxConnectivityHandler"),
-                Message("NetworkStatus=${NetworkStatus.NOT_REACHABLE}")
-            )
-        }
-    }
-
-    @Test
     fun `reachable via ethernet logger prints out reachable via ethernet`() {
-        every { mockedConnectivityManager.activeNetworkInfo } returns mockk()
         val mockedLogger: Logger = mockk(relaxUnitFun = true)
         val mockedNetworkStatusChannel: Channel<Boolean> = mockk(relaxed = true)
         val connectivityHandler = ConnectivityHandler(mockedLogger, mockedNetworkStatusChannel)
@@ -185,25 +104,7 @@ class ConnectivityHandlerTest {
     }
 
     @Test
-    fun `reachable via ethernet but activeNetwork null logger prints out not reachable`() {
-        every { mockedConnectivityManager.activeNetworkInfo } returns null
-        val mockedLogger: Logger = mockk(relaxUnitFun = true)
-        val mockedNetworkStatusChannel: Channel<Boolean> = mockk(relaxed = true)
-        val connectivityHandler = ConnectivityHandler(mockedLogger, mockedNetworkStatusChannel)
-
-        connectivityHandler.run(NetworkStatus.REACHABLE_VIA_ETHERNET)
-
-        verify {
-            mockedLogger.d(
-                Tag("MbxConnectivityHandler"),
-                Message("NetworkStatus=${NetworkStatus.NOT_REACHABLE}")
-            )
-        }
-    }
-
-    @Test
     fun `reachable via wwan logger prints out reachable via wwan`() {
-        every { mockedConnectivityManager.activeNetworkInfo } returns mockk()
         val mockedLogger: Logger = mockk(relaxUnitFun = true)
         val mockedNetworkStatusChannel: Channel<Boolean> = mockk(relaxed = true)
         val connectivityHandler = ConnectivityHandler(mockedLogger, mockedNetworkStatusChannel)
@@ -214,23 +115,6 @@ class ConnectivityHandlerTest {
             mockedLogger.d(
                 Tag("MbxConnectivityHandler"),
                 Message("NetworkStatus=${NetworkStatus.REACHABLE_VIA_WWAN}")
-            )
-        }
-    }
-
-    @Test
-    fun `reachable via wwan but activeNetwork null logger prints out not reachable`() {
-        every { mockedConnectivityManager.activeNetworkInfo } returns null
-        val mockedLogger: Logger = mockk(relaxUnitFun = true)
-        val mockedNetworkStatusChannel: Channel<Boolean> = mockk(relaxed = true)
-        val connectivityHandler = ConnectivityHandler(mockedLogger, mockedNetworkStatusChannel)
-
-        connectivityHandler.run(NetworkStatus.REACHABLE_VIA_WWAN)
-
-        verify {
-            mockedLogger.d(
-                Tag("MbxConnectivityHandler"),
-                Message("NetworkStatus=${NetworkStatus.NOT_REACHABLE}")
             )
         }
     }


### PR DESCRIPTION
### Description
Common SDK has already fixed the bug, so we don't need the workaround anymore.

### Tests
I was trying to turn on\off mobile data and wifi. Turned on/off an airplane mode. Debugger didn't stop in a point where status is not `NOT_REACHABLE` and `activeNetwork` is null. 
Testing proves that the Common SDK team has fixed the bug.


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
