### PR TITLE
Bump NN dependency version to `83.0.0`

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -12,7 +12,7 @@ ext {
   // version which we should use in this build
   def mapboxNavigatorVersion = System.getenv("FORCE_MAPBOX_NAVIGATION_NATIVE_VERSION")
   if (mapboxNavigatorVersion == null || mapboxNavigatorVersion == '') {
-      mapboxNavigatorVersion = '82.0.1'
+      mapboxNavigatorVersion = '83.0.0'
   }
   println("Navigation Native version: " + mapboxNavigatorVersion)
 

--- a/libnavigation-base/api/current.txt
+++ b/libnavigation-base/api/current.txt
@@ -333,14 +333,25 @@ package com.mapbox.navigation.base.options {
 package com.mapbox.navigation.base.road.model {
 
   public final class Road {
-    method public java.util.List<com.mapbox.api.directions.v5.models.MapboxShield>? getMapboxShield();
-    method public String? getName();
-    method public String? getShieldName();
-    method public String? getShieldUrl();
-    property public final java.util.List<com.mapbox.api.directions.v5.models.MapboxShield>? mapboxShield;
-    property public final String? name;
-    property public final String? shieldName;
-    property public final String? shieldUrl;
+    method public java.util.List<com.mapbox.navigation.base.road.model.RoadComponent> getComponents();
+    method @Deprecated public java.util.List<com.mapbox.api.directions.v5.models.MapboxShield>? getMapboxShield();
+    method @Deprecated public String? getName();
+    method @Deprecated public String? getShieldName();
+    method @Deprecated public String? getShieldUrl();
+    property public final java.util.List<com.mapbox.navigation.base.road.model.RoadComponent> components;
+    property @Deprecated public final java.util.List<com.mapbox.api.directions.v5.models.MapboxShield>? mapboxShield;
+    property @Deprecated public final String? name;
+    property @Deprecated public final String? shieldName;
+    property @Deprecated public final String? shieldUrl;
+  }
+
+  public final class RoadComponent {
+    method public String? getImageBaseUrl();
+    method public com.mapbox.api.directions.v5.models.MapboxShield? getShield();
+    method public String getText();
+    property public final String? imageBaseUrl;
+    property public final com.mapbox.api.directions.v5.models.MapboxShield? shield;
+    property public final String text;
   }
 
 }

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/extensions/ShieldEx.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/extensions/ShieldEx.kt
@@ -1,0 +1,19 @@
+@file:JvmName("ShieldExtensions")
+
+package com.mapbox.navigation.base.internal.extensions
+
+import com.mapbox.api.directions.v5.models.MapboxShield
+import com.mapbox.navigation.base.utils.ifNonNull
+import com.mapbox.navigator.Shield
+
+fun Shield?.toMapboxShield(): MapboxShield? {
+    return ifNonNull(this) { mapboxShield ->
+        MapboxShield
+            .builder()
+            .name(mapboxShield.name)
+            .baseUrl(mapboxShield.baseUrl)
+            .textColor(mapboxShield.textColor)
+            .displayRef(mapboxShield.displayRef)
+            .build()
+    }
+}

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/factory/RoadFactory.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/factory/RoadFactory.kt
@@ -1,8 +1,9 @@
 package com.mapbox.navigation.base.internal.factory
 
-import com.mapbox.api.directions.v5.models.MapboxShield
 import com.mapbox.navigation.base.ExperimentalMapboxNavigationAPI
+import com.mapbox.navigation.base.internal.extensions.toMapboxShield
 import com.mapbox.navigation.base.road.model.Road
+import com.mapbox.navigation.base.road.model.RoadComponent
 import com.mapbox.navigator.NavigationStatus
 
 /**
@@ -12,23 +13,13 @@ import com.mapbox.navigator.NavigationStatus
 object RoadFactory {
 
     fun buildRoadObject(navigationStatus: NavigationStatus): Road {
-        val mapboxShields = mutableListOf<MapboxShield>()
-        navigationStatus.shields.forEach { shield ->
-            mapboxShields.add(
-                MapboxShield
-                    .builder()
-                    .name(shield.name)
-                    .baseUrl(shield.baseUrl)
-                    .textColor(shield.textColor)
-                    .displayRef(shield.displayRef)
-                    .build()
+        val components = navigationStatus.roads.map { road ->
+            RoadComponent(
+                text = road.text,
+                shield = road.shield.toMapboxShield(),
+                imageBaseUrl = road.imageBaseUrl,
             )
         }
-        return Road(
-            name = navigationStatus.roadName,
-            shieldUrl = navigationStatus.imageBaseurl,
-            shieldName = navigationStatus.shieldName,
-            mapboxShield = mapboxShields
-        )
+        return Road(components = components)
     }
 }

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/road/model/Road.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/road/model/Road.kt
@@ -4,17 +4,47 @@ import com.mapbox.api.directions.v5.models.MapboxShield
 
 /**
  * Object that holds road properties
- * @property name of the road if available otherwise null
- * @property shieldUrl url for the route shield if available otherwise null
- * @property shieldName name of the route shield if available otherwise null
- * @property mapboxShield mapbox designed shield if available otherwise null
+ * @property components list of the [RoadComponent]
  */
 class Road internal constructor(
-    val name: String? = null,
-    val shieldUrl: String? = null,
-    val shieldName: String? = null,
-    val mapboxShield: List<MapboxShield>? = null
+    val components: List<RoadComponent>
 ) {
+
+    /**
+     * Name of the road.
+     */
+    @Deprecated(
+        message = "Use RoadComponent.text instead.",
+        replaceWith = ReplaceWith("RoadComponent.text")
+    )
+    val name: String? = null
+
+    /**
+     * URL for the route shield.
+     */
+    @Deprecated(
+        message = "Use RoadComponent.shield.baseUrl() instead.",
+        replaceWith = ReplaceWith("RoadComponent.shield.baseUrl()")
+    )
+    val shieldUrl: String? = null
+
+    /**
+     * Name of the route shield.
+     */
+    @Deprecated(
+        message = "Use RoadComponent.shield.name() instead.",
+        replaceWith = ReplaceWith("RoadComponent.shield.name()")
+    )
+    val shieldName: String? = null
+
+    /**
+     * Mapbox designed shield.
+     */
+    @Deprecated(
+        message = "Use RoadComponent.shield instead.",
+        replaceWith = ReplaceWith("RoadComponent.shield")
+    )
+    val mapboxShield: List<MapboxShield>? = null
 
     /**
      * Indicates whether some other object is "equal to" this one.
@@ -25,10 +55,7 @@ class Road internal constructor(
 
         other as Road
 
-        if (name != other.name) return false
-        if (shieldUrl != other.shieldUrl) return false
-        if (shieldName != other.shieldName) return false
-        if (mapboxShield != other.mapboxShield) return false
+        if (components != other.components) return false
 
         return true
     }
@@ -37,22 +64,13 @@ class Road internal constructor(
      * Returns a hash code value for the object.
      */
     override fun hashCode(): Int {
-        var result = name?.hashCode() ?: 0
-        result = 31 * result + (shieldUrl?.hashCode() ?: 0)
-        result = 31 * result + (shieldName?.hashCode() ?: 0)
-        result = 31 * result + (mapboxShield?.hashCode() ?: 0)
-        return result
+        return components.hashCode()
     }
 
     /**
      * Returns a string representation of the object.
      */
     override fun toString(): String {
-        return "Road(" +
-            "name=$name, " +
-            "shieldUrl=$shieldUrl, " +
-            "shieldName=$shieldName, " +
-            "mapboxShield=$mapboxShield" +
-            ")"
+        return "Road(components=$components)"
     }
 }

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/road/model/RoadComponent.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/road/model/RoadComponent.kt
@@ -1,0 +1,48 @@
+package com.mapbox.navigation.base.road.model
+
+import com.mapbox.api.directions.v5.models.MapboxShield
+
+/**
+ * Object that holds road components
+ * @property text of the road
+ * @property shield mapbox designed shield if available otherwise null
+ * @property imageBaseUrl url for the route shield if available otherwise null
+ */
+class RoadComponent internal constructor(
+    val text: String,
+    val shield: MapboxShield? = null,
+    val imageBaseUrl: String? = null
+) {
+    /**
+     * Indicates whether some other object is "equal to" this one.
+     */
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as RoadComponent
+
+        if (text != other.text) return false
+        if (shield != other.shield) return false
+        if (imageBaseUrl != other.imageBaseUrl) return false
+
+        return true
+    }
+
+    /**
+     * Returns a hash code value for the object.
+     */
+    override fun hashCode(): Int {
+        var result = text.hashCode()
+        result = 31 * result + (shield?.hashCode() ?: 0)
+        result = 31 * result + (imageBaseUrl?.hashCode() ?: 0)
+        return result
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    override fun toString(): String {
+        return "RoadComponent(text='$text', shield=$shield, imageBaseUrl=$imageBaseUrl)"
+    }
+}

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/navigator/NavigatorMapper.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/navigator/NavigatorMapper.kt
@@ -13,6 +13,7 @@ import com.mapbox.api.directions.v5.models.RouteLeg
 import com.mapbox.api.directions.v5.models.VoiceInstructions
 import com.mapbox.geojson.Point
 import com.mapbox.navigation.base.ExperimentalMapboxNavigationAPI
+import com.mapbox.navigation.base.internal.extensions.toMapboxShield
 import com.mapbox.navigation.base.internal.factory.RoadObjectFactory
 import com.mapbox.navigation.base.internal.factory.RouteLegProgressFactory.buildRouteLegProgressObject
 import com.mapbox.navigation.base.internal.factory.RouteProgressFactory.buildRouteProgressObject
@@ -251,11 +252,12 @@ private fun MutableList<BannerComponent>.mapToDirectionsApi(): MutableList<Banne
                 .abbreviationPriority(it.abbrPriority)
                 .active(it.active)
                 .directions(it.directions)
-                .imageBaseUrl(it.imageBaseurl)
+                .imageBaseUrl(it.shield?.baseUrl)
                 .imageUrl(it.imageURL)
                 .text(it.text)
                 .type(it.type)
                 .subType(it.subType?.name?.lowercase())
+                .mapboxShield(it.shield?.toMapboxShield())
                 .build()
         )
     }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/infra/factories/NativeFactories.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/infra/factories/NativeFactories.kt
