### PR TITLE
Fixed MapboxSpeedLimitView sizing when rendering Errors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Mapbox welcomes participation and contributions from everyone.
 - Improved reroute experience for a default controller. `MapboxRerouteController` now immediately switches to an alternative route when a user turns to it, without making an unnecessary route request. [#5645](https://github.com/mapbox/mapbox-navigation-android/pull/5645)
 - Made all reachable polygon entries and exits tracked instead of the closest one for E-horizon `RoadObject`s. [#5653](https://github.com/mapbox/mapbox-navigation-android/pull/5653)
 - Fixed an issue where enhanced location couldn't snap to correct road edge for a long time after leaving a tunnel. [#5653](https://github.com/mapbox/mapbox-navigation-android/pull/5653)
+- Fixed `MapboxSpeedLimitView` sizing when rendering `UpdateSpeedLimitError` value [#5666](https://github.com/mapbox/mapbox-navigation-android/pull/5666)
 
 #### Other changes
 - Up until this point, `RoutesObserver` fired nearly immediately with new route references after `MapboxNavigation@setNavigationRoutes` was called. Now, the Nav SDK first fully processes the routes (for example, to compute the `AlternativeRouteMetadata`) which results in a small delay between routes being set and actually returned by the `RoutesObserver`.

--- a/libnavui-speedlimit/src/main/java/com/mapbox/navigation/ui/speedlimit/view/MapboxSpeedLimitView.kt
+++ b/libnavui-speedlimit/src/main/java/com/mapbox/navigation/ui/speedlimit/view/MapboxSpeedLimitView.kt
@@ -87,6 +87,7 @@ class MapboxSpeedLimitView : AppCompatTextView {
     fun render(expected: Expected<UpdateSpeedLimitError, UpdateSpeedLimitValue>) {
         expected.fold(
             { // error
+                updateBackgroundSize(speedLimitSign)
                 val speedLimitSpan = when (speedLimitSign) {
                     SpeedLimitSign.MUTCD -> {
                         background = getViewDrawable(SpeedLimitSign.MUTCD)


### PR DESCRIPTION
Closes [#1602](https://github.com/mapbox/navigation-sdks/issues/1602)

### Description

Fixed `MapboxSpeedLimitView` sizing when rendering `UpdateSpeedLimitError`.

### Changelog

```
<changelog>Fixed `MapboxSpeedLimitView` sizing when rendering `UpdateSpeedLimitError`</changelog>
```

### Screenshots or Gifs

_MUTCD_

https://user-images.githubusercontent.com/2678039/162047842-6d611baa-9947-4da5-b2b6-901a68a98b45.mp4

_VIENNA_

https://user-images.githubusercontent.com/2678039/162047864-738d6950-f211-4b2d-90c1-d949ae76d7a6.mp4


