### PR TITLE
Fixed crash caused by null names

### DIFF
--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigatorImpl.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigatorImpl.kt
@@ -211,13 +211,11 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
             .routes(routes.toMutableList())
             .code("Ok")
             .waypoints(
-                coordinatesList().mapIndexed { index, point ->
-                    val waypointBuilder = DirectionsWaypoint.builder()
+                coordinatesList().map { point ->
+                    DirectionsWaypoint.builder()
                         .rawLocation(doubleArrayOf(point.longitude(), point.latitude()))
-                    waypointNamesList()?.getOrNull(index)?.let { name ->
-                        waypointBuilder.name(name)
-                    }
-                    waypointBuilder.build()
+                        .name("")
+                        .build()
                 }
             )
             .build()


### PR DESCRIPTION
### Description

[Directions API defines name in a waypoint as a required option now](https://docs.mapbox.com/api/navigation/directions/#waypoint-object). The latest version of [mapbox-java too](https://github.com/mapbox/mapbox-java/commit/75766419f8e6f6a4c4d481dafdc3c295f15ec556).

I test the latest mapbox java and got a crash. We're trying to use waypoint name as a name of waypoint. There're a 2 problems with it:
1. A waypoint can have no name
2. As I see Directions API always uses the street name as a waypoint name.

#5411 May have already fixed this issue. 