### PR TITLE
Updated the equals method to include distance remaining parameter.

### DIFF
--- a/libnavui-maneuver/src/main/java/com/mapbox/navigation/ui/maneuver/model/StepDistance.kt
+++ b/libnavui-maneuver/src/main/java/com/mapbox/navigation/ui/maneuver/model/StepDistance.kt
@@ -27,6 +27,7 @@ class StepDistance internal constructor(
         other as StepDistance
 
         if (totalDistance.notEqualDelta(other.totalDistance)) return false
+        if (distanceRemaining.notEqualDelta(other.distanceRemaining)) return false
 
         return true
     }
@@ -35,7 +36,9 @@ class StepDistance internal constructor(
      * Regenerate whenever a change is made
      */
     override fun hashCode(): Int {
-        return totalDistance.hashCode()
+        var result = totalDistance.hashCode()
+        result = 31 * result + distanceRemaining.hashCode()
+        return result
     }
 
     private fun Double?.notEqualDelta(other: Double?): Boolean {

--- a/libnavui-maneuver/src/test/java/com/mapbox/navigation/ui/maneuver/view/MapboxStepDistanceTest.kt
+++ b/libnavui-maneuver/src/test/java/com/mapbox/navigation/ui/maneuver/view/MapboxStepDistanceTest.kt
@@ -3,10 +3,12 @@ package com.mapbox.navigation.ui.maneuver.view
 import android.content.Context
 import android.text.SpannableString
 import androidx.test.core.app.ApplicationProvider
+import com.mapbox.navigation.base.formatter.DistanceFormatter
 import com.mapbox.navigation.ui.maneuver.model.StepDistance
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -39,5 +41,38 @@ class MapboxStepDistanceTest {
         val actual = view.text
 
         assertEquals(expected, actual)
+    }
+
+    @Test
+    fun equalsTest() {
+        val mockDistanceFormatter = mockk<DistanceFormatter>()
+        val stepDistance1 = StepDistance(mockDistanceFormatter, 5.5, 6.6)
+        val stepDistance2 = StepDistance(mockDistanceFormatter, 5.5, 6.6)
+
+        val areEqual = stepDistance1 == stepDistance2
+
+        assertTrue(areEqual)
+    }
+
+    @Test
+    fun equals_whenTotalDistanceNotEqual() {
+        val mockDistanceFormatter = mockk<DistanceFormatter>()
+        val stepDistance1 = StepDistance(mockDistanceFormatter, 5.5, 6.6)
+        val stepDistance2 = StepDistance(mockDistanceFormatter, 4.4, 6.6)
+
+        val areEqual = stepDistance1 != stepDistance2
+
+        assertTrue(areEqual)
+    }
+
+    @Test
+    fun equals_whenDistanceRemainingNotEqual() {
+        val mockDistanceFormatter = mockk<DistanceFormatter>()
+        val stepDistance1 = StepDistance(mockDistanceFormatter, 5.5, 6.6)
+        val stepDistance2 = StepDistance(mockDistanceFormatter, 5.5, 3.3)
+
+        val areEqual = stepDistance1 != stepDistance2
+
+        assertTrue(areEqual)
     }
 }


### PR DESCRIPTION
### Description
Fixes #5187 by updating the equals method.

### Changelog
```
<changelog>The equals method for the `StepDistance` class was updated to include the distance remaining parameter.</changelog>
```

### Screenshots or Gifs

