### PR TITLE
Changelog for 2.5.0-rc.2 and 2.6.0-alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,36 @@ Mapbox welcomes participation and contributions from everyone.
 
 ## Unreleased
 #### Features
+#### Bug fixes and improvements
+
+## Mapbox Navigation SDK 2.6.0-alpha.1 - May 19, 2022
+### Changelog
+[Changes between v2.5.0-rc.2 and v2.6.0-alpha.1](https://github.com/mapbox/mapbox-navigation-android/compare/v2.5.0-rc.1...v2.6.0-alpha.1)
+
+### Mapbox dependencies
+This release depends on, and has been tested with, the following Mapbox dependencies:
+- Mapbox Maps SDK `v10.5.0` ([release notes](https://github.com/mapbox/mapbox-maps-android/releases/tag/android-v10.5.0))
+- Mapbox Navigation Native `v100.0.0`
+- Mapbox Core Common `v21.3.1`
+- Mapbox Java `v6.5.0-beta.6` ([release notes](https://github.com/mapbox/mapbox-java/releases/tag/v6.5.0-beta.6))
+- Mapbox Android Core `v5.0.1`
+- Mapbox Android Telemetry `v8.1.1`
+
+## Mapbox Navigation SDK 2.5.0-rc.2 - May 19, 2022
+### Changelog
+[Changes between v2.5.0-rc.1 and v2.5.0-rc.2](https://github.com/mapbox/mapbox-navigation-android/compare/v2.5.0-rc.1...v2.5.0-rc.2)
 
 #### Bug fixes and improvements
 - Fixed an issue with the vanishing point being rendered ahead of the location indicator (especially on long routes) and other rendering artifact on the route line when the vanishing feature is enabled. [#5816](https://github.com/mapbox/mapbox-navigation-android/pull/5816)
+
+### Mapbox dependencies
+This release depends on, and has been tested with, the following Mapbox dependencies:
+- Mapbox Maps SDK `v10.5.0` ([release notes](https://github.com/mapbox/mapbox-maps-android/releases/tag/android-v10.5.0))
+- Mapbox Navigation Native `v100.0.0`
+- Mapbox Core Common `v21.3.1`
+- Mapbox Java `v6.5.0-beta.6` ([release notes](https://github.com/mapbox/mapbox-java/releases/tag/v6.5.0-beta.6))
+- Mapbox Android Core `v5.0.1`
+- Mapbox Android Telemetry `v8.1.1`
 
 ## Mapbox Navigation SDK 2.5.0-rc.1 - May 13, 2022
 ### Changelog


### PR DESCRIPTION
Release branch changelog https://github.com/mapbox/mapbox-navigation-android/pull/5831

## Mapbox Navigation SDK 2.6.0-alpha.1 - May 19, 2022
### Changelog
[Changes between v2.5.0-rc.2 and v2.6.0-alpha.1](https://github.com/mapbox/mapbox-navigation-android/compare/v2.5.0-rc.1...v2.6.0-alpha.1)

### Mapbox dependencies
This release depends on, and has been tested with, the following Mapbox dependencies:
- Mapbox Maps SDK `v10.5.0` ([release notes](https://github.com/mapbox/mapbox-maps-android/releases/tag/android-v10.5.0))
- Mapbox Navigation Native `v100.0.0`
- Mapbox Core Common `v21.3.1`
- Mapbox Java `v6.5.0-beta.6` ([release notes](https://github.com/mapbox/mapbox-java/releases/tag/v6.5.0-beta.6))
- Mapbox Android Core `v5.0.1`
- Mapbox Android Telemetry `v8.1.1`

## Mapbox Navigation SDK 2.5.0-rc.2 - May 19, 2022
### Changelog
[Changes between v2.5.0-rc.1 and v2.5.0-rc.2](https://github.com/mapbox/mapbox-navigation-android/compare/v2.5.0-rc.1...v2.5.0-rc.2)

#### Bug fixes and improvements
- Fixed an issue with the vanishing point being rendered ahead of the location indicator (especially on long routes) and other rendering artifact on the route line when the vanishing feature is enabled. [#5816](https://github.com/mapbox/mapbox-navigation-android/pull/5816)

### Mapbox dependencies
This release depends on, and has been tested with, the following Mapbox dependencies:
- Mapbox Maps SDK `v10.5.0` ([release notes](https://github.com/mapbox/mapbox-maps-android/releases/tag/android-v10.5.0))
- Mapbox Navigation Native `v100.0.0`
- Mapbox Core Common `v21.3.1`
- Mapbox Java `v6.5.0-beta.6` ([release notes](https://github.com/mapbox/mapbox-java/releases/tag/v6.5.0-beta.6))
- Mapbox Android Core `v5.0.1`
- Mapbox Android Telemetry `v8.1.1`