@@ -7,8 +7,8 @@ import com.mapbox.navigator.BannerSection
 import com.mapbox.navigator.FixLocation
 import com.mapbox.navigator.MapMatcherOutput
 import com.mapbox.navigator.NavigationStatus
+import com.mapbox.navigator.Road
 import com.mapbox.navigator.RouteState
-import com.mapbox.navigator.Shield
 import com.mapbox.navigator.SpeedLimit
 import com.mapbox.navigator.UpcomingRouteAlert
 import com.mapbox.navigator.VoiceInstruction
@@ -28,10 +28,7 @@ fun createNavigationStatus(
     predicted: Long = 0,
     shapeIndex: Int = 0,
     intersectionIndex: Int = 0,
-    roadName: String = "test road name",
-    shieldName: String = "test shield name",
-    imageBaseUrl: String = "baseUrl",
-    shields: List<Shield> = emptyList(),
+    roads: List<Road> = emptyList(),
     voiceInstruction: VoiceInstruction? = null,
     // default banner instruction workarounds the direct usage of the MapboxNativeNavigatorImpl
     bannerInstruction: BannerInstruction? = createBannerInstruction(),
@@ -57,10 +54,7 @@ fun createNavigationStatus(
         predicted,
         shapeIndex,
         intersectionIndex,
-        roadName,
-        shieldName,
-        imageBaseUrl,
-        shields,
+        roads,
         voiceInstruction,
         bannerInstruction,
         speedLimit,

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/navigator/NavigatorMapperTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/navigator/NavigatorMapperTest.kt
@@ -119,8 +119,7 @@ class NavigatorMapperTest {
                     )
                 }
                 every { layer } returns null
-                every { roadName } returns "Central Avenue"
-                every { shieldName } returns "I880"
+                every { roads } returns listOf(com.mapbox.navigator.Road("Central Av", null, null))
             }
         )
         val expected = LocationMatcherResult(
@@ -162,8 +161,7 @@ class NavigatorMapperTest {
                     )
                 }
                 every { layer } returns null
