### PR TITLE
Custom Router: delegates invokes from NN if custom Router is provided

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,7 +341,7 @@ commands:
         type: string
     steps:
       - run:
-          name: Run instrumentation tests on internal SDK classes on Firebase
+          name: Run instrumentation tests on internal SDK classes on Firebase (module << parameters.module_target >>)
           no_output_timeout: 1200
           shell: /bin/bash -euo pipefail
           command: |
@@ -477,6 +477,8 @@ jobs:
                 variant: "Debug"
             - assemble-instrumentation-test:
                 module_target: "libnavigation-core"
+            - assemble-instrumentation-test:
+                module_target: "libnavigator"
             - write-workspace
 
   unit-tests-core:
@@ -603,6 +605,10 @@ jobs:
             - login-google-cloud-platform
             - run-internal-firebase-instrumentation:
                 module_target: "libnavigation-core"
+                module_wrapper: "app-tests-wrapper"
+                variant: "debug"
+            - run-internal-firebase-instrumentation:
+                module_target: "libnavigator"
                 module_wrapper: "app-tests-wrapper"
                 variant: "debug"
       - run: exit 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Mapbox welcomes participation and contributions from everyone.
 
 ## Unreleased
+- :warning: Deprecated `RouterOrigin.Custom(obj: Any?)`. The SDK doesn't keep `RouteOrigin.Custom#obj` anymore, it always becomes `null` when the `obj` returns in `RoutesObserver`. [#5500](https://github.com/mapbox/mapbox-navigation-android/pull/5500)
 
 #### Features
 - Exposed option in MapboxRouteLineOptions to change the default icon pitch alignment for waypoint icons. [#5531](https://github.com/mapbox/mapbox-navigation-android/pull/5531)

--- a/libnavigation-base/api/current.txt
+++ b/libnavigation-base/api/current.txt
@@ -708,11 +708,11 @@ package com.mapbox.navigation.base.route {
   }
 
   public static final class RouterOrigin.Custom extends com.mapbox.navigation.base.route.RouterOrigin {
-    ctor public RouterOrigin.Custom(Object? obj = null);
+    ctor @Deprecated public RouterOrigin.Custom(Object? obj = null);
     method public Object? component1();
     method public com.mapbox.navigation.base.route.RouterOrigin.Custom copy(Object? obj);
-    method public Object? getObj();
-    property public final Object? obj;
+    method @Deprecated public Object? getObj();
+    property @Deprecated public final Object? obj;
   }
 
   public static final class RouterOrigin.Offboard extends com.mapbox.navigation.base.route.RouterOrigin {

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/route/InternalRouter.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/route/InternalRouter.kt
@@ -1,0 +1,8 @@
+package com.mapbox.navigation.base.internal.route
+
+import com.mapbox.navigation.base.route.Router
+
+/**
+ * Marks [Router] inhered class as internal implementation
+ */
+interface InternalRouter

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/route/RouterOrigin.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/route/RouterOrigin.kt
@@ -17,10 +17,22 @@ sealed class RouterOrigin {
     object Onboard : RouterOrigin()
 
     /**
-     * Can be used as a router origin of custom routes source, different from [Offboard] and [Onboard]. The
-     * SDK doesn't operate with [obj], it might be used to spread any additional data.
-     *
+     * Can be used as a router origin of custom routes source, different from [Offboard] and [Onboard].
      * @param obj is used to provide additional data with [Custom] router origin
      */
-    data class Custom @JvmOverloads constructor(val obj: Any? = null) : RouterOrigin()
+    data class Custom
+    @Deprecated(
+        "`Nullable obj` is not supported anymore, `obj` becomes `null` when " +
+            "it's passed in custom Router.",
+        ReplaceWith("RouterOrigin.Custom()")
+    )
+    constructor(
+        @Deprecated(
+            "`obj` is not supported anymore, it becomes `null` when passed " +
+                "in custom Router."
+        )
+        val obj: Any? = null
+    ) : RouterOrigin() {
+        constructor() : this(null)
+    }
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/NavigationComponentProvider.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/NavigationComponentProvider.kt
@@ -20,6 +20,7 @@ import com.mapbox.navigation.navigator.internal.MapboxNativeNavigator
 import com.mapbox.navigation.navigator.internal.MapboxNativeNavigatorImpl
 import com.mapbox.navigation.utils.internal.ThreadController
 import com.mapbox.navigator.NavigatorConfig
+import com.mapbox.navigator.RouterInterface
 import com.mapbox.navigator.TilesConfig
 
 internal object NavigationComponentProvider {
@@ -33,12 +34,14 @@ internal object NavigationComponentProvider {
         tilesConfig: TilesConfig,
         historyDir: String?,
         accessToken: String,
+        routerInterface: RouterInterface,
     ): MapboxNativeNavigator = MapboxNativeNavigatorImpl.create(
         deviceProfile,
         navigatorConfig,
         tilesConfig,
         historyDir,
         accessToken,
+        routerInterface,
     )
 
     fun createTripService(

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/utils/ModulesUtils.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/utils/ModulesUtils.kt
@@ -1,0 +1,52 @@
+package com.mapbox.navigation.core.internal.utils
+
+import com.mapbox.common.module.provider.ModuleProviderArgument
+import com.mapbox.navigation.base.formatter.DistanceFormatter
+import com.mapbox.navigation.base.formatter.DistanceFormatterOptions
+import com.mapbox.navigation.base.options.NavigationOptions
+import com.mapbox.navigation.core.formatter.MapboxDistanceFormatter
+import com.mapbox.navigation.utils.internal.ThreadController
+import com.mapbox.navigator.RouterInterface
+
+internal fun paramsProvider(moduleParams: ModuleParams): Array<ModuleProviderArgument> =
+    when (moduleParams) {
+        is ModuleParams.NavigationRoute -> arrayOf(
+            ModuleProviderArgument(
+                String::class.java,
+                moduleParams.accessToken
+            ),
+            ModuleProviderArgument(
+                RouterInterface::class.java,
+                moduleParams.nativeRouter
+            ),
+            ModuleProviderArgument(
+                ThreadController::class.java,
+                moduleParams.threadController
+            ),
+        )
+        is ModuleParams.NavigationTripNotification -> arrayOf(
+            ModuleProviderArgument(
+                NavigationOptions::class.java, moduleParams.navigationOptions
+            ),
+            ModuleProviderArgument(
+                DistanceFormatter::class.java,
+                MapboxDistanceFormatter(moduleParams.distanceFormatterOptions),
+            ),
+        )
+        is ModuleParams.CommonLogger -> arrayOf()
+    }
+
+internal sealed class ModuleParams {
+    class NavigationRoute(
+        val accessToken: String,
+        val nativeRouter: RouterInterface,
+        val threadController: ThreadController,
+    ) : ModuleParams()
+
+    class NavigationTripNotification(
+        val navigationOptions: NavigationOptions,
+        val distanceFormatterOptions: DistanceFormatterOptions,
+    ) : ModuleParams()
+
+    object CommonLogger : ModuleParams()
+}

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/utils/RouterEx.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/utils/RouterEx.kt
@@ -1,0 +1,9 @@
+package com.mapbox.navigation.core.internal.utils
+
+import com.mapbox.navigation.base.internal.route.InternalRouter
+import com.mapbox.navigation.base.route.Router
+
+/**
+ * Check if [Router] interface impl in Nav SDK
+ */
+internal fun Router.isInternalImplementation(): Boolean = this is InternalRouter

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
@@ -50,6 +50,7 @@ import com.mapbox.navigation.core.trip.session.TripSession
 import com.mapbox.navigation.core.trip.session.TripSessionLocationEngine
 import com.mapbox.navigation.core.trip.session.TripSessionState
 import com.mapbox.navigation.navigator.internal.MapboxNativeNavigator
+import com.mapbox.navigation.navigator.internal.NavigatorLoader
 import com.mapbox.navigation.testing.MainCoroutineRule
 import com.mapbox.navigation.testing.MockLoggerRule
 import com.mapbox.navigation.utils.internal.ThreadController
@@ -156,6 +157,11 @@ class MapboxNavigationTest {
 
     @Before
     fun setUp() {
+        mockkObject(NavigatorLoader)
+        every {
+            NavigatorLoader.createNativeRouterInterface(any(), any(), any(), any())
+        } returns mockk()
+
         mockkObject(MapboxSDKCommon)
         every {
             MapboxSDKCommon.getContext().getSystemService(Context.CONNECTIVITY_SERVICE)
@@ -205,7 +211,7 @@ class MapboxNavigationTest {
             NavigationComponentProvider.createArrivalProgressObserver(tripSession)
         } returns arrivalProgressObserver
 
-        every { navigator.create(any(), any(), any(), any(), any()) } returns navigator
+        every { navigator.create(any(), any(), any(), any(), any(), any()) } returns navigator
         mockkStatic(TelemetryEnabler::class)
         every { TelemetryEnabler.isEventsEnabled(any()) } returns true
     }
@@ -216,6 +222,7 @@ class MapboxNavigationTest {
             mapboxNavigation.onDestroy()
         }
 
+        unmockkObject(NavigatorLoader)
         unmockkObject(MapboxSDKCommon)
         unmockkObject(MapboxModuleProvider)
         unmockkObject(NavigationComponentProvider)
@@ -734,7 +741,7 @@ class MapboxNavigationTest {
         val slot = slot<TilesConfig>()
         every {
             NavigationComponentProvider.createNativeNavigator(
-                any(), any(), capture(slot), any(), any()
+                any(), any(), capture(slot), any(), any(), any()
             )
         } returns navigator
         val options = navigationOptions.toBuilder()
@@ -752,7 +759,7 @@ class MapboxNavigationTest {
         val slot = slot<TilesConfig>()
         every {
             NavigationComponentProvider.createNativeNavigator(
-                any(), any(), capture(slot), any(), any()
+                any(), any(), capture(slot), any(), any(), any()
             )
         } returns navigator
         val options = navigationOptions.toBuilder()
@@ -775,7 +782,7 @@ class MapboxNavigationTest {
         val slot = slot<NavigatorConfig>()
         every {
             NavigationComponentProvider.createNativeNavigator(
-                any(), capture(slot), any(), any(), any()
+                any(), capture(slot), any(), any(), any(), any()
             )
         } returns navigator
 
@@ -790,7 +797,7 @@ class MapboxNavigationTest {
         val slot = slot<NavigatorConfig>()
         every {
             NavigationComponentProvider.createNativeNavigator(
-                any(), capture(slot), any(), any(), any()
+                any(), capture(slot), any(), any(), any(), any()
             )
         } returns navigator
         val options = navigationOptions.toBuilder()
@@ -813,7 +820,7 @@ class MapboxNavigationTest {
         val slot = slot<NavigatorConfig>()
         every {
             NavigationComponentProvider.createNativeNavigator(
-                any(), capture(slot), any(), any(), any()
+                any(), capture(slot), any(), any(), any(), any()
             )
         } returns navigator
         val options = navigationOptions.toBuilder()
@@ -942,7 +949,7 @@ class MapboxNavigationTest {
         val slot = slot<TilesConfig>()
         every {
             NavigationComponentProvider.createNativeNavigator(
-                any(), any(), capture(slot), any(), any()
+                any(), any(), capture(slot), any(), any(), any()
             )
         } returns navigator
         val tilesVersion = "tilesVersion"
@@ -980,7 +987,8 @@ class MapboxNavigationTest {
                 any(),
                 capture(tileConfigSlot),
                 any(),
-                any()
+                any(),
+                any(),
             )
         } just Runs
 
@@ -1014,7 +1022,8 @@ class MapboxNavigationTest {
                 any(),
                 capture(tileConfigSlot),
                 any(),
-                any()
+                any(),
+                any(),
             )
         } just Runs
 
@@ -1189,7 +1198,8 @@ class MapboxNavigationTest {
                 any(),
                 any(),
                 any(),
-                any()
+                any(),
+                any(),
             )
         } returns navigator
     }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/internal/utils/RouterExTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/internal/utils/RouterExTest.kt
@@ -1,0 +1,30 @@
+package com.mapbox.navigation.core.internal.utils
+
+import com.mapbox.navigation.base.route.Router
+import com.mapbox.navigation.route.internal.RouterWrapper
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class RouterExTest {
+
+    @Test
+    fun testIsInternalImplementation() {
+        listOf<Triple<String, Router, Boolean>>(
+            Triple(
+                "Router interface",
+                mockk(),
+                false
+            ),
+            Triple(
+                "RouterWrapper, internal implementation",
+                mockk<RouterWrapper>(),
+                true
+            ),
+        ).let { testCases ->
+            testCases.forEach { (message, router, isInternal) ->
+                assertEquals(message, isInternal, router.isInternalImplementation())
+            }
+        }
+    }
+}

--- a/libnavigation-router/src/main/java/com/mapbox/navigation/route/internal/RouterWrapper.kt
+++ b/libnavigation-router/src/main/java/com/mapbox/navigation/route/internal/RouterWrapper.kt
@@ -9,6 +9,7 @@ import com.mapbox.annotation.module.MapboxModuleType
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.RouteOptions
 import com.mapbox.navigation.base.ExperimentalMapboxNavigationAPI
+import com.mapbox.navigation.base.internal.route.InternalRouter
 import com.mapbox.navigation.base.internal.utils.parseDirectionsResponse
 import com.mapbox.navigation.base.route.NavigationRoute
 import com.mapbox.navigation.base.route.NavigationRouter
@@ -43,7 +44,7 @@ class RouterWrapper(
     private val accessToken: String,
     private val router: RouterInterface,
     private val threadController: ThreadController,
-) : NavigationRouter {
+) : NavigationRouter, InternalRouter {
 
     private val mainJobControl by lazy { threadController.getMainScopeAndRootJob() }
 

--- a/libnavigator/build.gradle
+++ b/libnavigator/build.gradle
@@ -12,10 +12,15 @@ android {
     }
 
     defaultConfig {
+        testApplicationId "com.mapbox.navigation.navigator.test"
         minSdkVersion androidVersions.minSdkVersion
         targetSdkVersion androidVersions.targetSdkVersion
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'proguard-rules.pro', "${rootDir}/proguard/proguard-project.pro"
+    }
+
+    testOptions {
+        execution 'ANDROIDX_TEST_ORCHESTRATOR'
     }
 
     testOptions {
@@ -43,6 +48,10 @@ dependencies {
 
     testImplementation(project(':libtesting-utils'))
     apply from: "${rootDir}/gradle/unit-testing-dependencies.gradle"
+    // instrumentation tests
+    androidTestImplementation project(':libtesting-ui')
+    androidTestImplementation dependenciesList.testRunner
+    androidTestUtil dependenciesList.testOrchestrator
 }
 
 apply from: "${rootDir}/gradle/track-public-apis.gradle"

--- a/libnavigator/src/androidTest/java/com/mapbox/navigation/navigator/internal/NavigatorTest.kt
+++ b/libnavigator/src/androidTest/java/com/mapbox/navigation/navigator/internal/NavigatorTest.kt
@@ -1,0 +1,130 @@
+package com.mapbox.navigation.navigator.internal
+
+import androidx.annotation.RawRes
+import androidx.test.platform.app.InstrumentationRegistry
+import com.mapbox.api.directions.v5.DirectionsCriteria
+import com.mapbox.api.directions.v5.models.DirectionsResponse
+import com.mapbox.api.directions.v5.models.RouteOptions
+import com.mapbox.geojson.Point
+import com.mapbox.navigation.base.route.NavigationRoute
+import com.mapbox.navigation.navigator.internal.util.readRawFileText
+import com.mapbox.navigation.navigator.internal.util.runOnMainSync
+import com.mapbox.navigator.CacheFactory
+import com.mapbox.navigator.CacheHandle
+import com.mapbox.navigator.ConfigFactory
+import com.mapbox.navigator.ConfigHandle
+import com.mapbox.navigator.Navigator
+import com.mapbox.navigator.NavigatorConfig
+import com.mapbox.navigator.ProfileApplication
+import com.mapbox.navigator.ProfilePlatform
+import com.mapbox.navigator.Routes
+import com.mapbox.navigator.SettingsProfile
+import com.mapbox.navigator.TilesConfig
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+
+class NavigatorTest {
+
+    private companion object {
+        @RawRes
+        private val DIRECTIONS_RESPONSE =
+            com.mapbox.navigation.navigator.test.R.raw.directions_response_two_leg_route
+    }
+
+    @Test(timeout = 5_000)
+    fun successfulSetRoutesToNN() {
+        val cdl = CountDownLatch(1)
+        runOnMainSync {
+            val navigator = provideNavigator()
+            val routes = provideDirectionsRouteAndRouteOptions()
+            navigator.setRoutes(
+                Routes(
+                    routes.mapToDirectionsResponse().toJson(),
+                    0,
+                    0,
+                    routes.first().routeOptions.toUrl("pk.**").toString()
+                )
+            ) { expected ->
+                assertTrue(expected.isValue)
+                cdl.countDown()
+            }
+        }
+        cdl.await()
+    }
+
+    private fun provideDirectionsRouteAndRouteOptions(): List<NavigationRoute> =
+        listOf(
+            NavigationRoute(
+                DirectionsResponse.fromJson(
+                    readRawFileText(
+                        InstrumentationRegistry.getInstrumentation().targetContext,
+                        DIRECTIONS_RESPONSE,
+                    )
+                ),
+                0,
+                RouteOptions.builder()
+                    .profile(DirectionsCriteria.PROFILE_DRIVING)
+                    .coordinatesList(
+                        listOf(
+                            Point.fromLngLat(-77.063888, 38.798979),
+                            Point.fromLngLat(-77.078234, 38.894377),
+                            Point.fromLngLat(-77.028263, 38.962309),
+                        )
+                    )
+                    .waypointNamesList(
+                        listOf(
+                            "", "North Quinn Street", ""
+                        )
+                    )
+                    .build()
+            ),
+        )
+
+    private fun provideNavigator(
+        config: ConfigHandle = providesConfigHandle()
+    ): Navigator {
+        return Navigator(
+            config,
+            provideCacheHandle(configHandle = config),
+            null,
+            null,
+        )
+    }
+
+    private fun providesConfigHandle(): ConfigHandle =
+        ConfigFactory.build(
+            SettingsProfile(ProfileApplication.MOBILE, ProfilePlatform.ANDROID),
+            NavigatorConfig(
+                null, null, null, null, null, null, null
+            ),
+            """
+            {
+                "input": {
+            	    "stopDetector": {
+            		    "mobile": {
+            			    "useImu": false
+            		    }
+            	    }
+                }
+            }
+            """.trimIndent()
+        )
+
+    private fun provideCacheHandle(
+        tilesConfig: TilesConfig = provideTilesConfig(),
+        configHandle: ConfigHandle,
+    ): CacheHandle =
+        CacheFactory.build(tilesConfig, configHandle, null)
+
+    private fun provideTilesConfig(): TilesConfig = TilesConfig(
+        InstrumentationRegistry.getInstrumentation()
+            .targetContext.getExternalFilesDir(null)!!.absolutePath,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+    )
+}

--- a/libnavigator/src/androidTest/java/com/mapbox/navigation/navigator/internal/util/ExpressoUtils.kt
+++ b/libnavigator/src/androidTest/java/com/mapbox/navigation/navigator/internal/util/ExpressoUtils.kt
@@ -1,0 +1,15 @@
+package com.mapbox.navigation.navigator.internal.util
+
+import androidx.test.platform.app.InstrumentationRegistry
+
+/**
+ * Runs the code block on the app's main thread and blocks until the block returns.
+ */
+fun runOnMainSync(runnable: Runnable) =
+    InstrumentationRegistry.getInstrumentation().runOnMainSync(runnable)
+
+/**
+ * Runs the code block on the app's main thread and blocks until the block returns.
+ */
+fun runOnMainSync(fn: () -> Unit) =
+    InstrumentationRegistry.getInstrumentation().runOnMainSync(fn)

--- a/libnavigator/src/androidTest/java/com/mapbox/navigation/navigator/internal/util/FileUtil.kt
+++ b/libnavigator/src/androidTest/java/com/mapbox/navigation/navigator/internal/util/FileUtil.kt
@@ -1,0 +1,7 @@
+package com.mapbox.navigation.navigator.internal.util
+
+import android.content.Context
+import androidx.annotation.IntegerRes
+
+fun readRawFileText(context: Context, @IntegerRes res: Int): String =
+    context.resources.openRawResource(res).bufferedReader().use { it.readText() }

--- a/libnavigator/src/androidTest/res/raw/directions_response_two_leg_route.json
+++ b/libnavigator/src/androidTest/res/raw/directions_response_two_leg_route.json
@@ -1,0 +1,6104 @@
+{
+  "waypoints": [
+    {
+      "location": [
+        -77.063888,
+        38.798979
+      ],
+      "name": ""
+    },
+    {
+      "location": [
+        -77.078234,
+        38.894377
+      ],
+      "name": "North Quinn Street"
+    },
+    {
+      "location": [
+        -77.028263,
+        38.962309
+      ],
+      "name": ""
+    }
+  ],
+  "routes": [
+    {
+      "legs": [
+        {
+          "steps": [
+            {
+              "intersections": [
+                {
+                  "out": 0,
+                  "entry": [
+                    true
+                  ],
+                  "location": [
+                    -77.063888,
+                    38.798979
+                  ],
+                  "bearings": [
+                    136
+                  ]
+                }
+              ],
+              "geometry": "egb_iA~kr~qCj[{a@^qI",
+              "duration": 39.9,
+              "distance": 84.7,
+              "name": "",
+              "weight": 154.3,
+              "mode": "driving",
+              "maneuver": {
+                "bearing_after": 136,
+                "location": [
+                  -77.063888,
+                  38.798979
+                ],
+                "type": "depart",
+                "bearing_before": 0,
+                "modifier": "right",
+                "instruction": "Head southeast"
+              }
+            },
+            {
+              "intersections": [
+                {
+                  "out": 1,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.063161,
+                    38.798509
+                  ],
+                  "bearings": [
+                    0,
+                    180,
+                    270
+                  ]
+                }
+              ],
+              "geometry": "yia_iAp~p~qCxDTT_J",
+              "duration": 16.9,
+              "distance": 25.7,
+              "name": "",
+              "weight": 51.5,
+              "mode": "driving",
+              "maneuver": {
+                "bearing_after": 184,
+                "location": [
+                  -77.063161,
+                  38.798509
+                ],
+                "type": "turn",
+                "bearing_before": 95,
+                "modifier": "right",
+                "instruction": "Turn right"
+              }
+            },
+            {
+              "intersections": [
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.062996,
+                    38.798405
+                  ],
+                  "bearings": [
+                    0,
+                    180,
+                    270
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.062941,
+                    38.7988
+                  ],
+                  "bearings": [
+                    0,
+                    60,
+                    195
+                  ]
+                }
+              ],
+              "geometry": "ica_iAftp~qCkNy@iHs@i`@oB_FY__@sBcZaBkAGwBK",
+              "duration": 44.5,
+              "distance": 232.8,
+              "name": "Hooffs Run Drive",
+              "weight": 44.5,
+              "mode": "driving",
+              "maneuver": {
+                "bearing_after": 4,
+                "location": [
+                  -77.062996,
+                  38.798405
+                ],
+                "type": "turn",
+                "bearing_before": 94,
+                "modifier": "left",
+                "instruction": "Turn left onto Hooffs Run Drive"
+              }
+            },
+            {
+              "intersections": [
+                {
+                  "out": 1,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false,
+                    false
+                  ],
+                  "location": [
+                    -77.062755,
+                    38.800489
+                  ],
+                  "bearings": [
+                    0,
+                    90,
+                    180,
+                    270
+                  ]
+                },
+                {
+                  "out": 1,
+                  "in": 2,
+                  "lanes": [
+                    {
+                      "valid": false,
+                      "indications": [
+                        "left"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "indications": [
+                        "none"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "indications": [
+                        "none"
+                      ]
+                    }
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.062015,
+                    38.800438
+                  ],
+                  "bearings": [
+                    15,
+                    90,
+                    270
+                  ]
+                }
+              ],
+              "geometry": "qee_iAdep~qCJ{DxAkg@LmEb@}QTgEb@_DbAeDfAyApAiB",
+              "duration": 13.6,
+              "distance": 135.9,
+              "name": "Eisenhower Avenue",
+              "weight": 13.6,
+              "mode": "driving",
+              "maneuver": {
+                "bearing_after": 94,
+                "location": [
+                  -77.062755,
+                  38.800489
+                ],
+                "type": "turn",
+                "bearing_before": 4,
+                "modifier": "right",
+                "instruction": "Turn right onto Eisenhower Avenue"
+              }
+            },
+            {
+              "intersections": [
+                {
+                  "out": 0,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ],
+                  "location": [
+                    -77.061248,
+                    38.800273
+                  ],
+                  "bearings": [
+                    150,
+                    315,
+                    345
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.060932,
+                    38.800095
+                  ],
+                  "bearings": [
+                    90,
+                    105,
+                    285
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ],
+                  "location": [
+                    -77.060481,
+                    38.800352
+                  ],
+                  "bearings": [
+                    0,
+                    180,
+                    195
+                  ]
+                },
+                {
+                  "out": 1,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.060473,
+                    38.800416
+                  ],
+                  "bearings": [
+                    0,
+                    15,
+                    180
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.060248,
+                    38.80088
+                  ],
+                  "bearings": [
+                    15,
+                    210,
+                    240
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.060117,
+                    38.801412
+                  ],
+                  "bearings": [
+                    15,
+                    195,
+                    270
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.059922,
+                    38.802358
+                  ],
+                  "bearings": [
+                    15,
+                    195,
+                    270
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.059772,
+                    38.803114
+                  ],
+                  "bearings": [
+                    15,
+                    105,
+                    195,
+                    285
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false,
+                    false
+                  ],
+                  "location": [
+                    -77.059499,
+                    38.804244
+                  ],
+                  "bearings": [
+                    15,
+                    105,
+                    195,
+                    285
+                  ]
+                }
+              ],
+              "geometry": "axd_iA~fm~qCdBqAz@}@|@yA|@}B^yAPeARoBDuBQ}De@_Ce@aBmA_CsAcBgAy@aAc@}Bm@_CO{FqAyAg@k@SwCuAeK}EoDaAwEw@_TkC{TqC{PsBkR_CuBW_KoAgOeBmJeA{BWmCaAuBu@iFcAyQyBcSaCqKqAuBWwER",
+              "duration": 74.8,
+              "distance": 543.2,
+              "name": "Holland Lane",
+              "weight": 76.39999999999999,
+              "mode": "driving",
+              "maneuver": {
+                "exit": 2,
+                "bearing_after": 147,
+                "location": [
+                  -77.061248,
+                  38.800273
+                ],
+                "type": "roundabout",
+                "bearing_before": 133,
+                "modifier": "straight",
+                "instruction": "Enter the roundabout and take the 2nd exit onto Holland Lane"
+              }
+            },
+            {
+              "intersections": [
+                {
+                  "out": 2,
+                  "in": 1,
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "location": [
+                    -77.059509,
+                    38.804352
+                  ],
+                  "bearings": [
+                    105,
+                    195,
+                    285
+                  ]
+                },
+                {
+                  "out": 3,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    true,
+                    true
+                  ],
+                  "location": [
+                    -77.059982,
+                    38.804413
+                  ],
+                  "bearings": [
+                    15,
+                    105,
+                    195,
+                    285
+                  ]
+                },
+                {
+                  "out": 3,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.061299,
+                    38.804607
+                  ],
+                  "bearings": [
+                    15,
+                    105,
+                    195,
+                    285
+                  ]
+                },
+                {
+                  "out": 3,
+                  "in": 1,
+                  "lanes": [
+                    {
+                      "valid": false,
+                      "indications": [
+                        "left"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "indications": [
+                        "none"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "indications": [
+                        "none"
+                      ]
+                    }
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true,
+                    true
+                  ],
+                  "location": [
+                    -77.061516,
+                    38.804639
+                  ],
+                  "bearings": [
+                    15,
+                    105,
+                    195,
+                    285
+                  ]
+                },
+                {
+                  "out": 1,
+                  "in": 0,
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "location": [
+                    -77.062804,
+                    38.804828
+                  ],
+                  "bearings": [
+                    105,
+                    285,
+                    300
+                  ]
+                },
+                {
+                  "out": 3,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.063276,
+                    38.804897
+                  ],
+                  "bearings": [
+                    30,
+                    105,
+                    195,
+                    285
+                  ]
+                },
+                {
+                  "out": 3,
+                  "in": 1,
+                  "lanes": [
+                    {
+                      "valid": false,
+                      "indications": [
+                        "left"
+                      ]
+                    },
+                    {
+                      "valid": false,
+                      "indications": [
+                        "left"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "indications": [
+                        "none"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "indications": [
+                        "none"
+                      ]
+                    }
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true,
+                    true
+                  ],
+                  "location": [
+                    -77.063379,
+                    38.804912
+                  ],
+                  "bearings": [
+                    45,
+                    105,
+                    195,
+                    285
+                  ]
+                }
+              ],
+              "maneuver": {
+                "bearing_after": 278,
+                "location": [
+                  -77.059509,
+                  38.804352
+                ],
+                "type": "end of road",
+                "bearing_before": 15,
+                "modifier": "left",
+                "instruction": "Turn left onto Duke Street (VA 236)"
+              },
+              "duration": 58.3,
+              "distance": 452.8,
+              "name": "Duke Street (VA 236)",
+              "geometry": "_wl_iAhzi~qCaBzVWtDq@lI{Fvt@}@bLW~C_ApLU~CcFjo@aBvS]jEiBrU_@zE]lEiAbQ{Ddh@YxEs@dL",
+              "ref": "VA 236",
+              "weight": 58.3,
+              "mode": "driving"
+            },
+            {
+              "intersections": [
+                {
+                  "out": 1,
+                  "in": 0,
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "location": [
+                    -77.064648,
+                    38.805082
+                  ],
+                  "bearings": [
+                    105,
+                    285,
+                    300
+                  ]
+                }
+              ],
+              "geometry": "sdn_iAn{s~qCcB`HkApBiAp@_BT{AIoA_@eAy@gAoA",
+              "duration": 9.5,
+              "distance": 50,
+              "name": "",
+              "weight": 9.5,
+              "mode": "driving",
+              "maneuver": {
+                "bearing_after": 292,
+                "location": [
+                  -77.064648,
+                  38.805082
+                ],
+                "type": "turn",
+                "bearing_before": 278,
+                "modifier": "slight right",
+                "instruction": "Make a slight right"
+              }
+            },
+            {
+              "intersections": [
+                {
+                  "out": 0,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ],
+                  "location": [
+                    -77.064796,
+                    38.805412
+                  ],
+                  "bearings": [
+                    45,
+                    225,
+                    240
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.062732,
+                    38.806871
+                  ],
+                  "bearings": [
+                    30,
+                    45,
+                    195
+                  ]
+                }
+              ],
+              "geometry": "gyn_iAvdt~qCsKcOsB}E_IgTkNaa@eF{N}CiHmC{DcDyCgD}AgMmFkGkCmKwE}A]wEM",
+              "duration": 38.3,
+              "distance": 291.1,
+              "name": "Callahan Drive",
+              "weight": 38.3,
+              "mode": "driving",
+              "maneuver": {
+                "bearing_after": 43,
+                "location": [
+                  -77.064796,
+                  38.805412
+                ],
+                "type": "turn",
+                "bearing_before": 40,
+                "modifier": "straight",
+                "instruction": "Go straight onto Callahan Drive"
+              }
+            },
+            {
+              "intersections": [
+                {
+                  "out": 2,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    true,
+                    true
+                  ],
+                  "location": [
+                    -77.062602,
+                    38.807225
+                  ],
+                  "bearings": [
+                    135,
+                    180,
+                    315,
+                    345
+                  ]
+                },
+                {
+                  "out": 2,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.063845,
+                    38.808159
+                  ],
+                  "bearings": [
+                    45,
+                    135,
+                    315
+                  ]
+                },
+                {
+                  "out": 2,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.064636,
+                    38.808788
+                  ],
+                  "bearings": [
+                    45,
+                    135,
+                    315
+                  ]
+                },
+                {
+                  "out": 2,
+                  "in": 0,
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "location": [
+                    -77.065142,
+                    38.809178
+                  ],
+                  "bearings": [
+                    135,
+                    225,
+                    315
+                  ]
+                },
+                {
+                  "out": 2,
+                  "in": 0,
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "location": [
+                    -77.066933,
+                    38.810558
+                  ],
+                  "bearings": [
+                    135,
+                    225,
+                    315
+                  ]
+                },
+                {
+                  "out": 2,
+                  "in": 0,
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "location": [
+                    -77.067584,
+                    38.811059
+                  ],
+                  "bearings": [
+                    135,
+                    225,
+                    315
+                  ]
+                },
+                {
+                  "out": 2,
+                  "in": 0,
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "location": [
+                    -77.069007,
+                    38.812155
+                  ],
+                  "bearings": [
+                    135,
+                    225,
+                    315
+                  ]
+                },
+                {
+                  "out": 2,
+                  "in": 0,
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "location": [
+                    -77.070983,
+                    38.813603
+                  ],
+                  "bearings": [
+                    135,
+                    210,
+                    315
+                  ]
+                },
+                {
+                  "out": 2,
+                  "in": 0,
+                  "entry": [
+                    false,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.071306,
+                    38.813855
+                  ],
+                  "bearings": [
+                    135,
+                    285,
+                    315
+                  ]
+                },
+                {
+                  "out": 2,
+                  "in": 0,
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "location": [
+                    -77.071553,
+                    38.814047
+                  ],
+                  "bearings": [
+                    135,
+                    225,
+                    315
+                  ]
+                },
+                {
+                  "out": 2,
+                  "in": 0,
+                  "entry": [
+                    false,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.071882,
+                    38.814332
+                  ],
+                  "bearings": [
+                    135,
+                    150,
+                    315
+                  ]
+                },
+                {
+                  "out": 2,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.072374,
+                    38.814771
+                  ],
+                  "bearings": [
+                    45,
+                    135,
+                    315
+                  ]
+                },
+                {
+                  "out": 2,
+                  "in": 0,
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "location": [
+                    -77.073247,
+                    38.815554
+                  ],
+                  "bearings": [
+                    135,
+                    225,
+                    315
+                  ]
+                },
+                {
+                  "out": 2,
+                  "in": 0,
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "location": [
+                    -77.074716,
+                    38.816877
+                  ],
+                  "bearings": [
+                    135,
+                    225,
+                    315
+                  ]
+                },
+                {
+                  "out": 2,
+                  "in": 0,
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "location": [
+                    -77.075329,
+                    38.817428
+                  ],
+                  "bearings": [
+                    135,
+                    225,
+                    315
+                  ]
+                },
+                {
+                  "out": 2,
+                  "in": 0,
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "location": [
+                    -77.075812,
+                    38.817872
+                  ],
+                  "bearings": [
+                    135,
+                    225,
+                    315
+                  ]
+                },
+                {
+                  "out": 2,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.076805,
+                    38.818769
+                  ],
+                  "bearings": [
+                    45,
+                    135,
+                    315
+                  ]
+                },
+                {
+                  "out": 2,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.077898,
+                    38.819768
+                  ],
+                  "bearings": [
+                    60,
+                    135,
+                    315
+                  ]
+                },
+                {
+                  "out": 2,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.079629,
+                    38.821377
+                  ],
+                  "bearings": [
+                    30,
+                    135,
+                    315
+                  ]
+                },
+                {
+                  "out": 2,
+                  "in": 1,
+                  "entry": [
+                    false,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.082245,
+                    38.823428
+                  ],
+                  "bearings": [
+                    45,
+                    135,
+                    315
+                  ]
+                },
+                {
+                  "out": 2,
+                  "in": 0,
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "location": [
+                    -77.083334,
+                    38.824126
+                  ],
+                  "bearings": [
+                    135,
+                    225,
+                    315
+                  ]
+                },
+                {
+                  "out": 3,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    true,
+                    true
+                  ],
+                  "location": [
+                    -77.085177,
+                    38.825338
+                  ],
+                  "bearings": [
+                    30,
+                    135,
+                    225,
+                    315
+                  ]
+                },
+                {
+                  "out": 3,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    true,
+                    true
+                  ],
+                  "location": [
+                    -77.086428,
+                    38.826186
+                  ],
+                  "bearings": [
+                    0,
+                    135,
+                    225,
+                    315
+                  ]
+                },
+                {
+                  "out": 3,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    true,
+                    true
+                  ],
+                  "location": [
+                    -77.087346,
+                    38.826837
+                  ],
+                  "bearings": [
+                    90,
+                    135,
+                    285,
+                    315
+                  ]
+                },
+                {
+                  "out": 2,
+                  "in": 1,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "indications": [
+                        "none"
+                      ]
+                    }
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.087556,
+                    38.826991
+                  ],
+                  "bearings": [
+                    90,
+                    135,
+                    315
+                  ]
+                }
+              ],
+              "maneuver": {
+                "bearing_after": 312,
+                "location": [
+                  -77.062602,
+                  38.807225
+                ],
+                "type": "turn",
+                "bearing_before": 1,
+                "modifier": "left",
+                "instruction": "Turn left onto King Street (VA 7)"
+              },
+              "duration": 317.8,
+              "distance": 3136.1,
+              "name": "King Street (VA 7)",
+              "geometry": "qjr_iAr{o~qCiClEgK|OcE|FwLzP}Tn[if@lp@kWr^guA|nB{RzXmJxMocA|wAoyAnzBwNdS_KlN_K`MyDnEmZv]gTtVcTpVqEhFaGxGuW|YgD|DiGhHuWtZuJbL_AjAm_@|b@wZd]mJtK_`@tc@cJ`KORed@vg@_OnPgH`ImXvZaBhBuEhFiPvQ}UlWcXrYkJnK}MbOqLhNsZb_@yPxV}OpV}X`g@sj@`cAwjAdrB_t@dmAgPhXgRhYeCvDsHbL}PlW",
+              "ref": "VA 7",
+              "weight": 317.8,
+              "mode": "driving"
+            },
+            {
+              "intersections": [
+                {
+                  "out": 0,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    false,
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.087947,
+                    38.827278
+                  ],
+                  "bearings": [
+                    90,
+                    135,
+                    195,
+                    270,
+                    300,
+                    330
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.087191,
+                    38.827589
+                  ],
+                  "bearings": [
+                    45,
+                    240,
+                    315
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.086365,
+                    38.828329
+                  ],
+                  "bearings": [
+                    30,
+                    90,
+                    210,
+                    285
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ],
+                  "location": [
+                    -77.086056,
+                    38.828904
+                  ],
+                  "bearings": [
+                    30,
+                    195,
+                    210
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.085615,
+                    38.829858
+                  ],
+                  "bearings": [
+                    15,
+                    120,
+                    180,
+                    240
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.085221,
+                    38.832019
+                  ],
+                  "bearings": [
+                    0,
+                    105,
+                    180,
+                    270
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.085249,
+                    38.832919
+                  ],
+                  "bearings": [
+                    0,
+                    120,
+                    180,
+                    270
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.085273,
+                    38.83386
+                  ],
+                  "bearings": [
+                    0,
+                    105,
+                    180,
+                    270
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "lanes": [
+                    {
+                      "valid": false,
+                      "indications": [
+                        "left"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "indications": [
+                        "none"
+                      ]
+                    },
+                    {
+                      "valid": false,
+                      "indications": [
+                        "right"
+                      ]
+                    }
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.084738,
+                    38.836207
+                  ],
+                  "bearings": [
+                    15,
+                    105,
+                    195,
+                    285
+                  ]
+                }
+              ],
+              "maneuver": {
+                "bearing_after": 85,
+                "location": [
+                  -77.087947,
+                  38.827278
+                ],
+                "type": "turn",
+                "bearing_before": 312,
+                "modifier": "sharp right",
+                "instruction": "Make a sharp right onto North Quaker Lane (SR 402)"
+              },
+              "duration": 126.29999999999998,
+              "distance": 1494.1,
+              "name": "North Quaker Lane (SR 402)",
+              "geometry": "{oy`iAtka`rCUcKaJcUuF_LiIiOwImKoIiJuMqJi[cNsFeC}HgEug@mU_Hb@uCmFoPqFy@SwFuAsCs@mKgByPiA}CQgHMi]h@}VPki@h@{LLsb@d@eVH_PDwK^kMb@oGMuDgAcMcDkOaFmPeFsPcFyUqEiFwA{IO{]u@sPW_GEsa@VyVGoTe@yNi@{M{AkMwCoW{G",
+              "ref": "SR 402",
+              "weight": 126.29999999999998,
+              "mode": "driving"
+            },
+            {
+              "intersections": [
+                {
+                  "out": 0,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ],
+                  "location": [
+                    -77.084348,
+                    38.839794
+                  ],
+                  "bearings": [
+                    15,
+                    195,
+                    210
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.084079,
+                    38.840378
+                  ],
+                  "bearings": [
+                    15,
+                    105,
+                    195
+                  ]
+                }
+              ],
+              "geometry": "c~qaiAvjz_rCoc@yOsWiJ",
+              "duration": 7.300000000000001,
+              "distance": 115.6,
+              "name": "Shirlington Circle",
+              "weight": 7.300000000000001,
+              "mode": "driving",
+              "maneuver": {
+                "bearing_after": 19,
+                "location": [
+                  -77.084348,
+                  38.839794
+                ],
+                "type": "turn",
+                "bearing_before": 15,
+                "modifier": "straight",
+                "instruction": "Go straight onto Shirlington Circle"
+              }
+            },
+            {
+              "intersections": [
+                {
+                  "out": 1,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.083898,
+                    38.840772
+                  ],
+                  "bearings": [
+                    15,
+                    30,
+                    195
+                  ]
+                }
+              ],
+              "geometry": "g{saiArny_rC}TkLmJwEwGiE_UyPoU}Rm[{VeTgOyOyK{`@uY",
+              "duration": 16,
+              "distance": 388.3,
+              "name": "",
+              "weight": 16,
+              "mode": "driving",
+              "maneuver": {
+                "bearing_after": 25,
+                "location": [
+                  -77.083898,
+                  38.840772
+                ],
+                "type": "on ramp",
+                "bearing_before": 19,
+                "modifier": "slight right",
+                "instruction": "Take the ramp on the right"
+              }
+            },
+            {
+              "intersections": [
+                {
+                  "out": 0,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ],
+                  "location": [
+                    -77.081597,
+                    38.843763
+                  ],
+                  "bearings": [
+                    36,
+                    212,
+                    216
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.081264,
+                    38.84412
+                  ],
+                  "bearings": [
+                    30,
+                    45,
+                    210
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ],
+                  "location": [
+                    -77.079427,
+                    38.846346
+                  ],
+                  "bearings": [
+                    30,
+                    195,
+                    210
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.079019,
+                    38.846855
+                  ],
+                  "bearings": [
+                    30,
+                    45,
+                    210
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ],
+                  "location": [
+                    -77.077163,
+                    38.849116
+                  ],
+                  "bearings": [
+                    32,
+                    206,
+                    213
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.070686,
+                    38.857997
+                  ],
+                  "bearings": [
+                    26,
+                    33,
+                    209
+                  ]
+                }
+              ],
+              "maneuver": {
+                "bearing_after": 35,
+                "location": [
+                  -77.081597,
+                  38.843763
+                ],
+                "type": "merge",
+                "bearing_before": 30,
+                "modifier": "slight left",
+                "instruction": "Merge left onto Shirley Highway (I 395)"
+              },
+              "duration": 86.5,
+              "distance": 2240.6,
+              "name": "Shirley Highway (I 395)",
+              "geometry": "evyaiAx~t_rCiUyScjCyqBo[{UiBsAkl@uc@{EkDaxA}hAew@ml@iTqPg{C{sBgRaMk|C}mBe_CcwAoOyJotAuu@sJeEqWaJk\\uI}ZwGu[uC",
+              "ref": "I 395",
+              "weight": 86.5,
+              "mode": "driving"
+            },
+            {
+              "intersections": [
+                {
+                  "out": 1,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.069149,
+                    38.86132
+                  ],
+                  "bearings": [
+                    0,
+                    15,
+                    180
+                  ]
+                }
+              ],
+              "geometry": "o_|biAxt|~qCimAwN_h@kImTaHqLkEoPmJwK_HyVoVePcUyKyVkNo_@gPsm@{a@uyAaMa\\",
+              "maneuver": {
+                "bearing_after": 8,
+                "location": [
+                  -77.069149,
+                  38.86132
+                ],
+                "type": "off ramp",
+                "bearing_before": 7,
+                "modifier": "slight right",
+                "instruction": "Take the ramp on the right towards VA-27"
+              },
+              "duration": 35.1,
+              "distance": 790.8,
+              "destinations": "VA-27, Washington Blvd, Pentagon, Arlington Cemetery, Rosslyn",
+              "name": "",
+              "weight": 35.1,
+              "mode": "driving"
+            },
+            {
+              "intersections": [
+                {
+                  "out": 0,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ],
+                  "location": [
+                    -77.063864,
+                    38.866439
+                  ],
+                  "bearings": [
+                    60,
+                    240,
+                    255
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.062024,
+                    38.868065
+                  ],
+                  "bearings": [
+                    30,
+                    45,
+                    210
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ],
+                  "location": [
+                    -77.06116,
+                    38.869217
+                  ],
+                  "bearings": [
+                    30,
+                    195,
+                    210
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ],
+                  "location": [
+                    -77.059241,
+                    38.871796
+                  ],
+                  "bearings": [
+                    28,
+                    205,
+                    208
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ],
+                  "location": [
+                    -77.058093,
+                    38.873823
+                  ],
+                  "bearings": [
+                    15,
+                    195,
+                    210
+                  ]
+                }
+              ],
+              "maneuver": {
+                "bearing_after": 57,
+                "location": [
+                  -77.063864,
+                  38.866439
+                ],
+                "type": "merge",
+                "bearing_before": 57,
+                "modifier": "slight left",
+                "instruction": "Merge left onto Washington Boulevard (VA 27)"
+              },
+              "duration": 68,
+              "distance": 1445,
+              "name": "Washington Boulevard (VA 27)",
+              "geometry": "m_fciAnjr~qCwNe`@gJaQmNmPwJuJ}HaGod@qY_gA_u@{KiHeOmKktAu`Awm@o_@yj@o\\yo@yZaa@mMeYmKci@_P_[sI{bAcOqr@sGyVgC}QW",
+              "ref": "VA 27",
+              "weight": 68,
+              "mode": "driving"
+            },
+            {
+              "intersections": [
+                {
+                  "out": 1,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.056976,
+                    38.877959
+                  ],
+                  "bearings": [
+                    0,
+                    15,
+                    180
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.056322,
+                    38.878169
+                  ],
+                  "bearings": [
+                    135,
+                    300,
+                    330
+                  ]
+                }
+              ],
+              "geometry": "mo|ciA~{d~qCqGwB{D_CeBgCmAwCYaFl@mDhEsJrFyJvGsN~IuT",
+              "duration": 25.7,
+              "distance": 165.3,
+              "name": "",
+              "weight": 25.7,
+              "mode": "driving",
+              "maneuver": {
+                "bearing_after": 18,
+                "location": [
+                  -77.056976,
+                  38.877959
+                ],
+                "type": "off ramp",
+                "bearing_before": 1,
+                "modifier": "slight right",
+                "instruction": "Take the ramp on the right"
+              }
+            },
+            {
+              "intersections": [
+                {
+                  "out": 1,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.055536,
+                    38.877731
+                  ],
+                  "bearings": [
+                    60,
+                    240,
+                    300
+                  ]
+                }
+              ],
+              "geometry": "ea|ciA~ab~qC|BvH`]rv@",
+              "duration": 13.1,
+              "distance": 109,
+              "name": "Pentagon Access Road",
+              "weight": 13.1,
+              "mode": "driving",
+              "maneuver": {
+                "bearing_after": 241,
+                "location": [
+                  -77.055536,
+                  38.877731
+                ],
+                "type": "end of road",
+                "bearing_before": 122,
+                "modifier": "right",
+                "instruction": "Turn right onto Pentagon Access Road"
+              }
+            },
+            {
+              "intersections": [
+                {
+                  "out": 2,
+                  "in": 0,
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "location": [
+                    -77.056582,
+                    38.877187
+                  ],
+                  "bearings": [
+                    60,
+                    150,
+                    240
+                  ]
+                }
+              ],
+              "geometry": "e_{ciAjcd~qCnCpHPfCDbEYvB}n@lv@aMbQmQhX",
+              "duration": 14.8,
+              "distance": 233.6,
+              "name": "",
+              "weight": 14.8,
+              "mode": "driving",
+              "maneuver": {
+                "bearing_after": 237,
+                "location": [
+                  -77.056582,
+                  38.877187
+                ],
+                "type": "new name",
+                "bearing_before": 234,
+                "modifier": "straight",
+                "instruction": "Continue straight"
+              }
+            },
+            {
+              "intersections": [
+                {
+                  "out": 2,
+                  "in": 0,
+                  "entry": [
+                    false,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.058543,
+                    38.878403
+                  ],
+                  "bearings": [
+                    133,
+                    141,
+                    319
+                  ]
+                },
+                {
+                  "out": 1,
+                  "in": 0,
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "location": [
+                    -77.061716,
+                    38.881589
+                  ],
+                  "bearings": [
+                    144,
+                    326,
+                    332
+                  ]
+                },
+                {
+                  "out": 2,
+                  "in": 0,
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "location": [
+                    -77.065754,
+                    38.887619
+                  ],
+                  "bearings": [
+                    156,
+                    326,
+                    330
+                  ]
+                }
+              ],
+              "maneuver": {
+                "bearing_after": 319,
+                "location": [
+                  -77.058543,
+                  38.878403
+                ],
+                "type": "merge",
+                "bearing_before": 312,
+                "modifier": "slight left",
+                "instruction": "Merge left onto North Jefferson Davis Highway (VA 110)"
+              },
+              "duration": 85.30000000000001,
+              "distance": 1818.1,
+              "name": "North Jefferson Davis Highway (VA 110)",
+              "geometry": "ek}ciA|}g~qCucAljAur@ts@uw@vp@aUlSu[tW}\\|Vmb@nZiWbQcd@pXy]vQ}JbFiY|NmaAjh@asAbo@y@f@sGbEeHlEqJhHyCzBaC~BmIfJ{SbUuPj[wF~FmF`FqD~BoGzCuFtB}NpDoKb@mq@fBoPR{S?iRuBs_@aIsNuB",
+              "ref": "VA 110",
+              "weight": 85.30000000000001,
+              "mode": "driving"
+            },
+            {
+              "intersections": [
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.06755,
+                    38.892563
+                  ],
+                  "bearings": [
+                    0,
+                    15,
+                    195
+                  ]
+                },
+                {
+                  "out": 3,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    true,
+                    true
+                  ],
+                  "location": [
+                    -77.068295,
+                    38.894006
+                  ],
+                  "bearings": [
+                    15,
+                    150,
+                    180,
+                    330
+                  ]
+                },
+                {
+                  "out": 2,
+                  "in": 0,
+                  "lanes": [
+                    {
+                      "valid": false,
+                      "indications": [
+                        "left"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "indications": [
+                        "none"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "indications": [
+                        "none"
+                      ]
+                    }
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "location": [
+                    -77.068613,
+                    38.894363
+                  ],
+                  "bearings": [
+                    150,
+                    225,
+                    315
+                  ]
+                },
+                {
+                  "out": 3,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.069354,
+                    38.894768
+                  ],
+                  "bearings": [
+                    0,
+                    120,
+                    210,
+                    300
+                  ]
+                },
+                {
+                  "out": 3,
+                  "in": 1,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "indications": [
+                        "none"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "indications": [
+                        "none"
+                      ]
+                    },
+                    {
+                      "valid": false,
+                      "indications": [
+                        "right"
+                      ]
+                    }
+                  ],
+                  "entry": [
+                    true,
+                    false,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.070746,
+                    38.895162
+                  ],
+                  "bearings": [
+                    0,
+                    105,
+                    180,
+                    270
+                  ]
+                },
+                {
+                  "out": 3,
+                  "in": 1,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "indications": [
+                        "none"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "indications": [
+                        "none"
+                      ]
+                    },
+                    {
+                      "valid": false,
+                      "indications": [
+                        "right"
+                      ]
+                    }
+                  ],
+                  "entry": [
+                    true,
+                    false,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.070814,
+                    38.895164
+                  ],
+                  "bearings": [
+                    15,
+                    90,
+                    195,
+                    270
+                  ]
+                },
+                {
+                  "out": 3,
+                  "in": 1,
+                  "entry": [
+                    false,
+                    false,
+                    true,
+                    true
+                  ],
+                  "location": [
+                    -77.071477,
+                    38.895119
+                  ],
+                  "bearings": [
+                    0,
+                    90,
+                    180,
+                    255
+                  ]
+                },
+                {
+                  "out": 3,
+                  "in": 1,
+                  "lanes": [
+                    {
+                      "valid": false,
+                      "indications": [
+                        "left"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "indications": [
+                        "none"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "indications": [
+                        "none"
+                      ]
+                    }
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true,
+                    true
+                  ],
+                  "location": [
+                    -77.072077,
+                    38.895013
+                  ],
+                  "bearings": [
+                    0,
+                    75,
+                    180,
+                    255
+                  ]
+                },
+                {
+                  "out": 3,
+                  "in": 1,
+                  "entry": [
+                    false,
+                    false,
+                    true,
+                    true
+                  ],
+                  "location": [
+                    -77.072287,
+                    38.894973
+                  ],
+                  "bearings": [
+                    0,
+                    75,
+                    180,
+                    255
+                  ]
+                },
+                {
+                  "out": 3,
+                  "in": 1,
+                  "lanes": [
+                    {
+                      "valid": false,
+                      "indications": [
+                        "left"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "indications": [
+                        "none"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "indications": [
+                        "none"
+                      ]
+                    }
+                  ],
+                  "entry": [
+                    true,
+                    false,
+                    true,
+                    true
+                  ],
+                  "location": [
+                    -77.073135,
+                    38.894874
+                  ],
+                  "bearings": [
+                    0,
+                    75,
+                    180,
+                    270
+                  ]
+                },
+                {
+                  "out": 2,
+                  "in": 1,
+                  "entry": [
+                    false,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.073512,
+                    38.894837
+                  ],
+                  "bearings": [
+                    45,
+                    90,
+                    270
+                  ]
+                },
+                {
+                  "out": 3,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    true,
+                    true
+                  ],
+                  "location": [
+                    -77.073852,
+                    38.894809
+                  ],
+                  "bearings": [
+                    0,
+                    90,
+                    180,
+                    255
+                  ]
+                },
+                {
+                  "out": 2,
+                  "in": 0,
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "location": [
+                    -77.07672,
+                    38.894394
+                  ],
+                  "bearings": [
+                    75,
+                    180,
+                    255
+                  ]
+                }
+              ],
+              "geometry": "e`ydiAzpy~qCyKT{Gt@{GhBsQ`J_h@x\\yEdDwLxJw@zAgEjIeKxToCnGkArDeGhOgDzKoAhHgBjL]fDkAxK[|Eg@bICfCR~IF`F^hO\\`Ft@dHZbDfB|PXfDnAbL^hFrAjRv@hQX~FRtDt@zP`@xLTlF`@dFtDpe@bBhTJvA^lEfEni@vCx`@pArRb@`FTzEz@tItApQj@vHnD~TpB|MdAbH",
+              "duration": 181.2,
+              "distance": 1088.7,
+              "name": "",
+              "weight": 181.2,
+              "mode": "driving",
+              "maneuver": {
+                "bearing_after": 357,
+                "location": [
+                  -77.06755,
+                  38.892563
+                ],
+                "type": "fork",
+                "bearing_before": 9,
+                "modifier": "slight left",
+                "instruction": "Keep left at the fork"
+              }
+            },
+            {
+              "intersections": [
+                {
+                  "out": 0,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.078191,
+                    38.894108
+                  ],
+                  "bearings": [
+                    0,
+                    75,
+                    240
+                  ]
+                }
+              ],
+              "geometry": "w`|diA|in_rCmCTwD\\sE`@",
+              "duration": 6.5,
+              "distance": 30.2,
+              "name": "North Quinn Street",
+              "weight": 6.5,
+              "mode": "driving",
+              "maneuver": {
+                "bearing_after": 351,
+                "location": [
+                  -77.078191,
+                  38.894108
+                ],
+                "type": "turn",
+                "bearing_before": 251,
+                "modifier": "right",
+                "instruction": "Turn right onto North Quinn Street"
+              }
+            },
+            {
+              "intersections": [
+                {
+                  "in": 0,
+                  "entry": [
+                    true
+                  ],
+                  "location": [
+                    -77.078234,
+                    38.894377
+                  ],
+                  "bearings": [
+                    173
+                  ]
+                }
+              ],
+              "geometry": "qq|diArln_rC",
+              "duration": 0,
+              "distance": 0,
+              "name": "North Quinn Street",
+              "weight": 0,
+              "mode": "driving",
+              "maneuver": {
+                "bearing_after": 0,
+                "location": [
+                  -77.078234,
+                  38.894377
+                ],
+                "type": "arrive",
+                "bearing_before": 353,
+                "modifier": "right",
+                "instruction": "You have arrived at your destination, on the right"
+              }
+            }
+          ],
+          "weight": 1430,
+          "distance": 14871.6,
+          "annotation": {
+            "congestion": [
+              "unknown",
+              "unknown",
+              "unknown",
+              "unknown",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "heavy",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "heavy",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "heavy",
+              "heavy",
+              "low",
+              "heavy",
+              "low",
+              "low",
+              "low",
+              "heavy",
+              "heavy",
+              "moderate",
+              "moderate",
+              "moderate",
+              "moderate",
+              "low",
+              "heavy",
+              "heavy",
+              "low",
+              "low",
+              "moderate",
+              "moderate",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "heavy",
+              "heavy",
+              "heavy",
+              "low",
+              "low",
+              "low",
+              "low",
+              "heavy",
+              "low",
+              "low",
+              "heavy",
+              "heavy",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "moderate",
+              "moderate",
+              "moderate",
+              "moderate",
+              "moderate",
+              "moderate",
+              "low",
+              "low",
+              "heavy",
+              "low",
+              "heavy",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "moderate",
+              "moderate",
+              "heavy",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "moderate",
+              "moderate",
+              "moderate",
+              "moderate",
+              "heavy",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "heavy",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "moderate",
+              "moderate",
+              "moderate",
+              "heavy",
+              "heavy",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "moderate",
+              "low",
+              "heavy",
+              "moderate",
+              "low",
+              "low",
+              "low",
+              "heavy",
+              "heavy",
+              "heavy",
+              "low",
+              "heavy",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "moderate",
+              "moderate",
+              "low",
+              "heavy",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "heavy",
+              "low",
+              "low",
+              "low"
+            ]
+          },
+          "summary": "King Street, North Wilson Boulevard",
+          "duration": 1279.4
+        },
+        {
+          "steps": [
+            {
+              "intersections": [
+                {
+                  "out": 0,
+                  "entry": [
+                    true
+                  ],
+                  "location": [
+                    -77.078234,
+                    38.894377
+                  ],
+                  "bearings": [
+                    352
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.078344,
+                    38.895312
+                  ],
+                  "bearings": [
+                    0,
+                    90,
+                    180
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.078428,
+                    38.896038
+                  ],
+                  "bearings": [
+                    0,
+                    90,
+                    180,
+                    270
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ],
+                  "location": [
+                    -77.078599,
+                    38.897331
+                  ],
+                  "bearings": [
+                    0,
+                    180,
+                    345
+                  ]
+                }
+              ],
+              "geometry": "qq|diArln_rCy@H_P|@sf@rCkEVga@xBwCTkF^oeAbH}APaKPeC?eCs@wBgBwByCgBiC",
+              "duration": 85.5,
+              "distance": 392.6,
+              "name": "North Quinn Street",
+              "weight": 85.5,
+              "mode": "driving",
+              "maneuver": {
+                "bearing_after": 352,
+                "location": [
+                  -77.078234,
+                  38.894377
+                ],
+                "type": "depart",
+                "bearing_before": 0,
+                "modifier": "right",
+                "instruction": "Head north on North Quinn Street"
+              }
+            },
+            {
+              "intersections": [
+                {
+                  "out": 0,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ],
+                  "location": [
+                    -77.078384,
+                    38.89783
+                  ],
+                  "bearings": [
+                    60,
+                    225,
+                    240
+                  ]
+                },
+                {
+                  "out": 1,
+                  "in": 3,
+                  "entry": [
+                    true,
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.073579,
+                    38.898436
+                  ],
+                  "bearings": [
+                    0,
+                    90,
+                    180,
+                    270
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.073048,
+                    38.898387
+                  ],
+                  "bearings": [
+                    90,
+                    120,
+                    270
+                  ]
+                },
+                {
+                  "out": 1,
+                  "in": 3,
+                  "entry": [
+                    false,
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.072514,
+                    38.898338
+                  ],
+                  "bearings": [
+                    30,
+                    90,
+                    180,
+                    270
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.072333,
+                    38.898329
+                  ],
+                  "bearings": [
+                    90,
+                    120,
+                    270
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "indications": [
+                        "left"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "indications": [
+                        "straight",
+                        "left"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "indications": [
+                        "straight"
+                      ]
+                    }
+                  ],
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ],
+                  "location": [
+                    -77.071298,
+                    38.898271
+                  ],
+                  "bearings": [
+                    90,
+                    210,
+                    270
+                  ]
+                }
+              ],
+              "maneuver": {
+                "bearing_after": 61,
+                "location": [
+                  -77.078384,
+                  38.89783
+                ],
+                "type": "turn",
+                "bearing_before": 43,
+                "modifier": "straight",
+                "instruction": "Go straight onto North Lee Highway (US 29)"
+              },
+              "duration": 71.8,
+              "distance": 670.9,
+              "name": "North Lee Highway (US 29)",
+              "geometry": "kiceiA~un_rCmGmTqKgg@{Fkb@aFyo@uAmV}@cTUwo@jBc|@RcFlAaYf@cMf@sLPsDHmEF{CZkOv@{_@^mNFwAdAm\\",
+              "ref": "US 29",
+              "weight": 71.8,
+              "mode": "driving"
+            },
+            {
+              "intersections": [
+                {
+                  "out": 0,
+                  "in": 3,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "indications": [
+                        "left"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "indications": [
+                        "straight",
+                        "left"
+                      ]
+                    },
+                    {
+                      "valid": false,
+                      "indications": [
+                        "straight"
+                      ]
+                    }
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false,
+                    false
+                  ],
+                  "location": [
+                    -77.070783,
+                    38.898232
+                  ],
+                  "bearings": [
+                    0,
+                    105,
+                    180,
+                    270
+                  ]
+                }
+              ],
+              "maneuver": {
+                "bearing_after": 2,
+                "location": [
+                  -77.070783,
+                  38.898232
+                ],
+                "type": "turn",
+                "bearing_before": 94,
+                "modifier": "left",
+                "instruction": "Turn left onto North Lynn Street (US 29)"
+              },
+              "duration": 16.3,
+              "distance": 83.8,
+              "name": "North Lynn Street (US 29)",
+              "geometry": "obdeiA|z__rCsHYkd@_B",
+              "ref": "US 29",
+              "weight": 16.3,
+              "mode": "driving"
+            },
+            {
+              "intersections": [
+                {
+                  "out": 0,
+                  "in": 2,
+                  "lanes": [
+                    {
+                      "valid": false,
+                      "indications": [
+                        "left"
+                      ]
+                    },
+                    {
+                      "valid": false,
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "indications": [
+                        "none"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "indications": [
+                        "none"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "indications": [
+                        "none"
+                      ]
+                    }
+                  ],
+                  "entry": [
+                    true,
+                    false,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.070722,
+                    38.898984
+                  ],
+                  "bearings": [
+                    0,
+                    105,
+                    180,
+                    270
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 1,
+                  "lanes": [
+                    {
+                      "valid": false,
+                      "indications": [
+                        "left"
+                      ]
+                    },
+                    {
+                      "valid": false,
+                      "indications": [
+                        "left"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "indications": [
+                        "none"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "indications": [
+                        "none"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "indications": [
+                        "none"
+                      ]
+                    }
+                  ],
+                  "entry": [
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.07072,
+                    38.899274
+                  ],
+                  "bearings": [
+                    0,
+                    180,
+                    345
+                  ]
+                },
+                {
+                  "out": 2,
+                  "in": 1,
+                  "entry": [
+                    false,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.070793,
+                    38.899998
+                  ],
+                  "bearings": [
+                    150,
+                    165,
+                    345
+                  ]
+                }
+              ],
+              "maneuver": {
+                "bearing_after": 0,
+                "location": [
+                  -77.070722,
+                  38.898984
+                ],
+                "type": "use lane",
+                "bearing_before": 2,
+                "modifier": "straight",
+                "instruction": "Keep right"
+              },
+              "duration": 15.9,
+              "distance": 167.5,
+              "name": "North Lynn Street (US 29)",
+              "geometry": "oqeeiAbw__rC{CAkA?oCAkE?{I?mMIqFd@wDh@sEjA{Fr@{ERgNqB",
+              "ref": "US 29",
+              "weight": 15.9,
+              "mode": "driving"
+            },
+            {
+              "intersections": [
+                {
+                  "out": 0,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ],
+                  "location": [
+                    -77.070772,
+                    38.900478
+                  ],
+                  "bearings": [
+                    15,
+                    195,
+                    210
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.06916,
+                    38.903874
+                  ],
+                  "bearings": [
+                    15,
+                    60,
+                    195
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 1,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "indications": [
+                        "left"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "indications": [
+                        "left"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "indications": [
+                        "right"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "indications": [
+                        "right"
+                      ]
+                    }
+                  ],
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ],
+                  "location": [
+                    -77.068766,
+                    38.904758
+                  ],
+                  "bearings": [
+                    15,
+                    195,
+                    345
+                  ]
+                }
+              ],
+              "maneuver": {
+                "bearing_after": 19,
+                "location": [
+                  -77.070772,
+                  38.900478
+                ],
+                "type": "new name",
+                "bearing_before": 9,
+                "modifier": "straight",
+                "instruction": "Continue straight onto Francis Scott Key Bridge (US 29)"
+              },
+              "duration": 64.60000000000001,
+              "distance": 541.6,
+              "name": "Francis Scott Key Bridge (US 29)",
+              "geometry": "{nheiAfz__rCoyDywAwX}Jw[mLiUcHeCaAuQqF",
+              "ref": "US 29",
+              "weight": 64.60000000000001,
+              "mode": "driving"
+            },
+            {
+              "intersections": [
+                {
+                  "out": 2,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.068645,
+                    38.905057
+                  ],
+                  "bearings": [
+                    90,
+                    195,
+                    270
+                  ]
+                },
+                {
+                  "out": 3,
+                  "in": 1,
+                  "entry": [
+                    false,
+                    false,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.069043,
+                    38.905044
+                  ],
+                  "bearings": [
+                    30,
+                    90,
+                    120,
+                    270
+                  ]
+                },
+                {
+                  "out": 2,
+                  "in": 0,
+                  "entry": [
+                    false,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.069892,
+                    38.905028
+                  ],
+                  "bearings": [
+                    90,
+                    225,
+                    270
+                  ]
+                }
+              ],
+              "geometry": "amqeiAhu{~qCHzHN~MJtVRj\\DrO?pB",
+              "duration": 25.1,
+              "distance": 135.9,
+              "name": "M Street Northwest",
+              "weight": 25.1,
+              "mode": "driving",
+              "maneuver": {
+                "bearing_after": 267,
+                "location": [
+                  -77.068645,
+                  38.905057
+                ],
+                "type": "end of road",
+                "bearing_before": 16,
+                "modifier": "left",
+                "instruction": "Turn left onto M Street Northwest"
+              }
+            },
+            {
+              "intersections": [
+                {
+                  "out": 3,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.070215,
+                    38.905025
+                  ],
+                  "bearings": [
+                    0,
+                    90,
+                    165,
+                    270
+                  ]
+                },
+                {
+                  "out": 1,
+                  "in": 0,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "indications": [
+                        "none"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "indications": [
+                        "none"
+                      ]
+                    },
+                    {
+                      "valid": false,
+                      "indications": [
+                        "right"
+                      ]
+                    }
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "location": [
+                    -77.074027,
+                    38.905522
+                  ],
+                  "bearings": [
+                    105,
+                    270,
+                    315
+                  ]
+                },
+                {
+                  "out": 2,
+                  "in": 0,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "indications": [
+                        "none"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "indications": [
+                        "none"
+                      ]
+                    },
+                    {
+                      "valid": false,
+                      "indications": [
+                        "right"
+                      ]
+                    }
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.07427,
+                    38.905532
+                  ],
+                  "bearings": [
+                    90,
+                    150,
+                    270,
+                    345
+                  ]
+                },
+                {
+                  "out": 2,
+                  "in": 1,
+                  "entry": [
+                    false,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.07558,
+                    38.905519
+                  ],
+                  "bearings": [
+                    75,
+                    90,
+                    270
+                  ]
+                }
+              ],
+              "geometry": "akqeiAlw~~qC}@bOS~CEvNEzEGpAw@lT_BhSkE~[eDlWuCze@sC|_@[~Hk@|MSdNDzX^pc@KtI?vGQjJ}AnVgDlYmIfj@}I|h@aAlPCbUBdAd@xUPnI",
+              "duration": 62.599999999999994,
+              "distance": 784.8,
+              "name": "Canal Road Northwest",
+              "weight": 62.599999999999994,
+              "mode": "driving",
+              "maneuver": {
+                "bearing_after": 270,
+                "location": [
+                  -77.070215,
+                  38.905025
+                ],
+                "type": "new name",
+                "bearing_before": 268,
+                "modifier": "straight",
+                "instruction": "Continue straight onto Canal Road Northwest"
+              }
+            },
+            {
+              "intersections": [
+                {
+                  "out": 2,
+                  "in": 0,
+                  "lanes": [
+                    {
+                      "valid": false,
+                      "indications": [
+                        "left"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "indications": [
+                        "none"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "indications": [
+                        "none"
+                      ]
+                    }
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "location": [
+                    -77.079125,
+                    38.906006
+                  ],
+                  "bearings": [
+                    90,
+                    240,
+                    270
+                  ]
+                },
+                {
+                  "out": 2,
+                  "in": 0,
+                  "entry": [
+                    false,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.080895,
+                    38.906603
+                  ],
+                  "bearings": [
+                    150,
+                    285,
+                    330
+                  ]
+                },
+                {
+                  "out": 2,
+                  "in": 1,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "indications": [
+                        "left"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "indications": [
+                        "none"
+                      ]
+                    }
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.081091,
+                    38.906863
+                  ],
+                  "bearings": [
+                    60,
+                    150,
+                    330
+                  ]
+                },
+                {
+                  "out": 2,
+                  "in": 0,
+                  "lanes": [
+                    {
+                      "valid": false,
+                      "indications": [
+                        "left"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "indications": [
+                        "none"
+                      ]
+                    }
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "location": [
+                    -77.081258,
+                    38.907079
+                  ],
+                  "bearings": [
+                    150,
+                    210,
+                    330
+                  ]
+                },
+                {
+                  "out": 2,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.082402,
+                    38.908632
+                  ],
+                  "bearings": [
+                    75,
+                    150,
+                    330
+                  ]
+                },
+                {
+                  "out": 2,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.083126,
+                    38.909617
+                  ],
+                  "bearings": [
+                    75,
+                    150,
+                    330
+                  ]
+                },
+                {
+                  "out": 3,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    true,
+                    true
+                  ],
+                  "location": [
+                    -77.083888,
+                    38.910655
+                  ],
+                  "bearings": [
+                    60,
+                    150,
+                    240,
+                    330
+                  ]
+                },
+                {
+                  "out": 2,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.08465,
+                    38.911687
+                  ],
+                  "bearings": [
+                    90,
+                    150,
+                    330
+                  ]
+                },
+                {
+                  "out": 1,
+                  "in": 0,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "indications": [
+                        "straight",
+                        "left"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "indications": [
+                        "straight",
+                        "right"
+                      ]
+                    }
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "location": [
+                    -77.084897,
+                    38.912025
+                  ],
+                  "bearings": [
+                    150,
+                    330,
+                    345
+                  ]
+                },
+                {
+                  "out": 2,
+                  "in": 0,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "indications": [
+                        "straight",
+                        "left"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "indications": [
+                        "none"
+                      ]
+                    }
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "location": [
+                    -77.085009,
+                    38.912252
+                  ],
+                  "bearings": [
+                    165,
+                    240,
+                    345
+                  ]
+                },
+                {
+                  "out": 3,
+                  "in": 1,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "indications": [
+                        "straight",
+                        "left"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "indications": [
+                        "none"
+                      ]
+                    }
+                  ],
+                  "entry": [
+                    true,
+                    false,
+                    true,
+                    true
+                  ],
+                  "location": [
+                    -77.085047,
+                    38.912426
+                  ],
+                  "bearings": [
+                    105,
+                    165,
+                    285,
+                    345
+                  ]
+                },
+                {
+                  "out": 2,
+                  "in": 0,
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "location": [
+                    -77.085189,
+                    38.912855
+                  ],
+                  "bearings": [
+                    165,
+                    210,
+                    345
+                  ]
+                },
+                {
+                  "out": 2,
+                  "in": 1,
+                  "entry": [
+                    false,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.085191,
+                    38.912865
+                  ],
+                  "bearings": [
+                    150,
+                    165,
+                    345
+                  ]
+                },
+                {
+                  "out": 2,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.085224,
+                    38.912984
+                  ],
+                  "bearings": [
+                    75,
+                    165,
+                    345
+                  ]
+                },
+                {
+                  "out": 2,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.085894,
+                    38.913868
+                  ],
+                  "bearings": [
+                    45,
+                    135,
+                    315
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 1,
+                  "lanes": [
+                    {
+                      "valid": false,
+                      "indications": [
+                        "left"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "indications": [
+                        "none"
+                      ]
+                    }
+                  ],
+                  "entry": [
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.088705,
+                    38.91644
+                  ],
+                  "bearings": [
+                    0,
+                    165,
+                    270
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.088772,
+                    38.918043
+                  ],
+                  "bearings": [
+                    0,
+                    90,
+                    180
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.088746,
+                    38.919166
+                  ],
+                  "bearings": [
+                    0,
+                    90,
+                    180,
+                    270
+                  ]
+                },
+                {
+                  "out": 2,
+                  "in": 0,
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "location": [
+                    -77.089562,
+                    38.922575
+                  ],
+                  "bearings": [
+                    165,
+                    270,
+                    345
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.089937,
+                    38.925102
+                  ],
+                  "bearings": [
+                    0,
+                    90,
+                    180,
+                    270
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.090041,
+                    38.925955
+                  ],
+                  "bearings": [
+                    0,
+                    75,
+                    180
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.090114,
+                    38.92655
+                  ],
+                  "bearings": [
+                    0,
+                    180,
+                    270
+                  ]
+                },
+                {
+                  "out": 3,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    true,
+                    true
+                  ],
+                  "location": [
+                    -77.090254,
+                    38.927529
+                  ],
+                  "bearings": [
+                    90,
+                    180,
+                    270,
+                    345
+                  ]
+                },
+                {
+                  "out": 2,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.090709,
+                    38.928868
+                  ],
+                  "bearings": [
+                    90,
+                    165,
+                    345
+                  ]
+                },
+                {
+                  "out": 2,
+                  "in": 0,
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "location": [
+                    -77.090757,
+                    38.929044
+                  ],
+                  "bearings": [
+                    165,
+                    255,
+                    345
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.091054,
+                    38.930275
+                  ],
+                  "bearings": [
+                    0,
+                    90,
+                    165,
+                    270
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.091065,
+                    38.931347
+                  ],
+                  "bearings": [
+                    0,
+                    90,
+                    180
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.091063,
+                    38.932415
+                  ],
+                  "bearings": [
+                    0,
+                    90,
+                    180
+                  ]
+                }
+              ],
+              "geometry": "khseiAhdp_rCjAnXOlRoAtRm@`CYz@k@bBkArCg@fAi@dAk@bAm@`A_B|BiH|G}CdCuBxAkCxByKtHmBpAeDbCoCdByBbBoDbC{RtMuMzIor@vd@iCfBe@X_SzMgTpNiDxB_N~IeJfGmQxLaVpOeK~Go_Arn@{CrBqMpIu@f@yB|Au@d@}@ZwE~@eBVuFr@gP|DqH|ASBcB\\_ANiARqCr@{JfDoCxA{CnBqCnBqEvDcA~@cCfCaKdLuQdTgHxJeFhIcEnHwD`IsFtLyFdPoBpFeCtFwClFkC|D_EhFaD|DgChCwDfD_EbDsCrBuAz@oDpBeD`BcEbBgGtBuA`@oD|@oDr@eBVeD`@cBH{DNyAB{Xz@wF^eDNqADyFFmG?{AA}A?mPKoFC_ICqB?_MGiBC_IEi\\]kc@I_QNuAHiDRyF`AyBl@iJ~Cub@xMcN~Dw@RcCl@{Dz@}Dv@}AX}GbAkNvBoV|DoGfAuDp@mG~@sSpCyCZeBNgTpAoM|@oMp@wMt@s`@`CqObAsCTuo@xDaCNc`@`Cae@zCqG^wD\\m@D{APk@Jm@Hu@NqAXwA`@}O`EuI`CwHrB_B`@aB^o@PcE~@o@Pm@Lk@Nm@Lk@NuDv@m@Jk@LuJdBkF`AsB\\gCd@kHnAuP~CeEr@u@JgDh@oIhAoN`Bu@JmBRk@DyBLoBFkv@@iCAwaACgK?eN@oK?sHD",
+              "duration": 346.6,
+              "distance": 3378.6,
+              "name": "MacArthur Boulevard Northwest",
+              "weight": 344.6,
+              "mode": "driving",
+              "maneuver": {
+                "bearing_after": 262,
+                "location": [
+                  -77.079125,
+                  38.906006
+                ],
+                "type": "turn",
+                "bearing_before": 267,
+                "modifier": "straight",
+                "instruction": "Go straight onto MacArthur Boulevard Northwest"
+              }
+            },
+            {
+              "intersections": [
+                {
+                  "out": 0,
+                  "in": 1,
+                  "lanes": [
+                    {
+                      "valid": false,
+                      "indications": [
+                        "left"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "indications": [
+                        "right"
+                      ]
+                    }
+                  ],
+                  "entry": [
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.091067,
+                    38.933208
+                  ],
+                  "bearings": [
+                    60,
+                    180,
+                    255
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.090487,
+                    38.933547
+                  ],
+                  "bearings": [
+                    45,
+                    105,
+                    225
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.089146,
+                    38.934542
+                  ],
+                  "bearings": [
+                    45,
+                    90,
+                    225,
+                    270
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.088642,
+                    38.934931
+                  ],
+                  "bearings": [
+                    45,
+                    180,
+                    225
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.087709,
+                    38.935779
+                  ],
+                  "bearings": [
+                    30,
+                    135,
+                    210
+                  ]
+                }
+              ],
+              "geometry": "olhgiAtng`rCwAoEa@eAi@oAy@wB_@{@aAqBeAoBqCiEmCaEge@{q@}V}_@mGmIuIaMeD_FoMiR_DsE{AwBm@y@]c@wBcCgDaDgRoOgCsBuYwUcCqBuIgHoLuJkKcIs@i@aNgL{QcOsEiD",
+              "duration": 78.2,
+              "distance": 652.6,
+              "name": "Nebraska Avenue Northwest",
+              "weight": 78.2,
+              "mode": "driving",
+              "maneuver": {
+                "bearing_after": 61,
+                "location": [
+                  -77.091067,
+                  38.933208
+                ],
+                "type": "end of road",
+                "bearing_before": 358,
+                "modifier": "right",
+                "instruction": "Turn right onto Nebraska Avenue Northwest"
+              }
+            },
+            {
+              "intersections": [
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false,
+                    false,
+                    false
+                  ],
+                  "location": [
+                    -77.086157,
+                    38.9376
+                  ],
+                  "bearings": [
+                    90,
+                    120,
+                    210,
+                    300,
+                    330
+                  ]
+                }
+              ],
+              "geometry": "__qgiAx{}_rCCiGuAeFmBuD}CiEwCkC_Bk@oC}@mFu@cBTkCbC",
+              "duration": 14.4,
+              "distance": 98.2,
+              "name": "Ward Circle Northwest",
+              "weight": 14.4,
+              "mode": "driving",
+              "maneuver": {
+                "exit": 1,
+                "bearing_after": 88,
+                "location": [
+                  -77.086157,
+                  38.9376
+                ],
+                "type": "roundabout",
+                "bearing_before": 32,
+                "modifier": "right",
+                "instruction": "Enter the roundabout and take the 1st exit onto Ward Circle Northwest"
+              }
+            },
+            {
+              "intersections": [
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    false,
+                    false,
+                    false,
+                    false
+                  ],
+                  "location": [
+                    -77.085644,
+                    38.938214
+                  ],
+                  "bearings": [
+                    30,
+                    120,
+                    150,
+                    270,
+                    300
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.081968,
+                    38.942518
+                  ],
+                  "bearings": [
+                    30,
+                    210,
+                    330
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.08142,
+                    38.94316
+                  ],
+                  "bearings": [
+                    30,
+                    90,
+                    210,
+                    270
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.080393,
+                    38.944364
+                  ],
+                  "bearings": [
+                    30,
+                    150,
+                    210
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.080036,
+                    38.944783
+                  ],
+                  "bearings": [
+                    30,
+                    90,
+                    210,
+                    270
+                  ]
+                },
+                {
+                  "out": 1,
+                  "in": 2,
+                  "entry": [
+                    false,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.079204,
+                    38.945752
+                  ],
+                  "bearings": [
+                    0,
+                    45,
+                    210
+                  ]
+                }
+              ],
+              "geometry": "kergiAv{|_rC}KuIgYaU_\\aXmNiL}AqAeCqB}PmN}MuK_Au@eFeE_ScPiAaAgEgD_CqBeScPyFuEgScPyM{KoO_MwJeI}CeCkFiEyTuQiQqNyIiHyUcRm`@y[eG}EeYiUaFaE{GyF_L{I}KaJcI{GiEqDgAw@oF{J_DiK{@mC",
+              "duration": 134.4,
+              "distance": 1054.1,
+              "name": "Nebraska Avenue Northwest",
+              "weight": 134.4,
+              "mode": "driving",
+              "maneuver": {
+                "bearing_after": 32,
+                "location": [
+                  -77.085644,
+                  38.938214
+                ],
+                "type": "turn",
+                "bearing_before": 324,
+                "modifier": "right",
+                "instruction": "Turn right onto Nebraska Avenue Northwest"
+              }
+            },
+            {
+              "intersections": [
+                {
+                  "out": 0,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ],
+                  "location": [
+                    -77.078746,
+                    38.945982
+                  ],
+                  "bearings": [
+                    60,
+                    240,
+                    255
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.078625,
+                    38.946033
+                  ],
+                  "bearings": [
+                    45,
+                    150,
+                    240,
+                    330
+                  ]
+                },
+                {
+                  "out": 1,
+                  "in": 3,
+                  "entry": [
+                    true,
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.07842,
+                    38.946283
+                  ],
+                  "bearings": [
+                    0,
+                    15,
+                    90,
+                    195
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    true,
+                    true
+                  ],
+                  "location": [
+                    -77.078345,
+                    38.946772
+                  ],
+                  "bearings": [
+                    30,
+                    195,
+                    240,
+                    345
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.078022,
+                    38.947141
+                  ],
+                  "bearings": [
+                    30,
+                    105,
+                    210
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.077693,
+                    38.947525
+                  ],
+                  "bearings": [
+                    30,
+                    210,
+                    300
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.077368,
+                    38.947905
+                  ],
+                  "bearings": [
+                    30,
+                    90,
+                    210,
+                    270
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.077074,
+                    38.948248
+                  ],
+                  "bearings": [
+                    30,
+                    165,
+                    210
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.075802,
+                    38.949735
+                  ],
+                  "bearings": [
+                    30,
+                    105,
+                    210
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.074947,
+                    38.950734
+                  ],
+                  "bearings": [
+                    30,
+                    90,
+                    210,
+                    270
+                  ]
+                },
+                {
+                  "out": 1,
+                  "in": 3,
+                  "entry": [
+                    true,
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.074654,
+                    38.951076
+                  ],
+                  "bearings": [
+                    15,
+                    30,
+                    180,
+                    210
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.074317,
+                    38.95147
+                  ],
+                  "bearings": [
+                    30,
+                    105,
+                    210
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.073732,
+                    38.952153
+                  ],
+                  "bearings": [
+                    30,
+                    105,
+                    210
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.073626,
+                    38.952277
+                  ],
+                  "bearings": [
+                    30,
+                    210,
+                    285
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.072255,
+                    38.953879
+                  ],
+                  "bearings": [
+                    30,
+                    150,
+                    210,
+                    330
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.072175,
+                    38.953978
+                  ],
+                  "bearings": [
+                    30,
+                    90,
+                    210
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.071596,
+                    38.954691
+                  ],
+                  "bearings": [
+                    30,
+                    90,
+                    210,
+                    270
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.070644,
+                    38.955761
+                  ],
+                  "bearings": [
+                    30,
+                    75,
+                    210
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.070411,
+                    38.956033
+                  ],
+                  "bearings": [
+                    30,
+                    150,
+                    210,
+                    330
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.068461,
+                    38.958311
+                  ],
+                  "bearings": [
+                    30,
+                    210,
+                    285
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.067886,
+                    38.958983
+                  ],
+                  "bearings": [
+                    30,
+                    210,
+                    300
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.067541,
+                    38.959387
+                  ],
+                  "bearings": [
+                    30,
+                    135,
+                    210,
+                    315
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.066235,
+                    38.960913
+                  ],
+                  "bearings": [
+                    30,
+                    165,
+                    210,
+                    345
+                  ]
+                }
+              ],
+              "geometry": "{jahiArlo_rCeBqFi@}@m@w@o@q@s@m@w@g@sBwAc@U}@]i@OeD_AkGQgEOeGc@qAOqAuAoSoP_WqSwViSaMaKkFiEeJqHsEuD{D_DeMcKik@}d@wIeHgJsH}RaPaSePeJqHaCoBeH{FcG}EaN{KqHeGuEwDc[aW{FwEaBsAuC_CcIuGoQyNoI_Hcr@wj@{HmGeE_Dqk@ec@{aAoz@cBuA{L{JkmC{xB_i@}b@eFcEsAgAqAeA{K_JwAkAqAeAey@yp@}DiD}X}TsEuD",
+              "maneuver": {
+                "exit": 2,
+                "bearing_after": 60,
+                "location": [
+                  -77.078746,
+                  38.945982
+                ],
+                "type": "rotary",
+                "bearing_before": 60,
+                "modifier": "straight",
+                "instruction": "Enter Tenley Circle Northwest and take the 2nd exit onto Nebraska Avenue Northwest"
+              },
+              "duration": 244.89999999999992,
+              "distance": 2004.3,
+              "name": "Nebraska Avenue Northwest",
+              "rotary_name": "Tenley Circle Northwest",
+              "weight": 244.89999999999992,
+              "mode": "driving"
+            },
+            {
+              "intersections": [
+                {
+                  "out": 1,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.066144,
+                    38.961019
+                  ],
+                  "bearings": [
+                    30,
+                    90,
+                    210,
+                    270
+                  ]
+                },
+                {
+                  "out": 1,
+                  "in": 3,
+                  "entry": [
+                    true,
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.063889,
+                    38.961016
+                  ],
+                  "bearings": [
+                    0,
+                    90,
+                    195,
+                    270
+                  ]
+                },
+                {
+                  "out": 1,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.062127,
+                    38.961016
+                  ],
+                  "bearings": [
+                    0,
+                    90,
+                    270
+                  ]
+                },
+                {
+                  "out": 1,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.060965,
+                    38.961016
+                  ],
+                  "bearings": [
+                    0,
+                    90,
+                    270
+                  ]
+                },
+                {
+                  "out": 1,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.059751,
+                    38.961018
+                  ],
+                  "bearings": [
+                    0,
+                    90,
+                    270
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.058748,
+                    38.961017
+                  ],
+                  "bearings": [
+                    90,
+                    180,
+                    270
+                  ]
+                },
+                {
+                  "out": 1,
+                  "in": 3,
+                  "entry": [
+                    true,
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.057472,
+                    38.961014
+                  ],
+                  "bearings": [
+                    0,
+                    90,
+                    180,
+                    270
+                  ]
+                },
+                {
+                  "out": 1,
+                  "in": 3,
+                  "entry": [
+                    true,
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.056201,
+                    38.961013
+                  ],
+                  "bearings": [
+                    0,
+                    90,
+                    180,
+                    270
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.053117,
+                    38.961402
+                  ],
+                  "bearings": [
+                    60,
+                    75,
+                    255
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "lanes": [
+                    {
+                      "valid": false,
+                      "indications": [
+                        "left"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "indications": [
+                        "none"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "indications": [
+                        "none"
+                      ]
+                    }
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.052682,
+                    38.961559
+                  ],
+                  "bearings": [
+                    60,
+                    195,
+                    240,
+                    345
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.044814,
+                    38.960642
+                  ],
+                  "bearings": [
+                    60,
+                    75,
+                    240
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.039042,
+                    38.963065
+                  ],
+                  "bearings": [
+                    90,
+                    105,
+                    270
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ],
+                  "location": [
+                    -77.033889,
+                    38.962069
+                  ],
+                  "bearings": [
+                    105,
+                    270,
+                    285
+                  ]
+                },
+                {
+                  "out": 1,
+                  "in": 3,
+                  "entry": [
+                    true,
+                    true,
+                    true,
+                    true
+                  ],
+                  "location": [
+                    -77.033421,
+                    38.962042
+                  ],
+                  "bearings": [
+                    0,
+                    105,
+                    180,
+                    285
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ],
+                  "location": [
+                    -77.032001,
+                    38.961838
+                  ],
+                  "bearings": [
+                    105,
+                    210,
+                    285
+                  ]
+                },
+                {
+                  "out": 1,
+                  "in": 3,
+                  "entry": [
+                    true,
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.029694,
+                    38.961506
+                  ],
+                  "bearings": [
+                    0,
+                    105,
+                    180,
+                    285
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.028546,
+                    38.961339
+                  ],
+                  "bearings": [
+                    105,
+                    180,
+                    285,
+                    345
+                  ]
+                }
+              ],
+              "geometry": "uv~hiA~xv~qC@g`@?c@@a`A@oh@?cmB?a@?qfAC{jAAiQBkk@Hmn@AwBAq[Ay@B{X?wr@vAuELeFMcLKaMOwJYgMc@qJa@oFu@qIkAgMq@aH}@sLgBqMoA{IiAaG}BgLsBkKyHeZiAiFeG}VwBkJwA}Hy@uHq@{G]cM?wM`@gJ`A{JbB{IvAkGhC}HxCkHfDuF~D{EtJgMbHaKfEgGzDuGpC{GbD}HdDkJpCgK|BgKjBqKvAwKlAkObAcOZaNTmKF{L?gMYcOaAwOy@wKsAgL{AwKqC}PyCqMqEkPqC{IiCqHmMkYuYcn@uImRyKoVoKcTeIaRaMeWmIcSgEwNeDaO_EyTmC_Wa@kHWqGUsDDySb@oOrA{P`BkPzEm^`Fc^~Ea^vFea@nFea@hFga@`D{WxCga@`A}MjAqPUuJvKwwAbBcTrPazBlIwfAxCo`@",
+              "duration": 376.5,
+              "distance": 3475.1,
+              "name": "Military Road Northwest",
+              "weight": 376.5,
+              "mode": "driving",
+              "maneuver": {
+                "bearing_after": 90,
+                "location": [
+                  -77.066144,
+                  38.961019
+                ],
+                "type": "turn",
+                "bearing_before": 32,
+                "modifier": "right",
+                "instruction": "Turn right onto Military Road Northwest"
+              }
+            },
+            {
+              "intersections": [
+                {
+                  "out": 0,
+                  "in": 2,
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "location": [
+                    -77.02801,
+                    38.961262
+                  ],
+                  "bearings": [
+                    0,
+                    180,
+                    285
+                  ]
+                },
+                {
+                  "out": 0,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.027996,
+                    38.961427
+                  ],
+                  "bearings": [
+                    0,
+                    180,
+                    285
+                  ]
+                }
+              ],
+              "maneuver": {
+                "bearing_after": 2,
+                "location": [
+                  -77.02801,
+                  38.961262
+                ],
+                "type": "end of road",
+                "bearing_before": 99,
+                "modifier": "left",
+                "instruction": "Turn left onto Georgia Avenue Northwest (US 29)"
+              },
+              "duration": 28.8,
+              "distance": 116,
+              "name": "Georgia Avenue Northwest (US 29)",
+              "geometry": "{e_iiAril|qCiI[aLe@yCK{c@_B",
+              "ref": "US 29",
+              "weight": 28.8,
+              "mode": "driving"
+            },
+            {
+              "intersections": [
+                {
+                  "out": 2,
+                  "in": 1,
+                  "entry": [
+                    true,
+                    false,
+                    true
+                  ],
+                  "location": [
+                    -77.027923,
+                    38.962303
+                  ],
+                  "bearings": [
+                    0,
+                    180,
+                    270
+                  ]
+                }
+              ],
+              "geometry": "}faiiAddl|qCGbNCbE",
+              "duration": 13.1,
+              "distance": 29.4,
+              "name": "",
+              "weight": 52.8,
+              "mode": "driving",
+              "maneuver": {
+                "bearing_after": 270,
+                "location": [
+                  -77.027923,
+                  38.962303
+                ],
+                "type": "turn",
+                "bearing_before": 2,
+                "modifier": "left",
+                "instruction": "Turn left"
+              }
+            },
+            {
+              "intersections": [
+                {
+                  "in": 0,
+                  "entry": [
+                    true
+                  ],
+                  "location": [
+                    -77.028263,
+                    38.962309
+                  ],
+                  "bearings": [
+                    92
+                  ]
+                }
+              ],
+              "geometry": "igaiiAlyl|qC",
+              "duration": 0,
+              "distance": 0,
+              "name": "",
+              "weight": 0,
+              "mode": "driving",
+              "maneuver": {
+                "bearing_after": 0,
+                "bearing_before": 272,
+                "type": "arrive",
+                "location": [
+                  -77.028263,
+                  38.962309
+                ],
+                "instruction": "You have arrived at your destination"
+              }
+            }
+          ],
+          "weight": 1616.4,
+          "distance": 13585.5,
+          "annotation": {
+            "congestion": [
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "heavy",
+              "moderate",
+              "moderate",
+              "moderate",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "moderate",
+              "low",
+              "low",
+              "low",
+              "low",
+              "heavy",
+              "low",
+              "low",
+              "moderate",
+              "moderate",
+              "moderate",
+              "low",
+              "heavy",
+              "low",
+              "moderate",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "moderate",
+              "moderate",
+              "low",
+              "low",
+              "low",
+              "heavy",
+              "low",
+              "low",
+              "moderate",
+              "moderate",
+              "low",
+              "heavy",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "heavy",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "heavy",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "heavy",
+              "low",
+              "heavy",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "heavy",
+              "low",
+              "moderate",
+              "moderate",
+              "moderate",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "moderate",
+              "low",
+              "low",
+              "unknown",
+              "moderate",
+              "moderate",
+              "moderate",
+              "moderate",
+              "moderate",
+              "moderate",
+              "moderate",
+              "low",
+              "moderate",
+              "moderate",
+              "moderate",
+              "moderate",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "heavy",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "unknown",
+              "unknown",
+              "unknown",
+              "unknown",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "moderate",
+              "moderate",
+              "low",
+              "low",
+              "moderate",
+              "heavy",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "moderate",
+              "low",
+              "low",
+              "moderate",
+              "severe",
+              "moderate",
+              "low",
+              "low",
+              "moderate",
+              "low",
+              "moderate",
+              "moderate",
+              "moderate",
+              "moderate",
+              "moderate",
+              "moderate",
+              "moderate",
+              "moderate",
+              "moderate",
+              "low",
+              "moderate",
+              "moderate",
+              "moderate",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "moderate",
+              "low",
+              "low",
+              "low",
+              "moderate",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "moderate",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "moderate",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "heavy",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "heavy",
+              "moderate",
+              "moderate",
+              "moderate",
+              "moderate",
+              "low",
+              "moderate",
+              "moderate",
+              "moderate",
+              "low",
+              "moderate",
+              "moderate",
+              "low",
+              "low",
+              "low",
+              "moderate",
+              "moderate",
+              "moderate",
+              "moderate",
+              "moderate",
+              "moderate",
+              "moderate",
+              "low",
+              "low",
+              "moderate",
+              "moderate",
+              "moderate",
+              "moderate",
+              "moderate",
+              "moderate",
+              "moderate",
+              "moderate",
+              "moderate",
+              "moderate",
+              "moderate",
+              "moderate",
+              "moderate",
+              "low",
+              "low",
+              "low",
+              "heavy",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "heavy",
+              "moderate",
+              "moderate",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "heavy",
+              "low",
+              "low",
+              "low",
+              "low",
+              "moderate",
+              "low",
+              "low",
+              "heavy",
+              "low",
+              "heavy",
+              "moderate",
+              "moderate",
+              "moderate",
+              "moderate",
+              "heavy",
+              "moderate",
+              "heavy",
+              "low",
+              "low",
+              "moderate",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "moderate",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "heavy",
+              "low",
+              "low",
+              "moderate",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "heavy",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "low",
+              "moderate",
+              "moderate",
+              "heavy",
+              "heavy",
+              "low",
+              "heavy",
+              "low",
+              "low",
+              "low",
+              "heavy",
+              "unknown",
+              "unknown"
+            ]
+          },
+          "summary": "Nebraska Avenue Northwest, Military Road Northwest",
+          "duration": 1578.7
+        }
+      ],
+      "weight_name": "routability",
+      "geometry": "egb_iA~kr~qCj[{a@^qIxDTT_JkNy@iHs@i`@oB_FY__@sBcZaBkAGwBKJ{DxAkg@LmEb@}QTgEb@_DbAeDfAyApAiBdBqAz@}@|@yA|@}B^yAPeARoBDuBQ}De@_Ce@aBmA_CsAcBgAy@aAc@}Bm@_CO{FqAyAg@k@SwCuAeK}EoDaAwEw@_TkC{TqC{PsBkR_CuBW_KoAgOeBmJeA{BWmCaAuBu@iFcAyQyBcSaCqKqAuBWwERaBzVWtDq@lI{Fvt@}@bLW~C_ApLU~CcFjo@aBvS]jEiBrU_@zE]lEiAbQ{Ddh@YxEs@dLcB`HkApBiAp@_BT{AIoA_@eAy@gAoAsKcOsB}E_IgTkNaa@eF{N}CiHmC{DcDyCgD}AgMmFkGkCmKwE}A]wEMiClEgK|OcE|FwLzP}Tn[if@lp@kWr^guA|nB{RzXmJxMocA|wAoyAnzBwNdS_KlN_K`MyDnEmZv]gTtVcTpVqEhFaGxGuW|YgD|DiGhHuWtZuJbL_AjAm_@|b@wZd]mJtK_`@tc@cJ`KORed@vg@_OnPgH`ImXvZaBhBuEhFiPvQ}UlWcXrYkJnK}MbOqLhNsZb_@yPxV}OpV}X`g@sj@`cAwjAdrB_t@dmAgPhXgRhYeCvDsHbL}PlWUcKaJcUuF_LiIiOwImKoIiJuMqJi[cNsFeC}HgEug@mU_Hb@uCmFoPqFy@SwFuAsCs@mKgByPiA}CQgHMi]h@}VPki@h@{LLsb@d@eVH_PDwK^kMb@oGMuDgAcMcDkOaFmPeFsPcFyUqEiFwA{IO{]u@sPW_GEsa@VyVGoTe@yNi@{M{AkMwCoW{Goc@yOsWiJ}TkLmJwEwGiE_UyPoU}Rm[{VeTgOyOyK{`@uYiUyScjCyqBo[{UiBsAkl@uc@{EkDaxA}hAew@ml@iTqPg{C{sBgRaMk|C}mBe_CcwAoOyJotAuu@sJeEqWaJk\\uI}ZwGu[uCimAwN_h@kImTaHqLkEoPmJwK_HyVoVePcUyKyVkNo_@gPsm@{a@uyAaMa\\wNe`@gJaQmNmPwJuJ}HaGod@qY_gA_u@{KiHeOmKktAu`Awm@o_@yj@o\\yo@yZaa@mMeYmKci@_P_[sI{bAcOqr@sGyVgC}QWqGwB{D_CeBgCmAwCYaFl@mDhEsJrFyJvGsN~IuT|BvH`]rv@nCpHPfCDbEYvB}n@lv@aMbQmQhXucAljAur@ts@uw@vp@aUlSu[tW}\\|Vmb@nZiWbQcd@pXy]vQ}JbFiY|NmaAjh@asAbo@y@f@sGbEeHlEqJhHyCzBaC~BmIfJ{SbUuPj[wF~FmF`FqD~BoGzCuFtB}NpDoKb@mq@fBoPR{S?iRuBs_@aIsNuByKT{Gt@{GhBsQ`J_h@x\\yEdDwLxJw@zAgEjIeKxToCnGkArDeGhOgDzKoAhHgBjL]fDkAxK[|Eg@bICfCR~IF`F^hO\\`Ft@dHZbDfB|PXfDnAbL^hFrAjRv@hQX~FRtDt@zP`@xLTlF`@dFtDpe@bBhTJvA^lEfEni@vCx`@pArRb@`FTzEz@tItApQj@vHnD~TpB|MdAbHmCTwD\\sE`@y@H_P|@sf@rCkEVga@xBwCTkF^oeAbH}APaKPeC?eCs@wBgBwByCgBiCmGmTqKgg@{Fkb@aFyo@uAmV}@cTUwo@jBc|@RcFlAaYf@cMf@sLPsDHmEF{CZkOv@{_@^mNFwAdAm\\sHYkd@_B{CAkA?oCAkE?{I?mMIqFd@wDh@sEjA{Fr@{ERgNqBoyDywAwX}Jw[mLiUcHeCaAuQqFHzHN~MJtVRj\\DrO?pB}@bOS~CEvNEzEGpAw@lT_BhSkE~[eDlWuCze@sC|_@[~Hk@|MSdNDzX^pc@KtI?vGQjJ}AnVgDlYmIfj@}I|h@aAlPCbUBdAd@xUPnIjAnXOlRoAtRm@`CYz@k@bBkArCg@fAi@dAk@bAm@`A_B|BiH|G}CdCuBxAkCxByKtHmBpAeDbCoCdByBbBoDbC{RtMuMzIor@vd@iCfBe@X_SzMgTpNiDxB_N~IeJfGmQxLaVpOeK~Go_Arn@{CrBqMpIu@f@yB|Au@d@}@ZwE~@eBVuFr@gP|DqH|ASBcB\\_ANiARqCr@{JfDoCxA{CnBqCnBqEvDcA~@cCfCaKdLuQdTgHxJeFhIcEnHwD`IsFtLyFdPoBpFeCtFwClFkC|D_EhFaD|DgChCwDfD_EbDsCrBuAz@oDpBeD`BcEbBgGtBuA`@oD|@oDr@eBVeD`@cBH{DNyAB{Xz@wF^eDNqADyFFmG?{AA}A?mPKoFC_ICqB?_MGiBC_IEi\\]kc@I_QNuAHiDRyF`AyBl@iJ~Cub@xMcN~Dw@RcCl@{Dz@}Dv@}AX}GbAkNvBoV|DoGfAuDp@mG~@sSpCyCZeBNgTpAoM|@oMp@wMt@s`@`CqObAsCTuo@xDaCNc`@`Cae@zCqG^wD\\m@D{APk@Jm@Hu@NqAXwA`@}O`EuI`CwHrB_B`@aB^o@PcE~@o@Pm@Lk@Nm@Lk@NuDv@m@Jk@LuJdBkF`AsB\\gCd@kHnAuP~CeEr@u@JgDh@oIhAoN`Bu@JmBRk@DyBLoBFkv@@iCAwaACgK?eN@oK?sHDwAoEa@eAi@oAy@wB_@{@aAqBeAoBqCiEmCaEge@{q@}V}_@mGmIuIaMeD_FoMiR_DsE{AwBm@y@]c@wBcCgDaDgRoOgCsBuYwUcCqBuIgHoLuJkKcIs@i@aNgL{QcOsEiDCiGuAeFmBuD}CiEwCkC_Bk@oC}@mFu@cBTkCbC}KuIgYaU_\\aXmNiL}AqAeCqB}PmN}MuK_Au@eFeE_ScPiAaAgEgD_CqBeScPyFuEgScPyM{KoO_MwJeI}CeCkFiEyTuQiQqNyIiHyUcRm`@y[eG}EeYiUaFaE{GyF_L{I}KaJcI{GiEqDgAw@oF{J_DiK{@mCeBqFi@}@m@w@o@q@s@m@w@g@sBwAc@U}@]i@OeD_AkGQgEOeGc@qAOqAuAoSoP_WqSwViSaMaKkFiEeJqHsEuD{D_DeMcKik@}d@wIeHgJsH}RaPaSePeJqHaCoBeH{FcG}EaN{KqHeGuEwDc[aW{FwEaBsAuC_CcIuGoQyNoI_Hcr@wj@{HmGeE_Dqk@ec@{aAoz@cBuA{L{JkmC{xB_i@}b@eFcEsAgAqAeA{K_JwAkAqAeAey@yp@}DiD}X}TsEuD@g`@?c@@a`A@oh@?cmB?a@?qfAC{jAAiQBkk@Hmn@AwBAq[Ay@B{X?wr@vAuELeFMcLKaMOwJYgMc@qJa@oFu@qIkAgMq@aH}@sLgBqMoA{IiAaG}BgLsBkKyHeZiAiFeG}VwBkJwA}Hy@uHq@{G]cM?wM`@gJ`A{JbB{IvAkGhC}HxCkHfDuF~D{EtJgMbHaKfEgGzDuGpC{GbD}HdDkJpCgK|BgKjBqKvAwKlAkObAcOZaNTmKF{L?gMYcOaAwOy@wKsAgL{AwKqC}PyCqMqEkPqC{IiCqHmMkYuYcn@uImRyKoVoKcTeIaRaMeWmIcSgEwNeDaO_EyTmC_Wa@kHWqGUsDDySb@oOrA{P`BkPzEm^`Fc^~Ea^vFea@nFea@hFga@`D{WxCga@`A}MjAqPUuJvKwwAbBcTrPazBlIwfAxCo`@iI[aLe@yCK{c@_BGbNCbE",
+      "weight": 3046.4,
+      "distance": 28457.1,
+      "duration": 2858.1000000000004
+    }
+  ],
+  "code": "Ok",
+  "uuid": "cjeacbr8s21bk47lggcvce7lv"
+}

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigator.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigator.kt
@@ -44,6 +44,7 @@ interface MapboxNativeNavigator {
         tilesConfig: TilesConfig,
         historyDir: String?,
         accessToken: String,
+        router: RouterInterface,
     ): MapboxNativeNavigator
 
     /**
@@ -55,6 +56,7 @@ interface MapboxNativeNavigator {
         tilesConfig: TilesConfig,
         historyDir: String?,
         accessToken: String,
+        router: RouterInterface,
     )
 
     /**

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/NavigatorLoader.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/NavigatorLoader.kt
@@ -29,13 +29,14 @@ import com.mapbox.navigator.TilesConfig
  * This class is expected to gain more responsibility as we define [customConfig].
  * The custom config can be exposed through the [DeviceProfile]
  */
