### PR TITLE
[Drop-In UI] Camera Mode button fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Mapbox welcomes participation and contributions from everyone.
 - Introduced `RoutesSetCallback` parameter to `MapboxNavigation#setNavigationRoutes`, which is called after the routes passed to `MapboxNavigation#setNavigationRoutes` are processed or are failed to be processed. [#5946](https://github.com/mapbox/mapbox-navigation-android/pull/5946)
 - Changed the behaviour of `RoutesObserver`: `onRoutesChanged` method will not be triggered if the navigator fails to process routes passed via `MapboxNavigation#setNavigationRoutes`. [#5946](https://github.com/mapbox/mapbox-navigation-android/pull/5946)
 - Fixed Attribution Icon position in `NavigationView` [#6012](https://github.com/mapbox/mapbox-navigation-android/pull/6012) 
+- Fixed Toggle Camera Mode Button behavior in `NavigationView`. [#6014](https://github.com/mapbox/mapbox-navigation-android/pull/6014)
 
 ## Mapbox Navigation SDK 2.7.0-alpha.2 - July 1, 2022
 ### Changelog

--- a/libnavui-app/src/main/java/com/mapbox/navigation/ui/app/internal/camera/CameraAction.kt
+++ b/libnavui-app/src/main/java/com/mapbox/navigation/ui/app/internal/camera/CameraAction.kt
@@ -8,19 +8,9 @@ import com.mapbox.navigation.ui.app.internal.Action
  */
 sealed class CameraAction : Action {
     /**
-     * Sets the [NavigationCamera] to Idle
+     * Sets the [NavigationCamera] to given [mode]
      */
-    object ToIdle : CameraAction()
-
-    /**
-     * Sets the [NavigationCamera] to overview
-     */
-    object ToOverview : CameraAction()
-
-    /**
-     * Sets the [NavigationCamera] to following
-     */
-    object ToFollowing : CameraAction()
+    data class SetCameraMode(val mode: TargetCameraMode) : CameraAction()
 
     /**
      * Updates the padding for camera viewport

--- a/libnavui-app/src/main/java/com/mapbox/navigation/ui/app/internal/camera/CameraState.kt
+++ b/libnavui-app/src/main/java/com/mapbox/navigation/ui/app/internal/camera/CameraState.kt
@@ -3,6 +3,7 @@ package com.mapbox.navigation.ui.app.internal.camera
 import com.mapbox.maps.EdgeInsets
 import com.mapbox.maps.MapView
 import com.mapbox.navigation.ui.maps.camera.NavigationCamera
+import com.mapbox.navigation.ui.maps.camera.state.NavigationCameraState
 
 /**
  * Defines the target camera mode desired for navigation camera
@@ -29,9 +30,31 @@ sealed class TargetCameraMode {
  * @property cameraMode sets the [TargetCameraMode]
  * @property cameraPadding sets the camera padding for the camera viewport
  * @property mapCameraState sets the [MapView] camera state
+ * @property savedCameraMode last [cameraMode] value before switching to [TargetCameraMode.Idle]
  */
 data class CameraState internal constructor(
     val cameraMode: TargetCameraMode = TargetCameraMode.Idle,
     val cameraPadding: EdgeInsets = EdgeInsets(0.0, 0.0, 0.0, 0.0),
-    val mapCameraState: com.mapbox.maps.CameraState? = null
+    val mapCameraState: com.mapbox.maps.CameraState? = null,
+    val savedCameraMode: TargetCameraMode = TargetCameraMode.Overview
 )
+
+/**
+ * Converts this [TargetCameraMode] to [NavigationCameraState].
+ */
+fun TargetCameraMode.toNavigationCameraState() = when (this) {
+    TargetCameraMode.Idle -> NavigationCameraState.IDLE
+    TargetCameraMode.Following -> NavigationCameraState.FOLLOWING
+    TargetCameraMode.Overview -> NavigationCameraState.OVERVIEW
+}
+
+/**
+ * Converts this [NavigationCameraState] to [TargetCameraMode]
+ */
+fun NavigationCameraState.toTargetCameraMode() = when (this) {
+    NavigationCameraState.TRANSITION_TO_OVERVIEW,
+    NavigationCameraState.OVERVIEW -> TargetCameraMode.Overview
+    NavigationCameraState.TRANSITION_TO_FOLLOWING,
+    NavigationCameraState.FOLLOWING -> TargetCameraMode.Following
+    NavigationCameraState.IDLE -> TargetCameraMode.Idle
+}

--- a/libnavui-app/src/main/java/com/mapbox/navigation/ui/app/internal/controller/CameraStateController.kt
+++ b/libnavui-app/src/main/java/com/mapbox/navigation/ui/app/internal/controller/CameraStateController.kt
@@ -25,14 +25,13 @@ class CameraStateController(
 
     private fun processCameraAction(state: CameraState, action: CameraAction): CameraState {
         return when (action) {
-            is CameraAction.ToIdle -> {
-                state.copy(cameraMode = TargetCameraMode.Idle)
-            }
-            is CameraAction.ToOverview -> {
-                state.copy(cameraMode = TargetCameraMode.Overview)
-            }
-            is CameraAction.ToFollowing -> {
-                state.copy(cameraMode = TargetCameraMode.Following)
+            is CameraAction.SetCameraMode -> {
+                when (action.mode) {
+                    TargetCameraMode.Idle ->
+                        state.copy(cameraMode = action.mode, savedCameraMode = state.cameraMode)
+                    else ->
+                        state.copy(cameraMode = action.mode)
+                }
             }
             is CameraAction.UpdatePadding -> {
                 state.copy(cameraPadding = action.padding)

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/recenter/RecenterButtonComponent.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/recenter/RecenterButtonComponent.kt
@@ -5,7 +5,7 @@ import androidx.core.view.isVisible
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.ui.app.internal.Store
-import com.mapbox.navigation.ui.app.internal.camera.CameraAction
+import com.mapbox.navigation.ui.app.internal.camera.CameraAction.SetCameraMode
 import com.mapbox.navigation.ui.app.internal.camera.TargetCameraMode
 import com.mapbox.navigation.ui.app.internal.navigation.NavigationState
 import com.mapbox.navigation.ui.base.lifecycle.UIComponent
@@ -26,7 +26,7 @@ internal class RecenterButtonComponent(
 
         recenterButton.updateStyle(recenterStyle)
         recenterButton.setOnClickListener {
-            store.dispatch(CameraAction.ToFollowing)
+            store.dispatch(SetCameraMode(TargetCameraMode.Following))
         }
 
         coroutineScope.launch {

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/cameramode/CameraModeButtonComponentTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/cameramode/CameraModeButtonComponentTest.kt
@@ -1,54 +1,53 @@
 package com.mapbox.navigation.dropin.component.cameramode
 
-import android.view.View
+import android.content.Context
 import androidx.core.view.isVisible
+import androidx.test.core.app.ApplicationProvider
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.core.MapboxNavigation
-import com.mapbox.navigation.dropin.R
 import com.mapbox.navigation.dropin.util.TestStore
 import com.mapbox.navigation.testing.MainCoroutineRule
 import com.mapbox.navigation.ui.app.internal.State
+import com.mapbox.navigation.ui.app.internal.camera.CameraAction.SetCameraMode
 import com.mapbox.navigation.ui.app.internal.camera.TargetCameraMode
 import com.mapbox.navigation.ui.app.internal.navigation.NavigationState
+import com.mapbox.navigation.ui.maps.R
 import com.mapbox.navigation.ui.maps.camera.state.NavigationCameraState
 import com.mapbox.navigation.ui.maps.view.MapboxCameraModeButton
-import io.mockk.Runs
-import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
 @OptIn(ExperimentalPreviewMapboxNavigationAPI::class, ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
 class CameraModeButtonComponentTest {
 
     @get:Rule
     var coroutineRule = MainCoroutineRule()
 
-    private val mockCameraModeButton: MapboxCameraModeButton = mockk {
-        every { setState(any()) } just Runs
-        every { visibility = View.VISIBLE } just Runs
-        every { visibility = View.GONE } just Runs
-        every { setOnClickListener(any()) } just Runs
-        every { updateStyle(any()) } just Runs
-    }
-    private val mockMapboxNavigation: MapboxNavigation = mockk(relaxed = true)
-
+    private lateinit var cameraModeButton: MapboxCameraModeButton
+    private lateinit var mockMapboxNavigation: MapboxNavigation
     private lateinit var testStore: TestStore
 
-    private lateinit var cameraModeButtonComponent: CameraModeButtonComponent
+    private lateinit var sut: CameraModeButtonComponent
 
     @Before
     fun setUp() {
+        val context: Context = ApplicationProvider.getApplicationContext()
+        cameraModeButton = spyk(MapboxCameraModeButton(context, null))
         testStore = spyk(TestStore())
-
-        cameraModeButtonComponent = CameraModeButtonComponent(
+        mockMapboxNavigation = mockk(relaxed = true)
+        sut = CameraModeButtonComponent(
             testStore,
-            mockCameraModeButton,
+            cameraModeButton,
             R.style.MapboxStyleCameraModeButton
         )
     }
@@ -56,52 +55,98 @@ class CameraModeButtonComponentTest {
     @Test
     fun `when camera mode is following button icon is overview`() =
         coroutineRule.runBlockingTest {
-            cameraModeButtonComponent.onAttached(mockMapboxNavigation)
+            sut.onAttached(mockMapboxNavigation)
 
-            testStore.setState(
-                State(
-                    camera = mockk {
-                        every { cameraMode } returns TargetCameraMode.Following
-                    },
-                )
+            val cameraState = testStore.state.value.camera.copy(
+                cameraMode = TargetCameraMode.Following
             )
+            testStore.setState(State(camera = cameraState))
 
-            verify { mockCameraModeButton.setState(NavigationCameraState.FOLLOWING) }
+            verify { cameraModeButton.setState(NavigationCameraState.FOLLOWING) }
         }
 
     @Test
     fun `when camera mode is overview button icon is following`() =
         coroutineRule.runBlockingTest {
-            cameraModeButtonComponent.onAttached(mockMapboxNavigation)
+            sut.onAttached(mockMapboxNavigation)
 
-            testStore.setState(
-                State(
-                    camera = mockk {
-                        every { cameraMode } returns TargetCameraMode.Overview
-                    },
-                )
+            val cameraState = testStore.state.value.camera.copy(
+                cameraMode = TargetCameraMode.Overview
             )
+            testStore.setState(State(camera = cameraState))
 
-            verify { mockCameraModeButton.setState(NavigationCameraState.OVERVIEW) }
+            verify { cameraModeButton.setState(NavigationCameraState.OVERVIEW) }
         }
 
     @Test
     fun `when navigation state is route preview camera mode button is not visible`() =
         coroutineRule.runBlockingTest {
-            cameraModeButtonComponent.onAttached(mockMapboxNavigation)
+            sut.onAttached(mockMapboxNavigation)
 
             testStore.setState(State(navigation = NavigationState.RoutePreview))
 
-            verify { mockCameraModeButton.isVisible = false }
+            assertFalse(cameraModeButton.isVisible)
         }
 
     @Test
     fun `when navigation state is not route preview camera mode button is not visible`() =
         coroutineRule.runBlockingTest {
-            cameraModeButtonComponent.onAttached(mockMapboxNavigation)
+            sut.onAttached(mockMapboxNavigation)
 
             testStore.setState(State(navigation = NavigationState.ActiveNavigation))
 
-            verify { mockCameraModeButton.isVisible = true }
+            assertTrue(cameraModeButton.isVisible)
         }
+
+    @Test
+    fun `when in Following mode onClick cameraModeButton should switch to Overview`() =
+        coroutineRule.runBlockingTest {
+            val cameraState = testStore.state.value.camera.copy(
+                cameraMode = TargetCameraMode.Following
+            )
+            testStore.setState(State(camera = cameraState))
+            sut.onAttached(mockMapboxNavigation)
+
+            cameraModeButton.performClick()
+
+            verify { testStore.dispatch(SetCameraMode(TargetCameraMode.Overview)) }
+        }
+
+    @Test
+    fun `when in Overview mode onClick cameraModeButton should switch to Following`() =
+        coroutineRule.runBlockingTest {
+            val cameraState = testStore.state.value.camera.copy(
+                cameraMode = TargetCameraMode.Overview
+            )
+            testStore.setState(State(camera = cameraState))
+            sut.onAttached(mockMapboxNavigation)
+
+            cameraModeButton.performClick()
+
+            verify { testStore.dispatch(SetCameraMode(TargetCameraMode.Following)) }
+        }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `when in Idle mode onClick cameraModeButton should use savedCameraMode to determine target camera mode`() =
+        coroutineRule.runBlockingTest {
+            val cameraState = testStore.state.value.camera.copy(
+                cameraMode = TargetCameraMode.Idle,
+                savedCameraMode = TargetCameraMode.Following
+            )
+            testStore.setState(State(camera = cameraState))
+            sut.onAttached(mockMapboxNavigation)
+
+            cameraModeButton.performClick()
+
+            verify { testStore.dispatch(SetCameraMode(TargetCameraMode.Overview)) }
+        }
+
+    @Test
+    fun `onDetached should remove OnClickListener`() = coroutineRule.runBlockingTest {
+        sut.onAttached(mockMapboxNavigation)
+        sut.onDetached(mockMapboxNavigation)
+
+        verify { cameraModeButton.setOnClickListener(null) }
+    }
 }


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-navigation-android/issues/5978

### Description
Changes:
- Replaced `CameraAction.To*` actions with `CameraAction.SetCameraMode`.
- Update `CameraComponent` to keep both `CameraState.cameraMode` and `NavigationCamera.state` in sync.
- Introduced `CameraState.savedCameraMode` for storing last `CameraState.cameraMode` value before switching to Idle mode.
- Updated `CameraModeButtonComponent` logic to correctly toggle between camera modes.

### Screenshots or Gifs

_(Recording of the QA Test App captured on Pixel 2)_

https://user-images.githubusercontent.com/2678039/177591491-210524ab-9008-44e7-9839-df2c937d6a8f.mp4


