### PR TITLE
Update androidauto-test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  android: circleci/android@1.0.3
+  android: circleci/android@2.0.3
 
 parameters:
   mapbox_navigation_native_upstream:
@@ -713,6 +713,7 @@ jobs:
     executor:
       name: android/android-machine
       resource-class: large
+      tag: 2022.04.1
     steps:
       - when:
           condition:
@@ -726,6 +727,7 @@ jobs:
                 post-emulator-launch-assemble-command: ./gradlew libnavui-androidauto:assembleDebugAndroidTest
                 test-command: ./gradlew libnavui-androidauto:connectedDebugAndroidTest
                 system-image: system-images;android-30;google_apis_playstore;x86
+                wait-for-emulator: false
             - run:
                 name: Save test results
                 command: |


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Addressing https://github.com/mapbox/mapbox-navigation-android/issues/5880

Here's a thread with CircleCI support https://support.circleci.com/hc/en-us/requests/111038, I'm essentially adding their suggestions here.

[Looking to improve these stats](https://app.circleci.com/insights/github/mapbox/mapbox-navigation-android/workflows/default/jobs?branch=main&reporting-window=last-30-days). The expected run-time is ~6 minutes. When it fails it takes a long time, so we may need to add retry parameters 
```
Duration (p95): 5h
Runs: 53
Success Rate: 85%
```