### PR TITLE
Remove `libtrip-notification` Transifex resources and pull latest translations from Transifex

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -3,12 +3,6 @@ host = https://www.transifex.com
 lang_map = pt_BR: pt-rBR, pt_PT: pt-rPT, es_ES: es-rES
 minimum_perc = 20
 
-[mapbox-navigation-sdk-for-android.libtrip-notification-strings-file]
-file_filter = libtrip-notification/src/main/res/values-<lang>/strings.xml
-source_file = libtrip-notification/src/main/res/values/strings.xml
-source_lang = en
-type = ANDROID
-
 [mapbox-navigation-sdk-for-android.libnavigation-util-strings-file]
 file_filter = libnavigation-util/src/main/res/values-<lang>/strings.xml
 source_file = libnavigation-util/src/main/res/values/strings.xml

--- a/libnavigation-base/src/main/res/values-ar/strings.xml
+++ b/libnavigation-base/src/main/res/values-ar/strings.xml
@@ -1,7 +1,7 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Time formatting -->
-    <plurals name="mapbox_number_of_days">
+    <plurals name="mapbox_number_of_days" tools:ignore="MissingTranslation">
         <item quantity="zero">يوم</item>
         <item quantity="one">يوم</item>
         <item quantity="two">يومان</item>
@@ -10,11 +10,11 @@
         <item quantity="other">أيام</item>
     </plurals>
     <!-- Hour -->
-    <string name="mapbox_unit_hr">ساعة</string>
+    <string name="mapbox_unit_hr" tools:ignore="MissingTranslation">ساعة</string>
     <!-- Minute -->
-    <string name="mapbox_unit_min">دقيقة</string>
+    <string name="mapbox_unit_min" tools:ignore="MissingTranslation">دقيقة</string>
 
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">انهاء الرحلة</string>
-    <string name="mapbox_eta_format">%s الوقت المتوقع للوصول</string>
+    <string name="mapbox_eta_format" tools:ignore="MissingTranslation">%s الوقت المتوقع للوصول</string>
 </resources>

--- a/libnavigation-base/src/main/res/values-bg/strings.xml
+++ b/libnavigation-base/src/main/res/values-bg/strings.xml
@@ -1,16 +1,16 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Time formatting -->
-    <plurals name="mapbox_number_of_days">
+    <plurals name="mapbox_number_of_days" tools:ignore="MissingTranslation">
         <item quantity="one">дни</item>
         <item quantity="other">дни</item>
     </plurals>
     <!-- Hour -->
-    <string name="mapbox_unit_hr">ч</string>
+    <string name="mapbox_unit_hr" tools:ignore="MissingTranslation">ч</string>
     <!-- Minute -->
-    <string name="mapbox_unit_min">мин</string>
+    <string name="mapbox_unit_min" tools:ignore="MissingTranslation">мин</string>
 
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Край на навигация</string>
-    <string name="mapbox_eta_format">%s Пристигане</string>
+    <string name="mapbox_eta_format" tools:ignore="MissingTranslation">%s Пристигане</string>
 </resources>

--- a/libnavigation-base/src/main/res/values-ca/strings.xml
+++ b/libnavigation-base/src/main/res/values-ca/strings.xml
@@ -1,19 +1,19 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Time formatting -->
-    <plurals name="mapbox_number_of_days">
+    <plurals name="mapbox_number_of_days" tools:ignore="MissingTranslation">
         <item quantity="one">dies</item>
         <item quantity="other">dies</item>
     </plurals>
     <!-- Hour -->
-    <string name="mapbox_unit_hr">h</string>
+    <string name="mapbox_unit_hr" tools:ignore="MissingTranslation">h</string>
     <!-- Minute -->
-    <string name="mapbox_unit_min">min</string>
+    <string name="mapbox_unit_min" tools:ignore="MissingTranslation">min</string>
 
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Aturar navegació</string>
-    <string name="mapbox_navigation_is_starting">Comença la navegació...</string>
-    <string name="mapbox_stop_session">Aturar sessió</string>
-    <string name="mapbox_free_drive_session">Sessió de conducció gratuïta</string>
-    <string name="mapbox_eta_format">%s ETA</string>
+    <string name="mapbox_navigation_is_starting" tools:ignore="MissingTranslation">Comença la navegació...</string>
+    <string name="mapbox_stop_session" tools:ignore="MissingTranslation">Aturar sessió</string>
+    <string name="mapbox_free_drive_session" tools:ignore="MissingTranslation">Sessió de conducció gratuïta</string>
+    <string name="mapbox_eta_format" tools:ignore="MissingTranslation">%s ETA</string>
 </resources>

--- a/libnavigation-base/src/main/res/values-cs/strings.xml
+++ b/libnavigation-base/src/main/res/values-cs/strings.xml
@@ -1,18 +1,18 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Time formatting -->
-    <plurals name="mapbox_number_of_days">
+    <plurals name="mapbox_number_of_days" tools:ignore="MissingTranslation">
         <item quantity="one">den</item>
         <item quantity="few">dni</item>
         <item quantity="many">dnů</item>
         <item quantity="other">den</item>
     </plurals>
     <!-- Hour -->
-    <string name="mapbox_unit_hr">hod.</string>
+    <string name="mapbox_unit_hr" tools:ignore="MissingTranslation">hod.</string>
     <!-- Minute -->
-    <string name="mapbox_unit_min">min.</string>
+    <string name="mapbox_unit_min" tools:ignore="MissingTranslation">min.</string>
 
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Ukončit navigaci</string>
-    <string name="mapbox_eta_format">%s Předpokládaný čas příjezdu</string>
+    <string name="mapbox_eta_format" tools:ignore="MissingTranslation">%s Předpokládaný čas příjezdu</string>
 </resources>

