### PR TITLE
[build] restore providing module version through command line

### DIFF
--- a/gradle/artifact-settings.gradle
+++ b/gradle/artifact-settings.gradle
@@ -16,6 +16,9 @@ ext {
 }
 
 def getVersionName() {
+    if (project.hasProperty('VERSION_NAME')) {
+      return project.property('VERSION_NAME')
+    }
     def prefix = project.ext.releaseTagPrefix
     def cmd = ["git", "describe", "--tag", "--match", "$prefix*", "--abbrev=0"]
     def version = cmd.execute().text


### PR DESCRIPTION
Fixes #6077, this PR allows to inject a version name through command line:

>    ./gradlew libtrip-notification:publishToMavenLocal -PVERSION_NAME=2.7.0-20220720-085212

While retaining the logic introduced from the [commit](https://github.com/mapbox/mapbox-navigation-android/commit/510ecf7f67b4f672213927cc3dde2ce8d25a8878) that regressed this behavior