### PR TITLE
More logs for get routes

### DIFF
--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/utils/DirectionsResponseUtils.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/utils/DirectionsResponseUtils.kt
@@ -6,6 +6,7 @@ import com.mapbox.bindgen.ExpectedFactory
 import com.mapbox.navigation.base.internal.route.toNavigationRoute
 import com.mapbox.navigation.base.route.NavigationRoute
 import com.mapbox.navigation.base.route.RouterOrigin
+import com.mapbox.navigation.utils.internal.logI
 import com.mapbox.navigator.RouteAlternative
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/utils/DirectionsResponseUtils.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/utils/DirectionsResponseUtils.kt
@@ -6,7 +6,6 @@ import com.mapbox.bindgen.ExpectedFactory
 import com.mapbox.navigation.base.internal.route.toNavigationRoute
 import com.mapbox.navigation.base.route.NavigationRoute
 import com.mapbox.navigation.base.route.RouterOrigin
-import com.mapbox.navigation.utils.internal.logI
 import com.mapbox.navigator.RouteAlternative
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/route/NavigationRoute.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/route/NavigationRoute.kt
@@ -181,7 +181,7 @@ class NavigationRoute internal constructor(
                 val deferredRouteOptionsParsing = async(ThreadController.DefaultDispatcher) {
                     RouteOptions.fromUrl(URL(routeRequestUrl)).also {
                         logI(
-                            "parsed request url to RouteOptions: $routeRequestUrl",
+                            "parsed request url to RouteOptions: ${it.toUrl("***")}",
                             LOG_CATEGORY
                         )
                     }

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/route/NavigationRoute.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/route/NavigationRoute.kt
@@ -19,6 +19,7 @@ import com.mapbox.navigation.base.internal.route.RouteCompatibilityCache
 import com.mapbox.navigation.base.internal.utils.mapToSdkRouteOrigin
 import com.mapbox.navigation.utils.internal.ThreadController
 import com.mapbox.navigation.utils.internal.logE
+import com.mapbox.navigation.utils.internal.logI
 import com.mapbox.navigator.RouteInterface
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -39,6 +40,9 @@ class NavigationRoute internal constructor(
 ) {
 
     companion object {
+
+        private final val TAG = "NavigationRoute"
+
         /**
          * Creates new instances of [NavigationRoute] based on the routes found in the [directionsResponse].
          *
@@ -151,19 +155,29 @@ class NavigationRoute internal constructor(
             routerOrigin: RouterOrigin,
             routeParser: SDKRouteParser = NativeRouteParserWrapper
         ): List<NavigationRoute> {
+            logI("NavigationRoute.create called for $routeRequestUrl", TAG)
             return coroutineScope {
                 val deferredResponseParsing = async(ThreadController.DefaultDispatcher) {
-                    DirectionsResponse.fromJson(directionsResponseJson)
+                    logI("parsing directions response to java model from $routeRequestUrl", TAG)
+                    val result = DirectionsResponse.fromJson(directionsResponseJson)
+                    logI("parsed directions response to java model from $routeRequestUrl", TAG)
+                    result
                 }
                 val deferredNativeParsing = async(ThreadController.DefaultDispatcher) {
-                    routeParser.parseDirectionsResponse(
+                    logI("parsing directions response to RouteInterface from $routeRequestUrl", TAG)
+                    val result = routeParser.parseDirectionsResponse(
                         directionsResponseJson,
                         routeRequestUrl,
                         routerOrigin,
                     )
+                    logI("parsed directions response to RouteInterface from $routeRequestUrl", TAG)
+                    result
                 }
                 val deferredRouteOptionsParsing = async(ThreadController.DefaultDispatcher) {
-                    RouteOptions.fromUrl(URL(routeRequestUrl))
+                    logI("parsing request url to RouteOptions: $routeRequestUrl", TAG)
+                    val result = RouteOptions.fromUrl(URL(routeRequestUrl))
+                    logI("parsed request url to RouteOptions: $routeRequestUrl", TAG)
+                    result
                 }
                 create(
                     deferredNativeParsing.await(),

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/route/NavigationRoute.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/route/NavigationRoute.kt
@@ -155,7 +155,7 @@ class NavigationRoute internal constructor(
             routerOrigin: RouterOrigin,
             routeParser: SDKRouteParser = NativeRouteParserWrapper
         ): List<NavigationRoute> {
-            logI("NavigationRoute.createAsync called for $routeRequestUrl", LOG_CATEGORY)
+            logI("NavigationRoute.createAsync is called", LOG_CATEGORY)
             return coroutineScope {
                 val deferredResponseParsing = async(ThreadController.DefaultDispatcher) {
                     DirectionsResponse.fromJson(directionsResponseJson).also {

--- a/libnavigation-router/src/main/java/com/mapbox/navigation/route/internal/RouterWrapper.kt
+++ b/libnavigation-router/src/main/java/com/mapbox/navigation/route/internal/RouterWrapper.kt
@@ -192,7 +192,7 @@ class RouterWrapper(
         return router.getRouteRefresh(
             refreshOptions
         ) { result, _ ->
-            logI("Received result from router.getRoutRefresh for ${route.id}", LOG_CATEGORY)
+            logI("Received result from router.getRouteRefresh for ${route.id}", LOG_CATEGORY)
             result.fold(
                 {
                     mainJobControl.scope.launch {

--- a/libnavigation-router/src/main/java/com/mapbox/navigation/route/internal/RouterWrapper.kt
+++ b/libnavigation-router/src/main/java/com/mapbox/navigation/route/internal/RouterWrapper.kt
@@ -94,7 +94,8 @@ class RouterWrapper(
                 {
                     mainJobControl.scope.launch {
                         logI(
-                            "processing successful response from router.getRoute for $urlWithoutToken",
+                            "processing successful response " +
+                                "from router.getRoute for $urlWithoutToken",
                             LOG_CATEGORY
                         )
                         parseDirectionsResponse(

--- a/libnavigation-router/src/main/java/com/mapbox/navigation/route/internal/RouterWrapper.kt
+++ b/libnavigation-router/src/main/java/com/mapbox/navigation/route/internal/RouterWrapper.kt
@@ -220,12 +220,16 @@ class RouterWrapper(
                         withContext(ThreadController.IODispatcher) {
                             parseDirectionsRouteRefresh(it)
                                 .onValue {
-                                    logI("Parsed route refresh response for route(${route.id})")
+                                    logI(
+                                        "Parsed route refresh response for route(${route.id})",
+                                        LOG_CATEGORY
+                                    )
                                 }
                                 .onError {
                                     logI(
                                         "Failed to parse route refresh response for " +
-                                            "route(${route.id})"
+                                            "route(${route.id})",
+                                        LOG_CATEGORY
                                     )
                                 }
                                 .mapValue { routeRefresh ->

--- a/libnavigation-router/src/main/java/com/mapbox/navigation/route/internal/RouterWrapper.kt
+++ b/libnavigation-router/src/main/java/com/mapbox/navigation/route/internal/RouterWrapper.kt
@@ -55,6 +55,7 @@ class RouterWrapper(
 
         return router.getRoute(routeUrl) { result, origin ->
             val urlWithoutToken = URL(routeUrl.redactQueryParam(ACCESS_TOKEN_QUERY_PARAM))
+            logI("received result from route.getRoute for $urlWithoutToken", LOG_CATEGORY)
             result.fold(
                 {
                     mainJobControl.scope.launch {
@@ -92,6 +93,10 @@ class RouterWrapper(
                 },
                 {
                     mainJobControl.scope.launch {
+                        logI(
+                            "processing successful response from router.getRoute for $urlWithoutToken",
+                            LOG_CATEGORY
+                        )
                         parseDirectionsResponse(
                             ThreadController.IODispatcher,
                             it,

--- a/libnavigation-router/src/test/java/com/mapbox/navigation/route/internal/RouterWrapperTests.kt
+++ b/libnavigation-router/src/test/java/com/mapbox/navigation/route/internal/RouterWrapperTests.kt
@@ -76,76 +76,34 @@ class RouterWrapperTests {
     private val routerResultSuccess: Expected<RouterError, String> = ExpectedFactory.createValue(
         testRouteFixtures.loadTwoLegRoute()
     )
-    private val routerResultFailure: Expected<RouterError, String> = mockk {
-        every { isValue } returns false
-        every { isError } returns true
-        every { value } returns null
-        every { error } returns RouterError(
+    private val routerResultFailure: Expected<RouterError, String> = ExpectedFactory.createError(
+        RouterError(
             FAILURE_MESSAGE,
             FAILURE_CODE,
             FAILURE_TYPE,
             REQUEST_ID
         )
-
-        val errorSlot = slot<Expected.Transformer<RouterError, Unit>>()
-        every { fold(capture(errorSlot), any()) } answers {
-            errorSlot.captured.invoke(this@mockk.error!!)
-        }
-    }
-    private val routerResultCancelled: Expected<RouterError, String> = mockk {
-        every { isValue } returns false
-        every { isError } returns true
-        every { value } returns null
-        every { error } returns RouterError(
+    )
+    private val routerResultCancelled: Expected<RouterError, String> = ExpectedFactory.createError(
+        RouterError(
             CANCELLED_MESSAGE,
             FAILURE_CODE,
             CANCELED_TYPE,
             REQUEST_ID
         )
-
-        val errorSlot = slot<Expected.Transformer<RouterError, Unit>>()
-        every { fold(capture(errorSlot), any()) } answers {
-            errorSlot.captured.invoke(this@mockk.error!!)
-        }
-    }
-    private val routerResultSuccessEmptyRoutes: Expected<RouterError, String> = mockk {
-        every { isValue } returns true
-        every { isError } returns false
-        every { value } returns testRouteFixtures.loadEmptyRoutesResponse()
-        every { error } returns null
-
-        val valueSlot = slot<Expected.Transformer<String, Unit>>()
-        every { fold(any(), capture(valueSlot)) } answers {
-            valueSlot.captured.invoke(this@mockk.value!!)
-        }
-    }
+    )
+    private val routerResultSuccessEmptyRoutes: Expected<RouterError, String> = ExpectedFactory
+        .createValue(testRouteFixtures.loadEmptyRoutesResponse())
     private val routerResultSuccessErroneousValue: Expected<RouterError, String> =
         ExpectedFactory.createValue(
             "{\"message\":\"should be >= 1\",\"code\":\"InvalidInput\"}"
         )
 
-    private val routerRefreshSuccess: Expected<RouterError, String> = mockk {
-        every { isValue } returns true
-        every { isError } returns false
-        every { value } returns testRouteFixtures.loadRefreshForMultiLegRoute()
-        every { error } returns null
-
-        val valueSlot = slot<Expected.Transformer<String, Unit>>()
-        every { fold(any(), capture(valueSlot)) } answers {
-            valueSlot.captured.invoke(this@mockk.value!!)
-        }
-    }
-    private val routerRefreshSuccessSecondLeg: Expected<RouterError, String> = mockk {
-        every { isValue } returns true
-        every { isError } returns false
-        every { value } returns testRouteFixtures.loadRefreshForMultiLegRouteSecondLeg()
-        every { error } returns null
-
-        val valueSlot = slot<Expected.Transformer<String, Unit>>()
-        every { fold(any(), capture(valueSlot)) } answers {
-            valueSlot.captured.invoke(this@mockk.value!!)
-        }
-    }
+    private val routerRefreshSuccess: Expected<RouterError, String> = ExpectedFactory.createValue(
+        testRouteFixtures.loadRefreshForMultiLegRoute()
+    )
+    private val routerRefreshSuccessSecondLeg: Expected<RouterError, String> = ExpectedFactory
+        .createValue(testRouteFixtures.loadRefreshForMultiLegRouteSecondLeg())
     private val nativeOriginOnline: RouterOrigin = RouterOrigin.ONLINE
     private val nativeOriginOnboard: RouterOrigin = RouterOrigin.ONBOARD
     private val getRouteSlot = slot<com.mapbox.navigator.RouterCallback>()

--- a/libtesting-navigation-base/src/main/java/com/mapbox/navigation/testing/factories/NavigationRouteFactory.kt
+++ b/libtesting-navigation-base/src/main/java/com/mapbox/navigation/testing/factories/NavigationRouteFactory.kt
@@ -50,22 +50,13 @@ fun createNavigationRoutes(
             request: String,
             routerOrigin: RouterOrigin
         ): Expected<String, List<RouteInterface>> {
-            val directionsResponse = DirectionsResponse.fromJson(response)
-            val result = mutableListOf<RouteInterface>()
-            for (directionsRoute in directionsResponse.routes()) {
-                val route = createRouteInterface(
-                    responseUUID = directionsRoute.requestUuid() ?: "null",
-                    routeIndex = directionsRoute.routeIndex()!!.toInt(),
-                    responseJson = response,
-                    routerOrigin = routerOrigin.mapToNativeRouteOrigin(),
-                    requestURI = directionsRoute.routeOptions()!!.toUrl("pk.*test_token*")
-                        .toString()
-                )
-                result.add(route)
-            }
+            val result = createRouteInterfacesFromDirectionRequestResponse(
+                requestUri = request,
+                response = response,
+                routerOrigin = routerOrigin
+            )
             return ExpectedFactory.createValue(result)
         }
-
     }
     return com.mapbox.navigation.base.internal.route.createNavigationRoutes(
         response,
@@ -73,4 +64,21 @@ fun createNavigationRoutes(
         parser,
         routerOrigin
     )
+}
+
+fun createRouteInterfacesFromDirectionRequestResponse(
+    requestUri: String,
+    response: String,
+    routerOrigin: RouterOrigin = RouterOrigin.Offboard
+): List<RouteInterface> {
+    return DirectionsResponse.fromJson(response).routes()
+        .map { directionsRoute ->
+            createRouteInterface(
+                responseUUID = directionsRoute.requestUuid() ?: "null",
+                routeIndex = directionsRoute.routeIndex()!!.toInt(),
+                responseJson = response,
+                routerOrigin = routerOrigin.mapToNativeRouteOrigin(),
+                requestURI = requestUri
+            )
+        }
 }


### PR DESCRIPTION
### Description

One of our customers had a problem when `MapboxNavigation.requestRoutes` stucked. It just didn't return anything: neither error nor result for a few minutes.

After a long investigation the customer found out that they did too many work using `Dispathers.Default`. The SDK just just couldn't parse direction response. Looks like it was caused by the absence of available threads in Dispathcers.Default` thread pool.

This PR adds more logs to let us detect similar situation in future by just reading the logs.