### PR TITLE
Support maps trim offset feature for vanishing route line.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,8 @@ allprojects {
     // we allow access to snapshots repo if ALLOW_SNAPSHOT_REPOSITORY is set, what means we are running on CI
     // with Navigation Native forced to be some snapshot version
     // if you need to use snapshots while development, just set `addSnapshotsRepo` to true manually
-    def addSnapshotsRepo = project.hasProperty('ALLOW_SNAPSHOT_REPOSITORY') ? project.property('ALLOW_SNAPSHOT_REPOSITORY') : (System.getenv("ALLOW_SNAPSHOT_REPOSITORY")?.toBoolean() ?: false)
+    //fixme remove the hardcoded value
+    def addSnapshotsRepo = true //project.hasProperty('ALLOW_SNAPSHOT_REPOSITORY') ? project.property('ALLOW_SNAPSHOT_REPOSITORY') : (System.getenv("ALLOW_SNAPSHOT_REPOSITORY")?.toBoolean() ?: false)
     if (addSnapshotsRepo) {
       println("Snapshot repository reference added.")
       maven {

--- a/examples/src/main/AndroidManifest.xml
+++ b/examples/src/main/AndroidManifest.xml
@@ -96,6 +96,16 @@
     </activity>
 
     <activity
+        android:name=".RouteRestrictionsActivity"
+        android:label="route restrictions testing">
+    </activity>
+
+    <activity
+        android:name=".InactiveRouteStylingWithRestrictionsActivity"
+        android:label="route restrictions with legs testing">
+    </activity>
+
+    <activity
         android:name="com.mapbox.navigation.examples.MainActivity"
         android:exported="true">
       <intent-filter>

--- a/examples/src/main/java/com/mapbox/navigation/examples/MainActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/MainActivity.kt
@@ -10,6 +10,7 @@ import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.mapbox.android.core.permissions.PermissionsListener
+import com.mapbox.navigation.examples.core.InactiveRouteStylingWithRestrictionsActivity
 import com.mapbox.navigation.examples.core.IndependentRouteGenerationActivity
 import com.mapbox.navigation.examples.core.MapboxBuildingHighlightActivity
 import com.mapbox.navigation.examples.core.MapboxCustomStyleActivity
@@ -24,6 +25,7 @@ import com.mapbox.navigation.examples.core.MapboxVoiceActivity
 import com.mapbox.navigation.examples.core.MultiLegRouteExampleActivity
 import com.mapbox.navigation.examples.core.R
 import com.mapbox.navigation.examples.core.ReplayHistoryActivity
+import com.mapbox.navigation.examples.core.RouteRestrictionsActivity
 import com.mapbox.navigation.examples.core.camera.MapboxCameraAnimationsActivity
 import com.mapbox.navigation.examples.core.databinding.LayoutActivityMainBinding
 import com.mapbox.navigation.examples.util.LocationPermissionsHelper
@@ -138,6 +140,18 @@ class MainActivity : AppCompatActivity(), PermissionsListener {
                 getString(R.string.title_draw_utility),
                 getString(R.string.description_draw_utility),
                 RouteDrawingActivity::class.java
+            ),
+
+            SampleItem(
+                "Route restrictions test",
+                "Route restrictions test",
+                RouteRestrictionsActivity::class.java
+            ),
+
+            SampleItem(
+                "Route restrictions with legs test",
+                "Route restrictions with legs test",
+                InactiveRouteStylingWithRestrictionsActivity::class.java
             ),
         )
     }

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/InactiveRouteStylingWithRestrictionsActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/InactiveRouteStylingWithRestrictionsActivity.kt
@@ -1,0 +1,238 @@
+package com.mapbox.navigation.examples.core
+
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.graphics.Color
+import android.location.Location
+import android.os.Bundle
+import android.util.Log
+import android.view.View
+import androidx.appcompat.app.AppCompatActivity
+import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.geojson.Point
+import com.mapbox.maps.CameraOptions
+import com.mapbox.maps.EdgeInsets
+import com.mapbox.maps.plugin.animation.CameraAnimationsPlugin
+import com.mapbox.maps.plugin.animation.MapAnimationOptions
+import com.mapbox.maps.plugin.animation.camera
+import com.mapbox.maps.plugin.locationcomponent.OnIndicatorPositionChangedListener
+import com.mapbox.maps.plugin.locationcomponent.location
+import com.mapbox.navigation.base.options.NavigationOptions
+import com.mapbox.navigation.base.utils.DecodeUtils.completeGeometryToPoints
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.MapboxNavigationProvider
+import com.mapbox.navigation.core.replay.MapboxReplayer
+import com.mapbox.navigation.core.replay.ReplayLocationEngine
+import com.mapbox.navigation.core.replay.route.ReplayProgressObserver
+import com.mapbox.navigation.core.replay.route.ReplayRouteMapper
+import com.mapbox.navigation.core.trip.session.LocationMatcherResult
+import com.mapbox.navigation.core.trip.session.LocationObserver
+import com.mapbox.navigation.core.trip.session.RouteProgressObserver
+import com.mapbox.navigation.examples.core.databinding.InactiveRouteWithRestrictionsLayoutBinding
+import com.mapbox.navigation.ui.maps.NavigationStyles
+import com.mapbox.navigation.ui.maps.location.NavigationLocationProvider
+import com.mapbox.navigation.ui.maps.route.line.api.MapboxRouteLineApi
+import com.mapbox.navigation.ui.maps.route.line.api.MapboxRouteLineView
+import com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions
+import com.mapbox.navigation.ui.maps.route.line.model.RouteLine
+import com.mapbox.navigation.ui.maps.route.line.model.RouteLineColorResources
+import com.mapbox.navigation.ui.maps.route.line.model.RouteLineResources
+
+// fixme delete me
+class InactiveRouteStylingWithRestrictionsActivity : AppCompatActivity() {
+
+    private companion object {
+        private const val TAG = "InactiveRouteStylingAct"
+    }
+
+    private val binding: InactiveRouteWithRestrictionsLayoutBinding by lazy {
+        InactiveRouteWithRestrictionsLayoutBinding.inflate(layoutInflater)
+    }
+
+    private val locationComponent by lazy {
+        binding.mapView.location.apply {
+            setLocationProvider(navigationLocationProvider)
+            enabled = true
+        }
+    }
+
+    private val navigationLocationProvider = NavigationLocationProvider()
+    private val replayRouteMapper = ReplayRouteMapper()
+    private val mapboxReplayer = MapboxReplayer()
+    private val replayProgressObserver = ReplayProgressObserver(mapboxReplayer)
+
+    private val mapCamera: CameraAnimationsPlugin by lazy {
+        binding.mapView.camera
+    }
+
+    private val mapboxNavigation: MapboxNavigation by lazy {
+        MapboxNavigationProvider.create(
+            NavigationOptions.Builder(this)
+                .accessToken(Utils.getMapboxAccessToken(this))
+                .locationEngine(ReplayLocationEngine(mapboxReplayer))
+                .build()
+        )
+    }
+
+    private val routeLineColorResources by lazy {
+        RouteLineColorResources.Builder()
+            .inActiveRouteLegsColor(Color.YELLOW)
+            .restrictedRoadColor(Color.MAGENTA)
+            // .routeLineTraveledColor(Color.LTGRAY)
+            // .routeLineTraveledCasingColor(Color.GRAY)
+            .build()
+    }
+
+    private val routeLineResources: RouteLineResources by lazy {
+        RouteLineResources.Builder()
+            .routeLineColorResources(routeLineColorResources)
+            .build()
+    }
+
+    private val options: MapboxRouteLineOptions by lazy {
+        MapboxRouteLineOptions.Builder(this)
+            .withRouteLineResources(routeLineResources)
+            .withRouteLineBelowLayerId("road-label-navigation")
+            .styleInactiveRouteLegsIndependently(true)
+            .displayRestrictedRoadSections(true)
+            .withVanishingRouteLineEnabled(true)
+            .build()
+    }
+
+    private val routeLineView by lazy {
+        MapboxRouteLineView(options)
+    }
+
+    private val routeLineApi: MapboxRouteLineApi by lazy {
+        MapboxRouteLineApi(options)
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(binding.root)
+
+        initNavigation()
+        initStyle()
+        initListeners()
+    }
+
+    override fun onStop() {
+        super.onStop()
+        locationComponent.removeOnIndicatorPositionChangedListener(onPositionChangedListener)
+        mapboxNavigation.unregisterRouteProgressObserver(replayProgressObserver)
+        mapboxNavigation.unregisterRouteProgressObserver(routeProgressObserver)
+        mapboxNavigation.unregisterLocationObserver(locationObserver)
+        mapboxNavigation.stopTripSession()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        routeLineApi.cancel()
+        routeLineView.cancel()
+        mapboxReplayer.finish()
+        mapboxNavigation.onDestroy()
+    }
+
+    private fun initNavigation() {
+        binding.mapView.location.apply {
+            setLocationProvider(navigationLocationProvider)
+            enabled = true
+        }
+        mapboxNavigation.setRoutes(listOf(getRoute()))
+        mapboxNavigation.registerLocationObserver(locationObserver)
+        mapboxNavigation.registerRouteProgressObserver(replayProgressObserver)
+        mapboxReplayer.pushRealLocation(this, 0.0)
+        mapboxReplayer.playbackSpeed(1.5)
+        mapboxReplayer.play()
+    }
+
+    private fun initStyle() {
+        binding.mapView.getMapboxMap().loadStyleUri(
+            NavigationStyles.NAVIGATION_DAY_STYLE
+        ) { style ->
+
+            val route = getRoute()
+            routeLineApi.setRoutes(listOf(RouteLine(route, null))) {
+                routeLineView.renderRouteDrawData(style, it)
+            }
+
+            val routeOrigin = Utils.getRouteOriginPoint(route)
+            val cameraOptions = CameraOptions.Builder().center(routeOrigin).zoom(14.0).build()
+            binding.mapView.getMapboxMap().setCamera(cameraOptions)
+        }
+    }
+
+    private val locationObserver = object : LocationObserver {
+        override fun onNewRawLocation(rawLocation: Location) {
+            Log.d(TAG, "raw location $rawLocation")
+        }
+
+        override fun onNewLocationMatcherResult(locationMatcherResult: LocationMatcherResult) {
+            navigationLocationProvider.changePosition(
+                locationMatcherResult.enhancedLocation,
+                locationMatcherResult.keyPoints,
+            )
+            updateCamera(locationMatcherResult.enhancedLocation)
+        }
+    }
+
+    private fun updateCamera(location: Location) {
+        val mapAnimationOptionsBuilder = MapAnimationOptions.Builder()
+        mapAnimationOptionsBuilder.duration(1500L)
+        mapCamera.easeTo(
+            CameraOptions.Builder()
+                .center(Point.fromLngLat(location.longitude, location.latitude))
+                .bearing(location.bearing.toDouble())
+                .zoom(15.0)
+                .padding(EdgeInsets(1000.0, 0.0, 0.0, 0.0))
+                .build(),
+            mapAnimationOptionsBuilder.build()
+        )
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun initListeners() {
+        binding.startNavigation.setOnClickListener {
+            mapboxNavigation.registerRouteProgressObserver(routeProgressObserver)
+            mapboxNavigation.startTripSession()
+            binding.startNavigation.visibility = View.GONE
+            locationComponent.addOnIndicatorPositionChangedListener(onPositionChangedListener)
+            startSimulation(getRoute())
+        }
+    }
+
+    private val routeProgressObserver = RouteProgressObserver { routeProgress ->
+
+        // This is the most important part of this example. The route progress will be used to
+        // determine the active leg and adjust the route line visibility accordingly.
+        routeLineApi.updateWithRouteProgress(routeProgress) { result ->
+            binding.mapView.getMapboxMap().getStyle()?.apply {
+                routeLineView.renderRouteLineUpdate(this, result)
+            }
+        }
+    }
+
+    private val onPositionChangedListener = OnIndicatorPositionChangedListener { point ->
+        val result = routeLineApi.updateTraveledRouteLine(point)
+        binding.mapView.getMapboxMap().getStyle()?.apply {
+            routeLineView.renderRouteLineUpdate(this, result)
+        }
+    }
+
+    private fun startSimulation(route: DirectionsRoute) {
+        mapboxReplayer.stop()
+        mapboxReplayer.clearEvents()
+        val replayData = replayRouteMapper.mapDirectionsRouteGeometry(route)
+        mapboxReplayer.pushEvents(replayData)
+        mapboxReplayer.seekTo(replayData[0])
+        mapboxReplayer.play()
+    }
+
+    private fun getRoute(): DirectionsRoute {
+        val routeAsString =
+            Utils.readRawFileText(this, R.raw.multileg_route_two_legs_with_restrictions)
+        return DirectionsRoute.fromJson(routeAsString)
+    }
+}
+

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxRouteLineAndArrowActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxRouteLineAndArrowActivity.kt
@@ -1,6 +1,7 @@
 package com.mapbox.navigation.examples.core
 
 import android.annotation.SuppressLint
+import android.graphics.Color
 import android.location.Location
 import android.os.Build
 import android.os.Bundle
@@ -109,7 +110,10 @@ class MapboxRouteLineAndArrowActivity : AppCompatActivity(), OnMapLongClickListe
 
     // RouteLine: Route line related colors can be customized via the RouteLineColorResources.
     private val routeLineColorResources by lazy {
-        RouteLineColorResources.Builder().build()
+        RouteLineColorResources.Builder()
+            .routeLineTraveledColor(Color.LTGRAY)
+            .routeLineTraveledCasingColor(Color.GRAY)
+            .build()
     }
 
     // RouteLine: Various route line related options can be customized here including applying
@@ -199,7 +203,7 @@ class MapboxRouteLineAndArrowActivity : AppCompatActivity(), OnMapLongClickListe
             null,
             ContextCompat.getDrawable(
                 this@MapboxRouteLineAndArrowActivity,
-                R.drawable.mapbox_navigation_puck_icon
+                R.drawable.custom_user_puck_icon
             ),
             null,
             null

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/RouteRestrictionsActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/RouteRestrictionsActivity.kt
@@ -1,0 +1,274 @@
+package com.mapbox.navigation.examples.core
+
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.graphics.Color
+import android.location.Location
+import android.os.Bundle
+import android.util.Log
+import android.view.View
+import androidx.appcompat.app.AppCompatActivity
+import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.geojson.Point
+import com.mapbox.maps.CameraOptions
+import com.mapbox.maps.EdgeInsets
+import com.mapbox.maps.plugin.animation.CameraAnimationsPlugin
+import com.mapbox.maps.plugin.animation.MapAnimationOptions
+import com.mapbox.maps.plugin.animation.camera
+import com.mapbox.maps.plugin.locationcomponent.OnIndicatorPositionChangedListener
+import com.mapbox.maps.plugin.locationcomponent.location
+import com.mapbox.navigation.base.options.NavigationOptions
+import com.mapbox.navigation.base.utils.DecodeUtils.completeGeometryToPoints
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.MapboxNavigationProvider
+import com.mapbox.navigation.core.replay.MapboxReplayer
+import com.mapbox.navigation.core.replay.ReplayLocationEngine
+import com.mapbox.navigation.core.replay.route.ReplayProgressObserver
+import com.mapbox.navigation.core.replay.route.ReplayRouteMapper
+import com.mapbox.navigation.core.trip.session.LocationMatcherResult
+import com.mapbox.navigation.core.trip.session.LocationObserver
+import com.mapbox.navigation.core.trip.session.RouteProgressObserver
+import com.mapbox.navigation.examples.core.R
+import com.mapbox.navigation.examples.core.Utils.getRouteOriginPoint
+import com.mapbox.navigation.examples.core.databinding.RouteRestrictionsActivityLayoutBinding
+import com.mapbox.navigation.ui.maps.NavigationStyles
+import com.mapbox.navigation.ui.maps.location.NavigationLocationProvider
+import com.mapbox.navigation.ui.maps.route.RouteLayerConstants
+import com.mapbox.navigation.ui.maps.route.arrow.api.MapboxRouteArrowApi
+import com.mapbox.navigation.ui.maps.route.arrow.api.MapboxRouteArrowView
+import com.mapbox.navigation.ui.maps.route.arrow.model.RouteArrowOptions
+import com.mapbox.navigation.ui.maps.route.line.api.MapboxRouteLineApi
+import com.mapbox.navigation.ui.maps.route.line.api.MapboxRouteLineView
+import com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions
+import com.mapbox.navigation.ui.maps.route.line.model.RouteLine
+import com.mapbox.navigation.ui.maps.route.line.model.RouteLineColorResources
+import com.mapbox.navigation.ui.maps.route.line.model.RouteLineResources
+
+// fixme remove this activity
+class RouteRestrictionsActivity : AppCompatActivity() {
+
+    private companion object {
+        private const val TAG = "RouteRestrictionsAct"
+    }
+
+    private val replayRouteMapper = ReplayRouteMapper()
+    private val mapboxReplayer = MapboxReplayer()
+    private val navigationLocationProvider = NavigationLocationProvider()
+
+    private val binding: RouteRestrictionsActivityLayoutBinding by lazy {
+        RouteRestrictionsActivityLayoutBinding.inflate(layoutInflater)
+    }
+
+    private val mapboxNavigation: MapboxNavigation by lazy {
+        MapboxNavigationProvider.create(
+            NavigationOptions.Builder(this)
+                .accessToken(Utils.getMapboxAccessToken(this))
+                .locationEngine(ReplayLocationEngine(mapboxReplayer))
+                .build()
+        )
+    }
+
+    private val locationComponent by lazy {
+        binding.mapView.location.apply {
+            setLocationProvider(navigationLocationProvider)
+            enabled = true
+        }
+    }
+
+    private val mapCamera: CameraAnimationsPlugin by lazy {
+        binding.mapView.camera
+    }
+
+    private val routeLineColorResources by lazy {
+        RouteLineColorResources.Builder()
+            .routeLineTraveledColor(Color.LTGRAY)
+            .routeLineTraveledCasingColor(Color.GRAY)
+            .restrictedRoadColor(Color.MAGENTA)
+            .build()
+    }
+
+    private val routeLineResources: RouteLineResources by lazy {
+        RouteLineResources.Builder()
+            .routeLineColorResources(routeLineColorResources)
+            .build()
+    }
+
+    private val options: MapboxRouteLineOptions by lazy {
+        MapboxRouteLineOptions.Builder(this)
+            .withRouteLineResources(routeLineResources)
+            .withRouteLineBelowLayerId("road-label-navigation")
+            .displayRestrictedRoadSections(true)
+            .withVanishingRouteLineEnabled(true)
+            .build()
+    }
+
+    private val routeLineView by lazy {
+        MapboxRouteLineView(options)
+    }
+
+    private val routeLineApi: MapboxRouteLineApi by lazy {
+        MapboxRouteLineApi(options)
+    }
+
+    private val routeArrowApi: MapboxRouteArrowApi by lazy {
+        MapboxRouteArrowApi()
+    }
+
+    private val routeArrowOptions by lazy {
+        RouteArrowOptions.Builder(this)
+            .withAboveLayerId(RouteLayerConstants.TOP_LEVEL_ROUTE_LINE_LAYER_ID)
+            .build()
+    }
+
+    private val routeArrowView: MapboxRouteArrowView by lazy {
+        MapboxRouteArrowView(routeArrowOptions)
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(binding.root)
+        initNavigation()
+        initStyle()
+        initListeners()
+    }
+
+    override fun onStop() {
+        super.onStop()
+        locationComponent.removeOnIndicatorPositionChangedListener(onPositionChangedListener)
+        mapboxNavigation.unregisterRouteProgressObserver(routeProgressObserver)
+        mapboxNavigation.unregisterRouteProgressObserver(replayProgressObserver)
+        mapboxNavigation.unregisterLocationObserver(locationObserver)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        routeLineApi.cancel()
+        routeLineView.cancel()
+        mapboxReplayer.finish()
+        mapboxNavigation.onDestroy()
+    }
+
+    private fun initStyle() {
+        binding.mapView.getMapboxMap().loadStyleUri(
+            NavigationStyles.NAVIGATION_DAY_STYLE
+        ) { style ->
+
+            val route = getRoute()
+            routeLineApi.setRoutes(listOf(RouteLine(route, null))) {
+                routeLineView.renderRouteDrawData(style, it)
+            }
+
+            val routeOrigin = getRouteOriginPoint(route)
+            val cameraOptions = CameraOptions.Builder().center(routeOrigin).zoom(15.0).build()
+            binding.mapView.getMapboxMap().setCamera(cameraOptions)
+        }
+    }
+
+    private fun initNavigation() {
+        binding.mapView.location.apply {
+            setLocationProvider(navigationLocationProvider)
+            enabled = true
+        }
+        mapboxNavigation.setRoutes(listOf(getRoute()))
+        mapboxNavigation.registerLocationObserver(locationObserver)
+        mapboxNavigation.registerRouteProgressObserver(replayProgressObserver)
+        mapboxReplayer.pushRealLocation(this, 0.0)
+        mapboxReplayer.playbackSpeed(1.5)
+        mapboxReplayer.play()
+    }
+
+    private val locationObserver: LocationObserver = object : LocationObserver {
+        override fun onNewRawLocation(rawLocation: Location) {
+            Log.d(TAG, "raw location $rawLocation")
+        }
+
+        override fun onNewLocationMatcherResult(locationMatcherResult: LocationMatcherResult) {
+            navigationLocationProvider.changePosition(
+                locationMatcherResult.enhancedLocation,
+                locationMatcherResult.keyPoints,
+            )
+            updateCamera(locationMatcherResult.enhancedLocation)
+        }
+    }
+
+    private fun updateCamera(location: Location) {
+        val mapAnimationOptionsBuilder = MapAnimationOptions.Builder()
+        mapAnimationOptionsBuilder.duration(1500L)
+        mapCamera.easeTo(
+            CameraOptions.Builder()
+                .center(Point.fromLngLat(location.longitude, location.latitude))
+                .bearing(location.bearing.toDouble())
+                .zoom(15.0)
+                .padding(EdgeInsets(1000.0, 0.0, 0.0, 0.0))
+                .build(),
+            mapAnimationOptionsBuilder.build()
+        )
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun initListeners() {
+        binding.startNavigation.setOnClickListener {
+            mapboxNavigation.registerRouteProgressObserver(routeProgressObserver)
+            mapboxNavigation.startTripSession()
+            binding.startNavigation.visibility = View.GONE
+            locationComponent.addOnIndicatorPositionChangedListener(onPositionChangedListener)
+            startSimulation(mapboxNavigation.getRoutes()[0])
+        }
+    }
+
+    private fun startSimulation(route: DirectionsRoute) {
+        mapboxReplayer.stop()
+        mapboxReplayer.clearEvents()
+        val replayData = replayRouteMapper.mapDirectionsRouteGeometry(route)
+        mapboxReplayer.pushEvents(replayData)
+        mapboxReplayer.seekTo(replayData[0])
+        mapboxReplayer.play()
+    }
+
+    private val onPositionChangedListener = OnIndicatorPositionChangedListener { point ->
+        val result = routeLineApi.updateTraveledRouteLine(point)
+        binding.mapView.getMapboxMap().getStyle()?.apply {
+            routeLineView.renderRouteLineUpdate(this, result)
+        }
+    }
+
+    private val routeProgressObserver = RouteProgressObserver { routeProgress ->
+        routeLineApi.updateWithRouteProgress(routeProgress) { result ->
+            binding.mapView.getMapboxMap().getStyle()?.apply {
+                routeLineView.renderRouteLineUpdate(this, result)
+            }
+        }
+
+        val arrowUpdate = routeArrowApi.addUpcomingManeuverArrow(routeProgress)
+        binding.mapView.getMapboxMap().getStyle()?.apply {
+            routeArrowView.renderManeuverUpdate(this, arrowUpdate)
+        }
+    }
+
+    private val replayProgressObserver = ReplayProgressObserver(mapboxReplayer)
+
+    private fun getRoute(): DirectionsRoute {
+        val routeAsString = Utils.readRawFileText(this, R.raw.route_with_restrictions)
+        return DirectionsRoute.fromJson(routeAsString)
+    }
+}
+
+object Utils {
+
+    fun getMapboxAccessToken(context: Context): String {
+        return context.getString(
+            context.resources.getIdentifier(
+                "mapbox_access_token",
+                "string",
+                context.packageName
+            )
+        )
+    }
+
+    fun readRawFileText(context: Context, res: Int): String =
+        context.resources.openRawResource(res).bufferedReader().use { it.readText() }
+
+    fun getRouteOriginPoint(route: DirectionsRoute): Point =
+        route.completeGeometryToPoints().first()
+}

--- a/examples/src/main/res/layout/inactive_route_with_restrictions_layout.xml
+++ b/examples/src/main/res/layout/inactive_route_with_restrictions_layout.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.mapbox.maps.MapView
+        android:id="@+id/mapView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/startNavigation"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:text="Start Navigation"
+        android:background="#990000"/>
+
+    <ProgressBar
+        android:id="@+id/routeLoadingProgressBar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:visibility="invisible"
+        />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/examples/src/main/res/layout/route_restrictions_activity_layout.xml
+++ b/examples/src/main/res/layout/route_restrictions_activity_layout.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.mapbox.maps.MapView
+        android:id="@+id/mapView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/startNavigation"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:background="#ff0000"
+        android:text="@string/label_start_navigation"
+        android:textColor="@android:color/white" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/examples/src/main/res/raw/multileg_route_two_legs_with_restrictions.json
+++ b/examples/src/main/res/raw/multileg_route_two_legs_with_restrictions.json
@@ -1,0 +1,1830 @@
+{
+  "routeIndex": "0",
+  "distance": 980.784,
+  "duration": 207.031,
+  "duration_typical": 212.296,
+  "geometry": "qzxlgAt`fuhF|\\fIfKdC|KrBtB^dF~@l^tGrVtDdR`DfDj@tDj@rTpDn\\lFdC`@rDj@x`@rGnInAlEb@??f@wMz@oTZeGJyCR_F^gMtAmMPuDlBe]dC{^JeGI{G?oDHcDXwDS{G~@mF`A}Sf@kKf@qKFcBdAgUl@iMp@mOJuFY}HmA_LeLy@",
+  "weight": 295.884,
+  "weight_name": "auto",
+  "legs": [
+    {
+      "distance": 479.784,
+      "duration": 120.071,
+      "duration_typical": 120.389,
+      "summary": "Lincoln Avenue",
+      "admins": [
+        {
+          "iso_3166_1": "US",
+          "iso_3166_1_alpha3": "USA"
+        }
+      ],
+      "steps": [
+        {
+          "distance": 479.784,
+          "duration": 120.071,
+          "duration_typical": 120.389,
+          "speedLimitUnit": "mph",
+          "speedLimitSign": "mutcd",
+          "geometry": "qzxlgAt`fuhF|\\fIfKdC|KrBtB^dF~@l^tGrVtDdR`DfDj@tDj@rTpDn\\lFdC`@rDj@x`@rGnInAlEb@",
+          "name": "Lincoln Avenue",
+          "mode": "driving",
+          "maneuver": {
+            "location": [
+              -122.523163,
+              37.974969
+            ],
+            "bearing_before": 0.0,
+            "bearing_after": 195.0,
+            "instruction": "Drive south on Lincoln Avenue.",
+            "type": "depart"
+          },
+          "voiceInstructions": [
+            {
+              "distanceAlongGeometry": 479.784,
+              "announcement": "Drive south on Lincoln Avenue. Then, in a quarter mile, You will arrive at your destination.",
+              "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eDrive south on Lincoln Avenue. Then, in a quarter mile, You will arrive at your destination.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+            },
+            {
+              "distanceAlongGeometry": 66.667,
+              "announcement": "You have arrived at your destination.",
+              "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eYou have arrived at your destination.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+            }
+          ],
+          "bannerInstructions": [
+            {
+              "distanceAlongGeometry": 479.784,
+              "primary": {
+                "text": "You will arrive at your destination",
+                "components": [
+                  {
+                    "text": "You will arrive at your destination",
+                    "type": "text"
+                  }
+                ],
+                "type": "arrive",
+                "modifier": "straight"
+              }
+            },
+            {
+              "distanceAlongGeometry": 66.667,
+              "primary": {
+                "text": "You have arrived at your destination",
+                "components": [
+                  {
+                    "text": "You have arrived at your destination",
+                    "type": "text"
+                  }
+                ],
+                "type": "arrive",
+                "modifier": "straight"
+              }
+            }
+          ],
+          "driving_side": "right",
+          "weight": 150.386,
+          "intersections": [
+            {
+              "location": [
+                -122.523163,
+                37.974969
+              ],
+              "bearings": [
+                195
+              ],
+              "entry": [
+                true
+              ],
+              "out": 0,
+              "geometry_index": 0,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              }
+            },
+            {
+              "location": [
+                -122.523394,
+                37.974294
+              ],
+              "bearings": [
+                15,
+                192
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 2,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              }
+            },
+            {
+              "location": [
+                -122.523452,
+                37.974087
+              ],
+              "bearings": [
+                12,
+                192
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 3,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              }
+            },
+            {
+              "location": [
+                -122.5235,
+                37.973913
+              ],
+              "bearings": [
+                12,
+                192
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 5,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              }
+            },
+            {
+              "location": [
+                -122.523639,
+                37.97341
+              ],
+              "bearings": [
+                12,
+                191
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 6,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              }
+            },
+            {
+              "location": [
+                -122.52373,
+                37.973032
+              ],
+              "bearings": [
+                11,
+                192
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 7,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              }
+            },
+            {
+              "location": [
+                -122.523811,
+                37.972725
+              ],
+              "bearings": [
+                12,
+                192
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 8,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              }
+            },
+            {
+              "location": [
+                -122.523833,
+                37.972641
+              ],
+              "bearings": [
+                12,
+                191
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 9,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              }
+            },
+            {
+              "location": [
+                -122.523855,
+                37.97255
+              ],
+              "bearings": [
+                11,
+                191
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 10,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              }
+            },
+            {
+              "location": [
+                -122.523944,
+                37.972204
+              ],
+              "bearings": [
+                11,
+                191
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 11,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              }
+            },
+            {
+              "location": [
+                -122.524063,
+                37.971732
+              ],
+              "bearings": [
+                11,
+                191
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 12,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              }
+            },
+            {
+              "location": [
+                -122.52408,
+                37.971665
+              ],
+              "bearings": [
+                11,
+                191
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 13,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              }
+            },
+            {
+              "location": [
+                -122.524102,
+                37.971575
+              ],
+              "bearings": [
+                11,
+                191
+              ],
+              "classes": [
+                "restricted",
+                "secondary"
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 14,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              }
+            },
+            {
+              "location": [
+                -122.52424,
+                37.971034
+              ],
+              "bearings": [
+                11,
+                191
+              ],
+              "classes": [
+                "restricted",
+                "secondary"
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 15,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              }
+            },
+            {
+              "location": [
+                -122.52428,
+                37.970866
+              ],
+              "bearings": [
+                11,
+                188
+              ],
+              "classes": [
+                "restricted",
+                "secondary"
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 16,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              }
+            }
+          ]
+        },
+        {
+          "distance": 0.0,
+          "duration": 0.0,
+          "duration_typical": 0.0,
+          "speedLimitUnit": "mph",
+          "speedLimitSign": "mutcd",
+          "geometry": "usplgArghuhF??",
+          "name": "Lincoln Avenue",
+          "mode": "driving",
+          "maneuver": {
+            "location": [
+              -122.524298,
+              37.970763
+            ],
+            "bearing_before": 188.0,
+            "bearing_after": 0.0,
+            "instruction": "You have arrived at your destination.",
+            "type": "arrive"
+          },
+          "voiceInstructions": [],
+          "bannerInstructions": [],
+          "driving_side": "right",
+          "weight": 0.0,
+          "intersections": [
+            {
+              "location": [
+                -122.524298,
+                37.970763
+              ],
+              "bearings": [
+                8
+              ],
+              "entry": [
+                true
+              ],
+              "in": 0,
+              "geometry_index": 17,
+              "admin_index": 0
+            }
+          ]
+        }
+      ],
+      "annotation": {
+        "distance": [
+          55.2,
+          22.6,
+          23.6,
+          6.7,
+          13.1,
+          57.3,
+          42.8,
+          34.9,
+          9.5,
+          10.3,
+          39.3,
+          53.6,
+          7.6,
+          10.2,
+          61.4,
+          19.0,
+          11.6
+        ],
+        "duration": [
+          7.641,
+          3.129,
+          4.72,
+          1.511,
+          2.949,
+          13.754,
+          7.342,
+          8.976,
+          2.455,
+          6.188,
+          23.58,
+          9.643,
+          1.369,
+          1.531,
+          9.214,
+          4.893,
+          2.976
+        ],
+        "speed": [
+          7.2,
+          7.2,
+          5.0,
+          4.4,
+          4.4,
+          4.2,
+          5.8,
+          3.9,
+          3.9,
+          1.7,
+          1.7,
+          5.6,
+          5.6,
+          6.7,
+          6.7,
+          3.9,
+          3.9
+        ],
+        "maxspeed": [
+          {
+            "speed": 48,
+            "unit": "km/h"
+          },
+          {
+            "speed": 48,
+            "unit": "km/h"
+          },
+          {
+            "speed": 48,
+            "unit": "km/h"
+          },
+          {
+            "speed": 48,
+            "unit": "km/h"
+          },
+          {
+            "speed": 48,
+            "unit": "km/h"
+          },
+          {
+            "speed": 48,
+            "unit": "km/h"
+          },
+          {
+            "speed": 48,
+            "unit": "km/h"
+          },
+          {
+            "speed": 48,
+            "unit": "km/h"
+          },
+          {
+            "speed": 48,
+            "unit": "km/h"
+          },
+          {
+            "speed": 48,
+            "unit": "km/h"
+          },
+          {
+            "speed": 48,
+            "unit": "km/h"
+          },
+          {
+            "speed": 48,
+            "unit": "km/h"
+          },
+          {
+            "speed": 48,
+            "unit": "km/h"
+          },
+          {
+            "speed": 48,
+            "unit": "km/h"
+          },
+          {
+            "speed": 48,
+            "unit": "km/h"
+          },
+          {
+            "speed": 48,
+            "unit": "km/h"
+          },
+          {
+            "speed": 48,
+            "unit": "km/h"
+          }
+        ],
+        "congestion": [
+          "low",
+          "low",
+          "unknown",
+          "moderate",
+          "moderate",
+          "unknown",
+          "unknown",
+          "unknown",
+          "unknown",
+          "moderate",
+          "moderate",
+          "low",
+          "low",
+          "low",
+          "low",
+          "unknown",
+          "unknown"
+        ]
+      }
+    },
+    {
+      "distance": 501.0,
+      "duration": 86.96,
+      "duration_typical": 91.907,
+      "summary": "Lincoln Avenue, Grand Avenue",
+      "admins": [
+        {
+          "iso_3166_1": "US",
+          "iso_3166_1_alpha3": "USA"
+        }
+      ],
+      "steps": [
+        {
+          "distance": 477.0,
+          "duration": 77.504,
+          "duration_typical": 82.451,
+          "speedLimitUnit": "mph",
+          "speedLimitSign": "mutcd",
+          "geometry": "usplgArghuhF??f@wMz@oTZeGJyCR_F^gMtAmMPuDlBe]dC{^JeGI{G?oDHcDXwDS{G~@mF`A}Sf@kKf@qKFcBdAgUl@iMp@mOJuFY}HmA_L",
+          "name": "Lincoln Avenue",
+          "mode": "driving",
+          "maneuver": {
+            "location": [
+              -122.524298,
+              37.970763
+            ],
+            "bearing_before": 0.0,
+            "bearing_after": 96.0,
+            "instruction": "Drive east on Lincoln Avenue.",
+            "type": "depart"
+          },
+          "voiceInstructions": [
+            {
+              "distanceAlongGeometry": 477.0,
+              "announcement": "Drive east on Lincoln Avenue.",
+              "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eDrive east on Lincoln Avenue.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+            },
+            {
+              "distanceAlongGeometry": 461.0,
+              "announcement": "In a quarter mile, Turn left onto Grand Avenue.",
+              "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eIn a quarter mile, Turn left onto Grand Avenue.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+            },
+            {
+              "distanceAlongGeometry": 84.444,
+              "announcement": "Turn left onto Grand Avenue. Then You will arrive at your destination.",
+              "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eTurn left onto Grand Avenue. Then You will arrive at your destination.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+            }
+          ],
+          "bannerInstructions": [
+            {
+              "distanceAlongGeometry": 477.0,
+              "primary": {
+                "text": "Grand Avenue",
+                "components": [
+                  {
+                    "text": "Grand Avenue",
+                    "type": "text"
+                  }
+                ],
+                "type": "turn",
+                "modifier": "left"
+              },
+              "sub": {
+                "text": "",
+                "components": [
+                  {
+                    "text": "",
+                    "type": "lane",
+                    "directions": [
+                      "left"
+                    ],
+                    "active": true
+                  },
+                  {
+                    "text": "",
+                    "type": "lane",
+                    "directions": [
+                      "straight"
+                    ],
+                    "active": false
+                  },
+                  {
+                    "text": "",
+                    "type": "lane",
+                    "directions": [
+                      "straight",
+                      "right"
+                    ],
+                    "active": false
+                  }
+                ]
+              }
+            }
+          ],
+          "driving_side": "right",
+          "weight": 125.154,
+          "intersections": [
+            {
+              "location": [
+                -122.524298,
+                37.970763
+              ],
+              "bearings": [
+                96
+              ],
+              "classes": [
+                "restricted",
+                "secondary"
+              ],
+              "entry": [
+                true
+              ],
+              "out": 0,
+              "geometry_index": 0,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              }
+            },
+            {
+              "location": [
+                -122.524298,
+                37.970763
+              ],
+              "bearings": [
+                96,
+                276
+              ],
+              "classes": [
+                "restricted",
+                "primary"
+              ],
+              "entry": [
+                true,
+                false
+              ],
+              "in": 1,
+              "out": 0,
+              "geometry_index": 1,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "primary"
+              }
+            },
+            {
+              "location": [
+                -122.524062,
+                37.970743
+              ],
+              "bearings": [
+                96,
+                276
+              ],
+              "classes": [
+                "restricted",
+                "primary"
+              ],
+              "entry": [
+                true,
+                false
+              ],
+              "in": 1,
+              "out": 0,
+              "geometry_index": 2,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "primary"
+              }
+            },
+            {
+              "location": [
+                -122.523718,
+                37.970713
+              ],
+              "bearings": [
+                98,
+                276
+              ],
+              "classes": [
+                "restricted",
+                "primary"
+              ],
+              "entry": [
+                true,
+                false
+              ],
+              "in": 1,
+              "out": 0,
+              "lanes": [
+                {
+                  "valid": true,
+                  "active": true,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight"
+                  ]
+                },
+                {
+                  "valid": true,
+                  "active": true,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight"
+                  ]
+                },
+                {
+                  "valid": true,
+                  "active": true,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight"
+                  ]
+                },
+                {
+                  "valid": true,
+                  "active": true,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight"
+                  ]
+                },
+                {
+                  "valid": false,
+                  "active": false,
+                  "indications": [
+                    "right"
+                  ]
+                }
+              ],
+              "geometry_index": 3,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "primary"
+              }
+            },
+            {
+              "location": [
+                -122.523587,
+                37.970699
+              ],
+              "bearings": [
+                96,
+                278
+              ],
+              "entry": [
+                true,
+                false
+              ],
+              "in": 1,
+              "out": 0,
+              "lanes": [
+                {
+                  "valid": true,
+                  "active": true,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight"
+                  ]
+                },
+                {
+                  "valid": true,
+                  "active": true,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight"
+                  ]
+                },
+                {
+                  "valid": true,
+                  "active": true,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight"
+                  ]
+                },
+                {
+                  "valid": true,
+                  "active": true,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight"
+                  ]
+                },
+                {
+                  "valid": false,
+                  "active": false,
+                  "indications": [
+                    "right"
+                  ]
+                }
+              ],
+              "geometry_index": 4,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "primary"
+              }
+            },
+            {
+              "location": [
+                -122.52351,
+                37.970693
+              ],
+              "bearings": [
+                96,
+                276
+              ],
+              "entry": [
+                true,
+                false
+              ],
+              "in": 1,
+              "out": 0,
+              "lanes": [
+                {
+                  "valid": true,
+                  "active": true,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight"
+                  ]
+                },
+                {
+                  "valid": true,
+                  "active": true,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight"
+                  ]
+                },
+                {
+                  "valid": true,
+                  "active": true,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight"
+                  ]
+                },
+                {
+                  "valid": true,
+                  "active": true,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight"
+                  ]
+                },
+                {
+                  "valid": false,
+                  "active": false,
+                  "indications": [
+                    "right"
+                  ]
+                }
+              ],
+              "geometry_index": 5,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "primary"
+              }
+            },
+            {
+              "location": [
+                -122.523398,
+                37.970683
+              ],
+              "bearings": [
+                95,
+                276
+              ],
+              "entry": [
+                true,
+                false
+              ],
+              "in": 1,
+              "out": 0,
+              "lanes": [
+                {
+                  "valid": true,
+                  "active": true,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "left",
+                    "straight"
+                  ]
+                },
+                {
+                  "valid": true,
+                  "active": false,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight"
+                  ]
+                },
+                {
+                  "valid": true,
+                  "active": false,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight"
+                  ]
+                },
+                {
+                  "valid": true,
+                  "active": false,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight"
+                  ]
+                },
+                {
+                  "valid": false,
+                  "active": false,
+                  "indications": [
+                    "right"
+                  ]
+                }
+              ],
+              "geometry_index": 6,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "primary"
+              }
+            },
+            {
+              "location": [
+                -122.52317,
+                37.970667
+              ],
+              "bearings": [
+                103,
+                275
+              ],
+              "entry": [
+                true,
+                false
+              ],
+              "in": 1,
+              "out": 0,
+              "geometry_index": 7,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "primary"
+              }
+            },
+            {
+              "location": [
+                -122.522848,
+                37.970615
+              ],
+              "bearings": [
+                98,
+                281
+              ],
+              "entry": [
+                true,
+                false
+              ],
+              "in": 1,
+              "out": 0,
+              "lanes": [
+                {
+                  "valid": true,
+                  "active": true,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight"
+                  ]
+                },
+                {
+                  "valid": true,
+                  "active": false,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight",
+                    "right"
+                  ]
+                },
+                {
+                  "valid": false,
+                  "active": false,
+                  "indications": [
+                    "right"
+                  ]
+                }
+              ],
+              "geometry_index": 9,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "primary"
+              }
+            },
+            {
+              "location": [
+                -122.522365,
+                37.97056
+              ],
+              "bearings": [
+                99,
+                278
+              ],
+              "entry": [
+                true,
+                false
+              ],
+              "in": 1,
+              "out": 0,
+              "lanes": [
+                {
+                  "valid": true,
+                  "active": true,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight"
+                  ]
+                },
+                {
+                  "valid": true,
+                  "active": false,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight",
+                    "right"
+                  ]
+                },
+                {
+                  "valid": false,
+                  "active": false,
+                  "indications": [
+                    "right"
+                  ]
+                }
+              ],
+              "geometry_index": 10,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "primary"
+              }
+            },
+            {
+              "location": [
+                -122.521178,
+                37.970484
+              ],
+              "bearings": [
+                109,
+                271
+              ],
+              "entry": [
+                true,
+                false
+              ],
+              "in": 1,
+              "out": 0,
+              "lanes": [
+                {
+                  "valid": true,
+                  "active": true,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight"
+                  ]
+                },
+                {
+                  "valid": true,
+                  "active": false,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight"
+                  ]
+                }
+              ],
+              "geometry_index": 17,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              }
+            },
+            {
+              "location": [
+                -122.521059,
+                37.970452
+              ],
+              "bearings": [
+                97,
+                289
+              ],
+              "entry": [
+                true,
+                false
+              ],
+              "in": 1,
+              "out": 0,
+              "geometry_index": 18,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              }
+            },
+            {
+              "location": [
+                -122.520724,
+                37.970419
+              ],
+              "bearings": [
+                97,
+                277
+              ],
+              "entry": [
+                true,
+                false
+              ],
+              "in": 1,
+              "out": 0,
+              "geometry_index": 19,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              }
+            },
+            {
+              "location": [
+                -122.520526,
+                37.970399
+              ],
+              "bearings": [
+                97,
+                277
+              ],
+              "entry": [
+                true,
+                false
+              ],
+              "in": 1,
+              "out": 0,
+              "geometry_index": 20,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              }
+            },
+            {
+              "location": [
+                -122.520325,
+                37.970379
+              ],
+              "bearings": [
+                96,
+                277
+              ],
+              "entry": [
+                true,
+                false
+              ],
+              "in": 1,
+              "out": 0,
+              "lanes": [
+                {
+                  "valid": true,
+                  "active": true,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight"
+                  ]
+                },
+                {
+                  "valid": true,
+                  "active": false,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight"
+                  ]
+                },
+                {
+                  "valid": true,
+                  "active": false,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight"
+                  ]
+                },
+                {
+                  "valid": true,
+                  "active": false,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight",
+                    "right"
+                  ]
+                }
+              ],
+              "geometry_index": 21,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              }
+            },
+            {
+              "location": [
+                -122.520275,
+                37.970375
+              ],
+              "bearings": [
+                97,
+                276
+              ],
+              "entry": [
+                true,
+                false
+              ],
+              "in": 1,
+              "out": 0,
+              "geometry_index": 22,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              }
+            },
+            {
+              "location": [
+                -122.519919,
+                37.97034
+              ],
+              "bearings": [
+                97,
+                277
+              ],
+              "entry": [
+                true,
+                false
+              ],
+              "in": 1,
+              "out": 0,
+              "geometry_index": 23,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              }
+            },
+            {
+              "location": [
+                -122.519304,
+                37.970286
+              ],
+              "bearings": [
+                82,
+                275
+              ],
+              "entry": [
+                true,
+                false
+              ],
+              "in": 1,
+              "out": 0,
+              "lanes": [
+                {
+                  "valid": false,
+                  "active": false,
+                  "indications": [
+                    "left"
+                  ]
+                },
+                {
+                  "valid": true,
+                  "active": true,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight"
+                  ]
+                },
+                {
+                  "valid": true,
+                  "active": false,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight"
+                  ]
+                },
+                {
+                  "valid": false,
+                  "active": false,
+                  "indications": [
+                    "right"
+                  ]
+                }
+              ],
+              "geometry_index": 26,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              }
+            }
+          ]
+        },
+        {
+          "distance": 24.0,
+          "duration": 9.456,
+          "duration_typical": 9.456,
+          "speedLimitUnit": "mph",
+          "speedLimitSign": "mutcd",
+          "geometry": "cyolgApx}thFeLy@",
+          "name": "Grand Avenue",
+          "mode": "driving",
+          "maneuver": {
+            "location": [
+              -122.518937,
+              37.970338
+            ],
+            "bearing_before": 77.0,
+            "bearing_after": 6.0,
+            "instruction": "Turn left onto Grand Avenue.",
+            "type": "turn",
+            "modifier": "left"
+          },
+          "voiceInstructions": [
+            {
+              "distanceAlongGeometry": 24.0,
+              "announcement": "You have arrived at your destination.",
+              "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eYou have arrived at your destination.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+            }
+          ],
+          "bannerInstructions": [
+            {
+              "distanceAlongGeometry": 24.0,
+              "primary": {
+                "text": "You have arrived at your destination",
+                "components": [
+                  {
+                    "text": "You have arrived at your destination",
+                    "type": "text"
+                  }
+                ],
+                "type": "arrive",
+                "modifier": "straight"
+              }
+            }
+          ],
+          "driving_side": "right",
+          "weight": 20.343,
+          "intersections": [
+            {
+              "location": [
+                -122.518937,
+                37.970338
+              ],
+              "bearings": [
+                6,
+                257
+              ],
+              "entry": [
+                true,
+                false
+              ],
+              "in": 1,
+              "out": 0,
+              "lanes": [
+                {
+                  "valid": true,
+                  "active": true,
+                  "valid_indication": "left",
+                  "indications": [
+                    "left"
+                  ]
+                },
+                {
+                  "valid": false,
+                  "active": false,
+                  "indications": [
+                    "straight"
+                  ]
+                },
+                {
+                  "valid": false,
+                  "active": false,
+                  "indications": [
+                    "straight",
+                    "right"
+                  ]
+                }
+              ],
+              "geometry_index": 28,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "tertiary"
+              }
+            }
+          ]
+        },
+        {
+          "distance": 0.0,
+          "duration": 0.0,
+          "duration_typical": 0.0,
+          "speedLimitUnit": "mph",
+          "speedLimitSign": "mutcd",
+          "geometry": "ifplgAvv}thF??",
+          "name": "Grand Avenue",
+          "mode": "driving",
+          "maneuver": {
+            "location": [
+              -122.518908,
+              37.970549
+            ],
+            "bearing_before": 6.0,
+            "bearing_after": 0.0,
+            "instruction": "You have arrived at your destination.",
+            "type": "arrive"
+          },
+          "voiceInstructions": [],
+          "bannerInstructions": [],
+          "driving_side": "right",
+          "weight": 0.0,
+          "intersections": [
+            {
+              "location": [
+                -122.518908,
+                37.970549
+              ],
+              "bearings": [
+                186
+              ],
+              "entry": [
+                true
+              ],
+              "in": 0,
+              "geometry_index": 29,
+              "admin_index": 0
+            }
+          ]
+        }
+      ],
+      "annotation": {
+        "distance": [
+          0.0,
+          20.8,
+          30.4,
+          11.6,
+          6.8,
+          9.9,
+          20.1,
+          20.8,
+          8.0,
+          42.8,
+          45.4,
+          11.5,
+          12.5,
+          7.7,
+          7.2,
+          8.2,
+          12.5,
+          11.0,
+          29.6,
+          17.5,
+          17.8,
+          4.4,
+          31.5,
+          20.3,
+          23.2,
+          10.8,
+          14.0,
+          18.8,
+          23.6
+        ],
+        "duration": [
+          0.0,
+          3.408,
+          4.97,
+          2.088,
+          1.111,
+          1.619,
+          3.616,
+          3.26,
+          1.26,
+          6.703,
+          4.084,
+          1.036,
+          1.123,
+          0.695,
+          0.65,
+          0.738,
+          1.126,
+          1.324,
+          3.555,
+          1.911,
+          1.94,
+          0.547,
+          4.928,
+          1.823,
+          2.092,
+          0.973,
+          2.971,
+          3.973,
+          4.476
+        ],
+        "speed": [
+          0.0,
+          6.1,
+          6.1,
+          5.6,
+          6.1,
+          6.1,
+          5.6,
+          6.4,
+          6.4,
+          6.4,
+          11.1,
+          11.1,
+          11.1,
+          11.1,
+          11.1,
+          11.1,
+          11.1,
+          8.3,
+          8.3,
+          9.2,
+          9.2,
+          8.1,
+          6.4,
+          11.1,
+          11.1,
+          11.1,
+          4.7,
+          4.7,
+          5.3
+        ],
+        "maxspeed": [
+          {
+            "speed": 48,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "unknown": true
+          }
+        ],
+        "congestion": [
+          "severe",
+          "moderate",
+          "moderate",
+          "unknown",
+          "low",
+          "low",
+          "moderate",
+          "low",
+          "low",
+          "low",
+          "unknown",
+          "unknown",
+          "unknown",
+          "unknown",
+          "unknown",
+          "unknown",
+          "unknown",
+          "low",
+          "low",
+          "low",
+          "low",
+          "unknown",
+          "low",
+          "moderate",
+          "moderate",
+          "moderate",
+          "unknown",
+          "unknown",
+          "unknown"
+        ]
+      }
+    }
+  ],
+  "routeOptions": {
+    "baseUrl": "https://api.mapbox.com",
+    "user": "mapbox",
+    "profile": "driving-traffic",
+    "coordinates": "-122.523179,37.974972;-122.524257,37.970785;-122.518925,37.970548",
+    "alternatives": true,
+    "language": "en",
+    "continue_straight": true,
+    "roundabout_exits": true,
+    "geometries": "polyline6",
+    "overview": "full",
+    "steps": true,
+    "annotations": "congestion,maxspeed,speed,duration,distance,closure",
+    "voice_instructions": true,
+    "banner_instructions": true,
+    "voice_units": "imperial",
+    "access_token": "omitted",
+    "uuid": "XG3zTka4ub-AUGlYzj4qX_NNjD8bX5oh88qzhmwv5bxibaFV_P0XOg\u003d\u003d"
+  },
+  "voiceLocale": "en-US"
+}

