### PR TITLE
[release-v2.5] Bump mapbox java to 5.6.0-beta.6

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -20,7 +20,7 @@ ext {
   version = [
       mapboxMapSdk              : '10.5.0',
       mapboxGLNative            : '10.5.2', // remove after upgrading Maps SDK to v10.6.0-beta.1
-      mapboxSdkServices         : '6.5.0-beta.5',
+      mapboxSdkServices         : '6.5.0-beta.6',
       mapboxEvents              : '8.1.1',
       mapboxCore                : '5.0.1',
       mapboxNavigator           : "${mapboxNavigatorVersion}",


### PR DESCRIPTION
Backporting https://github.com/mapbox/mapbox-navigation-android/pull/5822
