### PR TITLE
[Drop-In UI] Suspending actions support

### DIFF
--- a/libnavui-app/src/main/java/com/mapbox/navigation/ui/app/internal/ThunkActions.kt
+++ b/libnavui-app/src/main/java/com/mapbox/navigation/ui/app/internal/ThunkActions.kt
@@ -1,0 +1,81 @@
+package com.mapbox.navigation.ui.app.internal
+
+import com.mapbox.navigation.ui.app.internal.destination.DestinationAction
+import com.mapbox.navigation.ui.app.internal.extension.ThunkAction
+import com.mapbox.navigation.ui.app.internal.navigation.NavigationState
+import com.mapbox.navigation.ui.app.internal.navigation.NavigationStateAction
+import com.mapbox.navigation.ui.app.internal.routefetch.RoutePreviewAction
+import com.mapbox.navigation.ui.app.internal.routefetch.RoutePreviewState
+import com.mapbox.navigation.ui.app.internal.routefetch.RoutesAction
+import com.mapbox.navigation.utils.internal.ifNonNull
+import com.mapbox.navigation.utils.internal.toPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.takeWhile
+import kotlinx.coroutines.launch
+
+/**
+ * End Navigation ThunkAction creator.
+ */
+fun endNavigation() = ThunkAction { store ->
+    store.dispatch(RoutesAction.SetRoutes(emptyList()))
+    store.dispatch(RoutePreviewAction.Ready(emptyList()))
+    store.dispatch(DestinationAction.SetDestination(null))
+    store.dispatch(NavigationStateAction.Update(NavigationState.FreeDrive))
+}
+
+/**
+ * Show Route Preview ThunkAction creator.
+ */
+fun CoroutineScope.showRoutePreview() = fetchRouteAndContinue { store ->
+    store.dispatch(NavigationStateAction.Update(NavigationState.RoutePreview))
+}
+
+/**
+ * Start Active Navigation ThunkAction creator.
+ */
+fun CoroutineScope.startActiveNavigation() = fetchRouteAndContinue { store ->
+    if (store.state.value.previewRoutes is RoutePreviewState.Ready) {
+        store.dispatch(
+            RoutesAction.SetRoutes(
+                (store.state.value.previewRoutes as RoutePreviewState.Ready).routes
+            )
+        )
+        store.dispatch(NavigationStateAction.Update(NavigationState.ActiveNavigation))
+    }
+}
+
+private fun CoroutineScope.fetchRouteAndContinue(continuation: (Store) -> Unit) =
+    ThunkAction { store ->
+        launch {
+            if (fetchRouteIfNeeded(store)) {
+                continuation(store)
+            }
+        }
+    }
+
+/**
+ * Dispatch FetchPoints action and wait for RoutePreviewState.Ready.
+ * Method returns immediately if already in RoutePreviewState.Ready or RoutePreviewState.Fetching, or if
+ * required location or destination data is missing.
+ *
+ * @return `true` once in RoutePreviewState.Ready state, otherwise `false`
+ */
+private suspend fun fetchRouteIfNeeded(store: Store): Boolean {
+    val storeState = store.state.value
+    if (storeState.previewRoutes is RoutePreviewState.Ready) return true
+    if (storeState.previewRoutes is RoutePreviewState.Fetching) return false
+
+    return ifNonNull(
+        storeState.location?.enhancedLocation?.toPoint(),
+        storeState.destination
+    ) { lastPoint, destination ->
+        store.dispatch(RoutePreviewAction.FetchPoints(listOf(lastPoint, destination.point)))
+        store.waitWhileFetching()
+        store.state.value.previewRoutes is RoutePreviewState.Ready
+    } ?: false
+}
+
+private suspend fun Store.waitWhileFetching() {
+    select { it.previewRoutes }.takeWhile { it is RoutePreviewState.Fetching }.collect()
+}

--- a/libnavui-app/src/main/java/com/mapbox/navigation/ui/app/internal/controller/StateResetController.kt
+++ b/libnavui-app/src/main/java/com/mapbox/navigation/ui/app/internal/controller/StateResetController.kt
@@ -5,11 +5,8 @@ import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.internal.extensions.flowTripSessionState
 import com.mapbox.navigation.core.trip.session.TripSessionState
 import com.mapbox.navigation.ui.app.internal.Store
