### PR TITLE
[DropInUi] Fix location permission crash and launch race condition

### DIFF
--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/location/LocationViewModel.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/location/LocationViewModel.kt
@@ -1,16 +1,12 @@
 package com.mapbox.navigation.dropin.component.location
 
-import android.annotation.SuppressLint
 import android.location.Location
-import com.mapbox.android.core.location.LocationEngineCallback
-import com.mapbox.android.core.location.LocationEngineResult
 import com.mapbox.geojson.Point
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.dropin.extensions.flowLocationMatcherResult
 import com.mapbox.navigation.dropin.lifecycle.UIViewModel
 import com.mapbox.navigation.ui.maps.location.NavigationLocationProvider
-import com.mapbox.navigation.utils.internal.logE
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
@@ -19,7 +15,6 @@ sealed class LocationAction {
     data class Update(val location: Location) : LocationAction()
 }
 
-@SuppressLint("MissingPermission")
 @OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
 class LocationViewModel : UIViewModel<Location?, LocationAction>(null) {
     val navigationLocationProvider = NavigationLocationProvider()
@@ -56,21 +51,6 @@ class LocationViewModel : UIViewModel<Location?, LocationAction>(null) {
 
     override fun onAttached(mapboxNavigation: MapboxNavigation) {
         super.onAttached(mapboxNavigation)
-        val locationEngine = mapboxNavigation.navigationOptions.locationEngine
-        locationEngine.getLastLocation(object : LocationEngineCallback<LocationEngineResult> {
-            override fun onSuccess(result: LocationEngineResult) {
-                result.lastLocation?.let {
-                    navigationLocationProvider.changePosition(it, emptyList())
-                    invoke(LocationAction.Update(it))
-                }
-            }
-            override fun onFailure(exception: Exception) {
-                logE(
-                    "Failed to get immediate location exception=$exception",
-                    "LocationViewModel"
-                )
-            }
-        })
 
         mainJobControl.scope.launch {
             mapboxNavigation.flowLocationMatcherResult().collect { locationMatcherResult ->

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/tripsession/LocationPermissionComponent.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/tripsession/LocationPermissionComponent.kt
@@ -55,10 +55,18 @@ internal class LocationPermissionComponent(
         val isGranted = PermissionsManager.areLocationPermissionsGranted(
             mapboxNavigation.navigationOptions.applicationContext
         )
+
         if (isGranted) {
-            tripSessionStarterViewModel.invoke(
-                TripSessionStarterAction.OnLocationPermission(true)
-            )
+            // There can be a race condition between components and view models.
+            // The view model attaches, and then launches a coroutine to collect actions.
+            // The LocationPermissionComponent surfaces this issue because it is not owned by
+            // a coordinator and flowable binder. This issue was also difficult to reproduce on
+            // all devices. Launching a coroutine to update the state is a temporary solution.
+            coroutineScope.launch {
+                tripSessionStarterViewModel.invoke(
+                    TripSessionStarterAction.OnLocationPermission(true)
+                )
+            }
         } else {
             launcher?.launch(LOCATION_PERMISSIONS)
 

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/location/LocationViewModelTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/location/LocationViewModelTest.kt
@@ -1,9 +1,6 @@
 package com.mapbox.navigation.dropin.component.location
 
 import android.location.Location
-import com.mapbox.android.core.location.LocationEngineCallback
-import com.mapbox.android.core.location.LocationEngineResult
-import com.mapbox.common.Logger
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.trip.session.LocationObserver
@@ -14,7 +11,6 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.slot
-import io.mockk.verify
 import io.mockk.verifyOrder
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
@@ -32,127 +28,35 @@ class LocationViewModelTest {
     @get:Rule
     val mockLoggerTestRule = MockLoggerRule()
 
+    private val locationObserverSlot = slot<LocationObserver>()
+    private val mockMapboxNavigation = mockk<MapboxNavigation>(relaxed = true) {
+        every { registerLocationObserver(capture(locationObserverSlot)) } just Runs
+    }
+
+    private val locationViewModel = LocationViewModel()
+
     @Test
     fun `default state is a null location`() = runBlockingTest {
-        val locationViewModel = LocationViewModel()
-
         val location = locationViewModel.state.value
 
         assertNull(location)
     }
 
     @Test
-    fun `onAttached will use current location to update state`() = runBlockingTest {
-        val locationViewModel = LocationViewModel()
-        val mapboxNavigation = mockMapboxNavigationLastLocation(
-            mockk {
+    fun `onAttached will registerLocationObserver onNewLocationMatcherResult updates state`() =
+        runBlockingTest {
+            val mockLocation: Location = mockk {
                 every { longitude } returns -109.587335
                 every { latitude } returns 38.731370
             }
-        )
 
-        locationViewModel.onAttached(mapboxNavigation)
-
-        with(locationViewModel.state.value!!) {
-            assertEquals(-109.587335, longitude, 0.00001)
-            assertEquals(38.731370, latitude, 0.00001)
-        }
-    }
-
-    @Test
-    fun `onAttached will use current location to update navigationLocationProvider`() =
-        runBlockingTest {
-            val locationViewModel = LocationViewModel()
-            val mapboxNavigation = mockMapboxNavigationLastLocation(
-                mockk {
-                    every { longitude } returns -109.587335
-                    every { latitude } returns 38.731370
+            locationViewModel.onAttached(mockMapboxNavigation)
+            locationObserverSlot.captured.onNewLocationMatcherResult(
+                mockk(relaxed = true) {
+                    every { enhancedLocation } returns mockLocation
+                    every { keyPoints } returns listOf(mockLocation)
                 }
             )
-
-            locationViewModel.onAttached(mapboxNavigation)
-
-            with(locationViewModel.navigationLocationProvider.lastLocation!!) {
-                assertEquals(-109.587335, longitude, 0.00001)
-                assertEquals(38.731370, latitude, 0.00001)
-            }
-        }
-
-    @Test
-    fun `onAttached will use current location to update lastPoint`() = runBlockingTest {
-        val locationViewModel = LocationViewModel()
-        val mapboxNavigation = mockMapboxNavigationLastLocation(
-            mockk {
-                every { longitude } returns -109.587335
-                every { latitude } returns 38.731370
-            }
-        )
-
-        locationViewModel.onAttached(mapboxNavigation)
-
-        with(locationViewModel.lastPoint!!) {
-            assertEquals(-109.587335, longitude(), 0.00001)
-            assertEquals(38.731370, latitude(), 0.00001)
-        }
-    }
-
-    @Test
-    fun `onAttached will not log error when getLastLocation fails`() = runBlockingTest {
-        val locationViewModel = LocationViewModel()
-        val callbackSlot = slot<LocationEngineCallback<LocationEngineResult>>()
-        val mapboxNavigation = mockk<MapboxNavigation>(relaxed = true) {
-            every { navigationOptions } returns mockk {
-                every { locationEngine } returns mockk {
-                    every { getLastLocation(capture(callbackSlot)) } answers {
-                        callbackSlot.captured.onFailure(mockk())
-                    }
-                }
-            }
-        }
-
-        locationViewModel.onAttached(mapboxNavigation)
-
-        assertNull(locationViewModel.state.value)
-        verify(exactly = 1) { Logger.e(any(), any()) }
-    }
-
-    @Test
-    fun `onAttached registerLocationObserver onNewRawLocation are ignored`() = runBlockingTest {
-        val locationViewModel = LocationViewModel()
-        val locationObserver = slot<LocationObserver>()
-        val mapboxNavigation = mockk<MapboxNavigation>(relaxed = true) {
-            every { navigationOptions } returns mockk {
-                every { locationEngine } returns mockk {
-                    every { getLastLocation(any()) } just Runs
-                    every { registerLocationObserver(capture(locationObserver)) } answers {
-                        locationObserver.captured.onNewRawLocation(
-                            mockk {
-                                every { longitude } returns -109.587335
-                                every { latitude } returns 38.731370
-                            }
-                        )
-                    }
-                }
-            }
-        }
-
-        locationViewModel.onAttached(mapboxNavigation)
-
-        assertNull(locationViewModel.state.value)
-    }
-
-    @Test
-    fun `onAttached registerLocationObserver onNewLocationMatcherResult updates state`() =
-        runBlockingTest {
-            val locationViewModel = LocationViewModel()
-            val mapboxNavigation = mockMapboxNavigationRegisterObserver(
-                mockk {
-                    every { longitude } returns -109.587335
-                    every { latitude } returns 38.731370
-                }
-            )
-
-            locationViewModel.onAttached(mapboxNavigation)
 
             with(locationViewModel.state.value!!) {
                 assertEquals(-109.587335, longitude, 0.00001)
@@ -163,15 +67,18 @@ class LocationViewModelTest {
     @Test
     fun `onAttached registerLocationObserver onNewLocationMatcherResult updates navigationLocationProvider`() =
         runBlockingTest {
-            val locationViewModel = LocationViewModel()
-            val mapboxNavigation = mockMapboxNavigationRegisterObserver(
-                mockk {
-                    every { longitude } returns -109.587335
-                    every { latitude } returns 38.731370
+            val mockLocation: Location = mockk {
+                every { longitude } returns -109.587335
+                every { latitude } returns 38.731370
+            }
+
+            locationViewModel.onAttached(mockMapboxNavigation)
+            locationObserverSlot.captured.onNewLocationMatcherResult(
+                mockk(relaxed = true) {
+                    every { enhancedLocation } returns mockLocation
+                    every { keyPoints } returns listOf(mockLocation)
                 }
             )
-
-            locationViewModel.onAttached(mapboxNavigation)
 
             with(locationViewModel.navigationLocationProvider.lastLocation!!) {
                 assertEquals(-109.587335, longitude, 0.00001)
@@ -182,15 +89,18 @@ class LocationViewModelTest {
     @Test
     fun `onAttached registerLocationObserver onNewLocationMatcherResult updates lastPoint`() =
         runBlockingTest {
-            val locationViewModel = LocationViewModel()
-            val mapboxNavigation = mockMapboxNavigationRegisterObserver(
-                mockk {
-                    every { longitude } returns -109.587335
-                    every { latitude } returns 38.731370
+            val mockLocation: Location = mockk {
+                every { longitude } returns -109.587335
+                every { latitude } returns 38.731370
+            }
+
+            locationViewModel.onAttached(mockMapboxNavigation)
+            locationObserverSlot.captured.onNewLocationMatcherResult(
+                mockk(relaxed = true) {
+                    every { enhancedLocation } returns mockLocation
+                    every { keyPoints } returns listOf(mockLocation)
                 }
             )
-
-            locationViewModel.onAttached(mapboxNavigation)
 
             with(locationViewModel.lastPoint!!) {
                 assertEquals(-109.587335, longitude(), 0.00001)
@@ -200,58 +110,12 @@ class LocationViewModelTest {
 
     @Test
     fun `onDetached will unregisterLocationObserver`() = runBlockingTest {
-        val locationViewModel = LocationViewModel()
-        val mapboxNavigation = mockMapboxNavigationRegisterObserver(
-            mockk {
-                every { longitude } returns -109.587335
-                every { latitude } returns 38.731370
-            }
-        )
-
-        locationViewModel.onAttached(mapboxNavigation)
-        locationViewModel.onDetached(mapboxNavigation)
+        locationViewModel.onAttached(mockMapboxNavigation)
+        locationViewModel.onDetached(mockMapboxNavigation)
 
         verifyOrder {
-            mapboxNavigation.registerLocationObserver(any())
-            mapboxNavigation.unregisterLocationObserver(any())
-        }
-    }
-
-    private fun mockMapboxNavigationLastLocation(_lastLocation: Location?): MapboxNavigation {
-        val callbackSlot = slot<LocationEngineCallback<LocationEngineResult>>()
-        return mockk(relaxed = true) {
-            every { navigationOptions } returns mockk {
-                every { locationEngine } returns mockk {
-                    every { getLastLocation(capture(callbackSlot)) } answers {
-                        callbackSlot.captured.onSuccess(
-                            mockk {
-                                every { lastLocation } returns _lastLocation
-                            }
-                        )
-                    }
-                }
-            }
-        }
-    }
-
-    private fun mockMapboxNavigationRegisterObserver(
-        _enhancedLocation: Location
-    ): MapboxNavigation {
-        val locationObserver = slot<LocationObserver>()
-        return mockk(relaxed = true) {
-            every { navigationOptions } returns mockk {
-                every { locationEngine } returns mockk {
-                    every { getLastLocation(any()) } just Runs
-                    every { registerLocationObserver(capture(locationObserver)) } answers {
-                        locationObserver.captured.onNewLocationMatcherResult(
-                            mockk {
-                                every { enhancedLocation } returns _enhancedLocation
-                                every { keyPoints } returns emptyList()
-                            }
-                        )
-                    }
-                }
-            }
+            mockMapboxNavigation.registerLocationObserver(any())
+            mockMapboxNavigation.unregisterLocationObserver(any())
         }
     }
 }


### PR DESCRIPTION
### Description race condition

Big issue found with "UIComponent" -> "UIViewModel" communication using coroutines. The issue is:

1. Foo_UIViewModel.onAttached
1. Bar_UIComponent.onAttached
1. Bar_UIComponent calls Foo_UIViewModel.invoke
1. Foo_UIViewModel `mainJobControl.scope.launch {` scope begins

On step 3 the `Foo_UIViewModel.invoke` call can be dropped when there is a race with 4

There are several work arounds for this issue. Also, all other components are not affected by this race because they also launch a coroutine after attaching.

Our longer term solution will be part of "[synchronous actions](https://github.com/mapbox/navigation-sdks/issues/1571)" and/or "[centralized state](https://github.com/mapbox/mapbox-navigation-android/pull/5626)"

### Description crash
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

The LocationViewModel is requesting the location without location permissions accepted. This was fine before when we assumed navigation view had permission.

I'm also deleting it because the TripSessionStarterViewModel immediately starts the trip session after location permissions are accepted. 

The SDK does the early prefetch, so this will continue to have a fast "initial location"

https://github.com/mapbox/mapbox-navigation-android/blob/6575dbb6afb1730942c92eaa3745208bf96b7e72/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/TripSessionLocationEngine.kt#L51
