### PR TITLE
Replaced delay by stdout reading in instrumentation tests

### DIFF
--- a/libtesting-ui/src/main/java/com/mapbox/navigation/testing/ui/MockLocationUpdatesRule.kt
+++ b/libtesting-ui/src/main/java/com/mapbox/navigation/testing/ui/MockLocationUpdatesRule.kt
@@ -8,6 +8,7 @@ import android.os.SystemClock
 import android.util.Log
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
+import com.mapbox.navigation.testing.ui.utils.executeShellCommandBlocking
 import org.junit.rules.ExternalResource
 import java.util.Date
 
@@ -27,17 +28,11 @@ class MockLocationUpdatesRule : ExternalResource() {
     }
 
     override fun before() {
-        with(instrumentation.uiAutomation) {
-            val result = executeShellCommand(
-                "appops set " +
-                    appContext.packageName +
-                    " android:mock_location allow"
-            )
-            result.close()
-            // gives the adb command chance to process
-            // and avoids occasional issues with registering the mock provider
-            Thread.sleep(1000)
-        }
+        instrumentation.uiAutomation.executeShellCommandBlocking(
+            "appops set " +
+                appContext.packageName +
+                " android:mock_location allow"
+        )
 
         try {
             locationManager.addTestProvider(

--- a/libtesting-ui/src/main/java/com/mapbox/navigation/testing/ui/utils/UiAutomationUtils.kt
+++ b/libtesting-ui/src/main/java/com/mapbox/navigation/testing/ui/utils/UiAutomationUtils.kt
@@ -1,0 +1,9 @@
+package com.mapbox.navigation.testing.ui.utils
+
+import android.app.UiAutomation
+import java.io.FileInputStream
+
+fun UiAutomation.executeShellCommandBlocking(command: String): ByteArray {
+    val output = executeShellCommand(command)
+    return FileInputStream(output.fileDescriptor).use { it.readBytes() }
+}


### PR DESCRIPTION
### Description
I believe we can replace delay by reading output from the shell command. Solution is inspired by [facebook](https://github.com/facebook/screenshot-tests-for-android/blob/db51da6d7f03eb3c45564109f33ccb8497b9672a/core/src/main/java/com/facebook/testing/screenshot/internal/ScreenshotDirectories.java#L81)

### Testing
I run the `instrumentation-tests` job 10 times on CI and none of runs failed.