--- a/libnavigation-base/src/main/res/values-da/strings.xml
+++ b/libnavigation-base/src/main/res/values-da/strings.xml
@@ -1,16 +1,16 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Time formatting -->
-    <plurals name="mapbox_number_of_days">
+    <plurals name="mapbox_number_of_days" tools:ignore="MissingTranslation">
         <item quantity="one">dag</item>
         <item quantity="other">dage</item>
     </plurals>
     <!-- Hour -->
-    <string name="mapbox_unit_hr">t</string>
+    <string name="mapbox_unit_hr" tools:ignore="MissingTranslation">t</string>
     <!-- Minute -->
-    <string name="mapbox_unit_min">min</string>
+    <string name="mapbox_unit_min" tools:ignore="MissingTranslation">min</string>
 
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Slut navigation </string>
-    <string name="mapbox_eta_format">%s ETA</string>
+    <string name="mapbox_eta_format" tools:ignore="MissingTranslation">%s ETA</string>
 </resources>

--- a/libnavigation-base/src/main/res/values-de/strings.xml
+++ b/libnavigation-base/src/main/res/values-de/strings.xml
@@ -1,19 +1,19 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Time formatting -->
-    <plurals name="mapbox_number_of_days">
+    <plurals name="mapbox_number_of_days" tools:ignore="MissingTranslation">
         <item quantity="one">Tag</item>
         <item quantity="other">Tage</item>
     </plurals>
     <!-- Hour -->
-    <string name="mapbox_unit_hr">Std.</string>
+    <string name="mapbox_unit_hr" tools:ignore="MissingTranslation">Std.</string>
     <!-- Minute -->
-    <string name="mapbox_unit_min">Min.</string>
+    <string name="mapbox_unit_min" tools:ignore="MissingTranslation">Min.</string>
 
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Navigation beenden</string>
-    <string name="mapbox_navigation_is_starting">Navigation wird gestartet...</string>
-    <string name="mapbox_stop_session">Sitzung beenden</string>
-    <string name="mapbox_free_drive_session">Freie Fahrt-Sitzung</string>
-    <string name="mapbox_eta_format">%s ETA</string>
+    <string name="mapbox_navigation_is_starting" tools:ignore="MissingTranslation">Navigation wird gestartet...</string>
+    <string name="mapbox_stop_session" tools:ignore="MissingTranslation">Sitzung beenden</string>
+    <string name="mapbox_free_drive_session" tools:ignore="MissingTranslation">Freie Fahrt-Sitzung</string>
+    <string name="mapbox_eta_format" tools:ignore="MissingTranslation">%s ETA</string>
 </resources>

--- a/libnavigation-base/src/main/res/values-el/strings.xml
+++ b/libnavigation-base/src/main/res/values-el/strings.xml
@@ -1,16 +1,16 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Time formatting -->
-    <plurals name="mapbox_number_of_days">
+    <plurals name="mapbox_number_of_days" tools:ignore="MissingTranslation">
         <item quantity="one">μέρα</item>
         <item quantity="other">μέρες</item>
     </plurals>
     <!-- Hour -->
-    <string name="mapbox_unit_hr">ώρες</string>
+    <string name="mapbox_unit_hr" tools:ignore="MissingTranslation">ώρες</string>
     <!-- Minute -->
-    <string name="mapbox_unit_min">λεπτά</string>
+    <string name="mapbox_unit_min" tools:ignore="MissingTranslation">λεπτά</string>
 
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Τέλος πλοήγησης</string>
-    <string name="mapbox_eta_format">%s ETA</string>
+    <string name="mapbox_eta_format" tools:ignore="MissingTranslation">%s ETA</string>
 </resources>

--- a/libnavigation-base/src/main/res/values-es/strings.xml
+++ b/libnavigation-base/src/main/res/values-es/strings.xml
@@ -1,19 +1,19 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Time formatting -->
-    <plurals name="mapbox_number_of_days">
+    <plurals name="mapbox_number_of_days" tools:ignore="MissingTranslation">
         <item quantity="one">día</item>
         <item quantity="other">días</item>
     </plurals>
     <!-- Hour -->
-    <string name="mapbox_unit_hr">h</string>
+    <string name="mapbox_unit_hr" tools:ignore="MissingTranslation">h</string>
     <!-- Minute -->
-    <string name="mapbox_unit_min">min</string>
+    <string name="mapbox_unit_min" tools:ignore="MissingTranslation">min</string>
 
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Salir de la navegación</string>
-    <string name="mapbox_navigation_is_starting">Empezando la navegación…</string>
-    <string name="mapbox_stop_session">Parar la sesión</string>
-    <string name="mapbox_free_drive_session">Sesión de manejar libremente</string>
-    <string name="mapbox_eta_format">%s ETA</string>
+    <string name="mapbox_navigation_is_starting" tools:ignore="MissingTranslation">Empezando la navegación…</string>
+    <string name="mapbox_stop_session" tools:ignore="MissingTranslation">Parar la sesión</string>
+    <string name="mapbox_free_drive_session" tools:ignore="MissingTranslation">Sesión de manejar libremente</string>
+    <string name="mapbox_eta_format" tools:ignore="MissingTranslation">%s ETA</string>
 </resources>

--- a/libnavigation-base/src/main/res/values-fa/strings.xml
+++ b/libnavigation-base/src/main/res/values-fa/strings.xml
@@ -1,16 +1,16 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Time formatting -->
-    <plurals name="mapbox_number_of_days">
+    <plurals name="mapbox_number_of_days" tools:ignore="MissingTranslation">
         <item quantity="one" tools:ignore="ImpliedQuantity">روز</item>
         <item quantity="other">روزها</item>
     </plurals>
     <!-- Hour -->
-    <string name="mapbox_unit_hr">ساعت</string>
+    <string name="mapbox_unit_hr" tools:ignore="MissingTranslation">ساعت</string>
     <!-- Minute -->
