### PR TITLE
Improve replay route when selecting alternatives routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Mapbox welcomes participation and contributions from everyone.
 #### Features
 - Added a new `RailwayCrossing` type to `RoadObject`s. [#5552](https://github.com/mapbox/mapbox-navigation-android/pull/5552)
 - Added point exclusion option for onboard router. [#5552](https://github.com/mapbox/mapbox-navigation-android/pull/5552)
+- Improved capabilities to replay route alternatives with the `ReplayProgressObserver` by respecting the current distance traveled. This fixes the jump to the beginning of the alternative route upon the switch. [#5586](https://github.com/mapbox/mapbox-navigation-android/pull/5586)
 
 #### Bug fixes and improvements
 - Fixed an issue where a route refresh would only refresh annotations for the current leg of a route instead of for all remaining legs of a route. [#5552](https://github.com/mapbox/mapbox-navigation-android/pull/5552)

--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -480,6 +480,7 @@ package com.mapbox.navigation.core.replay.history {
 package com.mapbox.navigation.core.replay.route {
 
   public final class ReplayProgressObserver implements com.mapbox.navigation.core.trip.session.RouteProgressObserver {
+    ctor public ReplayProgressObserver(com.mapbox.navigation.core.replay.MapboxReplayer mapboxReplayer, com.mapbox.navigation.core.replay.route.ReplayRouteMapper replayRouteMapper = ReplayRouteMapper());
     ctor public ReplayProgressObserver(com.mapbox.navigation.core.replay.MapboxReplayer mapboxReplayer);
     method public void onRouteProgressChanged(com.mapbox.navigation.base.trip.model.RouteProgress routeProgress);
     method public com.mapbox.navigation.core.replay.route.ReplayProgressObserver updateOptions(com.mapbox.navigation.core.replay.route.ReplayRouteOptions options);

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayProgressObserver.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayProgressObserver.kt
@@ -1,25 +1,30 @@
 package com.mapbox.navigation.core.replay.route
 
 import com.mapbox.api.directions.v5.models.RouteLeg
+import com.mapbox.geojson.Point
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.replay.MapboxReplayer
+import com.mapbox.navigation.core.replay.history.ReplayEventBase
+import com.mapbox.navigation.core.replay.history.ReplayEventUpdateLocation
 import com.mapbox.navigation.core.trip.session.RouteProgressObserver
+import com.mapbox.turf.TurfConstants
+import com.mapbox.turf.TurfMeasurement
 
 /**
  * Register this to [MapboxNavigation.registerRouteProgressObserver].
  * This class will feed locations to your [MapboxReplayer] and simulate
  * your active route for you.
  */
-class ReplayProgressObserver(
+class ReplayProgressObserver @JvmOverloads constructor(
     /**
      * As navigation receives [RouteProgress], this will push events to your
      * replay history player to be played.
      */
-    private val mapboxReplayer: MapboxReplayer
+    private val mapboxReplayer: MapboxReplayer,
+    private val replayRouteMapper: ReplayRouteMapper = ReplayRouteMapper()
 ) : RouteProgressObserver {
 
-    private val replayRouteMapper = ReplayRouteMapper()
     private var currentRouteLeg: RouteLeg? = null
 
     /**
@@ -38,20 +43,53 @@ class ReplayProgressObserver(
      * @param routeProgress from the navigation session
      */
     override fun onRouteProgressChanged(routeProgress: RouteProgress) {
-        val routeProgressRouteLeg = routeProgress.currentLegProgress?.routeLeg
-        if (routeProgressRouteLeg != currentRouteLeg) {
+        val currentLegProgress = routeProgress.currentLegProgress
+        val routeProgressRouteLeg = currentLegProgress?.routeLeg
+        if (routeProgressRouteLeg != currentRouteLeg && currentLegProgress != null) {
             this.currentRouteLeg = routeProgressRouteLeg
-            onRouteLegChanged(routeProgressRouteLeg)
+            onRouteLegChanged(routeProgressRouteLeg, currentLegProgress.distanceTraveled)
         }
     }
 
-    private fun onRouteLegChanged(routeProgressRouteLeg: RouteLeg?) {
-        if (routeProgressRouteLeg != null) {
-            val replayEvents = replayRouteMapper.mapRouteLegGeometry(routeProgressRouteLeg)
-            if (replayEvents.isNotEmpty()) {
-                mapboxReplayer.pushEvents(replayEvents)
-                mapboxReplayer.seekTo(replayEvents.first())
+    private fun onRouteLegChanged(routeProgressRouteLeg: RouteLeg?, distanceTraveled: Float) {
+        if (routeProgressRouteLeg == null) return
+        val replayEvents = replayRouteMapper.mapRouteLegGeometry(routeProgressRouteLeg)
+        if (replayEvents.isEmpty()) return
+        val seekToIndex = indexAlong(replayEvents, distanceTraveled)
+        mapboxReplayer.pushEvents(replayEvents)
+        mapboxReplayer.seekTo(replayEvents[seekToIndex])
+    }
+
+    /**
+     * Measures the distance between the [events] and returns the index of an event that is greater
+     * than the [distanceTraveled]. If the distanceTraveled is greater than the event distance, the
+     * last index is returned. If the event list is empty -1 is returned.
+     *
+     * events: 0---1-------2------3--4-----5------
+     *         ==distanceTraveled====>||
+     * returns index: 5
+     */
+    private fun indexAlong(events: List<ReplayEventBase>, distanceTraveled: Float): Int {
+        var currentDistance = 0.0
+        var index = -1
+        var lastPoint: Point? = null
+        for (item in events) {
+            if (item is ReplayEventUpdateLocation) {
+                val currentPoint = Point.fromLngLat(item.location.lon, item.location.lat)
+                lastPoint?.let { point ->
+                    currentDistance += TurfMeasurement.distance(
+                        point,
+                        currentPoint,
+                        TurfConstants.UNIT_METERS
+                    )
+                }
+                lastPoint = currentPoint
+            }
+            index++
+            if (currentDistance >= distanceTraveled) {
+                return index
             }
         }
+        return index
     }
 }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/route/ReplayProgressObserverTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/route/ReplayProgressObserverTest.kt
@@ -1,0 +1,188 @@
+package com.mapbox.navigation.core.replay.route
+
+import com.mapbox.api.directions.v5.models.RouteLeg
+import com.mapbox.geojson.utils.PolylineUtils
+import com.mapbox.navigation.base.trip.model.RouteProgress
+import com.mapbox.navigation.core.replay.MapboxReplayer
+import com.mapbox.navigation.core.replay.history.ReplayEventBase
+import com.mapbox.navigation.core.replay.history.ReplayEventUpdateLocation
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import io.mockk.verifyOrder
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class ReplayProgressObserverTest {
+
+    private val mapboxReplayer = mockk<MapboxReplayer>(relaxed = true)
+    private val replayRouteMapper = mockk<ReplayRouteMapper>(relaxed = true)
+    private val replayProgressObserver = ReplayProgressObserver(mapboxReplayer, replayRouteMapper)
+
+    @Test
+    fun `should map progress and push to replayer`() {
+        every { replayRouteMapper.mapRouteLegGeometry(any()) } returns mockEventsForShortRoute()
+
+        replayProgressObserver.onRouteProgressChanged(
+            mockValidRouteProgress(mockk(), mockDistanceTraveled = 0.0f)
+        )
+
+        verifyOrder {
+            replayRouteMapper.mapRouteLegGeometry(any())
+            mapboxReplayer.pushEvents(any())
+            mapboxReplayer.seekTo(any<ReplayEventBase>())
+        }
+    }
+
+    @Test
+    fun `should push events once per route leg`() {
+        every { replayRouteMapper.mapRouteLegGeometry(any()) } returns mockEventsForShortRoute()
+
+        val mockRouteLeg = mockk<RouteLeg>()
+        replayProgressObserver.onRouteProgressChanged(
+            mockValidRouteProgress(mockRouteLeg, mockDistanceTraveled = 10.0f)
+        )
+        replayProgressObserver.onRouteProgressChanged(
+            mockValidRouteProgress(mockRouteLeg, mockDistanceTraveled = 50.0f)
+        )
+
+        verify(exactly = 1) {
+            replayRouteMapper.mapRouteLegGeometry(any())
+            mapboxReplayer.pushEvents(any())
+            mapboxReplayer.seekTo(any<ReplayEventBase>())
+        }
+    }
+
+    @Test
+    fun `should push new events for new route leg`() {
+        every { replayRouteMapper.mapRouteLegGeometry(any()) } returns mockEventsForShortRoute()
+
+        replayProgressObserver.onRouteProgressChanged(
+            mockValidRouteProgress(mockk(), mockDistanceTraveled = 10.0f)
+        )
+        replayProgressObserver.onRouteProgressChanged(
+            mockValidRouteProgress(mockk(), mockDistanceTraveled = 50.0f)
+        )
+
+        verify(exactly = 2) {
+            replayRouteMapper.mapRouteLegGeometry(any())
+            mapboxReplayer.pushEvents(any())
+            mapboxReplayer.seekTo(any<ReplayEventBase>())
+        }
+    }
+
+    @Test
+    fun `should seekTo first event when distanceTraveled is zero`() {
+        every { replayRouteMapper.mapRouteLegGeometry(any()) } returns mockEvents(
+            """yg{bgA|cufhFoEiAiA[}i@oNoD_As@QqdAeX"""
+        )
+        val eventsSlot = slot<List<ReplayEventBase>>()
+        val seekToSlot = slot<ReplayEventBase>()
+        every { mapboxReplayer.pushEvents(capture(eventsSlot)) } returns mapboxReplayer
+        every { mapboxReplayer.seekTo(capture(seekToSlot)) } just Runs
+
+        replayProgressObserver.onRouteProgressChanged(
+            mockValidRouteProgress(mockk(), 0.0f)
+        )
+
+        // Seek to first location because 0.0 distance traveled
+        assertEquals(7, eventsSlot.captured.size)
+        assertEquals(0.0, eventsSlot.captured[0].eventTimestamp, 0.0)
+        assertEquals(0.0, seekToSlot.captured.eventTimestamp, 0.0)
+    }
+
+    @Test
+    fun `should seekTo mid route when distanceTraveled is mid route`() {
+        every { replayRouteMapper.mapRouteLegGeometry(any()) } returns mockEvents(
+            """yg{bgA|cufhFoEiAiA[}i@oNoD_As@QqdAeX"""
+        )
+        val eventsSlot = slot<List<ReplayEventBase>>()
+        val seekToSlot = slot<ReplayEventBase>()
+        every { mapboxReplayer.pushEvents(capture(eventsSlot)) } returns mapboxReplayer
+        every { mapboxReplayer.seekTo(capture(seekToSlot)) } just Runs
+
+        replayProgressObserver.onRouteProgressChanged(
+            mockValidRouteProgress(mockk(), 90.0f)
+        )
+
+        // Seek to the 3rd event timestamp because 90 meters has been traveled
+        assertEquals(7, eventsSlot.captured.size)
+        assertEquals(0.0, eventsSlot.captured[0].eventTimestamp, 0.0)
+        assertEquals(3.0, seekToSlot.captured.eventTimestamp, 0.0)
+    }
+
+    @Test
+    fun `should not push events when route is empty`() {
+        every { replayRouteMapper.mapRouteLegGeometry(any()) } returns mockEvents("")
+        val eventsSlot = slot<List<ReplayEventBase>>()
+        val seekToSlot = slot<ReplayEventBase>()
+        every { mapboxReplayer.pushEvents(capture(eventsSlot)) } returns mapboxReplayer
+        every { mapboxReplayer.seekTo(capture(seekToSlot)) } just Runs
+
+        replayProgressObserver.onRouteProgressChanged(
+            mockValidRouteProgress(mockk(), 90.0f)
+        )
+
+        assertFalse(eventsSlot.isCaptured)
+        assertFalse(seekToSlot.isCaptured)
+    }
+
+    @Test
+    fun `should seekTo alternative route with distanceTraveled`() {
+        val firstRouteLeg: RouteLeg = mockk()
+        val secondRouteLeg: RouteLeg = mockk()
+        every { replayRouteMapper.mapRouteLegGeometry(firstRouteLeg) } returns mockEvents(
+            """yg{bgA|cufhFoEiAiA[}i@oNoD_As@QqdAeX"""
+        )
+        every { replayRouteMapper.mapRouteLegGeometry(secondRouteLeg) } returns mockEvents(
+            """yg{bgA|cufhFoEiAiA[}i@oNoD_As@Q"""
+        )
+        val eventsSlot = mutableListOf<List<ReplayEventBase>>()
+        val seekToSlot = mutableListOf<ReplayEventBase>()
+        every { mapboxReplayer.pushEvents(capture(eventsSlot)) } returns mapboxReplayer
+        every { mapboxReplayer.seekTo(capture(seekToSlot)) } just Runs
+
+        replayProgressObserver.onRouteProgressChanged(
+            mockValidRouteProgress(firstRouteLeg, 0.0f)
+        )
+        replayProgressObserver.onRouteProgressChanged(
+            mockValidRouteProgress(secondRouteLeg, 90.0f)
+        )
+
+        val alternativeRouteEvents = eventsSlot[1]
+        val alternativeRouteSeekTo = seekToSlot[1]
+        assertEquals(6, alternativeRouteEvents.size)
+        assertEquals(0.0, alternativeRouteEvents[0].eventTimestamp, 0.0)
+        assertEquals(3.0, alternativeRouteSeekTo.eventTimestamp, 0.0)
+    }
+
+    private fun mockValidRouteProgress(
+        mockRouteLeg: RouteLeg,
+        mockDistanceTraveled: Float
+    ): RouteProgress = mockk {
+        every { currentLegProgress } returns mockk {
+            every { routeLeg } returns mockRouteLeg
+            every { distanceTraveled } returns mockDistanceTraveled
+        }
+    }
+
+    private fun mockEventsForShortRoute(): List<ReplayEventBase> {
+        return mockEvents("""wt}ohAj||tfFoD`Sm_@iMcKgD""")
+    }
+
+    private fun mockEvents(encodedPolyline: String): List<ReplayEventBase> {
+        return PolylineUtils.decode(encodedPolyline, 6).mapIndexed { index, value ->
+            ReplayEventUpdateLocation(
+                index.toDouble(),
+                mockk(relaxed = true) {
+                    every { lon } returns value.longitude()
+                    every { lat } returns value.latitude()
+                }
+            )
+        }
+    }
+}


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Resolves https://github.com/mapbox/mapbox-navigation-android/issues/5419

There has been a long outstanding issue. When replaying a route with alternatives, the replayer will reset to the beginning when an alternative is selected.

This pull request looks is fixing that.

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


https://user-images.githubusercontent.com/3021882/158919028-87aa3349-911e-4eaf-8388-da688f8e02c7.mp4


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
