### PR TITLE
WIP - POC for syncing location puck updates with NavigationCamera

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/camera/Experimental.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/camera/Experimental.kt
@@ -1,0 +1,386 @@
+package com.mapbox.navigation.examples.core.camera
+
+import android.animation.Animator
+import android.animation.TimeInterpolator
+import android.animation.TypeEvaluator
+import android.animation.ValueAnimator
+import android.graphics.Path
+import android.location.Location
+import android.location.LocationManager
+import android.view.animation.PathInterpolator
+import com.mapbox.geojson.Point
+import com.mapbox.maps.plugin.locationcomponent.LocationConsumer
+import com.mapbox.maps.plugin.locationcomponent.LocationProvider
+import com.mapbox.navigation.ui.maps.camera.data.MapboxNavigationViewportDataSource
+import com.mapbox.navigation.ui.maps.location.NavigationLocationProvider
+import com.mapbox.navigation.utils.internal.logD
+import java.util.concurrent.ConcurrentLinkedQueue
+import kotlin.math.pow
+
+//region Synced Puck
+
+fun NavigationLocationProvider.syncedWith(
+    viewportDataSource: MapboxNavigationViewportDataSource
+): LocationProvider {
+    val downstream = PuckLocationProvider(NavigationLocationProvider().asPublisher())
+    val provider = DeferredLocationProvider(this, downstream)
+    viewportDataSource.registerUpdateObserver {
+        provider.publishLocation()
+    }
+    return provider
+}
+
+fun NavigationLocationProvider.syncedWith(
+    viewportDataSource: MapboxNavigationViewportDataSource,
+    animationRecorder: AnimRecorder
+): LocationProvider {
+    val downstream = PuckLocationProvider(NavigationLocationProvider().asPublisher())
+    val recorder = RecordingLocationProvider(downstream, animationRecorder)
+    val provider = DeferredLocationProvider(this, recorder)
+    viewportDataSource.registerUpdateObserver {
+        provider.publishLocation()
+    }
+    return provider
+}
+
+interface LocationPublisher : LocationProvider {
+    fun publish(
+        location: Location,
+        keyPoints: List<Location> = emptyList(),
+        latLngTransitionOptions: (ValueAnimator.() -> Unit)? = null,
+        bearingTransitionOptions: (ValueAnimator.() -> Unit)? = null
+    )
+}
+
+fun NavigationLocationProvider.asPublisher(): LocationPublisher {
+    return object : LocationPublisher, LocationProvider by this {
+        override fun publish(
+            location: Location,
+            keyPoints: List<Location>,
+            latLngTransitionOptions: (ValueAnimator.() -> Unit)?,
+            bearingTransitionOptions: (ValueAnimator.() -> Unit)?
+        ) {
+            changePosition(location, keyPoints, latLngTransitionOptions, bearingTransitionOptions)
+        }
+    }
+}
+
+class DeferredLocationProvider(
+    private val upstreamProvider: NavigationLocationProvider,
+    private val downstreamProvider: LocationPublisher
+) : LocationProvider by downstreamProvider {
+
+    init {
+        upstreamProvider.onFirstLocation {
+            downstreamProvider.publish(it)
+        }
+    }
+
+    fun publishLocation() {
+        upstreamProvider.lastLocation?.also {
+            downstreamProvider.publish(it, upstreamProvider.lastKeyPoints)
+        }
+    }
+
+    private fun NavigationLocationProvider.onFirstLocation(action: (Location) -> Unit) {
+        lastLocation?.also {
+            action(it)
+            return
+        }
+        registerLocationConsumer(object : AbstractLocationConsumer() {
+            override fun onLocationUpdated(
+                vararg location: Point,
+                options: (ValueAnimator.() -> Unit)?
+            ) {
+                location.firstOrNull()?.also {
+                    action(Location(LocationManager.PASSIVE_PROVIDER).apply {
+                        latitude = it.latitude()
+                        longitude = it.longitude()
+                    })
+                }
+                unRegisterLocationConsumer(this)
+            }
+        })
+    }
+
+    private abstract class AbstractLocationConsumer : LocationConsumer {
+        override fun onBearingUpdated(
+            vararg bearing: Double,
+            options: (ValueAnimator.() -> Unit)?
+        ) = Unit
+
+        override fun onLocationUpdated(
+            vararg location: Point,
+            options: (ValueAnimator.() -> Unit)?
+        ) = Unit
+
+        override fun onPuckBearingAnimatorDefaultOptionsUpdated(options: ValueAnimator.() -> Unit) =
+            Unit
+
+        override fun onPuckLocationAnimatorDefaultOptionsUpdated(options: ValueAnimator.() -> Unit) =
+            Unit
+    }
+}
+
+//endregion
+
+class PuckLocationProvider(
+    private val downstreamProvider: LocationPublisher,
+) : LocationProvider by downstreamProvider, LocationPublisher {
+
+    override fun publish(
+        location: Location,
+        keyPoints: List<Location>,
+        latLngTransitionOptions: (ValueAnimator.() -> Unit)?,
+        bearingTransitionOptions: (ValueAnimator.() -> Unit)?
+    ) {
+        logD("", "PuckLocationProvider")
+        logD(
+            "changePosition keyPoints(${keyPoints.size}) = ${keyPoints.asStr()}; location = ${location.asStr()};",
+            "PuckLocationProvider"
+        )
+        val latLngUpdates = if (keyPoints.isNotEmpty()) {
+            keyPoints.map { Point.fromLngLat(it.longitude, it.latitude) }.toTypedArray()
+        } else {
+            arrayOf(Point.fromLngLat(location.longitude, location.latitude))
+        }
+
+        val evaluator = PuckAnimationEvaluator(latLngUpdates)
+
+        val options: (ValueAnimator.() -> Unit) = {
+            latLngTransitionOptions?.also { apply(it) }
+            interpolator = evaluator
+            setEvaluator(evaluator)
+        }
+
+        downstreamProvider.publish(
+            location,
+            keyPoints,
+            options,
+            bearingTransitionOptions
+        )
+    }
+}
+
+class PuckAnimationEvaluator(
+    private val keyPoints: Array<Point>
+) : TimeInterpolator, TypeEvaluator<Point> {
+
+    private var interpolator: TimeInterpolator? = null
+
+    override fun getInterpolation(input: Float): Float =
+        interpolator?.getInterpolation(input) ?: input
+
+    override fun evaluate(fraction: Float, startValue: Point, endValue: Point): Point {
+        if (interpolator == null) {
+            // we defer creation of TimeInterpolator until we know startValue
+            interpolator = createTimeInterpolator(startValue)
+        }
+        return POINT.evaluate(fraction, startValue, endValue)
+    }
+
+    private fun createTimeInterpolator(startValue: Point): TimeInterpolator {
+        val distances = mutableListOf<Double>()
+        var total = 0.0
+        keyPoints.fold(startValue) { prevPoint, point ->
+            val d = prevPoint.distanceSqrTo(point)
+            distances.add(d)
+            total += d
+            point
+        }
+
+        if (0 < total) {
+            val path = Path()
+            val pathDebug = mutableListOf<Pair<Float, Float>>(0.0f to 0.0f)
+            val step = 1.0f / keyPoints.size
+            var rs = 0.0
+            val rr = keyPoints.mapIndexed { index, point ->
+                val r = distances[index] / total
+                rs += r
+                path.lineTo(rs.toFloat(), step * (index + 1))
+                pathDebug.add(rs.toFloat() to step * (index + 1))
+                r to point.asStr()
+            }
+            logD("ratios = $rr; pathInterpolator = $pathDebug", "PuckAnimationEvaluator")
+            return PathInterpolator(path)
+        }
+        return TimeInterpolator { it }
+    }
+
+    companion object {
+        private val POINT = TypeEvaluator<Point> { fraction, startValue, endValue ->
+            Point.fromLngLat(
+                startValue.longitude() + fraction * (endValue.longitude() - startValue.longitude()),
+                startValue.latitude() + fraction * (endValue.latitude() - startValue.latitude())
+            )
+        }
+    }
+}
+
+private fun Point.distanceSqrTo(p: Point): Double {
+    return (p.latitude() - latitude()).pow(2) + (p.longitude() - longitude()).pow(2)
+}
+
+private fun Location.asStr() = "(${latitude},${longitude})"
+private fun List<Location>.asStr() =
+    map { it.asStr() }.joinToString(prefix = "[", postfix = "]")
+
+private fun Point.asStr() = "(${latitude()},${longitude()})"
+
+// --
+
+class RecordingLocationProvider(
+    private val downstreamProvider: LocationPublisher,
+    private val animationRecorder: AnimRecorder
+) : LocationProvider by downstreamProvider, LocationPublisher {
+
+    override fun publish(
+        location: Location,
+        keyPoints: List<Location>,
+        latLngTransitionOptions: (ValueAnimator.() -> Unit)?,
+        bearingTransitionOptions: (ValueAnimator.() -> Unit)?
+    ) {
+        val options: (ValueAnimator.() -> Unit) = {
+            latLngTransitionOptions?.also { apply(it) }
+            animationRecorder.attachTo(this)
+        }
+
+        downstreamProvider.publish(
+            location,
+            keyPoints,
+            options,
+            bearingTransitionOptions
+        )
+    }
+}
+
+class AnimRecorder : Animator.AnimatorListener, ValueAnimator.AnimatorUpdateListener {
+
+    var isRecording = false
+        private set
+
+    val recordings = mutableListOf<Recording>()
+
+    private val sampleRate: Long = 100 // milliseconds
+    private var lastSampleTime: Long = 0
+    private var listeners = ConcurrentLinkedQueue<Listener>()
+    private var currentRecording: Recording? = null
+    private var attachedTo: ValueAnimator? = null
+
+    fun attachTo(valueAnimator: ValueAnimator) {
+        if (attachedTo != valueAnimator) {
+            detach()
+        }
+        attachedTo = valueAnimator
+        valueAnimator.addListener(this)
+        valueAnimator.addUpdateListener(this)
+    }
+
+    fun start() {
+        isRecording = true
+    }
+
+    fun stop() {
+        isRecording = false
+        detach()
+        currentRecording = null
+    }
+
+    fun detach() {
+        attachedTo?.also {
+            it.removeUpdateListener(this)
+            it.removeListener(this)
+        }
+        attachedTo = null
+    }
+
+    fun addListener(l: Listener) {
+        listeners.add(l)
+    }
+
+    fun removeListener(l: Listener) {
+        listeners.remove(l)
+    }
+
+    override fun onAnimationStart(animation: Animator) {
+        if (!isRecording || animation !is ValueAnimator) return
+        currentRecording = Recording.from(animation)
+    }
+
+    override fun onAnimationUpdate(animation: ValueAnimator) {
+        if (!isRecording) return
+        System.currentTimeMillis().also { now ->
+            if (sampleRate <= now - lastSampleTime) {
+                currentRecording?.pushFrame(animation)
+                lastSampleTime = now
+            }
+        }
+    }
+
+    override fun onAnimationEnd(animation: Animator) {
+        if (!isRecording || animation !is ValueAnimator) return
+        currentRecording?.ended = true
+        currentRecording?.endValue = animation.animatedValue
+        saveRecording()
+    }
+
+    override fun onAnimationCancel(animation: Animator) {
+        if (!isRecording) return
+        currentRecording?.cancelled = true
+        saveRecording()
+    }
+
+    override fun onAnimationRepeat(animation: Animator) = Unit
+
+    private fun saveRecording() {
+        currentRecording?.also {
+            recordings.add(it)
+            notifyRecordingSaved(it)
+        }
+        currentRecording = null
+    }
+
+    private fun notifyRecordingSaved(r: Recording) {
+        listeners.forEach { it.onRecordingSaved(r) }
+    }
+
+    class Recording(
+        val duration: Long,
+        var startValue: Any
+    ) {
+        var endValue: Any? = null
+        val frames = mutableListOf<Frame>()
+        var ended = false
+        var cancelled = false
+
+        fun pushFrame(animator: ValueAnimator) {
+            frames.add(Frame.from(animator))
+        }
+
+        companion object {
+            fun from(animator: ValueAnimator): Recording {
+                return Recording(animator.duration, animator.animatedValue)
+            }
+        }
+    }
+
+    data class Frame(
+        val currentPlayTime: Long,
+        val animatedFraction: Float,
+        val animatedValue: Any,
+        val timestamp: Long = System.currentTimeMillis()
+    ) {
+        companion object {
+            fun from(animator: ValueAnimator) =
+                Frame(
+                    animator.currentPlayTime,
+                    animator.animatedFraction,
+                    animator.animatedValue,
+                )
+        }
+    }
+
+    interface Listener {
+        fun onRecordingSaved(recording: Recording)
+    }
+}

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/camera/MapboxCameraAnimationsActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/camera/MapboxCameraAnimationsActivity.kt
@@ -5,7 +5,6 @@ import android.annotation.SuppressLint
 import android.content.res.Resources
 import android.graphics.Color
 import android.location.Location
