### PR TITLE
refactored ci config, `release-snapshot` job: - enable for `release-v*` branches; - remove overkilled documentation generation.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,7 @@ workflows:
             branches:
               only:
                 - main
+                - release-v.*
       - release:
           filters:
             tags:
@@ -639,7 +640,6 @@ jobs:
       - assemble-core-release
       - assemble-ui-release
       - check-public-documentation
-      - generate-documentation
       - prepare-mbx-ci
       - setup-aws-credentials
       - upload-artifacts


### PR DESCRIPTION
### Description
refactored ci config, `release-snapshot` job: - enable for `release-v*` branches; - remove overkilled documentation generation.

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
