### PR TITLE
Fixed crashes and waypoints accumulation during rerouting

### DIFF
--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/infra/factories/DirectionsResponseFactories.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/infra/factories/DirectionsResponseFactories.kt
@@ -1,10 +1,38 @@
 package com.mapbox.navigation.core.infra.factories
 
+import com.mapbox.api.directions.v5.DirectionsCriteria
 import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.api.directions.v5.models.RouteLeg
+import com.mapbox.api.directions.v5.models.RouteOptions
+import com.mapbox.geojson.Point
 
-fun createDirectionsRoute(): DirectionsRoute {
+fun createDirectionsRoute(
+    legs: List<RouteLeg> = listOf(createRouteLeg()), // each route should have at least one leg,
+    routeOptions: RouteOptions = createRouteOptions()
+): DirectionsRoute {
     return DirectionsRoute.builder()
         .distance(5.0)
         .duration(9.0)
+        .legs(legs)
+        .routeOptions(routeOptions)
+        .build()
+}
+
+fun createRouteLeg(): RouteLeg {
+    return RouteLeg.builder().build()
+}
+
+fun createRouteOptions(
+    // the majority of tests needs 2 waypoints
+    coordinatesList: List<Point> = listOf(
+        Point.fromLngLat(1.0, 1.0),
+        Point.fromLngLat(2.0, 2.0),
+    ),
+    profile: String = DirectionsCriteria.PROFILE_DRIVING
+): RouteOptions {
+    return RouteOptions
+        .builder()
+        .coordinatesList(coordinatesList)
+        .profile(profile)
         .build()
 }


### PR DESCRIPTION
### Description
This PR should fix at least 3 issues: #4179 , #5157, and [#1308](https://github.com/mapbox/navigation-sdks/issues/1308).

All the issues were caused by the wrong `remainingWaypoints` value. `remainingWaypoints` was wrong because NN returns `NavigationStatus.nextWaypointIndex` 0. But `nextWaypointIndex` can't be 0 because SDK always navigates from the current position. So we can assume that if `nextWaypointIndex` is 0 it's an error in NN and we can fallback to 1.

@averkhaturau told me that the wrong `nextWaypointIndex` could be caused by the [issue with schedulers in NN](https://github.com/mapbox/mapbox-navigation-native/pull/4871).
@wanfranck analysed the history file sent by one of our customers and confirmed that the scheduler issue took place just before the bug happened. 

#### Does the workaround work for multi-leg waypoints.
No. I heard that not so many customers use multi-legs waypoints. So at least the workaround targets the most popular case: navigation from A to B. Multi-legs waypoints should be fixed by when NN release fix for their scheduler. 

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Fixed: crashes and waypoints accumulation during rerouting.</changelog>
```
<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
