### PR TITLE
Bump Navigation Native dependency version to `107.0.0`

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -13,7 +13,7 @@ ext {
   // version which we should use in this build
   def mapboxNavigatorVersion = System.getenv("FORCE_MAPBOX_NAVIGATION_NATIVE_VERSION")
   if (mapboxNavigatorVersion == null || mapboxNavigatorVersion == '') {
-      mapboxNavigatorVersion = '106.0.0'
+      mapboxNavigatorVersion = '107.0.0'
   }
   println("Navigation Native version: " + mapboxNavigatorVersion)
 


### PR DESCRIPTION
### Description
- Bumps Navigation Native dependency version to `107.0.0`

cc @mapbox/navnative 