### PR TITLE
Added feature to reset the route line related cache.

### DIFF
--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/util/CacheResultUtils.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/util/CacheResultUtils.kt
@@ -7,22 +7,23 @@ internal object CacheResultUtils {
         operator fun invoke(f: F): R
     }
 
-    private data class CacheResultKey1<out P1, R>(val p1: P1) :
+    data class CacheResultKey1<out P1, R>(val p1: P1) :
         CacheResultCall<(P1) -> R, R> {
         override fun invoke(f: (P1) -> R) = f(p1)
     }
 
-    private data class CacheResultKey2<out P1, P2, R>(val p1: P1, val p2: P2) :
+    data class CacheResultKey2<out P1, P2, R>(val p1: P1, val p2: P2) :
         CacheResultCall<(P1, P2) -> R, R> {
         override fun invoke(f: (P1, P2) -> R) = f(p1, p2)
     }
 
     fun <P1, R> ((P1) -> R).cacheResult(maxSize: Int): (P1) -> R {
         return object : (P1) -> R {
+            val cache: LruCache<CacheResultKey1<P1, R>, R> = LruCache(maxSize)
             private val handler =
                 CacheResultHandler<((P1) -> R), CacheResultKey1<P1, R>, R>(
                     this@cacheResult,
-                    maxSize
+                    cache
                 )
             override fun invoke(p1: P1) = handler(CacheResultKey1(p1))
         }
@@ -30,20 +31,44 @@ internal object CacheResultUtils {
 
     fun <P1, P2, R> ((P1, P2) -> R).cacheResult(maxSize: Int): (P1, P2) -> R {
         return object : (P1, P2) -> R {
+            val cache: LruCache<CacheResultKey2<P1, P2, R>, R> = LruCache(maxSize)
             private val handler =
                 CacheResultHandler<((P1, P2) -> R), CacheResultKey2<P1, P2, R>, R>(
                     this@cacheResult,
-                    maxSize
+                    cache
                 )
             override fun invoke(p1: P1, p2: P2) = handler(CacheResultKey2(p1, p2))
         }
     }
 
-    private class CacheResultHandler<F, in K : CacheResultCall<F, R>, out R>(
+    fun <P1, R> ((P1) -> R).cacheResult(cache: LruCache<CacheResultKey1<P1, R>, R>): (P1) -> R {
+        return object : (P1) -> R {
+            private val handler =
+                CacheResultHandler<((P1) -> R), CacheResultKey1<P1, R>, R>(
+                    this@cacheResult,
+                    cache
+                )
+            override fun invoke(p1: P1) = handler(CacheResultKey1(p1))
+        }
+    }
+
+    fun <P1, P2, R> ((P1, P2) -> R).cacheResult(
+        cache: LruCache<CacheResultKey2<P1, P2, R>, R>
+    ): (P1, P2) -> R {
+        return object : (P1, P2) -> R {
+            private val handler =
+                CacheResultHandler<((P1, P2) -> R), CacheResultKey2<P1, P2, R>, R>(
+                    this@cacheResult,
+                    cache
+                )
+            override fun invoke(p1: P1, p2: P2) = handler(CacheResultKey2(p1, p2))
+        }
+    }
+
+    private class CacheResultHandler<F, K : CacheResultCall<F, R>, R>(
         val f: F,
-        maxSize: Int
+        val cache: LruCache<K, R>
     ) {
-        private val cache = LruCache<K, R>(maxSize)
         operator fun invoke(k: K): R {
             synchronized(cache) {
                 return cache[k] ?: run {

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtilsRoboTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtilsRoboTest.kt
@@ -799,4 +799,20 @@ class MapboxRouteLineUtilsRoboTest {
         assertTrue(result.isEmpty())
         verify(exactly = 1) { route.legs() }
     }
+
+    @Test
+    fun resetExtractRouteDataCache() {
+        val route1 = mockk<DirectionsRoute> {
+            every { legs() } returns null
+        }
+        val trafficCongestionProvider = MapboxRouteLineUtils.getRouteLegTrafficCongestionProvider
+        MapboxRouteLineUtils.extractRouteData(route1, trafficCongestionProvider)
+        MapboxRouteLineUtils.extractRouteData(route1, trafficCongestionProvider)
+        verify(exactly = 1) { route1.legs() }
+
+        MapboxRouteLineUtils.resetCache()
+        MapboxRouteLineUtils.extractRouteData(route1, trafficCongestionProvider)
+
+        verify(exactly = 2) { route1.legs() }
+    }
 }

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApiTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApiTest.kt
@@ -283,6 +283,20 @@ class MapboxRouteLineApiTest {
     }
 
     @Test
+    fun setRoutes_resetsCache() = coroutineRule.runBlockingTest {
+        mockkObject(MapboxRouteLineUtils)
+        val options = MapboxRouteLineOptions.Builder(ctx).build()
+        val api = MapboxRouteLineApi(options)
+        val route = loadRoute("short_route.json")
+        val routes = listOf(RouteLine(route, null))
+
+        api.setRoutes(routes)
+
+        verify { MapboxRouteLineUtils.resetCache() }
+        unmockkObject(MapboxRouteLineUtils)
+    }
+
+    @Test
     fun setRoutes_doesNotResetVanishingPointWhenSameRoute() = coroutineRule.runBlockingTest {
         val options = MapboxRouteLineOptions.Builder(ctx)
             .withVanishingRouteLineEnabled(true)
@@ -879,6 +893,7 @@ class MapboxRouteLineApiTest {
 
     @Test
     fun clearRouteLine() = coroutineRule.runBlockingTest {
+        mockkObject(MapboxRouteLineUtils)
         val options = MapboxRouteLineOptions.Builder(ctx).build()
         val api = MapboxRouteLineApi(options)
 
@@ -888,6 +903,8 @@ class MapboxRouteLineApiTest {
         assertTrue(result.value!!.alternativeRouteSourceSources[1].features()!!.isEmpty())
         assertTrue(result.value!!.primaryRouteSource.features()!!.isEmpty())
         assertTrue(result.value!!.waypointsSource.features()!!.isEmpty())
+        verify { MapboxRouteLineUtils.resetCache() }
+        unmockkObject(MapboxRouteLineUtils)
     }
 
     @Test

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/util/CacheResultUtilsTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/util/CacheResultUtilsTest.kt
@@ -1,5 +1,6 @@
 package com.mapbox.navigation.ui.maps.util
 
+import android.util.LruCache
 import com.mapbox.navigation.ui.maps.util.CacheResultUtils.cacheResult
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -58,5 +59,21 @@ class CacheResultUtilsTest {
 
         assertEquals(8, result)
         assertEquals(3, counter)
+    }
+
+    @Test
+    fun cacheResultWithProvidedCache() {
+        val cache: LruCache<CacheResultUtils.CacheResultKey1<Int, Int>, Int> = LruCache(1)
+        var counter = 0
+        val testFun: (a: Int) -> Int = { a: Int ->
+            counter += 1
+            a + counter
+        }.cacheResult(cache)
+        testFun(5)
+        testFun(5)
+
+        testFun(5)
+
+        assertEquals(1, cache.size())
     }
 }


### PR DESCRIPTION
### Description
Responds to #5311 by clearing the route cache when new routes are set on the `MapboxRouteLineApi` including an empty route list, in addition to calls to `clearRouteLine`.

### Screenshots or Gifs

