### PR TITLE
remove jcenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,9 @@
 buildscript {
   apply from: "${rootDir}/gradle/dependencies.gradle"
-    repositories {
+  repositories {
     google()
     mavenCentral()
-    jcenter()
-    maven { url 'https://plugins.gradle.org/m2' }
+    gradlePluginPortal()
     maven {
       url 'https://api.mapbox.com/downloads/v2/releases/maven'
       authentication {
@@ -45,8 +44,7 @@ allprojects {
   repositories {
     google()
     mavenCentral()
-    jcenter()
-    maven { url 'https://plugins.gradle.org/m2' }
+    gradlePluginPortal()
     maven {
       url 'https://api.mapbox.com/downloads/v2/releases/maven'
       authentication {

--- a/gradle/dependency-updates.gradle
+++ b/gradle/dependency-updates.gradle
@@ -1,6 +1,7 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
+        gradlePluginPortal()
     }
     dependencies {
         classpath pluginDependencies.dependencyUpdates

--- a/gradle/script-git-version.gradle
+++ b/gradle/script-git-version.gradle
@@ -2,10 +2,10 @@
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
     dependencies {
-        classpath 'org.ajoberstar:grgit:1.5.0'
+        classpath 'org.ajoberstar.grgit:grgit-core:4.1.1'
     }
 }
 

--- a/gradle/track-public-apis.gradle
+++ b/gradle/track-public-apis.gradle
@@ -2,8 +2,8 @@ buildscript {
     apply from: "${rootDir}/gradle/dependencies.gradle"
 
     repositories {
-        jcenter()
         google()
+        mavenCentral()
     }
 
     dependencies {


### PR DESCRIPTION
### Description
Removed JCenter repository as it is deprecated and goes offline sometimes. 
The only dependency I had to update was grgit, so there shouldn't be any customer impact. 

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
