### PR TITLE
[DROP-IN] Fix: Maneuver arrow remains on map after navigation terminated

### DIFF
--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/routearrow/RouteArrowComponent.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/routearrow/RouteArrowComponent.kt
@@ -8,7 +8,6 @@ import com.mapbox.navigation.dropin.lifecycle.UIComponent
 import com.mapbox.navigation.ui.maps.route.arrow.api.MapboxRouteArrowApi
 import com.mapbox.navigation.ui.maps.route.arrow.api.MapboxRouteArrowView
 import com.mapbox.navigation.ui.maps.route.arrow.model.RouteArrowOptions
-import com.mapbox.navigation.utils.internal.ifNonNull
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 
@@ -24,11 +23,18 @@ internal class RouteArrowComponent(
         super.onAttached(mapboxNavigation)
         coroutineScope.launch {
             mapboxNavigation.flowRouteProgress().collect { routeProgress ->
-                ifNonNull(mapView.getMapboxMap().getStyle()) { style ->
+                mapView.getMapboxMap().getStyle()?.also { style ->
                     val arrowUpdate = routeArrowApi.addUpcomingManeuverArrow(routeProgress)
                     routeArrowView.renderManeuverUpdate(style, arrowUpdate)
                 }
             }
+        }
+    }
+
+    override fun onDetached(mapboxNavigation: MapboxNavigation) {
+        super.onDetached(mapboxNavigation)
+        mapView.getMapboxMap().getStyle()?.also { style ->
+            routeArrowView.render(style, routeArrowApi.clearArrows())
         }
     }
 }

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/routearrow/RouteArrowComponentTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/routearrow/RouteArrowComponentTest.kt
@@ -12,6 +12,7 @@ import com.mapbox.navigation.core.trip.session.RouteProgressObserver
 import com.mapbox.navigation.testing.MainCoroutineRule
 import com.mapbox.navigation.ui.maps.route.arrow.api.MapboxRouteArrowApi
 import com.mapbox.navigation.ui.maps.route.arrow.api.MapboxRouteArrowView
+import com.mapbox.navigation.ui.maps.route.arrow.model.ClearArrowsValue
 import com.mapbox.navigation.ui.maps.route.arrow.model.InvalidPointError
 import com.mapbox.navigation.ui.maps.route.arrow.model.RouteArrowOptions
 import com.mapbox.navigation.ui.maps.route.arrow.model.UpdateManeuverArrowValue
@@ -82,5 +83,32 @@ class RouteArrowComponentTest {
         routeProgressObserverSlot.captured.onRouteProgressChanged(mockk())
 
         verify { mockView.renderManeuverUpdate(mockStyle, expected) }
+    }
+
+    @Test
+    fun `onDetached should clear all route arrows`() {
+        val style = mockk<Style>()
+        val mockMapView = mockk<MapView> {
+            every { getMapboxMap() } returns mockk {
+                every { getStyle() } returns style
+            }
+        }
+        val clearValue = mockk<ClearArrowsValue>()
+        val mockApi = mockk<MapboxRouteArrowApi> {
+            every { clearArrows() } returns clearValue
+        }
+        val mockView = mockk<MapboxRouteArrowView>(relaxed = true)
+        val mockMapboxNavigation = mockk<MapboxNavigation>(relaxed = true)
+
+        val sut = RouteArrowComponent(
+            mockMapView,
+            routeArrowOptions,
+            mockApi,
+            mockView
+        )
+        sut.onAttached(mockMapboxNavigation)
+        sut.onDetached(mockMapboxNavigation)
+
+        verify { mockView.render(style, clearValue) }
     }
 }


### PR DESCRIPTION
Closes [#5633](https://github.com/mapbox/mapbox-navigation-android/issues/5633)

### Description

- Updated RouteArrowComponent to clear route arrows in onDetached.

### Screenshots or Gifs
_QA App Screen recording on Pixel 2_

https://user-images.githubusercontent.com/2678039/161587619-a8327cf5-d6c0-47b5-8989-ab242ff205ae.mp4