-    <string name="mapbox_unit_min">دقیقه</string>
+    <string name="mapbox_unit_min" tools:ignore="MissingTranslation">دقیقه</string>
 
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">پایان مسیر یابی</string>
-    <string name="mapbox_eta_format">%s ETA</string>
+    <string name="mapbox_eta_format" tools:ignore="MissingTranslation">%s ETA</string>
 </resources>

--- a/libnavigation-base/src/main/res/values-fr/strings.xml
+++ b/libnavigation-base/src/main/res/values-fr/strings.xml
@@ -1,15 +1,15 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Time formatting -->
-    <plurals name="mapbox_number_of_days">
+    <plurals name="mapbox_number_of_days" tools:ignore="MissingTranslation">
         <item quantity="one" tools:ignore="ImpliedQuantity">jour</item>
         <item quantity="other">jours</item>
     </plurals>
     <!-- Hour -->
-    <string name="mapbox_unit_hr">h</string>
+    <string name="mapbox_unit_hr" tools:ignore="MissingTranslation">h</string>
     <!-- Minute -->
-    <string name="mapbox_unit_min">min</string>
+    <string name="mapbox_unit_min" tools:ignore="MissingTranslation">min</string>
 
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Fin de navigation</string>
-</resources>
+    </resources>

--- a/libnavigation-base/src/main/res/values-gl/strings.xml
+++ b/libnavigation-base/src/main/res/values-gl/strings.xml
@@ -1,16 +1,16 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Time formatting -->
-    <plurals name="mapbox_number_of_days">
+    <plurals name="mapbox_number_of_days" tools:ignore="MissingTranslation">
         <item quantity="one">día</item>
         <item quantity="other">días</item>
     </plurals>
     <!-- Hour -->
-    <string name="mapbox_unit_hr">h</string>
+    <string name="mapbox_unit_hr" tools:ignore="MissingTranslation">h</string>
     <!-- Minute -->
-    <string name="mapbox_unit_min">min</string>
+    <string name="mapbox_unit_min" tools:ignore="MissingTranslation">min</string>
 
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Remata a navegación</string>
-    <string name="mapbox_eta_format">%s ETA</string>
+    <string name="mapbox_eta_format" tools:ignore="MissingTranslation">%s ETA</string>
 </resources>

--- a/libnavigation-base/src/main/res/values-he/strings.xml
+++ b/libnavigation-base/src/main/res/values-he/strings.xml
@@ -1,17 +1,17 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Time formatting -->
-    <plurals name="mapbox_number_of_days">
+    <plurals name="mapbox_number_of_days" tools:ignore="MissingTranslation">
         <item quantity="one">ימים</item>
         <item quantity="two">ימים</item>
         <item quantity="many">ימים</item>
         <item quantity="other">ימים</item>
     </plurals>
     <!-- Hour -->
-    <string name="mapbox_unit_hr">שעות</string>
+    <string name="mapbox_unit_hr" tools:ignore="MissingTranslation">שעות</string>
     <!-- Minute -->
-    <string name="mapbox_unit_min">דק׳</string>
+    <string name="mapbox_unit_min" tools:ignore="MissingTranslation">דק׳</string>
 
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">סיום ניווט</string>
-</resources>
+    </resources>

--- a/libnavigation-base/src/main/res/values-hu/strings.xml
+++ b/libnavigation-base/src/main/res/values-hu/strings.xml
@@ -1,16 +1,16 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Time formatting -->
-    <plurals name="mapbox_number_of_days">
+    <plurals name="mapbox_number_of_days" tools:ignore="MissingTranslation">
         <item quantity="one">nap</item>
         <item quantity="other">nap</item>
     </plurals>
     <!-- Hour -->
-    <string name="mapbox_unit_hr">óra</string>
+    <string name="mapbox_unit_hr" tools:ignore="MissingTranslation">óra</string>
     <!-- Minute -->
-    <string name="mapbox_unit_min">perc</string>
+    <string name="mapbox_unit_min" tools:ignore="MissingTranslation">perc</string>
 
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Navigáció vége</string>
-    <string name="mapbox_eta_format">%s érkezés</string>
+    <string name="mapbox_eta_format" tools:ignore="MissingTranslation">%s érkezés</string>
 </resources>

--- a/libnavigation-base/src/main/res/values-ja/strings.xml
+++ b/libnavigation-base/src/main/res/values-ja/strings.xml
@@ -1,15 +1,15 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Time formatting -->
-    <plurals name="mapbox_number_of_days">
+    <plurals name="mapbox_number_of_days" tools:ignore="MissingTranslation">
         <item quantity="other">日</item>
     </plurals>
     <!-- Hour -->
-    <string name="mapbox_unit_hr">時間</string>
+    <string name="mapbox_unit_hr" tools:ignore="MissingTranslation">時間</string>
     <!-- Minute -->
-    <string name="mapbox_unit_min">分</string>
+    <string name="mapbox_unit_min" tools:ignore="MissingTranslation">分</string>
 
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">ナビゲーションを終了</string>
-    <string name="mapbox_eta_format">到着予定時刻%s</string>
+    <string name="mapbox_eta_format" tools:ignore="MissingTranslation">到着予定時刻%s</string>
 </resources>

--- a/libnavigation-base/src/main/res/values-ko/strings.xml
+++ b/libnavigation-base/src/main/res/values-ko/strings.xml
@@ -1,10 +1,10 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Hour -->
-    <string name="mapbox_unit_hr">시</string>
+    <string name="mapbox_unit_hr" tools:ignore="MissingTranslation">시</string>
     <!-- Minute -->
-    <string name="mapbox_unit_min">분</string>
+    <string name="mapbox_unit_min" tools:ignore="MissingTranslation">분</string>
 
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">네비게이션 종료</string>
-</resources>
+    </resources>

