### PR TITLE
Disabled Puck Velocity Fix introduced in #5925

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,7 @@ Mapbox welcomes participation and contributions from everyone.
 - Added support for `NavigationViewListener`. This listener can be registered with `NavigationView` to observe changes to: navigation state, destination setting/clearing, Map `Style`, camera modes, camera viewport size, and audio guidance mute/un-mute state. [#5922](https://github.com/mapbox/mapbox-navigation-android/pull/5922)
 
 #### Bug fixes and improvements
-- Fixed an issue where the default `NavigationCamera` transition to the `Following` state did not respect `NavigationCameraTransitionOptions#maxDuration`. [#5921](https://github.com/mapbox/mapbox-navigation-android/pull/5921)
-- Fixed user location indicator's velocity when `NavigationLocationProvider` is used together with `keyPoints`. [#5925](https://github.com/mapbox/mapbox-navigation-android/pull/5925) 
+- Fixed an issue where the default `NavigationCamera` transition to the `Following` state did not respect `NavigationCameraTransitionOptions#maxDuration`. [#5921](https://github.com/mapbox/mapbox-navigation-android/pull/5921) 
 
 ## Mapbox Navigation SDK 2.6.0-beta.2 - June 9, 2022
 ### Changelog

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/location/NavigationLocationProvider.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/location/NavigationLocationProvider.kt
@@ -156,10 +156,13 @@ class NavigationLocationProvider : LocationProvider {
             doubleArrayOf(location.bearing.toDouble())
         }
 
-        this.onLocationUpdated(
-            location = latLngUpdates,
-            options = locationAnimatorOptions(latLngUpdates, latLngTransitionOptions)
-        )
+        // Disabling Puck Velocity fix introduced in https://github.com/mapbox/mapbox-navigation-android/pull/5925
+        // TODO: Investigate why Puck jumps when using Mock Locations app but doesn't when using MapboxReplayer.
+        // this.onLocationUpdated(
+        //     location = latLngUpdates,
+        //     options = locationAnimatorOptions(latLngUpdates, latLngTransitionOptions)
+        // )
+        this.onLocationUpdated(location = latLngUpdates, options = latLngTransitionOptions)
         this.onBearingUpdated(bearing = bearingUpdates, options = bearingTransitionOptions)
     }
 


### PR DESCRIPTION
### Description
We observed a strange behaviour after merging ["Puck Velocity Fix PR"](https://github.com/mapbox/mapbox-navigation-android/pull/5925). This "jumpy" puck begaviour can be observed only under specific conditions:

1. Mock Location app started
2. Fresh install of the **example** app
3. First-time launch of "Turn By Turn" activity _(see below screen recording)_

Notice after restarting "Turn By Turn" activity... everything works as expected.

This PR disables ["the Fix"](https://github.com/mapbox/mapbox-navigation-android/pull/5925) and removes CHANGELOG entry so we can investigate it further. 

https://user-images.githubusercontent.com/2678039/174149007-8952ae2a-6f1c-4a40-a4cd-cc5e5cbe438a.mp4



