### PR TITLE
Resetting the trim-offset to 0.0 when routes are drawn. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Mapbox welcomes participation and contributions from everyone.
 
 #### Bug fixes and improvements
 - Reduced memory consumptions on startup by not decoding tiles in predictive cache and latest version controller [#5848](https://github.com/mapbox/mapbox-navigation-android/pull/5847)
+- Fixed an issue where the vanishing point of the primary route line was not always reset when new routes were drawn following a previous active navigation session. [#5842](https://github.com/mapbox/mapbox-navigation-android/pull/5842)
 
 ## Mapbox Navigation SDK 2.6.0-alpha.1 - May 19, 2022
 ### Changelog

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/internal/route/line/RouteLineTrimOffset.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/internal/route/line/RouteLineTrimOffset.kt
@@ -1,0 +1,9 @@
+package com.mapbox.navigation.ui.maps.internal.route.line
+
+/**
+ * Value for the offset at which the primary route line should change the appearance or vanish.
+ *
+ * @param offset the percentage offset
+ */
+@JvmInline
+internal value class RouteLineTrimOffset(val offset: Double)

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApi.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApi.kt
@@ -29,6 +29,7 @@ import com.mapbox.navigation.core.trip.session.RouteProgressObserver
 import com.mapbox.navigation.ui.base.util.MapboxNavigationConsumer
 import com.mapbox.navigation.ui.maps.internal.route.line.MapboxRouteLineUtils
 import com.mapbox.navigation.ui.maps.internal.route.line.MapboxRouteLineUtils.getMatchingColors
+import com.mapbox.navigation.ui.maps.internal.route.line.RouteLineTrimOffset
 import com.mapbox.navigation.ui.maps.route.RouteLayerConstants
 import com.mapbox.navigation.ui.maps.route.line.model.ClosestRouteValue
 import com.mapbox.navigation.ui.maps.route.line.model.ExtractedRouteData
@@ -1421,7 +1422,10 @@ class MapboxRouteLineApi(
                         primaryRouteBaseExpressionProducer,
                         primaryRouteCasingExpressionProducer,
                         primaryRouteTrafficLineExpressionProducer,
-                        primaryRouteRestrictedSectionsExpressionProducer
+                        primaryRouteRestrictedSectionsExpressionProducer,
+                        RouteLineTrimOffset(
+                            routeLineOptions.vanishingRouteLine?.vanishPointOffset ?: 0.0
+                        )
                     )
                 ),
                 alternativeRouteLinesData = listOf(

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineView.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineView.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import com.mapbox.bindgen.Expected
 import com.mapbox.geojson.FeatureCollection
 import com.mapbox.maps.Style
+import com.mapbox.maps.extension.style.expressions.dsl.generated.literal
 import com.mapbox.maps.extension.style.expressions.generated.Expression
 import com.mapbox.maps.extension.style.layers.Layer
 import com.mapbox.maps.extension.style.layers.generated.LineLayer
@@ -97,6 +98,9 @@ class MapboxRouteLineView(var options: MapboxRouteLineOptions) {
                         )
 
                         value.primaryRouteLineData.also {
+                            it.dynamicData.trimOffset?.apply {
+                                setTrimOffsetForPrimaryRouteLineLayers(style, offset)
+                            }
                             updateSource(
                                 style,
                                 RouteLayerConstants.PRIMARY_ROUTE_SOURCE_ID,
@@ -603,5 +607,41 @@ class MapboxRouteLineView(var options: MapboxRouteLineOptions) {
                 (it as LineLayer).lineGradient(expression)
             }
         }
+    }
+
+    private fun setTrimOffsetForPrimaryRouteLineLayers(style: Style, offset: Double) {
+        val trafficLineExpressionProvider = RouteLineTrimExpressionProvider {
+            literal(listOf(0.0, offset))
+        }
+        updateTrimOffset(
+            style,
+            RouteLayerConstants.PRIMARY_ROUTE_TRAFFIC_LAYER_ID,
+            trafficLineExpressionProvider
+        )
+        updateTrimOffset(
+            style,
+            RouteLayerConstants.PRIMARY_ROUTE_CASING_LAYER_ID,
+            trafficLineExpressionProvider
+        )
+        updateTrimOffset(
+            style,
+            RouteLayerConstants.PRIMARY_ROUTE_LAYER_ID,
+            trafficLineExpressionProvider
+        )
+        updateTrimOffset(
+            style,
+            RouteLayerConstants.PRIMARY_ROUTE_TRAIL_LAYER_ID,
+            trafficLineExpressionProvider
+        )
+        updateTrimOffset(
+            style,
+            RouteLayerConstants.PRIMARY_ROUTE_CASING_TRAIL_LAYER_ID,
+            trafficLineExpressionProvider
+        )
+        updateTrimOffset(
+            style,
+            RouteLayerConstants.RESTRICTED_ROAD_LAYER_ID,
+            trafficLineExpressionProvider
+        )
     }
 }

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineDynamicData.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineDynamicData.kt
@@ -1,5 +1,7 @@
 package com.mapbox.navigation.ui.maps.route.line.model
 
+import com.mapbox.navigation.ui.maps.internal.route.line.RouteLineTrimOffset
+
 /**
  * Provides information needed to draw a route.
  *
@@ -12,7 +14,8 @@ class RouteLineDynamicData internal constructor(
     val baseExpressionProvider: RouteLineExpressionProvider,
     val casingExpressionProvider: RouteLineExpressionProvider,
     val trafficExpressionProvider: RouteLineExpressionProvider?,
-    val restrictedSectionExpressionProvider: RouteLineExpressionProvider?
+    val restrictedSectionExpressionProvider: RouteLineExpressionProvider?,
+    internal val trimOffset: RouteLineTrimOffset? = null
 ) {
 
     /**
@@ -22,7 +25,8 @@ class RouteLineDynamicData internal constructor(
         baseExpressionProvider,
         casingExpressionProvider,
         trafficExpressionProvider,
-        restrictedSectionExpressionProvider
+        restrictedSectionExpressionProvider,
+        trimOffset
     )
 
     /**
@@ -32,12 +36,14 @@ class RouteLineDynamicData internal constructor(
      * @param casingExpressionProvider expression used to style the case of the line
      * @param trafficExpressionProvider expression used to style the congestion colors on the line
      * @param restrictedSectionExpressionProvider expression used to style the restricted sections on the line
+     * @param trimOffset a value representing the section of the line that should be trimmed and made transparent
      */
     class MutableRouteLineDynamicData internal constructor(
         var baseExpressionProvider: RouteLineExpressionProvider,
         var casingExpressionProvider: RouteLineExpressionProvider,
         var trafficExpressionProvider: RouteLineExpressionProvider?,
-        var restrictedSectionExpressionProvider: RouteLineExpressionProvider?
+        var restrictedSectionExpressionProvider: RouteLineExpressionProvider?,
+        internal var trimOffset: RouteLineTrimOffset? = null
     ) {
 
         /**
@@ -47,7 +53,8 @@ class RouteLineDynamicData internal constructor(
             baseExpressionProvider,
             casingExpressionProvider,
             trafficExpressionProvider,
-            restrictedSectionExpressionProvider
+            restrictedSectionExpressionProvider,
+            trimOffset
         )
     }
 
@@ -65,6 +72,7 @@ class RouteLineDynamicData internal constructor(
         if (trafficExpressionProvider != other.trafficExpressionProvider) return false
         if (restrictedSectionExpressionProvider != other.restrictedSectionExpressionProvider)
             return false
+        if (trimOffset != other.trimOffset) return false
 
         return true
     }
@@ -77,6 +85,7 @@ class RouteLineDynamicData internal constructor(
         result = 31 * result + casingExpressionProvider.hashCode()
         result = 31 * result + (trafficExpressionProvider?.hashCode() ?: 0)
         result = 31 * result + (restrictedSectionExpressionProvider?.hashCode() ?: 0)
+        result = 31 * result + (trimOffset?.hashCode() ?: 0)
         return result
     }
 
@@ -88,7 +97,8 @@ class RouteLineDynamicData internal constructor(
             "baseExpressionProvider=$baseExpressionProvider, " +
             "casingExpressionProvider=$casingExpressionProvider, " +
             "trafficExpressionProvider=$trafficExpressionProvider, " +
-            "restrictedSectionExpressionProvider=$restrictedSectionExpressionProvider" +
+            "restrictedSectionExpressionProvider=$restrictedSectionExpressionProvider," +
+            "trimOffset=$trimOffset" +
             ")"
     }
 }

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApiTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApiTest.kt
@@ -454,6 +454,38 @@ class MapboxRouteLineApiTest {
     }
 
     @Test
+    fun setRoutes_trimOffsetValueFromVanishingRouteLine() =
+        coroutineRule.runBlockingTest {
+            val vanishingRouteLine = mockk<VanishingRouteLine>(relaxed = true) {
+                every { vanishPointOffset } returns 9.9
+            }
+            val realOptions = MapboxRouteLineOptions.Builder(ctx).build()
+            val options = mockk<MapboxRouteLineOptions>()
+            every { options.routeLayerProvider } returns realOptions.routeLayerProvider
+            every { options.resourceProvider } returns realOptions.resourceProvider
+            every { options.vanishingRouteLine } returns vanishingRouteLine
+            every { options.displayRestrictedRoadSections } returns false
+            every {
+                options.styleInactiveRouteLegsIndependently
+            } returns realOptions.styleInactiveRouteLegsIndependently
+            every { options.displaySoftGradientForTraffic } returns false
+            every { options.softGradientTransition } returns 30.0
+            every { options.routeStyleDescriptors } returns listOf()
+
+            val api = MapboxRouteLineApi(options)
+            val route = loadRoute("short_route.json")
+            val routes = listOf(RouteLine(route, null))
+
+            val result = api.setRoutes(routes).value!!
+
+            assertEquals(
+                9.9,
+                result.primaryRouteLineData.dynamicData.trimOffset!!.offset,
+                0.0
+            )
+        }
+
+    @Test
     fun setRoutesAlternativeRouteColorOverride() = coroutineRule.runBlockingTest {
         val routeStyleDescriptors = listOf(
             RouteStyleDescriptor("alternativeRoute1", Color.YELLOW, Color.CYAN),

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineViewTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineViewTest.kt
@@ -9,6 +9,7 @@ import com.mapbox.bindgen.ExpectedFactory
 import com.mapbox.geojson.Feature
 import com.mapbox.geojson.FeatureCollection
 import com.mapbox.maps.Style
+import com.mapbox.maps.extension.style.expressions.dsl.generated.literal
 import com.mapbox.maps.extension.style.expressions.generated.Expression
 import com.mapbox.maps.extension.style.layers.generated.LineLayer
 import com.mapbox.maps.extension.style.layers.getLayer
@@ -17,6 +18,7 @@ import com.mapbox.maps.extension.style.sources.generated.GeoJsonSource
 import com.mapbox.maps.extension.style.sources.getSource
 import com.mapbox.navigation.testing.MainCoroutineRule
 import com.mapbox.navigation.ui.maps.internal.route.line.MapboxRouteLineUtils
+import com.mapbox.navigation.ui.maps.internal.route.line.RouteLineTrimOffset
 import com.mapbox.navigation.ui.maps.route.RouteLayerConstants.ALTERNATIVE_ROUTE1_CASING_LAYER_ID
 import com.mapbox.navigation.ui.maps.route.RouteLayerConstants.ALTERNATIVE_ROUTE1_LAYER_ID
 import com.mapbox.navigation.ui.maps.route.RouteLayerConstants.ALTERNATIVE_ROUTE1_SOURCE_ID
@@ -26,9 +28,11 @@ import com.mapbox.navigation.ui.maps.route.RouteLayerConstants.ALTERNATIVE_ROUTE
 import com.mapbox.navigation.ui.maps.route.RouteLayerConstants.ALTERNATIVE_ROUTE2_SOURCE_ID
 import com.mapbox.navigation.ui.maps.route.RouteLayerConstants.ALTERNATIVE_ROUTE2_TRAFFIC_LAYER_ID
 import com.mapbox.navigation.ui.maps.route.RouteLayerConstants.PRIMARY_ROUTE_CASING_LAYER_ID
+import com.mapbox.navigation.ui.maps.route.RouteLayerConstants.PRIMARY_ROUTE_CASING_TRAIL_LAYER_ID
 import com.mapbox.navigation.ui.maps.route.RouteLayerConstants.PRIMARY_ROUTE_LAYER_ID
 import com.mapbox.navigation.ui.maps.route.RouteLayerConstants.PRIMARY_ROUTE_SOURCE_ID
 import com.mapbox.navigation.ui.maps.route.RouteLayerConstants.PRIMARY_ROUTE_TRAFFIC_LAYER_ID
+import com.mapbox.navigation.ui.maps.route.RouteLayerConstants.PRIMARY_ROUTE_TRAIL_LAYER_ID
 import com.mapbox.navigation.ui.maps.route.RouteLayerConstants.RESTRICTED_ROAD_LAYER_ID
 import com.mapbox.navigation.ui.maps.route.RouteLayerConstants.TOP_LEVEL_ROUTE_LINE_LAYER_ID
 import com.mapbox.navigation.ui.maps.route.RouteLayerConstants.WAYPOINT_LAYER_ID
@@ -378,6 +382,8 @@ class MapboxRouteLineViewTest {
         val altRoute1Source = mockk<GeoJsonSource>(relaxed = true)
         val altRoute2Source = mockk<GeoJsonSource>(relaxed = true)
         val wayPointSource = mockk<GeoJsonSource>(relaxed = true)
+        val trailLayer = mockk<LineLayer>(relaxed = true)
+        val trailCasingLayer = mockk<LineLayer>(relaxed = true)
 
         val state: Expected<RouteLineError, RouteSetValue> = ExpectedFactory.createValue(
             RouteSetValue(
@@ -387,7 +393,8 @@ class MapboxRouteLineViewTest {
                         { routeLineExp },
                         { casingLineEx },
                         { trafficLineExp },
-                        { restrictedRouteExpression }
+                        { restrictedRouteExpression },
+                        RouteLineTrimOffset(9.9)
                     )
                 ),
                 alternativeRouteLinesData = listOf(
@@ -447,6 +454,12 @@ class MapboxRouteLineViewTest {
             every {
                 getLayer(TOP_LEVEL_ROUTE_LINE_LAYER_ID)
             } returns topLevelLayer
+            every {
+                getLayer(PRIMARY_ROUTE_TRAIL_LAYER_ID)
+            } returns trailLayer
+            every {
+                getLayer(PRIMARY_ROUTE_CASING_TRAIL_LAYER_ID)
+            } returns trailCasingLayer
             every { getSource(PRIMARY_ROUTE_SOURCE_ID) } returns primaryRouteSource
             every { getSource(ALTERNATIVE_ROUTE1_SOURCE_ID) } returns altRoute1Source
             every { getSource(ALTERNATIVE_ROUTE2_SOURCE_ID) } returns altRoute2Source
@@ -477,6 +490,13 @@ class MapboxRouteLineViewTest {
         verify { altRoute2Source.featureCollection(alternativeRoute2FeatureCollection) }
         verify { wayPointSource.featureCollection(waypointsFeatureCollection) }
         verify { restrictedRouteLayer.lineGradient(restrictedRouteExpression) }
+        verify { primaryRouteTrafficLayer.lineTrimOffset(literal(listOf(0.0, 9.9))) }
+        verify { primaryRouteLayer.lineTrimOffset(literal(listOf(0.0, 9.9))) }
+        verify { primaryRouteCasingLayer.lineTrimOffset(literal(listOf(0.0, 9.9))) }
+        verify { restrictedRouteLayer.lineTrimOffset(literal(listOf(0.0, 9.9))) }
+        verify { trailCasingLayer.lineTrimOffset(literal(listOf(0.0, 9.9))) }
+        verify { trailLayer.lineTrimOffset(literal(listOf(0.0, 9.9))) }
+
         unmockkObject(MapboxRouteLineUtils)
         unmockkStatic("com.mapbox.maps.extension.style.layers.LayerUtils")
         unmockkStatic("com.mapbox.maps.extension.style.sources.SourceUtils")

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineDynamicDataTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineDynamicDataTest.kt
@@ -1,5 +1,6 @@
 package com.mapbox.navigation.ui.maps.route.line.model
 
+import com.mapbox.navigation.ui.maps.internal.route.line.RouteLineTrimOffset
 import io.mockk.mockk
 import junit.framework.TestCase.assertEquals
 import org.junit.Test
@@ -12,7 +13,8 @@ class RouteLineDynamicDataTest {
             mockk(),
             mockk(),
             mockk(),
-            mockk()
+            mockk(),
+            RouteLineTrimOffset(9.9)
         )
 
         val result = original.toMutableValue()
@@ -24,6 +26,7 @@ class RouteLineDynamicDataTest {
             result.restrictedSectionExpressionProvider
         )
         assertEquals(original.trafficExpressionProvider, result.trafficExpressionProvider)
+        assertEquals(original.trimOffset, result.trimOffset)
     }
 
     @Test
@@ -32,7 +35,8 @@ class RouteLineDynamicDataTest {
             mockk(),
             mockk(),
             mockk(),
-            mockk()
+            mockk(),
+            RouteLineTrimOffset(9.9)
         )
         val replacementBaseProvider = mockk<RouteLineExpressionProvider>()
         val replacementCasingProvider = mockk<RouteLineExpressionProvider>()
@@ -50,5 +54,6 @@ class RouteLineDynamicDataTest {
         assertEquals(replacementCasingProvider, result.casingExpressionProvider)
         assertEquals(replacementTrafficProvider, result.trafficExpressionProvider)
         assertEquals(replacementSectionProvider, result.restrictedSectionExpressionProvider)
+        assertEquals(original.trimOffset, result.trimOffset)
     }
 }


### PR DESCRIPTION
### Description
Fixing a bug found when using the trim-offset feature.  It appears the trim-offset must be explicitly reset to 0.0.  Setting a line gradient on the layer isn't enough to change the line's appearance.  

### Screenshots or Gifs