--- a/libnavigation-base/src/main/res/values-pt-rBR/strings.xml
+++ b/libnavigation-base/src/main/res/values-pt-rBR/strings.xml
@@ -1,16 +1,16 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Time formatting -->
-    <plurals name="mapbox_number_of_days">
+    <plurals name="mapbox_number_of_days" tools:ignore="MissingTranslation">
         <item quantity="one" tools:ignore="ImpliedQuantity">dia</item>
         <item quantity="other">dias</item>
     </plurals>
     <!-- Hour -->
-    <string name="mapbox_unit_hr">hr</string>
+    <string name="mapbox_unit_hr" tools:ignore="MissingTranslation">hr</string>
     <!-- Minute -->
-    <string name="mapbox_unit_min">min</string>
+    <string name="mapbox_unit_min" tools:ignore="MissingTranslation">min</string>
 
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Finalizar navegação</string>
-    <string name="mapbox_eta_format">%s estimado</string>
+    <string name="mapbox_eta_format" tools:ignore="MissingTranslation">%s estimado</string>
 </resources>

--- a/libnavigation-base/src/main/res/values-pt-rPT/strings.xml
+++ b/libnavigation-base/src/main/res/values-pt-rPT/strings.xml
@@ -1,16 +1,16 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Time formatting -->
-    <plurals name="mapbox_number_of_days">
+    <plurals name="mapbox_number_of_days" tools:ignore="MissingTranslation">
         <item quantity="one" tools:ignore="ImpliedQuantity">dia</item>
         <item quantity="other">dias</item>
     </plurals>
     <!-- Hour -->
-    <string name="mapbox_unit_hr">hor</string>
+    <string name="mapbox_unit_hr" tools:ignore="MissingTranslation">hor</string>
     <!-- Minute -->
-    <string name="mapbox_unit_min">min</string>
+    <string name="mapbox_unit_min" tools:ignore="MissingTranslation">min</string>
 
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Terminar Navegação</string>
-    <string name="mapbox_eta_format">%s TEC</string>
+    <string name="mapbox_eta_format" tools:ignore="MissingTranslation">%s TEC</string>
 </resources>

--- a/libnavigation-base/src/main/res/values-ru/strings.xml
+++ b/libnavigation-base/src/main/res/values-ru/strings.xml
@@ -1,21 +1,21 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Time formatting -->
-    <plurals name="mapbox_number_of_days">
+    <plurals name="mapbox_number_of_days" tools:ignore="MissingTranslation">
         <item quantity="one" tools:ignore="ImpliedQuantity">день</item>
         <item quantity="few">дня</item>
         <item quantity="many">дней</item>
         <item quantity="other">дней</item>
     </plurals>
     <!-- Hour -->
-    <string name="mapbox_unit_hr">ч.</string>
+    <string name="mapbox_unit_hr" tools:ignore="MissingTranslation">ч.</string>
     <!-- Minute -->
-    <string name="mapbox_unit_min">мин.</string>
+    <string name="mapbox_unit_min" tools:ignore="MissingTranslation">мин.</string>
 
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Завершить</string>
-    <string name="mapbox_navigation_is_starting">Навигация запущена...</string>
-    <string name="mapbox_stop_session">Остановить сессию</string>
-    <string name="mapbox_free_drive_session">Освободить сессию</string>
-    <string name="mapbox_eta_format">Ожидаемое прибытие %s</string>
+    <string name="mapbox_navigation_is_starting" tools:ignore="MissingTranslation">Навигация запущена...</string>
+    <string name="mapbox_stop_session" tools:ignore="MissingTranslation">Остановить сессию</string>
+    <string name="mapbox_free_drive_session" tools:ignore="MissingTranslation">Освободить сессию</string>
+    <string name="mapbox_eta_format" tools:ignore="MissingTranslation">Ожидаемое прибытие %s</string>
 </resources>

--- a/libnavigation-base/src/main/res/values-sv/strings.xml
+++ b/libnavigation-base/src/main/res/values-sv/strings.xml
@@ -1,5 +1,6 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
+
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Avsluta Navigering</string>
-    <string name="mapbox_eta_format">%s ETA</string>
+    <string name="mapbox_eta_format" tools:ignore="MissingTranslation">%s ETA</string>
 </resources>

--- a/libnavigation-base/src/main/res/values-uk/strings.xml
+++ b/libnavigation-base/src/main/res/values-uk/strings.xml
@@ -1,21 +1,21 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Time formatting -->
-    <plurals name="mapbox_number_of_days">
+    <plurals name="mapbox_number_of_days" tools:ignore="MissingTranslation">
         <item quantity="one" tools:ignore="ImpliedQuantity">день</item>
         <item quantity="few">дні</item>
         <item quantity="many">днів</item>
         <item quantity="other">днів</item>
     </plurals>
     <!-- Hour -->
-    <string name="mapbox_unit_hr">год</string>
+    <string name="mapbox_unit_hr" tools:ignore="MissingTranslation">год</string>
     <!-- Minute -->
-    <string name="mapbox_unit_min">хв</string>
+    <string name="mapbox_unit_min" tools:ignore="MissingTranslation">хв</string>
 
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Закінчити навігацію</string>
-    <string name="mapbox_navigation_is_starting">Початок навігації…</string>
-    <string name="mapbox_stop_session">Призупинити сесію</string>
-    <string name="mapbox_free_drive_session">Вільна драйв-сесія</string>
-    <string name="mapbox_eta_format">Прибуття: %s</string>
+    <string name="mapbox_navigation_is_starting" tools:ignore="MissingTranslation">Початок навігації…</string>
+    <string name="mapbox_stop_session" tools:ignore="MissingTranslation">Призупинити сесію</string>
+    <string name="mapbox_free_drive_session" tools:ignore="MissingTranslation">Вільна драйв-сесія</string>
+    <string name="mapbox_eta_format" tools:ignore="MissingTranslation">Прибуття: %s</string>
 </resources>

