### PR TITLE
[DropInUi] Make `UIViewModel` invoke happen synchronously 

### DIFF
--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/camera/CameraComponent.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/camera/CameraComponent.kt
@@ -92,9 +92,8 @@ internal class CameraComponent constructor(
 
     private fun saveCameraState() {
         val map = mapView.getMapboxMap()
-        val state = map.cameraState
-        cameraViewModel.saveCameraState(state)
-        logD("saveCameraState $map; $state", "CameraComponent")
+        cameraViewModel.invoke(CameraAction.SaveMapState(map.cameraState))
+        logD("saveCameraState $map; ${map.cameraState}", "CameraComponent")
     }
 
     private fun restoreCameraState() {

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/camera/CameraViewModel.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/camera/CameraViewModel.kt
@@ -9,13 +9,10 @@ sealed class CameraAction {
     object ToOverview : CameraAction()
     object ToFollowing : CameraAction()
     data class UpdatePadding(val padding: EdgeInsets) : CameraAction()
+    data class SaveMapState(val mapState: com.mapbox.maps.CameraState) : CameraAction()
 }
 
 internal class CameraViewModel : UIViewModel<CameraState, CameraAction>(CameraState()) {
-
-    fun saveCameraState(cameraState: com.mapbox.maps.CameraState) {
-        _state.value = _state.value.copy(mapCameraState = cameraState)
-    }
 
     override fun process(
         mapboxNavigation: MapboxNavigation,
@@ -35,6 +32,9 @@ internal class CameraViewModel : UIViewModel<CameraState, CameraAction>(CameraSt
             }
             is CameraAction.UpdatePadding -> {
                 state.copy(cameraPadding = action.padding)
+            }
+            is CameraAction.SaveMapState -> {
+                state.copy(mapCameraState = action.mapState)
             }
         }
     }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/lifecycle/UICoordinator.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/lifecycle/UICoordinator.kt
@@ -24,11 +24,11 @@ abstract class UICoordinator<T : ViewGroup>(
     private val viewGroup: T
 ) : MapboxNavigationObserver {
 
+    private var attachedObserver: MapboxNavigationObserver? = null
     lateinit var coroutineScope: CoroutineScope
 
     @CallSuper
     override fun onAttached(mapboxNavigation: MapboxNavigation) {
-        var attachedObserver: MapboxNavigationObserver? = null
         coroutineScope = MainScope()
 
         coroutineScope.launch {
@@ -37,14 +37,14 @@ abstract class UICoordinator<T : ViewGroup>(
                 attachedObserver = viewBinder.bind(viewGroup)
                 attachedObserver?.onAttached(mapboxNavigation)
             }
-        }.invokeOnCompletion {
-            attachedObserver?.onDetached(mapboxNavigation)
         }
     }
 
     @CallSuper
     override fun onDetached(mapboxNavigation: MapboxNavigation) {
         coroutineScope.cancel()
+        attachedObserver?.onDetached(mapboxNavigation)
+        attachedObserver = null
     }
 
     /**

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/camera/CameraViewModelTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/camera/CameraViewModelTest.kt
@@ -4,10 +4,17 @@ import com.mapbox.geojson.Point
 import com.mapbox.maps.EdgeInsets
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.lifecycle.MapboxNavigationApp
 import com.mapbox.navigation.testing.MainCoroutineRule
+import com.mapbox.navigation.testing.MockLoggerRule
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
@@ -16,6 +23,19 @@ class CameraViewModelTest {
 
     @get:Rule
     var coroutineRule = MainCoroutineRule()
+
+    @get:Rule
+    val mockLoggerTestRule = MockLoggerRule()
+
+    @Before
+    fun setup() {
+        mockkObject(MapboxNavigationApp)
+    }
+
+    @After
+    fun teardown() {
+        unmockkAll()
+    }
 
     @Test
     fun `default state is idle`() {
@@ -29,8 +49,7 @@ class CameraViewModelTest {
     @Test
     fun `when action toIdle updates camera mode`() = coroutineRule.runBlockingTest {
         val cameraViewModel = CameraViewModel()
-        val mockMapboxNavigation = mockk<MapboxNavigation>(relaxed = true)
-        cameraViewModel.onAttached(mockMapboxNavigation)
+        cameraViewModel.onAttached(mockMapboxNavigation())
         cameraViewModel.invoke(CameraAction.ToIdle)
 
         val cameraState = cameraViewModel.state.value
@@ -41,8 +60,7 @@ class CameraViewModelTest {
     @Test
     fun `when action toOverview updates camera mode`() = coroutineRule.runBlockingTest {
         val cameraViewModel = CameraViewModel()
-        val mockMapboxNavigation = mockk<MapboxNavigation>(relaxed = true)
-        cameraViewModel.onAttached(mockMapboxNavigation)
+        cameraViewModel.onAttached(mockMapboxNavigation())
         cameraViewModel.invoke(CameraAction.ToOverview)
 
         val cameraState = cameraViewModel.state.value
@@ -54,8 +72,7 @@ class CameraViewModelTest {
     fun `when action toFollowing updates camera mode and zoomUpdatesAllowed`() =
         coroutineRule.runBlockingTest {
             val cameraViewModel = CameraViewModel()
-            val mockMapboxNavigation = mockk<MapboxNavigation>(relaxed = true)
-            cameraViewModel.onAttached(mockMapboxNavigation)
+            cameraViewModel.onAttached(mockMapboxNavigation())
             cameraViewModel.invoke(CameraAction.ToFollowing)
 
             val cameraState = cameraViewModel.state.value
@@ -68,8 +85,7 @@ class CameraViewModelTest {
         coroutineRule.runBlockingTest {
             val padding = EdgeInsets(1.0, 2.0, 3.0, 4.0)
             val cameraViewModel = CameraViewModel()
-            val mockMapboxNavigation = mockk<MapboxNavigation>(relaxed = true)
-            cameraViewModel.onAttached(mockMapboxNavigation)
+            cameraViewModel.onAttached(mockMapboxNavigation())
 
             cameraViewModel.invoke(CameraAction.UpdatePadding(padding))
 
@@ -77,7 +93,7 @@ class CameraViewModelTest {
         }
 
     @Test
-    fun `saveCameraState should save map camera state`() {
+    fun `saveCameraState should save map camera state after detached`() {
         val cameraState = com.mapbox.maps.CameraState(
             Point.fromLngLat(11.0, 22.0),
             EdgeInsets(1.0, 2.0, 3.0, 4.0),
@@ -85,10 +101,19 @@ class CameraViewModelTest {
             40.0,
             50.0
         )
+        val mockMapboxNavigation = mockMapboxNavigation()
         val cameraViewModel = CameraViewModel()
 
-        cameraViewModel.saveCameraState(cameraState)
+        cameraViewModel.onAttached(mockMapboxNavigation)
+        cameraViewModel.onDetached(mockMapboxNavigation)
+        cameraViewModel.invoke(CameraAction.SaveMapState(cameraState))
 
         assertEquals(cameraState, cameraViewModel.state.value.mapCameraState)
+    }
+
+    private fun mockMapboxNavigation(): MapboxNavigation {
+        val mapboxNavigation = mockk<MapboxNavigation>(relaxed = true)
+        every { MapboxNavigationApp.current() } returns mapboxNavigation
+        return mapboxNavigation
     }
 }

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/infopanel/InfoPanelHeaderComponentTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/infopanel/InfoPanelHeaderComponentTest.kt
@@ -20,9 +20,7 @@ import com.mapbox.navigation.dropin.component.routefetch.RoutesState
 import com.mapbox.navigation.dropin.component.routefetch.RoutesViewModel
 import com.mapbox.navigation.dropin.databinding.MapboxInfoPanelHeaderLayoutBinding
 import com.mapbox.navigation.testing.MainCoroutineRule
-import io.mockk.Runs
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -188,7 +186,9 @@ internal class InfoPanelHeaderComponentTest {
         every { mockLocationViewModel.lastPoint } returns mockk()
         every { mockRoutesViewModel.state } returns MutableStateFlow(RoutesState.Ready(mockk()))
         val routeActionSlot = mutableListOf<RoutesAction>()
-        every { mockRoutesViewModel.invoke(capture(routeActionSlot)) } just Runs
+        every {
+            mockRoutesViewModel.invoke(capture(routeActionSlot))
+        } returns RoutesState.Ready(mockk())
 
         sut.onAttached(mockk())
         binding.routePreview.performClick()
@@ -204,7 +204,7 @@ internal class InfoPanelHeaderComponentTest {
         )
         every { mockLocationViewModel.lastPoint } returns mockk()
         every { mockRoutesViewModel.state } returns MutableStateFlow(RoutesState.Ready(mockk()))
-        every { mockRoutesViewModel.invoke(any()) } just Runs
+        every { mockRoutesViewModel.invoke(any()) } returns RoutesState.Ready(mockk())
 
         sut.onAttached(mockk())
         binding.routePreview.performClick()
@@ -224,7 +224,9 @@ internal class InfoPanelHeaderComponentTest {
         every { mockLocationViewModel.lastPoint } returns mockk()
         every { mockRoutesViewModel.state } returns MutableStateFlow(RoutesState.Ready(mockk()))
         val routeActionSlot = mutableListOf<RoutesAction>()
-        every { mockRoutesViewModel.invoke(capture(routeActionSlot)) } just Runs
+        every {
+            mockRoutesViewModel.invoke(capture(routeActionSlot))
+        } returns RoutesState.Ready(mockk())
 
         sut.onAttached(mockk())
         binding.startNavigation.performClick()
@@ -240,7 +242,7 @@ internal class InfoPanelHeaderComponentTest {
         )
         every { mockLocationViewModel.lastPoint } returns mockk()
         every { mockRoutesViewModel.state } returns MutableStateFlow(RoutesState.Ready(mockk()))
-        every { mockRoutesViewModel.invoke(any()) } just Runs
+        every { mockRoutesViewModel.invoke(any()) } returns RoutesState.Ready(mockk())
 
         sut.onAttached(mockk())
         binding.startNavigation.performClick()

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/navigation/NavigationStateViewModelTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/navigation/NavigationStateViewModelTest.kt
@@ -1,9 +1,15 @@
 package com.mapbox.navigation.dropin.component.navigation
 
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.lifecycle.MapboxNavigationApp
 import com.mapbox.navigation.testing.MainCoroutineRule
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
@@ -19,15 +25,27 @@ internal class NavigationStateViewModelTest {
 
     @Before
     fun setUp() {
+        mockkObject(MapboxNavigationApp)
         sut = NavigationStateViewModel(NavigationState.FreeDrive)
+    }
+
+    @After
+    fun teardown() {
+        unmockkAll()
     }
 
     @Test
     fun `should set new state on Update action`() = coroutineRule.runBlockingTest {
-        sut.onAttached(mockk())
+        sut.onAttached(mockMapboxNavigation())
 
         sut.invoke(NavigationStateAction.Update(NavigationState.RoutePreview))
 
         assertEquals(NavigationState.RoutePreview, sut.state.value)
+    }
+
+    private fun mockMapboxNavigation(): MapboxNavigation {
+        val mapboxNavigation = mockk<MapboxNavigation>()
+        every { MapboxNavigationApp.current() } returns mapboxNavigation
+        return mapboxNavigation
     }
 }

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/tripsession/TripSessionStarterViewModelTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/tripsession/TripSessionStarterViewModelTest.kt
@@ -2,18 +2,23 @@ package com.mapbox.navigation.dropin.component.tripsession
 
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.lifecycle.MapboxNavigationApp
 import com.mapbox.navigation.dropin.component.navigation.NavigationState
 import com.mapbox.navigation.dropin.component.navigation.NavigationStateViewModel
 import com.mapbox.navigation.testing.MainCoroutineRule
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
 import io.mockk.verify
 import io.mockk.verifyOrder
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runBlockingTest
+import org.junit.After
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
@@ -22,6 +27,16 @@ class TripSessionStarterViewModelTest {
 
     @get:Rule
     var coroutineRule = MainCoroutineRule()
+
+    @Before
+    fun setup() {
+        mockkObject(MapboxNavigationApp)
+    }
+
+    @After
+    fun teardown() {
+        unmockkAll()
+    }
 
     @Test
     fun `verify default state is respected`() = runBlockingTest {
@@ -156,7 +171,11 @@ class TripSessionStarterViewModelTest {
             verify(exactly = 1) { mapboxNavigation.startReplayTripSession() }
         }
 
-    private fun mockMapboxNavigation(): MapboxNavigation = mockk(relaxed = true)
+    private fun mockMapboxNavigation(): MapboxNavigation {
+        val mapboxNavigation = mockk<MapboxNavigation>(relaxed = true)
+        every { MapboxNavigationApp.current() } returns mapboxNavigation
+        return mapboxNavigation
+    }
 
     private fun mockNavigationStateViewModel(
         initialState: NavigationState = NavigationState.FreeDrive

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/lifecycle/UIViewModelTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/lifecycle/UIViewModelTest.kt
@@ -1,19 +1,46 @@
 package com.mapbox.navigation.dropin.lifecycle
 
+import com.mapbox.common.Logger
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.lifecycle.MapboxNavigationApp
 import com.mapbox.navigation.testing.MainCoroutineRule
+import com.mapbox.navigation.testing.MockLoggerRule
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.test.runBlockingTest
+import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
-@OptIn(ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalPreviewMapboxNavigationAPI::class)
 class UIViewModelTest {
 
     @get:Rule
     var coroutineRule = MainCoroutineRule()
+
+    @get:Rule
+    val mockLoggerTestRule = MockLoggerRule()
+
+    @Before
+    fun setup() {
+        mockkObject(MapboxNavigationApp)
+    }
+
+    @After
+    fun teardown() {
+        unmockkAll()
+    }
 
     @Test
     fun `default value is equal to state`() = runBlockingTest {
@@ -26,41 +53,75 @@ class UIViewModelTest {
     fun `state will change change when view model is attached`() = runBlockingTest {
         val viewModel = AdderViewModel(10)
 
-        viewModel.onAttached(mockk())
+        val mapboxNavigation = mockMapboxNavigation()
+        viewModel.onAttached(mapboxNavigation)
         viewModel.invoke(3)
-        viewModel.onDetached(mockk())
+        viewModel.onDetached(mapboxNavigation)
 
         assertEquals(13, viewModel.state.value)
     }
 
     @Test
-    fun `state does not change when view model is detached`() = runBlockingTest {
+    fun `state is updated when view model is detached`() = runBlockingTest {
         val viewModel = AdderViewModel(10)
 
-        val mapboxNavigation = mockk<MapboxNavigation>()
+        val mapboxNavigation = mockMapboxNavigation()
         viewModel.invoke(1)
         viewModel.onAttached(mapboxNavigation)
         viewModel.invoke(3)
         viewModel.onDetached(mapboxNavigation)
         viewModel.invoke(5)
 
-        assertEquals(13, viewModel.state.value)
+        assertEquals(19, viewModel.state.value)
     }
 
     @Test
     fun `state will survive mapboxNavigation changes`() = runBlockingTest {
         val viewModel = AdderViewModel(10)
 
-        val mapboxNavigationFirst = mockk<MapboxNavigation>()
+        val mapboxNavigationFirst = mockMapboxNavigation()
         viewModel.onAttached(mapboxNavigationFirst)
         viewModel.invoke(3)
         viewModel.onDetached(mapboxNavigationFirst)
-        val mapboxNavigationSecond = mockk<MapboxNavigation>()
+        val mapboxNavigationSecond = mockMapboxNavigation()
         viewModel.onAttached(mapboxNavigationSecond)
         viewModel.invoke(4)
         viewModel.onDetached(mapboxNavigationSecond)
 
         assertEquals(17, viewModel.state.value)
+    }
+
+    @Test
+    fun `invoke logs a warning when MapboxNavigationApp is not setup`() = runBlockingTest {
+        val viewModel = AdderViewModel(10)
+        every { MapboxNavigationApp.current() } returns null
+
+        viewModel.invoke(4)
+
+        assertEquals(10, viewModel.state.value)
+        verify { Logger.w(any(), any()) }
+    }
+
+    @Test
+    fun `Actions can be observed`() = runBlockingTest {
+        val viewModel = AdderViewModel(10)
+        val actionsSlot = mutableListOf<Int>()
+        val mapboxNavigation = mockMapboxNavigation()
+        val actions = async { viewModel.action.collect { actionsSlot.add(it) } }
+
+        viewModel.onAttached(mapboxNavigation)
+        viewModel.invoke(3)
+        viewModel.invoke(4)
+        viewModel.onDetached(mapboxNavigation)
+        actions.cancelAndJoin()
+
+        assertTrue(actionsSlot.containsAll(listOf(3, 4)))
+    }
+
+    private fun mockMapboxNavigation(): MapboxNavigation {
+        val mapboxNavigation = mockk<MapboxNavigation>()
+        every { MapboxNavigationApp.current() } returns mapboxNavigation
+        return mapboxNavigation
     }
 }
 


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

There has been a few issues pop up with invoking actions on the `UIViewModel`

- Clearing the route line in the `onDetached` https://github.com/mapbox/navigation-sdks/issues/1530#issuecomment-1067221267
- Trying to save camera state in the `onDetached` method https://github.com/mapbox/mapbox-navigation-android/pull/5655#discussion_r843091181
- Location permissions is not granted `onAttached` https://github.com/mapbox/mapbox-navigation-android/pull/5643

We are also discussing an architecture change with a centralized `Store` https://github.com/mapbox/mapbox-navigation-android/pull/5626. That will also be able to address this issue because it removes the `MapboxNavigation` from the process function `process(_state.value, action)`. It also uses a single coroutine scope where individual actions are not canceled automatically.

For now, this change is proposing a small change that helps us keep track of how often this is an issue. It also provides a mechanism to continue using this architecture without becoming blocked.

### Synchronous vs suspending actions

Note that we discussed "synchronous" actions before. https://github.com/mapbox/navigation-sdks/issues/1571

But there is a difference between these. The issues/1571 is better described as a `suspending` action because it requires a coroutine to complete. For example, requesting routes from the network is a suspending function. 

Synchronous in this context, is that the action is processed immediately and the new state is returned. This is needed in order to guarantee the action completes without the coroutine dropping the event.

