### PR TITLE
fix route shield comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Mapbox welcomes participation and contributions from everyone.
 #### Bug fixes and improvements
 - Refactored `Status` class to POJO and decreased its constructor visibility. Introduced `StatusFactory` class for public use. [#5432](https://github.com/mapbox/mapbox-navigation-android/pull/5432)   
 - Fixed an issue where setting a custom `MapboxRouteLineOptions#vanishingRouteLineUpdateIntervalNano` that happened to be longer than the typical rate of `RouteProgress` updates delivered via `mapboxRouteLineApi#updateWithRouteProgress`, the traveled portion of the route wouldn't vanish at all. [#5435](https://github.com/mapbox/mapbox-navigation-android/pull/5435)
+- Fixed an issue where `MapboxManeuverView` or `MapboxRoadNameView` displayed wrong shield. [#5426](https://github.com/mapbox/mapbox-navigation-android/pull/5426)
 
 ## Mapbox Navigation SDK 2.3.0-beta.1 - January 28, 2022
 #### Features

--- a/libnavui-shield/src/main/java/com/mapbox/navigation/ui/shield/model/RouteShield.kt
+++ b/libnavui-shield/src/main/java/com/mapbox/navigation/ui/shield/model/RouteShield.kt
@@ -5,7 +5,6 @@ import android.graphics.Bitmap
 import android.util.TypedValue
 import com.mapbox.api.directions.v5.models.MapboxShield
 import com.mapbox.api.directions.v5.models.ShieldSprite
-import com.mapbox.navigation.ui.shield.internal.model.getRefLen
 import com.mapbox.navigation.ui.utils.internal.SvgUtil
 import java.io.ByteArrayInputStream
 
@@ -195,17 +194,12 @@ sealed class RouteShield(
         }
 
         /**
-         * Invoke the method to compare two shields based on whether the shield url contains the
-         * shield name from [other]
+         * Invoke the method to compare two shields based on shield data
          *
          * @param other mapbox designed shield
          */
         fun compareWith(other: MapboxShield?): Boolean {
-            if (other == null) { return false }
-            val shieldName = other.name()
-            val displayRefLength = other.getRefLen()
-            val shieldRequested = shieldName.plus("-$displayRefLength")
-            return this.url.contains(shieldRequested)
+            return mapboxShield == other
         }
     }
 }

--- a/libnavui-shield/src/test/java/com/mapbox/navigation/ui/shield/model/RouteShieldTest.kt
+++ b/libnavui-shield/src/test/java/com/mapbox/navigation/ui/shield/model/RouteShieldTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.os.Build
 import androidx.test.core.app.ApplicationProvider
+import com.mapbox.api.directions.v5.models.MapboxShield
 import com.mapbox.navigation.ui.utils.internal.SvgUtil
 import io.mockk.every
 import io.mockk.mockk
@@ -185,26 +186,26 @@ class RouteShieldTest {
         val mapboxDesignedShield = RouteShield.MapboxDesignedShield(
             url = "https://shield.mapbox.designed.us-interstate-3",
             byteArrayOf(1),
-            mockk {
-                every { name() } returns "us-interstate"
-                every { textColor() } returns "white"
-                every { baseUrl() } returns "https://api.mapbox.com/styles/v1"
-                every { displayRef() } returns "880"
-            },
+            MapboxShield.builder()
+                .name("us-interstate")
+                .textColor("white")
+                .baseUrl("https://api.mapbox.com/styles/v1")
+                .displayRef("880")
+                .build(),
             mockk {
                 every { spriteAttributes().width() } returns 72
                 every { spriteAttributes().height() } returns 24
             }
         )
         val otherDesignedShield = RouteShield.MapboxDesignedShield(
-            url = "https://shield.mapbox.designed",
+            url = "https://shield.mapbox.designed.us-interstate-3",
             byteArrayOf(1),
-            mockk {
-                every { name() } returns "us-interstate"
-                every { textColor() } returns "white"
-                every { baseUrl() } returns "https://api.mapbox.com/styles/v1"
-                every { displayRef() } returns "880"
-            },
+            MapboxShield.builder()
+                .name("us-interstate")
+                .textColor("white")
+                .baseUrl("https://api.mapbox.com/styles/v1")
+                .displayRef("880")
+                .build(),
             mockk {
                 every { spriteAttributes().width() } returns 72
                 every { spriteAttributes().height() } returns 24
@@ -219,28 +220,28 @@ class RouteShieldTest {
     @Test
     fun `when compare two mapbox designed shields that don't have same same shields`() {
         val mapboxDesignedShield = RouteShield.MapboxDesignedShield(
-            url = "https://shield.mapbox.designed",
+            url = "https://shield.mapbox.designed.us-interstate-3",
             byteArrayOf(1),
-            mockk {
-                every { name() } returns "us-interstate"
-                every { textColor() } returns "white"
-                every { baseUrl() } returns "https://api.mapbox.com/styles/v1"
-                every { displayRef() } returns "880"
-            },
+            MapboxShield.builder()
+                .name("us-interstate")
+                .textColor("white")
+                .baseUrl("https://api.mapbox.com/styles/v1")
+                .displayRef("880")
+                .build(),
             mockk {
                 every { spriteAttributes().width() } returns 72
                 every { spriteAttributes().height() } returns 24
             }
         )
         val otherDesignedShield = RouteShield.MapboxDesignedShield(
-            url = "https://shield.mapbox.designed",
+            url = "https://shield.mapbox.designed.us-interstate-3",
             byteArrayOf(1),
-            mockk {
-                every { name() } returns "rectangle-yellow"
-                every { textColor() } returns "white"
-                every { baseUrl() } returns "https://api.mapbox.com/styles/v1"
-                every { displayRef() } returns "880"
-            },
+            MapboxShield.builder()
+                .name("us-interstate")
+                .textColor("white")
+                .baseUrl("https://api.mapbox.com/styles/v1")
+                .displayRef("990")
+                .build(),
             mockk {
                 every { spriteAttributes().width() } returns 72
                 every { spriteAttributes().height() } returns 24


### PR DESCRIPTION
### Description
Comparing `url`s is not enough, because they are only responsible for displaying background. 

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
