### PR TITLE
Added max height/width to certain UI component containers.

### DIFF
--- a/libnavui-dropin/src/main/res/layout/drop_in_navigation_view.xml
+++ b/libnavui-dropin/src/main/res/layout/drop_in_navigation_view.xml
@@ -31,25 +31,27 @@
 
             <FrameLayout
                 android:id="@+id/guidanceLayout"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
                 app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 tools:layout_height="120dp"
+                app:layout_constraintHeight_max="350dp"
                 tools:background="@color/mapbox_main_maneuver_background_color" />
 
             <FrameLayout
                 android:id="@+id/speedLimitLayout"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
+                android:layout_width="75dp"
+                android:layout_height="86dp"
                 android:layout_marginStart="8dp"
                 android:layout_marginTop="8dp"
-                app:layout_constraintTop_toBottomOf="@id/guidanceLayout"
                 app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/guidanceLayout"
                 tools:background="#eee"
+                tools:layout_height="60dp"
                 tools:layout_width="50dp"
-                tools:layout_height="60dp" />
+                android:layout_gravity="start|top"/>
 
             <LinearLayout
                 android:id="@+id/actionListLayout"
@@ -66,7 +68,7 @@
             <FrameLayout
                 android:id="@+id/roadNameLayout"
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
+                android:layout_height="0dp"
                 android:layout_gravity="center"
                 tools:background="#eee"
                 tools:layout_height="52dp"
@@ -74,7 +76,8 @@
                 app:layout_constraintBottom_toTopOf="@+id/guidelineBottom"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                android:layout_marginBottom="15dp" />
+                android:layout_marginBottom="15dp"
+                app:layout_constraintHeight_max="62dp"/>
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 


### PR DESCRIPTION
### Description
Max width/height attributes set on certain drop-in UI element containers.  As a starting point a max height/width of 20% greater than the default height/widths of the Mapbox widgets was tested with and used.  

### Screenshots or Gifs

