### PR TITLE
[DropInUi] Fix audio guidance

### DIFF
--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/audioguidance/AudioGuidanceViewModel.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/audioguidance/AudioGuidanceViewModel.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.launch
 
 sealed class AudioAction {
@@ -46,13 +47,13 @@ class AudioGuidanceViewModel(
 
         val audioGuidanceApi = AudioGuidanceApi.create(mapboxNavigation, AudioGuidanceServices())
         mainJobControl.scope.launch {
-            flowSpeakInstructions().collect { speakInstructions ->
+            flowSpeakInstructions().flatMapLatest { speakInstructions ->
                 if (speakInstructions) {
                     audioGuidanceApi.speakVoiceInstructions()
                 } else {
                     emptyFlow()
                 }
-            }
+            }.collect()
         }
     }
 


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

When fixing audio guidance for trip sessions, i actually broke it by removing the `collect()` 

https://github.com/mapbox/mapbox-navigation-android/pull/5594/files#diff-40a318214b2ecb47bb12c7659ca3b0ef90d3f8674901fb5f90691d2677618a23L52

This means audio guidance is not actually subscribing. Going back to the flatMapLatest that was in the original flow.
