### PR TITLE
Make `RouteArrowComponent` compatible with android auto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Mapbox welcomes participation and contributions from everyone.
 ## Unreleased
 #### Features
 #### Bug fixes and improvements
+- Remove the `MapView` from the `RouteArrowComponent` so that it can be used by Android Auto. [#6053](https://github.com/mapbox/mapbox-navigation-android/pull/6053)
 
 ## Mapbox Navigation SDK 2.7.0-beta.1 - 14 July, 2022
 ### Changelog

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/binder/map/MapBinder.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/binder/map/MapBinder.kt
@@ -111,7 +111,7 @@ internal class MapBinder(
         navigationState: NavigationState,
         arrowOptions: RouteArrowOptions
     ) = if (navigationState == NavigationState.ActiveNavigation) {
-        RouteArrowComponent(mapView, arrowOptions)
+        RouteArrowComponent(mapView.getMapboxMap(), arrowOptions)
     } else {
         null
     }

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/installer/ComponentInstaller.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/installer/ComponentInstaller.kt
@@ -45,7 +45,7 @@ fun ComponentInstaller.routeArrow(
     config: RouteArrowComponentConfig.() -> Unit = {}
 ): Installation {
     val componentConfig = RouteArrowComponentConfig(mapView.context).apply(config)
-    return component(RouteArrowComponent(mapView, componentConfig.options))
+    return component(RouteArrowComponent(mapView.getMapboxMap(), componentConfig.options))
 }
 
 /**

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/internal/ui/RouteArrowComponentTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/internal/ui/RouteArrowComponentTest.kt
@@ -3,11 +3,11 @@ package com.mapbox.navigation.ui.maps.internal.ui
 import android.content.Context
 import androidx.appcompat.content.res.AppCompatResources
 import com.mapbox.bindgen.ExpectedFactory
-import com.mapbox.maps.MapView
 import com.mapbox.maps.MapboxMap
 import com.mapbox.maps.Style
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.directions.session.RoutesObserver
 import com.mapbox.navigation.core.trip.session.RouteProgressObserver
 import com.mapbox.navigation.testing.MainCoroutineRule
 import com.mapbox.navigation.ui.maps.route.arrow.api.MapboxRouteArrowApi
@@ -16,7 +16,9 @@ import com.mapbox.navigation.ui.maps.route.arrow.model.ClearArrowsValue
 import com.mapbox.navigation.ui.maps.route.arrow.model.InvalidPointError
 import com.mapbox.navigation.ui.maps.route.arrow.model.RouteArrowOptions
 import com.mapbox.navigation.ui.maps.route.arrow.model.UpdateManeuverArrowValue
+import io.mockk.Runs
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.slot
@@ -28,10 +30,9 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
-@OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
+@OptIn(ExperimentalPreviewMapboxNavigationAPI::class, ExperimentalCoroutinesApi::class)
 class RouteArrowComponentTest {
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @get:Rule
     var coroutineRule = MainCoroutineRule()
 
@@ -53,62 +54,86 @@ class RouteArrowComponentTest {
     }
 
     @Test
-    fun `route progress test`() {
+    fun `route progress test`() = coroutineRule.runBlockingTest {
         val expected = ExpectedFactory.createError<InvalidPointError, UpdateManeuverArrowValue>(
             InvalidPointError("", null)
         )
         val routeProgressObserverSlot = slot<RouteProgressObserver>()
-        val mockMapboxNavigation = mockk<MapboxNavigation>(relaxed = true)
+        val mockMapboxNavigation = mockk<MapboxNavigation>(relaxed = true) {
+            every { registerRoutesObserver(any()) } just Runs
+            every { registerRouteProgressObserver(capture(routeProgressObserverSlot)) } just Runs
+        }
         val mockApi = mockk<MapboxRouteArrowApi> {
             every { addUpcomingManeuverArrow(any()) } returns expected
         }
         val mockStyle = mockk<Style>()
-        val mockMap = mockk<MapboxMap> {
-            every { getStyle() } returns mockStyle
-        }
-        val mockMapView = mockk<MapView>() {
-            every { getMapboxMap() } returns mockMap
-        }
         val mockView = mockk<MapboxRouteArrowView>(relaxed = true)
-        RouteArrowComponent(
-            mockMapView,
+        val sut = RouteArrowComponent(
+            mockMapWithStyleLoaded(mockStyle),
             routeArrowOptions,
             mockApi,
             mockView
-        ).onAttached(mockMapboxNavigation)
-        verify {
-            mockMapboxNavigation.registerRouteProgressObserver(capture(routeProgressObserverSlot))
-        }
+        )
 
+        sut.onAttached(mockMapboxNavigation)
         routeProgressObserverSlot.captured.onRouteProgressChanged(mockk())
 
         verify { mockView.renderManeuverUpdate(mockStyle, expected) }
     }
 
     @Test
-    fun `onDetached should clear all route arrows`() {
-        val style = mockk<Style>()
-        val mockMapView = mockk<MapView> {
-            every { getMapboxMap() } returns mockk {
-                every { getStyle() } returns style
-            }
+    fun `should clear route arrows when routes are cleared`() = coroutineRule.runBlockingTest {
+        val routesObserverSlot = slot<RoutesObserver>()
+        val mockMapboxNavigation = mockk<MapboxNavigation>(relaxed = true) {
+            every { registerRoutesObserver(capture(routesObserverSlot)) } just Runs
+            every { registerRouteProgressObserver(any()) } just Runs
         }
+        val mockStyle = mockk<Style>()
+        val clearValue = mockk<ClearArrowsValue>()
+        val mockApi = mockk<MapboxRouteArrowApi> {
+            every { clearArrows() } returns clearValue
+        }
+        val mockView = mockk<MapboxRouteArrowView>(relaxed = true)
+        val sut = RouteArrowComponent(
+            mockMapWithStyleLoaded(mockStyle),
+            routeArrowOptions,
+            mockApi,
+            mockView
+        )
+
+        sut.onAttached(mockMapboxNavigation)
+        routesObserverSlot.captured.onRoutesChanged(
+            mockk {
+                every { navigationRoutes } returns emptyList()
+            }
+        )
+
+        verify { mockView.render(mockStyle, clearValue) }
+    }
+
+    @Test
+    fun `onDetached should clear all route arrows`() = coroutineRule.runBlockingTest {
+        val mockStyle = mockk<Style>()
         val clearValue = mockk<ClearArrowsValue>()
         val mockApi = mockk<MapboxRouteArrowApi> {
             every { clearArrows() } returns clearValue
         }
         val mockView = mockk<MapboxRouteArrowView>(relaxed = true)
         val mockMapboxNavigation = mockk<MapboxNavigation>(relaxed = true)
-
         val sut = RouteArrowComponent(
-            mockMapView,
+            mockMapWithStyleLoaded(mockStyle),
             routeArrowOptions,
             mockApi,
             mockView
         )
+
         sut.onAttached(mockMapboxNavigation)
         sut.onDetached(mockMapboxNavigation)
 
-        verify { mockView.render(style, clearValue) }
+        verify { mockView.render(mockStyle, clearValue) }
+    }
+
+    private fun mockMapWithStyleLoaded(style: Style): MapboxMap = mockk {
+        every { getStyle() } returns style
     }
 }


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Similar to this one https://github.com/mapbox/mapbox-navigation-android/pull/5909

Android Auto does not have access to the `MapView`, so make the dependency be `MapboxMap`.

Also, Android Auto is able to clear the `MapboxNavigation` routes without telling drop in ui. Right now it is assumed that `RouteArrowComponent` will be detached when the routes are cleared. Adding a clear call because this was an issue we fixed in the [`CarRouteLine`](https://github.com/mapbox/mapbox-navigation-android/blob/9f849f7f3051c85cfc6808474e8734ae1b482931/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/preview/CarRouteLine.kt#L75-L76)

Referring to a bug fix for the `CarRouteLine` https://github.com/mapbox/1tap-android/pull/1206