### PR TITLE
added a callback to MapboxNavigation#requestAlternativeRoutes

### DIFF
--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -39,6 +39,7 @@ package com.mapbox.navigation.core {
     method public void registerRoutesObserver(com.mapbox.navigation.core.directions.session.RoutesObserver routesObserver);
     method public void registerTripSessionStateObserver(com.mapbox.navigation.core.trip.session.TripSessionStateObserver tripSessionStateObserver);
     method public void registerVoiceInstructionsObserver(com.mapbox.navigation.core.trip.session.VoiceInstructionsObserver voiceInstructionsObserver);
+    method public void requestAlternativeRoutes(com.mapbox.navigation.core.routealternatives.RouteAlternativesRequestCallback? callback = null);
     method public void requestAlternativeRoutes();
     method public long requestRoutes(com.mapbox.api.directions.v5.models.RouteOptions routeOptions, com.mapbox.navigation.base.route.RouterCallback routesRequestCallback);
     method public void resetTripSession();
@@ -505,6 +506,11 @@ package com.mapbox.navigation.core.routealternatives {
 
   public fun interface RouteAlternativesObserver {
     method public void onRouteAlternatives(com.mapbox.navigation.base.trip.model.RouteProgress routeProgress, java.util.List<? extends com.mapbox.api.directions.v5.models.DirectionsRoute> alternatives, com.mapbox.navigation.base.route.RouterOrigin routerOrigin);
+  }
+
+  public interface RouteAlternativesRequestCallback {
+    method public void onRouteAlternativeRequestFinished(com.mapbox.navigation.base.trip.model.RouteProgress routeProgress, java.util.List<? extends com.mapbox.api.directions.v5.models.DirectionsRoute> alternatives, com.mapbox.navigation.base.route.RouterOrigin routerOrigin);
+    method public void onRouteAlternativesAborted(String message);
   }
 
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -54,6 +54,7 @@ import com.mapbox.navigation.core.reroute.RerouteState
 import com.mapbox.navigation.core.routealternatives.RouteAlternativesController
 import com.mapbox.navigation.core.routealternatives.RouteAlternativesControllerProvider
 import com.mapbox.navigation.core.routealternatives.RouteAlternativesObserver
+import com.mapbox.navigation.core.routealternatives.RouteAlternativesRequestCallback
 import com.mapbox.navigation.core.routeoptions.RouteOptionsUpdater
 import com.mapbox.navigation.core.routerefresh.RouteRefreshController
 import com.mapbox.navigation.core.routerefresh.RouteRefreshControllerProvider
@@ -656,8 +657,9 @@ class MapboxNavigation @VisibleForTesting internal constructor(
      * [MapboxNavigation.setRoutes()] call and [Router] implementation.
      * @see [registerRouteAlternativesObserver]
      */
-    fun requestAlternativeRoutes() {
-        routeAlternativesController.triggerAlternativeRequest()
+    @JvmOverloads
+    fun requestAlternativeRoutes(callback: RouteAlternativesRequestCallback? = null) {
+        routeAlternativesController.triggerAlternativeRequest(callback)
     }
 
     /**

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesRequestCallback.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesRequestCallback.kt
@@ -1,32 +1,28 @@
 package com.mapbox.navigation.core.routealternatives
 
 import com.mapbox.api.directions.v5.models.DirectionsRoute
-import com.mapbox.navigation.base.route.RouteAlternativesOptions
 import com.mapbox.navigation.base.route.RouterOrigin
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesObserver
 
 /**
- * Interface definition for an observer that is notified whenever
- * the Navigation SDK checks for alternative routes to the destination change.
+ * Interface definition for a callback that is notified whenever alternatives routes are refreshed on demand.
  *
- * @see [RouteAlternativesOptions] to control the callback interval.
+ * See [MapboxNavigation.requestAlternativeRoutes].
  */
-fun interface RouteAlternativesObserver {
+interface RouteAlternativesRequestCallback {
+
     /**
-     * Invoked whenever available alternative routes to the destination change.
-     *
-     * This callback if invoked whenever new alternatives are available (addition to the list),
-     * or when a fork between an alternative and the current primary route has been passed (removal from the list).
+     * Invoked when on-demand alternative routes request finishes.
      *
      * The [alternatives] list always represent all available, up-to-date, alternatives for the current route.
      *
      * The alternatives are not automatically added to [MapboxNavigation],
      * you need to add them manually to trigger [RoutesObserver], for example:
      * ```kotlin
-     * mapboxNavigation.registerRouteAlternativesObserver(
-     *     RouteAlternativesObserver { routeProgress, alternatives, routerOrigin ->
+     * mapboxNavigation.requestAlternativeRoutes(
+     *     RouteAlternativesRequestListener { routeProgress, alternatives, routerOrigin ->
      *         val newRoutes = mutableListOf<DirectionsRoute>().apply {
      *             add(mapboxNavigation.getRoutes().first())
      *             addAll(alternatives)
@@ -43,9 +39,16 @@ fun interface RouteAlternativesObserver {
      * @param routerOrigin reports the source of all the new alternative routes in the list.
      * If there are no new routes, reports the source that returned the latest additions.
      */
-    fun onRouteAlternatives(
+    fun onRouteAlternativeRequestFinished(
         routeProgress: RouteProgress,
         alternatives: List<DirectionsRoute>,
         routerOrigin: RouterOrigin
+    )
+
+    /**
+     * Invoked when the request fails or is canceled.
+     */
+    fun onRouteAlternativesAborted(
+        message: String
     )
 }


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Closes https://github.com/mapbox/mapbox-navigation-android/issues/5175.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Exposed a callback for `MapboxNavigation#requestAlternativeRoutes` to track progress of the on-demand alternative routes request.</changelog>
```
