### PR TITLE
Send custom events to determine the usage of Drop-In UI

### DIFF
--- a/libnavigation-base/api/current.txt
+++ b/libnavigation-base/api/current.txt
@@ -272,7 +272,7 @@ package com.mapbox.navigation.base.metrics {
     property public abstract String metricName;
   }
 
-  @StringDef({com.mapbox.navigation.base.metrics.DirectionsMetrics.ROUTE_RETRIEVAL, com.mapbox.navigation.base.metrics.NavigationMetrics.ARRIVE, com.mapbox.navigation.base.metrics.NavigationMetrics.CANCEL_SESSION, com.mapbox.navigation.base.metrics.NavigationMetrics.DEPART, com.mapbox.navigation.base.metrics.NavigationMetrics.REROUTE, com.mapbox.navigation.base.metrics.NavigationMetrics.FEEDBACK, com.mapbox.navigation.base.metrics.NavigationMetrics.INITIAL_GPS, com.mapbox.navigation.base.metrics.NavigationMetrics.FASTER_ROUTE, com.mapbox.navigation.base.metrics.NavigationMetrics.APP_USER_TURNSTILE, com.mapbox.navigation.base.metrics.NavigationMetrics.FREE_DRIVE}) @kotlin.annotation.Retention(kotlin.annotation.AnnotationRetention.BINARY) public static @interface MetricEvent.Metric {
+  @StringDef({com.mapbox.navigation.base.metrics.DirectionsMetrics.ROUTE_RETRIEVAL, com.mapbox.navigation.base.metrics.NavigationMetrics.ARRIVE, com.mapbox.navigation.base.metrics.NavigationMetrics.CANCEL_SESSION, com.mapbox.navigation.base.metrics.NavigationMetrics.DEPART, com.mapbox.navigation.base.metrics.NavigationMetrics.REROUTE, com.mapbox.navigation.base.metrics.NavigationMetrics.FEEDBACK, com.mapbox.navigation.base.metrics.NavigationMetrics.INITIAL_GPS, com.mapbox.navigation.base.metrics.NavigationMetrics.FASTER_ROUTE, com.mapbox.navigation.base.metrics.NavigationMetrics.APP_USER_TURNSTILE, com.mapbox.navigation.base.metrics.NavigationMetrics.FREE_DRIVE, com.mapbox.navigation.base.metrics.NavigationMetrics.CUSTOM_EVENT}) @kotlin.annotation.Retention(kotlin.annotation.AnnotationRetention.BINARY) public static @interface MetricEvent.Metric {
   }
 
   public fun interface MetricsObserver {
@@ -289,6 +289,7 @@ package com.mapbox.navigation.base.metrics {
     field public static final String APP_USER_TURNSTILE = "appUserTurnstile";
     field public static final String ARRIVE = "navigation.arrive";
     field public static final String CANCEL_SESSION = "navigation.cancel";
+    field public static final String CUSTOM_EVENT = "navigation.customEvent";
     field public static final String DEPART = "navigation.depart";
     field public static final String FASTER_ROUTE = "navigation.fasterRoute";
     field public static final String FEEDBACK = "navigation.feedback";

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/metrics/MetricEvent.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/metrics/MetricEvent.kt
@@ -22,7 +22,8 @@ interface MetricEvent {
         NavigationMetrics.INITIAL_GPS,
         NavigationMetrics.FASTER_ROUTE,
         NavigationMetrics.APP_USER_TURNSTILE,
-        NavigationMetrics.FREE_DRIVE
+        NavigationMetrics.FREE_DRIVE,
+        NavigationMetrics.CUSTOM_EVENT,
     )
     annotation class Metric
 
@@ -90,6 +91,11 @@ object NavigationMetrics {
      * Navigation Event "FreeDrive" name
      */
     const val FREE_DRIVE = "navigation.freeDrive"
+
+    /**
+     * Navigation Event "Custom" name
+     */
+    const val CUSTOM_EVENT = "navigation.customEvent"
 }
 
 /**

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -51,6 +51,7 @@ import com.mapbox.navigation.core.directions.session.RoutesObserver
 import com.mapbox.navigation.core.history.MapboxHistoryReader
 import com.mapbox.navigation.core.history.MapboxHistoryRecorder
 import com.mapbox.navigation.core.internal.ReachabilityService
+import com.mapbox.navigation.core.internal.telemetry.CustomEvent
 import com.mapbox.navigation.core.internal.telemetry.UserFeedbackCallback
 import com.mapbox.navigation.core.internal.utils.InternalUtils
 import com.mapbox.navigation.core.internal.utils.ModuleParams
@@ -1340,6 +1341,21 @@ class MapboxNavigation @VisibleForTesting internal constructor(
                 feedbackSubType,
                 feedbackMetadata,
                 userFeedbackCallback,
+            )
+        }
+    }
+
+    @ExperimentalPreviewMapboxNavigationAPI
+    internal fun postCustomEvent(
+        payload: String,
+        @CustomEvent.Type customEventType: String,
+        customEventVersion: String,
+    ) {
+        runInTelemetryContext { telemetry ->
+            telemetry.postCustomEvent(
+                payload = payload,
+                customEventType = customEventType,
+                customEventVersion = customEventVersion
             )
         }
     }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/telemetry/CustomEvent.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/telemetry/CustomEvent.kt
@@ -1,0 +1,19 @@
+package com.mapbox.navigation.core.internal.telemetry
+
+import androidx.annotation.StringDef
+
+interface CustomEvent {
+
+    /**
+     * [CustomEvent] names scope
+     */
+    @Retention(AnnotationRetention.BINARY)
+    @StringDef(
+        NavigationCustomEventType.ANALYTICS,
+    )
+    annotation class Type
+}
+
+object NavigationCustomEventType {
+    const val ANALYTICS = "analytics"
+}

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/telemetry/TelemetryEx.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/telemetry/TelemetryEx.kt
@@ -90,3 +90,12 @@ fun MapboxNavigation.postUserFeedback(
         feedbackSubType, feedbackMetadata, userFeedbackCallback,
     )
 }
+
+@ExperimentalPreviewMapboxNavigationAPI
+fun MapboxNavigation.sendCustomEvent(
+    payload: String,
+    @CustomEvent.Type customEventType: String,
+    customEventVersion: String,
+) {
+    postCustomEvent(payload, customEventType, customEventVersion)
+}

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/events/NavigationCustomEvent.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/events/NavigationCustomEvent.kt
@@ -1,0 +1,52 @@
+package com.mapbox.navigation.core.telemetry.events
+
+import android.annotation.SuppressLint
+import android.os.Build
+import android.os.Parcel
+import com.google.gson.Gson
+import com.mapbox.android.telemetry.Event
+import com.mapbox.android.telemetry.TelemetryUtils
+import com.mapbox.navigation.base.metrics.MetricEvent
+import com.mapbox.navigation.base.metrics.NavigationMetrics
+
+@SuppressLint("ParcelCreator")
+internal class NavigationCustomEvent : Event(), MetricEvent {
+
+    private companion object {
+        private val OPERATING_SYSTEM = "Android - ${Build.VERSION.RELEASE}"
+    }
+
+    var type: String = ""
+    var payload: String? = null
+    val version: String = "2.4"
+    var customEventVersion: String = "1.0.0"
+    val event: String = NavigationMetrics.CUSTOM_EVENT
+
+    val created: String = TelemetryUtils.obtainCurrentDate()
+    var createdMonotime: Int = 0
+    val operatingSystem: String = OPERATING_SYSTEM
+    val device: String? = Build.MODEL
+    var driverMode: String = ""
+    // Setting driverModeId to the following to match the pattern: "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}?"
+    val driverModeId: String = "00000000-0000-0000-0000-000000000000"
+    val driverModeStartTimestamp: String = "non_valid"
+    var driverModeStartTimestampMonotime: Int = 0
+    var sdkIdentifier: String? = null
+    var eventVersion: Int = 0
+    var simulation: Boolean = false
+    var locationEngine: String? = null
+    var lat: Double = 0.toDouble()
+    var lng: Double = 0.toDouble()
+
+    override val metricName: String
+        get() = NavigationMetrics.CUSTOM_EVENT
+
+    override fun toJson(gson: Gson): String = gson.toJson(this)
+
+    override fun describeContents(): Int {
+        return 0
+    }
+
+    override fun writeToParcel(dest: Parcel, flags: Int) {
+    }
+}

--- a/libnavigation-metrics/src/main/java/com/mapbox/navigation/metrics/extensions/MetricEventEx.kt
+++ b/libnavigation-metrics/src/main/java/com/mapbox/navigation/metrics/extensions/MetricEventEx.kt
@@ -16,6 +16,7 @@ internal fun MetricEvent.toTelemetryEvent(): Event? =
         NavigationMetrics.FEEDBACK,
         NavigationMetrics.INITIAL_GPS,
         NavigationMetrics.FASTER_ROUTE,
+        NavigationMetrics.CUSTOM_EVENT,
         NavigationMetrics.FREE_DRIVE -> this as Event
         NavigationMetrics.APP_USER_TURNSTILE -> (this as NavigationAppUserTurnstileEvent).event
         else -> null

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationView.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationView.kt
@@ -20,6 +20,7 @@ import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.core.internal.extensions.attachCreated
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationApp
 import com.mapbox.navigation.core.replay.MapboxReplayer
+import com.mapbox.navigation.dropin.component.analytics.AnalyticsComponent
 import com.mapbox.navigation.dropin.component.backpress.OnKeyListenerComponent
 import com.mapbox.navigation.dropin.component.location.LocationPermissionComponent
 import com.mapbox.navigation.dropin.coordinator.ActionButtonsCoordinator
@@ -115,6 +116,7 @@ class NavigationView @JvmOverloads constructor(
         MapboxNavigationApp.attach(this)
 
         attachCreated(
+            AnalyticsComponent(),
             LocationPermissionComponent(context.toComponentActivityRef(), navigationContext.store),
             MapLayoutCoordinator(navigationContext, binding),
             OnKeyListenerComponent(navigationContext.store, this),

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/analytics/AnalyticsComponent.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/analytics/AnalyticsComponent.kt
@@ -1,0 +1,34 @@
+package com.mapbox.navigation.dropin.component.analytics
+
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.internal.telemetry.NavigationCustomEventType
+import com.mapbox.navigation.core.internal.telemetry.sendCustomEvent
+import com.mapbox.navigation.ui.base.lifecycle.UIComponent
+
+@OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
+internal class AnalyticsComponent : UIComponent() {
+
+    private companion object {
+        private const val STARTED = "Drop-In UI : started"
+        private const val STOPPED = "Drop-In UI : stopped"
+    }
+
+    override fun onAttached(mapboxNavigation: MapboxNavigation) {
+        mapboxNavigation.sendCustomEvent(
+            payload = STARTED,
+            customEventType = NavigationCustomEventType.ANALYTICS,
+            customEventVersion = "1.0.0"
+        )
+        super.onAttached(mapboxNavigation)
+    }
+
+    override fun onDetached(mapboxNavigation: MapboxNavigation) {
+        mapboxNavigation.sendCustomEvent(
+            payload = STOPPED,
+            customEventType = NavigationCustomEventType.ANALYTICS,
+            customEventVersion = "1.0.0"
+        )
+        super.onDetached(mapboxNavigation)
+    }
+}

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/analytics/AnalyticsComponentTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/analytics/AnalyticsComponentTest.kt
@@ -1,0 +1,64 @@
+package com.mapbox.navigation.dropin.component.analytics
+
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.internal.telemetry.sendCustomEvent
+import com.mapbox.navigation.testing.MainCoroutineRule
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+@ExperimentalPreviewMapboxNavigationAPI
+@OptIn(ExperimentalCoroutinesApi::class)
+class AnalyticsComponentTest {
+
+    @get:Rule
+    var coroutineRule = MainCoroutineRule()
+
+    private val sut = AnalyticsComponent()
+    private val mockMapboxNavigation: MapboxNavigation = mockk(relaxed = true) {
+        every { navigationOptions } returns mockk {
+            every { applicationContext } returns mockk(relaxed = true)
+        }
+    }
+
+    @Before
+    fun setUp() {
+        mockkStatic("com.mapbox.navigation.core.internal.extensions.MapboxNavigationEx")
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic("com.mapbox.navigation.core.internal.extensions.MapboxNavigationEx")
+    }
+
+    @Test
+    fun `when attached custom event is sent`() =
+        coroutineRule.runBlockingTest {
+            every { mockMapboxNavigation.sendCustomEvent(any(), any(), any()) } just Runs
+
+            sut.onAttached(mapboxNavigation = mockMapboxNavigation)
+
+            verify(exactly = 1) { mockMapboxNavigation.sendCustomEvent(any(), any(), any()) }
+        }
+
+    @Test
+    fun `when detached followed by attached custom event is sent multiple times`() =
+        coroutineRule.runBlockingTest {
+            every { mockMapboxNavigation.sendCustomEvent(any(), any(), any()) } just Runs
+
+            sut.onAttached(mapboxNavigation = mockMapboxNavigation)
+            sut.onDetached(mapboxNavigation = mockMapboxNavigation)
+
+            verify(exactly = 2) { mockMapboxNavigation.sendCustomEvent(any(), any(), any()) }
+        }
+}


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Fixes [#navigation-sdks](https://github.com/mapbox/navigation-sdks/issues/1776)

The implementation creates a new event `NavigationCustomEvent` that can be sent to record custom events sent by the SDK. This can be used to collect analytics based events. Drop-In UI in particular uses it to send 2 events:
- Every time the Drop-In UI is instantiated, the payload will be: "Drop-In UI : started, userId : <some_value>"
- Every time the Drop-In UI is destroyed, the payload will be: "Drop-In UI : stopped, userId : <some_value>"

Based on the data collected in `NavigationCustomEvent`, I am recording `userId` in the payload. This would allow the person reading the data to know 
- how many accounts are using the Drop-In UI by looking at `token` and `owner` entries in the database.
- how many users belonging to an account are using Drop-In UI. 

Note: Although not practical, if an actual user opens an app using Drop-In UI 50 times, this implementation would collect 100 events.

#### Things to consider:
- Since Drop-In UI is being actively developed and integrated in 1TAP, Nav SDK engineers will be sending 100(s) of events targeting production environment. I think we should set up `mapbox-navigation-android/examples` and `mapbox-navigation-android/qa-test-app` to only send events to staging endpoint. 
- 1Tap on the other hand should also set up it's build so that events should be recorded on staging environment when features/bugs are being developed/fixed, but should target production environment when someone downloads the app from playstore.

Any thoughts? @Guardiola31337 @RingerJK 

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
