### PR TITLE
Bump `mapboxBaseAndroid` version to `0.6.0`

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -25,7 +25,7 @@ ext {
       mapboxCommonNative        : '21.2.0-rc.1',
       mapboxCrashMonitor        : '2.0.0',
       mapboxAnnotationPlugin    : '0.8.0',
-      mapboxBaseAndroid         : '0.5.0',
+      mapboxBaseAndroid         : '0.6.0',
       androidXLifecycle         : '2.4.0',
       androidXCoreVersion       : '1.6.0',
       androidXArchCoreVersion   : '2.1.0',


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Bumps `mapboxBaseAndroid` version to [`0.6.0`](https://github.com/mapbox/mapbox-base-android/releases/tag/v0.6.0).