### PR TITLE
Bump `POM_SNAPSHOT_VERSION_NAME` to `2.4.0-SNAPSHOT`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ POM_LICENCE_DIST=repo
 POM_DEVELOPER_ID=mapbox
 POM_DEVELOPER_NAME=Mapbox
 
-POM_SNAPSHOT_VERSION_NAME=2.2.0-SNAPSHOT
+POM_SNAPSHOT_VERSION_NAME=2.4.0-SNAPSHOT
 
 # IDE (e.g. Android Studio) users:
 # Gradle settings configured through the IDE *will override*


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Bumps `POM_SNAPSHOT_VERSION_NAME` to `2.4.0-SNAPSHOT` now that [`2.3.0-rc.1`](https://github.com/mapbox/mapbox-navigation-android/releases/tag/v2.3.0-rc.1) was released and [`release-v2.3` branch](https://github.com/mapbox/mapbox-navigation-android/tree/release-v2.3) was cut.