### PR TITLE
Synchronously clear route alternatives source to minimize flash

### DIFF
--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/AlternativeRouteActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/AlternativeRouteActivity.kt
@@ -327,6 +327,7 @@ class AlternativeRouteActivity : AppCompatActivity(), OnMapLongClickListener {
     }
 
     private val routesObserver = RoutesObserver { result ->
+        Log.e("lp_test", "newRoutes: ${result.navigationRoutes.size}")
         CoroutineScope(Dispatchers.Main).launch {
             routeLineApi.setNavigationRoutes(
                 newRoutes = result.navigationRoutes,


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Attempts to improve https://github.com/mapbox/mapbox-navigation-android/issues/5687.

The problem is that when an alternative route changes, we clear its `GeoJsonSource` data and reset the expression to remove the vanishing portion. However, due to the async nature of the renderer, the expression that removes the vanishing portion (making all layer visible) is applied faster then the call that clears the source, briefly uncovering the whole geometry.

One factor here is the fact that by default Android Maps SDK parses the geometries on a worker thread, even if the geometry is empty, which unnecessarily adds a delay of context switching to the equation. In the current state of the branch I'm skipping the async parsing and setting the empty source directly.

Before:

https://user-images.githubusercontent.com/16925074/161552830-9ba6dda9-6abe-40c6-88db-3dd9f9149fe4.mp4

After:

https://user-images.githubusercontent.com/16925074/162733504-595aa229-9e88-4998-b51f-39f3dcdc6f2b.mp4

This by no means resolves the problem but does seem to improve it ever so slightly. It looks like we'd need an API that would allow us to batch both source and layer property updates together, similarly to existing `setStyleSourceProperties` and `setStyleLayerProperties`, something like `setStyleProperties([{source ID, property}, {layer ID, property}])`.

Opening this just as a POC, we can consider merging but don't really need to as we'd have to resolve the root cause anyway.

cc @cafesilencio @zmiao @alexshalamov @tobrun @kiryldz 

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
