### PR TITLE
Fix `ReplayHistoryActivity` `navigationCamera` `UninitializedPropertyAccessException`

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayHistoryActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayHistoryActivity.kt
@@ -176,6 +176,11 @@ class ReplayHistoryActivity : AppCompatActivity() {
             binding.mapView.getMapboxMap()
         )
         val mapboxMap = binding.mapView.getMapboxMap()
+        navigationCamera = NavigationCamera(
+            mapboxMap,
+            binding.mapView.camera,
+            viewportDataSource
+        )
         initialCameraOptions?.let { mapboxMap.setCamera(it) }
         mapboxMap.loadStyleUri(
             NavigationStyles.NAVIGATION_DAY_STYLE,
@@ -191,11 +196,6 @@ class ReplayHistoryActivity : AppCompatActivity() {
                     enabled = true
                 }
                 locationComponent.addOnIndicatorPositionChangedListener(onPositionChangedListener)
-                navigationCamera = NavigationCamera(
-                    mapboxMap,
-                    binding.mapView.camera,
-                    viewportDataSource
-                )
                 viewportDataSource.evaluate()
             },
             object : OnMapLoadErrorListener {


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
- Removes `lateinit` from `ReplayHistoryActivity` `navigationCamera` property to avoid `UninitializedPropertyAccessException`

Fixes https://github.com/mapbox/mapbox-navigation-android/issues/5424