### PR TITLE
Default IO dispatcher

### DIFF
--- a/libnavigation-util/src/main/java/com/mapbox/navigation/utils/internal/ThreadController.kt
+++ b/libnavigation-util/src/main/java/com/mapbox/navigation/utils/internal/ThreadController.kt
@@ -6,14 +6,12 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.channels.ClosedReceiveChannelException
 import kotlinx.coroutines.channels.ClosedSendChannelException
 import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import java.util.concurrent.Executors
 
 fun <T> CoroutineScope.monitorChannelWithException(
     channel: ReceiveChannel<T>,
@@ -47,18 +45,10 @@ fun Exception.ifChannelException(action: () -> Unit) {
 
 data class JobControl(val job: Job, val scope: CoroutineScope)
 
-private const val MAX_THREAD_COUNT = 2
-
 class ThreadController {
 
     companion object {
-
-        private val maxCoresUsed = Runtime.getRuntime().availableProcessors().coerceAtMost(
-            MAX_THREAD_COUNT,
-        )
-        val IODispatcher: CoroutineDispatcher =
-            Executors.newFixedThreadPool(maxCoresUsed).asCoroutineDispatcher()
-
+        val IODispatcher: CoroutineDispatcher = Dispatchers.IO
         val DefaultDispatcher: CoroutineDispatcher = Dispatchers.Default
     }
 


### PR DESCRIPTION
### Description

Usually, in java, IO thread pool has a big size because Input/Output operations, the pool is designed for, are blocking. See examples of[ IO Scheduler form RxJava](http://reactivex.io/RxJava/3.x/javadoc/io/reactivex/rxjava3/schedulers/Schedulers.html#io--) or [IO Dispatcher from Kotlin coroutines](https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/-dispatchers/-i-o.html).

I don't know why we used to limit threads count in IO Dispatcher, but I guess it made some sense at least in the past. Does somebody remember why the limit was needed? 

