### PR TITLE
Removed redundant calls of gradle in make file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,9 +33,12 @@ examples \
 instrumentation-tests \
 
 define run-gradle-tasks
-	for module in $(1) ; do \
-		./gradlew $$module:$(2) || exit 1 ; \
-	done
+    COMMAND=./gradlew; \
+	for module in $(1); do \
+	    COMMAND+=" "; \
+	    COMMAND+=$$module:$(2); \
+	done; \
+	eval $$COMMAND
 endef
 
 .PHONY: check-kotlin-lint

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ define run-gradle-tasks
 	    COMMAND+=" "; \
 	    COMMAND+="$$module:$(2)"; \
 	done; \
+	echo "executing $$COMMAND"; \
 	eval $$COMMAND
 endef
 

--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,7 @@ instrumentation-tests \
 define run-gradle-tasks
     COMMAND="./gradlew"; \
 	for module in $(1); do \
-	    COMMAND+=" "; \
-	    COMMAND+="$$module:$(2)"; \
+	    COMMAND="$${COMMAND} $$module:$(2)"; \
 	done; \
 	echo "executing $$COMMAND"; \
 	eval $$COMMAND

--- a/Makefile
+++ b/Makefile
@@ -33,10 +33,10 @@ examples \
 instrumentation-tests \
 
 define run-gradle-tasks
-    COMMAND=./gradlew; \
+    COMMAND="./gradlew"; \
 	for module in $(1); do \
 	    COMMAND+=" "; \
-	    COMMAND+=$$module:$(2); \
+	    COMMAND+="$$module:$(2)"; \
 	done; \
 	eval $$COMMAND
 endef


### PR DESCRIPTION
### Description
Every time we call `gradle`, it does some work to initialise: builds dependencies graphs, checks if tasks are up-to date, etc. Calling `gradle` for every module separately make him do the same initialisation work many times. This PR replaces `./gradlew modouleA; ./gradlew moduleB; ./gradlew moduleC` by `./gradlew modouleA moduleB moduleC`.

### Testing
```
make assemble-core-debug  # 16.64s user 2.11s system 16% cpu 1:50.66 total
# applied change from this PR
./gradlew clean
make assemble-core-debug  # 2.82s user 0.39s system 5% cpu 55.583 total
git stash
./gradlew clean
make assemble-core-debug  # 16.32s user 2.04s system 24% cpu 1:14.59 total
git stash apply
./gradlew clean
make assemble-core-debug  # 2.95s user 0.41s system 6% cpu 48.865 total
```
This PR speeds up cold build of core module on ~ **19%**