### PR TITLE
Turn off jetifier

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,7 @@ POM_SNAPSHOT_VERSION_NAME=2.1.0-SNAPSHOT
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx2048M
 android.useAndroidX=true
-android.enableJetifier=true
+android.enableJetifier=false
 
 # Increases stack size for the Kotlin compiler to prevent StackOverflowError
 # when compiling MapboxRouteLineViewTest.kt. Similar issue:


### PR DESCRIPTION
### Description
We don't use any pre AndroidX libraries so it doesn't make sense to launch the Jetifier during the build. In theory build should be faster because we get rid of unnecessary step.

### Measurements 
I measured performance on my mac by running `./gradlew clean; time make assemble-core-debug` with and without jetifier.

make assemble-core-debug  11.37s user 1.16s system **30% cpu 41.165 total** -  jetifier is **turned on**
make assemble-core-debug  10.72s user 1.14s system **29% cpu 40.690 total** - jetfier is **turned off**

Build is slightly faster without jetfier.
