### PR TITLE
fixed maneuver avoidance calculation for reroutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Mapbox welcomes participation and contributions from everyone.
 
 ## Unreleased
+- Fixed an issue where calculation of dangerous maneuver avoidance (`RerouteOptions#avoidManeuverSeconds`) during a reroute was resulting in much smaller radius than expected. [#5307](https://github.com/mapbox/mapbox-navigation-android/pull/5307)
 
 ## Mapbox Navigation SDK 2.2.0-beta.1 - December 17, 2021
 

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/reroute/MapboxRerouteController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/reroute/MapboxRerouteController.kt
@@ -82,9 +82,8 @@ internal class MapboxRerouteController(
                 this.profile() == DirectionsCriteria.PROFILE_DRIVING_TRAFFIC
             ) {
                 val avoidManeuverRadius = rerouteOptions.avoidManeuverSeconds
-                    .takeIf { it != 0 }
-                    ?.let { speed / it }?.toInt()
-                    ?.takeIf { it >= 1 }
+                    .let { speed * it }.toInt()
+                    .takeIf { it >= 1 }
                     ?.coerceAtMost(MAX_DANGEROUS_MANEUVERS_RADIUS)
 
                 builder.avoidManeuverRadius(avoidManeuverRadius)

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/reroute/MapboxRerouteControllerTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/reroute/MapboxRerouteControllerTest.kt
@@ -339,7 +339,7 @@ class MapboxRerouteControllerTest {
         listOf(
             Triple(200f, 1, 200),
             Triple(0f, 1, null),
-            Triple(1000f, 1, 1000),
+            Triple(200f, 3, 600),
             Triple(5000f, 1, 1000),
             Triple(200f, 0, null),
         ).forEach { (speed, secondsRadius, expectedMetersRadius) ->


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
We were calculating the avoidance radius to be much smaller than expected because of a `/` instead of `*` typo.

cc @oleg-liatte 