### PR TITLE
Use medium+ resource class for documentation publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -531,6 +531,7 @@ jobs:
 
   publish-documentation:
     executor: ndk-r22-latest-executor
+    resource_class: medium+
     steps:
       - checkout
       - prepare-mbx-ci


### PR DESCRIPTION
### Description
15 days ago gradle daemon died every time until I changed executor to Medium+. See the branch with different tries of fixing the daemon's crash https://github.com/mapbox/mapbox-navigation-android/tree/vv-troubleshoot-gradle-crash-on-2.2.0-beta.1

It doesn't fail always. But more powerful executor can make docs publishing stable. 
