### PR TITLE
Kyv alternatives cache limit to 3 portion

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesCacheManager.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesCacheManager.kt
@@ -1,15 +1,16 @@
 package com.mapbox.navigation.core.routealternatives
 
+import androidx.annotation.VisibleForTesting
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.navigation.core.trip.session.NavigationSession
 import com.mapbox.navigation.core.trip.session.NavigationSessionState
 import com.mapbox.navigation.core.trip.session.NavigationSessionStateObserver
-import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.ConcurrentLinkedQueue
 
 internal class RouteAlternativesCacheManager(
     navigationSession: NavigationSession,
 ) {
-    private val cachedAlternatives = CopyOnWriteArrayList<DirectionsRoute>()
+    private val cachedAlternatives = ConcurrentLinkedQueue<List<DirectionsRoute>>()
 
     private val sessionStateObserver = NavigationSessionStateObserver { state ->
         when (state) {
@@ -21,14 +22,24 @@ internal class RouteAlternativesCacheManager(
         }
     }
 
+    @VisibleForTesting
+    internal companion object {
+        internal const val CACHE_SIZE = 3
+    }
+
     init {
         navigationSession.registerNavigationSessionStateObserver(sessionStateObserver)
     }
 
     fun push(alternatives: List<DirectionsRoute>) {
-        cachedAlternatives.addAll(alternatives)
+        if (cachedAlternatives.size == CACHE_SIZE) {
+            cachedAlternatives.remove()
+        }
+        cachedAlternatives.add(alternatives)
     }
 
     fun areAlternatives(routes: List<DirectionsRoute>): Boolean =
-        routes.map { it in cachedAlternatives }.any { it }
+        cachedAlternatives.any { cachedAlternative ->
+            routes.any { cachedAlternative.contains(it) }
+        }
 }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesCacheManagerTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesCacheManagerTest.kt
@@ -80,6 +80,19 @@ class RouteAlternativesCacheManagerTest {
         assertFalse(routeAlternativesCacheManager.areAlternatives(alternatives))
     }
 
+    @Test
+    fun cacheRetainedWhenOneIsFull() {
+        val alternatives = listOf(mockFirstRoute, mockFirstRoute)
+
+        nextState(NavigationSessionState.ActiveGuidance("-1"))
+        routeAlternativesCacheManager.push(alternatives)
+        for (i in 0 until RouteAlternativesCacheManager.CACHE_SIZE) {
+            routeAlternativesCacheManager.push(emptyList())
+        }
+
+        assertFalse(routeAlternativesCacheManager.areAlternatives(alternatives))
+    }
+
     private fun nextState(navSessionState: NavigationSessionState) {
         navSessionObserverSlot.captured.onNavigationSessionStateChanged(navSessionState)
     }


### PR DESCRIPTION
### Description
RouteAlternativesCacheManager: limit cache to 3 portions (avoid OOM Exception)

Closes #5308 

```
<changelog>Fixed OOM Exception because of non-limited internal cached of alternative routes</changelog>
```

cc @zeac 

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
