### PR TITLE
[DROP-IN] DestinationViewModel

### DIFF
--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/DropInNavigationViewContext.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/DropInNavigationViewContext.kt
@@ -5,6 +5,8 @@ import androidx.activity.OnBackPressedCallback
 import androidx.lifecycle.LifecycleOwner
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.dropin.binder.UIBinder
+import com.mapbox.navigation.dropin.component.destination.DestinationAction
+import com.mapbox.navigation.dropin.component.destination.DestinationState
 import com.mapbox.navigation.dropin.component.maneuver.ManeuverViewBinder
 import com.mapbox.navigation.dropin.component.marker.MapMarkerFactory
 import com.mapbox.navigation.dropin.component.navigationstate.NavigationState
@@ -55,11 +57,13 @@ internal class DropInNavigationViewContext(
     val dispatch: (action: Any) -> Unit = { action ->
         when (action) {
             is RoutesAction -> viewModel.routesViewModel.invoke(action)
+            is DestinationAction -> viewModel.destinationViewModel.invoke(action)
         }
     }
 
     val navigationState: StateFlow<NavigationState> get() = viewModel.navigationStateViewModel.state
     val routesState: StateFlow<RoutesState> get() = viewModel.routesViewModel.state
+    val destinationState: StateFlow<DestinationState> get() = viewModel.destinationViewModel.state
 
     //region Builders & Factories
 

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/DropInNavigationViewModel.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/DropInNavigationViewModel.kt
@@ -5,6 +5,7 @@ import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationApp
 import com.mapbox.navigation.dropin.component.audioguidance.AudioGuidanceViewModel
 import com.mapbox.navigation.dropin.component.camera.CameraViewModel
+import com.mapbox.navigation.dropin.component.destination.DestinationViewModel
 import com.mapbox.navigation.dropin.component.location.LocationViewModel
 import com.mapbox.navigation.dropin.component.navigation.NavigationStateComponent
 import com.mapbox.navigation.dropin.component.navigation.NavigationStateViewModel
@@ -38,15 +39,19 @@ internal class DropInNavigationViewModel : ViewModel() {
 
     val cameraViewModel = CameraViewModel()
     val navigationStateViewModel = NavigationStateViewModel(NavigationState.FreeDrive)
+    val destinationViewModel = DestinationViewModel()
     val routesViewModel = RoutesViewModel(
         navigationStateViewModel,
         locationViewModel,
+        destinationViewModel,
     )
     val navigationStateComponent = NavigationStateComponent(
         navigationStateViewModel,
+        destinationViewModel,
         routesViewModel
     )
     private val navigationObservers = listOf(
+        destinationViewModel,
         replayViewModel,
         audioGuidanceViewModel,
         locationViewModel,

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/destination/DestinationAction.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/destination/DestinationAction.kt
@@ -1,0 +1,7 @@
+package com.mapbox.navigation.dropin.component.destination
+
+import com.mapbox.navigation.dropin.model.Destination
+
+sealed class DestinationAction {
+    data class SetDestination(val destination: Destination?) : DestinationAction()
+}

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/destination/DestinationState.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/destination/DestinationState.kt
@@ -1,0 +1,7 @@
+package com.mapbox.navigation.dropin.component.destination
+
+import com.mapbox.navigation.dropin.model.Destination
+
+internal data class DestinationState(
+    val destination: Destination? = null
+)

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/destination/DestinationViewModel.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/destination/DestinationViewModel.kt
@@ -1,0 +1,23 @@
+package com.mapbox.navigation.dropin.component.destination
+
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.dropin.lifecycle.UIViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class DestinationViewModel(
+    initialState: DestinationState = DestinationState()
+) : UIViewModel<DestinationState, DestinationAction>(initialState) {
+
+    override fun process(
+        mapboxNavigation: MapboxNavigation,
+        state: DestinationState,
+        action: DestinationAction
+    ): DestinationState {
+        when (action) {
+            is DestinationAction.SetDestination -> {
+                return state.copy(destination = action.destination)
+            }
+        }
+    }
+}

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/marker/LongPressMapComponent.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/marker/LongPressMapComponent.kt
@@ -5,7 +5,7 @@ import com.mapbox.maps.plugin.gestures.OnMapLongClickListener
 import com.mapbox.maps.plugin.gestures.gestures
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.dropin.DropInNavigationViewContext
-import com.mapbox.navigation.dropin.component.routefetch.RoutesAction
+import com.mapbox.navigation.dropin.component.destination.DestinationAction
 import com.mapbox.navigation.dropin.lifecycle.UIComponent
 import com.mapbox.navigation.dropin.model.Destination
 
@@ -25,7 +25,7 @@ internal class LongPressMapComponent(
     }
 
     private val longClickListener = OnMapLongClickListener { point ->
-        context.dispatch(RoutesAction.SetDestination(Destination(point)))
+        context.dispatch(DestinationAction.SetDestination(Destination(point)))
         false
     }
 }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/marker/MapMarkersComponent.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/marker/MapMarkersComponent.kt
@@ -16,13 +16,13 @@ internal open class MapMarkersComponent(
     protected val context: DropInNavigationViewContext
 ) : UIComponent() {
     private val mapAnnotationFactory = context.mapAnnotationFactory()
-    private val routesState = context.routesState
+    private val destinationState = context.destinationState
     private var annotationManager = mapView.annotations.createPointAnnotationManager()
 
     override fun onAttached(mapboxNavigation: MapboxNavigation) {
         super.onAttached(mapboxNavigation)
 
-        routesState.map { it.destination }.observe { destination ->
+        destinationState.map { it.destination }.observe { destination ->
             annotationManager.deleteAll()
             if (destination != null) {
                 val annotation = mapAnnotationFactory.createPin(destination.point)

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/routefetch/RoutesAction.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/routefetch/RoutesAction.kt
@@ -3,10 +3,8 @@ package com.mapbox.navigation.dropin.component.routefetch
 import com.mapbox.api.directions.v5.models.RouteOptions
 import com.mapbox.geojson.Point
 import com.mapbox.navigation.base.route.NavigationRoute
-import com.mapbox.navigation.dropin.model.Destination
 
 sealed class RoutesAction {
-    data class SetDestination(val destination: Destination?) : RoutesAction()
     object FetchAndSetRoute : RoutesAction()
     object StartNavigation : RoutesAction()
     object StopNavigation : RoutesAction()

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/routefetch/RoutesState.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/routefetch/RoutesState.kt
@@ -1,12 +1,5 @@
 package com.mapbox.navigation.dropin.component.routefetch
 
-import com.mapbox.navigation.dropin.model.Destination
-
 internal data class RoutesState(
-    val destination: Destination?,
-    val navigationStarted: Boolean,
-) {
-    companion object {
-        val INITIAL_STATE = RoutesState(null, false)
-    }
-}
+    val navigationStarted: Boolean = false
+)

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/coordinator/BackPressManager.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/coordinator/BackPressManager.kt
@@ -2,9 +2,10 @@ package com.mapbox.navigation.dropin.coordinator
 
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.dropin.DropInNavigationViewContext
+import com.mapbox.navigation.dropin.component.destination.DestinationAction
+import com.mapbox.navigation.dropin.component.destination.DestinationState
 import com.mapbox.navigation.dropin.component.navigationstate.NavigationState
 import com.mapbox.navigation.dropin.component.routefetch.RoutesAction
-import com.mapbox.navigation.dropin.component.routefetch.RoutesState
 import com.mapbox.navigation.dropin.lifecycle.UIComponent
 import com.mapbox.navigation.dropin.model.Destination
 import kotlinx.coroutines.flow.SharedFlow
@@ -26,21 +27,21 @@ internal class BackPressManager(
     private val context: DropInNavigationViewContext
 ) : UIComponent() {
 
-    private val routesState: StateFlow<RoutesState> = context.routesState
+    private val destinationState: StateFlow<DestinationState> = context.destinationState
     private val onBackPressedEvent: SharedFlow<Unit> = context.viewModel.onBackPressedEvent
     private val navigationState: StateFlow<NavigationState> = context.navigationState
 
     override fun onAttached(mapboxNavigation: MapboxNavigation) {
         super.onAttached(mapboxNavigation)
 
-        routesState.map { it.destination }.observe { d: Destination? ->
+        destinationState.map { it.destination }.observe { d: Destination? ->
             context.onBackPressedCallback.isEnabled = d != null
         }
 
         onBackPressedEvent.observe {
             when (navigationState.value) {
                 NavigationState.FreeDrive -> {
-                    context.dispatch(RoutesAction.SetDestination(null))
+                    context.dispatch(DestinationAction.SetDestination(null))
                 }
                 NavigationState.RoutePreview -> {
                     context.dispatch(RoutesAction.SetRoutes(emptyList(), 0))

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/coordinator/InfoPanelCoordinator.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/coordinator/InfoPanelCoordinator.kt
@@ -27,7 +27,7 @@ internal class InfoPanelCoordinator(
     private val guidelineBottom: Guideline
 ) : UICoordinator<ViewGroup>(infoPanel) {
 
-    private val routesState = context.routesState
+    private val destinationState = context.destinationState
     private val behavior = BottomSheetBehavior.from(infoPanel)
 
     init {
@@ -39,7 +39,7 @@ internal class InfoPanelCoordinator(
 
         behavior.addBottomSheetCallback(updateGuideline)
         coroutineScope.launch {
-            routesState.map { it.destination }.collect { destination ->
+            destinationState.map { it.destination }.collect { destination ->
                 if (destination != null) behavior.collapse()
                 else behavior.hide()
             }

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/marker/LongPressMapComponentTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/marker/LongPressMapComponentTest.kt
@@ -7,7 +7,7 @@ import com.mapbox.maps.plugin.gestures.OnMapLongClickListener
 import com.mapbox.maps.plugin.gestures.gestures
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.dropin.DropInNavigationViewContext
-import com.mapbox.navigation.dropin.component.routefetch.RoutesAction
+import com.mapbox.navigation.dropin.component.destination.DestinationAction
 import com.mapbox.navigation.dropin.model.Destination
 import com.mapbox.navigation.dropin.testutil.DispatchRegistry
 import io.mockk.MockKAnnotations
@@ -70,7 +70,7 @@ internal class LongPressMapComponentTest {
         slot.captured.onMapLongClick(point)
 
         dispatchRegistry.verifyDispatched(
-            RoutesAction.SetDestination(Destination(point))
+            DestinationAction.SetDestination(Destination(point))
         )
     }
 }

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/marker/MapMarkersComponentTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/marker/MapMarkersComponentTest.kt
@@ -8,7 +8,7 @@ import com.mapbox.maps.plugin.annotation.generated.PointAnnotationOptions
 import com.mapbox.maps.plugin.annotation.generated.createPointAnnotationManager
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.dropin.DropInNavigationViewContext
-import com.mapbox.navigation.dropin.component.routefetch.RoutesState
+import com.mapbox.navigation.dropin.component.destination.DestinationState
 import com.mapbox.navigation.dropin.model.Destination
 import com.mapbox.navigation.testing.MainCoroutineRule
 import io.mockk.MockKAnnotations
@@ -29,7 +29,7 @@ internal class MapMarkersComponentTest {
     var coroutineRule = MainCoroutineRule()
 
     private lateinit var sut: MapMarkersComponent
-    private lateinit var routesStateFlow: MutableStateFlow<RoutesState>
+    private lateinit var destinationStateFlow: MutableStateFlow<DestinationState>
 
     @MockK
     lateinit var mockAnnotationFactory: MapMarkerFactory
@@ -40,14 +40,14 @@ internal class MapMarkersComponentTest {
     @Before
     fun setUp() {
         MockKAnnotations.init(this, relaxUnitFun = true)
-        routesStateFlow = MutableStateFlow(RoutesState.INITIAL_STATE)
+        destinationStateFlow = MutableStateFlow(DestinationState())
         val mapView = mockk<MapView> {
             every { annotations } returns mockk {
                 every { createPointAnnotationManager() } returns mockAnnotationManager
             }
         }
         val navContext = mockk<DropInNavigationViewContext> {
-            every { routesState } returns routesStateFlow
+            every { destinationState } returns destinationStateFlow
             every { mapAnnotationFactory() } returns mockAnnotationFactory
         }
 
@@ -59,7 +59,7 @@ internal class MapMarkersComponentTest {
         coroutineRule.runBlockingTest {
             val annotation = mockk<PointAnnotationOptions>()
             val point = Point.fromLngLat(10.0, 11.0)
-            routesStateFlow.value = RoutesState(Destination(point), false)
+            destinationStateFlow.value = DestinationState(Destination(point))
             every { mockAnnotationFactory.createPin(point) } returns annotation
 
             sut.onAttached(mockk())

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/navigation/NavigationStateComponentTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/navigation/NavigationStateComponentTest.kt
@@ -7,6 +7,8 @@ import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.base.trip.model.RouteProgressState
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesUpdatedResult
+import com.mapbox.navigation.dropin.component.destination.DestinationState
+import com.mapbox.navigation.dropin.component.destination.DestinationViewModel
 import com.mapbox.navigation.dropin.component.navigation.NavigationStateAction.Update
 import com.mapbox.navigation.dropin.component.navigationstate.NavigationState
 import com.mapbox.navigation.dropin.component.navigationstate.NavigationState.ActiveNavigation
@@ -42,6 +44,7 @@ internal class NavigationStateComponentTest {
 
     lateinit var sut: NavigationStateComponent
     lateinit var navigationStateFlow: MutableStateFlow<NavigationState>
+    lateinit var destinationStateFlow: MutableStateFlow<DestinationState>
     lateinit var routesStateFlow: MutableStateFlow<RoutesState>
     lateinit var flowRoutesUpdated: MutableSharedFlow<RoutesUpdatedResult>
     lateinit var flowOnFinalDestinationArrival: MutableSharedFlow<RouteProgress>
@@ -53,6 +56,9 @@ internal class NavigationStateComponentTest {
     lateinit var mockRoutesViewModel: RoutesViewModel
 
     @MockK
+    lateinit var mockDestinationViewModel: DestinationViewModel
+
+    @MockK
     lateinit var mockMapboxNavigation: MapboxNavigation
 
     @Before
@@ -60,11 +66,13 @@ internal class NavigationStateComponentTest {
         mockkStatic("com.mapbox.navigation.dropin.extensions.MapboxNavigationEx")
         MockKAnnotations.init(this, relaxUnitFun = true)
         navigationStateFlow = MutableStateFlow(FreeDrive)
-        routesStateFlow = MutableStateFlow(RoutesState.INITIAL_STATE)
+        routesStateFlow = MutableStateFlow(RoutesState())
+        destinationStateFlow = MutableStateFlow(DestinationState())
         flowRoutesUpdated = MutableSharedFlow()
         flowOnFinalDestinationArrival = MutableSharedFlow()
 
         every { mockNavigationStateViewModel.state } returns navigationStateFlow
+        every { mockDestinationViewModel.state } returns destinationStateFlow
         every { mockRoutesViewModel.state } returns routesStateFlow
         every { mockMapboxNavigation.flowRoutesUpdated() } returns flowRoutesUpdated
         every {
@@ -73,7 +81,8 @@ internal class NavigationStateComponentTest {
 
         sut = NavigationStateComponent(
             mockNavigationStateViewModel,
-            mockRoutesViewModel
+            mockDestinationViewModel,
+            mockRoutesViewModel,
         )
     }
 
@@ -160,7 +169,8 @@ internal class NavigationStateComponentTest {
         navigationStarted: Boolean,
         routesList: List<DirectionsRoute>
     ) {
-        routesStateFlow.value = RoutesState(destination, navigationStarted)
+        destinationStateFlow.value = DestinationState(destination)
+        routesStateFlow.value = RoutesState(navigationStarted)
         every { mockMapboxNavigation.getRoutes() } returns routesList
     }
 


### PR DESCRIPTION
Blocks [#1521](https://github.com/mapbox/navigation-sdks/issues/1521)

### Description
Following @abhishek1508 [suggestion](https://github.com/mapbox/mapbox-navigation-android/pull/5506#discussion_r821060459) to introduce `DestinationViewModel` for `GeocoderComponent` to observe, `Destination` data must be moved from `RoutesState` to `DestinationState` first.

This PR:
- Introduces DestinationViewModel, DestinationState and DestinationAction
- Moves Destination from RoutesState to DestinationState
- Updates all references to `RoutesState.destination` -> `DestinationState.destination`


