### PR TITLE
Exclude certain maneuver types from the 'pitch to 0 near maneuvers' feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Mapbox welcomes participation and contributions from everyone.
 ## Unreleased
 
 #### Features
+- Added support for excluding maneuvers from the 'pitch to 0' camera updates when `FollowingFrameOptions#pitchNearManeuvers` is enabled. See `FollowingFrameOptions#pitchNearManeuvers#excludedManeuvers`. [#5717](https://github.com/mapbox/mapbox-navigation-android/pull/5717)
+- :warning: Navigation Camera will no longer animate to `pitch 0` when approaching following maneuvers: "continue", "merge", "on ramp", "off ramp" and "fork". Original behavior can be restored by setting an empty list to `FollowingFrameOptions#pitchNearManeuvers#excludedManeuvers`.
 
 #### Bug fixes and improvements
 

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/camera/MapboxCameraAnimationsActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/camera/MapboxCameraAnimationsActivity.kt
@@ -11,6 +11,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.mapbox.api.directions.v5.models.RouteOptions
+import com.mapbox.api.directions.v5.models.StepManeuver
 import com.mapbox.geojson.FeatureCollection
 import com.mapbox.geojson.Point
 import com.mapbox.maps.CameraOptions
@@ -267,6 +268,14 @@ class MapboxCameraAnimationsActivity :
         viewportDataSource = MapboxNavigationViewportDataSource(
             binding.mapView.getMapboxMap()
         )
+        viewportDataSource.options.followingFrameOptions.pitchNearManeuvers.apply {
+            // An example of maneuver exclusion from "pitch to 0 near maneuvers" updates.
+            excludedManeuvers = listOf(
+                StepManeuver.FORK,
+                StepManeuver.OFF_RAMP,
+                StepManeuver.ARRIVE
+            )
+        }
         viewportDataSource.debugger = debugger
         navigationCamera = NavigationCamera(
             binding.mapView.getMapboxMap(),

--- a/libnavui-maps/api/current.txt
+++ b/libnavui-maps/api/current.txt
@@ -195,10 +195,13 @@ package com.mapbox.navigation.ui.maps.camera.data {
 
   public static final class FollowingFrameOptions.PitchNearManeuvers {
     method public boolean getEnabled();
+    method public java.util.List<java.lang.String> getExcludedManeuvers();
     method public double getTriggerDistanceFromManeuver();
     method public void setEnabled(boolean p);
+    method public void setExcludedManeuvers(java.util.List<java.lang.String> p);
     method public void setTriggerDistanceFromManeuver(double p);
     property public final boolean enabled;
+    property public final java.util.List<java.lang.String> excludedManeuvers;
     property public final double triggerDistanceFromManeuver;
   }
 

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/MapboxNavigationViewportDataSource.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/MapboxNavigationViewportDataSource.kt
@@ -481,14 +481,10 @@ class MapboxNavigationViewportDataSource(
             routeProgress.currentLegProgress,
             routeProgress.currentLegProgress?.currentStepProgress
         ) { currentLegProgress, currentStepProgress ->
-            options.followingFrameOptions.run {
-                followingPitchProperty.fallback = getPitchFallbackFromRouteProgress(
-                    pitchNearManeuvers.enabled,
-                    pitchNearManeuvers.triggerDistanceFromManeuver,
-                    defaultPitch,
-                    currentStepProgress.distanceRemaining
-                )
-            }
+            followingPitchProperty.fallback = getPitchFallbackFromRouteProgress(
+                routeProgress,
+                options.followingFrameOptions
+            )
 
             options.followingFrameOptions.intersectionDensityCalculation.run {
                 pointsToFrameOnCurrentStep = getPointsToFrameOnCurrentStep(

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/MapboxNavigationViewportDataSourceOptions.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/MapboxNavigationViewportDataSourceOptions.kt
@@ -191,6 +191,8 @@ class FollowingFrameOptions internal constructor() {
          * List of maneuvers for which camera frames pitch should not be set to `0`.
          *
          * Defaults to `listOf("continue", "merge", "on ramp", "off ramp", "fork")`.
+         *
+         * See [available maneuver types](https://docs.mapbox.com/api/navigation/directions/#maneuver-types) and [StepManeuver] class for more options.
          */
         var excludedManeuvers: List<String> = listOf(
             StepManeuver.CONTINUE,

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/MapboxNavigationViewportDataSourceOptions.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/MapboxNavigationViewportDataSourceOptions.kt
@@ -1,6 +1,7 @@
 package com.mapbox.navigation.ui.maps.camera.data
 
 import android.location.Location
+import com.mapbox.api.directions.v5.models.StepManeuver
 
 /**
  * Options that impact generation of frames.
@@ -185,6 +186,19 @@ class FollowingFrameOptions internal constructor() {
          * Defaults to `180.0` meters.
          */
         var triggerDistanceFromManeuver = 180.0
+
+        /**
+         * List of maneuvers for which camera frames pitch should not be set to `0`.
+         *
+         * Defaults to `listOf("continue", "merge", "on ramp", "off ramp", "fork")`.
+         */
+        var excludedManeuvers: List<String> = listOf(
+            StepManeuver.CONTINUE,
+            StepManeuver.MERGE,
+            StepManeuver.ON_RAMP,
+            StepManeuver.OFF_RAMP,
+            StepManeuver.FORK
+        )
     }
 
     /**

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/camera/data/MapboxNavigationViewportDataSourceTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/camera/data/MapboxNavigationViewportDataSourceTest.kt
@@ -172,10 +172,7 @@ class MapboxNavigationViewportDataSourceTest {
         } returns postManeuverFramingPoints
         every {
             getPitchFallbackFromRouteProgress(
-                viewportDataSource.options.followingFrameOptions.pitchNearManeuvers.enabled,
-                viewportDataSource.options.followingFrameOptions.pitchNearManeuvers
-                    .triggerDistanceFromManeuver,
-                viewportDataSource.options.followingFrameOptions.defaultPitch,
+                any(),
                 any()
             )
         } returns pitchFromProgress
@@ -1031,13 +1028,7 @@ class MapboxNavigationViewportDataSourceTest {
     @Test
     fun `verify frame - location + route + progress + reset route`() {
         every {
-            getPitchFallbackFromRouteProgress(
-                viewportDataSource.options.followingFrameOptions.pitchNearManeuvers.enabled,
-                viewportDataSource.options.followingFrameOptions.pitchNearManeuvers
-                    .triggerDistanceFromManeuver,
-                viewportDataSource.options.followingFrameOptions.defaultPitch,
-                any()
-            )
+            getPitchFallbackFromRouteProgress(any(), any())
         } returns ZERO_PITCH
 
         val stepProgress = mockk<RouteStepProgress> {
@@ -1108,13 +1099,7 @@ class MapboxNavigationViewportDataSourceTest {
         mockkStatic(Logger::class)
         every { Logger.e(any(), any()) } just Runs
         every {
-            getPitchFallbackFromRouteProgress(
-                viewportDataSource.options.followingFrameOptions.pitchNearManeuvers.enabled,
-                viewportDataSource.options.followingFrameOptions.pitchNearManeuvers
-                    .triggerDistanceFromManeuver,
-                viewportDataSource.options.followingFrameOptions.defaultPitch,
-                any()
-            )
+            getPitchFallbackFromRouteProgress(any(), any())
         } returns ZERO_PITCH
 
         val stepProgress = mockk<RouteStepProgress> {


### PR DESCRIPTION
Closes [#4845](https://github.com/mapbox/mapbox-navigation-android/issues/4845)

### Description

- Added `excludedManeuvers` option to `FollowingFrameOptions.PitchNearManeuvers` with defaults `listOf("continue", "merge", "on ramp", "off ramp", "fork")`.
- Updated `ViewportDataSourceProcessor#getPitchFallbackFromRouteProgress()` logic.
- Regenerated metalava API file.
- Added Maneuver exclusion demo to Camera Example.

### Changelog

```xml
<changelog>Added support for excluding maneuvers from the 'pitch to 0' camera updates when `FollowingFrameOptions#pitchNearManeuvers` is enabled. See `FollowingFrameOptions#pitchNearManeuvers#excludedManeuvers`.</changelog>
<changelog>:warning: Navigation Camera will no longer animate to `pitch 0` when approaching following maneuvers: "continue", "merge", "on ramp", "off ramp" and "fork". Original behavior can be restored by setting an empty list to `FollowingFrameOptions#pitchNearManeuvers#excludedManeuvers`.</changelog>
```

### Screenshots or Gifs

_Screen cap of Camera Example with the "arrival" maneuver excluded from pitch 0 updates_

https://user-images.githubusercontent.com/2678039/163472169-c7c0ae30-6e87-4248-b4be-686a5c91d17b.mp4


