### PR TITLE
- RerouteOptionsDelegate allows apply own route options on reroute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Mapbox welcomes participation and contributions from everyone.
 
 ## Unreleased
+- Added `RerouteOptionsAdapter`. It allows to modify `RouteOptions` on reroute for default implementation of `RerouteController` via `MapboxNavigation#setRerouteOptionsAdapter`. [#5573](https://github.com/mapbox/mapbox-navigation-android/pull/5573)
 
 ## Mapbox Navigation SDK 2.4.0-beta.2 - March 18, 2022
 ### Changelog

--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -54,6 +54,7 @@ package com.mapbox.navigation.core {
     method public void setRerouteController(com.mapbox.navigation.core.reroute.RerouteController rerouteController);
     method public void setRerouteController(com.mapbox.navigation.core.reroute.NavigationRerouteController? rerouteController = com.mapbox.navigation.core.MapboxNavigation.defaultRerouteController);
     method public void setRerouteController();
+    method public void setRerouteOptionsAdapter(com.mapbox.navigation.core.reroute.RerouteOptionsAdapter? rerouteOptionsAdapter);
     method @Deprecated public void setRoutes(java.util.List<? extends com.mapbox.api.directions.v5.models.DirectionsRoute> routes, int initialLegIndex = 0);
     method @Deprecated public void setRoutes(java.util.List<? extends com.mapbox.api.directions.v5.models.DirectionsRoute> routes);
     method @com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI public void startReplayTripSession(boolean withForegroundService = true);
@@ -540,7 +541,7 @@ package com.mapbox.navigation.core.reroute {
   }
 
   public static fun interface NavigationRerouteController.RoutesCallback {
-    method public void onNewRoutes(java.util.List<com.mapbox.navigation.base.route.NavigationRoute> routes);
+    method public void onNewRoutes(java.util.List<com.mapbox.navigation.base.route.NavigationRoute> routes, com.mapbox.navigation.base.route.RouterOrigin routerOrigin);
   }
 
   public interface RerouteController {
@@ -558,6 +559,10 @@ package com.mapbox.navigation.core.reroute {
 
   public static fun interface RerouteController.RoutesCallback {
     method public void onNewRoutes(java.util.List<? extends com.mapbox.api.directions.v5.models.DirectionsRoute> routes);
+  }
+
+  public interface RerouteOptionsAdapter {
+    method public com.mapbox.api.directions.v5.models.RouteOptions onRouteOptions(com.mapbox.api.directions.v5.models.RouteOptions routeOptions);
   }
 
   public abstract sealed class RerouteState {

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -59,6 +59,7 @@ import com.mapbox.navigation.core.reroute.LegacyRerouteControllerAdapter
 import com.mapbox.navigation.core.reroute.MapboxRerouteController
 import com.mapbox.navigation.core.reroute.NavigationRerouteController
 import com.mapbox.navigation.core.reroute.RerouteController
+import com.mapbox.navigation.core.reroute.RerouteOptionsAdapter
 import com.mapbox.navigation.core.reroute.RerouteState
 import com.mapbox.navigation.core.routealternatives.NavigationRouteAlternativesObserver
 import com.mapbox.navigation.core.routealternatives.NavigationRouteAlternativesRequestCallback
@@ -1054,9 +1055,8 @@ class MapboxNavigation @VisibleForTesting internal constructor(
     }
 
     /**
-     * Set [NavigationRerouteController] that's automatically invoked when user is off-route.
-     *
-     * By default uses [MapboxRerouteController]. Setting to `null` disables auto-reroute.
+     * Set [RerouteOptionsAdapter]. It allows to modify [RouteOptions] before a reroute request
+     * is sent if the default reroute controller is used. Pass `null` to clear the adapter.
      */
     @JvmOverloads
     fun setRerouteController(
@@ -1067,6 +1067,17 @@ class MapboxNavigation @VisibleForTesting internal constructor(
             rerouteController.interrupt()
             reroute()
         }
+    }
+
+    /**
+     * Set [RerouteOptionsAdapter]. It allows modify [RouteOptions] of default implementation of
+     * [NavigationRerouteController] ([RerouteController])
+     */
+    fun setRerouteOptionsAdapter(
+        rerouteOptionsAdapter: RerouteOptionsAdapter?
+    ) {
+        (rerouteController as? MapboxRerouteController)
+            ?.setRerouteOptionsAdapter(rerouteOptionsAdapter)
     }
 
     /**
@@ -1460,7 +1471,7 @@ class MapboxNavigation @VisibleForTesting internal constructor(
 
     private fun reroute() {
         rerouteController?.reroute(
-            NavigationRerouteController.RoutesCallback { routes ->
+            NavigationRerouteController.RoutesCallback { routes, _ ->
                 directionsSession.setRoutes(
                     routes,
                     routesUpdateReason = RoutesExtra.ROUTES_UPDATE_REASON_REROUTE

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/reroute/LegacyRerouteControllerAdapter.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/reroute/LegacyRerouteControllerAdapter.kt
@@ -1,13 +1,15 @@
 package com.mapbox.navigation.core.reroute
 
+import com.mapbox.navigation.base.route.RouterOrigin
 import com.mapbox.navigation.base.route.toNavigationRoutes
 
 internal class LegacyRerouteControllerAdapter(
     private val legacyRerouteController: RerouteController
-) : NavigationRerouteController, RerouteController by legacyRerouteController {
+) : NavigationRerouteController,
+    RerouteController by legacyRerouteController {
     override fun reroute(callback: NavigationRerouteController.RoutesCallback) {
         legacyRerouteController.reroute { routes ->
-            callback.onNewRoutes(routes.toNavigationRoutes())
+            callback.onNewRoutes(routes.toNavigationRoutes(), RouterOrigin.Custom())
         }
     }
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/reroute/NavigationRerouteController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/reroute/NavigationRerouteController.kt
@@ -1,6 +1,7 @@
 package com.mapbox.navigation.core.reroute
 
 import com.mapbox.navigation.base.route.NavigationRoute
+import com.mapbox.navigation.base.route.RouterOrigin
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.trip.session.OffRouteObserver
 
@@ -27,6 +28,6 @@ interface NavigationRerouteController : RerouteController {
          * Called whenever new route(s) has been fetched.
          * @see [MapboxNavigation.setRoutes]
          */
-        fun onNewRoutes(routes: List<NavigationRoute>)
+        fun onNewRoutes(routes: List<NavigationRoute>, routerOrigin: RouterOrigin)
     }
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/reroute/RerouteOptionsAdapter.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/reroute/RerouteOptionsAdapter.kt
@@ -1,0 +1,15 @@
+package com.mapbox.navigation.core.reroute
+
+import com.mapbox.api.directions.v5.models.RouteOptions
+
+/**
+ * Interface allowing to modify [RouteOptions] during a reroute request with the default
+ * Navigation SDK's reroute controller.
+ */
+interface RerouteOptionsAdapter {
+
+    /**
+     * Allows to modify [RouteOptions] before a reroute request is sent.
+     */
+    fun onRouteOptions(routeOptions: RouteOptions): RouteOptions
+}


### PR DESCRIPTION
### Description
- RerouteOptionsDelegate allows to apply own route options on reroute


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
