### PR TITLE
Location puck velocity fix.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Mapbox welcomes participation and contributions from everyone.
 
 #### Bug fixes and improvements
 - Fixed an issue where the default `NavigationCamera` transition to the `Following` state did not respect `NavigationCameraTransitionOptions#maxDuration`. [#5921](https://github.com/mapbox/mapbox-navigation-android/pull/5921)
+- Fixed user location indicator's velocity when `NavigationLocationProvider` is used together with `keyPoints`. [#5925](https://github.com/mapbox/mapbox-navigation-android/pull/5925) 
 
 ## Mapbox Navigation SDK 2.6.0-beta.2 - June 9, 2022
 ### Changelog

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/internal/location/ConstantVelocityInterpolator.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/internal/location/ConstantVelocityInterpolator.kt
@@ -1,0 +1,51 @@
+package com.mapbox.navigation.ui.maps.internal.location
+
+import android.animation.TimeInterpolator
+import android.graphics.Path
+import android.view.animation.PathInterpolator
+import com.mapbox.geojson.Point
+import kotlin.math.hypot
+
+/**
+ * A time interpolator that animates between key points at constant velocity.
+ */
+class ConstantVelocityInterpolator(
+    startPoint: Point,
+    keyPoints: Array<Point>
+) : TimeInterpolator {
+
+    private val innerInterpolator: TimeInterpolator
+
+    init {
+        val distances = mutableListOf<Double>()
+        var total = 0.0
+        keyPoints.fold(startPoint) { prevPoint, point ->
+            val d = distanceTo(prevPoint, point)
+            distances.add(d)
+            total += d
+            point
+        }
+
+        innerInterpolator = if (0 < total) {
+            val path = Path()
+            val step = 1.0f / keyPoints.size
+            var pathTime = 0.0
+            keyPoints.forEachIndexed { index, _ ->
+                // simplified from (distances[index] / velocity) where (velocity = total / duration) and duration = 1.0
+                val deltaTime = distances[index] / total
+                pathTime += deltaTime
+                path.lineTo(pathTime.toFloat(), step * (index + 1))
+            }
+            PathInterpolator(path)
+        } else {
+            TimeInterpolator { it }
+        }
+    }
+
+    override fun getInterpolation(input: Float): Float =
+        innerInterpolator.getInterpolation(input)
+
+    private fun distanceTo(p1: Point, p2: Point): Double {
+        return hypot(p2.latitude() - p1.latitude(), p2.longitude() - p1.longitude())
+    }
+}

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/internal/location/PuckAnimationEvaluator.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/internal/location/PuckAnimationEvaluator.kt
@@ -1,0 +1,57 @@
+package com.mapbox.navigation.ui.maps.internal.location
+
+import android.animation.TimeInterpolator
+import android.animation.TypeEvaluator
+import android.animation.ValueAnimator
+import com.mapbox.geojson.Point
+
+/**
+ * A time and value interpolator for puck's animator. It uses [ConstantVelocityInterpolator] to
+ * animate at constant velocity between key points.
+ *
+ * Use [PuckAnimationEvaluator.installIn] to install it in [ValueAnimator].
+ * Use [PuckAnimationEvaluator.reset] to reset TimeInterpolator values for re-use with
+ * next ValueAnimator.
+ */
+internal class PuckAnimationEvaluator(
+    private val keyPoints: Array<Point>
+) : TimeInterpolator, TypeEvaluator<Point> {
+
+    private var interpolator: TimeInterpolator? = null
+
+    override fun getInterpolation(input: Float): Float =
+        interpolator?.getInterpolation(input) ?: input
+
+    override fun evaluate(fraction: Float, startValue: Point, endValue: Point): Point {
+        if (interpolator == null) {
+            // we defer creation of TimeInterpolator until we know startValue
+            interpolator = ConstantVelocityInterpolator(startValue, keyPoints)
+        }
+        return POINT.evaluate(fraction, startValue, endValue)
+    }
+
+    /**
+     * Reset TimeInterpolator values for re-use with next ValueAnimator.
+     */
+    fun reset() {
+        interpolator = null
+    }
+
+    /**
+     * Set this evaluator as [animator] TimeInterpolator and TypeEvaluator.
+     */
+    fun installIn(animator: ValueAnimator) {
+        reset()
+        animator.interpolator = this
+        animator.setEvaluator(this)
+    }
+
+    companion object {
+        private val POINT = TypeEvaluator<Point> { fraction, startValue, endValue ->
+            Point.fromLngLat(
+                startValue.longitude() + fraction * (endValue.longitude() - startValue.longitude()),
+                startValue.latitude() + fraction * (endValue.latitude() - startValue.latitude())
+            )
+        }
+    }
+}

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/location/NavigationLocationProvider.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/location/NavigationLocationProvider.kt
@@ -10,6 +10,7 @@ import com.mapbox.maps.plugin.locationcomponent.LocationProvider
 import com.mapbox.maps.plugin.locationcomponent.OnIndicatorPositionChangedListener
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.trip.session.LocationObserver
+import com.mapbox.navigation.ui.maps.internal.location.PuckAnimationEvaluator
 import com.mapbox.navigation.utils.internal.ifNonNull
 import java.util.concurrent.CopyOnWriteArraySet
 
@@ -154,7 +155,22 @@ class NavigationLocationProvider : LocationProvider {
         } else {
             doubleArrayOf(location.bearing.toDouble())
         }
-        this.onLocationUpdated(location = latLngUpdates, options = latLngTransitionOptions)
+
+        this.onLocationUpdated(
+            location = latLngUpdates,
+            options = locationAnimatorOptions(latLngUpdates, latLngTransitionOptions)
+        )
         this.onBearingUpdated(bearing = bearingUpdates, options = bearingTransitionOptions)
+    }
+
+    private fun locationAnimatorOptions(
+        keyPoints: Array<Point>,
+        clientOptions: (ValueAnimator.() -> Unit)?
+    ): (ValueAnimator.() -> Unit) {
+        val evaluator = PuckAnimationEvaluator(keyPoints)
+        return {
+            clientOptions?.also { apply(it) }
+            evaluator.installIn(this)
+        }
     }
 }

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/internal/location/ConstantVelocityInterpolatorTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/internal/location/ConstantVelocityInterpolatorTest.kt
@@ -1,0 +1,87 @@
+package com.mapbox.navigation.ui.maps.internal.location
+
+import com.mapbox.geojson.Point
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.math.pow
+import kotlin.math.sqrt
+
+@RunWith(RobolectricTestRunner::class)
+class ConstantVelocityInterpolatorTest {
+
+    @Test
+    fun `should calculate timings for constant velocity`() {
+        val p0 = Point.fromLngLat(0.0, 0.0)
+        val keyPoints = arrayOf(
+            Point.fromLngLat(0.3, 0.4),
+            Point.fromLngLat(0.6, 0.8),
+            Point.fromLngLat(1.0, 1.0),
+        )
+
+        val sut = ConstantVelocityInterpolator(p0, keyPoints)
+
+        val path = calculatePathValues(p0, *keyPoints)
+        assertEquals(keyPoints.size, path.size)
+        path.forEach { (outTime, inTime) ->
+            assertEquals(outTime, sut.getInterpolation(inTime))
+        }
+    }
+
+    @Test
+    fun `should use linear interpolation for key points at zero distance`() {
+        val p0 = Point.fromLngLat(1.0, 1.0)
+
+        assertEquals(
+            0.7f,
+            ConstantVelocityInterpolator(p0, emptyArray()).getInterpolation(0.7f)
+        )
+        assertEquals(
+            0.3f,
+            ConstantVelocityInterpolator(p0, arrayOf(p0)).getInterpolation(0.3f)
+        )
+    }
+
+    @Test
+    fun `should use linear interpolation for single key point`() {
+        val p0 = Point.fromLngLat(1.0, 1.0)
+        val p1 = Point.fromLngLat(2.0, 2.0)
+
+        assertEquals(
+            0.3f,
+            ConstantVelocityInterpolator(p0, arrayOf(p1)).getInterpolation(0.3f)
+        )
+    }
+
+    private fun calculatePathValues(p0: Point, vararg points: Point): List<Pair<Float, Float>> {
+        val distances = mutableListOf<Double>()
+        var totalDistance = 0.0
+        points.fold(p0) { a, b ->
+            val d = sqrt(
+                (b.latitude() - a.latitude()).pow(2.0) +
+                    (b.longitude() - a.longitude()).pow(2.0)
+            )
+            distances.add(d)
+            totalDistance += d
+            b
+        }
+        val timeStep = 1.0f / points.size
+        var pathTime = 0.0
+        val velocities = mutableListOf<Double>()
+        val path = mutableListOf<Pair<Float, Float>>()
+        distances.forEachIndexed { i, d ->
+            val dt = d / totalDistance
+            velocities.add(d / dt)
+            pathTime += dt
+            path.add(timeStep * (i + 1) to pathTime.toFloat())
+        }
+
+        // verify constant velocity
+        for (i in 1 until points.size) {
+            assertEquals(velocities[i - 1], velocities[i], 0.0001)
+        }
+
+        return path
+    }
+}

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/location/NavigationLocationProviderTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/location/NavigationLocationProviderTest.kt
@@ -61,7 +61,7 @@ class NavigationLocationProviderTest {
 
         val expectedPoints =
             arrayOf(Point.fromLngLat(location.longitude, location.latitude))
-        verify(exactly = 1) { consumer.onLocationUpdated(*expectedPoints, options = latLngOptions) }
+        verify(exactly = 1) { consumer.onLocationUpdated(*expectedPoints, options = any()) }
         val expectedBearings = doubleArrayOf(location.bearing.toDouble())
         verify(exactly = 1) {
             consumer.onBearingUpdated(*expectedBearings, options = bearingOptions)
@@ -97,7 +97,7 @@ class NavigationLocationProviderTest {
             Point.fromLngLat(keyPoint.longitude, keyPoint.latitude),
             Point.fromLngLat(location.longitude, location.latitude),
         )
-        verify(exactly = 1) { consumer.onLocationUpdated(*expectedPoints, options = latLngOptions) }
+        verify(exactly = 1) { consumer.onLocationUpdated(*expectedPoints, options = any()) }
         val expectedBearings = doubleArrayOf(
             keyPoint.bearing.toDouble(),
             location.bearing.toDouble()
@@ -123,6 +123,8 @@ class NavigationLocationProviderTest {
         val consumer: LocationConsumer = mockk(relaxUnitFun = true)
         val latLngAnimator: ValueAnimator = mockk {
             every { setDuration(any()) } returns this
+            every { setInterpolator(any()) } returns Unit
+            every { setEvaluator(any()) } returns Unit
         }
         every { consumer.onLocationUpdated(*anyVararg(), options = captureLambda()) } answers {
             secondArg<(ValueAnimator.() -> Unit)>().invoke(latLngAnimator)


### PR DESCRIPTION
Closes [#4140](https://github.com/mapbox/mapbox-navigation-android/issues/4140)

### Description

**tl;dr;** Using PathInterpolator to animate location puck at a constant speed over key points.

- Introduced `ConstantVelocityInterpolator` that uses Android PathInterpolator to calculate timings for ValueAnimator with key points.
- Added `PuckAnimationEvaluator` encapsulates wiring of `ConstantVelocityInterpolator` with location puck ValueAnimators.
- Updated `NavigationLocationProvider` to use `PuckAnimationEvaluator` to configure puck position ValueAnimator.

### Screenshots or Gifs

**Before**

https://user-images.githubusercontent.com/2678039/173482267-01fef844-cfc6-4571-a0bd-9c6ca2759eda.mp4

**After**

https://user-images.githubusercontent.com/2678039/173482098-26aa5099-4944-41c2-a15f-8255e3c4361a.mp4


