### PR TITLE
fix empty profile in feedback events

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetry.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetry.kt
@@ -31,6 +31,7 @@ import com.mapbox.navigation.core.telemetry.events.FeedbackMetadataWrapper
 import com.mapbox.navigation.core.telemetry.events.FreeDriveEventType
 import com.mapbox.navigation.core.telemetry.events.FreeDriveEventType.START
 import com.mapbox.navigation.core.telemetry.events.FreeDriveEventType.STOP
+import com.mapbox.navigation.core.telemetry.events.MetricsDirectionsRoute
 import com.mapbox.navigation.core.telemetry.events.MetricsRouteProgress
 import com.mapbox.navigation.core.telemetry.events.NavigationArriveEvent
 import com.mapbox.navigation.core.telemetry.events.NavigationCancelEvent
@@ -425,7 +426,8 @@ internal object MapboxNavigationTelemetry {
                 lifecycleMonitor?.obtainForegroundPercentage(),
                 EVENT_VERSION,
                 PhoneState.newInstance(applicationContext),
-                NavigationStepData(MetricsRouteProgress(routeData.routeProgress)),
+                MetricsDirectionsRoute(routeData.originalRoute),
+                MetricsRouteProgress(routeData.routeProgress),
                 createAppMetadata(),
                 locationsCollector
             )
