### PR TITLE
Bump NN, `common` and Maps dependency versions to `87.0.2`, `10.3.0-rc.1` and `21.1.0-rc.1` respectively

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -12,17 +12,17 @@ ext {
   // version which we should use in this build
   def mapboxNavigatorVersion = System.getenv("FORCE_MAPBOX_NAVIGATION_NATIVE_VERSION")
   if (mapboxNavigatorVersion == null || mapboxNavigatorVersion == '') {
-      mapboxNavigatorVersion = '87.0.1'
+      mapboxNavigatorVersion = '87.0.2'
   }
   println("Navigation Native version: " + mapboxNavigatorVersion)
 
   version = [
-      mapboxMapSdk              : '10.3.0-beta.1',
+      mapboxMapSdk              : '10.3.0-rc.1',
       mapboxSdkServices         : '6.3.0-beta.1',
       mapboxEvents              : '8.1.1',
       mapboxCore                : '5.0.1',
       mapboxNavigator           : "${mapboxNavigatorVersion}",
-      mapboxCommonNative        : '21.1.0-beta.1',
+      mapboxCommonNative        : '21.1.0-rc.1',
       mapboxCrashMonitor        : '2.0.0',
       mapboxAnnotationPlugin    : '0.8.0',
       mapboxBaseAndroid         : '0.5.0',


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Bumps NN, `common` and Maps dependency versions to `87.0.2`, `10.3.0-rc.1` and `21.1.0-rc.1` respectively