### PR TITLE
Fix / remove silent `MapboxNavigationTest`s exceptions

### DIFF
--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
@@ -121,7 +121,7 @@ class MapboxNavigationTest {
     private val locationEngine: LocationEngine = mockk(relaxUnitFun = true)
     private val distanceFormatterOptions: DistanceFormatterOptions = mockk(relaxed = true)
     private val routingTilesOptions: RoutingTilesOptions = mockk(relaxed = true)
-    private val routeRefreshController: RouteRefreshController = mockk(relaxUnitFun = true)
+    private val routeRefreshController: RouteRefreshController = mockk(relaxed = true)
     private val routeAlternativesController: RouteAlternativesController = mockk(relaxed = true)
     private val routeProgress: RouteProgress = mockk(relaxed = true)
     private val navigationSession: NavigationSession = mockk(relaxed = true)


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Fixes / removes silent `MapboxNavigationTest`s exceptions

Follow up from https://github.com/mapbox/mapbox-navigation-android/pull/5934#issuecomment-1158075831