### PR TITLE
Generate markdown with dependencies for release notes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,3 +100,5 @@ dokkaHtmlMultiModule {
 task clean(type: Delete) {
   delete rootProject.buildDir
 }
+
+apply from: "${rootDir}/gradle/dependencies-changelog.gradle"

--- a/gradle/dependencies-changelog.gradle
+++ b/gradle/dependencies-changelog.gradle
@@ -1,0 +1,15 @@
+apply from: "${rootDir}/gradle/dependencies.gradle"
+
+task createDependenciesMd {
+    inputs.properties(this.ext.version)
+    outputs.file("$buildDir/dependencies.md")
+    doLast {
+        def versions = "- Mapbox Maps SDK v${this.ext.version.mapboxMapSdk} ([release notes](https://github.com/mapbox/mapbox-maps-android/releases/tag/android-v${this.ext.version.mapboxMapSdk}))  \n" +
+                "- Mapbox Navigation Native v${this.ext.version.mapboxNavigator}  \n" +
+                "- Mapbox Core Common v${this.ext.version.mapboxCommonNative}  \n" +
+                "- Mapbox Java v${this.ext.version.mapboxSdkServices} ([release notes](https://github.com/mapbox/mapbox-java/releases/tag/v${this.ext.version.mapboxSdkServices}))  \n" +
+                "- Mapbox Android Core v${this.ext.version.mapboxCore}  \n" +
+                "- Mapbox Android Telemetry v${this.ext.version.mapboxEvents}  "
+        new File(buildDir, "dependencies.md").text = versions
+    }
+}


### PR DESCRIPTION
### Description

Wrote this script working on #5354. It generates `dependencies.md` file which contains versions we use.

### Example of dependencies.md

- Mapbox Maps SDK v10.3.0 ([release notes](https://github.com/mapbox/mapbox-maps-android/releases/tag/android-v10.3.0))  
- Mapbox Navigation Native v88.0.0  
- Mapbox Core Common v21.1.1  
- Mapbox Java v6.3.0-beta.1 ([release notes](https://github.com/mapbox/mapbox-java/releases/tag/v6.3.0-beta.1))  
- Mapbox Android Core v5.0.1  
- Mapbox Android Telemetry v8.1.1  

### Known issues

As I see from #5492 we can transitively get different patch version.  @mapbox/navigation-android , does somebody want to help with this?