### PR TITLE
Removed check call which threw uncaught exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Mapbox welcomes participation and contributions from everyone.
 
 #### Bug fixes and improvements
 - Fixed `MapboxNavigationApp` issue, that caused unexpected `MapboxNavigation` destroy, when one of the attached lifecycles is destroyed and the other one is stopped. [#5518](https://github.com/mapbox/mapbox-navigation-android/pull/5518)
+- Fixed uncaught exception in the `ShieldsCache` class. [#5524](https://github.com/mapbox/mapbox-navigation-android/pull/5524)
 
 ## Mapbox Navigation SDK 2.4.0-alpha.1 - February 24, 2022
 ### Changelog

--- a/libnavui-shield/src/main/java/com/mapbox/navigation/ui/shield/ShieldsCache.kt
+++ b/libnavui-shield/src/main/java/com/mapbox/navigation/ui/shield/ShieldsCache.kt
@@ -10,6 +10,7 @@ import com.mapbox.navigation.ui.shield.internal.model.RouteShieldToDownload
 import com.mapbox.navigation.ui.shield.internal.model.generateSpriteSheetUrl
 import com.mapbox.navigation.ui.shield.internal.model.getSpriteFrom
 import com.mapbox.navigation.ui.shield.model.RouteShield
+import com.mapbox.navigation.utils.internal.ifNonNull
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlin.coroutines.resume
@@ -50,9 +51,10 @@ internal abstract class ResourceCache<Argument, Value>(cacheSize: Int) {
                      * Returns if true or keeps waiting if false.
                      */
                     val callback = {
-                        check(!continuation.isCancelled)
-                        cache.get(argument)?.let {
-                            continuation.resume(it)
+                        ifNonNull(cache.get(argument)) { expected ->
+                            if (!continuation.isCancelled) {
+                                continuation.resume(expected)
+                            }
                             true
                         } ?: false
                     }


### PR DESCRIPTION
### Description
Fixes #5467 by removing the Preconditions.check call which states an exception is thrown in the event the expression results in a value of false.  The method making the check call was not catching the potential exception.

### Screenshots or Gifs
