### PR TITLE
Issue-#5420: MapboxStatusView use internal class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Mapbox welcomes participation and contributions from everyone.
 #### Features
 
 #### Bug fixes and improvements
-
+- Refactored `Status` class to POJO and decreased its constructor visibility. Introduced `StatusFactory` class for public use. [#5432](https://github.com/mapbox/mapbox-navigation-android/pull/5432)   
 
 ## Mapbox Navigation SDK 2.3.0-beta.1 - January 28, 2022
 #### Features

--- a/libnavui-status/api/current.txt
+++ b/libnavui-status/api/current.txt
@@ -2,13 +2,6 @@
 package com.mapbox.navigation.ui.status.model {
 
   public final class Status {
-    ctor public Status(String message, long duration = 0, boolean animated = true, boolean spinner = false, @DrawableRes int icon = 0);
-    method public String component1();
-    method public long component2();
-    method public boolean component3();
-    method public boolean component4();
-    method public int component5();
-    method public com.mapbox.navigation.ui.status.model.Status copy(String message, long duration, boolean animated, boolean spinner, int icon);
     method public boolean getAnimated();
     method public long getDuration();
     method public int getIcon();
@@ -19,6 +12,15 @@ package com.mapbox.navigation.ui.status.model {
     property public final int icon;
     property public final String message;
     property public final boolean spinner;
+  }
+
+  @com.mapbox.navigation.base.ExperimentalMapboxNavigationAPI public final class StatusFactory {
+    method public static com.mapbox.navigation.ui.status.model.Status buildStatus(String message, long duration = 0, boolean animated = true, boolean spinner = false, @DrawableRes int icon = 0);
+    method public static com.mapbox.navigation.ui.status.model.Status buildStatus(String message, long duration = 0, boolean animated = true, boolean spinner = false);
+    method public static com.mapbox.navigation.ui.status.model.Status buildStatus(String message, long duration = 0, boolean animated = true);
+    method public static com.mapbox.navigation.ui.status.model.Status buildStatus(String message, long duration = 0);
+    method public static com.mapbox.navigation.ui.status.model.Status buildStatus(String message);
+    field public static final com.mapbox.navigation.ui.status.model.StatusFactory INSTANCE;
   }
 
 }

--- a/libnavui-status/src/main/java/com/mapbox/navigation/ui/status/model/Status.kt
+++ b/libnavui-status/src/main/java/com/mapbox/navigation/ui/status/model/Status.kt
@@ -5,37 +5,71 @@ import androidx.annotation.DrawableRes
 /**
  * This class stores information to be displayed by the [MapboxStatusView].
  */
-data class Status(
+class Status internal constructor(
     /**
-     * The text that will appear on the [MapboxStatusView]
+     * The text for this status.
      */
     val message: String,
 
     /**
-     * The duration in milliseconds after which the [MapboxStatusView] should hide.
-     * Setting this value to `0` or [Long.MAX_VALUE] will display the [MapboxStatusView] indefinitely.
-     *
-     * Defaults to `0`.
+     * The duration in milliseconds after which this status should hide.
+     * If this value is set to `0` or [Long.MAX_VALUE], this status will be displayed indefinitely.
      */
-    val duration: Long = 0,
+    val duration: Long,
 
     /**
-     * Animate showing and hiding of the [MapboxStatusView].
-     *
-     * Defaults to `true`.
+     * Indicates if this status should animate when showing and hiding.
      */
-    val animated: Boolean = true,
+    val animated: Boolean,
 
     /**
-     * Show indeterminate ProgressBar on the [MapboxStatusView].
-     * Defaults to `false`
+     * Indicates if an indeterminate ProgressBar should be displayed when showing this status.
      */
-    val spinner: Boolean = false,
+    val spinner: Boolean,
 
     /**
-     * Resource ID of the square Icon Drawable to show on the [MapboxStatusView].
-     * Defaults to `0`
+     * A Resource ID of the square Icon Drawable that should be displayed with this status.
      */
     @DrawableRes
-    val icon: Int = 0
-)
+    val icon: Int
+) {
+    /**
+     * Indicates whether some other object is "equal to" this one.
+     */
+    override fun equals(other: Any?): Boolean {
+        // IMPORTANT! This method must be regenerated on any class field change.
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as Status
+
+        if (message != other.message) return false
+        if (duration != other.duration) return false
+        if (animated != other.animated) return false
+        if (spinner != other.spinner) return false
+        if (icon != other.icon) return false
+
+        return true
+    }
+
+    /**
+     * Returns a hash code value for the object.
+     */
+    override fun hashCode(): Int {
+        // IMPORTANT! This method must be regenerated on any class field change.
+        var result = message.hashCode()
+        result = 31 * result + duration.hashCode()
+        result = 31 * result + animated.hashCode()
+        result = 31 * result + spinner.hashCode()
+        result = 31 * result + icon
+        return result
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    override fun toString(): String {
+        // IMPORTANT! This method must be regenerated on any class field change.
+        return "Status(message='$message', duration=$duration, animated=$animated, spinner=$spinner, icon=$icon)" // ktlint-disable
+    }
+}

--- a/libnavui-status/src/main/java/com/mapbox/navigation/ui/status/model/StatusFactory.kt
+++ b/libnavui-status/src/main/java/com/mapbox/navigation/ui/status/model/StatusFactory.kt
@@ -1,0 +1,30 @@
+package com.mapbox.navigation.ui.status.model
+
+import androidx.annotation.DrawableRes
+import com.mapbox.navigation.base.ExperimentalMapboxNavigationAPI
+
+/**
+ * An object that creates new [Status] instances.
+ */
+@ExperimentalMapboxNavigationAPI
+object StatusFactory {
+
+    /**
+     * Instantiate a new status with a given field values.
+     *
+     * @param message The message field value.
+     * @param duration The duration field value in milliseconds. The default value is `0`.
+     * @param animated The animate field value. The default value is `true`.
+     * @param spinner The spinner field value. The default value is `false`.
+     * @param icon The icon field value. The default value is `0`.
+     */
+    @JvmStatic
+    @JvmOverloads
+    fun buildStatus(
+        message: String,
+        duration: Long = 0,
+        animated: Boolean = true,
+        spinner: Boolean = false,
+        @DrawableRes icon: Int = 0
+    ) = Status(message, duration, animated, spinner, icon)
+}

--- a/libnavui-status/src/test/java/com/mapbox/navigation/ui/status/view/MapboxStatusViewTest.kt
+++ b/libnavui-status/src/test/java/com/mapbox/navigation/ui/status/view/MapboxStatusViewTest.kt
@@ -4,8 +4,8 @@ import android.content.Context
 import android.os.Build
 import androidx.core.view.isVisible
 import androidx.test.core.app.ApplicationProvider
+import com.mapbox.navigation.base.ExperimentalMapboxNavigationAPI
 import com.mapbox.navigation.ui.status.R
-import com.mapbox.navigation.ui.status.model.Status
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -15,7 +15,9 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowLooper
+import com.mapbox.navigation.ui.status.model.StatusFactory.buildStatus as status
 
+@OptIn(ExperimentalMapboxNavigationAPI::class)
 @Config(sdk = [Build.VERSION_CODES.O_MR1])
 @RunWith(RobolectricTestRunner::class)
 class MapboxStatusViewTest {
@@ -48,7 +50,7 @@ class MapboxStatusViewTest {
 
     @Test
     fun `render - should update isRendered and currentState`() {
-        val status = Status("message", animated = false)
+        val status = status("message", animated = false)
 
         sut.render(status)
 
@@ -58,7 +60,7 @@ class MapboxStatusViewTest {
 
     @Test
     fun `render - should update message text`() {
-        val status = Status("message", animated = false)
+        val status = status("message", animated = false)
 
         sut.render(status)
 
@@ -67,7 +69,7 @@ class MapboxStatusViewTest {
 
     @Test
     fun `render - should update spinner`() {
-        val status = Status("message", animated = false, spinner = true)
+        val status = status("message", animated = false, spinner = true)
 
         sut.render(status)
 
@@ -76,7 +78,7 @@ class MapboxStatusViewTest {
 
     @Test
     fun `render - should update icon`() {
-        val status = Status("message", animated = false, icon = android.R.drawable.ic_secure)
+        val status = status("message", animated = false, icon = android.R.drawable.ic_secure)
 
         sut.render(status)
 
@@ -85,7 +87,7 @@ class MapboxStatusViewTest {
 
     @Test
     fun `cancel - should hide the view`() {
-        val status = Status("message", animated = true, icon = android.R.drawable.ic_secure)
+        val status = status("message", animated = true, icon = android.R.drawable.ic_secure)
         sut.render(status)
         sut.cancel()
 

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/StatusActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/StatusActivity.kt
@@ -23,6 +23,7 @@ import com.mapbox.maps.plugin.gestures.OnMapLongClickListener
 import com.mapbox.maps.plugin.gestures.gestures
 import com.mapbox.maps.plugin.locationcomponent.LocationComponentPlugin
 import com.mapbox.maps.plugin.locationcomponent.location
+import com.mapbox.navigation.base.ExperimentalMapboxNavigationAPI
 import com.mapbox.navigation.base.extensions.applyDefaultNavigationOptions
 import com.mapbox.navigation.base.extensions.applyLanguageAndVoiceUnitOptions
 import com.mapbox.navigation.base.extensions.coordinates
@@ -67,6 +68,7 @@ import com.mapbox.navigation.utils.internal.LoggerProvider
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import com.mapbox.navigation.ui.status.model.StatusFactory.buildStatus as status
 
 /**
  * This activity demonstrates the usage of the [MapboxManeuverApi]. There is boiler plate
@@ -77,6 +79,7 @@ import kotlinx.coroutines.launch
  * attention to its usage. Long press anywhere on the map to set a destination and trigger
  * navigation.
  */
+@OptIn(ExperimentalMapboxNavigationAPI::class)
 class StatusActivity : AppCompatActivity(), OnMapLongClickListener {
 
     private lateinit var mapboxMap: MapboxMap
@@ -364,12 +367,12 @@ class StatusActivity : AppCompatActivity(), OnMapLongClickListener {
 
     private val testStatuses by lazy {
         mutableListOf<Status>(
-            Status(message = "3 sec status", duration = 3000),
-            Status(message = "2 sec status", duration = 2000),
-            Status(message = "1 sec status", duration = 1000),
-            Status(message = "sticky"),
-            Status(message = "sticky + no anim + spinner", animated = false, spinner = true),
-            Status(
+            status(message = "3 sec status", duration = 3000),
+            status(message = "2 sec status", duration = 2000),
+            status(message = "1 sec status", duration = 1000),
+            status(message = "sticky"),
+            status(message = "sticky + no anim + spinner", animated = false, spinner = true),
+            status(
                 message = "sticky + no anim + icon",
                 animated = false,
                 icon = R.drawable.ic_layers_24dp,


### PR DESCRIPTION
Closes #5420 

### Description

_libnavui-status_
- converted Status class to POJO and limited its constructor visibility to module only
- implemented StatusFactory
- updated metalava api
- updated Unit Tests StatusFactory instead

_qa-test-app_
- updated StatusActivity to use StatusFactory
