### PR TITLE
Remove double route JSON parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Mapbox welcomes participation and contributions from everyone.
 #### Features
 
 #### Bug fixes and improvements
+- Fixed double direction response parsing. Directions response handling is up to 30% faster. [#5747](https://github.com/mapbox/mapbox-navigation-android/pull/5747)
 
 ## Mapbox Navigation SDK 2.2.2 - February 3, 2022
 ### Changelog

--- a/libnavigation-router/src/test/java/com/mapbox/navigation/route/internal/RouterWrapperTests.kt
+++ b/libnavigation-router/src/test/java/com/mapbox/navigation/route/internal/RouterWrapperTests.kt
@@ -264,9 +264,7 @@ class RouterWrapperTests {
                     .toUrl(),
                 routerOrigin = Onboard,
                 message = "failed for response: ${routerResultSuccessErroneousValue.value}",
-                throwable = IllegalStateException(
-                    """route response should contain "routes" array"""
-                )
+                throwable = IllegalStateException("Null routes")
             )
 
             val failures = slot<List<RouterFailure>>()


### PR DESCRIPTION
### Description

This changes reduces route calculation time up to 30% on long routes and slow CPUs.

These changes are not applicable for the code in main branch after integration of `NavigationRoute`.
