### PR TITLE
Swap `setRoutesToTripSession` and `directionsSession.setRoutes` order so that the `NavigationSessionStateObserver` is fired off before the `Navigator` adds the `setRoute` event to the history file

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -804,8 +804,11 @@ class MapboxNavigation @VisibleForTesting internal constructor(
         restartRouteScope()
         threadController.getMainScopeAndRootJob().scope.launch(Dispatchers.Main.immediate) {
             routeUpdateMutex.withLock {
-                setRoutesToTripSession(routes, legIndex, reason)
+                // Order MUST be `directionsSession.setRoutes` and then `tripSession.setRoutes` so that the `NavigationSessionStateObserver`
+                // is fired off before the `Navigator` adds the `setRoute` event to the history file
+                // so `setRoute` events are recorded properly when the navigation session state changes
                 directionsSession.setRoutes(routes, legIndex, reason)
+                setRoutesToTripSession(routes, legIndex, reason)
             }
         }
     }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
@@ -1253,11 +1253,15 @@ class MapboxNavigationTest {
             mapboxNavigation.setNavigationRoutes(routes)
 
             coVerifyOrder {
+                // See MapboxNavigation#internalSetNavigationRoutes
+                // Order must be `directionsSession.setRoutes` and then `tripSession.setRoutes` so that the `NavigationSessionStateObserver`
+                // is fired off before the `Navigator` adds the `setRoute` event to the history file
+                // so `setRoute` events are recorded properly when the navigation session state changes
+                directionsSession.setRoutes(routes, 0, RoutesExtra.ROUTES_UPDATE_REASON_NEW)
                 routeAlternativesController.pauseUpdates()
                 tripSession.setRoutes(routes, 0, RoutesExtra.ROUTES_UPDATE_REASON_NEW)
                 routeAlternativesController.processAlternativesMetadata(routes, nativeAlternatives)
                 routeAlternativesController.resumeUpdates()
-                directionsSession.setRoutes(routes, 0, RoutesExtra.ROUTES_UPDATE_REASON_NEW)
             }
         }
 
@@ -1321,8 +1325,12 @@ class MapboxNavigationTest {
             }
 
             coVerifyOrder {
-                tripSession.setRoutes(routes, 0, RoutesExtra.ROUTES_UPDATE_REASON_NEW)
+                // See MapboxNavigation#internalSetNavigationRoutes
+                // Order must be `directionsSession.setRoutes` and then `tripSession.setRoutes` so that the `NavigationSessionStateObserver`
+                // is fired off before the `Navigator` adds the `setRoute` event to the history file
+                // so `setRoute` events are recorded properly when the navigation session state changes
                 directionsSession.setRoutes(routes, any(), any())
+                tripSession.setRoutes(routes, 0, RoutesExtra.ROUTES_UPDATE_REASON_NEW)
                 tripSession.setRoutes(routes, 0, RoutesExtra.ROUTES_UPDATE_REASON_NEW)
             }
 

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
@@ -115,13 +115,13 @@ class MapboxNavigationTest {
 
     private val accessToken = "pk.1234"
     private val directionsSession: DirectionsSession = mockk(relaxUnitFun = true)
-    private val navigator: MapboxNativeNavigator = mockk(relaxUnitFun = true)
+    private val navigator: MapboxNativeNavigator = mockk(relaxed = true)
     private val tripService: TripService = mockk(relaxUnitFun = true)
     private val tripSession: TripSession = mockk(relaxUnitFun = true)
     private val locationEngine: LocationEngine = mockk(relaxUnitFun = true)
     private val distanceFormatterOptions: DistanceFormatterOptions = mockk(relaxed = true)
     private val routingTilesOptions: RoutingTilesOptions = mockk(relaxed = true)
-    private val routeRefreshController: RouteRefreshController = mockk(relaxUnitFun = true)
+    private val routeRefreshController: RouteRefreshController = mockk(relaxed = true)
     private val routeAlternativesController: RouteAlternativesController = mockk(relaxed = true)
     private val routeProgress: RouteProgress = mockk(relaxed = true)
     private val navigationSession: NavigationSession = mockk(relaxed = true)
@@ -1412,6 +1412,9 @@ class MapboxNavigationTest {
                 any(),
             )
         } returns navigator
+        coEvery { navigator.setRoutes(any(), any(), any()) } answers {
+            createSetRouteResult()
+        }
     }
 
     private fun mockTripService() {


### PR DESCRIPTION
While testing we noticed that sometimes we're missing `setRoute` events in the history files.

Capturing from @korshaknn 

> in `mapboxNavigation` we `setRoutes` with
>```
>routeUpdateMutex.withLock {
>    setRoutesToTripSession(routes, legIndex, reason)
>    directionsSession.setRoutes(routes, legIndex, reason)
>}
>```
> 1. the first method `setRoutesToTripSession` will pass routes to NN -> NN will add `setRoute` event to the history
> 2. the second method `directionsSession.setRoutes`  will notify routes observers with new routes -> `NavigationSession` will handle this event and notify `NavigationSessionStateObserver` with `ActiveGuidance` state
> 3. App `HistoryRecordingSession` will get new state ^^ and will start recording `historyRecorder.startRecording()` so, we miss the event
> we can try to change methods order and call:
>```
>routeUpdateMutex.withLock {
>    directionsSession.setRoutes(routes, legIndex, reason)
>    setRoutesToTripSession(routes, legIndex, reason)
>}
>```
> but it requires a very deep investigation if it's safe! there are too many affected components, so I would ask core  team to investigate it

Also @RingerJK confirmed that this approach should work fine

> I see @LukasPaczos [added tests for order](https://github.com/mapbox/mapbox-navigation-android/pull/5653/files#diff-35f493ac2992ea5fd1f44e58406f629aedbe141637e0d42538faf0f426f1408aR1229-R1235), but don't see any red flags to change one. Also, if you're gonna change it, please mention in tests why it's important to keep a particular order

This PR swaps `setRoutesToTripSession` and `directionsSession.setRoutes` order in `internalSetNavigationRoutes` so that the `NavigationSessionStateObserver` is fired off before the `Navigator` adds the `setRoute` event to the history file so `setRoute` events are recorded properly when the navigation session state changes.

Took that for a spin and tested it and seems everything is working normally.

The idea here is to include this in the upcoming `2.6.0-beta.3` and test it thoroughly and if we run into any regressions we'll revert this change before `2.6.0-rc.1` cc @mapbox/driver-operations 

cc @mskurydin @korshaknn @abhishek1508 