### PR TITLE
exposed NavigationRoute#origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Mapbox welcomes participation and contributions from everyone.
 ## Unreleased
 
 #### Features
+- Exposed `NavigationRoute#origin` that describes the type of router that generated the particular route. [#5766](https://github.com/mapbox/mapbox-navigation-android/pull/5766)
 
 #### Bug fixes and improvements
 

--- a/libnavigation-base/api/current.txt
+++ b/libnavigation-base/api/current.txt
@@ -595,11 +595,13 @@ package com.mapbox.navigation.base.route {
     method public com.mapbox.api.directions.v5.models.DirectionsResponse getDirectionsResponse();
     method public com.mapbox.api.directions.v5.models.DirectionsRoute getDirectionsRoute();
     method public String getId();
+    method public com.mapbox.navigation.base.route.RouterOrigin getOrigin();
     method public int getRouteIndex();
     method public com.mapbox.api.directions.v5.models.RouteOptions getRouteOptions();
     property public final com.mapbox.api.directions.v5.models.DirectionsResponse directionsResponse;
     property public final com.mapbox.api.directions.v5.models.DirectionsRoute directionsRoute;
     property public final String id;
+    property public final com.mapbox.navigation.base.route.RouterOrigin origin;
     property public final int routeIndex;
     property public final com.mapbox.api.directions.v5.models.RouteOptions routeOptions;
     field public static final com.mapbox.navigation.base.route.NavigationRoute.Companion Companion;

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/route/NavigationRoute.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/route/NavigationRoute.kt
@@ -16,6 +16,7 @@ import com.mapbox.geojson.Point
 import com.mapbox.navigation.base.internal.NativeRouteParserWrapper
 import com.mapbox.navigation.base.internal.SDKRouteParser
 import com.mapbox.navigation.base.internal.route.RouteCompatibilityCache
+import com.mapbox.navigation.base.internal.utils.mapToSdkRouteOrigin
 import com.mapbox.navigation.utils.internal.ThreadController
 import com.mapbox.navigation.utils.internal.logE
 import com.mapbox.navigator.RouteInterface
@@ -230,6 +231,11 @@ class NavigationRoute internal constructor(
      * For routes which were generated onboard and do not have a UUID it's equal to: `"local@" + generateUuid() + "#" + routeIndex`, for example: `local@84438c3e-f608-47e9-88cc-cddf341d2fb1#0`.
      */
     val id: String = nativeRoute.routeId
+
+    /**
+     * Describes which router type generated the route.
+     */
+    val origin: RouterOrigin = nativeRoute.routerOrigin.mapToSdkRouteOrigin()
 
     /**
      * [DirectionsRoute] that this [NavigationRoute] represents.

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/route/RouteExclusionsJavaTest.java
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/route/RouteExclusionsJavaTest.java
@@ -13,6 +13,7 @@ import com.mapbox.navigation.base.internal.SDKRouteParser;
 import com.mapbox.navigation.base.internal.route.NavigationRouteEx;
 import com.mapbox.navigation.testing.FileUtils;
 import com.mapbox.navigator.RouteInterface;
+import com.mapbox.navigator.RouterOrigin;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -37,6 +38,7 @@ public class RouteExclusionsJavaTest {
     List<RouteInterface> nativeRoutes = new ArrayList<>();
     RouteInterface nativeRoute = Mockito.mock(RouteInterface.class);
     Mockito.doReturn("route_id").when(nativeRoute).getRouteId();
+    Mockito.doReturn(RouterOrigin.ONLINE).when(nativeRoute).getRouterOrigin();
     nativeRoutes.add(nativeRoute);
     Mockito.doReturn(
         ExpectedFactory.createValue(nativeRoutes)

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/route/RouteExclusionsTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/route/RouteExclusionsTest.kt
@@ -35,6 +35,7 @@ class RouteExclusionsTest {
                     add(
                         mockk {
                             every { routeId } returns "$it"
+                            every { routerOrigin } returns com.mapbox.navigator.RouterOrigin.ONBOARD
                         }
                     )
                 }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
@@ -241,6 +241,7 @@ class MapboxNavigationTest {
                     add(
                         mockk {
                             every { routeId } returns "$it"
+                            every { routerOrigin } returns com.mapbox.navigator.RouterOrigin.ONBOARD
                         }
                     )
                 }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesControllerTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesControllerTest.kt
@@ -89,6 +89,7 @@ class RouteAlternativesControllerTest {
                     add(
                         mockk {
                             every { routeId } returns "$it"
+                            every { routerOrigin } returns com.mapbox.navigator.RouterOrigin.ONBOARD
                         }
                     )
                 }

--- a/libnavigation-router/src/test/java/com/mapbox/navigation/route/internal/RouterWrapperTests.kt
+++ b/libnavigation-router/src/test/java/com/mapbox/navigation/route/internal/RouterWrapperTests.kt
@@ -191,6 +191,7 @@ class RouterWrapperTests {
                     add(
                         mockk {
                             every { routeId } returns "$it"
+                            every { routerOrigin } returns com.mapbox.navigator.RouterOrigin.ONBOARD
                         }
                     )
                 }

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/routeline/RouteLineComponentTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/routeline/RouteLineComponentTest.kt
@@ -102,6 +102,7 @@ class RouteLineComponentTest {
                     add(
                         mockk {
                             every { routeId } returns "$it"
+                            every { routerOrigin } returns com.mapbox.navigator.RouterOrigin.ONBOARD
                         }
                     )
                 }

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtilsTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtilsTest.kt
@@ -1389,6 +1389,7 @@ class MapboxRouteLineUtilsTest {
                     add(
                         mockk {
                             every { routeId } returns "$it"
+                            every { routerOrigin } returns com.mapbox.navigator.RouterOrigin.ONBOARD
                         }
                     )
                 }

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApiRoboTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApiRoboTest.kt
@@ -81,6 +81,7 @@ class MapboxRouteLineApiRoboTest {
                     add(
                         mockk {
                             every { routeId } returns "$it"
+                            every { routerOrigin } returns com.mapbox.navigator.RouterOrigin.ONBOARD
                         }
                     )
                 }

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApiTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApiTest.kt
@@ -103,6 +103,7 @@ class MapboxRouteLineApiTest {
                     add(
                         mockk {
                             every { routeId } returns "$it"
+                            every { routerOrigin } returns com.mapbox.navigator.RouterOrigin.ONBOARD
                         }
                     )
                 }

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/VanishingRouteLineRoboTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/VanishingRouteLineRoboTest.kt
@@ -64,6 +64,7 @@ class VanishingRouteLineRoboTest {
                     add(
                         mockk {
                             every { routeId } returns "$it"
+                            every { routerOrigin } returns com.mapbox.navigator.RouterOrigin.ONBOARD
                         }
                     )
                 }

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/VanishingRouteLineTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/VanishingRouteLineTest.kt
@@ -97,6 +97,7 @@ class VanishingRouteLineTest {
                     add(
                         mockk {
                             every { routeId } returns "$it"
+                            every { routerOrigin } returns com.mapbox.navigator.RouterOrigin.ONBOARD
                         }
                     )
                 }


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Closes https://github.com/mapbox/mapbox-navigation-android/issues/5745. Unfortunately function parameters cannot be deprecated so existing `RouterOrigin` values need to remain as they are.

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->