### PR TITLE
Don't upload cov in changelog branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -560,8 +560,16 @@ jobs:
   codecov-upload:
     executor: ndk-r22-latest-executor
     steps:
-      - read-workspace
-      - codecov-upload
+      - when:
+          condition:
+            not:
+              matches:
+                pattern: "^add-changelog.*"
+                value: << pipeline.git.branch >>
+          steps:
+            - read-workspace
+            - codecov-upload
+      - run: exit 0
 
   unit-tests-androidauto:
     executor: ndk-r22-latest-executor


### PR DESCRIPTION
### Description
Fix the problem in the PR https://github.com/mapbox/mapbox-navigation-android/pull/5808

Job codecov-upload will be skipped in changelog branches