### PR TITLE
[Android Auto] Enable androidTest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,6 @@
 version: 2.1
+orbs:
+  android: circleci/android@1.0.3
 
 parameters:
   mapbox_navigation_native_upstream:
@@ -78,6 +80,7 @@ workflows:
       - instrumentation-tests:
           requires:
             - prepare-and-assemble
+      - androidauto-test
       - mobile-metrics-dry-run:
           type: approval
       - mobile-metrics-benchmarks:
@@ -656,6 +659,33 @@ jobs:
             - login-google-cloud-platform
             - run-firebase-instrumentation:
                 variant: "debug"
+      - run: exit 0
+
+  androidauto-test:
+    executor:
+      name: android/android-machine
+      resource-class: large
+    steps:
+      - when:
+          condition:
+            not:
+              matches:
+                pattern: "^add-changelog.*"
+                value: << pipeline.git.branch >>
+          steps:
+            - checkout
+            - android/start-emulator-and-run-tests:
+                post-emulator-launch-assemble-command: ./gradlew libnavui-androidauto:assembleDebugAndroidTest
+                test-command: ./gradlew libnavui-androidauto:connectedDebugAndroidTest
+                system-image: system-images;android-30;google_apis_playstore;x86
+            - run:
+                name: Save test results
+                command: |
+                  mkdir -p ~/mapbox_test/
+                  adb pull sdcard/Download/mapbox_test ~/mapbox_test/
+                when: on_fail
+            - store_artifacts:
+                path: ~/mapbox_test/
       - run: exit 0
 
   mobile-metrics-benchmarks:

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -147,6 +147,7 @@ ext {
       junit                     : "junit:junit:${version.junit}",
       mockito                   : "org.mockito:mockito-core:${version.mockito}",
       mockk                     : "io.mockk:mockk:${version.mockkVersion}",
+      mockkAndroid              : "io.mockk:mockk-android:${version.mockkVersion}",
       commonsIO                 : "commons-io:commons-io:${version.commonsIO}",
       robolectric               : "org.robolectric:robolectric:${version.robolectric}",
       mockwebserver             : "com.squareup.okhttp3:mockwebserver:${version.mockwebserver}",

--- a/libnavui-androidauto/build.gradle
+++ b/libnavui-androidauto/build.gradle
@@ -34,6 +34,9 @@ android {
 }
 
 dependencies {
+    compileOnly(dependenciesList.mapboxAnnotations)
+    kapt(dependenciesList.mapboxAnnotationsProcessor)
+
     api(dependenciesList.mapboxMapsAndroidAuto)
     api(project(":libnavigation-android"))
     implementation(project(":libnavui-resources"))
@@ -53,6 +56,11 @@ dependencies {
     apply from: "${rootDir}/gradle/unit-testing-dependencies.gradle"
     testImplementation(project(':libtesting-utils'))
     testImplementation(dependenciesList.androidXArchCoreTesting)
+
+    androidTestImplementation(dependenciesList.testRunner)
+    androidTestImplementation(dependenciesList.testRules)
+    androidTestImplementation(dependenciesList.androidxTestCore)
+    androidTestImplementation(dependenciesList.mockkAndroid)
 }
 
 dokkaHtml {


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Am sharing some options here for integration tests in android auto. We have the `:instrumentation-tests:` which runs on firebase. 1tap has been using [circle android-machine-image](https://circleci.com/docs/2.0/android-machine-image/) to run android auto tests and there has been no issues.

Average time on 1tap for androidtest is ~15 minutes. Over here it happened to run in [8m 49s](https://app.circleci.com/pipelines/github/mapbox/mapbox-navigation-android/17902/workflows/a1191146-b950-4834-84fb-aa357f628a79/jobs/81705). Only `33s` was running the tests, the rest of it is spinning up the circle ci emulator and assembling. EDIT: But the extra pipeline runs in parallel, the overall-PR-build-time does not change because it is not adding a new bottleneck.

It may make sense to move the [androidTest](https://github.com/mapbox/mapbox-navigation-android/tree/main/libnavui-androidauto/src/androidTest) into the `:instrumentation-tests:`. But it is also nice to have a fully decoupled test here. It seems we could run tests per module in this way. EDIT: Here is a PR if we want to move it to `:instrumentation-tests:` https://github.com/mapbox/mapbox-navigation-android/pull/5775.

If we do not want to bump the minSdkVersion to 23 in `:instrumentation-tests:`. We could also consider this pull request a temporary solution. And then after we bump minSdkVersion to 23, we [could bring this back](https://github.com/mapbox/mapbox-navigation-android/pull/5775). cc: @LukasPaczos @abhishek1508 


https://www.appbrain.com/stats/top-android-sdk-versions
![Screen Shot 2022-05-04 at 6 24 18 PM](https://user-images.githubusercontent.com/3021882/166851511-eb2d99f8-7d4a-4f90-9268-39188497d3d7.png)
