### PR TITLE
Following camera Focal Point offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Mapbox welcomes participation and contributions from everyone.
 
 ## Unreleased
 #### Features
+- Added `FollowingFrameOptions.focalPoint` that can be used to define the position of the first framed geometry point (typically the user location indicator, if available) in the `MapboxNavigationViewportDataSource.followingPadding`. [#5875](https://github.com/mapbox/mapbox-navigation-android/pull/5875)
+
 #### Bug fixes and improvements
 - Introduced `NavigationViewListener#onInfoPanelHidden` to inform user when `InfoPanel` hides. [#6113](https://github.com/mapbox/mapbox-navigation-android/pull/6113)
 - Introduced `NavigationViewListener#onInfoPanelExpanded` to inform user when `InfoPanel` expands. [#6113](https://github.com/mapbox/mapbox-navigation-android/pull/6113)

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/camera/AnimationAdapter.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/camera/AnimationAdapter.kt
@@ -19,6 +19,7 @@ class AnimationAdapter(
     init {
         animationList.add(AnimationType.Following)
         animationList.add(AnimationType.Overview)
+        animationList.add(AnimationType.FollowingNorth)
         animationList.add(AnimationType.FastFollowing)
         animationList.add(AnimationType.ToPOI)
         animationList.add(AnimationType.LookAtPOIWhenFollowing)

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/camera/AnimationType.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/camera/AnimationType.kt
@@ -3,6 +3,7 @@ package com.mapbox.navigation.examples.core.camera
 enum class AnimationType {
     Following,
     Overview,
+    FollowingNorth,
     FastFollowing,
     ToPOI,
     LookAtPOIWhenFollowing,

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/camera/MapboxCameraAnimationsActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/camera/MapboxCameraAnimationsActivity.kt
@@ -54,6 +54,7 @@ import com.mapbox.navigation.examples.core.camera.AnimationAdapter.OnAnimationBu
 import com.mapbox.navigation.examples.core.databinding.LayoutActivityCameraBinding
 import com.mapbox.navigation.examples.util.Utils
 import com.mapbox.navigation.ui.maps.camera.NavigationCamera
+import com.mapbox.navigation.ui.maps.camera.data.FollowingFrameOptions.FocalPoint
 import com.mapbox.navigation.ui.maps.camera.data.MapboxNavigationViewportDataSource
 import com.mapbox.navigation.ui.maps.camera.data.debugger.MapboxNavigationViewportDataSourceDebugger
 import com.mapbox.navigation.ui.maps.camera.lifecycle.NavigationScaleGestureHandler
@@ -268,13 +269,16 @@ class MapboxCameraAnimationsActivity :
         viewportDataSource = MapboxNavigationViewportDataSource(
             binding.mapView.getMapboxMap()
         )
-        viewportDataSource.options.followingFrameOptions.pitchNearManeuvers.apply {
+        viewportDataSource.options.followingFrameOptions.apply {
             // An example of maneuver exclusion from "pitch to 0 near maneuvers" updates.
-            excludedManeuvers = listOf(
+            pitchNearManeuvers.excludedManeuvers = listOf(
                 StepManeuver.FORK,
                 StepManeuver.OFF_RAMP,
                 StepManeuver.ARRIVE
             )
+
+            // An example of Following Camera Focal Point adjustment
+            focalPoint = FocalPoint(0.5, 0.9)
         }
         viewportDataSource.debugger = debugger
         navigationCamera = NavigationCamera(

--- a/libnavui-maps/api/current.txt
+++ b/libnavui-maps/api/current.txt
@@ -134,6 +134,7 @@ package com.mapbox.navigation.ui.maps.camera.data {
     method public boolean getBearingUpdatesAllowed();
     method public boolean getCenterUpdatesAllowed();
     method public double getDefaultPitch();
+    method public com.mapbox.navigation.ui.maps.camera.data.FollowingFrameOptions.FocalPoint getFocalPoint();
     method public com.mapbox.navigation.ui.maps.camera.data.FollowingFrameOptions.FrameGeometryAfterManeuver getFrameGeometryAfterManeuver();
     method public com.mapbox.navigation.ui.maps.camera.data.FollowingFrameOptions.IntersectionDensityCalculation getIntersectionDensityCalculation();
     method public double getMaxZoom();
@@ -146,6 +147,7 @@ package com.mapbox.navigation.ui.maps.camera.data {
     method public void setBearingUpdatesAllowed(boolean);
     method public void setCenterUpdatesAllowed(boolean);
     method public void setDefaultPitch(double);
+    method public void setFocalPoint(com.mapbox.navigation.ui.maps.camera.data.FollowingFrameOptions.FocalPoint);
     method public void setMaxZoom(double);
     method public void setMaximizeViewableGeometryWhenPitchZero(boolean);
     method public void setMinZoom(double);
@@ -156,6 +158,7 @@ package com.mapbox.navigation.ui.maps.camera.data {
     property public final boolean bearingUpdatesAllowed;
     property public final boolean centerUpdatesAllowed;
     property public final double defaultPitch;
+    property public final com.mapbox.navigation.ui.maps.camera.data.FollowingFrameOptions.FocalPoint focalPoint;
     property public final com.mapbox.navigation.ui.maps.camera.data.FollowingFrameOptions.FrameGeometryAfterManeuver frameGeometryAfterManeuver;
     property public final com.mapbox.navigation.ui.maps.camera.data.FollowingFrameOptions.IntersectionDensityCalculation intersectionDensityCalculation;
     property public final double maxZoom;
@@ -174,6 +177,17 @@ package com.mapbox.navigation.ui.maps.camera.data {
     method public void setMaxBearingAngleDiff(double);
     property public final boolean enabled;
     property public final double maxBearingAngleDiff;
+  }
+
+  public static final class FollowingFrameOptions.FocalPoint {
+    ctor public FollowingFrameOptions.FocalPoint(@FloatRange(from=0.0, to=1.0) double x, @FloatRange(from=0.0, to=1.0) double y);
+    method public double component1();
+    method public double component2();
+    method public com.mapbox.navigation.ui.maps.camera.data.FollowingFrameOptions.FocalPoint copy(@FloatRange(from=0.0, to=1.0) double x, @FloatRange(from=0.0, to=1.0) double y);
+    method public double getX();
+    method public double getY();
+    property public final double x;
+    property public final double y;
   }
 
   public static final class FollowingFrameOptions.FrameGeometryAfterManeuver {

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/MapboxNavigationViewportDataSource.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/MapboxNavigationViewportDataSource.kt
@@ -744,11 +744,16 @@ class MapboxNavigationViewportDataSource(
                 val mapSize = mapboxMap.getSize()
                 val screenBox = getScreenBoxForFraming(mapSize, followingPadding)
                 val cameraState = mapboxMap.cameraState
+                val padding = getMapAnchoredPaddingFromUserPadding(
+                    mapSize,
+                    followingPadding,
+                    options.followingFrameOptions.focalPoint
+                )
                 val fallbackCameraOptions = CameraOptions.Builder()
                     .center(
                         pointsForFollowing.firstOrNull() ?: cameraState.center
                     )
-                    .padding(getMapAnchoredPaddingFromUserPadding(mapSize, followingPadding))
+                    .padding(padding)
                     .bearing(followingBearingProperty.get())
                     .pitch(followingPitchProperty.get())
                     .zoom(cameraState.zoom)

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/MapboxNavigationViewportDataSourceOptions.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/MapboxNavigationViewportDataSourceOptions.kt
@@ -279,6 +279,8 @@ class FollowingFrameOptions internal constructor() {
 
     /**
      * Focal point that defines the position of the first framed geometry point.
+     * @param x position from the left edge of the padding in the `<0.0, 1.0>` range
+     * @param y position from the top edge of the padding in the `<0.0, 1.0>` range
      */
     data class FocalPoint(
         @FloatRange(from = 0.0, to = 1.0) val x: Double,

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/MapboxNavigationViewportDataSourceOptions.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/MapboxNavigationViewportDataSourceOptions.kt
@@ -51,9 +51,9 @@ class FollowingFrameOptions internal constructor() {
      *
      * The value is a horizontal and vertical ratio starting from the top left corner of the padding, in the `<0.0, 1.0>` range.
      * Example:
-     * - FocalPoint(0.0, 0.0)` positions the first geometry point in the top left
-     * - FocalPoint(0.5, 0.5)` positions the first geometry point in the center
-     * - FocalPoint(1.0, 1.0)` positions the first geometry point in the bottom right
+     * - `FocalPoint(0.0, 0.0)` positions the first geometry point in the top left
+     * - `FocalPoint(0.5, 0.5)` positions the first geometry point in the center
+     * - `FocalPoint(1.0, 1.0)` positions the first geometry point in the bottom right
      *
      * Defaults to `FocalPoint(0.5, 1.0)` that centers horizontally on the bottom edge of the padding.
      *

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/MapboxNavigationViewportDataSourceOptions.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/MapboxNavigationViewportDataSourceOptions.kt
@@ -1,6 +1,7 @@
 package com.mapbox.navigation.ui.maps.camera.data
 
 import android.location.Location
+import androidx.annotation.FloatRange
 import com.mapbox.api.directions.v5.models.StepManeuver
 
 /**
@@ -43,6 +44,22 @@ class FollowingFrameOptions internal constructor() {
      * Defaults to `16.35`.
      */
     var maxZoom = 16.35
+
+    /**
+     * Focal point that defines the position of the first framed geometry point (typically the user location indicator, if available)
+     * in the [MapboxNavigationViewportDataSource.followingPadding].
+     *
+     * The value is a horizontal and vertical ratio starting from the top left corner of the padding, in the `<0.0, 1.0>` range.
+     * Example:
+     * - FocalPoint(0.0, 0.0)` positions the first geometry point in the top left
+     * - FocalPoint(0.5, 0.5)` positions the first geometry point in the center
+     * - FocalPoint(1.0, 1.0)` positions the first geometry point in the bottom right
+     *
+     * Defaults to `FocalPoint(0.5, 1.0)` that centers horizontally on the bottom edge of the padding.
+     *
+     * **NOTE:** The focal point change has no effect when the camera's pitch is `0` and [maximizeViewableGeometryWhenPitchZero] is enabled.
+     */
+    var focalPoint: FocalPoint = FocalPoint(0.5, 1.0)
 
     /**
      * When a produced **following frame** has pitch `0` and there are at least 2 points available for framing,
@@ -258,6 +275,19 @@ class FollowingFrameOptions internal constructor() {
          * Defaults to `45.0` degrees.
          */
         var maxBearingAngleDiff = 45.0
+    }
+
+    /**
+     * Focal point that defines the position of the first framed geometry point.
+     */
+    data class FocalPoint(
+        @FloatRange(from = 0.0, to = 1.0) val x: Double,
+        @FloatRange(from = 0.0, to = 1.0) val y: Double
+    ) {
+        init {
+            require(x in 0.0..1.0) { "x value must be within [0.0..1.0] range" }
+            require(y in 0.0..1.0) { "y value must be within [0.0..1.0] range" }
+        }
     }
 }
 

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/ViewportDataSourceProcessor.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/ViewportDataSourceProcessor.kt
@@ -317,7 +317,11 @@ internal object ViewportDataSourceProcessor {
      *
      * That single-pixel anchor sits on the bottom edge of the provided padding, centered horizontally.
      */
-    fun getMapAnchoredPaddingFromUserPadding(mapSize: Size, padding: EdgeInsets): EdgeInsets {
+    fun getMapAnchoredPaddingFromUserPadding(
+        mapSize: Size,
+        padding: EdgeInsets,
+        focalPoint: FocalPoint = FocalPoint(0.5, 1.0)
+    ): EdgeInsets {
         val verticalRange = 0f..mapSize.height
         val horizontalRange = 0f..mapSize.width
         padding.run {
@@ -342,12 +346,9 @@ internal object ViewportDataSourceProcessor {
             }
         }
 
-        val anchorPointX =
-            ((mapSize.width - padding.left - padding.right) / 2.0) + padding.left
-        val centerInsidePaddingY =
-            ((mapSize.height - padding.top - padding.bottom) / 2.0) + padding.top
-        val anchorPointY =
-            ((mapSize.height - padding.bottom - centerInsidePaddingY)).plus(centerInsidePaddingY)
+        val (fx, fy) = focalPoint
+        val anchorPointX = (mapSize.width - padding.left - padding.right) * fx + padding.left
+        val anchorPointY = (mapSize.height - padding.top - padding.bottom) * fy + padding.top
 
         return EdgeInsets(
             anchorPointY,

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/ViewportDataSourceProcessor.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/ViewportDataSourceProcessor.kt
@@ -320,7 +320,7 @@ internal object ViewportDataSourceProcessor {
     fun getMapAnchoredPaddingFromUserPadding(
         mapSize: Size,
         padding: EdgeInsets,
-        focalPoint: FocalPoint = FocalPoint(0.5, 1.0)
+        focalPoint: FollowingFrameOptions.FocalPoint
     ): EdgeInsets {
         val verticalRange = 0f..mapSize.height
         val horizontalRange = 0f..mapSize.width

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/camera/data/MapboxNavigationViewportDataSourceTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/camera/data/MapboxNavigationViewportDataSourceTest.kt
@@ -136,7 +136,9 @@ class MapboxNavigationViewportDataSourceTest {
         viewportDataSource = MapboxNavigationViewportDataSource(mapboxMap)
 
         mockkObject(ViewportDataSourceProcessor)
-        every { getMapAnchoredPaddingFromUserPadding(mapSize, any()) } returns singlePixelEdgeInsets
+        every {
+            getMapAnchoredPaddingFromUserPadding(mapSize, any(), any())
+        } returns singlePixelEdgeInsets
         every { getScreenBoxForFraming(mapSize, any()) } returns followingScreenBox
         every {
             getSmootherBearingForMap(

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/camera/data/ViewportDataSourceProcessorTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/camera/data/ViewportDataSourceProcessorTest.kt
@@ -103,6 +103,8 @@ class ViewportDataSourceProcessorTest {
         doubleAdapter
     )
 
+    private val defaultFocalPoint = FollowingFrameOptions.FocalPoint(0.5, 1.0)
+
     @Test
     fun `test processRoutePoints`() {
         val expected = completeRoutePoints
@@ -652,7 +654,7 @@ class ViewportDataSourceProcessorTest {
         val padding = EdgeInsets(0.0, 0.0, 0.0, 0.0)
         val expected = EdgeInsets(1000.0, 500.0, 0.0, 500.0)
 
-        val actual = getMapAnchoredPaddingFromUserPadding(mapSize, padding)
+        val actual = getMapAnchoredPaddingFromUserPadding(mapSize, padding, defaultFocalPoint)
 
         assertEquals(expected, actual)
     }
@@ -663,7 +665,7 @@ class ViewportDataSourceProcessorTest {
         val padding = EdgeInsets(300.0, 150.0, 200.0, 100.0)
         val expected = EdgeInsets(800.0, 525.0, 200.0, 475.0)
 
-        val actual = getMapAnchoredPaddingFromUserPadding(mapSize, padding)
+        val actual = getMapAnchoredPaddingFromUserPadding(mapSize, padding, defaultFocalPoint)
 
         assertEquals(expected, actual)
     }
@@ -676,15 +678,15 @@ class ViewportDataSourceProcessorTest {
         val expected = EdgeInsets(0.0, 0.0, 0.0, 0.0)
 
         val padding1 = EdgeInsets(0.0, 1100.0, 0.0, 0.0)
-        val actual1 = getMapAnchoredPaddingFromUserPadding(mapSize, padding1)
+        val actual1 = getMapAnchoredPaddingFromUserPadding(mapSize, padding1, defaultFocalPoint)
         assertEquals(expected, actual1)
 
         val padding2 = EdgeInsets(0.0, 0.0, 0.0, 1100.0)
-        val actual2 = getMapAnchoredPaddingFromUserPadding(mapSize, padding2)
+        val actual2 = getMapAnchoredPaddingFromUserPadding(mapSize, padding2, defaultFocalPoint)
         assertEquals(expected, actual2)
 
         val padding3 = EdgeInsets(0.0, 600.0, 0.0, 600.0)
-        val actual3 = getMapAnchoredPaddingFromUserPadding(mapSize, padding3)
+        val actual3 = getMapAnchoredPaddingFromUserPadding(mapSize, padding3, defaultFocalPoint)
         assertEquals(expected, actual3)
         unmockkStatic(Logger::class)
     }
@@ -697,15 +699,15 @@ class ViewportDataSourceProcessorTest {
         val expected = EdgeInsets(0.0, 0.0, 0.0, 0.0)
 
         val padding1 = EdgeInsets(1100.0, 0.0, 0.0, 0.0)
-        val actual1 = getMapAnchoredPaddingFromUserPadding(mapSize, padding1)
+        val actual1 = getMapAnchoredPaddingFromUserPadding(mapSize, padding1, defaultFocalPoint)
         assertEquals(expected, actual1)
 
         val padding2 = EdgeInsets(0.0, 0.0, 1100.0, 0.0)
-        val actual2 = getMapAnchoredPaddingFromUserPadding(mapSize, padding2)
+        val actual2 = getMapAnchoredPaddingFromUserPadding(mapSize, padding2, defaultFocalPoint)
         assertEquals(expected, actual2)
 
         val padding3 = EdgeInsets(600.0, 0.0, 600.0, 0.0)
-        val actual3 = getMapAnchoredPaddingFromUserPadding(mapSize, padding3)
+        val actual3 = getMapAnchoredPaddingFromUserPadding(mapSize, padding3, defaultFocalPoint)
         assertEquals(expected, actual3)
         unmockkStatic(Logger::class)
     }
@@ -716,13 +718,25 @@ class ViewportDataSourceProcessorTest {
 
         val padding1 = EdgeInsets(250.0, 300.0, 750.0, 0.0)
         val expected1 = EdgeInsets(250.0, 650.0, 750.0, 350.0)
-        val actual1 = getMapAnchoredPaddingFromUserPadding(mapSize, padding1)
+        val actual1 = getMapAnchoredPaddingFromUserPadding(mapSize, padding1, defaultFocalPoint)
         assertEquals(expected1, actual1)
 
         val padding2 = EdgeInsets(200.0, 250.0, 0.0, 750.0)
         val expected2 = EdgeInsets(1000.0, 250.0, 0.0, 750.0)
-        val actual2 = getMapAnchoredPaddingFromUserPadding(mapSize, padding2)
+        val actual2 = getMapAnchoredPaddingFromUserPadding(mapSize, padding2, defaultFocalPoint)
         assertEquals(expected2, actual2)
+    }
+
+    @Test
+    fun `test getMapAnchoredPaddingFromUserPadding - focal point offset`() {
+        val mapSize = Size(1000f, 1000f)
+        val padding = EdgeInsets(0.0, 0.0, 0.0, 0.0)
+        val expected = EdgeInsets(500.0, 500.0, 500.0, 500.0)
+        val focalPoint = FollowingFrameOptions.FocalPoint(0.5, 0.5)
+
+        val actual = getMapAnchoredPaddingFromUserPadding(mapSize, padding, focalPoint)
+
+        assertEquals(expected, actual)
     }
 
     @Test


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-navigation-android/issues/4347

## Changelog entry
```
- Added `FollowingFrameOptions.focalPoint` that can be used to define the position of the first framed geometry point (typically the user location indicator, if available) in the `MapboxNavigationViewportDataSource.followingPadding`. [#5875](https://github.com/mapbox/mapbox-navigation-android/pull/5875)
```

## TODOs
- [x] bump Maps SDK dependency
- [x] add changelog entry
