### PR TITLE
Fix `HistoryEventMapper#mapNavigationRoute` for when `SetRouteHistoryRecord` has empty `routeRequest`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Mapbox welcomes participation and contributions from everyone.
 #### Features
 
 #### Bug fixes and improvements
+- Fixed `HistoryEventMapper#mapNavigationRoute` for when `SetRouteHistoryRecord` has empty `routeRequest`. [#5614](https://github.com/mapbox/mapbox-navigation-android/pull/5614)
 
 ## Mapbox Navigation SDK 2.4.0-beta.3 - March 25, 2022
 ### Changelog

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/history/model/HistoryEventMapper.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/history/model/HistoryEventMapper.kt
@@ -84,6 +84,8 @@ internal class HistoryEventMapper {
             try {
                 val directionsResponse = DirectionsResponse.fromJson(response)
                 val routeOptions = setRoute.routeRequest?.let {
+                    // Old records may include empty routeRequest
+                    if (it.isEmpty()) return@let null
                     RouteOptions.fromUrl(URL(it))
                 } ?: directionsResponse.routes().firstOrNull()?.routeOptions()
                     ?: throw noOptionsException


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Fixes `HistoryEventMapper#mapNavigationRoute` for when `SetRouteHistoryRecord` has empty `routeRequest` (old history files may include empty).

Found it when trying to replay [2021-12-13T19_28_13_2021-12-13T20_11_45_active_guidance_9c145c6e-cb71-4bf2-9895-1b0ee96a1d78.pbf.gz](https://github.com/mapbox/mapbox-navigation-android/files/8354026/2021-12-13T19_28_13_2021-12-13T20_11_45_active_guidance_9c145c6e-cb71-4bf2-9895-1b0ee96a1d78.pbf.gz) that was causing the following crash:

```
2022-03-25 14:52:36.467 4305-4305/com.mapbox.navigation.examples E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.mapbox.navigation.examples, PID: 4305
    java.lang.NullPointerException: Null distance
        at com.mapbox.api.directions.v5.models.$AutoValue_DirectionsRoute.<init>($AutoValue_DirectionsRoute.java:40)
        at com.mapbox.api.directions.v5.models.AutoValue_DirectionsRoute.<init>(AutoValue_DirectionsRoute.java:28)
        at com.mapbox.api.directions.v5.models.AutoValue_DirectionsRoute$GsonTypeAdapter.read(AutoValue_DirectionsRoute.java:280)
        at com.mapbox.api.directions.v5.models.AutoValue_DirectionsRoute$GsonTypeAdapter.read(AutoValue_DirectionsRoute.java:31)
        at com.google.gson.Gson.fromJson(Gson.java:932)
        at com.google.gson.Gson.fromJson(Gson.java:1003)
        at com.google.gson.Gson.fromJson(Gson.java:975)
        at com.mapbox.api.directions.v5.models.DirectionsRoute.fromJson(DirectionsRoute.java:182)
        at com.mapbox.navigation.core.history.model.HistoryEventMapper.mapNavigationRoute(HistoryEventMapper.kt:98)
        at com.mapbox.navigation.core.history.model.HistoryEventMapper.mapSetRoute(HistoryEventMapper.kt:63)
        at com.mapbox.navigation.core.history.model.HistoryEventMapper.map(HistoryEventMapper.kt:31)
        at com.mapbox.navigation.core.history.MapboxHistoryReader.loadNext(MapboxHistoryReader.kt:44)
        at com.mapbox.navigation.core.history.MapboxHistoryReader.next(MapboxHistoryReader.kt:38)
        at com.mapbox.navigation.core.history.MapboxHistoryReader.next(MapboxHistoryReader.kt:13)
        at kotlin.sequences.TransformingSequence$iterator$1.next(Sequences.kt:210)
        at kotlin.sequences.FilteringSequence$iterator$1.calcNext(Sequences.kt:170)
        at kotlin.sequences.FilteringSequence$iterator$1.hasNext(Sequences.kt:194)
        at kotlin.sequences.SequencesKt___SequencesKt.toCollection(_Sequences.kt:786)
        at kotlin.sequences.SequencesKt___SequencesKt.toMutableList(_Sequences.kt:816)
        at kotlin.sequences.SequencesKt___SequencesKt.toList(_Sequences.kt:807)
        at com.mapbox.navigation.examples.core.replay.HistoryFileLoader$loadSelectedHistory$2.invokeSuspend(HistoryFileLoader.kt:31)
        at com.mapbox.navigation.examples.core.replay.HistoryFileLoader$loadSelectedHistory$2.invoke(Unknown Source:8)
        at com.mapbox.navigation.examples.core.replay.HistoryFileLoader$loadSelectedHistory$2.invoke(Unknown Source:4)
        at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturn(Undispatched.kt:89)
        at kotlinx.coroutines.BuildersKt__Builders_commonKt.withContext(Builders.common.kt:165)
        at kotlinx.coroutines.BuildersKt.withContext(Unknown Source:1)
        at com.mapbox.navigation.examples.core.replay.HistoryFileLoader.loadSelectedHistory(HistoryFileLoader.kt:28)
        at com.mapbox.navigation.examples.core.replay.HistoryFileLoader.access$loadSelectedHistory(HistoryFileLoader.kt:12)
        at com.mapbox.navigation.examples.core.replay.HistoryFileLoader$loadReplayHistory$2.invokeSuspend(HistoryFileLoader.kt:24)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
        at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)
```

Which will be fix when https://github.com/mapbox/mapbox-java/pull/1386 lands and gets integrated into the SDK.

I've tested with Mapbox Java `v6.5.0-PGS-SNAPSHOT`. Noting that a Mapbox Java release is not blocking this PR but it is needed to support replaying old history files.