### PR TITLE
Bump Maps, NN and Common dependency versions to `10.7.0-rc.1`, `109.0.0` and `22.1.0-rc.1` respectively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Mapbox welcomes participation and contributions from everyone.
 #### Features
 #### Bug fixes and improvements
 - Remove the `MapView` from the `RouteArrowComponent` so that it can be used by Android Auto. [#6053](https://github.com/mapbox/mapbox-navigation-android/pull/6053)
+- Enabled tunnel dead reckoning drift compensation by default for Auto profile. [#6061](https://github.com/mapbox/mapbox-navigation-android/pull/6061)
+- Increased route line stickiness for Auto profile. [#6061](https://github.com/mapbox/mapbox-navigation-android/pull/6061)
+- Improved off-road detection for Auto profile by relying more on the heading change relative to the road. [#6061](https://github.com/mapbox/mapbox-navigation-android/pull/6061)
 
 ## Mapbox Navigation SDK 2.7.0-beta.1 - 14 July, 2022
 ### Changelog

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1393,6 +1393,12 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 
 ===========================================================================
 
+Mapbox Navigation uses portions of the Android DB.
+URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)
+License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+===========================================================================
+
 Mapbox Navigation uses portions of the Android Lifecycle LiveData.
 URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -1407,6 +1413,12 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 
 Mapbox Navigation uses portions of the Android Lifecycle Runtime.
 URL: [https://developer.android.com/jetpack/androidx/releases/lifecycle#2.3.1](https://developer.android.com/jetpack/androidx/releases/lifecycle#2.3.1)
+License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+===========================================================================
+
+Mapbox Navigation uses portions of the Android Lifecycle Service.
+URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
@@ -1431,6 +1443,18 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 
 Mapbox Navigation uses portions of the Android Resources Library (The Resources Library is a static library that you can add to your Android application in order to use resource APIs that backport the latest APIs to older versions of the platform. Compatible on devices running API 14 or later.).
 URL: [https://developer.android.com/jetpack/androidx/releases/appcompat#1.3.1](https://developer.android.com/jetpack/androidx/releases/appcompat#1.3.1)
+License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+===========================================================================
+
+Mapbox Navigation uses portions of the Android Room-Common.
+URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)
+License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+===========================================================================
+
+Mapbox Navigation uses portions of the Android Room-Runtime.
+URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
@@ -1543,6 +1567,12 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 
 ===========================================================================
 
+Mapbox Navigation uses portions of the Android Support SQLite - Framework Implementation (The implementation of Support SQLite library using the framework code.).
+URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)
+License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+===========================================================================
+
 Mapbox Navigation uses portions of the Android Support VectorDrawable.
 URL: [https://developer.android.com/jetpack/androidx](https://developer.android.com/jetpack/androidx)
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -1557,6 +1587,12 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 
 Mapbox Navigation uses portions of the Android Transition Support Library.
 URL: [https://developer.android.com/jetpack/androidx](https://developer.android.com/jetpack/androidx)
+License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+===========================================================================
+
+Mapbox Navigation uses portions of the Android WorkManager Runtime (Android WorkManager runtime library).
+URL: [https://developer.android.com/jetpack/androidx/releases/work#2.7.1](https://developer.android.com/jetpack/androidx/releases/work#2.7.1)
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
@@ -1581,6 +1617,27 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 
 Mapbox Navigation uses portions of the Gson.
 License: [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+===========================================================================
+
+Mapbox Navigation uses portions of the Guava ListenableFuture only (Contains Guava's com.google.common.util.concurrent.ListenableFuture class,
+    without any of its other classes -- but is also available in a second
+    "version" that omits the class to avoid conflicts with the copy in Guava
+    itself. The idea is:
+
+    - If users want only ListenableFuture, they depend on listenablefuture-1.0.
+
+    - If users want all of Guava, they depend on guava, which, as of Guava
+    27.0, depends on
+    listenablefuture-9999.0-empty-to-avoid-conflict-with-guava. The 9999.0-...
+    version number is enough for some build systems (notably, Gradle) to select
+    that empty artifact over the "real" listenablefuture-1.0 -- avoiding a
+    conflict with the copy of ListenableFuture in guava itself. If users are
+    using an older version of Guava or a build system other than Gradle, they
+    may see class conflicts. If so, they can solve them by manually excluding
+    the listenablefuture artifact or manually forcing their build systems to
+    use 9999.0-....).
+License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -13,17 +13,17 @@ ext {
   // version which we should use in this build
   def mapboxNavigatorVersion = System.getenv("FORCE_MAPBOX_NAVIGATION_NATIVE_VERSION")
   if (mapboxNavigatorVersion == null || mapboxNavigatorVersion == '') {
-      mapboxNavigatorVersion = '108.0.1'
+      mapboxNavigatorVersion = '109.0.0'
   }
   println("Navigation Native version: " + mapboxNavigatorVersion)
 
   version = [
-      mapboxMapSdk              : '10.7.0-beta.1',
+      mapboxMapSdk              : '10.7.0-rc.1',
       mapboxSdkServices         : '6.6.0',
       mapboxEvents              : '8.1.5',
       mapboxCore                : '5.0.2',
       mapboxNavigator           : "${mapboxNavigatorVersion}",
-      mapboxCommonNative        : '22.1.0-beta.1',
+      mapboxCommonNative        : '22.1.0-rc.1',
       mapboxSearchSdk           : '1.0.0-beta.29',
       mapboxCrashMonitor        : '2.0.0',
       mapboxAnnotationPlugin    : '0.8.0',

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/eh/EHorizonMapper.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/eh/EHorizonMapper.kt
@@ -28,8 +28,6 @@ import com.mapbox.navigator.MatchableGeometry
 import com.mapbox.navigator.MatchableOpenLr
 import com.mapbox.navigator.MatchablePoint
 import com.mapbox.navigator.MatchedRoadObjectLocation
-import com.mapbox.navigator.OpenLROrientation
-import com.mapbox.navigator.OpenLRSideOfRoad
 import com.mapbox.navigator.Position
 import com.mapbox.navigator.RoadObjectDistance
 import com.mapbox.navigator.RoadObjectDistanceInfo
@@ -40,6 +38,8 @@ import com.mapbox.navigator.RoadObjectProvider
 import com.mapbox.navigator.RoadObjectType
 import com.mapbox.navigator.RoadSurface
 import com.mapbox.navigator.SubgraphEdge
+import com.mapbox.navigator.match.openlr.Orientation
+import com.mapbox.navigator.match.openlr.SideOfRoad
 
 private typealias SDKRoadObjectType =
     com.mapbox.navigation.base.trip.model.roadobject.RoadObjectType
@@ -274,22 +274,22 @@ internal fun RoadObjectType.mapToRoadObjectType(): Int {
     }
 }
 
-internal fun OpenLRSideOfRoad.mapToSideOfRoad(): Int {
+internal fun SideOfRoad.mapToSideOfRoad(): Int {
     return when (this) {
-        OpenLRSideOfRoad.BOTH -> SDKOpenLRSideOfRoad.BOTH
-        OpenLRSideOfRoad.LEFT -> SDKOpenLRSideOfRoad.LEFT
-        OpenLRSideOfRoad.RIGHT -> SDKOpenLRSideOfRoad.RIGHT
-        OpenLRSideOfRoad.ON_ROAD_OR_UNKNOWN -> SDKOpenLRSideOfRoad.ON_ROAD_OR_UNKNOWN
+        SideOfRoad.BOTH -> SDKOpenLRSideOfRoad.BOTH
+        SideOfRoad.LEFT -> SDKOpenLRSideOfRoad.LEFT
+        SideOfRoad.RIGHT -> SDKOpenLRSideOfRoad.RIGHT
+        SideOfRoad.ON_ROAD_OR_UNKNOWN -> SDKOpenLRSideOfRoad.ON_ROAD_OR_UNKNOWN
     }
 }
 
-internal fun OpenLROrientation.mapToOrientation(): Int {
+internal fun Orientation.mapToOrientation(): Int {
     return when (this) {
-        OpenLROrientation.BOTH -> SDKOpenLROrientation.BOTH
-        OpenLROrientation.NO_ORIENTATION_OR_UNKNOWN ->
+        Orientation.BOTH -> SDKOpenLROrientation.BOTH
+        Orientation.NO_ORIENTATION_OR_UNKNOWN ->
             SDKOpenLROrientation.NO_ORIENTATION_OR_UNKNOWN
-        OpenLROrientation.WITH_LINE_DIRECTION -> SDKOpenLROrientation.WITH_LINE_DIRECTION
-        OpenLROrientation.AGAINST_LINE_DIRECTION -> SDKOpenLROrientation.AGAINST_LINE_DIRECTION
+        Orientation.WITH_LINE_DIRECTION -> SDKOpenLROrientation.WITH_LINE_DIRECTION
+        Orientation.AGAINST_LINE_DIRECTION -> SDKOpenLROrientation.AGAINST_LINE_DIRECTION
     }
 }
 
@@ -341,10 +341,10 @@ internal fun EdgeMetadata.mapToEHorizonEdgeMetadata(): EHorizonEdgeMetadata {
     )
 }
 
-internal fun String.mapToOpenLRStandard(): com.mapbox.navigator.OpenLRStandard {
+internal fun String.mapToOpenLRStandard(): com.mapbox.navigator.match.openlr.Standard {
     return when (this) {
-        OpenLRStandard.TOM_TOM -> com.mapbox.navigator.OpenLRStandard.TOM_TOM
-        OpenLRStandard.TPEG -> com.mapbox.navigator.OpenLRStandard.TPEG
+        OpenLRStandard.TOM_TOM -> com.mapbox.navigator.match.openlr.Standard.TOM_TOM
+        OpenLRStandard.TPEG -> com.mapbox.navigator.match.openlr.Standard.TPEG
         else -> throw Exception("Invalid OpenLRStandard.")
     }
 }

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/trip/model/roadobject/RoadObjectMapperTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/trip/model/roadobject/RoadObjectMapperTest.kt
@@ -23,11 +23,11 @@ import com.mapbox.navigation.base.trip.model.roadobject.tunnel.TunnelInfo
 import com.mapbox.navigator.Amenity
 import com.mapbox.navigator.IncidentCongestionDescription
 import com.mapbox.navigator.MatchedRoadObjectLocation
-import com.mapbox.navigator.OpenLRStandard
 import com.mapbox.navigator.RoadObject
 import com.mapbox.navigator.RoadObjectMetadata
 import com.mapbox.navigator.RoadObjectProvider
 import com.mapbox.navigator.RouteAlertLocation
+import com.mapbox.navigator.match.openlr.Standard
 import io.mockk.mockk
 import org.junit.Assert.assertEquals
 import org.junit.Ignore
@@ -269,7 +269,7 @@ class RoadObjectMapperTest {
         type = com.mapbox.navigator.RoadObjectType.INCIDENT,
         incidentInfo = com.mapbox.navigator.IncidentInfo(
             INCIDENT_ID,
-            com.mapbox.navigator.OpenLR(OpenLRStandard.TOM_TOM, INCIDENT_OPEN_LR),
+            com.mapbox.navigator.match.openlr.OpenLR(Standard.TOM_TOM, INCIDENT_OPEN_LR),
             com.mapbox.navigator.IncidentType.CONSTRUCTION,
             INCIDENT_CREATION_TIME,
             INCIDENT_START_TIME,


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Bump Maps, NN and Common dependency versions to [`10.7.0-rc.1`](https://github.com/mapbox/mapbox-maps-android/releases/tag/android-v10.7.0-rc.1), `109.0.0` and `22.1.0-rc.1` respectively.