### PR TITLE
[DROP-IN] Renaming *ViewModel classes to *StateController.

### DIFF
--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewModel.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewModel.kt
@@ -7,13 +7,13 @@ import androidx.lifecycle.ViewModel
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationApp
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver
-import com.mapbox.navigation.dropin.component.audioguidance.AudioGuidanceViewModel
-import com.mapbox.navigation.dropin.component.camera.CameraViewModel
-import com.mapbox.navigation.dropin.component.destination.DestinationViewModel
-import com.mapbox.navigation.dropin.component.location.LocationViewModel
-import com.mapbox.navigation.dropin.component.navigation.NavigationStateViewModel
-import com.mapbox.navigation.dropin.component.routefetch.RoutesViewModel
-import com.mapbox.navigation.dropin.component.tripsession.TripSessionStarterViewModel
+import com.mapbox.navigation.dropin.controller.AudioGuidanceStateController
+import com.mapbox.navigation.dropin.controller.CameraStateController
+import com.mapbox.navigation.dropin.controller.DestinationStateController
+import com.mapbox.navigation.dropin.controller.LocationStateController
+import com.mapbox.navigation.dropin.controller.NavigationStateController
+import com.mapbox.navigation.dropin.controller.RoutesStateController
+import com.mapbox.navigation.dropin.controller.TripSessionStarterStateController
 import com.mapbox.navigation.dropin.internal.extensions.attachCreated
 import com.mapbox.navigation.dropin.model.Store
 