-import android.location.LocationManager
 import android.os.Bundle
 import android.util.Log
 import androidx.appcompat.app.AppCompatActivity
@@ -37,8 +36,6 @@ import com.mapbox.maps.plugin.annotation.generated.createPointAnnotationManager
 import com.mapbox.maps.plugin.delegates.listeners.OnMapLoadErrorListener
 import com.mapbox.maps.plugin.gestures.OnMapLongClickListener
 import com.mapbox.maps.plugin.gestures.gestures
-import com.mapbox.maps.plugin.locationcomponent.LocationConsumer
-import com.mapbox.maps.plugin.locationcomponent.LocationProvider
 import com.mapbox.maps.plugin.locationcomponent.OnIndicatorPositionChangedListener
 import com.mapbox.maps.plugin.locationcomponent.location
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
@@ -64,8 +61,6 @@ import com.mapbox.navigation.examples.core.databinding.LayoutActivityCameraBindi
 import com.mapbox.navigation.examples.util.Utils
 import com.mapbox.navigation.ui.maps.camera.NavigationCamera
 import com.mapbox.navigation.ui.maps.camera.data.MapboxNavigationViewportDataSource
-import com.mapbox.navigation.ui.maps.camera.data.ViewportData
-import com.mapbox.navigation.ui.maps.camera.data.ViewportDataSourceUpdateObserver
 import com.mapbox.navigation.ui.maps.camera.data.debugger.MapboxNavigationViewportDataSourceDebugger
 import com.mapbox.navigation.ui.maps.camera.lifecycle.NavigationScaleGestureHandler
 import com.mapbox.navigation.ui.maps.camera.state.NavigationCameraState
