### PR TITLE
Fix Events `distanceTraveled` not being accumulated

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetry.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetry.kt
@@ -15,6 +15,7 @@ import com.mapbox.navigation.base.metrics.MetricsReporter
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.trip.model.RouteLegProgress
 import com.mapbox.navigation.base.trip.model.RouteProgress
+import com.mapbox.navigation.base.trip.model.RouteProgressState
 import com.mapbox.navigation.core.BuildConfig
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.arrival.ArrivalObserver
@@ -93,18 +94,31 @@ private data class SessionMetadata(
  * @param timeOfReroute time of reroute. Unit is **time in millis**.
  * @param timeSinceLastReroute time since last reroute. Unit is **millis**.
  * @param driverModeArrivalTime arrival time of driver mode
+ * @param currentDistanceTraveled for the active session
  */
 private data class DynamicSessionValues(
     var rerouteCount: Int = 0,
     var timeOfReroute: Long = 0L,
     var timeSinceLastReroute: Int = 0,
     var driverModeArrivalTime: Date? = null,
+    var currentDistanceTraveled: Int = 0,
+    var accumulatedDistanceTraveled: Int = 0,
 ) {
     fun reset() {
         rerouteCount = 0
         timeOfReroute = 0
         timeSinceLastReroute = 0
         driverModeArrivalTime = null
+        currentDistanceTraveled = 0
+        accumulatedDistanceTraveled = 0
+    }
+
+    fun accumulateDistanceTraveled(distance: Int) {
+        accumulatedDistanceTraveled += distance
+    }
+
+    fun resetCurrentDistanceTraveled() {
+        currentDistanceTraveled = 0
     }
 }
 
@@ -289,6 +303,16 @@ internal object MapboxNavigationTelemetry {
 
     private val routeProgressObserver = RouteProgressObserver { routeProgress ->
         this.routeData.routeProgress = routeProgress
+        val dynamicValues = getSessionMetadataIfTelemetryRunning()?.dynamicValues
+        if (routeProgress.currentState == RouteProgressState.OFF_ROUTE) {
+            dynamicValues?.accumulateDistanceTraveled(
+                routeProgress.distanceTraveled.toInt()
+            )
+            dynamicValues?.resetCurrentDistanceTraveled()
+        } else {
+            dynamicValues?.currentDistanceTraveled =
+                routeProgress.distanceTraveled.toInt()
+        }
     }
 
     private val onRouteDataChanged: () -> Unit = {
@@ -480,6 +504,8 @@ internal object MapboxNavigationTelemetry {
                 this.feedbackSubType = feedbackSubType
                 this.locationsBefore = feedbackMetadata.locationsBeforeEvent
                 this.locationsAfter = feedbackMetadata.locationsAfterEvent
+                val distanceTraveled =
+                    getSessionMetadataIfTelemetryRunning()?.dynamicValues.retrieveDistanceTraveled()
                 populate(
                     this@MapboxNavigationTelemetry.sdkIdentifier,
                     null,
@@ -493,6 +519,7 @@ internal object MapboxNavigationTelemetry {
                     feedbackMetadata.driverMode,
                     feedbackMetadata.driverModeStartTime,
                     feedbackMetadata.rerouteCount,
+                    distanceTraveled,
                     feedbackMetadata.eventVersion,
                     feedbackMetadata.appMetadata,
                 )
@@ -727,6 +754,7 @@ internal object MapboxNavigationTelemetry {
     }
 
     private fun NavigationEvent.populateWithLocalVars(sessionMetadata: SessionMetadata?) {
+        val distanceTraveled = sessionMetadata?.dynamicValues.retrieveDistanceTraveled()
         this.populate(
             this@MapboxNavigationTelemetry.sdkIdentifier,
             routeData.originalRoute,
@@ -740,9 +768,16 @@ internal object MapboxNavigationTelemetry {
             sessionMetadata?.telemetryNavSessionState?.getModeName(),
             sessionMetadata?.driverModeStartTime?.let { generateCreateDateFormatted(it) },
             sessionMetadata?.dynamicValues?.rerouteCount,
+            distanceTraveled,
             EVENT_VERSION,
             createAppMetadata()
         )
+    }
+
+    private fun DynamicSessionValues?.retrieveDistanceTraveled(): Int {
+        val currentDistanceTraveled = this?.currentDistanceTraveled ?: 0
+        val accumulatedDistanceTraveled = this?.accumulatedDistanceTraveled ?: 0
+        return currentDistanceTraveled + accumulatedDistanceTraveled
     }
 
     private fun NavigationFreeDriveEvent.populate(

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/NavEventsPopulateUtil.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/NavEventsPopulateUtil.kt
@@ -28,6 +28,7 @@ import com.mapbox.navigation.utils.internal.logD
  * @param driverModeStartTime driver mode start time.
  * Use [TelemetryUtils.generateCreateDateFormatted]
  * @param rerouteCount reroute count
+ * @param distanceTraveled accumulated for the session
  * @param eventVersion events version [MapboxNavigationTelemetry.EVENT_VERSION]
  * @param appMetadata use [MapboxNavigationTelemetry.createAppMetadata]
  */
@@ -44,6 +45,7 @@ internal fun NavigationEvent.populate(
     @FeedbackEvent.DriverMode driverMode: String?,
     driverModeStartTime: String?,
     rerouteCount: Int?,
+    distanceTraveled: Int,
     eventVersion: Int,
     appMetadata: AppMetadata?,
 ) {
@@ -56,7 +58,7 @@ internal fun NavigationEvent.populate(
 
         distanceRemaining = routeProgressNonNull.distanceRemaining.toInt()
         durationRemaining = routeProgressNonNull.durationRemaining.toInt()
-        distanceCompleted = routeProgressNonNull.distanceTraveled.toInt()
+        distanceCompleted = distanceTraveled
 
         routeProgressNonNull.route.let {
             geometry = it.geometry()


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
- Fixes Events `distanceTraveled` not being accumulated

Regression from https://github.com/mapbox/mapbox-navigation-android/pull/3540 https://github.com/mapbox/mapbox-navigation-android/pull/3540/files#diff-c5b716f21ea8e298bbe4b1f715880f4d4e8f1a8d4d42fbeb1008f286f0587c55L632-L634

Opening this as a `Draft` to get initial feedback while doing further testing downstream.

cc @baddleydone @truburt @pavel-4 @bamx23 