### PR TITLE
Added icon offset and icon anchor options for the symbol layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 Mapbox welcomes participation and contributions from everyone.
 
-## Unreleased
+## Unreleased 
+- Added options to the MapboxRouteLineOptions class to control the icon anchor and icon offset for the route line related waypoint icons including the origin and destination points. [#5409](https://github.com/mapbox/mapbox-navigation-android/pull/5409)
 #### Features
 
 #### Bug fixes and improvements

--- a/libnavui-maps/api/current.txt
+++ b/libnavui-maps/api/current.txt
@@ -844,6 +844,8 @@ package com.mapbox.navigation.ui.maps.route.line.model {
     method public boolean getStyleInactiveRouteLegsIndependently();
     method public double getTolerance();
     method public long getVanishingRouteLineUpdateIntervalNano();
+    method public com.mapbox.maps.extension.style.layers.properties.generated.IconAnchor getWaypointLayerIconAnchor();
+    method public java.util.List<java.lang.Double> getWaypointLayerIconOffset();
     method public com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions.Builder toBuilder(android.content.Context context);
     property public final android.graphics.drawable.Drawable destinationIcon;
     property public final boolean displayRestrictedRoadSections;
@@ -855,6 +857,8 @@ package com.mapbox.navigation.ui.maps.route.line.model {
     property public final boolean styleInactiveRouteLegsIndependently;
     property public final double tolerance;
     property public final long vanishingRouteLineUpdateIntervalNano;
+    property public final com.mapbox.maps.extension.style.layers.properties.generated.IconAnchor waypointLayerIconAnchor;
+    property public final java.util.List<java.lang.Double> waypointLayerIconOffset;
   }
 
   public static final class MapboxRouteLineOptions.Builder {
@@ -865,6 +869,8 @@ package com.mapbox.navigation.ui.maps.route.line.model {
     method public com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions.Builder softGradientTransition(int transitionDistance);
     method public com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions.Builder styleInactiveRouteLegsIndependently(boolean enable);
     method public com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions.Builder vanishingRouteLineUpdateInterval(long interval = 62500000L);
+    method public com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions.Builder waypointLayerIconAnchor(com.mapbox.maps.extension.style.layers.properties.generated.IconAnchor iconAnchor = IconAnchor.CENTER);
+    method public com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions.Builder waypointLayerIconOffset(java.util.List<java.lang.Double> iconOffset = listOf(0.0, 0.0));
     method public com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions.Builder withRouteLineBelowLayerId(String layerId);
     method public com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions.Builder withRouteLineResources(com.mapbox.navigation.ui.maps.route.line.model.RouteLineResources resourceProvider);
     method public com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions.Builder withRouteStyleDescriptors(java.util.List<com.mapbox.navigation.ui.maps.route.line.model.RouteStyleDescriptor> routeStyleDescriptors);

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtils.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtils.kt
@@ -1050,7 +1050,9 @@ object MapboxRouteLineUtils {
         options.routeLayerProvider.buildWayPointLayer(
             style,
             options.originIcon,
-            options.destinationIcon
+            options.destinationIcon,
+            options.waypointLayerIconOffset,
+            options.waypointLayerIconAnchor
         ).let {
             style.addPersistentLayer(it, LayerPosition(null, belowLayerIdToUse, null))
         }

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/MapboxRouteLayerProvider.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/MapboxRouteLayerProvider.kt
@@ -9,6 +9,7 @@ import com.mapbox.maps.extension.style.expressions.generated.Expression
 import com.mapbox.maps.extension.style.expressions.generated.Expression.Companion.switchCase
 import com.mapbox.maps.extension.style.layers.generated.LineLayer
 import com.mapbox.maps.extension.style.layers.generated.SymbolLayer
+import com.mapbox.maps.extension.style.layers.properties.generated.IconAnchor
 import com.mapbox.maps.extension.style.layers.properties.generated.IconPitchAlignment
 import com.mapbox.maps.extension.style.layers.properties.generated.LineCap
 import com.mapbox.maps.extension.style.layers.properties.generated.LineJoin
@@ -205,7 +206,9 @@ internal class MapboxRouteLayerProvider(
     fun buildWayPointLayer(
         style: Style,
         originIcon: Drawable,
-        destinationIcon: Drawable
+        destinationIcon: Drawable,
+        iconOffset: List<Double>,
+        iconAnchor: IconAnchor
     ): SymbolLayer {
         if (style.styleLayerExists(RouteLayerConstants.WAYPOINT_LAYER_ID)) {
             style.removeStyleLayer(RouteLayerConstants.WAYPOINT_LAYER_ID)
@@ -228,23 +231,25 @@ internal class MapboxRouteLayerProvider(
         return SymbolLayer(
             RouteLayerConstants.WAYPOINT_LAYER_ID,
             RouteLayerConstants.WAYPOINT_SOURCE_ID
-        ).iconImage(
-            match {
-                toString {
-                    get { literal(RouteLayerConstants.WAYPOINT_PROPERTY_KEY) }
-                }
-                literal(RouteLayerConstants.WAYPOINT_ORIGIN_VALUE)
-                stop {
-                    RouteLayerConstants.WAYPOINT_ORIGIN_VALUE
-                    literal(RouteLayerConstants.ORIGIN_MARKER_NAME)
-                }
-                stop {
-                    RouteLayerConstants.WAYPOINT_DESTINATION_VALUE
-                    literal(RouteLayerConstants.DESTINATION_MARKER_NAME)
-                }
-            }
         )
-            .iconSize(
+            .iconOffset(iconOffset)
+            .iconAnchor(iconAnchor)
+            .iconImage(
+                match {
+                    toString {
+                        get { literal(RouteLayerConstants.WAYPOINT_PROPERTY_KEY) }
+                    }
+                    literal(RouteLayerConstants.WAYPOINT_ORIGIN_VALUE)
+                    stop {
+                        RouteLayerConstants.WAYPOINT_ORIGIN_VALUE
+                        literal(RouteLayerConstants.ORIGIN_MARKER_NAME)
+                    }
+                    stop {
+                        RouteLayerConstants.WAYPOINT_DESTINATION_VALUE
+                        literal(RouteLayerConstants.DESTINATION_MARKER_NAME)
+                    }
+                }
+            ).iconSize(
                 interpolate {
                     exponential { literal(1.5) }
                     zoom()

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/MapboxRouteLineOptions.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/MapboxRouteLineOptions.kt
@@ -3,6 +3,7 @@ package com.mapbox.navigation.ui.maps.route.line.model
 import android.content.Context
 import android.graphics.drawable.Drawable
 import androidx.appcompat.content.res.AppCompatResources
+import com.mapbox.maps.extension.style.layers.properties.generated.IconAnchor
 import com.mapbox.maps.plugin.locationcomponent.LocationComponentConstants
 import com.mapbox.navigation.ui.maps.route.RouteLayerConstants
 import com.mapbox.navigation.ui.maps.route.RouteLayerConstants.DEFAULT_ROUTE_SOURCES_TOLERANCE
@@ -31,6 +32,8 @@ import kotlin.math.abs
  * parameter is true.
  * @param vanishingRouteLineUpdateIntervalNano can be used to decrease the frequency of the vanishing route
  * line updates improving the performance at the expense of visual appearance of the vanishing point on the line during navigation.
+ * @param waypointLayerIconOffset the list of offset values for waypoint icons
+ * @param waypointLayerIconAnchor the anchor value, the default is [IconAnchor.CENTER]
  */
 class MapboxRouteLineOptions private constructor(
     val resourceProvider: RouteLineResources,
@@ -45,7 +48,9 @@ class MapboxRouteLineOptions private constructor(
     val displaySoftGradientForTraffic: Boolean = false,
     val softGradientTransition: Double = RouteLayerConstants.SOFT_GRADIENT_STOP_GAP_METERS,
     val vanishingRouteLineUpdateIntervalNano: Long =
-        RouteLayerConstants.DEFAULT_VANISHING_POINT_MIN_UPDATE_INTERVAL_NANO
+        RouteLayerConstants.DEFAULT_VANISHING_POINT_MIN_UPDATE_INTERVAL_NANO,
+    val waypointLayerIconOffset: List<Double> = listOf(0.0, 0.0),
+    val waypointLayerIconAnchor: IconAnchor = IconAnchor.CENTER
 ) {
 
     /**
@@ -66,7 +71,9 @@ class MapboxRouteLineOptions private constructor(
             styleInactiveRouteLegsIndependently,
             displaySoftGradientForTraffic,
             softGradientTransition,
-            vanishingRouteLineUpdateIntervalNano
+            vanishingRouteLineUpdateIntervalNano,
+            waypointLayerIconOffset,
+            waypointLayerIconAnchor
         )
     }
 
@@ -93,6 +100,8 @@ class MapboxRouteLineOptions private constructor(
         if (softGradientTransition != other.softGradientTransition) return false
         if (vanishingRouteLineUpdateIntervalNano != other.vanishingRouteLineUpdateIntervalNano)
             return false
+        if (waypointLayerIconOffset != other.waypointLayerIconOffset) return false
+        if (waypointLayerIconAnchor != other.waypointLayerIconAnchor) return false
 
         return true
     }
@@ -113,6 +122,8 @@ class MapboxRouteLineOptions private constructor(
         result = 31 * result + (displaySoftGradientForTraffic.hashCode())
         result = 31 * result + (softGradientTransition.hashCode())
         result = 31 * result + (vanishingRouteLineUpdateIntervalNano.hashCode())
+        result = 31 * result + (waypointLayerIconOffset.hashCode())
+        result = 31 * result + (waypointLayerIconAnchor.hashCode())
         return result
     }
 
@@ -131,7 +142,9 @@ class MapboxRouteLineOptions private constructor(
             "styleInactiveRouteLegsIndependently=$styleInactiveRouteLegsIndependently," +
             "displaySoftGradientForTraffic=$displaySoftGradientForTraffic," +
             "softGradientTransition=$softGradientTransition," +
-            "vanishingRouteLineUpdateIntervalNano=$vanishingRouteLineUpdateIntervalNano" +
+            "vanishingRouteLineUpdateIntervalNano=$vanishingRouteLineUpdateIntervalNano," +
+            "waypointLayerIconOffset=$waypointLayerIconOffset," +
+            "waypointLayerIconAnchor=$waypointLayerIconAnchor" +
             ")"
     }
 
@@ -167,7 +180,9 @@ class MapboxRouteLineOptions private constructor(
         private var styleInactiveRouteLegsIndependently: Boolean,
         private var displaySoftGradientForTraffic: Boolean,
         private var softGradientTransition: Double,
-        private var vanishingRouteLineUpdateIntervalNano: Long
+        private var vanishingRouteLineUpdateIntervalNano: Long,
+        private var iconOffset: List<Double>,
+        private var iconAnchor: IconAnchor
     ) {
 
         /**
@@ -186,7 +201,9 @@ class MapboxRouteLineOptions private constructor(
             false,
             false,
             RouteLayerConstants.SOFT_GRADIENT_STOP_GAP_METERS,
-            RouteLayerConstants.DEFAULT_VANISHING_POINT_MIN_UPDATE_INTERVAL_NANO
+            RouteLayerConstants.DEFAULT_VANISHING_POINT_MIN_UPDATE_INTERVAL_NANO,
+            listOf(0.0, 0.0),
+            IconAnchor.CENTER
         )
 
         /**
@@ -302,6 +319,32 @@ class MapboxRouteLineOptions private constructor(
         ): Builder = apply { this.vanishingRouteLineUpdateIntervalNano = interval }
 
         /**
+         * Determines the icon offset for the [SymbolLayer] that hosts the waypoint icons
+         * including the icons for the origin and destination points.
+         *
+         * Offset distance of icon from its anchor. Positive values indicate right and down,
+         * while negative values indicate left and up. Each component is multiplied by the
+         * value of icon-size to obtain the final offset in pixels.
+         * When combined with icon-rotate the offset will be as if the rotated direction was up.
+         *
+         * @param iconOffset the list of offset values
+         * @return the builder
+         */
+        fun waypointLayerIconOffset(iconOffset: List<Double> = listOf(0.0, 0.0)): Builder =
+            apply { this.iconOffset = iconOffset }
+
+        /**
+         * Determines the icon anchor for the [SymbolLayer] that hosts the waypoint icons
+         * including the icons for the origin and destination points.
+         *
+         * Part of the icon placed closest to the anchor
+         *
+         * @param iconAnchor the anchor value, the default is [IconAnchor.CENTER]
+         */
+        fun waypointLayerIconAnchor(iconAnchor: IconAnchor = IconAnchor.CENTER): Builder =
+            apply { this.iconAnchor = iconAnchor }
+
+        /**
          * @return an instance of [MapboxRouteLineOptions]
          */
         fun build(): MapboxRouteLineOptions {
@@ -346,7 +389,9 @@ class MapboxRouteLineOptions private constructor(
                 styleInactiveRouteLegsIndependently,
                 displaySoftGradientForTraffic,
                 softGradientTransition,
-                vanishingRouteLineUpdateIntervalNano
+                vanishingRouteLineUpdateIntervalNano,
+                iconOffset,
+                iconAnchor
             )
         }
     }

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtilsTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtilsTest.kt
@@ -20,6 +20,7 @@ import com.mapbox.maps.Style
 import com.mapbox.maps.StyleObjectInfo
 import com.mapbox.maps.extension.style.layers.Layer
 import com.mapbox.maps.extension.style.layers.getLayer
+import com.mapbox.maps.extension.style.layers.properties.generated.IconAnchor
 import com.mapbox.maps.extension.style.layers.properties.generated.Visibility
 import com.mapbox.maps.plugin.locationcomponent.LocationComponentConstants
 import com.mapbox.navigation.testing.FileUtils.loadJsonFixture
@@ -71,6 +72,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import java.util.ArrayList
 
 @RunWith(RobolectricTestRunner::class)
 class MapboxRouteLineUtilsTest {
@@ -446,6 +448,8 @@ class MapboxRouteLineUtilsTest {
         val options = MapboxRouteLineOptions.Builder(ctx)
             .withRouteLineBelowLayerId(LocationComponentConstants.MODEL_LAYER)
             .displayRestrictedRoadSections(true)
+            .waypointLayerIconAnchor(IconAnchor.BOTTOM_RIGHT)
+            .waypointLayerIconOffset(listOf(33.3, 44.4))
             .build()
         val waypointSourceValueSlots = mutableListOf<Value>()
         val primaryRouteSourceValueSlots = mutableListOf<Value>()
@@ -693,6 +697,24 @@ class MapboxRouteLineUtilsTest {
         assertEquals(
             "mapbox-navigation-waypoint-layer",
             (addStyleLayerSlots[12].contents as HashMap<String, Value>)["id"]!!.contents
+        )
+        assertEquals(
+            "bottom-right",
+            (addStyleLayerSlots[12].contents as HashMap<String, Value>)["icon-anchor"]!!.contents
+        )
+        assertEquals(
+            33.3,
+            (
+                (addStyleLayerSlots[12].contents as HashMap<String, Value>)["icon-offset"]
+                !!.contents as ArrayList<Value>
+                ).first().contents
+        )
+        assertEquals(
+            44.4,
+            (
+                (addStyleLayerSlots[12].contents as HashMap<String, Value>)["icon-offset"]
+                !!.contents as ArrayList<Value>
+                ).component2().contents
         )
         assertEquals(
             LocationComponentConstants.MODEL_LAYER,

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/model/MapboxRouteLineOptionsTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/model/MapboxRouteLineOptionsTest.kt
@@ -3,6 +3,7 @@ package com.mapbox.navigation.ui.maps.route.line.model
 import android.content.Context
 import android.graphics.Color
 import androidx.test.core.app.ApplicationProvider
+import com.mapbox.maps.extension.style.layers.properties.generated.IconAnchor
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
@@ -114,6 +115,26 @@ class MapboxRouteLineOptionsTest {
     }
 
     @Test
+    fun waypointLayerIconOffset() {
+        val options = MapboxRouteLineOptions.Builder(ctx)
+            .waypointLayerIconOffset(listOf(3.0, 4.4))
+            .build()
+
+        assertEquals(3.0, options.waypointLayerIconOffset.first(), 0.0)
+        assertEquals(4.4, options.waypointLayerIconOffset.component2(), 0.0)
+        assertEquals(2, options.waypointLayerIconOffset.size)
+    }
+
+    @Test
+    fun waypointLayerIconAnchor() {
+        val options = MapboxRouteLineOptions.Builder(ctx)
+            .waypointLayerIconAnchor(IconAnchor.BOTTOM_LEFT)
+            .build()
+
+        assertEquals(IconAnchor.BOTTOM_LEFT, options.waypointLayerIconAnchor)
+    }
+
+    @Test
     fun toBuilder() {
         val routeLineResources = RouteLineResources.Builder().build()
         val routeStyleDescriptors =
@@ -130,6 +151,8 @@ class MapboxRouteLineOptionsTest {
             .displaySoftGradientForTraffic(true)
             .softGradientTransition(77)
             .vanishingRouteLineUpdateInterval(44L)
+            .waypointLayerIconOffset(listOf(3.0, 4.4))
+            .waypointLayerIconAnchor(IconAnchor.BOTTOM)
             .build()
             .toBuilder(ctx)
             .build()
@@ -144,5 +167,9 @@ class MapboxRouteLineOptionsTest {
         assertTrue(options.displaySoftGradientForTraffic)
         assertEquals(77.0, options.softGradientTransition, 0.0)
         assertEquals(44, options.vanishingRouteLineUpdateIntervalNano)
+        assertEquals(3.0, options.waypointLayerIconOffset.first(), 0.0)
+        assertEquals(4.4, options.waypointLayerIconOffset.component2(), 0.0)
+        assertEquals(2, options.waypointLayerIconOffset.size)
+        assertEquals(IconAnchor.BOTTOM, options.waypointLayerIconAnchor)
     }
 }


### PR DESCRIPTION
### Description
Fixes #5389 by adding layer options for the symbol layer that hosts the waypoint icons related to the route line.

### Screenshots or Gifs

