### PR TITLE
Allow VERSION_NAME to be used as name for publishing artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -295,12 +295,11 @@ commands:
           command: |
             if [[ -n "$CIRCLE_TAG" ]]; then
               if [[ $CIRCLE_TAG == v* ]]; then
-                POM_VERSION_NAME=`echo $CIRCLE_TAG | sed s/v//`
+                sed -i -e "s/^VERSION_NAME=.*/VERSION_NAME=${CIRCLE_TAG:1}/" gradle.properties
               else
                 echo "Exiting the job as this is not a release TAG"
                 exit 1
               fi
-              echo "export POM_VERSION_NAME=$POM_VERSION_NAME" >> $BASH_ENV
             fi
 
   generate-google-services-json:

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ POM_LICENCE_DIST=repo
 POM_DEVELOPER_ID=mapbox
 POM_DEVELOPER_NAME=Mapbox
 
-POM_SNAPSHOT_VERSION_NAME=2.4.0-SNAPSHOT
+SNAPSHOT_VERSION_NAME=2.4.0-SNAPSHOT
 
 # IDE (e.g. Android Studio) users:
 # Gradle settings configured through the IDE *will override*

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ POM_LICENCE_DIST=repo
 POM_DEVELOPER_ID=mapbox
 POM_DEVELOPER_NAME=Mapbox
 
-SNAPSHOT_VERSION_NAME=2.4.0-SNAPSHOT
+VERSION_NAME=2.4.0-SNAPSHOT
 
 # IDE (e.g. Android Studio) users:
 # Gradle settings configured through the IDE *will override*

--- a/gradle/artifact-settings.gradle
+++ b/gradle/artifact-settings.gradle
@@ -10,5 +10,5 @@ ext {
     mapboxArtifactScmUrl = 'scm:git@github.com:mapbox/mapbox-navigation-android.git'
     mapboxArtifactLicenseName = 'Mapbox Terms of Service'
     mapboxArtifactLicenseUrl = 'https://www.mapbox.com/legal/tos/'
-    versionName = System.getenv('POM_VERSION_NAME') ?: project.property('POM_SNAPSHOT_VERSION_NAME')
+    versionName = project.hasProperty('VERSION_NAME') ? project.property('VERSION_NAME') : project.property('SNAPSHOT_VERSION_NAME')
 }

--- a/gradle/artifact-settings.gradle
+++ b/gradle/artifact-settings.gradle
@@ -10,5 +10,5 @@ ext {
     mapboxArtifactScmUrl = 'scm:git@github.com:mapbox/mapbox-navigation-android.git'
     mapboxArtifactLicenseName = 'Mapbox Terms of Service'
     mapboxArtifactLicenseUrl = 'https://www.mapbox.com/legal/tos/'
-    versionName = project.hasProperty('VERSION_NAME') ? project.property('VERSION_NAME') : project.property('SNAPSHOT_VERSION_NAME')
+    versionName = project.hasProperty('VERSION_NAME') ? project.property('VERSION_NAME') : System.getenv('VERSION_NAME')
 }


### PR DESCRIPTION
This PR allows VERSION_NAME to be used when publishing artifacts. This is to drive alignment across Mapbox SDK build systems and allow more easily to build binaries on demand.
