### PR TITLE
[Drop-In UI] Fixed attribution icon left margin.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Mapbox welcomes participation and contributions from everyone.
 - Made `rerouteController` argument in `MapboxNavigation#setRerouteController` nullable. Null can be passed to disable automatic rerouting. [#5977](https://github.com/mapbox/mapbox-navigation-android/pull/5977)
 - Introduced `RoutesSetCallback` parameter to `MapboxNavigation#setNavigationRoutes`, which is called after the routes passed to `MapboxNavigation#setNavigationRoutes` are processed or are failed to be processed. [#5946](https://github.com/mapbox/mapbox-navigation-android/pull/5946)
 - Changed the behaviour of `RoutesObserver`: `onRoutesChanged` method will not be triggered if the navigator fails to process routes passed via `MapboxNavigation#setNavigationRoutes`. [#5946](https://github.com/mapbox/mapbox-navigation-android/pull/5946)
+- Fixed Attribution Icon position in `NavigationView` [#6012](https://github.com/mapbox/mapbox-navigation-android/pull/6012) 
 
 ## Mapbox Navigation SDK 2.7.0-alpha.2 - July 1, 2022
 ### Changelog

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/logo/LogoAttributionComponent.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/logo/LogoAttributionComponent.kt
@@ -18,6 +18,7 @@ internal class LogoAttributionComponent(
     override fun onAttached(mapboxNavigation: MapboxNavigation) {
         super.onAttached(mapboxNavigation)
 
+        val initialAttributionMarginLeft = mapView.attribution.getSettings().marginLeft
         systemBarInsets.observe { insets ->
             if (insets != null) {
                 val bottom = insets.bottom.toFloat()
@@ -30,7 +31,7 @@ internal class LogoAttributionComponent(
                 }
                 mapView.attribution.updateSettings {
                     marginBottom = bottom
-                    marginLeft = left
+                    marginLeft = initialAttributionMarginLeft + left
                     marginRight = right
                 }
             }

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/logo/LogoAttributionComponentTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/logo/LogoAttributionComponentTest.kt
@@ -51,6 +51,10 @@ internal class LogoAttributionComponentTest {
     fun `onAttached - should update map logo and attribution margins`() {
         val logoSettings = LogoSettings()
         val attributionSettings = AttributionSettings()
+        val initialAttributionSettings = AttributionSettings().apply {
+            marginLeft = 123f
+        }
+        every { mockAttributionPlugin.getSettings() } returns initialAttributionSettings
         captureUpdatedSettings(
             logoSettings = logoSettings,
             attributionSettings = attributionSettings
@@ -68,7 +72,10 @@ internal class LogoAttributionComponentTest {
         assertEquals(leftInset, logoSettings.marginLeft)
         assertEquals(rightInset, logoSettings.marginRight)
         assertEquals(bottomInset, attributionSettings.marginBottom)
-        assertEquals(leftInset, attributionSettings.marginLeft)
+        assertEquals(
+            initialAttributionSettings.marginLeft + leftInset,
+            attributionSettings.marginLeft
+        )
         assertEquals(rightInset, attributionSettings.marginRight)
     }
 


### PR DESCRIPTION
### Description

- Updated `LogoAttributionComponent` to correctly position attribution icon.

### Screenshots or Gifs

| Before | After |
|:---:|:----:|
|![before](https://user-images.githubusercontent.com/2678039/176271135-1423d342-0b41-45c3-bae3-54c01fe54a8f.png)|![attribution-icon-fix](https://user-images.githubusercontent.com/2678039/177381215-5cf905ca-c795-443b-881f-df4a7897fe88.png)|

