### PR TITLE
lazily update the focal point for location gesture handling

### DIFF
--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/lifecycle/LocationGesturesManager.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/lifecycle/LocationGesturesManager.kt
@@ -6,13 +6,14 @@ import com.mapbox.android.gestures.AndroidGesturesManager
 
 internal class LocationGesturesManager(
     context: Context,
-    private val onUpEventCallback: (AndroidGesturesManager) -> Unit
+    private val onUpEventCallback: (AndroidGesturesManager) -> Unit,
+    private val onDownEventCallback: (AndroidGesturesManager) -> Unit,
 ) : AndroidGesturesManager(context) {
     override fun onTouchEvent(motionEvent: MotionEvent?): Boolean {
         if (motionEvent != null) {
-            val action: Int = motionEvent.actionMasked
-            if (action == MotionEvent.ACTION_UP) {
-                onUpEventCallback.invoke(this)
+            when (motionEvent.actionMasked) {
+                MotionEvent.ACTION_UP -> onUpEventCallback.invoke(this)
+                MotionEvent.ACTION_DOWN -> onDownEventCallback.invoke(this)
             }
         }
         return super.onTouchEvent(motionEvent)

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/lifecycle/NavigationCameraLifecycleProvider.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/lifecycle/NavigationCameraLifecycleProvider.kt
@@ -6,6 +6,11 @@ import com.mapbox.android.gestures.AndroidGesturesManager
 internal object NavigationCameraLifecycleProvider {
     fun getCustomGesturesManager(
         context: Context,
-        onUpEventCallback: (AndroidGesturesManager) -> Unit
-    ): AndroidGesturesManager = LocationGesturesManager(context, onUpEventCallback)
+        onUpEventCallback: (AndroidGesturesManager) -> Unit,
+        onDownEventCallback: (AndroidGesturesManager) -> Unit,
+    ): AndroidGesturesManager = LocationGesturesManager(
+        context,
+        onUpEventCallback,
+        onDownEventCallback,
+    )
 }


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
The `NavigationScaleGestureHandler` used to update the focal point of the gesture plugin on each frame of the camera animation, and on each frame of the location puck's animation, which resulted in hundreds of calls to `MapboxMap#pixelForCoordinate` per second.

This PR tries to lazily recalculate the focal point only when the map is actually interacted with.

cc @tobrun who noticed the increased number of calls to the projection API made by the SDK in general

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