@@ -36,13 +36,13 @@ internal class NavigationViewModel : ViewModel() {
     /**
      * These classes are accessible through MapboxNavigationApp.getObserver(..)
      */
-    private val navigationStateViewModel = NavigationStateViewModel(store)
-    val locationViewModel = LocationViewModel(store)
-    private val tripSessionStarterViewModel = TripSessionStarterViewModel(store)
-    private val audioGuidanceViewModel = AudioGuidanceViewModel(store)
-    private val cameraViewModel = CameraViewModel(store)
-    private val destinationViewModel = DestinationViewModel(store)
-    private val routesViewModel = RoutesViewModel(store)
+    private val navigationStateViewModel = NavigationStateController(store)
+    val locationViewModel = LocationStateController(store)
+    private val tripSessionStarterViewModel = TripSessionStarterStateController(store)
+    private val audioGuidanceViewModel = AudioGuidanceStateController(store)
+    private val cameraViewModel = CameraStateController(store)
+    private val destinationViewModel = DestinationStateController(store)
+    private val routesViewModel = RoutesStateController(store)
     private val navigationObservers: Array<MapboxNavigationObserver> = arrayOf(
         destinationViewModel,
         tripSessionStarterViewModel,

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/location/LocationComponent.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/location/LocationComponent.kt
@@ -7,13 +7,14 @@ import com.mapbox.maps.plugin.locationcomponent.location
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.dropin.R
+import com.mapbox.navigation.dropin.controller.LocationStateController
 import com.mapbox.navigation.dropin.lifecycle.UIComponent
 import kotlinx.coroutines.launch
 
 @ExperimentalPreviewMapboxNavigationAPI
 internal class LocationComponent(
     private val mapView: MapView,
-    private val locationViewModel: LocationViewModel,
+    private val locationViewModel: LocationStateController,
 ) : UIComponent() {
 
     override fun onAttached(mapboxNavigation: MapboxNavigation) {

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/controller/AudioGuidanceStateController.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/controller/AudioGuidanceStateController.kt
@@ -1,11 +1,13 @@
-package com.mapbox.navigation.dropin.component.audioguidance
+package com.mapbox.navigation.dropin.controller
 
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.dropin.component.audioguidance.AudioAction
+import com.mapbox.navigation.dropin.component.audioguidance.AudioGuidanceApi
+import com.mapbox.navigation.dropin.component.audioguidance.AudioGuidanceServices
+import com.mapbox.navigation.dropin.component.audioguidance.AudioGuidanceState
 import com.mapbox.navigation.dropin.component.navigation.NavigationState
-import com.mapbox.navigation.dropin.lifecycle.UIComponent
 import com.mapbox.navigation.dropin.model.Action
-import com.mapbox.navigation.dropin.model.Reducer
 import com.mapbox.navigation.dropin.model.State
 import com.mapbox.navigation.dropin.model.Store
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -22,9 +24,9 @@ import kotlinx.coroutines.launch
  */
 @ExperimentalPreviewMapboxNavigationAPI
 @OptIn(ExperimentalCoroutinesApi::class)
-internal class AudioGuidanceViewModel(
-    val store: Store
-) : UIComponent(), Reducer {
+internal class AudioGuidanceStateController(
+    private val store: Store
+) : StateController() {
     init {
         store.register(this)
     }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/controller/CameraStateController.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/controller/CameraStateController.kt
@@ -1,14 +1,17 @@
-package com.mapbox.navigation.dropin.component.camera
+package com.mapbox.navigation.dropin.controller
 
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
-import com.mapbox.navigation.dropin.lifecycle.UIComponent
+import com.mapbox.navigation.dropin.component.camera.CameraAction
+import com.mapbox.navigation.dropin.component.camera.CameraState
+import com.mapbox.navigation.dropin.component.camera.TargetCameraMode
 import com.mapbox.navigation.dropin.model.Action
-import com.mapbox.navigation.dropin.model.Reducer
 import com.mapbox.navigation.dropin.model.State
 import com.mapbox.navigation.dropin.model.Store
 
 @ExperimentalPreviewMapboxNavigationAPI
-internal class CameraViewModel(store: Store) : UIComponent(), Reducer {
+internal class CameraStateController(
+    store: Store
+) : StateController() {
     init {
         store.register(this)
     }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/controller/DestinationStateController.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/controller/DestinationStateController.kt
@@ -1,16 +1,17 @@
-package com.mapbox.navigation.dropin.component.destination
+package com.mapbox.navigation.dropin.controller
 
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
-import com.mapbox.navigation.dropin.lifecycle.UIComponent
+import com.mapbox.navigation.dropin.component.destination.DestinationAction
 import com.mapbox.navigation.dropin.model.Action
-import com.mapbox.navigation.dropin.model.Reducer
 import com.mapbox.navigation.dropin.model.State
 import com.mapbox.navigation.dropin.model.Store
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 
 @ExperimentalPreviewMapboxNavigationAPI
 @OptIn(ExperimentalCoroutinesApi::class)
-internal class DestinationViewModel(store: Store) : UIComponent(), Reducer {
+internal class DestinationStateController(
+    store: Store
+) : StateController() {
     init {
         store.register(this)
     }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/controller/LocationStateController.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/controller/LocationStateController.kt
@@ -1,23 +1,22 @@
-package com.mapbox.navigation.dropin.component.location
+package com.mapbox.navigation.dropin.controller
 
 import android.location.Location
 import com.mapbox.geojson.Point
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.trip.session.LocationMatcherResult
+import com.mapbox.navigation.dropin.component.location.LocationAction
 import com.mapbox.navigation.dropin.internal.extensions.flowLocationMatcherResult
-import com.mapbox.navigation.dropin.lifecycle.UIComponent
 import com.mapbox.navigation.dropin.model.Action
-import com.mapbox.navigation.dropin.model.Reducer
 import com.mapbox.navigation.dropin.model.State
 import com.mapbox.navigation.dropin.model.Store
 import com.mapbox.navigation.ui.maps.location.NavigationLocationProvider
 import kotlinx.coroutines.delay
 
 @ExperimentalPreviewMapboxNavigationAPI
-internal class LocationViewModel(
+internal class LocationStateController(
     private val store: Store
-) : UIComponent(), Reducer {
+) : StateController() {
     init {
         store.register(this)
     }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/controller/NavigationStateController.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/controller/NavigationStateController.kt
@@ -1,11 +1,11 @@
-package com.mapbox.navigation.dropin.component.navigation
+package com.mapbox.navigation.dropin.controller
 
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.dropin.component.navigation.NavigationState
+import com.mapbox.navigation.dropin.component.navigation.NavigationStateAction
 import com.mapbox.navigation.dropin.internal.extensions.flowOnFinalDestinationArrival
-import com.mapbox.navigation.dropin.lifecycle.UIComponent
 import com.mapbox.navigation.dropin.model.Action
-import com.mapbox.navigation.dropin.model.Reducer
 import com.mapbox.navigation.dropin.model.State
 import com.mapbox.navigation.dropin.model.Store
 import kotlinx.coroutines.flow.collect
@@ -17,9 +17,9 @@ import kotlinx.coroutines.launch
  * @param default the default [NavigationState] to start with
  */
 @ExperimentalPreviewMapboxNavigationAPI
-internal class NavigationStateViewModel(
+internal class NavigationStateController(
     private val store: Store
-) : UIComponent(), Reducer {
+) : StateController() {
     init {
         store.register(this)
     }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/controller/RoutesStateController.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/controller/RoutesStateController.kt
@@ -1,4 +1,4 @@
-package com.mapbox.navigation.dropin.component.routefetch
+package com.mapbox.navigation.dropin.controller
 
 import com.mapbox.api.directions.v5.models.RouteOptions
 import com.mapbox.geojson.Point
@@ -10,19 +10,19 @@ import com.mapbox.navigation.base.route.NavigationRouterCallback
 import com.mapbox.navigation.base.route.RouterFailure
 import com.mapbox.navigation.base.route.RouterOrigin
 import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.dropin.component.routefetch.RoutesAction
+import com.mapbox.navigation.dropin.component.routefetch.RoutesState
 import com.mapbox.navigation.dropin.internal.extensions.flowRoutesUpdated
-import com.mapbox.navigation.dropin.lifecycle.UIComponent
 import com.mapbox.navigation.dropin.model.Action
-import com.mapbox.navigation.dropin.model.Reducer
 import com.mapbox.navigation.dropin.model.State
 import com.mapbox.navigation.dropin.model.Store
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 
 @ExperimentalPreviewMapboxNavigationAPI
-internal class RoutesViewModel(
+internal class RoutesStateController(
     private val store: Store
-) : UIComponent(), Reducer {
+) : StateController() {
     init {
         store.register(this)
     }
@@ -48,6 +48,7 @@ internal class RoutesViewModel(
             is RoutesState.Fetching -> {
                 mapboxNavigation.cancelRouteRequest(currentState.requestId)
             }
+            else -> Unit
         }
         this.mapboxNavigation = null
     }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/controller/StateController.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/controller/StateController.kt
@@ -1,0 +1,8 @@
+package com.mapbox.navigation.dropin.controller
+
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.dropin.lifecycle.UIComponent
+import com.mapbox.navigation.dropin.model.Reducer
+
+@ExperimentalPreviewMapboxNavigationAPI
+internal abstract class StateController : UIComponent(), Reducer

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/controller/TripSessionStarterStateController.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/controller/TripSessionStarterStateController.kt
@@ -1,12 +1,13 @@
-package com.mapbox.navigation.dropin.component.tripsession
+package com.mapbox.navigation.dropin.controller
 
 import android.annotation.SuppressLint
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.dropin.component.navigation.NavigationState
-import com.mapbox.navigation.dropin.lifecycle.UIComponent
+import com.mapbox.navigation.dropin.component.tripsession.ReplayRouteTripSession
+import com.mapbox.navigation.dropin.component.tripsession.TripSessionStarterAction
+import com.mapbox.navigation.dropin.component.tripsession.TripSessionStarterState
 import com.mapbox.navigation.dropin.model.Action
-import com.mapbox.navigation.dropin.model.Reducer
 import com.mapbox.navigation.dropin.model.State
 import com.mapbox.navigation.dropin.model.Store
 import kotlinx.coroutines.flow.Flow
@@ -22,9 +23,9 @@ import kotlinx.coroutines.launch
  */
 @ExperimentalPreviewMapboxNavigationAPI
 @SuppressLint("MissingPermission")
-internal class TripSessionStarterViewModel(
-    val store: Store
-) : UIComponent(), Reducer {
+internal class TripSessionStarterStateController(
+    private val store: Store
+) : StateController() {
     init {
         store.register(this)
     }

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/location/LocationComponentTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/location/LocationComponentTest.kt
@@ -7,6 +7,7 @@ import com.mapbox.maps.plugin.LocationPuck2D
 import com.mapbox.maps.plugin.locationcomponent.LocationComponentPlugin
 import com.mapbox.maps.plugin.locationcomponent.location
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.dropin.controller.LocationStateController
 import com.mapbox.navigation.testing.MainCoroutineRule
 import com.mapbox.navigation.ui.maps.location.NavigationLocationProvider
 import io.mockk.MockKAnnotations
@@ -34,7 +35,7 @@ internal class LocationComponentTest {
     private lateinit var locationProvider: NavigationLocationProvider
 
     @MockK
-    internal lateinit var mockLocationViewModel: LocationViewModel
+    internal lateinit var mockLocationStateController: LocationStateController
 
     @MockK
     lateinit var mockLocationPlugin: LocationComponentPlugin
@@ -55,10 +56,10 @@ internal class LocationComponentTest {
             every { location } returns mockLocationPlugin
         }
         every { ContextCompat.getDrawable(any(), any()) } returns mockk()
-        coEvery { mockLocationViewModel.firstLocation() } returns mockk()
-        every { mockLocationViewModel.navigationLocationProvider } returns locationProvider
+        coEvery { mockLocationStateController.firstLocation() } returns mockk()
+        every { mockLocationStateController.navigationLocationProvider } returns locationProvider
 
-        sut = LocationComponent(mockMapView, mockLocationViewModel)
+        sut = LocationComponent(mockMapView, mockLocationStateController)
     }
 
     @After

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/controller/AudioGuidanceStateControllerTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/controller/AudioGuidanceStateControllerTest.kt
@@ -1,8 +1,11 @@
-package com.mapbox.navigation.dropin.component.audioguidance
+package com.mapbox.navigation.dropin.controller
 
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationApp
+import com.mapbox.navigation.dropin.component.audioguidance.AudioAction
+import com.mapbox.navigation.dropin.component.audioguidance.AudioGuidanceApi
+import com.mapbox.navigation.dropin.component.audioguidance.AudioGuidanceState
 import com.mapbox.navigation.dropin.component.navigation.NavigationState
 import com.mapbox.navigation.dropin.model.State
 import com.mapbox.navigation.dropin.util.TestStore
@@ -26,7 +29,7 @@ import org.junit.Rule
 import org.junit.Test
 
 @OptIn(ExperimentalPreviewMapboxNavigationAPI::class, ExperimentalCoroutinesApi::class)
-class AudioGuidanceViewModelTest {
+class AudioGuidanceStateControllerTest {
 
     @get:Rule
     var coroutineRule = MainCoroutineRule()
@@ -49,7 +52,7 @@ class AudioGuidanceViewModelTest {
 
     @Test
     fun `onAttach will collect voice instructions for ActiveNavigation`() = runBlockingTest {
-        val mapboxAudioViewModel = AudioGuidanceViewModel(testStore)
+        val sut = AudioGuidanceStateController(testStore)
         testStore.setState(
             State(
                 navigation = NavigationState.ActiveNavigation,
@@ -57,7 +60,7 @@ class AudioGuidanceViewModelTest {
             )
         )
 
-        mapboxAudioViewModel.onAttached(mockMapboxNavigation())
+        sut.onAttached(mockMapboxNavigation())
 
         verify(exactly = 1) { mapboxAudioApi.speakVoiceInstructions() }
     }
@@ -70,9 +73,9 @@ class AudioGuidanceViewModelTest {
                 audio = AudioGuidanceState(isMuted = false)
             )
         )
-        val mapboxAudioViewModel = AudioGuidanceViewModel(testStore)
+        val sut = AudioGuidanceStateController(testStore)
 
-        mapboxAudioViewModel.onAttached(mockMapboxNavigation())
+        sut.onAttached(mockMapboxNavigation())
 
         verify(exactly = 0) { mapboxAudioApi.speakVoiceInstructions() }
     }
@@ -85,11 +88,11 @@ class AudioGuidanceViewModelTest {
                 audio = AudioGuidanceState(isMuted = true)
             )
         )
-        val mapboxAudioViewModel = AudioGuidanceViewModel(testStore)
+        val sut = AudioGuidanceStateController(testStore)
 
         val mapboxNavigation = mockMapboxNavigation()
-        mapboxAudioViewModel.onAttached(mapboxNavigation)
-        mapboxAudioViewModel.onDetached(mapboxNavigation)
+        sut.onAttached(mapboxNavigation)
+        sut.onDetached(mapboxNavigation)
         testStore.dispatch(AudioAction.Unmute)
 
         verify(exactly = 0) { mapboxAudioApi.speakVoiceInstructions() }
@@ -103,12 +106,12 @@ class AudioGuidanceViewModelTest {
                 audio = AudioGuidanceState(isMuted = false)
             )
         )
-        val mapboxAudioViewModel = AudioGuidanceViewModel(testStore)
+        val sut = AudioGuidanceStateController(testStore)
 
         val mapboxNavigation = mockMapboxNavigation()
-        mapboxAudioViewModel.onAttached(mapboxNavigation)
+        sut.onAttached(mapboxNavigation)
         testStore.dispatch(AudioAction.Toggle)
-        mapboxAudioViewModel.onDetached(mapboxNavigation)
+        sut.onDetached(mapboxNavigation)
 
         verify(exactly = 1) { mapboxAudioApi.speakVoiceInstructions() }
         assertTrue(testStore.state.value.audio.isMuted)
@@ -122,7 +125,7 @@ class AudioGuidanceViewModelTest {
                 audio = AudioGuidanceState(isMuted = false)
             )
         )
-        val mapboxAudioViewModel = AudioGuidanceViewModel(testStore)
+        val sut = AudioGuidanceStateController(testStore)
 
         val captureSpeechAnnouncement = mutableListOf<SpeechAnnouncement?>()
         every { mapboxAudioApi.speakVoiceInstructions() } answers {
@@ -131,7 +134,7 @@ class AudioGuidanceViewModelTest {
             }
         }
 
-        mapboxAudioViewModel.onAttached(mockk())
+        sut.onAttached(mockk())
 
         assertEquals(2, captureSpeechAnnouncement.size)
     }

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/controller/CameraStateControllerTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/controller/CameraStateControllerTest.kt
@@ -1,10 +1,12 @@
-package com.mapbox.navigation.dropin.component.camera
+package com.mapbox.navigation.dropin.controller
 
 import com.mapbox.geojson.Point
 import com.mapbox.maps.EdgeInsets
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationApp
+import com.mapbox.navigation.dropin.component.camera.CameraAction
+import com.mapbox.navigation.dropin.component.camera.TargetCameraMode
 import com.mapbox.navigation.dropin.util.TestStore
 import com.mapbox.navigation.testing.MainCoroutineRule
 import com.mapbox.navigation.testing.MockLoggerRule
@@ -15,13 +17,13 @@ import io.mockk.spyk
 import io.mockk.unmockkObject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.After
-import org.junit.Assert.assertEquals
+import org.junit.Assert
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
 @OptIn(ExperimentalPreviewMapboxNavigationAPI::class, ExperimentalCoroutinesApi::class)
-class CameraViewModelTest {
+class CameraStateControllerTest {
 
     @get:Rule
     var coroutineRule = MainCoroutineRule()
@@ -44,49 +46,49 @@ class CameraViewModelTest {
 
     @Test
     fun `when action toIdle updates camera mode`() = coroutineRule.runBlockingTest {
-        val cameraViewModel = CameraViewModel(testStore)
-        cameraViewModel.onAttached(mockMapboxNavigation())
+        val sut = CameraStateController(testStore)
+        sut.onAttached(mockMapboxNavigation())
 
         testStore.dispatch(CameraAction.ToIdle)
 
         val cameraState = testStore.state.value.camera
-        assertEquals(TargetCameraMode.Idle, cameraState.cameraMode)
+        Assert.assertEquals(TargetCameraMode.Idle, cameraState.cameraMode)
     }
 
     @Test
     fun `when action toOverview updates camera mode`() = coroutineRule.runBlockingTest {
-        val cameraViewModel = CameraViewModel(testStore)
-        cameraViewModel.onAttached(mockMapboxNavigation())
+        val sut = CameraStateController(testStore)
+        sut.onAttached(mockMapboxNavigation())
 
         testStore.dispatch(CameraAction.ToOverview)
 
         val cameraState = testStore.state.value.camera
-        assertEquals(TargetCameraMode.Overview, cameraState.cameraMode)
+        Assert.assertEquals(TargetCameraMode.Overview, cameraState.cameraMode)
     }
 
     @Test
     fun `when action toFollowing updates camera mode and zoomUpdatesAllowed`() =
         coroutineRule.runBlockingTest {
-            val cameraViewModel = CameraViewModel(testStore)
-            cameraViewModel.onAttached(mockMapboxNavigation())
+            val sut = CameraStateController(testStore)
+            sut.onAttached(mockMapboxNavigation())
 
             testStore.dispatch(CameraAction.ToFollowing)
 
             val cameraState = testStore.state.value.camera
-            assertEquals(TargetCameraMode.Following, cameraState.cameraMode)
+            Assert.assertEquals(TargetCameraMode.Following, cameraState.cameraMode)
         }
 
     @Test
     fun `when action UpdatePadding updates cameraPadding`() =
         coroutineRule.runBlockingTest {
             val padding = EdgeInsets(1.0, 2.0, 3.0, 4.0)
-            val cameraViewModel = CameraViewModel(testStore)
-            cameraViewModel.onAttached(mockMapboxNavigation())
+            val sut = CameraStateController(testStore)
+            sut.onAttached(mockMapboxNavigation())
 
             testStore.dispatch(CameraAction.UpdatePadding(padding))
 
             val cameraState = testStore.state.value.camera
-            assertEquals(padding, cameraState.cameraPadding)
+            Assert.assertEquals(padding, cameraState.cameraPadding)
         }
 
     @Test
@@ -99,12 +101,12 @@ class CameraViewModelTest {
             50.0
         )
         val mockMapboxNavigation = mockMapboxNavigation()
-        val cameraViewModel = CameraViewModel(testStore)
-        cameraViewModel.onAttached(mockMapboxNavigation)
+        val sut = CameraStateController(testStore)
+        sut.onAttached(mockMapboxNavigation)
 
         testStore.dispatch(CameraAction.SaveMapState(cameraState))
 
-        assertEquals(cameraState, testStore.state.value.camera.mapCameraState)
+        Assert.assertEquals(cameraState, testStore.state.value.camera.mapCameraState)
     }
 
     private fun mockMapboxNavigation(): MapboxNavigation {

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/controller/DestinationStateControllerTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/controller/DestinationStateControllerTest.kt
@@ -1,0 +1,59 @@
+package com.mapbox.navigation.dropin.controller
+
+import com.mapbox.api.geocoding.v5.models.CarmenFeature
+import com.mapbox.geojson.Point
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.dropin.component.destination.Destination
+import com.mapbox.navigation.dropin.component.destination.DestinationAction
+import com.mapbox.navigation.dropin.model.State
+import com.mapbox.navigation.dropin.util.TestStore
+import io.mockk.spyk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
+internal class DestinationStateControllerTest {
+
+    private lateinit var testStore: TestStore
+    private lateinit var sut: DestinationStateController
+
+    @Before
+    fun setUp() {
+        testStore = spyk(TestStore())
+        sut = DestinationStateController(testStore)
+    }
+
+    @Test
+    fun `on SetDestination action should save destination in the store`() {
+        val destination = Destination(Point.fromLngLat(10.0, 20.0))
+
+        testStore.dispatch(DestinationAction.SetDestination(destination))
+
+        assertEquals(destination, testStore.state.value.destination)
+    }
+
+    @Test
+    fun `on DidReverseGeocode action should save CarmenFeature in the store`() {
+        val point = Point.fromLngLat(10.0, 20.0)
+        val features = listOf(CarmenFeature.builder().address("1234 some address").build())
+        testStore.setState(State(Destination(point)))
+
+        testStore.dispatch(DestinationAction.DidReverseGeocode(point, features))
+
+        assertEquals(features, testStore.state.value.destination?.features)
+    }
+
+    @Test
+    fun `on DidReverseGeocode action should NOT save CarmenFeature for wrong coordinates`() {
+        val point1 = Point.fromLngLat(10.0, 20.0)
+        val point2 = Point.fromLngLat(11.0, 21.0)
+        val features = listOf(CarmenFeature.builder().address("1234 some address").build())
+        testStore.setState(State(Destination(point1)))
+
+        testStore.dispatch(DestinationAction.DidReverseGeocode(point2, features))
+
+        assertNull(testStore.state.value.destination?.features)
+    }
+}

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/controller/NavigationStateControllerTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/controller/NavigationStateControllerTest.kt
@@ -1,9 +1,11 @@
-package com.mapbox.navigation.dropin.component.navigation
+package com.mapbox.navigation.dropin.controller
 
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.arrival.ArrivalObserver
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationApp
+import com.mapbox.navigation.dropin.component.navigation.NavigationState
+import com.mapbox.navigation.dropin.component.navigation.NavigationStateAction
 import com.mapbox.navigation.dropin.util.TestStore
 import com.mapbox.navigation.testing.MainCoroutineRule
 import io.mockk.every
@@ -19,14 +21,14 @@ import org.junit.Rule
 import org.junit.Test
 
 @OptIn(ExperimentalPreviewMapboxNavigationAPI::class, ExperimentalCoroutinesApi::class)
-internal class NavigationStateViewModelTest {
+internal class NavigationStateControllerTest {
 
     @get:Rule
     var coroutineRule = MainCoroutineRule()
 
     private lateinit var testStore: TestStore
 
-    lateinit var sut: NavigationStateViewModel
+    lateinit var sut: NavigationStateController
     lateinit var mockMapboxNavigation: MapboxNavigation
 
     @Before
@@ -36,7 +38,7 @@ internal class NavigationStateViewModelTest {
         every { MapboxNavigationApp.current() } returns mockMapboxNavigation
 
         testStore = TestStore()
-        sut = NavigationStateViewModel(testStore)
+        sut = NavigationStateController(testStore)
     }
 
     @After

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/controller/TripSessionStarterStateControllerTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/controller/TripSessionStarterStateControllerTest.kt
@@ -1,9 +1,11 @@
-package com.mapbox.navigation.dropin.component.tripsession
+package com.mapbox.navigation.dropin.controller
 
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationApp
 import com.mapbox.navigation.dropin.component.navigation.NavigationState
+import com.mapbox.navigation.dropin.component.tripsession.TripSessionStarterAction
+import com.mapbox.navigation.dropin.component.tripsession.TripSessionStarterState
 import com.mapbox.navigation.dropin.model.State
 import com.mapbox.navigation.dropin.util.TestStore
 import com.mapbox.navigation.testing.MainCoroutineRule
@@ -22,7 +24,7 @@ import org.junit.Rule
 import org.junit.Test
 
 @OptIn(ExperimentalCoroutinesApi::class, ExperimentalPreviewMapboxNavigationAPI::class)
-class TripSessionStarterViewModelTest {
+class TripSessionStarterStateControllerTest {
 
     @get:Rule
     var coroutineRule = MainCoroutineRule()
@@ -51,10 +53,10 @@ class TripSessionStarterViewModelTest {
                     )
                 )
             )
-            val tripSessionStarterViewModel = TripSessionStarterViewModel(testStore)
+            val sut = TripSessionStarterStateController(testStore)
             val mapboxNavigation = mockMapboxNavigation()
 
-            tripSessionStarterViewModel.onAttached(mapboxNavigation)
+            sut.onAttached(mapboxNavigation)
             testStore.dispatch(
                 TripSessionStarterAction.OnLocationPermission(true)
             )
@@ -73,11 +75,11 @@ class TripSessionStarterViewModelTest {
                     )
                 )
             )
-            val tripSessionStarterViewModel = TripSessionStarterViewModel(testStore)
+            val sut = TripSessionStarterStateController(testStore)
             val mapboxNavigation = mockMapboxNavigation()
 
-            tripSessionStarterViewModel.onAttached(mapboxNavigation)
-            tripSessionStarterViewModel.onDetached(mapboxNavigation)
+            sut.onAttached(mapboxNavigation)
+            sut.onDetached(mapboxNavigation)
 
             verify(exactly = 1) { mapboxNavigation.startTripSession() }
             verify(exactly = 0) { mapboxNavigation.stopTripSession() }
@@ -95,10 +97,10 @@ class TripSessionStarterViewModelTest {
                     )
                 )
             )
-            val tripSessionStarterViewModel = TripSessionStarterViewModel(testStore)
+            val sut = TripSessionStarterStateController(testStore)
             val mapboxNavigation = mockMapboxNavigation()
 
-            tripSessionStarterViewModel.onAttached(mapboxNavigation)
+            sut.onAttached(mapboxNavigation)
             testStore.dispatch(TripSessionStarterAction.EnableTripSession)
 
             verifyOrder {
@@ -116,10 +118,10 @@ class TripSessionStarterViewModelTest {
                     navigation = NavigationState.ActiveNavigation
                 )
             )
-            val tripSessionStarterViewModel = TripSessionStarterViewModel(testStore)
+            val sut = TripSessionStarterStateController(testStore)
             val mapboxNavigation = mockMapboxNavigation()
 
-            tripSessionStarterViewModel.onAttached(mapboxNavigation)
+            sut.onAttached(mapboxNavigation)
             testStore.dispatch(
                 TripSessionStarterAction.OnLocationPermission(true)
             )
@@ -136,10 +138,10 @@ class TripSessionStarterViewModelTest {
                     navigation = NavigationState.ActiveNavigation,
                 )
             )
-            val tripSessionStarterViewModel = TripSessionStarterViewModel(testStore)
+            val sut = TripSessionStarterStateController(testStore)
             val mapboxNavigation = mockMapboxNavigation()
 
-            tripSessionStarterViewModel.onAttached(mapboxNavigation)
+            sut.onAttached(mapboxNavigation)
             testStore.dispatch(
                 TripSessionStarterAction.OnLocationPermission(false)
             )
@@ -160,11 +162,11 @@ class TripSessionStarterViewModelTest {
                     )
                 )
             )
-            val tripSessionStarterViewModel = TripSessionStarterViewModel(testStore)
+            val sut = TripSessionStarterStateController(testStore)
 
             val mapboxNavigation = mockMapboxNavigation()
 
-            tripSessionStarterViewModel.onAttached(mapboxNavigation)
+            sut.onAttached(mapboxNavigation)
             testStore.setNavigationState(NavigationState.DestinationPreview)
             testStore.setNavigationState(NavigationState.RoutePreview)
             testStore.setNavigationState(NavigationState.Arrival)


### PR DESCRIPTION
Closes [#1640](https://github.com/mapbox/navigation-sdks/issues/1640)

### Description

Changes:
- Moved all StateControllers to `com.mapbox.navigation.dropin.controller` package.
- Added unit tests for `DestinationStateController`.

| Before | After |
|:---:|:---:|
| ![drop in redux after](https://user-images.githubusercontent.com/2678039/166525284-50f9cc73-8c7f-4474-8c4b-4f40e8dcdbf0.png) | ![drop in - ViewModels to StateControllers](https://user-images.githubusercontent.com/2678039/166525282-342407dc-e66c-42da-a3cc-076dd2cb698c.png) |
