### PR TITLE
[DROP-IN] Keep the device awake when using DropInNavigationView.

### DIFF
--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/DropInNavigationView.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/DropInNavigationView.kt
@@ -92,6 +92,8 @@ class DropInNavigationView @JvmOverloads constructor(
     }
 
     init {
+        keepScreenOn = true
+
         /**
          * Default setup for MapboxNavigationApp. The developer can customize this by
          * setting up the MapboxNavigationApp before the view is constructed.


### PR DESCRIPTION
Closes [#1582](https://github.com/mapbox/navigation-sdks/issues/1582)

### Testing instructions

1. Set your android device `Settings > Display > Screen timeout` setting to 15 seconds
2. Install `qa-test-app` and disconnect USB cable
3. Open `qa-test-app` and launch either "Navigation View test" or "Customized navigation View test"

_Expected behaviour_: Device should remain awake after 15 seconds of inactivity.