-                every { roadName } returns "Central Avenue"
-                every { shieldName } returns "I880"
+                every { roads } returns listOf(com.mapbox.navigator.Road("Central Av", null, null))
             }
         )
         val expected = LocationMatcherResult(
@@ -205,8 +203,7 @@ class NavigatorMapperTest {
                     )
                 }
                 every { layer } returns null
-                every { roadName } returns "Central Avenue"
-                every { shieldName } returns "I880"
+                every { roads } returns listOf(com.mapbox.navigator.Road("Central Av", null, null))
             }
         )
         val expected = LocationMatcherResult(
@@ -248,8 +245,7 @@ class NavigatorMapperTest {
                     )
                 }
                 every { layer } returns null
-                every { roadName } returns "Central Avenue"
-                every { shieldName } returns "I880"
+                every { roads } returns listOf(com.mapbox.navigator.Road("Central Av", null, null))
             }
         )
         val expected = LocationMatcherResult(
@@ -284,10 +280,7 @@ class NavigatorMapperTest {
                 every { matches } returns listOf()
             }
             every { layer } returns null
-            every { roadName } returns navigationStatus.roadName
-            every { shieldName } returns navigationStatus.shieldName
-            every { shields } returns navigationStatus.shields
-            every { imageBaseurl } returns navigationStatus.imageBaseurl
+            every { roads } returns listOf(com.mapbox.navigator.Road("Central Av", null, null))
         }
         val road: Road = RoadFactory.buildRoadObject(navigationStatus)
         val tripStatus = TripStatus(
@@ -333,8 +326,7 @@ class NavigatorMapperTest {
                     )
                 }
                 every { layer } returns 2