--- a/libnavigation-base/src/main/res/values-uz/strings.xml
+++ b/libnavigation-base/src/main/res/values-uz/strings.xml
@@ -1,15 +1,16 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Time formatting -->
-    <plurals name="mapbox_number_of_days">
+    <plurals name="mapbox_number_of_days" tools:ignore="MissingTranslation">
         <item quantity="one">kun</item>
         <item quantity="other">kun</item>
     </plurals>
     <!-- Hour -->
-    <string name="mapbox_unit_hr">soat</string>
+    <string name="mapbox_unit_hr" tools:ignore="MissingTranslation">soat</string>
     <!-- Minute -->
-    <string name="mapbox_unit_min">minut</string>
+    <string name="mapbox_unit_min" tools:ignore="MissingTranslation">minut</string>
 
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Yo\'nalish tugallandi</string>
-</resources>
+
+    </resources>

--- a/libnavigation-base/src/main/res/values-vi/strings.xml
+++ b/libnavigation-base/src/main/res/values-vi/strings.xml
@@ -1,18 +1,18 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Time formatting -->
-    <plurals name="mapbox_number_of_days">
+    <plurals name="mapbox_number_of_days" tools:ignore="MissingTranslation">
         <item quantity="other">ngày</item>
     </plurals>
     <!-- Hour -->
-    <string name="mapbox_unit_hr">giờ</string>
+    <string name="mapbox_unit_hr" tools:ignore="MissingTranslation">giờ</string>
     <!-- Minute -->
-    <string name="mapbox_unit_min">phút</string>
+    <string name="mapbox_unit_min" tools:ignore="MissingTranslation">phút</string>
 
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Kết thúc Điều hướng</string>
-    <string name="mapbox_navigation_is_starting">Đang bắt đầu điều hướng…</string>
-    <string name="mapbox_stop_session">Ngừng phiên điều hướng</string>
-    <string name="mapbox_free_drive_session">Phiên Lái xe Tự do</string>
-    <string name="mapbox_eta_format">Đến %s</string>
+    <string name="mapbox_navigation_is_starting" tools:ignore="MissingTranslation">Đang bắt đầu điều hướng…</string>
+    <string name="mapbox_stop_session" tools:ignore="MissingTranslation">Ngừng phiên điều hướng</string>
+    <string name="mapbox_free_drive_session" tools:ignore="MissingTranslation">Phiên Lái xe Tự do</string>
+    <string name="mapbox_eta_format" tools:ignore="MissingTranslation">Đến %s</string>
 </resources>

--- a/libnavigation-base/src/main/res/values-yo/strings.xml
+++ b/libnavigation-base/src/main/res/values-yo/strings.xml
@@ -1,15 +1,15 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Time formatting -->
-    <plurals name="mapbox_number_of_days">
+    <plurals name="mapbox_number_of_days" tools:ignore="MissingTranslation">
         <item quantity="other">ọjọ</item>
     </plurals>
     <!-- Hour -->
-    <string name="mapbox_unit_hr">hr</string>
+    <string name="mapbox_unit_hr" tools:ignore="MissingTranslation">hr</string>
     <!-- Minute -->
-    <string name="mapbox_unit_min">min</string>
+    <string name="mapbox_unit_min" tools:ignore="MissingTranslation">min</string>
 
     <!-- Notification Strings -->
     <string name="mapbox_end_navigation">Muu Lilọ kiri</string>
-    <string name="mapbox_eta_format">%s ETA</string>
+    <string name="mapbox_eta_format" tools:ignore="MissingTranslation">%s ETA</string>
 </resources>

--- a/libnavigation-base/src/main/res/values/strings.xml
+++ b/libnavigation-base/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Time formatting -->
-    <plurals name="mapbox_number_of_days">
+    <plurals name="mapbox_number_of_days" tools:ignore="MissingTranslation">
         <item quantity="one">day</item>
         <item quantity="other">days</item>
     </plurals>

--- a/libnavigation-util/src/main/res/values-ar/strings.xml
+++ b/libnavigation-util/src/main/res/values-ar/strings.xml
@@ -1,6 +1,6 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="mapbox_unit_kilometers">كم</string>
     <string name="mapbox_unit_meters">م</string>
     <string name="mapbox_unit_miles">ميل</string>
-    <string name="mapbox_unit_feet">قدم</string>
+    <string name="mapbox_unit_feet" tools:ignore="MissingTranslation">قدم</string>
 </resources>

--- a/libnavigation-util/src/main/res/values-bg/strings.xml
+++ b/libnavigation-util/src/main/res/values-bg/strings.xml
@@ -1,6 +1,6 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="mapbox_unit_kilometers">км</string>
     <string name="mapbox_unit_meters">м</string>
     <string name="mapbox_unit_miles">мили</string>
-    <string name="mapbox_unit_feet">фута</string>
+    <string name="mapbox_unit_feet" tools:ignore="MissingTranslation">фута</string>
 </resources>

--- a/libnavigation-util/src/main/res/values-ca/strings.xml
+++ b/libnavigation-util/src/main/res/values-ca/strings.xml
@@ -1,6 +1,6 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="mapbox_unit_kilometers">km</string>
     <string name="mapbox_unit_meters">m</string>
     <string name="mapbox_unit_miles">mi</string>
-    <string name="mapbox_unit_feet">ft</string>
+    <string name="mapbox_unit_feet" tools:ignore="MissingTranslation">ft</string>
 </resources>