--- a/examples/src/main/res/raw/route_with_restrictions.json
+++ b/examples/src/main/res/raw/route_with_restrictions.json
@@ -1,0 +1,1479 @@
+{
+  "routeIndex": "0",
+  "distance": 1286.745,
+  "duration": 252.592,
+  "duration_typical": 245.6,
+  "geometry": "}tylgAd`guhFhKzBuD`g@iBdVa@nFtThE`RnDpFhBf^nF`C^|VvDQbCiD~c@`o@tC~EVzRj@jOfA~Rp@iAdQiBh^o@|N[fSSrE]nHmBvb@_G`oA}Bxg@qBpc@aA`UiAjWI|A]zH}@tSjUdBtM`ArGf@vMbAxAsYR}DVsEf@qK",
+  "weight": 362.336,
+  "weight_name": "auto",
+  "legs": [
+    {
+      "distance": 1286.745,
+      "duration": 252.592,
+      "duration_typical": 245.6,
+      "summary": "Lootens Place, 3rd Street",
+      "admins": [
+        {
+          "iso_3166_1": "US",
+          "iso_3166_1_alpha3": "USA"
+        }
+      ],
+      "steps": [
+        {
+          "distance": 22.991,
+          "duration": 4.138,
+          "duration_typical": 4.138,
+          "geometry": "}tylgAd`guhFhKzB",
+          "name": "",
+          "mode": "driving",
+          "maneuver": {
+            "location": [
+              -122.523667,
+              37.975391
+            ],
+            "bearing_before": 0,
+            "bearing_after": 194,
+            "instruction": "Drive south.",
+            "type": "depart"
+          },
+          "voiceInstructions": [
+            {
+              "distanceAlongGeometry": 22.991,
+              "announcement": "Drive south. Then Turn right onto Laurel Place.",
+              "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Drive south. Then Turn right onto Laurel Place.</prosody></amazon:effect></speak>"
+            }
+          ],
+          "bannerInstructions": [
+            {
+              "distanceAlongGeometry": 22.991,
+              "primary": {
+                "text": "Laurel Place",
+                "components": [
+                  {
+                    "text": "Laurel Place",
+                    "type": "text"
+                  }
+                ],
+                "type": "turn",
+                "modifier": "right"
+              },
+              "sub": {
+                "text": "Nye Street",
+                "components": [
+                  {
+                    "text": "Nye Street",
+                    "type": "text"
+                  }
+                ],
+                "type": "turn",
+                "modifier": "left"
+              }
+            }
+          ],
+          "driving_side": "right",
+          "weight": 4.656,
+          "intersections": [
+            {
+              "location": [
+                -122.523667,
+                37.975391
+              ],
+              "bearings": [
+                194
+              ],
+              "entry": [
+                true
+              ],
+              "out": 0,
+              "geometry_index": 0,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "service"
+              }
+            }
+          ]
+        },
+        {
+          "distance": 101,
+          "duration": 24.173,
+          "duration_typical": 24.173,
+          "geometry": "shylgA`dguhFuD`g@iBdVa@nF",
+          "name": "Laurel Place",
+          "mode": "driving",
+          "maneuver": {
+            "location": [
+              -122.523729,
+              37.975194
+            ],
+            "bearing_before": 194,
+            "bearing_after": 280,
+            "instruction": "Turn right onto Laurel Place.",
+            "type": "turn",
+            "modifier": "right"
+          },
+          "voiceInstructions": [
+            {
+              "distanceAlongGeometry": 50,
+              "announcement": "Turn left onto Nye Street.",
+              "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Turn left onto Nye Street.</prosody></amazon:effect></speak>"
+            }
+          ],
+          "bannerInstructions": [
+            {
+              "distanceAlongGeometry": 101,
+              "primary": {
+                "text": "Nye Street",
+                "components": [
+                  {
+                    "text": "Nye Street",
+                    "type": "text"
+                  }
+                ],
+                "type": "turn",
+                "modifier": "left"
+              }
+            }
+          ],
+          "driving_side": "right",
+          "weight": 36.24,
+          "intersections": [
+            {
+              "location": [
+                -122.523729,
+                37.975194
+              ],
+              "bearings": [
+                14,
+                280
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 1,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "street"
+              }
+            },
+            {
+              "location": [
+                -122.52437,
+                37.975285
+              ],
+              "bearings": [
+                100,
+                280
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 2,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "street"
+              }
+            },
+            {
+              "location": [
+                -122.524741,
+                37.975338
+              ],
+              "bearings": [
+                100,
+                280
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 3,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "street"
+              }
+            }
+          ]
+        },
+        {
+          "distance": 196,
+          "duration": 41.333,
+          "duration_typical": 41.333,
+          "geometry": "urylgAxjiuhFtThE`RnDpFhBf^nF`C^|VvD",
+          "name": "Nye Street",
+          "mode": "driving",
+          "maneuver": {
+            "location": [
+              -122.524861,
+              37.975355
+            ],
+            "bearing_before": 280,
+            "bearing_after": 193,
+            "instruction": "Turn left onto Nye Street.",
+            "type": "turn",
+            "modifier": "left"
+          },
+          "voiceInstructions": [
+            {
+              "distanceAlongGeometry": 186,
+              "announcement": "In 600 feet, Turn right onto 5th Avenue.",
+              "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 600 feet, Turn right onto 5th Avenue.</prosody></amazon:effect></speak>"
+            },
+            {
+              "distanceAlongGeometry": 68.333,
+              "announcement": "Turn right onto 5th Avenue. Then, in 200 feet, Turn left onto Lootens Place.",
+              "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Turn right onto 5th Avenue. Then, in 200 feet, Turn left onto Lootens Place.</prosody></amazon:effect></speak>"
+            }
+          ],
+          "bannerInstructions": [
+            {
+              "distanceAlongGeometry": 196,
+              "primary": {
+                "text": "5th Avenue",
+                "components": [
+                  {
+                    "text": "5th Avenue",
+                    "type": "text"
+                  }
+                ],
+                "type": "turn",
+                "modifier": "right"
+              },
+              "sub": {
+                "text": "Lootens Place",
+                "components": [
+                  {
+                    "text": "Lootens Place",
+                    "type": "text"
+                  }
+                ],
+                "type": "turn",
+                "modifier": "left"
+              }
+            }
+          ],
+          "driving_side": "right",
+          "weight": 67.277,
+          "intersections": [
+            {
+              "location": [
+                -122.524861,
+                37.975355
+              ],
+              "bearings": [
+                100,
+                193
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 4,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "street"
+              }
+            },
+            {
+              "location": [
+                -122.524962,
+                37.975008
+              ],
+              "bearings": [
+                13,
+                193
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 5,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "street"
+              }
+            },
+            {
+              "location": [
+                -122.52505,
+                37.974703
+              ],
+              "bearings": [
+                13,
+                199
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 6,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "street"
+              }
+            },
+            {
+              "location": [
+                -122.525103,
+                37.974582
+              ],
+              "bearings": [
+                19,
+                191
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 7,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "street"
+              }
+            },
+            {
+              "location": [
+                -122.525223,
+                37.974082
+              ],
+              "bearings": [
+                11,
+                191
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 8,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "street"
+              }
+            },
+            {
+              "location": [
+                -122.525239,
+                37.974017
+              ],
+              "bearings": [
+                11,
+                191
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 9,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "street"
+              }
+            }
+          ]
+        },
+        {
+          "distance": 59,
+          "duration": 8.629,
+          "duration_typical": 8.629,
+          "geometry": "cgvlgAdhjuhFQbCiD~c@",
+          "name": "5th Avenue",
+          "mode": "driving",
+          "maneuver": {
+            "location": [
+              -122.525331,
+              37.973634
+            ],
+            "bearing_before": 191,
+            "bearing_after": 280,
+            "instruction": "Turn right onto 5th Avenue.",
+            "type": "turn",
+            "modifier": "right"
+          },
+          "voiceInstructions": [
+            {
+              "distanceAlongGeometry": 50,
+              "announcement": "Turn left onto Lootens Place.",
+              "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Turn left onto Lootens Place.</prosody></amazon:effect></speak>"
+            }
+          ],
+          "bannerInstructions": [
+            {
+              "distanceAlongGeometry": 59,
+              "primary": {
+                "text": "Lootens Place",
+                "components": [
+                  {
+                    "text": "Lootens Place",
+                    "type": "text"
+                  }
+                ],
+                "type": "turn",
+                "modifier": "left"
+              }
+            }
+          ],
+          "driving_side": "right",
+          "weight": 16.944,
+          "intersections": [
+            {
+              "location": [
+                -122.525331,
+                37.973634
+              ],
+              "bearings": [
+                11,
+                280
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 10,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "street"
+              }
+            },
+            {
+              "location": [
+                -122.525397,
+                37.973643
+              ],
+              "bearings": [
+                100,
+                280
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 11,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "street"
+              }
+            }
+          ]
+        },
+        {
+          "distance": 199,
+          "duration": 56.764,
+          "duration_typical": 56.764,
+          "geometry": "_mvlgAhqkuhF`o@tC~EVzRj@jOfA~Rp@",
+          "name": "Lootens Place",
+          "mode": "driving",
+          "maneuver": {
+            "location": [
+              -122.525989,
+              37.973728
+            ],
+            "bearing_before": 280,
+            "bearing_after": 184,
+            "instruction": "Turn left onto Lootens Place.",
+            "type": "turn",
+            "modifier": "left"
+          },
+          "voiceInstructions": [
+            {
+              "distanceAlongGeometry": 189,
+              "announcement": "In 700 feet, Turn right onto 3rd Street.",
+              "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 700 feet, Turn right onto 3rd Street.</prosody></amazon:effect></speak>"
+            },
+            {
+              "distanceAlongGeometry": 50,
+              "announcement": "Turn right onto 3rd Street.",
+              "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Turn right onto 3rd Street.</prosody></amazon:effect></speak>"
+            }
+          ],
+          "bannerInstructions": [
+            {
+              "distanceAlongGeometry": 199,
+              "primary": {
+                "text": "3rd Street",
+                "components": [
+                  {
+                    "text": "3rd Street",
+                    "type": "text"
+                  }
+                ],
+                "type": "turn",
+                "modifier": "right"
+              }
+            }
+          ],
+          "driving_side": "right",
+          "weight": 78.291,
+          "intersections": [
+            {
+              "location": [
+                -122.525989,
+                37.973728
+              ],
+              "bearings": [
+                100,
+                184
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 12,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "street"
+              }
+            },
+            {
+              "location": [
+                -122.526064,
+                37.972959
+              ],
+              "bearings": [
+                4,
+                185
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 13,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "street"
+              }
+            },
+            {
+              "location": [
+                -122.526098,
+                37.972529
+              ],
+              "bearings": [
+                3,
+                186
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 15,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "street"
+              }
+            },
+            {
+              "location": [
+                -122.526134,
+                37.972267
+              ],
+              "bearings": [
+                6,
+                184
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 16,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "street"
+              }
+            }
+          ]
+        },
+        {
+          "distance": 529,
+          "duration": 68.78,
+          "duration_typical": 61.788,
+          "geometry": "u}rlgA|{kuhFiAdQiBh^o@|N[fSSrE]nHmBvb@_G`oA}Bxg@qBpc@aA`UiAjWI|A]zH}@tS",
+          "name": "3rd Street",
+          "mode": "driving",
+          "maneuver": {
+            "location": [
+              -122.526159,
+              37.971947
+            ],
+            "bearing_before": 184,
+            "bearing_after": 279,
+            "instruction": "Turn right onto 3rd Street.",
+            "type": "end of road",
+            "modifier": "right"
+          },
+          "voiceInstructions": [
+            {
+              "distanceAlongGeometry": 515.667,
+              "announcement": "In a quarter mile, Turn left onto D Street.",
+              "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In a quarter mile, Turn left onto D Street.</prosody></amazon:effect></speak>"
+            },
+            {
+              "distanceAlongGeometry": 91.111,
+              "announcement": "Turn left onto D Street. Then, in 400 feet, Turn left onto 2nd Street.",
+              "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Turn left onto D Street. Then, in 400 feet, Turn left onto 2nd Street.</prosody></amazon:effect></speak>"
+            }
+          ],
+          "bannerInstructions": [
+            {
+              "distanceAlongGeometry": 529,
+              "primary": {
+                "text": "D Street",
+                "components": [
+                  {
+                    "text": "D Street",
+                    "type": "text"
+                  }
+                ],
+                "type": "turn",
+                "modifier": "left"
+              },
+              "sub": {
+                "text": "2nd Street",
+                "components": [
+                  {
+                    "text": "2nd Street",
+                    "type": "text"
+                  }
+                ],
+                "type": "turn",
+                "modifier": "left"
+              }
+            }
+          ],
+          "driving_side": "right",
+          "weight": 82.471,
+          "intersections": [
+            {
+              "location": [
+                -122.526159,
+                37.971947
+              ],
+              "bearings": [
+                4,
+                279
+              ],
+              "classes": [
+                "restricted",
+                "primary"
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 17,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "primary"
+              }
+            },
+            {
+              "location": [
+                -122.52645,
+                -122.52645
+              ],
+              "classes": [
+                "restricted",
+                "primary"
+              ],
+              "bearings": [
+                99,
+                278
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 18,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "primary"
+              }
+            },
+            {
+              "location": [
+                -122.526951,
+                37.972037
+              ],
+              "bearings": [
+                98,
+                277
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 19,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "primary"
+              }
+            },
+            {
+              "location": [
+                -122.527206,
+                37.972061
+              ],
+              "bearings": [
+                97,
+                273
+              ],
+              "classes": [
+                "restricted",
+                "primary"
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 20,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "primary"
+              }
+            },
+            {
+              "location": [
+                -122.52753,
+                37.972075
+              ],
+              "bearings": [
+                93,
+                277
+              ],
+              "classes": [
+                "restricted",
+                "primary"
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 21,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "primary"
+              }
+            },
+            {
+              "location": [
+                -122.527636,
+                37.972085
+              ],
+              "bearings": [
+                97,
+                277
+              ],
+              "classes": [
+                "restricted",
+                "primary"
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 22,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "primary"
+              }
+            },
+            {
+              "location": [
+                -122.527788,
+                37.9721
+              ],
+              "bearings": [
+                97,
+                277
+              ],
+              "classes": [
+                "restricted",
+                "primary"
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 23,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "primary"
+              }
+            },
+            {
+              "location": [
+                -122.52836,
+                37.972155
+              ],
+              "bearings": [
+                97,
+                277
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 24,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "primary"
+              }
+            },
+            {
+              "location": [
+                -122.529641,
+                37.972283
+              ],
+              "bearings": [
+                97,
+                277
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 25,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "primary"
+              }
+            },
+            {
+              "location": [
+                -122.530294,
+                37.972346
+              ],
+              "bearings": [
+                97,
+                277
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 26,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "primary"
+              }
+            },
+            {
+              "location": [
+                -122.530879,
+                37.972403
+              ],
+              "bearings": [
+                97,
+                277
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 27,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "primary"
+              }
+            },
+            {
+              "location": [
+                -122.531232,
+                37.972436
+              ],
+              "bearings": [
+                97,
+                277
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 28,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "primary"
+              }
+            },
+            {
+              "location": [
+                -122.531622,
+                37.972473
+              ],
+              "bearings": [
+                97,
+                278
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 29,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "primary"
+              }
+            },
+            {
+              "location": [
+                -122.531669,
+                37.972478
+              ],
+              "bearings": [
+                98,
+                277
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 30,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "primary"
+              }
+            },
+            {
+              "location": [
+                -122.531827,
+                37.972493
+              ],
+              "bearings": [
+                97,
+                277
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 31,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "primary"
+              }
+            }
+          ]
+        },
+        {
+          "distance": 107,
+          "duration": 33.907,
+          "duration_typical": 33.907,
+          "geometry": "watlgAzrwuhFjUdBtM`ArGf@vMbA",
+          "name": "D Street",
+          "mode": "driving",
+          "maneuver": {
+            "location": [
+              -122.532158,
+              37.972524
+            ],
+            "bearing_before": 277,
+            "bearing_after": 186,
+            "instruction": "Turn left onto D Street.",
+            "type": "turn",
+            "modifier": "left"
+          },
+          "voiceInstructions": [
+            {
+              "distanceAlongGeometry": 94.444,
+              "announcement": "Turn left onto 2nd Street. Then, in 200 feet, You will arrive at your destination.",
+              "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Turn left onto 2nd Street. Then, in 200 feet, You will arrive at your destination.</prosody></amazon:effect></speak>"
+            }
+          ],
+          "bannerInstructions": [
+            {
+              "distanceAlongGeometry": 107,
+              "primary": {
+                "text": "2nd Street",
+                "components": [
+                  {
+                    "text": "2nd Street",
+                    "type": "text"
+                  }
+                ],
+                "type": "turn",
+                "modifier": "left"
+              }
+            }
+          ],
+          "driving_side": "right",
+          "weight": 45.159,
+          "intersections": [
+            {
+              "location": [
+                -122.532158,
+                37.972524
+              ],
+              "bearings": [
+                97,
+                186
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 32,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "tertiary"
+              }
+            },
+            {
+              "location": [
+                -122.532209,
+                37.972166
+              ],
+              "bearings": [
+                6,
+                186
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 33,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "tertiary"
+              }
+            },
+            {
+              "location": [
+                -122.532242,
+                37.971931
+              ],
+              "bearings": [
+                6,
+                187
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 34,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "tertiary"
+              }
+            },
+            {
+              "location": [
+                -122.532262,
+                37.971793
+              ],
+              "bearings": [
+                7,
+                186
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 35,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "tertiary"
+              }
+            }
+          ]
+        },
+        {
+          "distance": 72.754,
+          "duration": 14.868,
+          "duration_typical": 14.868,
+          "geometry": "ierlgAn{wuhFxAsYR}DVsEf@qK",
+          "name": "2nd Street",
+          "mode": "driving",
+          "maneuver": {
+            "location": [
+              -122.532296,
+              37.971557
+            ],
+            "bearing_before": 186,
+            "bearing_after": 98,
+            "instruction": "Turn left onto 2nd Street.",
+            "type": "turn",
+            "modifier": "left"
+          },
+          "voiceInstructions": [
+            {
+              "distanceAlongGeometry": 55.556,
+              "announcement": "You have arrived at your destination.",
+              "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">You have arrived at your destination.</prosody></amazon:effect></speak>"
+            }
+          ],
+          "bannerInstructions": [
+            {
+              "distanceAlongGeometry": 72.754,
+              "primary": {
+                "text": "You will arrive at your destination",
+                "components": [
+                  {
+                    "text": "You will arrive at your destination",
+                    "type": "text"
+                  }
+                ],
+                "type": "arrive",
+                "modifier": "straight"
+              }
+            },
+            {
+              "distanceAlongGeometry": 55.556,
+              "primary": {
+                "text": "You have arrived at your destination",
+                "components": [
+                  {
+                    "text": "You have arrived at your destination",
+                    "type": "text"
+                  }
+                ],
+                "type": "arrive",
+                "modifier": "straight"
+              }
+            }
+          ],
+          "driving_side": "right",
+          "weight": 31.298,
+          "intersections": [
+            {
+              "location": [
+                -122.532296,
+                37.971557
+              ],
+              "bearings": [
+                6,
+                98
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 36,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "primary"
+              }
+            },
+            {
+              "location": [
+                -122.53187,
+                37.971512
+              ],
+              "bearings": [
+                98,
+                278
+              ],
+              "entry": [
+                true,
+                false
+              ],
+              "in": 1,
+              "out": 0,
+              "geometry_index": 37,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "primary"
+              }
+            },
+            {
+              "location": [
+                -122.531775,
+                37.971502
+              ],
+              "bearings": [
+                98,
+                278
+              ],
+              "entry": [
+                true,
+                false
+              ],
+              "in": 1,
+              "out": 0,
+              "geometry_index": 38,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "primary"
+              }
+            },
+            {
+              "location": [
+                -122.531669,
+                37.97149
+              ],
+              "bearings": [
+                97,
+                278
+              ],
+              "entry": [
+                true,
+                false
+              ],
+              "in": 1,
+              "out": 0,
+              "geometry_index": 39,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "primary"
+              }
+            }
+          ]
+        },
+        {
+          "distance": 0,
+          "duration": 0,
+          "duration_typical": 0,
+          "geometry": "{_rlgAvgvuhF??",
+          "name": "2nd Street",
+          "mode": "driving",
+          "maneuver": {
+            "location": [
+              -122.531468,
+              37.97147
+            ],
+            "bearing_before": 97,
+            "bearing_after": 0,
+            "instruction": "You have arrived at your destination.",
+            "type": "arrive"
+          },
+          "voiceInstructions": [],
+          "bannerInstructions": [],
+          "driving_side": "right",
+          "weight": 0,
+          "intersections": [
+            {
+              "location": [
+                -122.531468,
+                37.97147
+              ],
+              "bearings": [
+                277
+              ],
+              "entry": [
+                true
+              ],
+              "in": 0,
+              "geometry_index": 40,
+              "admin_index": 0
+            }
+          ]
+        }
+      ],
+      "annotation": {
+        "distance": [
+          22.6,
+          57.2,
+          33.1,
+          10.7,
+          39.6,
+          34.8,
+          14.3,
+          56.6,
+          7.4,
+          43.4,
+          5.9,
+          52.8,
+          85.9,
+          12.5,
+          35.5,
+          29.3,
+          35.7,
+          25.9,
+          44.4,
+          22.5,
+          28.5,
+          9.4,
+          13.4,
+          50.6,
+          113.3,
+          57.7,
+          51.7,
+          31.2,
+          34.5,
+          4.2,
+          14,
+          29.3,
+          40.1,
+          26.3,
+          15.5,
+          26.4,
+          37.7,
+          8.4,
+          9.4,
+          17.8
+        ],
+        "congestion": [
+          "unknown",
+          "unknown",
+          "unknown",
+          "unknown",
+          "unknown",
+          "unknown",
+          "unknown",
+          "unknown",
+          "unknown",
+          "unknown",
+          "unknown",
+          "unknown",
+          "low",
+          "low",
+          "low",
+          "unknown",
+          "unknown",
+          "low",
+          "moderate",
+          "low",
+          "low",
+          "unknown",
+          "low",
+          "low",
+          "low",
+          "low",
+          "low",
+          "low",
+          "low",
+          "unknown",
+          "unknown",
+          "unknown",
+          "moderate",
+          "low",
+          "unknown",
+          "unknown",
+          "low",
+          "low",
+          "low",
+          "low"
+        ]
+      }
+    }
+  ],
+  "routeOptions": {
+    "baseUrl": "https://api.mapbox.com/",
+    "user": "mapbox",
+    "profile": "driving-traffic",
+    "coordinates": "-122.5237628,37.9754096;-122.5314743,37.9714342",
+    "alternatives": true,
+    "language": "en",
+    "bearings": "147.032028,45;",
+    "continue_straight": false,
+    "roundabout_exits": false,
+    "geometries": "polyline6",
+    "overview": "full",
+    "steps": true,
+    "annotations": "congestion,distance",
+    "voice_instructions": true,
+    "banner_instructions": true,
+    "voice_units": "imperial",
+    "access_token": "omitted",
+    "uuid": "IpVPAi2-NVeMFql46rqadH7Ag5QrBGPWCRdfz-cUrXHk2e1n7gKjYg=="
+  },
+  "voiceLocale": "en-US"
+}

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -17,7 +17,7 @@ ext {
   println("Navigation Native version: " + mapboxNavigatorVersion)
 
   version = [
-      mapboxMapSdk              : '10.4.0',
+      mapboxMapSdk              : '10.4.0-beta.1-line-trim-offset-SNAPSHOT', //fixme don't keep this snapshot
       mapboxSdkServices         : '6.4.0-beta.4',
       mapboxEvents              : '8.1.1',
       mapboxCore                : '5.0.1',

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/lifecycle/UIComponent.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/lifecycle/UIComponent.kt
@@ -33,7 +33,7 @@ open class UIComponent : MapboxNavigationObserver {
     }
 
     protected inline fun <T> Flow<T>.observe(crossinline action: suspend (value: T) -> Unit) {
-        coroutineScope.launch { collect(action) }
+        //coroutineScope.launch { collect(action) } //SBNOTE: fixme restore this
     }
 }
 

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtils.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtils.kt
@@ -1002,6 +1002,21 @@ internal object MapboxRouteLineUtils {
             style.addPersistentLayer(it, LayerPosition(null, belowLayerIdToUse, null))
         }
 
+        options.routeLayerProvider.buildPrimaryRouteCasingTrailLayer(
+            style,
+            options.resourceProvider.routeLineColorResources.routeLineTraveledCasingColor
+        ).let {
+            style.addPersistentLayer(it, LayerPosition(null, belowLayerIdToUse, null))
+        }
+
+        options.routeLayerProvider.buildPrimaryRouteTrailLayer(
+            style,
+            options.resourceProvider.roundedLineCap,
+            options.resourceProvider.routeLineColorResources.routeLineTraveledColor
+        ).let {
+            style.addPersistentLayer(it, LayerPosition(null, belowLayerIdToUse, null))
+        }
+
         options.routeLayerProvider.buildPrimaryRouteCasingLayer(
             style,
             options.resourceProvider.routeLineColorResources.routeCasingColor

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/RouteLayerConstants.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/RouteLayerConstants.kt
@@ -36,6 +36,16 @@ object RouteLayerConstants {
     internal const val PRIMARY_ROUTE_CASING_LAYER_ID = "mapbox-navigation-route-casing-layer"
 
     /**
+     * Layer ID for the primary route line trail
+     */
+    internal const val PRIMARY_ROUTE_TRAIL_LAYER_ID = "mapbox-navigation-route-trail-layer"
+
+    /**
+     * Layer ID for the primary route casing line trail
+     */
+    internal const val PRIMARY_ROUTE_CASING_TRAIL_LAYER_ID = "mapbox-navigation-route-casing-trail-layer"
+
+    /**
      * Layer ID for the first alternative route line
      */
     internal const val ALTERNATIVE_ROUTE1_LAYER_ID = "mapbox-navigation-alt-route1-layer"

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/MapboxRouteLayerProvider.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/MapboxRouteLayerProvider.kt
@@ -57,10 +57,44 @@ internal class MapboxRouteLayerProvider(
                 routeStyleDescriptors,
                 RouteStyleDescriptor::lineColor
             )
+        return buildPrimaryRouteRelatedLayer(
+            RouteLayerConstants.PRIMARY_ROUTE_LAYER_ID,
+            style,
+            roundedLineCap,
+            routeLineColorExpressions
+        )
+    }
+
+    fun buildPrimaryRouteTrailLayer(
+        style: Style,
+        roundedLineCap: Boolean,
+        color: Int
+    ): LineLayer {
+        val routeLineColorExpressions =
+            getRouteLineColorExpressions(
+                color,
+                listOf(),
+                RouteStyleDescriptor::lineColor
+            )
+
+        return buildPrimaryRouteRelatedLayer(
+            RouteLayerConstants.PRIMARY_ROUTE_TRAIL_LAYER_ID,
+            style,
+            roundedLineCap,
+            routeLineColorExpressions
+        )
+    }
+
+    private fun buildPrimaryRouteRelatedLayer(
+        layerId: String,
+        style: Style,
+        roundedLineCap: Boolean,
+        routeLineColorExpressions: List<Expression>
+    ): LineLayer {
         return initializeRouteLayer(
             style,
             roundedLineCap,
-            RouteLayerConstants.PRIMARY_ROUTE_LAYER_ID,
+            layerId,
             RouteLayerConstants.PRIMARY_ROUTE_SOURCE_ID,
             routeLineScaleExpression,
             routeLineColorExpressions
@@ -98,10 +132,39 @@ internal class MapboxRouteLayerProvider(
                 routeStyleDescriptors,
                 RouteStyleDescriptor::lineCasingColor
             )
+        return buildPrimaryRouteCasingRelatedLayer(
+            RouteLayerConstants.PRIMARY_ROUTE_CASING_LAYER_ID,
+            style,
+            routeLineColorExpressions
+        )
+    }
+
+    fun buildPrimaryRouteCasingTrailLayer(
+        style: Style,
+        color: Int
+    ): LineLayer {
+        val routeLineColorExpressions =
+            getRouteLineColorExpressions(
+                color,
+                listOf(),
+                RouteStyleDescriptor::lineCasingColor
+            )
+        return buildPrimaryRouteCasingRelatedLayer(
+            RouteLayerConstants.PRIMARY_ROUTE_CASING_TRAIL_LAYER_ID,
+            style,
+            routeLineColorExpressions
+        )
+    }
+
+    private fun buildPrimaryRouteCasingRelatedLayer(
+        layerId: String,
+        style: Style,
+        routeLineColorExpressions: List<Expression>
+    ): LineLayer {
         return initializeRouteLayer(
             style,
             true,
-            RouteLayerConstants.PRIMARY_ROUTE_CASING_LAYER_ID,
+            layerId,
             RouteLayerConstants.PRIMARY_ROUTE_SOURCE_ID,
             routeCasingLineScaleExpression,
             routeLineColorExpressions

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApi.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApi.kt
@@ -467,7 +467,7 @@ class MapboxRouteLineApi(
                 }
             }
 
-        val routeLineExpressionProviders =
+        val routeLineExpressionProviders = if (routeLineOptions.styleInactiveRouteLegsIndependently) {
             routeLineOptions.vanishingRouteLine?.getTraveledRouteLineExpressions(
                 point,
                 workingRouteLineExpressionData,
@@ -475,8 +475,11 @@ class MapboxRouteLineApi(
                 routeLineOptions.resourceProvider,
                 activeLegIndex,
                 stopGap,
-                routeLineOptions.displaySoftGradientForTraffic
+                routeLineOptions.displaySoftGradientForTraffic,
             )
+        } else {
+            routeLineOptions.vanishingRouteLine?.getTraveledRouteLineExpressions(point)
+        }
 
         lastPointUpdateTimeNano = System.nanoTime()
         return when (routeLineExpressionProviders) {

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineView.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineView.kt
@@ -19,9 +19,11 @@ import com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions
 import com.mapbox.navigation.ui.maps.route.line.model.RouteLineClearValue
 import com.mapbox.navigation.ui.maps.route.line.model.RouteLineError
 import com.mapbox.navigation.ui.maps.route.line.model.RouteLineExpressionProvider
+import com.mapbox.navigation.ui.maps.route.line.model.RouteLineTrimExpressionProvider
 import com.mapbox.navigation.ui.maps.route.line.model.RouteLineUpdateValue
 import com.mapbox.navigation.ui.maps.route.line.model.RouteSetValue
 import com.mapbox.navigation.utils.internal.InternalJobControlFactory
+import com.mapbox.navigation.utils.internal.ifNonNull
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -196,6 +198,7 @@ class MapboxRouteLineView(var options: MapboxRouteLineOptions) {
      * @param style an instance of the Style
      * @param update an instance of VanishingRouteLineUpdateState
      */
+
     fun renderRouteLineUpdate(
         style: Style,
         update: Expected<RouteLineError, RouteLineUpdateValue>
@@ -204,28 +207,53 @@ class MapboxRouteLineView(var options: MapboxRouteLineOptions) {
         jobControl.scope.launch(Dispatchers.Main) {
             mutex.withLock {
                 update.onValue {
-                    updateLineGradient(
-                        style,
-                        RouteLayerConstants.PRIMARY_ROUTE_TRAFFIC_LAYER_ID,
+                    getExpressionUpdateFun(
                         it.primaryRouteLineDynamicData.trafficExpressionProvider
-                    )
-                    updateLineGradient(
-                        style,
-                        RouteLayerConstants.PRIMARY_ROUTE_LAYER_ID,
+                    ).apply {
+                        this(
+                            style,
+                            RouteLayerConstants.PRIMARY_ROUTE_TRAFFIC_LAYER_ID,
+                            it.primaryRouteLineDynamicData.trafficExpressionProvider
+                        )
+                    }
+                    getExpressionUpdateFun(
                         it.primaryRouteLineDynamicData.baseExpressionProvider
-                    )
-                    updateLineGradient(
-                        style,
-                        RouteLayerConstants.PRIMARY_ROUTE_CASING_LAYER_ID,
+                    ).apply {
+                        this(
+                            style,
+                            RouteLayerConstants.PRIMARY_ROUTE_LAYER_ID,
+                            it.primaryRouteLineDynamicData.baseExpressionProvider
+                        )
+                    }
+                    getExpressionUpdateFun(
                         it.primaryRouteLineDynamicData.casingExpressionProvider
-                    )
-                    updateLineGradient(
-                        style,
-                        RouteLayerConstants.RESTRICTED_ROAD_LAYER_ID,
+                    ).apply {
+                        this(
+                            style,
+                            RouteLayerConstants.PRIMARY_ROUTE_CASING_LAYER_ID,
+                            it.primaryRouteLineDynamicData.casingExpressionProvider
+                        )
+                    }
+                    getExpressionUpdateFun(
                         it.primaryRouteLineDynamicData.restrictedSectionExpressionProvider
-                    )
+                    ).apply {
+                        this(
+                            style,
+                            RouteLayerConstants.RESTRICTED_ROAD_LAYER_ID,
+                            it.primaryRouteLineDynamicData.restrictedSectionExpressionProvider
+                        )
+                    }
                 }
             }
+        }
+    }
+
+    private fun getExpressionUpdateFun(
+        provider: RouteLineExpressionProvider?
+    ): (Style, String, RouteLineExpressionProvider?) -> Unit {
+        return when (provider) {
+            is RouteLineTrimExpressionProvider -> ::updateTrimOffset
+            else -> ::updateLineGradient
         }
     }
 
@@ -544,6 +572,18 @@ class MapboxRouteLineView(var options: MapboxRouteLineOptions) {
                     this,
                     layerId,
                 )
+            }
+        }
+    }
+
+    private fun updateTrimOffset(
+        style: Style,
+        layerId: String,
+        expressionProvider: RouteLineExpressionProvider?
+    ) {
+        ifNonNull(expressionProvider) { expressionProvider ->
+            style.getLayer(layerId)?.let {
+                (it as LineLayer).lineTrimOffset(expressionProvider.generateExpression())
             }
         }
     }

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/VanishingRouteLine.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/VanishingRouteLine.kt
@@ -2,6 +2,8 @@ package com.mapbox.navigation.ui.maps.route.line.api
 
 import android.graphics.Color
 import com.mapbox.geojson.Point
+import com.mapbox.maps.extension.style.expressions.dsl.generated.literal
+import com.mapbox.maps.extension.style.expressions.generated.Expression
 import com.mapbox.navigation.base.route.NavigationRoute
 import com.mapbox.navigation.base.trip.model.RouteProgressState
 import com.mapbox.navigation.ui.maps.internal.route.line.MapboxRouteLineUtils
@@ -11,6 +13,7 @@ import com.mapbox.navigation.ui.maps.route.line.model.ExtractedRouteData
 import com.mapbox.navigation.ui.maps.route.line.model.RouteLineExpressionData
 import com.mapbox.navigation.ui.maps.route.line.model.RouteLineGranularDistances
 import com.mapbox.navigation.ui.maps.route.line.model.RouteLineResources
+import com.mapbox.navigation.ui.maps.route.line.model.RouteLineTrimExpressionProvider
 import com.mapbox.navigation.ui.maps.route.line.model.RoutePoints
 import com.mapbox.navigation.ui.maps.route.line.model.VanishingPointState
 import com.mapbox.navigation.ui.maps.route.line.model.VanishingRouteLineExpressions
@@ -109,6 +112,94 @@ internal class VanishingRouteLine {
         }
     }
 
+    private fun getOffset(
+        point: Point,
+        granularDistances: RouteLineGranularDistances,
+        index: Int
+    ): Double? {
+        val upcomingIndex = granularDistances.distancesArray[index]
+        if (upcomingIndex == null) {
+            logD(
+                "Upcoming route line index is null.",
+                "VanishingRouteLine"
+            )
+            return null
+        }
+        val upcomingPoint = upcomingIndex.point
+        if (index > 0) {
+            val distanceToLine = MapboxRouteLineUtils.findDistanceToNearestPointOnCurrentLine(
+                point,
+                granularDistances,
+                index
+            )
+            if (
+                distanceToLine >
+                RouteLayerConstants.ROUTE_LINE_UPDATE_MAX_DISTANCE_THRESHOLD_IN_METERS
+            ) {
+                return null
+            }
+        }
+
+        /**
+         * Take the remaining distance from the upcoming point on the route and extends it
+         * by the exact position of the puck.
+         */
+        val remainingDistance =
+            upcomingIndex.distanceRemaining + MapboxRouteLineUtils.calculateDistance(
+                upcomingPoint,
+                point
+            )
+
+        /**
+         * Calculate the percentage of the route traveled and update the expression.
+         */
+        /**
+         * Calculate the percentage of the route traveled and update the expression.
+         */
+        val offset = if (granularDistances.distance >= remainingDistance) {
+            (1.0 - remainingDistance / granularDistances.distance)
+        } else {
+            0.0
+        }
+
+        if (vanishingPointState == VanishingPointState.ONLY_INCREASE_PROGRESS &&
+            vanishPointOffset > offset
+        ) {
+            return null
+        }
+        return offset
+    }
+
+    internal fun getTraveledRouteLineExpressions(point: Point): VanishingRouteLineExpressions? {
+        return ifNonNull(
+            primaryRouteLineGranularDistances,
+            primaryRouteRemainingDistancesIndex
+        ) { granularDistances, index ->
+            ifNonNull(getOffset(point, granularDistances, index)) { offset ->
+                vanishPointOffset = offset
+                val trimmedOffsetExpression = literal(listOf(0.0, offset))
+                val trafficLineExpressionProvider = RouteLineTrimExpressionProvider {
+                    trimmedOffsetExpression
+                }
+                val routeLineExpressionProvider = RouteLineTrimExpressionProvider {
+                    trimmedOffsetExpression
+                }
+                val routeLineCasingExpressionProvider = RouteLineTrimExpressionProvider {
+                    trimmedOffsetExpression
+                }
+                val restrictedRoadExpressionProvider = RouteLineTrimExpressionProvider {
+                    trimmedOffsetExpression
+                }
+                VanishingRouteLineExpressions(
+                    trafficLineExpressionProvider,
+                    routeLineExpressionProvider,
+                    routeLineCasingExpressionProvider,
+                    restrictedRoadExpressionProvider
+                )
+            }
+        }
+    }
+
     internal fun getTraveledRouteLineExpressions(
         point: Point,
         routeLineExpressionData: List<RouteLineExpressionData>,
@@ -116,126 +207,75 @@ internal class VanishingRouteLine {
         routeResourceProvider: RouteLineResources,
         activeLegIndex: Int,
         softGradientTransition: Double,
-        useSoftGradient: Boolean
+        useSoftGradient: Boolean,
     ): VanishingRouteLineExpressions? {
-        ifNonNull(
+        return ifNonNull(
             primaryRouteLineGranularDistances,
             primaryRouteRemainingDistancesIndex
         ) { granularDistances, index ->
-            val upcomingIndex = granularDistances.distancesArray[index]
-            if (upcomingIndex == null) {
-                logD(
-                    "Upcoming route line index is null.",
-                    "VanishingRouteLine"
-                )
-                return null
-            }
-            val upcomingPoint = upcomingIndex.point
-            if (index > 0) {
-                val distanceToLine = MapboxRouteLineUtils.findDistanceToNearestPointOnCurrentLine(
-                    point,
-                    granularDistances,
-                    index
-                )
-                if (
-                    distanceToLine >
-                    RouteLayerConstants.ROUTE_LINE_UPDATE_MAX_DISTANCE_THRESHOLD_IN_METERS
-                ) {
-                    return null
-                }
-            }
-
-            /**
-             * Take the remaining distance from the upcoming point on the route and extends it
-             * by the exact position of the puck.
-             */
-            val remainingDistance =
-                upcomingIndex.distanceRemaining + MapboxRouteLineUtils.calculateDistance(
-                    upcomingPoint,
-                    point
-                )
-
-            /**
-             * Calculate the percentage of the route traveled and update the expression.
-             */
-            /**
-             * Calculate the percentage of the route traveled and update the expression.
-             */
-            val offset = if (granularDistances.distance >= remainingDistance) {
-                (1.0 - remainingDistance / granularDistances.distance)
-            } else {
-                0.0
-            }
-
-            if (vanishingPointState == VanishingPointState.ONLY_INCREASE_PROGRESS &&
-                vanishPointOffset > offset
-            ) {
-                return null
-            }
-            vanishPointOffset = offset
-
-            val trafficLineExpressionProvider = if (useSoftGradient) {
-                {
-                    MapboxRouteLineUtils.getTrafficLineExpressionSoftGradient(
-                        offset,
-                        routeResourceProvider.routeLineColorResources.routeLineTraveledColor,
-                        routeResourceProvider.routeLineColorResources.routeUnknownCongestionColor,
-                        softGradientTransition,
-                        routeLineExpressionData
-                    )
-                }
-            } else {
-                {
-                    MapboxRouteLineUtils.getTrafficLineExpression(
-                        offset,
-                        routeResourceProvider.routeLineColorResources.routeLineTraveledColor,
-                        routeResourceProvider.routeLineColorResources.routeUnknownCongestionColor,
-                        routeLineExpressionData
-                    )
-                }
-            }
-
-            val routeLineExpressionProvider = {
-                MapboxRouteLineUtils.getRouteLineExpression(
-                    offset,
-                    routeLineExpressionData,
-                    routeResourceProvider.routeLineColorResources.routeLineTraveledColor,
-                    routeResourceProvider.routeLineColorResources.routeDefaultColor,
-                    routeResourceProvider.routeLineColorResources.inActiveRouteLegsColor,
-                    activeLegIndex
-                )
-            }
-            val routeLineCasingExpressionProvider = {
-                MapboxRouteLineUtils.getRouteLineExpression(
-                    offset,
-                    routeLineExpressionData,
-                    routeResourceProvider.routeLineColorResources.routeLineTraveledCasingColor,
-                    routeResourceProvider.routeLineColorResources.routeCasingColor,
-                    Color.TRANSPARENT,
-                    activeLegIndex
-                )
-            }
-
-            val restrictedRoadExpressionProvider =
-                ifNonNull(restrictedLineExpressionData) { expressionData ->
+            ifNonNull(getOffset(point, granularDistances, index)) { offset ->
+                vanishPointOffset = offset
+                val trafficLineExpressionProvider = if (useSoftGradient) {
                     {
-                        MapboxRouteLineUtils.getRestrictedLineExpression(
+                        MapboxRouteLineUtils.getTrafficLineExpressionSoftGradient(
                             offset,
-                            activeLegIndex,
-                            routeResourceProvider.routeLineColorResources.restrictedRoadColor,
-                            expressionData
+                            routeResourceProvider.routeLineColorResources.routeLineTraveledColor,
+                            routeResourceProvider.routeLineColorResources.routeUnknownCongestionColor,
+                            softGradientTransition,
+                            routeLineExpressionData
+                        )
+                    }
+                } else {
+                    {
+                        MapboxRouteLineUtils.getTrafficLineExpression(
+                            offset,
+                            routeResourceProvider.routeLineColorResources.routeLineTraveledColor,
+                            routeResourceProvider.routeLineColorResources.routeUnknownCongestionColor,
+                            routeLineExpressionData
                         )
                     }
                 }
+                val routeLineExpressionProvider = {
+                    MapboxRouteLineUtils.getRouteLineExpression(
+                        offset,
+                        routeLineExpressionData,
+                        routeResourceProvider.routeLineColorResources.routeLineTraveledColor,
+                        routeResourceProvider.routeLineColorResources.routeDefaultColor,
+                        routeResourceProvider.routeLineColorResources.inActiveRouteLegsColor,
+                        activeLegIndex
+                    )
+                }
+                val routeLineCasingExpressionProvider = {
+                    MapboxRouteLineUtils.getRouteLineExpression(
+                        offset,
+                        routeLineExpressionData,
+                        routeResourceProvider.routeLineColorResources.routeLineTraveledCasingColor,
+                        routeResourceProvider.routeLineColorResources.routeCasingColor,
+                        Color.TRANSPARENT,
+                        activeLegIndex
+                    )
+                }
+                val restrictedRoadExpressionProvider =
+                    ifNonNull(restrictedLineExpressionData) { expressionData ->
+                        {
+                            MapboxRouteLineUtils.getRestrictedLineExpression(
+                                offset,
+                                activeLegIndex,
+                                routeResourceProvider.routeLineColorResources.restrictedRoadColor,
+                                expressionData
+                            )
+                        }
+                    }
 
-            return VanishingRouteLineExpressions(
-                trafficLineExpressionProvider,
-                routeLineExpressionProvider,
-                routeLineCasingExpressionProvider,
-                restrictedRoadExpressionProvider
-            )
+                VanishingRouteLineExpressions(
+                    trafficLineExpressionProvider,
+                    routeLineExpressionProvider,
+                    routeLineCasingExpressionProvider,
+                    restrictedRoadExpressionProvider
+                )
+            }
         }
-        return null
+
     }
 
     /**

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/RouteSetValue.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/RouteSetValue.kt
@@ -58,3 +58,8 @@ fun interface RouteLineExpressionProvider {
      */
     fun generateExpression(): Expression
 }
+
+/**
+ * Represents a function that returns an [Expression]
+ */
+fun interface RouteLineTrimExpressionProvider : RouteLineExpressionProvider

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtilsTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtilsTest.kt
@@ -12,6 +12,7 @@ import com.mapbox.core.constants.Constants
 import com.mapbox.geojson.LineString
 import com.mapbox.geojson.Point
 import com.mapbox.maps.Style
+import com.mapbox.maps.extension.style.expressions.dsl.generated.literal
 import com.mapbox.maps.extension.style.layers.Layer
 import com.mapbox.maps.extension.style.layers.getLayer
 import com.mapbox.maps.extension.style.layers.properties.generated.Visibility

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineViewTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineViewTest.kt
@@ -52,6 +52,7 @@ import io.mockk.unmockkStatic
 import io.mockk.verify
 import kotlinx.coroutines.CompletableJob
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancelChildren
 import org.junit.After
@@ -61,6 +62,7 @@ import org.junit.Rule
 import org.junit.Test
 import java.util.UUID
 
+@ExperimentalCoroutinesApi
 class MapboxRouteLineViewTest {
 
     @get:Rule


### PR DESCRIPTION
### Description
Resolves #5673 by taking advantage of the trim offset feature available in the maps SDK for use with the vanishing route line.

NOTES:

- It appears this feature is being targeted for the 10.5 release of the maps SDK.
- The code in this draft PR is using a snapshot build of maps to implement the feature.
- There are several //fixme labels for code that had to be modified and/or included to implement and test this feature.
- Unit testing is incomplete. Something about the maps SDK snapshot causes an unresolved reference error for the `pauseDispatcher` in some of the route line related unit test classes. It's unknown if the final release will have the same effect.

The above issues should be resolved before this can be merged.

### Screenshots or Gifs

