### PR TITLE
[DropInUi] Create lifecycle to survive configuration changes

### DIFF
--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/DropInNavigationView.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/DropInNavigationView.kt
@@ -101,8 +101,8 @@ class DropInNavigationView @JvmOverloads constructor(
         }
 
         /**
-         * Attach the lifecycle to mapbox navigation. This ensures that all
-         * MapboxNavigationObservers will be attached.
+         * Attach the lifecycle to mapbox navigation. This gives MapboxNavigationApp a lifecycle
+         * that allows it to determine the foreground and background state.
          */
         MapboxNavigationApp.attach(this)
 


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Resolves https://github.com/mapbox/navigation-sdks/issues/1551
Resolves https://github.com/mapbox/navigation-sdks/issues/1552

The `ViewLifecycleOwner` does not have a mechanism available for determining if a lifecycle is undergoing a configuration change. When the `MapboxNavigationApp`is attached to the view lifecycle alone, it will consider itself deleted when a configuration is changed.

The first approach I considered, was building a strong connection to the hosting `ComponentActivity`, to watch the `isChangingConfigurations` flag. But that requires some new dependencies in the `libnavui-module`. It also feels unnecessary to do this, so searched for a different solution.

That led me to this, it's essentially a `ViewModelLifecycle`. We want to use a Lifecycle because that works with the `MapboxNavigationApp`, as it is today. As you can see from the video, this change fixes the issue where `MapboxNavigation` is destroyed.

But there are still issues with re-initializing the camera and the route line. I'm also investigating these issues, but will keep the fixes separate.

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->

#### Before

https://user-images.githubusercontent.com/3021882/160179138-85ee65a2-c410-4911-8f9d-2bba0b0b78eb.mp4

#### After

https://user-images.githubusercontent.com/3021882/160180064-f0c88ec2-26fc-483b-8868-1a8d4d8d90f0.mp4

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
