### PR TITLE
catch exceptions when parsing DirectionsRefreshResponse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Mapbox welcomes participation and contributions from everyone.
 
 #### Bug fixes and improvements
 - Fixed `HistoryEventMapper#mapNavigationRoute` for when `SetRouteHistoryRecord` has empty `routeRequest`. [#5614](https://github.com/mapbox/mapbox-navigation-android/pull/5614)
+- Fixed an issue where route refresh failure led to a parsing error and runtime crash instead of failure callback. [#5617](https://github.com/mapbox/mapbox-navigation-android/pull/5617)
 
 ## Mapbox Navigation SDK 2.4.0-beta.3 - March 25, 2022
 ### Changelog

--- a/libnavigation-router/src/main/java/com/mapbox/navigation/route/internal/util/DirectionsRouteRefreshUtils.kt
+++ b/libnavigation-router/src/main/java/com/mapbox/navigation/route/internal/util/DirectionsRouteRefreshUtils.kt
@@ -1,0 +1,21 @@
+package com.mapbox.navigation.route.internal.util
+
+import com.mapbox.api.directionsrefresh.v1.models.DirectionsRefreshResponse
+import com.mapbox.api.directionsrefresh.v1.models.DirectionsRouteRefresh
+import com.mapbox.bindgen.Expected
+import com.mapbox.bindgen.ExpectedFactory
+
+internal fun parseDirectionsRouteRefresh(
+    json: String,
+): Expected<Throwable, DirectionsRouteRefresh> {
+    return try {
+        val route = DirectionsRefreshResponse.fromJson(json).route()
+        if (route != null) {
+            ExpectedFactory.createValue(route)
+        } else {
+            ExpectedFactory.createError(IllegalStateException("no route refresh returned"))
+        }
+    } catch (ex: Exception) {
+        ExpectedFactory.createError(ex)
+    }
+}


### PR DESCRIPTION
### Description
Fixed these crashes:
1. `DirectionsRefreshResponse.fromJson` returns `null` when argument is `null` or empty, but we don't check the result's nullability. 
2. `DirectionsRefreshResponse.fromJson` throws NPE when argument is not a valid `DirectionsRefreshResponse` (e.g. `{}`). 
3. `JsonParseException` hasn't happened yet, but added a catch for it in case nav-native sends invalid json. 

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
