### PR TITLE
[Android Auto] Remove extra arrival feedback options

### DIFF
--- a/libnavui-androidauto/CHANGELOG.md
+++ b/libnavui-androidauto/CHANGELOG.md
@@ -7,6 +7,7 @@ Mapbox welcomes participation and contributions from everyone.
 #### Features
 
 #### Bug fixes and improvements
+ - Remove extra arrival feedback options. [#5805](https://github.com/mapbox/mapbox-navigation-android/pull/5805)
 
 ## androidauto-v0.1.0 - May 05, 2022
 

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/feedback/ui/CarFeedbackItem.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/feedback/ui/CarFeedbackItem.kt
@@ -233,29 +233,14 @@ fun buildArrivalFeedbackProvider(
 ) = listOf(
     CarFeedbackItem(
         carFeedbackTitle = carContext.getString(
-            R.string.car_feedback_positive_arrived_at_destination
+            R.string.car_feedback_arrival_positive
         ),
         carFeedbackIcon = PositiveCarFeedbackIcon,
         navigationFeedbackType = FeedbackEvent.ARRIVAL_FEEDBACK_GOOD,
     ),
     CarFeedbackItem(
-        carFeedbackTitle = carContext.getString(R.string.car_feedback_positive_no_issue),
-        carFeedbackIcon = PositiveCarFeedbackIcon,
-        navigationFeedbackType = FeedbackEvent.ARRIVAL_FEEDBACK_GOOD,
-    ),
-    CarFeedbackItem(
-        carFeedbackTitle = carContext.getString(R.string.car_feedback_positive_amazing),
-        carFeedbackIcon = PositiveCarFeedbackIcon,
-        navigationFeedbackType = FeedbackEvent.ARRIVAL_FEEDBACK_GOOD,
-    ),
-    CarFeedbackItem(
-        carFeedbackTitle = carContext.getString(R.string.car_feedback_negative_unable_arrive),
+        carFeedbackTitle = carContext.getString(R.string.car_feedback_arrival_negative),
         carFeedbackIcon = NegativeCarFeedbackIcon,
         navigationFeedbackType = FeedbackEvent.ARRIVAL_FEEDBACK_NOT_GOOD,
     ),
-    CarFeedbackItem(
-        carFeedbackTitle = carContext.getString(R.string.car_feedback_negative_other_issue),
-        carFeedbackIcon = NegativeCarFeedbackIcon,
-        navigationFeedbackType = FeedbackEvent.ARRIVAL_FEEDBACK_NOT_GOOD,
-    )
 )

--- a/libnavui-androidauto/src/main/res/values/strings.xml
+++ b/libnavui-androidauto/src/main/res/values/strings.xml
@@ -43,8 +43,6 @@
     <string name="car_feedback_search_incorrect_name">Incorrect name</string>
     <string name="car_feedback_search_other">Other issue</string>
 
-    <string name="car_feedback_positive_arrived_at_destination">Arrived</string>
-    <string name="car_feedback_positive_no_issue">No issue</string>
-    <string name="car_feedback_positive_amazing">Amazing!</string>
-    <string name="car_feedback_negative_unable_arrive">Unable to arrive</string>
+    <string name="car_feedback_arrival_positive">Good</string>
+    <string name="car_feedback_arrival_negative">Not good</string>
 </resources>

--- a/scripts/validate-changelog.py
+++ b/scripts/validate-changelog.py
@@ -11,7 +11,7 @@ github_token = sys.argv[2]
 api_url = "https://api.github.com/repos/mapbox/mapbox-navigation-android/pulls/" + str(pr_number)
 pr_link_regex = "\[#\d+]\(https:\/\/github\.com\/mapbox\/mapbox-navigation-android\/pull\/\d+\)"
 headers = {"accept": "application/vnd.github.v3+json", "authorization": "token " + github_token}
-changelog_diff_substring = "diff --git a/CHANGELOG.md b/CHANGELOG.md"
+changelog_diff_regex = "diff --git a(.*)\/CHANGELOG.md b(.*)\/CHANGELOG.md"
 any_diff_substring = "diff --git"
 
 with requests.get(api_url, headers=headers) as pr_response:
@@ -29,15 +29,14 @@ with requests.get(api_url, headers=headers) as pr_response:
         pr_diff_url = response_json["diff_url"]
         with requests.get(pr_diff_url, headers) as diff_response:
             diff = diff_response.text
-            changelog_entry_index = diff.find(changelog_diff_substring)
-            if changelog_entry_index == -1:
+            changelog_diff_matches = re.search(changelog_diff_regex, diff)
+            if not changelog_diff_matches:
                 raise Exception("Add a non-empty changelog entry in a CHANGELOG.md or add a `skip changelog` label if not applicable.")
             else:
-                changelog_entry_last_index = changelog_entry_index + len(changelog_diff_substring)
-                last_reachable_index = diff.find(any_diff_substring, changelog_entry_last_index)
+                last_reachable_index = diff.find(any_diff_substring, changelog_diff_matches.end())
                 if last_reachable_index == -1:
                     last_reachable_index = len(diff)
-                diff_searchable = diff[changelog_entry_last_index:last_reachable_index]
+                diff_searchable = diff[changelog_diff_matches.end():last_reachable_index]
                 pr_link_matches = re.search(pr_link_regex, diff_searchable)
                 if not pr_link_matches:
                     raise Exception("The changelog entry should contain a link to the original PR that matches `" + pr_link_regex + "`")


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
I've made a larger task to refactor the feedback options so they're customizable within screens https://github.com/mapbox/mapbox-navigation-android/issues/5804

But this pull request is to support a simple request downstream. Am also seeing that the repository CHANGELOG rules only apply to the main release channel. Made a small abstraction so that it will will ensure at least one `CHANGELOG.md` is modified in any module.

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->
<img width="808" alt="Screen Shot 2022-05-12 at 2 55 49 PM" src="https://user-images.githubusercontent.com/3021882/168174544-628ce2fe-bc8f-4c67-89a4-8cdb0357cdbf.png">

Also, didn't find a way to center these options in the grid template
``` kotlin
    private GridTemplate() {
        mIsLoading = false;
        mTitle = null;
        mHeaderAction = null;
        mSingleList = null;
        mActionStrip = null;
    }
```

![Screen Shot 2022-05-12 at 3 07 15 PM](https://user-images.githubusercontent.com/3021882/168175771-dd7ce1fe-ff93-4ff9-bbc8-1fefc2e5ee79.png)


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