-import com.mapbox.navigation.ui.app.internal.destination.DestinationAction
-import com.mapbox.navigation.ui.app.internal.navigation.NavigationState
-import com.mapbox.navigation.ui.app.internal.navigation.NavigationStateAction
-import com.mapbox.navigation.ui.app.internal.routefetch.RoutePreviewAction
-import com.mapbox.navigation.ui.app.internal.routefetch.RoutesAction
+import com.mapbox.navigation.ui.app.internal.endNavigation
+import com.mapbox.navigation.ui.app.internal.extension.dispatch
 import com.mapbox.navigation.ui.base.lifecycle.UIComponent
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.debounce
@@ -27,10 +24,7 @@ internal class StateResetController(private val store: Store) : UIComponent() {
         mapboxNavigation.flowTripSessionState().debounce(100).observe { newState ->
             if (prevState == TripSessionState.STARTED && newState == TripSessionState.STOPPED) {
                 // we only reset Store state when TripSessionState switches from STARTED to STOPPED.
-                store.dispatch(RoutesAction.SetRoutes(emptyList()))
-                store.dispatch(RoutePreviewAction.Ready(emptyList()))
-                store.dispatch(DestinationAction.SetDestination(null))
-                store.dispatch(NavigationStateAction.Update(NavigationState.FreeDrive))
+                store.dispatch(endNavigation())
             }
             prevState = newState
         }

--- a/libnavui-app/src/main/java/com/mapbox/navigation/ui/app/internal/extension/StoreSaga.kt
+++ b/libnavui-app/src/main/java/com/mapbox/navigation/ui/app/internal/extension/StoreSaga.kt
@@ -1,0 +1,73 @@
+package com.mapbox.navigation.ui.app.internal.extension
+
+import com.mapbox.navigation.ui.app.internal.Action
+import com.mapbox.navigation.ui.app.internal.Middleware
+import com.mapbox.navigation.ui.app.internal.State
+import com.mapbox.navigation.ui.app.internal.Store
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+
+/**
+ * Delays coroutine until an [Action] that matches the [predicate] has been dispatched
+ * to the receiving [Store].
+ */
+suspend fun Store.takeAction(predicate: (action: Action) -> Boolean): Action =
+    suspendCancellableCoroutine { cont ->
+        val m = object : Middleware {
+            override fun onDispatch(state: State, action: Action): Boolean {
+                if (predicate(action)) {
+                    cont.resume(action)
+                    unregisterMiddleware(this)
+                }
+                return false
+            }
+        }
+        registerMiddleware(m)
+        cont.invokeOnCancellation { unregisterMiddleware(m) }
+    }
+
+/**
+ * Delays coroutine until an [Action] of a type T has been dispatched to the receiving [Store].
+ *
+ * It is a shorthand for `store.takeAction { it is MyAction }`.
+ */
+suspend inline fun <reified T : Action> Store.takeAction(): T =
+    takeAction { it is T } as T
+
+/**
+ * Create an instance of a cold Flow with all Actions dispatched to the receiving Store.
+ *
+ * The resulting flow is cold, which means it will contain only dispatched actions since
+ * a terminal operator was applied to the returned flow.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+fun Store.actionsFlowable(): Flow<Action> = callbackFlow {
+    val m = object : Middleware {
+        override fun onDispatch(state: State, action: Action): Boolean {
+            trySend(action)
+            return false
+        }
+    }
+    registerMiddleware(m)
+    awaitClose { unregisterMiddleware(m) }
+}
+
+/**
+ * Terminal flow operator that collects only latest Action of type [T] from the receiving Flow.
+ *
+ * Just like [Flow.collectLatest], the action block for the previous value is cancelled
+ * when the original flow emits a new value.
+ *
+ * It is a shorthand for `flow.filterIsInstance<MyAction>().collectLatest { block(it) }`.
+ */
+suspend inline fun <reified T : Action> Flow<Action>.collectLatestAction(
+    crossinline block: suspend (T) -> Unit
+) {
+    filterIsInstance<T>().collectLatest { block(it) }
+}

--- a/libnavui-app/src/main/java/com/mapbox/navigation/ui/app/internal/extension/StoreThunk.kt
+++ b/libnavui-app/src/main/java/com/mapbox/navigation/ui/app/internal/extension/StoreThunk.kt
@@ -1,0 +1,21 @@
+package com.mapbox.navigation.ui.app.internal.extension
+
+import com.mapbox.navigation.ui.app.internal.Store
+
+/**
+ * Interface that describes "thunk" actions.
+ */
+fun interface ThunkAction {
+    /**
+     * Thunk actions accept [Store] reference that can be used to access current [Store.state] and
+     * [Store.dispatch] for notifying of a computation result.
+     */
+    operator fun invoke(store: Store)
+}
+
+/**
+ * Extension that allows dispatching ThunkActions.
+ */
+fun Store.dispatch(thunkAction: ThunkAction) {
+    thunkAction(this)
+}

--- a/libnavui-app/src/main/java/com/mapbox/navigation/ui/app/internal/routefetch/RoutePreviewAction.kt
+++ b/libnavui-app/src/main/java/com/mapbox/navigation/ui/app/internal/routefetch/RoutePreviewAction.kt
@@ -45,4 +45,10 @@ sealed class RoutePreviewAction : Action {
         val routeOptions: RouteOptions,
         val routerOrigin: RouterOrigin
     ) : RoutePreviewAction()
+
+    /**
+     * The actions informs that fetch route request has started.
+     * @param requestId of the route requested
+     */
+    data class StartedFetchRequest(val requestId: Long) : RoutePreviewAction()
 }

