### PR TITLE
add notification interceptor for android auto

### DIFF
--- a/libnavui-androidauto/CHANGELOG.md
+++ b/libnavui-androidauto/CHANGELOG.md
@@ -5,6 +5,7 @@ Mapbox welcomes participation and contributions from everyone.
 ## Unreleased
 
 #### Features
+ - Added notification interceptor for Android Auto. [#5778](https://github.com/mapbox/mapbox-navigation-android/pull/5778)
 
 #### Bug fixes and improvements
  - Remove extra arrival feedback options. [#5805](https://github.com/mapbox/mapbox-navigation-android/pull/5805)

--- a/libnavui-androidauto/build.gradle
+++ b/libnavui-androidauto/build.gradle
@@ -41,8 +41,8 @@ dependencies {
     // This defines the minimum version of Maps, Navigation, and Search which are included in
     // this SDK. To upgrade the SDK versions, you can specify a newer version in your downstream
     // build.gradle.
-    api("com.mapbox.navigation:android:2.4.1")
-    api("com.mapbox.search:mapbox-search-android:1.0.0-beta.26")
+    api("com.mapbox.navigation:android:2.5.0-rc.1")
+    api("com.mapbox.search:mapbox-search-android:1.0.0-beta.29")
 
     implementation(dependenciesList.androidXAppCompat)
     implementation(dependenciesList.coroutinesCore)

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/notification/ActiveGuidanceExtenderUpdater.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/notification/ActiveGuidanceExtenderUpdater.kt
@@ -1,0 +1,181 @@
+package com.mapbox.androidauto.notification
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Matrix
+import android.graphics.drawable.Drawable
+import android.text.SpannableString
+import android.text.SpannableStringBuilder
+import android.text.TextUtils
+import android.text.format.DateFormat
+import androidx.car.app.notification.CarAppExtender
+import androidx.core.content.ContextCompat
+import com.mapbox.androidauto.R
+import com.mapbox.api.directions.v5.models.BannerInstructions
+import com.mapbox.api.directions.v5.models.ManeuverModifier
+import com.mapbox.api.directions.v5.models.StepManeuver
+import com.mapbox.navigation.base.TimeFormat
+import com.mapbox.navigation.base.formatter.DistanceFormatter
+import com.mapbox.navigation.base.internal.maneuver.TurnIconHelper
+import com.mapbox.navigation.base.internal.time.TimeFormatter
+import com.mapbox.navigation.base.internal.trip.notification.NotificationTurnIconResources
+import com.mapbox.navigation.base.trip.model.RouteProgress
+import java.util.Calendar
+
+internal class ActiveGuidanceExtenderUpdater(private val context: Context) {
+
+    @StepManeuver.StepManeuverType private var currentManeuverType: String? = null
+    private var currentManeuverModifier: String? = null
+    private var currentRoundaboutAngle: Float? = null
+    private var currentManeuverImage: Bitmap? = null
+
+    private var currentInstructionText: String? = null
+    private var currentDistanceText: Double? = null
+    private var currentFormattedDistance: SpannableString? = null
+    private var currentFormattedTime: String? = null
+    private val turnIconHelper = TurnIconHelper(NotificationTurnIconResources.defaultIconSet())
+
+    fun update(
+        extenderBuilder: CarAppExtender.Builder,
+        routeProgress: RouteProgress,
+        distanceFormatter: DistanceFormatter,
+        @TimeFormat.Type timeFormatType: Int,
+    ) {
+        val bannerInstructions = routeProgress.bannerInstructions
+        val currentLegProgress = routeProgress.currentLegProgress
+        val durationRemaining = currentLegProgress?.durationRemaining
+        val drivingSide = currentLegProgress?.currentStepProgress?.step?.drivingSide()
+
+        updateDistanceText(
+            currentLegProgress?.currentStepProgress?.distanceRemaining?.toDouble(),
+            distanceFormatter,
+        )
+        updateViewsWithArrival(durationRemaining, timeFormatType)
+        val titleBuilder = SpannableStringBuilder()
+        currentFormattedDistance?.let { titleBuilder.append(it) }
+        titleBuilder.append(" • ")
+        extenderBuilder.setContentTitle(titleBuilder)
+        currentFormattedTime?.let { titleBuilder.append(it) }
+
+        updateInstructionText(bannerInstructions, extenderBuilder)
+        updateManeuverImage(bannerInstructions, drivingSide, extenderBuilder)
+    }
+
+    fun updateCurrentManeuverToDefault() {
+        currentManeuverType = null
+        currentManeuverModifier = null
+        currentRoundaboutAngle = null
+    }
+
+    private fun updateDistanceText(
+        distanceRemaining: Double?,
+        distanceFormatter: DistanceFormatter,
+    ) {
+        if (isDistanceTextChanged(distanceRemaining) && distanceRemaining != null) {
+            currentDistanceText = distanceRemaining
+            currentFormattedDistance = distanceFormatter.formatDistance(distanceRemaining)
+        }
+    }
+
+    private fun updateViewsWithArrival(
+        durationRemaining: Double?,
+        @TimeFormat.Type timeFormatType: Int,
+    ) {
+        generateArrivalTime(durationRemaining, timeFormatType)?.let { currentFormattedTime = it }
+    }
+
+    private fun updateInstructionText(
+        bannerInstructions: BannerInstructions?,
+        extenderBuilder: CarAppExtender.Builder,
+    ) {
+        bannerInstructions?.primary()?.text()
+            ?.takeIf { isInstructionTextChanged(it) }
+            ?.let { currentInstructionText = it }
+        currentInstructionText?.let { extenderBuilder.setContentText(it) }
+    }
+
+    private fun updateManeuverImage(
+        bannerInstructions: BannerInstructions?,
+        drivingSide: String?,
+        extenderBuilder: CarAppExtender.Builder,
+    ) {
+        if (bannerInstructions != null && isManeuverStateChanged(bannerInstructions)) {
+            turnIconHelper.retrieveTurnIcon(
+                currentManeuverType,
+                currentRoundaboutAngle,
+                currentManeuverModifier,
+                drivingSide = drivingSide ?: ManeuverModifier.RIGHT,
+            )?.let { turnIcon ->
+                turnIcon.icon
+                    ?.let { ContextCompat.getDrawable(context, it) }
+                    ?.let { getManeuverBitmap(it, turnIcon.shouldFlipIcon) }
+                    ?.let { currentManeuverImage = it }
+            }
+        }
+        currentManeuverImage?.let { extenderBuilder.setLargeIcon(it) }
+    }
+
+    private fun isDistanceTextChanged(distanceRemaining: Double?): Boolean {
+        return currentDistanceText != distanceRemaining
+    }
+
+    private fun generateArrivalTime(
+        durationRemaining: Double?,
+        @TimeFormat.Type timeFormatType: Int,
+    ): String? {
+        val time = Calendar.getInstance()
+        return durationRemaining?.let {
+            val arrivalTime = TimeFormatter.formatTime(
+                time,
+                durationRemaining,
+                timeFormatType,
+                DateFormat.is24HourFormat(context),
+            )
+            context.getString(R.string.mapbox_eta_format, arrivalTime)
+        }
+    }
+
+    private fun isInstructionTextChanged(primaryText: String): Boolean {
+        return currentInstructionText.isNullOrEmpty() || currentInstructionText != primaryText
+    }
+
+    private fun isManeuverStateChanged(bannerInstruction: BannerInstructions): Boolean {
+        val previousManeuverType = currentManeuverType
+        val previousManeuverModifier = currentManeuverModifier
+        val previousRoundaboutAngle = currentRoundaboutAngle
+
+        currentManeuverType = bannerInstruction.primary().type()
+        currentManeuverModifier = bannerInstruction.primary().modifier()
+        currentRoundaboutAngle = bannerInstruction.primary().degrees()?.toFloat()
+
+        return !TextUtils.equals(currentManeuverType, previousManeuverType) ||
+            !TextUtils.equals(currentManeuverModifier, previousManeuverModifier) ||
+            currentRoundaboutAngle != previousRoundaboutAngle
+    }
+
+    private fun getManeuverBitmap(drawable: Drawable, shouldFlipIcon: Boolean): Bitmap? {
+        val maneuverImageBitmap = Bitmap.createBitmap(
+            drawable.intrinsicWidth,
+            drawable.intrinsicHeight,
+            Bitmap.Config.ARGB_8888,
+        )
+        val maneuverCanvas = Canvas(maneuverImageBitmap)
+        drawable.setBounds(0, 0, maneuverCanvas.width, maneuverCanvas.height)
+        drawable.draw(maneuverCanvas)
+        maneuverCanvas.restoreToCount(maneuverCanvas.saveCount)
+        return if (shouldFlipIcon) {
+            Bitmap.createBitmap(
+                maneuverImageBitmap,
+                0,
+                0,
+                drawable.intrinsicWidth,
+                drawable.intrinsicHeight,
+                Matrix().apply { preScale(-1f, 1f) },
+                false,
+            )
+        } else {
+            maneuverImageBitmap
+        }
+    }
+}

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/notification/CarNotificationInterceptor.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/notification/CarNotificationInterceptor.kt
@@ -1,0 +1,130 @@
+package com.mapbox.androidauto.notification
+
+import android.app.PendingIntent
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import androidx.car.app.CarAppService
+import androidx.car.app.model.CarColor
+import androidx.car.app.notification.CarAppExtender
+import androidx.car.app.notification.CarPendingIntent
+import androidx.core.app.NotificationCompat
+import com.mapbox.androidauto.R
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.base.TimeFormat
+import com.mapbox.navigation.base.formatter.DistanceFormatter
+import com.mapbox.navigation.base.trip.model.RouteProgress
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.formatter.MapboxDistanceFormatter
+import com.mapbox.navigation.core.lifecycle.MapboxNavigationApp
+import com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver
+import com.mapbox.navigation.core.trip.session.NavigationSessionState
+import com.mapbox.navigation.core.trip.session.NavigationSessionStateObserver
+import com.mapbox.navigation.core.trip.session.RouteProgressObserver
+
+/**
+ * Register this observer using [MapboxNavigationApp.registerObserver]. As long as it is
+ * registered, the trip notification will be shown in the car using
+ * [MapboxNavigation.setTripNotificationInterceptor].
+ */
+@ExperimentalPreviewMapboxNavigationAPI
+class CarNotificationInterceptor internal constructor(
+    private val context: Context,
+    private val pendingOpenIntent: PendingIntent?,
+    private val idleExtenderUpdater: IdleExtenderUpdater,
+    private val freeDriveExtenderUpdater: FreeDriveExtenderUpdater,
+    private val activeGuidanceExtenderUpdater: ActiveGuidanceExtenderUpdater,
+) : MapboxNavigationObserver {
+
+    private var navigationSessionState: NavigationSessionState = NavigationSessionState.Idle
+    private var routeProgress: RouteProgress? = null
+
+    private val navigationSessionStateObserver = NavigationSessionStateObserver { sessionState ->
+        navigationSessionState = sessionState
+    }
+
+    private val routeProgressObserver = RouteProgressObserver { routeProgress ->
+        this.routeProgress = routeProgress
+    }
+
+    constructor(context: Context, carAppServiceClass: Class<out CarAppService>) : this(
+        context,
+        CarPendingIntent.getCarApp(
+            context,
+            0,
+            Intent(Intent.ACTION_VIEW).setComponent(ComponentName(context, carAppServiceClass)),
+            PendingIntent.FLAG_UPDATE_CURRENT,
+        ),
+        IdleExtenderUpdater(context),
+        FreeDriveExtenderUpdater(context),
+        ActiveGuidanceExtenderUpdater(context),
+    )
+
+    override fun onAttached(mapboxNavigation: MapboxNavigation) {
+        mapboxNavigation.registerNavigationSessionStateObserver(navigationSessionStateObserver)
+        mapboxNavigation.registerRouteProgressObserver(routeProgressObserver)
+        mapboxNavigation.setTripNotificationInterceptor { notificationBuilder ->
+            val color = context.getColor(R.color.mapbox_notification_blue)
+            val formatterOptions = mapboxNavigation.navigationOptions.distanceFormatterOptions
+            val extenderBuilder = getExtenderBuilder(
+                MapboxDistanceFormatter(formatterOptions),
+                mapboxNavigation.navigationOptions.timeFormatType,
+                CarColor.createCustom(color, color),
+            )
+            notificationBuilder
+                .setOngoing(true)
+                .setCategory(NotificationCompat.CATEGORY_NAVIGATION)
+                .extend(extenderBuilder.build())
+        }
+    }
+
+    override fun onDetached(mapboxNavigation: MapboxNavigation) {
+        mapboxNavigation.setTripNotificationInterceptor(null)
+        mapboxNavigation.unregisterNavigationSessionStateObserver(navigationSessionStateObserver)
+        mapboxNavigation.unregisterRouteProgressObserver(routeProgressObserver)
+    }
+
+    private fun getExtenderBuilder(
+        distanceFormatter: DistanceFormatter,
+        @TimeFormat.Type timeFormatType: Int,
+        color: CarColor,
+    ): CarAppExtender.Builder {
+        val extenderBuilder = CarAppExtender.Builder()
+            .setColor(color)
+            .setSmallIcon(R.drawable.mapbox_ic_navigation)
+
+        if (pendingOpenIntent != null) {
+            extenderBuilder.setContentIntent(pendingOpenIntent)
+        }
+
+        when (navigationSessionState) {
+            is NavigationSessionState.Idle -> setIdleMode(extenderBuilder)
+            is NavigationSessionState.FreeDrive -> setFreeDriveMode(extenderBuilder)
+            is NavigationSessionState.ActiveGuidance -> {
+                val routeProgress = routeProgress
+                if (routeProgress != null) {
+                    activeGuidanceExtenderUpdater.update(
+                        extenderBuilder,
+                        routeProgress,
+                        distanceFormatter,
+                        timeFormatType,
+                    )
+                } else {
+                    setIdleMode(extenderBuilder)
+                }
+            }
+        }
+
+        return extenderBuilder
+    }
+
+    private fun setIdleMode(extenderBuilder: CarAppExtender.Builder) {
+        idleExtenderUpdater.update(extenderBuilder)
+        activeGuidanceExtenderUpdater.updateCurrentManeuverToDefault()
+    }
+
+    private fun setFreeDriveMode(extenderBuilder: CarAppExtender.Builder) {
+        freeDriveExtenderUpdater.update(extenderBuilder)
+        activeGuidanceExtenderUpdater.updateCurrentManeuverToDefault()
+    }
+}

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/notification/FreeDriveExtenderUpdater.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/notification/FreeDriveExtenderUpdater.kt
@@ -1,0 +1,25 @@
+package com.mapbox.androidauto.notification
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import androidx.car.app.notification.CarAppExtender
+import androidx.core.content.ContextCompat
+import com.mapbox.androidauto.R
+
+internal class FreeDriveExtenderUpdater(private val context: Context) {
+
+    fun update(extenderBuilder: CarAppExtender.Builder) {
+        extenderBuilder.setContentTitle(context.getString(R.string.mapbox_free_drive_session))
+        val drawable = ContextCompat.getDrawable(context, R.drawable.mapbox_ic_navigation)!!
+        val bitmap = Bitmap.createBitmap(
+            drawable.intrinsicWidth,
+            drawable.intrinsicHeight,
+            Bitmap.Config.ARGB_8888,
+        )
+        val canvas = Canvas(bitmap)
+        drawable.setBounds(0, 0, canvas.width, canvas.height)
+        drawable.draw(canvas)
+        extenderBuilder.setLargeIcon(bitmap)
+    }
+}

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/notification/IdleExtenderUpdater.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/notification/IdleExtenderUpdater.kt
@@ -1,0 +1,12 @@
+package com.mapbox.androidauto.notification
+
+import android.content.Context
+import androidx.car.app.notification.CarAppExtender
+import com.mapbox.androidauto.R
+
+internal class IdleExtenderUpdater(private val context: Context) {
+
+    fun update(extenderBuilder: CarAppExtender.Builder) {
+        extenderBuilder.setContentTitle(context.getString(R.string.mapbox_navigation_is_starting))
+    }
+}

--- a/libnavui-androidauto/src/test/java/com/mapbox/androidauto/notification/CarNotificationInterceptorTest.kt
+++ b/libnavui-androidauto/src/test/java/com/mapbox/androidauto/notification/CarNotificationInterceptorTest.kt
@@ -1,0 +1,212 @@
+package com.mapbox.androidauto.notification
+
+import android.app.PendingIntent
+import android.content.Context
+import android.graphics.Color
+import androidx.car.app.model.CarColor
+import androidx.car.app.notification.CarAppExtender
+import androidx.core.app.NotificationCompat
+import com.mapbox.androidauto.R
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.base.TimeFormat
+import com.mapbox.navigation.base.formatter.DistanceFormatterOptions
+import com.mapbox.navigation.base.trip.model.RouteProgress
+import com.mapbox.navigation.base.trip.notification.TripNotificationInterceptor
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.formatter.MapboxDistanceFormatter
+import com.mapbox.navigation.core.trip.session.NavigationSessionState
+import com.mapbox.navigation.core.trip.session.NavigationSessionStateObserver
+import com.mapbox.navigation.core.trip.session.RouteProgressObserver
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import io.mockk.verifyOrder
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+@ExperimentalPreviewMapboxNavigationAPI
+class CarNotificationInterceptorTest {
+
+    private val context = mockk<Context> {
+        every { getColor(R.color.mapbox_notification_blue) } returns Color.BLUE
+    }
+    private val pendingOpenIntent = mockk<PendingIntent>()
+    private val idleExtenderUpdater = mockk<IdleExtenderUpdater>(relaxUnitFun = true)
+    private val freeDriveExtenderUpdater = mockk<FreeDriveExtenderUpdater>(relaxUnitFun = true)
+    private val activeGuidanceExtenderUpdater =
+        mockk<ActiveGuidanceExtenderUpdater>(relaxUnitFun = true)
+    private val carNotificationInterceptor = CarNotificationInterceptor(
+        context,
+        pendingOpenIntent,
+        idleExtenderUpdater,
+        freeDriveExtenderUpdater,
+        activeGuidanceExtenderUpdater,
+    )
+    private val formatterOptions = mockk<DistanceFormatterOptions>()
+    private val mapboxNavigation = mockk<MapboxNavigation>(relaxUnitFun = true) {
+        every { navigationOptions } returns mockk {
+            every { distanceFormatterOptions } returns formatterOptions
+            every { timeFormatType } returns TimeFormat.TWENTY_FOUR_HOURS
+        }
+    }
+    private val navigationSessionStateObserverSlot = slot<NavigationSessionStateObserver>()
+    private val routeProgressObserverSlot = slot<RouteProgressObserver>()
+    private val tripNotificationInterceptorSlot = slot<TripNotificationInterceptor>()
+    private val carAppExtenderSlot = slot<CarAppExtender>()
+    private val notificationBuilder = mockk<NotificationCompat.Builder> {
+        every { setOngoing(any()) } returns this
+        every { setCategory(any()) } returns this
+        every { extend(capture(carAppExtenderSlot)) } returns this
+    }
+    private val routeProgress = mockk<RouteProgress>()
+
+    @Before
+    fun setUp() {
+        every {
+            mapboxNavigation.registerNavigationSessionStateObserver(
+                capture(navigationSessionStateObserverSlot),
+            )
+        } just Runs
+        every {
+            mapboxNavigation.registerRouteProgressObserver(capture(routeProgressObserverSlot))
+        } just Runs
+        every {
+            mapboxNavigation.setTripNotificationInterceptor(
+                capture(tripNotificationInterceptorSlot),
+            )
+        } just Runs
+    }
+
+    @Test
+    fun `interceptor and observers are registered in onAttached`() {
+        carNotificationInterceptor.onAttached(mapboxNavigation)
+        verify { mapboxNavigation.registerNavigationSessionStateObserver(any()) }
+        verify { mapboxNavigation.registerRouteProgressObserver(any()) }
+        verify { mapboxNavigation.setTripNotificationInterceptor(any()) }
+    }
+
+    @Test
+    fun `interceptor and observers are unregistered in onDetached`() {
+        carNotificationInterceptor.onAttached(mapboxNavigation)
+        carNotificationInterceptor.onDetached(mapboxNavigation)
+        verify { mapboxNavigation.setTripNotificationInterceptor(null) }
+        verify {
+            mapboxNavigation.registerNavigationSessionStateObserver(
+                navigationSessionStateObserverSlot.captured,
+            )
+        }
+        verify {
+            mapboxNavigation.registerRouteProgressObserver(routeProgressObserverSlot.captured)
+        }
+    }
+
+    @Test
+    fun `notification is idle by default`() {
+        carNotificationInterceptor.onAttached(mapboxNavigation)
+        routeProgressObserverSlot.captured.onRouteProgressChanged(routeProgress)
+        tripNotificationInterceptorSlot.captured.intercept(notificationBuilder)
+        verifyCommonProperties()
+        verifyIdleProperties()
+    }
+
+    @Test
+    fun `notification is updated in free drive state`() {
+        carNotificationInterceptor.onAttached(mapboxNavigation)
+        setNavigationSessionState(mockk<NavigationSessionState.FreeDrive>())
+        tripNotificationInterceptorSlot.captured.intercept(notificationBuilder)
+        verifyCommonProperties()
+        verifyFreeDriveProperties()
+    }
+
+    @Test
+    fun `notification is idle in active guidance state without route progress`() {
+        carNotificationInterceptor.onAttached(mapboxNavigation)
+        setNavigationSessionState(mockk<NavigationSessionState.ActiveGuidance>())
+        tripNotificationInterceptorSlot.captured.intercept(notificationBuilder)
+        verifyCommonProperties()
+        verifyIdleProperties()
+    }
+
+    @Test
+    fun `notification is updated in active guidance state with route progress`() {
+        carNotificationInterceptor.onAttached(mapboxNavigation)
+        setNavigationSessionState(mockk<NavigationSessionState.ActiveGuidance>())
+        routeProgressObserverSlot.captured.onRouteProgressChanged(routeProgress)
+        tripNotificationInterceptorSlot.captured.intercept(notificationBuilder)
+        verifyCommonProperties()
+        verifyActiveGuidanceProperties()
+    }
+
+    private fun verifyCommonProperties() {
+        verifyOrder {
+            notificationBuilder.setOngoing(true)
+            notificationBuilder.setCategory(NotificationCompat.CATEGORY_NAVIGATION)
+            notificationBuilder.extend(any())
+        }
+        val carAppExtender = carAppExtenderSlot.captured
+        assertEquals(CarColor.createCustom(Color.BLUE, Color.BLUE), carAppExtender.color)
+        assertEquals(R.drawable.mapbox_ic_navigation, carAppExtender.smallIcon)
+        assertEquals(pendingOpenIntent, carAppExtender.contentIntent)
+    }
+
+    private fun verifyIdleProperties() {
+        verify {
+            idleExtenderUpdater.update(match { checkExtender(it) })
+            activeGuidanceExtenderUpdater.updateCurrentManeuverToDefault()
+        }
+        verify(exactly = 0) {
+            freeDriveExtenderUpdater.update(any())
+            activeGuidanceExtenderUpdater.update(any(), any(), any(), any())
+        }
+    }
+
+    private fun verifyFreeDriveProperties() {
+        verify {
+            freeDriveExtenderUpdater.update(match { checkExtender(it) })
+            activeGuidanceExtenderUpdater.updateCurrentManeuverToDefault()
+        }
+        verify(exactly = 0) {
+            idleExtenderUpdater.update(any())
+            activeGuidanceExtenderUpdater.update(any(), any(), any(), any())
+        }
+    }
+
+    private fun verifyActiveGuidanceProperties() {
+        verify {
+            activeGuidanceExtenderUpdater.update(
+                match { checkExtender(it) },
+                routeProgress,
+                match { it is MapboxDistanceFormatter && it.options == formatterOptions },
+                TimeFormat.TWENTY_FOUR_HOURS,
+            )
+        }
+        verify(exactly = 0) {
+            idleExtenderUpdater.update(any())
+            freeDriveExtenderUpdater.update(any())
+            activeGuidanceExtenderUpdater.updateCurrentManeuverToDefault()
+        }
+    }
+
+    private fun setNavigationSessionState(sessionState: NavigationSessionState) {
+        navigationSessionStateObserverSlot.captured.onNavigationSessionStateChanged(sessionState)
+    }
+
+    private fun checkExtender(actualExtenderBuilder: CarAppExtender.Builder): Boolean {
+        val expectedExtender = carAppExtenderSlot.captured
+        val actualExtender = actualExtenderBuilder.build()
+        return expectedExtender.contentTitle == actualExtender.contentTitle &&
+            expectedExtender.contentText == actualExtender.contentText &&
+            expectedExtender.smallIcon == actualExtender.smallIcon &&
+            expectedExtender.largeIcon == actualExtender.largeIcon &&
+            expectedExtender.contentIntent == actualExtender.contentIntent &&
+            expectedExtender.deleteIntent == actualExtender.deleteIntent &&
+            expectedExtender.actions == actualExtender.actions &&
+            expectedExtender.importance == actualExtender.importance &&
+            expectedExtender.color == actualExtender.color &&
+            expectedExtender.channelId == actualExtender.channelId
+    }
+}

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/car/MainCarSession.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/car/MainCarSession.kt
@@ -21,6 +21,7 @@ import com.mapbox.androidauto.car.map.widgets.logo.CarLogoSurfaceRenderer
 import com.mapbox.androidauto.car.permissions.NeedsLocationPermissionsScreen
 import com.mapbox.androidauto.deeplink.GeoDeeplinkNavigateAction
 import com.mapbox.androidauto.logAndroidAuto
+import com.mapbox.androidauto.notification.CarNotificationInterceptor
 import com.mapbox.maps.MapInitOptions
 import com.mapbox.maps.MapboxExperimental
 import com.mapbox.maps.extension.androidauto.MapboxCarMap
@@ -41,6 +42,9 @@ class MainCarSession : Session() {
     private lateinit var mapboxCarMap: MapboxCarMap
     private lateinit var mapboxNavigationManager: MapboxCarNavigationManager
     private val carMapStyleLoader = MainCarMapLoader()
+    private val notificationInterceptor by lazy {
+        CarNotificationInterceptor(carContext, MainCarAppService::class.java)
+    }
 
     init {
         val logoSurfaceRenderer = CarLogoSurfaceRenderer()
@@ -72,6 +76,7 @@ class MainCarSession : Session() {
                         mainScreenManager.observeCarAppState()
                     }
                 }
+                MapboxNavigationApp.registerObserver(notificationInterceptor)
             }
 
             override fun onResume(owner: LifecycleOwner) {
@@ -95,6 +100,7 @@ class MainCarSession : Session() {
                 MapboxNavigationApp.unregisterObserver(mapboxNavigationManager)
                 mapboxCarMap.unregisterObserver(carMapStyleLoader)
                 mainCarContext = null
+                MapboxNavigationApp.unregisterObserver(notificationInterceptor)
             }
         })
 


### PR DESCRIPTION
### Description
Added a notification interceptor, that lets easily set up notifications in Android Auto. Not sure about adding a dependency on `:libtrip-notification` module, but needed a way to re-use notification resources somehow. 

### Screenshots or Gifs
<img width="912" alt="Screenshot 2022-05-05 at 19 23 09" src="https://user-images.githubusercontent.com/2395284/166969656-69b9a796-223c-4bdd-a99e-881dc3fc008e.png">
<img width="912" alt="Screenshot 2022-05-05 at 19 23 15" src="https://user-images.githubusercontent.com/2395284/166969674-639bd762-f51a-4efb-b82d-92f443674de0.png">

There is also an option to show a heads-up notification by setting high importance, but since the notification is updated approximately every two seconds this option should be used only when there is a significant change in the route progress. This and any other extra customization can be applied via `CarNotificationInterceptor` arguments if needed. 

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
