### PR TITLE
Increase release CI resources to `medium+`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -758,6 +758,7 @@ jobs:
 
   release:
     executor: ndk-r22-latest-executor
+    resource_class: medium+
     steps:
       - checkout
       - assemble-core-release


### PR DESCRIPTION
We're seeing `daemon` issues from CircleCI lately e.g. https://app.circleci.com/pipelines/github/mapbox/mapbox-navigation-android/19014/workflows/6d5db647-77e3-498e-9b9d-96eb41731627/jobs/90907

```
----- End of the daemon log -----


FAILURE: Build failed with an exception.

* What went wrong:
Gradle build daemon disappeared unexpectedly (it may have been killed or may have crashed)
```

This PR increases the `release` resources to `medium+`.

cc @MrSwimmer 