@@ -495,7 +497,7 @@ internal object MapboxNavigationTelemetry {
             log("post user feedback with feedback metadata")
             val feedbackEvent = NavigationFeedbackEvent(
                 feedbackMetadata.phoneState,
-                feedbackMetadata.navigationStepData,
+                NavigationStepData(feedbackMetadata.metricsRouteProgress),
             ).apply {
                 this.feedbackType = feedbackType
                 this.source = feedbackSource
@@ -508,8 +510,8 @@ internal object MapboxNavigationTelemetry {
                     getSessionMetadataIfTelemetryRunning()?.dynamicValues.retrieveDistanceTraveled()
                 populate(
                     this@MapboxNavigationTelemetry.sdkIdentifier,
-                    null,
-                    null,
+                    feedbackMetadata.metricsDirectionsRoute,
+                    feedbackMetadata.metricsRouteProgress,
                     feedbackMetadata.lastLocation,
                     feedbackMetadata.locationEngineNameExternal,
                     feedbackMetadata.percentTimeInPortrait,
@@ -757,8 +759,8 @@ internal object MapboxNavigationTelemetry {
         val distanceTraveled = sessionMetadata?.dynamicValues.retrieveDistanceTraveled()
         this.populate(
             this@MapboxNavigationTelemetry.sdkIdentifier,
-            routeData.originalRoute,
-            routeData.routeProgress,
+            MetricsDirectionsRoute(routeData.originalRoute),
+            MetricsRouteProgress(routeData.routeProgress),
             locationsCollector.lastLocation?.toPoint(),
             locationEngineNameExternal,
             lifecycleMonitor?.obtainPortraitPercentage(),

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/events/FeedbackMetadata.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/events/FeedbackMetadata.kt
@@ -31,7 +31,8 @@ class FeedbackMetadataWrapper internal constructor(
     private val percentTimeInForeground: Int?,
     private val eventVersion: Int,
     private val phoneState: PhoneState,
-    private val navigationStepData: NavigationStepData,
+    private val metricsDirectionsRoute: MetricsDirectionsRoute,
+    private val metricsRouteProgress: MetricsRouteProgress,
     private val appMetadata: AppMetadata?,
     private val locationsCollector: LocationsCollector,
 ) {
@@ -73,7 +74,8 @@ class FeedbackMetadataWrapper internal constructor(
             percentTimeInForeground,
             eventVersion,
             phoneState,
-            navigationStepData,
+            metricsDirectionsRoute,
+            metricsRouteProgress,
             appMetadata,
         )
     }
@@ -102,7 +104,8 @@ class FeedbackMetadata internal constructor(
     internal val percentTimeInForeground: Int? = null,
     internal val eventVersion: Int,
     internal val phoneState: PhoneState,
-    internal val navigationStepData: NavigationStepData,
+    internal val metricsDirectionsRoute: MetricsDirectionsRoute,
+    internal val metricsRouteProgress: MetricsRouteProgress,
     internal val appMetadata: AppMetadata? = null,
 ) {
 
@@ -144,7 +147,8 @@ class FeedbackMetadata internal constructor(
         if (percentTimeInForeground != other.percentTimeInForeground) return false
         if (eventVersion != other.eventVersion) return false
         if (phoneState != other.phoneState) return false
-        if (navigationStepData != other.navigationStepData) return false
+        if (metricsDirectionsRoute != other.metricsDirectionsRoute) return false
+        if (metricsRouteProgress != other.metricsRouteProgress) return false
         if (appMetadata != other.appMetadata) return false
 
         return true
@@ -167,7 +171,8 @@ class FeedbackMetadata internal constructor(
         result = 31 * result + percentTimeInForeground.hashCode()
         result = 31 * result + eventVersion.hashCode()
         result = 31 * result + phoneState.hashCode()
-        result = 31 * result + navigationStepData.hashCode()
+        result = 31 * result + metricsDirectionsRoute.hashCode()
+        result = 31 * result + metricsRouteProgress.hashCode()
         result = 31 * result + appMetadata.hashCode()
         return result
     }
@@ -190,7 +195,8 @@ class FeedbackMetadata internal constructor(
             "percentTimeInForeground=$percentTimeInForeground, " +
             "eventVersion=$eventVersion, " +
             "phoneState=$phoneState, " +
-            "navigationStepData=$navigationStepData, " +
+            "metricsDirectionsRoute=$metricsDirectionsRoute, " +
+            "metricsRouteProgress=$metricsRouteProgress, " +
             "appMetadata=$appMetadata" +
             ")"
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/events/MetricsDirectionsRoute.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/events/MetricsDirectionsRoute.kt
@@ -1,0 +1,21 @@
+package com.mapbox.navigation.core.telemetry.events
+
+import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.navigation.core.telemetry.obtainStepCount
+
+internal data class MetricsDirectionsRoute(
+    val stepCount: Int,
+    val distance: Int,
+    val duration: Int,
+    val requestIdentifier: String?,
+    val geometry: String?,
+) {
+
+    constructor(directionsRoute: DirectionsRoute?) : this(
+        obtainStepCount(directionsRoute),
+        distance = directionsRoute?.distance()?.toInt() ?: 0,
+        duration = directionsRoute?.duration()?.toInt() ?: 0,
+        directionsRoute?.requestUuid(),
+        directionsRoute?.geometry(),
+    )
+}

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetryTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetryTest.kt
@@ -38,6 +38,7 @@ import com.mapbox.navigation.core.telemetry.events.FeedbackEvent
 import com.mapbox.navigation.core.telemetry.events.FeedbackMetadata
 import com.mapbox.navigation.core.telemetry.events.FreeDriveEventType.START
 import com.mapbox.navigation.core.telemetry.events.FreeDriveEventType.STOP
+import com.mapbox.navigation.core.telemetry.events.MetricsDirectionsRoute
 import com.mapbox.navigation.core.telemetry.events.MetricsRouteProgress
 import com.mapbox.navigation.core.telemetry.events.NavigationArriveEvent
 import com.mapbox.navigation.core.telemetry.events.NavigationCancelEvent
@@ -46,7 +47,6 @@ import com.mapbox.navigation.core.telemetry.events.NavigationEvent
 import com.mapbox.navigation.core.telemetry.events.NavigationFeedbackEvent
 import com.mapbox.navigation.core.telemetry.events.NavigationFreeDriveEvent
 import com.mapbox.navigation.core.telemetry.events.NavigationRerouteEvent
-import com.mapbox.navigation.core.telemetry.events.NavigationStepData
 import com.mapbox.navigation.core.telemetry.events.PhoneState
 import com.mapbox.navigation.core.telemetry.events.TelemetryLocation
 import com.mapbox.navigation.core.testutil.ifCaptured
@@ -72,10 +72,8 @@ import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertNotSame
 import junit.framework.TestCase.assertSame
 import junit.framework.TestCase.assertTrue
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.InternalCoroutinesApi
-import kotlinx.coroutines.SupervisorJob
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -142,8 +140,6 @@ class MapboxNavigationTelemetryTest {
 
     @get:Rule
     var coroutineRule = MainCoroutineRule()
-    private val parentJob = SupervisorJob()
-    private val testScope = CoroutineScope(parentJob + coroutineRule.testDispatcher)
 
     private val context: Context = mockk(relaxed = true)
     private val applicationContext: Context = mockk(relaxed = true)
@@ -681,7 +677,8 @@ class MapboxNavigationTelemetryTest {
             eventVersion = eventVersion,
             lastLocation = lastLocation,
             phoneState = phoneState,
-            navigationStepData = NavigationStepData(MetricsRouteProgress(null)),
+            metricsDirectionsRoute = MetricsDirectionsRoute(directionsRoute = null),
+            metricsRouteProgress = MetricsRouteProgress(routeProgress = null),
             appMetadata = appMetadata,
         )
         baseMock()
@@ -1412,7 +1409,8 @@ class MapboxNavigationTelemetryTest {
             phoneState = PhoneState(
                 1, 2, 3, true, "connectivity", "audioType", "appState", "01-01-2000", "5", "6"
             ),
-            navigationStepData = NavigationStepData(MetricsRouteProgress(null)),
+            metricsDirectionsRoute = MetricsDirectionsRoute(directionsRoute = null),
+            metricsRouteProgress = MetricsRouteProgress(routeProgress = null),
         )
     ) {
         MapboxNavigationTelemetry.postUserFeedback(

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/events/FeedbackMetadataTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/events/FeedbackMetadataTest.kt
@@ -103,7 +103,8 @@ class FeedbackMetadataTest {
                 feedbackId = "FEEDBACK_ID",
                 userId = "USER_ID"
             ),
-            navigationStepData = NavigationStepData(MetricsRouteProgress(null)),
+            metricsDirectionsRoute = MetricsDirectionsRoute(directionsRoute = null),
+            metricsRouteProgress = MetricsRouteProgress(routeProgress = null),
             appMetadata = AppMetadata(
                 name = "APP_METADATA_NAME",
                 version = "APP_METADATA_VERSION",

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/events/FeedbackMetadataWrapperTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/events/FeedbackMetadataWrapperTest.kt
@@ -85,7 +85,8 @@ class FeedbackMetadataWrapperTest {
             eventVersion = 100,
             lastLocation = Point.fromLngLat(30.0, 40.0),
             phoneState = phoneState,
-            navigationStepData = NavigationStepData(MetricsRouteProgress(null)),
+            metricsDirectionsRoute = MetricsDirectionsRoute(directionsRoute = null),
+            metricsRouteProgress = MetricsRouteProgress(routeProgress = null),
             appMetadata = AppMetadata(
                 name = "APP_METADATA_NAME",
                 version = "APP_METADATA_VERSION",

--- a/libnavigation-core/src/test/resources/feedback_metadata.json
+++ b/libnavigation-core/src/test/resources/feedback_metadata.json
@@ -105,18 +105,34 @@
       "verticalAccuracy": 0.0
     }
   ],
-  "navigationStepData": {
-    "distance": 354,
-    "distanceRemaining": 285,
+  "metricsDirectionsRoute": {
+    "distance": 744,
     "duration": 52,
-    "durationRemaining": 42,
-    "previousInstruction": "Drive south on улица Толбухина.",
-    "previousName": "улица Толбухина",
-    "previousType": "depart",
-    "upcomingInstruction": "Turn left onto проспект Независимости.",
-    "upcomingModifier": "left",
-    "upcomingName": "проспект Независимости",
-    "upcomingType": "end of road"
+    "stepCount": 65
+  },
+  "metricsRouteProgress": {
+    "currentStepDistance": 354,
+    "currentStepDistanceRemaining": 285,
+    "currentStepDuration": 52,
+    "currentStepDurationRemaining": 42,
+    "directionsRouteDistance": 821,
+    "directionsRouteDuration": 27,
+    "directionsRouteIndex": 5,
+    "directionsRouteStepCount": 20,
+    "distanceRemaining": 141,
+    "distanceTraveled": 338,
+    "durationRemaining": 35,
+    "legCount": 7,
+    "legIndex": 2,
+    "previousStepInstruction": "Drive south on улица Толбухина.",
+    "previousStepName": "улица Толбухина",
+    "previousStepType": "depart",
+    "stepCount": 83,
+    "stepIndex": 56,
+    "upcomingStepInstruction": "Turn left onto проспект Независимости.",
+    "upcomingStepModifier": "left",
+    "upcomingStepName": "проспект Независимости",
+    "upcomingStepType": "end of road"
   },
   "percentTimeInForeground": 100,
   "percentTimeInPortrait": 100,


### PR DESCRIPTION
### Description
`FeedbackMetadata` now stores all necessary information from DirectionsRoute and RouteProgress to fully populate feedback events. Also `driving` is now used as a default profile when route is not available, e.g. during free drive. 

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
