### PR TITLE
refresh alternative routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ This release depends on, and has been tested with, the following Mapbox dependen
 #### Features
 - Added `MapboxNavigationApp#installComponents()` and `MapboxNavigation#installComponents()` APIs that offer simplified integration of voice, route line and route arrow APIs. These extensions allow to instantiate wrappers that automatically integrate `MapboxNavigation` with the selected components, taking care of data and lifecycle management. See documentation for `RouteLineComponent`, `RouteArrowComponent` and `AudioGuidanceButtonComponent`. [#5874](https://github.com/mapbox/mapbox-navigation-android/pull/5874)
 - Added support for user feedbacks with custom types and subtypes. [#5915](https://github.com/mapbox/mapbox-navigation-android/pull/5915)
+- Added refresh of alternatives routes. [#5923](https://github.com/mapbox/mapbox-navigation-android/pull/5923)
 
 #### Bug fixes and improvements
 - :warning: Moved `MapboxAudioGuidanceButton` from Drop-in UI to Voice module. [#5874](https://github.com/mapbox/mapbox-navigation-android/pull/5874)

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxNavigationActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/MapboxNavigationActivity.kt
@@ -29,7 +29,6 @@ import com.mapbox.navigation.base.options.EventsAppMetadata
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.route.NavigationRoute
 import com.mapbox.navigation.base.route.NavigationRouterCallback
-import com.mapbox.navigation.base.route.RouteRefreshOptions
 import com.mapbox.navigation.base.route.RouterFailure
 import com.mapbox.navigation.base.route.RouterOrigin
 import com.mapbox.navigation.core.MapboxNavigation
@@ -292,7 +291,6 @@ class MapboxNavigationActivity : AppCompatActivity() {
         mapboxNavigation = MapboxNavigationProvider.create(
             NavigationOptions.Builder(this)
                 .accessToken(getMapboxAccessTokenFromResources())
-                .routeRefreshOptions(RouteRefreshOptions.Builder().intervalMillis(30_000).build())
                 .eventsAppMetadata(
                     EventsAppMetadata.Builder(
                         BuildConfig.APPLICATION_ID, BuildConfig.VERSION_NAME
@@ -471,7 +469,6 @@ class MapboxNavigationActivity : AppCompatActivity() {
                 .applyDefaultNavigationOptions()
                 .applyLanguageAndVoiceUnitOptions(this)
                 .coordinatesList(listOf(origin, destination))
-                .alternatives(true)
                 .layersList(listOf(mapboxNavigation.getZLevel(), null))
                 .build(),
             object : NavigationRouterCallback {

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/RouteRefreshTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/RouteRefreshTest.kt
@@ -109,11 +109,6 @@ class RouteRefreshTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.ja
                 .getSuccessfulResultOrThrowException()
                 .routes
                 .reversed()
-            assertEquals(
-                "the test works only with 2 routes",
-                2,
-                requestedRoutes.size
-            )
 
             mapboxNavigation.setNavigationRoutes(requestedRoutes)
             mapboxNavigation.startTripSession()
@@ -136,6 +131,11 @@ class RouteRefreshTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.ja
                 }
                 .first()
 
+            assertEquals(
+                "the test works only with 2 routes",
+                2,
+                requestedRoutes.size
+            )
             assertEquals(
                 listOf("11589180127444257"),
                 initialRoutes[0].getIncidentsIdFromTheRoute(0)

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/RouteRefreshTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/RouteRefreshTest.kt
@@ -1,17 +1,15 @@
 package com.mapbox.navigation.instrumentation_tests.core
 
 import android.location.Location
-import androidx.test.espresso.Espresso
 import com.mapbox.api.directions.v5.DirectionsCriteria
-import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.RouteOptions
 import com.mapbox.geojson.Point
 import com.mapbox.navigation.base.extensions.applyDefaultNavigationOptions
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.options.RoutingTilesOptions
+import com.mapbox.navigation.base.route.NavigationRoute
 import com.mapbox.navigation.base.route.RouteRefreshOptions
 import com.mapbox.navigation.base.trip.model.RouteProgress
-import com.mapbox.navigation.base.trip.model.RouteProgressState
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.MapboxNavigationProvider
 import com.mapbox.navigation.core.directions.session.RoutesExtra.ROUTES_UPDATE_REASON_REFRESH
@@ -20,6 +18,7 @@ import com.mapbox.navigation.instrumentation_tests.activity.EmptyTestActivity
 import com.mapbox.navigation.instrumentation_tests.utils.MapboxNavigationRule
 import com.mapbox.navigation.instrumentation_tests.utils.coroutines.getSuccessfulResultOrThrowException
 import com.mapbox.navigation.instrumentation_tests.utils.coroutines.requestRoutes
+import com.mapbox.navigation.instrumentation_tests.utils.coroutines.roadObjectsOnRoute
 import com.mapbox.navigation.instrumentation_tests.utils.coroutines.routeProgressUpdates
 import com.mapbox.navigation.instrumentation_tests.utils.coroutines.routesUpdates
 import com.mapbox.navigation.instrumentation_tests.utils.coroutines.sdkTest
@@ -29,18 +28,16 @@ import com.mapbox.navigation.instrumentation_tests.utils.http.MockDirectionsRefr
 import com.mapbox.navigation.instrumentation_tests.utils.http.MockDirectionsRequestHandler
 import com.mapbox.navigation.instrumentation_tests.utils.http.MockRoutingTileEndpointErrorRequestHandler
 import com.mapbox.navigation.instrumentation_tests.utils.idling.IdlingPolicyTimeoutRule
-import com.mapbox.navigation.instrumentation_tests.utils.idling.RouteProgressStateIdlingResource
-import com.mapbox.navigation.instrumentation_tests.utils.idling.RouteRequestIdlingResource
-import com.mapbox.navigation.instrumentation_tests.utils.idling.RoutesObserverIdlingResource
 import com.mapbox.navigation.instrumentation_tests.utils.location.MockLocationReplayerRule
 import com.mapbox.navigation.instrumentation_tests.utils.readRawFileText
 import com.mapbox.navigation.testing.ui.BaseTest
 import com.mapbox.navigation.testing.ui.utils.getMapboxAccessTokenFromResources
 import com.mapbox.navigation.testing.ui.utils.runOnMainSync
-import com.mapbox.navigation.utils.internal.logD
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
@@ -49,15 +46,10 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import java.net.URI
-import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import kotlin.math.absoluteValue
 
 class RouteRefreshTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.java) {
-
-    private companion object {
-        private const val LOG_CATEGORY = "RouteRefreshTest"
-    }
 
     @get:Rule
     val mapboxNavigationRule = MapboxNavigationRule()
@@ -110,98 +102,68 @@ class RouteRefreshTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.ja
     }
 
     @Test
-    fun expect_route_refresh_to_update_traffic_annotations_and_incidents() {
-        // Request a route.
-        val routes = requestDirectionsRouteSync(coordinates).reversed()
+    fun expect_route_refresh_to_update_traffic_annotations_and_incidents_for_all_routes() =
+        sdkTest {
+            val routeOptions = generateRouteOptions(coordinates)
+            val requestedRoutes = mapboxNavigation.requestRoutes(routeOptions)
+                .getSuccessfulResultOrThrowException()
+                .routes
+                .reversed()
 
-        // Create an observer resource that captures the routes.
-        val initialRouteIdlingResource = RoutesObserverIdlingResource(mapboxNavigation)
-            .register()
-
-        // Set navigation with the route.
-        runOnMainSync {
-            mapboxNavigation.setRoutes(routes)
+            mapboxNavigation.setNavigationRoutes(requestedRoutes)
             mapboxNavigation.startTripSession()
-            mockLocationReplayerRule.loopUpdate(
-                mockLocationUpdatesRule.generateLocationUpdate {
-                    latitude = coordinates[0].latitude()
-                    longitude = coordinates[0].longitude()
-                    bearing = 190f
-                },
-                times = 60
-            )
-            mapboxNavigation.registerRouteProgressObserver { routeProgress ->
-                logD(
-                    "progress state: ${routeProgress.currentState}",
-                    LOG_CATEGORY
-                )
-                logD(
-                    "progress duration remaining: ${routeProgress.durationRemaining}",
-                    LOG_CATEGORY
-                )
-            }
-        }
+            stayOnInitialPosition()
+            val routeUpdates = mapboxNavigation.routesUpdates()
+                .take(2)
+                .map { it.navigationRoutes }
+                .toList()
+            val initialRoutes = routeUpdates[0]
+            val refreshedRoutes = routeUpdates[1]
 
-        // Wait for the initial route.
-        val initialRoutes = initialRouteIdlingResource.next()
-
-        // Wait for the route refresh.
-        val refreshedRoutes = initialRouteIdlingResource.next()
-        initialRouteIdlingResource.unregister()
-
-        val progressIdlingResource = RouteProgressStateIdlingResource(
-            mapboxNavigation,
-            RouteProgressState.TRACKING
-        )
-        progressIdlingResource.register()
-        Espresso.onIdle()
-        progressIdlingResource.unregister()
-
-        val latch = CountDownLatch(2)
-        runOnMainSync {
-            mapboxNavigation.registerRouteProgressObserver { routeProgress ->
-                if (isRefreshedRouteDistance(routeProgress)) {
-                    latch.countDown()
+            mapboxNavigation.routeProgressUpdates()
+                .filter { routeProgress -> isRefreshedRouteDistance(routeProgress) }
+                .first()
+            mapboxNavigation.roadObjectsOnRoute()
+                .filter { upcomingRoadObjects ->
+                    upcomingRoadObjects.size == 2 &&
+                        upcomingRoadObjects.map { it.roadObject.id }
+                            .containsAll(listOf("11589180127444257", "14158569638505033"))
                 }
-            }
-            mapboxNavigation.registerRoadObjectsOnRouteObserver { upcomingRoadObjects ->
-                // upcoming road's objects mut be exact 2 with following ids
-                if (upcomingRoadObjects.size == 2 &&
-                    upcomingRoadObjects.map { it.roadObject.id }
-                        .containsAll(listOf("11589180127444257", "14158569638505033"))
-                ) {
-                    latch.countDown()
-                }
-            }
-        }
-        if (!latch.await(10, TimeUnit.SECONDS)) {
-            throw AssertionError(
-                """progress duration remaining or upcoming road objects weren't  
-                    refreshed by native navigator
-                """.trimMargin()
+                .first()
+
+            assertEquals(
+                listOf("11589180127444257"),
+                initialRoutes[0].getIncidentsIdFromTheRoute(0)
             )
+            assertEquals(
+                listOf("11589180127444257", "14158569638505033").sorted(),
+                refreshedRoutes[0].getIncidentsIdFromTheRoute(0)?.sorted()
+            )
+            assertEquals(
+                listOf("11589180127444257"),
+                initialRoutes[1].getIncidentsIdFromTheRoute(0)
+            )
+            assertEquals(
+                listOf("11589180127444257", "14158569638505033").sorted(),
+                refreshedRoutes[1].getIncidentsIdFromTheRoute(0)?.sorted()
+            )
+
+            assertEquals(
+                requestedRoutes[0].getDurationOfLeg(0),
+                initialRoutes[0].getDurationOfLeg(0),
+                0.0
+            )
+            assertEquals(227.918, initialRoutes[0].getDurationOfLeg(0), 0.0001)
+            assertEquals(1189.651, refreshedRoutes[0].getDurationOfLeg(0), 0.0001)
+
+            assertEquals(
+                requestedRoutes[1].getDurationOfLeg(0),
+                initialRoutes[1].getDurationOfLeg(0),
+                0.0
+            )
+            assertEquals(224.2239, initialRoutes[1].getDurationOfLeg(0), 0.0001)
+            assertEquals(1189.651, refreshedRoutes[1].getDurationOfLeg(0), 0.0001)
         }
-
-        // Only the annotations AND incidents are refreshed. So sum up the duration from the old and new.
-        val sanityLeg = routes.first().legs()!!
-        val sanityDuration = sanityLeg.first().annotation()?.duration()?.sum()!!
-        val initialLeg = initialRoutes.first().legs()?.first()!!
-        val initialDuration = initialLeg.annotation()?.duration()?.sum()!!
-        val refreshedLeg = refreshedRoutes.first().legs()?.first()!!
-        val refreshedDuration = refreshedLeg.annotation()?.duration()?.sum()!!
-
-        assertEquals(1, initialLeg.incidents()!!.size)
-        assertEquals("11589180127444257", initialLeg.incidents()!!.first().id())
-        assertEquals(2, refreshedLeg.incidents()!!.size)
-        assertTrue(
-            refreshedLeg.incidents()!!.map { it.id() }
-                .containsAll(listOf("11589180127444257", "14158569638505033"))
-        )
-
-        assertEquals(sanityDuration, initialDuration, 0.0)
-        assertEquals(227.918, initialDuration, 0.0001)
-        assertEquals(1189.651, refreshedDuration, 0.0001)
-    }
 
     @Test
     fun routeRefreshesWorksAfterSettingsNewRoutes() = sdkTest {
@@ -321,12 +283,6 @@ class RouteRefreshTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.ja
         )
     }
 
-    private fun requestDirectionsRouteSync(coordinates: List<Point>): List<DirectionsRoute> {
-        val routeOptions = generateRouteOptions(coordinates)
-        val routeRequestIdlingResource = RouteRequestIdlingResource(mapboxNavigation, routeOptions)
-        return routeRequestIdlingResource.requestRoutesSync()
-    }
-
     private fun generateRouteOptions(coordinates: List<Point>): RouteOptions {
         return RouteOptions.builder().applyDefaultNavigationOptions()
             .profile(DirectionsCriteria.PROFILE_DRIVING_TRAFFIC)
@@ -336,3 +292,14 @@ class RouteRefreshTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.ja
             .build()
     }
 }
+
+private fun NavigationRoute.getDurationOfLeg(legIndex: Int): Double =
+    directionsRoute.legs()!![legIndex]
+        .annotation()
+        ?.duration()
+        ?.sum()!!
+
+private fun NavigationRoute.getIncidentsIdFromTheRoute(legIndex: Int): List<String>? =
+    directionsRoute.legs()?.get(legIndex)
+        ?.incidents()
+        ?.map { it.id() }

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/RouteRefreshTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/RouteRefreshTest.kt
@@ -109,6 +109,11 @@ class RouteRefreshTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.ja
                 .getSuccessfulResultOrThrowException()
                 .routes
                 .reversed()
+            assertEquals(
+                "the test works only with 2 routes",
+                2,
+                requestedRoutes.size
+            )
 
             mapboxNavigation.setNavigationRoutes(requestedRoutes)
             mapboxNavigation.startTripSession()

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/RouteRefreshTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/RouteRefreshTest.kt
@@ -149,9 +149,9 @@ class RouteRefreshTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.ja
             )
 
             assertEquals(
-                requestedRoutes[0].getDurationOfLeg(0),
-                initialRoutes[0].getDurationOfLeg(0),
-                0.0
+                "initial should be the same as requested",
+                requestedRoutes[0].getDurationAnnotationsFromLeg(0),
+                initialRoutes[0].getDurationAnnotationsFromLeg(0)
             )
             assertEquals(227.918, initialRoutes[0].getDurationOfLeg(0), 0.0001)
             assertEquals(1189.651, refreshedRoutes[0].getDurationOfLeg(0), 0.0001)
@@ -294,10 +294,13 @@ class RouteRefreshTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.ja
 }
 
 private fun NavigationRoute.getDurationOfLeg(legIndex: Int): Double =
-    directionsRoute.legs()!![legIndex]
-        .annotation()
-        ?.duration()
+    getDurationAnnotationsFromLeg(legIndex)
         ?.sum()!!
+
+private fun NavigationRoute.getDurationAnnotationsFromLeg(legIndex: Int): List<Double>? =
+    directionsRoute.legs()?.get(legIndex)
+        ?.annotation()
+        ?.duration()
 
 private fun NavigationRoute.getIncidentsIdFromTheRoute(legIndex: Int): List<String>? =
     directionsRoute.legs()?.get(legIndex)

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/utils/coroutines/Adapters.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/utils/coroutines/Adapters.kt
@@ -6,9 +6,11 @@ import com.mapbox.navigation.base.route.NavigationRouterCallback
 import com.mapbox.navigation.base.route.RouterFailure
 import com.mapbox.navigation.base.route.RouterOrigin
 import com.mapbox.navigation.base.trip.model.RouteProgress
+import com.mapbox.navigation.base.trip.model.roadobject.UpcomingRoadObject
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesObserver
 import com.mapbox.navigation.core.directions.session.RoutesUpdatedResult
+import com.mapbox.navigation.core.trip.session.RoadObjectsOnRouteObserver
 import com.mapbox.navigation.core.trip.session.RouteProgressObserver
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
@@ -38,6 +40,19 @@ fun MapboxNavigation.routeProgressUpdates(): Flow<RouteProgress> {
         navigation.registerRouteProgressObserver(observer)
         awaitClose {
             navigation.unregisterRouteProgressObserver(observer)
+        }
+    }
+}
+
+fun MapboxNavigation.roadObjectsOnRoute(): Flow<List<UpcomingRoadObject>> {
+    val navigation = this
+    return callbackFlow {
+        val observer = RoadObjectsOnRouteObserver {
+            trySend(it)
+        }
+        navigation.registerRoadObjectsOnRouteObserver(observer)
+        awaitClose {
+            navigation.unregisterRoadObjectsOnRouteObserver(observer)
         }
     }
 }

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/route/NavigationRouteEx.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/route/NavigationRouteEx.kt
@@ -2,9 +2,11 @@
 
 package com.mapbox.navigation.base.internal.route
 
+import com.mapbox.api.directions.v5.models.DirectionsResponse
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.Incident
 import com.mapbox.api.directions.v5.models.LegAnnotation
+import com.mapbox.api.directions.v5.models.RouteOptions
 import com.mapbox.navigation.base.internal.SDKRouteParser
 import com.mapbox.navigation.base.route.NavigationRoute
 import com.mapbox.navigation.base.route.toNavigationRoute
@@ -71,6 +73,18 @@ fun createNavigationRoute(
 ): NavigationRoute =
     directionsRoute
         .toNavigationRoute(sdkRouteParser, com.mapbox.navigation.base.route.RouterOrigin.Custom())
+
+/**
+ * Internal API used for testing purposes. Needed to avoid calling native parser from unit tests.
+ */
+@TestOnly
+fun createNavigationRoutes(
+    directionsResponse: DirectionsResponse,
+    routeOptions: RouteOptions,
+    routeParser: SDKRouteParser,
+    routerOrigin: com.mapbox.navigation.base.route.RouterOrigin,
+): List<NavigationRoute> =
+    NavigationRoute.create(directionsResponse, routeOptions, routeParser, routerOrigin)
 
 /**
  * Internal API to create a new [NavigationRoute] from a native peer.

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/route/NavigationRouteEx.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/route/NavigationRouteEx.kt
@@ -2,6 +2,7 @@
 
 package com.mapbox.navigation.base.internal.route
 
+import androidx.annotation.VisibleForTesting
 import com.mapbox.api.directions.v5.models.DirectionsResponse
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.Incident
@@ -77,7 +78,7 @@ fun createNavigationRoute(
 /**
  * Internal API used for testing purposes. Needed to avoid calling native parser from unit tests.
  */
-@TestOnly
+@VisibleForTesting
 fun createNavigationRoutes(
     directionsResponse: DirectionsResponse,
     routeOptions: RouteOptions,

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/routerefresh/DirectionsRouteDiffProvider.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/routerefresh/DirectionsRouteDiffProvider.kt
@@ -20,7 +20,10 @@ internal class DirectionsRouteDiffProvider {
             val newLeg = newRouteLegs[legIndex]
             val updatedAnnotations = getUpdatedData(oldLeg, newLeg)
             if (updatedAnnotations.isNotEmpty()) {
-                routeDiffs.add("Updated ${updatedAnnotations.joinToString()} at leg $legIndex")
+                routeDiffs.add(
+                    "Updated ${updatedAnnotations.joinToString()} at " +
+                        "route ${newRoute.id} leg $legIndex"
+                )
             }
         }
         return routeDiffs

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/routerefresh/RouteRefreshController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/routerefresh/RouteRefreshController.kt
@@ -39,10 +39,6 @@ internal class RouteRefreshController(
 
     suspend fun refresh(routes: List<NavigationRoute>): List<NavigationRoute> {
         return if (routes.isNotEmpty()) {
-            require(
-                routes.none { it.directionsRoute.legs().isNullOrEmpty() }
-            ) { "Can't refresh a route without legs" }
-
             val routesValidationResults = routes.map { validateRoute(it) }
             if (routesValidationResults.any { it is RouteValidationResult.Valid }) {
                 tryRefreshingRoutesUntilRouteChanges(routes)
@@ -96,11 +92,10 @@ internal class RouteRefreshController(
         route: NavigationRoute
     ): NavigationRoute {
         val routeLegs = route.directionsRoute.legs()
-        require(routeLegs != null) { "Can't refresh route without legs" }
         val currentLegIndex = currentLegIndexProvider()
         return route.updateDirectionsRouteOnly {
             toBuilder().legs(
-                routeLegs.mapIndexed { legIndex, leg ->
+                routeLegs?.mapIndexed { legIndex, leg ->
                     val legHasAlreadyBeenPassed = legIndex < currentLegIndex
                     if (legHasAlreadyBeenPassed) {
                         leg

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/routerefresh/DirectionsRouteDiffProviderTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/routerefresh/DirectionsRouteDiffProviderTest.kt
@@ -37,10 +37,10 @@ class DirectionsRouteDiffProviderTest {
         assertEquals(
             routeDiffProvider.buildRouteDiffs(oldRoute, newRoute, currentLegIndex = 1),
             listOf(
-                "Updated distance, duration, speed, congestion at leg 1",
-                "Updated duration, speed, maxSpeed, congestion at leg 3",
-                "Updated distance, maxSpeed, congestionNumeric at leg 4",
-                "Updated incidents at leg 5",
+                "Updated distance, duration, speed, congestion at route testDiff#0 leg 1",
+                "Updated duration, speed, maxSpeed, congestion at route testDiff#0 leg 3",
+                "Updated distance, maxSpeed, congestionNumeric at route testDiff#0 leg 4",
+                "Updated incidents at route testDiff#0 leg 5",
             ),
         )
     }
@@ -48,6 +48,7 @@ class DirectionsRouteDiffProviderTest {
     private fun createTestNavigationRoute(vararg legs: RouteLeg): NavigationRoute {
         return createNavigationRoute(
             createDirectionsRoute(
+                requestUuid = "testDiff",
                 legs = legs.toList()
             )
         )

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/routerefresh/RouteRefreshControllerTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/routerefresh/RouteRefreshControllerTest.kt
@@ -305,7 +305,6 @@ class RouteRefreshControllerTest {
             val routeRefreshStub = RouteRefreshStub().apply {
                 setRefreshedRoute(refreshedRoutes[0])
             }
-
             val routeRefreshController = createRouteRefreshController(
                 routeRefresh = routeRefreshStub,
             )
@@ -316,7 +315,10 @@ class RouteRefreshControllerTest {
 
             verify {
                 logger.logI(
-                    "No changes in annotations for route testNoDiff#0",
+                    withArg {
+                        it.contains("no changes", ignoreCase = true) &&
+                            it.contains("testNoDiff#0")
+                    },
                     RouteRefreshController.LOG_CATEGORY
                 )
             }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/routerefresh/RouteRefreshControllerTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/routerefresh/RouteRefreshControllerTest.kt
@@ -11,9 +11,11 @@ import com.mapbox.navigation.core.directions.session.DirectionsSession
 import com.mapbox.navigation.core.directions.session.RouteRefresh
 import com.mapbox.navigation.testing.add
 import com.mapbox.navigation.testing.factories.createCoordinatesList
+import com.mapbox.navigation.testing.factories.createDirectionsResponse
 import com.mapbox.navigation.testing.factories.createDirectionsRoute
 import com.mapbox.navigation.testing.factories.createIncident
 import com.mapbox.navigation.testing.factories.createNavigationRoute
+import com.mapbox.navigation.testing.factories.createNavigationRoutes
 import com.mapbox.navigation.testing.factories.createRouteLeg
 import com.mapbox.navigation.testing.factories.createRouteLegAnnotation
 import com.mapbox.navigation.testing.factories.createRouteOptions
@@ -68,11 +70,11 @@ class RouteRefreshControllerTest {
     @Test
     fun `route refreshes`() = runBlockingTest {
         val (initialRoute, refreshedRoute) = createTestInitialAndRefreshedTestRoutes()
-        val directionsSession = mockk<DirectionsSession>().apply {
-            onRefresh { _, _, _, callback -> callback.onRefreshReady(refreshedRoute) }
+        val routeRefreshStub = RouteRefreshStub().apply {
+            setRefreshedRoute(refreshedRoute)
         }
         val routeRefreshController = createRouteRefreshController(
-            routeRefresh = directionsSession,
+            routeRefresh = routeRefreshStub,
             routeRefreshOptions = RouteRefreshOptions.Builder()
                 .intervalMillis(30_000)
                 .build(),
@@ -82,22 +84,22 @@ class RouteRefreshControllerTest {
         advanceTimeBy(TimeUnit.SECONDS.toMillis(30))
 
         assertEquals(listOf(refreshedRoute), refreshJob.getCompletedTest())
-        verify(exactly = 1) { directionsSession.requestRouteRefresh(any(), any(), any()) }
-        verify(exactly = 0) { directionsSession.cancelRouteRefreshRequest(any()) }
     }
 
     @Test
     fun `should refresh route with any annotation`() = runBlockingTest {
-        val routeWithoutAnnotations = createTestTwoLegRoute(
-            firstLegAnnotations = null,
-            secondLegAnnotations = null
+        val routeWithoutAnnotations = createNavigationRoute(
+            createTestTwoLegRoute(
+                firstLegAnnotations = null,
+                secondLegAnnotations = null
+            )
         )
         val refreshedRoute = createNavigationRoute()
-        val directionsSession = mockk<DirectionsSession>().apply {
-            onRefresh { _, _, _, callback -> callback.onRefreshReady(refreshedRoute) }
+        val routeRefreshStub = RouteRefreshStub().apply {
+            setRefreshedRoute(refreshedRoute)
         }
         val routeRefreshController = createRouteRefreshController(
-            routeRefresh = directionsSession
+            routeRefresh = routeRefreshStub
         )
 
         val refreshedRouteDeferred =
@@ -105,20 +107,17 @@ class RouteRefreshControllerTest {
         advanceTimeBy(TimeUnit.MINUTES.toMillis(6))
 
         assertEquals(listOf(refreshedRoute), refreshedRouteDeferred.getCompletedTest())
-        verify(exactly = 1) { directionsSession.requestRouteRefresh(any(), any(), any()) }
     }
 
     @Test
-    fun `should log warning when route is not supported`() = runBlockingTest {
-        val primaryRoute = createTestTwoLegRoute(requestUuid = null)
-        val directionsSession = mockk<DirectionsSession>()
+    fun `should log warning when the only route is not supported`() = runBlockingTest {
+        val primaryRoute = createNavigationRoute(createTestTwoLegRoute(requestUuid = null))
         val routeRefreshController = createRouteRefreshController()
 
         val refreshedDeferred = async { routeRefreshController.refresh(listOf(primaryRoute)) }
         advanceTimeBy(TimeUnit.HOURS.toMillis(6))
 
         assertTrue(refreshedDeferred.isActive)
-        verify(exactly = 0) { directionsSession.requestRouteRefresh(any(), any(), any()) }
         verify(exactly = 1) {
             logger.logI(
                 withArg {
@@ -146,34 +145,44 @@ class RouteRefreshControllerTest {
 
     @Test
     fun `cancel request when stopped`() = runBlockingTest {
-        val directionsSession = mockk<DirectionsSession> {
+        val routeRefresh = mockk<RouteRefresh> {
             every { requestRouteRefresh(any(), any(), any()) } returns 8
             every { cancelRouteRefreshRequest(any()) } returns Unit
         }
         val routeRefreshController = createRouteRefreshController(
-            routeRefresh = directionsSession
+            routeRefresh = routeRefresh
         )
 
-        val refreshJob = async { routeRefreshController.refresh(listOf(createTestTwoLegRoute())) }
+        val refreshJob =
+            async {
+                routeRefreshController.refresh(
+                    listOf(
+                        createNavigationRoute(
+                            createTestTwoLegRoute()
+                        )
+                    )
+                )
+            }
         advanceTimeBy(TimeUnit.MINUTES.toMillis(6))
         refreshJob.cancel()
 
-        verify(exactly = 1) { directionsSession.cancelRouteRefreshRequest(8) }
+        verify(exactly = 1) { routeRefresh.requestRouteRefresh(any(), any(), any()) }
+        verify(exactly = 1) { routeRefresh.cancelRouteRefreshRequest(8) }
     }
 
     @Test
     fun `do not send a request when uuid is empty`() = runBlockingTest {
-        val directionsSession = mockk<DirectionsSession>(relaxed = true)
+        val routeRefresh = mockk<RouteRefresh>(relaxed = true)
         val routeRefreshController = createRouteRefreshController(
-            routeRefresh = directionsSession
+            routeRefresh = routeRefresh
         )
-        val route = createTestTwoLegRoute(requestUuid = "")
+        val route = createNavigationRoute(createTestTwoLegRoute(requestUuid = ""))
 
         val refreshDeferred = launch { routeRefreshController.refresh(listOf(route)) }
         advanceTimeBy(TimeUnit.MINUTES.toMillis(6))
 
         assertTrue(refreshDeferred.isActive)
-        verify(exactly = 0) { directionsSession.requestRouteRefresh(any(), any(), any()) }
+        verify(exactly = 0) { routeRefresh.requestRouteRefresh(any(), any(), any()) }
         refreshDeferred.cancel()
     }
 
@@ -187,41 +196,85 @@ class RouteRefreshControllerTest {
         )
         val routeRefreshController = createRouteRefreshController()
 
-        routeRefreshController.refresh(listOf(initialRoute))
+        val result = async { routeRefreshController.refresh(listOf(initialRoute)) }
+
+        throw result.getCompletionExceptionOrNull()!!
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `refresh alternative route without legs`() = runBlockingTest {
+        val initialRoutes = createNavigationRoutes(
+            createDirectionsResponse(
+                routes = listOf(
+                    createTestTwoLegRoute(),
+                    createTestTwoLegRoute().toBuilder().legs(emptyList()).build()
+                )
+            )
+        )
+        val routeRefreshController = createRouteRefreshController()
+
+        val result = async { routeRefreshController.refresh(initialRoutes) }
+
+        throw result.getCompletionExceptionOrNull()!!
     }
 
     @Test
     fun `should log route diffs when there is a successful response`() =
         runBlockingTest {
-            val initialRoute = createTestTwoLegRoute(
-                firstLegAnnotations = createRouteLegAnnotation(
-                    congestion = listOf("moderate", "heavy"),
-                    congestionNumeric = listOf(50, 94)
-                ),
-            )
-            val refreshedRoute = createTestTwoLegRoute(
-                firstLegAnnotations = createRouteLegAnnotation(
-                    congestion = listOf("heavy", "heavy"),
-                    congestionNumeric = listOf(93, 94),
-                ),
-                firstLegIncidents = listOf(
-                    createIncident(id = "1")
+            val initialRoutes = createNavigationRoutes(
+                createDirectionsResponse(
+                    uuid = "test",
+                    routes = listOf(
+                        createTestTwoLegRoute(
+                            firstLegAnnotations = createRouteLegAnnotation(
+                                congestion = listOf("moderate", "heavy"),
+                                congestionNumeric = listOf(50, 94)
+                            ),
+                        ),
+                        createTestTwoLegRoute(
+                            firstLegAnnotations = createRouteLegAnnotation(
+                                congestion = listOf("moderate", "heavy"),
+                                congestionNumeric = listOf(50, 94)
+                            ),
+                        )
+                    )
                 )
             )
-            val directionsSession = mockk<DirectionsSession>().apply {
-                onRefresh { _, _, _, callback -> callback.onRefreshReady(refreshedRoute) }
+            val refreshedRoutes = createNavigationRoutes(
+                createDirectionsResponse(
+                    uuid = "test",
+                    routes = listOf(
+                        createTestTwoLegRoute(
+                            firstLegAnnotations = createRouteLegAnnotation(
+                                congestion = listOf("heavy", "heavy"),
+                                congestionNumeric = listOf(93, 94),
+                            ),
+                            firstLegIncidents = listOf(
+                                createIncident(id = "1")
+                            )
+                        ),
+                        createTestTwoLegRoute(
+                            firstLegAnnotations = createRouteLegAnnotation(
+                                congestion = listOf("moderate", "heavy"),
+                                congestionNumeric = listOf(50, 94)
+                            ),
+                        )
+                    )
+                )
+            )
+            val routeRefresh = RouteRefreshStub().apply {
+                setRefreshedRoute(refreshedRoutes[0])
+                setRefreshedRoute(refreshedRoutes[1])
             }
             val routeRefreshController = createRouteRefreshController(
-                routeRefresh = directionsSession,
+                routeRefresh = routeRefresh,
             )
 
-            val refreshJob = launch { routeRefreshController.refresh(listOf(initialRoute)) }
-            advanceTimeBy(TimeUnit.MINUTES.toMillis(6))
+            routeRefreshController.refresh(initialRoutes)
 
-            assertTrue(refreshJob.isCompleted)
             verify {
                 logger.logI(
-                    "Updated congestion, congestionNumeric, incidents at leg 0",
+                    "Updated congestion, congestionNumeric, incidents at route test#0 leg 0",
                     RouteRefreshController.LOG_CATEGORY
                 )
             }
@@ -230,23 +283,36 @@ class RouteRefreshControllerTest {
     @Test
     fun `should log message when there is a successful response without route diffs`() =
         runBlockingTest {
-            val initialRoute = createTestTwoLegRoute()
-            val refreshedRoute = createTestTwoLegRoute()
-            val directionsSession = mockk<DirectionsSession>().onRefresh { _, _, _, callback ->
-                callback.onRefreshReady(refreshedRoute)
+            val initialRoutes = createNavigationRoutes(
+                createDirectionsResponse(
+                    routes = listOf(createTestTwoLegRoute()),
+                    uuid = "testNoDiff"
+                )
+            )
+            val refreshedRoutes = createNavigationRoutes(
+                createDirectionsResponse(
+                    routes = listOf(createTestTwoLegRoute()),
+                    uuid = "testNoDiff"
+                )
+            )
+            val routeRefreshStub = RouteRefreshStub().apply {
+                setRefreshedRoute(refreshedRoutes[0])
             }
 
             val routeRefreshController = createRouteRefreshController(
-                routeRefresh = directionsSession,
+                routeRefresh = routeRefreshStub,
             )
 
-            val refreshJob = launch { routeRefreshController.refresh(listOf(initialRoute)) }
+            val refreshJob = launch { routeRefreshController.refresh(initialRoutes) }
             advanceTimeBy(TimeUnit.MINUTES.toMillis(6))
+            refreshJob.cancel()
 
             verify {
-                logger.logI("No changes to route annotations", RouteRefreshController.LOG_CATEGORY)
+                logger.logI(
+                    "No changes in annotations for route testNoDiff#0",
+                    RouteRefreshController.LOG_CATEGORY
+                )
             }
-            refreshJob.cancel()
         }
 
     @Test
@@ -260,45 +326,45 @@ class RouteRefreshControllerTest {
                 minute = 30,
                 second = 0
             )
-            val primaryRoute = createTestTwoLegRoute(
-                firstLegIncidents = listOf(
-                    createIncident(
-                        id = "1",
-                        endTime = "2022-05-22T14:00:00Z",
+            val primaryRoute = createNavigationRoute(
+                createTestTwoLegRoute(
+                    firstLegIncidents = listOf(
+                        createIncident(
+                            id = "1",
+                            endTime = "2022-05-22T14:00:00Z",
+                        ),
+                        createIncident(
+                            id = "2",
+                            endTime = "2022-05-22T12:00:00Z", // expired
+                        ),
+                        createIncident(
+                            id = "3",
+                            endTime = "2022-05-22T12:00:00-01",
+                        ),
+                        createIncident(
+                            id = "4",
+                            endTime = null,
+                        )
                     ),
-                    createIncident(
-                        id = "2",
-                        endTime = "2022-05-22T12:00:00Z", // expired
-                    ),
-                    createIncident(
-                        id = "3",
-                        endTime = "2022-05-22T12:00:00-01",
-                    ),
-                    createIncident(
-                        id = "4",
-                        endTime = null,
-                    )
-                ),
-                secondLegIncidents = listOf(
-                    createIncident(
-                        id = "5",
-                        endTime = "2022-05-23T10:00:00Z",
-                    ),
-                    createIncident(
-                        id = "6",
-                        endTime = "2022-05-22T12:29:00Z", // expired
-                    ),
-                    createIncident(
-                        id = "7",
-                        endTime = "wrong date format",
+                    secondLegIncidents = listOf(
+                        createIncident(
+                            id = "5",
+                            endTime = "2022-05-23T10:00:00Z",
+                        ),
+                        createIncident(
+                            id = "6",
+                            endTime = "2022-05-22T12:29:00Z", // expired
+                        ),
+                        createIncident(
+                            id = "7",
+                            endTime = "wrong date format",
+                        )
                     )
                 )
             )
-            val directionsSession = mockk<DirectionsSession>()
-                .onRefresh { _, _, _, callback ->
-                    callback.onFailure(RouterFactory.buildNavigationRouterRefreshError())
-                }
-
+            val routeRefreshStub = RouteRefreshStub().apply {
+                failRouteRefresh(primaryRoute.id)
+            }
             val routeRefreshOptions = RouteRefreshOptions.Builder()
                 .intervalMillis(30_000)
                 .build()
@@ -306,7 +372,7 @@ class RouteRefreshControllerTest {
                 routeRefreshOptions = routeRefreshOptions,
                 currentLegIndexProvider = { 0 },
                 localDateProvider = { currentTime },
-                routeRefresh = directionsSession,
+                routeRefresh = routeRefreshStub,
             )
             // act
             val refreshedRoutesDeffer = async {
@@ -332,14 +398,14 @@ class RouteRefreshControllerTest {
     @Test
     fun `after invalidation route isn't updated until successful refresh`() =
         runBlockingTest {
-            val initialRoute = createTestTwoLegRoute()
-            val directionsSession = mockk<DirectionsSession>().onRefresh { _, _, _, callback ->
-                callback.onFailure(RouterFactory.buildNavigationRouterRefreshError())
+            val initialRoute = createNavigationRoute(createTestTwoLegRoute())
+            val routeRefreshStub = RouteRefreshStub().apply {
+                failRouteRefresh(initialRoute.id)
             }
             val routeRefreshOptions = RouteRefreshOptions.Builder().build()
             val routeRefreshController = createRouteRefreshController(
                 routeRefreshOptions = routeRefreshOptions,
-                routeRefresh = directionsSession
+                routeRefresh = routeRefreshStub
             )
             val invalidatedRouteDeffer = async {
                 routeRefreshController.refresh(listOf(initialRoute))
@@ -356,9 +422,7 @@ class RouteRefreshControllerTest {
                 expectedTimeToInvalidateCongestions(routeRefreshOptions.intervalMillis) * 100
             )
             assertFalse(refreshedRoute.isCompleted)
-            directionsSession.onRefresh { _, _, _, callback ->
-                callback.onRefreshReady(initialRoute)
-            }
+            routeRefreshStub.setRefreshedRoute(initialRoute)
             advanceTimeBy(routeRefreshOptions.intervalMillis)
             // assert
             assertEquals(listOf(initialRoute), refreshedRoute.getCompletedTest())
@@ -375,21 +439,23 @@ class RouteRefreshControllerTest {
                 minute = 0,
                 second = 0
             )
-            val initialRoute = createTestTwoLegRoute(
-                firstLegIncidents = listOf(
-                    createIncident(
-                        id = "1",
-                        endTime = "2022-05-22T12:00:00Z" // expires in 3 hours
+            val initialRoute = createNavigationRoute(
+                createTestTwoLegRoute(
+                    firstLegIncidents = listOf(
+                        createIncident(
+                            id = "1",
+                            endTime = "2022-05-22T12:00:00Z" // expires in 3 hours
+                        )
                     )
                 )
             )
-            val directionsSession = mockk<DirectionsSession>().onRefresh { _, _, _, callback ->
-                callback.onFailure(RouterFactory.buildNavigationRouterRefreshError())
+            val routeRefreshStub = RouteRefreshStub().apply {
+                failRouteRefresh(initialRoute.id)
             }
             val routeRefreshOptions = RouteRefreshOptions.Builder().build()
             val routeRefreshController = createRouteRefreshController(
                 routeRefreshOptions = routeRefreshOptions,
-                routeRefresh = directionsSession,
+                routeRefresh = routeRefreshStub,
                 localDateProvider = { currentTime }
             )
             val invalidatedRouteDeffer = async {
@@ -429,27 +495,30 @@ class RouteRefreshControllerTest {
                 minute = 0,
                 second = 0
             )
-            val currentRoute = createTestTwoLegRoute(
-                firstLegIncidents = listOf(
-                    createIncident(
-                        id = "1",
-                        endTime = "2022-05-22T09:00:00Z",
+            val currentRoute = createNavigationRoute(
+                createTestTwoLegRoute(
+                    firstLegIncidents = listOf(
+                        createIncident(
+                            id = "1",
+                            endTime = "2022-05-22T09:00:00Z",
+                        ),
                     ),
-                ),
-                secondLegIncidents = listOf(
-                    createIncident(
-                        id = "2",
-                        endTime = "2022-05-22T09:59:00Z"
-                    ),
-                    createIncident(
-                        id = "3",
-                        endTime = "2022-05-22T10:00:01Z"
-                    ),
+                    secondLegIncidents = listOf(
+                        createIncident(
+                            id = "2",
+                            endTime = "2022-05-22T09:59:00Z"
+                        ),
+                        createIncident(
+                            id = "3",
+                            endTime = "2022-05-22T10:00:01Z"
+                        ),
+                    )
                 )
             )
             val currentLegIndexProvider = { 1 }
-            val directionsSession = mockk<DirectionsSession>(relaxed = true)
-                .onRefresh { _, _, _, _ -> }
+            val routeRefreshStub = RouteRefreshStub().apply {
+                doNotRespondForRouteRefresh(currentRoute.id)
+            }
             val routeRefreshOptions = RouteRefreshOptions.Builder()
                 .intervalMillis(30_000L)
                 .build()
@@ -458,17 +527,16 @@ class RouteRefreshControllerTest {
                 routeDiffProvider = DirectionsRouteDiffProvider(),
                 currentLegIndexProvider = currentLegIndexProvider,
                 localDateProvider = { currentTime },
-                routeRefresh = directionsSession
+                routeRefresh = routeRefreshStub
             )
             // act
             val refreshedRoutesDeferred = async {
                 routeRefreshController.refresh(listOf(currentRoute))
             }
-            // in case of timeout controller will wait for the third response, so congestion will be
-            // invalidated after 4X refresh intervals
             advanceTimeBy(
-                expectedTimeToInvalidateCongestions(routeRefreshOptions.intervalMillis) +
+                expectedTimeToInvalidateCongestionsInCaseOfTimeout(
                     routeRefreshOptions.intervalMillis
+                )
             )
             // assert
             val refreshedRoute = refreshedRoutesDeferred.getCompletedTest().first()
@@ -492,16 +560,20 @@ class RouteRefreshControllerTest {
     @Test
     fun `route successfully refreshes on time if first try doesn't respond`() =
         runBlockingTest {
-            val initialRoute = createTestTwoLegRoute(
-                firstLegAnnotations = createRouteLegAnnotation(
-                    congestion = listOf("severe", "moderate"),
-                    congestionNumeric = listOf(90, 50),
+            val initialRoute = createNavigationRoute(
+                createTestTwoLegRoute(
+                    firstLegAnnotations = createRouteLegAnnotation(
+                        congestion = listOf("severe", "moderate"),
+                        congestionNumeric = listOf(90, 50),
+                    )
                 )
             )
-            val refreshed = createTestTwoLegRoute(
-                firstLegAnnotations = createRouteLegAnnotation(
-                    congestion = listOf("severe", "severe"),
-                    congestionNumeric = listOf(90, 90),
+            val refreshed = createNavigationRoute(
+                createTestTwoLegRoute(
+                    firstLegAnnotations = createRouteLegAnnotation(
+                        congestion = listOf("severe", "severe"),
+                        congestionNumeric = listOf(90, 90),
+                    )
                 )
             )
             var currentRoute = initialRoute
@@ -531,16 +603,20 @@ class RouteRefreshControllerTest {
     @Test
     fun `route successfully refreshes on time if first try failed`() =
         runBlockingTest {
-            val initialRoute = createTestTwoLegRoute(
-                firstLegAnnotations = createRouteLegAnnotation(
-                    congestion = listOf("severe", "moderate"),
-                    congestionNumeric = listOf(90, 50),
+            val initialRoute = createNavigationRoute(
+                createTestTwoLegRoute(
+                    firstLegAnnotations = createRouteLegAnnotation(
+                        congestion = listOf("severe", "moderate"),
+                        congestionNumeric = listOf(90, 50),
+                    )
                 )
             )
-            val refreshed = createTestTwoLegRoute(
-                firstLegAnnotations = createRouteLegAnnotation(
-                    congestion = listOf("severe", "severe"),
-                    congestionNumeric = listOf(90, 90),
+            val refreshed = createNavigationRoute(
+                createTestTwoLegRoute(
+                    firstLegAnnotations = createRouteLegAnnotation(
+                        congestion = listOf("severe", "severe"),
+                        congestionNumeric = listOf(90, 90),
+                    )
                 )
             )
             var currentRoute = initialRoute
@@ -570,9 +646,396 @@ class RouteRefreshControllerTest {
             assertEquals(listOf(refreshed), refreshedDeferred.getCompletedTest())
         }
 
+    @Test
+    fun `successful refresh of two routes`() = runBlockingTest {
+        val initialRoutes = createNavigationRoutes(
+            createDirectionsResponse(
+                routes = listOf(
+                    createTestTwoLegRoute(
+                        firstLegAnnotations = createRouteLegAnnotation(
+                            congestion = listOf("severe", "moderate"),
+                            congestionNumeric = listOf(90, 50),
+                        )
+                    ),
+                    createTestTwoLegRoute(
+                        firstLegAnnotations = createRouteLegAnnotation(
+                            congestion = listOf("severe", "moderate"),
+                            congestionNumeric = listOf(90, 50),
+                        )
+                    )
+                )
+            )
+        )
+        val refreshedRoutes = createNavigationRoutes(
+            createDirectionsResponse(
+                routes = listOf(
+                    createTestTwoLegRoute(
+                        firstLegAnnotations = createRouteLegAnnotation(
+                            congestion = listOf("severe", "severe"),
+                            congestionNumeric = listOf(90, 90),
+                        )
+                    ),
+                    createTestTwoLegRoute(
+                        firstLegAnnotations = createRouteLegAnnotation(
+                            congestion = listOf("severe", "severe"),
+                            congestionNumeric = listOf(90, 90),
+                        )
+                    )
+                )
+            )
+        )
+        val routeRefreshStub = RouteRefreshStub().apply {
+            setRefreshedRoute(refreshedRoutes[0])
+            setRefreshedRoute(refreshedRoutes[1])
+        }
+        val refreshOptions = RouteRefreshOptions.Builder().build()
+        val routeRefreshController = createRouteRefreshController(
+            routeRefresh = routeRefreshStub,
+            routeRefreshOptions = refreshOptions
+        )
+
+        val refreshedRoutesDeferred = async {
+            routeRefreshController.refresh(initialRoutes)
+        }
+        advanceTimeBy(refreshOptions.intervalMillis)
+
+        val result = refreshedRoutesDeferred.getCompletedTest()
+
+        assertEquals(
+            refreshedRoutes,
+            result
+        )
+    }
+
+    @Test
+    fun `primary route refresh failed, alternative route refreshed successfully`() =
+        runBlockingTest {
+            val initialRoutes = createNavigationRoutes(
+                createDirectionsResponse(
+                    routes = listOf(
+                        createTestTwoLegRoute(
+                            firstLegAnnotations = createRouteLegAnnotation(
+                                congestion = listOf("severe", "moderate"),
+                                congestionNumeric = listOf(90, 50),
+                            )
+                        ),
+                        createTestTwoLegRoute(
+                            firstLegAnnotations = createRouteLegAnnotation(
+                                congestion = listOf("severe", "moderate"),
+                                congestionNumeric = listOf(90, 50),
+                            )
+                        )
+                    )
+                )
+            )
+            val expectedRefreshedRoutes = createNavigationRoutes(
+                createDirectionsResponse(
+                    routes = listOf(
+                        initialRoutes[0].directionsRoute,
+                        createTestTwoLegRoute(
+                            firstLegAnnotations = createRouteLegAnnotation(
+                                congestion = listOf("severe", "severe"),
+                                congestionNumeric = listOf(90, 90),
+                            )
+                        )
+                    )
+                )
+            )
+            val routeRefreshStub = RouteRefreshStub().apply {
+                failRouteRefresh(expectedRefreshedRoutes[0].id)
+                setRefreshedRoute(expectedRefreshedRoutes[1])
+            }
+            val refreshOptions = RouteRefreshOptions.Builder().build()
+            val routeRefreshController = createRouteRefreshController(
+                routeRefresh = routeRefreshStub,
+                routeRefreshOptions = refreshOptions
+            )
+
+            val refreshedRoutesDeferred = async {
+                routeRefreshController.refresh(initialRoutes)
+            }
+            advanceTimeBy(refreshOptions.intervalMillis)
+            val result = refreshedRoutesDeferred.getCompletedTest()
+
+            assertEquals(
+                expectedRefreshedRoutes,
+                result
+            )
+        }
+
+    @Test
+    fun `routes won't refresh until one of them(second) changes`() = runBlockingTest {
+        val routeRefreshStub = RouteRefreshStub()
+        val initialRoutes = createNavigationRoutes(
+            createDirectionsResponse(
+                routes = listOf(
+                    createTestTwoLegRoute(
+                        firstLegAnnotations = createRouteLegAnnotation(
+                            congestion = listOf("severe", "moderate"),
+                            congestionNumeric = listOf(90, 50),
+                        )
+                    ),
+                    createTestTwoLegRoute(
+                        firstLegAnnotations = createRouteLegAnnotation(
+                            congestion = listOf("severe", "moderate"),
+                            congestionNumeric = listOf(90, 50),
+                        )
+                    )
+                )
+            )
+        )
+        val refreshedRoutes = createNavigationRoutes(
+            createDirectionsResponse(
+                routes = listOf(
+                    initialRoutes[0].directionsRoute,
+                    createTestTwoLegRoute(
+                        firstLegAnnotations = createRouteLegAnnotation(
+                            congestion = listOf("severe", "severe"),
+                            congestionNumeric = listOf(90, 90),
+                        )
+                    )
+                )
+            )
+        )
+        val refreshOptions = RouteRefreshOptions.Builder().build()
+        val routeRefreshController = createRouteRefreshController(
+            routeRefresh = routeRefreshStub,
+            routeRefreshOptions = refreshOptions
+        )
+
+        val refreshedRoutesDeferred = async {
+            routeRefreshController.refresh(initialRoutes)
+        }
+        routeRefreshStub.setRefreshedRoute(initialRoutes[0])
+        routeRefreshStub.setRefreshedRoute(initialRoutes[1])
+        advanceTimeBy(TimeUnit.HOURS.toMillis(7))
+        assertFalse(refreshedRoutesDeferred.isCompleted)
+        routeRefreshStub.setRefreshedRoute(refreshedRoutes[1])
+        advanceTimeBy(refreshOptions.intervalMillis)
+
+        val result = refreshedRoutesDeferred.getCompletedTest()
+
+        assertEquals(
+            refreshedRoutes,
+            result
+        )
+    }
+
+    @Test
+    fun `should updated primary and log warning when only alternative route is not supported`() =
+        runBlockingTest {
+            val primaryRoute = createNavigationRoute(createTestTwoLegRoute(requestUuid = "testid"))
+            val alternativeRoute = createNavigationRoute(createTestTwoLegRoute(requestUuid = null))
+            val updatedPrimary = createNavigationRoute(
+                createTestTwoLegRoute(
+                    requestUuid = "testid",
+                    firstLegAnnotations = createRouteLegAnnotation(
+                        congestion = listOf("severe", "severe"),
+                        congestionNumeric = listOf(95, 93),
+                    )
+                )
+            )
+            val routeRefresh = RouteRefreshStub().apply {
+                setRefreshedRoute(updatedPrimary)
+            }
+            val refreshOptions = RouteRefreshOptions.Builder().build()
+            val routeRefreshController = createRouteRefreshController(
+                routeRefresh = routeRefresh,
+                routeRefreshOptions = refreshOptions
+            )
+
+            val refreshedDeferred = async {
+                routeRefreshController.refresh(listOf(primaryRoute, alternativeRoute))
+            }
+            advanceTimeBy(refreshOptions.intervalMillis)
+            val result = refreshedDeferred.getCompletedTest()
+
+            assertEquals(
+                listOf(updatedPrimary, alternativeRoute),
+                result
+            )
+            verify(exactly = 1) {
+                logger.logI(
+                    withArg {
+                        assertTrue(
+                            "message doesn't mention the reason of failure - empty uuid: $it",
+                            it.contains("uuid", ignoreCase = true)
+                        )
+                        assertTrue(
+                            "message doesn't mention the route index",
+                            it.contains("0", ignoreCase = true)
+                        )
+                    },
+                    any()
+                )
+            }
+        }
+
+    @Test
+    fun `no refreshes when all routes disable refresh`() = runBlockingTest {
+        val routes = createNavigationRoutes(
+            createDirectionsResponse(
+                routes = listOf(
+                    createDirectionsRoute(
+                        routeOptions = createRouteOptions(enableRefresh = false)
+                    ),
+                    createDirectionsRoute(
+                        routeOptions = createRouteOptions(enableRefresh = false)
+                    ),
+                )
+            )
+        )
+        val routeRefresh = RouteRefreshStub()
+        val routeRefreshController = createRouteRefreshController(
+            routeRefresh = routeRefresh
+        )
+
+        val refreshedDeferred = async { routeRefreshController.refresh(routes) }
+        advanceTimeBy(TimeUnit.HOURS.toMillis(8))
+        assertFalse(refreshedDeferred.isCompleted)
+        refreshedDeferred.cancel()
+        verify(exactly = 1) {
+            logger.logI(
+                withArg {
+                    assertTrue(
+                        "message doesn't mention the reason of failure - enableRefresh=false: $it",
+                        it.contains("enableRefresh", ignoreCase = true)
+                    )
+                    assertTrue(
+                        "message doesn't mention the route index",
+                        it.contains("0", ignoreCase = true)
+                    )
+                },
+                any()
+            )
+            logger.logI(
+                withArg {
+                    assertTrue(
+                        "message doesn't mention the reason of failure - enableRefresh=false: $it",
+                        it.contains("enableRefresh", ignoreCase = true)
+                    )
+                    assertTrue(
+                        "message doesn't mention the route index",
+                        it.contains("1", ignoreCase = true)
+                    )
+                },
+                any()
+            )
+        }
+    }
+
+    @Test
+    fun `traffic annotations are cleaned up if all routes refresh fails`() =
+        runBlockingTest {
+            val initialRoutes = createNavigationRoutes(
+                createDirectionsResponse(
+                    routes = listOf(
+                        createTestTwoLegRoute(),
+                        createTestTwoLegRoute()
+                    )
+                )
+            )
+            val routeRefresh = RouteRefreshStub().apply {
+                failRouteRefresh(initialRoutes[0].id)
+                failRouteRefresh(initialRoutes[1].id)
+            }
+            val currentLegIndexProvider = { 1 }
+            val routeRefreshOptions = RouteRefreshOptions.Builder().build()
+            val routeRefreshController = createRouteRefreshController(
+                routeRefreshOptions = routeRefreshOptions,
+                routeDiffProvider = DirectionsRouteDiffProvider(),
+                currentLegIndexProvider = currentLegIndexProvider,
+                routeRefresh = routeRefresh
+            )
+            // act
+            val refreshedRoutesDeferred = async {
+                routeRefreshController.refresh(initialRoutes)
+            }
+            advanceTimeBy(
+                expectedTimeToInvalidateCongestions(routeRefreshOptions.intervalMillis)
+            )
+            // assert
+            val refreshedRoutes = refreshedRoutesDeferred.getCompletedTest()
+            refreshedRoutes[0].assertCongestionExpiredForLeg(1)
+            refreshedRoutes[1].assertCongestionExpiredForLeg(1)
+        }
+
+    @Test
+    fun `if route refresh works only for one route, the controller updates only one route`() =
+        runBlockingTest {
+            val currentTime = utcToLocalTime(
+                year = 2022,
+                month = Month.MAY,
+                date = 22,
+                hourOfDay = 12,
+                minute = 30,
+                second = 0
+            )
+            val routeRefreshStub = RouteRefreshStub()
+            val initialRoutes = createNavigationRoutes(
+                createDirectionsResponse(
+                    routes = listOf(
+                        createTestTwoLegRoute(),
+                        createTestTwoLegRoute(
+                            secondLegIncidents = listOf(
+                                createIncident(
+                                    id = "1",
+                                    endTime = "2022-05-21T14:00:00Z", // expired
+                                ),
+                                createIncident(
+                                    id = "2",
+                                    endTime = "2022-05-22T14:00:00Z",
+                                ),
+                            )
+                        )
+                    )
+                )
+            )
+            val refreshedRoutes = createNavigationRoutes(
+                createDirectionsResponse(
+                    routes = listOf(
+                        createTestTwoLegRoute(
+                            firstLegAnnotations = createRouteLegAnnotation(
+                                congestion = listOf("severe", "severe"),
+                                congestionNumeric = listOf(90, 99),
+                            )
+                        ),
+                        createTestTwoLegRoute()
+                    )
+                )
+            )
+            routeRefreshStub.setRefreshedRoute(refreshedRoutes[0])
+            routeRefreshStub.doNotRespondForRouteRefresh(refreshedRoutes[1].id)
+            val refreshOptions = RouteRefreshOptions.Builder().build()
+            val routeRefreshController = createRouteRefreshController(
+                routeRefresh = routeRefreshStub,
+                routeRefreshOptions = refreshOptions,
+                localDateProvider = { currentTime },
+                currentLegIndexProvider = { 1 }
+            )
+
+            val refreshedRoutesDeferred = async {
+                routeRefreshController.refresh(initialRoutes)
+            }
+            advanceTimeBy(
+                expectedTimeToInvalidateCongestionsInCaseOfTimeout(refreshOptions.intervalMillis)
+            )
+
+            val result = refreshedRoutesDeferred.getCompletedTest()
+
+            assertEquals(
+                refreshedRoutes[0],
+                result[0]
+            )
+            assertEquals(
+                initialRoutes[1], // no cleanup happens
+                result[1]
+            )
+        }
+
     private fun createRouteRefreshController(
         routeRefreshOptions: RouteRefreshOptions = RouteRefreshOptions.Builder().build(),
-        routeRefresh: RouteRefresh = mockk(),
+        routeRefresh: RouteRefresh = RouteRefreshStub(),
         currentLegIndexProvider: () -> Int = { 0 },
         routeDiffProvider: DirectionsRouteDiffProvider = DirectionsRouteDiffProvider(),
         localDateProvider: () -> Date = { Date(1653493148247) }
@@ -599,7 +1062,7 @@ private fun createTestTwoLegRoute(
         distance = listOf(28.0, 29.0)
     ),
     requestUuid: String? = "testUUID"
-) = createNavigationRoute(
+) =
     createDirectionsRoute(
         legs = listOf(
             createRouteLeg(
@@ -617,7 +1080,6 @@ private fun createTestTwoLegRoute(
         ),
         requestUuid = requestUuid
     )
-)
 
 private fun NavigationRoute.assertCongestionExpiredForLeg(legIndex: Int) {
     val legToCheck = this.directionsRoute.legs()!![legIndex].annotation()!!
@@ -652,18 +1114,27 @@ private fun DirectionsSession.onRefresh(
 
 private fun expectedTimeToInvalidateCongestions(refreshInterval: Long): Long = refreshInterval * 3
 
+// in case of timeout controller will wait for the one more response
+private fun expectedTimeToInvalidateCongestionsInCaseOfTimeout(refreshInterval: Long) =
+    expectedTimeToInvalidateCongestions(refreshInterval) +
+        refreshInterval
+
 private fun createTestInitialAndRefreshedTestRoutes(): Pair<NavigationRoute, NavigationRoute> =
     Pair(
-        createTestTwoLegRoute(
-            firstLegAnnotations = createRouteLegAnnotation(
-                congestion = listOf("moderate", "heavy"),
-                congestionNumeric = listOf(50, 94),
-            ),
+        createNavigationRoute(
+            createTestTwoLegRoute(
+                firstLegAnnotations = createRouteLegAnnotation(
+                    congestion = listOf("moderate", "heavy"),
+                    congestionNumeric = listOf(50, 94),
+                ),
+            )
         ),
-        createTestTwoLegRoute(
-            firstLegAnnotations = createRouteLegAnnotation(
-                congestion = listOf("heavy", "heavy"),
-                congestionNumeric = listOf(93, 94),
+        createNavigationRoute(
+            createTestTwoLegRoute(
+                firstLegAnnotations = createRouteLegAnnotation(
+                    congestion = listOf("heavy", "heavy"),
+                    congestionNumeric = listOf(93, 94),
+                )
             )
         )
     )

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/routerefresh/RouteRefreshStub.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/routerefresh/RouteRefreshStub.kt
@@ -1,0 +1,66 @@
+package com.mapbox.navigation.core.routerefresh
+
+import com.mapbox.navigation.base.ExperimentalMapboxNavigationAPI
+import com.mapbox.navigation.base.route.NavigationRoute
+import com.mapbox.navigation.base.route.NavigationRouterRefreshCallback
+import com.mapbox.navigation.base.route.RouterFactory.buildNavigationRouterRefreshError
+import com.mapbox.navigation.core.directions.session.RouteRefresh
+
+@OptIn(ExperimentalMapboxNavigationAPI::class)
+class RouteRefreshStub : RouteRefresh {
+
+    private var requestId = 0L
+    private val handlers = mutableMapOf<String, RouteRefreshHandler>()
+
+    override fun requestRouteRefresh(
+        route: NavigationRoute,
+        legIndex: Int,
+        callback: NavigationRouterRefreshCallback
+    ): Long {
+        val currentRequestId = requestId++
+        val handler = handlers[route.id]
+        if (handler != null) {
+            handler(route, legIndex, callback)
+        } else {
+            callback.onFailure(buildNavigationRouterRefreshError("handle isn't configured yet"))
+        }
+
+        return currentRequestId
+    }
+
+    override fun cancelRouteRefreshRequest(requestId: Long) {
+    }
+
+    /***
+     * Tne next route refresh requests will return the actual routes
+     */
+    fun setRefreshedRoute(refreshedRoute: NavigationRoute) {
+        handlers[refreshedRoute.id] = { _, _, callback ->
+            // TODO: refresh legs only from the passed index
+            callback.onRefreshReady(refreshedRoute)
+        }
+    }
+
+    /***
+     * The next route refresh requests for the given route route will fail
+     */
+    fun failRouteRefresh(navigationRouteId: String) {
+        handlers[navigationRouteId] = { _, _, callback ->
+            callback.onFailure(
+                buildNavigationRouterRefreshError(
+                    "Failed by RouteRefreshStub#failPendingRefreshRequest"
+                )
+            )
+        }
+    }
+
+    fun doNotRespondForRouteRefresh(navigationRouteId: String) {
+        handlers[navigationRouteId] = { _, _, _ -> }
+    }
+}
+
+private typealias RouteRefreshHandler = (
+    route: NavigationRoute,
+    legIndex: Int,
+    callback: NavigationRouterRefreshCallback
+) -> Unit

--- a/libtesting-navigation-base/src/main/java/com/mapbox/navigation/testing/factories/NavigationRouteFactory.kt
+++ b/libtesting-navigation-base/src/main/java/com/mapbox/navigation/testing/factories/NavigationRouteFactory.kt
@@ -1,6 +1,8 @@
 package com.mapbox.navigation.testing.factories
 
+import com.mapbox.api.directions.v5.models.DirectionsResponse
 import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.api.directions.v5.models.RouteOptions
 import com.mapbox.bindgen.Expected
 import com.mapbox.bindgen.ExpectedFactory
 import com.mapbox.navigation.base.internal.SDKRouteParser
@@ -34,5 +36,41 @@ fun createNavigationRoute(
                 )
             }
         }
+    )
+}
+
+fun createNavigationRoutes(
+    response: DirectionsResponse = createDirectionsResponse(),
+    options: RouteOptions = response.routes().first().routeOptions()!!,
+    routerOrigin: RouterOrigin = RouterOrigin.Offboard,
+): List<NavigationRoute> {
+    val parser = object : SDKRouteParser {
+        override fun parseDirectionsResponse(
+            response: String,
+            request: String,
+            routerOrigin: RouterOrigin
+        ): Expected<String, List<RouteInterface>> {
+            val directionsResponse = DirectionsResponse.fromJson(response)
+            val result = mutableListOf<RouteInterface>()
+            for (directionsRoute in directionsResponse.routes()) {
+                val route = createRouteInterface(
+                    responseUUID = directionsRoute.requestUuid() ?: "null",
+                    routeIndex = directionsRoute.routeIndex()!!.toInt(),
+                    responseJson = response,
+                    routerOrigin = routerOrigin.mapToNativeRouteOrigin(),
+                    requestURI = directionsRoute.routeOptions()!!.toUrl("pk.*test_token*")
+                        .toString()
+                )
+                result.add(route)
+            }
+            return ExpectedFactory.createValue(result)
+        }
+
+    }
+    return com.mapbox.navigation.base.internal.route.createNavigationRoutes(
+        response,
+        options,
+        parser,
+        routerOrigin
     )
 }

--- a/libtesting-thirdparty/src/main/java/com/mapbox/navigation/testing/factories/DirectionsResponseFactories.kt
+++ b/libtesting-thirdparty/src/main/java/com/mapbox/navigation/testing/factories/DirectionsResponseFactories.kt
@@ -1,6 +1,7 @@
 package com.mapbox.navigation.testing.factories
 
 import com.mapbox.api.directions.v5.DirectionsCriteria
+import com.mapbox.api.directions.v5.models.DirectionsResponse
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.Incident
 import com.mapbox.api.directions.v5.models.LegAnnotation
@@ -8,6 +9,20 @@ import com.mapbox.api.directions.v5.models.MaxSpeed
 import com.mapbox.api.directions.v5.models.RouteLeg
 import com.mapbox.api.directions.v5.models.RouteOptions
 import com.mapbox.geojson.Point
+
+fun createDirectionsResponse(
+    uuid: String = "testUUID",
+    routes: List<DirectionsRoute> = listOf(createDirectionsRoute())
+): DirectionsResponse {
+    val processedRoutes = routes.map {
+        it.toBuilder().requestUuid(uuid).build()
+    }
+    return DirectionsResponse.builder()
+        .uuid(uuid)
+        .code("Ok")
+        .routes(processedRoutes)
+        .build()
+}
 
 fun createDirectionsRoute(
     legs: List<RouteLeg>? = listOf(createRouteLeg()),


### PR DESCRIPTION
### Description
The SDK used to refresh only primary route. This PR adds refreshing of alternatives routes too. 

### TODO

- [x] more manual testing