### PR TITLE
MapboxRerouteController: fix crash when no requestId when route request is in progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Mapbox welcomes participation and contributions from everyone.
   - extension `DirectionsRoute#toNavigationRoute()` by `DirectionsRoute#toNavigationRoute(RouterOrigin)`.
 - Fixed an issue where [replacing the default logger module](https://docs.mapbox.com/android/navigation/guides/get-started/modularization/#logger) was throwing a runtime exception during library loading. [#5738](https://github.com/mapbox/mapbox-navigation-android/pull/5738)
 - :warning: Refactored the designs for `MapboxTripProgressView`. [#5744](https://github.com/mapbox/mapbox-navigation-android/pull/5744)
+- Fixed the crash of default `RerouteController` when it immediately switches to an existing alternative. [#5753](https://github.com/mapbox/mapbox-navigation-android/pull/5753)
 
 ## Mapbox Navigation SDK 2.5.0-beta.1 - April 22, 2022
 

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/reroute/MapboxRerouteController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/reroute/MapboxRerouteController.kt
@@ -125,9 +125,9 @@ internal class MapboxRerouteController(
                 logD("Reroute switch to alternative", LOG_CATEGORY)
 
                 val origin = relevantAlternative.routerOrigin.mapToSdkRouteOrigin()
-                callback.onNewRoutes(newList, origin)
 
                 state = RerouteState.RouteFetched(origin)
+                callback.onNewRoutes(newList, origin)
                 state = RerouteState.Idle
                 return
             }


### PR DESCRIPTION
### Description
Fix MapboxRerouteController crash: throws exceptions when no `requestId` for a request. It's occurring for case `MapboxRerouteController` immediately switches to existing alternative and invoked callback without route request. This way, route request is in progress, but without actually request to external API and without `requestId`. Setting a new route invokes interrupting an existing reroute request, which is `in Progress` but without `requestId`. It leads to throwing an exception. 

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
