### PR TITLE
[Android Auto] Use specific version of ui-app

### DIFF
--- a/libnavui-androidauto/build.gradle
+++ b/libnavui-androidauto/build.gradle
@@ -41,9 +41,11 @@ dependencies {
     // This defines the minimum version of Maps, Navigation, and Search which are included in
     // this SDK. To upgrade the SDK versions, you can specify a newer version in your downstream
     // build.gradle.
-    api("com.mapbox.navigation:android:2.6.0-alpha.2")
-    api("com.mapbox.search:mapbox-search-android:1.0.0-beta.29")
-    implementation project(":libnavui-app")
+    def carNavVersion = "2.6.0-alpha.2"
+    def carSearchVersion = "1.0.0-beta.29"
+    api("com.mapbox.navigation:android:${carNavVersion}")
+    api("com.mapbox.search:mapbox-search-android:${carSearchVersion}")
+    implementation("com.mapbox.navigation:ui-app:${carNavVersion}")
 
     implementation(dependenciesList.androidXAppCompat)
     implementation(dependenciesList.coroutinesCore)

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/QaTestApplication.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/QaTestApplication.kt
@@ -1,14 +1,15 @@
 package com.mapbox.navigation.qa_test_app
 
 import android.app.Application
+import com.mapbox.androidauto.MapboxCarApp
+import com.mapbox.navigation.qa_test_app.car.search.MapboxCarSearchApp
 
 class QaTestApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
 
-        // Uncomment when testing android-auto
-        // MapboxCarApp.setup(this)
-        // MapboxCarSearchApp.setup(this)
+        MapboxCarApp.setup(this)
+        MapboxCarSearchApp.setup(this)
     }
 }


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Following up from https://github.com/mapbox/mapbox-navigation-android/pull/5846#discussion_r885970396

Thanks @Zayankovsky for raising! 

Example of the issue:

1. Downstream uses `ui-androidauto:0.3.0` (if we released this)
1. Make an incompatible api in `ui-app` and release to `2.6.0-alpha.3` (current is alpha.2)
1. Downstream upgrades nav sdk to `2.6.0-alpha.3`
1. ui-androidauto:0.3.0 expects alpha.2 code but is linked to alpha.3

Results in runtime crashes
