### PR TITLE
Separating the functionality of the previous distance formatter to ma…

### DIFF
--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -143,11 +143,29 @@ package com.mapbox.navigation.core.directions.session {
 
 package com.mapbox.navigation.core.formatter {
 
+  public final class FormattedDistanceData {
+    method public double getDistance();
+    method public String getDistanceAsString();
+    method public String getDistanceSuffix();
+    method public com.mapbox.navigation.base.formatter.UnitType getUnitType();
+    property public final double distance;
+    property public final String distanceAsString;
+    property public final String distanceSuffix;
+    property public final com.mapbox.navigation.base.formatter.UnitType unitType;
+  }
+
   public final class MapboxDistanceFormatter implements com.mapbox.navigation.base.formatter.DistanceFormatter {
     ctor public MapboxDistanceFormatter(com.mapbox.navigation.base.formatter.DistanceFormatterOptions options);
     method public android.text.SpannableString formatDistance(double distance);
     method public com.mapbox.navigation.base.formatter.DistanceFormatterOptions getOptions();
     property public final com.mapbox.navigation.base.formatter.DistanceFormatterOptions options;
+  }
+
+  public final class MapboxDistanceUtil {
+    method public com.mapbox.navigation.core.formatter.FormattedDistanceData formatDistance(double distanceInMeters, int roundingIncrement, com.mapbox.navigation.base.formatter.UnitType unitType, android.content.Context context, java.util.Locale locale);
+    method public com.mapbox.navigation.core.formatter.FormattedDistanceData formatDistance(double distanceInMeters, int roundingIncrement, com.mapbox.navigation.base.formatter.UnitType unitType, android.content.Context context);
+    method public double formatDistance(double distanceInMeters, int roundingIncrement, com.mapbox.navigation.base.formatter.UnitType unitType);
+    field public static final com.mapbox.navigation.core.formatter.MapboxDistanceUtil INSTANCE;
   }
 
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/formatter/FormattedDistanceData.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/formatter/FormattedDistanceData.kt
@@ -1,0 +1,59 @@
+package com.mapbox.navigation.core.formatter
+
+import com.mapbox.navigation.base.formatter.UnitType
+
+/**
+ * Represents a distance that has been formatted and potentially rounded for display purposes.
+ *
+ * @param distance the calculated distance value
+ * @param distanceAsString a rounded string representation of the distance. For example a distance value of 19.3121 might result in a string value of '19'
+ * @param distanceSuffix a suffix that goes with the string value of the distance like 'km' for kilometers, 'ft' for foot/feet, 'mi' for miles etc. depending on the Locale and the UnitType
+ * @param unitType indicates if the values represented are metric or imperial
+ */
+class FormattedDistanceData internal constructor(
+    val distance: Double,
+    val distanceAsString: String,
+    val distanceSuffix: String,
+    val unitType: UnitType
+) {
+
+    /**
+     * Indicates whether some other object is "equal to" this one.
+     */
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as FormattedDistanceData
+
+        if (distance != other.distance) return false
+        if (distanceAsString != other.distanceAsString) return false
+        if (distanceSuffix != other.distanceSuffix) return false
+        if (unitType != other.unitType) return false
+
+        return true
+    }
+
+    /**
+     * Returns a hash code value for the object.
+     */
+    override fun hashCode(): Int {
+        var result = distance.hashCode()
+        result = 31 * result + distanceAsString.hashCode()
+        result = 31 * result + distanceSuffix.hashCode()
+        result = 31 * result + unitType.hashCode()
+        return result
+    }
+
+    /**
+     * The toString implementation
+     */
+    override fun toString(): String {
+        return "FormattedDistanceData(" +
+            "distance=$distance, " +
+            "distanceAsString=$distanceAsString, " +
+            "distanceSuffix=$distanceSuffix, " +
+            "unitType=$unitType" +
+            ")"
+    }
+}

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/formatter/MapboxDistanceFormatter.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/formatter/MapboxDistanceFormatter.kt
@@ -1,8 +1,5 @@
 package com.mapbox.navigation.core.formatter
 
-import android.content.Context
-import android.content.res.Configuration
-import android.content.res.Resources
 import android.graphics.Typeface
 import android.text.SpannableString
 import android.text.Spanned
@@ -10,13 +7,6 @@ import android.text.style.RelativeSizeSpan
 import android.text.style.StyleSpan
 import com.mapbox.navigation.base.formatter.DistanceFormatter
 import com.mapbox.navigation.base.formatter.DistanceFormatterOptions
-import com.mapbox.navigation.base.formatter.UnitType
-import com.mapbox.navigation.core.R
-import com.mapbox.turf.TurfConstants
-import com.mapbox.turf.TurfConversion
-import java.text.NumberFormat
-import java.util.Locale
-import kotlin.math.roundToInt
 
 /**
  * Implementation of DistanceFormatter, which can format distances in meters
@@ -28,21 +18,6 @@ class MapboxDistanceFormatter(
     val options: DistanceFormatterOptions
 ) : DistanceFormatter {
 
-    private val smallUnit = when (options.unitType) {
-        UnitType.IMPERIAL -> TurfConstants.UNIT_FEET
-        UnitType.METRIC -> TurfConstants.UNIT_METERS
-    }
-
-    private val largeUnit = when (options.unitType) {
-        UnitType.IMPERIAL -> TurfConstants.UNIT_MILES
-        UnitType.METRIC -> TurfConstants.UNIT_KILOMETERS
-    }
-
-    private companion object {
-        private const val smallDistanceUpperThresholdInMeters = 400.0
-        private const val mediumDistanceUpperThresholdInMeters = 10000.0
-    }
-
     /**
      * Returns a formatted SpannableString with bold and size formatting. I.e., "10 mi", "350 m"
      *
@@ -51,63 +26,15 @@ class MapboxDistanceFormatter(
      * relative size of .65 times the size of the number
      */
     override fun formatDistance(distance: Double): SpannableString {
-        val distanceAndSuffix = when (distance) {
-            !in 0.0..Double.MAX_VALUE -> {
-                formatDistanceAndSuffixForSmallUnit(0.0)
-            }
-            in 0.0..smallDistanceUpperThresholdInMeters -> {
-                formatDistanceAndSuffixForSmallUnit(distance)
-            }
-            in smallDistanceUpperThresholdInMeters..mediumDistanceUpperThresholdInMeters -> {
-                formatDistanceAndSuffixForLargeUnit(distance, 1)
-            }
-            else -> {
-                formatDistanceAndSuffixForLargeUnit(distance, 0)
-            }
-        }
-        return getSpannableDistanceString(distanceAndSuffix)
-    }
-
-    private fun formatDistanceAndSuffixForSmallUnit(distance: Double): Pair<String, String> {
-        val resources = options.applicationContext.resourcesWithLocale(options.locale)
-        val unitStringSuffix = getUnitString(resources, smallUnit)
-
-        if (distance < 0) {
-            return Pair("0", unitStringSuffix)
-        }
-
-        val distanceUnit = TurfConversion.convertLength(
+        return MapboxDistanceUtil.formatDistance(
             distance,
-            TurfConstants.UNIT_METERS,
-            smallUnit
-        )
-
-        val roundedValue = if (options.roundingIncrement > 0) {
-            val roundedDistance = distanceUnit.roundToInt()
-            if (roundedDistance < options.roundingIncrement) {
-                options.roundingIncrement
-            } else {
-                roundedDistance / options.roundingIncrement * options.roundingIncrement
-            }
-        } else {
-            distanceUnit.roundToInt()
-        }.toString()
-
-        return Pair(roundedValue, unitStringSuffix)
-    }
-
-    private fun formatDistanceAndSuffixForLargeUnit(
-        distance: Double,
-        maxFractionDigits: Int
-    ): Pair<String, String> {
-        val resources = options.applicationContext.resourcesWithLocale(options.locale)
-        val unitStringSuffix = getUnitString(resources, largeUnit)
-        val distanceUnit =
-            TurfConversion.convertLength(distance, TurfConstants.UNIT_METERS, largeUnit)
-        val roundedValue = NumberFormat.getNumberInstance(options.locale).also {
-            it.maximumFractionDigits = maxFractionDigits
-        }.format(distanceUnit)
-        return Pair(roundedValue, unitStringSuffix)
+            options.roundingIncrement,
+            options.unitType,
+            options.applicationContext,
+            options.locale
+        ).run {
+            getSpannableDistanceString(Pair(this.distanceAsString, this.distanceSuffix))
+        }
     }
 
     /**
@@ -138,21 +65,5 @@ class MapboxDistanceFormatter(
         )
 
         return spannableString
-    }
-
-    private fun getUnitString(resources: Resources, @TurfConstants.TurfUnitCriteria unit: String) =
-        when (unit) {
-            TurfConstants.UNIT_KILOMETERS -> resources.getString(R.string.mapbox_unit_kilometers)
-            TurfConstants.UNIT_METERS -> resources.getString(R.string.mapbox_unit_meters)
-            TurfConstants.UNIT_MILES -> resources.getString(R.string.mapbox_unit_miles)
-            TurfConstants.UNIT_FEET -> resources.getString(R.string.mapbox_unit_feet)
-            else -> ""
-        }
-
-    private fun Context.resourcesWithLocale(locale: Locale?): Resources {
-        val config = Configuration(this.resources.configuration).also {
-            it.setLocale(locale)
-        }
-        return this.createConfigurationContext(config).resources
     }
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/formatter/MapboxDistanceUtil.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/formatter/MapboxDistanceUtil.kt
@@ -1,0 +1,237 @@
+package com.mapbox.navigation.core.formatter
+
+import android.content.Context
+import android.content.res.Configuration
+import android.content.res.Resources
+import com.mapbox.navigation.base.formatter.UnitType
+import com.mapbox.navigation.core.R
+import com.mapbox.turf.TurfConstants
+import com.mapbox.turf.TurfConversion
+import java.text.NumberFormat
+import java.util.Locale
+import kotlin.math.roundToInt
+
+/**
+ * A utility for rounding distances for displaying in view components.
+ */
+object MapboxDistanceUtil {
+
+    private const val smallDistanceUpperThresholdInMeters = 400.0
+    private const val mediumDistanceUpperThresholdInMeters = 10000.0
+
+    /**
+     * This will recalculate and format a distance based on the parameters inputted. The value
+     * will be rounded for visual display and a distance suffix like 'km' for kilometers or 'ft' for foot/feet will be included.
+     *
+     * @param distanceInMeters in meters
+     * @param roundingIncrement used to alter the original value for display purposes
+     * @param unitType indicates whether the value should be returned as metric or imperial
+     * @param context a context for determining the correct value for the distance display, for example 3.5 or 3,5
+     * @param locale a specified locale to use rather than the default locale provided by the context
+     * @return an object containing values for displaying the formatted distance
+     */
+    fun formatDistance(
+        distanceInMeters: Double,
+        roundingIncrement: Int,
+        unitType: UnitType,
+        context: Context,
+        locale: Locale
+    ): FormattedDistanceData {
+        return when (distanceInMeters) {
+            !in 0.0..Double.MAX_VALUE -> {
+                formatDistanceAndSuffixForSmallUnit(
+                    0.0,
+                    roundingIncrement,
+                    unitType,
+                    context,
+                    locale
+                )
+            }
+            in 0.0..smallDistanceUpperThresholdInMeters -> {
+                formatDistanceAndSuffixForSmallUnit(
+                    distanceInMeters,
+                    roundingIncrement,
+                    unitType,
+                    context,
+                    locale
+                )
+            }
+            in smallDistanceUpperThresholdInMeters..mediumDistanceUpperThresholdInMeters -> {
+                formatDistanceAndSuffixForLargeUnit(distanceInMeters, 1, unitType, context, locale)
+            }
+            else -> {
+                formatDistanceAndSuffixForLargeUnit(distanceInMeters, 0, unitType, context, locale)
+            }
+        }
+    }
+
+    /**
+     * This will recalculate and format a distance based on the parameters inputted. The value
+     * will be rounded for visual display and a distance suffix like 'km' for kilometers or 'ft' for foot/feet will be included.
+     *
+     * @param distanceInMeters in meters
+     * @param roundingIncrement used to alter the original value for display purposes
+     * @param unitType indicates whether the value should be returned as metric or imperial
+     * @param context a context for determining the correct value for the distance display, for example 3.5 or 3,5
+     * @return an object containing values for displaying the formatted distance
+     */
+    fun formatDistance(
+        distanceInMeters: Double,
+        roundingIncrement: Int,
+        unitType: UnitType,
+        context: Context
+    ): FormattedDistanceData {
+        return formatDistance(
+            distanceInMeters,
+            roundingIncrement,
+            unitType,
+            context,
+            Locale.getDefault()
+        )
+    }
+
+    /**
+     * This will recalculate and format a distance based on the parameters inputted. The value
+     * will be rounded for visual display and a distance suffix like 'km' for kilometers or 'ft' for foot/feet will be included.
+     *
+     * @param distanceInMeters in meters
+     * @param roundingIncrement used to alter the original value for display purposes
+     * @param unitType indicates whether the value should be returned as metric or imperial
+     * @return an object containing values for displaying the formatted distance
+     */
+    fun formatDistance(
+        distanceInMeters: Double,
+        roundingIncrement: Int,
+        unitType: UnitType
+    ): Double {
+        return when (distanceInMeters) {
+            !in 0.0..Double.MAX_VALUE -> {
+                roundSmallDistance(distanceInMeters, roundingIncrement, unitType).toDouble()
+            }
+            in 0.0..smallDistanceUpperThresholdInMeters -> {
+                roundSmallDistance(distanceInMeters, roundingIncrement, unitType).toDouble()
+            }
+            in smallDistanceUpperThresholdInMeters..mediumDistanceUpperThresholdInMeters -> {
+                roundLargeDistance(distanceInMeters, unitType)
+            }
+            else -> {
+                roundLargeDistance(distanceInMeters, unitType)
+            }
+        }
+    }
+
+    private fun roundSmallDistance(
+        distance: Double,
+        roundingIncrement: Int,
+        unitType: UnitType
+    ): Int {
+        if (distance < 0) {
+            return 0
+        }
+
+        val distanceUnit = TurfConversion.convertLength(
+            distance,
+            TurfConstants.UNIT_METERS,
+            getSmallTurfUnitType(unitType)
+        )
+
+        val roundedValue = if (roundingIncrement > 0) {
+            val roundedDistance = distanceUnit.roundToInt()
+            if (roundedDistance < roundingIncrement) {
+                roundingIncrement
+            } else {
+                roundedDistance / roundingIncrement * roundingIncrement
+            }
+        } else {
+            distanceUnit
+        }
+        return roundedValue.toInt()
+    }
+
+    private fun roundLargeDistance(
+        distance: Double,
+        unitType: UnitType
+    ): Double {
+        return TurfConversion.convertLength(
+            distance,
+            TurfConstants.UNIT_METERS,
+            getLargeTurfUnitType(unitType)
+        )
+    }
+
+    private fun formatDistanceAndSuffixForSmallUnit(
+        distance: Double,
+        roundingIncrement: Int,
+        unitType: UnitType,
+        context: Context,
+        locale: Locale
+    ): FormattedDistanceData {
+        val resources = context.applicationContext.resourcesWithLocale(locale)
+        val unitStringSuffix = getUnitString(resources, getSmallTurfUnitType(unitType))
+        if (distance < 0) {
+            return FormattedDistanceData(0.0, "0", unitStringSuffix, unitType)
+        }
+        val roundedValue = roundSmallDistance(
+            distance,
+            roundingIncrement,
+            unitType
+        )
+
+        return FormattedDistanceData(
+            roundedValue.toDouble(),
+            roundedValue.toString(),
+            unitStringSuffix,
+            unitType
+        )
+    }
+
+    private fun formatDistanceAndSuffixForLargeUnit(
+        distance: Double,
+        maxFractionDigits: Int,
+        unitType: UnitType,
+        context: Context,
+        locale: Locale
+    ): FormattedDistanceData {
+        val resources = context.applicationContext.resourcesWithLocale(locale)
+        val unitStringSuffix = getUnitString(resources, getLargeTurfUnitType(unitType))
+        val distanceUnit = roundLargeDistance(
+            distance,
+            unitType
+        )
+        val roundedValue = NumberFormat.getNumberInstance(locale).also {
+            it.maximumFractionDigits = maxFractionDigits
+        }.format(distanceUnit)
+
+        return FormattedDistanceData(distanceUnit, roundedValue, unitStringSuffix, unitType)
+    }
+
+    private fun getSmallTurfUnitType(unitType: UnitType): String {
+        return when (unitType) {
+            UnitType.IMPERIAL -> TurfConstants.UNIT_FEET
+            UnitType.METRIC -> TurfConstants.UNIT_METERS
+        }
+    }
+
+    private fun getLargeTurfUnitType(unitType: UnitType): String {
+        return when (unitType) {
+            UnitType.IMPERIAL -> TurfConstants.UNIT_MILES
+            UnitType.METRIC -> TurfConstants.UNIT_KILOMETERS
+        }
+    }
+
+    private fun getUnitString(resources: Resources, @TurfConstants.TurfUnitCriteria unit: String) =
+        when (unit) {
+            TurfConstants.UNIT_KILOMETERS -> resources.getString(R.string.mapbox_unit_kilometers)
+            TurfConstants.UNIT_METERS -> resources.getString(R.string.mapbox_unit_meters)
+            TurfConstants.UNIT_MILES -> resources.getString(R.string.mapbox_unit_miles)
+            TurfConstants.UNIT_FEET -> resources.getString(R.string.mapbox_unit_feet)
+            else -> ""
+        }
+
+    private fun Context.resourcesWithLocale(locale: Locale?): Resources {
+        val config = Configuration(this.resources.configuration).also {
+            it.setLocale(locale)
+        }
+        return this.createConfigurationContext(config).resources
+    }
+}

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/formatter/MapboxDistanceUtilTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/formatter/MapboxDistanceUtilTest.kt
@@ -1,0 +1,187 @@
+package com.mapbox.navigation.core.formatter
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.mapbox.navigation.base.formatter.Rounding
+import com.mapbox.navigation.base.formatter.UnitType
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.util.Locale
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class MapboxDistanceUtilTest {
+
+    private lateinit var ctx: Context
+
+    @Before
+    fun setup() {
+        ctx = ApplicationProvider.getApplicationContext()
+    }
+
+    @Config(qualifiers = "en")
+    @Test
+    fun `formatDistance large value imperial with default locale`() {
+        val result = MapboxDistanceUtil.formatDistance(
+            19312.1,
+            Rounding.INCREMENT_FIFTY,
+            UnitType.IMPERIAL,
+            ctx
+        )
+
+        assertEquals("12", result.distanceAsString)
+        assertEquals("mi", result.distanceSuffix)
+        assertEquals(UnitType.IMPERIAL, result.unitType)
+        assertEquals(12.0, result.distance, 0.1)
+    }
+
+    @Config(qualifiers = "en")
+    @Test
+    fun `formatDistance large value metric with default locale`() {
+        val result = MapboxDistanceUtil.formatDistance(
+            19312.1,
+            Rounding.INCREMENT_FIFTY,
+            UnitType.METRIC,
+            ctx
+        )
+
+        assertEquals("19", result.distanceAsString)
+        assertEquals("km", result.distanceSuffix)
+        assertEquals(UnitType.METRIC, result.unitType)
+        assertEquals(19.3121, result.distance, 0.0)
+    }
+
+    @Config(qualifiers = "en")
+    @Test
+    fun `formatDistance small value metric with default locale`() {
+        val result = MapboxDistanceUtil.formatDistance(
+            55.3,
+            Rounding.INCREMENT_FIFTY,
+            UnitType.METRIC,
+            ctx
+        )
+
+        assertEquals("50", result.distanceAsString)
+        assertEquals("m", result.distanceSuffix)
+        assertEquals(UnitType.METRIC, result.unitType)
+        assertEquals(50.0, result.distance, 0.0)
+    }
+
+    @Config(qualifiers = "en")
+    @Test
+    fun `formatDistance small value imperial with default locale`() {
+        val result = MapboxDistanceUtil.formatDistance(
+            10.0,
+            Rounding.INCREMENT_FIVE,
+            UnitType.IMPERIAL,
+            ctx
+        )
+
+        assertEquals("30", result.distanceAsString)
+        assertEquals("ft", result.distanceSuffix)
+        assertEquals(UnitType.IMPERIAL, result.unitType)
+        assertEquals(30.0, result.distance, 0.1)
+    }
+
+    @Config(qualifiers = "en")
+    @Test
+    fun `formatDistance small value imperial with specified locale`() {
+        val result = MapboxDistanceUtil.formatDistance(
+            55.3,
+            Rounding.INCREMENT_FIFTY,
+            UnitType.IMPERIAL,
+            ctx,
+            Locale.JAPANESE
+        )
+
+        assertEquals("150", result.distanceAsString)
+        assertEquals("フィート", result.distanceSuffix)
+        assertEquals(UnitType.IMPERIAL, result.unitType)
+        assertEquals(150.0, result.distance, 0.1)
+    }
+
+    @Config(qualifiers = "en")
+    @Test
+    fun `formatDistance medium value metric with default locale`() {
+        val result = MapboxDistanceUtil.formatDistance(
+            1000.0,
+            Rounding.INCREMENT_FIFTY,
+            UnitType.METRIC,
+            ctx
+        )
+
+        assertEquals("1", result.distanceAsString)
+        assertEquals("km", result.distanceSuffix)
+        assertEquals(UnitType.METRIC, result.unitType)
+        assertEquals(1.0, result.distance, 0.0)
+    }
+
+    @Config(qualifiers = "en")
+    @Test
+    fun `formatDistance medium fractional value metric with default locale`() {
+        val result = MapboxDistanceUtil.formatDistance(
+            400.5,
+            Rounding.INCREMENT_FIFTY,
+            UnitType.METRIC,
+            ctx
+        )
+
+        assertEquals("0.4", result.distanceAsString)
+        assertEquals("km", result.distanceSuffix)
+        assertEquals(UnitType.METRIC, result.unitType)
+        assertEquals(0.4005, result.distance, 0.0)
+    }
+
+    @Config(qualifiers = "en")
+    @Test
+    fun `formatDistance medium value imperial with default locale`() {
+        val result = MapboxDistanceUtil.formatDistance(
+            1000.0,
+            Rounding.INCREMENT_FIFTY,
+            UnitType.IMPERIAL,
+            ctx
+        )
+
+        assertEquals("0.6", result.distanceAsString)
+        assertEquals("mi", result.distanceSuffix)
+        assertEquals(UnitType.IMPERIAL, result.unitType)
+        assertEquals(0.6213714106386318, result.distance, 0.0)
+    }
+
+    @Test
+    fun `formatDistance return small distance only`() {
+        val result = MapboxDistanceUtil.formatDistance(
+            10.0,
+            Rounding.INCREMENT_TEN,
+            UnitType.IMPERIAL
+        )
+
+        assertEquals(30.0, result, 0.0)
+    }
+
+    @Test
+    fun `formatDistance return small distance only when input negative`() {
+        val result = MapboxDistanceUtil.formatDistance(
+            -10.0,
+            Rounding.INCREMENT_TEN,
+            UnitType.IMPERIAL
+        )
+
+        assertEquals(0.0, result, 0.0)
+    }
+
+    @Test
+    fun `formatDistance return large distance only`() {
+        val result = MapboxDistanceUtil.formatDistance(
+            1000.0,
+            Rounding.INCREMENT_FIFTY,
+            UnitType.IMPERIAL
+        )
+
+        assertEquals(0.6213714106386318, result, 0.0)
+    }
+}


### PR DESCRIPTION
### Description
Addresses what is described in #5065 by refactoring the formatter related code so that the rounding calculations are decoupled from the formatting of the text used in the display. Backwards compatibility is maintained. In addition the new implementation should be usable by the Android Auto implementation which is one of the goals. 

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Added `MapboxDistanceUtil` which moves some of the implementation from `MapboxDistanceFormatter` so that the calculation of the distance rounding and the accompanying text is separated from the SpannableString construction done in  `MapboxDistanceFormatter`.</changelog>
```

### Screenshots or Gifs