@@ -79,12 +74,14 @@ import com.mapbox.navigation.ui.maps.route.line.api.MapboxRouteLineApi
 import com.mapbox.navigation.ui.maps.route.line.api.MapboxRouteLineView
 import com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions
 import com.mapbox.navigation.utils.internal.ifNonNull
+import com.mapbox.navigation.utils.internal.logD
 import com.mapbox.navigation.utils.internal.toPoint
 import com.mapbox.turf.TurfMeasurement
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
+@SuppressLint("MissingPermission")
 class MapboxCameraAnimationsActivity :
     AppCompatActivity(),
     OnAnimationButtonClicked,
@@ -157,16 +154,10 @@ class MapboxCameraAnimationsActivity :
         override fun onNewRawLocation(rawLocation: Location) {}
 
         override fun onNewLocationMatcherResult(locationMatcherResult: LocationMatcherResult) {
-            val transitionOptions: (ValueAnimator.() -> Unit) =
-                if (locationMatcherResult.isTeleport) {
-                    {
-                        duration = 0
-                    }
-                } else {
-                    {
-                        duration = 1000
-                    }
-                }
+            val transitionOptions: (ValueAnimator.() -> Unit) = {
+                duration = if (locationMatcherResult.isTeleport) 0 else 1000
+            }
+
             navigationLocationProvider.changePosition(
                 locationMatcherResult.enhancedLocation,
                 locationMatcherResult.keyPoints,
@@ -266,7 +257,9 @@ class MapboxCameraAnimationsActivity :
                 )
             )
             // setLocationProvider(navigationLocationProvider)
