### PR TITLE
#5304 Use listeners copy to prevents concurrent modifications of the listeners list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Mapbox welcomes participation and contributions from everyone.
 
 ## Unreleased
 - Fixed an issue where calculation of dangerous maneuver avoidance (`RerouteOptions#avoidManeuverSeconds`) during a reroute was resulting in much smaller radius than expected. [#5307](https://github.com/mapbox/mapbox-navigation-android/pull/5307)
+- Fixed a crash when `ReplayLocationEngine`'s location callback removes itself during getting a location update. [#5305](https://github.com/mapbox/mapbox-navigation-android/pull/5305)
 
 ## Mapbox Navigation SDK 2.2.0-beta.1 - December 17, 2021
 

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/ReplayLocationEngine.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/ReplayLocationEngine.kt
@@ -12,6 +12,7 @@ import com.mapbox.navigation.core.replay.history.ReplayEventBase
 import com.mapbox.navigation.core.replay.history.ReplayEventUpdateLocation
 import com.mapbox.navigation.core.replay.history.ReplayEventsObserver
 import java.util.Date
+import java.util.concurrent.CopyOnWriteArrayList
 
 private typealias EngineCallback = LocationEngineCallback<LocationEngineResult>
 
@@ -22,7 +23,7 @@ class ReplayLocationEngine(
     mapboxReplayer: MapboxReplayer
 ) : LocationEngine, ReplayEventsObserver {
 
-    private val registeredCallbacks: MutableList<EngineCallback> = mutableListOf()
+    private val registeredCallbacks: MutableList<EngineCallback> = CopyOnWriteArrayList()
     private val lastLocationCallbacks: MutableList<EngineCallback> = mutableListOf()
     private var lastLocationEngineResult: LocationEngineResult? = null
 


### PR DESCRIPTION
Fixes #5304 
### Description

This PR fixes ConcurrentModificationException on the location callbacks list.

