### PR TITLE
ensure Common SDK pre-release versions are the same across deps

### DIFF
--- a/gradle/verify-common-sdk-version.gradle
+++ b/gradle/verify-common-sdk-version.gradle
@@ -20,7 +20,7 @@ task verifyCommonSdkVersion(dependsOn: generateDependencyReportFile) {
 
         // find all Common SDK versions
         Set<String> commonVersions = new ArrayList<>()
-        Pattern p = Pattern.compile("com.mapbox.common:common:\\d+\\.\\d+\\.\\d+")
+        Pattern p = Pattern.compile("com.mapbox.common:common:\\d+\\.\\d+\\.[^\\s]+")
         Matcher m = p.matcher(dependenciesString)
         while (m.find()) {
             String[] elements = m.group().split(":")
@@ -38,6 +38,9 @@ task verifyCommonSdkVersion(dependsOn: generateDependencyReportFile) {
                 mismatchArea = "MAJOR"
             } else if (Arrays.stream(versionComponents).map({ it[1] }).distinct().count() != 1) {
                 mismatchArea = "MINOR"
+            } else if (!Arrays.stream(versionComponents).allMatch({ it[2].matches("^\\d+") })) {
+                // If there are more than one version of Common SDK, and any of them is a pre-release, we have no compatibility guarantees
+                mismatchArea = "PRE-RELEASE"
             }
 
             if (mismatchArea != null) {
@@ -45,7 +48,7 @@ task verifyCommonSdkVersion(dependsOn: generateDependencyReportFile) {
                 println(dependenciesString)
                 throw new IllegalArgumentException(
                         mismatchArea + " Common SDK versions across dependencies are mismatched."
-                                + " All projects should use the same major and minor versions of the Common SDK.\n"
+                                + " All projects should use the same major, minor, and pre-release versions of the Common SDK. Only mismatched patches of stable versions are allowed.\n"
                                 + " Found versions: " + commonVersions
                 )
             } else if (Arrays.stream(versionComponents).map({ it[2] }).distinct().count() != 1) {


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Pre-releases do not come with binary compatibility guarantees across versions, so we should ensure that we ship with a single version of a Common SDK pre-release only.

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
