### PR TITLE
fixed a memory leak in ReplayProgressObserver

### DIFF
--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -302,6 +302,7 @@ package com.mapbox.navigation.core.replay {
     method public double durationSeconds();
     method public double eventSeconds(double eventTimestamp);
     method public void finish();
+    method public boolean isPlaying();
     method public void play();
     method public void playFirstLocation();
     method public void playbackSpeed(double scale);
@@ -431,9 +432,10 @@ package com.mapbox.navigation.core.replay.history {
 package com.mapbox.navigation.core.replay.route {
 
   public final class ReplayProgressObserver implements com.mapbox.navigation.core.trip.session.RouteProgressObserver {
+    ctor public ReplayProgressObserver(com.mapbox.navigation.core.replay.MapboxReplayer mapboxReplayer, com.mapbox.navigation.core.replay.route.ReplayRouteMapper replayRouteMapper = ReplayRouteMapper());
     ctor public ReplayProgressObserver(com.mapbox.navigation.core.replay.MapboxReplayer mapboxReplayer);
     method public void onRouteProgressChanged(com.mapbox.navigation.base.trip.model.RouteProgress routeProgress);
-    method public com.mapbox.navigation.core.replay.route.ReplayProgressObserver updateOptions(com.mapbox.navigation.core.replay.route.ReplayRouteOptions options);
+    method @Deprecated public com.mapbox.navigation.core.replay.route.ReplayProgressObserver updateOptions(com.mapbox.navigation.core.replay.route.ReplayRouteOptions options);
   }
 
   public final class ReplayRouteMapper {

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/MapboxReplayer.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/MapboxReplayer.kt
@@ -24,6 +24,15 @@ class MapboxReplayer {
     private val replayEventsObservers: MutableSet<ReplayEventsObserver> = mutableSetOf()
 
     /**
+     * Returns whether the replay is active an playing provided events.
+     *
+     * @see play
+     * @see stop
+     * @see clearEvents
+     */
+    fun isPlaying() = replayEventSimulator.isPlaying()
+
+    /**
      * Appends events to be replayed. Notice the basis of your [ReplayEventBase.eventTimestamp].
      * When they are drastically different, you may need to [seekTo] events.
      *

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/history/ReplayEventSimulator.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/history/ReplayEventSimulator.kt
@@ -22,6 +22,7 @@ internal class ReplayEventSimulator(
 ) {
 
     private val jobControl = InternalJobControlFactory.createMainScopeJobControl()
+    private var simulatorJob: Job? = null
 
     // The pivot will move forward through the events with time.
     private var historyTimeOffset: Double = 0.0
@@ -30,9 +31,9 @@ internal class ReplayEventSimulator(
 
     private var pivotIndex = 0
 
-    fun launchSimulator(replayEventsCallback: (List<ReplayEventBase>) -> Unit): Job {
+    fun launchSimulator(replayEventsCallback: (List<ReplayEventBase>) -> Unit) {
         resetSimulatorClock()
-        return jobControl.scope.launch {
+        simulatorJob = jobControl.scope.launch {
             while (isActive) {
                 if (isDonePlayingEvents()) {
                     delay(IS_DONE_PLAYING_EVENTS_DELAY_MILLIS)
@@ -60,6 +61,8 @@ internal class ReplayEventSimulator(
     fun stopSimulator() {
         jobControl.job.cancelChildren()
     }
+
+    fun isPlaying() = simulatorJob?.isActive == true
 
     fun seekTo(indexOfEvent: Int) {
         historyTimeOffset = replayEvents.events[indexOfEvent].eventTimestamp

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/route/ReplayProgressObserverTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/route/ReplayProgressObserverTest.kt
@@ -1,0 +1,80 @@
+package com.mapbox.navigation.core.replay.route
+
+import com.mapbox.api.directions.v5.models.RouteLeg
+import com.mapbox.navigation.core.replay.MapboxReplayer
+import com.mapbox.navigation.core.replay.history.ReplayEventBase
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.verifyOrder
+import org.junit.Test
+
+class ReplayProgressObserverTest {
+    private val replayer = mockk<MapboxReplayer>(relaxUnitFun = true) {
+        every { pushEvents(any()) } returns this
+    }
+    private val mapper = mockk<ReplayRouteMapper>()
+
+    private val replayProgressObserver = ReplayProgressObserver(replayer, mapper)
+
+    @Test
+    fun `old events are cleared when new leg starts`() {
+        val oldLeg = mockk<RouteLeg>()
+        val oldEvents = listOf<ReplayEventBase>(mockk())
+        val newLeg = mockk<RouteLeg>()
+        val newEvents = listOf<ReplayEventBase>(mockk())
+        every { mapper.mapRouteLegGeometry(oldLeg) } returns oldEvents
+        every { mapper.mapRouteLegGeometry(newLeg) } returns newEvents
+        every { replayer.isPlaying() } returns true
+
+        // provide old leg
+        replayProgressObserver.onRouteProgressChanged(
+            mockk {
+                every { currentLegProgress } returns mockk {
+                    every { routeLeg } returns oldLeg
+                }
+            }
+        )
+
+        // provide new leg
+        replayProgressObserver.onRouteProgressChanged(
+            mockk {
+                every { currentLegProgress } returns mockk {
+                    every { routeLeg } returns newLeg
+                }
+            }
+        )
+
+        verifyOrder {
+            replayer.clearEvents()
+            replayer.pushEvents(oldEvents)
+            replayer.seekTo(oldEvents.first())
+            replayer.play()
+            replayer.clearEvents()
+            replayer.pushEvents(newEvents)
+            replayer.seekTo(newEvents.first())
+            replayer.play()
+        }
+    }
+
+    @Test
+    fun `when new leg starts don't start playing if we were not already playing`() {
+        val newLeg = mockk<RouteLeg>()
+        val newEvents = listOf<ReplayEventBase>()
+        every { mapper.mapRouteLegGeometry(newLeg) } returns newEvents
+        every { replayer.isPlaying() } returns false
+
+        // provide new leg
+        replayProgressObserver.onRouteProgressChanged(
+            mockk {
+                every { currentLegProgress } returns mockk {
+                    every { routeLeg } returns newLeg
+                }
+            }
+        )
+
+        verify(exactly = 0) {
+            replayer.play()
+        }
+    }
+}


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
On each route leg change, regardless of a source (new route, reroute, new waypoint reached), we were appending all new events to the list of old events. For long running instrumentation tests with a significant amounts of route resets, the memory allocated for the list of events would grow indefinitely.

For a ~40 miles route reset every ~5 seconds the memory footprint could grow by ~30MB every ~20 minutes, or so.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Fixed a small memory leak in the `ReplayProgressObserver` which accumulated events whenever current route leg changed.</changelog>
```
<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
