### PR TITLE
fix unexpected MapboxNavigation destroy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Mapbox welcomes participation and contributions from everyone.
 #### Features
 
 #### Bug fixes and improvements
+- Fixed `MapboxNavigationApp` issue, that caused unexpected `MapboxNavigation` destroy, when one of the attached lifecycles is destroyed and the other one is stopped. [#5518](https://github.com/mapbox/mapbox-navigation-android/pull/5518)
 
 ## Mapbox Navigation SDK 2.4.0-alpha.1 - February 24, 2022
 ### Changelog

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/lifecycle/CarAppLifecycleOwner.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/lifecycle/CarAppLifecycleOwner.kt
@@ -40,7 +40,7 @@ internal class CarAppLifecycleOwner : LifecycleOwner {
             } else {
                 lifecycleCreated++
                 logger.i(TAG, Message("LifecycleOwner ($owner) onCreate"))
-                if (activitiesCreated == 0 && lifecycleCreated > 0 && lifecycleForegrounded == 0) {
+                if (activitiesCreated == 0 && lifecycleCreated == 1) {
                     changeState(Lifecycle.State.STARTED)
                 }
             }
@@ -52,7 +52,7 @@ internal class CarAppLifecycleOwner : LifecycleOwner {
             } else {
                 lifecycleForegrounded++
                 logger.i(TAG, Message("LifecycleOwner ($owner) onStart"))
-                if (activitiesCreated == 0 && lifecycleForegrounded > 0) {
+                if (activitiesForegrounded == 0 && lifecycleForegrounded == 1) {
                     changeState(Lifecycle.State.RESUMED)
                 }
             }
@@ -76,7 +76,7 @@ internal class CarAppLifecycleOwner : LifecycleOwner {
             } else {
                 lifecycleCreated--
                 logger.i(TAG, Message("LifecycleOwner ($owner) onDestroy"))
-                if (activitiesForegrounded == 0 && lifecycleForegrounded == 0) {
+                if (activitiesCreated == 0 && lifecycleCreated == 0) {
                     changeState(Lifecycle.State.CREATED)
                 }
             }
@@ -107,7 +107,7 @@ internal class CarAppLifecycleOwner : LifecycleOwner {
             } else {
                 activitiesForegrounded++
                 logger.i(TAG, Message("app onActivityStarted"))
-                if (lifecycleCreated == 0 && activitiesForegrounded == 1) {
+                if (lifecycleForegrounded == 0 && activitiesForegrounded == 1) {
                     changeState(Lifecycle.State.RESUMED)
                 }
             }
@@ -127,7 +127,7 @@ internal class CarAppLifecycleOwner : LifecycleOwner {
             } else {
                 activitiesForegrounded--
                 logger.i(TAG, Message("app onActivityStopped"))
-                if (lifecycleCreated == 0 && activitiesForegrounded == 0) {
+                if (lifecycleForegrounded == 0 && activitiesForegrounded == 0) {
                     changeState(Lifecycle.State.STARTED)
                 }
             }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/lifecycle/CarAppLifecycleOwnerTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/lifecycle/CarAppLifecycleOwnerTest.kt
@@ -108,29 +108,31 @@ class CarAppLifecycleOwnerTest {
 
     @Test
     fun `verify the lifecycle is not stopped when the activities are destroyed`() {
+        val activity = mockActivity()
         carAppLifecycleOwner.startedReferenceCounter.apply {
             onCreate(carAppLifecycleOwner)
             onStart(carAppLifecycleOwner)
         }
         carAppLifecycleOwner.activityLifecycleCallbacks.apply {
-            val activity: Activity = mockActivity()
             onActivityCreated(activity, mockk())
             onActivityStarted(activity)
             onActivityStopped(activity)
-            onActivityDestroyed(activity)
         }
+        carAppLifecycleOwner.startedReferenceCounter.onStop(carAppLifecycleOwner)
+        carAppLifecycleOwner.activityLifecycleCallbacks.onActivityDestroyed(activity)
 
         verify(exactly = 1) { testLifecycleObserver.onCreate(any()) }
         verify(exactly = 1) { testLifecycleObserver.onStart(any()) }
         verify(exactly = 1) { testLifecycleObserver.onResume(any()) }
+        verify(exactly = 1) { testLifecycleObserver.onPause(any()) }
         verify(exactly = 0) { testLifecycleObserver.onStop(any()) }
         verify(exactly = 0) { testLifecycleObserver.onDestroy(any()) }
     }
 
     @Test
     fun `verify the lifecycle is not stopped when the car session is destroyed`() {
+        val activity = mockActivity()
         carAppLifecycleOwner.activityLifecycleCallbacks.apply {
-            val activity: Activity = mockActivity()
             onActivityCreated(activity, mockk())
             onActivityStarted(activity)
             onActivityResumed(activity)
@@ -141,12 +143,37 @@ class CarAppLifecycleOwnerTest {
             onResume(carAppLifecycleOwner)
             onPause(carAppLifecycleOwner)
             onStop(carAppLifecycleOwner)
-            onDestroy(carAppLifecycleOwner)
         }
+        carAppLifecycleOwner.activityLifecycleCallbacks.onActivityStopped(activity)
+        carAppLifecycleOwner.startedReferenceCounter.onDestroy(carAppLifecycleOwner)
 
         verify(exactly = 1) { testLifecycleObserver.onCreate(any()) }
         verify(exactly = 1) { testLifecycleObserver.onStart(any()) }
         verify(exactly = 1) { testLifecycleObserver.onResume(any()) }
+        verify(exactly = 1) { testLifecycleObserver.onPause(any()) }
+        verify(exactly = 0) { testLifecycleObserver.onStop(any()) }
+        verify(exactly = 0) { testLifecycleObserver.onDestroy(any()) }
+    }
+
+    @Test
+    fun `verify the lifecycle is not stopped when only one attached lifecycle is destroyed`() {
+        val testLifecycleOwnerA = TestLifecycleOwner()
+        val testLifecycleOwnerB = TestLifecycleOwner()
+        carAppLifecycleOwner.startedReferenceCounter.onCreate(testLifecycleOwnerA)
+        carAppLifecycleOwner.startedReferenceCounter.onStart(testLifecycleOwnerA)
+        carAppLifecycleOwner.startedReferenceCounter.onResume(testLifecycleOwnerA)
+        carAppLifecycleOwner.startedReferenceCounter.onCreate(testLifecycleOwnerB)
+        carAppLifecycleOwner.startedReferenceCounter.onStart(testLifecycleOwnerB)
+        carAppLifecycleOwner.startedReferenceCounter.onResume(testLifecycleOwnerB)
+        carAppLifecycleOwner.startedReferenceCounter.onPause(testLifecycleOwnerB)
+        carAppLifecycleOwner.startedReferenceCounter.onStop(testLifecycleOwnerB)
+        carAppLifecycleOwner.startedReferenceCounter.onStop(testLifecycleOwnerA)
+        carAppLifecycleOwner.startedReferenceCounter.onDestroy(testLifecycleOwnerB)
+
+        verify(exactly = 1) { testLifecycleObserver.onCreate(any()) }
+        verify(exactly = 1) { testLifecycleObserver.onStart(any()) }
+        verify(exactly = 1) { testLifecycleObserver.onResume(any()) }
+        verify(exactly = 1) { testLifecycleObserver.onPause(any()) }
         verify(exactly = 0) { testLifecycleObserver.onStop(any()) }
         verify(exactly = 0) { testLifecycleObserver.onDestroy(any()) }
     }


### PR DESCRIPTION
### Description
Fixed `MapboxNavigationApp` issue, that caused unexpected `MapboxNavigation` destroy, when one of the attached lifecycles is destroyed and the other one is stopped. 

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
