### PR TITLE
Bump `mapboxEvents` dependency library version to `8.1.2`

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -20,7 +20,7 @@ ext {
   version = [
       mapboxMapSdk              : '10.6.0-beta.2',
       mapboxSdkServices         : '6.5.0',
-      mapboxEvents              : '8.1.1',
+      mapboxEvents              : '8.1.2',
       mapboxCore                : '5.0.1',
       mapboxNavigator           : "${mapboxNavigatorVersion}",
       mapboxCommonNative        : '22.0.0-beta.1',

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetryTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetryTest.kt
@@ -1372,6 +1372,7 @@ class MapboxNavigationTelemetryTest {
             applicationContext.getSystemService(Context.ACTIVITY_SERVICE)
         } returns activityManager
         every { activityManager.runningAppProcesses } returns listOf()
+        every { activityManager.getRunningTasks(any()) } returns listOf()
     }
 
     private fun initTelemetry() {


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Bumps `mapboxEvents` dependency library version to [`8.1.2`](https://github.com/mapbox/mapbox-events-android/releases/tag/telem-8.1.2-core-5.0.2)

cc @tarigo @mr1sunshine @DorkMatter 