### PR TITLE
Decouple route fetching from the drop in route line component

### DIFF
--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/DropInNavigationView.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/DropInNavigationView.kt
@@ -1,9 +1,11 @@
 package com.mapbox.navigation.dropin
 
+import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
 import android.util.AttributeSet
+import android.util.Log
 import android.view.LayoutInflater
 import android.widget.FrameLayout
 import androidx.core.content.res.use
@@ -12,11 +14,16 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
+import com.mapbox.android.core.location.LocationEngineCallback
+import com.mapbox.android.core.location.LocationEngineResult
+import com.mapbox.geojson.Point
 import com.mapbox.maps.extension.style.style
+import com.mapbox.maps.plugin.gestures.gestures
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationApp
 import com.mapbox.navigation.dropin.binder.UIBinder
+import com.mapbox.navigation.dropin.component.routefetch.MapboxDropInRouteRequester
 import com.mapbox.navigation.dropin.coordinator.ActionListCoordinator
 import com.mapbox.navigation.dropin.coordinator.GuidanceCoordinator
 import com.mapbox.navigation.dropin.coordinator.InfoPanelCoordinator
@@ -28,6 +35,8 @@ import com.mapbox.navigation.ui.maps.NavigationStyles
 import com.mapbox.navigation.ui.maps.route.arrow.model.RouteArrowOptions
 import com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions
 import com.mapbox.navigation.ui.utils.internal.lifecycle.ViewLifecycleRegistry
+import com.mapbox.navigation.utils.internal.ifNonNull
+import java.lang.Exception
 
 @OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
 class DropInNavigationView @JvmOverloads constructor(
@@ -130,12 +139,50 @@ class DropInNavigationView @JvmOverloads constructor(
             ActionListCoordinator(navigationContext, binding.actionListLayout),
             SpeedLimitCoordinator(navigationContext, binding.speedLimitLayout),
         )
+
+        initMapLongClickListener()
     }
 
     override fun getLifecycle(): Lifecycle = viewLifecycleRegistry
 
     private inline fun <reified T : ViewModel> lazyViewModel(): Lazy<T> = lazy {
         viewModelProvider[T::class.java]
+    }
+
+    // todo At the moment this seems like the most logical place to put this since the
+    // navigation view owns the map. Putting this here now decouples it from other components
+    // and is easily portable to a more appropriate place in the near future.
+    @SuppressLint("MissingPermission")
+    private fun initMapLongClickListener() {
+        binding.mapView.gestures.addOnMapLongClickListener { clickPoint ->
+            ifNonNull(MapboxNavigationApp.current()) { mapboxNavigation ->
+                mapboxNavigation.navigationOptions.locationEngine.getLastLocation(object :
+                        LocationEngineCallback<LocationEngineResult> {
+                        override fun onSuccess(result: LocationEngineResult?) {
+                            ifNonNull(result?.lastLocation) { lastLocation ->
+                                MapboxDropInRouteRequester.fetchAndSetRoute(
+                                    listOf(
+                                        Point.fromLngLat(
+                                            lastLocation.longitude,
+                                            lastLocation.latitude
+                                        ),
+                                        clickPoint
+                                    )
+                                )
+                            }
+                        }
+
+                        override fun onFailure(exception: Exception) {
+                            Log.e(
+                                "DropInNavigationView",
+                                "Failed to get last location on map long click."
+                            )
+                        }
+                    }
+                )
+            }
+            false
+        }
     }
 }
 

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/binder/map/ActiveGuidanceMapBinder.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/binder/map/ActiveGuidanceMapBinder.kt
@@ -9,6 +9,7 @@ import com.mapbox.navigation.dropin.binder.navigationListOf
 import com.mapbox.navigation.dropin.component.camera.DropInCameraMode
 import com.mapbox.navigation.dropin.component.camera.DropInNavigationCamera
 import com.mapbox.navigation.dropin.component.location.LocationPuck
+import com.mapbox.navigation.dropin.component.routefetch.RouteFetchComponent
 import com.mapbox.navigation.dropin.component.routeline.RouteLineComponent
 
 @OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
