### PR TITLE
Bump `mapbox-java` dependency version to `6.2.0`

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -18,7 +18,7 @@ ext {
 
   version = [
       mapboxMapSdk              : '10.3.0-beta.1',
-      mapboxSdkServices         : '6.2.0-beta.2',
+      mapboxSdkServices         : '6.2.0',
       mapboxEvents              : '8.1.1',
       mapboxCore                : '5.0.1',
       mapboxNavigator           : "${mapboxNavigatorVersion}",


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Bumps `mapbox-java` dependency version to `6.2.0`