--- a/libnavigation-util/src/main/res/values-cs/strings.xml
+++ b/libnavigation-util/src/main/res/values-cs/strings.xml
@@ -1,6 +1,6 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="mapbox_unit_kilometers">km</string>
     <string name="mapbox_unit_meters">m</string>
     <string name="mapbox_unit_miles">míle</string>
-    <string name="mapbox_unit_feet">stopy</string>
+    <string name="mapbox_unit_feet" tools:ignore="MissingTranslation">stopy</string>
 </resources>

--- a/libnavigation-util/src/main/res/values-da/strings.xml
+++ b/libnavigation-util/src/main/res/values-da/strings.xml
@@ -1,6 +1,6 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="mapbox_unit_kilometers">km</string>
     <string name="mapbox_unit_meters">m</string>
     <string name="mapbox_unit_miles">mi</string>
-    <string name="mapbox_unit_feet">ft</string>
+    <string name="mapbox_unit_feet" tools:ignore="MissingTranslation">ft</string>
 </resources>

--- a/libnavigation-util/src/main/res/values-de/strings.xml
+++ b/libnavigation-util/src/main/res/values-de/strings.xml
@@ -1,6 +1,6 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="mapbox_unit_kilometers">km</string>
     <string name="mapbox_unit_meters">m</string>
     <string name="mapbox_unit_miles">mile</string>
-    <string name="mapbox_unit_feet">Fuß</string>
+    <string name="mapbox_unit_feet" tools:ignore="MissingTranslation">Fuß</string>
 </resources>

--- a/libnavigation-util/src/main/res/values-el/strings.xml
+++ b/libnavigation-util/src/main/res/values-el/strings.xml
@@ -1,6 +1,6 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="mapbox_unit_kilometers">χλμ</string>
     <string name="mapbox_unit_meters">μ</string>
     <string name="mapbox_unit_miles">μίλια</string>
-    <string name="mapbox_unit_feet">πόδια</string>
+    <string name="mapbox_unit_feet" tools:ignore="MissingTranslation">πόδια</string>
 </resources>

--- a/libnavigation-util/src/main/res/values-es/strings.xml
+++ b/libnavigation-util/src/main/res/values-es/strings.xml
@@ -1,6 +1,6 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="mapbox_unit_kilometers">km</string>
     <string name="mapbox_unit_meters">m</string>
     <string name="mapbox_unit_miles">mi</string>
-    <string name="mapbox_unit_feet">pie</string>
+    <string name="mapbox_unit_feet" tools:ignore="MissingTranslation">pie</string>
 </resources>

--- a/libnavigation-util/src/main/res/values-fa/strings.xml
+++ b/libnavigation-util/src/main/res/values-fa/strings.xml
@@ -1,6 +1,6 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="mapbox_unit_kilometers">کیلومتر</string>
     <string name="mapbox_unit_meters">متر</string>
     <string name="mapbox_unit_miles">مایل</string>
-    <string name="mapbox_unit_feet">قدم</string>
+    <string name="mapbox_unit_feet" tools:ignore="MissingTranslation">قدم</string>
 </resources>

--- a/libnavigation-util/src/main/res/values-fr/strings.xml
+++ b/libnavigation-util/src/main/res/values-fr/strings.xml
@@ -1,6 +1,6 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="mapbox_unit_kilometers">km</string>
     <string name="mapbox_unit_meters">m</string>
     <string name="mapbox_unit_miles">mi</string>
-    <string name="mapbox_unit_feet">ft</string>
+    <string name="mapbox_unit_feet" tools:ignore="MissingTranslation">ft</string>
 </resources>

--- a/libnavigation-util/src/main/res/values-gl/strings.xml
+++ b/libnavigation-util/src/main/res/values-gl/strings.xml
@@ -1,6 +1,6 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="mapbox_unit_kilometers">km</string>
     <string name="mapbox_unit_meters">m</string>
     <string name="mapbox_unit_miles">mi</string>
-    <string name="mapbox_unit_feet">pé</string>
+    <string name="mapbox_unit_feet" tools:ignore="MissingTranslation">pé</string>
 </resources>

--- a/libnavigation-util/src/main/res/values-he/strings.xml
+++ b/libnavigation-util/src/main/res/values-he/strings.xml
@@ -1,5 +1,5 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="mapbox_unit_kilometers">ק״מ</string>
     <string name="mapbox_unit_meters">מ׳</string>
     <string name="mapbox_unit_miles">מייל</string>
-</resources>
+    </resources>

--- a/libnavigation-util/src/main/res/values-hu/strings.xml
+++ b/libnavigation-util/src/main/res/values-hu/strings.xml
@@ -1,6 +1,6 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="mapbox_unit_kilometers">km</string>
     <string name="mapbox_unit_meters">m</string>
     <string name="mapbox_unit_miles">mérföld</string>
-    <string name="mapbox_unit_feet">láb</string>
+    <string name="mapbox_unit_feet" tools:ignore="MissingTranslation">láb</string>
 </resources>

--- a/libnavigation-util/src/main/res/values-ja/strings.xml
+++ b/libnavigation-util/src/main/res/values-ja/strings.xml
@@ -1,6 +1,6 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="mapbox_unit_kilometers">km</string>
     <string name="mapbox_unit_meters">m</string>
     <string name="mapbox_unit_miles">マイル</string>
-    <string name="mapbox_unit_feet">フィート</string>
+    <string name="mapbox_unit_feet" tools:ignore="MissingTranslation">フィート</string>
 </resources>

--- a/libnavigation-util/src/main/res/values-ko/strings.xml
+++ b/libnavigation-util/src/main/res/values-ko/strings.xml
@@ -1,6 +1,6 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="mapbox_unit_kilometers">km</string>
     <string name="mapbox_unit_meters">m</string>
     <string name="mapbox_unit_miles">mi</string>
