### PR TITLE
changed deprecated CommonSingletonModuleProvider.httpServiceInstance to HttpServiceFactoryWrapper.getInstance()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Mapbox welcomes participation and contributions from everyone.
 - Updated `MapboxManeuverView` or `MapboxRoadNameView` to prefer Mapbox designed shields over legacy ones. [#5445](https://github.com/mapbox/mapbox-navigation-android/pull/5445)
 - Fixed `Nav Telemetry` to not run if `Telemetry events` is disabled. [#5455](https://github.com/mapbox/mapbox-navigation-android/pull/5455)
 - Updated `MapboxNavigtation#provideFeedbackMetadataWrapper` to throw `IllegalStateException` if `Telemetry events` is disabled. [#5455](https://github.com/mapbox/mapbox-navigation-android/pull/5455)
+- Fixed an issue where some resource requests dispatched by Nav SDK (namely junction images and shields) were not wired through the same HTTP client instance that can be interacted with using `HttpServiceFactory.getInstance()`. Note: `MapboxSpeechApi` requests are still wired through an independent HTTP client. [#5459](https://github.com/mapbox/mapbox-navigation-android/pull/5459)
+
 ## Mapbox Navigation SDK 2.3.0-beta.2 - February 2, 2022
 ### Changelog
 [Changes between v2.3.0-beta.1 and v2.3.0-beta.2](https://github.com/mapbox/mapbox-navigation-android/compare/v2.3.0-beta.1...v2.3.0-beta.2)

--- a/libnavigation-util/src/main/java/com/mapbox/navigation/utils/internal/HttpServiceFactoryWrapper.kt
+++ b/libnavigation-util/src/main/java/com/mapbox/navigation/utils/internal/HttpServiceFactoryWrapper.kt
@@ -1,0 +1,7 @@
+package com.mapbox.navigation.utils.internal
+
+import com.mapbox.common.HttpServiceFactory
+
+object HttpServiceFactoryWrapper {
+    fun getInstance() = HttpServiceFactory.getInstance()
+}

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/guidance/junction/api/MapboxJunctionApi.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/guidance/junction/api/MapboxJunctionApi.kt
@@ -5,7 +5,6 @@ import com.mapbox.api.directions.v5.models.BannerInstructions
 import com.mapbox.bindgen.Expected
 import com.mapbox.bindgen.ExpectedFactory
 import com.mapbox.common.HttpResponse
-import com.mapbox.common.core.module.CommonSingletonModuleProvider
 import com.mapbox.navigation.ui.base.util.MapboxNavigationConsumer
 import com.mapbox.navigation.ui.maps.guidance.junction.JunctionAction
 import com.mapbox.navigation.ui.maps.guidance.junction.JunctionProcessor
@@ -13,6 +12,7 @@ import com.mapbox.navigation.ui.maps.guidance.junction.JunctionResult
 import com.mapbox.navigation.ui.maps.guidance.junction.model.JunctionError
 import com.mapbox.navigation.ui.maps.guidance.junction.model.JunctionValue
 import com.mapbox.navigation.ui.maps.guidance.junction.model.MapboxJunctionRequest
+import com.mapbox.navigation.utils.internal.HttpServiceFactoryWrapper
 import com.mapbox.navigation.utils.internal.InternalJobControlFactory
 import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.launch
@@ -69,7 +69,7 @@ class MapboxJunctionApi(
      */
     fun cancelAll() {
         requestList.forEach {
-            CommonSingletonModuleProvider.httpServiceInstance.cancelRequest(it.requestId) {
+            HttpServiceFactoryWrapper.getInstance().cancelRequest(it.requestId) {
             }
         }
         requestList.clear()
@@ -85,7 +85,7 @@ class MapboxJunctionApi(
         )
         val junctionRequest = JunctionProcessor.process(requestAction)
         val httpRequest = (junctionRequest as JunctionResult.JunctionRequest).request
-        val requestId = CommonSingletonModuleProvider.httpServiceInstance.request(
+        val requestId = HttpServiceFactoryWrapper.getInstance().request(
             httpRequest
         ) { httpResponse ->
             mainJobController.scope.launch {

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/guidance/signboard/api/MapboxSignboardApi.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/guidance/signboard/api/MapboxSignboardApi.kt
@@ -6,7 +6,6 @@ import com.mapbox.api.directions.v5.models.BannerInstructions
 import com.mapbox.bindgen.Expected
 import com.mapbox.bindgen.ExpectedFactory
 import com.mapbox.common.HttpResponse
-import com.mapbox.common.core.module.CommonSingletonModuleProvider
 import com.mapbox.navigation.ui.base.util.MapboxNavigationConsumer
 import com.mapbox.navigation.ui.maps.guidance.signboard.SignboardAction
 import com.mapbox.navigation.ui.maps.guidance.signboard.SignboardProcessor
@@ -15,6 +14,7 @@ import com.mapbox.navigation.ui.maps.guidance.signboard.model.MapboxSignboardOpt
 import com.mapbox.navigation.ui.maps.guidance.signboard.model.MapboxSignboardRequest
 import com.mapbox.navigation.ui.maps.guidance.signboard.model.SignboardError
 import com.mapbox.navigation.ui.maps.guidance.signboard.model.SignboardValue
+import com.mapbox.navigation.utils.internal.HttpServiceFactoryWrapper
 import com.mapbox.navigation.utils.internal.InternalJobControlFactory
 import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.launch
@@ -66,7 +66,7 @@ class MapboxSignboardApi @JvmOverloads constructor(
                 )
                 val signboardRequest = SignboardProcessor.process(requestAction)
                 val httpRequest = (signboardRequest as SignboardResult.SignboardRequest).request
-                val requestId = CommonSingletonModuleProvider.httpServiceInstance.request(
+                val requestId = HttpServiceFactoryWrapper.getInstance().request(
                     httpRequest
                 ) { httpResponse ->
                     mainJobController.scope.launch {
@@ -97,7 +97,7 @@ class MapboxSignboardApi @JvmOverloads constructor(
      */
     fun cancelAll() {
         requestList.forEach {
-            CommonSingletonModuleProvider.httpServiceInstance.cancelRequest(it.requestId) {
+            HttpServiceFactoryWrapper.getInstance().cancelRequest(it.requestId) {
             }
         }
         requestList.clear()

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/guidance/junction/api/MapboxJunctionApiTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/guidance/junction/api/MapboxJunctionApiTest.kt
@@ -11,7 +11,6 @@ import com.mapbox.common.HttpResponse
 import com.mapbox.common.HttpResponseCallback
 import com.mapbox.common.HttpResponseData
 import com.mapbox.common.HttpServiceInterface
-import com.mapbox.common.core.module.CommonSingletonModuleProvider
 import com.mapbox.navigation.testing.MainCoroutineRule
 import com.mapbox.navigation.ui.base.util.MapboxNavigationConsumer
 import com.mapbox.navigation.ui.maps.guidance.junction.JunctionAction
@@ -19,6 +18,7 @@ import com.mapbox.navigation.ui.maps.guidance.junction.JunctionProcessor
 import com.mapbox.navigation.ui.maps.guidance.junction.JunctionResult
 import com.mapbox.navigation.ui.maps.guidance.junction.model.JunctionError
 import com.mapbox.navigation.ui.maps.guidance.junction.model.JunctionValue
+import com.mapbox.navigation.utils.internal.HttpServiceFactoryWrapper
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -52,13 +52,13 @@ class MapboxJunctionApiTest {
     @Before
     fun setUp() {
         mockkObject(JunctionProcessor)
-        mockkObject(CommonSingletonModuleProvider)
+        mockkObject(HttpServiceFactoryWrapper)
     }
 
     @After
     fun tearDown() {
         unmockkObject(JunctionProcessor)
-        unmockkObject(CommonSingletonModuleProvider)
+        unmockkObject(HttpServiceFactoryWrapper)
     }
 
     @Test
@@ -105,7 +105,7 @@ class MapboxJunctionApiTest {
         val mockHttpService = mockk<HttpServiceInterface> {
             every { request(mockRequest, capture(httpResponseCallbackSlot)) } returns 0
         }
-        every { CommonSingletonModuleProvider.httpServiceInstance } returns mockHttpService
+        every { HttpServiceFactoryWrapper.getInstance() } returns mockHttpService
         every {
             JunctionProcessor.process(
                 JunctionAction.CheckJunctionAvailability(bannerInstructions)
@@ -147,7 +147,7 @@ class MapboxJunctionApiTest {
         val mockHttpService = mockk<HttpServiceInterface> {
             every { request(mockRequest, capture(httpResponseCallbackSlot)) } returns 0
         }
-        every { CommonSingletonModuleProvider.httpServiceInstance } returns mockHttpService
+        every { HttpServiceFactoryWrapper.getInstance() } returns mockHttpService
         every {
             JunctionProcessor.process(
                 JunctionAction.CheckJunctionAvailability(bannerInstructions)
@@ -195,7 +195,7 @@ class MapboxJunctionApiTest {
         val mockHttpService = mockk<HttpServiceInterface> {
             every { request(mockRequest, capture(httpResponseCallbackSlot)) } returns 0
         }
-        every { CommonSingletonModuleProvider.httpServiceInstance } returns mockHttpService
+        every { HttpServiceFactoryWrapper.getInstance() } returns mockHttpService
         every {
             JunctionProcessor.process(
                 JunctionAction.CheckJunctionAvailability(bannerInstructions)
@@ -251,7 +251,7 @@ class MapboxJunctionApiTest {
         val mockHttpService = mockk<HttpServiceInterface> {
             every { request(mockRequest, capture(httpResponseCallbackSlot)) } returns 0
         }
-        every { CommonSingletonModuleProvider.httpServiceInstance } returns mockHttpService
+        every { HttpServiceFactoryWrapper.getInstance() } returns mockHttpService
         every {
             JunctionProcessor.process(
                 JunctionAction.CheckJunctionAvailability(bannerInstructions)

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/guidance/signboard/api/MapboxSignboardApiTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/guidance/signboard/api/MapboxSignboardApiTest.kt
@@ -10,7 +10,6 @@ import com.mapbox.common.HttpResponse
 import com.mapbox.common.HttpResponseCallback
 import com.mapbox.common.HttpResponseData
 import com.mapbox.common.HttpServiceInterface
-import com.mapbox.common.core.module.CommonSingletonModuleProvider
 import com.mapbox.navigation.testing.MainCoroutineRule
 import com.mapbox.navigation.ui.base.util.MapboxNavigationConsumer
 import com.mapbox.navigation.ui.maps.guidance.signboard.SignboardAction
@@ -19,6 +18,7 @@ import com.mapbox.navigation.ui.maps.guidance.signboard.SignboardResult
 import com.mapbox.navigation.ui.maps.guidance.signboard.model.MapboxSignboardOptions
 import com.mapbox.navigation.ui.maps.guidance.signboard.model.SignboardError
 import com.mapbox.navigation.ui.maps.guidance.signboard.model.SignboardValue
+import com.mapbox.navigation.utils.internal.HttpServiceFactoryWrapper
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -53,13 +53,13 @@ class MapboxSignboardApiTest {
     @Before
     fun setUp() {
         mockkObject(SignboardProcessor)
-        mockkObject(CommonSingletonModuleProvider)
+        mockkObject(HttpServiceFactoryWrapper)
     }
 
     @After
     fun tearDown() {
         unmockkObject(SignboardProcessor)
-        unmockkObject(CommonSingletonModuleProvider)
+        unmockkObject(HttpServiceFactoryWrapper)
     }
 
     @Test
@@ -106,7 +106,7 @@ class MapboxSignboardApiTest {
         val mockHttpService = mockk<HttpServiceInterface>() {
             every { request(mockRequest, capture(httpResponseCallbackSlot)) } returns 0
         }
-        every { CommonSingletonModuleProvider.httpServiceInstance } returns mockHttpService
+        every { HttpServiceFactoryWrapper.getInstance() } returns mockHttpService
         every {
             SignboardProcessor.process(
                 SignboardAction.CheckSignboardAvailability(bannerInstructions)
@@ -148,7 +148,7 @@ class MapboxSignboardApiTest {
         val mockHttpService = mockk<HttpServiceInterface>() {
             every { request(mockRequest, capture(httpResponseCallbackSlot)) } returns 0
         }
-        every { CommonSingletonModuleProvider.httpServiceInstance } returns mockHttpService
+        every { HttpServiceFactoryWrapper.getInstance() } returns mockHttpService
         every {
             SignboardProcessor.process(
                 SignboardAction.CheckSignboardAvailability(bannerInstructions)
@@ -194,7 +194,7 @@ class MapboxSignboardApiTest {
         val mockHttpService = mockk<HttpServiceInterface>() {
             every { request(mockRequest, capture(httpResponseCallbackSlot)) } returns 0
         }
-        every { CommonSingletonModuleProvider.httpServiceInstance } returns mockHttpService
+        every { HttpServiceFactoryWrapper.getInstance() } returns mockHttpService
         every {
             SignboardProcessor.process(
                 SignboardAction.CheckSignboardAvailability(bannerInstructions)
@@ -249,7 +249,7 @@ class MapboxSignboardApiTest {
         val mockHttpService = mockk<HttpServiceInterface>() {
             every { request(mockRequest, capture(httpResponseCallbackSlot)) } returns 0
         }
-        every { CommonSingletonModuleProvider.httpServiceInstance } returns mockHttpService
+        every { HttpServiceFactoryWrapper.getInstance() } returns mockHttpService
         every {
             SignboardProcessor.process(
                 SignboardAction.CheckSignboardAvailability(bannerInstructions)


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Removed usage of the deprecated `CommonSingletonModuleProvider.httpServiceInstance` which with deprecation started leading to creation of an unnecessary instance of the HTTP client.

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
