### PR TITLE
[DropIn] Add info panel layout

### DIFF
--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/binder/infopanel/InfoPanelBinder.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/binder/infopanel/InfoPanelBinder.kt
@@ -1,11 +1,13 @@
 package com.mapbox.navigation.dropin.binder.infopanel
 
+import android.transition.Scene
 import android.view.ViewGroup
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver
 import com.mapbox.navigation.dropin.R
 import com.mapbox.navigation.dropin.binder.UIBinder
 import com.mapbox.navigation.dropin.binder.navigationListOf
+import com.mapbox.navigation.dropin.databinding.MapboxInfoPanelLayoutBinding
 
 @OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
 internal class InfoPanelBinder(
@@ -14,11 +16,19 @@ internal class InfoPanelBinder(
 ) : UIBinder {
 
     override fun bind(viewGroup: ViewGroup): MapboxNavigationObserver {
+        Scene.getSceneForLayout(
+            viewGroup,
+            R.layout.mapbox_info_panel_layout,
+            viewGroup.context
+        ).enter()
+
+        val binding = MapboxInfoPanelLayoutBinding.bind(viewGroup)
+
         val binders = mutableListOf(
-            headerBinder.bind(viewGroup.findViewById(R.id.infoPanelHeader))
+            headerBinder.bind(binding.infoPanelHeader)
         )
         if (contentBinder != null) {
-            binders.add(contentBinder.bind(viewGroup.findViewById(R.id.infoPanelContent)))
+            binders.add(contentBinder.bind(binding.infoPanelContent))
         }
         return navigationListOf(*binders.toTypedArray())
     }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/lifecycle/UICoordinator.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/lifecycle/UICoordinator.kt
@@ -18,10 +18,18 @@ import kotlinx.coroutines.launch
  * Attach a UICoordinator to a [ViewGroup] of your choosing. When you implement this class
  * you will need to build a [Flow] with [Binder]. There can only be one view binder
  * attached at a time for the [ViewGroup].
+ *
+ * If you have [Binder]s that do not add or remove views, you can set the parameter
+ * removeViewsOnDetached to true. This allows you to coordinate data in views.
+ *
+ * @param viewGroup provide a view group that will be passed to [Binder.bind]
+ * @param removeViewsOnDetached by default an empty view group is assumed,
+ *    if false the view group not remove the views on detached.
  */
 @OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
 abstract class UICoordinator<T : ViewGroup>(
-    private val viewGroup: T
+    private val viewGroup: T,
+    private val removeViewsOnDetached: Boolean = true
 ) : MapboxNavigationObserver {
 
     lateinit var coroutineScope: CoroutineScope
@@ -39,7 +47,9 @@ abstract class UICoordinator<T : ViewGroup>(
             }
         }.invokeOnCompletion {
             attachedObserver?.onDetached(mapboxNavigation)
-            viewGroup.removeAllViews()
+            if (removeViewsOnDetached) {
+                viewGroup.removeAllViews()
+            }
         }
     }
 

--- a/libnavui-dropin/src/main/res/layout/drop_in_navigation_view.xml
+++ b/libnavui-dropin/src/main/res/layout/drop_in_navigation_view.xml
@@ -88,19 +88,7 @@
             app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior"
             app:behavior_hideable="true"
             app:behavior_fitToContents="true"
-            app:behavior_peekHeight="@dimen/mapbox_infoPanel_peekHeight">
-
-            <FrameLayout
-                android:id="@+id/infoPanelHeader"
-                android:layout_width="match_parent"
-                android:layout_height="@dimen/mapbox_infoPanel_peekHeight" />
-
-            <FrameLayout
-                android:id="@+id/infoPanelContent"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
-
-        </LinearLayout>
+            app:behavior_peekHeight="@dimen/mapbox_infoPanel_peekHeight" />
 
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 

--- a/libnavui-dropin/src/main/res/layout/mapbox_info_panel_layout.xml
+++ b/libnavui-dropin/src/main/res/layout/mapbox_info_panel_layout.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:parentTag="android.widget.LinearLayout">
+
+    <FrameLayout
+        android:id="@+id/infoPanelHeader"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/mapbox_infoPanel_peekHeight" />
+
+    <FrameLayout
+        android:id="@+id/infoPanelContent"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+</merge>

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/binder/infopanel/InfoPanelBinderTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/binder/infopanel/InfoPanelBinderTest.kt
@@ -1,14 +1,11 @@
 package com.mapbox.navigation.dropin.binder.infopanel
 
 import android.content.Context
-import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.test.core.app.ApplicationProvider
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.dropin.binder.EmptyBinder
 import io.mockk.MockKAnnotations
-import io.mockk.every
-import io.mockk.impl.annotations.MockK
 import io.mockk.impl.annotations.SpyK
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -30,27 +27,23 @@ internal class InfoPanelBinderTest {
     @SpyK
     var contentBinder = EmptyBinder()
 
-    @MockK
-    lateinit var mockViewGroup: ViewGroup
-
     @Before
     fun setUp() {
         MockKAnnotations.init(this, relaxUnitFun = true)
         ctx = ApplicationProvider.getApplicationContext()
         sut = InfoPanelBinder(headerBinder, contentBinder)
-        every { mockViewGroup.findViewById<ViewGroup>(any()) } returns FrameLayout(ctx)
     }
 
     @Test
     fun `bind should call headerBinder`() {
-        sut.bind(mockViewGroup)
+        sut.bind(FrameLayout(ctx))
 
         verify { headerBinder.bind(allAny()) }
     }
 
     @Test
     fun `bind should call contentBinder`() {
-        sut.bind(mockViewGroup)
+        sut.bind(FrameLayout(ctx))
 
         verify { contentBinder.bind(allAny()) }
     }

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/lifecycle/UICoordinatorTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/lifecycle/UICoordinatorTest.kt
@@ -1,0 +1,140 @@
+package com.mapbox.navigation.dropin.lifecycle
+
+import android.view.ViewGroup
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver
+import com.mapbox.navigation.dropin.binder.Binder
+import com.mapbox.navigation.dropin.binder.UIBinder
+import com.mapbox.navigation.testing.MainCoroutineRule
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.verifyOrder
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalPreviewMapboxNavigationAPI::class, ExperimentalCoroutinesApi::class)
+class UICoordinatorTest {
+
+    @get:Rule
+    var coroutineRule = MainCoroutineRule()
+
+    @Test
+    fun `should bind ViewGroup when onAttached`() = runBlockingTest {
+        val viewGroup = mockk<ViewGroup>(relaxed = true)
+        val coordinator = TestUICoordinator(viewGroup, true)
+        val mapboxNavigation = mockk<MapboxNavigation>()
+        val mapboxNavigationObserver = mockk<MapboxNavigationObserver>(relaxed = true)
+        val binder = mockk<UIBinder>(relaxed = true) {
+            every { bind(any()) } returns mapboxNavigationObserver
+        }
+
+        coordinator.onAttached(mapboxNavigation)
+        coordinator.flow.emit(binder)
+
+        verify { binder.bind(viewGroup) }
+    }
+
+    @Test
+    fun `should attach the binder MapboxNavigationObserver`() = runBlockingTest {
+        val viewGroup = mockk<ViewGroup>(relaxed = true)
+        val coordinator = TestUICoordinator(viewGroup, true)
+        val mapboxNavigation = mockk<MapboxNavigation>()
+        val mapboxNavigationObserver = mockk<MapboxNavigationObserver>(relaxed = true)
+        val binder = mockk<UIBinder>(relaxed = true) {
+            every { bind(any()) } returns mapboxNavigationObserver
+        }
+
+        coordinator.onAttached(mapboxNavigation)
+        coordinator.flow.emit(binder)
+
+        verify(exactly = 1) { mapboxNavigationObserver.onAttached(mapboxNavigation) }
+        verify(exactly = 0) { mapboxNavigationObserver.onDetached(mapboxNavigation) }
+    }
+
+    @Test
+    fun `should remove views from ViewGroup when coordinator is detached`() = runBlockingTest {
+        val viewGroup = mockk<ViewGroup>(relaxed = true)
+        val coordinator = TestUICoordinator(viewGroup, true)
+        val mapboxNavigation = mockk<MapboxNavigation>()
+        val mapboxNavigationObserver = mockk<MapboxNavigationObserver>(relaxed = true)
+        val binder = mockk<UIBinder>(relaxed = true) {
+            every { bind(any()) } returns mapboxNavigationObserver
+        }
+
+        coordinator.onAttached(mapboxNavigation)
+        coordinator.flow.emit(binder)
+        coordinator.onDetached(mapboxNavigation)
+
+        verify(exactly = 1) { mapboxNavigationObserver.onAttached(mapboxNavigation) }
+        verify(exactly = 1) { mapboxNavigationObserver.onDetached(mapboxNavigation) }
+        verify(exactly = 1) { viewGroup.removeAllViews() }
+    }
+
+    @Test
+    fun `false removeViewsOnDetached will not remove views from ViewGroup`() = runBlockingTest {
+        val viewGroup = mockk<ViewGroup>(relaxed = true)
+        val coordinator = TestUICoordinator(viewGroup, false)
+        val mapboxNavigation = mockk<MapboxNavigation>()
+        val mapboxNavigationObserver = mockk<MapboxNavigationObserver>(relaxed = true)
+        val binder = mockk<UIBinder>(relaxed = true) {
+            every { bind(any()) } returns mapboxNavigationObserver
+        }
+
+        coordinator.onAttached(mapboxNavigation)
+        coordinator.flow.emit(binder)
+        coordinator.onDetached(mapboxNavigation)
+
+        verify(exactly = 1) { mapboxNavigationObserver.onAttached(mapboxNavigation) }
+        verify(exactly = 1) { mapboxNavigationObserver.onDetached(mapboxNavigation) }
+        verify(exactly = 0) { viewGroup.removeAllViews() }
+    }
+
+    @Test
+    fun `verify transition when binder is updated`() = runBlockingTest {
+        val viewGroup = mockk<ViewGroup>(relaxed = true)
+        val coordinator = TestUICoordinator(viewGroup, true)
+        val mapboxNavigation = mockk<MapboxNavigation>()
+        val mapboxNavigationObserverFirst = mockk<MapboxNavigationObserver>(relaxed = true)
+        val binderFirst = mockk<UIBinder>(relaxed = true) {
+            every { bind(any()) } returns mapboxNavigationObserverFirst
+        }
+        val mapboxNavigationObserverSecond = mockk<MapboxNavigationObserver>(relaxed = true)
+        val binderSecond = mockk<UIBinder>(relaxed = true) {
+            every { bind(any()) } returns mapboxNavigationObserverSecond
+        }
+
+        coordinator.onAttached(mapboxNavigation)
+        coordinator.flow.emit(binderFirst)
+        coordinator.flow.emit(binderSecond)
+
+        verifyOrder {
+            // First binder is attached
+            binderFirst.bind(viewGroup)
+            mapboxNavigationObserverFirst.onAttached(mapboxNavigation)
+
+            // Second binder is attached, the first observer is detached.
+            mapboxNavigationObserverFirst.onDetached(mapboxNavigation)
+            binderSecond.bind(viewGroup)
+            mapboxNavigationObserverSecond.onAttached(mapboxNavigation)
+        }
+        // The views are not removed. The new binder is responsible for transitioning.
+        verify(exactly = 0) { viewGroup.removeAllViews() }
+    }
+}
+
+private class TestUICoordinator(
+    viewGroup: ViewGroup,
+    removeViewsOnDetached: Boolean,
+) : UICoordinator<ViewGroup>(viewGroup, removeViewsOnDetached) {
+    val flow = MutableSharedFlow<UIBinder>()
+
+    override fun MapboxNavigation.flowViewBinders(): Flow<Binder<ViewGroup>> {
+        return flow
+    }
+}


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Following up with an issue that happened with robo-testing when [introducing the info panel](https://github.com/mapbox/mapbox-navigation-android/pull/5506#issuecomment-1063477664) 
```
Fatal Exception: java.lang.NullPointerException: viewGroup.findViewById(R.id.infoPanelHeader) must not be null
       at com.mapbox.navigation.dropin.binder.infopanel.InfoPanelBinder.bind(InfoPanelBinder.java:18)
       at com.mapbox.navigation.dropin.binder.infopanel.InfoPanelBinder.bind(InfoPanelBinder.java:2)
       at com.mapbox.navigation.dropin.lifecycle.UICoordinator$onAttached$1$invokeSuspend$$inlined$collect$1.emit(UICoordinator.java:24)
       at com.mapbox.navigation.dropin.coordinator.InfoPanelCoordinator$flowViewBinders$$inlined$map$1$2.emit(InfoPanelCoordinator.java:84)
       at kotlinx.coroutines.flow.StateFlowImpl.collect(StateFlowImpl.java:201)
       at com.mapbox.navigation.dropin.coordinator.InfoPanelCoordinator$flowViewBinders$$inlined$map$1.collect(InfoPanelCoordinator.java:9)
       at com.mapbox.navigation.dropin.lifecycle.UICoordinator$onAttached$1.invokeSuspend(UICoordinator.java:47)
       at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(BaseContinuationImpl.java:9)
       at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.java:129)
       at android.os.Handler.handleCallback(Handler.java:938)
       at android.os.Handler.dispatchMessage(Handler.java:99)
       at android.os.Looper.loop(Looper.java:223)
       at android.app.ActivityThread.main(ActivityThread.java:7664)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:947)
```

### Explanation

Before we changed the root lifecycle for inflating coordinator views to the onCreate event https://github.com/mapbox/mapbox-navigation-android/pull/5553

This would cause all UICoordinators to inflate their views `onStart`, and `removeAllViews onStop`. This caused the `infoPanelHeader` to be removed when the app is backgrounded. 

A test case that I'd like to add for `UIBinder` is that they can only be bound to "empty" ViewGroup. I've added a parameter to the UICoordinator that will allow us to do this. But I've also updated the InfoPanel to inflate what it needs when it is attached. 

In this pull request I'm moving the layout, so it is inflated at the time of binding. Although, I'm considering the addition of the flag an enhancement to allow us to reduce view inflation. 
