### PR TITLE
Add empty containers on the left and right sides for drop-in ui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Mapbox welcomes participation and contributions from everyone.
 
 #### Bug fixes and improvements
 - Fixed an issue where the default `NavigationCamera` transition to the `Following` state did not respect `NavigationCameraTransitionOptions#maxDuration`. [#5921](https://github.com/mapbox/mapbox-navigation-android/pull/5921) 
+- Added empty frames to Drop-In UI on the left and right side of the screen, thereby allowing users to inject custom views. [#5930](https://github.com/mapbox/mapbox-navigation-android/pull/5930)
 
 ## Mapbox Navigation SDK 2.6.0-beta.2 - June 9, 2022
 ### Changelog

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationView.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationView.kt
@@ -24,8 +24,10 @@ import com.mapbox.navigation.dropin.component.backpress.OnKeyListenerComponent
 import com.mapbox.navigation.dropin.component.location.LocationPermissionComponent
 import com.mapbox.navigation.dropin.coordinator.ActionButtonsCoordinator
 import com.mapbox.navigation.dropin.coordinator.InfoPanelCoordinator
+import com.mapbox.navigation.dropin.coordinator.LeftFrameCoordinator
 import com.mapbox.navigation.dropin.coordinator.ManeuverCoordinator
 import com.mapbox.navigation.dropin.coordinator.MapLayoutCoordinator
+import com.mapbox.navigation.dropin.coordinator.RightFrameCoordinator
 import com.mapbox.navigation.dropin.coordinator.RoadNameLabelCoordinator
 import com.mapbox.navigation.dropin.coordinator.SpeedLimitCoordinator
 import com.mapbox.navigation.dropin.databinding.MapboxNavigationViewLayoutBinding
@@ -124,7 +126,9 @@ class NavigationView @JvmOverloads constructor(
             ),
             ActionButtonsCoordinator(navigationContext, binding.actionListLayout),
             SpeedLimitCoordinator(navigationContext, binding.speedLimitLayout),
-            RoadNameLabelCoordinator(navigationContext, binding.roadNameLayout)
+            RoadNameLabelCoordinator(navigationContext, binding.roadNameLayout),
+            LeftFrameCoordinator(navigationContext, binding.emptyLeftContainer),
+            RightFrameCoordinator(navigationContext, binding.emptyRightContainer)
         )
     }
 

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/ViewBinder.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/ViewBinder.kt
@@ -21,6 +21,8 @@ internal class ViewBinder {
     private val _infoPanelHeaderBinder: MutableStateFlow<UIBinder?> = MutableStateFlow(null)
     private val _infoPanelContentBinder: MutableStateFlow<UIBinder?> = MutableStateFlow(null)
     private val _actionButtonsBinder: MutableStateFlow<UIBinder?> = MutableStateFlow(null)
+    private val _leftFrameBinder: MutableStateFlow<UIBinder?> = MutableStateFlow(null)
+    private val _rightFrameBinder: MutableStateFlow<UIBinder?> = MutableStateFlow(null)
 
     val speedLimit: StateFlow<UIBinder?> get() = _speedLimit.asStateFlow()
     val maneuver: StateFlow<UIBinder?> get() = _maneuver.asStateFlow()
@@ -30,6 +32,8 @@ internal class ViewBinder {
     val infoPanelHeaderBinder: StateFlow<UIBinder?> get() = _infoPanelHeaderBinder.asStateFlow()
     val infoPanelContentBinder: StateFlow<UIBinder?> get() = _infoPanelContentBinder.asStateFlow()
     val actionButtonsBinder: StateFlow<UIBinder?> get() = _actionButtonsBinder.asStateFlow()
+    val leftFrameContentBinder: StateFlow<UIBinder?> get() = _leftFrameBinder.asStateFlow()
+    val rightFrameContentBinder: StateFlow<UIBinder?> get() = _rightFrameBinder.asStateFlow()
 
     fun applyCustomization(customization: ViewBinderCustomization) {
         customization.speedLimitBinder?.also { _speedLimit.emitOrNull(it) }
@@ -41,6 +45,8 @@ internal class ViewBinder {
         customization.infoPanelHeaderBinder?.also { _infoPanelHeaderBinder.emitOrNull(it) }
         customization.infoPanelContentBinder?.also { _infoPanelContentBinder.emitOrNull(it) }
         customization.actionButtonsBinder?.also { _actionButtonsBinder.emitOrNull(it) }
+        customization.leftFrameBinder?.also { _leftFrameBinder.emitOrNull(it) }
+        customization.rightFrameBinder?.also { _rightFrameBinder.emitOrNull(it) }
     }
 
     private fun MutableStateFlow<UIBinder?>.emitOrNull(v: UIBinder) {

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/ViewBinderCustomization.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/ViewBinderCustomization.kt
@@ -52,4 +52,16 @@ class ViewBinderCustomization {
      * Use [UIBinder.USE_DEFAULT] to reset to default.
      */
     var actionButtonsBinder: UIBinder? = null
+
+    /**
+     * Customize the empty frame container on left side of the screen by providing your own [UIBinder].
+     * Use [UIBinder.USE_DEFAULT] to reset to default.
+     */
+    var leftFrameBinder: UIBinder? = null
+
+    /**
+     * Customize the empty frame container on right side of the screen by providing your own [UIBinder].
+     * Use [UIBinder.USE_DEFAULT] to reset to default.
+     */
+    var rightFrameBinder: UIBinder? = null
 }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/coordinator/LeftFrameCoordinator.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/coordinator/LeftFrameCoordinator.kt
@@ -1,0 +1,24 @@
+package com.mapbox.navigation.dropin.coordinator
+
+import android.view.ViewGroup
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.dropin.NavigationViewContext
+import com.mapbox.navigation.dropin.binder.EmptyBinder
+import com.mapbox.navigation.ui.base.lifecycle.Binder
+import com.mapbox.navigation.ui.base.lifecycle.UICoordinator
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+@ExperimentalPreviewMapboxNavigationAPI
+internal class LeftFrameCoordinator(
+    private val context: NavigationViewContext,
+    frameLayout: ViewGroup
+) : UICoordinator<ViewGroup>(frameLayout) {
+
+    override fun MapboxNavigation.flowViewBinders(): Flow<Binder<ViewGroup>> {
+        return context.uiBinders.leftFrameContentBinder.map {
+            it ?: EmptyBinder()
+        }
+    }
+}

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/coordinator/RightFrameCoordinator.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/coordinator/RightFrameCoordinator.kt
@@ -1,0 +1,24 @@
+package com.mapbox.navigation.dropin.coordinator
+
+import android.view.ViewGroup
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.dropin.NavigationViewContext
+import com.mapbox.navigation.dropin.binder.EmptyBinder
+import com.mapbox.navigation.ui.base.lifecycle.Binder
+import com.mapbox.navigation.ui.base.lifecycle.UICoordinator
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+@ExperimentalPreviewMapboxNavigationAPI
+internal class RightFrameCoordinator(
+    private val context: NavigationViewContext,
+    frameLayout: ViewGroup
+) : UICoordinator<ViewGroup>(frameLayout) {
+
+    override fun MapboxNavigation.flowViewBinders(): Flow<Binder<ViewGroup>> {
+        return context.uiBinders.rightFrameContentBinder.map {
+            it ?: EmptyBinder()
+        }
+    }
+}

--- a/libnavui-dropin/src/main/res/layout-land/mapbox_navigation_view_layout.xml
+++ b/libnavui-dropin/src/main/res/layout-land/mapbox_navigation_view_layout.xml
@@ -61,6 +61,36 @@
                 tools:layout_width="50dp"
                 android:layout_gravity="start|top"/>
 
+            <FrameLayout
+                android:id="@+id/emptyLeftContainer"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_marginStart="4dp"
+                android:layout_marginTop="8dp"
+                android:layout_marginBottom="8dp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/speedLimitLayout"
+                app:layout_constraintBottom_toTopOf="@id/guidelineBottom"
+                app:layout_constraintEnd_toStartOf="@id/guidelineBegin"
+                tools:background="#F6A1A1"
+                android:layout_gravity="start|top"/>
+
+            <FrameLayout
+                android:id="@+id/emptyRightContainer"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="4dp"
+                android:layout_marginTop="8dp"
+                android:layout_marginBottom="8dp"
+                android:layout_marginStart="4dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/actionListLayout"
+                app:layout_constraintBottom_toTopOf="@id/roadNameLayout"
+                tools:background="#F6A1A1"
+                tools:layout_height="130dp"
+                tools:layout_width="76dp"
+                android:layout_gravity="start|top"/>
+
             <LinearLayout
                 android:id="@+id/actionListLayout"
                 android:layout_width="@dimen/mapbox_actionList_width"

--- a/libnavui-dropin/src/main/res/layout/mapbox_navigation_view_layout.xml
+++ b/libnavui-dropin/src/main/res/layout/mapbox_navigation_view_layout.xml
@@ -54,6 +54,35 @@
                 tools:layout_width="50dp"
                 android:layout_gravity="start|top"/>
 
+            <FrameLayout
+                android:id="@+id/emptyLeftContainer"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_marginTop="8dp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/speedLimitLayout"
+                app:layout_constraintBottom_toTopOf="@id/roadNameLayout"
+                tools:background="#F6A1A1"
+                tools:layout_height="350dp"
+                tools:layout_width="50dp"
+                android:layout_gravity="start|top"/>
+
+            <FrameLayout
+                android:id="@+id/emptyRightContainer"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="8dp"
+                android:layout_marginTop="8dp"
+                android:layout_marginBottom="8dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/actionListLayout"
+                app:layout_constraintBottom_toTopOf="@id/roadNameLayout"
+                tools:background="#F6A1A1"
+                tools:layout_height="220dp"
+                tools:layout_width="76dp"
+                android:layout_gravity="start|top"/>
+
             <LinearLayout
                 android:id="@+id/actionListLayout"
                 android:layout_width="@dimen/mapbox_actionList_width"


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Fixes https://github.com/mapbox/navigation-sdks/issues/1782

I decided to add empty frame containers because of the following reasons:

- It keeps the approach consistent on how to inject custom views by creating a custom view binder
- This gives us more control by allowing us to decide the constraints of parent frame layout

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->
<img src="https://user-images.githubusercontent.com/9770186/173898264-160b378c-ae50-4b11-b587-a45591f83310.png" width="300" />

<img src="https://user-images.githubusercontent.com/9770186/173898364-a529bbca-d1a3-4384-b73c-e81469c061fb.png" width="300" />


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
