### PR TITLE
Trim offset calls do not get applied to trail related layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Mapbox welcomes participation and contributions from everyone.
 
 #### Bug fixes and improvements
 - Fixed reroute request interruption when setting the `NavigationRerouteController` [#5950](https://github.com/mapbox/mapbox-navigation-android/pull/5950).
+- Fixed setting trim offsets to route line trail layers. [#5982](https://github.com/mapbox/mapbox-navigation-android/pull/5982)
 
 ## Mapbox Navigation SDK 2.7.0-alpha.1 - June 24, 2022
 ### Changelog

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApi.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApi.kt
@@ -1180,7 +1180,7 @@ class MapboxRouteLineApi(
         val partitionedRoutes = routeFeatureData.partition {
             it.route == routes.first()
         }
-
+        val vanishingPointOffset = routeLineOptions.vanishingRouteLine?.vanishPointOffset ?: 0.0
         val primaryRouteTrafficLineExpressionDef = jobControl.scope.async {
             partitionedRoutes.first.firstOrNull()?.route?.run {
                 MapboxRouteLineUtils.getTrafficLineExpressionProducer(
@@ -1188,7 +1188,7 @@ class MapboxRouteLineApi(
                     routeLineOptions.resourceProvider.routeLineColorResources,
                     trafficBackfillRoadClasses,
                     true,
-                    routeLineOptions.vanishingRouteLine?.vanishPointOffset ?: 0.0,
+                    vanishingPointOffset,
                     Color.TRANSPARENT,
                     routeLineOptions.resourceProvider.routeLineColorResources
                         .routeUnknownCongestionColor,
@@ -1200,7 +1200,7 @@ class MapboxRouteLineApi(
 
         val primaryRouteBaseExpressionDef = jobControl.scope.async {
             MapboxRouteLineUtils.getRouteLineExpression(
-                routeLineOptions.vanishingRouteLine?.vanishPointOffset ?: 0.0,
+                vanishingPointOffset,
                 routeLineOptions.resourceProvider.routeLineColorResources.routeLineTraveledColor,
                 routeLineOptions.resourceProvider.routeLineColorResources.routeDefaultColor
             )
@@ -1208,7 +1208,7 @@ class MapboxRouteLineApi(
 
         val primaryRouteCasingExpressionDef = jobControl.scope.async {
             MapboxRouteLineUtils.getRouteLineExpression(
-                routeLineOptions.vanishingRouteLine?.vanishPointOffset ?: 0.0,
+                vanishingPointOffset,
                 routeLineOptions
                     .resourceProvider
                     .routeLineColorResources
@@ -1219,7 +1219,7 @@ class MapboxRouteLineApi(
 
         val primaryRouteTrailExpressionDef = jobControl.scope.async {
             MapboxRouteLineUtils.getRouteLineExpression(
-                routeLineOptions.vanishingRouteLine?.vanishPointOffset ?: 0.0,
+                vanishingPointOffset,
                 routeLineOptions.resourceProvider.routeLineColorResources.routeLineTraveledColor,
                 routeLineOptions.resourceProvider.routeLineColorResources.routeLineTraveledColor
             )
@@ -1227,7 +1227,7 @@ class MapboxRouteLineApi(
 
         val primaryRouteTrailCasingExpressionDef = jobControl.scope.async {
             MapboxRouteLineUtils.getRouteLineExpression(
-                routeLineOptions.vanishingRouteLine?.vanishPointOffset ?: 0.0,
+                vanishingPointOffset,
                 routeLineOptions
                     .resourceProvider
                     .routeLineColorResources
@@ -1559,9 +1559,7 @@ class MapboxRouteLineApi(
                         primaryRouteCasingExpressionProducer,
                         primaryRouteTrafficLineExpressionProducer,
                         primaryRouteRestrictedSectionsExpressionProducer,
-                        RouteLineTrimOffset(
-                            routeLineOptions.vanishingRouteLine?.vanishPointOffset ?: 0.0
-                        ),
+                        RouteLineTrimOffset(vanishingPointOffset),
                         primaryRouteTrailExpressionProducer,
                         primaryRouteTrailCasingExpressionProducer
                     )

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineView.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineView.kt
@@ -661,15 +661,17 @@ class MapboxRouteLineView(var options: MapboxRouteLineOptions) {
         sourceLayerMap: Map<RouteLineSourceKey, Set<String>>
     ): List<() -> Unit> {
         val mutationCommands = mutableListOf<() -> Unit>()
-        sourceLayerMap[routeLineSourceKey]?.forEach { layerId ->
-            val provider = ifNonNull(routeLineData.dynamicData.trimOffset?.offset) { offset ->
-                RouteLineExpressionProvider {
-                    literal(listOf(0.0, offset))
+        val trailLayerIds = trailCasingLayerIds.plus(trailLayerIds)
+        sourceLayerMap[routeLineSourceKey]?.filter { !trailLayerIds.contains(it) }
+            ?.forEach { layerId ->
+                val provider = ifNonNull(routeLineData.dynamicData.trimOffset?.offset) { offset ->
+                    RouteLineExpressionProvider {
+                        literal(listOf(0.0, offset))
+                    }
                 }
-            }
 
-            mutationCommands.add { updateTrimOffset(layerId, provider)(style) }
-        }
+                mutationCommands.add { updateTrimOffset(layerId, provider)(style) }
+            }
         return mutationCommands
     }
 

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineDynamicData.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/RouteLineDynamicData.kt
@@ -84,7 +84,7 @@ class RouteLineDynamicData internal constructor(
         if (restrictedSectionExpressionProvider != other.restrictedSectionExpressionProvider)
             return false
         if (trimOffset != other.trimOffset) return false
-        if (trailExpressionProvider != other.trafficExpressionProvider) return false
+        if (trailExpressionProvider != other.trailExpressionProvider) return false
         if (trailCasingExpressionProvider != other.trailCasingExpressionProvider) return false
 
         return true

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineViewTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineViewTest.kt
@@ -550,22 +550,22 @@ class MapboxRouteLineViewTest {
         verify { route3Traffic.lineGradient(layerGroup3Expression) }
         verify { route3Restricted.lineGradient(layerGroup3Expression) }
 
-        verify { route1TrailCasing.lineTrimOffset(literal(listOf(0.0, 9.9))) }
-        verify { route1Trail.lineTrimOffset(literal(listOf(0.0, 9.9))) }
+        verify(exactly = 0) { route1TrailCasing.lineTrimOffset(literal(listOf(0.0, 9.9))) }
+        verify(exactly = 0) { route1Trail.lineTrimOffset(literal(listOf(0.0, 9.9))) }
         verify { route1Casing.lineTrimOffset(literal(listOf(0.0, 9.9))) }
         verify { route1Main.lineTrimOffset(literal(listOf(0.0, 9.9))) }
         verify { route1Traffic.lineTrimOffset(literal(listOf(0.0, 9.9))) }
         verify { route1Restricted.lineTrimOffset(literal(listOf(0.0, 9.9))) }
 
-        verify { route2TrailCasing.lineTrimOffset(literal(listOf(0.0, 0.0))) }
-        verify { route2Trail.lineTrimOffset(literal(listOf(0.0, 0.0))) }
+        verify(exactly = 0) { route2TrailCasing.lineTrimOffset(literal(listOf(0.0, 0.0))) }
+        verify(exactly = 0) { route2Trail.lineTrimOffset(literal(listOf(0.0, 0.0))) }
         verify { route2Casing.lineTrimOffset(literal(listOf(0.0, 0.0))) }
         verify { route2Main.lineTrimOffset(literal(listOf(0.0, 0.0))) }
         verify { route2Traffic.lineTrimOffset(literal(listOf(0.0, 0.0))) }
         verify { route2Restricted.lineTrimOffset(literal(listOf(0.0, 0.0))) }
 
-        verify { route3TrailCasing.lineTrimOffset(literal(listOf(0.0, 0.1))) }
-        verify { route3Trail.lineTrimOffset(literal(listOf(0.0, 0.1))) }
+        verify(exactly = 0) { route3TrailCasing.lineTrimOffset(literal(listOf(0.0, 0.1))) }
+        verify(exactly = 0) { route3Trail.lineTrimOffset(literal(listOf(0.0, 0.1))) }
         verify { route3Casing.lineTrimOffset(literal(listOf(0.0, 0.1))) }
         verify { route3Main.lineTrimOffset(literal(listOf(0.0, 0.1))) }
         verify { route3Traffic.lineTrimOffset(literal(listOf(0.0, 0.1))) }


### PR DESCRIPTION
### Description
Fix for #5981. Trim offset calls do not get applied to trail related layers

### Screenshots or Gifs

Compare to video in issue ticket.

https://user-images.githubusercontent.com/2249818/176580348-1f05f46d-89bc-41d2-93b0-e167f32f8439.mp4



