### PR TITLE
explicitly define Mapbox OkHttp dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Mapbox welcomes participation and contributions from everyone.
 #### Bug fixes and improvements
 - Adopted Common SDK log messages parsing logic so it's consistent across Mapbox SDKs. As an example, this is how the logs would look like `D/Mapbox: [nav-sdk] [ConnectivityHandler] NetworkStatus=ReachableViaWiFi`. [#5604](https://github.com/mapbox/mapbox-navigation-android/pull/5604)
 - :warning: `NavigationRoute`'s constructor has been hidden in favor of `NavigationRoute#create` static factories. [#5587](https://github.com/mapbox/mapbox-navigation-android/pull/5587)
-- This version again fixes [`ConnectivityManager`'s occasional security exception on Android 11 and older](https://github.com/mapbox/mapbox-navigation-android/pull/5492). [#5587](https://github.com/mapbox/mapbox-navigation-android/pull/5587)
+- Added a workaround for [`ConnectivityManager`'s occasional security exception on Android 11 and older](https://issuetracker.google.com/issues/175055271). [#5587](https://github.com/mapbox/mapbox-navigation-android/pull/5587)
 - Fixed an issue where off-route wouldn't be reported if we were navigating in a fallback mode (without routing tiles on device). [#5587](https://github.com/mapbox/mapbox-navigation-android/pull/5587)
 - `RouteProgressState#INITIALIZED` might now be reported for each leg start, not only for the route start. [#5587](https://github.com/mapbox/mapbox-navigation-android/pull/5587)
 
@@ -37,8 +37,6 @@ This release depends on, and has been tested with, the following Mapbox dependen
 ## Mapbox Navigation SDK 2.4.0-beta.2 - March 18, 2022
 ### Changelog
 [Changes between v2.4.0-beta.1 and v2.4.0-beta.2](https://github.com/mapbox/mapbox-navigation-android/compare/v2.4.0-beta.1...v2.4.0-beta.2)
-
-- :warning: This version regresses the fix for [`ConnectivityManager`'s occasional security exception on Android 11 and older](https://github.com/mapbox/mapbox-navigation-android/pull/5492) which will be addressed again in the upcoming release.
 
 #### Features
 - Added a new `RailwayCrossing` type to `RoadObject`s. [#5552](https://github.com/mapbox/mapbox-navigation-android/pull/5552)
@@ -122,7 +120,7 @@ This release depends on, and has been tested with, the following Mapbox dependen
 - Fixed an issue where an alternative route was equal a current route. [#5457](https://github.com/mapbox/mapbox-navigation-android/pull/5457)
 - Added delay before re-attempting to request alternatives in case the first attempt resulted in the deviation point behind the current position. [#5457](https://github.com/mapbox/mapbox-navigation-android/pull/5457)
 - Fixed using `POST` for long requests [#5480](https://github.com/mapbox/mapbox-navigation-android/pull/5480)
-- Added a workaround for [`ConnectivityManager`'s occasional security exception on Android 11 and older](https://issuetracker.google.com/issues/175055271). [#5492](https://github.com/mapbox/mapbox-navigation-android/pull/5492)
+- (**Correction** - this workaround only actually became available in `v2.4.0-beta.3`) Added a workaround for [`ConnectivityManager`'s occasional security exception on Android 11 and older](https://issuetracker.google.com/issues/175055271). [#5492](https://github.com/mapbox/mapbox-navigation-android/pull/5492)
 - Fixed `MapboxNavigationApp` issue, that caused unexpected `MapboxNavigation` destroy, when one of the attached lifecycles is destroyed and the other one is stopped. [#5518](https://github.com/mapbox/mapbox-navigation-android/pull/5518)
 
 ### Mapbox dependencies
@@ -163,7 +161,7 @@ This release is a re-tag of the `v2.3.0-rc.2` to correct the commit which should
 [Changes between v2.3.0-rc.2 and v2.3.0-rc.3](https://github.com/mapbox/mapbox-navigation-android/compare/v2.3.0-rc.2...v2.3.0-rc.3)
 
 #### Bug fixes and improvements
-- Added a workaround for [`ConnectivityManager`'s occasional security exception on Android 11 and older](https://issuetracker.google.com/issues/175055271). [#5492](https://github.com/mapbox/mapbox-navigation-android/pull/5492)
+- (**Correction** - this workaround only actually became available in `v2.4.0-beta.3`) Added a workaround for [`ConnectivityManager`'s occasional security exception on Android 11 and older](https://issuetracker.google.com/issues/175055271). [#5492](https://github.com/mapbox/mapbox-navigation-android/pull/5492)
 
 ### Mapbox dependencies
 This release depends on, and has been tested with, the following Mapbox dependencies:
@@ -179,7 +177,7 @@ This release depends on, and has been tested with, the following Mapbox dependen
 [Changes between v2.3.0-rc.1 and v2.3.0-rc.2](https://github.com/mapbox/mapbox-navigation-android/compare/v2.3.0-rc.1...v2.3.0-rc.2)
 
 #### Bug fixes and improvements
-- Added a workaround for [`ConnectivityManager`'s occasional security exception on Android 11 and older](https://issuetracker.google.com/issues/175055271). [#5492](https://github.com/mapbox/mapbox-navigation-android/pull/5492)
+- (**Correction** - this workaround only actually became available in `v2.4.0-beta.3`) Added a workaround for [`ConnectivityManager`'s occasional security exception on Android 11 and older](https://issuetracker.google.com/issues/175055271). [#5492](https://github.com/mapbox/mapbox-navigation-android/pull/5492)
 
 ### Mapbox dependencies
 This release depends on, and has been tested with, the following Mapbox dependencies:

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -519,6 +519,12 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 
 ===========================================================================
 
+Mapbox Navigation uses portions of the Mapbox Android Commmon OkHttp SDK.
+URL: [https://github.com/mapbox/mapbox-sdk-common](https://github.com/mapbox/mapbox-sdk-common)
+License: [Mapbox Terms of Service](https://www.mapbox.com/legal/tos)
+
+===========================================================================
+
 Mapbox Navigation uses portions of the Mapbox Android Commmon SDK.
 URL: [https://github.com/mapbox/mapbox-sdk-common](https://github.com/mapbox/mapbox-sdk-common)
 License: [Mapbox Terms of Service](https://www.mapbox.com/legal/tos)
@@ -552,6 +558,18 @@ License: [BSD](https://opensource.org/licenses/BSD-2-Clause)
 Mapbox Navigation uses portions of the Mapbox Logger (Artifact that provides Mapbox Logger module implementation).
 URL: [https://github.com/mapbox/mapbox-base-android](https://github.com/mapbox/mapbox-base-android)
 License: [BSD](https://opensource.org/licenses/BSD-2-Clause)
+
+===========================================================================
+
+Mapbox Navigation uses portions of the okhttp (Square’s meticulous HTTP client for Java and Kotlin.).
+URL: [https://square.github.io/okhttp/](https://square.github.io/okhttp/)
+License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+===========================================================================
+
+Mapbox Navigation uses portions of the Okio (A modern I/O API for Java).
+URL: [https://github.com/square/okio/](https://github.com/square/okio/)
+License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -73,6 +73,11 @@ ext {
       mapboxCore                : "com.mapbox.mapboxsdk:mapbox-android-core:${version.mapboxCore}",
       mapboxNavigator           : "com.mapbox.navigator:mapbox-navigation-native:${version.mapboxNavigator}",
       mapboxCommonNative        : "com.mapbox.common:common:${version.mapboxCommonNative}",
+      /**
+       * explicitly define Mapbox OkHttp dependency so that we are sure it's in sync with the Common SDK version we define
+       * and we're not relying on Mapbox OKHttp coming in transitively
+       */
+      mapboxCommonOkHttp        : "com.mapbox.common:okhttp:${version.mapboxCommonNative}",
       mapboxAnnotationPlugin    : "com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v9:${version.mapboxAnnotationPlugin}",
       mapboxCrashMonitor        : "com.mapbox.crashmonitor:mapbox-crash-monitor-native:${version.mapboxCrashMonitor}",
       mapboxAnnotations         : "com.mapbox.base:annotations:${version.mapboxBaseAndroid}",

--- a/libnavigation-core/build.gradle
+++ b/libnavigation-core/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     implementation project(':libnavigation-util')
     implementation project(':libnavigator')
     api dependenciesList.mapboxCommonNative
+    implementation dependenciesList.mapboxCommonOkHttp
     runtimeOnly project(':libnavigation-router')
     runtimeOnly project(':libtrip-notification')
     runtimeOnly dependenciesList.mapboxLogger

--- a/libnavigation-util/build.gradle
+++ b/libnavigation-util/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation dependenciesList.androidXCore
     api dependenciesList.mapboxSdkDirectionsModels
     api dependenciesList.mapboxCommonNative
+    implementation dependenciesList.mapboxCommonOkHttp
     api dependenciesList.mapboxAndroidCommon
     implementation dependenciesList.mapboxAnnotations
 


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

We made a bump of Common SDK in https://github.com/mapbox/mapbox-navigation-android/pull/5492 to attempt to provide a workaround for [`ConnectivityManager`'s occasional security exception on Android 11 and older](https://issuetracker.google.com/issues/175055271), however, the workaround was not part of the Common SDK itself but rather the Mapbox OkHttp module. This modules was coming in transitively with Maps SDK and the bump of Common SDK we did, didn't actually bump the version of the library we wanted to bring in.

I'm cutting this PR so that Nav SDK can have a direct control over the Mapbox OkHttp dependency and bump it independently to provide a patch if needed in the future. 


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