-                every { roadName } returns "Central Avenue"
-                every { shieldName } returns "I880"
+                every { roads } returns listOf(com.mapbox.navigator.Road("Central Av", null, null))
             }
         )
         val expected = LocationMatcherResult(
@@ -538,10 +530,7 @@ class NavigatorMapperTest {
         every { voiceInstruction } returns nativeVoiceInstructions
         every { inTunnel } returns true
         every { upcomingRouteAlerts } returns emptyList()
-        every { roadName } returns "Central Avenue"
-        every { shieldName } returns "I880"
-        every { imageBaseurl } returns "https://mapbox.shields.com/"
-        every { shields } returns listOf()
+        every { roads } returns listOf(com.mapbox.navigator.Road("Central Av", null, null))
     }
 
     val routeAlertLocation: RouteAlertLocation = mockk()

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/roadname/RoadNameProcessor.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/roadname/RoadNameProcessor.kt
@@ -16,6 +16,10 @@ internal object RoadNameProcessor {
         // Shield is being passed as null on purpose because this info is not yet available from
         // nav native. The ticket is being tracked here
         // https://github.com/mapbox/mapbox-navigation-native/issues/4325
-        return RoadNameResult.RoadNameLabel(road.name, null, road.shieldName)
+        return RoadNameResult.RoadNameLabel(
+            road.components.joinToString(separator = " ") { it.text },
+            null,
+            null
+        )
     }
 }

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/roadname/RoadNameProcessorTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/roadname/RoadNameProcessorTest.kt
@@ -1,6 +1,7 @@
 package com.mapbox.navigation.ui.maps.roadname
 
 import com.mapbox.navigation.base.road.model.Road
