### PR TITLE
Bump `mapboxMapSdk` to 10.5.0 (gl-native v10.5.1)

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -18,7 +18,7 @@ ext {
   println("Navigation Native version: " + mapboxNavigatorVersion)
 
   version = [
-      mapboxMapSdk              : '10.5.0-rc.1',
+      mapboxMapSdk              : '10.5.0',
       mapboxSdkServices         : '6.5.0-beta.4',
       mapboxEvents              : '8.1.1',
       mapboxCore                : '5.0.1',


### PR DESCRIPTION
### Description

Bumped `mapboxMapSdk` to `10.5.0` (`gl-native v10.5.1`)
