### PR TITLE
[Android Auto] Update dokka

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -309,20 +309,6 @@ commands:
           name: Post code coverage reports to Codecov.io
           command: sh scripts/coverage.sh
 
-  generate-version-name:
-    steps:
-      - run:
-          name: Generate Core version name
-          command: |
-            if [[ -n "$CIRCLE_TAG" ]]; then
-              if [[ $CIRCLE_TAG == v* ]]; then
-                sed -i -e "s/^VERSION_NAME=.*/VERSION_NAME=${CIRCLE_TAG:1}/" gradle.properties
-              else
-                echo "Exiting the job as this is not a release TAG"
-                exit 1
-              fi
-            fi
-
   generate-google-services-json:
     steps:
       - run:
@@ -466,6 +452,12 @@ commands:
       - run:
           name: Generate documentation
           command: make javadoc-dokka
+
+  generate-documentation-androidauto:
+    steps:
+      - run:
+          name: Generate documentation
+          command: make javadoc-dokka-androidauto
 
   trigger-mobile-metrics:
     steps:
@@ -727,7 +719,6 @@ jobs:
     executor: ndk-r22-latest-executor
     steps:
       - checkout
-      - generate-version-name
       - assemble-core-release
       - assemble-ui-release
       - check-public-documentation
@@ -740,7 +731,6 @@ jobs:
     executor: ndk-r22-latest-executor
     steps:
       - checkout
-      - generate-version-name
       - assemble-core-release
       - assemble-ui-release
       - check-public-documentation
@@ -755,7 +745,7 @@ jobs:
     steps:
       - checkout
       - check-public-documentation
-      - generate-documentation
+      - generate-documentation-androidauto
       - prepare-mbx-ci
       - setup-aws-credentials
       - upload-artifacts-androidauto

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,10 @@ javadoc-dokka:
 	./gradlew dokkaHtmlMultiModule
 	./docs/replace-styles.sh
 
+.PHONY: javadoc-dokka-androidauto
+javadoc-dokka-androidauto:
+	./gradlew libnavui-androidauto:dokkaHtml
+
 .PHONY: dependency-graphs
 dependency-graphs:
 	$(call run-gradle-tasks,$(CORE_MODULES),generateDependencyGraphMapboxLibraries) \


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Generate documentation failed because androidauto is not trying to build the main release channels. 
https://app.circleci.com/pipelines/github/mapbox/mapbox-navigation-android/18020/workflows/92f9332e-d460-4a9d-9c81-e264d960624a/jobs/82584

We can also delete `generate-version-name` because the version is read from the release tags https://github.com/mapbox/mapbox-navigation-android/pull/5773/files#diff-226f5cade15955b90742f0e9d012e5e355fca535a25ba3764dfba1fa1846836cR18
