### PR TITLE
[DROP-IN] Added haptic feedback for map long press.

### DIFF
--- a/libnavui-dropin/src/main/AndroidManifest.xml
+++ b/libnavui-dropin/src/main/AndroidManifest.xml
@@ -2,4 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.mapbox.navigation.dropin">
 
+    <uses-permission android:name="android.permission.VIBRATE"/>
+
 </manifest>

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/marker/FreeDriveLongPressMapComponent.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/marker/FreeDriveLongPressMapComponent.kt
@@ -13,6 +13,7 @@ import com.mapbox.navigation.dropin.component.routefetch.RoutesAction
 import com.mapbox.navigation.dropin.component.routefetch.RoutesViewModel
 import com.mapbox.navigation.dropin.lifecycle.UIComponent
 import com.mapbox.navigation.dropin.model.Destination
+import com.mapbox.navigation.dropin.util.HapticFeedback
 
 internal class FreeDriveLongPressMapComponent(
     private val mapView: MapView,
@@ -21,14 +22,19 @@ internal class FreeDriveLongPressMapComponent(
     private val destinationViewModel: DestinationViewModel,
 ) : UIComponent() {
 
+    private var hapticFeedback: HapticFeedback? = null
+
     override fun onAttached(mapboxNavigation: MapboxNavigation) {
         super.onAttached(mapboxNavigation)
+        hapticFeedback =
+            HapticFeedback.create(mapboxNavigation.navigationOptions.applicationContext)
         mapView.gestures.addOnMapLongClickListener(longClickListener)
     }
 
     override fun onDetached(mapboxNavigation: MapboxNavigation) {
         super.onDetached(mapboxNavigation)
         mapView.gestures.removeOnMapLongClickListener(longClickListener)
+        hapticFeedback = null
     }
 
     private val longClickListener = OnMapLongClickListener { point ->
@@ -41,6 +47,7 @@ internal class FreeDriveLongPressMapComponent(
         navigationStateViewModel.invoke(
             NavigationStateAction.Update(NavigationState.DestinationPreview)
         )
+        hapticFeedback?.tick()
         false
     }
 }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/marker/RoutePreviewLongPressMapComponent.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/marker/RoutePreviewLongPressMapComponent.kt
@@ -11,6 +11,7 @@ import com.mapbox.navigation.dropin.component.routefetch.RoutesAction
 import com.mapbox.navigation.dropin.component.routefetch.RoutesViewModel
 import com.mapbox.navigation.dropin.lifecycle.UIComponent
 import com.mapbox.navigation.dropin.model.Destination
+import com.mapbox.navigation.dropin.util.HapticFeedback
 import com.mapbox.navigation.utils.internal.ifNonNull
 import com.mapbox.navigation.utils.internal.logW
 
@@ -21,20 +22,26 @@ internal class RoutePreviewLongPressMapComponent(
     private val destinationViewModel: DestinationViewModel,
 ) : UIComponent() {
 
+    private var hapticFeedback: HapticFeedback? = null
+
     override fun onAttached(mapboxNavigation: MapboxNavigation) {
         super.onAttached(mapboxNavigation)
+        hapticFeedback =
+            HapticFeedback.create(mapboxNavigation.navigationOptions.applicationContext)
         mapView.gestures.addOnMapLongClickListener(longClickListener)
     }
 
     override fun onDetached(mapboxNavigation: MapboxNavigation) {
         super.onDetached(mapboxNavigation)
         mapView.gestures.removeOnMapLongClickListener(longClickListener)
+        hapticFeedback = null
     }
 
     private val longClickListener = OnMapLongClickListener { point ->
         ifNonNull(locationViewModel.lastPoint) { lastPoint ->
             destinationViewModel.invoke(DestinationAction.SetDestination(Destination(point)))
             routesViewModel.invoke(RoutesAction.FetchPoints(listOf(lastPoint, point)))
+            hapticFeedback?.tick()
         } ?: logW(TAG, "Current location is unknown so map long press does nothing")
         false
     }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/util/HapticFeedback.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/util/HapticFeedback.kt
@@ -1,0 +1,43 @@
+package com.mapbox.navigation.dropin.util
+
+import android.content.Context
+import android.os.Build
+import android.os.VibrationEffect
+import android.os.Vibrator
+import android.os.VibratorManager
+
+/**
+ * Facade for OS Vibrator.
+ */
+internal class HapticFeedback(context: Context) {
+
+    internal val vibrator = if (Build.VERSION_CODES.S <= Build.VERSION.SDK_INT) {
+        (context.getSystemService(Context.VIBRATOR_MANAGER_SERVICE) as? VibratorManager)
+            ?.defaultVibrator
+    } else {
+        (context.getSystemService(Context.VIBRATOR_SERVICE) as? Vibrator)
+    }
+
+    fun tick() {
+        vibrate(TICK_DURATION_MS)
+    }
+
+    fun vibrate(milliseconds: Long) {
+        if (Build.VERSION_CODES.O <= Build.VERSION.SDK_INT) {
+            vibrator?.vibrate(
+                VibrationEffect.createOneShot(
+                    milliseconds,
+                    VibrationEffect.DEFAULT_AMPLITUDE
+                )
+            )
+        } else {
+            vibrator?.vibrate(milliseconds)
+        }
+    }
+
+    companion object {
+        const val TICK_DURATION_MS: Long = 10
+
+        fun create(context: Context) = HapticFeedback(context)
+    }
+}

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/util/HapticFeedbackTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/util/HapticFeedbackTest.kt
@@ -1,0 +1,58 @@
+package com.mapbox.navigation.dropin.util
+
+import android.content.Context
+import android.os.Build
+import android.os.VibrationEffect
+import android.os.Vibrator
+import android.os.VibratorManager
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+class HapticFeedbackTest {
+
+    lateinit var context: Context
+    lateinit var oldVibrator: Vibrator
+    lateinit var newVibrator: Vibrator
+
+    @Before
+    fun setUp() {
+        oldVibrator = mockk(relaxed = true)
+        newVibrator = mockk(relaxed = true)
+        context = mockk {
+            every { getSystemService(Context.VIBRATOR_MANAGER_SERVICE) } answers {
+                mockk<VibratorManager> {
+                    every { defaultVibrator } returns newVibrator
+                }
+            }
+            every { getSystemService(Context.VIBRATOR_SERVICE) } returns oldVibrator
+        }
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.N])
+    @Test
+    fun `vibrate should use old Vibrator API`() {
+        val sut = HapticFeedback.create(context)
+
+        sut.vibrate(100)
+
+        verify { oldVibrator.vibrate(100) }
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.S])
+    @Test
+    fun `vibrate should use new Vibrator API`() {
+        val sut = HapticFeedback.create(context)
+
+        sut.vibrate(100)
+
+        val vibe = VibrationEffect.createOneShot(100, VibrationEffect.DEFAULT_AMPLITUDE)
+        verify { newVibrator.vibrate(vibe) }
+    }
+}


### PR DESCRIPTION
Closes [#1535](https://github.com/mapbox/navigation-sdks/issues/1535)

### Description

- Introduced `HapticFeedback` class that wraps system Vibrator.
- Updated `LongPressMapComponent` to use  `HapticFeedback` to vibrate on map long click
