### PR TITLE
[DropIn] Migrate location to the UIViewModel

### DIFF
--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/DropInNavigationViewModel.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/DropInNavigationViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.ViewModel
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationApp
 import com.mapbox.navigation.dropin.component.camera.CameraViewModel
-import com.mapbox.navigation.dropin.component.location.LocationBehavior
+import com.mapbox.navigation.dropin.component.location.LocationViewModel
 import com.mapbox.navigation.dropin.component.navigationstate.NavigationState
 import com.mapbox.navigation.dropin.component.replay.ReplayViewModel
 import com.mapbox.navigation.dropin.component.routefetch.RoutesViewModel
@@ -26,13 +26,13 @@ internal class DropInNavigationViewModel : ViewModel() {
      */
     val replayViewModel = ReplayViewModel()
     val audioGuidanceViewModel = MapboxAudioViewModel()
-    val locationBehavior = LocationBehavior()
+    val locationViewModel = LocationViewModel()
     val routesViewModel = RoutesViewModel()
-    val cameraViewModel = CameraViewModel(locationBehavior)
+    val cameraViewModel = CameraViewModel()
     val navigationObservers = listOf(
         replayViewModel,
         audioGuidanceViewModel,
-        locationBehavior,
+        locationViewModel,
         routesViewModel,
         cameraViewModel,
         // TODO can add more mapbox navigation observers here

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/binder/map/ActiveGuidanceMapBinder.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/binder/map/ActiveGuidanceMapBinder.kt
@@ -19,7 +19,11 @@ internal class ActiveGuidanceMapBinder(
         return navigationListOf(
             LocationPuck(mapView),
             RouteLineComponent(mapView, navigationViewContext.routeLineOptions),
-            CameraComponent(mapView, navigationViewContext.viewModel.cameraViewModel),
+            CameraComponent(
+                mapView,
+                navigationViewContext.viewModel.locationViewModel,
+                navigationViewContext.viewModel.cameraViewModel,
+            ),
         )
     }
 }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/binder/map/FreeDriveMapBinder.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/binder/map/FreeDriveMapBinder.kt
@@ -17,7 +17,11 @@ internal class FreeDriveMapBinder(
     override fun bind(mapView: MapView): MapboxNavigationObserver {
         return navigationListOf(
             LocationPuck(mapView),
-            CameraComponent(mapView, navigationViewContext.viewModel.cameraViewModel),
+            CameraComponent(
+                mapView,
+                navigationViewContext.viewModel.locationViewModel,
+                navigationViewContext.viewModel.cameraViewModel,
+            ),
         )
     }
 }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/camera/CameraComponent.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/camera/CameraComponent.kt
@@ -7,6 +7,7 @@ import com.mapbox.maps.plugin.animation.camera
 import com.mapbox.maps.plugin.gestures.OnMoveListener
 import com.mapbox.maps.plugin.gestures.gestures
 import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.dropin.component.location.LocationViewModel
 import com.mapbox.navigation.dropin.extensions.flowNavigationCameraState
 import com.mapbox.navigation.dropin.extensions.flowRouteProgress
 import com.mapbox.navigation.dropin.extensions.flowRoutesUpdated
@@ -15,10 +16,12 @@ import com.mapbox.navigation.ui.maps.camera.NavigationCamera
 import com.mapbox.navigation.ui.maps.camera.data.MapboxNavigationViewportDataSource
 import com.mapbox.navigation.ui.maps.camera.state.NavigationCameraState
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.launch
 
 internal class CameraComponent constructor(
     private val mapView: MapView,
+    private val locationViewModel: LocationViewModel,
     private val cameraViewModel: CameraViewModel,
 ) : UIComponent() {
 
@@ -109,6 +112,11 @@ internal class CameraComponent constructor(
                         cameraViewModel.invoke(CameraAction.ToIdle)
                     }
                 }
+            }
+        }
+        coroutineScope.launch {
+            locationViewModel.state.filterNotNull().collect {
+                cameraViewModel.invoke(CameraAction.UpdateLocation(it))
             }
         }
     }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/camera/CameraViewModel.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/camera/CameraViewModel.kt
@@ -1,14 +1,10 @@
 package com.mapbox.navigation.dropin.component.camera
 
 import android.location.Location
-import androidx.lifecycle.asFlow
 import com.mapbox.geojson.Point
 import com.mapbox.maps.CameraOptions
 import com.mapbox.navigation.core.MapboxNavigation