-    <string name="mapbox_unit_feet">ft</string>
+    <string name="mapbox_unit_feet" tools:ignore="MissingTranslation">ft</string>
 </resources>

--- a/libnavigation-util/src/main/res/values-my/strings.xml
+++ b/libnavigation-util/src/main/res/values-my/strings.xml
@@ -1,6 +1,6 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="mapbox_unit_kilometers">ကီလိုမီတာ</string>
     <string name="mapbox_unit_meters">မီတာ</string>
     <string name="mapbox_unit_miles">မိုင်</string>
-    <string name="mapbox_unit_feet">ပေ</string>
+    <string name="mapbox_unit_feet" tools:ignore="MissingTranslation">ပေ</string>
 </resources>

--- a/libnavigation-util/src/main/res/values-pt-rBR/strings.xml
+++ b/libnavigation-util/src/main/res/values-pt-rBR/strings.xml
@@ -1,6 +1,6 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="mapbox_unit_kilometers">KM</string>
     <string name="mapbox_unit_meters">M</string>
     <string name="mapbox_unit_miles">MI</string>
-    <string name="mapbox_unit_feet">FT</string>
+    <string name="mapbox_unit_feet" tools:ignore="MissingTranslation">FT</string>
 </resources>

--- a/libnavigation-util/src/main/res/values-pt-rPT/strings.xml
+++ b/libnavigation-util/src/main/res/values-pt-rPT/strings.xml
@@ -1,6 +1,6 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="mapbox_unit_kilometers">km</string>
     <string name="mapbox_unit_meters">m</string>
     <string name="mapbox_unit_miles">mi</string>
-    <string name="mapbox_unit_feet">ft</string>
+    <string name="mapbox_unit_feet" tools:ignore="MissingTranslation">ft</string>
 </resources>

--- a/libnavigation-util/src/main/res/values-ru/strings.xml
+++ b/libnavigation-util/src/main/res/values-ru/strings.xml
@@ -1,6 +1,6 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="mapbox_unit_kilometers">км</string>
     <string name="mapbox_unit_meters">м</string>
     <string name="mapbox_unit_miles">миль</string>
-    <string name="mapbox_unit_feet">футов</string>
+    <string name="mapbox_unit_feet" tools:ignore="MissingTranslation">футов</string>
 </resources>

--- a/libnavigation-util/src/main/res/values-sv/strings.xml
+++ b/libnavigation-util/src/main/res/values-sv/strings.xml
@@ -1,6 +1,6 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="mapbox_unit_kilometers">km</string>
     <string name="mapbox_unit_meters">m</string>
     <string name="mapbox_unit_miles">mi</string>
-    <string name="mapbox_unit_feet">fot</string>
+    <string name="mapbox_unit_feet" tools:ignore="MissingTranslation">fot</string>
 </resources>

--- a/libnavigation-util/src/main/res/values-uk/strings.xml
+++ b/libnavigation-util/src/main/res/values-uk/strings.xml
@@ -1,6 +1,6 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="mapbox_unit_kilometers">км</string>
     <string name="mapbox_unit_meters">м</string>
     <string name="mapbox_unit_miles">mi</string>
-    <string name="mapbox_unit_feet">фт</string>
+    <string name="mapbox_unit_feet" tools:ignore="MissingTranslation">фт</string>
 </resources>

--- a/libnavigation-util/src/main/res/values-uz/strings.xml
+++ b/libnavigation-util/src/main/res/values-uz/strings.xml
@@ -1,6 +1,6 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="mapbox_unit_kilometers">km</string>
     <string name="mapbox_unit_meters">m</string>
     <string name="mapbox_unit_miles">mil</string>
-    <string name="mapbox_unit_feet">fut</string>
+    <string name="mapbox_unit_feet" tools:ignore="MissingTranslation">fut</string>
 </resources>

--- a/libnavigation-util/src/main/res/values-vi/strings.xml
+++ b/libnavigation-util/src/main/res/values-vi/strings.xml
@@ -1,6 +1,6 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="mapbox_unit_kilometers">km</string>
     <string name="mapbox_unit_meters">m</string>
     <string name="mapbox_unit_miles">dặm</string>
-    <string name="mapbox_unit_feet">foot</string>
+    <string name="mapbox_unit_feet" tools:ignore="MissingTranslation">foot</string>
 </resources>

--- a/libnavigation-util/src/main/res/values-yo/strings.xml
+++ b/libnavigation-util/src/main/res/values-yo/strings.xml
@@ -1,6 +1,6 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="mapbox_unit_kilometers">km</string>
     <string name="mapbox_unit_meters">m</string>
     <string name="mapbox_unit_miles">mi</string>
-    <string name="mapbox_unit_feet">ft</string>
+    <string name="mapbox_unit_feet" tools:ignore="MissingTranslation">ft</string>
 </resources>

--- a/libnavui-maps/src/main/res/values-ca/strings.xml
+++ b/libnavui-maps/src/main/res/values-ca/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="mapbox_recenter">Centra de nou</string>
-    <string name="mapbox_route_overview">Visió General</string>
-</resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <string name="mapbox_recenter" tools:ignore="MissingTranslation">Centra de nou</string>
+    <string name="mapbox_route_overview" tools:ignore="MissingTranslation">Visió General</string>
+    </resources>

--- a/libnavui-maps/src/main/res/values-cs/strings.xml
+++ b/libnavui-maps/src/main/res/values-cs/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="mapbox_recenter">Znovu vycentrovat</string>
-    <string name="mapbox_route_overview">Přehled</string>
-</resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <string name="mapbox_recenter" tools:ignore="MissingTranslation">Znovu vycentrovat</string>
+    <string name="mapbox_route_overview" tools:ignore="MissingTranslation">Přehled</string>
+    </resources>

