### PR TITLE
Add LocationMatcherResult#isDegradedMapMatching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Mapbox welcomes participation and contributions from everyone.
 
 ## Unreleased
 - Added `RerouteOptionsAdapter`. It allows to modify `RouteOptions` on reroute for default implementation of `RerouteController` via `MapboxNavigation#setRerouteOptionsAdapter`. [#5573](https://github.com/mapbox/mapbox-navigation-android/pull/5573)
+- Added `LocationMatcherResult#isDegradedMapMatching` which allows to understand if current matched location was produced using limited map matching approach(e.g. due to lack of map data). [#5606](https://github.com/mapbox/mapbox-navigation-android/pull/5606)
 
 ## Mapbox Navigation SDK 2.4.0-beta.2 - March 18, 2022
 ### Changelog

--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -807,9 +807,11 @@ package com.mapbox.navigation.core.trip.session {
     method public float getRoadEdgeMatchProbability();
     method public com.mapbox.navigation.base.speed.model.SpeedLimit? getSpeedLimit();
     method public Integer? getZLevel();
+    method public boolean isDegradedMapMatching();
     method public boolean isOffRoad();
     method public boolean isTeleport();
     property public final android.location.Location enhancedLocation;
+    property public final boolean isDegradedMapMatching;
     property public final boolean isOffRoad;
     property public final boolean isTeleport;
     property public final java.util.List<android.location.Location> keyPoints;

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/navigator/NavigatorMapper.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/navigator/NavigatorMapper.kt
@@ -321,7 +321,8 @@ internal fun TripStatus.getLocationMatcherResult(
         navigationStatus.prepareSpeedLimit(),
         navigationStatus.mapMatcherOutput.matches.firstOrNull()?.proba ?: 0f,
         navigationStatus.layer,
-        road
+        road,
+        navigationStatus.isFallback
     )
 }
 

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/LocationMatcherResult.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/LocationMatcherResult.kt
@@ -22,7 +22,8 @@ import com.mapbox.navigation.base.speed.model.SpeedLimit
  * @param roadEdgeMatchProbability when map matcher snaps to a road, this is the confidence in the chosen edge from all nearest edges.
  * @param zLevel [Int] current Z-level. Can be used to build a route from a proper level of a road.
  * @param road Road can be used to get information about the [Road] including name, shield name and shield url.
- * @param isDegradedMapMatching whether map matching was running in "degraded" mode, i.e. can have worse quality(usually happens due to the lack of map data)
+ * @param isDegradedMapMatching whether map matching was running in "degraded" mode, i.e. can have worse quality(usually happens due to the lack of map data).
+ * In practice "degraded" mode means raw location in free drive and worse off-route experience in case of route set.
  */
 class LocationMatcherResult internal constructor(
     val enhancedLocation: Location,

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/LocationMatcherResult.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/LocationMatcherResult.kt
@@ -22,6 +22,7 @@ import com.mapbox.navigation.base.speed.model.SpeedLimit
  * @param roadEdgeMatchProbability when map matcher snaps to a road, this is the confidence in the chosen edge from all nearest edges.
  * @param zLevel [Int] current Z-level. Can be used to build a route from a proper level of a road.
  * @param road Road can be used to get information about the [Road] including name, shield name and shield url.
+ * @param isDegradedMapMatching whether map matching was running in "degraded" mode, i.e. can have worse quality(usually happens due to the lack of map data)
  */
 class LocationMatcherResult internal constructor(
     val enhancedLocation: Location,
@@ -33,6 +34,7 @@ class LocationMatcherResult internal constructor(
     val roadEdgeMatchProbability: Float,
     val zLevel: Int?,
     val road: Road,
+    val isDegradedMapMatching: Boolean
 ) {
 
     /**
@@ -52,7 +54,7 @@ class LocationMatcherResult internal constructor(
         if (speedLimit != other.speedLimit) return false
         if (roadEdgeMatchProbability != other.roadEdgeMatchProbability) return false
         if (road != other.road) return false
-
+        if (isDegradedMapMatching != other.isDegradedMapMatching) return false
         return true
     }
 
@@ -68,6 +70,7 @@ class LocationMatcherResult internal constructor(
         result = 31 * result + speedLimit.hashCode()
         result = 31 * result + roadEdgeMatchProbability.hashCode()
         result = 31 * result + road.hashCode()
+        result = 31 * result + isDegradedMapMatching.hashCode()
         return result
     }
 
@@ -78,6 +81,7 @@ class LocationMatcherResult internal constructor(
         return "LocationMatcherResult(enhancedLocation=$enhancedLocation, " +
             "keyPoints=$keyPoints, isOffRoad=$isOffRoad, offRoadProbability=$offRoadProbability, " +
             "isTeleport=$isTeleport, speedLimit=$speedLimit, " +
-            "roadEdgeMatchProbability=$roadEdgeMatchProbability, road=$road)"
+            "roadEdgeMatchProbability=$roadEdgeMatchProbability, road=$road, " +
+            "isDegradedMapMatching=$isDegradedMapMatching)"
     }
 }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/navigator/NavigatorMapperTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/navigator/NavigatorMapperTest.kt
@@ -128,6 +128,7 @@ class NavigatorMapperTest {
                 }
                 every { layer } returns null
                 every { roads } returns listOf(com.mapbox.navigator.Road("Central Av", null, null))
+                every { isFallback } returns false
             }
         )
         val expected = LocationMatcherResult(
@@ -143,7 +144,8 @@ class NavigatorMapperTest {
             ),
             roadEdgeMatchProbability = 1f,
             zLevel = null,
-            road = road
+            road = road,
+            isDegradedMapMatching = false
         )
 
         val result = tripStatus.getLocationMatcherResult(enhancedLocation, keyPoints, road)
@@ -170,6 +172,7 @@ class NavigatorMapperTest {
                 }
                 every { layer } returns null
                 every { roads } returns listOf(com.mapbox.navigator.Road("Central Av", null, null))
+                every { isFallback } returns false
             }
         )
         val expected = LocationMatcherResult(
@@ -185,7 +188,8 @@ class NavigatorMapperTest {
             ),
             roadEdgeMatchProbability = 1f,
             zLevel = null,
-            road = road
+            road = road,
+            isDegradedMapMatching = false
         )
 
         val result = tripStatus.getLocationMatcherResult(enhancedLocation, keyPoints, road)
@@ -195,7 +199,7 @@ class NavigatorMapperTest {
 
     @OptIn(ExperimentalMapboxNavigationAPI::class)
     @Test
-    fun `location matcher result when off road`() {
+    fun `location matcher result when off road and degraded map matching`() {
         val road: Road = RoadFactory.buildRoadObject(navigationStatus)
         val tripStatus = TripStatus(
             route,
@@ -212,6 +216,7 @@ class NavigatorMapperTest {
                 }
                 every { layer } returns null
                 every { roads } returns listOf(com.mapbox.navigator.Road("Central Av", null, null))
+                every { isFallback } returns true
             }
         )
         val expected = LocationMatcherResult(
@@ -227,7 +232,8 @@ class NavigatorMapperTest {
             ),
             roadEdgeMatchProbability = 1f,
             zLevel = null,
-            road = road
+            road = road,
+            isDegradedMapMatching = true
         )
 
         val result = tripStatus.getLocationMatcherResult(enhancedLocation, keyPoints, road)
@@ -254,6 +260,7 @@ class NavigatorMapperTest {
                 }
                 every { layer } returns null
                 every { roads } returns listOf(com.mapbox.navigator.Road("Central Av", null, null))
+                every { isFallback } returns false
             }
         )
         val expected = LocationMatcherResult(
@@ -269,7 +276,8 @@ class NavigatorMapperTest {
             ),
             roadEdgeMatchProbability = 1f,
             zLevel = null,
-            road = road
+            road = road,
+            isDegradedMapMatching = false
         )
 
         val result = tripStatus.getLocationMatcherResult(enhancedLocation, keyPoints, road)
@@ -289,6 +297,7 @@ class NavigatorMapperTest {
             }
             every { layer } returns null
             every { roads } returns listOf(com.mapbox.navigator.Road("Central Av", null, null))
+            every { isFallback } returns false
         }
         val road: Road = RoadFactory.buildRoadObject(navigationStatus)
         val tripStatus = TripStatus(
@@ -308,7 +317,8 @@ class NavigatorMapperTest {
             ),
             roadEdgeMatchProbability = 0f,
             zLevel = null,
-            road = road
+            road = road,
+            isDegradedMapMatching = false
         )
 
         val result = tripStatus.getLocationMatcherResult(enhancedLocation, keyPoints, road)
@@ -335,6 +345,7 @@ class NavigatorMapperTest {
                 }
                 every { layer } returns 2
                 every { roads } returns listOf(com.mapbox.navigator.Road("Central Av", null, null))
+                every { isFallback } returns false
             }
         )
         val expected = LocationMatcherResult(
@@ -350,7 +361,8 @@ class NavigatorMapperTest {
             ),
             roadEdgeMatchProbability = 1f,
             zLevel = 2,
-            road = road
+            road = road,
+            isDegradedMapMatching = false
         )
 
         val result = tripStatus.getLocationMatcherResult(enhancedLocation, keyPoints, road)


### PR DESCRIPTION
### Description
Sometimes developers want to know if SDK used so called "fallback" mode when doing map matching, which can have worse quality than usual one.  This PR adds `LocationMatcherResult#isDegradedMapMatching` which exposes existing `NavigationStatus#isFallback`(which is true in "fallback" mode) flag publicly. 

<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
