### PR TITLE
[Android Auto] Enable linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ libnavui-dropin \
 
 UI_MODULES = $(RELEASED_UI_MODULES)
 
+EXTENSION_MODULES = \
+libnavui-androidauto
+
 APPLICATION_MODULES = \
 qa-test-app \
 examples \
@@ -43,12 +46,14 @@ endef
 check-kotlin-lint:
 	$(call run-gradle-tasks,$(CORE_MODULES),ktlint) \
 	&& $(call run-gradle-tasks,$(UI_MODULES),ktlint) \
+	&& $(call run-gradle-tasks,$(EXTENSION_MODULES),ktlint) \
 	&& $(call run-gradle-tasks,$(APPLICATION_MODULES),ktlint)
 
 .PHONY: check-android-lint
 check-android-lint:
 	$(call run-gradle-tasks,$(CORE_MODULES),lint) \
 	&& $(call run-gradle-tasks,$(UI_MODULES),lint) \
+	&& $(call run-gradle-tasks,$(EXTENSION_MODULES),lint) \
 	&& $(call run-gradle-tasks,$(APPLICATION_MODULES),lint)
 
 .PHONY: license-verification

--- a/libnavui-androidauto/src/androidTest/java/com/mapbox/androidauto/car/navigation/roadlabel/RoadLabelRendererTest.kt
+++ b/libnavui-androidauto/src/androidTest/java/com/mapbox/androidauto/car/navigation/roadlabel/RoadLabelRendererTest.kt
@@ -70,7 +70,10 @@ class RoadLabelRendererTest {
     @Test
     fun very_long_street_name() {
         val bitmap = roadLabelBitmapRenderer.render(
-            createRoad("Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu"),
+            createRoad(
+                "Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhen" +
+                    "uakitanatahu"
+            ),
             emptyList(),
             RoadLabelOptions.Builder()
                 .backgroundColor(0x784D4DD3)
@@ -101,8 +104,19 @@ class RoadLabelRendererTest {
         val byteArray = context.assets.open("shield.svg").use { it.readBytes() }
         val mapboxShield = mockk<MapboxShield>()
         val bitmap = roadLabelBitmapRenderer.render(
-            listOf(createComponent("Clarksburg Road"), createComponent("/"), createComponent("121", mapboxShield)),
-            listOf(RouteShieldFactory.buildRouteShield("download-url", byteArray, mapboxShield, mockk())),
+            listOf(
+                createComponent("Clarksburg Road"),
+                createComponent("/"),
+                createComponent("121", mapboxShield)
+            ),
+            listOf(
+                RouteShieldFactory.buildRouteShield(
+                    "download-url",
+                    byteArray,
+                    mapboxShield,
+                    mockk()
+                )
+            ),
             RoadLabelOptions.Builder()
                 .backgroundColor(0x784D4DD3)
                 .build(),

--- a/libnavui-androidauto/src/androidTest/java/com/mapbox/androidauto/car/navigation/speedlimit/SpeedLimitRendererTest.kt
+++ b/libnavui-androidauto/src/androidTest/java/com/mapbox/androidauto/car/navigation/speedlimit/SpeedLimitRendererTest.kt
@@ -33,36 +33,57 @@ class SpeedLimitRendererTest {
 
     @Test
     fun speed_limit_120_speed_150() {
-        bitmapUtils.assertBitmapsSimilar(testName, speedLimitWidget.drawSpeedLimitSign(speedLimit = 120, speed = 150))
+        bitmapUtils.assertBitmapsSimilar(
+            testName,
+            speedLimitWidget.drawSpeedLimitSign(speedLimit = 120, speed = 150)
+        )
     }
 
     @Test
     fun speed_limit_120_speed_90() {
-        bitmapUtils.assertBitmapsSimilar(testName, speedLimitWidget.drawSpeedLimitSign(speedLimit = 120, speed = 90))
+        bitmapUtils.assertBitmapsSimilar(
+            testName,
+            speedLimitWidget.drawSpeedLimitSign(speedLimit = 120, speed = 90)
+        )
     }
 
     @Test
     fun speed_limit_65_speed_90() {
-        bitmapUtils.assertBitmapsSimilar(testName, speedLimitWidget.drawSpeedLimitSign(speedLimit = 65, speed = 90))
+        bitmapUtils.assertBitmapsSimilar(
+            testName,
+            speedLimitWidget.drawSpeedLimitSign(speedLimit = 65, speed = 90)
+        )
     }
 
     @Test
     fun speed_limit_65_speed_30() {
-        bitmapUtils.assertBitmapsSimilar(testName, speedLimitWidget.drawSpeedLimitSign(speedLimit = 65, speed = 30))
+        bitmapUtils.assertBitmapsSimilar(
+            testName,
+            speedLimitWidget.drawSpeedLimitSign(speedLimit = 65, speed = 30)
+        )
     }
 
     @Test
     fun speed_limit_5_speed_30() {
-        bitmapUtils.assertBitmapsSimilar(testName, speedLimitWidget.drawSpeedLimitSign(speedLimit = 5, speed = 30))
+        bitmapUtils.assertBitmapsSimilar(
+            testName,
+            speedLimitWidget.drawSpeedLimitSign(speedLimit = 5, speed = 30)
+        )
     }
 
     @Test
     fun speed_limit_5_speed_0() {
-        bitmapUtils.assertBitmapsSimilar(testName, speedLimitWidget.drawSpeedLimitSign(speedLimit = 5, speed = 0))
+        bitmapUtils.assertBitmapsSimilar(
+            testName,
+            speedLimitWidget.drawSpeedLimitSign(speedLimit = 5, speed = 0)
+        )
     }
 
     @Test
     fun speed_limit_unknown_speed_5() {
-        bitmapUtils.assertBitmapsSimilar(testName, speedLimitWidget.drawSpeedLimitSign(speedLimit = null, speed = 5))
+        bitmapUtils.assertBitmapsSimilar(
+            testName,
+            speedLimitWidget.drawSpeedLimitSign(speedLimit = null, speed = 5)
+        )
     }
 }

--- a/libnavui-androidauto/src/androidTest/java/com/mapbox/androidauto/testing/BitmapTestUtil.kt
+++ b/libnavui-androidauto/src/androidTest/java/com/mapbox/androidauto/testing/BitmapTestUtil.kt
@@ -75,11 +75,17 @@ class BitmapTestUtil(
             context.assets.open(expectedBitmapFile).use {
                 val expected = BitmapFactory.decodeStream(it)
                 val difference = calculateDifference(expected, actual)
-                // If the images are different, write them to a file so they can be uploaded for debugging.
+                // If the images are different, write them to a file so they can be uploaded for
+                // debugging.
                 if (difference.similarity > 0.01) {
                     writeBitmapFile(testName, actual)
-                    writeBitmapFile("${testName.methodName}-diff", difference.difference)
-                    fail("The ${testName.methodName} image failed with similarity: ${difference.similarity}")
+                    writeBitmapFile(
+                        "${testName.methodName}-diff", difference.difference
+                    )
+                    fail(
+                        "The ${testName.methodName} image failed with similarity: " +
+                            "${difference.similarity}"
+                    )
                 }
             }
         } catch (t: Throwable) {

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/MainCarScreen.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/MainCarScreen.kt
@@ -6,13 +6,13 @@ import androidx.car.app.model.Template
 import androidx.car.app.navigation.model.NavigationTemplate
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
-import com.mapbox.androidauto.car.navigation.roadlabel.RoadLabelSurfaceLayer
-import com.mapbox.androidauto.car.navigation.speedlimit.CarSpeedLimitRenderer
-import com.mapbox.androidauto.logAndroidAuto
 import com.mapbox.androidauto.car.location.CarLocationRenderer
 import com.mapbox.androidauto.car.navigation.CarCameraMode
 import com.mapbox.androidauto.car.navigation.CarNavigationCamera
+import com.mapbox.androidauto.car.navigation.roadlabel.RoadLabelSurfaceLayer
+import com.mapbox.androidauto.car.navigation.speedlimit.CarSpeedLimitRenderer
 import com.mapbox.androidauto.car.preview.CarRouteLine
+import com.mapbox.androidauto.logAndroidAuto
 import com.mapbox.maps.MapboxExperimental
 
 /**

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/MainMapActionStrip.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/MainMapActionStrip.kt
@@ -32,9 +32,15 @@ class MainMapActionStrip(
             .addAction(buildPanAction())
         val nextCameraMode = carNavigationCamera.nextCameraMode.value
         when {
-            nextCameraMode == CarCameraMode.FOLLOWING -> mapActionStripBuilder.addAction(buildRecenterAction())
-            nextCameraMode == CarCameraMode.OVERVIEW -> mapActionStripBuilder.addAction(buildOverviewAction())
-            !carNavigationCamera.followingZoomUpdatesAllowed() -> mapActionStripBuilder.addAction(buildRecenterAction())
+            nextCameraMode == CarCameraMode.FOLLOWING -> mapActionStripBuilder.addAction(
+                buildRecenterAction()
+            )
+            nextCameraMode == CarCameraMode.OVERVIEW -> mapActionStripBuilder.addAction(
+                buildOverviewAction()
+            )
+            !carNavigationCamera.followingZoomUpdatesAllowed() -> mapActionStripBuilder.addAction(
+                buildRecenterAction()
+            )
         }
 
         return mapActionStripBuilder
@@ -84,9 +90,11 @@ class MainMapActionStrip(
         }
         .build()
 
-    private fun buildRecenterAction() = buildCameraAction(R.drawable.ic_recenter_24, CarCameraMode.FOLLOWING)
+    private fun buildRecenterAction() =
+        buildCameraAction(R.drawable.ic_recenter_24, CarCameraMode.FOLLOWING)
 
-    private fun buildOverviewAction() = buildCameraAction(R.drawable.ic_route_overview, CarCameraMode.OVERVIEW)
+    private fun buildOverviewAction() =
+        buildCameraAction(R.drawable.ic_route_overview, CarCameraMode.OVERVIEW)
 
     private fun buildCameraAction(@DrawableRes iconId: Int, carCameraMode: CarCameraMode): Action {
         return Action.Builder()

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/MainScreenManager.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/MainScreenManager.kt
@@ -8,8 +8,6 @@ import com.mapbox.androidauto.CarAppState
 import com.mapbox.androidauto.FreeDriveState
 import com.mapbox.androidauto.MapboxCarApp
 import com.mapbox.androidauto.RoutePreviewState
-import com.mapbox.androidauto.logAndroidAuto
-import com.mapbox.androidauto.navigation.audioguidance.CarAudioGuidanceUi
 import com.mapbox.androidauto.car.feedback.core.CarFeedbackSender
 import com.mapbox.androidauto.car.feedback.ui.CarFeedbackAction
 import com.mapbox.androidauto.car.feedback.ui.CarGridFeedbackScreen
@@ -17,6 +15,8 @@ import com.mapbox.androidauto.car.feedback.ui.activeGuidanceCarFeedbackProvider
 import com.mapbox.androidauto.car.feedback.ui.buildArrivalFeedbackProvider
 import com.mapbox.androidauto.car.navigation.ActiveGuidanceScreen
 import com.mapbox.androidauto.car.navigation.CarActiveGuidanceCarContext
+import com.mapbox.androidauto.logAndroidAuto
+import com.mapbox.androidauto.navigation.audioguidance.CarAudioGuidanceUi
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.map
@@ -41,7 +41,8 @@ class MainScreenManager(val mainCarContext: MainCarContext) {
                     )
                 )
             }
-            // Push screen and capture feedback. When completed, go back to FreeDriveState and clear the current route.
+            // Push screen and capture feedback. When completed, go back to FreeDriveState
+            // and clear the current route.
             ArrivalState -> CarGridFeedbackScreen(
                 mainCarContext.carContext,
                 javaClass.simpleName,
@@ -56,13 +57,17 @@ class MainScreenManager(val mainCarContext: MainCarContext) {
     }
 
     suspend fun observeCarAppState() {
-        MapboxCarApp.carAppState.map { currentScreen(it) }.distinctUntilChangedBy { it.javaClass }.collect { screen ->
-            val screenManager = mainCarContext.carContext.getCarService(ScreenManager::class.java)
-            logAndroidAuto("MainScreenManager screen change ${screen.javaClass.simpleName}")
-            if (screenManager.top.javaClass != screen.javaClass) {
-                screenManager.replace(screen)
+        MapboxCarApp.carAppState
+            .map { currentScreen(it) }
+            .distinctUntilChangedBy { it.javaClass }
+            .collect { screen ->
+                val screenManager = mainCarContext.carContext
+                    .getCarService(ScreenManager::class.java)
+                logAndroidAuto("MainScreenManager screen change ${screen.javaClass.simpleName}")
+                if (screenManager.top.javaClass != screen.javaClass) {
+                    screenManager.replace(screen)
+                }
             }
-        }
     }
 }
 

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/feedback/ui/CarFeedbackIcon.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/feedback/ui/CarFeedbackIcon.kt
@@ -40,8 +40,10 @@ fun CarFeedbackIcon.drawableRes() = when (this) {
 
     // Search feedback icons
     IncorrectNameCarFeedbackIcon -> R.drawable.mapbox_search_sdk_ic_feedback_reason_incorrect_name
-    IncorrectAddressCarFeedbackIcon -> R.drawable.mapbox_search_sdk_ic_feedback_reason_incorrect_address
-    IncorrectLocationCarFeedbackIcon -> R.drawable.mapbox_search_sdk_ic_feedback_reason_incorrect_location
+    IncorrectAddressCarFeedbackIcon ->
+        R.drawable.mapbox_search_sdk_ic_feedback_reason_incorrect_address
+    IncorrectLocationCarFeedbackIcon ->
+        R.drawable.mapbox_search_sdk_ic_feedback_reason_incorrect_location
     SearchOtherIssueCarFeedbackIcon -> R.drawable.mapbox_search_sdk_ic_three_dots
 
     // Generic feedback icons

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/feedback/ui/CarFeedbackItem.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/feedback/ui/CarFeedbackItem.kt
@@ -2,9 +2,9 @@ package com.mapbox.androidauto.car.feedback.ui
 
 import androidx.annotation.Keep
 import androidx.car.app.CarContext
-import com.mapbox.api.geocoding.v5.models.GeocodingResponse
 import com.mapbox.androidauto.R
 import com.mapbox.androidauto.car.feedback.core.CarFeedbackItemProvider
+import com.mapbox.api.geocoding.v5.models.GeocodingResponse
 import com.mapbox.navigation.core.geodeeplink.GeoDeeplink
 import com.mapbox.navigation.core.telemetry.events.FeedbackEvent
 import com.mapbox.search.analytics.FeedbackEvent.FeedbackReason.Companion.INCORRECT_ADDRESS
@@ -232,7 +232,9 @@ fun buildArrivalFeedbackProvider(
     carContext: CarContext,
 ) = listOf(
     CarFeedbackItem(
-        carFeedbackTitle = carContext.getString(R.string.car_feedback_positive_arrived_at_destination),
+        carFeedbackTitle = carContext.getString(
+            R.string.car_feedback_positive_arrived_at_destination
+        ),
         carFeedbackIcon = PositiveCarFeedbackIcon,
         navigationFeedbackType = FeedbackEvent.ARRIVAL_FEEDBACK_GOOD,
     ),

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/feedback/ui/CarGridFeedbackScreen.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/feedback/ui/CarGridFeedbackScreen.kt
@@ -51,7 +51,11 @@ class CarGridFeedbackScreen constructor(
                             CarToast.LENGTH_LONG
                         ).show()
                     } else {
-                        carFeedbackSender.send(selectedItem, encodedSnapshot, sourceScreenSimpleName)
+                        carFeedbackSender.send(
+                            selectedItem,
+                            encodedSnapshot,
+                            sourceScreenSimpleName
+                        )
                         CarToast.makeText(
                             carContext,
                             carContext.getString(R.string.car_feedback_submit_toast_success),

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/location/CarLocationPuck.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/location/CarLocationPuck.kt
@@ -2,8 +2,8 @@ package com.mapbox.androidauto.car.location
 
 import android.content.Context
 import androidx.core.content.ContextCompat
-import com.mapbox.maps.plugin.LocationPuck2D
 import com.mapbox.androidauto.R
+import com.mapbox.maps.plugin.LocationPuck2D
 
 object CarLocationPuck {
 

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/location/CarLocationRenderer.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/location/CarLocationRenderer.kt
@@ -1,8 +1,8 @@
 package com.mapbox.androidauto.car.location
 
 import com.mapbox.androidauto.MapboxCarApp
-import com.mapbox.androidauto.logAndroidAuto
 import com.mapbox.androidauto.car.MainCarContext
+import com.mapbox.androidauto.logAndroidAuto
 import com.mapbox.maps.MapboxExperimental
 import com.mapbox.maps.extension.androidauto.MapboxCarMapObserver
 import com.mapbox.maps.extension.androidauto.MapboxCarMapSurface

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/map/widgets/ImageOverlayHost.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/map/widgets/ImageOverlayHost.kt
@@ -72,17 +72,22 @@ open class ImageOverlayHost(
         this.margins = margins
         logE(
             TAG,
-            "onSizeChanged-> bitmap size: ${bitmap.width}, ${bitmap.height}; screen size: $width, $height"
+            "onSizeChanged-> bitmap size: ${bitmap.width}," +
+                " ${bitmap.height}; screen size: $width, $height"
         )
         val heightOffset = when (position) {
-            WidgetPosition.BOTTOM_LEFT -> height.toFloat() - bitmap.height.toFloat() / 2f - margins.marginBottom
-            WidgetPosition.BOTTOM_RIGHT -> height.toFloat() - bitmap.height.toFloat() / 2f - margins.marginBottom
+            WidgetPosition.BOTTOM_LEFT ->
+                height.toFloat() - bitmap.height.toFloat() / 2f - margins.marginBottom
+            WidgetPosition.BOTTOM_RIGHT ->
+                height.toFloat() - bitmap.height.toFloat() / 2f - margins.marginBottom
             WidgetPosition.TOP_LEFT -> margins.marginTop + bitmap.height.toFloat() / 2f
             WidgetPosition.TOP_RIGHT -> margins.marginTop + bitmap.height.toFloat() / 2f
         }
         val widthOffset = when (position) {
-            WidgetPosition.TOP_RIGHT -> width.toFloat() - bitmap.width.toFloat() / 2f - margins.marginRight
-            WidgetPosition.BOTTOM_RIGHT -> width.toFloat() - bitmap.width.toFloat() / 2f - margins.marginRight
+            WidgetPosition.TOP_RIGHT ->
+                width.toFloat() - bitmap.width.toFloat() / 2f - margins.marginRight
+            WidgetPosition.BOTTOM_RIGHT ->
+                width.toFloat() - bitmap.width.toFloat() / 2f - margins.marginRight
             WidgetPosition.TOP_LEFT -> margins.marginLeft + bitmap.width.toFloat() / 2f
             WidgetPosition.BOTTOM_LEFT -> margins.marginLeft + bitmap.width.toFloat() / 2f
         }

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/map/widgets/compass/CompassWidget.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/map/widgets/compass/CompassWidget.kt
@@ -2,10 +2,10 @@ package com.mapbox.androidauto.car.map.widgets.compass
 
 import android.content.Context
 import android.graphics.BitmapFactory
-import com.mapbox.androidauto.car.map.widgets.WidgetPosition
 import com.mapbox.androidauto.R
 import com.mapbox.androidauto.car.map.widgets.ImageOverlayHost
 import com.mapbox.androidauto.car.map.widgets.Margin
+import com.mapbox.androidauto.car.map.widgets.WidgetPosition
 
 /**
  * A widget to show the compass on the map.

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/map/widgets/logo/LogoWidget.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/map/widgets/logo/LogoWidget.kt
@@ -2,10 +2,10 @@ package com.mapbox.androidauto.car.map.widgets.logo
 
 import android.content.Context
 import android.graphics.BitmapFactory
-import com.mapbox.androidauto.car.map.widgets.WidgetPosition
 import com.mapbox.androidauto.R
 import com.mapbox.androidauto.car.map.widgets.ImageOverlayHost
 import com.mapbox.androidauto.car.map.widgets.Margin
+import com.mapbox.androidauto.car.map.widgets.WidgetPosition
 
 /**
  * Logo widget displays the Mapbox logo on the map.

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/navigation/ActiveGuidanceScreen.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/navigation/ActiveGuidanceScreen.kt
@@ -10,15 +10,15 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.mapbox.androidauto.ArrivalState
 import com.mapbox.androidauto.MapboxCarApp
-import com.mapbox.androidauto.car.navigation.roadlabel.RoadLabelSurfaceLayer
-import com.mapbox.androidauto.car.navigation.speedlimit.CarSpeedLimitRenderer
-import com.mapbox.androidauto.logAndroidAuto
 import com.mapbox.androidauto.R
 import com.mapbox.androidauto.car.MainMapActionStrip
 import com.mapbox.androidauto.car.action.MapboxActionProvider
 import com.mapbox.androidauto.car.location.CarLocationRenderer
+import com.mapbox.androidauto.car.navigation.roadlabel.RoadLabelSurfaceLayer
+import com.mapbox.androidauto.car.navigation.speedlimit.CarSpeedLimitRenderer
 import com.mapbox.androidauto.car.placeslistonmap.PlacesListOnMapLayerUtil
 import com.mapbox.androidauto.car.preview.CarRouteLine
+import com.mapbox.androidauto.logAndroidAuto
 import com.mapbox.geojson.Feature
 import com.mapbox.geojson.FeatureCollection
 import com.mapbox.maps.MapboxExperimental
@@ -93,9 +93,12 @@ class ActiveGuidanceScreen(
     }
 
     private val routesObserver = RoutesObserver { result ->
-        val route = result.navigationRoutes.firstOrNull() ?: return@RoutesObserver
-        val coordinate = route.routeOptions.coordinatesList().lastOrNull() ?: return@RoutesObserver
-        val mapboxCarMapSurface = carActiveGuidanceContext.mapboxCarMap.carMapSurface ?: return@RoutesObserver
+        val route = result.navigationRoutes.firstOrNull()
+            ?: return@RoutesObserver
+        val coordinate = route.routeOptions.coordinatesList().lastOrNull()
+            ?: return@RoutesObserver
+        val mapboxCarMapSurface = carActiveGuidanceContext.mapboxCarMap.carMapSurface
+            ?: return@RoutesObserver
         val featureCollection = FeatureCollection.fromFeature(Feature.fromGeometry(coordinate))
         mapboxCarMapSurface.mapSurface.getMapboxMap().getStyle { style ->
             placesLayerUtil.updatePlacesListOnMapLayer(style, featureCollection)

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/navigation/CarActiveGuidanceCarContext.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/navigation/CarActiveGuidanceCarContext.kt
@@ -1,10 +1,10 @@
 package com.mapbox.androidauto.car.navigation
 
+import com.mapbox.androidauto.car.MainCarContext
 import com.mapbox.androidauto.car.navigation.lanes.CarLanesImageRenderer
 import com.mapbox.androidauto.car.navigation.maneuver.CarManeuverIconOptions
 import com.mapbox.androidauto.car.navigation.maneuver.CarManeuverIconRenderer
 import com.mapbox.androidauto.car.navigation.maneuver.CarManeuverInstructionRenderer
-import com.mapbox.androidauto.car.MainCarContext
 import com.mapbox.navigation.ui.tripprogress.api.MapboxTripProgressApi
 import com.mapbox.navigation.ui.tripprogress.model.TripProgressUpdateFormatter
 
@@ -18,10 +18,10 @@ class CarActiveGuidanceCarContext(
     val distanceFormatter = mainCarContext.distanceFormatter
 
     /** NavigationCarContext **/
-    val carDistanceFormatter = CarDistanceFormatter(
+    private val carDistanceFormatter = CarDistanceFormatter(
         mapboxNavigation.navigationOptions.distanceFormatterOptions.unitType
     )
-    val carLaneImageGenerator = CarLanesImageRenderer(carContext)
+    private val carLaneImageGenerator = CarLanesImageRenderer(carContext)
     val navigationInfoMapper = CarNavigationInfoMapper(
         carContext.applicationContext,
         CarManeuverInstructionRenderer(),

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/navigation/CarLocationsOverviewCamera.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/navigation/CarLocationsOverviewCamera.kt
@@ -53,7 +53,9 @@ class CarLocationsOverviewCamera(
                     .maxDuration(0)
                     .build()
 
-                navigationCamera.requestNavigationCameraToOverview(stateTransitionOptions = instantTransition)
+                navigationCamera.requestNavigationCameraToOverview(
+                    stateTransitionOptions = instantTransition
+                )
             }
         }
     }

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/navigation/CarNavigationCamera.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/navigation/CarNavigationCamera.kt
@@ -1,14 +1,12 @@
-@file:Suppress("TooManyFunctions")
-
 package com.mapbox.androidauto.car.navigation
 
 import android.graphics.Rect
 import android.location.Location
 import com.mapbox.androidauto.car.RendererUtils.dpToPx
-import com.mapbox.androidauto.logAndroidAuto
 import com.mapbox.androidauto.car.routes.NavigationRoutesProvider
 import com.mapbox.androidauto.car.routes.RoutesListener
 import com.mapbox.androidauto.car.routes.RoutesProvider
+import com.mapbox.androidauto.logAndroidAuto
 import com.mapbox.maps.CameraOptions
 import com.mapbox.maps.EdgeInsets
 import com.mapbox.maps.MapboxExperimental

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/navigation/CarNavigationEtaMapper.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/navigation/CarNavigationEtaMapper.kt
@@ -5,6 +5,7 @@ import androidx.car.app.model.DateTimeWithZone
 import androidx.car.app.navigation.model.TravelEstimate
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.ui.tripprogress.api.MapboxTripProgressApi
+import com.mapbox.navigation.ui.tripprogress.model.TripProgressUpdateValue
 import java.util.TimeZone
 import java.util.concurrent.TimeUnit
 
@@ -16,10 +17,16 @@ class CarNavigationEtaMapper(
     fun from(routeProgress: RouteProgress): TravelEstimate {
         val result = tripProgressApi.getTripProgress(routeProgress)
         val distance = carDistanceFormatter.carDistance(result.distanceRemaining)
-        val zonedDateTime = DateTimeWithZone.create(result.estimatedTimeToArrival, TimeZone.getDefault())
+        val zonedDateTime =
+            DateTimeWithZone.create(result.estimatedTimeToArrival, TimeZone.getDefault())
         return TravelEstimate.Builder(distance, zonedDateTime)
-            .setRemainingTimeSeconds(result.currentLegTimeRemaining.toLong() + TimeUnit.MINUTES.toSeconds(1) / 2)
+            .setRemainingTimeSeconds(remainingTimeSeconds(result))
             .setRemainingTimeColor(CarColor.GREEN)
             .build()
+    }
+
+    private fun remainingTimeSeconds(tripProgressUpdateValue: TripProgressUpdateValue): Long {
+        val halfSecond = TimeUnit.MINUTES.toSeconds(1) / 2
+        return tripProgressUpdateValue.currentLegTimeRemaining.toLong() + halfSecond
     }
 }

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/navigation/CarNavigationInfoMapper.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/navigation/CarNavigationInfoMapper.kt
@@ -48,14 +48,25 @@ class CarNavigationInfoMapper(
         val distanceRemaining = currentStepProgress?.distanceRemaining ?: return null
         val maneuver = expectedManeuvers.value?.firstOrNull()
         return maneuver?.primary?.let { primary ->
-            val carManeuver = CarManeuverMapper.from(primary.type, primary.modifier, primary.degrees)
+            val carManeuver =
+                CarManeuverMapper.from(primary.type, primary.modifier, primary.degrees)
             carManeuverIconRenderer.renderManeuverIcon(primary)?.let { carManeuver.setIcon(it) }
             val primaryInstruction =
-                renderManeuver(primary.componentList, routeShields, primaryExitOptions, primary.modifier)
+                renderManeuver(
+                    primary.componentList,
+                    routeShields,
+                    primaryExitOptions,
+                    primary.modifier
+                )
             val instruction = SpannableStringBuilder.valueOf(primaryInstruction)
             maneuver.secondary?.let { secondary ->
                 val secondaryInstruction =
-                    renderManeuver(secondary.componentList, routeShields, secondaryExitOptions, secondary.modifier)
+                    renderManeuver(
+                        secondary.componentList,
+                        routeShields,
+                        secondaryExitOptions,
+                        secondary.modifier
+                    )
                 instruction.append(System.lineSeparator())
                 instruction.append(secondaryInstruction)
             }
@@ -72,12 +83,22 @@ class CarNavigationInfoMapper(
         }
     }
 
-    private fun RoutingInfo.Builder.withOptionalNextStep(maneuver: Maneuver, routeShields: List<RouteShield>) = apply {
+    private fun RoutingInfo.Builder.withOptionalNextStep(
+        maneuver: Maneuver,
+        routeShields: List<RouteShield>
+    ) = apply {
         maneuver.sub?.let { subManeuver ->
-            val nextCarManeuver = CarManeuverMapper.from(subManeuver.type, subManeuver.modifier, subManeuver.degrees)
-            carManeuverIconRenderer.renderManeuverIcon(subManeuver)?.let { nextCarManeuver.setIcon(it) }
+            val nextCarManeuver =
+                CarManeuverMapper.from(subManeuver.type, subManeuver.modifier, subManeuver.degrees)
+            carManeuverIconRenderer.renderManeuverIcon(subManeuver)
+                ?.let { nextCarManeuver.setIcon(it) }
             val instruction =
-                renderManeuver(subManeuver.componentList, routeShields, subExitOptions, subManeuver.modifier)
+                renderManeuver(
+                    subManeuver.componentList,
+                    routeShields,
+                    subExitOptions,
+                    subManeuver.modifier
+                )
             val nextStep = Step.Builder(instruction)
                 .setManeuver(nextCarManeuver.build())
                 .build()
@@ -95,7 +116,13 @@ class CarNavigationInfoMapper(
         exitView.updateTextAppearance(exitOptions.textAppearance)
         // TODO write when to check the type and pass MUTCD or VIENNA when the data is available
         exitView.updateExitProperties(exitOptions.mutcdExitProperties)
-        return carManeuverInstructionRenderer.renderInstruction(maneuver, shields, exitView, modifier, IMAGE_HEIGHT)
+        return carManeuverInstructionRenderer.renderInstruction(
+            maneuver,
+            shields,
+            exitView,
+            modifier,
+            IMAGE_HEIGHT
+        )
     }
 
     private companion object {

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/navigation/maneuver/CarManeuverIconRenderer.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/navigation/maneuver/CarManeuverIconRenderer.kt
@@ -24,17 +24,37 @@ class CarManeuverIconRenderer(
     private val turnIconsApi = MapboxTurnIconsApi(turnIconResources)
 
     fun renderManeuverIcon(maneuver: PrimaryManeuver): CarIcon? {
-        return renderManeuverIcon(maneuver.type, maneuver.degrees, maneuver.modifier, maneuver.drivingSide)
+        return renderManeuverIcon(
+            maneuver.type,
+            maneuver.degrees,
+            maneuver.modifier,
+            maneuver.drivingSide
+        )
     }
 
     fun renderManeuverIcon(maneuver: SubManeuver): CarIcon? {
-        return renderManeuverIcon(maneuver.type, maneuver.degrees, maneuver.modifier, maneuver.drivingSide)
+        return renderManeuverIcon(
+            maneuver.type,
+            maneuver.degrees,
+            maneuver.modifier,
+            maneuver.drivingSide
+        )
     }
 
-    private fun renderManeuverIcon(type: String?, degrees: Double?, modifier: String?, drivingSide: String?): CarIcon? {
-        val maneuverTurnIcon = turnIconsApi.generateTurnIcon(type, degrees?.toFloat(), modifier, drivingSide)
-            .onError { logAndroidAutoFailure("CarManeuverIconRenderer renderManeuverIcon error ${it.errorMessage}") }
-            .value
+    private fun renderManeuverIcon(
+        type: String?,
+        degrees: Double?,
+        modifier: String?,
+        drivingSide: String?
+    ): CarIcon? {
+        val maneuverTurnIcon =
+            turnIconsApi.generateTurnIcon(type, degrees?.toFloat(), modifier, drivingSide)
+                .onError {
+                    logAndroidAutoFailure(
+                        "CarManeuverIconRenderer renderManeuverIcon error ${it.errorMessage}"
+                    )
+                }
+                .value
         val turnIconRes = maneuverTurnIcon?.icon ?: return null
         val bitmap = renderBitmap(turnIconRes, maneuverTurnIcon.shouldFlipIcon)
         return CarIcon.Builder(IconCompat.createWithBitmap(bitmap)).build()

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/navigation/maneuver/CarManeuverInstructionRenderer.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/navigation/maneuver/CarManeuverInstructionRenderer.kt
@@ -49,7 +49,13 @@ class CarManeuverInstructionRenderer {
                 append(getRenderedExit(node, exitView, modifier)).append(" ")
             }
             is RoadShieldComponentNode -> {
-                append(getRenderedShield(node.text, desiredHeight, getShieldToRender(node, shields))).append(" ")
+                append(
+                    getRenderedShield(
+                        node.text,
+                        desiredHeight,
+                        getShieldToRender(node, shields)
+                    )
+                ).append(" ")
             }
             is DelimiterComponentNode -> {
                 append(node.text).append(" ")
@@ -72,7 +78,10 @@ class CarManeuverInstructionRenderer {
         return exitBuilder
     }
 
-    private fun getShieldToRender(node: RoadShieldComponentNode, roadShields: List<RouteShield>): RouteShield? {
+    private fun getShieldToRender(
+        node: RoadShieldComponentNode,
+        roadShields: List<RouteShield>
+    ): RouteShield? {
         return node.mapboxShield?.let { shield ->
             roadShields.find { it is RouteShield.MapboxDesignedShield && it.compareWith(shield) }
         } ?: node.shieldUrl?.let { shieldUrl ->
@@ -80,7 +89,11 @@ class CarManeuverInstructionRenderer {
         }
     }
 
-    private fun getRenderedShield(shieldText: String, desiredHeight: Int, shield: RouteShield?): CharSequence {
+    private fun getRenderedShield(
+        shieldText: String,
+        desiredHeight: Int,
+        shield: RouteShield?
+    ): CharSequence {
         val roadShieldBuilder = SpannableStringBuilder(shieldText)
         val shieldIcon = shield?.byteArray
         if (shieldIcon != null && shieldIcon.isNotEmpty()) {
@@ -88,7 +101,12 @@ class CarManeuverInstructionRenderer {
             SvgUtil.renderAsBitmapWithHeight(stream, desiredHeight)?.let { svgBitmap ->
                 val icon = CarIcon.Builder(IconCompat.createWithBitmap(svgBitmap)).build()
                 val carIconSpan = CarIconSpan.create(icon, CarIconSpan.ALIGN_CENTER)
-                roadShieldBuilder.setSpan(carIconSpan, 0, shieldText.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+                roadShieldBuilder.setSpan(
+                    carIconSpan,
+                    0,
+                    shieldText.length,
+                    Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+                )
             }
         }
         return roadShieldBuilder

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/navigation/maneuver/CarManeuverMapper.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/navigation/maneuver/CarManeuverMapper.kt
@@ -15,7 +15,6 @@ import com.mapbox.navigation.ui.maneuver.model.ManeuverError
 import java.util.Calendar
 import java.util.TimeZone
 
-@Suppress("TooManyFunctions")
 object CarManeuverMapper {
 
     fun from(routeProgress: RouteProgress, maneuverApi: MapboxManeuverApi): Trip {

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/navigation/roadlabel/RoadLabelRenderer.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/navigation/roadlabel/RoadLabelRenderer.kt
@@ -38,7 +38,11 @@ class RoadLabelRenderer(private val resources: Resources) {
                 is Component.Shield -> component.bitmap.height
             }
         }
-        val bitmap = Bitmap.createBitmap(width + TEXT_PADDING * 2, height + TEXT_PADDING * 2, Bitmap.Config.ARGB_8888)
+        val bitmap = Bitmap.createBitmap(
+            width + TEXT_PADDING * 2,
+            height + TEXT_PADDING * 2,
+            Bitmap.Config.ARGB_8888
+        )
         val textBaselineY = TEXT_PADDING + (height - textPaint.descent() - textPaint.ascent()) / 2
         val shieldCenterY = TEXT_PADDING + height / 2f
         bitmap.eraseColor(options.backgroundColor)
@@ -49,7 +53,10 @@ class RoadLabelRenderer(private val resources: Resources) {
         return bitmap
     }
 
-    private fun measureRoadLabel(road: List<RoadComponent>, shields: List<RouteShield>): List<Component> {
+    private fun measureRoadLabel(
+        road: List<RoadComponent>,
+        shields: List<RouteShield>
+    ): List<Component> {
         return road.map { component ->
             getShieldBitmap(component, shields)
                 ?.let { Component.Shield(it) }
@@ -98,7 +105,12 @@ class RoadLabelRenderer(private val resources: Resources) {
         components.fold(TEXT_PADDING) { x, component ->
             x + spaceWidth + when (component) {
                 is Component.Text -> {
-                    drawText(component.value, x + component.rect.width() / 2f, textBaselineY, textPaint)
+                    drawText(
+                        component.value,
+                        x + component.rect.width() / 2f,
+                        textBaselineY,
+                        textPaint
+                    )
                     component.rect.width()
                 }
                 is Component.Shield -> {

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/navigation/speedlimit/CarSpeedLimitRenderer.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/navigation/speedlimit/CarSpeedLimitRenderer.kt
@@ -2,8 +2,8 @@ package com.mapbox.androidauto.car.navigation.speedlimit
 
 import android.graphics.Rect
 import android.location.Location
-import com.mapbox.androidauto.logAndroidAuto
 import com.mapbox.androidauto.car.MainCarContext
+import com.mapbox.androidauto.logAndroidAuto
 import com.mapbox.maps.EdgeInsets
 import com.mapbox.maps.MapboxExperimental
 import com.mapbox.maps.extension.androidauto.MapboxCarMapObserver
@@ -25,25 +25,33 @@ class CarSpeedLimitRenderer(
 
     private val locationObserver = object : LocationObserver {
 
-        @Suppress("MagicNumber")
         override fun onNewLocationMatcherResult(locationMatcherResult: LocationMatcherResult) {
-            val speedKmph = locationMatcherResult.enhancedLocation.speed / METERS_IN_KILOMETER * SECONDS_IN_HOUR
-            when (mainCarContext.mapboxNavigation.navigationOptions.distanceFormatterOptions.unitType) {
-                UnitType.IMPERIAL -> {
-                    val speedLimit = locationMatcherResult.speedLimit?.speedKmph?.let { speedLimitKmph ->
-                        5 * (speedLimitKmph / KILOMETERS_IN_MILE / 5).roundToInt()
-                    }
-                    val speed = speedKmph / KILOMETERS_IN_MILE
-                    speedLimitWidget.update(speedLimit, speed.roundToInt())
-                }
-                UnitType.METRIC -> {
-                    speedLimitWidget.update(locationMatcherResult.speedLimit?.speedKmph, speedKmph.roundToInt())
-                }
-            }
+            updateSpeed(locationMatcherResult)
         }
 
         override fun onNewRawLocation(rawLocation: Location) {
             // no op
+        }
+    }
+
+    private fun updateSpeed(locationMatcherResult: LocationMatcherResult) {
+        val speedKmph =
+            locationMatcherResult.enhancedLocation.speed / METERS_IN_KILOMETER * SECONDS_IN_HOUR
+        when (mainCarContext.mapboxNavigation.navigationOptions.distanceFormatterOptions.unitType) {
+            UnitType.IMPERIAL -> {
+                val speedLimit =
+                    locationMatcherResult.speedLimit?.speedKmph?.let { speedLimitKmph ->
+                        5 * (speedLimitKmph / KILOMETERS_IN_MILE / 5).roundToInt()
+                    }
+                val speed = speedKmph / KILOMETERS_IN_MILE
+                speedLimitWidget.update(speedLimit, speed.roundToInt())
+            }
+            UnitType.METRIC -> {
+                speedLimitWidget.update(
+                    locationMatcherResult.speedLimit?.speedKmph,
+                    speedKmph.roundToInt()
+                )
+            }
         }
     }
 

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/navigation/speedlimit/SpeedLimitWidget.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/navigation/speedlimit/SpeedLimitWidget.kt
@@ -15,7 +15,6 @@ import com.mapbox.maps.EdgeInsets
 /**
  * Widget to display a speed limit sign on the map.
  */
-@Suppress("MagicNumber")
 class SpeedLimitWidget(
     /**
      * The position of the widget.

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/placeslistonmap/PlaceMarkerRenderer.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/placeslistonmap/PlaceMarkerRenderer.kt
@@ -9,8 +9,8 @@ import androidx.appcompat.view.ContextThemeWrapper
 import androidx.car.app.model.CarIcon
 import androidx.core.graphics.drawable.IconCompat
 import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat
-import com.mapbox.androidauto.car.RendererUtils.dpToPx
 import com.mapbox.androidauto.R
+import com.mapbox.androidauto.car.RendererUtils.dpToPx
 
 /**
  * Render bitmaps that can be shown as markers on the map.

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/placeslistonmap/PlacesListOnMapProvider.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/placeslistonmap/PlacesListOnMapProvider.kt
@@ -1,8 +1,8 @@
 package com.mapbox.androidauto.car.placeslistonmap
 
-import com.mapbox.bindgen.Expected
-import com.mapbox.androidauto.car.search.PlaceRecord
 import com.mapbox.androidauto.car.search.GetPlacesError
+import com.mapbox.androidauto.car.search.PlaceRecord
+import com.mapbox.bindgen.Expected
 
 interface PlacesListOnMapProvider {
     suspend fun getPlaces(): Expected<GetPlacesError, List<PlaceRecord>>

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/placeslistonmap/PlacesListOnMapScreen.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/placeslistonmap/PlacesListOnMapScreen.kt
@@ -11,7 +11,6 @@ import androidx.car.app.navigation.model.PlaceListNavigationTemplate
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.mapbox.androidauto.MapboxCarApp
-import com.mapbox.androidauto.logAndroidAuto
 import com.mapbox.androidauto.R
 import com.mapbox.androidauto.car.MainCarContext
 import com.mapbox.androidauto.car.action.MapboxActionProvider
@@ -22,6 +21,7 @@ import com.mapbox.androidauto.car.preview.CarRouteRequestCallback
 import com.mapbox.androidauto.car.preview.RoutePreviewCarContext
 import com.mapbox.androidauto.car.search.PlaceRecord
 import com.mapbox.androidauto.car.search.SearchCarContext
+import com.mapbox.androidauto.logAndroidAuto
 import com.mapbox.geojson.Feature
 import com.mapbox.geojson.FeatureCollection
 import com.mapbox.geojson.Point
@@ -35,7 +35,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.util.concurrent.CopyOnWriteArrayList
 
-@OptIn(MapboxExperimental::class)
+@MapboxExperimental
 class PlacesListOnMapScreen(
     private val mainCarContext: MainCarContext,
     private val placesProvider: PlacesListOnMapProvider,
@@ -192,7 +192,9 @@ class PlacesListOnMapScreen(
             placeRecords.clear()
             expectedPlaceRecords.fold(
                 {
-                    logAndroidAuto("PlacesListOnMapScreen ${it.errorMessage}, ${it.throwable?.stackTrace}")
+                    logAndroidAuto(
+                        "PlacesListOnMapScreen ${it.errorMessage}, ${it.throwable?.stackTrace}"
+                    )
                 },
                 {
                     placeRecords.addAll(it)

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/preview/CarRouteLine.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/preview/CarRouteLine.kt
@@ -1,10 +1,10 @@
 package com.mapbox.androidauto.car.preview
 
-import com.mapbox.androidauto.logAndroidAuto
 import com.mapbox.androidauto.car.MainCarContext
 import com.mapbox.androidauto.car.routes.NavigationRoutesProvider
 import com.mapbox.androidauto.car.routes.RoutesListener
 import com.mapbox.androidauto.car.routes.RoutesProvider
+import com.mapbox.androidauto.logAndroidAuto
 import com.mapbox.maps.MapboxExperimental
 import com.mapbox.maps.extension.androidauto.MapboxCarMapObserver
 import com.mapbox.maps.extension.androidauto.MapboxCarMapSurface
@@ -51,7 +51,8 @@ class CarRouteLine internal constructor(
 
     private val onPositionChangedListener = OnIndicatorPositionChangedListener { point ->
         val result = routeLineApi.updateTraveledRouteLine(point)
-        mainCarContext.mapboxCarMap.carMapSurface?.mapSurface?.getMapboxMap()?.getStyle()?.let { style ->
+        val mapboxMap = mainCarContext.mapboxCarMap.carMapSurface?.mapSurface?.getMapboxMap()
+        mapboxMap?.getStyle()?.let { style ->
             routeLineView.renderRouteLineUpdate(style, result)
         }
     }

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/preview/CarRoutePreviewScreen.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/preview/CarRoutePreviewScreen.kt
@@ -14,9 +14,6 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.mapbox.androidauto.ActiveGuidanceState
 import com.mapbox.androidauto.MapboxCarApp
-import com.mapbox.androidauto.car.navigation.speedlimit.CarSpeedLimitRenderer
-import com.mapbox.androidauto.logAndroidAuto
-import com.mapbox.androidauto.navigation.audioguidance.muteAudioGuidance
 import com.mapbox.androidauto.R
 import com.mapbox.androidauto.car.feedback.core.CarFeedbackSender
 import com.mapbox.androidauto.car.feedback.ui.CarFeedbackAction
@@ -24,10 +21,14 @@ import com.mapbox.androidauto.car.feedback.ui.routePreviewCarFeedbackProvider
 import com.mapbox.androidauto.car.location.CarLocationRenderer
 import com.mapbox.androidauto.car.navigation.CarCameraMode
 import com.mapbox.androidauto.car.navigation.CarNavigationCamera
+import com.mapbox.androidauto.car.navigation.speedlimit.CarSpeedLimitRenderer
 import com.mapbox.androidauto.car.placeslistonmap.PlacesListOnMapLayerUtil
 import com.mapbox.androidauto.car.search.PlaceRecord
+import com.mapbox.androidauto.logAndroidAuto
+import com.mapbox.androidauto.navigation.audioguidance.muteAudioGuidance
 import com.mapbox.geojson.Feature
 import com.mapbox.geojson.FeatureCollection
+import com.mapbox.maps.MapboxExperimental
 import com.mapbox.maps.extension.androidauto.MapboxCarMapObserver
 import com.mapbox.maps.extension.androidauto.MapboxCarMapSurface
 import com.mapbox.navigation.base.route.NavigationRoute
@@ -36,6 +37,7 @@ import com.mapbox.navigation.base.route.NavigationRoute
  * After a destination has been selected. This view previews the route and lets
  * you select alternatives. From here, you can start turn-by-turn navigation.
  */
+@MapboxExperimental
 class CarRoutePreviewScreen(
     private val routePreviewCarContext: RoutePreviewCarContext,
     private val placeRecord: PlaceRecord,
@@ -99,7 +101,9 @@ class CarRoutePreviewScreen(
         lifecycle.addObserver(object : DefaultLifecycleObserver {
             override fun onResume(owner: LifecycleOwner) {
                 logAndroidAuto("CarRoutePreviewScreen onResume")
-                routePreviewCarContext.carContext.onBackPressedDispatcher.addCallback(backPressCallback)
+                routePreviewCarContext.carContext.onBackPressedDispatcher.addCallback(
+                    backPressCallback
+                )
                 routePreviewCarContext.mapboxCarMap.registerObserver(carLocationRenderer)
                 routePreviewCarContext.mapboxCarMap.registerObserver(carSpeedLimitRenderer)
                 routePreviewCarContext.mapboxCarMap.registerObserver(carNavigationCamera)
@@ -173,7 +177,9 @@ class CarRoutePreviewScreen(
                 Action.Builder()
                     .setTitle(carContext.getString(R.string.car_action_preview_navigate_button))
                     .setOnClickListener {
-                        routePreviewCarContext.mapboxNavigation.setNavigationRoutes(routesProvider.routes)
+                        routePreviewCarContext.mapboxNavigation.setNavigationRoutes(
+                            routesProvider.routes
+                        )
                         MapboxCarApp.updateCarAppState(ActiveGuidanceState)
                     }
                     .build(),

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/preview/CarRouteRequest.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/preview/CarRouteRequest.kt
@@ -1,10 +1,10 @@
 package com.mapbox.androidauto.car.preview
 
+import com.mapbox.androidauto.car.search.PlaceRecord
 import com.mapbox.androidauto.logAndroidAuto
 import com.mapbox.androidauto.logAndroidAutoFailure
 import com.mapbox.api.directions.v5.DirectionsCriteria
 import com.mapbox.api.directions.v5.models.RouteOptions
-import com.mapbox.androidauto.car.search.PlaceRecord
 import com.mapbox.geojson.Point
 import com.mapbox.navigation.base.extensions.applyDefaultNavigationOptions
 import com.mapbox.navigation.base.formatter.UnitType
@@ -45,7 +45,10 @@ class CarRouteRequest(
                 placeRecord,
                 object : CarRouteRequestCallback {
 
-                    override fun onRoutesReady(placeRecord: PlaceRecord, routes: List<NavigationRoute>) {
+                    override fun onRoutesReady(
+                        placeRecord: PlaceRecord,
+                        routes: List<NavigationRoute>
+                    ) {
                         continuation.resume(routes)
                     }
 

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/search/CarSearchEngine.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/search/CarSearchEngine.kt
@@ -26,7 +26,10 @@ class CarSearchEngine(
 
     private val searchCallback = object : SearchSuggestionsCallback {
 
-        override fun onSuggestions(suggestions: List<SearchSuggestion>, responseInfo: ResponseInfo) {
+        override fun onSuggestions(
+            suggestions: List<SearchSuggestion>,
+            responseInfo: ResponseInfo
+        ) {
             logAndroidAuto("carLocationProvider result ${searchResults.size}")
             searchResults.clear()
             searchResults.addAll(suggestions)

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/search/FavoritesApi.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/search/FavoritesApi.kt
@@ -1,12 +1,12 @@
 package com.mapbox.androidauto.car.search
 
 import androidx.car.app.CarContext
-import com.mapbox.bindgen.Expected
-import com.mapbox.bindgen.ExpectedFactory
 import com.mapbox.androidauto.car.feedback.core.CarFeedbackItemProvider
 import com.mapbox.androidauto.car.feedback.ui.CarFeedbackItem
 import com.mapbox.androidauto.car.feedback.ui.buildSearchPlacesCarFeedbackItems
 import com.mapbox.androidauto.car.placeslistonmap.PlacesListOnMapProvider
+import com.mapbox.bindgen.Expected
+import com.mapbox.bindgen.ExpectedFactory
 import com.mapbox.search.AsyncOperationTask
 import com.mapbox.search.CompletionCallback
 import com.mapbox.search.record.FavoriteRecord
@@ -65,7 +65,9 @@ class FavoritesApi(
         }
     }
 
-    suspend fun addFavorite(favoriteRecord: FavoriteRecord): Expected<GetPlacesError, FavoriteRecord> {
+    suspend fun addFavorite(
+        favoriteRecord: FavoriteRecord
+    ): Expected<GetPlacesError, FavoriteRecord> {
         addFavoriteTask?.cancel()
         return suspendCoroutine { continuation ->
             addFavoriteTask = favoritesProvider.add(

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/search/SearchScreen.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/search/SearchScreen.kt
@@ -9,8 +9,6 @@ import androidx.car.app.model.ItemList
 import androidx.car.app.model.Row
 import androidx.car.app.model.SearchTemplate
 import androidx.car.app.model.Template
-import com.mapbox.androidauto.logAndroidAuto
-import com.mapbox.androidauto.logAndroidAutoFailure
 import com.mapbox.androidauto.R
 import com.mapbox.androidauto.car.feedback.core.CarFeedbackSender
 import com.mapbox.androidauto.car.feedback.ui.CarFeedbackAction
@@ -18,6 +16,8 @@ import com.mapbox.androidauto.car.feedback.ui.buildSearchPlacesCarFeedbackProvid
 import com.mapbox.androidauto.car.preview.CarRoutePreviewScreen
 import com.mapbox.androidauto.car.preview.CarRouteRequestCallback
 import com.mapbox.androidauto.car.preview.RoutePreviewCarContext
+import com.mapbox.androidauto.logAndroidAuto
+import com.mapbox.androidauto.logAndroidAutoFailure
 import com.mapbox.navigation.base.route.NavigationRoute
 import com.mapbox.search.result.SearchSuggestion
 

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/deeplink/GeoDeeplinkGeocoding.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/deeplink/GeoDeeplinkGeocoding.kt
@@ -20,7 +20,6 @@ class GeoDeeplinkGeocoding(
 ) {
     var currentMapboxGeocoding: MapboxGeocoding? = null
 
-    @Suppress("UseCheckOrError")
     suspend fun requestPlaces(
         geoDeeplink: GeoDeeplink,
         origin: Point

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/deeplink/GeoDeeplinkNavigateAction.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/deeplink/GeoDeeplinkNavigateAction.kt
@@ -3,13 +3,13 @@ package com.mapbox.androidauto.deeplink
 import android.content.Intent
 import androidx.car.app.Screen
 import androidx.lifecycle.Lifecycle
-import com.mapbox.androidauto.logAndroidAuto
 import com.mapbox.androidauto.car.MainCarContext
 import com.mapbox.androidauto.car.feedback.core.CarFeedbackSender
 import com.mapbox.androidauto.car.feedback.ui.CarFeedbackAction
 import com.mapbox.androidauto.car.placeslistonmap.PlaceMarkerRenderer
 import com.mapbox.androidauto.car.placeslistonmap.PlacesListItemMapper
 import com.mapbox.androidauto.car.placeslistonmap.PlacesListOnMapScreen
+import com.mapbox.androidauto.logAndroidAuto
 import com.mapbox.navigation.core.geodeeplink.GeoDeeplink
 import com.mapbox.navigation.core.geodeeplink.GeoDeeplinkParser
 

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/deeplink/GeoDeeplinkPlacesListOnMapProvider.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/deeplink/GeoDeeplinkPlacesListOnMapProvider.kt
@@ -2,9 +2,6 @@ package com.mapbox.androidauto.deeplink
 
 import androidx.car.app.CarContext
 import com.mapbox.androidauto.MapboxCarApp
-import com.mapbox.api.geocoding.v5.models.GeocodingResponse
-import com.mapbox.bindgen.Expected
-import com.mapbox.bindgen.ExpectedFactory
 import com.mapbox.androidauto.car.feedback.core.CarFeedbackItemProvider
 import com.mapbox.androidauto.car.feedback.ui.CarFeedbackItem
 import com.mapbox.androidauto.car.feedback.ui.buildSearchPlacesCarFeedbackItems
@@ -12,6 +9,9 @@ import com.mapbox.androidauto.car.placeslistonmap.PlacesListOnMapProvider
 import com.mapbox.androidauto.car.search.GetPlacesError
 import com.mapbox.androidauto.car.search.PlaceRecord
 import com.mapbox.androidauto.car.search.PlaceRecordMapper
+import com.mapbox.api.geocoding.v5.models.GeocodingResponse
+import com.mapbox.bindgen.Expected
+import com.mapbox.bindgen.ExpectedFactory
 import com.mapbox.geojson.Point
 import com.mapbox.navigation.core.geodeeplink.GeoDeeplink
 
@@ -23,7 +23,6 @@ class GeoDeeplinkPlacesListOnMapProvider(
 
     private var geocodingResponse: GeocodingResponse? = null
 
-    @Suppress("ReturnCount")
     override suspend fun getPlaces(): Expected<GetPlacesError, List<PlaceRecord>> {
         // Wait for an origin location
         val origin = MapboxCarApp.carAppLocationService().validLocation()

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/navigation/audioguidance/CarAudioGuidanceUi.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/navigation/audioguidance/CarAudioGuidanceUi.kt
@@ -10,9 +10,9 @@ import androidx.lifecycle.coroutineScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.mapbox.androidauto.MapboxCarApp
 import com.mapbox.androidauto.R
-import kotlinx.coroutines.flow.collect
 import com.mapbox.androidauto.car.MainActionStrip
 import com.mapbox.androidauto.car.action.MapboxActionProvider
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 
@@ -57,7 +57,11 @@ class CarAudioGuidanceUi : MapboxActionProvider.ScreenActionProvider {
         return buildSoundButtonAction(screen)
     }
 
-    private fun buildIconAction(screen: Screen, @DrawableRes icon: Int, onClick: () -> Unit) = Action.Builder()
+    private fun buildIconAction(
+        screen: Screen,
+        @DrawableRes icon: Int,
+        onClick: () -> Unit
+    ) = Action.Builder()
         .setIcon(
             CarIcon.Builder(
                 IconCompat.createWithResource(screen.carContext, icon)

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/navigation/audioguidance/MapboxAudioGuidanceServices.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/navigation/audioguidance/MapboxAudioGuidanceServices.kt
@@ -7,11 +7,16 @@ import com.mapbox.navigation.ui.voice.api.MapboxSpeechApi
 import com.mapbox.navigation.ui.voice.api.MapboxVoiceInstructionsPlayer
 
 interface MapboxAudioGuidanceServices {
-    fun mapboxAudioGuidanceVoice(mapboxNavigation: MapboxNavigation, language: String): MapboxAudioGuidanceVoice
+    fun mapboxAudioGuidanceVoice(
+        mapboxNavigation: MapboxNavigation,
+        language: String
+    ): MapboxAudioGuidanceVoice
+
     fun mapboxSpeechApi(mapboxNavigation: MapboxNavigation, language: String): MapboxSpeechApi
     fun mapboxVoiceInstructionsPlayer(
         mapboxNavigation: MapboxNavigation,
         language: String,
     ): MapboxVoiceInstructionsPlayer
+
     fun mapboxVoiceInstructions(mapboxNavigation: MapboxNavigation): MapboxVoiceInstructions
 }

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/navigation/audioguidance/impl/MapboxAudioGuidanceImpl.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/navigation/audioguidance/impl/MapboxAudioGuidanceImpl.kt
@@ -99,14 +99,17 @@ class MapboxAudioGuidanceImpl(
      * Top level flow that will switch based on the language and muted state.
      */
     @OptIn(ExperimentalCoroutinesApi::class)
-    private fun audioGuidanceFlow(mapboxNavigation: MapboxNavigation): Flow<MapboxAudioGuidance.State> {
+    private fun audioGuidanceFlow(
+        mapboxNavigation: MapboxNavigation
+    ): Flow<MapboxAudioGuidance.State> {
         return combine(
             audioGuidanceServices.mapboxVoiceInstructions(mapboxNavigation).voiceLanguage(),
             carAppConfigOwner.language(),
         ) { voiceLanguage, deviceLanguage -> voiceLanguage ?: deviceLanguage }
             .distinctUntilChanged()
             .flatMapLatest { language ->
-                val audioGuidance = audioGuidanceServices.mapboxAudioGuidanceVoice(mapboxNavigation, language)
+                val audioGuidance =
+                    audioGuidanceServices.mapboxAudioGuidanceVoice(mapboxNavigation, language)
                 carAppDataStore.read(StoreAudioGuidanceMuted).flatMapLatest { isMuted ->
                     if (isMuted) {
                         silentFlow(mapboxNavigation)

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/navigation/audioguidance/impl/MapboxAudioGuidanceServicesImpl.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/navigation/audioguidance/impl/MapboxAudioGuidanceServicesImpl.kt
@@ -12,14 +12,18 @@ class MapboxAudioGuidanceServicesImpl : MapboxAudioGuidanceServices {
         language: String,
     ): MapboxAudioGuidanceVoice {
         val mapboxSpeechApi = mapboxSpeechApi(mapboxNavigation, language)
-        val mapboxVoiceInstructionsPlayer = mapboxVoiceInstructionsPlayer(mapboxNavigation, language)
+        val mapboxVoiceInstructionsPlayer =
+            mapboxVoiceInstructionsPlayer(mapboxNavigation, language)
         return MapboxAudioGuidanceVoice(
             mapboxSpeechApi,
             mapboxVoiceInstructionsPlayer
         )
     }
 
-    override fun mapboxSpeechApi(mapboxNavigation: MapboxNavigation, language: String): MapboxSpeechApi {
+    override fun mapboxSpeechApi(
+        mapboxNavigation: MapboxNavigation,
+        language: String
+    ): MapboxSpeechApi {
         val applicationContext = mapboxNavigation.navigationOptions.applicationContext
         val accessToken = mapboxNavigation.navigationOptions.accessToken!!
         return MapboxSpeechApi(applicationContext, accessToken, language)
@@ -34,7 +38,7 @@ class MapboxAudioGuidanceServicesImpl : MapboxAudioGuidanceServices {
         return MapboxVoiceInstructionsPlayer(applicationContext, accessToken, language)
     }
 
-    override fun mapboxVoiceInstructions(mapboxNavigation: MapboxNavigation): MapboxVoiceInstructions {
-        return MapboxVoiceInstructions(mapboxNavigation)
-    }
+    override fun mapboxVoiceInstructions(
+        mapboxNavigation: MapboxNavigation
+    ) = MapboxVoiceInstructions(mapboxNavigation)
 }

--- a/libnavui-androidauto/src/test/java/com/mapbox/androidauto/MapboxCarNavigationManagerTest.kt
+++ b/libnavui-androidauto/src/test/java/com/mapbox/androidauto/MapboxCarNavigationManagerTest.kt
@@ -1,5 +1,3 @@
-@file:Suppress("NoMockkVerifyImport")
-
 package com.mapbox.androidauto
 
 import androidx.car.app.CarContext

--- a/libnavui-androidauto/src/test/java/com/mapbox/androidauto/car/navigation/maneuver/CarManeuverMapperTest.kt
+++ b/libnavui-androidauto/src/test/java/com/mapbox/androidauto/car/navigation/maneuver/CarManeuverMapperTest.kt
@@ -1,5 +1,3 @@
-@file:Suppress("NoMockkVerifyImport")
-
 package com.mapbox.androidauto.car.navigation.maneuver
 
 import androidx.car.app.navigation.model.Maneuver

--- a/libnavui-androidauto/src/test/java/com/mapbox/androidauto/car/placeslistonmap/PlacesListItemMapperTest.kt
+++ b/libnavui-androidauto/src/test/java/com/mapbox/androidauto/car/placeslistonmap/PlacesListItemMapperTest.kt
@@ -3,8 +3,8 @@ package com.mapbox.androidauto.car.placeslistonmap
 import android.location.Location
 import androidx.car.app.model.CarIcon
 import androidx.core.graphics.drawable.IconCompat
-import com.mapbox.androidauto.testing.MapboxRobolectricTestRunner
 import com.mapbox.androidauto.car.search.PlaceRecord
+import com.mapbox.androidauto.testing.MapboxRobolectricTestRunner
 import com.mapbox.geojson.Point
 import com.mapbox.navigation.base.formatter.UnitType
 import io.mockk.every

--- a/libnavui-androidauto/src/test/java/com/mapbox/androidauto/car/placeslistonmap/PlacesListOnMapLayerUtilTest.kt
+++ b/libnavui-androidauto/src/test/java/com/mapbox/androidauto/car/placeslistonmap/PlacesListOnMapLayerUtilTest.kt
@@ -1,12 +1,10 @@
-@file:Suppress("NoMockkVerifyImport")
-
 package com.mapbox.androidauto.car.placeslistonmap
 
 import android.content.Context
 import android.graphics.Bitmap
 import androidx.test.core.app.ApplicationProvider
-import com.mapbox.bindgen.ExpectedFactory
 import com.mapbox.androidauto.testing.MapboxRobolectricTestRunner
+import com.mapbox.bindgen.ExpectedFactory
 import com.mapbox.geojson.FeatureCollection
 import com.mapbox.maps.Style
 import com.mapbox.maps.extension.style.layers.addLayer

--- a/libnavui-androidauto/src/test/java/com/mapbox/androidauto/car/preview/CarRouteRequestTest.kt
+++ b/libnavui-androidauto/src/test/java/com/mapbox/androidauto/car/preview/CarRouteRequestTest.kt
@@ -1,5 +1,3 @@
-@file:Suppress("NoMockkVerifyImport")
-
 package com.mapbox.androidauto.car.preview
 
 import androidx.test.core.app.ApplicationProvider

--- a/libnavui-androidauto/src/test/java/com/mapbox/androidauto/car/search/FavoritesApiTest.kt
+++ b/libnavui-androidauto/src/test/java/com/mapbox/androidauto/car/search/FavoritesApiTest.kt
@@ -1,5 +1,3 @@
-@file:Suppress("NoMockkVerifyImport")
-
 package com.mapbox.androidauto.car.search
 
 import androidx.car.app.CarContext

--- a/libnavui-androidauto/src/test/java/com/mapbox/androidauto/car/settings/CarSettingsScreenTest.kt
+++ b/libnavui-androidauto/src/test/java/com/mapbox/androidauto/car/settings/CarSettingsScreenTest.kt
@@ -1,14 +1,12 @@
-@file:Suppress("NoMockkVerifyImport")
-
 package com.mapbox.androidauto.car.settings
 
 import android.content.Context
 import androidx.car.app.model.ListTemplate
 import androidx.car.app.model.Row
 import androidx.test.core.app.ApplicationProvider
+import com.mapbox.androidauto.R
 import com.mapbox.androidauto.testing.MapboxRobolectricTestRunner
 import com.mapbox.androidauto.testing.TestOnDoneCallback
-import com.mapbox.androidauto.R
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify

--- a/libnavui-androidauto/src/test/java/com/mapbox/androidauto/deeplink/GeoDeeplinkPlacesListOnMapProviderTest.kt
+++ b/libnavui-androidauto/src/test/java/com/mapbox/androidauto/deeplink/GeoDeeplinkPlacesListOnMapProviderTest.kt
@@ -1,5 +1,3 @@
-@file:Suppress("NoMockkVerifyImport")
-
 package com.mapbox.androidauto.deeplink
 
 import android.location.Location
@@ -79,9 +77,10 @@ class GeoDeeplinkPlacesListOnMapProviderTest {
         val carContext = mockk<CarContext> {
             every { getString(any()) } returns "test_string"
         }
-        val result = GeoDeeplinkPlacesListOnMapProvider(carContext, geoDeeplinkGeocoding, geoDeeplink)
-            .getPlaces()
-            .value!!
+        val result =
+            GeoDeeplinkPlacesListOnMapProvider(carContext, geoDeeplinkGeocoding, geoDeeplink)
+                .getPlaces()
+                .value!!
 
         assertEquals(45.6824467, originSlot.captured.latitude(), 0.0001)
         assertEquals(-121.8544717, originSlot.captured.longitude(), 0.0001)

--- a/libnavui-androidauto/src/test/java/com/mapbox/androidauto/navigation/CarLocationsOverviewCameraTest.kt
+++ b/libnavui-androidauto/src/test/java/com/mapbox/androidauto/navigation/CarLocationsOverviewCameraTest.kt
@@ -1,4 +1,3 @@
-@file:Suppress("NoMockkVerifyImport")
 package com.mapbox.androidauto.navigation
 
 import com.mapbox.androidauto.car.navigation.CarLocationsOverviewCamera
@@ -24,7 +23,6 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Before
-
 import org.junit.Test
 
 @OptIn(MapboxExperimental::class)

--- a/libnavui-androidauto/src/test/java/com/mapbox/androidauto/navigation/audioguidance/impl/MapboxAudioGuidanceImplTest.kt
+++ b/libnavui-androidauto/src/test/java/com/mapbox/androidauto/navigation/audioguidance/impl/MapboxAudioGuidanceImplTest.kt
@@ -1,5 +1,3 @@
-@file:Suppress("NoMockkVerifyImport")
-
 package com.mapbox.androidauto.navigation.audioguidance.impl
 
 import com.mapbox.androidauto.configuration.CarAppConfigOwner
@@ -198,21 +196,23 @@ class MapboxAudioGuidanceImplTest {
     }
 
     @Test
-    fun `voice language from route is preferred to device language`() = coroutineRule.runBlockingTest {
-        carAppAudioGuidance.onAttached(mockk())
+    fun `voice language from route is preferred to device language`() =
+        coroutineRule.runBlockingTest {
+            carAppAudioGuidance.onAttached(mockk())
 
-        val voiceLanguage = "ru"
-        testMapboxAudioGuidanceServices.emitVoiceLanguage(voiceLanguage)
-        delay(SPEECH_ANNOUNCEMENT_DELAY_MS)
+            val voiceLanguage = "ru"
+            testMapboxAudioGuidanceServices.emitVoiceLanguage(voiceLanguage)
+            delay(SPEECH_ANNOUNCEMENT_DELAY_MS)
 
-        val mapboxAudioGuidanceServices = testMapboxAudioGuidanceServices.mapboxAudioGuidanceServices
-        excludeRecords {
-            mapboxAudioGuidanceServices.mapboxVoiceInstructions(any())
+            val mapboxAudioGuidanceServices =
+                testMapboxAudioGuidanceServices.mapboxAudioGuidanceServices
+            excludeRecords {
+                mapboxAudioGuidanceServices.mapboxVoiceInstructions(any())
+            }
+            verifySequence {
+                mapboxAudioGuidanceServices.mapboxAudioGuidanceVoice(any(), deviceLanguage)
+                mapboxAudioGuidanceServices.mapboxAudioGuidanceVoice(any(), voiceLanguage)
+            }
+            carAppAudioGuidance.onDetached(mockk())
         }
-        verifySequence {
-            mapboxAudioGuidanceServices.mapboxAudioGuidanceVoice(any(), deviceLanguage)
-            mapboxAudioGuidanceServices.mapboxAudioGuidanceVoice(any(), voiceLanguage)
-        }
-        carAppAudioGuidance.onDetached(mockk())
-    }
 }

--- a/libnavui-androidauto/src/test/java/com/mapbox/androidauto/navigation/audioguidance/impl/MapboxAudioGuidanceVoiceTest.kt
+++ b/libnavui-androidauto/src/test/java/com/mapbox/androidauto/navigation/audioguidance/impl/MapboxAudioGuidanceVoiceTest.kt
@@ -1,5 +1,3 @@
-@file:Suppress("NoMockkVerifyImport")
-
 package com.mapbox.androidauto.navigation.audioguidance.impl
 
 import com.mapbox.androidauto.testing.CarAppTestRule

--- a/libnavui-androidauto/src/test/java/com/mapbox/androidauto/navigation/audioguidance/impl/MapboxVoiceInstructionsTest.kt
+++ b/libnavui-androidauto/src/test/java/com/mapbox/androidauto/navigation/audioguidance/impl/MapboxVoiceInstructionsTest.kt
@@ -55,9 +55,11 @@ class MapboxVoiceInstructionsTest {
 
         val state = carAppVoiceInstructions.voiceInstructions().take(3).toList()
 
-        assertFalse(state[0].isPlayable) // routesFlow() on start sends empty list to disable sound button  in FreeDrive
+        // routesFlow() on start sends empty list to disable sound button  in FreeDrive
+        assertFalse(state[0].isPlayable)
         assertEquals(null, state[0].voiceInstructions)
-        assertTrue(state[1].isPlayable) // voiceInstructionsFlow() sends null voiceInstruction before observer is fired
+        // voiceInstructionsFlow() sends null voiceInstruction before observer is fired
+        assertTrue(state[1].isPlayable)
         assertEquals("Left on Broadway", state[2].voiceInstructions?.announcement())
     }
 
@@ -88,8 +90,10 @@ class MapboxVoiceInstructionsTest {
         val voiceInstruction = carAppVoiceInstructions.voiceInstructions().take(4).toList()
 
         val actual = voiceInstruction.map { it.voiceInstructions?.announcement() }
-        assertEquals(null, actual[0]) // routesFlow() on start sends empty list to disable sound button  in FreeDrive
-        assertEquals(null, actual[1]) // voiceInstructionsFlow() sends null voiceInstruction before observer is fired
+        // routesFlow() on start sends empty list to disable sound button  in FreeDrive
+        assertEquals(null, actual[0])
+        // voiceInstructionsFlow() sends null voiceInstruction before observer is fired
+        assertEquals(null, actual[1])
         assertEquals("Left on Broadway", actual[2])
         assertEquals("Right on Pennsylvania", actual[3])
     }
@@ -131,15 +135,20 @@ class MapboxVoiceInstructionsTest {
         val language = "de"
         every { mapboxNavigation.registerRoutesObserver(any()) } answers {
             val result = mockk<RoutesUpdatedResult> {
-                every { navigationRoutes } returns listOf(createRoute(language), createRoute(voiceLanguage = "en"))
+                every { navigationRoutes } returns listOf(
+                    createRoute(language),
+                    createRoute(voiceLanguage = "en")
+                )
             }
             firstArg<RoutesObserver>().onRoutesChanged(result)
         }
 
         val state = carAppVoiceInstructions.voiceLanguage().take(3).toList()
 
-        assertEquals(null, state[0]) // routesFlow() on start sends empty list to disable sound button  in FreeDrive
-        assertEquals(null, state[1]) // voiceInstructionsFlow() sends null voiceInstruction before observer is fired
+        // routesFlow() on start sends empty list to disable sound button  in FreeDrive
+        assertEquals(null, state[0])
+        // voiceInstructionsFlow() sends null voiceInstruction before observer is fired
+        assertEquals(null, state[1])
         assertEquals(language, state[2])
     }
 
@@ -156,11 +165,12 @@ class MapboxVoiceInstructionsTest {
     }
 
     @Test
-    fun `should emit null voice language before routes are updated`() = coroutineRule.runBlockingTest {
-        every { mapboxNavigation.registerRoutesObserver(any()) } just Runs
+    fun `should emit null voice language before routes are updated`() =
+        coroutineRule.runBlockingTest {
+            every { mapboxNavigation.registerRoutesObserver(any()) } just Runs
 
-        assertNull(carAppVoiceInstructions.voiceLanguage().first())
-    }
+            assertNull(carAppVoiceInstructions.voiceLanguage().first())
+        }
 
     private fun createRoute(voiceLanguage: String): NavigationRoute {
         return mockk {

--- a/libnavui-androidauto/src/test/java/com/mapbox/androidauto/search/PlaceRecordMapperTest.kt
+++ b/libnavui-androidauto/src/test/java/com/mapbox/androidauto/search/PlaceRecordMapperTest.kt
@@ -1,8 +1,8 @@
 package com.mapbox.androidauto.search
 
+import com.mapbox.androidauto.car.search.PlaceRecordMapper
 import com.mapbox.androidauto.testing.FileUtils
 import com.mapbox.api.geocoding.v5.models.CarmenFeature
-import com.mapbox.androidauto.car.search.PlaceRecordMapper
 import com.mapbox.geojson.Point
 import com.mapbox.search.record.FavoriteRecord
 import com.mapbox.search.result.SearchAddress
@@ -31,7 +31,9 @@ class PlaceRecordMapperTest {
                 country = "United States"
             )
             every { categories } returns null
-            every { coordinate } returns Point.fromLngLat(-122.27494049, 37.80561066)
+            every {
+                coordinate
+            } returns Point.fromLngLat(-122.27494049, 37.80561066)
         }
 
         val placeRecord = PlaceRecordMapper.fromFavoriteRecord(favoriteRecord)
@@ -55,7 +57,10 @@ class PlaceRecordMapperTest {
         assertEquals(placeRecord.name, "Starbucks")
         assertEquals(placeRecord.coordinate?.latitude(), 37.800456)
         assertEquals(placeRecord.coordinate?.longitude(), -122.273904)
-        assertEquals(placeRecord.description, "Starbucks, 801 Broadway, Oakland, California 94607, United States")
+        assertEquals(
+            placeRecord.description,
+            "Starbucks, 801 Broadway, Oakland, California 94607, United States"
+        )
         assertEquals(placeRecord.categories, listOf("poi"))
     }
 }

--- a/libnavui-androidauto/src/test/java/com/mapbox/androidauto/testing/TestCarAppDataStoreOwner.kt
+++ b/libnavui-androidauto/src/test/java/com/mapbox/androidauto/testing/TestCarAppDataStoreOwner.kt
@@ -9,7 +9,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 
 class TestCarAppDataStoreOwner {
 
-    private val booleanStorageMap = mutableMapOf<CarAppDataStoreKey<Boolean>, MutableStateFlow<Boolean>>()
+    private val booleanStorageMap =
+        mutableMapOf<CarAppDataStoreKey<Boolean>, MutableStateFlow<Boolean>>()
 
     val carAppDataStoreOwner: CarAppDataStoreOwner = mockk {
         every { read(any<CarAppDataStoreKey<Boolean>>()) } answers {


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Resolves https://github.com/mapbox/mapbox-navigation-android/issues/5787

libnavui-androidauto was ported from a repository with different linter. These two rules were broken most often
- Exceeded max line length (100) (cannot be auto-corrected) (max-line-length)
- Imports must be ordered in lexicographic order without any empty lines in-between with "java", "javax", "kotlin" and aliases in the end (import-ordering)

This fixes the issues and adds libnavui-androidauto to the ci lint pipeline. There are no functional changes.