### PR TITLE
Increase release-snapshot CI resources to medium+

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -746,6 +746,7 @@ jobs:
 
   release-snapshot:
     executor: ndk-r22-latest-executor
+    resource_class: medium+
     steps:
       - checkout
       - assemble-core-release


### PR DESCRIPTION
@Guardiola31337 already increased resources for the release job. It helped to decrease avg RAM using
<img width="226" alt="image" src="https://user-images.githubusercontent.com/25399022/177743052-09e2030b-efe2-47fc-984a-5d693e693cde.png">
It's okay for the monthly credits price, it will increase the cost in 1.5x
<img width="385" alt="image" src="https://user-images.githubusercontent.com/25399022/177743615-ddb06d12-b006-42d2-8ec5-a85c4716db02.png">
Also, we need increase resources for the release-snapshot job. Its avg RAM using is 100%
<img width="593" alt="image" src="https://user-images.githubusercontent.com/25399022/177744018-42142593-2f7d-4143-86e7-e89f552a110b.png">
This improvement will be more expensive than the release job, but it's still okay. It will cost x1.5 from the current price.
<img width="383" alt="image" src="https://user-images.githubusercontent.com/25399022/177744408-8b4228d5-dd2e-492c-bc0f-04284118b5c3.png">
@zugaldia need your approval