### PR TITLE
fixed coupling of vanishing route lines route progress and location point update intervals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Mapbox welcomes participation and contributions from everyone.
 
 #### Bug fixes and improvements
 - Refactored `Status` class to POJO and decreased its constructor visibility. Introduced `StatusFactory` class for public use. [#5432](https://github.com/mapbox/mapbox-navigation-android/pull/5432)   
+- Fixed an issue where setting a custom `MapboxRouteLineOptions#vanishingRouteLineUpdateIntervalNano` that happened to be longer than the typical rate of `RouteProgress` updates delivered via `mapboxRouteLineApi#updateWithRouteProgress`, the traveled portion of the route wouldn't vanish at all. [#5435](https://github.com/mapbox/mapbox-navigation-android/pull/5435)
 
 ## Mapbox Navigation SDK 2.3.0-beta.1 - January 28, 2022
 #### Features

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApi.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApi.kt
@@ -185,6 +185,7 @@ class MapboxRouteLineApi(
     private val directionsRoutes: MutableList<DirectionsRoute> = mutableListOf()
     private var routeLineExpressionData: List<RouteLineExpressionData> = emptyList()
     private var lastIndexUpdateTimeNano: Long = 0
+    private var lastPointUpdateTimeNano: Long = 0
     private val routeFeatureData: MutableList<RouteFeatureData> = mutableListOf()
     private val jobControl = InternalJobControlFactory.createDefaultScopeJobControl()
     private val mutex = Mutex()
@@ -296,7 +297,7 @@ class MapboxRouteLineApi(
         if (routeLineOptions.vanishingRouteLine?.vanishingPointState ==
             VanishingPointState.DISABLED || currentNanoTime - lastIndexUpdateTimeNano >
             RouteLayerConstants.MAX_ELAPSED_SINCE_INDEX_UPDATE_NANO ||
-            currentNanoTime - lastIndexUpdateTimeNano <
+            currentNanoTime - lastPointUpdateTimeNano <
             routeLineOptions.vanishingRouteLineUpdateIntervalNano
         ) {
             return ExpectedFactory.createError(
@@ -345,6 +346,7 @@ class MapboxRouteLineApi(
                 routeLineOptions.displaySoftGradientForTraffic
             )
 
+        lastPointUpdateTimeNano = System.nanoTime()
         return when (routeLineExpressionProviders) {
             null -> {
                 ExpectedFactory.createError(


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Fixed a bug introduced in https://github.com/mapbox/mapbox-navigation-android/pull/5344 where by coupling of vanishing route line's route progress and location point updates the last update value was taken from progress updates instead of point updates for `MapboxRouteLineOptions#vanishingRouteLineUpdateIntervalNano` and could result in drawing artifacts. If the set interval was longer than the typical frequency of route progress updates, the line wouldn't vanish at all.

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
