### PR TITLE
#5308: keep only last alternatives in RouteAlternativesCacheManager

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesCacheManager.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesCacheManager.kt
@@ -4,19 +4,18 @@ import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.navigation.core.trip.session.NavigationSession
 import com.mapbox.navigation.core.trip.session.NavigationSessionState
 import com.mapbox.navigation.core.trip.session.NavigationSessionStateObserver
-import java.util.concurrent.CopyOnWriteArrayList
 
 internal class RouteAlternativesCacheManager(
     navigationSession: NavigationSession,
 ) {
-    private val cachedAlternatives = CopyOnWriteArrayList<DirectionsRoute>()
+    private var cachedAlternatives = emptyList<DirectionsRoute>()
 
     private val sessionStateObserver = NavigationSessionStateObserver { state ->
         when (state) {
             is NavigationSessionState.ActiveGuidance -> Unit
             is NavigationSessionState.FreeDrive,
             NavigationSessionState.Idle -> {
-                cachedAlternatives.clear()
+                cachedAlternatives = emptyList()
             }
         }
     }
@@ -26,7 +25,7 @@ internal class RouteAlternativesCacheManager(
     }
 
     fun push(alternatives: List<DirectionsRoute>) {
-        cachedAlternatives.addAll(alternatives)
+        cachedAlternatives = alternatives
     }
 
     fun areAlternatives(routes: List<DirectionsRoute>): Boolean =


### PR DESCRIPTION
### Description
RouteAlternativesCacheManager can accumulate too many routes otherwise.

```
<changelog>Fixed a memory leak in the `RouteAlternativesCacheManager` which accumulated all alternative routes during AG.</changelog>