+import com.mapbox.navigation.base.road.model.RoadComponent
 import com.mapbox.navigation.ui.maps.roadname.model.RoadLabel
 import io.mockk.every
 import io.mockk.mockk
@@ -12,13 +13,16 @@ class RoadNameProcessorTest {
 
     @Test
     fun `when road has data then return road result`() {
-        val road = mockk<Road>() {
-            every { name } returns "Central Avenue"
-            every { shieldUrl } returns ""
-            every { shieldName } returns "101 South"
+        val roadComponent = mockk<RoadComponent> {
+            every { text } returns "Central Av"
+            every { shield } returns null
+            every { imageBaseUrl } returns null
+        }
+        val road = mockk<Road> {
+            every { components } returns listOf(roadComponent)
         }
         val action = RoadNameAction.GetRoadNameLabel(road)
-        val expected = RoadLabel(road.name, null, road.shieldName)
+        val expected = RoadLabel("Central Av", null, null)
 
         val result = RoadNameProcessor.process(action) as RoadNameResult.RoadNameLabel
 

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/roadname/api/MapboxRoadNameLabelApiTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/roadname/api/MapboxRoadNameLabelApiTest.kt
@@ -1,6 +1,7 @@
 package com.mapbox.navigation.ui.maps.roadname.api
 
 import com.mapbox.navigation.base.road.model.Road
+import com.mapbox.navigation.base.road.model.RoadComponent
 import com.mapbox.navigation.ui.maps.roadname.RoadNameAction
 import com.mapbox.navigation.ui.maps.roadname.RoadNameProcessor
 import com.mapbox.navigation.ui.maps.roadname.RoadNameResult
@@ -28,21 +29,24 @@ class MapboxRoadNameLabelApiTest {
 
     @Test
     fun `when function invoked return a road label`() {
+        val roadComponent = mockk<RoadComponent> {
+            every { text } returns "Central Av"
+            every { shield } returns null
+            every { imageBaseUrl } returns null
+        }
         val road = mockk<Road> {
-            every { name } returns "Central Avenue"
-            every { shieldUrl } returns ""
-            every { shieldName } returns "101 South"
+            every { components } returns listOf(roadComponent)
         }
         val action = RoadNameAction.GetRoadNameLabel(road)
         every {
             RoadNameProcessor.process(action)
-        } returns RoadNameResult.RoadNameLabel(road.name, null, road.shieldName)
+        } returns RoadNameResult.RoadNameLabel("Central Av", null, null)
         val roadNameApi = MapboxRoadNameLabelApi()
 
-        val expected = roadNameApi.getRoadNameLabel(road)
+        val actual = roadNameApi.getRoadNameLabel(road)
 
-        assertEquals(expected.roadName, road.name)
-        assertNull(expected.shield)
-        assertEquals(expected.shieldName, road.shieldName)
+        assertEquals("Central Av", actual.roadName)
+        assertNull(actual.shield)
+        assertNull(actual.shieldName)
     }
 }

--- a/libnavui-shield/src/main/java/com/mapbox/navigation/ui/shield/api/MapboxRouteShieldApi.kt
+++ b/libnavui-shield/src/main/java/com/mapbox/navigation/ui/shield/api/MapboxRouteShieldApi.kt
@@ -228,16 +228,18 @@ class MapboxRouteShieldApi {
         styleId: String?,
     ): List<RouteShieldToDownload> {
         val routeShieldToDownload = mutableListOf<RouteShieldToDownload>()
-        val legacyShieldUrl = shieldUrl
-        val legacy = if (legacyShieldUrl != null) {
-            RouteShieldToDownload.MapboxLegacy(legacyShieldUrl)
-        } else {
-            null
-        }
-        val mapboxDesign = mapboxShield?.mapNotNull { shield ->
-            if (
-                userId != null && styleId != null &&
-                mapboxShield != null && accessToken != null
+        components.forEach { roadComponent ->
+            val legacyShieldUrl = roadComponent.imageBaseUrl
+            val legacy = if (legacyShieldUrl != null) {
+                RouteShieldToDownload.MapboxLegacy(legacyShieldUrl)
+            } else {
+                null
+            }
+            val mapboxDesign = if (
+                userId != null &&
+                styleId != null &&
+                accessToken != null &&
+                roadComponent.shield != null
             ) {
                 RouteShieldToDownload.MapboxDesign(
                     ShieldSpriteToDownload(
@@ -245,17 +247,17 @@ class MapboxRouteShieldApi {
                         styleId = styleId
                     ),
                     accessToken = accessToken,
-                    mapboxShield = shield,
+                    mapboxShield = roadComponent.shield!!,
                     legacyFallback = legacy
                 )
             } else {
                 null
             }
-        }
-        if (!mapboxDesign.isNullOrEmpty()) {
-            routeShieldToDownload.addAll(mapboxDesign)
-        } else if (legacy != null) {
-            routeShieldToDownload.add(legacy)
+            if (mapboxDesign != null) {
+                routeShieldToDownload.add(mapboxDesign)
+            } else if (legacy != null) {
+                routeShieldToDownload.add(legacy)
+            }
         }
         return routeShieldToDownload
     }

--- a/libnavui-shield/src/test/java/com/mapbox/navigation/ui/shield/api/MapboxRouteShieldApiTest.kt
+++ b/libnavui-shield/src/test/java/com/mapbox/navigation/ui/shield/api/MapboxRouteShieldApiTest.kt
@@ -5,6 +5,7 @@ import com.mapbox.api.directions.v5.models.MapboxShield
 import com.mapbox.bindgen.Expected
 import com.mapbox.bindgen.ExpectedFactory
 import com.mapbox.navigation.base.road.model.Road
+import com.mapbox.navigation.base.road.model.RoadComponent
 import com.mapbox.navigation.testing.MainCoroutineRule
 import com.mapbox.navigation.ui.shield.RoadShieldContentManagerContainer
 import com.mapbox.navigation.ui.shield.internal.model.RouteShieldToDownload
@@ -403,11 +404,18 @@ class MapboxRouteShieldApiTest {
                 .textColor("black")
                 .displayRef("680")
                 .build()
+            val roadComponent1 = mockk<RoadComponent> {
+                every { text } returns "Central Av"
+                every { shield } returns mockMapboxShield1
+                every { imageBaseUrl } returns null
+            }
+            val roadComponent2 = mockk<RoadComponent> {
+                every { text } returns "North Av"
+                every { shield } returns mockMapboxShield2
+                every { imageBaseUrl } returns null
+            }
             val road = mockk<Road> {
-                every { name } returns "Central Av"
-                every { shieldName } returns "I 880"
-                every { shieldUrl } returns null
-                every { mapboxShield } returns listOf(mockMapboxShield1, mockMapboxShield2)
+                every { components } returns listOf(roadComponent1, roadComponent2)
             }
             val mockResultList = listOf<Expected<RouteShieldError, RouteShieldResult>>(
                 ExpectedFactory.createValue(
@@ -466,11 +474,13 @@ class MapboxRouteShieldApiTest {
         coroutineRule.runBlockingTest {
             val initialUrl1 = "https://shields.mapbox.com/mapbox/legacy/using/road/1"
             val toDownloadUrl1 = "https://shields.mapbox.com/mapbox/legacy/using/road/1.svg"
+            val roadComponent = mockk<RoadComponent> {
+                every { text } returns "Central Av"
+                every { shield } returns null
+                every { imageBaseUrl } returns initialUrl1
+            }
             val road = mockk<Road> {
-                every { name } returns "Central Av"
-                every { shieldName } returns "I 880"
-                every { shieldUrl } returns initialUrl1
-                every { mapboxShield } returns null
+                every { components } returns listOf(roadComponent)
             }
             val mockResultList = listOf<Expected<RouteShieldError, RouteShieldResult>>(
                 ExpectedFactory.createValue(
@@ -520,11 +530,13 @@ class MapboxRouteShieldApiTest {
                 .build()
             val initialUrl1 = "https://shields.mapbox.com/mapbox/legacy/using/road/1"
             val toDownloadUrl1 = "https://shields.mapbox.com/mapbox/legacy/using/road/1.svg"
+            val roadComponent = mockk<RoadComponent> {
+                every { text } returns "Central Av"
+                every { shield } returns mockMapboxShield1
+                every { imageBaseUrl } returns initialUrl1
+            }
             val road = mockk<Road> {
-                every { name } returns "Central Av"
-                every { shieldName } returns "I 880"
-                every { shieldUrl } returns initialUrl1
-                every { mapboxShield } returns listOf(mockMapboxShield1)
+                every { components } returns listOf(roadComponent)
             }
             val mockResultList = listOf<Expected<RouteShieldError, RouteShieldResult>>(
                 ExpectedFactory.createValue(


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Bumps NN dependency version to `83.0.0`

Opening this as a `Draft` as I'm getting `null` values from NN for supposedly `@NonNull` values e.g. `Shield#name`

```java
@NonNull
public String getName() {
    return name;
}
```

```
2022-01-11 15:40:50.102 11473-11473/com.mapbox.navigation.examples W/System.err: java.lang.NullPointerException: Null name
2022-01-11 15:40:50.102 11473-11473/com.mapbox.navigation.examples W/System.err:     at com.mapbox.api.directions.v5.models.$AutoValue_MapboxShield$Builder.name($AutoValue_MapboxShield.java:130)
2022-01-11 15:40:50.102 11473-11473/com.mapbox.navigation.examples W/System.err:     at com.mapbox.navigation.base.internal.factory.RoadFactory.buildRoadObject(RoadFactory.kt:21)
2022-01-11 15:40:50.102 11473-11473/com.mapbox.navigation.examples W/System.err:     at com.mapbox.navigation.core.trip.session.MapboxTripSession$navigatorObserver$1.onStatus(MapboxTripSession.kt:269)
2022-01-11 15:40:50.102 11473-11473/com.mapbox.navigation.examples W/System.err:     at android.os.MessageQueue.nativePollOnce(Native Method)
2022-01-11 15:40:50.102 11473-11473/com.mapbox.navigation.examples W/System.err:     at android.os.MessageQueue.next(MessageQueue.java:335)
2022-01-11 15:40:50.102 11473-11473/com.mapbox.navigation.examples W/System.err:     at android.os.Looper.loopOnce(Looper.java:161)
2022-01-11 15:40:50.102 11473-11473/com.mapbox.navigation.examples W/System.err:     at android.os.Looper.loop(Looper.java:288)
2022-01-11 15:40:50.102 11473-11473/com.mapbox.navigation.examples W/System.err:     at android.app.ActivityThread.main(ActivityThread.java:7842)
2022-01-11 15:40:50.102 11473-11473/com.mapbox.navigation.examples W/System.err:     at java.lang.reflect.Method.invoke(Native Method)
2022-01-11 15:40:50.102 11473-11473/com.mapbox.navigation.examples W/System.err:     at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
2022-01-11 15:40:50.102 11473-11473/com.mapbox.navigation.examples W/System.err:     at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003)
```

cc @mapbox/navnative 