### PR TITLE
Bump `mapboxSdkServices` dependency to 6.5.0-beta.4

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -19,7 +19,7 @@ ext {
 
   version = [
       mapboxMapSdk              : '10.5.0-rc.1',
-      mapboxSdkServices         : '6.5.0-beta.3',
+      mapboxSdkServices         : '6.5.0-beta.4',
       mapboxEvents              : '8.1.1',
       mapboxCore                : '5.0.1',
       mapboxNavigator           : "${mapboxNavigatorVersion}",


### PR DESCRIPTION
### Description

Bumped `mapboxSdkServices` dependency version to `6.5.0-beta.4`
