### PR TITLE
[Drop-In UI] Added support for Info Panel layout customization.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Mapbox welcomes participation and contributions from everyone.
 
 ## Unreleased
 #### Features
+- Added `ViewBinderCustomization.infoPanelBinder` that allows installation of a custom info panel layout in `NavigationView`. [#6049](https://github.com/mapbox/mapbox-navigation-android/pull/6049) 
+- Added `ViewStyleCustomization.infoPanelPeekHeight` that allows customization of `NavigationView` info panel bottom sheet peek height. [#6049](https://github.com/mapbox/mapbox-navigation-android/pull/6049) 
+- Added `ViewStyleCustomization.infoPanelMarginStart`, `ViewStyleCustomization.infoPanelMarginEnd`, `ViewStyleCustomization.infoPanelBackground` that allows customization of a `NavigatioView` default info panel margins and background. [#6049](https://github.com/mapbox/mapbox-navigation-android/pull/6049)
+
 #### Bug fixes and improvements
 - Remove the `MapView` from the `RouteArrowComponent` so that it can be used by Android Auto. [#6053](https://github.com/mapbox/mapbox-navigation-android/pull/6053)
 - Enabled tunnel dead reckoning drift compensation by default for Auto profile. [#6061](https://github.com/mapbox/mapbox-navigation-android/pull/6061)

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/extensions/MapboxNavigationObserverEx.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/extensions/MapboxNavigationObserverEx.kt
@@ -2,6 +2,7 @@
 
 package com.mapbox.navigation.core.internal.extensions
 
+import androidx.annotation.VisibleForTesting
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver
@@ -55,4 +56,6 @@ class MapboxNavigationObserverChain : MapboxNavigationObserver {
     fun clear() {
         queue.clear()
     }
+
+    fun toList(): List<MapboxNavigationObserver> = queue.toList()
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/extensions/MapboxNavigationObserverEx.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/extensions/MapboxNavigationObserverEx.kt
@@ -2,7 +2,6 @@
 
 package com.mapbox.navigation.core.internal.extensions
 
-import androidx.annotation.VisibleForTesting
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver

--- a/libnavui-dropin/api/current.txt
+++ b/libnavui-dropin/api/current.txt
@@ -127,6 +127,9 @@ package com.mapbox.navigation.dropin {
     method public Integer? getCameraModeButtonStyle();
     method public Integer? getDestinationMarker();
     method public Integer? getEndNavigationButtonStyle();
+    method public Integer? getInfoPanelBackground();
+    method public Integer? getInfoPanelMarginEnd();
+    method public Integer? getInfoPanelMarginStart();
     method public Integer? getInfoPanelPeekHeight();
     method public com.mapbox.navigation.ui.maneuver.model.ManeuverViewOptions? getManeuverViewOptions();
     method public Integer? getRecenterButtonStyle();
@@ -141,6 +144,9 @@ package com.mapbox.navigation.dropin {
     method public void setCameraModeButtonStyle(Integer?);
     method public void setDestinationMarker(Integer?);
     method public void setEndNavigationButtonStyle(Integer?);
+    method public void setInfoPanelBackground(Integer?);
+    method public void setInfoPanelMarginEnd(Integer?);
+    method public void setInfoPanelMarginStart(Integer?);
     method public void setInfoPanelPeekHeight(Integer?);
     method public void setManeuverViewOptions(com.mapbox.navigation.ui.maneuver.model.ManeuverViewOptions?);
     method public void setRecenterButtonStyle(Integer?);
@@ -155,6 +161,9 @@ package com.mapbox.navigation.dropin {
     property public final Integer? cameraModeButtonStyle;
     property public final Integer? destinationMarker;
     property public final Integer? endNavigationButtonStyle;
+    property public final Integer? infoPanelBackground;
+    property public final Integer? infoPanelMarginEnd;
+    property public final Integer? infoPanelMarginStart;
     property public final Integer? infoPanelPeekHeight;
     property public final com.mapbox.navigation.ui.maneuver.model.ManeuverViewOptions? maneuverViewOptions;
     property public final Integer? recenterButtonStyle;
@@ -173,6 +182,9 @@ package com.mapbox.navigation.dropin {
     method @StyleRes public int defaultCameraModeButtonStyle();
     method @DrawableRes public int defaultDestinationMarker();
     method @StyleRes public int defaultEndNavigationButtonStyle();
+    method @DrawableRes public int defaultInfoPanelBackground();
+    method @Px public int defaultInfoPanelMarginEnd();
+    method @Px public int defaultInfoPanelMarginStart();
     method @Px public int defaultInfoPanelPeekHeight(android.content.Context context);
     method public com.mapbox.navigation.ui.maneuver.model.ManeuverViewOptions defaultManeuverViewOptions();
     method @StyleRes public int defaultRecenterButtonStyle();
@@ -199,8 +211,7 @@ package com.mapbox.navigation.dropin.binder.infopanel {
   }
 
   public static final class InfoPanelBinder.Companion {
-    method public com.mapbox.navigation.dropin.binder.infopanel.InfoPanelBinder getDefaultBinder();
-    property public final com.mapbox.navigation.dropin.binder.infopanel.InfoPanelBinder defaultBinder;
+    method public com.mapbox.navigation.dropin.binder.infopanel.InfoPanelBinder defaultBinder();
   }
 
 }

--- a/libnavui-dropin/api/current.txt
+++ b/libnavui-dropin/api/current.txt
@@ -63,6 +63,7 @@ package com.mapbox.navigation.dropin {
     ctor public ViewBinderCustomization();
     method public com.mapbox.navigation.ui.base.lifecycle.UIBinder? getActionButtonsBinder();
     method public java.util.List<com.mapbox.navigation.dropin.ActionButtonDescription>? getCustomActionButtons();
+    method public com.mapbox.navigation.dropin.binder.infopanel.InfoPanelBinder? getInfoPanelBinder();
     method public com.mapbox.navigation.ui.base.lifecycle.UIBinder? getInfoPanelContentBinder();
     method public com.mapbox.navigation.ui.base.lifecycle.UIBinder? getInfoPanelHeaderBinder();
     method public com.mapbox.navigation.ui.base.lifecycle.UIBinder? getInfoPanelTripProgressBinder();
@@ -73,6 +74,7 @@ package com.mapbox.navigation.dropin {
     method public com.mapbox.navigation.ui.base.lifecycle.UIBinder? getSpeedLimitBinder();
     method public void setActionButtonsBinder(com.mapbox.navigation.ui.base.lifecycle.UIBinder?);
     method public void setCustomActionButtons(java.util.List<com.mapbox.navigation.dropin.ActionButtonDescription>?);
+    method public void setInfoPanelBinder(com.mapbox.navigation.dropin.binder.infopanel.InfoPanelBinder?);
     method public void setInfoPanelContentBinder(com.mapbox.navigation.ui.base.lifecycle.UIBinder?);
     method public void setInfoPanelHeaderBinder(com.mapbox.navigation.ui.base.lifecycle.UIBinder?);
     method public void setInfoPanelTripProgressBinder(com.mapbox.navigation.ui.base.lifecycle.UIBinder?);
@@ -83,6 +85,7 @@ package com.mapbox.navigation.dropin {
     method public void setSpeedLimitBinder(com.mapbox.navigation.ui.base.lifecycle.UIBinder?);
     property public final com.mapbox.navigation.ui.base.lifecycle.UIBinder? actionButtonsBinder;
     property public final java.util.List<com.mapbox.navigation.dropin.ActionButtonDescription>? customActionButtons;
+    property public final com.mapbox.navigation.dropin.binder.infopanel.InfoPanelBinder? infoPanelBinder;
     property public final com.mapbox.navigation.ui.base.lifecycle.UIBinder? infoPanelContentBinder;
     property public final com.mapbox.navigation.ui.base.lifecycle.UIBinder? infoPanelHeaderBinder;
     property public final com.mapbox.navigation.ui.base.lifecycle.UIBinder? infoPanelTripProgressBinder;
@@ -124,6 +127,7 @@ package com.mapbox.navigation.dropin {
     method public Integer? getCameraModeButtonStyle();
     method public Integer? getDestinationMarker();
     method public Integer? getEndNavigationButtonStyle();
+    method public Integer? getInfoPanelPeekHeight();
     method public com.mapbox.navigation.ui.maneuver.model.ManeuverViewOptions? getManeuverViewOptions();
     method public Integer? getRecenterButtonStyle();
     method public Integer? getRoadNameBackground();
@@ -137,6 +141,7 @@ package com.mapbox.navigation.dropin {
     method public void setCameraModeButtonStyle(Integer?);
     method public void setDestinationMarker(Integer?);
     method public void setEndNavigationButtonStyle(Integer?);
+    method public void setInfoPanelPeekHeight(Integer?);
     method public void setManeuverViewOptions(com.mapbox.navigation.ui.maneuver.model.ManeuverViewOptions?);
     method public void setRecenterButtonStyle(Integer?);
     method public void setRoadNameBackground(Integer?);
@@ -150,6 +155,7 @@ package com.mapbox.navigation.dropin {
     property public final Integer? cameraModeButtonStyle;
     property public final Integer? destinationMarker;
     property public final Integer? endNavigationButtonStyle;
+    property public final Integer? infoPanelPeekHeight;
     property public final com.mapbox.navigation.ui.maneuver.model.ManeuverViewOptions? maneuverViewOptions;
     property public final Integer? recenterButtonStyle;
     property public final Integer? roadNameBackground;
@@ -167,6 +173,7 @@ package com.mapbox.navigation.dropin {
     method @StyleRes public int defaultCameraModeButtonStyle();
     method @DrawableRes public int defaultDestinationMarker();
     method @StyleRes public int defaultEndNavigationButtonStyle();
+    method @Px public int defaultInfoPanelPeekHeight(android.content.Context context);
     method public com.mapbox.navigation.ui.maneuver.model.ManeuverViewOptions defaultManeuverViewOptions();
     method @StyleRes public int defaultRecenterButtonStyle();
     method @DrawableRes public int defaultRoadNameBackground();
@@ -176,6 +183,24 @@ package com.mapbox.navigation.dropin {
     method @StyleRes public int defaultSpeedLimitTextAppearance();
     method @StyleRes public int defaultStartNavigationButtonStyle();
     method @StyleRes public int defaultTripProgressStyle();
+  }
+
+}
+
+package com.mapbox.navigation.dropin.binder.infopanel {
+
+  @com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI public abstract class InfoPanelBinder implements com.mapbox.navigation.ui.base.lifecycle.UIBinder {
+    ctor public InfoPanelBinder();
+    method public com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver bind(android.view.ViewGroup viewGroup);
+    method public abstract android.view.ViewGroup? getContentLayout(android.view.ViewGroup layout);
+    method public abstract android.view.ViewGroup? getHeaderLayout(android.view.ViewGroup layout);
+    method public abstract android.view.ViewGroup onCreateLayout(android.view.LayoutInflater layoutInflater, android.view.ViewGroup root);
+    field public static final com.mapbox.navigation.dropin.binder.infopanel.InfoPanelBinder.Companion Companion;
+  }
+
+  public static final class InfoPanelBinder.Companion {
+    method public com.mapbox.navigation.dropin.binder.infopanel.InfoPanelBinder getDefaultBinder();
+    property public final com.mapbox.navigation.dropin.binder.infopanel.InfoPanelBinder defaultBinder;
   }
 
 }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewStyles.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewStyles.kt
@@ -10,6 +10,14 @@ import kotlinx.coroutines.flow.asStateFlow
 @ExperimentalPreviewMapboxNavigationAPI
 internal class NavigationViewStyles(context: Context) {
 
+    private var _infoPanelPeekHeight: MutableStateFlow<Int> =
+        MutableStateFlow(ViewStyleCustomization.defaultInfoPanelPeekHeight(context))
+    private var _infoPanelMarginStart: MutableStateFlow<Int> =
+        MutableStateFlow(ViewStyleCustomization.defaultInfoPanelMarginStart())
+    private var _infoPanelMarginEnd: MutableStateFlow<Int> =
+        MutableStateFlow(ViewStyleCustomization.defaultInfoPanelMarginEnd())
+    private var _infoPanelBackground: MutableStateFlow<Int> =
+        MutableStateFlow(ViewStyleCustomization.defaultInfoPanelBackground())
     private var _tripProgressStyle: MutableStateFlow<Int> =
         MutableStateFlow(ViewStyleCustomization.defaultTripProgressStyle())
     private var _audioGuidanceButtonStyle: MutableStateFlow<Int> =
@@ -37,6 +45,10 @@ internal class NavigationViewStyles(context: Context) {
     private var _maneuverViewOptions: MutableStateFlow<ManeuverViewOptions> =
         MutableStateFlow(ViewStyleCustomization.defaultManeuverViewOptions())
 
+    val infoPanelPeekHeight: StateFlow<Int> = _infoPanelPeekHeight.asStateFlow()
+    val infoPanelMarginStart: StateFlow<Int> = _infoPanelMarginStart.asStateFlow()
+    val infoPanelMarginEnd: StateFlow<Int> = _infoPanelMarginEnd.asStateFlow()
+    val infoPanelBackground: StateFlow<Int> = _infoPanelBackground.asStateFlow()
     val tripProgressStyle: StateFlow<Int> = _tripProgressStyle.asStateFlow()
     val recenterButtonStyle: StateFlow<Int> = _recenterButtonStyle.asStateFlow()
     val audioGuidanceButtonStyle: StateFlow<Int> = _audioGuidanceButtonStyle.asStateFlow()
@@ -52,6 +64,10 @@ internal class NavigationViewStyles(context: Context) {
     val maneuverViewOptions: StateFlow<ManeuverViewOptions> = _maneuverViewOptions.asStateFlow()
 
     fun applyCustomization(customization: ViewStyleCustomization) {
+        customization.infoPanelPeekHeight?.also { _infoPanelPeekHeight.tryEmit(it) }
+        customization.infoPanelMarginStart?.also { _infoPanelMarginStart.tryEmit(it) }
+        customization.infoPanelMarginEnd?.also { _infoPanelMarginEnd.tryEmit(it) }
+        customization.infoPanelBackground?.also { _infoPanelBackground.tryEmit(it) }
         customization.tripProgressStyle?.also { _tripProgressStyle.tryEmit(it) }
         customization.recenterButtonStyle?.also { _recenterButtonStyle.tryEmit(it) }
         customization.cameraModeButtonStyle?.also { _cameraModeButtonStyle.tryEmit(it) }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/ViewBinder.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/ViewBinder.kt
@@ -1,6 +1,7 @@
 package com.mapbox.navigation.dropin
 
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.dropin.binder.infopanel.InfoPanelBinder
 import com.mapbox.navigation.ui.base.lifecycle.UIBinder
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -16,6 +17,7 @@ internal class ViewBinder {
     private val _speedLimit: MutableStateFlow<UIBinder?> = MutableStateFlow(null)
     private val _maneuver: MutableStateFlow<UIBinder?> = MutableStateFlow(null)
     private val _roadName: MutableStateFlow<UIBinder?> = MutableStateFlow(null)
+    private val _infoPanelBinder: MutableStateFlow<InfoPanelBinder?> = MutableStateFlow(null)
     private val _infoPanelTripProgressBinder: MutableStateFlow<UIBinder?> =
         MutableStateFlow(null)
     private val _infoPanelHeaderBinder: MutableStateFlow<UIBinder?> = MutableStateFlow(null)
@@ -30,6 +32,7 @@ internal class ViewBinder {
     val speedLimit: StateFlow<UIBinder?> get() = _speedLimit.asStateFlow()
     val maneuver: StateFlow<UIBinder?> get() = _maneuver.asStateFlow()
     val roadName: StateFlow<UIBinder?> get() = _roadName.asStateFlow()
+    val infoPanelBinder: StateFlow<InfoPanelBinder?> get() = _infoPanelBinder.asStateFlow()
     val infoPanelTripProgressBinder: StateFlow<UIBinder?>
         get() = _infoPanelTripProgressBinder.asStateFlow()
     val infoPanelHeaderBinder: StateFlow<UIBinder?> get() = _infoPanelHeaderBinder.asStateFlow()
@@ -45,6 +48,7 @@ internal class ViewBinder {
         customization.speedLimitBinder?.also { _speedLimit.emitOrNull(it) }
         customization.maneuverBinder?.also { _maneuver.emitOrNull(it) }
         customization.roadNameBinder?.also { _roadName.emitOrNull(it) }
+        customization.infoPanelBinder?.also { _infoPanelBinder.emitOrNull(it) }
         customization.infoPanelTripProgressBinder?.also {
             _infoPanelTripProgressBinder.emitOrNull(it)
         }
@@ -57,7 +61,7 @@ internal class ViewBinder {
         customization.customActionButtons?.also { _customActionButtons.value = it }
     }
 
-    private fun MutableStateFlow<UIBinder?>.emitOrNull(v: UIBinder) {
+    private fun <T : UIBinder> MutableStateFlow<T?>.emitOrNull(v: T) {
         tryEmit(if (v != UIBinder.USE_DEFAULT) v else null)
     }
 }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/ViewBinderCustomization.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/ViewBinderCustomization.kt
@@ -1,6 +1,7 @@
 package com.mapbox.navigation.dropin
 
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.dropin.binder.infopanel.InfoPanelBinder
 import com.mapbox.navigation.ui.base.lifecycle.UIBinder
 
 /**
@@ -28,6 +29,12 @@ class ViewBinderCustomization {
      * Use [UIBinder.USE_DEFAULT] to reset to default.
      */
     var roadNameBinder: UIBinder? = null
+
+    /**
+     * Customize the Info Panel layout by providing your own [InfoPanelBinder].
+     * Use [InfoPanelBinder.defaultBinder] to reset to default.
+     */
+    var infoPanelBinder: InfoPanelBinder? = null
 
     /**
      * Customize the Info Panel Trip Progress by providing your own [UIBinder].

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/ViewStyleCustomization.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/ViewStyleCustomization.kt
@@ -1,6 +1,8 @@
 package com.mapbox.navigation.dropin
 
+import android.content.Context
 import androidx.annotation.DrawableRes
+import androidx.annotation.Px
 import androidx.annotation.StyleRes
 import com.google.android.material.resources.TextAppearance
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
@@ -24,67 +26,118 @@ import com.mapbox.navigation.ui.voice.view.MapboxAudioGuidanceButton
  */
 @ExperimentalPreviewMapboxNavigationAPI
 class ViewStyleCustomization {
+    /**
+     * Specify info panel peek height.
+     * Use [defaultInfoPanelPeekHeight] to reset to default.
+     */
+    @Px
+    var infoPanelPeekHeight: Int? = null
+
+    /**
+     * Specify info panel start margin.
+     * Use [defaultInfoPanelMarginStart] to reset to default.
+     */
+    @Px
+    var infoPanelMarginStart: Int? = null
+
+    /**
+     * Specify info panel end margin.
+     * Use [defaultInfoPanelMarginEnd] to reset to default.
+     */
+    @Px
+    var infoPanelMarginEnd: Int? = null
+
+    /**
+     * Specify info panel background drawable.
+     * Use [defaultInfoPanelBackground] to reset to default.
+     */
+    @DrawableRes
+    var infoPanelBackground: Int? = null
 
     /**
      * Provide custom destination marker icon.
      * Use [defaultDestinationMarker] to reset to default.
      */
-    @DrawableRes var destinationMarker: Int? = null
+    @DrawableRes
+    var destinationMarker: Int? = null
+
     /**
      * Provide custom [MapboxRoadNameView] background.
      * Use [defaultRoadNameBackground] to reset to default.
      */
-    @DrawableRes var roadNameBackground: Int? = null
+    @DrawableRes
+    var roadNameBackground: Int? = null
+
     /**
      * Provide custom [MapboxTripProgressView] style.
      * Use [defaultTripProgressStyle] to reset to default.
      */
-    @StyleRes var tripProgressStyle: Int? = null
+    @StyleRes
+    var tripProgressStyle: Int? = null
+
     /**
      * Provide custom [MapboxSpeedLimitView] style.
      * Use [defaultSpeedLimitStyle] to reset to default.
      */
-    @StyleRes var speedLimitStyle: Int? = null
+    @StyleRes
+    var speedLimitStyle: Int? = null
+
     /**
      * Provide custom [MapboxSpeedLimitView] [TextAppearance].
      * Use [defaultSpeedLimitTextAppearance] to reset to default.
      */
-    @StyleRes var speedLimitTextAppearance: Int? = null
+    @StyleRes
+    var speedLimitTextAppearance: Int? = null
+
     /**
      * Provide custom [MapboxRoadNameView] [TextAppearance].
      * Use [defaultRoadNameTextAppearance] to reset to default.
      */
-    @StyleRes var roadNameTextAppearance: Int? = null
+    @StyleRes
+    var roadNameTextAppearance: Int? = null
+
     /**
      * Provide custom [MapboxExtendableButton] style for re-center button.
      * Use [defaultRecenterButtonStyle] to reset to default.
      */
-    @StyleRes var recenterButtonStyle: Int? = null
+    @StyleRes
+    var recenterButtonStyle: Int? = null
+
     /**
      * Provide custom [MapboxCameraModeButton] style.
      * Use [defaultCameraModeButtonStyle] to reset to default.
      */
-    @StyleRes var cameraModeButtonStyle: Int? = null
+    @StyleRes
+    var cameraModeButtonStyle: Int? = null
+
     /**
      * Provide custom [MapboxExtendableButton] style for route preview button.
      * Use [defaultRoutePreviewButtonStyle] to reset to default.
      */
-    @StyleRes var routePreviewButtonStyle: Int? = null
+    @StyleRes
+    var routePreviewButtonStyle: Int? = null
+
     /**
      * Provide custom [MapboxAudioGuidanceButton] style.
      * Use [defaultAudioGuidanceButtonStyle] to reset to default.
      */
-    @StyleRes var audioGuidanceButtonStyle: Int? = null
+    @StyleRes
+    var audioGuidanceButtonStyle: Int? = null
+
     /**
      * Provide custom [MapboxExtendableButton] style for end navigation button.
      * Use [defaultEndNavigationButtonStyle] to reset to default.
      */
-    @StyleRes var endNavigationButtonStyle: Int? = null
+    @StyleRes
+    var endNavigationButtonStyle: Int? = null
+
     /**
      * Provide custom [MapboxExtendableButton] style for start navigation button.
      * Use [defaultStartNavigationButtonStyle] to reset to default.
      */
-    @StyleRes var startNavigationButtonStyle: Int? = null
+    @StyleRes
+    var startNavigationButtonStyle: Int? = null
+
     /**
      * Provide custom [ManeuverViewOptions] to style [MapboxManeuverView].
      * Use [defaultManeuverViewOptions] to reset to default.
@@ -92,6 +145,31 @@ class ViewStyleCustomization {
     var maneuverViewOptions: ManeuverViewOptions? = null
 
     companion object {
+        /**
+         * Default info panel peek height in pixels.
+         */
+        @Px
+        fun defaultInfoPanelPeekHeight(context: Context): Int =
+            context.resources.getDimensionPixelSize(R.dimen.mapbox_infoPanel_peekHeight)
+
+        /**
+         * Default info panel start margin value.
+         */
+        @Px
+        fun defaultInfoPanelMarginStart(): Int = 0
+
+        /**
+         * Default info panel end margin value.
+         */
+        @Px
+        fun defaultInfoPanelMarginEnd(): Int = 0
+
+        /**
+         * Default info panel background drawable.
+         */
+        @DrawableRes
+        fun defaultInfoPanelBackground(): Int = R.drawable.mapbox_bg_info_panel
+
         /**
          * Default destination marker icon.
          */

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/binder/infopanel/InfoPanelBinder.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/binder/infopanel/InfoPanelBinder.kt
@@ -1,26 +1,119 @@
 package com.mapbox.navigation.dropin.binder.infopanel
 
+import android.content.Context
+import android.view.LayoutInflater
 import android.view.ViewGroup
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.core.internal.extensions.navigationListOf
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver
+import com.mapbox.navigation.dropin.NavigationViewContext
 import com.mapbox.navigation.dropin.R
+import com.mapbox.navigation.dropin.component.infopanel.InfoPanelComponent
 import com.mapbox.navigation.ui.base.lifecycle.UIBinder
+import com.mapbox.navigation.utils.internal.ifNonNull
 
+/**
+ * Base Binder class used for inflating and binding Info Panel layout.
+ * Use [InfoPanelBinder.defaultBinder] to access default implementation.
+ */
 @ExperimentalPreviewMapboxNavigationAPI
-internal class InfoPanelBinder(
-    private val headerBinder: UIBinder?,
-    private val contentBinder: UIBinder?
-) : UIBinder {
+abstract class InfoPanelBinder : UIBinder {
 
+    private var headerBinder: UIBinder? = null
+    private var contentBinder: UIBinder? = null
+    internal var context: NavigationViewContext? = null
+
+    /**
+     * Create layout that will host both header and content layouts.
+     *
+     * @param layoutInflater The LayoutInflater service.
+     * @param root Parent view that provides a set of LayoutParams values for root of the returned hierarchy.
+     *
+     * @return ViewGroup that can host both header and content layouts. Returned view must not be attached to [root] view.
+     */
+    abstract fun onCreateLayout(layoutInflater: LayoutInflater, root: ViewGroup): ViewGroup
+
+    /**
+     * Get layout that can be passed to header UIBinder.
+     *
+     * @param layout ViewGroup returned by [onCreateLayout]
+     *
+     * @return ViewGroup that will be passed to the header UIBinder to install header view or
+     *  `null` if header view is not supported by parent [layout].
+     */
+    abstract fun getHeaderLayout(layout: ViewGroup): ViewGroup?
+
+    /**
+     * Get layout that can be passed to content UIBinder.
+     *
+     * @param layout ViewGroup returned by [onCreateLayout]
+     *
+     * @return ViewGroup that will be passed to the content UIBinder to install content view or
+     *  `null` if content view is not supported by parent [layout].
+     */
+    abstract fun getContentLayout(layout: ViewGroup): ViewGroup?
+
+    internal fun setBinders(headerBinder: UIBinder?, contentBinder: UIBinder?) {
+        this.headerBinder = headerBinder
+        this.contentBinder = contentBinder
+    }
+
+    internal fun setNavigationViewContext(context: NavigationViewContext) {
+        this.context = context
+    }
+
+    /**
+     * Triggered when this view binder instance is attached. The [viewGroup] returns a
+     * [MapboxNavigationObserver] which gives this view a simple lifecycle.
+     */
     override fun bind(viewGroup: ViewGroup): MapboxNavigationObserver {
+        val layout = onCreateLayout(
+            viewGroup.context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater,
+            viewGroup
+        )
+        viewGroup.removeAllViews()
+        viewGroup.addView(layout)
+
         val binders = mutableListOf<MapboxNavigationObserver>()
-        if (headerBinder != null) {
-            binders.add(headerBinder.bind(viewGroup.findViewById(R.id.infoPanelHeader)))
+        ifNonNull(headerBinder, getHeaderLayout(layout)) { binder, headerLayout ->
+            binders.add(binder.bind(headerLayout))
         }
-        if (contentBinder != null) {
-            binders.add(contentBinder.bind(viewGroup.findViewById(R.id.infoPanelContent)))
+        ifNonNull(contentBinder, getContentLayout(layout)) { binder, contentLayout ->
+            binders.add(binder.bind(contentLayout))
         }
         return navigationListOf(*binders.toTypedArray())
+    }
+
+    companion object {
+        /**
+         * Default Info Panel Binder.
+         */
+        fun defaultBinder(): InfoPanelBinder = MapboxInfoPanelBinder()
+    }
+}
+
+@ExperimentalPreviewMapboxNavigationAPI
+internal class MapboxInfoPanelBinder : InfoPanelBinder() {
+
+    override fun onCreateLayout(layoutInflater: LayoutInflater, root: ViewGroup): ViewGroup {
+        return layoutInflater
+            .inflate(R.layout.mapbox_info_panel_layout, root, false) as ViewGroup
+    }
+
+    override fun getHeaderLayout(layout: ViewGroup): ViewGroup? =
+        layout.findViewById(R.id.infoPanelHeader)
+
+    override fun getContentLayout(layout: ViewGroup): ViewGroup? =
+        layout.findViewById(R.id.infoPanelContent)
+
+    override fun bind(viewGroup: ViewGroup): MapboxNavigationObserver {
+        val observer = super.bind(viewGroup)
+        return context?.let { context ->
+            val layout = viewGroup.findViewById<ViewGroup>(R.id.infoPanelContainer)
+            navigationListOf(
+                InfoPanelComponent(layout, context),
+                observer
+            )
+        } ?: observer
     }
 }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/infopanel/InfoPanelComponent.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/infopanel/InfoPanelComponent.kt
@@ -1,0 +1,33 @@
+package com.mapbox.navigation.dropin.component.infopanel
+
+import android.view.ViewGroup
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.dropin.NavigationViewContext
+import com.mapbox.navigation.ui.base.lifecycle.UIComponent
+import kotlinx.coroutines.flow.combine
+
+@ExperimentalPreviewMapboxNavigationAPI
+class InfoPanelComponent internal constructor(
+    private val layout: ViewGroup,
+    private val context: NavigationViewContext
+) : UIComponent() {
+
+    override fun onAttached(mapboxNavigation: MapboxNavigation) {
+        super.onAttached(mapboxNavigation)
+        stylesFlow().observe { (background, marginLeft, marginRight) ->
+            layout.layoutParams = (layout.layoutParams as? ViewGroup.MarginLayoutParams)?.apply {
+                setMargins(marginLeft, topMargin, marginRight, bottomMargin)
+            }
+            layout.setBackgroundResource(background)
+        }
+    }
+
+    private fun stylesFlow() = context.styles.let { styles ->
+        combine(
+            styles.infoPanelBackground,
+            styles.infoPanelMarginStart,
+            styles.infoPanelMarginEnd
+        ) { background, marginStart, marginEnd -> Triple(background, marginStart, marginEnd) }
+    }
+}

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/infopanel/InfoPanelComponent.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/infopanel/InfoPanelComponent.kt
@@ -8,7 +8,7 @@ import com.mapbox.navigation.ui.base.lifecycle.UIComponent
 import kotlinx.coroutines.flow.combine
 
 @ExperimentalPreviewMapboxNavigationAPI
-class InfoPanelComponent internal constructor(
+internal class InfoPanelComponent internal constructor(
     private val layout: ViewGroup,
     private val context: NavigationViewContext
 ) : UIComponent() {

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/infopanel/InfoPanelComponent.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/infopanel/InfoPanelComponent.kt
@@ -8,7 +8,7 @@ import com.mapbox.navigation.ui.base.lifecycle.UIComponent
 import kotlinx.coroutines.flow.combine
 
 @ExperimentalPreviewMapboxNavigationAPI
-internal class InfoPanelComponent internal constructor(
+internal class InfoPanelComponent(
     private val layout: ViewGroup,
     private val context: NavigationViewContext
 ) : UIComponent() {

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/coordinator/InfoPanelCoordinator.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/coordinator/InfoPanelCoordinator.kt
@@ -33,6 +33,7 @@ internal class InfoPanelCoordinator(
 
     init {
         infoPanel.addOnLayoutChangeListener(FixBottomSheetLayoutWhenHidden(infoPanel, behavior))
+        behavior.peekHeight = context.styles.infoPanelPeekHeight.value
         behavior.hide()
     }
 
@@ -49,6 +50,11 @@ internal class InfoPanelCoordinator(
                 setGuidelinePosition(infoPanel)
             }
         }
+        coroutineScope.launch {
+            context.styles.infoPanelPeekHeight.collect { peekHeight ->
+                behavior.peekHeight = peekHeight
+            }
+        }
     }
 
     override fun onDetached(mapboxNavigation: MapboxNavigation) {
@@ -58,13 +64,17 @@ internal class InfoPanelCoordinator(
 
     override fun MapboxNavigation.flowViewBinders(): Flow<UIBinder> {
         return combine(
+            context.uiBinders.infoPanelBinder,
             context.uiBinders.infoPanelHeaderBinder,
             context.uiBinders.infoPanelContentBinder
-        ) { headerBinder, contentBinder ->
-            InfoPanelBinder(
-                headerBinder ?: InfoPanelHeaderBinder(context),
-                contentBinder
-            )
+        ) { infoPanelBinder, headerBinder, contentBinder ->
+            (infoPanelBinder ?: InfoPanelBinder.defaultBinder()).also {
+                it.setNavigationViewContext(context)
+                it.setBinders(
+                    headerBinder ?: InfoPanelHeaderBinder(context),
+                    contentBinder
+                )
+            }
         }
     }
 

--- a/libnavui-dropin/src/main/res/layout-land/mapbox_navigation_view_layout.xml
+++ b/libnavui-dropin/src/main/res/layout-land/mapbox_navigation_view_layout.xml
@@ -129,29 +129,16 @@
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 
-            <LinearLayout
+            <FrameLayout
                 android:id="@+id/infoPanelLayout"
-                android:orientation="vertical"
                 android:layout_width="375dp"
                 android:layout_height="wrap_content"
-                android:elevation="8dp"
-                android:background="@drawable/mapbox_bg_info_panel"
                 app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior"
                 app:behavior_hideable="true"
                 app:behavior_fitToContents="true"
-                app:behavior_peekHeight="@dimen/mapbox_infoPanel_peekHeight">
-
-                <FrameLayout
-                    android:id="@+id/infoPanelHeader"
-                    android:layout_width="match_parent"
-                    android:layout_height="@dimen/mapbox_infoPanel_peekHeight" />
-
-                <FrameLayout
-                    android:id="@+id/infoPanelContent"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content" />
-
-            </LinearLayout>
+                tools:behavior_peekHeight="@dimen/mapbox_infoPanel_peekHeight"
+                tools:background="@drawable/mapbox_bg_info_panel"
+                tools:minHeight="@dimen/mapbox_infoPanel_peekHeight" />
 
         </androidx.coordinatorlayout.widget.CoordinatorLayout>
     </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/libnavui-dropin/src/main/res/layout/mapbox_info_panel_header_layout.xml
+++ b/libnavui-dropin/src/main/res/layout/mapbox_info_panel_header_layout.xml
@@ -3,20 +3,13 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_height="wrap_content"
     tools:background="@drawable/mapbox_bg_info_panel"
     tools:parentTag="android.widget.FrameLayout">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="@dimen/mapbox_infoPanel_peekHeight">
-
-        <View
-            style="@style/DropInStyleDragHandle"
-            android:id="@+id/handle"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent" />
 
         <androidx.constraintlayout.widget.Barrier
             android:id="@+id/tripProgressGuideline"

--- a/libnavui-dropin/src/main/res/layout/mapbox_info_panel_layout.xml
+++ b/libnavui-dropin/src/main/res/layout/mapbox_info_panel_layout.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/infoPanelContainer"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:background="@drawable/mapbox_bg_info_panel"
+    android:elevation="8dp">
+
+    <FrameLayout
+        android:id="@+id/infoPanelHeader"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        tools:minHeight="@dimen/mapbox_infoPanel_peekHeight"
+        tools:background="#00ccff" />
+
+    <FrameLayout
+        android:id="@+id/infoPanelContent"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toBottomOf="@id/infoPanelHeader"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        tools:background="#ccffcc"
+        tools:minHeight="200dp" />
+
+    <View
+        style="@style/DropInStyleDragHandle"
+        android:id="@+id/handle"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/libnavui-dropin/src/main/res/layout/mapbox_navigation_view_layout.xml
+++ b/libnavui-dropin/src/main/res/layout/mapbox_navigation_view_layout.xml
@@ -122,29 +122,16 @@
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 
-            <LinearLayout
+            <FrameLayout
                 android:id="@+id/infoPanelLayout"
-                android:orientation="vertical"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:elevation="8dp"
-                android:background="@drawable/mapbox_bg_info_panel"
                 app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior"
                 app:behavior_hideable="true"
                 app:behavior_fitToContents="true"
-                app:behavior_peekHeight="@dimen/mapbox_infoPanel_peekHeight">
-
-                <FrameLayout
-                    android:id="@+id/infoPanelHeader"
-                    android:layout_width="match_parent"
-                    android:layout_height="@dimen/mapbox_infoPanel_peekHeight" />
-
-                <FrameLayout
-                    android:id="@+id/infoPanelContent"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content" />
-
-            </LinearLayout>
+                tools:behavior_peekHeight="@dimen/mapbox_infoPanel_peekHeight"
+                tools:background="@drawable/mapbox_bg_info_panel"
+                tools:minHeight="@dimen/mapbox_infoPanel_peekHeight" />
 
         </androidx.coordinatorlayout.widget.CoordinatorLayout>
     </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/ViewBinderTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/ViewBinderTest.kt
@@ -4,6 +4,8 @@ import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.dropin.ActionButtonDescription.Position.END
 import com.mapbox.navigation.dropin.ActionButtonDescription.Position.START
 import com.mapbox.navigation.dropin.binder.EmptyBinder
+import com.mapbox.navigation.dropin.binder.infopanel.InfoPanelBinder
+import com.mapbox.navigation.dropin.binder.infopanel.MapboxInfoPanelBinder
 import com.mapbox.navigation.ui.base.lifecycle.UIBinder
 import io.mockk.mockk
 import org.junit.Assert.assertEquals
@@ -51,6 +53,7 @@ internal class ViewBinderTest {
                 infoPanelContentBinder = UIBinder.USE_DEFAULT
                 actionButtonsBinder = UIBinder.USE_DEFAULT
                 customActionButtons = emptyList()
+                infoPanelBinder = InfoPanelBinder.defaultBinder()
             }
         )
 
@@ -62,6 +65,7 @@ internal class ViewBinderTest {
         assertTrue(sut.infoPanelContentBinder.value == null)
         assertTrue(sut.actionButtonsBinder.value == null)
         assertTrue(sut.customActionButtons.value.isEmpty())
+        assertTrue(sut.infoPanelBinder.value is MapboxInfoPanelBinder)
     }
 
     private fun customization() = ViewBinderCustomization().apply {
@@ -77,5 +81,6 @@ internal class ViewBinderTest {
             ActionButtonDescription(mockk(), START),
             ActionButtonDescription(mockk(), END)
         )
+        infoPanelBinder = mockk()
     }
 }

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/binder/infopanel/MapboxInfoPanelBinderTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/binder/infopanel/MapboxInfoPanelBinderTest.kt
@@ -1,0 +1,58 @@
+package com.mapbox.navigation.dropin.binder.infopanel
+
+import android.content.Context
+import android.widget.FrameLayout
+import androidx.test.core.app.ApplicationProvider
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.core.internal.extensions.MapboxNavigationObserverChain
+import com.mapbox.navigation.dropin.NavigationViewContext
+import com.mapbox.navigation.dropin.component.infopanel.InfoPanelComponent
+import io.mockk.MockKAnnotations
+import io.mockk.impl.annotations.MockK
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
+@RunWith(RobolectricTestRunner::class)
+internal class MapboxInfoPanelBinderTest {
+
+    private lateinit var ctx: Context
+    private lateinit var sut: MapboxInfoPanelBinder
+
+    @MockK
+    lateinit var mockNavContext: NavigationViewContext
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this, relaxUnitFun = true)
+        ctx = ApplicationProvider.getApplicationContext()
+
+        sut = MapboxInfoPanelBinder()
+    }
+
+    @Test
+    fun `bind should return MapboxNavigationObserver with InfoPanelComponent`() {
+        sut.setNavigationViewContext(mockNavContext)
+
+        val observers = (sut.bind(FrameLayout(ctx)) as MapboxNavigationObserverChain).toList()
+
+        assertEquals(2, observers.size)
+        assertNotNull(
+            "Expected InfoPanelComponent",
+            observers.firstOrNull { it is InfoPanelComponent }
+        )
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `bind should NOT return MapboxNavigationObserver with InfoPanelComponent if NavigationViewContext is not set`() {
+        val observers = (sut.bind(FrameLayout(ctx)) as MapboxNavigationObserverChain).toList()
+
+        assertNull(observers.firstOrNull { it is InfoPanelComponent })
+    }
+}

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/infopanel/InfoPanelComponentTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/infopanel/InfoPanelComponentTest.kt
@@ -1,0 +1,77 @@
+package com.mapbox.navigation.dropin.component.infopanel
+
+import android.content.Context
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import androidx.test.core.app.ApplicationProvider
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.dropin.NavigationViewContext
+import com.mapbox.navigation.dropin.NavigationViewStyles
+import com.mapbox.navigation.dropin.R
+import com.mapbox.navigation.dropin.ViewStyleCustomization
+import com.mapbox.navigation.testing.MainCoroutineRule
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@OptIn(ExperimentalPreviewMapboxNavigationAPI::class, ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class InfoPanelComponentTest {
+
+    @get:Rule
+    var coroutineRule = MainCoroutineRule()
+
+    private lateinit var ctx: Context
+    private lateinit var viewStyles: NavigationViewStyles
+    private lateinit var layout: StubLayout
+    private lateinit var mockNavContext: NavigationViewContext
+
+    private lateinit var sut: InfoPanelComponent
+
+    @Before
+    fun setUp() {
+        ctx = ApplicationProvider.getApplicationContext()
+        viewStyles = NavigationViewStyles(ctx)
+        layout = StubLayout(ctx).apply {
+            layoutParams = ViewGroup.MarginLayoutParams(1, 1)
+        }
+        mockNavContext = mockk {
+            every { styles } returns viewStyles
+        }
+
+        sut = InfoPanelComponent(layout, mockNavContext)
+    }
+
+    @Test
+    fun `onAttached should observe and apply info panel styles`() = coroutineRule.runBlockingTest {
+        val customization = ViewStyleCustomization().apply {
+            infoPanelBackground = R.drawable.mapbox_ic_camera_recenter
+            infoPanelMarginStart = 11
+            infoPanelMarginEnd = 22
+        }
+
+        viewStyles.applyCustomization(customization)
+        sut.onAttached(mockk())
+
+        val lp = layout.layoutParams as ViewGroup.MarginLayoutParams
+        assertEquals(customization.infoPanelMarginStart!!, lp.leftMargin)
+        assertEquals(customization.infoPanelMarginEnd!!, lp.rightMargin)
+        assertEquals(customization.infoPanelBackground!!, layout.backgroundResId)
+    }
+
+    // Stub layout that exposes assigned background resource id.
+    private class StubLayout(context: Context) : FrameLayout(context) {
+        var backgroundResId = 0
+
+        override fun setBackgroundResource(resid: Int) {
+            super.setBackgroundResource(resid)
+            backgroundResId = resid
+        }
+    }
+}

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/CustomInfoPanelBinder.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/CustomInfoPanelBinder.kt
@@ -1,0 +1,23 @@
+package com.mapbox.navigation.qa_test_app.view.customnavview
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.dropin.binder.infopanel.InfoPanelBinder
+import com.mapbox.navigation.qa_test_app.R
+
+@OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
+class CustomInfoPanelBinder : InfoPanelBinder() {
+    override fun onCreateLayout(
+        layoutInflater: LayoutInflater,
+        root: ViewGroup
+    ): ViewGroup {
+        return layoutInflater.inflate(R.layout.layout_info_panel, root, false) as ViewGroup
+    }
+
+    override fun getHeaderLayout(layout: ViewGroup): ViewGroup? =
+        layout.findViewById(R.id.infoPanelHeader)
+
+    override fun getContentLayout(layout: ViewGroup): ViewGroup? =
+        layout.findViewById(R.id.infoPanelContent)
+}

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/CustomizedViewModel.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/CustomizedViewModel.kt
@@ -7,5 +7,8 @@ class CustomizedViewModel : ViewModel() {
     val useCustomViews = MutableLiveData(false)
     val useCustomStyles = MutableLiveData(false)
     val showCustomMapView = MutableLiveData(false)
+    val useCustomInfoPanelLayout = MutableLiveData(false)
+    val useCustomInfoPanelStyles = MutableLiveData(false)
+    val showCustomInfoPanelContent = MutableLiveData(false)
     val showBottomSheetInFreeDrive = MutableLiveData(false)
 }

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/MapboxNavigationViewCustomizedActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/MapboxNavigationViewCustomizedActivity.kt
@@ -289,8 +289,8 @@ class MapboxNavigationViewCustomizedActivity : DrawerActivity() {
         binding.navigationView.customizeViewStyles {
             if (enabled) {
                 infoPanelBackground = R.drawable.bg_custom_info_panel2
-                infoPanelMarginStart = 5.dp
-                infoPanelMarginEnd = 5.dp
+                infoPanelMarginStart = 10.dp
+                infoPanelMarginEnd = 10.dp
             } else {
                 infoPanelBackground = defaultInfoPanelBackground()
                 infoPanelMarginStart = defaultInfoPanelMarginStart()

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/MapboxNavigationViewCustomizedActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/MapboxNavigationViewCustomizedActivity.kt
@@ -23,6 +23,10 @@ import com.mapbox.navigation.dropin.ViewStyleCustomization.Companion.defaultAudi
 import com.mapbox.navigation.dropin.ViewStyleCustomization.Companion.defaultCameraModeButtonStyle
 import com.mapbox.navigation.dropin.ViewStyleCustomization.Companion.defaultDestinationMarker
 import com.mapbox.navigation.dropin.ViewStyleCustomization.Companion.defaultEndNavigationButtonStyle
+import com.mapbox.navigation.dropin.ViewStyleCustomization.Companion.defaultInfoPanelBackground
+import com.mapbox.navigation.dropin.ViewStyleCustomization.Companion.defaultInfoPanelMarginEnd
+import com.mapbox.navigation.dropin.ViewStyleCustomization.Companion.defaultInfoPanelMarginStart
+import com.mapbox.navigation.dropin.ViewStyleCustomization.Companion.defaultInfoPanelPeekHeight
 import com.mapbox.navigation.dropin.ViewStyleCustomization.Companion.defaultManeuverViewOptions
 import com.mapbox.navigation.dropin.ViewStyleCustomization.Companion.defaultRecenterButtonStyle
 import com.mapbox.navigation.dropin.ViewStyleCustomization.Companion.defaultRoadNameBackground
@@ -32,6 +36,7 @@ import com.mapbox.navigation.dropin.ViewStyleCustomization.Companion.defaultSpee
 import com.mapbox.navigation.dropin.ViewStyleCustomization.Companion.defaultSpeedLimitTextAppearance
 import com.mapbox.navigation.dropin.ViewStyleCustomization.Companion.defaultStartNavigationButtonStyle
 import com.mapbox.navigation.dropin.ViewStyleCustomization.Companion.defaultTripProgressStyle
+import com.mapbox.navigation.dropin.binder.infopanel.InfoPanelBinder
 import com.mapbox.navigation.qa_test_app.R
 import com.mapbox.navigation.qa_test_app.databinding.LayoutActivityNavigationViewBinding
 import com.mapbox.navigation.qa_test_app.databinding.LayoutDrawerMenuNavViewCustomBinding
@@ -100,6 +105,22 @@ class MapboxNavigationViewCustomizedActivity : DrawerActivity() {
             menuBinding.toggleCustomMap,
             viewModel.showCustomMapView,
             ::customizeMap
+        )
+
+        bindSwitch(
+            menuBinding.toggleCustomInfoPanelContent,
+            viewModel.showCustomInfoPanelContent,
+            ::toggleCustomInfoPanelContent
+        )
+        bindSwitch(
+            menuBinding.toggleCustomInfoPanel,
+            viewModel.useCustomInfoPanelLayout,
+            ::toggleCustomInfoPanelLayout
+        )
+        bindSwitch(
+            menuBinding.toggleCustomInfoPanelStyles,
+            viewModel.useCustomInfoPanelStyles,
+            ::toggleCustomInfoPanelStyles
         )
 
         bindSwitch(
@@ -236,6 +257,48 @@ class MapboxNavigationViewCustomizedActivity : DrawerActivity() {
         }
     }
 
+    private fun toggleCustomInfoPanelContent(enabled: Boolean) {
+        binding.navigationView.customizeViewBinders {
+            if (enabled) {
+                infoPanelContentBinder = UIBinder { viewGroup ->
+                    supportFragmentManager.beginTransaction()
+                        .replace(viewGroup.id, CustomInfoPanelDetailsFragment())
+                        .commitAllowingStateLoss()
+                    UIComponent()
+                }
+            } else {
+                infoPanelContentBinder = UIBinder.USE_DEFAULT
+            }
+        }
+    }
+
+    private fun toggleCustomInfoPanelLayout(enabled: Boolean) {
+        binding.navigationView.customizeViewBinders {
+            infoPanelBinder =
+                if (enabled) CustomInfoPanelBinder()
+                else InfoPanelBinder.defaultBinder()
+        }
+        binding.navigationView.customizeViewStyles {
+            infoPanelPeekHeight =
+                if (enabled) defaultInfoPanelPeekHeight(applicationContext) + 20.dp
+                else defaultInfoPanelPeekHeight(applicationContext)
+        }
+    }
+
+    private fun toggleCustomInfoPanelStyles(enabled: Boolean) {
+        binding.navigationView.customizeViewStyles {
+            if (enabled) {
+                infoPanelBackground = R.drawable.bg_custom_info_panel2
+                infoPanelMarginStart = 5.dp
+                infoPanelMarginEnd = 5.dp
+            } else {
+                infoPanelBackground = defaultInfoPanelBackground()
+                infoPanelMarginStart = defaultInfoPanelMarginStart()
+                infoPanelMarginEnd = defaultInfoPanelMarginEnd()
+            }
+        }
+    }
+
     private fun toggleShowInfoPanelInFreeDrive(showInFreeDrive: Boolean) {
         // Show Bottom Sheet in Free Drive
         binding.navigationView.customizeViewOptions {
@@ -337,17 +400,9 @@ class MapboxNavigationViewCustomizedActivity : DrawerActivity() {
             binding.navigationView.customizeViewBinders {
                 infoPanelHeaderBinder = UIBinder { viewGroup ->
                     viewGroup.removeAllViews()
-                    viewGroup.addView(LayoutInfoPanelHeaderBinding.inflate(layoutInflater).root)
-                    UIComponent()
-                }
-                infoPanelContentBinder = UIBinder { viewGroup ->
-                    val existingFragment =
-                        supportFragmentManager.findFragmentById(viewGroup.id)
-                    if (existingFragment !is CustomInfoPanelDetailsFragment) {
-                        supportFragmentManager.beginTransaction()
-                            .replace(viewGroup.id, CustomInfoPanelDetailsFragment())
-                            .commitAllowingStateLoss()
-                    }
+                    val header = LayoutInfoPanelHeaderBinding
+                        .inflate(layoutInflater, viewGroup, false).root
+                    viewGroup.addView(header)
                     UIComponent()
                 }
             }

--- a/qa-test-app/src/main/res/drawable/bg_custom_info_panel.xml
+++ b/qa-test-app/src/main/res/drawable/bg_custom_info_panel.xml
@@ -1,0 +1,4 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+  <corners android:radius="20dp" />
+  <solid android:color="@color/colorSurface" />
+</shape>

--- a/qa-test-app/src/main/res/drawable/bg_custom_info_panel2.xml
+++ b/qa-test-app/src/main/res/drawable/bg_custom_info_panel2.xml
@@ -1,4 +1,4 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
-  <corners android:topLeftRadius="20dp" android:topRightRadius="20dp" />
+  <corners android:topLeftRadius="5dp" android:topRightRadius="5dp" />
   <solid android:color="@color/colorSurface" />
 </shape>

--- a/qa-test-app/src/main/res/drawable/bg_custom_info_panel2.xml
+++ b/qa-test-app/src/main/res/drawable/bg_custom_info_panel2.xml
@@ -1,0 +1,4 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+  <corners android:topLeftRadius="20dp" android:topRightRadius="20dp" />
+  <solid android:color="@color/colorSurface" />
+</shape>

--- a/qa-test-app/src/main/res/layout/layout_drawer_menu_nav_view_custom.xml
+++ b/qa-test-app/src/main/res/layout/layout_drawer_menu_nav_view_custom.xml
@@ -71,11 +71,38 @@
         </TableRow>
         <TableRow android:padding="5dp">
             <androidx.appcompat.widget.SwitchCompat
+                android:id="@+id/toggleCustomInfoPanel"
+                android:layout_weight="1"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Custom Info Panel Layout"
+                android:textAllCaps="true" />
+        </TableRow>
+        <TableRow android:padding="5dp">
+            <androidx.appcompat.widget.SwitchCompat
+                android:id="@+id/toggleCustomInfoPanelStyles"
+                android:layout_weight="1"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Custom Info Panel Styles"
+                android:textAllCaps="true" />
+        </TableRow>
+        <TableRow android:padding="5dp">
+            <androidx.appcompat.widget.SwitchCompat
+                android:id="@+id/toggleCustomInfoPanelContent"
+                android:layout_weight="1"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Custom Info Panel Content"
+                android:textAllCaps="true" />
+        </TableRow>
+        <TableRow android:padding="5dp">
+            <androidx.appcompat.widget.SwitchCompat
                 android:id="@+id/toggleBottomSheetFD"
                 android:layout_weight="1"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="SHOW BOTTOM SHEET IN \nFree Drive"
+                android:text="Show Info Panel IN \nFree Drive"
                 android:textAllCaps="true" />
         </TableRow>
     </TableLayout>

--- a/qa-test-app/src/main/res/layout/layout_info_panel.xml
+++ b/qa-test-app/src/main/res/layout/layout_info_panel.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="10dp"
+    android:orientation="vertical"
+    android:background="@drawable/bg_custom_info_panel"
+    android:elevation="8dp">
+
+    <FrameLayout
+        android:id="@+id/infoPanelHeader"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/mapbox_infoPanel_peekHeight"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        tools:background="#00ccff" />
+
+    <FrameLayout
+        android:id="@+id/infoPanelContent"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        tools:background="#ccffcc"
+        tools:minHeight="200dp"
+        app:layout_constraintTop_toBottomOf="@id/infoPanelHeader"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/qa-test-app/src/main/res/layout/layout_info_panel_header.xml
+++ b/qa-test-app/src/main/res/layout/layout_info_panel_header.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="@dimen/mapbox_infoPanel_peekHeight">
@@ -7,7 +8,7 @@
     <androidx.appcompat.widget.AppCompatTextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="^^ Pull up for details ^^"
+        android:text="Custom header view for Free Drive mode"
         android:textColor="#009688"
         android:textSize="16sp"
         android:textStyle="italic"
@@ -16,4 +17,5 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Closes [#1824](https://github.com/mapbox/navigation-sdks/issues/1824)

### TL;DR
This PR updates how Info Panel is laid out in the NavigationView. It introduces InfoPanelBinder which can be used to inject a custom info panel layout.

<img width="500" src="https://user-images.githubusercontent.com/2678039/178594686-33e3d93f-850e-469e-8ab1-230458e9c535.png"/>


### Description

Changes:
- Introduced `ViewBinderCustomization.infoPanelBinder` that can be used to inject custom info panel binder implementation.
- Refactored `InfoPanelBinder` into an abstract, base binder class that must be subclassed to provide a custom info panel layout.
- Introduced `ViewStyleCustomization.infoPanelPeekHeight` that allows change of bottom sheet peek height.
- Updated InfoPanelCoordinator to support new customization values.
- Updated QA Test App "Customized NavigationView" activity to showcase new info panel customizations.

### Screenshots or Gifs

_(Recording of QA Test App captured on Pixel 2)_

https://user-images.githubusercontent.com/2678039/178601130-560c4cd3-48d4-4f7c-a409-b1078aad6ec1.mp4