@@ -25,7 +26,8 @@ internal class ActiveGuidanceMapBinder(
             DropInNavigationCamera(
                 navigationViewContext.viewModel.cameraState,
                 mapView
-            )
+            ),
+            RouteFetchComponent(mapView.context),
         )
     }
 }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/binder/map/FreeDriveMapBinder.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/binder/map/FreeDriveMapBinder.kt
@@ -9,7 +9,7 @@ import com.mapbox.navigation.dropin.binder.navigationListOf
 import com.mapbox.navigation.dropin.component.camera.DropInCameraMode
 import com.mapbox.navigation.dropin.component.camera.DropInNavigationCamera
 import com.mapbox.navigation.dropin.component.location.LocationPuck
-import com.mapbox.navigation.dropin.component.routeline.RouteLineComponent
+import com.mapbox.navigation.dropin.component.routefetch.RouteFetchComponent
 
 @OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
 internal class FreeDriveMapBinder(
@@ -22,11 +22,11 @@ internal class FreeDriveMapBinder(
         cameraState.cameraMode.value = DropInCameraMode.OVERVIEW
         return navigationListOf(
             LocationPuck(mapView),
-            RouteLineComponent(mapView, navigationViewContext.routeLineOptions),
             DropInNavigationCamera(
                 navigationViewContext.viewModel.cameraState,
                 mapView
-            )
+            ),
+            RouteFetchComponent(mapView.context),
         )
     }
 }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/routefetch/MapboxDropInRouteRequester.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/routefetch/MapboxDropInRouteRequester.kt
