### PR TITLE
[DROP-IN] Flattened UIBinders in NavigationUIBinders.

### DIFF
--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/DropInNavigationView.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/DropInNavigationView.kt
@@ -77,10 +77,10 @@ class DropInNavigationView @JvmOverloads constructor(
     fun getOnBackPressedCallback(): OnBackPressedCallback = navigationContext.onBackPressedCallback
 
     /**
-     * Customize the views by implementing your own [UIBinder] components.
+     * Customize view by providing your own [UIBinder] components and options.
      */
-    fun customize(navigationUIBinders: NavigationUIBinders) {
-        navigationContext.uiBinders.value = navigationUIBinders
+    fun customizeViewBinders(action: ViewBinderCustomization.() -> Unit) {
+        navigationContext.applyCustomization(action)
     }
 
     /**

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationUIBinders.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationUIBinders.kt
@@ -5,13 +5,47 @@ import com.mapbox.navigation.dropin.binder.infopanel.InfoPanelTripProgressBinder
 import com.mapbox.navigation.dropin.component.maneuver.ManeuverViewBinder
 import com.mapbox.navigation.dropin.component.roadlabel.RoadNameViewBinder
 import com.mapbox.navigation.dropin.component.speedlimit.SpeedLimitViewBinder
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
-class NavigationUIBinders(
-    val speedLimit: UIBinder = SpeedLimitViewBinder(),
-    val maneuver: UIBinder = ManeuverViewBinder(),
-    val roadName: UIBinder = RoadNameViewBinder(),
-    val infoPanelTripProgressBinder: UIBinder = InfoPanelTripProgressBinder(),
-    val infoPanelHeaderBinder: UIBinder? = null,
-    val infoPanelContentBinder: UIBinder? = null,
-    val actionButtonsBinder: UIBinder? = null,
-)
+internal class NavigationUIBinders {
+
+    private val _speedLimit: MutableStateFlow<UIBinder> = MutableStateFlow(SpeedLimitViewBinder())
+    private val _maneuver: MutableStateFlow<UIBinder> = MutableStateFlow(ManeuverViewBinder())
+    private val _roadName: MutableStateFlow<UIBinder> = MutableStateFlow(RoadNameViewBinder())
+    private val _infoPanelTripProgressBinder: MutableStateFlow<UIBinder> =
+        MutableStateFlow(InfoPanelTripProgressBinder())
+    private val _infoPanelHeaderBinder: MutableStateFlow<UIBinder?> = MutableStateFlow(null)
+    private val _infoPanelContentBinder: MutableStateFlow<UIBinder?> = MutableStateFlow(null)
+    private val _actionButtonsBinder: MutableStateFlow<UIBinder?> = MutableStateFlow(null)
+
+    val speedLimit: StateFlow<UIBinder> get() = _speedLimit.asStateFlow()
+    val maneuver: StateFlow<UIBinder> get() = _maneuver.asStateFlow()
+    val roadName: StateFlow<UIBinder> get() = _roadName.asStateFlow()
+    val infoPanelTripProgressBinder: StateFlow<UIBinder>
+        get() = _infoPanelTripProgressBinder.asStateFlow()
+    val infoPanelHeaderBinder: StateFlow<UIBinder?> get() = _infoPanelHeaderBinder.asStateFlow()
+    val infoPanelContentBinder: StateFlow<UIBinder?> get() = _infoPanelContentBinder.asStateFlow()
+    val actionButtonsBinder: StateFlow<UIBinder?> get() = _actionButtonsBinder.asStateFlow()
+
+    fun applyCustomization(customization: ViewBinderCustomization) {
+        customization.speedLimit?.also { _speedLimit.emitOrDefault(it, SpeedLimitViewBinder()) }
+        customization.maneuver?.also { _maneuver.emitOrDefault(it, ManeuverViewBinder()) }
+        customization.roadName?.also { _roadName.emitOrDefault(it, RoadNameViewBinder()) }
+        customization.infoPanelTripProgressBinder?.also {
+            _infoPanelTripProgressBinder.emitOrDefault(it, InfoPanelTripProgressBinder())
+        }
+        customization.infoPanelHeaderBinder?.also { _infoPanelHeaderBinder.emitOrNull(it) }
+        customization.infoPanelContentBinder?.also { _infoPanelContentBinder.emitOrNull(it) }
+        customization.actionButtonsBinder?.also { _actionButtonsBinder.emitOrNull(it) }
+    }
+
+    private fun MutableStateFlow<UIBinder>.emitOrDefault(v: UIBinder, default: UIBinder) {
+        tryEmit(if (v != UIBinder.USE_DEFAULT) v else default)
+    }
+
+    private fun MutableStateFlow<UIBinder?>.emitOrNull(v: UIBinder) {
+        tryEmit(if (v != UIBinder.USE_DEFAULT) v else null)
+    }
+}

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/ViewBinderCustomization.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/ViewBinderCustomization.kt
@@ -1,0 +1,51 @@
+package com.mapbox.navigation.dropin
+
+import com.mapbox.navigation.dropin.binder.UIBinder
+
+/**
+ * DropInNavigationView customizations.
+ */
+class ViewBinderCustomization {
+
+    /**
+     * Customize the speed limit view by providing your own [UIBinder].
+     * Use [UIBinder.USE_DEFAULT] to reset to default.
+     */
+    var speedLimit: UIBinder? = null
+
+    /**
+     * Customize the maneuvers view by providing your own [UIBinder].
+     * Use [UIBinder.USE_DEFAULT] to reset to default.
+     */
+    var maneuver: UIBinder? = null
+
+    /**
+     * Customize the road name view by providing your own [UIBinder].
+     * Use [UIBinder.USE_DEFAULT] to reset to default.
+     */
+    var roadName: UIBinder? = null
+
+    /**
+     * Customize the Info Panel Trip Progress by providing your own [UIBinder].
+     * Use [UIBinder.USE_DEFAULT] to reset to default.
+     */
+    var infoPanelTripProgressBinder: UIBinder? = null
+
+    /**
+     * Customize the Info Panel Header by providing your own [UIBinder].
+     * Use [UIBinder.USE_DEFAULT] to reset to default.
+     */
+    var infoPanelHeaderBinder: UIBinder? = null
+
+    /**
+     * Customize the Info Panel Content by providing your own [UIBinder].
+     * Use [UIBinder.USE_DEFAULT] to reset to default.
+     */
+    var infoPanelContentBinder: UIBinder? = null
+
+    /**
+     * Customize the Action Buttons by providing your own [UIBinder].
+     * Use [UIBinder.USE_DEFAULT] to reset to default.
+     */
+    var actionButtonsBinder: UIBinder? = null
+}

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/binder/UIBinder.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/binder/UIBinder.kt
@@ -26,7 +26,17 @@ interface Binder<T> {
  * deciding what components should be part of the view.
  */
 @OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
-interface UIBinder : Binder<ViewGroup>
+fun interface UIBinder : Binder<ViewGroup> {
+    companion object {
+        val USE_DEFAULT: UIBinder = UIBinder { NoOpMapboxNavigationObserver }
+    }
+}
+
+@OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
+internal object NoOpMapboxNavigationObserver : MapboxNavigationObserver {
+    override fun onAttached(mapboxNavigation: MapboxNavigation) = Unit
+    override fun onDetached(mapboxNavigation: MapboxNavigation) = Unit
+}
 
 /**
  * When returning an observer from [UIBinder.bind], you can use this extension to return

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/binder/infopanel/InfoPanelHeaderBinder.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/binder/infopanel/InfoPanelHeaderBinder.kt
@@ -17,7 +17,7 @@ internal class InfoPanelHeaderBinder(
     private val context: DropInNavigationViewContext
 ) : UIBinder {
 
-    private val tripProgressBinder get() = context.uiBinders.value.infoPanelTripProgressBinder
+    private val tripProgressBinder get() = context.uiBinders.infoPanelTripProgressBinder.value
 
     override fun bind(viewGroup: ViewGroup): MapboxNavigationObserver {
         val scene = Scene.getSceneForLayout(

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/coordinator/ActionButtonsCoordinator.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/coordinator/ActionButtonsCoordinator.kt
@@ -19,8 +19,8 @@ internal class ActionButtonsCoordinator(
 ) : UICoordinator<ViewGroup>(actionList) {
 
     override fun MapboxNavigation.flowViewBinders(): Flow<UIBinder> {
-        return navContext.uiBinders.map { uiBinders ->
-            uiBinders.actionButtonsBinder ?: ActionButtonBinder(navContext)
+        return navContext.uiBinders.actionButtonsBinder.map {
+            it ?: ActionButtonBinder(navContext)
         }
     }
 }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/coordinator/InfoPanelCoordinator.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/coordinator/InfoPanelCoordinator.kt
@@ -13,6 +13,7 @@ import com.mapbox.navigation.dropin.binder.infopanel.InfoPanelHeaderBinder
 import com.mapbox.navigation.dropin.lifecycle.UICoordinator
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
@@ -52,10 +53,13 @@ internal class InfoPanelCoordinator(
     }
 
     override fun MapboxNavigation.flowViewBinders(): Flow<UIBinder> {
-        return context.uiBinders.map { uiBinders ->
+        return combine(
+            context.uiBinders.infoPanelHeaderBinder,
+            context.uiBinders.infoPanelContentBinder
+        ) { headerBinder, contentBinder ->
             InfoPanelBinder(
-                uiBinders.infoPanelHeaderBinder ?: InfoPanelHeaderBinder(context),
-                uiBinders.infoPanelContentBinder
+                headerBinder ?: InfoPanelHeaderBinder(context),
+                contentBinder
             )
         }
     }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/coordinator/ManeuverCoordinator.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/coordinator/ManeuverCoordinator.kt
@@ -28,8 +28,8 @@ internal class ManeuverCoordinator(
             .navigationStateViewModel
             .state
             .flatMapLatest { state ->
-                navigationViewContext.flowUiBinder {
-                    if (state == NavigationState.ActiveNavigation) it.maneuver else EmptyBinder()
+                navigationViewContext.flowUiBinder({ it.maneuver }) { maneuverBinder ->
+                    if (state == NavigationState.ActiveNavigation) maneuverBinder else EmptyBinder()
                 }
             }
     }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/coordinator/RoadNameLabelCoordinator.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/coordinator/RoadNameLabelCoordinator.kt
@@ -14,6 +14,6 @@ internal class RoadNameLabelCoordinator(
 ) : UICoordinator<ViewGroup>(roadNameLabelLayout) {
 
     override fun MapboxNavigation.flowViewBinders(): Flow<UIBinder> {
-        return navigationViewContext.flowUiBinder { it.roadName }
+        return navigationViewContext.flowUiBinder({ it.roadName })
     }
 }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/coordinator/SpeedLimitCoordinator.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/coordinator/SpeedLimitCoordinator.kt
@@ -18,6 +18,6 @@ internal class SpeedLimitCoordinator(
 ) : UICoordinator<ViewGroup>(speedLimitLayout) {
 
     override fun MapboxNavigation.flowViewBinders(): Flow<UIBinder> {
-        return navigationViewContext.flowUiBinder { it.speedLimit }
+        return navigationViewContext.flowUiBinder({ it.speedLimit })
     }
 }

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/NavigationUIBindersTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/NavigationUIBindersTest.kt
@@ -1,0 +1,72 @@
+package com.mapbox.navigation.dropin
+
+import com.mapbox.navigation.dropin.binder.EmptyBinder
+import com.mapbox.navigation.dropin.binder.UIBinder
+import com.mapbox.navigation.dropin.binder.infopanel.InfoPanelTripProgressBinder
+import com.mapbox.navigation.dropin.component.maneuver.ManeuverViewBinder
+import com.mapbox.navigation.dropin.component.roadlabel.RoadNameViewBinder
+import com.mapbox.navigation.dropin.component.speedlimit.SpeedLimitViewBinder
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+internal class NavigationUIBindersTest {
+
+    lateinit var sut: NavigationUIBinders
+
+    @Before
+    fun setUp() {
+        sut = NavigationUIBinders()
+    }
+
+    @Test
+    fun `applyCustomization should update NON NULL binders`() {
+        val c = customization()
+
+        sut.applyCustomization(c)
+
+        assertEquals(c.speedLimit, sut.speedLimit.value)
+        assertEquals(c.maneuver, sut.maneuver.value)
+        assertEquals(c.roadName, sut.roadName.value)
+        assertEquals(c.infoPanelTripProgressBinder, sut.infoPanelTripProgressBinder.value)
+        assertEquals(c.infoPanelHeaderBinder, sut.infoPanelHeaderBinder.value)
+        assertEquals(c.infoPanelContentBinder, sut.infoPanelContentBinder.value)
+        assertEquals(c.actionButtonsBinder, sut.actionButtonsBinder.value)
+    }
+
+    @Test
+    fun `applyCustomization should reset to default binders`() {
+        sut.applyCustomization(customization())
+
+        sut.applyCustomization(
+            ViewBinderCustomization().apply {
+                speedLimit = UIBinder.USE_DEFAULT
+                maneuver = UIBinder.USE_DEFAULT
+                roadName = UIBinder.USE_DEFAULT
+                infoPanelTripProgressBinder = UIBinder.USE_DEFAULT
+                infoPanelHeaderBinder = UIBinder.USE_DEFAULT
+                infoPanelContentBinder = UIBinder.USE_DEFAULT
+                actionButtonsBinder = UIBinder.USE_DEFAULT
+            }
+        )
+
+        assertTrue(sut.speedLimit.value is SpeedLimitViewBinder)
+        assertTrue(sut.maneuver.value is ManeuverViewBinder)
+        assertTrue(sut.roadName.value is RoadNameViewBinder)
+        assertTrue(sut.infoPanelTripProgressBinder.value is InfoPanelTripProgressBinder)
+        assertTrue(sut.infoPanelHeaderBinder.value == null)
+        assertTrue(sut.infoPanelContentBinder.value == null)
+        assertTrue(sut.actionButtonsBinder.value == null)
+    }
+
+    private fun customization() = ViewBinderCustomization().apply {
+        speedLimit = EmptyBinder()
+        maneuver = EmptyBinder()
+        roadName = EmptyBinder()
+        infoPanelTripProgressBinder = EmptyBinder()
+        infoPanelHeaderBinder = EmptyBinder()
+        infoPanelContentBinder = EmptyBinder()
+        actionButtonsBinder = EmptyBinder()
+    }
+}

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/binder/infopanel/InfoPanelHeaderBinderTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/binder/infopanel/InfoPanelHeaderBinderTest.kt
@@ -6,6 +6,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.dropin.DropInNavigationViewContext
 import com.mapbox.navigation.dropin.NavigationUIBinders
+import com.mapbox.navigation.dropin.ViewBinderCustomization
 import com.mapbox.navigation.dropin.binder.EmptyBinder
 import io.mockk.MockKAnnotations
 import io.mockk.every
@@ -13,7 +14,6 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.impl.annotations.SpyK
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -38,11 +38,13 @@ internal class InfoPanelHeaderBinderTest {
         ctx = ApplicationProvider.getApplicationContext()
         sut = InfoPanelHeaderBinder(mockNavContext)
 
-        every { mockNavContext.uiBinders } returns MutableStateFlow(
-            NavigationUIBinders(
-                infoPanelTripProgressBinder = tripProgressBinder,
+        every { mockNavContext.uiBinders } returns NavigationUIBinders().apply {
+            applyCustomization(
+                ViewBinderCustomization().apply {
+                    infoPanelTripProgressBinder = tripProgressBinder
+                }
             )
-        )
+        }
         every { mockNavContext.dispatch } returns {}
     }
 

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/MapboxNavigationViewCustomizedActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/MapboxNavigationViewCustomizedActivity.kt
@@ -12,7 +12,6 @@ import androidx.transition.TransitionManager
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver
-import com.mapbox.navigation.dropin.NavigationUIBinders
 import com.mapbox.navigation.dropin.binder.UIBinder
 import com.mapbox.navigation.dropin.extensions.flowLocationMatcherResult
 import com.mapbox.navigation.dropin.lifecycle.UIComponent
@@ -56,16 +55,14 @@ class MapboxNavigationViewCustomizedActivity : AppCompatActivity() {
         // the default views.
         showCustomViews.observe(this) { showCustomViews ->
             if (showCustomViews) {
-                binding.navigationView.customize(
-                    NavigationUIBinders(
-                        speedLimit = CustomSpeedLimitViewBinder(),
-                    )
-                )
+                binding.navigationView.customizeViewBinders {
+                    speedLimit = CustomSpeedLimitViewBinder()
+                }
             } else {
                 // Reset defaults
-                binding.navigationView.customize(
-                    NavigationUIBinders()
-                )
+                binding.navigationView.customizeViewBinders {
+                    speedLimit = UIBinder.USE_DEFAULT
+                }
             }
         }
         binding.toggleCustomViews.setOnClickListener {


### PR DESCRIPTION
Closes [#1515](https://github.com/mapbox/navigation-sdks/issues/1515)

### Description

- Introduced Customization DSL.
- Removed redundant DropInNavigationView#customize methods
- Updated all binders and coordinators to use updated NavigationUIBinders.
