### PR TITLE
bring back `Road`'s legacy fields values (cherry-pick)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Mapbox welcomes participation and contributions from everyone.
 
 ## Unreleased
+#### Features
+
+#### Bug fixes and improvements
 
 ## Mapbox Navigation SDK 2.2.0 - January 20, 2022
 

--- a/libnavigation-base/api/current.txt
+++ b/libnavigation-base/api/current.txt
@@ -334,12 +334,10 @@ package com.mapbox.navigation.base.road.model {
 
   public final class Road {
     method public java.util.List<com.mapbox.navigation.base.road.model.RoadComponent> getComponents();
-    method @Deprecated public java.util.List<com.mapbox.api.directions.v5.models.MapboxShield>? getMapboxShield();
     method @Deprecated public String? getName();
     method @Deprecated public String? getShieldName();
     method @Deprecated public String? getShieldUrl();
     property public final java.util.List<com.mapbox.navigation.base.road.model.RoadComponent> components;
-    property @Deprecated public final java.util.List<com.mapbox.api.directions.v5.models.MapboxShield>? mapboxShield;
     property @Deprecated public final String? name;
     property @Deprecated public final String? shieldName;
     property @Deprecated public final String? shieldUrl;

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/factory/RoadFactory.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/factory/RoadFactory.kt
@@ -20,6 +20,11 @@ object RoadFactory {
                 imageBaseUrl = road.imageBaseUrl,
             )
         }
-        return Road(components = components)
+        return Road(
+            components = components,
+            name = navigationStatus.roads.firstOrNull()?.text,
+            shieldName = navigationStatus.roads.firstOrNull()?.shield?.name,
+            shieldUrl = navigationStatus.roads.firstOrNull()?.imageBaseUrl,
+        )
     }
 }

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/road/model/Road.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/road/model/Road.kt
@@ -1,50 +1,30 @@
 package com.mapbox.navigation.base.road.model
 
