### PR TITLE
[DROP-IN] Overriding overview pitch to 0.0 when in Free Drive.

### DIFF
--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/camera/CameraComponent.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/camera/CameraComponent.kt
@@ -89,6 +89,7 @@ internal class CameraComponent constructor(
                     is NavigationState.FreeDrive -> {
                         viewportDataSource.followingZoomPropertyOverride(FOLLOWING_ZOOM_OVERRIDE)
                         viewportDataSource.overviewZoomPropertyOverride(OVERVIEW_ZOOM_OVERRIDE)
+                        viewportDataSource.overviewPitchPropertyOverride(OVERVIEW_PITCH_OVERRIDE)
                     }
                     else -> {
                         viewportDataSource.clearFollowingOverrides()
@@ -218,6 +219,7 @@ internal class CameraComponent constructor(
 
     companion object {
         private const val OVERVIEW_ZOOM_OVERRIDE = 16.5
+        private const val OVERVIEW_PITCH_OVERRIDE = 0.0
         private const val FOLLOWING_ZOOM_OVERRIDE = 16.5
     }
 }

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/camera/CameraComponentTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/camera/CameraComponentTest.kt
@@ -187,12 +187,13 @@ class CameraComponentTest {
         }
 
     @Test
-    fun `when in free drive zoom property is overridden`() =
+    fun `when in free drive zoom and pitch property is overridden`() =
         coroutineRule.runBlockingTest {
             cameraComponent.onAttached(mockMapboxNavigation)
 
             verify {
                 mockViewPortDataSource.overviewZoomPropertyOverride(16.5)
+                mockViewPortDataSource.overviewPitchPropertyOverride(0.0)
                 mockViewPortDataSource.followingZoomPropertyOverride(16.5)
                 mockViewPortDataSource.evaluate()
             }


### PR DESCRIPTION
Closes [#1533](https://github.com/mapbox/navigation-sdks/issues/1533)

### Screenshots or Gifs

_QA App Screen recording on Pixel 2_

https://user-images.githubusercontent.com/2678039/161787748-c4e476d7-1942-43fa-a4da-ab75a7483d6a.mp4


