### PR TITLE
allow creating mapbox navigation with new options every time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Mapbox welcomes participation and contributions from everyone.
 
 #### Bug fixes and improvements
 - Added a workaround for [`ConnectivityManager`'s occasional security exception on Android 11 and older](https://issuetracker.google.com/issues/175055271). [#5492](https://github.com/mapbox/mapbox-navigation-android/pull/5492)
+- Added `MapboxNavigationApp.setup` overload, that accepts `NavigationOptionsProvider` instead of prebuilt `NavigationOptions`. [#5490](https://github.com/mapbox/mapbox-navigation-android/pull/5490)
 
 ## Mapbox Navigation SDK 2.3.0-rc.1 - February 17, 2022
 

--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -269,7 +269,7 @@ package com.mapbox.navigation.core.lifecycle {
 
   @com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI public final class MapboxNavigationApp {
     method public com.mapbox.navigation.core.lifecycle.MapboxNavigationApp attach(androidx.lifecycle.LifecycleOwner lifecycleOwner);
-    method public com.mapbox.navigation.core.lifecycle.MapboxNavigationApp attachAllActivities();
+    method public com.mapbox.navigation.core.lifecycle.MapboxNavigationApp attachAllActivities(android.app.Application application);
     method public com.mapbox.navigation.core.MapboxNavigation? current();
     method public com.mapbox.navigation.core.lifecycle.MapboxNavigationApp detach(androidx.lifecycle.LifecycleOwner lifecycleOwner);
     method public com.mapbox.navigation.core.lifecycle.MapboxNavigationApp disable();
@@ -278,6 +278,7 @@ package com.mapbox.navigation.core.lifecycle {
     method public boolean isSetup();
     method public com.mapbox.navigation.core.lifecycle.MapboxNavigationApp registerObserver(com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver mapboxNavigationObserver);
     method public com.mapbox.navigation.core.lifecycle.MapboxNavigationApp setup(com.mapbox.navigation.base.options.NavigationOptions navigationOptions);
+    method public com.mapbox.navigation.core.lifecycle.MapboxNavigationApp setup(com.mapbox.navigation.core.lifecycle.NavigationOptionsProvider navigationOptionsProvider);
     method public com.mapbox.navigation.core.lifecycle.MapboxNavigationApp unregisterObserver(com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver mapboxNavigationObserver);
     property public final androidx.lifecycle.LifecycleOwner lifecycleOwner;
     field public static final com.mapbox.navigation.core.lifecycle.MapboxNavigationApp INSTANCE;
@@ -286,6 +287,10 @@ package com.mapbox.navigation.core.lifecycle {
   @com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI public interface MapboxNavigationObserver {
     method public void onAttached(com.mapbox.navigation.core.MapboxNavigation mapboxNavigation);
     method public void onDetached(com.mapbox.navigation.core.MapboxNavigation mapboxNavigation);
+  }
+
+  @com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI public fun interface NavigationOptionsProvider {
+    method public com.mapbox.navigation.base.options.NavigationOptions createNavigationOptions();
   }
 
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/lifecycle/MapboxNavigationApp.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/lifecycle/MapboxNavigationApp.kt
@@ -1,6 +1,7 @@
 package com.mapbox.navigation.core.lifecycle
 
 import android.app.Activity
+import android.app.Application
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
@@ -80,15 +81,26 @@ object MapboxNavigationApp {
      * [Activity.isChangingConfigurations].
      */
     fun setup(navigationOptions: NavigationOptions) = apply {
-        mapboxNavigationAppDelegate.setup(navigationOptions)
+        mapboxNavigationAppDelegate.setup { navigationOptions }
+    }
+
+    /**
+     * Call [MapboxNavigationApp.setup] to provide the application with [NavigationOptionsProvider].
+     * New [NavigationOptions] will be created for every [MapboxNavigation] instance.
+     *
+     * This call is a no-op if an attached activity is changing configurations
+     * [Activity.isChangingConfigurations].
+     */
+    fun setup(navigationOptionsProvider: NavigationOptionsProvider) = apply {
+        mapboxNavigationAppDelegate.setup(navigationOptionsProvider)
     }
 
     /**
      * Detect when any Activity is in the foreground. Use [attach] and [detach] for
      * granular control of which lifecycle is used for creating [MapboxNavigation].
      */
-    fun attachAllActivities() = apply {
-        mapboxNavigationAppDelegate.attachAllActivities()
+    fun attachAllActivities(application: Application) = apply {
+        mapboxNavigationAppDelegate.attachAllActivities(application)
     }
 
     /**

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/lifecycle/MapboxNavigationAppDelegate.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/lifecycle/MapboxNavigationAppDelegate.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.LifecycleOwner
 import com.mapbox.base.common.logger.model.Message
 import com.mapbox.base.common.logger.model.Tag
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
-import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.utils.internal.logI
 import kotlin.reflect.KClass
@@ -23,7 +22,7 @@ internal class MapboxNavigationAppDelegate {
 
     var isSetup = false
 
-    fun setup(navigationOptions: NavigationOptions) = apply {
+    fun setup(navigationOptionsProvider: NavigationOptionsProvider) = apply {
         if (carAppLifecycleOwner.isConfigurationChanging()) {
             return this
         }
@@ -43,13 +42,12 @@ internal class MapboxNavigationAppDelegate {
             return this
         }
 
-        mapboxNavigationOwner.setup(navigationOptions)
+        mapboxNavigationOwner.setup(navigationOptionsProvider)
         carAppLifecycleOwner.lifecycle.addObserver(mapboxNavigationOwner.carAppLifecycleObserver)
         isSetup = true
     }
 
-    fun attachAllActivities() {
-        val application = mapboxNavigationOwner.navigationOptions.applicationContext as Application
+    fun attachAllActivities(application: Application) {
         carAppLifecycleOwner.attachAllActivities(application)
     }
 

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/lifecycle/MapboxNavigationOwner.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/lifecycle/MapboxNavigationOwner.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.LifecycleOwner
 import com.mapbox.base.common.logger.model.Message
 import com.mapbox.base.common.logger.model.Tag
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
-import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.MapboxNavigationProvider
 import com.mapbox.navigation.utils.internal.logI
@@ -14,8 +13,8 @@ import kotlin.reflect.KClass
 
 @ExperimentalPreviewMapboxNavigationAPI
 internal class MapboxNavigationOwner {
-    internal lateinit var navigationOptions: NavigationOptions
-        private set
+
+    private lateinit var navigationOptionsProvider: NavigationOptionsProvider
 
     private val services = CopyOnWriteArraySet<MapboxNavigationObserver>()
     private var mapboxNavigation: MapboxNavigation? = null
@@ -28,6 +27,7 @@ internal class MapboxNavigationOwner {
             check(!MapboxNavigationProvider.isCreated()) {
                 "MapboxNavigation should only be created by the MapboxNavigationOwner"
             }
+            val navigationOptions = navigationOptionsProvider.createNavigationOptions()
             val mapboxNavigation = MapboxNavigationProvider.create(navigationOptions)
             this@MapboxNavigationOwner.mapboxNavigation = mapboxNavigation
             attached = true
@@ -43,8 +43,8 @@ internal class MapboxNavigationOwner {
         }
     }
 
-    fun setup(navigationOptions: NavigationOptions) {
-        this.navigationOptions = navigationOptions
+    fun setup(navigationOptionsProvider: NavigationOptionsProvider) {
+        this.navigationOptionsProvider = navigationOptionsProvider
     }
 
     fun register(mapboxNavigationObserver: MapboxNavigationObserver) = apply {

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/lifecycle/NavigationOptionsProvider.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/lifecycle/NavigationOptionsProvider.kt
@@ -1,0 +1,16 @@
+package com.mapbox.navigation.core.lifecycle
+
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.base.options.NavigationOptions
+
+/**
+ * Represents a function that returns [NavigationOptions]
+ */
+@ExperimentalPreviewMapboxNavigationAPI
+fun interface NavigationOptionsProvider {
+
+    /**
+     * Generates [NavigationOptions].
+     */
+    fun createNavigationOptions(): NavigationOptions
+}

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/lifecycle/MapboxNavigationAppDelegateTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/lifecycle/MapboxNavigationAppDelegateTest.kt
@@ -26,7 +26,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import java.lang.IllegalStateException
 
 @ExperimentalPreviewMapboxNavigationAPI
 @RunWith(RobolectricTestRunner::class)
@@ -55,7 +54,7 @@ class MapboxNavigationAppDelegateTest {
 
     @Test
     fun `verify onAttached and onDetached when multiple lifecycles have started`() {
-        mapboxNavigationApp.setup(navigationOptions)
+        mapboxNavigationApp.setup { navigationOptions }
 
         val testLifecycleOwnerA = CarAppLifecycleOwnerTest.TestLifecycleOwner()
         val testLifecycleOwnerB = CarAppLifecycleOwnerTest.TestLifecycleOwner()
@@ -77,7 +76,7 @@ class MapboxNavigationAppDelegateTest {
 
     @Test
     fun `verify onAttached is called when LifecycleOwner is started`() {
-        mapboxNavigationApp.setup(navigationOptions)
+        mapboxNavigationApp.setup { navigationOptions }
 
         val firstObserver = mockk<MapboxNavigationObserver>(relaxUnitFun = true)
         val secondObserver = mockk<MapboxNavigationObserver>(relaxUnitFun = true)
@@ -106,7 +105,7 @@ class MapboxNavigationAppDelegateTest {
         mapboxNavigationApp.attach(testLifecycleOwner)
 
         testLifecycleOwner.lifecycleRegistry.currentState = Lifecycle.State.RESUMED
-        mapboxNavigationApp.setup(navigationOptions)
+        mapboxNavigationApp.setup { navigationOptions }
 
         verify(exactly = 1) { firstObserver.onAttached(any()) }
         verify(exactly = 1) { secondObserver.onAttached(any()) }
@@ -116,7 +115,7 @@ class MapboxNavigationAppDelegateTest {
 
     @Test
     fun `verify multiple setup calls are ignored`() {
-        mapboxNavigationApp.setup(navigationOptions)
+        mapboxNavigationApp.setup { navigationOptions }
         val firstObserver = mockk<MapboxNavigationObserver>(relaxUnitFun = true)
         val secondObserver = mockk<MapboxNavigationObserver>(relaxUnitFun = true)
         mapboxNavigationApp.registerObserver(firstObserver)
@@ -124,9 +123,9 @@ class MapboxNavigationAppDelegateTest {
 
         val testLifecycleOwner = CarAppLifecycleOwnerTest.TestLifecycleOwner()
         mapboxNavigationApp.attach(testLifecycleOwner)
-        mapboxNavigationApp.setup(navigationOptions)
+        mapboxNavigationApp.setup { navigationOptions }
         testLifecycleOwner.lifecycleRegistry.currentState = Lifecycle.State.RESUMED
-        mapboxNavigationApp.setup(navigationOptions)
+        mapboxNavigationApp.setup { navigationOptions }
 
         verify(exactly = 1) { firstObserver.onAttached(any()) }
         verify(exactly = 1) { secondObserver.onAttached(any()) }
@@ -143,7 +142,7 @@ class MapboxNavigationAppDelegateTest {
 
         val (portraitActivity, portraitLifecycle) = mockActivityLifecycle()
         portraitLifecycle.currentState = Lifecycle.State.RESUMED
-        mapboxNavigationApp.setup(navigationOptions)
+        mapboxNavigationApp.setup { navigationOptions }
         mapboxNavigationApp.attach(portraitActivity)
         every { portraitActivity.isChangingConfigurations } returns true
         portraitLifecycle.currentState = Lifecycle.State.DESTROYED
@@ -152,7 +151,7 @@ class MapboxNavigationAppDelegateTest {
         landscapeLifecycle.currentState = Lifecycle.State.RESUMED
         every { landscapeActivity.isChangingConfigurations } returns false
         landscapeLifecycle.currentState = Lifecycle.State.RESUMED
-        mapboxNavigationApp.setup(navigationOptions)
+        mapboxNavigationApp.setup { navigationOptions }
         mapboxNavigationApp.attach(landscapeActivity)
 
         verify(exactly = 1) { firstObserver.onAttached(any()) }
@@ -207,7 +206,7 @@ class MapboxNavigationAppDelegateTest {
 
     @Test
     fun `verify detaching all LifecycleOwners detaches all observers`() {
-        mapboxNavigationApp.setup(navigationOptions)
+        mapboxNavigationApp.setup { navigationOptions }
 
         val testLifecycleOwnerA = CarAppLifecycleOwnerTest.TestLifecycleOwner()
         val testLifecycleOwnerB = CarAppLifecycleOwnerTest.TestLifecycleOwner()
@@ -235,7 +234,7 @@ class MapboxNavigationAppDelegateTest {
 
     @Test
     fun `verify disable will call observers onDetached`() {
-        mapboxNavigationApp.setup(navigationOptions)
+        mapboxNavigationApp.setup { navigationOptions }
 
         val testLifecycleOwnerA = CarAppLifecycleOwnerTest.TestLifecycleOwner()
         val testLifecycleOwnerB = CarAppLifecycleOwnerTest.TestLifecycleOwner()
@@ -262,7 +261,7 @@ class MapboxNavigationAppDelegateTest {
 
     @Test
     fun `verify disable will prevent mapboxNavigation from restarting`() {
-        mapboxNavigationApp.setup(navigationOptions)
+        mapboxNavigationApp.setup { navigationOptions }
 
         val testLifecycleOwner = CarAppLifecycleOwnerTest.TestLifecycleOwner()
         mapboxNavigationApp.attach(testLifecycleOwner)
@@ -281,7 +280,7 @@ class MapboxNavigationAppDelegateTest {
 
     @Test
     fun `verify current is null when all lifecycle owners are destroyed`() {
-        mapboxNavigationApp.setup(navigationOptions)
+        mapboxNavigationApp.setup { navigationOptions }
 
         val testLifecycleOwner = CarAppLifecycleOwnerTest.TestLifecycleOwner()
         mapboxNavigationApp.attach(testLifecycleOwner)
@@ -296,7 +295,7 @@ class MapboxNavigationAppDelegateTest {
 
     @Test
     fun `verify current is set after LifecycleOwner is created`() {
-        mapboxNavigationApp.setup(navigationOptions)
+        mapboxNavigationApp.setup { navigationOptions }
 
         val testLifecycleOwner = CarAppLifecycleOwnerTest.TestLifecycleOwner()
         mapboxNavigationApp.attach(testLifecycleOwner)

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/MapboxNavigationViewModelTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/MapboxNavigationViewModelTest.kt
@@ -7,8 +7,8 @@ import com.mapbox.api.directions.v5.models.RouteOptions
 import com.mapbox.api.directions.v5.models.VoiceInstructions
 import com.mapbox.geojson.Point
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.route.RouterCallback
-import com.mapbox.navigation.base.route.RouterOrigin
 import com.mapbox.navigation.base.trip.model.RouteLegProgress
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.MapboxNavigation
@@ -53,7 +53,7 @@ class MapboxNavigationViewModelTest {
     fun setup() {
         mockkObject(MapboxNavigationApp)
         every {
-            MapboxNavigationApp.setup(any())
+            MapboxNavigationApp.setup(any<NavigationOptions>())
         } returns MapboxNavigationApp
         every {
             MapboxNavigationApp.registerObserver(capture(mapboxNavigationObserver))
@@ -339,7 +339,7 @@ class MapboxNavigationViewModelTest {
         val callbackSlot = slot<RouterCallback>()
         val mockMapboxNavigation = mockk<MapboxNavigation>(relaxed = true) {
             every { requestRoutes(options, capture(callbackSlot)) } answers {
-                callbackSlot.captured.onRoutesReady(routes, mockk<RouterOrigin>())
+                callbackSlot.captured.onRoutesReady(routes, mockk())
                 0L
             }
         }


### PR DESCRIPTION
### Description

Currently it is very hard to recreate `MapboxNavigation` with different options using `MapboxNavigationApp`. The only way to do this is to call `disable` and then call `setup` with new options. It is tricky to call these methods at the right time, because you need to do this after all the data is available (or updated), but before `MapboxNavigation` is going to be created. Very often not all data is available in `Application.onCreate`, e.g. for `EventsAppMetadata` we need to provide `userId`, which is available only after user is logged in (it also changes when the user logs into a different account). With these changes options are created right before creating `MapboxNavigation` and each time we create new ones. 

Opening this as a draft to discuss the proposed changes. Looks like we will have to add `Application` parameter to `attachAllActivites`, which is a breaking change. But `MapboxNavigationApp` is marked as experimental, so maybe it is fine. I will update tests and documentation after we come to an agreement. 

In the linked PR you can see how this limitation can be overcome at the moment. 

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
