### PR TITLE
Remove MapView from RouteLineComponent

### DIFF
--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/binder/map/MapBinder.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/binder/map/MapBinder.kt
@@ -80,7 +80,7 @@ internal class MapBinder(
     }
 
     private fun routeLineComponent(lineOptions: MapboxRouteLineOptions) =
-        RouteLineComponent(mapView, lineOptions, contractProvider = {
+        RouteLineComponent(mapView.getMapboxMap(), mapView, lineOptions, contractProvider = {
             RouteLineComponentContractImpl(store)
         })
 

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/installer/ComponentInstaller.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/installer/ComponentInstaller.kt
@@ -30,7 +30,7 @@ fun ComponentInstaller.routeLine(
     config: RouteLineComponentConfig.() -> Unit = {}
 ): Installation {
     val componentConfig = RouteLineComponentConfig(mapView.context).apply(config)
-    return component(RouteLineComponent(mapView, componentConfig.options))
+    return component(RouteLineComponent(mapView.getMapboxMap(), mapView, componentConfig.options))
 }
 
 /**


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

It is impossible for androidauto `MapSurface` to use the `RouteLineComponent` because it is using the `MapView`.

Integrating `RouteLineComponent` into `libnavui-androidauto` has many more opinions - so I'll open those pull requests separately. 

