### PR TITLE
[Drop-In UI] Added support for edge-to-edge display.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Mapbox welcomes participation and contributions from everyone.
 - Fixed reroute request interruption when setting the `NavigationRerouteController` [#5950](https://github.com/mapbox/mapbox-navigation-android/pull/5950).
 - Fixed setting trim offsets to route line trail layers. [#5982](https://github.com/mapbox/mapbox-navigation-android/pull/5982)
 - Fixed a Drop-In UI issue where legacy shields were displayed instead of Mapbox designed ones with some of the map styles. [#5984](https://github.com/mapbox/mapbox-navigation-android/pull/5984)
+- Updated `NavigationView` to support edge-to-edge display. [#5976](https://github.com/mapbox/mapbox-navigation-android/pull/5976) 
 
 ## Mapbox Navigation SDK 2.7.0-alpha.1 - June 24, 2022
 ### Changelog

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationView.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationView.kt
@@ -8,6 +8,8 @@ import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.FrameLayout
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
@@ -103,6 +105,7 @@ class NavigationView @JvmOverloads constructor(
 
     init {
         keepScreenOn = true
+        adjustForSystemBars()
 
         SharedApp.setup(context.applicationContext as Application)
         if (!MapboxNavigationApp.isSetup()) {
@@ -132,6 +135,19 @@ class NavigationView @JvmOverloads constructor(
             LeftFrameCoordinator(navigationContext, binding.emptyLeftContainer),
             RightFrameCoordinator(navigationContext, binding.emptyRightContainer)
         )
+    }
+
+    private fun adjustForSystemBars() {
+        ViewCompat.setOnApplyWindowInsetsListener(this) { _, insets ->
+            val navigationBarInsets =
+                insets.getInsetsIgnoringVisibility(WindowInsetsCompat.Type.navigationBars())
+
+            val lp = (binding.coordinatorLayout.layoutParams as MarginLayoutParams)
+            lp.bottomMargin = navigationBarInsets.bottom
+            binding.coordinatorLayout.layoutParams = lp
+
+            insets
+        }
     }
 
     /**

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationView.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationView.kt
@@ -105,7 +105,7 @@ class NavigationView @JvmOverloads constructor(
 
     init {
         keepScreenOn = true
-        adjustForSystemBars()
+        captureSystemBarsInsets()
 
         SharedApp.setup(context.applicationContext as Application)
         if (!MapboxNavigationApp.isSetup()) {
@@ -137,15 +137,10 @@ class NavigationView @JvmOverloads constructor(
         )
     }
 
-    private fun adjustForSystemBars() {
+    private fun captureSystemBarsInsets() {
         ViewCompat.setOnApplyWindowInsetsListener(this) { _, insets ->
-            val navigationBarInsets =
-                insets.getInsetsIgnoringVisibility(WindowInsetsCompat.Type.navigationBars())
-
-            val lp = (binding.coordinatorLayout.layoutParams as MarginLayoutParams)
-            lp.bottomMargin = navigationBarInsets.bottom
-            binding.coordinatorLayout.layoutParams = lp
-
+            val systemBarsInsets = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            navigationContext.systemBarsInsets.value = systemBarsInsets
             insets
         }
     }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewContext.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewContext.kt
@@ -1,6 +1,7 @@
 package com.mapbox.navigation.dropin
 
 import android.content.Context
+import androidx.core.graphics.Insets
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import com.mapbox.maps.MapView
@@ -28,6 +29,8 @@ internal class NavigationViewContext(
     val store by lazy { SharedApp.store }
 
     val mapView = MutableStateFlow<MapView?>(null)
+
+    val systemBarsInsets = MutableStateFlow<Insets?>(null)
 
     val uiBinders = ViewBinder()
     val styles = NavigationViewStyles(context)

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/binder/map/MapBinder.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/binder/map/MapBinder.kt
@@ -13,6 +13,7 @@ import com.mapbox.navigation.dropin.NavigationViewContext
 import com.mapbox.navigation.dropin.component.camera.CameraComponent
 import com.mapbox.navigation.dropin.component.camera.CameraLayoutObserver
 import com.mapbox.navigation.dropin.component.location.LocationComponent
+import com.mapbox.navigation.dropin.component.logo.LogoAttributionComponent
 import com.mapbox.navigation.dropin.component.marker.FreeDriveLongPressMapComponent
 import com.mapbox.navigation.dropin.component.marker.GeocodingComponent
 import com.mapbox.navigation.dropin.component.marker.MapMarkersComponent
@@ -48,10 +49,8 @@ internal class MapBinder(
         val navigationState = store.select { it.navigation }
         return navigationListOf(
             CameraLayoutObserver(store, mapView, binding),
-            LocationComponent(
-                mapView,
-                SharedApp.locationStateController,
-            ),
+            LocationComponent(mapView, SharedApp.locationStateController),
+            LogoAttributionComponent(mapView, context.systemBarsInsets),
             reloadOnChange(
                 context.mapStyleLoader.loadedMapStyle,
                 context.options.routeLineOptions

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/logo/LogoAttributionComponent.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/logo/LogoAttributionComponent.kt
@@ -1,0 +1,33 @@
+package com.mapbox.navigation.dropin.component.logo
+
+import androidx.core.graphics.Insets
+import com.mapbox.maps.MapView
+import com.mapbox.maps.plugin.attribution.attribution
+import com.mapbox.maps.plugin.logo.logo
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.ui.base.lifecycle.UIComponent
+import kotlinx.coroutines.flow.StateFlow
+
+@ExperimentalPreviewMapboxNavigationAPI
+internal class LogoAttributionComponent(
+    private val mapView: MapView,
+    private val systemBarInsets: StateFlow<Insets?>
+) : UIComponent() {
+
+    override fun onAttached(mapboxNavigation: MapboxNavigation) {
+        super.onAttached(mapboxNavigation)
+
+        systemBarInsets.observe { insets ->
+            if (insets != null) {
+                val bottom = insets.bottom.toFloat()
+                mapView.logo.updateSettings {
+                    marginBottom = bottom
+                }
+                mapView.attribution.updateSettings {
+                    marginBottom = bottom
+                }
+            }
+        }
+    }
+}

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/logo/LogoAttributionComponent.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/logo/LogoAttributionComponent.kt
@@ -21,11 +21,17 @@ internal class LogoAttributionComponent(
         systemBarInsets.observe { insets ->
             if (insets != null) {
                 val bottom = insets.bottom.toFloat()
+                val left = insets.left.toFloat()
+                val right = insets.right.toFloat()
                 mapView.logo.updateSettings {
                     marginBottom = bottom
+                    marginLeft = left
+                    marginRight = right
                 }
                 mapView.attribution.updateSettings {
                     marginBottom = bottom
+                    marginLeft = left
+                    marginRight = right
                 }
             }
         }

--- a/libnavui-dropin/src/main/res/layout-land/mapbox_navigation_view_layout.xml
+++ b/libnavui-dropin/src/main/res/layout-land/mapbox_navigation_view_layout.xml
@@ -12,136 +12,147 @@
         android:layout_height="match_parent"
         tools:background="#00ccff" />
 
+    <!--
+        Using outer CoordinatorLayout to adjust inner CoordinatorLayout layout based on system
+        windows such as the status bar and the navigation bar.
+        CoordinatorLayout allows customization of navigation bar color using android:statusBarColor
+        theme attribute, while FrameLayout doesn't.
+    -->
     <androidx.coordinatorlayout.widget.CoordinatorLayout
-        android:id="@+id/coordinatorLayout"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:fitsSystemWindows="true">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/container"
+        <androidx.coordinatorlayout.widget.CoordinatorLayout
+            android:id="@+id/coordinatorLayout"
             android:layout_width="match_parent"
             android:layout_height="match_parent">
 
-            <androidx.constraintlayout.widget.Guideline
-                android:id="@+id/guidelineBottom"
-                android:orientation="horizontal"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                app:layout_constraintGuide_end="0dp"
-                tools:layout_constraintGuide_end="100dp" />
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/container"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
 
-            <androidx.constraintlayout.widget.Guideline
-                android:id="@+id/guidelineBegin"
+                <androidx.constraintlayout.widget.Guideline
+                    android:id="@+id/guidelineBottom"
+                    android:orientation="horizontal"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:layout_constraintGuide_end="0dp"
+                    tools:layout_constraintGuide_end="100dp" />
+
+                <androidx.constraintlayout.widget.Guideline
+                    android:id="@+id/guidelineBegin"
+                    android:orientation="vertical"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:layout_constraintGuide_begin="375dp"
+                    tools:layout_constraintGuide_begin="375dp" />
+
+                <FrameLayout
+                    android:id="@+id/guidanceLayout"
+                    android:layout_width="wrap_content"
+                    android:layout_height="0dp"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    tools:layout_height="120dp"
+                    app:layout_constraintWidth_max="375dp"
+                    tools:background="@color/mapbox_main_maneuver_background_color" />
+
+                <FrameLayout
+                    android:id="@+id/speedLimitLayout"
+                    android:layout_width="75dp"
+                    android:layout_height="86dp"
+                    android:layout_marginStart="4dp"
+                    android:layout_marginTop="8dp"
+                    app:layout_constraintStart_toEndOf="@id/guidanceLayout"
+                    app:layout_constraintTop_toTopOf="@id/guidanceLayout"
+                    tools:background="#eee"
+                    tools:layout_height="60dp"
+                    tools:layout_width="50dp"
+                    android:layout_gravity="start|top" />
+
+                <FrameLayout
+                    android:id="@+id/emptyLeftContainer"
+                    android:layout_width="0dp"
+                    android:layout_height="0dp"
+                    android:layout_marginStart="4dp"
+                    android:layout_marginTop="8dp"
+                    android:layout_marginBottom="8dp"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/speedLimitLayout"
+                    app:layout_constraintBottom_toTopOf="@id/guidelineBottom"
+                    app:layout_constraintEnd_toStartOf="@id/guidelineBegin"
+                    tools:background="#F6A1A1"
+                    android:layout_gravity="start|top" />
+
+                <FrameLayout
+                    android:id="@+id/emptyRightContainer"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="4dp"
+                    android:layout_marginTop="8dp"
+                    android:layout_marginBottom="8dp"
+                    android:layout_marginStart="4dp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/actionListLayout"
+                    app:layout_constraintBottom_toTopOf="@id/roadNameLayout"
+                    tools:background="#F6A1A1"
+                    tools:layout_height="130dp"
+                    tools:layout_width="76dp"
+                    android:layout_gravity="start|top" />
+
+                <FrameLayout
+                    android:id="@+id/actionListLayout"
+                    android:layout_width="@dimen/mapbox_actionList_width"
+                    android:layout_height="wrap_content"
+                    android:gravity="top|right"
+                    android:layout_marginEnd="8dp"
+                    app:layout_constraintTop_toTopOf="@id/speedLimitLayout"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    tools:layout_height="200dp"
+                    tools:background="#eee" />
+
+                <FrameLayout
+                    android:id="@+id/roadNameLayout"
+                    android:layout_width="wrap_content"
+                    android:layout_height="0dp"
+                    android:layout_gravity="center"
+                    tools:background="#eee"
+                    tools:layout_height="52dp"
+                    tools:layout_width="140dp"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    android:layout_marginBottom="8dp"
+                    app:layout_constraintHeight_max="62dp" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+            <LinearLayout
+                android:id="@+id/infoPanelLayout"
                 android:orientation="vertical"
-                android:layout_width="wrap_content"
+                android:layout_width="375dp"
                 android:layout_height="wrap_content"
-                app:layout_constraintGuide_begin="375dp"
-                tools:layout_constraintGuide_begin="375dp" />
+                android:elevation="8dp"
+                android:background="@drawable/mapbox_bg_info_panel"
+                app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior"
+                app:behavior_hideable="true"
+                app:behavior_fitToContents="true"
+                app:behavior_peekHeight="@dimen/mapbox_infoPanel_peekHeight">
 
-            <FrameLayout
-                android:id="@+id/guidanceLayout"
-                android:layout_width="wrap_content"
-                android:layout_height="0dp"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                tools:layout_height="120dp"
-                app:layout_constraintWidth_max="375dp"
-                tools:background="@color/mapbox_main_maneuver_background_color" />
+                <FrameLayout
+                    android:id="@+id/infoPanelHeader"
+                    android:layout_width="match_parent"
+                    android:layout_height="@dimen/mapbox_infoPanel_peekHeight" />
 
-            <FrameLayout
-                android:id="@+id/speedLimitLayout"
-                android:layout_width="75dp"
-                android:layout_height="86dp"
-                android:layout_marginStart="4dp"
-                android:layout_marginTop="8dp"
-                app:layout_constraintStart_toEndOf="@id/guidanceLayout"
-                app:layout_constraintTop_toTopOf="@id/guidanceLayout"
-                tools:background="#eee"
-                tools:layout_height="60dp"
-                tools:layout_width="50dp"
-                android:layout_gravity="start|top"/>
+                <FrameLayout
+                    android:id="@+id/infoPanelContent"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content" />
 
-            <FrameLayout
-                android:id="@+id/emptyLeftContainer"
-                android:layout_width="0dp"
-                android:layout_height="0dp"
-                android:layout_marginStart="4dp"
-                android:layout_marginTop="8dp"
-                android:layout_marginBottom="8dp"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/speedLimitLayout"
-                app:layout_constraintBottom_toTopOf="@id/guidelineBottom"
-                app:layout_constraintEnd_toStartOf="@id/guidelineBegin"
-                tools:background="#F6A1A1"
-                android:layout_gravity="start|top"/>
+            </LinearLayout>
 
-            <FrameLayout
-                android:id="@+id/emptyRightContainer"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginEnd="4dp"
-                android:layout_marginTop="8dp"
-                android:layout_marginBottom="8dp"
-                android:layout_marginStart="4dp"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/actionListLayout"
-                app:layout_constraintBottom_toTopOf="@id/roadNameLayout"
-                tools:background="#F6A1A1"
-                tools:layout_height="130dp"
-                tools:layout_width="76dp"
-                android:layout_gravity="start|top"/>
-
-            <FrameLayout
-                android:id="@+id/actionListLayout"
-                android:layout_width="@dimen/mapbox_actionList_width"
-                android:layout_height="wrap_content"
-                android:gravity="top|right"
-                android:layout_marginEnd="8dp"
-                app:layout_constraintTop_toTopOf="@id/speedLimitLayout"
-                app:layout_constraintEnd_toEndOf="parent"
-                tools:layout_height="200dp"
-                tools:background="#eee" />
-
-            <FrameLayout
-                android:id="@+id/roadNameLayout"
-                android:layout_width="wrap_content"
-                android:layout_height="0dp"
-                android:layout_gravity="center"
-                tools:background="#eee"
-                tools:layout_height="52dp"
-                tools:layout_width="140dp"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                android:layout_marginBottom="8dp"
-                app:layout_constraintHeight_max="62dp"/>
-
-        </androidx.constraintlayout.widget.ConstraintLayout>
-
-        <LinearLayout
-            android:id="@+id/infoPanelLayout"
-            android:orientation="vertical"
-            android:layout_width="375dp"
-            android:layout_height="wrap_content"
-            android:elevation="8dp"
-            android:background="@drawable/mapbox_bg_info_panel"
-            app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior"
-            app:behavior_hideable="true"
-            app:behavior_fitToContents="true"
-            app:behavior_peekHeight="@dimen/mapbox_infoPanel_peekHeight">
-
-            <FrameLayout
-                android:id="@+id/infoPanelHeader"
-                android:layout_width="match_parent"
-                android:layout_height="@dimen/mapbox_infoPanel_peekHeight" />
-
-            <FrameLayout
-                android:id="@+id/infoPanelContent"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
-
-        </LinearLayout>
-
+        </androidx.coordinatorlayout.widget.CoordinatorLayout>
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
-
 </merge>

--- a/libnavui-dropin/src/main/res/layout/mapbox_navigation_view_layout.xml
+++ b/libnavui-dropin/src/main/res/layout/mapbox_navigation_view_layout.xml
@@ -12,130 +12,140 @@
         android:layout_height="match_parent"
         tools:background="#00ccff" />
 
+    <!--
+        Using outer CoordinatorLayout to adjust inner CoordinatorLayout layout based on system
+        windows such as the status bar and the navigation bar.
+        CoordinatorLayout allows customization of navigation bar color using android:statusBarColor
+        theme attribute, while FrameLayout doesn't.
+    -->
     <androidx.coordinatorlayout.widget.CoordinatorLayout
-        android:id="@+id/coordinatorLayout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:fitsSystemWindows="true">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/container"
+        <androidx.coordinatorlayout.widget.CoordinatorLayout
+            android:id="@+id/coordinatorLayout"
             android:layout_width="match_parent"
             android:layout_height="match_parent">
 
-            <androidx.constraintlayout.widget.Guideline
-                android:id="@+id/guidelineBottom"
-                android:orientation="horizontal"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                app:layout_constraintGuide_end="0dp"
-                tools:layout_constraintGuide_end="100dp" />
-
-            <FrameLayout
-                android:id="@+id/guidanceLayout"
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/container"
                 android:layout_width="match_parent"
-                android:layout_height="0dp"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                tools:layout_height="120dp"
-                app:layout_constraintHeight_max="350dp"
-                tools:background="@color/mapbox_main_maneuver_background_color" />
+                android:layout_height="match_parent">
 
-            <FrameLayout
-                android:id="@+id/speedLimitLayout"
-                android:layout_width="75dp"
-                android:layout_height="86dp"
-                android:layout_marginStart="8dp"
-                android:layout_marginTop="8dp"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/guidanceLayout"
-                tools:background="#eee"
-                tools:layout_height="60dp"
-                tools:layout_width="50dp"
-                android:layout_gravity="start|top" />
+                <androidx.constraintlayout.widget.Guideline
+                    android:id="@+id/guidelineBottom"
+                    android:orientation="horizontal"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:layout_constraintGuide_end="0dp"
+                    tools:layout_constraintGuide_end="100dp" />
 
-            <FrameLayout
-                android:id="@+id/emptyLeftContainer"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:layout_marginTop="8dp"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/speedLimitLayout"
-                app:layout_constraintBottom_toTopOf="@id/roadNameLayout"
-                tools:background="#F6A1A1"
-                tools:layout_height="350dp"
-                tools:layout_width="50dp"
-                android:layout_gravity="start|top" />
+                <FrameLayout
+                    android:id="@+id/guidanceLayout"
+                    android:layout_width="match_parent"
+                    android:layout_height="0dp"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    tools:layout_height="120dp"
+                    app:layout_constraintHeight_max="350dp"
+                    tools:background="@color/mapbox_main_maneuver_background_color" />
 
-            <FrameLayout
-                android:id="@+id/emptyRightContainer"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginEnd="8dp"
-                android:layout_marginTop="8dp"
-                android:layout_marginBottom="8dp"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/actionListLayout"
-                app:layout_constraintBottom_toTopOf="@id/roadNameLayout"
-                tools:background="#F6A1A1"
-                tools:layout_height="220dp"
-                tools:layout_width="76dp"
-                android:layout_gravity="start|top" />
+                <FrameLayout
+                    android:id="@+id/speedLimitLayout"
+                    android:layout_width="75dp"
+                    android:layout_height="86dp"
+                    android:layout_marginStart="8dp"
+                    android:layout_marginTop="8dp"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/guidanceLayout"
+                    tools:background="#eee"
+                    tools:layout_height="60dp"
+                    tools:layout_width="50dp"
+                    android:layout_gravity="start|top" />
 
-            <FrameLayout
-                android:id="@+id/actionListLayout"
-                android:layout_width="@dimen/mapbox_actionList_width"
-                android:layout_height="wrap_content"
-                android:gravity="top|right"
-                android:layout_marginTop="8dp"
-                android:layout_marginEnd="8dp"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/guidanceLayout"
-                tools:background="#eee"
-                tools:layout_height="200dp" />
+                <FrameLayout
+                    android:id="@+id/emptyLeftContainer"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="8dp"
+                    android:layout_marginTop="8dp"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/speedLimitLayout"
+                    app:layout_constraintBottom_toTopOf="@id/roadNameLayout"
+                    tools:background="#F6A1A1"
+                    tools:layout_height="350dp"
+                    tools:layout_width="50dp"
+                    android:layout_gravity="start|top" />
 
-            <FrameLayout
-                android:id="@+id/roadNameLayout"
-                android:layout_width="wrap_content"
-                android:layout_height="0dp"
-                android:layout_gravity="center"
-                tools:background="#eee"
-                tools:layout_height="52dp"
-                tools:layout_width="140dp"
-                app:layout_constraintBottom_toTopOf="@+id/guidelineBottom"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                android:layout_marginBottom="15dp"
-                app:layout_constraintHeight_max="62dp" />
+                <FrameLayout
+                    android:id="@+id/emptyRightContainer"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="8dp"
+                    android:layout_marginTop="8dp"
+                    android:layout_marginBottom="8dp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/actionListLayout"
+                    app:layout_constraintBottom_toTopOf="@id/roadNameLayout"
+                    tools:background="#F6A1A1"
+                    tools:layout_height="220dp"
+                    tools:layout_width="76dp"
+                    android:layout_gravity="start|top" />
 
-        </androidx.constraintlayout.widget.ConstraintLayout>
+                <FrameLayout
+                    android:id="@+id/actionListLayout"
+                    android:layout_width="@dimen/mapbox_actionList_width"
+                    android:layout_height="wrap_content"
+                    android:gravity="top|right"
+                    android:layout_marginTop="8dp"
+                    android:layout_marginEnd="8dp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/guidanceLayout"
+                    tools:background="#eee"
+                    tools:layout_height="200dp" />
 
-        <LinearLayout
-            android:id="@+id/infoPanelLayout"
-            android:orientation="vertical"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:elevation="8dp"
-            android:background="@drawable/mapbox_bg_info_panel"
-            app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior"
-            app:behavior_hideable="true"
-            app:behavior_fitToContents="true"
-            app:behavior_peekHeight="@dimen/mapbox_infoPanel_peekHeight">
+                <FrameLayout
+                    android:id="@+id/roadNameLayout"
+                    android:layout_width="wrap_content"
+                    android:layout_height="0dp"
+                    android:layout_gravity="center"
+                    tools:background="#eee"
+                    tools:layout_height="52dp"
+                    tools:layout_width="140dp"
+                    app:layout_constraintBottom_toTopOf="@+id/guidelineBottom"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    android:layout_marginBottom="15dp"
+                    app:layout_constraintHeight_max="62dp" />
 
-            <FrameLayout
-                android:id="@+id/infoPanelHeader"
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+            <LinearLayout
+                android:id="@+id/infoPanelLayout"
+                android:orientation="vertical"
                 android:layout_width="match_parent"
-                android:layout_height="@dimen/mapbox_infoPanel_peekHeight" />
+                android:layout_height="wrap_content"
+                android:elevation="8dp"
+                android:background="@drawable/mapbox_bg_info_panel"
+                app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior"
+                app:behavior_hideable="true"
+                app:behavior_fitToContents="true"
+                app:behavior_peekHeight="@dimen/mapbox_infoPanel_peekHeight">
 
-            <FrameLayout
-                android:id="@+id/infoPanelContent"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
+                <FrameLayout
+                    android:id="@+id/infoPanelHeader"
+                    android:layout_width="match_parent"
+                    android:layout_height="@dimen/mapbox_infoPanel_peekHeight" />
 
-        </LinearLayout>
+                <FrameLayout
+                    android:id="@+id/infoPanelContent"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content" />
 
+            </LinearLayout>
+
+        </androidx.coordinatorlayout.widget.CoordinatorLayout>
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
-
 </merge>

--- a/libnavui-dropin/src/main/res/layout/mapbox_navigation_view_layout.xml
+++ b/libnavui-dropin/src/main/res/layout/mapbox_navigation_view_layout.xml
@@ -15,7 +15,8 @@
     <androidx.coordinatorlayout.widget.CoordinatorLayout
         android:id="@+id/coordinatorLayout"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:fitsSystemWindows="true">
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/container"
@@ -52,7 +53,7 @@
                 tools:background="#eee"
                 tools:layout_height="60dp"
                 tools:layout_width="50dp"
-                android:layout_gravity="start|top"/>
+                android:layout_gravity="start|top" />
 
             <FrameLayout
                 android:id="@+id/emptyLeftContainer"
@@ -66,7 +67,7 @@
                 tools:background="#F6A1A1"
                 tools:layout_height="350dp"
                 tools:layout_width="50dp"
-                android:layout_gravity="start|top"/>
+                android:layout_gravity="start|top" />
 
             <FrameLayout
                 android:id="@+id/emptyRightContainer"
@@ -81,7 +82,7 @@
                 tools:background="#F6A1A1"
                 tools:layout_height="220dp"
                 tools:layout_width="76dp"
-                android:layout_gravity="start|top"/>
+                android:layout_gravity="start|top" />
 
             <FrameLayout
                 android:id="@+id/actionListLayout"
@@ -107,7 +108,7 @@
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 android:layout_marginBottom="15dp"
-                app:layout_constraintHeight_max="62dp"/>
+                app:layout_constraintHeight_max="62dp" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/logo/LogoAttributionComponentTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/logo/LogoAttributionComponentTest.kt
@@ -57,12 +57,19 @@ internal class LogoAttributionComponentTest {
         )
 
         val bottomInset = 123.0f
-        systemBarsInsets.value = Insets.of(0, 0, 0, bottomInset.toInt())
+        val leftInset = 10.0f
+        val rightInset = 20.0f
+        systemBarsInsets.value =
+            Insets.of(leftInset.toInt(), 0, rightInset.toInt(), bottomInset.toInt())
 
         sut.onAttached(mockk())
 
         assertEquals(bottomInset, logoSettings.marginBottom)
+        assertEquals(leftInset, logoSettings.marginLeft)
+        assertEquals(rightInset, logoSettings.marginRight)
         assertEquals(bottomInset, attributionSettings.marginBottom)
+        assertEquals(leftInset, attributionSettings.marginLeft)
+        assertEquals(rightInset, attributionSettings.marginRight)
     }
 
     private fun captureUpdatedSettings(

--- a/qa-test-app/src/main/AndroidManifest.xml
+++ b/qa-test-app/src/main/AndroidManifest.xml
@@ -52,7 +52,7 @@
             />
         <activity
             android:name=".view.MapboxNavigationViewFragmentActivity"
-            android:theme="@style/Theme.AppCompat.NoActionBar"
+            android:theme="@style/Theme.Fullscreen"
             />
         <activity
             android:name=".view.NavigationViewFragmentLifecycleActivity"

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/domain/TestActivitySuite.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/domain/TestActivitySuite.kt
@@ -142,22 +142,22 @@ object TestActivitySuite {
             activity.startActivity<IconsPreviewActivity>()
         },
         TestActivityDescription(
-            "Navigation View test",
+            "Default NavigationView",
             R.string.navigation_view_description,
             launchAfterPermissionResult = false
         ) { activity -> activity.startActivity<MapboxNavigationViewActivity>() },
         TestActivityDescription(
-            "Customized navigation View test",
+            "Customized NavigationView",
             R.string.navigation_view_customized_description,
             launchAfterPermissionResult = false
         ) { activity -> activity.startActivity<MapboxNavigationViewCustomizedActivity>() },
         TestActivityDescription(
-            "Navigation View in a Fragment test",
+            "Fullscreen NavigationView in a Fragment",
             R.string.navigation_view_fragment_description,
             launchAfterPermissionResult = false
         ) { activity -> activity.startActivity<MapboxNavigationViewFragmentActivity>() },
         TestActivityDescription(
-            "Navigation View lifecycle test with Fragments",
+            "NavigationView lifecycle test with Fragments",
             R.string.navigation_view_fragment_lifecycle_description,
             launchAfterPermissionResult = false
         ) { activity -> activity.startActivity<NavigationViewFragmentLifecycleActivity>() },

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/MapboxNavigationViewFragmentActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/MapboxNavigationViewFragmentActivity.kt
@@ -2,6 +2,7 @@ package com.mapbox.navigation.qa_test_app.view
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.WindowCompat
 import com.mapbox.navigation.qa_test_app.databinding.LayoutActivityNavigationViewFragmentBinding
 
 class MapboxNavigationViewFragmentActivity : AppCompatActivity() {
@@ -12,5 +13,7 @@ class MapboxNavigationViewFragmentActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         binding = LayoutActivityNavigationViewFragmentBinding.inflate(layoutInflater)
         setContentView(binding.root)
+
+        WindowCompat.setDecorFitsSystemWindows(window, false)
     }
 }

--- a/qa-test-app/src/main/res/values-night/themes.xml
+++ b/qa-test-app/src/main/res/values-night/themes.xml
@@ -27,4 +27,11 @@
         <item name="background">@color/primary</item>
         <item name="android:background">@color/primary</item>
     </style>
+
+    <!-- Fullscreen activity -->
+    <style name="Theme.Fullscreen" parent="@style/Theme.AppCompat.NoActionBar">
+        <item name="android:windowLightStatusBar">false</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+    </style>
 </resources>

--- a/qa-test-app/src/main/res/values/themes.xml
+++ b/qa-test-app/src/main/res/values/themes.xml
@@ -30,6 +30,6 @@
     <style name="Theme.Fullscreen" parent="@style/Theme.AppCompat.NoActionBar">
         <item name="android:windowLightStatusBar">true</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
-        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">#80000000</item>
     </style>
 </resources>

--- a/qa-test-app/src/main/res/values/themes.xml
+++ b/qa-test-app/src/main/res/values/themes.xml
@@ -26,4 +26,10 @@
         <item name="android:background">@color/primary</item>
     </style>
 
+    <!-- Fullscreen activity -->
+    <style name="Theme.Fullscreen" parent="@style/Theme.AppCompat.NoActionBar">
+        <item name="android:windowLightStatusBar">true</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+    </style>
 </resources>


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-navigation-android/issues/5952

### Description

- Re-wired mapbox_navigation_view_layout to offset map overlay content based on system windows such as the status bar and the navigation bar.
- Introduced LogoAttributionComponent that offsets Map Logo and Attribution views above system navigationBar.

### Screenshots or Gifs

<details><summary>Android 6 (API 23) (emulator)</summary>

| Default | Fullscreen | Fullscreen <br/> destination set |
|:---:|:---:|:---:|
| ![navview-api23-light](https://user-images.githubusercontent.com/2678039/176251310-b3986d20-79db-4e18-952d-89d42d1159f2.png) | ![navview-api23-light-full](https://user-images.githubusercontent.com/2678039/176251305-db830429-e5ab-4e0d-b8a1-485eef585439.png) | ![navview-api23-light-full-2](https://user-images.githubusercontent.com/2678039/176251302-d2f017f7-66c5-4505-bb9b-26722a7a291b.png) |

| Landscape left | Landscape right |
|:---:|:---:|
| ![navview-api23-light-full-land-l](https://user-images.githubusercontent.com/2678039/176271205-c9699bde-3315-403f-94a8-8e3a075a48f5.png) | _Not supported in emulator_ |

</details>

<details><summary>Android 11 (API 30) (Pixel 2)</summary>

| Default | Fullscreen | Fullscreen <br/> destination set |
|:---:|:---:|:---:|
| ![navview-api30-light](https://user-images.githubusercontent.com/2678039/176252016-51b52916-436e-4b72-8f59-0166918a4751.png) | ![navview-api30-light-full](https://user-images.githubusercontent.com/2678039/176252014-4aec0b78-2069-4b38-a1bf-5a1d93bccb66.png) | ![navview-api30-light-full-2](https://user-images.githubusercontent.com/2678039/176252010-babf3466-a0cd-4b56-a7b7-0780fdd5e219.png) |

| Landscape left | Landscape right |
|:---:|:---:|
| ![navview-api30-light-full-land-l](https://user-images.githubusercontent.com/2678039/176271133-44249fd6-d9a7-4219-b67f-cd7f420b50b5.png) | ![navview-api30-light-full-land-r](https://user-images.githubusercontent.com/2678039/176271135-1423d342-0b41-45c3-bae3-54c01fe54a8f.png) |


</details>

<details><summary>Android 12 (API 32) (Pixel 6)</summary>

| Default | Fullscreen | Fullscreen <br/> destination set |
|:---:|:---:|:---:|
| ![navview-api32-dark](https://user-images.githubusercontent.com/2678039/176252170-fec6eab5-11c6-4988-a9c5-72a07950eaee.png) | ![navview-api32-dark-full](https://user-images.githubusercontent.com/2678039/176252200-9e6e80d6-bbdf-48f1-9b9d-631f4cef7748.png) | ![navview-api32-dark-full-2](https://user-images.githubusercontent.com/2678039/176252220-117d4be3-1c5f-4956-955c-f3bc9bdb52b2.png) |

| Landscape left | Landscape right |
|:---:|:---:|
| ![navview-api32-dark-full-land-l](https://user-images.githubusercontent.com/2678039/176271028-c07340d4-fb42-4651-a44a-8df74e1f6b54.png) | ![navview-api32-dark-full-land-r](https://user-images.githubusercontent.com/2678039/176271034-7baa60f5-8056-474b-af1d-b5e0f314e542.png) |


</details>
