### PR TITLE
Added option to throttle the vanishing route line update.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Mapbox welcomes participation and contributions from everyone.
 - Refactored extension `RouteOptions.Builder#applyDefaultNavigationOptions`, might be set profile param explicitly. [#5322](https://github.com/mapbox/mapbox-navigation-android/pull/5322)
 - Exposed a new API `MapboxManeuverView.updateLaneGuidanceIconStyle` that would allow changing the style of `MapboxLaneGuidanceAdapter` at runtime. [#5334](https://github.com/mapbox/mapbox-navigation-android/pull/5334)
 - Fixed a crash when `MapboxNavigationViewportDataSourceDebugger.enabled` is repeatedly set to true. [#5347](https://github.com/mapbox/mapbox-navigation-android/pull/5347)
+- Implemented vanishing route line feature from 1.x for exposing an option to adjust/limit the frequency of the vanishing route line updates. The MapboxRouteLineOptions.vanishingRouteLineUpdateIntervalNano can reduce the frequency of vanishing route line updates when the value of the option increases. [#5344](https://github.com/mapbox/mapbox-navigation-android/pull/5344)
 
 ## Mapbox Navigation SDK 2.0.5 - January 7, 2022
 This is a patch release on top of `v2.0.x` which does not include changes introduced in `v2.1.x` and later.

--- a/examples/src/main/res/drawable/custom_user_puck_icon.xml
+++ b/examples/src/main/res/drawable/custom_user_puck_icon.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="75dp"
+    android:height="75dp"
+    android:viewportHeight="75.0"
+    android:viewportWidth="75.0">
+    <item>
+        <shape android:shape="oval">
+            <stroke android:color="#ffcc00" android:width="5dp"/>
+            <size android:width="75dp" android:height="75dp"/>
+        </shape>
+    </item>
+</selector>

--- a/libnavui-maps/api/current.txt
+++ b/libnavui-maps/api/current.txt
@@ -835,6 +835,7 @@ package com.mapbox.navigation.ui.maps.route.line.model {
     method public double getSoftGradientTransition();
     method public boolean getStyleInactiveRouteLegsIndependently();
     method public double getTolerance();
+    method public long getVanishingRouteLineUpdateIntervalNano();
     method public com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions.Builder toBuilder(android.content.Context context);
     property public final android.graphics.drawable.Drawable destinationIcon;
     property public final boolean displayRestrictedRoadSections;
@@ -845,6 +846,7 @@ package com.mapbox.navigation.ui.maps.route.line.model {
     property public final double softGradientTransition;
     property public final boolean styleInactiveRouteLegsIndependently;
     property public final double tolerance;
+    property public final long vanishingRouteLineUpdateIntervalNano;
   }
 
   public static final class MapboxRouteLineOptions.Builder {
@@ -854,6 +856,7 @@ package com.mapbox.navigation.ui.maps.route.line.model {
     method public com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions.Builder displaySoftGradientForTraffic(boolean enable);
     method public com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions.Builder softGradientTransition(int transitionDistance);
     method public com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions.Builder styleInactiveRouteLegsIndependently(boolean enable);
+    method public com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions.Builder vanishingRouteLineUpdateInterval(long interval = 62500000L);
     method public com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions.Builder withRouteLineBelowLayerId(String layerId);
     method public com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions.Builder withRouteLineResources(com.mapbox.navigation.ui.maps.route.line.model.RouteLineResources resourceProvider);
     method public com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions.Builder withRouteStyleDescriptors(java.util.List<com.mapbox.navigation.ui.maps.route.line.model.RouteStyleDescriptor> routeStyleDescriptors);

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/RouteLayerConstants.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/RouteLayerConstants.kt
@@ -144,12 +144,12 @@ object RouteLayerConstants {
     internal const val MAX_ELAPSED_SINCE_INDEX_UPDATE_NANO = 1500000000.0 // 1.5s
     internal const val DEFAULT_ROUTE_SOURCES_TOLERANCE = 0.375
     internal const val ROUNDED_LINE_CAP = true
-    internal const val RESTRICTED_ROAD_SECTION_SCALE = 10.0
     internal const val SOFT_GRADIENT_STOP_GAP_METERS: Double = 30.0
     internal val TRAFFIC_BACKFILL_ROAD_CLASSES = emptyList<String>()
     internal const val RESTRICTED_ROAD_LINE_OPACITY = 1.0
     internal const val RESTRICTED_ROAD_LINE_WIDTH = 7.0
     internal val RESTRICTED_ROAD_DASH_ARRAY = listOf(.5, 2.0)
+    internal const val DEFAULT_VANISHING_POINT_MIN_UPDATE_INTERVAL_NANO = 62_500_000L
 
     internal val LOW_CONGESTION_RANGE = 0..39
 

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApi.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApi.kt
@@ -292,14 +292,17 @@ class MapboxRouteLineApi(
     fun updateTraveledRouteLine(
         point: Point
     ): Expected<RouteLineError, RouteLineUpdateValue> {
+        val currentNanoTime = System.nanoTime()
         if (routeLineOptions.vanishingRouteLine?.vanishingPointState ==
-            VanishingPointState.DISABLED || System.nanoTime() - lastIndexUpdateTimeNano >
-            RouteLayerConstants.MAX_ELAPSED_SINCE_INDEX_UPDATE_NANO
+            VanishingPointState.DISABLED || currentNanoTime - lastIndexUpdateTimeNano >
+            RouteLayerConstants.MAX_ELAPSED_SINCE_INDEX_UPDATE_NANO ||
+            currentNanoTime - lastIndexUpdateTimeNano <
+            routeLineOptions.vanishingRouteLineUpdateIntervalNano
         ) {
             return ExpectedFactory.createError(
                 RouteLineError(
-                    "Vanishing point state is disabled or too much time has " +
-                        "elapsed since last update.",
+                    "Vanishing point state is disabled or the update doesn't fall" +
+                        "within the configured interval window.",
                     null
                 )
             )

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/MapboxRouteLineOptions.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/MapboxRouteLineOptions.kt
@@ -29,6 +29,8 @@ import kotlin.math.abs
  * changes should use a soft gradient appearance or abrupt color change. This is false by default.
  * @param softGradientTransition influences the length of the color transition when the displaySoftGradientForTraffic
  * parameter is true.
+ * @param vanishingRouteLineUpdateIntervalNano can be used to decrease the frequency of the vanishing route
+ * line updates improving the performance at the expense of visual appearance of the vanishing point on the line during navigation.
  */
 class MapboxRouteLineOptions private constructor(
     val resourceProvider: RouteLineResources,
@@ -41,7 +43,9 @@ class MapboxRouteLineOptions private constructor(
     val displayRestrictedRoadSections: Boolean = false,
     val styleInactiveRouteLegsIndependently: Boolean = false,
     val displaySoftGradientForTraffic: Boolean = false,
-    val softGradientTransition: Double = RouteLayerConstants.SOFT_GRADIENT_STOP_GAP_METERS
+    val softGradientTransition: Double = RouteLayerConstants.SOFT_GRADIENT_STOP_GAP_METERS,
+    val vanishingRouteLineUpdateIntervalNano: Long =
+        RouteLayerConstants.DEFAULT_VANISHING_POINT_MIN_UPDATE_INTERVAL_NANO
 ) {
 
     /**
@@ -61,7 +65,8 @@ class MapboxRouteLineOptions private constructor(
             displayRestrictedRoadSections,
             styleInactiveRouteLegsIndependently,
             displaySoftGradientForTraffic,
-            softGradientTransition
+            softGradientTransition,
+            vanishingRouteLineUpdateIntervalNano
         )
     }
 
@@ -86,6 +91,8 @@ class MapboxRouteLineOptions private constructor(
             return false
         if (displaySoftGradientForTraffic != other.displayRestrictedRoadSections) return false
         if (softGradientTransition != other.softGradientTransition) return false
+        if (vanishingRouteLineUpdateIntervalNano != other.vanishingRouteLineUpdateIntervalNano)
+            return false
 
         return true
     }
@@ -105,6 +112,7 @@ class MapboxRouteLineOptions private constructor(
         result = 31 * result + (styleInactiveRouteLegsIndependently.hashCode())
         result = 31 * result + (displaySoftGradientForTraffic.hashCode())
         result = 31 * result + (softGradientTransition.hashCode())
+        result = 31 * result + (vanishingRouteLineUpdateIntervalNano.hashCode())
         return result
     }
 
@@ -122,7 +130,8 @@ class MapboxRouteLineOptions private constructor(
             "displayRestrictedRoadSections=$displayRestrictedRoadSections, " +
             "styleInactiveRouteLegsIndependently=$styleInactiveRouteLegsIndependently," +
             "displaySoftGradientForTraffic=$displaySoftGradientForTraffic," +
-            "softGradientTransition=$softGradientTransition" +
+            "softGradientTransition=$softGradientTransition," +
+            "vanishingRouteLineUpdateIntervalNano=$vanishingRouteLineUpdateIntervalNano" +
             ")"
     }
 
@@ -144,6 +153,8 @@ class MapboxRouteLineOptions private constructor(
      * one color to the next.
      * @param softGradientTransition this value influences the length of the color transition when
      * the displaySoftGradientForTraffic param is set to true
+     * @param vanishingRouteLineUpdateIntervalNano can be used to decrease the frequency of the vanishing route
+     * line updates improving the performance at the expense of visual appearance of the vanishing point on the line during navigation.
      */
     class Builder internal constructor(
         private val context: Context,
@@ -155,7 +166,8 @@ class MapboxRouteLineOptions private constructor(
         private var displayRestrictedRoadSections: Boolean,
         private var styleInactiveRouteLegsIndependently: Boolean,
         private var displaySoftGradientForTraffic: Boolean,
-        private var softGradientTransition: Double
+        private var softGradientTransition: Double,
+        private var vanishingRouteLineUpdateIntervalNano: Long
     ) {
 
         /**
@@ -173,7 +185,8 @@ class MapboxRouteLineOptions private constructor(
             false,
             false,
             false,
-            RouteLayerConstants.SOFT_GRADIENT_STOP_GAP_METERS
+            RouteLayerConstants.SOFT_GRADIENT_STOP_GAP_METERS,
+            RouteLayerConstants.DEFAULT_VANISHING_POINT_MIN_UPDATE_INTERVAL_NANO
         )
 
         /**
@@ -278,6 +291,17 @@ class MapboxRouteLineOptions private constructor(
         }
 
         /**
+         * Used for throttling the interval of updates to the vanishing route line.
+         * The default value is [RouteLayerConstants.DEFAULT_VANISHING_POINT_MIN_UPDATE_INTERVAL_NANO].
+         *
+         * @param interval a value in nano seconds for optimizing the updating of the vanishing route line feature.
+         * @return the builder
+         */
+        fun vanishingRouteLineUpdateInterval(
+            interval: Long = RouteLayerConstants.DEFAULT_VANISHING_POINT_MIN_UPDATE_INTERVAL_NANO
+        ): Builder = apply { this.vanishingRouteLineUpdateIntervalNano = interval }
+
+        /**
          * @return an instance of [MapboxRouteLineOptions]
          */
         fun build(): MapboxRouteLineOptions {
@@ -321,7 +345,8 @@ class MapboxRouteLineOptions private constructor(
                 displayRestrictedRoadSections,
                 styleInactiveRouteLegsIndependently,
                 displaySoftGradientForTraffic,
-                softGradientTransition
+                softGradientTransition,
+                vanishingRouteLineUpdateIntervalNano
             )
         }
     }

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/model/MapboxRouteLineOptionsTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/model/MapboxRouteLineOptionsTest.kt
@@ -105,6 +105,15 @@ class MapboxRouteLineOptionsTest {
     }
 
     @Test
+    fun vanishingRouteLineUpdateIntervalNano() {
+        val options = MapboxRouteLineOptions.Builder(ctx)
+            .vanishingRouteLineUpdateInterval(44L)
+            .build()
+
+        assertEquals(44, options.vanishingRouteLineUpdateIntervalNano)
+    }
+
+    @Test
     fun toBuilder() {
         val routeLineResources = RouteLineResources.Builder().build()
         val routeStyleDescriptors =
@@ -120,6 +129,7 @@ class MapboxRouteLineOptionsTest {
             .styleInactiveRouteLegsIndependently(true)
             .displaySoftGradientForTraffic(true)
             .softGradientTransition(77)
+            .vanishingRouteLineUpdateInterval(44L)
             .build()
             .toBuilder(ctx)
             .build()
@@ -133,5 +143,6 @@ class MapboxRouteLineOptionsTest {
         assertTrue(options.styleInactiveRouteLegsIndependently)
         assertTrue(options.displaySoftGradientForTraffic)
         assertEquals(77.0, options.softGradientTransition, 0.0)
+        assertEquals(44, options.vanishingRouteLineUpdateIntervalNano)
     }
 }


### PR DESCRIPTION
### Description
Implemented a feature included in 1.x but left out of 2.x to throttle the vanishing route line updates. Limiting the update frequency can improve performance especially in cases where the map is zoomed in which often happens in apps. built for larger screens like in cars.

### Screenshots or Gifs


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
