### PR TITLE
handle inconsistent data on reroute

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/routeoptions/MapboxRouteOptionsUpdater.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/routeoptions/MapboxRouteOptionsUpdater.kt
@@ -43,6 +43,15 @@ class MapboxRouteOptionsUpdater(
         val coordinates = routeOptions.coordinates()
         val remainingWaypoints = routeProgress.remainingWaypoints
 
+        if (coordinates.size <= remainingWaypoints) {
+            val msg = "Cannot combine routeOptions with routeProgress. Inconsistent data." +
+                "coordinates: $coordinates, " +
+                "remainingWaypoints $remainingWaypoints, " +
+                "coordinates ${routeProgress.route.routeOptions()?.coordinates()}"
+            logger?.e(Tag("MapboxRouteOptionsUpdater"), Message(msg))
+            return RouteOptionsUpdater.RouteOptionsResult.Error(Throwable(msg))
+        }
+
         try {
             routeProgress.currentLegProgress?.legIndex?.let { index ->
                 optionsBuilder

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/routeoptions/MapboxRouteOptionsUpdaterTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/routeoptions/MapboxRouteOptionsUpdaterTest.kt
@@ -129,6 +129,24 @@ class MapboxRouteOptionsUpdaterTest {
     }
 
     @Test
+    fun `inconsistent route options and route progress`() {
+        val routeOptions = provideDefaultRouteOptionsBuilder()
+            .coordinates(
+                listOf(
+                    Point.fromLngLat(1.0, 1.0),
+                    Point.fromLngLat(2.0, 2.0)
+                )
+            )
+            .build()
+        val routeProgress: RouteProgress = mockk(relaxed = true) {
+            every { remainingWaypoints } returns 3
+        }
+
+        val updateResult = routeRefreshAdapter.update(routeOptions, routeProgress, location)
+        assertTrue(updateResult is RouteOptionsUpdater.RouteOptionsResult.Error)
+    }
+
+    @Test
     fun no_options_on_invalid_input() {
         val invalidInput = mutableListOf<Triple<RouteOptions?, RouteProgress?, Location?>>()
         invalidInput.add(Triple(null, mockk(), mockk()))


### PR DESCRIPTION
### Description
Potential fix for the crash on reroute #4179 . PR is draft, let's discuss the solution. 

The crash happens because current route progress from `TripSession` is inconsistent with route options from `DirectionSession`. `navigator!!.remainingWaypoints().size` returns more waypoints than the route options from `DirectionSession` have.

I don't have good explanation of how this could happen in theory. But I see that the work happens with 2 different threads: UI and 1 worker thread which we use in `MapboxNativeNavigatorImpl`. Maybe there is some case when routes are updated on UI thread but `TripSession` still keeps a route progress from the previous route? If it's the case then it should be okay that rerouting is interrupted. 


### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Fixes crash on reroute for version 1.x</changelog>
```

