### PR TITLE
Use the same `HistoryRecorderHandle` instance everywhere

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -269,7 +269,7 @@ class MapboxNavigation @VisibleForTesting internal constructor(
                 isFallback = false,
                 tilesVersion = navigationOptions.routingTilesOptions.tilesVersion
             ),
-            historyRecorder.fileDirectory(),
+            historyRecorder.historyRecorderHandle,
         )
     }
 

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/NavigatorLoader.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/NavigatorLoader.kt
@@ -65,14 +65,13 @@ object NavigatorLoader {
         deviceProfile: DeviceProfile,
         navigatorConfig: NavigatorConfig,
         tilesConfig: TilesConfig,
-        historyDir: String?,
+        historyRecorder: HistoryRecorderHandle?,
     ): RouterInterface {
         val config = ConfigFactory.build(
             settingsProfile(deviceProfile),
             navigatorConfig,
             deviceProfile.customConfig
         )
-        val historyRecorder = buildHistoryRecorder(historyDir, config)
         val cache = CacheFactory.build(tilesConfig, config, historyRecorder)
         return RouterFactory.build(
             RouterType.HYBRID,


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Fixes https://github.com/mapbox/mapbox-navigation-android/issues/5932

This PR refactors `MapboxNavigation` and `NavigatorLoader` so that the same `HistoryRecorderHandle` instance is used everywhere.

cc @mskurydin 