### PR TITLE
move alternatives routes parsing to a worker thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Mapbox welcomes participation and contributions from everyone.
 - Fixed an issue where `RouteProgress` might not have been delivered in active guidance when `MapboxNavigation#setRoutes` calls were dispatched in quick succession (session was locked in an invalid state). [#5629](https://github.com/mapbox/mapbox-navigation-android/pull/5629)
 - Improved the time between the router getting access to a raw Directions API response and Nav SDK delivering a `NavigationRoute` instance in `NavigationRouterCallback`. [#5629](https://github.com/mapbox/mapbox-navigation-android/pull/5629)
 - Fixed an issue where line `RoadObject`s matched with `RoadObjectMatcher` which consisted of only one edge and multiple lines where calculated incorrectly. [#5629](https://github.com/mapbox/mapbox-navigation-android/pull/5629)
+- Moved alternative route line processing to a worker thread, relieving a little bit of load from the main thread during each recalculation. [#5634](https://github.com/mapbox/mapbox-navigation-android/pull/5634)
 
 ## Mapbox Navigation SDK 2.4.0-beta.3 - March 25, 2022
 ### Changelog


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
In https://github.com/mapbox/mapbox-navigation-android/pull/4791 there was [a `TODO` added](https://github.com/mapbox/mapbox-navigation-android/pull/4791/files#diff-485e7c2048009511ed2cb55f1631f02e1cf718c0a97b7173a8b32e457cd1b471R75) to move the alternatives parsing to a worker thread that got lost with further refactorings and the processing function remained blocking.

This PRs removes the blocking call and let's the parsing suspend until finished, without blocking.

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