--- a/libnavui-app/src/test/java/com/mapbox/navigation/ui/app/internal/StoreTest.kt
+++ b/libnavui-app/src/test/java/com/mapbox/navigation/ui/app/internal/StoreTest.kt
@@ -1,15 +1,17 @@
-package com.mapbox.navigation.dropin.model
+package com.mapbox.navigation.ui.app.internal
 
 import com.mapbox.geojson.Point
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
-import com.mapbox.navigation.dropin.util.TestStore
 import com.mapbox.navigation.testing.MainCoroutineRule
-import com.mapbox.navigation.ui.app.internal.Reducer
-import com.mapbox.navigation.ui.app.internal.State
+import com.mapbox.navigation.ui.app.internal.camera.CameraAction
+import com.mapbox.navigation.ui.app.internal.camera.TargetCameraMode
 import com.mapbox.navigation.ui.app.internal.destination.Destination
+import com.mapbox.navigation.ui.app.internal.destination.DestinationAction
 import com.mapbox.navigation.ui.app.internal.navigation.NavigationState
 import com.mapbox.navigation.ui.app.internal.navigation.NavigationStateAction
 import com.mapbox.navigation.ui.app.internal.routefetch.RoutePreviewState
+import com.mapbox.navigation.ui.app.testing.TestReducer
+import com.mapbox.navigation.ui.app.testing.TestStore
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -17,7 +19,9 @@ import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -103,5 +107,27 @@ internal class StoreTest {
 
         sut.reset()
         assertEquals(State(), sut.state.value)
+    }
+
+    @Test
+    fun `should allow action intercept with Middleware`() {
+        val middleware = object : Middleware {
+            override fun onDispatch(state: State, action: Action): Boolean {
+                return (action is DestinationAction.SetDestination)
+            }
+        }
+        val reducer = TestReducer()
+        sut.registerMiddleware(middleware)
+        sut.register(reducer)
+
+        val action1 = DestinationAction.SetDestination(
+            Destination(Point.fromLngLat(1.0, 2.0))
+        )
+        val action2 = CameraAction.SetCameraMode(TargetCameraMode.Overview)
+        sut.dispatch(action1)
+        sut.dispatch(action2)
+
+        assertFalse(action1 in reducer.actions)
+        assertTrue(action2 in reducer.actions)
     }
 }

--- a/libnavui-app/src/test/java/com/mapbox/navigation/ui/app/internal/controller/RoutePreviewStateControllerTest.kt
+++ b/libnavui-app/src/test/java/com/mapbox/navigation/ui/app/internal/controller/RoutePreviewStateControllerTest.kt
@@ -12,6 +12,7 @@ import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesObserver
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationApp
 import com.mapbox.navigation.testing.MainCoroutineRule
+import com.mapbox.navigation.ui.app.internal.destination.DestinationAction
 import com.mapbox.navigation.ui.app.internal.routefetch.RoutePreviewAction
 import com.mapbox.navigation.ui.app.internal.routefetch.RoutePreviewState
 import com.mapbox.navigation.ui.app.testing.TestStore
@@ -56,7 +57,84 @@ internal class RoutePreviewStateControllerTest {
     }
 
     @Test
