### PR TITLE
Add location frequency to the replayer and improve speed and distance calculations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ Mapbox welcomes participation and contributions from everyone.
 
 #### Features
 - Added `TollCollection#name` field which contains a name of the toll collection point, when available. [#5784](https://github.com/mapbox/mapbox-navigation-android/pull/5784)
+- Added `ReplayRouteOptions#frequency` to allow adjusting the simulated location frequency. [#5724](https://github.com/mapbox/mapbox-navigation-android/pull/5724)
 
 #### Bug fixes and improvements
+- Improved the accuracy of simulated locations speeds and the coordinate distance. This also fixed issues where the simulated driver would stall or jump near route turns. [#5724](https://github.com/mapbox/mapbox-navigation-android/pull/5724)
 
 #### Known issues
 - If your instrumentation tests use a mocked, prettified JSON response for Mapbox Directions services, you might need to remove white spaces from `"code": "Ok"` substring to `"code":"Ok"`.

--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -512,12 +512,14 @@ package com.mapbox.navigation.core.replay.route {
   }
 
   public final class ReplayRouteOptions {
+    method public double getFrequency();
     method public double getMaxAcceleration();
     method public double getMaxSpeedMps();
     method public double getMinAcceleration();
     method public double getTurnSpeedMps();
     method public double getUTurnSpeedMps();
     method public com.mapbox.navigation.core.replay.route.ReplayRouteOptions.Builder toBuilder();
+    property public final double frequency;
     property public final double maxAcceleration;
     property public final double maxSpeedMps;
     property public final double minAcceleration;
@@ -528,6 +530,7 @@ package com.mapbox.navigation.core.replay.route {
   public static final class ReplayRouteOptions.Builder {
     ctor public ReplayRouteOptions.Builder();
     method public com.mapbox.navigation.core.replay.route.ReplayRouteOptions build();
+    method public com.mapbox.navigation.core.replay.route.ReplayRouteOptions.Builder frequency(double frequency);
     method public com.mapbox.navigation.core.replay.route.ReplayRouteOptions.Builder maxAcceleration(double maxAcceleration);
     method public com.mapbox.navigation.core.replay.route.ReplayRouteOptions.Builder maxSpeedMps(double maxSpeedMps);
     method public com.mapbox.navigation.core.replay.route.ReplayRouteOptions.Builder minAcceleration(double minAcceleration);

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayRouteLocation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayRouteLocation.kt
@@ -6,12 +6,17 @@ import com.mapbox.navigation.core.replay.MapboxReplayer
 
 internal data class ReplayRouteSegment(
     val startSpeedMps: Double,
+    val maxSpeedMps: Double,
     val endSpeedMps: Double,
-    val distanceMeters: Double,
+    val totalDistance: Double,
+    val speedUpDistance: Double,
+    val cruiseDistance: Double,
+    val slowDownDistance: Double,
     val steps: List<ReplayRouteStep>
 )
 
 internal data class ReplayRouteStep(
+    val timeSeconds: Double,
     val acceleration: Double,
     val speedMps: Double,
     val positionMeters: Double

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayRouteOptions.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayRouteOptions.kt
@@ -6,6 +6,7 @@ package com.mapbox.navigation.core.replay.route
  *
  * Note that the default values are recommended because they have been tested.
  *
+ * @param frequency The number of signals per second
  * @param maxSpeedMps Max speed the driver will drive on straight-aways
  * @param turnSpeedMps Speed the driver will slow down for turns approaching 90 degrees
  * @param uTurnSpeedMps Speed the driver will go when facing a u-turn
@@ -13,6 +14,7 @@ package com.mapbox.navigation.core.replay.route
  * @param minAcceleration How fast the driver will decelerate in mps^2
  */
 class ReplayRouteOptions private constructor(
+    val frequency: Double,
     val maxSpeedMps: Double,
     val turnSpeedMps: Double,
     val uTurnSpeedMps: Double,
@@ -23,6 +25,7 @@ class ReplayRouteOptions private constructor(
      * @return the builder that created the [ReplayRouteOptions]
      */
     fun toBuilder(): Builder = Builder().apply {
+        frequency(frequency)
         maxSpeedMps(maxSpeedMps)
         turnSpeedMps(turnSpeedMps)
         uTurnSpeedMps(uTurnSpeedMps)
@@ -39,6 +42,7 @@ class ReplayRouteOptions private constructor(
 
         other as ReplayRouteOptions
 
+        if (frequency != other.frequency) return false
         if (maxSpeedMps != other.maxSpeedMps) return false
         if (turnSpeedMps != other.turnSpeedMps) return false
         if (uTurnSpeedMps != other.uTurnSpeedMps) return false
@@ -52,7 +56,8 @@ class ReplayRouteOptions private constructor(
      * Regenerate whenever a change is made
      */
     override fun hashCode(): Int {
-        var result = maxSpeedMps.hashCode()
+        var result = frequency.hashCode()
+        result = 31 * result + maxSpeedMps.hashCode()
         result = 31 * result + turnSpeedMps.hashCode()
         result = 31 * result + uTurnSpeedMps.hashCode()
         result = 31 * result + maxAcceleration.hashCode()
@@ -65,6 +70,7 @@ class ReplayRouteOptions private constructor(
      */
     override fun toString(): String {
         return "ReplayRouteOptions(" +
+            "frequency=$frequency, " +
             "maxSpeedMps=$maxSpeedMps, " +
             "turnSpeedMps=$turnSpeedMps, " +
             "uTurnSpeedMps=$uTurnSpeedMps, " +
@@ -77,6 +83,7 @@ class ReplayRouteOptions private constructor(
      * Used to build [ReplayRouteOptions].
      */
     class Builder {
+        private var frequency = 1.0
         private var maxSpeedMps = 30.0
         private var turnSpeedMps = 3.0
         private var uTurnSpeedMps = 1.0
@@ -94,8 +101,22 @@ class ReplayRouteOptions private constructor(
                 turnSpeedMps = turnSpeedMps,
                 uTurnSpeedMps = uTurnSpeedMps,
                 maxAcceleration = maxAcceleration,
-                minAcceleration = minAcceleration
+                minAcceleration = minAcceleration,
+                frequency = frequency
             )
+        }
+
+        /**
+         * Number of signals per second.
+         *   1 will produce 1 location per second (default)
+         *   10 will produce 10 locations per second
+         *   0.5 will produce 1 location every 2 seconds
+         *
+         * @param frequency
+         * @return [Builder]
+         */
+        fun frequency(frequency: Double): Builder = apply {
+            this.frequency = frequency
         }
 
         /**

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/route/ReplayRouteInterpolatorTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/route/ReplayRouteInterpolatorTest.kt
@@ -116,7 +116,7 @@ class ReplayRouteInterpolatorTest {
             assertTrue(first().speedMps <= startSpeedMps)
             assertTrue(last().speedMps < 0.001)
         }
-        assertTrue("${segment.steps.size} < 13", segment.steps.size < 13)
+        assertTrue("${segment.steps.size} < 14", segment.steps.size < 14)
     }
 
     @Test
@@ -154,6 +154,26 @@ class ReplayRouteInterpolatorTest {
 
         assertEquals(223.96630390737917, segment.steps.last().positionMeters, 0.00001)
         assertEquals(3.0, segment.endSpeedMps, 0.0001)
+    }
+
+    @Test
+    fun `should accelerate to complete short route`() {
+        val startSpeedMps = 0.0
+        val endSpeedMps = 0.0
+        val distanceMeters = 200.0
+
+        val segment = routeInterpolator.interpolateSpeed(
+            defaultOptions,
+            startSpeedMps,
+            endSpeedMps,
+            distanceMeters
+        )
+
+        segment.steps.apply {
+            val midStep = get(lastIndex / 2)
+            assertTrue(size > 5)
+            assertTrue("${midStep.speedMps} > 5.0", midStep.speedMps > 5.0)
+        }
     }
 
     @Test

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/route/ReplayRouteOptionsTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/route/ReplayRouteOptionsTest.kt
@@ -9,6 +9,7 @@ class ReplayRouteOptionsTest : BuilderTest<ReplayRouteOptions, ReplayRouteOption
 
     override fun getFilledUpBuilder(): ReplayRouteOptions.Builder {
         return ReplayRouteOptions.Builder()
+            .frequency(10.0)
             .maxAcceleration(12.0)
             .maxSpeedMps(34.0)
             .minAcceleration(56.0)


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Resolves https://github.com/mapbox/mapbox-navigation-android/issues/5560

Thanks [Yuanyuan](https://www.linkedin.com/in/yuanyuanpao/)! So helpful with the [equations of motion](https://en.wikipedia.org/wiki/Equations_of_motion ) 😄 

After introducing better equations for simulating locations. This makes it so we can introduce a frequency for location updates.

- [x] Calculate accurate feasibility for calculating turn speeds
- [x] Calculate accurate acceleration needed for turns
- [x] Accelerate and decelerate from cruising speeds
- [x] Find a formula rather than iterative speed estimate
- [x] Clean up
