### PR TITLE
[DropInUi] Request location permissions by default

### DIFF
--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/tripsession/LocationPermissionComponent.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/tripsession/LocationPermissionComponent.kt
@@ -1,0 +1,107 @@
+package com.mapbox.navigation.dropin.component.tripsession
+
+import android.Manifest
+import android.content.Context
+import androidx.activity.ComponentActivity
+import androidx.activity.result.ActivityResultCallback
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.repeatOnLifecycle
+import com.mapbox.android.core.permissions.PermissionsManager
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.dropin.lifecycle.UIComponent
+import com.mapbox.navigation.utils.internal.logW
+import kotlinx.coroutines.launch
+import java.lang.ref.WeakReference
+
+/**
+ * Default experience for location permissions.
+ *
+ * @param componentActivityRef used for requesting location permissions
+ * @param tripSessionStarterViewModel used to notify when location permissions are granted
+ */
+internal class LocationPermissionComponent(
+    private val componentActivityRef: WeakReference<ComponentActivity>?,
+    private val tripSessionStarterViewModel: TripSessionStarterViewModel,
+) : UIComponent() {
+
+    private val callback = ActivityResultCallback { permissions: Map<String, Boolean> ->
+        val accessFineLocation = permissions[FINE_LOCATION_PERMISSIONS]
+            ?: false
+        val accessCoarseLocation = permissions[COARSE_LOCATION_PERMISSIONS]
+            ?: false
+        val granted = accessFineLocation || accessCoarseLocation
+        tripSessionStarterViewModel.invoke(
+            TripSessionStarterAction.OnLocationPermission(granted)
+        )
+    }
+
+    private val launcher = try {
+        componentActivityRef?.get()?.registerForActivityResult(
+            ActivityResultContracts.RequestMultiplePermissions(), callback
+        )
+    } catch (illegalStateException: IllegalStateException) {
+        logW(
+            "Unable to request location permissions when view is created late in the " +
+                "activity lifecycle. ${illegalStateException.message}",
+            LOG_CATEGORY
+        )
+        null
+    }
+
+    override fun onAttached(mapboxNavigation: MapboxNavigation) {
+        super.onAttached(mapboxNavigation)
+
+        val isGranted = PermissionsManager.areLocationPermissionsGranted(
+            mapboxNavigation.navigationOptions.applicationContext
+        )
+        if (isGranted) {
+            tripSessionStarterViewModel.invoke(
+                TripSessionStarterAction.OnLocationPermission(true)
+            )
+        } else {
+            launcher?.launch(LOCATION_PERMISSIONS)
+
+            notifyGrantedOnForegrounded(mapboxNavigation.navigationOptions.applicationContext)
+        }
+    }
+
+    /**
+     * When the app is launched without location permissions. Run a check to see if location
+     * permissions have been accepted yet. This will catch the case where a user will enable
+     * location permissions through the app settings.
+     */
+    private fun notifyGrantedOnForegrounded(applicationContext: Context) {
+        coroutineScope.launch {
+            componentActivityRef?.get()?.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                if (!tripSessionStarterViewModel.state.value.isLocationPermissionGranted) {
+                    val isGranted = PermissionsManager.areLocationPermissionsGranted(
+                        applicationContext
+                    )
+                    if (isGranted) {
+                        tripSessionStarterViewModel.invoke(
+                            TripSessionStarterAction.OnLocationPermission(true)
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    override fun onDetached(mapboxNavigation: MapboxNavigation) {
+        super.onDetached(mapboxNavigation)
+
+        launcher?.unregister()
+    }
+
+    internal companion object {
+        private val LOG_CATEGORY = this::class.java.simpleName
+
+        private const val FINE_LOCATION_PERMISSIONS = Manifest.permission.ACCESS_FINE_LOCATION
+        private const val COARSE_LOCATION_PERMISSIONS = Manifest.permission.ACCESS_COARSE_LOCATION
+        private val LOCATION_PERMISSIONS = arrayOf(
+            FINE_LOCATION_PERMISSIONS,
+            COARSE_LOCATION_PERMISSIONS
+        )
+    }
+}

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/tripsession/LocationPermissionComponentTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/tripsession/LocationPermissionComponentTest.kt
@@ -1,0 +1,197 @@
+package com.mapbox.navigation.dropin.component.tripsession
+
+import android.Manifest
+import androidx.activity.ComponentActivity
+import androidx.activity.result.ActivityResultCallback
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContract
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import com.mapbox.android.core.permissions.PermissionsManager
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.testing.MainCoroutineRule
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.lang.ref.WeakReference
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class LocationPermissionComponentTest {
+
+    @get:Rule
+    var coroutineRule = MainCoroutineRule()
+
+    private val testLauncher = mockk<ActivityResultLauncher<Any>>(relaxed = true)
+    private val resultContractSlot = slot<ActivityResultContract<Any, Any>>()
+    private val callbackSlot = slot<ActivityResultCallback<Any>>()
+    private val testLifecycle = TestLifecycleOwner()
+    private var componentActivity: ComponentActivity = mockk(relaxed = true) {
+        every { lifecycle } returns testLifecycle.lifecycle
+        every {
+            registerForActivityResult(
+                capture(resultContractSlot),
+                capture(callbackSlot)
+            )
+        } answers {
+            testLauncher
+        }
+    }
+    private val componentActivityRef = WeakReference(componentActivity)
+    private val tripSessionStarterStateFlow = MutableStateFlow(TripSessionStarterState())
+    private val tripSessionStarterViewModel: TripSessionStarterViewModel = mockk(relaxed = true) {
+        every { state } returns tripSessionStarterStateFlow
+    }
+
+    @Before
+    fun setup() {
+        mockkStatic(PermissionsManager::class)
+        mockkStatic(Lifecycle::class)
+    }
+
+    @After
+    fun teardown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `onAttached will notify permissions granted when granted`() {
+        val locationPermissionComponent = LocationPermissionComponent(
+            componentActivityRef, tripSessionStarterViewModel
+        )
+        every { PermissionsManager.areLocationPermissionsGranted(any()) } returns true
+
+        locationPermissionComponent.onAttached(mockMapboxNavigation())
+
+        verify {
+            tripSessionStarterViewModel.invoke(
+                TripSessionStarterAction.OnLocationPermission(true)
+            )
+        }
+    }
+
+    @Test
+    fun `onAttached will not notify permissions granted when not granted`() {
+        val locationPermissionComponent = LocationPermissionComponent(
+            componentActivityRef, tripSessionStarterViewModel
+        )
+        every { PermissionsManager.areLocationPermissionsGranted(any()) } returns false
+
+        locationPermissionComponent.onAttached(mockMapboxNavigation())
+
+        verify(exactly = 0) {
+            tripSessionStarterViewModel.invoke(
+                TripSessionStarterAction.OnLocationPermission(false)
+            )
+        }
+    }
+
+    @Test
+    fun `onAttached will request permissions when not granted`() {
+        val locationPermissionComponent = LocationPermissionComponent(
+            componentActivityRef, tripSessionStarterViewModel
+        )
+        every { PermissionsManager.areLocationPermissionsGranted(any()) } returns false
+
+        locationPermissionComponent.onAttached(mockMapboxNavigation())
+
+        verify { testLauncher.launch(any()) }
+    }
+
+    @Test
+    fun `onAttached grant location permissions if request succeeds`() {
+        val locationPermissionComponent = LocationPermissionComponent(
+            componentActivityRef, tripSessionStarterViewModel
+        )
+        every { PermissionsManager.areLocationPermissionsGranted(any()) } returns false
+
+        locationPermissionComponent.onAttached(mockMapboxNavigation())
+        val permissions = mapOf(
+            Manifest.permission.ACCESS_FINE_LOCATION to true,
+            Manifest.permission.ACCESS_COARSE_LOCATION to true,
+        )
+        callbackSlot.captured.onActivityResult(permissions)
+
+        verify {
+            tripSessionStarterViewModel.invoke(
+                TripSessionStarterAction.OnLocationPermission(true)
+            )
+        }
+    }
+
+    @Test
+    fun `onAttached not grant location permissions if request is denied`() {
+        val locationPermissionComponent = LocationPermissionComponent(
+            componentActivityRef, tripSessionStarterViewModel
+        )
+        every { PermissionsManager.areLocationPermissionsGranted(any()) } returns false
+
+        locationPermissionComponent.onAttached(mockMapboxNavigation())
+        val permissions = mapOf(
+            Manifest.permission.ACCESS_FINE_LOCATION to false,
+            Manifest.permission.ACCESS_COARSE_LOCATION to false,
+        )
+        callbackSlot.captured.onActivityResult(permissions)
+
+        verify {
+            tripSessionStarterViewModel.invoke(
+                TripSessionStarterAction.OnLocationPermission(false)
+            )
+        }
+    }
+
+    @Test
+    fun `onDetached will unregister from the launcher`() {
+        val locationPermissionComponent = LocationPermissionComponent(
+            componentActivityRef, tripSessionStarterViewModel
+        )
+
+        locationPermissionComponent.onAttached(mockMapboxNavigation())
+        locationPermissionComponent.onDetached(mockMapboxNavigation())
+
+        verify { testLauncher.unregister() }
+    }
+
+    @Test
+    fun `should invoke LocationPermissionResult when permissions are accepted from background`() =
+        coroutineRule.runBlockingTest {
+            val locationPermissionComponent = LocationPermissionComponent(
+                componentActivityRef, tripSessionStarterViewModel
+            )
+            tripSessionStarterStateFlow.value = TripSessionStarterState(
+                isLocationPermissionGranted = false
+            )
+            every { PermissionsManager.areLocationPermissionsGranted(any()) } returns false
+
+            locationPermissionComponent.onAttached(mockMapboxNavigation())
+            every { PermissionsManager.areLocationPermissionsGranted(any()) } returns true
+            testLifecycle.lifecycleRegistry.currentState = Lifecycle.State.STARTED
+
+            verify {
+                tripSessionStarterViewModel.invoke(
+                    TripSessionStarterAction.OnLocationPermission(true)
+                )
+            }
+        }
+
+    private fun mockMapboxNavigation(): MapboxNavigation = mockk(relaxed = true)
+
+    private class TestLifecycleOwner : LifecycleOwner {
+        val lifecycleRegistry = LifecycleRegistry(this)
+            .also { it.currentState = Lifecycle.State.INITIALIZED }
+
+        override fun getLifecycle(): Lifecycle = lifecycleRegistry
+    }
+}

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/tripsession/TripSessionStarterViewModelTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/tripsession/TripSessionStarterViewModelTest.kt
@@ -1,0 +1,168 @@
+package com.mapbox.navigation.dropin.component.tripsession
+
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.dropin.component.navigation.NavigationState
+import com.mapbox.navigation.dropin.component.navigation.NavigationStateViewModel
+import com.mapbox.navigation.testing.MainCoroutineRule
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.verifyOrder
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalPreviewMapboxNavigationAPI::class)
+class TripSessionStarterViewModelTest {
+
+    @get:Rule
+    var coroutineRule = MainCoroutineRule()
+
+    @Test
+    fun `verify default state is respected`() = runBlockingTest {
+        val navigationStateViewModel = mockNavigationStateViewModel()
+        val tripSessionStarterViewModel = TripSessionStarterViewModel(
+            navigationStateViewModel,
+            TripSessionStarterState(isReplayEnabled = false, isLocationPermissionGranted = true)
+        )
+
+        tripSessionStarterViewModel.onAttached(mockMapboxNavigation())
+
+        assertFalse(tripSessionStarterViewModel.state.value.isReplayEnabled)
+        assertTrue(tripSessionStarterViewModel.state.value.isLocationPermissionGranted)
+    }
+    @Test
+    fun `startTripSession if location permissions are granted`() =
+        runBlockingTest {
+            val tripSessionStarterViewModel = TripSessionStarterViewModel(
+                mockNavigationStateViewModel(),
+                TripSessionStarterState(
+                    isLocationPermissionGranted = false,
+                    isReplayEnabled = false
+                )
+            )
+            val mapboxNavigation = mockMapboxNavigation()
+
+            tripSessionStarterViewModel.onAttached(mapboxNavigation)
+            tripSessionStarterViewModel.invoke(
+                TripSessionStarterAction.OnLocationPermission(true)
+            )
+
+            verify { mapboxNavigation.startTripSession() }
+        }
+
+    @Test
+    fun `onDetached does not stopTripSession for a regular session`() =
+        runBlockingTest {
+            val tripSessionStarterViewModel = TripSessionStarterViewModel(
+                mockNavigationStateViewModel(),
+                TripSessionStarterState(
+                    isLocationPermissionGranted = true,
+                    isReplayEnabled = false
+                )
+            )
+            val mapboxNavigation = mockMapboxNavigation()
+
+            tripSessionStarterViewModel.onAttached(mapboxNavigation)
+            tripSessionStarterViewModel.onDetached(mapboxNavigation)
+
+            verify(exactly = 1) { mapboxNavigation.startTripSession() }
+            verify(exactly = 0) { mapboxNavigation.stopTripSession() }
+        }
+
+    @Test
+    fun `EnableTripSession will restart a trip session when replay is enabled`() =
+        runBlockingTest {
+            val tripSessionStarterViewModel = TripSessionStarterViewModel(
+                mockNavigationStateViewModel(NavigationState.ActiveNavigation),
+                TripSessionStarterState(
+                    isLocationPermissionGranted = true,
+                    isReplayEnabled = true
+                )
+            )
+            val mapboxNavigation = mockMapboxNavigation()
+
+            tripSessionStarterViewModel.onAttached(mapboxNavigation)
+            tripSessionStarterViewModel.invoke(TripSessionStarterAction.EnableTripSession)
+
+            verifyOrder {
+                mapboxNavigation.startReplayTripSession()
+                mapboxNavigation.stopTripSession()
+                mapboxNavigation.startTripSession()
+            }
+        }
+
+    @Test
+    fun `EnableReplayTripSession will startReplayTripSession`() =
+        runBlockingTest {
+            val navigationStateViewModel = mockNavigationStateViewModel(
+                NavigationState.ActiveNavigation
+            )
+            val tripSessionStarterViewModel = TripSessionStarterViewModel(navigationStateViewModel)
+            val mapboxNavigation = mockMapboxNavigation()
+
+            tripSessionStarterViewModel.onAttached(mapboxNavigation)
+            tripSessionStarterViewModel.invoke(
+                TripSessionStarterAction.OnLocationPermission(true)
+            )
+            tripSessionStarterViewModel.invoke(TripSessionStarterAction.EnableReplayTripSession)
+
+            verify { mapboxNavigation.startReplayTripSession() }
+        }
+
+    @Test
+    fun `EnableReplayTripSession will not startReplayTripSession without location permissions`() =
+        runBlockingTest {
+            val navigationStateViewModel = mockNavigationStateViewModel(
+                NavigationState.ActiveNavigation
+            )
+            val tripSessionStarterViewModel = TripSessionStarterViewModel(navigationStateViewModel)
+            val mapboxNavigation = mockMapboxNavigation()
+
+            tripSessionStarterViewModel.onAttached(mapboxNavigation)
+            tripSessionStarterViewModel.invoke(
+                TripSessionStarterAction.OnLocationPermission(false)
+            )
+            tripSessionStarterViewModel.invoke(TripSessionStarterAction.EnableReplayTripSession)
+
+            verify(exactly = 0) { mapboxNavigation.startReplayTripSession() }
+        }
+
+    @Test
+    fun `EnableReplayTripSession will only startReplayTripSession for ActiveGuidance`() =
+        runBlockingTest {
+            val stateFlow = MutableStateFlow<NavigationState>(NavigationState.FreeDrive)
+            val navigationStateViewModel: NavigationStateViewModel = mockk {
+                every { state } returns stateFlow
+            }
+            val tripSessionStarterViewModel = TripSessionStarterViewModel(
+                navigationStateViewModel,
+                TripSessionStarterState(isLocationPermissionGranted = true, isReplayEnabled = true)
+            )
+            val mapboxNavigation = mockMapboxNavigation()
+
+            tripSessionStarterViewModel.onAttached(mapboxNavigation)
+            stateFlow.emit(NavigationState.DestinationPreview)
+            stateFlow.emit(NavigationState.RoutePreview)
+            stateFlow.emit(NavigationState.Arrival)
+
+            verify(exactly = 0) { mapboxNavigation.startReplayTripSession() }
+            stateFlow.emit(NavigationState.ActiveNavigation)
+            verify(exactly = 1) { mapboxNavigation.startReplayTripSession() }
+        }
+
+    private fun mockMapboxNavigation(): MapboxNavigation = mockk(relaxed = true)
+
+    private fun mockNavigationStateViewModel(
+        initialState: NavigationState = NavigationState.FreeDrive
+    ): NavigationStateViewModel {
+        return mockk {
+            every { state } returns MutableStateFlow(initialState)
+        }
+    }
+}

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/domain/TestActivitySuite.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/domain/TestActivitySuite.kt
@@ -105,7 +105,8 @@ object TestActivitySuite {
         },
         TestActivityDescription(
             "Navigation View test",
-            R.string.navigation_view_description
+            R.string.navigation_view_description,
+            launchAfterPermissionResult = false
         ) { activity -> activity.startActivity<MapboxNavigationViewActivity>() },
         TestActivityDescription(
             "Customized navigation View test",


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Resolves https://github.com/mapbox/navigation-sdks/issues/1543

Adding a `LocationPermissionComponent`. There is a relatively new api that allows downstream components to register to permission requests. https://developer.android.com/training/permissions/requesting#allow-system-manage-request-code

This will work when the hosting activity is a `ComponentActivity`. I have also made this a soft requirement, if something goes wrong with this it will fail with a warning log. This gives a place for providing a default experience.

If location permissions have not been accepted, do not start a trip session. When they are accepted, this will start the trip session

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->

Accepting through dialog request

https://user-images.githubusercontent.com/3021882/160505363-d6ec4542-1124-407c-a4e9-537079b0bc55.mp4

Accepting through app settings

https://user-images.githubusercontent.com/3021882/160506549-6cca65d2-8007-4d70-ba29-6f86e9afb6df.mp4

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
