### PR TITLE
Updated naming of next waypoint index fallback to make its purpose clear

### DIFF
--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionNoSetupTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionNoSetupTest.kt
@@ -242,7 +242,7 @@ class MapboxTripSessionNoSetupTest {
     }
 
     @Test
-    fun `fallback to the next waypoint index 1 when navigator makes mistake returning 0`() {
+    fun `fallback to the next waypoint index 1 when navigator doesn't think we reached it and returns 0`() {
         // arrange
         val nativeNavigator = createNativeNavigatorMock()
         coEvery {


### PR DESCRIPTION
### Description
We wanted to get rid from fallback when SDK calculates remaining waypoints, but it's turned out that it's better to keep the fallback. The Android SDK and NN treads this aspects differently. On the Android side we always start navigation from the current position and expect that the next waypoint index will not be less than 1. But native part considers the origin as usual waypoint can return next waypoint index 0. 
The fallback helps "translate" NN understanding to ours.

See also #5275
