### PR TITLE
Added fix to stop the camera from setting itself to idle when an ongoing transition is canceled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Mapbox welcomes participation and contributions from everyone.
 #### Features
 
 #### Bug fixes and improvements
+- :warning: Realigned all `NavigationCamera` transitions to not fallback to `Idle` if a transition is canceled to keep the behavior consistent and predictable (state transitions used to be cancelable while frame transitions weren't). If you need the `NavigationCamera` to reset to `Idle` on external interactions or cancellations, use `NavigationBasicGesturesHandler` or `NavigationScaleGestureHandler` [#5607](https://github.com/mapbox/mapbox-navigation-android/pull/5607)
 
 ## Mapbox Navigation SDK 2.4.0-beta.3 - March 25, 2022
 ### Changelog

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/NavigationCamera.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/NavigationCamera.kt
@@ -77,10 +77,9 @@ import java.util.concurrent.CopyOnWriteArraySet
  * executing, listening for cancellation, adjusting states, etc.
  *
  * ## Gestures and other camera interactions
- * When [FOLLOWING] or [OVERVIEW] states are engaged, the `NavigationCamera` assumes full ownership
- * of the [CameraAnimationsPlugin]. This means that if any other camera transition is scheduled
- * outside of the `NavigationCamera`’s context, there might be side-effects or glitches.
- * Consequently, if you want to perform other camera transitions,
+ * The `NavigationCamera` assumes full ownership of the [CameraAnimationsPlugin]. This means that
+ * if any other camera transition is scheduled outside of the `NavigationCamera`’s context, there
+ * might be side-effects or glitches. Consequently, if you want to perform other camera transitions,
  * first call [requestNavigationCameraToIdle], and only after that perform the desired transition.
  *
  * Alternatively, you can use one of the default implementations
@@ -163,7 +162,7 @@ class NavigationCamera(
 
     /**
      * Executes a transition to [FOLLOWING] state. When started, goes to [TRANSITION_TO_FOLLOWING]
-     * and to the final [FOLLOWING] when ended. If transition is canceled, state goes to [IDLE].
+     * and to the final [FOLLOWING] when ended.
      *
      * The target camera position is obtained with [ViewportDataSource.getViewportData].
      *
@@ -189,7 +188,7 @@ class NavigationCamera(
 
     /**
      * Executes a transition to [FOLLOWING] state. When started, goes to [TRANSITION_TO_FOLLOWING]
-     * and to the final [FOLLOWING] when ended. If transition is canceled, state goes to [IDLE].
+     * and to the final [FOLLOWING] when ended.
      *
      * The target camera position is obtained with [ViewportDataSource.getViewportData].
      *
@@ -239,7 +238,7 @@ class NavigationCamera(
 
     /**
      * Executes a transition to [OVERVIEW] state. When started, goes to [TRANSITION_TO_OVERVIEW]
-     * and to the final [OVERVIEW] when ended. If transition is canceled, state goes to [IDLE].
+     * and to the final [OVERVIEW] when ended.
      *
      * The target camera position is obtained with [ViewportDataSource.getViewportData].
      *
@@ -265,7 +264,7 @@ class NavigationCamera(
 
     /**
      * Executes a transition to [OVERVIEW] state. When started, goes to [TRANSITION_TO_OVERVIEW]
-     * and to the final [OVERVIEW] when ended. If transition is canceled, state goes to [IDLE].
+     * and to the final [OVERVIEW] when ended.
      *
      * The target camera position is obtained with [ViewportDataSource.getViewportData].
      *
@@ -443,9 +442,7 @@ class NavigationCamera(
         }
 
         override fun onAnimationEnd(animation: Animator?) {
-            if (isCanceled) {
-                setIdleProperties()
-            } else {
+            if (!isCanceled) {
                 this@NavigationCamera.frameTransitionOptions = frameTransitionOptions
                 state = finalState
             }

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/camera/NavigationCameraTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/camera/NavigationCameraTest.kt
@@ -208,23 +208,23 @@ class NavigationCameraTest {
     }
 
     @Test
-    fun `when following request canceled, state changes to IDLE`() {
+    fun `when following request canceled, state does not changes to IDLE`() {
         navigationCamera.requestNavigationCameraToFollowing()
 
         internalTransitionListenerSlot.captured.onAnimationStart(followingAnimatorSet)
         internalTransitionListenerSlot.captured.onAnimationCancel(followingAnimatorSet)
         internalTransitionListenerSlot.captured.onAnimationEnd(followingAnimatorSet)
-        assertEquals(NavigationCameraState.IDLE, navigationCamera.state)
+        assertEquals(NavigationCameraState.TRANSITION_TO_FOLLOWING, navigationCamera.state)
     }
 
     @Test
-    fun `when overview request canceled, state changes to IDLE`() {
+    fun `when overview request canceled, state does not changes to IDLE`() {
         navigationCamera.requestNavigationCameraToOverview()
 
         internalTransitionListenerSlot.captured.onAnimationStart(overviewAnimatorSet)
         internalTransitionListenerSlot.captured.onAnimationCancel(overviewAnimatorSet)
         internalTransitionListenerSlot.captured.onAnimationEnd(overviewAnimatorSet)
-        assertEquals(NavigationCameraState.IDLE, navigationCamera.state)
+        assertEquals(NavigationCameraState.TRANSITION_TO_OVERVIEW, navigationCamera.state)
     }
 
     @Test
@@ -708,7 +708,6 @@ class NavigationCameraTest {
         verifySequence {
             listener.onNavigationCameraStateChanged(NavigationCameraState.IDLE)
             listener.onNavigationCameraStateChanged(NavigationCameraState.TRANSITION_TO_FOLLOWING)
-            listener.onNavigationCameraStateChanged(NavigationCameraState.IDLE)
         }
     }
 
@@ -741,7 +740,6 @@ class NavigationCameraTest {
         verifySequence {
             listener.onNavigationCameraStateChanged(NavigationCameraState.IDLE)
             listener.onNavigationCameraStateChanged(NavigationCameraState.TRANSITION_TO_OVERVIEW)
-            listener.onNavigationCameraStateChanged(NavigationCameraState.IDLE)
         }
     }
 


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Fixes #5600 

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
