### PR TITLE
Fix routeRefreshesWorksAfterSettingsNewRoutes flakiness

### DIFF
--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/RouteRefreshTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/RouteRefreshTest.kt
@@ -16,6 +16,7 @@ import com.mapbox.navigation.core.directions.session.RoutesExtra.ROUTES_UPDATE_R
 import com.mapbox.navigation.instrumentation_tests.R
 import com.mapbox.navigation.instrumentation_tests.activity.EmptyTestActivity
 import com.mapbox.navigation.instrumentation_tests.utils.MapboxNavigationRule
+import com.mapbox.navigation.instrumentation_tests.utils.coroutines.clearNavigationRoutesAndWaitForUpdate
 import com.mapbox.navigation.instrumentation_tests.utils.coroutines.getSuccessfulResultOrThrowException
 import com.mapbox.navigation.instrumentation_tests.utils.coroutines.requestRoutes
 import com.mapbox.navigation.instrumentation_tests.utils.coroutines.roadObjectsOnRoute
@@ -181,7 +182,7 @@ class RouteRefreshTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.ja
         stayOnInitialPosition()
 
         waitForRouteToSuccessfullyRefresh()
-        mapboxNavigation.setNavigationRoutesAndWaitForUpdate(listOf())
+        mapboxNavigation.clearNavigationRoutesAndWaitForUpdate()
         mapboxNavigation.setNavigationRoutesAndWaitForUpdate(routes)
         waitForRouteToSuccessfullyRefresh()
     }

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/utils/coroutines/TestUtils.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/utils/coroutines/TestUtils.kt
@@ -3,6 +3,8 @@ package com.mapbox.navigation.instrumentation_tests.utils.coroutines
 import com.mapbox.navigation.base.route.NavigationRoute
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesExtra
+import com.mapbox.navigation.core.directions.session.RoutesObserver
+import com.mapbox.navigation.core.directions.session.RoutesUpdatedResult
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.filter
@@ -10,6 +12,8 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 private const val MAX_TIME_TO_UPDATE_ROUTE = 5_000L
 private const val DEFAULT_TIMEOUT_FOR_SDK_TEST = 30_000L
@@ -25,15 +29,34 @@ fun sdkTest(
     }
 }
 
+fun MapboxNavigation.clearNavigationRoutesAndWaitForUpdate() {
+    val latch = CountDownLatch(1)
+    val observer = object : RoutesObserver {
+        override fun onRoutesChanged(result: RoutesUpdatedResult) {
+            if (result.reason == RoutesExtra.ROUTES_UPDATE_REASON_CLEAN_UP) {
+                unregisterRoutesObserver(this)
+                latch.countDown()
+            }
+        }
+    }
+    registerRoutesObserver(observer)
+    setNavigationRoutes(emptyList())
+    if (getNavigationRoutes().isEmpty()) {
+        latch.countDown()
+    }
+    latch.await(MAX_TIME_TO_UPDATE_ROUTE, TimeUnit.MILLISECONDS)
+}
+
 suspend fun MapboxNavigation.setNavigationRoutesAndWaitForUpdate(routes: List<NavigationRoute>) {
+    if (routes.isEmpty()) {
+        throw IllegalArgumentException(
+            "For empty routes use `clearNavigationRoutesAndWaitForUpdate` instead"
+        )
+    }
     withTimeout(MAX_TIME_TO_UPDATE_ROUTE) {
         coroutineScope {
             launch {
-                if (routes.isEmpty()) {
-                    waitForRoutesCleanup()
-                } else {
-                    waitForNewRoute()
-                }
+                waitForNewRoute()
             }
             setNavigationRoutes(routes)
         }
@@ -42,10 +65,6 @@ suspend fun MapboxNavigation.setNavigationRoutesAndWaitForUpdate(routes: List<Na
 
 suspend fun MapboxNavigation.waitForNewRoute() {
     waitForRoutesUpdate(RoutesExtra.ROUTES_UPDATE_REASON_NEW)
-}
-
-suspend fun MapboxNavigation.waitForRoutesCleanup() {
-    waitForRoutesUpdate(RoutesExtra.ROUTES_UPDATE_REASON_CLEAN_UP)
 }
 
 private suspend fun MapboxNavigation.waitForRoutesUpdate(


### PR DESCRIPTION
### Description
Closes #5931.

#### Problem
We might get stuck when we set empty routes.
The actions are the following:
1. We set an empty list of routes;
2. `MapboxNavigation` clears the routes and notifies the observers;
3. After `setRoutes` the observer is registered;
4. It does not get the current state because the state is passed to a new observer only if the routes are not empty.
5. As a result, we wait forever.

#### Solution
Guarantee that the observer will be registered before the routes are set.

#### Notes
I've also added a minor fix that checks if `MapboxNavigation` had any routes before empty list was set (if there are no routes, the callback will never be called).