### PR TITLE
Bump NN, Maps and Common dependency versions to `108.0.0`, `10.7.0-beta.1` and `22.1.0-beta.1` respectively

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -13,17 +13,17 @@ ext {
   // version which we should use in this build
   def mapboxNavigatorVersion = System.getenv("FORCE_MAPBOX_NAVIGATION_NATIVE_VERSION")
   if (mapboxNavigatorVersion == null || mapboxNavigatorVersion == '') {
-      mapboxNavigatorVersion = '107.0.0'
+      mapboxNavigatorVersion = '108.0.0'
   }
   println("Navigation Native version: " + mapboxNavigatorVersion)
 
   version = [
-      mapboxMapSdk              : '10.6.0',
+      mapboxMapSdk              : '10.7.0-beta.1',
       mapboxSdkServices         : '6.5.0',
       mapboxEvents              : '8.1.2',
       mapboxCore                : '5.0.1',
       mapboxNavigator           : "${mapboxNavigatorVersion}",
-      mapboxCommonNative        : '22.0.0',
+      mapboxCommonNative        : '22.1.0-beta.1',
       mapboxSearchSdk           : '1.0.0-beta.29',
       mapboxCrashMonitor        : '2.0.0',
       mapboxAnnotationPlugin    : '0.8.0',


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Bumps `mapboxNavigatorVersion`, `mapboxMapSdk` and `mapboxCommonNative` dependency versions to `108.0.0`, [`10.7.0-beta.1`](https://github.com/mapbox/mapbox-maps-android/releases/tag/android-v10.7.0-beta.1) and `22.1.0-beta.1` respectively.

cc @zugaldia 