### PR TITLE
Bump MME dependency version to `8.1.5`

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -20,7 +20,7 @@ ext {
   version = [
       mapboxMapSdk              : '10.7.0-beta.1',
       mapboxSdkServices         : '6.6.0',
-      mapboxEvents              : '8.1.4',
+      mapboxEvents              : '8.1.5',
       mapboxCore                : '5.0.2',
       mapboxNavigator           : "${mapboxNavigatorVersion}",
       mapboxCommonNative        : '22.1.0-beta.1',
@@ -37,7 +37,6 @@ ext {
       androidXAnnotationVersion : '1.2.0',
       androidXFragmentVersion   : '1.4.0',
       androidXDataStore         : '1.0.0',
-      androidXWorkManager       : '2.7.1',
       cardViewVersion           : '1.0.0',
       recyclerViewVersion       : '1.1.0',
       materialDesignVersion     : '1.1.0',
@@ -133,7 +132,6 @@ ext {
       androidXFragment          : "androidx.fragment:fragment-ktx:${version.androidXFragmentVersion}",
       androidXArchCoreTesting   : "androidx.arch.core:core-testing:${version.androidXArchCoreVersion}",
       androidXDataStore         : "androidx.datastore:datastore-preferences:${version.androidXDataStore}",
-      androidXWorkManager       : "androidx.work:work-runtime:${version.androidXWorkManager}",
 
       // lifecycle
       androidXLifecycleRuntime  : "androidx.lifecycle:lifecycle-runtime-ktx:${version.androidXLifecycle}",

--- a/libnavigation-metrics/build.gradle
+++ b/libnavigation-metrics/build.gradle
@@ -27,8 +27,6 @@ dependencies {
     api (dependenciesList.mapboxEvents) {
         exclude group: "com.mapbox.mapboxsdk", module: "mapbox-android-core"
     }
-    // TODO Remove when MME uses WorkManager 2.7.0+
-    implementation dependenciesList.androidXWorkManager
 
     implementation dependenciesList.kotlinStdLib
     implementation dependenciesList.coroutinesAndroid


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Bumps MME dependency version to [`8.1.5`](https://github.com/mapbox/mapbox-events-android/releases/tag/telem-8.1.5-core-5.0.2) and removes related `TODO`s.

Refs. https://github.com/mapbox/mapbox-events-android/pull/573

cc @zach2good 