### PR TITLE
[Android auto] first instruction fix

### DIFF
--- a/libnavui-androidauto/CHANGELOG.md
+++ b/libnavui-androidauto/CHANGELOG.md
@@ -8,6 +8,7 @@ Mapbox welcomes participation and contributions from everyone.
 
 #### Bug fixes and improvements
  - Remove extra arrival feedback options. [#5805](https://github.com/mapbox/mapbox-navigation-android/pull/5805)
+ - Fixed an issue when the first voice instruction was not played. [#5825](https://github.com/mapbox/mapbox-navigation-android/pull/5825)
 
 ## androidauto-v0.1.0 - May 05, 2022
 

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/navigation/audioguidance/MapboxAudioGuidanceServices.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/navigation/audioguidance/MapboxAudioGuidanceServices.kt
@@ -18,5 +18,5 @@ interface MapboxAudioGuidanceServices {
         language: String,
     ): MapboxVoiceInstructionsPlayer
 
-    fun mapboxVoiceInstructions(mapboxNavigation: MapboxNavigation): MapboxVoiceInstructions
+    fun mapboxVoiceInstructions(): MapboxVoiceInstructions
 }

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/navigation/audioguidance/impl/MapboxAudioGuidanceServicesImpl.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/navigation/audioguidance/impl/MapboxAudioGuidanceServicesImpl.kt
@@ -38,7 +38,5 @@ class MapboxAudioGuidanceServicesImpl : MapboxAudioGuidanceServices {
         return MapboxVoiceInstructionsPlayer(applicationContext, accessToken, language)
     }
 
-    override fun mapboxVoiceInstructions(
-        mapboxNavigation: MapboxNavigation
-    ) = MapboxVoiceInstructions(mapboxNavigation)
+    override fun mapboxVoiceInstructions() = MapboxVoiceInstructions()
 }

--- a/libnavui-androidauto/src/test/java/com/mapbox/androidauto/navigation/audioguidance/impl/MapboxAudioGuidanceImplTest.kt
+++ b/libnavui-androidauto/src/test/java/com/mapbox/androidauto/navigation/audioguidance/impl/MapboxAudioGuidanceImplTest.kt
@@ -207,7 +207,7 @@ class MapboxAudioGuidanceImplTest {
             val mapboxAudioGuidanceServices =
                 testMapboxAudioGuidanceServices.mapboxAudioGuidanceServices
             excludeRecords {
-                mapboxAudioGuidanceServices.mapboxVoiceInstructions(any())
+                mapboxAudioGuidanceServices.mapboxVoiceInstructions()
             }
             verifySequence {
                 mapboxAudioGuidanceServices.mapboxAudioGuidanceVoice(any(), deviceLanguage)

--- a/libnavui-androidauto/src/test/java/com/mapbox/androidauto/testing/TestMapboxAudioGuidanceServices.kt
+++ b/libnavui-androidauto/src/test/java/com/mapbox/androidauto/testing/TestMapboxAudioGuidanceServices.kt
@@ -6,7 +6,9 @@ import com.mapbox.androidauto.navigation.audioguidance.impl.MapboxVoiceInstructi
 import com.mapbox.androidauto.navigation.audioguidance.impl.MapboxVoiceInstructionsState
 import com.mapbox.api.directions.v5.models.VoiceInstructions
 import com.mapbox.navigation.ui.voice.model.SpeechAnnouncement
+import io.mockk.Runs
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -22,6 +24,8 @@ class TestMapboxAudioGuidanceServices {
     private val voiceLanguageFlow = MutableStateFlow<String?>(value = null)
 
     private val mapboxVoiceInstructions = mockk<MapboxVoiceInstructions> {
+        every { registerObservers(any()) } just Runs
+        every { unregisterObservers(any()) } just Runs
         every { voiceInstructions() } returns voiceInstructionsFlow
         every { voiceLanguage() } returns voiceLanguageFlow
     }
@@ -45,7 +49,7 @@ class TestMapboxAudioGuidanceServices {
     }
 
     val mapboxAudioGuidanceServices = mockk<MapboxAudioGuidanceServices> {
-        every { mapboxVoiceInstructions(any()) } returns mapboxVoiceInstructions
+        every { mapboxVoiceInstructions() } returns mapboxVoiceInstructions
         every { mapboxAudioGuidanceVoice(any(), any()) } returns mapboxAudioGuidanceVoice
     }
 


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

This PR fixes an issue when the first instruction is not played.
It's related to `libnavui-androidauto` module only and can be tested with 1Tap.
Also it might be useful to have some activity (or a separate test app?) in `examples` to test `libnavui-androidauto` module.

### issue details:
- when routes observer triggered we cancel previous voice instructions flow, create a new flow with a new instructions observer
- new instructions observer ^^ created too late and we lost the first instruction

### changes:
- start/stop listening for `routes`, `instructions`, `tripSessionState` on `attach`/`detach`
- pass values ^^ to flows stored in `MapboxAudioGuidanceServicesImpl`

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
