### PR TITLE
bump search sdk to 1.0.0-beta.33

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -3965,7 +3965,7 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 ===========================================================================
 
 Mapbox Navigation uses portions of the Android App Startup Runtime.
-URL: [https://developer.android.com/jetpack/androidx/releases/startup#1.1.0](https://developer.android.com/jetpack/androidx/releases/startup#1.1.0)
+URL: [https://developer.android.com/jetpack/androidx/releases/startup#1.1.1](https://developer.android.com/jetpack/androidx/releases/startup#1.1.1)
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
@@ -4012,6 +4012,12 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 
 ===========================================================================
 
+Mapbox Navigation uses portions of the Android DB.
+URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)
+License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+===========================================================================
+
 Mapbox Navigation uses portions of the Android for Cars App Library (Build navigation, parking, and charging apps for Android Auto).
 URL: [https://developer.android.com/jetpack/androidx/releases/car-app#1.1.0](https://developer.android.com/jetpack/androidx/releases/car-app#1.1.0)
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -4038,6 +4044,12 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 
 Mapbox Navigation uses portions of the Android Lifecycle Runtime.
 URL: [https://developer.android.com/jetpack/androidx/releases/lifecycle#2.4.0](https://developer.android.com/jetpack/androidx/releases/lifecycle#2.4.0)
+License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+===========================================================================
+
+Mapbox Navigation uses portions of the Android Lifecycle Service.
+URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
@@ -4086,6 +4098,18 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 
 Mapbox Navigation uses portions of the Android Resources Library (The Resources Library is a static library that you can add to your Android application in order to use resource APIs that backport the latest APIs to older versions of the platform. Compatible on devices running API 14 or later.).
 URL: [https://developer.android.com/jetpack/androidx/releases/appcompat#1.3.1](https://developer.android.com/jetpack/androidx/releases/appcompat#1.3.1)
+License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+===========================================================================
+
+Mapbox Navigation uses portions of the Android Room-Common.
+URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)
+License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+===========================================================================
+
+Mapbox Navigation uses portions of the Android Room-Runtime.
+URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
@@ -4198,6 +4222,12 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 
 ===========================================================================
 
+Mapbox Navigation uses portions of the Android Support SQLite - Framework Implementation (The implementation of Support SQLite library using the framework code.).
+URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)
+License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+===========================================================================
+
 Mapbox Navigation uses portions of the Android Support VectorDrawable.
 URL: [https://developer.android.com/jetpack/androidx](https://developer.android.com/jetpack/androidx)
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -4212,6 +4242,12 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 
 Mapbox Navigation uses portions of the Android Transition Support Library.
 URL: [https://developer.android.com/jetpack/androidx](https://developer.android.com/jetpack/androidx)
+License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+===========================================================================
+
+Mapbox Navigation uses portions of the Android WorkManager Runtime (Android WorkManager runtime library).
+URL: [https://developer.android.com/jetpack/androidx/releases/work#2.7.1](https://developer.android.com/jetpack/androidx/releases/work#2.7.1)
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================

--- a/libnavui-androidauto/CHANGELOG.md
+++ b/libnavui-androidauto/CHANGELOG.md
@@ -5,6 +5,7 @@ Mapbox welcomes participation and contributions from everyone.
 ## Unreleased
 #### Features
 #### Bug fixes and improvements
+- Allow injection of your own SearchEngine. [#6042](https://github.com/mapbox/mapbox-navigation-android/pull/6042)
 
 ## androidauto-v0.3.0 - Jun 24, 2022
 ### Changelog

--- a/libnavui-androidauto/build.gradle
+++ b/libnavui-androidauto/build.gradle
@@ -41,8 +41,8 @@ dependencies {
     // This defines the minimum version of Maps, Navigation, and Search which are included in
     // this SDK. To upgrade the SDK versions, you can specify a newer version in your downstream
     // build.gradle.
-    def carNavVersion = "2.6.0-rc.1"
-    def carSearchVersion = "1.0.0-beta.29"
+    def carNavVersion = "2.7.0-alpha.3"
+    def carSearchVersion = "1.0.0-beta.33"
     api("com.mapbox.navigation:android:${carNavVersion}")
     api("com.mapbox.search:mapbox-search-android:${carSearchVersion}")
     implementation("com.mapbox.navigation:ui-app:${carNavVersion}")

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/MainCarContext.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/MainCarContext.kt
@@ -10,6 +10,7 @@ import com.mapbox.navigation.core.MapboxNavigationProvider
 import com.mapbox.navigation.core.formatter.MapboxDistanceFormatter
 import com.mapbox.navigation.ui.maneuver.api.MapboxManeuverApi
 import com.mapbox.navigation.utils.internal.JobControl
+import com.mapbox.search.SearchEngine
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -17,7 +18,8 @@ import kotlinx.coroutines.SupervisorJob
 @OptIn(MapboxExperimental::class)
 class MainCarContext(
     val carContext: CarContext,
-    val mapboxCarMap: MapboxCarMap
+    val mapboxCarMap: MapboxCarMap,
+    val searchEngine: SearchEngine,
 ) {
     val carSettingsStorage = CarSettingsStorage(carContext)
 

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/search/FavoritesApi.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/search/FavoritesApi.kt
@@ -70,7 +70,7 @@ class FavoritesApi(
     ): Expected<GetPlacesError, FavoriteRecord> {
         addFavoriteTask?.cancel()
         return suspendCoroutine { continuation ->
-            addFavoriteTask = favoritesProvider.add(
+            addFavoriteTask = favoritesProvider.upsert(
                 favoriteRecord,
                 object : CompletionCallback<Unit> {
                     override fun onComplete(result: Unit) {

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/search/SearchCarContext.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/search/SearchCarContext.kt
@@ -3,7 +3,6 @@ package com.mapbox.androidauto.car.search
 import com.mapbox.androidauto.MapboxCarApp
 import com.mapbox.androidauto.car.MainCarContext
 import com.mapbox.androidauto.car.preview.CarRouteRequest
-import com.mapbox.search.MapboxSearchSdk
 
 /**
  * Contains the dependencies for the search feature.
@@ -17,7 +16,7 @@ class SearchCarContext(
 
     /** SearchCarContext **/
     val carSearchEngine = CarSearchEngine(
-        MapboxSearchSdk.getSearchEngine(),
+        mainCarContext.searchEngine,
         MapboxCarApp.carAppLocationService().navigationLocationProvider
     )
     val carRouteRequest = CarRouteRequest(

--- a/libnavui-androidauto/src/test/java/com/mapbox/androidauto/car/search/FavoritesApiTest.kt
+++ b/libnavui-androidauto/src/test/java/com/mapbox/androidauto/car/search/FavoritesApiTest.kt
@@ -111,7 +111,7 @@ class FavoritesApiTest {
         val expected = mockk<FavoriteRecord>(relaxed = true)
         val callbackSlot = slot<CompletionCallback<Unit>>()
         val mockFavoritesProvider = mockk<FavoritesDataProvider>(relaxed = true) {
-            every { add(expected, capture(callbackSlot)) } answers {
+            every { upsert(expected, capture(callbackSlot)) } answers {
                 callbackSlot.captured.onComplete(Unit)
                 mockk()
             }
@@ -129,7 +129,7 @@ class FavoritesApiTest {
         val callbackSlot = slot<CompletionCallback<Unit>>()
 
         val mockFavoritesProvider = mockk<FavoritesDataProvider>(relaxed = true) {
-            every { add(favoriteRecord, capture(callbackSlot)) } answers {
+            every { upsert(favoriteRecord, capture(callbackSlot)) } answers {
                 callbackSlot.captured.onComplete(Unit)
                 expectedAsyncOperationTask
             }
@@ -189,7 +189,7 @@ class FavoritesApiTest {
                 removeCallbackSlot.captured.onComplete(true)
                 removeFavoriteTask
             }
-            every { add(any(), capture(addCallbackSlot)) } coAnswers {
+            every { upsert(any(), capture(addCallbackSlot)) } coAnswers {
                 addCallbackSlot.captured.onComplete(Unit)
                 getAllTask
             }

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/QaTestApplication.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/QaTestApplication.kt
@@ -10,6 +10,6 @@ class QaTestApplication : Application() {
         super.onCreate()
 
         MapboxCarApp.setup(this)
-        MapboxCarSearchApp.setup(this)
+        MapboxCarSearchApp.setup()
     }
 }

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/car/MainCarSession.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/car/MainCarSession.kt
@@ -26,7 +26,10 @@ import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.core.internal.extensions.attachStarted
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationApp
 import com.mapbox.navigation.core.trip.session.TripSessionState
+import com.mapbox.navigation.qa_test_app.car.search.CarSearchLocationProvider
 import com.mapbox.navigation.qa_test_app.utils.Utils
+import com.mapbox.search.MapboxSearchSdk
+import com.mapbox.search.SearchEngineSettings
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -62,7 +65,13 @@ class MainCarSession : Session() {
 
                 mapboxCarMap = MapboxCarMap(MapInitOptions(context = carContext))
                 mapboxCarMap.registerObserver(carMapStyleLoader)
-                val mainCarContext = MainCarContext(carContext, mapboxCarMap)
+                val searchEngine = MapboxSearchSdk.createSearchEngineWithBuiltInDataProviders(
+                    SearchEngineSettings(
+                        Utils.getMapboxAccessToken(carContext.applicationContext),
+                        MapboxNavigationApp.getObserver(CarSearchLocationProvider::class),
+                    ),
+                )
+                val mainCarContext = MainCarContext(carContext, mapboxCarMap, searchEngine)
                     .also { mainCarContext = it }
 
                 val mapboxScreenManager = MapboxScreenManager(mainCarContext)

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/car/search/MapboxCarSearchApp.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/car/search/MapboxCarSearchApp.kt
@@ -1,22 +1,13 @@
 package com.mapbox.navigation.qa_test_app.car.search
 
-import android.app.Application
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationApp
-import com.mapbox.navigation.qa_test_app.utils.Utils
-import com.mapbox.search.MapboxSearchSdk
 
 @OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
 object MapboxCarSearchApp {
 
-    fun setup(application: Application) {
+    fun setup() {
         System.setProperty("com.mapbox.mapboxsearch.enableSBS", true.toString())
-        val carSearchLocationProvider = CarSearchLocationProvider()
-        MapboxSearchSdk.initialize(
-            application = application,
-            accessToken = Utils.getMapboxAccessToken(application),
-            locationEngine = carSearchLocationProvider,
-        )
-        MapboxNavigationApp.registerObserver(carSearchLocationProvider)
+        MapboxNavigationApp.registerObserver(CarSearchLocationProvider())
     }
 }


### PR DESCRIPTION
### Description
Search SDK introduced breaking changes in 1.0.0-beta.33 and we have to use this version with Nav SDK 2.7.0 because of Common SDK, thus we have to bump Search SDK in Android Auto and release a new version of it. 

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
