### PR TITLE
Adding support for sharing multiple instances of MapboxNavigationObserver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Mapbox welcomes participation and contributions from everyone.
 
 ## Unreleased
 #### Features
+- Added support for sharing multiple instances of `MapboxNavigationObserver`. [#5829](https://github.com/mapbox/mapbox-navigation-android/pull/5829)
+
 #### Bug fixes and improvements
 
 ## Mapbox Navigation SDK 2.6.0-alpha.1 - May 19, 2022

--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -291,6 +291,7 @@ package com.mapbox.navigation.core.lifecycle {
     method public com.mapbox.navigation.core.lifecycle.MapboxNavigationApp disable();
     method public androidx.lifecycle.LifecycleOwner getLifecycleOwner();
     method public <T extends com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver> T getObserver(kotlin.reflect.KClass<T> kClass);
+    method public <T extends com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver> java.util.List<T> getObservers(kotlin.reflect.KClass<T> kClass);
     method public boolean isSetup();
     method public com.mapbox.navigation.core.lifecycle.MapboxNavigationApp registerObserver(com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver mapboxNavigationObserver);
     method public com.mapbox.navigation.core.lifecycle.MapboxNavigationApp setup(com.mapbox.navigation.base.options.NavigationOptions navigationOptions);

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/lifecycle/MapboxNavigationApp.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/lifecycle/MapboxNavigationApp.kt
@@ -162,6 +162,14 @@ object MapboxNavigationApp {
     }
 
     /**
+     * Provides access to any registered observer instance. If no observers have been registered
+     * with this class type, an empty list is returned.
+     */
+    fun <T : MapboxNavigationObserver> getObservers(kClass: KClass<T>): List<T> {
+        return mapboxNavigationAppDelegate.getObservers(kClass)
+    }
+
+    /**
      * [MapboxNavigation] has functions that do not require observation streams. This function
      * allows you to get the current instance to call those functions.
      *

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/lifecycle/MapboxNavigationAppDelegate.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/lifecycle/MapboxNavigationAppDelegate.kt
@@ -77,6 +77,12 @@ internal class MapboxNavigationAppDelegate {
     fun <T : MapboxNavigationObserver> getObserver(kClass: KClass<T>): T =
         mapboxNavigationOwner.getObserver(kClass)
 
+    fun <T : MapboxNavigationObserver> getObservers(clazz: Class<T>): List<T> =
+        mapboxNavigationOwner.getObservers(clazz)
+
+    fun <T : MapboxNavigationObserver> getObservers(kClass: KClass<T>): List<T> =
+        mapboxNavigationOwner.getObservers(kClass)
+
     private companion object {
         private const val LOG_CATEGORY = "MapboxNavigationAppDelegate"
     }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/lifecycle/MapboxNavigationOwner.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/lifecycle/MapboxNavigationOwner.kt
@@ -46,13 +46,15 @@ internal class MapboxNavigationOwner {
     }
 
     fun register(mapboxNavigationObserver: MapboxNavigationObserver) = apply {
-        mapboxNavigation?.let { mapboxNavigationObserver.onAttached(it) }
-        services.add(mapboxNavigationObserver)
+        if (services.add(mapboxNavigationObserver)) {
+            mapboxNavigation?.let { mapboxNavigationObserver.onAttached(it) }
+        }
     }
 
     fun unregister(mapboxNavigationObserver: MapboxNavigationObserver) {
-        mapboxNavigation?.let { mapboxNavigationObserver.onDetached(it) }
-        services.remove(mapboxNavigationObserver)
+        if (services.remove(mapboxNavigationObserver)) {
+            mapboxNavigation?.let { mapboxNavigationObserver.onDetached(it) }
+        }
     }
 
     fun disable() {
@@ -68,10 +70,16 @@ internal class MapboxNavigationOwner {
     fun <T : MapboxNavigationObserver> getObserver(clazz: KClass<T>): T = getObserver(clazz.java)
 
     // Java
-    fun <T : MapboxNavigationObserver> getObserver(clazz: Class<T>): T {
-        return services.filterIsInstance(clazz).firstOrNull()
+    fun <T : MapboxNavigationObserver> getObserver(clazz: Class<T>): T =
+        getObservers(clazz).firstOrNull()
             ?: error("Class ${clazz.simpleName} is not been registered to MapboxNavigationApp")
-    }
+
+    fun <T : MapboxNavigationObserver> getObservers(clazz: KClass<T>): List<T> =
+        getObservers(clazz.java)
+
+    // Java
+    fun <T : MapboxNavigationObserver> getObservers(clazz: Class<T>): List<T> =
+        services.filterIsInstance(clazz)
 
     private companion object {
         private const val LOG_CATEGORY = "MapboxNavigationOwner"


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

We're going to use `MapboxNavigationApp.registerObserver` to share subscriptions between different architectures. For example, android auto will register a `MapboxNavigationObserver` that may also be registered by drop in ui.

This pull request is adding safe ways to get and register `MapboxNavigationObserver` instances. Note that thread safety is not yet being address in this pull request. 

### Code samples
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->

#### Register from multiple paths

Android Auto Session onCreate
and a Fragment onCreate
``` kotlin
object AudioGuidanceObserver : MapboxNavigationObserver
if (MapboxNavigationApp.getObservers(MyObserver::class).isEmpty()) {
  MapboxNavigationApp.registerObserver(MyObserver)
}
```

This will ensure that only one `MyObserver` is registered. The unregister is tied to the `MapboxNavigationApp.lifecycleOwner`; meaning that when there are no lifecycles attached the `MyObserver` instance will be unregistered.

#### Sharing multiple subscriptions

The current `MapboxNavigationApp.getObserver` will crash when the observer is not found. There are implementations that we should support in case there are multiple/optional observers registered. For example, you may have registered multiple observers that are updating status on a map (nearby places while navigating for example).

MyFragment
``` kotlin
// Periodically update the the waiting line size of ev charging stations
class EvStationObserver : MapboxNavigationObserver
val evStations = MapboxNavigationApp.getObservers(EvStationObserver::class)
evStations.forEach {
  // update map marker
}
```

// Clear all the instances of a specific observer type
``` kotlin
class NearbyGasStationObserver : MapboxNavigationObserver
val evStations = MapboxNavigationApp.getObservers(NearbyGasStationObserver::class)
evStations.forEach {
  MapboxNavigationApp.unregister(evStations)
}
```

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