-import com.mapbox.api.directions.v5.models.MapboxShield
-
 /**
  * Object that holds road properties
  * @property components list of the [RoadComponent]
+ * @property name of the road if available otherwise null
+ * @property shieldUrl url for the route shield if available otherwise null
+ * @property shieldName name of the route shield if available otherwise null
  */
 class Road internal constructor(
-    val components: List<RoadComponent>
-) {
-
-    /**
-     * Name of the road.
-     */
+    val components: List<RoadComponent>,
     @Deprecated(
         message = "Use RoadComponent.text instead.",
         replaceWith = ReplaceWith("RoadComponent.text")
     )
-    val name: String? = null
-
-    /**
-     * URL for the route shield.
-     */
+    val name: String? = null,
     @Deprecated(
         message = "Use RoadComponent.shield.baseUrl() instead.",
         replaceWith = ReplaceWith("RoadComponent.shield.baseUrl()")
     )
-    val shieldUrl: String? = null
-
-    /**
-     * Name of the route shield.
-     */
+    val shieldUrl: String? = null,
     @Deprecated(
         message = "Use RoadComponent.shield.name() instead.",
         replaceWith = ReplaceWith("RoadComponent.shield.name()")
     )
-    val shieldName: String? = null
-
-    /**
-     * Mapbox designed shield.
-     */
-    @Deprecated(
-        message = "Use RoadComponent.shield instead.",
-        replaceWith = ReplaceWith("RoadComponent.shield")
-    )
-    val mapboxShield: List<MapboxShield>? = null
+    val shieldName: String? = null,
+) {
 
     /**
      * Indicates whether some other object is "equal to" this one.
@@ -56,6 +36,9 @@ class Road internal constructor(
         other as Road
 
         if (components != other.components) return false
+        if (name != other.name) return false
+        if (shieldUrl != other.shieldUrl) return false
+        if (shieldName != other.shieldName) return false
 
         return true
     }
@@ -64,13 +47,22 @@ class Road internal constructor(
      * Returns a hash code value for the object.
      */
     override fun hashCode(): Int {
-        return components.hashCode()
+        var result = components.hashCode()
+        result = 31 * result + (name?.hashCode() ?: 0)
+        result = 31 * result + (shieldUrl?.hashCode() ?: 0)
+        result = 31 * result + (shieldName?.hashCode() ?: 0)
+        return result
     }
 
     /**
      * Returns a string representation of the object.
      */
     override fun toString(): String {
-        return "Road(components=$components)"
+        return "Road(" +
+            "components=$components, " +
+            "name=$name, " +
+            "shieldUrl=$shieldUrl, " +
+            "shieldName=$shieldName" +
+            ")"
     }
 }

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/internal/factory/RoadFactoryTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/internal/factory/RoadFactoryTest.kt
@@ -1,0 +1,64 @@
+package com.mapbox.navigation.base.internal.factory
+
+import com.mapbox.navigation.base.ExperimentalMapboxNavigationAPI
+import com.mapbox.navigator.NavigationStatus
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert
+import org.junit.Test
+
+@OptIn(ExperimentalMapboxNavigationAPI::class)
+class RoadFactoryTest {
+
+    @Test
+    fun `road object provides name`() {
+        val status = createNavigationStatus()
+
+        val road = RoadFactory.buildRoadObject(status)
+
+        Assert.assertEquals("roadName1", road.name)
+        Assert.assertEquals("roadName1", road.components[0].text)
+        Assert.assertEquals("roadName2", road.components[1].text)
+    }
+
+    @Test
+    fun `road object provides legacy shield url`() {
+        val status = createNavigationStatus()
+
+        val road = RoadFactory.buildRoadObject(status)
+
+        Assert.assertEquals("legacyUrl1", road.shieldUrl)
+        Assert.assertEquals("legacyUrl1", road.components[0].imageBaseUrl)
+        Assert.assertEquals("designUrl", road.components[0].shield?.baseUrl())
+    }
+
+    @Test
+    fun `road object provides shield name`() {
+        val status = createNavigationStatus()
+
+        val road = RoadFactory.buildRoadObject(status)
+
+        Assert.assertEquals("shieldName", road.shieldName)
+        Assert.assertEquals("shieldName", road.components[0].shield?.name())
+    }
+
+    private fun createNavigationStatus(): NavigationStatus = mockk {
+        every { roads } returns listOf(
+            com.mapbox.navigator.Road(
+                "roadName1",
+                "legacyUrl1",
+                com.mapbox.navigator.Shield(
+                    "designUrl",
+                    "displayRef",
+                    "shieldName",
+                    "color"
+                )
+            ),
+            com.mapbox.navigator.Road(
+                "roadName2",
+                null,
+                null
+            )
+        )
+    }
+}

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/navigator/NavigatorMapper.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/navigator/NavigatorMapper.kt
@@ -252,7 +252,7 @@ private fun MutableList<BannerComponent>.mapToDirectionsApi(): MutableList<Banne
                 .abbreviationPriority(it.abbrPriority)
                 .active(it.active)
                 .directions(it.directions)
-                .imageBaseUrl(it.shield?.baseUrl)
+                .imageBaseUrl(it.imageBaseUrl)
                 .imageUrl(it.imageURL)
                 .text(it.text)
                 .type(it.type)

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/navigator/NavigatorMapperTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/navigator/NavigatorMapperTest.kt
@@ -476,6 +476,16 @@ class NavigatorMapperTest {
         )
     }
 
+    @Test
+    fun `banner components mapper correctly sets legacy shield url`() {
+        val result = nativeBannerInstructions.mapToDirectionsApi()
+
+        assertEquals(
+            "legacyShieldUrl",
+            result.primary().components()!!.first().imageBaseUrl()
+        )
+    }
+
     private fun createSpeedLimit(): com.mapbox.navigator.SpeedLimit {
         return com.mapbox.navigator.SpeedLimit(
             10,
@@ -491,7 +501,14 @@ class NavigatorMapperTest {
     private val nativeBannerInstructions = mockk<BannerInstruction> {
         every { remainingStepDistance } returns 111f
         every { primary } returns mockk {
-            every { components } returns listOf()
+            every { components } returns listOf(
+                mockk(relaxed = true) {
+                    every { imageBaseUrl } returns "legacyShieldUrl"
+                    every { shield } returns mockk(relaxed = true) {
+                        every { baseUrl } returns "designBaseUrl"
+                    }
+                }
+            )
             every { degrees } returns 45
             every { drivingSide } returns "drivingSide"
             every { modifier } returns "modifier"


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Backports https://github.com/mapbox/mapbox-navigation-android/pull/5396 to `release-v2.2`. Skipping changelog because the issue was introduced during pre-release phase.

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
