### PR TITLE
RerouteController: switch to alternative if exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Mapbox welcomes participation and contributions from everyone.
 
 #### Bug fixes and improvements
 - :warning: Realigned all `NavigationCamera` transitions to not fallback to `Idle` if a transition is canceled to keep the behavior consistent and predictable (state transitions used to be cancelable while frame transitions weren't). If you need the `NavigationCamera` to reset to `Idle` on external interactions or cancellations, use `NavigationBasicGesturesHandler` or `NavigationScaleGestureHandler` [#5607](https://github.com/mapbox/mapbox-navigation-android/pull/5607)
+- Improved reroute experience for a default controller. `MapboxRerouteController` now immediately switches to an alternative route when a user turns to it, without making an unnecessary route request. [#5645](https://github.com/mapbox/mapbox-navigation-android/pull/5645)
 
 ### Mapbox dependencies
 This release depends on, and has been tested with, the following Mapbox dependencies:

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/factory/RouteProgressFactory.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/factory/RouteProgressFactory.kt
@@ -41,6 +41,8 @@ object RouteProgressFactory {
      * @param upcomingRoadObjects list of upcoming road objects.
      * @param stale `true` if there were no location updates for a significant amount which causes
      * a lack of confidence in the progress updates being sent.
+     * @param alternativeRouteId id of an alternative route user started to follow deviating from
+     * a primary route. **null** if a route is not exist
      */
     fun buildRouteProgressObject(
         route: NavigationRoute,
@@ -57,6 +59,7 @@ object RouteProgressFactory {
         remainingWaypoints: Int,
         upcomingRoadObjects: List<UpcomingRoadObject>,
         stale: Boolean,
+        alternativeRouteId: String?
     ): RouteProgress {
         return RouteProgress(
             navigationRoute = route,
@@ -73,6 +76,7 @@ object RouteProgressFactory {
             remainingWaypoints = remainingWaypoints,
             upcomingRoadObjects = upcomingRoadObjects,
             stale = stale,
+            alternativeRouteId,
         )
     }
 }

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/route/NavigationRouteEx.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/route/NavigationRouteEx.kt
@@ -1,3 +1,5 @@
+@file:JvmName("NavigationRouteEx")
+
 package com.mapbox.navigation.base.internal.route
 
 import com.mapbox.api.directions.v5.models.DirectionsRoute
@@ -7,6 +9,11 @@ import com.mapbox.navigation.base.route.NavigationRoute
 import com.mapbox.navigation.base.route.toNavigationRoute
 import com.mapbox.navigator.Navigator
 import com.mapbox.navigator.RouteInterface
+import com.mapbox.navigator.RouterOrigin
+
+val NavigationRoute.routeId: String get() = nativeRoute.routeId
+
+val NavigationRoute.routerOrigin: RouterOrigin get() = nativeRoute.routerOrigin
 
 /**
  * Internal handle for the route's native peer.

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/utils/RouteProgressEx.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/utils/RouteProgressEx.kt
@@ -1,0 +1,7 @@
+@file:JvmName("RouteProgressEx")
+
+package com.mapbox.navigation.base.internal.utils
+
+import com.mapbox.navigation.base.trip.model.RouteProgress
+
+val RouteProgress.routeAlternativeId: String? get() = routeAlternativeId

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteProgress.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/RouteProgress.kt
@@ -53,6 +53,7 @@ class RouteProgress internal constructor(
     val remainingWaypoints: Int,
     val upcomingRoadObjects: List<UpcomingRoadObject>,
     val stale: Boolean,
+    internal val routeAlternativeId: String?,
 ) {
 
     /**

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/route/RouteExclusionsJavaTest.java
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/route/RouteExclusionsJavaTest.java
@@ -10,7 +10,7 @@ import com.mapbox.bindgen.ExpectedFactory;
 import com.mapbox.geojson.Point;
 import com.mapbox.navigation.base.extensions.RouteOptionsExtensions;
 import com.mapbox.navigation.base.internal.SDKRouteParser;
-import com.mapbox.navigation.base.internal.route.NavigationRouteExKt;
+import com.mapbox.navigation.base.internal.route.NavigationRouteEx;
 import com.mapbox.navigation.testing.FileUtils;
 import com.mapbox.navigator.RouteInterface;
 
@@ -61,7 +61,7 @@ public class RouteExclusionsJavaTest {
         .distance(183888.609)
         .duration(10697.573)
         .build();
-    NavigationRoute navigationRoute = NavigationRouteExKt.createNavigationRoute(
+    NavigationRoute navigationRoute = NavigationRouteEx.createNavigationRoute(
         directionsRoute, parser
     );
 
@@ -76,7 +76,7 @@ public class RouteExclusionsJavaTest {
     DirectionsRoute directionsRoute = DirectionsRoute.fromJson(
         FileUtils.INSTANCE.loadJsonFixture("toll_and_ferry_directions_route.json")
     );
-    NavigationRoute navigationRoute = NavigationRouteExKt.createNavigationRoute(
+    NavigationRoute navigationRoute = NavigationRouteEx.createNavigationRoute(
         directionsRoute, parser
     );
 
@@ -91,7 +91,7 @@ public class RouteExclusionsJavaTest {
     DirectionsRoute directionsRoute = DirectionsRoute.fromJson(
         FileUtils.INSTANCE.loadJsonFixture("toll_and_ferry_directions_route.json")
     );
-    NavigationRoute navigationRoute = NavigationRouteExKt.createNavigationRoute(
+    NavigationRoute navigationRoute = NavigationRouteEx.createNavigationRoute(
         directionsRoute, parser
     );
 

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/MapboxDirectionsSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/MapboxDirectionsSession.kt
@@ -32,6 +32,7 @@ internal class MapboxDirectionsSession(
     override var routes: List<NavigationRoute> = emptyList()
         private set
 
+    @RoutesExtra.RoutesUpdateReason
     private var routesUpdateReason: String = RoutesExtra.ROUTES_UPDATE_REASON_CLEAN_UP
 
     override var initialLegIndex = 0

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/navigator/NavigatorMapper.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/navigator/NavigatorMapper.kt
@@ -211,6 +211,7 @@ private fun NavigationStatus.getRouteProgress(
             remainingWaypoints,
             upcomingRouteAlerts.toUpcomingRoadObjects(),
             stale,
+            locatedAlternativeRouteId,
         )
     }
     return null

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/navigator/NavigatorMapperTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/navigator/NavigatorMapperTest.kt
@@ -95,6 +95,7 @@ class NavigatorMapperTest {
             stale = true,
             remainingWaypoints = 1,
             upcomingRoadObjects = listOf(),
+            alternativeRouteId = "alternative_id",
         )
 
         val result = getRouteProgressFrom(
@@ -564,6 +565,7 @@ class NavigatorMapperTest {
         every { inTunnel } returns true
         every { upcomingRouteAlerts } returns emptyList()
         every { roads } returns listOf(com.mapbox.navigator.Road("Central Av", null, null))
+        every { locatedAlternativeRouteId } returns "alternative_id"
     }
 
     val routeAlertLocation: RouteAlertLocation = mockk()


### PR DESCRIPTION
### Description
RerouteController: switch to alternative if exist

Closes https://github.com/mapbox/mapbox-navigation-android/issues/5039

Additionally unit tests also were checked manually 🚀  

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
