### PR TITLE
Publish API docs during release for 2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,14 @@ workflows:
               only: /^v.*/
             branches:
               ignore: /.*/
+      - publish-documentation:
+          requires:
+            - release
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
   default:
     jobs:
       - prepare-and-assemble
@@ -507,6 +515,19 @@ jobs:
             - check-api-ui
             - check-public-documentation
       - run: exit 0
+
+  publish-documentation:
+    executor: ndk-r21e-latest-executor
+    steps:
+      - checkout
+      - prepare-mbx-ci
+      - run:
+          name: Publish API docs Android
+          command: |
+            GITHUB_WRITER_TOKEN=$(./mbx-ci github writer public token)
+            git remote set-url origin "https://x-access-token:$GITHUB_WRITER_TOKEN@github.com/mapbox/mapbox-navigation-android"
+            git config --global user.email no-reply@mapbox.com && git config --global user.name mapbox-ci
+            ./scripts/publish_api_docs_android.sh -p $GITHUB_WRITER_TOKEN -t $CIRCLE_TAG
 
   changelog-verification:
     executor: ndk-r21e-latest-executor

--- a/scripts/publish_api_docs_android.sh
+++ b/scripts/publish_api_docs_android.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    echo "Usage: " 1>&2;
+    echo "$0 arguments [optional arguments]" 1>&2;
+    echo "  Arguments : " 1>&2;
+    echo "   -t <TAG>                       tag of navigation, e.g. v1.0.0" 1>&2;
+    echo "   -p <GITHUB APP TOKEN>          access token for pull request creation" 1>&2;
+    echo "  Optional arguments : " 1>&2;
+    echo "   -a <NAVIGATION_GIT_REPOSITORY> path to navigation repository, by default uses current path" 1>&2;
+    exit 1;
+}
+
+readonly DOCS_BASE_BRANCH_NAME_PRODUCTION="publisher-production"
+readonly DOCS_BASE_BRANCH_NAME_STAGING="publisher-staging"
+NAVIGATION_GIT_REPO=$(pwd)
+GITHUB_PR_ACCESS_TOKEN=""
+
+while getopts "t:a:p:" opt; do
+    case "${opt}" in
+        t)
+            TAG=${OPTARG}
+            VERSION_NUMBER="${TAG//v}"
+            BRANCH_NAME="docs-${TAG}"
+            DOCS_FOLDER=${NAVIGATION_GIT_REPO}/${VERSION_NUMBER}/
+            ;;
+        p)
+            GITHUB_PR_ACCESS_TOKEN=${OPTARG}
+            ;;
+        a)
+            NAVIGATION_GIT_REPO=${OPTARG}
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+
+echo "Repository path=${NAVIGATION_GIT_REPO}"
+
+checkIfGithubTokensAreProvided() {
+    if [ -z "$GITHUB_PR_ACCESS_TOKEN" ]; then
+        usage
+    fi
+}
+
+checkIfTagExist() {
+    pushd "${NAVIGATION_GIT_REPO}"
+    if [ "$(git tag --points-at HEAD)" = "$TAG" ]; then
+        echo "tag ${TAG} exist"
+    else
+        echo "current commit is not point at tag ${TAG}"
+        usage
+    fi
+    echo "VERSION_NUMBER=${VERSION_NUMBER}"
+
+    popd > /dev/null
+}
+
+generateDocs() {
+    pushd "${NAVIGATION_GIT_REPO}"
+    echo "Start generating docs"
+
+    make javadoc-dokka
+
+    echo "Finish generating docs"
+    popd > /dev/null
+}
+
+checkoutToPublisherStaging() {
+    pushd "${NAVIGATION_GIT_REPO}"
+
+    echo "checkout to ${DOCS_BASE_BRANCH_NAME_STAGING}"
+    git checkout "${DOCS_BASE_BRANCH_NAME_STAGING}"
+
+    popd > /dev/null
+}
+
+checkoutToPublisherProduction() {
+    pushd "${NAVIGATION_GIT_REPO}"
+
+    echo "checkout to ${DOCS_BASE_BRANCH_NAME_PRODUCTION}"
+    git checkout "${DOCS_BASE_BRANCH_NAME_PRODUCTION}"
+
+    popd > /dev/null
+}
+
+moveDocumentsToDocsFolders() {
+    pushd "${NAVIGATION_GIT_REPO}" > /dev/null
+
+    echo "Create DOCS folder ${DOCS_FOLDER}"
+    mkdir -p $DOCS_FOLDER
+
+    echo "Moving NAV Docs to docs folder"
+    cp -r "build/kdoc/." $DOCS_FOLDER
+
+    popd > /dev/null
+}
+
+pushDocsToStaging() {
+    pushd "${NAVIGATION_GIT_REPO}"
+
+    echo "push docs to staging"
+    git add "${VERSION_NUMBER}/"
+    git commit -m "Docs ${TAG}"
+    git push origin HEAD --set-upstream
+
+    popd > /dev/null
+}
+
+createBranchProduction() {
+    pushd "${NAVIGATION_GIT_REPO}"
+
+    echo "create a docs brach"
+    git checkout -b ${BRANCH_NAME}
+    git add "${VERSION_NUMBER}/"
+    git commit -m "Docs ${TAG}"
+    git push origin HEAD --set-upstream
+    popd > /dev/null
+}
+
+createPullRequest() {
+    pushd "${NAVIGATION_GIT_REPO}"
+
+    echo "create pull request"
+
+    GITHUB_TOKEN=$GITHUB_PR_ACCESS_TOKEN gh pr create \
+        --title "Docs ${TAG}" \
+        --body "**Docs ${TAG}**
+        <br/>**Staging**:
+        - github/${DOCS_BASE_BRANCH_NAME_STAGING} https://github.com/mapbox/mapbox-navigation-android/tree/publisher-staging/${VERSION_NUMBER}
+        - staging docs https://docs.tilestream.net/android/navigation/api-reference/
+        - staging docs ${TAG} https://docs.tilestream.net/android/navigation/api/${VERSION_NUMBER}/-modules.html
+        <br/>**cc** @mapbox/navigation-android" \
+        --base ${DOCS_BASE_BRANCH_NAME_PRODUCTION} \
+        --head ${BRANCH_NAME}
+
+    popd > /dev/null
+}
+
+checkIfGithubTokensAreProvided
+checkIfTagExist
+generateDocs
+# staging
+checkoutToPublisherStaging
+moveDocumentsToDocsFolders
+pushDocsToStaging
+# production
+checkoutToPublisherProduction
+moveDocumentsToDocsFolders
+createBranchProduction
+createPullRequest


### PR DESCRIPTION
### Description
Cherry-picked publish API docs script and CI setup for the version 2.0. Originally implemented in #5044



<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