--- a/libnavui-maps/src/main/res/values-de/strings.xml
+++ b/libnavui-maps/src/main/res/values-de/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="mapbox_recenter">Neu zentrieren</string>
-    <string name="mapbox_route_overview">Übersicht</string>
-</resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <string name="mapbox_recenter" tools:ignore="MissingTranslation">Neu zentrieren</string>
+    <string name="mapbox_route_overview" tools:ignore="MissingTranslation">Übersicht</string>
+    </resources>

--- a/libnavui-maps/src/main/res/values-el/strings.xml
+++ b/libnavui-maps/src/main/res/values-el/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="mapbox_route_overview">Επισκόπηση</string>
-</resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <string name="mapbox_route_overview" tools:ignore="MissingTranslation">Επισκόπηση</string>
+    </resources>

--- a/libnavui-maps/src/main/res/values-es-rES/strings.xml
+++ b/libnavui-maps/src/main/res/values-es-rES/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="mapbox_route_overview">Vista previa</string>
-</resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <string name="mapbox_route_overview" tools:ignore="MissingTranslation">Vista previa</string>
+    </resources>

--- a/libnavui-maps/src/main/res/values-es/strings.xml
+++ b/libnavui-maps/src/main/res/values-es/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="mapbox_route_overview">Vista previa</string>
-</resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <string name="mapbox_route_overview" tools:ignore="MissingTranslation">Vista previa</string>
+    </resources>

--- a/libnavui-maps/src/main/res/values-fr/strings.xml
+++ b/libnavui-maps/src/main/res/values-fr/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="mapbox_route_overview">Aperçu</string>
-</resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <string name="mapbox_route_overview" tools:ignore="MissingTranslation">Aperçu</string>
+    </resources>

--- a/libnavui-maps/src/main/res/values-hu/strings.xml
+++ b/libnavui-maps/src/main/res/values-hu/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="mapbox_route_overview">Áttekintés</string>
-</resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <string name="mapbox_route_overview" tools:ignore="MissingTranslation">Áttekintés</string>
+    </resources>

--- a/libnavui-maps/src/main/res/values-ja/strings.xml
+++ b/libnavui-maps/src/main/res/values-ja/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="mapbox_route_overview">全体を見る</string>
-</resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <string name="mapbox_route_overview" tools:ignore="MissingTranslation">全体を見る</string>
+    </resources>

--- a/libnavui-maps/src/main/res/values-pt-rPT/strings.xml
+++ b/libnavui-maps/src/main/res/values-pt-rPT/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="mapbox_route_overview">Vista geral</string>
-</resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <string name="mapbox_route_overview" tools:ignore="MissingTranslation">Vista geral</string>
+    </resources>

--- a/libnavui-maps/src/main/res/values-ru/strings.xml
+++ b/libnavui-maps/src/main/res/values-ru/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="mapbox_recenter">По центру</string>
-    <string name="mapbox_route_overview">Обзор</string>
-</resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <string name="mapbox_recenter" tools:ignore="MissingTranslation">По центру</string>
+    <string name="mapbox_route_overview" tools:ignore="MissingTranslation">Обзор</string>
+    </resources>

--- a/libnavui-maps/src/main/res/values-sv/strings.xml
+++ b/libnavui-maps/src/main/res/values-sv/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="mapbox_route_overview">Översikt</string>
-</resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <string name="mapbox_route_overview" tools:ignore="MissingTranslation">Översikt</string>
+    </resources>

--- a/libnavui-maps/src/main/res/values-uk/strings.xml
+++ b/libnavui-maps/src/main/res/values-uk/strings.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="mapbox_route_overview">Огляд</string>
-</resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <string name="mapbox_recenter" tools:ignore="MissingTranslation">Повернутись</string>
+    <string name="mapbox_route_overview" tools:ignore="MissingTranslation">Огляд</string>
+    </resources>

--- a/libnavui-maps/src/main/res/values-vi/strings.xml
+++ b/libnavui-maps/src/main/res/values-vi/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="mapbox_recenter">Tập trung lại</string>
-    <string name="mapbox_route_overview">Tóm tắt</string>
-</resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <string name="mapbox_recenter" tools:ignore="MissingTranslation">Tập trung lại</string>
+    <string name="mapbox_route_overview" tools:ignore="MissingTranslation">Tóm tắt</string>
+    </resources>

--- a/libnavui-maps/src/main/res/values-yo/strings.xml
+++ b/libnavui-maps/src/main/res/values-yo/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="mapbox_route_overview">Akopọ</string>
-</resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <string name="mapbox_route_overview" tools:ignore="MissingTranslation">Akopọ</string>
+    </resources>

--- a/libnavui-speedlimit/src/main/res/values-uk/strings.xml
+++ b/libnavui-speedlimit/src/main/res/values-uk/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <string name="max_speed">Макс Швид\n%1$d</string>
+    <string name="max_speed_no_value" tools:ignore="TypographyDashes">Макс Швид\n--</string>
+</resources>


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Fixes https://github.com/mapbox/mapbox-navigation-android/pull/5803#issuecomment-1126368175

Removes `libtrip-notification` Transifex resources and pulls latest translations from Transifex including the ones that were moved to `libnavigation-base` (from `libtrip-notification`) as part of https://github.com/mapbox/mapbox-navigation-android/pull/5803

I've also went ahead and removed the URL from Transifex `Automatic update of source files` config as the `strings.xml` doesn't exist anymore

![Screen Shot 2022-05-13 at 4 23 51 PM](https://user-images.githubusercontent.com/1668582/168393296-21d04c3f-a491-40a4-b94e-b3488382f2a3.png)

This is to avoid 👇
 
<img width="622" alt="Screen Shot 2022-05-13 at 12 16 57 PM" src="https://user-images.githubusercontent.com/1668582/168393507-74e9adbd-44a9-41f3-b790-4f556c886025.png">

cc @1ec5 