### PR TITLE
Bump Maps, NN and `common` dependency versions to `10.2.0`, `82.0.1` and `21.0.1` respectively

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -12,17 +12,17 @@ ext {
   // version which we should use in this build
   def mapboxNavigatorVersion = System.getenv("FORCE_MAPBOX_NAVIGATION_NATIVE_VERSION")
   if (mapboxNavigatorVersion == null || mapboxNavigatorVersion == '') {
-      mapboxNavigatorVersion = '82.0.0'
+      mapboxNavigatorVersion = '82.0.1'
   }
   println("Navigation Native version: " + mapboxNavigatorVersion)
 
   version = [
-      mapboxMapSdk              : '10.2.0-rc.1',
+      mapboxMapSdk              : '10.2.0',
       mapboxSdkServices         : '6.2.0-beta.2',
       mapboxEvents              : '8.1.0',
       mapboxCore                : '5.0.0',
       mapboxNavigator           : "${mapboxNavigatorVersion}",
-      mapboxCommonNative        : '21.0.0-rc.2',
+      mapboxCommonNative        : '21.0.1',
       mapboxCrashMonitor        : '2.0.0',
       mapboxAnnotationPlugin    : '0.8.0',
       mapboxBaseAndroid         : '0.5.0',


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Bumps Maps, NN and `common` dependency versions to `10.2.0`, `82.0.1` and `21.0.1` respectively

Opening this as a `Draft` waiting to get a NN release based off `common` `21.0.1` cc @etl 

EDIT:

NN `82.0.1` is currently available 🚀 

cc @truburt 