### PR TITLE
add API to populate trip details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Mapbox welcomes participation and contributions from everyone.
 - Added `ViewBinderCustomization.infoPanelBinder` that allows installation of a custom info panel layout in `NavigationView`. [#6049](https://github.com/mapbox/mapbox-navigation-android/pull/6049) 
 - Added `ViewStyleCustomization.infoPanelPeekHeight` that allows customization of `NavigationView` info panel bottom sheet peek height. [#6049](https://github.com/mapbox/mapbox-navigation-android/pull/6049) 
 - Added `ViewStyleCustomization.infoPanelMarginStart`, `ViewStyleCustomization.infoPanelMarginEnd`, `ViewStyleCustomization.infoPanelBackground` that allows customization of a `NavigatioView` default info panel margins and background. [#6049](https://github.com/mapbox/mapbox-navigation-android/pull/6049)
+- Introduced new API(s) `MapboxTripProgressApi#getTripDetails()`, `MapboxTripProgressView#renderTripOverview()` and `MapboxTripProgressView#renderLegOverview()` to allow users to visualize trip related details for the entire route or a given leg of a route, before starting active navigation. [#6068](https://github.com/mapbox/mapbox-navigation-android/pull/6068)
 
 #### Bug fixes and improvements
 - :warning: Fixed an issue where `RoutesObserver` would be called with the previous routes set upon registration while a new routes set was already being processed. Now, the observer waits for the processing of `MapboxNavigation#setNavigationRoutes` to finish before delivering the result. [#6079](https://github.com/mapbox/mapbox-navigation-android/pull/6079)

--- a/libnavui-tripprogress/api/current.txt
+++ b/libnavui-tripprogress/api/current.txt
@@ -4,6 +4,7 @@ package com.mapbox.navigation.ui.tripprogress.api {
   public final class MapboxTripProgressApi {
     ctor public MapboxTripProgressApi(com.mapbox.navigation.ui.tripprogress.model.TripProgressUpdateFormatter formatter);
     method public com.mapbox.navigation.ui.tripprogress.model.TripProgressUpdateFormatter getFormatter();
+    method public com.mapbox.bindgen.Expected<com.mapbox.navigation.ui.tripprogress.model.TripOverviewError,com.mapbox.navigation.ui.tripprogress.model.TripOverviewValue> getTripDetails(com.mapbox.navigation.base.route.NavigationRoute route);
     method public com.mapbox.navigation.ui.tripprogress.model.TripProgressUpdateValue getTripProgress(com.mapbox.navigation.base.trip.model.RouteProgress routeProgress);
     method public void setFormatter(com.mapbox.navigation.ui.tripprogress.model.TripProgressUpdateFormatter);
     property public final com.mapbox.navigation.ui.tripprogress.model.TripProgressUpdateFormatter formatter;
@@ -28,12 +29,43 @@ package com.mapbox.navigation.ui.tripprogress.model {
     method public android.text.SpannableString format(double update);
   }
 
+  public final class RouteLegTripOverview {
+    method public long getEstimatedTimeToArrival();
+    method public double getLegDistance();
+    method public int getLegIndex();
+    method public double getLegTime();
+    property public final long estimatedTimeToArrival;
+    property public final double legDistance;
+    property public final int legIndex;
+    property public final double legTime;
+  }
+
   public final class TimeRemainingFormatter implements com.mapbox.navigation.ui.base.formatter.ValueFormatter<java.lang.Double,android.text.SpannableString> {
     ctor public TimeRemainingFormatter(android.content.Context context, java.util.Locale? locale = null);
     method public android.text.SpannableString format(double update);
     method public java.util.Locale? getLocale();
     method public void setLocale(java.util.Locale?);
     property public final java.util.Locale? locale;
+  }
+
+  public final class TripOverviewError {
+    method public String? getErrorMessage();
+    method public Throwable? getThrowable();
+    property public final String? errorMessage;
+    property public final Throwable? throwable;
+  }
+
+  public final class TripOverviewValue {
+    method public com.mapbox.navigation.ui.tripprogress.model.TripProgressUpdateFormatter getFormatter();
+    method public java.util.List<com.mapbox.navigation.ui.tripprogress.model.RouteLegTripOverview> getRouteLegTripDetail();
+    method public double getTotalDistance();
+    method public long getTotalEstimatedTimeToArrival();
+    method public double getTotalTime();
+    property public final com.mapbox.navigation.ui.tripprogress.model.TripProgressUpdateFormatter formatter;
+    property public final java.util.List<com.mapbox.navigation.ui.tripprogress.model.RouteLegTripOverview> routeLegTripDetail;
+    property public final double totalDistance;
+    property public final long totalEstimatedTimeToArrival;
+    property public final double totalTime;
   }
 
   public final class TripProgressUpdateFormatter {
@@ -113,6 +145,8 @@ package com.mapbox.navigation.ui.tripprogress.view {
     ctor public MapboxTripProgressView(android.content.Context context, android.util.AttributeSet? attrs);
     ctor public MapboxTripProgressView(android.content.Context context, android.util.AttributeSet? attrs, int defStyleAttr);
     method public void render(com.mapbox.navigation.ui.tripprogress.model.TripProgressUpdateValue result);
+    method public void renderLegOverview(int legIndex, com.mapbox.bindgen.Expected<com.mapbox.navigation.ui.tripprogress.model.TripOverviewError,com.mapbox.navigation.ui.tripprogress.model.TripOverviewValue> result);
+    method public void renderTripOverview(com.mapbox.bindgen.Expected<com.mapbox.navigation.ui.tripprogress.model.TripOverviewError,com.mapbox.navigation.ui.tripprogress.model.TripOverviewValue> result);
     method public void updateOptions(com.mapbox.navigation.ui.tripprogress.model.TripProgressViewOptions options);
     method @Deprecated public void updateStyle(@StyleRes int style);
   }

--- a/libnavui-tripprogress/src/main/java/com/mapbox/navigation/ui/tripprogress/TripProgressAction.kt
+++ b/libnavui-tripprogress/src/main/java/com/mapbox/navigation/ui/tripprogress/TripProgressAction.kt
@@ -1,7 +1,9 @@
 package com.mapbox.navigation.ui.tripprogress
 
+import com.mapbox.navigation.base.route.NavigationRoute
 import com.mapbox.navigation.base.trip.model.RouteProgress
 
 internal sealed class TripProgressAction {
+    data class CalculateTripDetails(val route: NavigationRoute) : TripProgressAction()
     data class CalculateTripProgress(val routeProgress: RouteProgress) : TripProgressAction()
 }

--- a/libnavui-tripprogress/src/main/java/com/mapbox/navigation/ui/tripprogress/TripProgressResult.kt
+++ b/libnavui-tripprogress/src/main/java/com/mapbox/navigation/ui/tripprogress/TripProgressResult.kt
@@ -8,4 +8,25 @@ internal sealed class TripProgressResult {
         val totalTimeRemaining: Double,
         val percentRouteTraveled: Double
     ) : TripProgressResult()
+
+    sealed class TripOverview : TripProgressResult() {
+        data class RouteLegTripOverview(
+            val legIndex: Int,
+            val legTime: Double,
+            val legDistance: Double,
+            val estimatedTimeToArrival: Long,
+        )
+
+        data class Success(
+            val routeLegTripDetail: List<RouteLegTripOverview>,
+            val totalTime: Double,
+            val totalDistance: Double,
+            val totalEstimatedTimeToArrival: Long,
+        ) : TripOverview()
+
+        data class Failure(
+            val errorMessage: String?,
+            val throwable: Throwable?
+        ) : TripOverview()
+    }
 }

--- a/libnavui-tripprogress/src/main/java/com/mapbox/navigation/ui/tripprogress/api/MapboxTripProgressApi.kt
+++ b/libnavui-tripprogress/src/main/java/com/mapbox/navigation/ui/tripprogress/api/MapboxTripProgressApi.kt
@@ -1,9 +1,16 @@
 package com.mapbox.navigation.ui.tripprogress.api
 
+import com.mapbox.api.directions.v5.models.RouteLeg
+import com.mapbox.bindgen.Expected
+import com.mapbox.bindgen.ExpectedFactory
+import com.mapbox.navigation.base.route.NavigationRoute
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.ui.tripprogress.TripProgressAction
 import com.mapbox.navigation.ui.tripprogress.TripProgressProcessor
 import com.mapbox.navigation.ui.tripprogress.TripProgressResult
+import com.mapbox.navigation.ui.tripprogress.model.RouteLegTripOverview
+import com.mapbox.navigation.ui.tripprogress.model.TripOverviewError
+import com.mapbox.navigation.ui.tripprogress.model.TripOverviewValue
 import com.mapbox.navigation.ui.tripprogress.model.TripProgressUpdateFormatter
 import com.mapbox.navigation.ui.tripprogress.model.TripProgressUpdateValue
 
@@ -45,5 +52,51 @@ class MapboxTripProgressApi internal constructor(
             -1,
             formatter
         )
+    }
+
+    /**
+     * Calculates trip details based on [NavigationRoute]. The return value contains `leg time`,
+     * `leg duration` and `estimated time to arrival` for each [RouteLeg] in
+     * [NavigationRoute.directionsRoute] in the form of [RouteLegTripOverview]. It also contains
+     * `totalTime`, `totalDistance` and `totalEstimatedTimeToArrival` for the entire
+     * [NavigationRoute.directionsRoute]
+     *
+     * The API would return [TripOverviewError] in case the [NavigationRoute] does not have [RouteLeg]
+     * or it does have [RouteLeg] but [RouteLeg.duration] or [RouteLeg.distance] is `null`.
+     *
+     * @param route to be used to compute the trip details for.
+     * @return an update to be rendered with `MapboxTripProgressView`
+     */
+    fun getTripDetails(route: NavigationRoute): Expected<TripOverviewError, TripOverviewValue> {
+        val action = TripProgressAction.CalculateTripDetails(route)
+
+        return when (val result = processor.process(action) as TripProgressResult.TripOverview) {
+            is TripProgressResult.TripOverview.Success -> {
+                ExpectedFactory.createValue(
+                    TripOverviewValue(
+                        routeLegTripDetail = result.routeLegTripDetail.map {
+                            RouteLegTripOverview(
+                                legIndex = it.legIndex,
+                                legTime = it.legTime,
+                                legDistance = it.legDistance,
+                                estimatedTimeToArrival = it.estimatedTimeToArrival
+                            )
+                        },
+                        totalTime = result.totalTime,
+                        totalDistance = result.totalDistance,
+                        totalEstimatedTimeToArrival = result.totalEstimatedTimeToArrival,
+                        formatter = formatter
+                    )
+                )
+            }
+            is TripProgressResult.TripOverview.Failure -> {
+                ExpectedFactory.createError(
+                    TripOverviewError(
+                        errorMessage = result.errorMessage,
+                        throwable = result.throwable
+                    )
+                )
+            }
+        }
     }
 }

--- a/libnavui-tripprogress/src/main/java/com/mapbox/navigation/ui/tripprogress/model/RouteLegTripOverview.kt
+++ b/libnavui-tripprogress/src/main/java/com/mapbox/navigation/ui/tripprogress/model/RouteLegTripOverview.kt
@@ -1,0 +1,18 @@
+package com.mapbox.navigation.ui.tripprogress.model
+
+import com.mapbox.api.directions.v5.models.RouteLeg
+
+/**
+ * Represents the trip detail for a [RouteLeg]
+ *
+ * @param legIndex index of [RouteLeg]
+ * @param legTime time remaining for the [RouteLeg]
+ * @param legDistance distance remaining for the [RouteLeg]
+ * @param estimatedTimeToArrival the estimated time to arrival for the [RouteLeg]
+ */
+class RouteLegTripOverview internal constructor(
+    val legIndex: Int,
+    val legTime: Double,
+    val legDistance: Double,
+    val estimatedTimeToArrival: Long,
+)

--- a/libnavui-tripprogress/src/main/java/com/mapbox/navigation/ui/tripprogress/model/TripOverviewError.kt
+++ b/libnavui-tripprogress/src/main/java/com/mapbox/navigation/ui/tripprogress/model/TripOverviewError.kt
@@ -1,0 +1,11 @@
+package com.mapbox.navigation.ui.tripprogress.model
+
+/**
+ * The state is returned if there is an error calculating trip overview.
+ * @param errorMessage an error message
+ * @param throwable an optional throwable value expressing the error
+ */
+class TripOverviewError internal constructor(
+    val errorMessage: String?,
+    val throwable: Throwable?
+)

--- a/libnavui-tripprogress/src/main/java/com/mapbox/navigation/ui/tripprogress/model/TripOverviewValue.kt
+++ b/libnavui-tripprogress/src/main/java/com/mapbox/navigation/ui/tripprogress/model/TripOverviewValue.kt
@@ -1,0 +1,20 @@
+package com.mapbox.navigation.ui.tripprogress.model
+
+import com.mapbox.api.directions.v5.models.RouteLeg
+
+/**
+ * Represents a trip detail for the entire route to be rendered
+ *
+ * @param routeLegTripDetail list of trip details for each [RouteLeg]
+ * @param totalTime the total time
+ * @param totalDistance the total distance
+ * @param totalEstimatedTimeToArrival the total estimated arrival time
+ * @param formatter an object containing various types of formatters
+ */
+class TripOverviewValue internal constructor(
+    val routeLegTripDetail: List<RouteLegTripOverview>,
+    val totalTime: Double,
+    val totalDistance: Double,
+    val totalEstimatedTimeToArrival: Long,
+    val formatter: TripProgressUpdateFormatter
+)

--- a/libnavui-tripprogress/src/test/java/com/mapbox/navigation/ui/tripprogress/TripProgressProcessorTest.kt
+++ b/libnavui-tripprogress/src/test/java/com/mapbox/navigation/ui/tripprogress/TripProgressProcessorTest.kt
@@ -1,6 +1,7 @@
 package com.mapbox.navigation.ui.tripprogress
 
-import com.mapbox.navigation.base.trip.model.RouteLegProgress
+import com.mapbox.api.directions.v5.models.RouteLeg
+import com.mapbox.navigation.base.route.NavigationRoute
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.base.trip.model.RouteProgressState
 import io.mockk.every
@@ -12,11 +13,11 @@ import java.util.Calendar
 class TripProgressProcessorTest {
 
     @Test
-    fun processWhenCalculateTripProgress() {
+    fun `process trip details with route progress`() {
         val routeProgress = mockk<RouteProgress> {
             every { durationRemaining } returns 600.0
             every { distanceRemaining } returns 100f
-            every { currentLegProgress } returns mockk<RouteLegProgress> {
+            every { currentLegProgress } returns mockk {
                 every { durationRemaining } returns 2.0
             }
             every { distanceTraveled } returns 50f
@@ -41,5 +42,154 @@ class TripProgressProcessorTest {
         assertEquals(2.0, result.currentLegTimeRemaining, 0.0)
         assertEquals(600.0, result.totalTimeRemaining, 0.0)
         assertEquals(0.3333333432674408, result.percentRouteTraveled, 0.0)
+    }
+
+    @Test
+    fun `process trip details with route containing no legs`() {
+        val route = mockk<NavigationRoute>(relaxed = true) {
+            every { directionsRoute } returns mockk(relaxed = true) {
+                every { legs() } returns null
+                every { duration() } returns 100.0
+                every { distance() } returns 200.0
+            }
+        }
+
+        val result =
+            TripProgressProcessor().process(
+                TripProgressAction.CalculateTripDetails(route)
+            ) as TripProgressResult.TripOverview.Failure
+
+        assertEquals("Directions route should not have null RouteLegs", result.errorMessage)
+    }
+
+    @Test
+    fun `process trip details with route containing null leg duration`() {
+        val leg = mockk<RouteLeg>(relaxed = true) {
+            every { duration() } returns null
+            every { distance() } returns 100.0
+        }
+        val route = mockk<NavigationRoute>(relaxed = true) {
+            every { directionsRoute } returns mockk(relaxed = true) {
+                every { legs() } returns listOf(leg)
+                every { duration() } returns 100.0
+                every { distance() } returns 200.0
+            }
+        }
+
+        val result =
+            TripProgressProcessor().process(
+                TripProgressAction.CalculateTripDetails(route)
+            ) as TripProgressResult.TripOverview.Failure
+
+        assertEquals(
+            "RouteLeg duration and RouteLeg distance cannot be null",
+            result.errorMessage
+        )
+    }
+
+    @Test
+    fun `process trip details with route containing null leg distance`() {
+        val leg = mockk<RouteLeg>(relaxed = true) {
+            every { duration() } returns 100.0
+            every { distance() } returns null
+        }
+        val route = mockk<NavigationRoute>(relaxed = true) {
+            every { directionsRoute } returns mockk(relaxed = true) {
+                every { legs() } returns listOf(leg)
+                every { duration() } returns 100.0
+                every { distance() } returns 200.0
+            }
+        }
+
+        val result =
+            TripProgressProcessor().process(
+                TripProgressAction.CalculateTripDetails(route)
+            ) as TripProgressResult.TripOverview.Failure
+
+        assertEquals(
+            "RouteLeg duration and RouteLeg distance cannot be null",
+            result.errorMessage
+        )
+    }
+
+    @Test
+    fun `process trip details with route containing one leg`() {
+        val leg = mockk<RouteLeg>(relaxed = true) {
+            every { duration() } returns 50.0
+            every { distance() } returns 100.0
+        }
+        val route = mockk<NavigationRoute>(relaxed = true) {
+            every { directionsRoute } returns mockk(relaxed = true) {
+                every { legs() } returns listOf(leg)
+                every { duration() } returns 100.0
+                every { distance() } returns 200.0
+            }
+        }
+        val expectedEta = Calendar.getInstance().also {
+            it.add(Calendar.SECOND, route.directionsRoute.duration().toInt())
+        }.timeInMillis
+
+        val result =
+            TripProgressProcessor().process(
+                TripProgressAction.CalculateTripDetails(route)
+            ) as TripProgressResult.TripOverview.Success
+
+        assertEquals(expectedEta.toDouble(), result.totalEstimatedTimeToArrival.toDouble(), 30000.0)
+        assertEquals(route.directionsRoute.duration(), result.totalTime, 0.0)
+        assertEquals(route.directionsRoute.distance(), result.totalDistance, 0.0)
+    }
+
+    @Test
+    fun `process trip details with route containing multiple legs`() {
+        val leg1 = mockk<RouteLeg>(relaxed = true) {
+            every { duration() } returns 50.0
+            every { distance() } returns 100.0
+        }
+        val leg2 = mockk<RouteLeg>(relaxed = true) {
+            every { duration() } returns 100.0
+            every { distance() } returns 200.0
+        }
+        val route = mockk<NavigationRoute>(relaxed = true) {
+            every { directionsRoute } returns mockk(relaxed = true) {
+                every { legs() } returns listOf(leg1, leg2)
+                every { duration() } returns 150.0
+                every { distance() } returns 300.0
+            }
+        }
+        val expectedEta1 = Calendar.getInstance().also {
+            it.add(Calendar.SECOND, leg1.duration()!!.toInt())
+        }.timeInMillis
+        val expectedEta2 = Calendar.getInstance().also {
+            it.add(Calendar.SECOND, leg2.duration()!!.toInt())
+        }.timeInMillis
+        val expectedEta = Calendar.getInstance().also {
+            it.add(Calendar.SECOND, route.directionsRoute.duration().toInt())
+        }.timeInMillis
+
+        val result =
+            TripProgressProcessor().process(
+                TripProgressAction.CalculateTripDetails(route)
+            ) as TripProgressResult.TripOverview.Success
+
+        // For 1st route leg
+        assertEquals(
+            expectedEta1.toDouble(),
+            result.routeLegTripDetail[0].estimatedTimeToArrival.toDouble(),
+            30000.0
+        )
+        assertEquals(leg1.duration()!!, result.routeLegTripDetail[0].legTime, 0.0)
+        assertEquals(leg1.distance()!!, result.routeLegTripDetail[0].legDistance, 0.0)
+        // For 2nd route leg
+        assertEquals(
+            expectedEta2.toDouble(),
+            result.routeLegTripDetail[1].estimatedTimeToArrival.toDouble(),
+            30000.0
+        )
+        assertEquals(leg2.duration()!!, result.routeLegTripDetail[1].legTime, 0.0)
+        assertEquals(leg2.distance()!!, result.routeLegTripDetail[1].legDistance, 0.0)
+        // For complete route
+        assertEquals(expectedEta.toDouble(), result.totalEstimatedTimeToArrival.toDouble(), 30000.0)
+        assertEquals(route.directionsRoute.duration(), result.totalTime, 0.0)
+        assertEquals(route.directionsRoute.distance(), result.totalDistance, 0.0)
     }
 }

--- a/libnavui-tripprogress/src/test/java/com/mapbox/navigation/ui/tripprogress/view/MapboxTripProgressViewTest.kt
+++ b/libnavui-tripprogress/src/test/java/com/mapbox/navigation/ui/tripprogress/view/MapboxTripProgressViewTest.kt
@@ -6,7 +6,11 @@ import android.text.SpannableString
 import android.widget.TextView
 import androidx.core.content.ContextCompat
 import androidx.test.core.app.ApplicationProvider
+import com.mapbox.bindgen.ExpectedFactory
 import com.mapbox.navigation.ui.tripprogress.R
+import com.mapbox.navigation.ui.tripprogress.model.RouteLegTripOverview
+import com.mapbox.navigation.ui.tripprogress.model.TripOverviewError
+import com.mapbox.navigation.ui.tripprogress.model.TripOverviewValue
 import com.mapbox.navigation.ui.tripprogress.model.TripProgressUpdateFormatter
 import com.mapbox.navigation.ui.tripprogress.model.TripProgressUpdateValue
 import io.mockk.every
@@ -122,6 +126,169 @@ class MapboxTripProgressViewTest {
 
         val view = MapboxTripProgressView(ctx).also {
             it.render(state)
+        }
+
+        assertEquals(
+            "44 mi",
+            view.findViewById<TextView>(R.id.distanceRemainingText).text.toString()
+        )
+        assertEquals(
+            "11:59",
+            view.findViewById<TextView>(
+                R.id.estimatedTimeToArriveText
+            ).text.toString()
+        )
+        assertEquals(
+            "5 min",
+            view.findViewById<TextView>(R.id.timeRemainingText).text.toString()
+        )
+    }
+
+    @Test
+    fun `do not render trip overview when error`() {
+        val result = ExpectedFactory.createError<TripOverviewError, TripOverviewValue>(
+            TripOverviewError(
+                errorMessage = "Some error",
+                throwable = null
+            )
+        )
+
+        val view = MapboxTripProgressView(ctx).also {
+            it.renderTripOverview(result)
+        }
+
+        assertEquals(
+            "",
+            view.findViewById<TextView>(R.id.distanceRemainingText).text.toString()
+        )
+        assertEquals(
+            "",
+            view.findViewById<TextView>(
+                R.id.estimatedTimeToArriveText
+            ).text.toString()
+        )
+        assertEquals(
+            "",
+            view.findViewById<TextView>(R.id.timeRemainingText).text.toString()
+        )
+    }
+
+    @Test
+    fun `render trip overview`() {
+        val formatter = TripProgressUpdateFormatter.Builder(ctx)
+            .estimatedTimeToArrivalFormatter(
+                mockk {
+                    every { format(1L) } returns SpannableString("11:59")
+                }
+            )
+            .distanceRemainingFormatter(
+                mockk {
+                    every { format(2.0) } returns SpannableString("44 mi")
+                }
+            )
+            .timeRemainingFormatter(
+                mockk {
+                    every { format(3.0) } returns SpannableString("5 min")
+                }
+            )
+            .build()
+        val result = ExpectedFactory.createValue<TripOverviewError, TripOverviewValue>(
+            TripOverviewValue(
+                emptyList(),
+                3.0,
+                2.0,
+                1L,
+                formatter
+            )
+        )
+
+        val view = MapboxTripProgressView(ctx).also {
+            it.renderTripOverview(result)
+        }
+
+        assertEquals(
+            "44 mi",
+            view.findViewById<TextView>(R.id.distanceRemainingText).text.toString()
+        )
+        assertEquals(
+            "11:59",
+            view.findViewById<TextView>(
+                R.id.estimatedTimeToArriveText
+            ).text.toString()
+        )
+        assertEquals(
+            "5 min",
+            view.findViewById<TextView>(R.id.timeRemainingText).text.toString()
+        )
+    }
+
+    @Test
+    fun `do not render leg overview when error`() {
+        val result = ExpectedFactory.createError<TripOverviewError, TripOverviewValue>(
+            TripOverviewError(
+                errorMessage = "Some error",
+                throwable = null
+            )
+        )
+
+        val view = MapboxTripProgressView(ctx).also {
+            it.renderLegOverview(0, result)
+        }
+
+        assertEquals(
+            "",
+            view.findViewById<TextView>(R.id.distanceRemainingText).text.toString()
+        )
+        assertEquals(
+            "",
+            view.findViewById<TextView>(
+                R.id.estimatedTimeToArriveText
+            ).text.toString()
+        )
+        assertEquals(
+            "",
+            view.findViewById<TextView>(R.id.timeRemainingText).text.toString()
+        )
+    }
+
+    @Test
+    fun `render leg overview`() {
+        val formatter = TripProgressUpdateFormatter.Builder(ctx)
+            .estimatedTimeToArrivalFormatter(
+                mockk {
+                    every { format(1L) } returns SpannableString("11:59")
+                }
+            )
+            .distanceRemainingFormatter(
+                mockk {
+                    every { format(2.0) } returns SpannableString("44 mi")
+                }
+            )
+            .timeRemainingFormatter(
+                mockk {
+                    every { format(3.0) } returns SpannableString("5 min")
+                }
+            )
+            .build()
+        val result = ExpectedFactory.createValue<TripOverviewError, TripOverviewValue>(
+            TripOverviewValue(
+                listOf(
+                    RouteLegTripOverview(
+                        legIndex = 0,
+                        legTime = 3.0,
+                        legDistance = 2.0,
+                        estimatedTimeToArrival = 1L
+                    )
+                ),
+                3.0,
+                2.0,
+                1L,
+                formatter
+            )
+        )
+
+        val view = MapboxTripProgressView(ctx).also {
+            it.renderLegOverview(0, result)
         }
 
         assertEquals(

--- a/qa-test-app/src/main/AndroidManifest.xml
+++ b/qa-test-app/src/main/AndroidManifest.xml
@@ -40,6 +40,7 @@
         <activity android:name=".view.InactiveRouteStylingWithRestrictionsActivity" />
         <activity android:name=".view.StatusActivity" />
         <activity android:name=".view.RoadObjectsActivity" />
+        <activity android:name=".view.TripOverviewActivity" />
         <activity
             android:name=".view.IconsPreviewActivity"
             android:theme="@style/Theme.IconsPreviewActivity" />

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/domain/TestActivitySuite.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/domain/TestActivitySuite.kt
@@ -25,6 +25,7 @@ import com.mapbox.navigation.qa_test_app.view.RouteRestrictionsActivity
 import com.mapbox.navigation.qa_test_app.view.RouteTrafficUpdateActivity
 import com.mapbox.navigation.qa_test_app.view.StatusActivity
 import com.mapbox.navigation.qa_test_app.view.TrafficGradientActivity
+import com.mapbox.navigation.qa_test_app.view.TripOverviewActivity
 import com.mapbox.navigation.qa_test_app.view.customnavview.MapboxNavigationViewCustomizedActivity
 import com.mapbox.navigation.qa_test_app.view.util.RouteDrawingActivity
 
@@ -148,6 +149,12 @@ object TestActivitySuite {
             R.string.icons_preview_activity_description
         ) { activity ->
             activity.startActivity<IconsPreviewActivity>()
+        },
+        TestActivityDescription(
+            "Visualize Trip Overview",
+            R.string.trip_overview_activity_description
+        ) { activity ->
+            activity.startActivity<TripOverviewActivity>()
         },
         TestActivityDescription(
             "Default NavigationView",

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/TripOverviewActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/TripOverviewActivity.kt
@@ -1,0 +1,163 @@
+package com.mapbox.navigation.qa_test_app.view
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.maps.CameraOptions
+import com.mapbox.maps.plugin.locationcomponent.location
+import com.mapbox.navigation.base.formatter.DistanceFormatterOptions
+import com.mapbox.navigation.base.options.NavigationOptions
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.MapboxNavigationProvider
+import com.mapbox.navigation.core.directions.session.RoutesObserver
+import com.mapbox.navigation.core.replay.MapboxReplayer
+import com.mapbox.navigation.core.replay.ReplayLocationEngine
+import com.mapbox.navigation.qa_test_app.R
+import com.mapbox.navigation.qa_test_app.databinding.LayoutActivityTripOverviewBinding
+import com.mapbox.navigation.qa_test_app.utils.Utils
+import com.mapbox.navigation.ui.maps.NavigationStyles
+import com.mapbox.navigation.ui.maps.location.NavigationLocationProvider
+import com.mapbox.navigation.ui.maps.route.line.api.MapboxRouteLineApi
+import com.mapbox.navigation.ui.maps.route.line.api.MapboxRouteLineView
+import com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions
+import com.mapbox.navigation.ui.maps.route.line.model.RouteLine
+import com.mapbox.navigation.ui.maps.route.line.model.RouteLineResources
+import com.mapbox.navigation.ui.tripprogress.api.MapboxTripProgressApi
+import com.mapbox.navigation.ui.tripprogress.model.DistanceRemainingFormatter
+import com.mapbox.navigation.ui.tripprogress.model.EstimatedTimeToArrivalFormatter
+import com.mapbox.navigation.ui.tripprogress.model.TimeRemainingFormatter
+import com.mapbox.navigation.ui.tripprogress.model.TripProgressUpdateFormatter
+import com.mapbox.navigation.ui.tripprogress.model.TripProgressViewOptions
+import com.mapbox.navigation.ui.tripprogress.view.MapboxTripProgressView
+
+class TripOverviewActivity : AppCompatActivity() {
+
+    private val mapboxReplayer = MapboxReplayer()
+    private val navigationLocationProvider = NavigationLocationProvider()
+
+    private val tripProgressFormatter: TripProgressUpdateFormatter by lazy {
+        val distanceFormatterOptions =
+            DistanceFormatterOptions.Builder(this).build()
+        TripProgressUpdateFormatter.Builder(this)
+            .distanceRemainingFormatter(DistanceRemainingFormatter(distanceFormatterOptions))
+            .timeRemainingFormatter(TimeRemainingFormatter(this))
+            .estimatedTimeToArrivalFormatter(EstimatedTimeToArrivalFormatter(this))
+            .build()
+    }
+
+    /**
+     * TripProgress: The [MapboxTripProgressApi] consumes route progress data and produces trip related
+     * data that is consumed by the [MapboxTripProgressView] in the view layout.
+     */
+    private val tripProgressApi: MapboxTripProgressApi by lazy {
+        MapboxTripProgressApi(tripProgressFormatter)
+    }
+
+    private val binding: LayoutActivityTripOverviewBinding by lazy {
+        LayoutActivityTripOverviewBinding.inflate(layoutInflater)
+    }
+
+    private val mapboxNavigation: MapboxNavigation by lazy {
+        MapboxNavigationProvider.create(
+            NavigationOptions.Builder(this)
+                .accessToken(Utils.getMapboxSapaAccessToken(this))
+                .locationEngine(ReplayLocationEngine(mapboxReplayer))
+                .build()
+        )
+    }
+
+    private val options: MapboxRouteLineOptions by lazy {
+        MapboxRouteLineOptions.Builder(this)
+            .withRouteLineResources(RouteLineResources.Builder().build())
+            .withRouteLineBelowLayerId("road-label-navigation")
+            .displayRestrictedRoadSections(true)
+            .withVanishingRouteLineEnabled(true)
+            .build()
+    }
+
+    private val routeLineView by lazy {
+        MapboxRouteLineView(options)
+    }
+
+    private val routeLineApi: MapboxRouteLineApi by lazy {
+        MapboxRouteLineApi(options)
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(binding.root)
+        initNavigation()
+        initStyle()
+    }
+
+    override fun onStop() {
+        super.onStop()
+        mapboxNavigation.unregisterRoutesObserver(routesObserver)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        routeLineApi.cancel()
+        routeLineView.cancel()
+        mapboxNavigation.onDestroy()
+    }
+
+    private fun initStyle() {
+        binding.mapView.getMapboxMap().loadStyleUri(
+            NavigationStyles.NAVIGATION_DAY_STYLE
+        ) { style ->
+
+            val route = getRoute()
+            routeLineApi.setRoutes(listOf(RouteLine(route, null))) {
+                routeLineView.renderRouteDrawData(style, it)
+            }
+            mapboxNavigation.setRoutes(listOf(route))
+            val routeOrigin = Utils.getRouteOriginPoint(route)
+            val cameraOptions = CameraOptions.Builder().center(routeOrigin).zoom(15.0).build()
+            binding.mapView.getMapboxMap().setCamera(cameraOptions)
+            binding.legOverviewOne.updateOptions(
+                TripProgressViewOptions
+                    .Builder()
+                    .timeRemainingTextAppearance(R.style.MyCustomTimeRemaining)
+                    .build()
+            )
+            binding.legOverviewTwo.updateOptions(
+                TripProgressViewOptions
+                    .Builder()
+                    .backgroundColor(R.color.secondaryVariant)
+                    .timeRemainingTextAppearance(R.style.MyCustomTimeRemaining)
+                    .build()
+            )
+            binding.tripOverview.updateOptions(
+                TripProgressViewOptions
+                    .Builder()
+                    .timeRemainingTextAppearance(R.style.MyCustomTimeRemaining)
+                    .build()
+            )
+        }
+    }
+
+    private fun initNavigation() {
+        binding.mapView.location.apply {
+            setLocationProvider(navigationLocationProvider)
+            enabled = true
+        }
+        mapboxNavigation.registerRoutesObserver(routesObserver)
+        mapboxReplayer.pushRealLocation(this, 0.0)
+        mapboxReplayer.playbackSpeed(1.5)
+        mapboxReplayer.play()
+    }
+
+    private val routesObserver = RoutesObserver {
+        val navigationRoute = it.navigationRoutes.first()
+        val tripOverview = tripProgressApi.getTripDetails(navigationRoute)
+        binding.tripOverview.renderTripOverview(tripOverview)
+        binding.legOverviewOne.renderLegOverview(0, tripOverview)
+        binding.legOverviewTwo.renderLegOverview(1, tripOverview)
+    }
+
+    private fun getRoute(): DirectionsRoute {
+        val routeAsString = Utils.readRawFileText(this, R.raw.multileg_route_two_legs)
+        return DirectionsRoute.fromJson(routeAsString)
+    }
+}

--- a/qa-test-app/src/main/res/layout/layout_activity_trip_overview.xml
+++ b/qa-test-app/src/main/res/layout/layout_activity_trip_overview.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    >
+
+  <com.mapbox.maps.MapView
+      android:id="@+id/mapView"
+      android:layout_width="0dp"
+      android:layout_height="0dp"
+      app:layout_constraintTop_toTopOf="parent"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintBottom_toBottomOf="parent" />
+
+  <androidx.constraintlayout.widget.ConstraintLayout
+      android:id="@+id/legContainerOne"
+      android:layout_width="0dp"
+      android:layout_height="wrap_content"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintBottom_toTopOf="@id/legContainerTwo"
+      >
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/routeLegOne"
+        android:layout_width="100dp"
+        android:layout_height="0dp"
+        android:text="Route Leg 1"
+        android:textSize="14sp"
+        android:textStyle="bold"
+        android:gravity="center"
+        android:background="@color/secondaryVariant"
+        android:textColor="@android:color/black"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/legOverviewOne"
+        app:layout_constraintTop_toTopOf="@id/legOverviewOne"
+        app:layout_constraintBottom_toBottomOf="@id/legOverviewOne"/>
+
+    <com.mapbox.navigation.ui.tripprogress.view.MapboxTripProgressView
+        android:id="@+id/legOverviewOne"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:padding="4dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/routeLegOne"
+        app:layout_constraintBottom_toBottomOf="parent"/>
+
+  </androidx.constraintlayout.widget.ConstraintLayout>
+
+  <androidx.constraintlayout.widget.ConstraintLayout
+      android:id="@+id/legContainerTwo"
+      android:layout_width="0dp"
+      android:layout_height="wrap_content"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintBottom_toTopOf="@id/tripContainer"
+      >
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/routeLegTwo"
+        android:layout_width="100dp"
+        android:layout_height="0dp"
+        android:text="Route Leg 2"
+        android:textSize="14sp"
+        android:textStyle="bold"
+        android:gravity="center"
+        android:background="@android:color/white"
+        android:textColor="@android:color/black"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/legOverviewTwo"
+        app:layout_constraintTop_toTopOf="@id/legOverviewTwo"
+        app:layout_constraintBottom_toBottomOf="@id/legOverviewTwo"/>
+
+    <com.mapbox.navigation.ui.tripprogress.view.MapboxTripProgressView
+        android:id="@+id/legOverviewTwo"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:padding="4dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/routeLegTwo"
+        app:layout_constraintBottom_toBottomOf="parent" />
+
+  </androidx.constraintlayout.widget.ConstraintLayout>
+
+  <androidx.constraintlayout.widget.ConstraintLayout
+      android:id="@+id/tripContainer"
+      android:layout_width="0dp"
+      android:layout_height="wrap_content"
+      android:background="@color/secondaryVariant"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintBottom_toBottomOf="parent"
+      >
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/tripOverviewText"
+        android:layout_width="100dp"
+        android:layout_height="0dp"
+        android:text="Total Trip"
+        android:textSize="14sp"
+        android:textStyle="bold"
+        android:gravity="center"
+        android:background="@color/secondaryVariant"
+        android:textColor="@android:color/black"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/tripOverview"
+        app:layout_constraintTop_toTopOf="@id/tripOverview"
+        app:layout_constraintBottom_toBottomOf="@id/tripOverview"/>
+
+    <com.mapbox.navigation.ui.tripprogress.view.MapboxTripProgressView
+        android:id="@+id/tripOverview"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:padding="4dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/tripOverviewText"
+        app:layout_constraintBottom_toBottomOf="parent"/>
+  </androidx.constraintlayout.widget.ConstraintLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/qa-test-app/src/main/res/values/strings.xml
+++ b/qa-test-app/src/main/res/values/strings.xml
@@ -18,6 +18,7 @@
     <string name="feedback_activity_description" translatable="false">Screen to test feedback in ActiveGuidance and FreeDrive. Click on "START NAVIGATION" button to start FreeDrive session or long click on the map to get a route from current location to tapped and then click "START NAVIGATION" button to start ActiveGuidance session. Then you can observe in logcat how feedback is sent by clicking on `Feedback` button on the screen.</string>
     <string name="status_activity_description" translatable="false">Screen to test StatusView.</string>
     <string name="icons_preview_activity_description" translatable="false">Screen for viewing SDK icons.</string>
+    <string name="trip_overview_activity_description" translatable="false">Visualize trip and leg overview.</string>
     <string name="upcoming_bridge" translatable="false">Upcoming bridge in %1$s</string>
     <string name="no_upcoming_bridge" translatable="false">No upcoming bridge</string>
     <string name="upcoming_border_crossing" translatable="false">Upcoming border crossing in %1$s</string>


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Fixes https://github.com/mapbox/navigation-sdks/issues/1838

The fix introduces a new API `getTripDetails(route)` that could be used to visualize trip details along each leg of the route. In case there are multiple legs in a route, the API will allow users to display the `totalTime`, `totalDistance` and `totalETA` for the entire route. There is no specific UI on any examples for demonstration, but the image below will help to visualize the idea.

I found it simple to introduce a new model `TripDetailsValue` and a function `MapboxTripProgressView#renderTripDetails` without touching `TripProgressUpdateValue` since it is very much built for `RouteProgress` and it is difficult to change the object without breaking it. However, it's not impossible, but a lot of the fields in `TripProgressUpdateValue` would not make sense for the functionality exposed here and would have to be made either `nullable` or hold default values.

### Screenshot

<img src="https://user-images.githubusercontent.com/9770186/179859115-905f4272-7aa7-49a3-a0ea-259544eb6f26.jpg" width="250" />

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