-internal object NavigatorLoader {
+object NavigatorLoader {
 
-    fun createNavigator(
+    internal fun createNavigator(
         deviceProfile: DeviceProfile,
         navigatorConfig: NavigatorConfig,
         tilesConfig: TilesConfig,
-        historyDir: String?
+        historyDir: String?,
+        router: RouterInterface,
     ): NativeComponents {
         val config = ConfigFactory.build(
             settingsProfile(deviceProfile),
@@ -44,12 +45,6 @@ internal object NavigatorLoader {
         )
         val historyRecorder = buildHistoryRecorder(historyDir, config)
         val cache = CacheFactory.build(tilesConfig, config, historyRecorder)
-        val router = RouterFactory.build(
-            RouterType.HYBRID,
-            cache,
-            config,
-            historyRecorder,
-        )
         val navigator = Navigator(
             config,
             cache,
@@ -67,6 +62,27 @@ internal object NavigatorLoader {
             roadObjectMatcher,
             router,
             navigator.routeAlternativesController
+        )
+    }
+
+    fun createNativeRouterInterface(
+        deviceProfile: DeviceProfile,
+        navigatorConfig: NavigatorConfig,
+        tilesConfig: TilesConfig,
+        historyDir: String?,
+    ): RouterInterface {
+        val config = ConfigFactory.build(
+            settingsProfile(deviceProfile),
+            navigatorConfig,
+            customConfig(deviceProfile)
+        )
+        val historyRecorder = buildHistoryRecorder(historyDir, config)
+        val cache = CacheFactory.build(tilesConfig, config, historyRecorder)
+        return RouterFactory.build(
+            RouterType.HYBRID,
+            cache,
+            config,
+            historyRecorder,
         )
     }
 

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/RouterMapper.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/RouterMapper.kt
@@ -1,19 +1,29 @@
 package com.mapbox.navigation.navigator.internal
 
 import com.mapbox.api.directions.v5.DirectionsCriteria
+import com.mapbox.api.directions.v5.models.DirectionsResponse
+import com.mapbox.navigation.base.route.NavigationRoute
 import com.mapbox.navigation.base.route.RouterOrigin.Offboard
 import com.mapbox.navigation.base.route.RouterOrigin.Onboard
 import com.mapbox.navigator.RouterOrigin
 import com.mapbox.navigator.RoutingMode
 
+internal const val HTTP_SUCCESS_CODE = "Ok"
+
 fun RouterOrigin.mapToSdkRouteOrigin(): com.mapbox.navigation.base.route.RouterOrigin {
     return when (this) {
         RouterOrigin.ONLINE -> Offboard
         RouterOrigin.ONBOARD -> Onboard
-        // not actual till integrate sdk Router to NN
         RouterOrigin.CUSTOM -> com.mapbox.navigation.base.route.RouterOrigin.Custom()
     }
 }
+
+fun com.mapbox.navigation.base.route.RouterOrigin.mapToNativeRouteOrigin(): RouterOrigin =
+    when (this) {
+        Offboard -> RouterOrigin.ONLINE
+        Onboard -> RouterOrigin.ONBOARD
+        is com.mapbox.navigation.base.route.RouterOrigin.Custom -> RouterOrigin.CUSTOM
+    }
 
 fun String.mapToRoutingMode(): RoutingMode {
     return when (this) {
@@ -23,4 +33,20 @@ fun String.mapToRoutingMode(): RoutingMode {
         DirectionsCriteria.PROFILE_DRIVING_TRAFFIC -> RoutingMode.DRIVING_TRAFFIC
         else -> throw IllegalArgumentException("Invalid routing profile: $this")
     }
+}
+
+/**
+ * Map list of [NavigationRoute] to [DirectionsResponse]
+ *
+ * Until [mapbox-navigation-native#5142](https://github.com/mapbox/mapbox-navigation-native/issues/5142) is resolved,
+ * we'll keep providing injected routes into the first response.
+ *
+ * @throws IllegalStateException if list is empty
+ */
+internal fun List<NavigationRoute>.mapToDirectionsResponse(): DirectionsResponse {
+    val primaryRoute = this.firstOrNull()
+        ?: throw IllegalStateException("List of NavigationRoute mustn't be empty")
+    return primaryRoute.directionsResponse.toBuilder()
+        .routes(this.map { it.directionsRoute })
+        .build()
 }

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/router/RouterInterfaceAdapter.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/router/RouterInterfaceAdapter.kt
@@ -1,0 +1,173 @@
+package com.mapbox.navigation.navigator.internal.router
+
+import androidx.annotation.VisibleForTesting
+import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.api.directions.v5.models.RouteOptions
+import com.mapbox.bindgen.Expected
+import com.mapbox.bindgen.ExpectedFactory
+import com.mapbox.navigation.base.route.NavigationRoute
+import com.mapbox.navigation.base.route.NavigationRouter
+import com.mapbox.navigation.base.route.NavigationRouterCallback
+import com.mapbox.navigation.base.route.NavigationRouterRefreshCallback
+import com.mapbox.navigation.base.route.NavigationRouterRefreshError
+import com.mapbox.navigation.base.route.RouterCallback
+import com.mapbox.navigation.base.route.RouterFailure
+import com.mapbox.navigation.base.route.RouterOrigin
+import com.mapbox.navigation.base.route.toNavigationRoute
+import com.mapbox.navigation.navigator.internal.mapToDirectionsResponse
+import com.mapbox.navigation.navigator.internal.mapToNativeRouteOrigin
+import com.mapbox.navigator.RouteRefreshOptions
+import com.mapbox.navigator.RouterError
+import com.mapbox.navigator.RouterErrorType
+import com.mapbox.navigator.RouterInterface
+import java.net.URL
+
+private typealias NativeRouterCallback = com.mapbox.navigator.RouterCallback
+private typealias NativeRouterRefreshCallback = com.mapbox.navigator.RouterRefreshCallback
+private typealias NativeRouterOrigin = com.mapbox.navigator.RouterOrigin
+
+class RouterInterfaceAdapter(
+    private val router: NavigationRouter
+) : RouterInterface {
+
+    @VisibleForTesting
+    internal companion object {
+
+        private const val ROUTE_REQUEST_FAILED_DEFAULT_MESSAGE = "Route request failed"
+        private const val ROUTE_REQUEST_FAILED_EMPTY_ROUTES_LIST =
+            "Route request failed. Empty routes list"
+        private const val ROUTE_REQUEST_FAILED_DEFAULT_CODE = -1
+
+        private const val ROUTE_REFRESH_FAILED_DEFAULT_MESSAGE = "Route refresh failed"
+
+        @VisibleForTesting
+        internal const val ROUTE_REFRESH_FAILED_DEFAULT_CODE = -1
+
+        // take the latest item
+        private fun List<RouterFailure>.mapToNativeRouteError(requestId: Long): RouterError =
+            this.lastOrNull().let { routerFailure ->
+                RouterError(
+                    routerFailure?.message ?: ROUTE_REQUEST_FAILED_DEFAULT_MESSAGE,
+                    routerFailure?.code ?: ROUTE_REQUEST_FAILED_DEFAULT_CODE,
+                    RouterErrorType.UNKNOWN,
+                    requestId,
+                )
+            }
+
+        // take the latest item
+        private fun List<RouterFailure>.fetchAndMapRouterOrigin(): NativeRouterOrigin =
+            this.lastOrNull().let { routerFailure ->
+                routerFailure?.routerOrigin?.mapToNativeRouteOrigin()
+            } ?: NativeRouterOrigin.CUSTOM
+    }
+
+    override fun getRoute(directionsUri: String, callback: NativeRouterCallback): Long {
+        var requestId = -1L
+        requestId =
+            router.getRoute(
+                RouteOptions.fromUrl(URL(directionsUri)),
+                object : NavigationRouterCallback {
+                    override fun onRoutesReady(
+                        routes: List<NavigationRoute>,
+                        routerOrigin: RouterOrigin
+                    ) {
+                        val expected: Expected<RouterError, String> = if (routes.isNotEmpty()) {
+                            ExpectedFactory.createValue(routes.mapToDirectionsResponse().toJson())
+                        } else {
+                            ExpectedFactory.createError(
+                                RouterError(
+                                    ROUTE_REQUEST_FAILED_EMPTY_ROUTES_LIST,
+                                    ROUTE_REQUEST_FAILED_DEFAULT_CODE,
+                                    RouterErrorType.WRONG_RESPONSE,
+                                    requestId
+                                )
+                            )
+                        }
+                        callback.run(
+                            expected,
+                            routerOrigin.mapToNativeRouteOrigin(),
+                        )
+                    }
+
+                    override fun onFailure(
+                        reasons: List<RouterFailure>,
+                        routeOptions: RouteOptions
+                    ) {
+                        callback.run(
+                            ExpectedFactory.createError(
+                                reasons.mapToNativeRouteError(requestId)
+                            ),
+                            reasons.fetchAndMapRouterOrigin()
+                        )
+                    }
+
+                    override fun onCanceled(
+                        routeOptions: RouteOptions,
+                        routerOrigin: RouterOrigin
+                    ) {
+                        callback.run(
+                            ExpectedFactory.createError(
+                                RouterError(
+                                    "Route request is canceled",
+                                    ROUTE_REQUEST_FAILED_DEFAULT_CODE,
+                                    RouterErrorType.REQUEST_CANCELLED,
+                                    requestId,
+                                )
+                            ),
+                            routerOrigin.mapToNativeRouteOrigin()
+                        )
+                    }
+                }
+            )
+        return requestId
+    }
+
+    override fun getRouteRefresh(
+        options: RouteRefreshOptions,
+        route: String,
+        callback: NativeRouterRefreshCallback
+    ): Long {
+        var requestId = -1L
+        requestId = router.getRouteRefresh(
+            DirectionsRoute.fromJson(route).toNavigationRoute(),
+            options.legIndex,
+            object : NavigationRouterRefreshCallback {
+                override fun onRefreshReady(route: NavigationRoute) {
+                    callback.run(
+                        ExpectedFactory.createValue(route.directionsResponse.toJson()),
+                        NativeRouterOrigin.CUSTOM,
+                    )
+                }
+
+                override fun onFailure(error: NavigationRouterRefreshError) {
+                    callback.run(
+                        ExpectedFactory.createError(
+                            RouterError(
+                                error.message
+                                    ?: error.throwable?.message
+                                    ?: ROUTE_REFRESH_FAILED_DEFAULT_MESSAGE,
+                                ROUTE_REFRESH_FAILED_DEFAULT_CODE,
+                                RouterErrorType.UNKNOWN,
+                                requestId,
+                            )
+                        ),
+                        NativeRouterOrigin.CUSTOM
+                    )
+                }
+            }
+        )
+        return requestId
+    }
+
+    override fun cancelRouteRequest(token: Long) {
+        router.cancelRouteRequest(token)
+    }
+
+    override fun cancelRouteRefreshRequest(token: Long) {
+        router.cancelRouteRefreshRequest(token)
+    }
+
+    override fun cancelAll() {
+        router.cancelAll()
+    }
+}

--- a/libnavigator/src/test/java/com/mapbox/navigation/navigator/internal/router/RouterInterfaceAdapterTest.kt
+++ b/libnavigator/src/test/java/com/mapbox/navigation/navigator/internal/router/RouterInterfaceAdapterTest.kt
@@ -1,0 +1,315 @@
+package com.mapbox.navigation.navigator.internal.router
+
+import com.mapbox.api.directions.v5.DirectionsCriteria
+import com.mapbox.api.directions.v5.models.DirectionsResponse
+import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.api.directions.v5.models.RouteOptions
+import com.mapbox.bindgen.Expected
+import com.mapbox.geojson.Point
+import com.mapbox.navigation.base.route.NavigationRoute
+import com.mapbox.navigation.base.route.NavigationRouter
+import com.mapbox.navigation.base.route.NavigationRouterCallback
+import com.mapbox.navigation.base.route.NavigationRouterRefreshCallback
+import com.mapbox.navigation.base.route.RouterFailure
+import com.mapbox.navigation.base.route.RouterOrigin
+import com.mapbox.navigator.RouterError
+import com.mapbox.navigator.RouterErrorType
+import com.mapbox.navigator.RouterRefreshCallback
+import io.mockk.CapturingSlot
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkStatic
+import junit.framework.Assert.assertEquals
+import junit.framework.Assert.assertNotNull
+import junit.framework.Assert.assertTrue
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.net.URL
+
+class RouterInterfaceAdapterTest {
+
+    private lateinit var mockRouter: NavigationRouter
+
+    private companion object {
+        private const val VALID_URL = "https://mapbox.com"
+    }
+
+    @Before
+    fun setUp() {
+        mockRouter = mockk()
+
+        mockkStatic(RouteOptions::class)
+        mockkStatic(DirectionsRoute::class)
+    }
+
+    @After
+    fun cleanUp() {
+        unmockkStatic(RouteOptions::class)
+        unmockkStatic(DirectionsRoute::class)
+    }
+
+    @Test
+    fun routeRequestSuccess() {
+        val routerInterface = provideRouteInterfaceDelegate(mockRouter)
+        val routerCallback = slot<NavigationRouterCallback>()
+        val requestId = 5L
+        every { RouteOptions.fromUrl(any()) } returns mockk()
+        every { mockRouter.getRoute(any(), capture(routerCallback)) } returns requestId
+        val (nativeRouterCallback, slotNativeRouterCallback, slotNativeRouterOrigin) =
+            provideNativeRouteCallbackWithSlots()
+        val expectedNavigationRoute = provideNavigationRoute()
+
+        val receivedRequestId = routerInterface.getRoute(VALID_URL, nativeRouterCallback)
+        routerCallback.captured.onRoutesReady(
+            listOf(expectedNavigationRoute),
+            RouterOrigin.Onboard,
+        )
+
+        assertNotNull(slotNativeRouterCallback.captured)
+        assertTrue(slotNativeRouterCallback.captured.isValue)
+        val directionsResponse =
+            DirectionsResponse.fromJson(slotNativeRouterCallback.captured.value!!)
+        assertEquals(expectedNavigationRoute.directionsRoute, directionsResponse.routes().first())
+        assertEquals(com.mapbox.navigator.RouterOrigin.ONBOARD, slotNativeRouterOrigin.captured)
+        assertEquals(requestId, receivedRequestId)
+    }
+
+    @Test
+    fun routeRequestSuccessEmptyList() {
+        val routerInterface = provideRouteInterfaceDelegate(mockRouter)
+        val routerCallback = slot<NavigationRouterCallback>()
+        val requestId = 5L
+        every { RouteOptions.fromUrl(any()) } returns mockk()
+        every { mockRouter.getRoute(any(), capture(routerCallback)) } returns requestId
+        val (nativeRouterCallback, slotNativeRouterCallback, slotNativeRouterOrigin) =
+            provideNativeRouteCallbackWithSlots()
+
+        val receivedRequestId = routerInterface.getRoute(VALID_URL, nativeRouterCallback)
+        routerCallback.captured.onRoutesReady(
+            emptyList(),
+            RouterOrigin.Offboard,
+        )
+
+        assertNotNull(slotNativeRouterCallback.captured)
+        assertTrue(slotNativeRouterCallback.captured.isError)
+        with(slotNativeRouterCallback.captured.error!!) {
+            assertEquals(RouterErrorType.WRONG_RESPONSE, type)
+        }
+        assertEquals(com.mapbox.navigator.RouterOrigin.ONLINE, slotNativeRouterOrigin.captured)
+        assertEquals(requestId, receivedRequestId)
+    }
+
+    @Test
+    fun routeRequestFailure() {
+        val routerInterface = provideRouteInterfaceDelegate(mockRouter)
+        val routerCallback = slot<NavigationRouterCallback>()
+        val requestId = 5L
+        every { RouteOptions.fromUrl(any()) } returns mockk()
+        every { mockRouter.getRoute(any(), capture(routerCallback)) } returns requestId
+        val (nativeRouterCallback, slotNativeRouterCallback, slotNativeRouterOrigin) =
+            provideNativeRouteCallbackWithSlots()
+        val routeFailureList = listOf(
+            RouterFailure(
+                URL("https:://any.url"),
+                RouterOrigin.Onboard,
+                "Message failure",
+                400,
+            )
+        )
+
+        val receivedRequestId = routerInterface.getRoute(VALID_URL, nativeRouterCallback)
+        routerCallback.captured.onFailure(
+            routeFailureList,
+            mockk()
+        )
+
+        assertNotNull(slotNativeRouterCallback.captured)
+        assertTrue(slotNativeRouterCallback.captured.isError)
+        with(slotNativeRouterCallback.captured.error!!) {
+            assertEquals(requestId, receivedRequestId)
+            assertEquals(requestId, this.requestId)
+            assertEquals("Message failure", message)
+            assertEquals(400, code)
+            assertEquals(RouterErrorType.UNKNOWN, type)
+            assertEquals(
+                com.mapbox.navigator.RouterOrigin.ONBOARD, slotNativeRouterOrigin.captured
+            )
+        }
+    }
+
+    @Test
+    fun routeRequestCanceled() {
+        val routerInterface = provideRouteInterfaceDelegate(mockRouter)
+        val routerCallback = slot<NavigationRouterCallback>()
+        val requestId = 5L
+        every { RouteOptions.fromUrl(any()) } returns mockk()
+        every { mockRouter.getRoute(any(), capture(routerCallback)) } returns requestId
+        val (nativeRouterCallback, slotNativeRouterCallback, slotNativeRouterOrigin) =
+            provideNativeRouteCallbackWithSlots()
+
+        val receivedRequestId = routerInterface.getRoute(VALID_URL, nativeRouterCallback)
+        routerCallback.captured.onCanceled(
+            mockk(),
+            RouterOrigin.Offboard,
+        )
+
+        assertNotNull(slotNativeRouterCallback.captured)
+        assertTrue(slotNativeRouterCallback.captured.isError)
+        with(slotNativeRouterCallback.captured.error!!) {
+            assertEquals(requestId, receivedRequestId)
+            assertEquals(requestId, this.requestId)
+            assertEquals(RouterErrorType.REQUEST_CANCELLED, type)
+            assertEquals(RouterInterfaceAdapter.ROUTE_REFRESH_FAILED_DEFAULT_CODE, code)
+        }
+    }
+
+    @Test
+    fun routeRefreshSuccess() {
+        val routerInterface = provideRouteInterfaceDelegate(mockRouter)
+        val routerRefreshCallback = slot<NavigationRouterRefreshCallback>()
+        val requestId = 5L
+        every { RouteOptions.fromUrl(any()) } returns mockk()
+        every {
+            mockRouter.getRouteRefresh(any(), any(), capture(routerRefreshCallback))
+        } returns requestId
+        val (
+            nativeRouterRefreshCallback, slotNativeRouterRefreshCallback, slotNativeRouterOrigin
+        ) = provideNativeRouteRefreshCallbackWithSlots()
+        val mockRouteOptions = mockk<com.mapbox.navigator.RouteRefreshOptions> {
+            every { legIndex } returns 0
+        }
+        every {
+            DirectionsRoute.fromJson(any())
+        } returns provideDirectionsResponse().routes().first()
+        val navigationRoute = provideNavigationRoute()
+
+        routerInterface
+            .getRouteRefresh(mockRouteOptions, "route_json", nativeRouterRefreshCallback)
+        routerRefreshCallback.captured.onRefreshReady(navigationRoute)
+
+        assertNotNull(slotNativeRouterRefreshCallback.captured)
+        assertTrue(slotNativeRouterRefreshCallback.captured.isValue)
+        with(slotNativeRouterRefreshCallback.captured.value!!) {
+            assertEquals(navigationRoute.directionsResponse.toJson(), this)
+        }
+        assertEquals(com.mapbox.navigator.RouterOrigin.CUSTOM, slotNativeRouterOrigin.captured)
+    }
+
+    @Test
+    fun routeRefreshFailure() {
+        val routerInterface = provideRouteInterfaceDelegate(mockRouter)
+        val routerRefreshCallback = slot<NavigationRouterRefreshCallback>()
+        val requestId = 5L
+        every { RouteOptions.fromUrl(any()) } returns mockk()
+        every {
+            mockRouter.getRouteRefresh(any(), any(), capture(routerRefreshCallback))
+        } returns requestId
+        val (
+            nativeRouterRefreshCallback, slotNativeRouterRefreshCallback, slotNativeRouterOrigin
+        ) = provideNativeRouteRefreshCallbackWithSlots()
+        val mockRouteOptions = mockk<com.mapbox.navigator.RouteRefreshOptions> {
+            every { legIndex } returns 0
+        }
+        every {
+            DirectionsRoute.fromJson(any())
+        } returns provideDirectionsResponse().routes().first()
+
+        val receivedRequestId = routerInterface
+            .getRouteRefresh(mockRouteOptions, "route_json", nativeRouterRefreshCallback)
+        routerRefreshCallback.captured.onFailure(mockk(relaxed = true))
+
+        assertNotNull(slotNativeRouterRefreshCallback.captured)
+        assertTrue(slotNativeRouterRefreshCallback.captured.isError)
+        with(slotNativeRouterRefreshCallback.captured.error!!) {
+            assertEquals(requestId, receivedRequestId)
+            assertEquals(requestId, this.requestId)
+            assertEquals(RouterInterfaceAdapter.ROUTE_REFRESH_FAILED_DEFAULT_CODE, this.code)
+            assertEquals(RouterErrorType.UNKNOWN, this.type)
+        }
+        assertEquals(com.mapbox.navigator.RouterOrigin.CUSTOM, slotNativeRouterOrigin.captured)
+    }
+
+    private fun provideNativeRouteCallbackWithSlots(
+        nativeRouterCallback: com.mapbox.navigator.RouterCallback = mockk(),
+        slotNativeRouterCallback: CapturingSlot<Expected<RouterError, String>> = slot(),
+        slotNativeRouterOrigin: CapturingSlot<com.mapbox.navigator.RouterOrigin> = slot(),
+    ): Triple<com.mapbox.navigator.RouterCallback,
+        CapturingSlot<Expected<RouterError, String>>,
+        CapturingSlot<com.mapbox.navigator.RouterOrigin>> {
+        every {
+            nativeRouterCallback.run(
+                capture(slotNativeRouterCallback),
+                capture(slotNativeRouterOrigin),
+            )
+        } just Runs
+        return Triple(nativeRouterCallback, slotNativeRouterCallback, slotNativeRouterOrigin)
+    }
+
+    private fun provideNativeRouteRefreshCallbackWithSlots(
+        nativeRouteRefreshCallback: RouterRefreshCallback = mockk(),
+        slotNativeRouterRefreshCallback: CapturingSlot<Expected<RouterError, String>> = slot(),
+        slotNativeRouterOrigin: CapturingSlot<com.mapbox.navigator.RouterOrigin> = slot(),
+    ): Triple<RouterRefreshCallback,
+        CapturingSlot<Expected<RouterError, String>>,
+        CapturingSlot<com.mapbox.navigator.RouterOrigin>> {
+        every {
+            nativeRouteRefreshCallback.run(
+                capture(slotNativeRouterRefreshCallback),
+                capture(slotNativeRouterOrigin),
+            )
+        } just Runs
+        return Triple(
+            nativeRouteRefreshCallback, slotNativeRouterRefreshCallback, slotNativeRouterOrigin
+        )
+    }
+
+    private fun provideNavigationRoute(
+        directionsResponse: DirectionsResponse = provideDirectionsResponse(),
+        routeOptions: RouteOptions = provideRouteOptions(),
+    ): NavigationRoute {
+        val routeOptions =
+            return NavigationRoute(
+                directionsResponse,
+                0,
+                routeOptions
+            )
+    }
+
+    private fun provideDirectionsResponse(
+        routeOptions: RouteOptions = provideRouteOptions()
+    ): DirectionsResponse =
+        DirectionsResponse.builder()
+            .code("Ok")
+            .routes(
+                listOf(
+                    DirectionsRoute.builder()
+                        .routeIndex("0")
+                        .distance(10.0)
+                        .duration(20.0)
+                        .routeOptions(routeOptions)
+                        .build()
+                )
+            )
+            .build()
+
+    private fun provideRouteOptions(): RouteOptions =
+        RouteOptions.builder()
+            .profile(DirectionsCriteria.PROFILE_DRIVING)
+            .coordinatesList(
+                listOf(
+                    Point.fromLngLat(0.0, 0.0),
+                    Point.fromLngLat(1.0, 1.0),
+                )
+            )
+            .build()
+
+    private fun provideRouteInterfaceDelegate(
+        router: NavigationRouter
+    ): RouterInterfaceAdapter =
+        RouterInterfaceAdapter(router)
+}


### PR DESCRIPTION
### Description

Pull request provides adopt Customer Router for NN. 

A few concerns about API
- `Mapbox Directions Session` under the hood uses SDK's `Router` and if a customer provided its own Router implementation SDK use it with 'MapboxNavigation#requestRoutes', and don't use NN API. Cut the ticket https://github.com/mapbox/mapbox-navigation-android/issues/5501
- As far the SDK migrates major API to NN (Router, Reroute, Refresh route) as much SDK loses the context of work with route requests. For instance, with NN Router(and custom one) SDK doesn't know why NN make route request (is it RouteAlternativeRequest or Reroute?), so looks like we should also migrate keeping routes list with update reason to NN and SDK should only observe this list (it was already discussed with NN team, work is started)
- I was trying to find a good way to add tests Custom Router with NN (integration tests), if you have anything in mind please share it. For now, added a test that checks that the SDK makes the right serialization objects required for NN (see `NavigatorTest`). Suppose, it should be enough 

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
