### PR TITLE
Changelog for v2.3.0-alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,28 @@
 Mapbox welcomes participation and contributions from everyone.
 
 ## Unreleased
-- Add geo deeplink parser `GeoDeeplinkParser`. [#5103](https://github.com/mapbox/mapbox-navigation-android/pull/5103)
+
+## Mapbox Navigation SDK 2.2.0-rc.1 - January 14, 2021
+
+### Changelog
+#### Bug fixes and improvements
+- Bump NN, Maps and common dependency versions to 86.0.2, 10.3.0-beta.1 and 21.1.0-beta.1. [#5363](https://github.com/mapbox/mapbox-navigation-android/pull/5363)
+- Add geo deeplink parsing utility `GeoDeeplinkParser`. [#5103](https://github.com/mapbox/mapbox-navigation-android/pull/5103)
+
+### Mapbox dependencies
+This release depends on, and has been tested with, the following Mapbox dependencies:
+- Mapbox Maps SDK `v10.3.0-beta.1` ([release notes](https://github.com/mapbox/mapbox-maps-android/releases/tag/android-v10.3.0-beta.1))
+- Mapbox Navigation Native `v86.0.2`
+- Mapbox Core Common `v21.1.0-beta.1`
+- Mapbox Java `v6.2.0-beta.2` ([release notes](https://github.com/mapbox/mapbox-java/releases/tag/v6.2.0-beta.2))
+- Mapbox Android Core `v5.0.1`
+- Mapbox Android Telemetry `v8.1.1`
 
 ## Mapbox Navigation SDK 2.2.0-rc.1 - January 13, 2021
 
 For details on how v2 differs from v1 and guidance on migrating from v1 of the Mapbox Navigation SDK for Android to the v2 public preview, see [2.0 Navigation SDK Migration Guide](https://github.com/mapbox/mapbox-navigation-android/wiki/2.0-Navigation-SDK-Migration-Guide).
 
+### Changelog
 #### Bug fixes and improvements
 - Fixed an issue where calculation of dangerous maneuver avoidance (`RerouteOptions#avoidManeuverSeconds`) during a reroute was resulting in much smaller radius than expected. [#5307](https://github.com/mapbox/mapbox-navigation-android/pull/5307)
 - Fixed a crash when `ReplayLocationEngine`'s location callback removes itself during getting a location update. [#5305](https://github.com/mapbox/mapbox-navigation-android/pull/5305)
@@ -23,7 +39,7 @@ For details on how v2 differs from v1 and guidance on migrating from v1 of the M
 
 ### Mapbox dependencies
 This release depends on, and has been tested with, the following Mapbox dependencies:
-- Mapbox Maps SDK `v10.2.0` ([release notes](https://github.com/mapbox/mapbox-maps-android/releases/tag/android-v10.2.0)
+- Mapbox Maps SDK `v10.2.0` ([release notes](https://github.com/mapbox/mapbox-maps-android/releases/tag/android-v10.2.0))
 - Mapbox Navigation Native `v83.0.0`
 - Mapbox Core Common `v21.0.1`
 - Mapbox Java `v6.2.0-beta.2` ([release notes](https://github.com/mapbox/mapbox-java/releases/tag/v6.2.0-beta.2))


### PR DESCRIPTION
## Mapbox Navigation SDK 2.2.0-rc.1 - January 14, 2021

### Changelog
#### Bug fixes and improvements
- Bump NN, Maps and common dependency versions to 86.0.2, 10.3.0-beta.1 and 21.1.0-beta.1. [#5363](https://github.com/mapbox/mapbox-navigation-android/pull/5363)
- Add geo deeplink parsing utility `GeoDeeplinkParser`. [#5103](https://github.com/mapbox/mapbox-navigation-android/pull/5103)

### Mapbox dependencies
This release depends on, and has been tested with, the following Mapbox dependencies:
- Mapbox Maps SDK `v10.3.0-beta.1` ([release notes](https://github.com/mapbox/mapbox-maps-android/releases/tag/android-v10.3.0-beta.1))
- Mapbox Navigation Native `v86.0.2`
- Mapbox Core Common `v21.1.0-beta.1`
- Mapbox Java `v6.2.0-beta.2` ([release notes](https://github.com/mapbox/mapbox-java/releases/tag/v6.2.0-beta.2))
- Mapbox Android Core `v5.0.1`
- Mapbox Android Telemetry `v8.1.1`