-import com.mapbox.navigation.dropin.component.location.LocationBehavior
 import com.mapbox.navigation.dropin.lifecycle.UIViewModel
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.launch
 
 sealed class CameraAction {
     data class UpdateLocation(val location: Location) : CameraAction()
@@ -20,9 +16,7 @@ sealed class CameraAction {
     object ToFollowing : CameraAction()
 }
 
-class CameraViewModel(
-    private val locationBehavior: LocationBehavior,
-) : UIViewModel<CameraState, CameraAction>(CameraState.initial()) {
+class CameraViewModel : UIViewModel<CameraState, CameraAction>(CameraState.initial()) {
 
     override fun process(
         mapboxNavigation: MapboxNavigation,
@@ -61,16 +55,6 @@ class CameraViewModel(
             }
             is CameraAction.UpdateLocation -> {
                 state.copy(location = action.location)
-            }
-        }
-    }
-
-    override fun onAttached(mapboxNavigation: MapboxNavigation) {
-        super.onAttached(mapboxNavigation)
-
-        mainJobControl.scope.launch {
-            locationBehavior.locationLiveData.asFlow().collect {
-                invoke(CameraAction.UpdateLocation(it))
             }
         }
     }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/location/LocationPuck.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/location/LocationPuck.kt
@@ -18,7 +18,7 @@ class LocationPuck(
 ) : MapboxNavigationObserver {
 
     override fun onAttached(mapboxNavigation: MapboxNavigation) {
-        val locationStateManager = MapboxNavigationApp.getObserver(LocationBehavior::class)
+        val locationStateManager = MapboxNavigationApp.getObserver(LocationViewModel::class)
 
         mapView.getMapboxMap().getStyle {
             mapView.location.apply {

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/location/LocationViewModelTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/location/LocationViewModelTest.kt
@@ -1,0 +1,257 @@
+package com.mapbox.navigation.dropin.component.location
+
+import android.location.Location
+import com.mapbox.android.core.location.LocationEngineCallback
+import com.mapbox.android.core.location.LocationEngineResult
+import com.mapbox.common.Logger
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.trip.session.LocationObserver
+import com.mapbox.navigation.testing.MainCoroutineRule
+import com.mapbox.navigation.testing.MockLoggerRule
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import io.mockk.verifyOrder
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalPreviewMapboxNavigationAPI::class, ExperimentalCoroutinesApi::class)
+class LocationViewModelTest {
+
+    @get:Rule
+    var coroutineRule = MainCoroutineRule()
+
+    @get:Rule
+    val mockLoggerTestRule = MockLoggerRule()
+
+    @Test
+    fun `default state is a null location`() = runBlockingTest {
+        val locationViewModel = LocationViewModel()
+
+        val location = locationViewModel.state.value
+
+        assertNull(location)
+    }
+
+    @Test
+    fun `onAttached will use current location to update state`() = runBlockingTest {
+        val locationViewModel = LocationViewModel()
+        val mapboxNavigation = mockMapboxNavigationLastLocation(
+            mockk {
+                every { longitude } returns -109.587335
+                every { latitude } returns 38.731370
+            }
+        )
+
+        locationViewModel.onAttached(mapboxNavigation)
+
+        with(locationViewModel.state.value!!) {
+            assertEquals(-109.587335, longitude, 0.00001)
+            assertEquals(38.731370, latitude, 0.00001)
+        }
+    }
+
+    @Test
+    fun `onAttached will use current location to update navigationLocationProvider`() =
+        runBlockingTest {
+            val locationViewModel = LocationViewModel()
+            val mapboxNavigation = mockMapboxNavigationLastLocation(
+                mockk {
+                    every { longitude } returns -109.587335
+                    every { latitude } returns 38.731370
+                }
+            )
+
+            locationViewModel.onAttached(mapboxNavigation)
+
+            with(locationViewModel.navigationLocationProvider.lastLocation!!) {
+                assertEquals(-109.587335, longitude, 0.00001)
+                assertEquals(38.731370, latitude, 0.00001)
+            }
+        }
+
+    @Test
+    fun `onAttached will use current location to update lastPoint`() = runBlockingTest {
+        val locationViewModel = LocationViewModel()
+        val mapboxNavigation = mockMapboxNavigationLastLocation(
+            mockk {
+                every { longitude } returns -109.587335
+                every { latitude } returns 38.731370
+            }
+        )
+
+        locationViewModel.onAttached(mapboxNavigation)
+
+        with(locationViewModel.lastPoint!!) {
+            assertEquals(-109.587335, longitude(), 0.00001)
+            assertEquals(38.731370, latitude(), 0.00001)
+        }
+    }
+
+    @Test
+    fun `onAttached will not log error when getLastLocation fails`() = runBlockingTest {
+        val locationViewModel = LocationViewModel()
+        val callbackSlot = slot<LocationEngineCallback<LocationEngineResult>>()
+        val mapboxNavigation = mockk<MapboxNavigation>(relaxed = true) {
+            every { navigationOptions } returns mockk {
+                every { locationEngine } returns mockk {
+                    every { getLastLocation(capture(callbackSlot)) } answers {
+                        callbackSlot.captured.onFailure(mockk())
+                    }
+                }
+            }
+        }
+
+        locationViewModel.onAttached(mapboxNavigation)
+
+        assertNull(locationViewModel.state.value)
+        verify(exactly = 1) { Logger.e("MbxLocationViewModel", any()) }
+    }
+
+    @Test
+    fun `onAttached registerLocationObserver onNewRawLocation are ignored`() = runBlockingTest {
+        val locationViewModel = LocationViewModel()
+        val locationObserver = slot<LocationObserver>()
+        val mapboxNavigation = mockk<MapboxNavigation>(relaxed = true) {
+            every { navigationOptions } returns mockk {
+                every { locationEngine } returns mockk {
+                    every { getLastLocation(any()) } just Runs
+                    every { registerLocationObserver(capture(locationObserver)) } answers {
+                        locationObserver.captured.onNewRawLocation(
+                            mockk {
+                                every { longitude } returns -109.587335
+                                every { latitude } returns 38.731370
+                            }
+                        )
+                    }
+                }
+            }
+        }
+
+        locationViewModel.onAttached(mapboxNavigation)
+
+        assertNull(locationViewModel.state.value)
+    }
+
+    @Test
+    fun `onAttached registerLocationObserver onNewLocationMatcherResult updates state`() =
+        runBlockingTest {
+            val locationViewModel = LocationViewModel()
+            val mapboxNavigation = mockMapboxNavigationRegisterObserver(
+                mockk {
+                    every { longitude } returns -109.587335
+                    every { latitude } returns 38.731370
+                }
+            )
+
+            locationViewModel.onAttached(mapboxNavigation)
+
+            with(locationViewModel.state.value!!) {
+                assertEquals(-109.587335, longitude, 0.00001)
+                assertEquals(38.731370, latitude, 0.00001)
+            }
+        }
+
+    @Test
+    fun `onAttached registerLocationObserver onNewLocationMatcherResult updates navigationLocationProvider`() =
+        runBlockingTest {
+            val locationViewModel = LocationViewModel()
+            val mapboxNavigation = mockMapboxNavigationRegisterObserver(
+                mockk {
+                    every { longitude } returns -109.587335
+                    every { latitude } returns 38.731370
+                }
+            )
+
+            locationViewModel.onAttached(mapboxNavigation)
+
+            with(locationViewModel.navigationLocationProvider.lastLocation!!) {
+                assertEquals(-109.587335, longitude, 0.00001)
+                assertEquals(38.731370, latitude, 0.00001)
+            }
+        }
+
+    @Test
+    fun `onAttached registerLocationObserver onNewLocationMatcherResult updates lastPoint`() =
+        runBlockingTest {
+            val locationViewModel = LocationViewModel()
+            val mapboxNavigation = mockMapboxNavigationRegisterObserver(
+                mockk {
+                    every { longitude } returns -109.587335
+                    every { latitude } returns 38.731370
+                }
+            )
+
+            locationViewModel.onAttached(mapboxNavigation)
+
+            with(locationViewModel.lastPoint!!) {
+                assertEquals(-109.587335, longitude(), 0.00001)
+                assertEquals(38.731370, latitude(), 0.00001)
+            }
+        }
+
+    @Test
+    fun `onDetached will unregisterLocationObserver`() = runBlockingTest {
+        val locationViewModel = LocationViewModel()
+        val mapboxNavigation = mockMapboxNavigationRegisterObserver(
+            mockk {
+                every { longitude } returns -109.587335
+                every { latitude } returns 38.731370
+            }
+        )
+
+        locationViewModel.onAttached(mapboxNavigation)
+        locationViewModel.onDetached(mapboxNavigation)
+
+        verifyOrder {
+            mapboxNavigation.registerLocationObserver(any())
+            mapboxNavigation.unregisterLocationObserver(any())
+        }
+    }
+
+    private fun mockMapboxNavigationLastLocation(_lastLocation: Location?): MapboxNavigation {
+        val callbackSlot = slot<LocationEngineCallback<LocationEngineResult>>()
+        return mockk(relaxed = true) {
+            every { navigationOptions } returns mockk {
+                every { locationEngine } returns mockk {
+                    every { getLastLocation(capture(callbackSlot)) } answers {
+                        callbackSlot.captured.onSuccess(
+                            mockk {
+                                every { lastLocation } returns _lastLocation
+                            }
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private fun mockMapboxNavigationRegisterObserver(
+        _enhancedLocation: Location
+    ): MapboxNavigation {
+        val locationObserver = slot<LocationObserver>()
+        return mockk(relaxed = true) {
+            every { navigationOptions } returns mockk {
+                every { locationEngine } returns mockk {
+                    every { getLastLocation(any()) } just Runs
+                    every { registerLocationObserver(capture(locationObserver)) } answers {
+                        locationObserver.captured.onNewLocationMatcherResult(
+                            mockk {
+                                every { enhancedLocation } returns _enhancedLocation
+                                every { keyPoints } returns emptyList()
+                            }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Migrated the `LocationBehavior` to extend the `UIViewModel`. Now it's a `LocationViewModel`
Current definitions of UIViewModel are here https://github.com/mapbox/mapbox-navigation-android/pull/5521