-    fun `RoutesAction Ready with an empty list should result in Empty state`() {
+    @Suppress("MaxLineLength")
+    fun `onAttached should cancel previous route requests when FetchPoints action is dispatched`() {
+        val points = listOf(
+            Point.fromLngLat(1.0, 1.0),
+            Point.fromLngLat(2.0, 2.0)
+        )
+        val mapboxNavigation = mockMapboxNavigation()
+        every {
+            mapboxNavigation.requestRoutes(any(), ofType(NavigationRouterCallback::class))
+        } returnsMany listOf(1L, 2L, 3L)
+
+        sut.onAttached(mapboxNavigation)
+        store.dispatch(RoutePreviewAction.FetchPoints(points))
+        store.dispatch(RoutePreviewAction.FetchPoints(points))
+
+        verify { mapboxNavigation.cancelRouteRequest(1L) }
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `onAttached should cancel previous route requests when SetDestination action is dispatched`() {
+        val points = listOf(
+            Point.fromLngLat(1.0, 1.0),
+            Point.fromLngLat(2.0, 2.0)
+        )
+        val mapboxNavigation = mockMapboxNavigation()
+        every {
+            mapboxNavigation.requestRoutes(any(), ofType(NavigationRouterCallback::class))
+        } returnsMany listOf(1L, 2L, 3L)
+
+        sut.onAttached(mapboxNavigation)
+        store.dispatch(RoutePreviewAction.FetchPoints(points))
+        store.dispatch(DestinationAction.SetDestination(null))
+
+        verify { mapboxNavigation.cancelRouteRequest(1L) }
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `onAttached should cancel previous route requests when FetchOptions action is dispatched`() {
+        val mapboxNavigation = mockMapboxNavigation()
+        every {
+            mapboxNavigation.requestRoutes(any(), ofType(NavigationRouterCallback::class))
+        } returnsMany listOf(1L, 2L, 3L)
+
+        sut.onAttached(mapboxNavigation)
+        store.dispatch(RoutePreviewAction.FetchOptions(mockk()))
+        store.dispatch(RoutePreviewAction.FetchOptions(mockk()))
+
+        verify { mapboxNavigation.cancelRouteRequest(1L) }
+    }
+
+    @Test
+    fun `should dispatch StartedFetchRequest when fetching routes`() {
+        val mapboxNavigation = mockMapboxNavigation()
+        every {
+            mapboxNavigation.requestRoutes(any(), ofType(NavigationRouterCallback::class))
+        } returns 1L
+
+        sut.onAttached(mapboxNavigation)
+        store.dispatch(RoutePreviewAction.FetchOptions(mockk()))
+
+        verify { store.dispatch(RoutePreviewAction.StartedFetchRequest(1L)) }
+    }
+
+    @Test
+    fun `RoutePreviewAction StartedFetchRequest should save requestId in the store`() {
+        val mapboxNavigation = mockMapboxNavigation()
+        sut.onAttached(mapboxNavigation)
+
+        store.dispatch(RoutePreviewAction.StartedFetchRequest(1L))
+
+        val requestId = (store.state.value.previewRoutes as RoutePreviewState.Fetching).requestId
+        assertEquals(1L, requestId)
+    }
+
+    @Test
+    fun `RoutePreviewAction Ready with an empty list should result in Empty state`() {
         val mapboxNavigation = mockMapboxNavigation()
         every { mapboxNavigation.registerRoutesObserver(any()) } answers {
             firstArg<RoutesObserver>().onRoutesChanged(
@@ -72,7 +150,7 @@ internal class RoutePreviewStateControllerTest {
     }
 
     @Test
-    fun `RoutesAction FetchPoints will request routes with default options`() {
+    fun `RoutePreviewAction FetchPoints will request routes with default options`() {
         val mapboxNavigation = mockMapboxNavigation()
 
         sut.onAttached(mapboxNavigation)
@@ -83,7 +161,7 @@ internal class RoutePreviewStateControllerTest {
     }
 
     @Test
-    fun `RoutesAction FetchPoints is canceled when onDetached is called`() {
+    fun `RoutePreviewAction FetchPoints is canceled when onDetached is called`() {
         val mapboxNavigation = mockMapboxNavigation()
         every { mapboxNavigation.requestRoutes(any(), any<NavigationRouterCallback>()) } answers {
             123L
@@ -97,7 +175,7 @@ internal class RoutePreviewStateControllerTest {
     }
 
     @Test
-    fun `RoutesAction FetchPoints will cancel previous`() {
+    fun `RoutePreviewAction FetchPoints will cancel previous`() {
         val mapboxNavigation = mockMapboxNavigation()
 
         sut.onAttached(mapboxNavigation)
@@ -108,7 +186,7 @@ internal class RoutePreviewStateControllerTest {
     }
 
     @Test
-    fun `RoutesAction FetchPoints will go to Ready state when onRoutesReady`() {
+    fun `RoutePreviewAction FetchPoints will go to Ready state when onRoutesReady`() {
         val mapboxNavigation = mockMapboxNavigation()
         val routes = listOf<NavigationRoute>(mockk())
         val callbackSlot = slot<NavigationRouterCallback>()
@@ -126,7 +204,7 @@ internal class RoutePreviewStateControllerTest {
     }
 
     @Test
-    fun `RoutesAction FetchPoints will go to Failed state when onFailure`() {
+    fun `RoutePreviewAction FetchPoints will go to Failed state when onFailure`() {
         val mapboxNavigation = mockMapboxNavigation()
         val reasons = listOf<RouterFailure>(mockk())
         val routeOptions = mockk<RouteOptions>()
@@ -146,7 +224,7 @@ internal class RoutePreviewStateControllerTest {
     }
 
     @Test
-    fun `RoutesAction FetchPoints will go to Canceled state when onCanceled`() {
+    fun `RoutePreviewAction FetchPoints will go to Canceled state when onCanceled`() {
         val mapboxNavigation = mockMapboxNavigation()
         val routeOptions = mockk<RouteOptions>()
         val routerOrigin = mockk<RouterOrigin>()
@@ -162,11 +240,10 @@ internal class RoutePreviewStateControllerTest {
         assertNotNull(readyState)
         assertEquals(readyState?.routeOptions, routeOptions)
         assertEquals(readyState?.routerOrigin, routerOrigin)
-        verify(exactly = 0) { mapboxNavigation.cancelRouteRequest(123L) }
     }
 
     @Test
-    fun `RoutesAction FetchOptions will request routes with the options`() {
+    fun `RoutePreviewAction FetchOptions will request routes with the options`() {
         val mapboxNavigation = mockMapboxNavigation()
         val routeOptions = mockk<RouteOptions>()
 
@@ -178,7 +255,7 @@ internal class RoutePreviewStateControllerTest {
     }
 
     @Test
-    fun `RoutesAction FetchOptions is canceled when onDetached is called`() {
+    fun `RoutePreviewAction FetchOptions is canceled when onDetached is called`() {
         val mapboxNavigation = mockMapboxNavigation()
         every { mapboxNavigation.requestRoutes(any(), any<NavigationRouterCallback>()) } answers {
             123L
@@ -192,7 +269,7 @@ internal class RoutePreviewStateControllerTest {
     }
 
     @Test
-    fun `RoutesAction FetchOptions will go to Ready state when onRoutesReady`() {
+    fun `RoutePreviewAction FetchOptions will go to Ready state when onRoutesReady`() {
         val mapboxNavigation = mockMapboxNavigation()
         val routes = listOf<NavigationRoute>(mockk())
         val callbackSlot = slot<NavigationRouterCallback>()
@@ -209,7 +286,7 @@ internal class RoutePreviewStateControllerTest {
     }
 
     @Test
-    fun `RoutesAction FetchOptions will go to Failed state when onFailure`() {
+    fun `RoutePreviewAction FetchOptions will go to Failed state when onFailure`() {
         val mapboxNavigation = mockMapboxNavigation()
         val reasons = listOf<RouterFailure>(mockk())
         val routeOptions = mockk<RouteOptions>()
@@ -227,7 +304,7 @@ internal class RoutePreviewStateControllerTest {
     }
 
     @Test
-    fun `RoutesAction FetchOptions will go to Canceled state when onCanceled`() {
+    fun `RoutePreviewAction FetchOptions will go to Canceled state when onCanceled`() {
         val mapboxNavigation = mockMapboxNavigation()
         val routeOptions = mockk<RouteOptions>()
         val routerOrigin = mockk<RouterOrigin>()

--- a/libnavui-app/src/test/java/com/mapbox/navigation/ui/app/internal/extension/StoreSagaKtTest.kt
+++ b/libnavui-app/src/test/java/com/mapbox/navigation/ui/app/internal/extension/StoreSagaKtTest.kt
@@ -1,0 +1,58 @@
+package com.mapbox.navigation.ui.app.internal.extension
+
+import com.mapbox.navigation.ui.app.internal.Action
+import com.mapbox.navigation.ui.app.testing.TestMiddleware
+import com.mapbox.navigation.ui.app.testing.TestStore
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.yield
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class StoreSagaKtTest {
+
+    private lateinit var store: TestStore
+
+    @Before
+    fun setUp() {
+        store = TestStore()
+    }
+
+    @Test
+    fun `takeAction - should delay coroutine until action is dispatched`() = runBlockingTest {
+        val middleware = TestMiddleware()
+        store.registerMiddleware(middleware)
+
+        launch {
+            store.takeAction<Action1>() // wait for Action1
+            yield() // yielding to allow outer coroutine to resume
+            store.dispatch(Action2)
+        }
+        store.dispatch(Action1)
+        store.takeAction<Action2>() // wait for Action2
+
+        assertEquals(listOf(Action1, Action2), middleware.actions)
+    }
+
+    @Test
+    fun `actionsFlowable - should return cold flowable with dispatched actions`() =
+        runBlockingTest {
+            val actions = mutableListOf<Action>()
+            val job = launch {
+                store.actionsFlowable().take(2).toList(actions)
+            }
+            store.dispatch(Action1)
+            store.dispatch(Action2)
+            job.join()
+
+            assertEquals(listOf(Action1, Action2), actions)
+        }
+
+    private object Action1 : Action
+    private object Action2 : Action
+}

--- a/libnavui-app/src/test/java/com/mapbox/navigation/ui/app/internal/extension/StoreThunkKtTest.kt
+++ b/libnavui-app/src/test/java/com/mapbox/navigation/ui/app/internal/extension/StoreThunkKtTest.kt
@@ -1,0 +1,39 @@
+package com.mapbox.navigation.ui.app.internal.extension
+
+import com.mapbox.navigation.ui.app.internal.Action
+import com.mapbox.navigation.ui.app.testing.TestReducer
+import com.mapbox.navigation.ui.app.testing.TestStore
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+internal class StoreThunkKtTest {
+
+    private lateinit var sut: TestStore
+
+    @Before
+    fun setUp() {
+        sut = TestStore()
+    }
+
+    @Test
+    fun `should allow dispatch of ThunkActions`() {
+        val action1 = object : Action {}
+        val action2 = object : Action {}
+        val action3 = object : Action {}
+        val reducer = TestReducer()
+        sut.register(reducer)
+
+        sut.dispatch(
+            ThunkAction {
+                it.dispatch(action1)
+                it.dispatch(action2)
+                it.dispatch(action3)
+            }
+        )
+
+        assertTrue(action1 in reducer.actions)
+        assertTrue(action2 in reducer.actions)
+        assertTrue(action3 in reducer.actions)
+    }
+}

--- a/libnavui-app/src/test/java/com/mapbox/navigation/ui/app/testing/TestMiddleware.kt
+++ b/libnavui-app/src/test/java/com/mapbox/navigation/ui/app/testing/TestMiddleware.kt
@@ -1,0 +1,17 @@
+package com.mapbox.navigation.ui.app.testing
+
+import com.mapbox.navigation.ui.app.internal.Action
+import com.mapbox.navigation.ui.app.internal.Middleware
+import com.mapbox.navigation.ui.app.internal.State
+
+/**
+ * Middleware that records all dispatched actions.
+ */
+class TestMiddleware : Middleware {
+    val actions = mutableListOf<Action>()
+
+    override fun onDispatch(state: State, action: Action): Boolean {
+        actions.add(action)
+        return false
+    }
+}

--- a/libnavui-app/src/test/java/com/mapbox/navigation/ui/app/testing/TestReducer.kt
+++ b/libnavui-app/src/test/java/com/mapbox/navigation/ui/app/testing/TestReducer.kt
@@ -1,0 +1,17 @@
+package com.mapbox.navigation.ui.app.testing
+
+import com.mapbox.navigation.ui.app.internal.Action
+import com.mapbox.navigation.ui.app.internal.Reducer
+import com.mapbox.navigation.ui.app.internal.State
+
+/**
+ * Reducer that records all dispatched actions.
+ */
+internal class TestReducer : Reducer {
+    val actions = mutableListOf<Action>()
+
+    override fun process(state: State, action: Action): State {
+        actions.add(action)
+        return state
+    }
+}

--- a/libnavui-app/src/test/java/com/mapbox/navigation/ui/app/testing/TestStore.kt
+++ b/libnavui-app/src/test/java/com/mapbox/navigation/ui/app/testing/TestStore.kt
@@ -10,4 +10,8 @@ internal class TestStore : Store() {
     fun setState(state: State) {
         _state.value = state
     }
+
+    fun updateState(update: (State) -> State) {
+        setState(update(_state.value))
+    }
 }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewListenerRegistry.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewListenerRegistry.kt
@@ -60,7 +60,9 @@ internal class NavigationViewListenerRegistry(
                             )
                         }
                         is RoutePreviewState.Fetching -> {
-                            listener.onRouteFetching(requestId = it.requestId)
+                            if (0 < it.requestId) {
+                                listener.onRouteFetching(requestId = it.requestId)
+                            }
                         }
                     }
                 }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/infopanel/InfoPanelHeaderComponent.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/infopanel/InfoPanelHeaderComponent.kt
@@ -6,19 +6,14 @@ import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.dropin.R
 import com.mapbox.navigation.dropin.databinding.MapboxInfoPanelHeaderLayoutBinding
+import com.mapbox.navigation.dropin.internal.extensions.onClick
 import com.mapbox.navigation.ui.app.internal.Store
-import com.mapbox.navigation.ui.app.internal.destination.DestinationAction
+import com.mapbox.navigation.ui.app.internal.endNavigation
+import com.mapbox.navigation.ui.app.internal.extension.dispatch
 import com.mapbox.navigation.ui.app.internal.navigation.NavigationState
-import com.mapbox.navigation.ui.app.internal.navigation.NavigationStateAction
-import com.mapbox.navigation.ui.app.internal.routefetch.RoutePreviewAction
-import com.mapbox.navigation.ui.app.internal.routefetch.RoutePreviewState
-import com.mapbox.navigation.ui.app.internal.routefetch.RoutesAction
+import com.mapbox.navigation.ui.app.internal.showRoutePreview
+import com.mapbox.navigation.ui.app.internal.startActiveNavigation
 import com.mapbox.navigation.ui.base.lifecycle.UIComponent
-import com.mapbox.navigation.utils.internal.ifNonNull
-import com.mapbox.navigation.utils.internal.toPoint
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.takeWhile
-import kotlinx.coroutines.launch
 
 @ExperimentalPreviewMapboxNavigationAPI
 internal class InfoPanelHeaderComponent(
@@ -57,61 +52,16 @@ internal class InfoPanelHeaderComponent(
                 ?: resources.getString(R.string.mapbox_drop_in_dropped_pin)
         }
 
-        binding.routePreview.setOnClickListener {
-            coroutineScope.launch {
-                if (fetchRouteIfNeeded()) {
-                    store.dispatch(NavigationStateAction.Update(NavigationState.RoutePreview))
-                }
-            }
+        binding.routePreview.onClick(coroutineScope) {
+            store.dispatch(showRoutePreview())
         }
 
-        binding.startNavigation.setOnClickListener {
-            coroutineScope.launch {
-                if (
-                    fetchRouteIfNeeded() &&
-                    store.state.value.previewRoutes is RoutePreviewState.Ready
-                ) {
-                    store.dispatch(
-                        RoutesAction.SetRoutes(
-                            (store.state.value.previewRoutes as RoutePreviewState.Ready).routes
-                        )
-                    )
-                    store.dispatch(NavigationStateAction.Update(NavigationState.ActiveNavigation))
-                }
-            }
+        binding.startNavigation.onClick(coroutineScope) {
+            store.dispatch(startActiveNavigation())
         }
 
-        binding.endNavigation.setOnClickListener {
-            store.dispatch(RoutesAction.SetRoutes(emptyList()))
-            store.dispatch(RoutePreviewAction.Ready(emptyList()))
-            store.dispatch(DestinationAction.SetDestination(null))
-            store.dispatch(NavigationStateAction.Update(NavigationState.FreeDrive))
+        binding.endNavigation.onClick(coroutineScope) {
+            store.dispatch(endNavigation())
         }
-    }
-
-    /**
-     * Dispatch FetchPoints action and wait for RoutePreviewState.Ready.
-     * Method returns immediately if already in RoutePreviewState.Ready or RoutePreviewState.Fetching, or if
-     * required location or destination data is missing.
-     *
-     * @return `true` once in RoutePreviewState.Ready state, otherwise `false`
-     */
-    private suspend fun fetchRouteIfNeeded(): Boolean {
-        val storeState = store.state.value
-        if (storeState.previewRoutes is RoutePreviewState.Ready) return true
-        if (storeState.previewRoutes is RoutePreviewState.Fetching) return false
-
-        return ifNonNull(
-            storeState.location?.enhancedLocation?.toPoint(),
-            storeState.destination
-        ) { lastPoint, destination ->
-            store.dispatch(RoutePreviewAction.FetchPoints(listOf(lastPoint, destination.point)))
-            waitForReady()
-        } ?: false
-    }
-
-    private suspend fun waitForReady(): Boolean {
-        store.select { it.previewRoutes }.takeWhile { it is RoutePreviewState.Fetching }.collect()
-        return store.state.value.previewRoutes is RoutePreviewState.Ready
     }
 }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/internal/extensions/ViewEx.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/internal/extensions/ViewEx.kt
@@ -1,0 +1,28 @@
+package com.mapbox.navigation.dropin.internal.extensions
+
+import android.view.View
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.actor
+
+/**
+ * OnClick extension function that uses the actor coroutine to control how the [handler] processes
+ * the OnClick events. When a receiving view is clicked, the event is sent to the actor immediately,
+ * if it is possible, or discards it otherwise. This happens because the actor is busy with
+ * a [handler] coroutine and does not receive from its channel.
+ *
+ * @param scope a CoroutineScope in which the actor coroutine should launch
+ * @param handler the coroutine code which will be invoked when the receiver view is clicked
+ */
+fun View.onClick(scope: CoroutineScope, handler: suspend CoroutineScope.(View) -> Unit) {
+    // launch one actor
+    val eventActor = scope.actor<View>(Dispatchers.Main) {
+        for (event in channel) handler(event)
+    }
+    // install a listener to activate this actor
+    setOnClickListener {
+        // By default, an actor's mailbox is backed by RendezvousChannel,
+        // whose trySend operation succeeds only when the receive is active.
+        eventActor.trySend(it)
+    }
+}

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/NavigationViewListenerRegistryTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/NavigationViewListenerRegistryTest.kt
@@ -289,4 +289,13 @@ class NavigationViewListenerRegistryTest {
             testListener.onInfoPanelCollapsed()
         }
     }
+
+    fun `onRouteFetching should NOT notify listener if requestId is 0`() {
+        sut.registerListener(testListener)
+
+        val id = 0L
+        testStore.setState(State(previewRoutes = RoutePreviewState.Fetching(id)))
+
+        verify(exactly = 0) { testListener.onRouteFetching(id) }
+    }
 }


### PR DESCRIPTION
Closes https://github.com/mapbox/navigation-sdks/issues/1571

### TL;DR
This PR adds two new capabilities to the Store:

1. Allows dispatching "function actions" using Redux like Thunk Actions (https://redux.js.org/usage/writing-logic-thunks#writing-thunks)
  
  ```kotlin
  fun interface ThunkAction : Action {
      operator fun invoke(store: Store)
  }
  
  fun Store.dispatch(thunkAction: ThunkAction) {
      thunkAction(this)
  }
  
  // action creator
  fun CoroutineScope.fetchAndSetRoute(vararg points: Point): ThunkAction {
      return ThunkAction { store ->
          launch {
              val routes = fetchRoute(points)
              // dispatch result as a regular action that will be processed by a Reducer
              store.dispatch(RoutesAction.SetRoutes(routes))
          }
      }
  }
  
  // usage 
  fun demoThunk(store: Store, scope: CoroutineScope) {
      store.dispatch(scope.fetchAndSetRoute(currentLoc, destination))
  }
  
  ```

2. Allows collecting or waiting for dispatched actions using coroutines (see [Redux Saga for more details](https://redux-saga.js.org/docs/api/#takepattern))

  ```kotlin
  internal suspend fun <T: Action> Store.takeAction(actionCls: KClass<T>): T = { ... }

  fun demoSaga(store: Store, scope: CoroutineScope) {
      // launch fetch points saga
      scope.launch {
          while(isActive) {
              // this will suspend until FetchPoints action is dispatched
              val action = store.takeAction(RoutesAction.FetchPoints::class)
              // fetch routes using fetchRoute suspend function
              val routes = mapboxNavigation.fetchRoute(action.points)
              // dispatch result as a regular action that will be processed by a Reducer
              store.dispatch(RoutesAction.SetRoutes(routes))
          }
      }
  }
  
  ```

### Description

- Added `ThunkAction` support to the `Store`.
- Introduced show preview, start active navigation and end navigation thunk actions.
- Introduced `View.onClick` extension function that uses the actor coroutine to control how the event handler processes the OnClick events. 
- Added `Middleware` support to the `Store` that allows pre-processing of dispatched actions before forwarding them to the reducer chain. 
- Added `Saga` support to the `Store`.
- Refactored `RoutesStateController` to use fetchRouteSaga to control route request lifetime.

