### PR TITLE
Added methods to change the visibility of the route traffic layers.

### DIFF
--- a/libnavui-maps/api/current.txt
+++ b/libnavui-maps/api/current.txt
@@ -795,9 +795,11 @@ package com.mapbox.navigation.ui.maps.route.line.api {
     method public com.mapbox.maps.extension.style.layers.properties.generated.Visibility? getAlternativeRoutesVisibility(com.mapbox.maps.Style style);
     method public com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions getOptions();
     method public com.mapbox.maps.extension.style.layers.properties.generated.Visibility? getPrimaryRouteVisibility(com.mapbox.maps.Style style);
+    method public com.mapbox.maps.extension.style.layers.properties.generated.Visibility? getTrafficVisibility(com.mapbox.maps.Style style);
     method public void hideAlternativeRoutes(com.mapbox.maps.Style style);
     method public void hideOriginAndDestinationPoints(com.mapbox.maps.Style style);
     method public void hidePrimaryRoute(com.mapbox.maps.Style style);
+    method public void hideTraffic(com.mapbox.maps.Style style);
     method public void initializeLayers(com.mapbox.maps.Style style);
     method public void renderClearRouteLineValue(com.mapbox.maps.Style style, com.mapbox.bindgen.Expected<com.mapbox.navigation.ui.maps.route.line.model.RouteLineError,com.mapbox.navigation.ui.maps.route.line.model.RouteLineClearValue> clearRouteLineValue);
     method public void renderRouteDrawData(com.mapbox.maps.Style style, com.mapbox.bindgen.Expected<com.mapbox.navigation.ui.maps.route.line.model.RouteLineError,com.mapbox.navigation.ui.maps.route.line.model.RouteSetValue> routeDrawData);
@@ -806,6 +808,7 @@ package com.mapbox.navigation.ui.maps.route.line.api {
     method public void showAlternativeRoutes(com.mapbox.maps.Style style);
     method public void showOriginAndDestinationPoints(com.mapbox.maps.Style style);
     method public void showPrimaryRoute(com.mapbox.maps.Style style);
+    method public void showTraffic(com.mapbox.maps.Style style);
     property public final com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions options;
   }
 

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineView.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineView.kt
@@ -389,6 +389,65 @@ class MapboxRouteLineView(var options: MapboxRouteLineOptions) {
     }
 
     /**
+     * Hides the layers used for the traffic line(s).
+     *
+     * @param style an instance of the [Style]
+     */
+    fun hideTraffic(style: Style) {
+        jobControl.scope.launch(Dispatchers.Main) {
+            mutex.withLock {
+                updateLayerVisibility(
+                    style,
+                    RouteLayerConstants.PRIMARY_ROUTE_TRAFFIC_LAYER_ID, Visibility.NONE
+                )
+                updateLayerVisibility(
+                    style,
+                    RouteLayerConstants.ALTERNATIVE_ROUTE1_TRAFFIC_LAYER_ID, Visibility.NONE
+                )
+                updateLayerVisibility(
+                    style,
+                    RouteLayerConstants.ALTERNATIVE_ROUTE2_TRAFFIC_LAYER_ID, Visibility.NONE
+                )
+            }
+        }
+    }
+
+    /**
+     * Shows the layers used for the traffic line(s).
+     *
+     * @param style an instance of the [Style]
+     */
+    fun showTraffic(style: Style) {
+        jobControl.scope.launch(Dispatchers.Main) {
+            mutex.withLock {
+                updateLayerVisibility(
+                    style,
+                    RouteLayerConstants.PRIMARY_ROUTE_TRAFFIC_LAYER_ID, Visibility.VISIBLE
+                )
+                updateLayerVisibility(
+                    style,
+                    RouteLayerConstants.ALTERNATIVE_ROUTE1_TRAFFIC_LAYER_ID, Visibility.VISIBLE
+                )
+                updateLayerVisibility(
+                    style,
+                    RouteLayerConstants.ALTERNATIVE_ROUTE2_TRAFFIC_LAYER_ID, Visibility.VISIBLE
+                )
+            }
+        }
+    }
+
+    /**
+     * Returns the visibility of the primary route map traffic layer.
+     *
+     * @param style an instance of the Style
+     *
+     * @return the visibility value returned by the map.
+     */
+    fun getTrafficVisibility(style: Style): Visibility? {
+        return getLayerVisibility(style, RouteLayerConstants.PRIMARY_ROUTE_TRAFFIC_LAYER_ID)
+    }
+
+    /**
      * Returns the visibility of the primary route map layer.
      *
      * @param style an instance of the Style

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineViewTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineViewTest.kt
@@ -541,6 +541,82 @@ class MapboxRouteLineViewTest {
     }
 
     @Test
+    fun hideTraffic() {
+        mockkStatic("com.mapbox.maps.extension.style.layers.LayerUtils")
+        mockkObject(MapboxRouteLineUtils)
+        val options = MapboxRouteLineOptions.Builder(ctx).build()
+        val primaryRouteTraffic = mockk<LineLayer>(relaxed = true)
+        val altRouteTraffic1 = mockk<LineLayer>(relaxed = true)
+        val altRouteTraffic2 = mockk<LineLayer>(relaxed = true)
+        val style = mockk<Style> {
+            every {
+                getLayer(PRIMARY_ROUTE_TRAFFIC_LAYER_ID)
+            } returns primaryRouteTraffic
+            every {
+                getLayer(ALTERNATIVE_ROUTE1_TRAFFIC_LAYER_ID)
+            } returns altRouteTraffic1
+            every {
+                getLayer(ALTERNATIVE_ROUTE2_TRAFFIC_LAYER_ID)
+            } returns altRouteTraffic2
+        }
+
+        MapboxRouteLineView(options).hideTraffic(style)
+
+        verify { primaryRouteTraffic.visibility(Visibility.NONE) }
+        verify { altRouteTraffic1.visibility(Visibility.NONE) }
+        verify { altRouteTraffic2.visibility(Visibility.NONE) }
+        unmockkObject(MapboxRouteLineUtils)
+        unmockkStatic("com.mapbox.maps.extension.style.layers.LayerUtils")
+    }
+
+    @Test
+    fun showTraffic() {
+        mockkStatic("com.mapbox.maps.extension.style.layers.LayerUtils")
+        mockkObject(MapboxRouteLineUtils)
+        val options = MapboxRouteLineOptions.Builder(ctx).build()
+        val primaryRouteTraffic = mockk<LineLayer>(relaxed = true)
+        val altRouteTraffic1 = mockk<LineLayer>(relaxed = true)
+        val altRouteTraffic2 = mockk<LineLayer>(relaxed = true)
+        val style = mockk<Style> {
+            every {
+                getLayer(PRIMARY_ROUTE_TRAFFIC_LAYER_ID)
+            } returns primaryRouteTraffic
+            every {
+                getLayer(ALTERNATIVE_ROUTE1_TRAFFIC_LAYER_ID)
+            } returns altRouteTraffic1
+            every {
+                getLayer(ALTERNATIVE_ROUTE2_TRAFFIC_LAYER_ID)
+            } returns altRouteTraffic2
+        }
+
+        MapboxRouteLineView(options).showTraffic(style)
+
+        verify { primaryRouteTraffic.visibility(Visibility.VISIBLE) }
+        verify { altRouteTraffic1.visibility(Visibility.VISIBLE) }
+        verify { altRouteTraffic2.visibility(Visibility.VISIBLE) }
+        unmockkObject(MapboxRouteLineUtils)
+        unmockkStatic("com.mapbox.maps.extension.style.layers.LayerUtils")
+    }
+
+    @Test
+    fun getTrafficVisibility() {
+        mockkObject(MapboxRouteLineUtils)
+        val options = MapboxRouteLineOptions.Builder(ctx).build()
+        val style = mockk<Style>()
+        every {
+            MapboxRouteLineUtils.getLayerVisibility(
+                style,
+                PRIMARY_ROUTE_TRAFFIC_LAYER_ID
+            )
+        } returns Visibility.VISIBLE
+
+        val result = MapboxRouteLineView(options).getTrafficVisibility(style)
+
+        assertEquals(Visibility.VISIBLE, result)
+        unmockkObject(MapboxRouteLineUtils)
+    }
+
+    @Test
     fun showOriginAndDestinationPoints() {
         mockkStatic("com.mapbox.maps.extension.style.layers.LayerUtils")
         mockkObject(MapboxRouteLineUtils)

--- a/qa-test-app/src/main/res/layout/layout_activity_routeline.xml
+++ b/qa-test-app/src/main/res/layout/layout_activity_routeline.xml
@@ -32,9 +32,20 @@
         android:layout_marginEnd="24dp"
         android:layout_marginBottom="24dp"
         android:tint="@android:color/white"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/startNavigation"
         app:layout_constraintEnd_toEndOf="parent"
         app:srcCompat="@drawable/ic_layers_24dp"/>
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/toggleTrafficVisibilityButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toTopOf="@id/startNavigation"
+        app:layout_constraintStart_toStartOf="parent"
+        android:layout_marginStart="8dp"
+        android:layout_marginBottom="8dp"
+        android:text="Toggle Traffic Visibility"
+        android:visibility="invisible"/>
 
     <ProgressBar
         android:id="@+id/routeLoadingProgressBar"


### PR DESCRIPTION
### Description
In response to a customer request the work here facilitates changing the visibility of the traffic on the route lines by adding methods to hide and show the map layers that host the traffic lines.

### Changelog
```
<changelog>Added methods `MapboxRouteLineView` to change the visibility of the route traffic layers.</changelog>
```

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
