### PR TITLE
Fix attachAllActivities foregrounding case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Mapbox welcomes participation and contributions from everyone.
 - Fixed an issue where calculation of dangerous maneuver avoidance (`RerouteOptions#avoidManeuverSeconds`) during a reroute was resulting in much smaller radius than expected. [#5307](https://github.com/mapbox/mapbox-navigation-android/pull/5307)
 - Fixed a crash when `ReplayLocationEngine`'s location callback removes itself during getting a location update. [#5305](https://github.com/mapbox/mapbox-navigation-android/pull/5305)
 - Fixed `MapboxTripProgressView` landscape layout to handle `tripProgressViewBackgroundColor` attribute. [#5318](https://github.com/mapbox/mapbox-navigation-android/pull/5318)
+- Fixed an issue where the `onPause` is not called when the app is backgrounded and the implementation is using `MapboxNavigationApp.attachAllActivities`. [#5329](https://github.com/mapbox/mapbox-navigation-android/pull/5329)
 
 ## Mapbox Navigation SDK 2.2.0-beta.1 - December 17, 2021
 

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/lifecycle/CarAppLifecycleOwner.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/lifecycle/CarAppLifecycleOwner.kt
@@ -127,13 +127,7 @@ internal class CarAppLifecycleOwner : LifecycleOwner {
             } else {
                 activitiesForegrounded--
                 logger.i(TAG, Message("app onActivityStopped"))
-                if (lifecycleCreated == 0 &&
-                    activitiesCreated == 0 &&
-                    activitiesForegrounded == 0
-                ) {
-                    check(activitiesCreated == 0 && activitiesForegrounded == 0) {
-                        "onActivityStopped when no activities exist"
-                    }
+                if (lifecycleCreated == 0 && activitiesForegrounded == 0) {
                     changeState(Lifecycle.State.STARTED)
                 }
             }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/lifecycle/CarAppLifecycleOwnerTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/lifecycle/CarAppLifecycleOwnerTest.kt
@@ -38,11 +38,55 @@ class CarAppLifecycleOwnerTest {
             val activity: Activity = mockActivity()
             onActivityCreated(activity, mockk())
             onActivityStarted(activity)
+            onActivityResumed(activity)
         }
 
         verifyOrder {
             testLifecycleObserver.onCreate(any())
             testLifecycleObserver.onStart(any())
+            testLifecycleObserver.onResume(any())
+        }
+    }
+
+    @Test
+    fun `verify order when the app is foregrounded and backgrounded`() {
+        carAppLifecycleOwner.activityLifecycleCallbacks.apply {
+            val activity: Activity = mockActivity()
+            onActivityCreated(activity, mockk())
+            onActivityStarted(activity)
+            onActivityResumed(activity)
+            onActivityPaused(activity)
+            onActivityStopped(activity)
+            onActivityStarted(activity)
+            onActivityResumed(activity)
+        }
+
+        verifyOrder {
+            testLifecycleObserver.onCreate(any())
+            testLifecycleObserver.onStart(any())
+            testLifecycleObserver.onResume(any())
+            testLifecycleObserver.onPause(any())
+            testLifecycleObserver.onResume(any())
+        }
+    }
+
+    @Test
+    fun `verify order when the lifecycle is backgrounded and foregrounded`() {
+        carAppLifecycleOwner.startedReferenceCounter.apply {
+            onCreate(carAppLifecycleOwner)
+            onStart(carAppLifecycleOwner)
+            onResume(carAppLifecycleOwner)
+            onPause(carAppLifecycleOwner)
+            onStop(carAppLifecycleOwner)
+            onStart(carAppLifecycleOwner)
+            onResume(carAppLifecycleOwner)
+        }
+
+        verifyOrder {
+            testLifecycleObserver.onCreate(any())
+            testLifecycleObserver.onStart(any())
+            testLifecycleObserver.onResume(any())
+            testLifecycleObserver.onPause(any())
             testLifecycleObserver.onResume(any())
         }
     }


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

When using `MapboxNavigationApp.attachAllActivities`, the `onPause` event is not called when the app is backgrounded.

Note that this issue does not exist when you are using `MapboxNavigationApp.attach` with individual lifecycle owners.

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
