### PR TITLE
changed `RouteOptionsUpdater` to use `snapping_include_closures=true` for origin of each re-route request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Mapbox welcomes participation and contributions from everyone.
 #### Features
 
 #### Bug fixes and improvements
+- Changed `RouteOptionsUpdater` to use `snapping_include_closures=true` for origin of each re-route request. This resolves a situation when Nav SDK returned a route in an opposite direction or on a parallel road when a driver caused a re-route by entering a closed section of a road. [#6050](https://github.com/mapbox/mapbox-navigation-android/pull/6050)
 
 ## Mapbox Navigation SDK 2.7.0-alpha.3 - July 8, 2022
 ### Changelog

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/routeoptions/RouteOptionsUpdaterTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/routeoptions/RouteOptionsUpdaterTest.kt
@@ -55,19 +55,6 @@ class RouteOptionsUpdaterTest {
                 )
                 .build()
 
-        private fun provideRouteOptionsWithCoordinatesAndSnappingClosures() =
-            provideRouteOptionsWithCoordinates()
-                .toBuilder()
-                .snappingIncludeClosuresList(
-                    listOf(
-                        true,
-                        false,
-                        true,
-                        false
-                    )
-                )
-                .build()
-
         private fun provideRouteOptionsWithCoordinatesAndArriveByDepartAt() =
             provideRouteOptionsWithCoordinates()
                 .toBuilder()
@@ -475,7 +462,17 @@ class RouteOptionsUpdaterTest {
             @Parameterized.Parameters
             fun params() = listOf(
                 arrayOf(
-                    provideRouteOptionsWithCoordinatesAndSnappingClosures(),
+                    provideRouteOptionsWithCoordinates()
+                        .toBuilder()
+                        .snappingIncludeClosuresList(
+                            listOf(
+                                true,
+                                false,
+                                true,
+                                false
+                            )
+                        )
+                        .build(),
                     3,
                     0,
                     "true;false;true;false"
@@ -484,10 +481,11 @@ class RouteOptionsUpdaterTest {
                     provideRouteOptionsWithCoordinates(),
                     1,
                     2,
-                    null
+                    "true;"
                 ),
                 arrayOf(
-                    provideRouteOptionsWithCoordinates().toBuilder()
+                    provideRouteOptionsWithCoordinates()
+                        .toBuilder()
                         .snappingIncludeClosuresList(
                             listOf(
                                 true,
@@ -499,7 +497,7 @@ class RouteOptionsUpdaterTest {
                         .build(),
                     2,
                     1,
-                    "false;false;false"
+                    "true;false;false"
                 ),
                 arrayOf(
                     provideRouteOptionsWithCoordinates().toBuilder()


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Closes https://github.com/mapbox/mapbox-navigation-android/issues/5664.

Adding `snapping_include_closures=true` resolves an occasional problem that returned a route in opposite direction or on parallel road when a driver caused a re-route by entering a closed section of a road. When present, this issue typically caused a loop of reroutes until a driver left the closed section. With `snapping_include_closures=true`, we'll still try to navigate out of the closed section as soon as possible but without continuous re-routes that could be impossible to execute.

cc @mandeepsandhu 

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
