### PR TITLE
cleared up the error message when viewport padding is unusable

### DIFF
--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/ViewportDataSourceProcessor.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/ViewportDataSourceProcessor.kt
@@ -322,21 +322,18 @@ internal object ViewportDataSourceProcessor {
                 top + bottom > mapSize.height ||
                 left + right > mapSize.width
             ) {
+                val fallbackPadding = EdgeInsets(0.0, 0.0, 0.0, 0.0)
                 LoggerProvider.logger.e(
                     Tag(TAG),
                     Message(
-                        """Provided following padding does fit the map size:
+                        """Provided following padding does not fit the map size:
                         |mapSize: $mapSize
                         |padding: $padding
+                        |Using an empty fallback padding instead: $padding
                     """.trimMargin()
                     )
                 )
-                return EdgeInsets(
-                    mapSize.height / 2.0,
-                    mapSize.width / 2.0,
-                    mapSize.height / 2.0,
-                    mapSize.width / 2.0,
-                )
+                return fallbackPadding
             }
         }
 

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/camera/data/ViewportDataSourceProcessorTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/camera/data/ViewportDataSourceProcessorTest.kt
@@ -597,41 +597,37 @@ class ViewportDataSourceProcessorTest {
     @Test
     fun `test getMapAnchoredPaddingFromUserPadding - invalid horizontally`() {
         val mapSize = Size(1000f, 1000f)
+        val expected = EdgeInsets(0.0, 0.0, 0.0, 0.0)
 
         val padding1 = EdgeInsets(0.0, 1100.0, 0.0, 0.0)
-        val expected1 = EdgeInsets(500.0, 500.0, 500.0, 500.0)
         val actual1 = getMapAnchoredPaddingFromUserPadding(mapSize, padding1)
-        assertEquals(expected1, actual1)
+        assertEquals(expected, actual1)
 
         val padding2 = EdgeInsets(0.0, 0.0, 0.0, 1100.0)
-        val expected2 = EdgeInsets(500.0, 500.0, 500.0, 500.0)
         val actual2 = getMapAnchoredPaddingFromUserPadding(mapSize, padding2)
-        assertEquals(expected2, actual2)
+        assertEquals(expected, actual2)
 
         val padding3 = EdgeInsets(0.0, 600.0, 0.0, 600.0)
-        val expected3 = EdgeInsets(500.0, 500.0, 500.0, 500.0)
         val actual3 = getMapAnchoredPaddingFromUserPadding(mapSize, padding3)
-        assertEquals(expected3, actual3)
+        assertEquals(expected, actual3)
     }
 
     @Test
     fun `test getMapAnchoredPaddingFromUserPadding - invalid vertically`() {
         val mapSize = Size(1000f, 1000f)
+        val expected = EdgeInsets(0.0, 0.0, 0.0, 0.0)
 
         val padding1 = EdgeInsets(1100.0, 0.0, 0.0, 0.0)
-        val expected1 = EdgeInsets(500.0, 500.0, 500.0, 500.0)
         val actual1 = getMapAnchoredPaddingFromUserPadding(mapSize, padding1)
-        assertEquals(expected1, actual1)
+        assertEquals(expected, actual1)
 
         val padding2 = EdgeInsets(0.0, 0.0, 1100.0, 0.0)
-        val expected2 = EdgeInsets(500.0, 500.0, 500.0, 500.0)
         val actual2 = getMapAnchoredPaddingFromUserPadding(mapSize, padding2)
-        assertEquals(expected2, actual2)
+        assertEquals(expected, actual2)
 
         val padding3 = EdgeInsets(600.0, 0.0, 600.0, 0.0)
-        val expected3 = EdgeInsets(500.0, 500.0, 500.0, 500.0)
         val actual3 = getMapAnchoredPaddingFromUserPadding(mapSize, padding3)
-        assertEquals(expected3, actual3)
+        assertEquals(expected, actual3)
     }
 
     @Test


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Clears up the error message and fixes the fallback. It used to be narrowed down to a single pixel on the map but that was incorrect, it would result in an additional error in GL-Native. Opting to fallback to empty padding instead.

I'm considering just throwing an exception here but not sure if it's worth changing the behavior right now in case there are reasonable edge cases where this might occur.

### Changelog
<!--
Include changelog entry (e.g. Fixed an unexpected change in recenter button when resuming the app.).
See https://github.com/mapbox/navigation-sdks/blob/main/documentation/android-changelog-guidelines.md.
You can remove the changelog block and add a `skip changelog` label, when applicable.
 -->
```
<changelog>Fixed the fallback mechanism for a situation where `MapboxNavigationViewportDataSource` padding does not fit the map. Now falling back to empty padding.</changelog>
```

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
2. Update progress status on the project board.
3. Request a review from the team, if not a draft.
4. Add targeted milestone, when applicable.
5. Create ticket tracking addition of public documentation pages entry, when applicable.
-->

cc @tobrun 
