### PR TITLE
Fixed dispatching to the main queue 

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
@@ -41,6 +41,7 @@ import com.mapbox.navigator.NavigationStatusOrigin
 import com.mapbox.navigator.NavigatorObserver
 import com.mapbox.navigator.RouteState
 import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.launch
@@ -99,7 +100,7 @@ internal class MapboxTripSession(
                 updateLegIndexJob?.cancel()
                 updateRouteProgressJob?.cancel()
 
-                threadController.getMainScopeAndRootJob().scope.launch {
+                threadController.getMainScopeAndRootJob().scope.launch(Dispatchers.Main.immediate) {
                     nativeRouteProcessingListeners.forEach { it.onNativeRouteProcessingStarted() }
                     navigator.setRoute(routes, legIndex)?.let {
                         roadObjects = getRouteInitInfo(it)?.roadObjects ?: emptyList()
@@ -279,7 +280,7 @@ internal class MapboxTripSession(
             }
 
             updateRouteProgressJob?.cancel()
-            updateRouteProgressJob = mainJobController.scope.launch {
+            updateRouteProgressJob = mainJobController.scope.launch(Dispatchers.Main.immediate) {
                 var triggerObserver = false
                 if (tripStatus.navigationStatus.routeState != RouteState.INVALID) {
                     val nativeBannerInstruction: BannerInstruction? =


### PR DESCRIPTION
### Description

This PR fixes the issue that is related to dispatching work to Main queue.

When the SDK process status update, we post some processing to the end of the main queue. With the new version of NN, the Android SDK started to get status updates faster than the job scheduled on the Main queue gets processed. When the SDK gets new status update it cancels processing of the the previous one.

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
