### PR TITLE
add callbacks related to fecthing routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Mapbox welcomes participation and contributions from everyone.
 #### Bug fixes and improvements
 - Fixed user location indicator's velocity when `NavigationLocationProvider` is used together with `keyPoints`. [#5925](https://github.com/mapbox/mapbox-navigation-android/pull/5925)
 - Fixed the issue with the close icon in the trip notification occasionally using wrong color when including ui-dropin dependency. [#5956](https://github.com/mapbox/mapbox-navigation-android/pull/5956) 
+- Added more callbacks to `NavigationViewListener` to allow for observing events related to fecthing a route. [#5948](https://github.com/mapbox/mapbox-navigation-android/pull/5948)
 
 ## Mapbox Navigation SDK 2.6.0-beta.3 - June 17, 2022
 ### Changelog

--- a/libnavui-app/src/main/java/com/mapbox/navigation/ui/app/internal/routefetch/RoutesState.kt
+++ b/libnavui-app/src/main/java/com/mapbox/navigation/ui/app/internal/routefetch/RoutesState.kt
@@ -18,20 +18,20 @@ sealed class RoutesState {
      * Represents the state when the route is being fetched.
      * @param requestId of the route requested
      */
-    data class Fetching internal constructor(val requestId: Long) : RoutesState()
+    data class Fetching constructor(val requestId: Long) : RoutesState()
 
     /**
      * Represents the state when route fetching is complete and the route is ready.
      * @param routes fetched as a result of network request
      */
-    data class Ready internal constructor(val routes: List<NavigationRoute>) : RoutesState()
+    data class Ready constructor(val routes: List<NavigationRoute>) : RoutesState()
 
     /**
      * Represents the state when route fetching is canceled.
      * @param routeOptions used to fetch the route
      * @param routerOrigin origin of the route request
      */
-    data class Canceled internal constructor(
+    data class Canceled constructor(
         val routeOptions: RouteOptions,
         val routerOrigin: RouterOrigin
     ) : RoutesState()
@@ -41,7 +41,7 @@ sealed class RoutesState {
      * @param reasons for why the request failed
      * @param routeOptions used to fetch the route
      */
-    data class Failed internal constructor(
+    data class Failed constructor(
         val reasons: List<RouterFailure>,
         val routeOptions: RouteOptions
     ) : RoutesState()

--- a/libnavui-dropin/api/current.txt
+++ b/libnavui-dropin/api/current.txt
@@ -41,18 +41,22 @@ package com.mapbox.navigation.dropin {
 
   @com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI public abstract class NavigationViewListener {
     ctor public NavigationViewListener();
-    method public void onActiveNavigationStared();
-    method public void onArrivalStared();
+    method public void onActiveNavigation();
+    method public void onArrival();
     method public void onAudioGuidanceStateChanged(boolean muted);
     method public void onCameraPaddingChanged(com.mapbox.maps.EdgeInsets padding);
     method public void onDestinationChanged(com.mapbox.geojson.Point? destination);
-    method public void onDestinationPreviewStared();
+    method public void onDestinationPreview();
     method public void onFollowingCameraMode();
-    method public void onFreeDriveStarted();
+    method public void onFreeDrive();
     method public void onIdleCameraMode();
     method public void onMapStyleChanged(com.mapbox.maps.Style style);
     method public void onOverviewCameraMode();
-    method public void onRoutePreviewStared();
+    method public void onRouteFetchCanceled(com.mapbox.api.directions.v5.models.RouteOptions routeOptions, com.mapbox.navigation.base.route.RouterOrigin routerOrigin);
+    method public void onRouteFetchFailed(java.util.List<com.mapbox.navigation.base.route.RouterFailure> reasons, com.mapbox.api.directions.v5.models.RouteOptions routeOptions);
+    method public void onRouteFetchSuccessful(java.util.List<com.mapbox.navigation.base.route.NavigationRoute> routes);
+    method public void onRouteFetching(long requestId);
+    method public void onRoutePreview();
   }
 
   @com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI public final class ViewBinderCustomization {

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewListener.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewListener.kt
@@ -1,9 +1,14 @@
 package com.mapbox.navigation.dropin
 
+import com.mapbox.api.directions.v5.models.RouteOptions
 import com.mapbox.geojson.Point
 import com.mapbox.maps.EdgeInsets
 import com.mapbox.maps.Style
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.base.route.NavigationRoute
+import com.mapbox.navigation.base.route.Router
+import com.mapbox.navigation.base.route.RouterFailure
+import com.mapbox.navigation.base.route.RouterOrigin
 
 /**
  * Interface definition for the NavigationView listener.
@@ -20,27 +25,27 @@ abstract class NavigationViewListener {
     /**
      * Called when NavigationView enters Free Drive state.
      */
-    open fun onFreeDriveStarted() = Unit
+    open fun onFreeDrive() = Unit
 
     /**
      * Called when NavigationView enters Destination Preview state.
      */
-    open fun onDestinationPreviewStared() = Unit
+    open fun onDestinationPreview() = Unit
 
     /**
      * Called when NavigationView enters Route Preview state.
      */
-    open fun onRoutePreviewStared() = Unit
+    open fun onRoutePreview() = Unit
 
     /**
      * Called when NavigationView enters Active Navigation state.
      */
-    open fun onActiveNavigationStared() = Unit
+    open fun onActiveNavigation() = Unit
 
     /**
      * Called when NavigationView enters Arrival state.
      */
-    open fun onArrivalStared() = Unit
+    open fun onArrival() = Unit
 
     /**
      * Called when Map [Style] has changed. Invoked once the new style has been fully loaded,
@@ -78,4 +83,35 @@ abstract class NavigationViewListener {
      * @param muted Audio Guidance muted state.
      */
     open fun onAudioGuidanceStateChanged(muted: Boolean) = Unit
+
+    /**
+     * Called when route request using the [Router] was successful. The result contains a list of
+     * [NavigationRoute]. If there are no routes, then the list will be empty.
+     *
+     * @param routes All routes from origin to destination with waypoints if available.
+     */
+    open fun onRouteFetchSuccessful(routes: List<NavigationRoute>) = Unit
+
+    /**
+     * Called when route request using the [Router] was canceled.
+     *
+     * @param routeOptions Used to fetch the route.
+     * @param routerOrigin Origin of the route request
+     */
+    open fun onRouteFetchCanceled(routeOptions: RouteOptions, routerOrigin: RouterOrigin) = Unit
+
+    /**
+     * Called when route request using the [Router] failed.
+     *
+     * @param reasons For why the request failed.
+     * @param routeOptions Used to fetch the route.
+     */
+    open fun onRouteFetchFailed(reasons: List<RouterFailure>, routeOptions: RouteOptions) = Unit
+
+    /**
+     * Called when the route is being fetched using the [Router].
+     *
+     * @param requestId Id of the route requested.
+     */
+    open fun onRouteFetching(requestId: Long) = Unit
 }

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/MapboxNavigationViewCustomizedActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/MapboxNavigationViewCustomizedActivity.kt
@@ -18,6 +18,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.transition.Fade
 import androidx.transition.TransitionManager
+import com.mapbox.api.directions.v5.models.RouteOptions
 import com.mapbox.geojson.Point
 import com.mapbox.maps.CameraOptions
 import com.mapbox.maps.ConstrainMode
@@ -32,6 +33,9 @@ import com.mapbox.maps.Style
 import com.mapbox.maps.TileStoreUsageMode
 import com.mapbox.maps.applyDefaultParams
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.base.route.NavigationRoute
+import com.mapbox.navigation.base.route.RouterFailure
+import com.mapbox.navigation.base.route.RouterOrigin
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.internal.extensions.flowLocationMatcherResult
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver
@@ -314,24 +318,24 @@ class MapboxNavigationViewCustomizedActivity : AppCompatActivity() {
             log("listener onDestinationChanged = $destination")
         }
 
-        override fun onFreeDriveStarted() {
-            log("listener onFreeDriveStarted")
+        override fun onFreeDrive() {
+            log("listener onFreeDrive")
         }
 
-        override fun onDestinationPreviewStared() {
-            log("listener onDestinationPreviewStared")
+        override fun onDestinationPreview() {
+            log("listener onDestinationPreview")
         }
 
-        override fun onRoutePreviewStared() {
-            log("listener onRoutePreviewStared")
+        override fun onRoutePreview() {
+            log("listener onRoutePreview")
         }
 
-        override fun onActiveNavigationStared() {
-            log("listener onActiveNavigationStared")
+        override fun onActiveNavigation() {
+            log("listener onActiveNavigation")
         }
 
-        override fun onArrivalStared() {
-            log("listener onArrivalStared")
+        override fun onArrival() {
+            log("listener onArrival")
         }
 
         override fun onIdleCameraMode() {
@@ -356,6 +360,25 @@ class MapboxNavigationViewCustomizedActivity : AppCompatActivity() {
 
         override fun onAudioGuidanceStateChanged(muted: Boolean) {
             log("listener onAudioGuidanceStateChanged muted = $muted")
+        }
+
+        override fun onRouteFetching(requestId: Long) {
+            log("listener onRouteFetching requestId = $requestId")
+        }
+
+        override fun onRouteFetchFailed(reasons: List<RouterFailure>, routeOptions: RouteOptions) {
+            log("listener onRouteFetchFailed reasons = $reasons -- routeOptions = $routeOptions")
+        }
+
+        override fun onRouteFetchCanceled(routeOptions: RouteOptions, routerOrigin: RouterOrigin) {
+            log(
+                "listener onRouteFetchCanceled routeOptions = " +
+                    "$routeOptions -- routerOrigin = $routerOrigin"
+            )
+        }
+
+        override fun onRouteFetchSuccessful(routes: List<NavigationRoute>) {
+            log("listener onRouteFetchSuccessful routes = $routes")
         }
     }
 

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/NavigationViewFragment.java
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/NavigationViewFragment.java
@@ -43,28 +43,28 @@ public class NavigationViewFragment extends Fragment {
             }
 
             @Override
-            public void onFreeDriveStarted() {
-                Log.d(TAG, "onFreeDriveStarted");
+            public void onFreeDrive() {
+                Log.d(TAG, "onFreeDrive");
             }
 
             @Override
-            public void onDestinationPreviewStared() {
-                Log.d(TAG, "onDestinationPreviewStared");
+            public void onDestinationPreview() {
+                Log.d(TAG, "onDestinationPreview");
             }
 
             @Override
-            public void onRoutePreviewStared() {
-                Log.d(TAG, "onRoutePreviewStared");
+            public void onRoutePreview() {
+                Log.d(TAG, "onRoutePreview");
             }
 
             @Override
-            public void onActiveNavigationStared() {
-                Log.d(TAG, "onActiveNavigationStared");
+            public void onActiveNavigation() {
+                Log.d(TAG, "onActiveNavigation");
             }
 
             @Override
-            public void onArrivalStared() {
-                Log.d(TAG, "onArrivalStared");
+            public void onArrival() {
+                Log.d(TAG, "onArrival");
             }
         });
     }


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Given that Drop-In UI fetches route when required, there is no way to let the end users know if the route request was successful or not. The PR exposes callbacks for end users to observe various states in case route request succeeds, fails, cancels or fetching.

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
