### PR TITLE
Patched puck position anim glitch and re-enabled Puck Velocity Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Mapbox welcomes participation and contributions from everyone.
 #### Features
 
 #### Bug fixes and improvements
+- Fixed user location indicator's velocity when `NavigationLocationProvider` is used together with `keyPoints`. [#5925](https://github.com/mapbox/mapbox-navigation-android/pull/5925)
 
 ## Mapbox Navigation SDK 2.6.0-beta.3 - June 17, 2022
 ### Changelog

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/location/NavigationLocationProvider.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/location/NavigationLocationProvider.kt
@@ -4,6 +4,7 @@ import android.animation.ValueAnimator
 import android.annotation.SuppressLint
 import android.location.Location
 import com.mapbox.geojson.Point
+import com.mapbox.maps.plugin.locationcomponent.LocationComponentConstants
 import com.mapbox.maps.plugin.locationcomponent.LocationComponentPlugin
 import com.mapbox.maps.plugin.locationcomponent.LocationConsumer
 import com.mapbox.maps.plugin.locationcomponent.LocationProvider
@@ -156,13 +157,10 @@ class NavigationLocationProvider : LocationProvider {
             doubleArrayOf(location.bearing.toDouble())
         }
 
-        // Disabling Puck Velocity fix introduced in https://github.com/mapbox/mapbox-navigation-android/pull/5925
-        // TODO: Investigate why Puck jumps when using Mock Locations app but doesn't when using MapboxReplayer.
-        // this.onLocationUpdated(
-        //     location = latLngUpdates,
-        //     options = locationAnimatorOptions(latLngUpdates, latLngTransitionOptions)
-        // )
-        this.onLocationUpdated(location = latLngUpdates, options = latLngTransitionOptions)
+        this.onLocationUpdated(
+            location = latLngUpdates,
+            options = locationAnimatorOptions(latLngUpdates, latLngTransitionOptions)
+        )
         this.onBearingUpdated(bearing = bearingUpdates, options = bearingTransitionOptions)
     }
 
@@ -172,8 +170,9 @@ class NavigationLocationProvider : LocationProvider {
     ): (ValueAnimator.() -> Unit) {
         val evaluator = PuckAnimationEvaluator(keyPoints)
         return {
-            clientOptions?.also { apply(it) }
+            duration = LocationComponentConstants.DEFAULT_INTERVAL_MILLIS
             evaluator.installIn(this)
+            clientOptions?.also { apply(it) }
         }
     }
 }

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/location/NavigationLocationProvider.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/location/NavigationLocationProvider.kt
@@ -170,6 +170,7 @@ class NavigationLocationProvider : LocationProvider {
     ): (ValueAnimator.() -> Unit) {
         val evaluator = PuckAnimationEvaluator(keyPoints)
         return {
+            // TODO: Remove setDuration once patched in MapsSDK https://github.com/mapbox/mapbox-maps-android/issues/1446
             duration = LocationComponentConstants.DEFAULT_INTERVAL_MILLIS
             evaluator.installIn(this)
             clientOptions?.also { apply(it) }


### PR DESCRIPTION
Closes [#4140](https://github.com/mapbox/mapbox-navigation-android/issues/4140)

### Description

Patched puck position anim glitch and re-enabled Puck Velocity Fix introduced in [#5933](https://github.com/mapbox/mapbox-navigation-android/pull/5925)

### Investigation
[Puck Velocity Fix](https://github.com/mapbox/mapbox-navigation-android/pull/5925) relies on a mechanism that allows customization of ValueAnimator via `onLocationUpdated()` callback.

When we call `LocationConsumer.onLocationUpdated(vararg location: Point, options: (ValueAnimator.() -> Unit)? = null)` with non-null `options` in `NavigationLocationProvider.notifyLocationUpdates()`, the animator for puck position uses separate animator instance (see `userConfiguredAnimator` in `PuckAnimator.animate()`).

```kotlin 
// PuckAnimator.kt
class PuckAnimator(...) : ValueAnimator() {
  ... 
  init {
    setObjectValues(emptyArray<Any>())
    setEvaluator(evaluator)
    addUpdateListener {
      @Suppress("UNCHECKED_CAST")
      val updatedValue = it.animatedValue as T
      updateLayer(it.animatedFraction, updatedValue)
      updateListener?.invoke(updatedValue)
    }
    duration = LocationComponentConstants.DEFAULT_INTERVAL_MILLIS
    interpolator = DEFAULT_INTERPOLATOR
    userConfiguredAnimator = clone() // <-----------------
  }
  ...
  fun animate(
    vararg targets: T,
    options: (ValueAnimator.() -> Unit)? = null
  ) {
    cancelRunning()
    if (options == null) {
      setObjectValues(*targets)
      start()
    } else {  // <------------
      options.invoke(userConfiguredAnimator)
      userConfiguredAnimator.setObjectValues(*targets)
      userConfiguredAnimator.start()
    }
  }
  ...
}
```

The `userConfiguredAnimator` is created via `clone()` in the constructor. It appears that cloned version doesn't copy duration field, leaving `userConfiguredAnimator.duration = 0`.

(screenshots of debbuger session showing PuckAnimator duration fields)
| | |
|:---:|:---:|
|<img width="1552" alt="Screen Shot 2022-06-17 at 3 51 07 PM" src="https://user-images.githubusercontent.com/2678039/174395066-a250d581-fd3b-4cde-9142-6fb83daf0b22.png"/>|<img width="1552" alt="Screen Shot 2022-06-17 at 3 51 18 PM" src="https://user-images.githubusercontent.com/2678039/174395067-2cbe36ab-1378-40e9-91c8-b72b90caaa00.png"/>|

This PR patches the issue by always setting `ValueAnimator.duration` in `NavigationLocationProvider`.

_(recording of the fix captured in a fresh install of the _example_ app scenario)_

https://user-images.githubusercontent.com/2678039/174396335-9e578ac9-ef7c-40c5-af31-ee6e8052812e.mp4


<details><summary>Expand for glitch recording</summary>

https://user-images.githubusercontent.com/2678039/174207047-6719eeb9-5d77-422f-bcb3-529ae8bb6cfc.mp4

</details>