### PR TITLE
RouteOptions extensions: refactor default params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Mapbox welcomes participation and contributions from everyone.
 - Fixed a crash when `ReplayLocationEngine`'s location callback removes itself during getting a location update. [#5305](https://github.com/mapbox/mapbox-navigation-android/pull/5305)
 - Fixed `MapboxTripProgressView` landscape layout to handle `tripProgressViewBackgroundColor` attribute. [#5318](https://github.com/mapbox/mapbox-navigation-android/pull/5318)
 - Fixed an issue where the `onPause` is not called when the app is backgrounded and the implementation is using `MapboxNavigationApp.attachAllActivities`. [#5329](https://github.com/mapbox/mapbox-navigation-android/pull/5329)
+- Fixed a crash when use non-`driving-traffic` profile with extension `RouteOptions.Builder#applyDefaultNavigationOptions`. [#5322](https://github.com/mapbox/mapbox-navigation-android/pull/5322)
+- Refactored extension `RouteOptions.Builder#applyDefaultNavigationOptions`, might be set profile param explicitly. [#5322](https://github.com/mapbox/mapbox-navigation-android/pull/5322)
 
 ## Mapbox Navigation SDK 2.2.0-beta.1 - December 17, 2021
 

--- a/libnavigation-base/api/current.txt
+++ b/libnavigation-base/api/current.txt
@@ -22,6 +22,7 @@ package com.mapbox.navigation.base {
 package com.mapbox.navigation.base.extensions {
 
   public final class RouteOptionsExtensions {
+    method public static com.mapbox.api.directions.v5.models.RouteOptions.Builder applyDefaultNavigationOptions(com.mapbox.api.directions.v5.models.RouteOptions.Builder, @com.mapbox.api.directions.v5.DirectionsCriteria.ProfileCriteria String profile = "driving-traffic");
     method public static com.mapbox.api.directions.v5.models.RouteOptions.Builder applyDefaultNavigationOptions(com.mapbox.api.directions.v5.models.RouteOptions.Builder);
     method public static com.mapbox.api.directions.v5.models.RouteOptions.Builder applyLanguageAndVoiceUnitOptions(com.mapbox.api.directions.v5.models.RouteOptions.Builder, android.content.Context context);
     method public static com.mapbox.api.directions.v5.models.RouteOptions.Builder coordinates(com.mapbox.api.directions.v5.models.RouteOptions.Builder, com.mapbox.geojson.Point origin, java.util.List<com.mapbox.geojson.Point>? waypoints = null, com.mapbox.geojson.Point destination);

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/extensions/RouteOptionsEx.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/extensions/RouteOptionsEx.kt
@@ -11,28 +11,63 @@ import com.mapbox.navigation.base.internal.extensions.inferDeviceLocale
 import java.util.Locale
 
 /**
- * Applies the [RouteOptions] that are required for the route request to execute
+ * Applies the [RouteOptions] that are required for the route request for the selected profile to execute
  * or otherwise recommended for the Navigation SDK and all of its features to provide the best car navigation experience.
+ * See also [https://docs.mapbox.com/api/navigation/directions/](https://docs.mapbox.com/api/navigation/directions/).
+ *
+ * Default profile is [DirectionsCriteria.PROFILE_DRIVING_TRAFFIC].
+ *
+ * @see DirectionsCriteria.ProfileCriteria
  */
-fun RouteOptions.Builder.applyDefaultNavigationOptions(): RouteOptions.Builder = apply {
-    profile(DirectionsCriteria.PROFILE_DRIVING_TRAFFIC)
+@JvmOverloads
+fun RouteOptions.Builder.applyDefaultNavigationOptions(
+    @DirectionsCriteria.ProfileCriteria profile: String =
+        DirectionsCriteria.PROFILE_DRIVING_TRAFFIC
+): RouteOptions.Builder = apply {
+    val defaultAnnotations = listOf(
+        DirectionsCriteria.ANNOTATION_SPEED,
+        DirectionsCriteria.ANNOTATION_DURATION,
+        DirectionsCriteria.ANNOTATION_DISTANCE,
+    )
+
+    when (profile) {
+        DirectionsCriteria.PROFILE_DRIVING_TRAFFIC -> {
+            annotationsList(
+                mutableListOf(
+                    DirectionsCriteria.ANNOTATION_CONGESTION_NUMERIC,
+                    DirectionsCriteria.ANNOTATION_MAXSPEED,
+                    DirectionsCriteria.ANNOTATION_CLOSURE,
+                ).apply { addAll(defaultAnnotations) }
+            )
+            continueStraight(true)
+            enableRefresh(true)
+        }
+        DirectionsCriteria.PROFILE_DRIVING -> {
+            annotationsList(
+                mutableListOf(
+                    DirectionsCriteria.ANNOTATION_MAXSPEED,
+                ).apply { addAll(defaultAnnotations) }
+            )
+            continueStraight(true)
+            enableRefresh(false)
+        }
+        DirectionsCriteria.PROFILE_CYCLING,
+        DirectionsCriteria.PROFILE_WALKING -> {
+            annotationsList(defaultAnnotations)
+            continueStraight(false)
+            enableRefresh(false)
+        }
+        else -> throw IllegalArgumentException(
+            "Unknown profile [$profile]. It must be one [DirectionsCriteria.ProfileCriteria]"
+        )
+    }
+
+    profile(profile)
     overview(DirectionsCriteria.OVERVIEW_FULL)
     steps(true)
-    continueStraight(true)
     roundaboutExits(true)
-    annotationsList(
-        listOf(
-            DirectionsCriteria.ANNOTATION_CONGESTION_NUMERIC,
-            DirectionsCriteria.ANNOTATION_MAXSPEED,
-            DirectionsCriteria.ANNOTATION_SPEED,
-            DirectionsCriteria.ANNOTATION_DURATION,
-            DirectionsCriteria.ANNOTATION_DISTANCE,
-            DirectionsCriteria.ANNOTATION_CLOSURE
-        )
-    )
     voiceInstructions(true)
     bannerInstructions(true)
-    enableRefresh(true)
 }
 
 /**

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/extensions/RouteOptionsExTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/extensions/RouteOptionsExTest.kt
@@ -1,0 +1,106 @@
+package com.mapbox.navigation.base.extensions
+
+import com.mapbox.api.directions.v5.DirectionsCriteria
+import com.mapbox.api.directions.v5.models.RouteOptions
+import com.mapbox.geojson.Point
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+class RouteOptionsExTest {
+
+    @RunWith(Parameterized::class)
+    class DefaultNavOptionsParameterizedTest(
+        private val profile: String,
+        private val expectedContinueStraight: Boolean,
+        private val expectedEnableRefresh: Boolean,
+        private val expectedAnnotations: List<String>,
+    ) {
+
+        companion object {
+
+            @JvmStatic
+            @Parameterized.Parameters(name = "{0}")
+            fun data(): List<out Any> {
+                val defaultAnnotations = mutableListOf(
+                    DirectionsCriteria.ANNOTATION_SPEED,
+                    DirectionsCriteria.ANNOTATION_DURATION,
+                    DirectionsCriteria.ANNOTATION_DISTANCE,
+                )
+
+                return listOf(
+                    arrayOf(
+                        DirectionsCriteria.PROFILE_DRIVING_TRAFFIC,
+                        true,
+                        true,
+                        defaultAnnotations.plus(
+                            listOf(
+                                DirectionsCriteria.ANNOTATION_CONGESTION_NUMERIC,
+                                DirectionsCriteria.ANNOTATION_MAXSPEED,
+                                DirectionsCriteria.ANNOTATION_CLOSURE,
+                            )
+                        ),
+                    ),
+                    arrayOf(
+                        DirectionsCriteria.PROFILE_DRIVING,
+                        true,
+                        false,
+                        defaultAnnotations.plus(
+                            listOf(DirectionsCriteria.ANNOTATION_MAXSPEED)
+                        ),
+                    ),
+                    arrayOf(
+                        DirectionsCriteria.PROFILE_CYCLING,
+                        false,
+                        false,
+                        defaultAnnotations,
+                    ),
+                    arrayOf(
+                        DirectionsCriteria.PROFILE_WALKING,
+                        false,
+                        false,
+                        defaultAnnotations,
+                    ),
+                )
+            }
+        }
+
+        @Test
+        fun testData() {
+            val routeOptions = provideRouteOptions(profile).build()
+
+            assertEquals(profile, routeOptions.profile())
+            routeOptions.checkDefaultOptions()
+            routeOptions.checkAnnotations(expectedAnnotations)
+            assertEquals(expectedContinueStraight, routeOptions.continueStraight()!!)
+            assertEquals(expectedEnableRefresh, routeOptions.enableRefresh())
+        }
+
+        private fun RouteOptions.checkDefaultOptions() {
+            assertEquals(DirectionsCriteria.OVERVIEW_FULL, overview())
+            assertTrue(steps()!!)
+            assertTrue(roundaboutExits()!!)
+            assertTrue(voiceInstructions()!!)
+            assertTrue(bannerInstructions()!!)
+        }
+
+        private fun RouteOptions.checkAnnotations(expectedAnnotations: List<String>) {
+            assertTrue(expectedAnnotations.containsAll(annotationsList()!!))
+            assertEquals(expectedAnnotations.size, annotationsList()!!.size)
+        }
+
+        private fun provideRouteOptions(
+            @DirectionsCriteria.ProfileCriteria profile: String
+        ): RouteOptions.Builder =
+            RouteOptions.builder()
+                .coordinatesList(
+                    listOf(
+                        Point.fromLngLat(0.0, 0.0),
+                        Point.fromLngLat(1.1, 1.1),
+                    )
+                )
+                .applyDefaultNavigationOptions(profile)
+    }
+}


### PR DESCRIPTION
### Description
Refacor `RouteOptions.Builder#applyDefaultNavigationOptions` for different profiles
Resolved crash for non-`driving-traffic` profile when use `RouteOptions.Builder#applyDefaultNavigationOptions` extension

Closes https://github.com/mapbox/mapbox-navigation-android/issues/5214
<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
