### PR TITLE
[DropInUi] Attach all top level UICoordinators with the onCreate event

### DIFF
--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/DropInNavigationView.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/DropInNavigationView.kt
@@ -31,7 +31,7 @@ import com.mapbox.navigation.dropin.coordinator.MapCoordinator
 import com.mapbox.navigation.dropin.coordinator.RoadNameLabelCoordinator
 import com.mapbox.navigation.dropin.coordinator.SpeedLimitCoordinator
 import com.mapbox.navigation.dropin.databinding.DropInNavigationViewBinding
-import com.mapbox.navigation.dropin.extensions.attachStarted
+import com.mapbox.navigation.dropin.extensions.attachCreated
 import com.mapbox.navigation.ui.maps.NavigationStyles
 import com.mapbox.navigation.ui.maps.route.arrow.model.RouteArrowOptions
 import com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions
@@ -132,7 +132,7 @@ class DropInNavigationView @JvmOverloads constructor(
         /**
          * Single point of entry for the Mapbox Navigation View.
          */
-        attachStarted(
+        attachCreated(
             MapCoordinator(navigationContext, binding.mapView),
             GuidanceCoordinator(navigationContext, binding.guidanceLayout),
             InfoPanelCoordinator(navigationContext, binding.infoPanelLayout),


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

We have a growing concern of inflating views too often. For example the MapView will be re-inflated when you background and foreground the app https://github.com/mapbox/mapbox-navigation-android/pull/5548

We also found an issue where the MapView is removed from the view group when you background the app.

After discussing, we all agreed it would be better to make all of this happen onCreate/onDestroy. There is however, not an example of a UIComponent that needs to handle events for "onStart/onStop". Merging this may surface an issue, but we can use some ideas on how we should handle the life cycle events to resolve any issue we find.

EDIT: Already found a case where we want to have a component register to the onResume event. The solution fixes a blocking issue https://github.com/mapbox/mapbox-navigation-android/pull/5555

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