@@ -1,0 +1,34 @@
+package com.mapbox.navigation.dropin.component.routefetch
+
+import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.api.directions.v5.models.RouteOptions
+import com.mapbox.geojson.Point
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+
+object MapboxDropInRouteRequester {
+    private val routeRequestSink: MutableSharedFlow<List<Point>> =
+        MutableSharedFlow(onBufferOverflow = BufferOverflow.DROP_OLDEST, extraBufferCapacity = 1)
+    val routeRequests: Flow<List<Point>> = routeRequestSink
+
+    private val routeRequestFromOptionsSink: MutableSharedFlow<RouteOptions> =
+        MutableSharedFlow(onBufferOverflow = BufferOverflow.DROP_OLDEST, extraBufferCapacity = 1)
+    val routeOptionsRequests: Flow<RouteOptions> = routeRequestFromOptionsSink
+
+    private val routeSetRequestSink: MutableSharedFlow<List<DirectionsRoute>> =
+        MutableSharedFlow(onBufferOverflow = BufferOverflow.DROP_OLDEST, extraBufferCapacity = 1)
+    val setRouteRequests: Flow<List<DirectionsRoute>> = routeSetRequestSink
+
+    fun setRoutes(routes: List<DirectionsRoute>) {
+        routeSetRequestSink.tryEmit(routes)
+    }
+
+    fun fetchAndSetRoute(points: List<Point>) {
+        routeRequestSink.tryEmit(points)
+    }
+
+    fun fetchAndSetRoute(routeOptions: RouteOptions) {
+        routeRequestFromOptionsSink.tryEmit(routeOptions)
+    }
+}

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/routefetch/RouteFetchComponent.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/routefetch/RouteFetchComponent.kt
@@ -1,0 +1,99 @@
+package com.mapbox.navigation.dropin.component.routefetch
+
+import android.content.Context
+import android.util.Log
+import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.api.directions.v5.models.RouteOptions
+import com.mapbox.geojson.Point
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.base.extensions.applyDefaultNavigationOptions
+import com.mapbox.navigation.base.extensions.applyLanguageAndVoiceUnitOptions
+import com.mapbox.navigation.base.route.RouterCallback
+import com.mapbox.navigation.base.route.RouterFailure
+import com.mapbox.navigation.base.route.RouterOrigin
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver
+import com.mapbox.navigation.utils.internal.InternalJobControlFactory
+import kotlinx.coroutines.cancelChildren
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
+internal class RouteFetchComponent(private val context: Context) : MapboxNavigationObserver {
+
+    private var routeRequestId: Long? = null
+    private val jobControl = InternalJobControlFactory.createMainScopeJobControl()
+
+    override fun onAttached(mapboxNavigation: MapboxNavigation) {
+        jobControl.scope.launch {
+            MapboxDropInRouteRequester.setRouteRequests.collect {
+                mapboxNavigation.setRoutes(it)
+            }
+        }
+
+        jobControl.scope.launch {
+            MapboxDropInRouteRequester.routeRequests.collect {
+                val routeOptions = getDefaultOptions(mapboxNavigation, it)
+                fetchRoute(routeOptions, mapboxNavigation)
+            }
+        }
+
+        jobControl.scope.launch {
+            MapboxDropInRouteRequester.routeOptionsRequests.collect {
+                fetchRoute(it, mapboxNavigation)
+            }
+        }
+    }
+
+    override fun onDetached(mapboxNavigation: MapboxNavigation) {
+        jobControl.job.cancelChildren()
+        routeRequestId?.let {
+            mapboxNavigation.cancelRouteRequest(it)
+        }
+    }
+
+    private fun fetchRoute(options: RouteOptions, mapboxNavigation: MapboxNavigation) {
+        routeRequestId = mapboxNavigation.requestRoutes(
+            options,
+            object : RouterCallback {
+                override fun onRoutesReady(
+                    routes: List<DirectionsRoute>,
+                    routerOrigin: RouterOrigin
+                ) {
+                    mapboxNavigation.setRoutes(routes.reversed())
+                }
+
+                override fun onFailure(
+                    reasons: List<RouterFailure>,
+                    routeOptions: RouteOptions
+                ) {
+                    Log.e(TAG, "Failed to fetch route with reason(s):")
+                    reasons.forEach {
+                        Log.e(TAG, it.message)
+                    }
+                }
+
+                override fun onCanceled(routeOptions: RouteOptions, routerOrigin: RouterOrigin) {
+                    // no impl
+                }
+            }
+        )
+    }
+
+    private fun getDefaultOptions(
+        mapboxNavigation: MapboxNavigation,
+        points: List<Point>
+    ): RouteOptions {
+        return RouteOptions.builder()
+            .applyDefaultNavigationOptions()
+            .applyLanguageAndVoiceUnitOptions(context)
+            .layersList(listOf(mapboxNavigation.getZLevel(), null))
+            .coordinatesList(points)
+            .alternatives(true)
+            .build()
+    }
+
+    private companion object {
+        private val TAG = RouteFetchComponent::class.java.simpleName
+    }
+}

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/routefetch/MapboxDropInRouteRequesterTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/routefetch/MapboxDropInRouteRequesterTest.kt
@@ -1,0 +1,63 @@
+package com.mapbox.navigation.dropin.component.routefetch
+
+import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.api.directions.v5.models.RouteOptions
+import com.mapbox.geojson.Point
+import com.mapbox.navigation.testing.MainCoroutineRule
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.first
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MapboxDropInRouteRequesterTest {
+
+    @get:Rule
+    var coroutineRule = MainCoroutineRule()
+
+    @Test
+    fun `setRoutes emits to flow`() = coroutineRule.runBlockingTest {
+        val mockRoute = mockk<DirectionsRoute>()
+        val def = async {
+            MapboxDropInRouteRequester.setRouteRequests.first()
+        }
+        MapboxDropInRouteRequester.setRoutes(listOf(mockRoute))
+
+        val result = def.await()
+
+        assertEquals(mockRoute, result.first())
+    }
+
+    @Test
+    fun `fetchAndSetRoute with Points emits to flow`() = coroutineRule.runBlockingTest {
+        val points = listOf(
+            Point.fromLngLat(33.0, 44.0),
+            Point.fromLngLat(33.1, 44.1)
+        )
+        val def = async {
+            MapboxDropInRouteRequester.routeRequests.first()
+        }
+        MapboxDropInRouteRequester.fetchAndSetRoute(points)
+
+        val result = def.await()
+
+        assertEquals(points.first(), result.first())
+        assertEquals(points[1], result[1])
+    }
+
+    @Test
+    fun `fetchAndSetRoute with RouteOptions emits to flow`() = coroutineRule.runBlockingTest {
+        val expectedOptions = mockk<RouteOptions>()
+        val def = async {
+            MapboxDropInRouteRequester.routeOptionsRequests.first()
+        }
+        MapboxDropInRouteRequester.fetchAndSetRoute(expectedOptions)
+
+        val result = def.await()
+
+        assertEquals(expectedOptions, result)
+    }
+}

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/routefetch/RouteFetchComponentTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/routefetch/RouteFetchComponentTest.kt
@@ -1,0 +1,192 @@
+package com.mapbox.navigation.dropin.component.routefetch
+
+import android.content.Context
+import android.content.res.Resources
+import com.mapbox.api.directions.v5.DirectionsCriteria
+import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.api.directions.v5.models.RouteOptions
+import com.mapbox.geojson.Point
+import com.mapbox.navigation.base.internal.extensions.inferDeviceLocale
+import com.mapbox.navigation.base.route.RouterCallback
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.testing.MainCoroutineRule
+import com.mapbox.navigation.utils.internal.InternalJobControlFactory
+import com.mapbox.navigation.utils.internal.JobControl
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkObject
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import kotlinx.coroutines.CompletableJob
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelChildren
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import java.util.Locale
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class RouteFetchComponentTest {
+
+    @get:Rule
+    var coroutineRule = MainCoroutineRule()
+    private val parentJob = SupervisorJob()
+    private val testScope = CoroutineScope(parentJob + coroutineRule.testDispatcher)
+
+    private val mockResources = mockk<Resources> {
+        every { configuration } returns mockk()
+    }
+    private val context = mockk<Context> {
+        every { resources } returns mockResources
+    }
+
+    @Before
+    fun setUp() {
+        mockkStatic("com.mapbox.navigation.base.internal.extensions.ContextEx")
+        mockkObject(InternalJobControlFactory)
+        every {
+            InternalJobControlFactory.createDefaultScopeJobControl()
+        } returns JobControl(parentJob, testScope)
+
+        every { context.inferDeviceLocale() } returns Locale.ENGLISH
+    }
+
+    @After
+    fun cleanUp() {
+        unmockkStatic("com.mapbox.navigation.base.internal.extensions.ContextEx")
+        unmockkObject(InternalJobControlFactory)
+    }
+
+    @Test
+    fun `onAttached calls setRoutes on mapbox navigation via setRouteRequests flow`() {
+        val mockRoute = mockk<DirectionsRoute>()
+        val routes = listOf(mockRoute)
+        val mockMapboxNavigation = mockk<MapboxNavigation>(relaxed = true)
+
+        RouteFetchComponent(context).onAttached(mockMapboxNavigation).also {
+            MapboxDropInRouteRequester.setRoutes(routes)
+        }
+
+        verify { mockMapboxNavigation.setRoutes(routes) }
+    }
+
+    @Test
+    fun `onAttached calls requestRoutes on mapbox navigation via routeRequests flow`() {
+        val points = listOf(
+            Point.fromLngLat(33.0, 44.0),
+            Point.fromLngLat(33.1, 44.1)
+        )
+        val mockMapboxNavigation = mockk<MapboxNavigation>(relaxed = true)
+
+        RouteFetchComponent(context).onAttached(mockMapboxNavigation).also {
+            MapboxDropInRouteRequester.fetchAndSetRoute(points)
+        }
+
+        verify { mockMapboxNavigation.requestRoutes(any(), any()) }
+    }
+
+    @Test
+    fun `onAttached calls requestRoutes on mapbox navigation via routeOptionsRequests flow`() {
+        val routeOptions = mockk<RouteOptions>()
+        val mockMapboxNavigation = mockk<MapboxNavigation>(relaxed = true)
+
+        RouteFetchComponent(context).onAttached(mockMapboxNavigation).also {
+            MapboxDropInRouteRequester.fetchAndSetRoute(routeOptions)
+        }
+
+        verify { mockMapboxNavigation.requestRoutes(routeOptions, any()) }
+    }
+
+    @Test
+    fun `onRoutesReady route requests set routes on mapbox navigation`() {
+        val route1 = mockk<DirectionsRoute>()
+        val route2 = mockk<DirectionsRoute>()
+        val routes = listOf(route1, route2)
+        val routeOptions = mockk<RouteOptions>()
+        val mockMapboxNavigation = mockk<MapboxNavigation>(relaxed = true)
+        val callbackSlot = slot<RouterCallback>()
+        val setRoutesSlot = slot<List<DirectionsRoute>>()
+        RouteFetchComponent(context).onAttached(mockMapboxNavigation).also {
+            MapboxDropInRouteRequester.fetchAndSetRoute(routeOptions)
+        }
+        verify { mockMapboxNavigation.requestRoutes(routeOptions, capture(callbackSlot)) }
+
+        callbackSlot.captured.onRoutesReady(routes, mockk())
+
+        verify { mockMapboxNavigation.setRoutes(capture(setRoutesSlot)) }
+        assertEquals(route2, setRoutesSlot.captured.first())
+        assertEquals(route1, setRoutesSlot.captured[1])
+    }
+
+    @Test
+    fun `onDetached cancels mapbox navigation route request`() {
+        val requestCode = 333L
+        val routeOptions = mockk<RouteOptions>()
+        val mockMapboxNavigation = mockk<MapboxNavigation>(relaxed = true) {
+            every { requestRoutes(any(), any()) } returns requestCode
+        }
+        val component = RouteFetchComponent(context).also {
+            it.onAttached(mockMapboxNavigation)
+            MapboxDropInRouteRequester.fetchAndSetRoute(routeOptions)
+        }
+
+        component.onDetached(mockMapboxNavigation)
+
+        verify { mockMapboxNavigation.cancelRouteRequest(requestCode) }
+    }
+
+    @Test
+    fun `onDetached cancels coroutine children`() {
+        val mockParentJob = mockk<CompletableJob>(relaxed = true)
+        val mockJobControl = mockk<JobControl> {
+            every { job } returns mockParentJob
+        }
+        every { InternalJobControlFactory.createMainScopeJobControl() } returns mockJobControl
+        val mockMapboxNavigation = mockk<MapboxNavigation>(relaxed = true)
+
+        RouteFetchComponent(context).onDetached(mockMapboxNavigation)
+
+        verify { mockParentJob.cancelChildren() }
+    }
+
+    @Test
+    fun `route fetch with default route options`() {
+        val points = listOf(
+            Point.fromLngLat(33.0, 44.0),
+            Point.fromLngLat(33.1, 44.1)
+        )
+        val mockMapboxNavigation = mockk<MapboxNavigation>(relaxed = true) {
+            every { getZLevel() } returns 9
+        }
+        val optionsSlot = slot<RouteOptions>()
+
+        RouteFetchComponent(context).onAttached(mockMapboxNavigation).also {
+            MapboxDropInRouteRequester.fetchAndSetRoute(points)
+        }
+
+        verify { mockMapboxNavigation.requestRoutes(capture(optionsSlot), any()) }
+        assertEquals(points.first(), optionsSlot.captured.coordinatesList().first())
+        assertEquals(points[1], optionsSlot.captured.coordinatesList()[1])
+        assertTrue(optionsSlot.captured.alternatives()!!)
+        assertEquals(9, optionsSlot.captured.layersList()!!.first())
+        assertEquals("en", optionsSlot.captured.language())
+        assertEquals(DirectionsCriteria.PROFILE_DRIVING_TRAFFIC, optionsSlot.captured.profile())
+        assertEquals(DirectionsCriteria.OVERVIEW_FULL, optionsSlot.captured.overview())
+        assertTrue(optionsSlot.captured.steps()!!)
+        assertTrue(optionsSlot.captured.roundaboutExits()!!)
+        assertTrue(optionsSlot.captured.voiceInstructions()!!)
+        assertTrue(optionsSlot.captured.bannerInstructions()!!)
+        assertEquals(
+            "congestion_numeric,maxspeed,closure,speed,duration,distance",
+            optionsSlot.captured.annotations()
+        )
+    }
+}


### PR DESCRIPTION
### Description
Until now the route fetching was being done in the route line component in order to facilitate further development. The work here is a further iteration to decouple that behavior. 

There are several sources for initiating a route fetch. There is a requirement to support a long press on the map to fetch a route. There is also the requirement for a route fetch to occur based on input from an external developer's activity/fragment as well as a feature to accept a route that has already been generated.  

To facilitate this I created a static object to accept input for fetching a route which is then published to flows for consumption by a route fetching component.  This static object doesn't have any references to other objects so its decoupling from the rest of the code lets move the functionality if/when necessary in the near future.  There are plans to define some kind of interface for external developers interact with the drop-in UI so that can either abstract the static object behind that interface or we can leave it as is.  In the short term we have some flexibility.  

### Screenshots or Gifs

