### PR TITLE
Adding default speed limit sign type based on locale to view.

### DIFF
--- a/libnavui-speedlimit/src/test/java/com/mapbox/navigation/ui/speedlimit/view/MapboxSpeedLimitViewTest.kt
+++ b/libnavui-speedlimit/src/test/java/com/mapbox/navigation/ui/speedlimit/view/MapboxSpeedLimitViewTest.kt
@@ -8,6 +8,7 @@ import com.mapbox.navigation.base.speed.model.SpeedLimitSign
 import com.mapbox.navigation.base.speed.model.SpeedLimitUnit
 import com.mapbox.navigation.ui.speedlimit.R
 import com.mapbox.navigation.ui.speedlimit.model.SpeedLimitFormatter
+import com.mapbox.navigation.ui.speedlimit.model.UpdateSpeedLimitError
 import com.mapbox.navigation.ui.speedlimit.model.UpdateSpeedLimitValue
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -165,5 +166,35 @@ class MapboxSpeedLimitViewTest {
         val result = view.getSizeSpanStartIndex(SpeedLimitSign.VIENNA, "whatever")
 
         assertEquals(0, result)
+    }
+
+    @Test
+    @Config(qualifiers = "es-rPR")
+    fun defaultSpeedLimitSignLocalePuertoRico() {
+        val view = MapboxSpeedLimitView(ctx).also {
+            it.render(ExpectedFactory.createError(UpdateSpeedLimitError("oops", null)))
+        }
+
+        assertEquals("MAX\n--", view.text.toString())
+    }
+
+    @Test
+    @Config(qualifiers = "en-rUS")
+    fun defaultSpeedLimitSignLocaleUS() {
+        val view = MapboxSpeedLimitView(ctx).also {
+            it.render(ExpectedFactory.createError(UpdateSpeedLimitError("oops", null)))
+        }
+
+        assertEquals("MAX\n--", view.text.toString())
+    }
+
+    @Test
+    @Config(qualifiers = "en-rCA")
+    fun defaultSpeedLimitSignLocaleCanada() {
+        val view = MapboxSpeedLimitView(ctx).also {
+            it.render(ExpectedFactory.createError(UpdateSpeedLimitError("oops", null)))
+        }
+
+        assertEquals("MAX\n--", view.text.toString())
     }
 }


### PR DESCRIPTION
### Description
By default the `MapboxSpeedLimitView` doesn't have a value for the speed limit sign type.  Because of this nothing is rendered until at least one speed limit value is input successfully.  However an error condition inputted to the render method is a legitimate value that can result in a rendered view.  This "no data" speed limit view can't be rendered though until a speed limit sign type has been determined, either MUTCD or Vienna. 

The modification in this PR will determine an default sign type based on the locale. 

### Screenshots or Gifs

