### PR TITLE
Add changelog v2.1.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 Mapbox welcomes participation and contributions from everyone.
 
+## Mapbox Navigation SDK 2.1.0 - November 30, 2021
+
+For details on how v2 differs from v1 and guidance on migrating from v1 of the Mapbox Navigation SDK for Android to the v2 public preview, see [2.0 Navigation SDK Migration Guide](https://github.com/mapbox/mapbox-navigation-android/wiki/2.0-Navigation-SDK-Migration-Guide).
+
+### Changelog
+#### Bug fixes and improvements
+- Fixed an issue where reroute controller attempted to add request parameters unsuitable for the selected profile. [#5141](https://github.com/mapbox/mapbox-navigation-android/pull/5141)
+
+### Mapbox dependencies
+This release depends on, and has been tested with, the following Mapbox dependencies:
+- Mapbox Maps SDK `v10.0.1` ([release notes](https://github.com/mapbox/mapbox-maps-android/releases/tag/android-v10.0.1))
+- Mapbox Navigation Native `v79.0.3`
+- Mapbox Core Common `v20.0.0`
+- Mapbox Java `v6.1.0` ([release notes](https://github.com/mapbox/mapbox-java/releases/tag/v6.1.0))
+- Mapbox Android Core `v5.0.0`
+- Mapbox Android Telemetry `v8.1.0`
+
 ## Mapbox Navigation SDK 2.1.0-rc.2 - November 18, 2021
 
 For details on how v2 differs from v1 and guidance on migrating from v1 of the Mapbox Navigation SDK for Android to the v2 public preview, see [2.0 Navigation SDK Migration Guide](https://github.com/mapbox/mapbox-navigation-android/wiki/2.0-Navigation-SDK-Migration-Guide).


### PR DESCRIPTION
## Mapbox Navigation SDK 2.1.0 - November 30, 2021

For details on how v2 differs from v1 and guidance on migrating from v1 of the Mapbox Navigation SDK for Android to the v2 public preview, see [2.0 Navigation SDK Migration Guide](https://github.com/mapbox/mapbox-navigation-android/wiki/2.0-Navigation-SDK-Migration-Guide).

### Changelog
#### Bug fixes and improvements
- Fixed an issue where reroute controller attempted to add request parameters unsuitable for the selected profile. [#5141](https://github.com/mapbox/mapbox-navigation-android/pull/5141)

### Mapbox dependencies
This release depends on, and has been tested with, the following Mapbox dependencies:
- Mapbox Maps SDK `v10.0.1` ([release notes](https://github.com/mapbox/mapbox-maps-android/releases/tag/android-v10.0.1))
- Mapbox Navigation Native `v79.0.3`
- Mapbox Core Common `v20.0.0`
- Mapbox Java `v6.1.0` ([release notes](https://github.com/mapbox/mapbox-java/releases/tag/v6.1.0))
- Mapbox Android Core `v5.0.0`
- Mapbox Android Telemetry `v8.1.0`
