### PR TITLE
NavigationView lifecycle with Fragments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@ Mapbox welcomes participation and contributions from everyone.
 - Improved enhanced locations bearing changes calculation on corners with high frequency input signal. [#5878](https://github.com/mapbox/mapbox-navigation-android/pull/5878)
 - Fixed off-road detection in unmapped underground garages. [#5878](https://github.com/mapbox/mapbox-navigation-android/pull/5878)
 - Changed `SaveHistoryCallback` to fire on the main thread instead of a worker thread. [#5878](https://github.com/mapbox/mapbox-navigation-android/pull/5878)
+- Fixed an issue where the hosting `LifecycleOwner` used to dictate the lifecycle of the `NavigationView` was taken from the `Activity` even if the view was embedded in a `Fragment`. [#5818](https://github.com/mapbox/mapbox-navigation-android/pull/5818)
+- Added an option to use different `ViewModelStoreOwner`s with the `NavigationView` (for example the one hosted by a `Fragment`). [#5818](https://github.com/mapbox/mapbox-navigation-android/pull/5818)
 
 #### Known issues
-- :bangbang: Expiration of congestion annotations and incidents doesn't work for alternative routes, which can cause inconsistency and a false fact that alternative route is faster. 
+- :bangbang: Expiration of congestion annotations and incidents doesn't work for alternative routes, which can cause inconsistency and a false fact that alternative route is faster.
 
 ## Mapbox Navigation SDK 2.5.0 - May 26, 2022
 

--- a/instrumentation-tests/build.gradle
+++ b/instrumentation-tests/build.gradle
@@ -53,9 +53,11 @@ dependencies {
     implementation dependenciesList.androidXCore
     implementation dependenciesList.materialDesign
     implementation dependenciesList.androidXAppCompat
+    implementation dependenciesList.androidXCardView
     implementation dependenciesList.androidXConstraintLayout
-    implementation dependenciesList.androidXPreference
-    implementation dependenciesList.androidXLifecycleViewmodel
+    implementation dependenciesList.androidXFragment
+    implementation dependenciesList.androidXLifecycleLivedata
+    implementation dependenciesList.androidXLifecycleRuntime
 
     implementation dependenciesList.gmsLocation
 

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/ui/dropin/NavigationViewLifecycleTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/ui/dropin/NavigationViewLifecycleTest.kt
@@ -1,0 +1,132 @@
+package com.mapbox.navigation.instrumentation_tests.ui.dropin
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.IdlingResource
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.dropin.NavigationView
+import com.mapbox.navigation.instrumentation_tests.activity.NavigationViewLifecycleTestActivity
+import com.mapbox.navigation.testing.ui.BaseTest
+import com.mapbox.navigation.testing.ui.idling.NavigationIdlingResource
+import com.mapbox.navigation.testing.ui.utils.runOnMainSync
+import org.junit.Test
+
+@OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
+class NavigationViewLifecycleTest : BaseTest<NavigationViewLifecycleTestActivity>(
+    NavigationViewLifecycleTestActivity::class.java
+) {
+    override fun setupMockLocation() = mockLocationUpdatesRule.generateLocationUpdate {
+        latitude = 50.0
+        longitude = 16.0
+    }
+
+    @Test
+    fun NavigationView_destroyed_when_hosting_Fragment_destroyed() {
+        val idling = ViewLifecycleIdlingResource(
+            activity.firstFragment!!.navigationView!!,
+            Lifecycle.State.DESTROYED
+        )
+        idling.register()
+        runOnMainSync {
+            activity.swapFragments()
+        }
+        Espresso.onIdle()
+        idling.unregister()
+    }
+
+    @Test
+    fun NavigationView_stopped_when_view_detached() {
+        val idlingResumed = ViewLifecycleIdlingResource(
+            activity.firstFragment!!.navigationView!!,
+            Lifecycle.State.RESUMED
+        )
+        val idlingCreated = ViewLifecycleIdlingResource(
+            activity.firstFragment!!.navigationView!!,
+            Lifecycle.State.CREATED
+        )
+        idlingResumed.register()
+        Espresso.onIdle()
+        idlingResumed.unregister()
+
+        idlingCreated.register()
+        runOnMainSync {
+            activity.firstFragment!!.detachNavigationView()
+        }
+        Espresso.onIdle()
+        idlingCreated.unregister()
+    }
+
+    @Test
+    fun NavigationView_resumed_when_view_reattached() {
+        val idlingResumed = ViewLifecycleIdlingResource(
+            activity.firstFragment!!.navigationView!!,
+            Lifecycle.State.RESUMED
+        )
+        val idlingResumed2 = ViewLifecycleIdlingResource(
+            activity.firstFragment!!.navigationView!!,
+            Lifecycle.State.RESUMED
+        )
+        val idlingCreated = ViewLifecycleIdlingResource(
+            activity.firstFragment!!.navigationView!!,
+            Lifecycle.State.CREATED
+        )
+        idlingResumed.register()
+        Espresso.onIdle()
+        idlingResumed.unregister()
+
+        idlingCreated.register()
+        runOnMainSync {
+            activity.firstFragment!!.detachNavigationView()
+        }
+        Espresso.onIdle()
+        idlingCreated.unregister()
+
+        idlingResumed2.register()
+        runOnMainSync {
+            activity.firstFragment!!.attachNavigationView()
+        }
+        Espresso.onIdle()
+        idlingResumed2.unregister()
+    }
+}
+
+@OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
+class ViewLifecycleIdlingResource(
+    navigationView: NavigationView,
+    private val targetState: Lifecycle.State
+) : NavigationIdlingResource() {
+
+    private var state: Lifecycle.State? = null
+        set(value) {
+            field = value
+            if (value == targetState) {
+                callback?.onTransitionToIdle()
+            }
+        }
+    private var callback: IdlingResource.ResourceCallback? = null
+
+    init {
+        runOnMainSync {
+            navigationView.lifecycle.addObserver(
+                object : LifecycleEventObserver {
+                    override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
+                        state = event.targetState
+                    }
+                }
+            )
+        }
+    }
+
+    override fun getName() = this::class.simpleName
+
+    override fun isIdleNow() = state == targetState
+
+    override fun registerIdleTransitionCallback(callback: IdlingResource.ResourceCallback?) {
+        this.callback = callback
+        if (isIdleNow) {
+            callback?.onTransitionToIdle()
+        }
+    }
+}

--- a/instrumentation-tests/src/main/AndroidManifest.xml
+++ b/instrumentation-tests/src/main/AndroidManifest.xml
@@ -24,6 +24,10 @@
         <activity android:name=".activity.EmptyTestActivity" />
         <activity android:name=".activity.BasicNavigationViewActivity" />
         <activity android:name=".activity.NavigationViewTestActivity" />
+        <activity
+            android:name=".activity.NavigationViewLifecycleTestActivity"
+            android:theme="@style/Theme.AppCompat.NoActionBar"
+            />
     </application>
 
 </manifest>

--- a/instrumentation-tests/src/main/java/com/mapbox/navigation/instrumentation_tests/activity/NavigationViewLifecycleTestActivity.kt
+++ b/instrumentation-tests/src/main/java/com/mapbox/navigation/instrumentation_tests/activity/NavigationViewLifecycleTestActivity.kt
@@ -1,0 +1,151 @@
+package com.mapbox.navigation.instrumentation_tests.activity
+
+import android.annotation.SuppressLint
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.commit
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.dropin.NavigationView
+import com.mapbox.navigation.instrumentation_tests.R
+import com.mapbox.navigation.instrumentation_tests.databinding.LayoutActivityNavigationViewLifecycleTestBinding
+import com.mapbox.navigation.utils.internal.logD
+
+private const val FIRST_FRAGMENT_TAG = "FirstFragment"
+private const val SECOND_FRAGMENT_TAG = "SecondFragment"
+
+@OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
+class NavigationViewLifecycleTestActivity : AppCompatActivity() {
+
+    private lateinit var binding: LayoutActivityNavigationViewLifecycleTestBinding
+
+    val firstFragment: PageNavigationFragment?
+        get() {
+            return supportFragmentManager.findFragmentByTag(
+                FIRST_FRAGMENT_TAG
+            ) as? PageNavigationFragment
+        }
+
+    val secondFragment: PageNavigationFragment?
+        get() {
+            return supportFragmentManager.findFragmentByTag(
+                SECOND_FRAGMENT_TAG
+            ) as? PageNavigationFragment
+        }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = LayoutActivityNavigationViewLifecycleTestBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        supportFragmentManager.commit {
+            add(
+                R.id.navigationViewFragment,
+                PageNavigationFragment(FIRST_FRAGMENT_TAG),
+                FIRST_FRAGMENT_TAG
+            )
+        }
+    }
+
+    fun swapFragments() {
+        val fragment = supportFragmentManager.findFragmentById(R.id.navigationViewFragment)
+        val newFragmentPair = if (fragment?.tag == FIRST_FRAGMENT_TAG) {
+            Pair(PageNavigationFragment(SECOND_FRAGMENT_TAG), SECOND_FRAGMENT_TAG)
+        } else {
+            Pair(PageNavigationFragment(FIRST_FRAGMENT_TAG), FIRST_FRAGMENT_TAG)
+        }
+        supportFragmentManager.commit {
+            replace(R.id.navigationViewFragment, newFragmentPair.first, newFragmentPair.second)
+        }
+    }
+}
+
+@OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
+class PageNavigationFragment(private val logTag: String) : Fragment() {
+
+    var navigationView: NavigationView? = null
+        private set
+    private var frame: FrameLayout? = null
+
+    init {
+        lifecycle.addObserver(LifecycleLogger("$logTag(${hashCode()})"))
+    }
+
+    @SuppressLint("InflateParams")
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return inflater.inflate(R.layout.layout_fragment_frame, null).also { frameLayout ->
+            frameLayout as FrameLayout
+            frame = frameLayout
+            NavigationView(
+                context = requireContext(),
+                accessToken = getString(R.string.mapbox_access_token),
+            ).also { navView ->
+                frameLayout.addView(navView)
+                navView.lifecycle.addObserver(
+                    LifecycleLogger("${logTag}NavView(${navView.hashCode()})")
+                )
+                navigationView = navView
+            }
+        }
+    }
+
+    fun detachNavigationView() {
+        navigationView?.let {
+            frame?.removeView(it)
+        }
+    }
+
+    fun attachNavigationView() {
+        navigationView?.let {
+            frame?.addView(it)
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        navigationView = null
+        frame = null
+    }
+}
+
+private const val TAG = "navigation_view_lifecycle_debug"
+
+private class LifecycleLogger(val name: String) : DefaultLifecycleObserver {
+    override fun onCreate(owner: LifecycleOwner) {
+        log("onCreate")
+    }
+
+    override fun onStart(owner: LifecycleOwner) {
+        log("onStart")
+    }
+
+    override fun onResume(owner: LifecycleOwner) {
+        log("onResume")
+    }
+
+    override fun onPause(owner: LifecycleOwner) {
+        log("onPause")
+    }
+
+    override fun onStop(owner: LifecycleOwner) {
+        log("onStop")
+    }
+
+    override fun onDestroy(owner: LifecycleOwner) {
+        log("onDestroy")
+    }
+
+    private fun log(state: String) {
+        logD("$name - $state", TAG)
+    }
+}

--- a/instrumentation-tests/src/main/res/layout/layout_activity_navigation_view_lifecycle_test.xml
+++ b/instrumentation-tests/src/main/res/layout/layout_activity_navigation_view_lifecycle_test.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".activity.NavigationViewLifecycleTestActivity">
+
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/navigationViewFragment"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/instrumentation-tests/src/main/res/layout/layout_fragment_frame.xml
+++ b/instrumentation-tests/src/main/res/layout/layout_fragment_frame.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/navigationViewFrame"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />

--- a/libnavui-dropin/api/current.txt
+++ b/libnavui-dropin/api/current.txt
@@ -2,6 +2,7 @@
 package com.mapbox.navigation.dropin {
 
   @com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI public final class NavigationView extends android.widget.FrameLayout implements androidx.lifecycle.LifecycleOwner {
+    ctor public NavigationView(android.content.Context context, android.util.AttributeSet? attrs = null, String accessToken = attrs.navigationViewAccessToken(context), androidx.lifecycle.ViewModelStoreOwner viewModelStoreOwner = context.toViewModelStoreOwner());
     ctor public NavigationView(android.content.Context context, android.util.AttributeSet? attrs = null, String accessToken = attrs.navigationViewAccessToken(context));
     ctor public NavigationView(android.content.Context context, android.util.AttributeSet? attrs = null);
     ctor public NavigationView(android.content.Context context);

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/internal/extensions/ContextEx.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/internal/extensions/ContextEx.kt
@@ -6,7 +6,6 @@ import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
 import androidx.activity.ComponentActivity
-import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewModelStoreOwner
 import com.mapbox.navigation.utils.internal.logW
 import java.lang.ref.WeakReference
@@ -17,14 +16,6 @@ internal tailrec fun Context.recursiveUnwrap(): Context =
     } else {
         this
     }
-
-internal fun Context.toLifecycleOwner(): LifecycleOwner {
-    val lifecycleOwner = this.recursiveUnwrap() as? LifecycleOwner
-    checkNotNull(lifecycleOwner) {
-        "Please ensure that the hosting Context is a valid LifecycleOwner"
-    }
-    return lifecycleOwner
-}
 
 internal fun Context.toViewModelStoreOwner(): ViewModelStoreOwner {
     val viewModelStoreOwner = this.recursiveUnwrap() as? ViewModelStoreOwner

--- a/qa-test-app/README.md
+++ b/qa-test-app/README.md
@@ -5,7 +5,7 @@
 Though a great deal of effort is put into writing unit and instrumentation tests for the Navigation SDK the team decided there were some cases which required a visual assesment of the functionality of the SDK. The team decided to create a QA application so that we could consistently evalute various features to be sure there were no regressions during development. The application in this module called "Kaizen" serves that purpose.
 
 ### Usage
-Launch the 'qa-test-app' module from android studio. Upon opening the Kaizen application you are presented with a list of test activities. Each activity has an 'info' label which gives a brief summary of what to observe in the activity.  The activities are not meant to be comprehensive navigation activities or represent best practices but instead are purpose built to test a specific feature. If you observe someting other than what is described a regression may of occurred and further investigation should be done.
+Launch the 'qa-test-app' module from android studio. Upon opening the Kaizen application you are presented with a list of test activities. Each activity has an 'info' label which gives a brief summary of what to observe in the activity.  The activities are not meant to be comprehensive navigation activities or represent best practices but instead are purpose built to test a specific feature. If you observe something other than what is described a regression may of occurred and further investigation should be done.
 
 ### Contributing
 To add additional testing activites simply create your activity along with the others in the module and provide an explanation for what's intended to be tested. Add your activity to the TestActivitySuite class along with the others as well as to the AndroidManifest.xml.

--- a/qa-test-app/src/main/AndroidManifest.xml
+++ b/qa-test-app/src/main/AndroidManifest.xml
@@ -51,6 +51,10 @@
             android:name=".view.MapboxNavigationViewFragmentActivity"
             android:theme="@style/Theme.AppCompat.NoActionBar"
             />
+        <activity
+            android:name=".view.NavigationViewFragmentLifecycleActivity"
+            android:theme="@style/Theme.AppCompat.NoActionBar"
+            />
 
         <activity android:name=".view.CustomAlternativeRouteColoringActivity"/>
 

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/domain/TestActivitySuite.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/domain/TestActivitySuite.kt
@@ -15,6 +15,7 @@ import com.mapbox.navigation.qa_test_app.view.MapboxNavigationViewActivity
 import com.mapbox.navigation.qa_test_app.view.MapboxNavigationViewCustomizedActivity
 import com.mapbox.navigation.qa_test_app.view.MapboxNavigationViewFragmentActivity
 import com.mapbox.navigation.qa_test_app.view.MapboxRouteLineActivity
+import com.mapbox.navigation.qa_test_app.view.NavigationViewFragmentLifecycleActivity
 import com.mapbox.navigation.qa_test_app.view.RouteRestrictionsActivity
 import com.mapbox.navigation.qa_test_app.view.RouteTrafficUpdateActivity
 import com.mapbox.navigation.qa_test_app.view.StatusActivity
@@ -125,5 +126,10 @@ object TestActivitySuite {
             R.string.navigation_view_fragment_description,
             launchAfterPermissionResult = false
         ) { activity -> activity.startActivity<MapboxNavigationViewFragmentActivity>() },
+        TestActivityDescription(
+            "Navigation View lifecycle test with Fragments",
+            R.string.navigation_view_fragment_lifecycle_description,
+            launchAfterPermissionResult = false
+        ) { activity -> activity.startActivity<NavigationViewFragmentLifecycleActivity>() },
     )
 }

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/NavigationViewFragmentLifecycleActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/NavigationViewFragmentLifecycleActivity.kt
@@ -1,0 +1,153 @@
+package com.mapbox.navigation.qa_test_app.view
+
+import android.annotation.SuppressLint
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.commit
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.dropin.NavigationView
+import com.mapbox.navigation.qa_test_app.R
+import com.mapbox.navigation.qa_test_app.databinding.LayoutActivityNavigationViewFragmentLifecycleBinding
+import com.mapbox.navigation.utils.internal.logD
+
+private const val FIRST_FRAGMENT_TAG = "FirstFragment"
+private const val SECOND_FRAGMENT_TAG = "SecondFragment"
+
+@OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
+class NavigationViewFragmentLifecycleActivity : AppCompatActivity() {
+
+    private lateinit var binding: LayoutActivityNavigationViewFragmentLifecycleBinding
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = LayoutActivityNavigationViewFragmentLifecycleBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        supportFragmentManager.commit {
+            add(
+                R.id.navigationViewFragment,
+                PageNavigationFragment(FIRST_FRAGMENT_TAG),
+                FIRST_FRAGMENT_TAG
+            )
+        }
+        binding.swapFragments.setOnClickListener {
+            swapFragments()
+        }
+        binding.viewAttachment.setOnClickListener {
+            val fragment = supportFragmentManager
+                .findFragmentById(R.id.navigationViewFragment) as PageNavigationFragment
+            (it as TextView).text = if (fragment.navigationView?.isAttachedToWindow == true) {
+                fragment.detachNavigationView()
+                "ATTACH VIEW"
+            } else {
+                fragment.attachNavigationView()
+                "DETACH VIEW"
+            }
+        }
+    }
+
+    private fun swapFragments() {
+        val fragment = supportFragmentManager.findFragmentById(R.id.navigationViewFragment)
+        val newFragmentPair = if (fragment?.tag == FIRST_FRAGMENT_TAG) {
+            Pair(PageNavigationFragment(SECOND_FRAGMENT_TAG), SECOND_FRAGMENT_TAG)
+        } else {
+            Pair(PageNavigationFragment(FIRST_FRAGMENT_TAG), FIRST_FRAGMENT_TAG)
+        }
+        supportFragmentManager.commit {
+            replace(R.id.navigationViewFragment, newFragmentPair.first, newFragmentPair.second)
+        }
+        binding.viewAttachment.text = "DETACH VIEW"
+    }
+}
+
+@OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
+class PageNavigationFragment(private val logTag: String) : Fragment() {
+
+    var navigationView: NavigationView? = null
+        private set
+    private var frame: FrameLayout? = null
+
+    init {
+        lifecycle.addObserver(LifecycleLogger("$logTag(${hashCode()})"))
+    }
+
+    @SuppressLint("InflateParams")
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return inflater.inflate(R.layout.layout_fragment_frame, null).also { frameLayout ->
+            frameLayout as FrameLayout
+            frame = frameLayout
+            NavigationView(
+                context = requireContext(),
+                accessToken = getString(R.string.mapbox_access_token),
+            ).also { navView ->
+                frameLayout.addView(navView)
+                navView.lifecycle.addObserver(
+                    LifecycleLogger("${logTag}NavView(${navView.hashCode()})")
+                )
+                navigationView = navView
+            }
+        }
+    }
+
+    fun detachNavigationView() {
+        navigationView?.let {
+            frame?.removeView(it)
+        }
+    }
+
+    fun attachNavigationView() {
+        navigationView?.let {
+            frame?.addView(it)
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        navigationView = null
+        frame = null
+    }
+}
+
+private const val TAG = "navigation_view_lifecycle_debug"
+
+private class LifecycleLogger(val name: String) : DefaultLifecycleObserver {
+    override fun onCreate(owner: LifecycleOwner) {
+        log("onCreate")
+    }
+
+    override fun onStart(owner: LifecycleOwner) {
+        log("onStart")
+    }
+
+    override fun onResume(owner: LifecycleOwner) {
+        log("onResume")
+    }
+
+    override fun onPause(owner: LifecycleOwner) {
+        log("onPause")
+    }
+
+    override fun onStop(owner: LifecycleOwner) {
+        log("onStop")
+    }
+
+    override fun onDestroy(owner: LifecycleOwner) {
+        log("onDestroy")
+    }
+
+    private fun log(state: String) {
+        logD("$name - $state", TAG)
+    }
+}

--- a/qa-test-app/src/main/res/layout/layout_activity_navigation_view_fragment_lifecycle.xml
+++ b/qa-test-app/src/main/res/layout/layout_activity_navigation_view_fragment_lifecycle.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".view.MapboxNavigationViewFragmentActivity">
+
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/navigationViewFragment"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/swapFragments"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        />
+
+    <Button
+        android:id="@+id/swapFragments"
+        android:layout_gravity="bottom|center_horizontal"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/viewAttachment"
+        android:text="SWAP FRAGMENTS"/>
+
+    <Button
+        android:id="@+id/viewAttachment"
+        android:layout_gravity="bottom|center_horizontal"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toEndOf="@id/swapFragments"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:text="DETACH VIEW"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/qa-test-app/src/main/res/layout/layout_fragment_frame.xml
+++ b/qa-test-app/src/main/res/layout/layout_fragment_frame.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/navigationViewFrame"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />

--- a/qa-test-app/src/main/res/values/strings.xml
+++ b/qa-test-app/src/main/res/values/strings.xml
@@ -18,4 +18,5 @@
     <string name="navigation_view_description" translatable="false">Utility for testing Drop-In UI.</string>
     <string name="navigation_view_customized_description" translatable="false">Utility for testing customized Drop-In UI.</string>
     <string name="navigation_view_fragment_description" translatable="false">Utility for testing Drop-In UI in a fragment.</string>
+    <string name="navigation_view_fragment_lifecycle_description" translatable="false">Utility for testing Drop-In UI lifecycle with fragments. Verify the lifecycle by filtering logs with "navigation_view_lifecycle_debug".\n\nWhen a fragment is swapped, the previous fragment and its NavigationView should both reach the destroyed state.\nWhen a NavigationView is detached it should be stopped and resumed back when re-attached.\n\nDetaching a NavigationView and then swapping fragments should not leak.</string>
 </resources>


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Closes https://github.com/mapbox/mapbox-navigation-android/issues/5796.

This PR tries to optimize the `ViewLifecycleRegistry` for a use-case with fragments and opens up the `NavigationView` constructor to provide the `ViewModelStoreOwner` that's tied to a `Fragment` instead of an `Activity`. Both of these together should provide the closest tie to a `Fragment` lifecycle for both `ViewModel`s as well as coroutines run in the `NavigationView` lifecycle scope.

WIP, just documenting the idea for now, I haven't done any in-depth testing just yet

cc @pengdev @yunikkk for visibility 
<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
