### PR TITLE
Bump `mapboxSdkServices` dependency version to `6.4.0-beta.4`

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -18,7 +18,7 @@ ext {
 
   version = [
       mapboxMapSdk              : '10.4.0',
-      mapboxSdkServices         : '6.4.0-beta.3',
+      mapboxSdkServices         : '6.4.0-beta.4',
       mapboxEvents              : '8.1.1',
       mapboxCore                : '5.0.1',
       mapboxNavigator           : "${mapboxNavigatorVersion}",


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Bumps `mapboxSdkServices` dependency version to [`6.4.0-beta.4`](https://github.com/mapbox/mapbox-java/releases/tag/v6.4.0-beta.4)