-            setLocationProvider(navigationLocationProvider.syncedWith(viewportDataSource))
+            setLocationProvider(
+                navigationLocationProvider.syncedWith(viewportDataSource, animationRecorder)
+            )
             addOnIndicatorPositionChangedListener(onIndicatorPositionChangedListener)
             enabled = true
         }
@@ -590,6 +583,7 @@ class MapboxCameraAnimationsActivity :
                     routerOrigin: RouterOrigin
                 ) {
                     mapboxNavigation.setNavigationRoutes(routes)
+                    animationRecorder.start()
                 }
 
                 override fun onFailure(reasons: List<RouterFailure>, routeOptions: RouteOptions) {
@@ -677,73 +671,36 @@ class MapboxCameraAnimationsActivity :
         )
     }
     //endregion
-}
 
-//region Synced Puck
 
-fun NavigationLocationProvider.syncedWith(
-    viewportDataSource: MapboxNavigationViewportDataSource
-): LocationProvider {
-    return PuckLocationAdapter(this, viewportDataSource)
-}
+    private var recorderListener = object : AnimRecorder.Listener {
+        var c = 0
 
-class PuckLocationAdapter(
-    private val upstreamProvider: NavigationLocationProvider,
-    viewportDataSource: MapboxNavigationViewportDataSource,
-    private val downstreamProvider: NavigationLocationProvider = NavigationLocationProvider()
-) : LocationProvider by downstreamProvider, ViewportDataSourceUpdateObserver {
-
-    init {
-        upstreamProvider.onFirstLocation {
-            downstreamProvider.changePosition(it)
-        }
-        viewportDataSource.registerUpdateObserver(this)
-    }
-
-    override fun viewportDataSourceUpdated(viewportData: ViewportData) {
-        upstreamProvider.lastLocation?.also {
-            downstreamProvider.changePosition(it)
+        override fun onRecordingSaved(recording: AnimRecorder.Recording) {
+            logD("recording saved ${recording.frames.size}", "AnimRecorder")
+            val color = if (c++ % 2 == 0) Color.RED else Color.BLUE
+            renderRecording(recording, color)
         }
     }
 
-    private fun NavigationLocationProvider.onFirstLocation(action: (Location) -> Unit) {
-        lastLocation?.also {
-            action(it)
-            return
-        }
-        registerLocationConsumer(object : AbstractLocationConsumer() {
-            override fun onLocationUpdated(
-                vararg location: Point,
-                options: (ValueAnimator.() -> Unit)?
-            ) {
-                location.firstOrNull()?.also {
-                    action(Location(LocationManager.PASSIVE_PROVIDER).apply {
-                        latitude = it.latitude()
-                        longitude = it.longitude()
-                    })
-                }
-                unRegisterLocationConsumer(this)
+    private val animationRecorder: AnimRecorder by lazy {
+        AnimRecorder().apply { addListener(recorderListener) }
+    }
+
+    private fun renderRecording(recording: AnimRecorder.Recording, color: Int) {
+        val l = mutableListOf<PointAnnotationOptions>()
+        recording.frames.forEach {
+            //logD("ts = ${it.timestamp}; fraction = ${it.animatedFraction}; value = ${it.animatedValue}", "AnimRecorder")
+
+            (it.animatedValue as? Point)?.also { point ->
+                val options = PointAnnotationOptions()
+                    .withPoint(point)
+                    .withTextField("x")
+                    .withTextSize(12.0)
+                    .withTextColor(color)
+                l.add(options)
             }
-        })
-    }
-
-    private abstract class AbstractLocationConsumer : LocationConsumer {
-        override fun onBearingUpdated(
-            vararg bearing: Double,
-            options: (ValueAnimator.() -> Unit)?
-        ) = Unit
-
-        override fun onLocationUpdated(
-            vararg location: Point,
-            options: (ValueAnimator.() -> Unit)?
-        ) = Unit
-
-        override fun onPuckBearingAnimatorDefaultOptionsUpdated(options: ValueAnimator.() -> Unit) =
-            Unit
-
-        override fun onPuckLocationAnimatorDefaultOptionsUpdated(options: ValueAnimator.() -> Unit) =
-            Unit
+        }
+        annotationManager.create(l)
     }
 }
-
-//endregion

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/camera/MapboxCameraAnimationsActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/camera/MapboxCameraAnimationsActivity.kt
@@ -157,7 +157,14 @@ class MapboxCameraAnimationsActivity :
             val transitionOptions: (ValueAnimator.() -> Unit) = {
                 duration = if (locationMatcherResult.isTeleport) 0 else 1000
             }
-
+            val location = locationMatcherResult.enhancedLocation
+            val keyPoints = locationMatcherResult.keyPoints
+            logD("", "MapboxCameraAnimationsActivity")
+            logD("--------------------------------", "MapboxCameraAnimationsActivity")
+            logD(
+                "changePosition keyPoints(${keyPoints.size}) = ${keyPoints.asStr()}; location = ${location.asStr()};",
+                "MapboxCameraAnimationsActivity"
+            )
             navigationLocationProvider.changePosition(
                 locationMatcherResult.enhancedLocation,
                 locationMatcherResult.keyPoints,
@@ -677,9 +684,11 @@ class MapboxCameraAnimationsActivity :
         var c = 0
 
         override fun onRecordingSaved(recording: AnimRecorder.Recording) {
-            logD("recording saved ${recording.frames.size}", "AnimRecorder")
-            val color = if (c++ % 2 == 0) Color.RED else Color.BLUE
-            renderRecording(recording, color)
+            if (0 < recording.frames.size) {
+                logD("recording $c: saved ${recording.frames.size} frames", "AnimRecorder")
+                val color = if (c++ % 2 == 0) Color.RED else Color.BLUE
+                renderRecording(recording, color)
+            }
         }
     }
 

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/camera/PuckLocationProvider.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/camera/PuckLocationProvider.kt
@@ -1,0 +1,117 @@
+package com.mapbox.navigation.examples.core.camera
+
+import android.animation.TimeInterpolator
+import android.animation.TypeEvaluator
+import android.animation.ValueAnimator
+import android.graphics.Path
+import android.location.Location
+import android.view.animation.PathInterpolator
+import com.mapbox.geojson.Point
+import com.mapbox.maps.plugin.locationcomponent.LocationProvider
+import com.mapbox.navigation.utils.internal.logD
+
+
+interface LocationPublisher : LocationProvider {
+    fun publish(
+        location: Location,
+        keyPoints: List<Location> = emptyList(),
+        latLngTransitionOptions: (ValueAnimator.() -> Unit)? = null,
+        bearingTransitionOptions: (ValueAnimator.() -> Unit)? = null
+    )
+}
+
+class PuckLocationProvider(
+    private val downstreamProvider: LocationPublisher,
+) : LocationProvider by downstreamProvider, LocationPublisher {
+
+    override fun publish(
+        location: Location,
+        keyPoints: List<Location>,
+        latLngTransitionOptions: (ValueAnimator.() -> Unit)?,
+        bearingTransitionOptions: (ValueAnimator.() -> Unit)?
+    ) {
+        logD(
+            "changePosition keyPoints(${keyPoints.size}) = ${keyPoints.asStr()}; location = ${location.asStr()};",
+            "PuckLocationProvider"
+        )
+        val latLngUpdates = if (keyPoints.isNotEmpty()) {
+            keyPoints.map { Point.fromLngLat(it.longitude, it.latitude) }.toTypedArray()
+        } else {
+            arrayOf(Point.fromLngLat(location.longitude, location.latitude))
+        }
+
+        val evaluator = PuckAnimationEvaluator(latLngUpdates)
+
+        val options: (ValueAnimator.() -> Unit) = {
+            latLngTransitionOptions?.also { apply(it) }
+            interpolator = evaluator
+            setEvaluator(evaluator)
+        }
+
+        downstreamProvider.publish(
+            location,
+            keyPoints,
+            options,
+            bearingTransitionOptions
+        )
+    }
+}
+
+class PuckAnimationEvaluator(
+    private val keyPoints: Array<Point>
+) : TimeInterpolator, TypeEvaluator<Point> {
+
+    private var interpolator: TimeInterpolator? = null
+
+    override fun getInterpolation(input: Float): Float =
+        interpolator?.getInterpolation(input) ?: input
+
+    override fun evaluate(fraction: Float, startValue: Point, endValue: Point): Point {
+        if (interpolator == null) {
+            // we defer creation of TimeInterpolator until we know startValue
+            interpolator = createTimeInterpolator(startValue)
+        }
+        return POINT.evaluate(fraction, startValue, endValue)
+    }
+
+    private fun createTimeInterpolator(startValue: Point): TimeInterpolator {
+        val distances = mutableListOf<Double>()
+        var total = 0.0
+        keyPoints.fold(startValue) { prevPoint, point ->
+            val d = prevPoint.distanceSqrTo(point)
+            distances.add(d)
+            total += d
+            point
+        }
+
+        if (0 < total) {
+            val path = Path()
+            val pathDebug = mutableListOf<Pair<Float, Float>>(0.0f to 0.0f)
+            val step = 1.0f / keyPoints.size
+            var pathTime = 0.0
+            keyPoints.forEachIndexed { index, point ->
+                val deltaTime = distances[index] / total
+                val velocity = distances[index] / deltaTime // this velocity should be constant
+                logD(
+                    "$index; V = $velocity, dD = ${distances[index]}; dT = ${deltaTime}; point = ${point.asStr()}",
+                    "PuckAnimationEvaluator"
+                )
+                pathTime += deltaTime
+                path.lineTo(pathTime.toFloat(), step * (index + 1))
+                pathDebug.add(pathTime.toFloat() to step * (index + 1))
+            }
+            logD("pathInterpolator = $pathDebug", "PuckAnimationEvaluator")
+            return PathInterpolator(path)
+        }
+        return TimeInterpolator { it }
+    }
+
+    companion object {
+        private val POINT = TypeEvaluator<Point> { fraction, startValue, endValue ->
+            Point.fromLngLat(
+                startValue.longitude() + fraction * (endValue.longitude() - startValue.longitude()),
+                startValue.latitude() + fraction * (endValue.latitude() - startValue.latitude())
+            )
+        }
+    }
+}

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/location/NavigationLocationProvider.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/location/NavigationLocationProvider.kt
@@ -126,6 +126,12 @@ class NavigationLocationProvider : LocationProvider {
         latLngTransitionOptions: (ValueAnimator.() -> Unit)? = null,
         bearingTransitionOptions: (ValueAnimator.() -> Unit)? = null
     ) {
+        listener?.onChangePosition(
+            location,
+            keyPoints,
+            latLngTransitionOptions,
+            bearingTransitionOptions
+        )
         locationConsumers.forEach {
             it.notifyLocationUpdates(
                 location,
@@ -136,6 +142,17 @@ class NavigationLocationProvider : LocationProvider {
         }
         lastLocation = location
         lastKeyPoints = keyPoints
+    }
+
+    var listener: Listener? = null
+
+    interface Listener {
+        fun onChangePosition(
+            location: Location,
+            keyPoints: List<Location>,
+            latLngTransitionOptions: (ValueAnimator.() -> Unit)?,
+            bearingTransitionOptions: (ValueAnimator.() -> Unit)?
+        )
     }
 
     private fun LocationConsumer.notifyLocationUpdates(


### PR DESCRIPTION
POC for https://github.com/mapbox/mapbox-navigation-android/issues/4140 and https://github.com/mapbox/navigation-sdks/issues/1699

**Problem**
The location puck animation is started immediately on the `LocationConsumer` callback which is triggered by `NavigationLocationProvider.changePosition()` call.
The Navigation Camera animation is started immediately on the `ViewportDataSourceUpdateObserver` callback which is triggered once a new `ViewportData` is ready (`evaluate()` call). 
`ViewportData` calculation is a computationally heavy operation that slightly delays (probably by a few Choreographer frames) `NavigationCamera` animation start relative to the puck animation start time. That delay is signigican enought to throw both animations off sync resulting in a "jumpy" puck.

**Possible solution proposed by this PR**

Use a separate `LocationProvider` for the location puck updates and instead of updating its position in the `LocationObserver`, update its position in `ViewportDataSourceUpdateObserver` resulting in a puck animation start in the same Choreographer frame as NavigationCamera animation start.

<img src="https://user-images.githubusercontent.com/2678039/171501404-d7ecbaff-4dec-42e3-a036-f7d45fbaf001.png" />



(Captured on Google Pixel 2. Circle annotation indicates location sent to puck animator.)


_Old_

https://user-images.githubusercontent.com/2678039/171495798-aee6444a-a74d-4052-a453-425c5f40d523.mp4

_New_

https://user-images.githubusercontent.com/2678039/171495873-0b9fba3a-6886-434f-92e6-d9e35f2938ad.mp4|
