### PR TITLE
fix an issue where route refresh would clear the alternatives metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Mapbox welcomes participation and contributions from everyone.
 #### Bug fixes and improvements
 - Added `NavigationOptions#EHorizonOptions#AlertServiceOptions` which allow to control which road objects are picked up from the eHorizon graph. :warning: Since Restricted Areas can be resource intensive to pick up, they are now disabled by default. [#5693](https://github.com/mapbox/mapbox-navigation-android/pull/5693)
 - Fixed an issue where a call to `MapboxNavigation#stopTripSession` would clear the routes reference and led to a `RoutesObserver` notification with empty routes collection. [#5685](https://github.com/mapbox/mapbox-navigation-android/pull/5685)
+- Fixed an issue where `AlternativeRouteMetadata` would get cleared after route refresh (whenever routes update reason was `RoutesExtra#ROUTES_UPDATE_REASON_REFRESH`). [#5691](https://github.com/mapbox/mapbox-navigation-android/pull/5691)
 
 ## Mapbox Navigation SDK 2.5.0-alpha.2 - April 7, 2022
 

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -826,11 +826,14 @@ class MapboxNavigation @VisibleForTesting internal constructor(
         @RoutesExtra.RoutesUpdateReason reason: String,
     ) {
         routeAlternativesController.pauseUpdates()
-        val result = tripSession.setRoutes(routes, legIndex, reason)
-        routeAlternativesController.processAlternativesMetadata(
-            routes,
-            result.nativeAlternatives
-        )
+        tripSession.setRoutes(routes, legIndex, reason).run {
+            if (nativeAlternatives != null) {
+                routeAlternativesController.processAlternativesMetadata(
+                    routes,
+                    nativeAlternatives
+                )
+            }
+        }
         routeAlternativesController.resumeUpdates()
     }
 

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/routealternatives/AlternativeRouteInfo.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/routealternatives/AlternativeRouteInfo.kt
@@ -8,6 +8,8 @@ import com.mapbox.navigation.core.directions.session.RoutesObserver
  * @param distance distance (based on the referenced route)
  * @param duration duration (based on the referenced route)
  */
+// the values might get out of date after route refresh,
+// refs https://github.com/mapbox/mapbox-navigation-native/issues/5655
 class AlternativeRouteInfo internal constructor(
     val distance: Double,
     val duration: Double,

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/NativeSetRouteResult.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/NativeSetRouteResult.kt
@@ -3,5 +3,5 @@ package com.mapbox.navigation.core.trip.session
 import com.mapbox.navigator.RouteAlternative
 
 internal data class NativeSetRouteResult(
-    val nativeAlternatives: List<RouteAlternative>
+    val nativeAlternatives: List<RouteAlternative>? = null
 )


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Fixes an issue where a route update with a reason `ROUTES_UPDATE_REASON_REFRESH` would clear the `AlternativeRouteMetadata`s collection without providing new metadata in return.

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
