### PR TITLE
[DropIn] Remove flow parameter from UIViewModel

### DIFF
--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/routefetch/RoutesViewModel.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/routefetch/RoutesViewModel.kt
@@ -16,14 +16,13 @@ import com.mapbox.navigation.dropin.component.navigation.NavigationStateViewMode
 import com.mapbox.navigation.dropin.component.navigationstate.NavigationState
 import com.mapbox.navigation.dropin.lifecycle.UIViewModel
 import com.mapbox.navigation.dropin.model.Destination
-import kotlinx.coroutines.flow.MutableStateFlow
 
 @OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
 internal class RoutesViewModel(
     private val navigationStateViewModel: NavigationStateViewModel,
     private val locationViewModel: LocationViewModel,
-    state: MutableStateFlow<RoutesState> = MutableStateFlow(RoutesState.INITIAL_STATE)
-) : UIViewModel<RoutesState, RoutesAction>(state) {
+    initialState: RoutesState = RoutesState.INITIAL_STATE
+) : UIViewModel<RoutesState, RoutesAction>(initialState) {
 
     private var routeRequestId: Long? = null
 

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/lifecycle/UIViewModel.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/lifecycle/UIViewModel.kt
@@ -18,18 +18,16 @@ import kotlinx.coroutines.launch
  * Implement your version of a behavior. Behaviors do not reference android ui elements directly,
  * this is because their lifecycle will survive beyond a view or activity.
  *
- * Behaviors have a lifecycle, contain state, and process actions. [UIComponent] will respond
+ * UIViewModels have a lifecycle, contain state, and process actions.
+ *
+ * @param initialState used to initialize the [state]
  */
 @OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
-abstract class UIViewModel<State, Action>(
-    mutableState: MutableStateFlow<State>
-) : MapboxNavigationObserver {
-
-    constructor(initialState: State) : this(MutableStateFlow(initialState))
+abstract class UIViewModel<State, Action>(initialState: State) : MapboxNavigationObserver {
 
     private val _action = MutableSharedFlow<Action>(extraBufferCapacity = 1)
     val action: Flow<Action> = _action
-    private val _state: MutableStateFlow<State> = mutableState
+    private val _state: MutableStateFlow<State> = MutableStateFlow(initialState)
     val state: StateFlow<State> = _state
 
     lateinit var mainJobControl: JobControl

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/routefetch/RoutesViewModelTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/routefetch/RoutesViewModelTest.kt
@@ -38,7 +38,6 @@ internal class RoutesViewModelTest {
 
     lateinit var navigationStateViewModel: NavigationStateViewModel
     lateinit var navigationStateFlow: MutableStateFlow<NavigationState>
-    lateinit var routesStateFlow: MutableStateFlow<RoutesState>
     lateinit var locationViewModel: LocationViewModel
 
     lateinit var sut: RoutesViewModel
@@ -48,7 +47,6 @@ internal class RoutesViewModelTest {
     @Before
     fun setUp() {
         mockkStatic("com.mapbox.navigation.base.internal.extensions.ContextEx")
-        routesStateFlow = MutableStateFlow(RoutesState.INITIAL_STATE)
         navigationStateFlow = MutableStateFlow(NavigationState.FreeDrive)
         navigationStateViewModel = mockk {
             every { state } returns navigationStateFlow
@@ -56,7 +54,11 @@ internal class RoutesViewModelTest {
         locationViewModel = mockk(relaxed = true) {
             every { lastPoint } returns currentLoc
         }
-        sut = RoutesViewModel(navigationStateViewModel, locationViewModel, routesStateFlow)
+        sut = RoutesViewModel(
+            navigationStateViewModel,
+            locationViewModel,
+            RoutesState.INITIAL_STATE
+        )
     }
 
     @After
@@ -191,10 +193,11 @@ internal class RoutesViewModelTest {
     @Test
     fun `should fetch and set new route on FetchAndSet action`() =
         coroutineRule.runBlockingTest {
-            routesStateFlow.value = RoutesState(
+            val initialState = RoutesState(
                 Destination(Point.fromLngLat(1.0, 2.0)),
                 false
             )
+            sut = RoutesViewModel(navigationStateViewModel, locationViewModel, initialState)
             val mapboxNavigation = mockMapboxNavigation()
 
             sut.onAttached(mapboxNavigation)
@@ -221,10 +224,11 @@ internal class RoutesViewModelTest {
     @Test
     fun `should set navigationStarted to FALSE on DidStartNavigation`() =
         coroutineRule.runBlockingTest {
-            routesStateFlow.value = RoutesState(
+            val initialState = RoutesState(
                 Destination(Point.fromLngLat(1.0, 2.0)),
                 true
             )
+            sut = RoutesViewModel(navigationStateViewModel, locationViewModel, initialState)
             val mapboxNavigation = mockMapboxNavigation()
 
             sut.onAttached(mapboxNavigation)


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Reverting some of the logic change we introduced here https://github.com/mapbox/mapbox-navigation-android/pull/5506

There are two ways to construct a UIViewModel at the moment. You can pass in the `Flow<State>` or a default `State`. We never want to use the `Flow<State>` because we are getting the state from higher level objects (MapboxNavigation or other UIViewModel)

This was introduced to resolve a circular dependency between multiple ViewModels. But the solution to that problem is to introduce another high level object to help the communication (a component that depends on 2 ViewModels, or create 3 ViewModels).
