### PR TITLE
[DropIn] Change a custom speed limit at runtime

### DIFF
--- a/examples/src/main/res/layout/layout_activity_navigation_view_customized.xml
+++ b/examples/src/main/res/layout/layout_activity_navigation_view_customized.xml
@@ -1,15 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout
+<androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     >
+
     <com.mapbox.navigation.dropin.DropInNavigationView
         android:id="@+id/navigationView"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="0dp"
         app:accessToken="@string/mapbox_access_token"
+        app:layout_constraintBottom_toTopOf="@+id/toggleCustomViews"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/toggleCustomViews"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:text="toggle custom views"
         />
 
-</FrameLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/DropInNavigationView.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/DropInNavigationView.kt
@@ -81,7 +81,7 @@ class DropInNavigationView @JvmOverloads constructor(
      * Customize the views by implementing your own [UIBinder] components.
      */
     fun customize(navigationUIBinders: NavigationUIBinders) {
-        navigationContext.uiBinders = navigationUIBinders
+        navigationContext.uiBinders.value = navigationUIBinders
     }
 
     /**

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/DropInNavigationViewContext.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/DropInNavigationViewContext.kt
@@ -2,10 +2,16 @@ package com.mapbox.navigation.dropin
 
 import android.content.Context
 import androidx.lifecycle.LifecycleOwner
+import com.mapbox.navigation.dropin.binder.UIBinder
+import com.mapbox.navigation.dropin.lifecycle.UICoordinator
 import com.mapbox.navigation.ui.maps.route.RouteLayerConstants
 import com.mapbox.navigation.ui.maps.route.arrow.model.RouteArrowOptions
 import com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions
 import com.mapbox.navigation.ui.maps.route.line.model.RouteLineResources
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.distinctUntilChangedBy
+import kotlinx.coroutines.flow.map
 
 /**
  * This context is a top level data object for [DropInNavigationView].
@@ -17,7 +23,7 @@ internal class DropInNavigationViewContext(
     val lifecycleOwner: LifecycleOwner,
     val viewModel: DropInNavigationViewModel,
 ) {
-    var uiBinders = NavigationUIBinders()
+    val uiBinders = MutableStateFlow(NavigationUIBinders())
     var routeLineOptions: MapboxRouteLineOptions = MapboxRouteLineOptions.Builder(context)
         .withRouteLineResources(RouteLineResources.Builder().build())
         .withRouteLineBelowLayerId("road-label-navigation")
@@ -26,3 +32,11 @@ internal class DropInNavigationViewContext(
         .withAboveLayerId(RouteLayerConstants.TOP_LEVEL_ROUTE_LINE_LAYER_ID)
         .build()
 }
+
+/**
+ * Helper extension to map [UIBinder] inside a [UICoordinator].
+ * Uses a distinct by class to prevent refreshing views of the same type of [UIBinder].
+ */
+internal fun <T : UIBinder> DropInNavigationViewContext.flowUiBinder(
+    mapper: suspend (value: NavigationUIBinders) -> T
+): Flow<T> = this.uiBinders.map(mapper).distinctUntilChangedBy { it.javaClass }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/location/LocationPuck.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/location/LocationPuck.kt
@@ -22,14 +22,14 @@ class LocationPuck(
 
         mapView.getMapboxMap().getStyle {
             mapView.location.apply {
-                setLocationProvider(locationStateManager.navigationLocationProvider)
-                enabled = true
                 locationPuck = LocationPuck2D(
                     bearingImage = ContextCompat.getDrawable(
                         mapView.context,
                         R.drawable.mapbox_navigation_puck_icon
                     )
                 )
+                setLocationProvider(locationStateManager.navigationLocationProvider)
+                enabled = true
             }
         }
     }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/speedlimit/SpeedLimitViewBinder.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/speedlimit/SpeedLimitViewBinder.kt
@@ -1,8 +1,9 @@
 package com.mapbox.navigation.dropin.component.speedlimit
 
-import android.transition.Scene
-import android.transition.TransitionManager
 import android.view.ViewGroup
+import androidx.transition.Fade
+import androidx.transition.Scene
+import androidx.transition.TransitionManager
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver
 import com.mapbox.navigation.dropin.R
@@ -17,7 +18,7 @@ class SpeedLimitViewBinder : UIBinder {
             R.layout.mapbox_speed_limit_layout,
             viewGroup.context
         )
-        TransitionManager.go(scene)
+        TransitionManager.go(scene, Fade())
         val binding = MapboxSpeedLimitLayoutBinding.bind(viewGroup)
 
         return SpeedLimitComponent(binding.speedLimitView)

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/coordinator/ActionListCoordinator.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/coordinator/ActionListCoordinator.kt
@@ -23,9 +23,9 @@ internal class ActionListCoordinator(
         return navContext.viewModel.navigationState.map { navigationState ->
             when (navigationState) {
                 NavigationState.RoutePreview,
-                NavigationState.ActiveNavigation -> navContext.uiBinders.activeGuidanceActions
+                NavigationState.ActiveNavigation -> navContext.uiBinders.value.activeGuidanceActions
                 NavigationState.Arrival,
-                NavigationState.FreeDrive -> navContext.uiBinders.freeDriveActionBinder
+                NavigationState.FreeDrive -> navContext.uiBinders.value.freeDriveActionBinder
                 NavigationState.Empty -> EmptyActionBinder()
             }
         }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/coordinator/RoadNameLabelCoordinator.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/coordinator/RoadNameLabelCoordinator.kt
@@ -4,18 +4,16 @@ import android.view.ViewGroup
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.dropin.DropInNavigationViewContext
 import com.mapbox.navigation.dropin.binder.UIBinder
+import com.mapbox.navigation.dropin.flowUiBinder
 import com.mapbox.navigation.dropin.lifecycle.UICoordinator
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
 
 internal class RoadNameLabelCoordinator(
-    navigationViewContext: DropInNavigationViewContext,
+    val navigationViewContext: DropInNavigationViewContext,
     roadNameLabelLayout: ViewGroup
 ) : UICoordinator<ViewGroup>(roadNameLabelLayout) {
 
-    val stateFlow = MutableStateFlow(navigationViewContext.uiBinders.roadName)
-
     override fun MapboxNavigation.flowViewBinders(): Flow<UIBinder> {
-        return stateFlow
+        return navigationViewContext.flowUiBinder { it.roadName }
     }
 }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/coordinator/SpeedLimitCoordinator.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/coordinator/SpeedLimitCoordinator.kt
@@ -4,22 +4,20 @@ import android.view.ViewGroup
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.dropin.DropInNavigationViewContext
 import com.mapbox.navigation.dropin.binder.UIBinder
+import com.mapbox.navigation.dropin.flowUiBinder
 import com.mapbox.navigation.dropin.lifecycle.UICoordinator
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
 
 /**
  * Coordinator for the speed limit view.
  * This will include camera, location puck, and route line.
  */
 internal class SpeedLimitCoordinator(
-    navigationViewContext: DropInNavigationViewContext,
+    val navigationViewContext: DropInNavigationViewContext,
     speedLimitLayout: ViewGroup
 ) : UICoordinator<ViewGroup>(speedLimitLayout) {
 
-    val stateFlow = MutableStateFlow(navigationViewContext.uiBinders.speedLimit)
-
     override fun MapboxNavigation.flowViewBinders(): Flow<UIBinder> {
-        return stateFlow
+        return navigationViewContext.flowUiBinder { it.speedLimit }
     }
 }


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Issue in coordinators that observe customizable uibinders (e.g., `SpeedLimitCoordinator`). Essentially, the initial state is triggered before the `MapboxNavigationView.customize` function. To ensure this new state is applied on the `onStart` lifecycle, am adding an emit inside `override fun MapboxNavigation.flowViewBinders()`

So I was thinking, instead, lets make all uiBinders observable. This way it does not matter when you call MapboxNavitation.customize(uibinders). You will have a new view applied to the layout 🪂 

Minor issue when trying to build good transitions. For some reason transitions are not very good at restoring previous view. This issue is related https://github.com/mapbox/mapbox-navigation-android/issues/5516

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->

https://user-images.githubusercontent.com/3021882/155818095-3d98e9e9-f934-431c-8430-3c161bbb3f73.mp4


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
