### PR TITLE
6080 improve changelog verification

### DIFF
--- a/scripts/test_resources/test_changelog.md
+++ b/scripts/test_resources/test_changelog.md
@@ -1,0 +1,32 @@
+# Changelog for the Mapbox Navigation SDK for Android
+
+Changelog description.
+
+## Unreleased
+#### Features
+- Added first unreleased feature. [#6049](https://github.com/mapbox/mapbox-navigation-android/pull/6049)
+- Added second unreleased feature. [#6048](https://github.com/mapbox/mapbox-navigation-android/pull/6048)
+
+#### Bug fixes and improvements
+- Fixed first unreleased bug. [#6047](https://github.com/mapbox/mapbox-navigation-android/pull/6047)
+- Fixed second unreleased bug. [#6046](https://github.com/mapbox/mapbox-navigation-android/pull/6046)
+
+## Mapbox Navigation SDK 2.7.0-beta.1 - 14 July, 2022
+### Changelog
+[Changes between v2.7.0-alpha.3 and v2.7.0-beta.1](https://github.com/mapbox/mapbox-navigation-android/compare/v2.7.0-alpha.3...v2.7.0-beta.1)
+
+#### Features
+- Added first feature to 2.7.0-beta1. [#6045](https://github.com/mapbox/mapbox-navigation-android/pull/6045)
+
+#### Bug fixes and improvements
+
+## Mapbox Navigation SDK 2.6.0 - July 7, 2022
+### Changelog
+[Changes between v2.5.1 and v2.6.0](https://github.com/mapbox/mapbox-navigation-android/compare/v2.5.1...v2.6.0)
+
+#### Features
+- Added first feature to 2.6.0. [#6014](https://github.com/mapbox/mapbox-navigation-android/pull/6014)
+- Added second feature to 2.6.0. [#6013](https://github.com/mapbox/mapbox-navigation-android/pull/6013)
+
+#### Bug fixes and improvements
+- Fixed first bug in 2.6.0. [#6012](https://github.com/mapbox/mapbox-navigation-android/pull/6012)

--- a/scripts/test_resources/test_changelog_single_line_repeats_stable_version.md
+++ b/scripts/test_resources/test_changelog_single_line_repeats_stable_version.md
@@ -1,0 +1,33 @@
+# Changelog for the Mapbox Navigation SDK for Android
+
+Changelog description.
+
+## Unreleased
+#### Features
+- Added first unreleased feature. [#6049](https://github.com/mapbox/mapbox-navigation-android/pull/6049)
+- Added second unreleased feature. [#6048](https://github.com/mapbox/mapbox-navigation-android/pull/6048)
+- Added second feature to 2.6.0. [#6013](https://github.com/mapbox/mapbox-navigation-android/pull/6013)
+
+#### Bug fixes and improvements
+- Fixed first unreleased bug. [#6047](https://github.com/mapbox/mapbox-navigation-android/pull/6047)
+- Fixed second unreleased bug. [#6046](https://github.com/mapbox/mapbox-navigation-android/pull/6046)
+
+## Mapbox Navigation SDK 2.7.0-beta.1 - 14 July, 2022
+### Changelog
+[Changes between v2.7.0-alpha.3 and v2.7.0-beta.1](https://github.com/mapbox/mapbox-navigation-android/compare/v2.7.0-alpha.3...v2.7.0-beta.1)
+
+#### Features
+- Added first feature to 2.7.0-beta1. [#6045](https://github.com/mapbox/mapbox-navigation-android/pull/6045)
+
+#### Bug fixes and improvements
+
+## Mapbox Navigation SDK 2.6.0 - July 7, 2022
+### Changelog
+[Changes between v2.5.1 and v2.6.0](https://github.com/mapbox/mapbox-navigation-android/compare/v2.5.1...v2.6.0)
+
+#### Features
+- Added first feature to 2.6.0. [#6014](https://github.com/mapbox/mapbox-navigation-android/pull/6014)
+- Added second feature to 2.6.0. [#6013](https://github.com/mapbox/mapbox-navigation-android/pull/6013)
+
+#### Bug fixes and improvements
+- Fixed first bug in 2.6.0. [#6012](https://github.com/mapbox/mapbox-navigation-android/pull/6012)

--- a/scripts/test_resources/test_changelog_single_line_repeats_unstable_version.md
+++ b/scripts/test_resources/test_changelog_single_line_repeats_unstable_version.md
@@ -1,0 +1,33 @@
+# Changelog for the Mapbox Navigation SDK for Android
+
+Changelog description.
+
+## Unreleased
+#### Features
+- Added first unreleased feature. [#6049](https://github.com/mapbox/mapbox-navigation-android/pull/6049)
+- Added second unreleased feature. [#6048](https://github.com/mapbox/mapbox-navigation-android/pull/6048)
+
+#### Bug fixes and improvements
+- Fixed first unreleased bug. [#6047](https://github.com/mapbox/mapbox-navigation-android/pull/6047)
+- Fixed second unreleased bug. [#6046](https://github.com/mapbox/mapbox-navigation-android/pull/6046)
+- Added first feature to 2.7.0-beta1. [#6045](https://github.com/mapbox/mapbox-navigation-android/pull/6045)
+
+## Mapbox Navigation SDK 2.7.0-beta.1 - 14 July, 2022
+### Changelog
+[Changes between v2.7.0-alpha.3 and v2.7.0-beta.1](https://github.com/mapbox/mapbox-navigation-android/compare/v2.7.0-alpha.3...v2.7.0-beta.1)
+
+#### Features
+- Added first feature to 2.7.0-beta1. [#6045](https://github.com/mapbox/mapbox-navigation-android/pull/6045)
+
+#### Bug fixes and improvements
+
+## Mapbox Navigation SDK 2.6.0 - July 7, 2022
+### Changelog
+[Changes between v2.5.1 and v2.6.0](https://github.com/mapbox/mapbox-navigation-android/compare/v2.5.1...v2.6.0)
+
+#### Features
+- Added first feature to 2.6.0. [#6014](https://github.com/mapbox/mapbox-navigation-android/pull/6014)
+- Added second feature to 2.6.0. [#6013](https://github.com/mapbox/mapbox-navigation-android/pull/6013)
+
+#### Bug fixes and improvements
+- Fixed first bug in 2.6.0. [#6012](https://github.com/mapbox/mapbox-navigation-android/pull/6012)

--- a/scripts/validate-changelog-tests.py
+++ b/scripts/validate-changelog-tests.py
@@ -1,0 +1,448 @@
+import unittest
+import validate_changelog_utils
+import os
+
+class TestValidateChangelog(unittest.TestCase):
+
+    def test_should_skip_changelog_no_labels(self):
+        json = {}
+        self.assertEqual(validate_changelog_utils.should_skip_changelog(json), False)
+
+    def test_should_skip_changelog_no_skip_changelog_label(self):
+        json = { "labels": [{ "name": "some label" }] }
+        self.assertEqual(validate_changelog_utils.should_skip_changelog(json), False)
+
+    def test_should_skip_changelog_has_skip_changelog_label(self):
+        json = { "labels": [{"name": "some label"}, {"name": "skip changelog"}] }
+        self.assertEqual(validate_changelog_utils.should_skip_changelog(json), True)
+
+    def test_check_has_changelog_diff_no_diff(self):
+        diff = '''
+        Index: libnavigation-core/src/main/java/com/mapbox/navigation/core/TestClass.kt
+        IDEA additional info:
+        Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+        <+>UTF-8
+        ===================================================================
+        diff --git a/libnavigation-core/src/main/java/com/mapbox/navigation/core/TestClass.kt b/libnavigation-core/src/main/java/com/mapbox/navigation/core/TestClass.kt
+        --- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/TestClass.kt	(revision 25782d7748a343b2e4c85954cfa5c22846343f28)
+        +++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/TestClass.kt	(date 1659101434632)
+        @@ -5,4 +5,6 @@
+             fun testMethod1() {}
+
+             fun testMethod2(a: Int) = a * 10
+        +
+        +    fun testMethod3(): String = ""
+         }
+        '''
+        with self.assertRaises(Exception):
+            validate_changelog_utils.check_has_changelog_diff(diff)
+
+    def test_check_has_changelog_diff_has_diff(self):
+        diff = '''
+        Index: CHANGELOG.md
+        IDEA additional info:
+        Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+        <+>UTF-8
+        ===================================================================
+        diff --git a/CHANGELOG.md b/CHANGELOG.md
+        --- a/CHANGELOG.md	(revision d85b11703af7976027073a5e29ec51ffc2164b6e)
+        +++ b/CHANGELOG.md	(date 1659101554037)
+        @@ -6,6 +6,7 @@
+         #### Features
+         - Added first unreleased feature. [#6049](https://github.com/mapbox/mapbox-navigation-android/pull/6049)
+         - Added second unreleased feature. [#6048](https://github.com/mapbox/mapbox-navigation-android/pull/6048)
+        +- Added third unreleased feature. [#6050](https://github.com/mapbox/mapbox-navigation-android/pull/6050)
+
+         #### Bug fixes and improvements
+         - Fixed first unreleased bug. [#6047](https://github.com/mapbox/mapbox-navigation-android/pull/6047)
+        Index: libnavigation-core/src/main/java/com/mapbox/navigation/core/TestClass.kt
+        IDEA additional info:
+        Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+        <+>UTF-8
+        ===================================================================
+        diff --git a/libnavigation-core/src/main/java/com/mapbox/navigation/core/TestClass.kt b/libnavigation-core/src/main/java/com/mapbox/navigation/core/TestClass.kt
+        --- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/TestClass.kt	(revision 25782d7748a343b2e4c85954cfa5c22846343f28)
+        +++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/TestClass.kt	(date 1659101434632)
+        @@ -5,4 +5,6 @@
+             fun testMethod1() {}
+
+             fun testMethod2(a: Int) = a * 10
+        +
+        +    fun testMethod3(): String = ""
+         }
+        '''
+        validate_changelog_utils.check_has_changelog_diff(diff)
+
+    def test_parse_contents_url_empty_json(self):
+        with self.assertRaises(Exception):
+            validate_changelog_utils.parse_contents_url([])
+
+    def test_parse_contents_url_no_changelog(self):
+        with self.assertRaises(Exception):
+            validate_changelog_utils.parse_contents_url([{ "filename": "not_changelog.md" }])
+
+    def test_parse_contents_url_has_changelog_no_url(self):
+        with self.assertRaises(Exception):
+            validate_changelog_utils.parse_contents_url([{ "filename": "CHANGELOG.md" }])
+
+    def test_parse_contents_url_has_changelog_and_url(self):
+        url = "my url"
+        actual = validate_changelog_utils.parse_contents_url([{ "filename": "CHANGELOG.md", "contents_url": url }])
+        self.assertEqual(actual, url)
+
+    def test_extract_added_lines_only_changelog_nothing_added(self):
+        diff = '''diff --git a/CHANGELOG.md b/CHANGELOG.md
+        --- a/CHANGELOG.md	(revision 145c2d43cb3404f28975538ad440504d5ed74562)
+        +++ b/CHANGELOG.md	(date 1659101646796)
+        @@ -5,7 +5,6 @@
+         ## Unreleased
+         #### Features
+         - Added first unreleased feature. [#6049](https://github.com/mapbox/mapbox-navigation-android/pull/6049)
+        -- Added second unreleased feature. [#6048](https://github.com/mapbox/mapbox-navigation-android/pull/6048)
+
+         #### Bug fixes and improvements
+         - Fixed first unreleased bug. [#6047](https://github.com/mapbox/mapbox-navigation-android/pull/6047)
+        '''
+        self.assertEqual(validate_changelog_utils.extract_added_lines(diff), [])
+
+    def test_extract_added_lines_only_changelog_has_added(self):
+        expected = ['- Added third unreleased feature. [#6050](https://github.com/mapbox/mapbox-navigation-android/pull/6050)']
+        diff = '''diff --git a/CHANGELOG.md b/CHANGELOG.md
+        --- a/CHANGELOG.md	(revision fca6af9072a1b6cb7263460f7c3270e48bffed07)
+        +++ b/CHANGELOG.md	(date 1659101777554)
+        @@ -6,6 +6,7 @@
+         #### Features
+         - Added first unreleased feature. [#6049](https://github.com/mapbox/mapbox-navigation-android/pull/6049)
+         - Added second unreleased feature. [#6048](https://github.com/mapbox/mapbox-navigation-android/pull/6048)
+        +- Added third unreleased feature. [#6050](https://github.com/mapbox/mapbox-navigation-android/pull/6050)
+
+         #### Bug fixes and improvements
+         - Fixed first unreleased bug. [#6047](https://github.com/mapbox/mapbox-navigation-android/pull/6047)
+        '''
+        self.assertEqual(validate_changelog_utils.extract_added_lines(diff), expected)
+
+    def test_extract_added_lines_changelog_in_the_beginning_nothing_added(self):
+        diff = '''
+        Index: CHANGELOG.md
+        IDEA additional info:
+        Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+        <+>UTF-8
+        ===================================================================
+        diff --git a/CHANGELOG.md b/CHANGELOG.md
+        --- a/CHANGELOG.md	(revision 85db37c032b85d89c65f909c65dbf4e36130bc95)
+        +++ b/CHANGELOG.md	(date 1659101873752)
+        @@ -5,7 +5,6 @@
+         ## Unreleased
+         #### Features
+         - Added first unreleased feature. [#6049](https://github.com/mapbox/mapbox-navigation-android/pull/6049)
+        -- Added second unreleased feature. [#6048](https://github.com/mapbox/mapbox-navigation-android/pull/6048)
+
+         #### Bug fixes and improvements
+         - Fixed first unreleased bug. [#6047](https://github.com/mapbox/mapbox-navigation-android/pull/6047)
+        Index: libnavigation-core/src/main/java/com/mapbox/navigation/core/TestClass.kt
+        IDEA additional info:
+        Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+        <+>UTF-8
+        ===================================================================
+        diff --git a/libnavigation-core/src/main/java/com/mapbox/navigation/core/TestClass.kt b/libnavigation-core/src/main/java/com/mapbox/navigation/core/TestClass.kt
+        --- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/TestClass.kt	(revision 85db37c032b85d89c65f909c65dbf4e36130bc95)
+        +++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/TestClass.kt	(date 1659101643213)
+        @@ -4,5 +4,5 @@
+
+             fun testMethod1() {}
+
+        -    fun testMethod2(a: Int) = a * 10
+        +    fun testMethod2(a: Int, b: Int) = a * 10 + b
+         }
+        '''
+        self.assertEqual(validate_changelog_utils.extract_added_lines(diff), [])
+
+    def test_extract_added_lines_changelog_in_the_beginning_has_added(self):
+        expected = [
+        '- Added third unreleased feature. [#6050](https://github.com/mapbox/mapbox-navigation-android/pull/6050)',
+        '- Fixed third unreleased bug. [#6045](https://github.com/mapbox/mapbox-navigation-android/pull/6045)'
+        ]
+        diff = '''
+        Index: CHANGELOG.md
+        IDEA additional info:
+        Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+        <+>UTF-8
+        ===================================================================
+        diff --git a/CHANGELOG.md b/CHANGELOG.md
+        --- a/CHANGELOG.md	(revision 3231aea607a4bc1edc8ee28cf695dfdb06399a30)
+        +++ b/CHANGELOG.md	(date 1659104161551)
+        @@ -6,10 +6,12 @@
+         #### Features
+         - Added first unreleased feature. [#6049](https://github.com/mapbox/mapbox-navigation-android/pull/6049)
+         - Added second unreleased feature. [#6048](https://github.com/mapbox/mapbox-navigation-android/pull/6048)
+        +- Added third unreleased feature. [#6050](https://github.com/mapbox/mapbox-navigation-android/pull/6050)
+
+         #### Bug fixes and improvements
+         - Fixed first unreleased bug. [#6047](https://github.com/mapbox/mapbox-navigation-android/pull/6047)
+         - Fixed second unreleased bug. [#6046](https://github.com/mapbox/mapbox-navigation-android/pull/6046)
+        +- Fixed third unreleased bug. [#6045](https://github.com/mapbox/mapbox-navigation-android/pull/6045)
+
+         ## Mapbox Navigation SDK 2.7.0-beta.1 - 14 July, 2022
+         ### Changelog
+        Index: libnavigation-core/src/main/java/com/mapbox/navigation/core/TestClass.kt
+        IDEA additional info:
+        Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+        <+>UTF-8
+        ===================================================================
+        diff --git a/libnavigation-core/src/main/java/com/mapbox/navigation/core/TestClass.kt b/libnavigation-core/src/main/java/com/mapbox/navigation/core/TestClass.kt
+        --- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/TestClass.kt	(revision b96eff8c2c354263379ca588a17bbf4df6c802b8)
+        +++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/TestClass.kt	(date 1659104022448)
+        @@ -4,5 +4,5 @@
+
+             fun testMethod1() {}
+
+        -    fun testMethod2(a: Int) = a * 10
+        +    fun testMethod2(a: Int, b: Int) = a * 10 + b
+         }
+        '''
+        self.assertEqual(validate_changelog_utils.extract_added_lines(diff), expected)
+
+    def test_extract_added_lines_changelog_in_the_end_nothing_added(self):
+        diff = '''
+        Index: CHANGELOG.md
+        IDEA additional info:
+        Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+        <+>UTF-8
+        ===================================================================
+        diff --git a/.circleci/config2.yml b/.circleci/config2.yml
+        --- a/.circleci/config2.yml	(revision 2f1ddf175da5069b30d519119c52441f74a46974)
+        +++ b/.circleci/config2.yml	(date 1659105154622)
+        @@ -1,0 +1,1 @@
+        +Added line
+        Index: .circleci/config2.yml
+        IDEA additional info:
+        Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+        <+>UTF-8
+        ===================================================================
+        diff --git a/CHANGELOG.md b/CHANGELOG.md
+        --- a/CHANGELOG.md	(revision 2f1ddf175da5069b30d519119c52441f74a46974)
+        +++ b/CHANGELOG.md	(date 1659105181666)
+        @@ -9,7 +9,6 @@
+
+         #### Bug fixes and improvements
+         - Fixed first unreleased bug. [#6047](https://github.com/mapbox/mapbox-navigation-android/pull/6047)
+        -- Fixed second unreleased bug. [#6046](https://github.com/mapbox/mapbox-navigation-android/pull/6046)
+
+         ## Mapbox Navigation SDK 2.7.0-beta.1 - 14 July, 2022
+         ### Changelog
+        '''
+        self.assertEqual(validate_changelog_utils.extract_added_lines(diff), [])
+
+    def test_extract_added_lines_changelog_in_the_end_has_added(self):
+        expected = ['- Fixed third unreleased bug. [#6045](https://github.com/mapbox/mapbox-navigation-android/pull/6045)']
+        diff = '''
+        Index: .circleci/config2.yml
+        IDEA additional info:
+        Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+        <+>UTF-8
+        ===================================================================
+        diff --git a/.circleci/config2.yml b/.circleci/config2.yml
+        --- a/.circleci/config2.yml	(revision 03d0067b1a8fabbe70ccc9c8017c6c64a4d57cbb)
+        +++ b/.circleci/config2.yml	(date 1659105387306)
+        @@ -1,0 +1,1 @@
+        +Added line
+        Index: CHANGELOG.md
+        IDEA additional info:
+        Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+        <+>UTF-8
+        ===================================================================
+        diff --git a/CHANGELOG.md b/CHANGELOG.md
+        --- a/CHANGELOG.md	(revision ab3d6d6132f62cca268f5e664aecfc306d5c3fd5)
+        +++ b/CHANGELOG.md	(date 1659105404056)
+        @@ -9,6 +9,7 @@
+
+         #### Bug fixes and improvements
+         - Fixed first unreleased bug. [#6047](https://github.com/mapbox/mapbox-navigation-android/pull/6047)
+        +- Fixed third unreleased bug. [#6045](https://github.com/mapbox/mapbox-navigation-android/pull/6045)
+         - Fixed second unreleased bug. [#6046](https://github.com/mapbox/mapbox-navigation-android/pull/6046)
+
+         ## Mapbox Navigation SDK 2.7.0-beta.1 - 14 July, 2022
+        '''
+        self.assertEqual(validate_changelog_utils.extract_added_lines(diff), expected)
+
+    def test_extract_added_lines_changelog_in_the_middle_nothing_added(self):
+        diff = '''
+        Index: libnavigation-core/src/main/java/com/mapbox/navigation/core/TestClass.kt
+        IDEA additional info:
+        Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+        <+>UTF-8
+        ===================================================================
+        diff --git a/libnavigation-core/src/main/java/com/mapbox/navigation/core/TestClass.kt b/libnavigation-core/src/main/java/com/mapbox/navigation/core/TestClass.kt
+        --- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/TestClass.kt	(revision 0cf46e4ad84d2d914d1be07ac94401d1eb684ab5)
+        +++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/TestClass.kt	(date 1659105514618)
+        @@ -4,5 +4,5 @@
+
+             fun testMethod1() {}
+
+        -    fun testMethod2(a: Int) = a * 10
+        +    fun testMethod2(a: Int, b: Int) = a * 10 + b * 5
+         }
+        Index: CHANGELOG.md
+        IDEA additional info:
+        Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+        <+>UTF-8
+        ===================================================================
+        diff --git a/CHANGELOG.md b/CHANGELOG.md
+        --- a/CHANGELOG.md	(revision 2db5f9ac7a0be448ae6acc9108b722a75a8f1c7a)
+        +++ b/CHANGELOG.md	(date 1659105622366)
+        @@ -9,7 +9,6 @@
+
+         #### Bug fixes and improvements
+         - Fixed first unreleased bug. [#6047](https://github.com/mapbox/mapbox-navigation-android/pull/6047)
+        -- Fixed second unreleased bug. [#6046](https://github.com/mapbox/mapbox-navigation-android/pull/6046)
+
+         ## Mapbox Navigation SDK 2.7.0-beta.1 - 14 July, 2022
+         ### Changelog
+        Index: .circleci/config2.yml
+        IDEA additional info:
+        Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+        <+>UTF-8
+        ===================================================================
+        diff --git a/.circleci/config2.yml b/.circleci/config2.yml
+        --- a/.circleci/config2.yml	(revision 0cf46e4ad84d2d914d1be07ac94401d1eb684ab5)
+        +++ b/.circleci/config2.yml	(date 1659105387306)
+        @@ -1,0 +1,1 @@
+        +Added line
+        '''
+        self.assertEqual(validate_changelog_utils.extract_added_lines(diff), [])
+
+    def test_extract_added_lines_changelog_in_the_middle_has_added(self):
+        expected = ['- Fixed third unreleased bug. [#6045](https://github.com/mapbox/mapbox-navigation-android/pull/6045)']
+        diff = '''
+        Index: libnavigation-core/src/main/java/com/mapbox/navigation/core/TestClass.kt
+        IDEA additional info:
+        Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+        <+>UTF-8
+        ===================================================================
+        diff --git a/libnavigation-core/src/main/java/com/mapbox/navigation/core/TestClass.kt b/libnavigation-core/src/main/java/com/mapbox/navigation/core/TestClass.kt
+        --- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/TestClass.kt	(revision 0cf46e4ad84d2d914d1be07ac94401d1eb684ab5)
+        +++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/TestClass.kt	(date 1659105514618)
+        @@ -4,5 +4,5 @@
+
+             fun testMethod1() {}
+
+        -    fun testMethod2(a: Int) = a * 10
+        +    fun testMethod2(a: Int, b: Int) = a * 10 + b * 5
+         }
+        Index: CHANGELOG.md
+        IDEA additional info:
+        Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+        <+>UTF-8
+        ===================================================================
+        diff --git a/CHANGELOG.md b/CHANGELOG.md
+        --- a/CHANGELOG.md	(revision ab3d6d6132f62cca268f5e664aecfc306d5c3fd5)
+        +++ b/CHANGELOG.md	(date 1659105418509)
+        @@ -9,6 +9,7 @@
+
+         #### Bug fixes and improvements
+         - Fixed first unreleased bug. [#6047](https://github.com/mapbox/mapbox-navigation-android/pull/6047)
+        +- Fixed third unreleased bug. [#6045](https://github.com/mapbox/mapbox-navigation-android/pull/6045)
+         - Fixed second unreleased bug. [#6046](https://github.com/mapbox/mapbox-navigation-android/pull/6046)
+
+         ## Mapbox Navigation SDK 2.7.0-beta.1 - 14 July, 2022
+        Index: .circleci/config2.yml
+        IDEA additional info:
+        Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+        <+>UTF-8
+        ===================================================================
+        diff --git a/.circleci/config2.yml b/.circleci/config2.yml
+        --- a/.circleci/config2.yml	(revision ab3d6d6132f62cca268f5e664aecfc306d5c3fd5)
+        +++ b/.circleci/config2.yml	(date 1659105387306)
+        @@ -1,0 +1,1 @@
+        +Added line
+        '''
+        self.assertEqual(validate_changelog_utils.extract_added_lines(diff), expected)
+
+    def test_check_contains_pr_link_empty(self):
+        added_lines = []
+        validate_changelog_utils.check_contains_pr_link(added_lines)
+
+    def test_check_contains_pr_link_none_contain(self):
+        added_lines = ['- Added 1.', '- Added 2.']
+        with self.assertRaises(Exception):
+            validate_changelog_utils.check_contains_pr_link(added_lines)
+
+    def test_check_contains_pr_link_only_one_contains(self):
+        added_lines = [
+        '- Added 1. [#6053](https://github.com/mapbox/mapbox-navigation-android/pull/6053)',
+        '- Added 2.'
+        ]
+        with self.assertRaises(Exception):
+            validate_changelog_utils.check_contains_pr_link(added_lines)
+
+    def test_check_contains_pr_link_all_contain(self):
+        added_lines = [
+        '- Added 1. [#6053](https://github.com/mapbox/mapbox-navigation-android/pull/6053)',
+        '- Added 2. [#6012](https://github.com/mapbox/mapbox-navigation-android/pull/6012)'
+        ]
+        validate_changelog_utils.check_contains_pr_link(added_lines)
+
+    def test_check_version_section_empty_lines(self):
+        content = self.read_test_changelog("test_changelog.md")
+        added_lines = []
+        validate_changelog_utils.check_version_section(content, added_lines)
+
+    def test_check_version_section_single_line_not_unreleased(self):
+        content = self.read_test_changelog("test_changelog.md")
+        added_lines = ['- Added first feature to 2.7.0-beta1. [#6045](https://github.com/mapbox/mapbox-navigation-android/pull/6045)']
+        with self.assertRaises(Exception):
+            validate_changelog_utils.check_version_section(content, added_lines)
+
+    def test_check_version_section_multiple_lines_one_not_unreleased(self):
+        content = self.read_test_changelog("test_changelog.md")
+        added_lines = [
+        '- Fixed first unreleased bug. [#6047](https://github.com/mapbox/mapbox-navigation-android/pull/6047)',
+        '- Added first feature to 2.7.0-beta1. [#6045](https://github.com/mapbox/mapbox-navigation-android/pull/6045)',
+        ]
+        with self.assertRaises(Exception):
+            validate_changelog_utils.check_version_section(content, added_lines)
+
+    def test_check_version_section_multiple_lines_all_unreleased(self):
+        content = self.read_test_changelog("test_changelog.md")
+        added_lines = [
+        '- Fixed first unreleased bug. [#6047](https://github.com/mapbox/mapbox-navigation-android/pull/6047)',
+        '- Fixed second unreleased bug. [#6046](https://github.com/mapbox/mapbox-navigation-android/pull/6046)',
+        ]
+        validate_changelog_utils.check_version_section(content, added_lines)
+
+    def test_check_version_section_single_line_repeats_stable_version(self):
+        content = self.read_test_changelog("test_changelog_single_line_repeats_stable_version.md")
+        added_lines = ['- Added second feature to 2.6.0. [#6013](https://github.com/mapbox/mapbox-navigation-android/pull/6013)']
+        with self.assertRaises(Exception):
+            validate_changelog_utils.check_version_section(content, added_lines)
+
+    def test_check_version_section_multiple_lines_one_repeats_stable_version(self):
+        content = self.read_test_changelog("test_changelog_single_line_repeats_stable_version.md")
+        added_lines = [
+        '- Fixed first unreleased bug. [#6047](https://github.com/mapbox/mapbox-navigation-android/pull/6047)',
+        '- Added second feature to 2.6.0. [#6013](https://github.com/mapbox/mapbox-navigation-android/pull/6013)'
+        ]
+        with self.assertRaises(Exception):
+            validate_changelog_utils.check_version_section(content, added_lines)
+
+    def test_check_version_section_multiple_lines_all_unique(self):
+        content = self.read_test_changelog("test_changelog.md")
+        added_lines = [
+        '- Added first unreleased feature. [#6049](https://github.com/mapbox/mapbox-navigation-android/pull/6049)',
+        '- Fixed second unreleased bug. [#6046](https://github.com/mapbox/mapbox-navigation-android/pull/6046)'
+        ]
+        validate_changelog_utils.check_version_section(content, added_lines)
+
+    def test_check_version_section_single_line_repeats_unstable_version(self):
+        content = self.read_test_changelog("test_changelog_single_line_repeats_unstable_version.md")
+        added_lines = ['- Added first feature to 2.7.0-beta1. [#6045](https://github.com/mapbox/mapbox-navigation-android/pull/6045)']
+        validate_changelog_utils.check_version_section(content, added_lines)
+
+    def read_test_changelog(self, filename):
+        script_dir = os.path.dirname(__file__)
+        rel_path = "test_resources/" + filename
+        abs_file_path = os.path.join(script_dir, rel_path)
+        return open(abs_file_path, "r").read()
+
+if __name__ == "__main__":
+  unittest.main()

--- a/scripts/validate-changelog.py
+++ b/scripts/validate-changelog.py
@@ -1,130 +1,37 @@
 #!/usr/bin/python
 
-import re
 import requests
 import sys
 import base64
+import validate_changelog_utils
 
 print("Validating that changelog entry is provided in the CHANGELOG.md...")
 
 pr_number = sys.argv[1]
 github_token = sys.argv[2]
 api_url = "https://api.github.com/repos/mapbox/mapbox-navigation-android/pulls/" + str(pr_number)
-pr_link_regex = "\[#\d+]\(https:\/\/github\.com\/mapbox\/mapbox-navigation-android\/pull\/\d+\)"
 headers = {"accept": "application/vnd.github.v3+json", "authorization": "token " + github_token}
-changelog_diff_regex = "diff --git a(.*)\/CHANGELOG.md b(.*)\/CHANGELOG.md"
-any_diff_substring = "diff --git"
-diff_file_start_regex = "\\n\@\@(.*)\@\@"
-changelog_filename = "CHANGELOG.md"
 files_path = "/files"
-
-def is_line_added(line):
-    return line.startswith('+')
-
-def remove_plus(line):
-    return line[1:]
-
-def group_by_versions(lines):
-    groups = {}
-    group = []
-    group_name = ""
-    for line in lines:
-        if line.startswith("##") and len(line) > 2 and line[2] != '#':
-            if (len(group) > 0):
-                if len(group_name.strip()) > 0:
-                    groups[group_name] = group
-                group = []
-            group_name = line
-        elif len(line.strip()) > 0:
-            group.append(line)
-    if len(group) > 0 and len(group_name.strip()) > 0:
-        groups[group_name] = group
-    return groups
-
-def extract_unreleased_group(versions):
-    for version in versions.keys():
-        if 'Unreleased' in version:
-            return versions[version]
-    raise Exception("No 'Unreleased' section in CHANGELOG")
-
-def extract_stable_versions(versions):
-    str_before_version = "Mapbox Navigation SDK "
-    str_after_version = " "
-    stable_versions = {}
-    pattern = re.compile("[0-9]+\.[0-9]+\.[0-9]+")
-    for version in versions.keys():
-        beginIndex = version.find(str_before_version)
-        if beginIndex == -1:
-            continue
-        version_name = version[(beginIndex + len(str_before_version)):]
-        endIndex = version_name.find(str_after_version)
-        if endIndex == -1:
-            continue
-        version_name = version_name[:endIndex]
-        if pattern.fullmatch(version_name) != None:
-            stable_versions[version_name] = versions[version]
-    return stable_versions
+files_url = api_url + files_path
 
 with requests.get(api_url, headers=headers) as pr_response:
     response_json = pr_response.json()
-    pr_labels = response_json["labels"]
 
-    skip_changelog = False
-    if pr_labels is not None:
-        for label in pr_labels:
-            if label["name"] == "skip changelog":
-                skip_changelog = True
-                break
+    skip_changelog = validate_changelog_utils.should_skip_changelog(response_json)
 
     if not skip_changelog:
         pr_diff_url = response_json["diff_url"]
         with requests.get(pr_diff_url, headers) as diff_response:
             diff = diff_response.text
-            changelog_diff_matches = re.search(changelog_diff_regex, diff)
-            if not changelog_diff_matches:
-                raise Exception("Add a non-empty changelog entry in a CHANGELOG.md or add a `skip changelog` label if not applicable.")
-            else:
-                diff_starting_at_changelog = diff[changelog_diff_matches.end():]
-                first_changelog_diff_index = re.search(diff_file_start_regex, diff_starting_at_changelog).end()
-                if first_changelog_diff_index == -1:
-                    first_changelog_diff_index = 0
-                last_reachable_index = diff_starting_at_changelog.find(any_diff_substring, first_changelog_diff_index)
-                if last_reachable_index == -1:
-                    last_reachable_index = len(diff_starting_at_changelog)
-                diff_searchable = diff_starting_at_changelog[first_changelog_diff_index:last_reachable_index]
-
-                diff_lines = diff_searchable.split('\n')
-                added_lines = list(map(remove_plus, list(filter(is_line_added, diff_lines))))
-
-                files_url = api_url + files_path
-                with requests.get(files_url, headers) as files_response:
-                    files_response_json = files_response.json()
-                    contents_url = ''
-                    for file_json in files_response_json:
-                        if file_json["filename"] == changelog_filename:
-                            contents_url = file_json["contents_url"]
-                            break
-                    if len(contents_url) == 0:
-                        raise Exception("No CHANGELOG.md file in PR files")
-                    with requests.get(contents_url, headers) as contents_response:
-                        contents_response_json = contents_response.json()
-                        content = base64.b64decode(contents_response_json["content"]).decode("utf-8")
-                        lines = content.split("\n")
-                        versions = group_by_versions(lines)
-                        unreleased_group = extract_unreleased_group(versions)
-                        stable_versions = extract_stable_versions(versions)
-
-                        for added_line in added_lines:
-                            pr_link_matches = re.search(pr_link_regex, added_line)
-                            if not pr_link_matches:
-                                raise Exception("The changelog entry \"" + added_line + "\" should contain a link to the original PR that matches `" + pr_link_regex + "`")
-
-                            if added_line not in unreleased_group:
-                                raise Exception(added_line + " should be placed in 'Unreleased' section")
-
-                            for stable_version in stable_versions:
-                                if added_line in stable_versions[stable_version]:
-                                    raise Exception("The changelog entry \"" + added_line + "\" is already contained in " + stable_version + " changelog.")
-                print("Changelog entry validation successful.")
+            print("[ddlog] diff: " + diff)
+            validate_changelog_utils.check_has_changelog_diff(diff)
+            added_lines = validate_changelog_utils.extract_added_lines(diff)
+            validate_changelog_utils.check_contains_pr_link(added_lines)
+            with requests.get(files_url, headers) as files_response:
+                contents_url = validate_changelog_utils.parse_contents_url(files_response.json())
+                with requests.get(contents_url, headers) as contents_response:
+                    content = base64.b64decode(contents_response.json()["content"]).decode("utf-8")
+                    validate_changelog_utils.check_version_section(content, added_lines)
+            print("Changelog entry validation successful.")
     else:
         print("`skip changelog` label present, exiting.")

--- a/scripts/validate_changelog_utils.py
+++ b/scripts/validate_changelog_utils.py
@@ -1,0 +1,108 @@
+import re
+
+changelog_diff_regex = "^([\s]*)diff --git a(.*)\/CHANGELOG.md b(.*)\/CHANGELOG.md"
+changelog_filename = "CHANGELOG.md"
+any_diff_substring = "diff --git"
+diff_file_start_regex = "^([\s]*)\@\@(.*)\@\@"
+pr_link_regex = "\[#\d+]\(https:\/\/github\.com\/mapbox\/mapbox-navigation-android\/pull\/\d+\)"
+
+def is_line_added(line):
+    return line.strip().startswith('+')
+
+def remove_plus(line):
+    return line.strip()[1:]
+
+def group_by_versions(lines):
+    groups = {}
+    group = []
+    group_name = ""
+    for line in lines:
+        if line.startswith("##") and len(line) > 2 and line[2] != '#':
+            if (len(group) > 0):
+                if len(group_name.strip()) > 0:
+                    groups[group_name] = group
+                group = []
+            group_name = line
+        elif len(line.strip()) > 0:
+            group.append(line)
+    if len(group) > 0 and len(group_name.strip()) > 0:
+        groups[group_name] = group
+    return groups
+
+def extract_unreleased_group(versions):
+    for version in versions.keys():
+        if 'Unreleased' in version:
+            return versions[version]
+    raise Exception("No 'Unreleased' section in CHANGELOG")
+
+def extract_stable_versions(versions):
+    str_before_version = "Mapbox Navigation SDK "
+    str_after_version = " "
+    stable_versions = {}
+    pattern = re.compile("[0-9]+\.[0-9]+\.[0-9]+")
+    for version in versions.keys():
+        beginIndex = version.find(str_before_version)
+        if beginIndex == -1:
+            continue
+        version_name = version[(beginIndex + len(str_before_version)):]
+        endIndex = version_name.find(str_after_version)
+        if endIndex == -1:
+            continue
+        version_name = version_name[:endIndex]
+        if pattern.fullmatch(version_name) != None:
+            stable_versions[version_name] = versions[version]
+    return stable_versions
+
+def should_skip_changelog(response_json):
+    if "labels" in response_json:
+        pr_labels = response_json["labels"]
+        for label in pr_labels:
+            if label["name"] == "skip changelog":
+                return True
+    return False
+
+def check_has_changelog_diff(diff):
+    changelog_diff_matches = re.search(changelog_diff_regex, diff, re.MULTILINE)
+    if not changelog_diff_matches:
+        raise Exception("Add a non-empty changelog entry in a CHANGELOG.md or add a `skip changelog` label if not applicable.")
+
+def parse_contents_url(files_response_json):
+    for file_json in files_response_json:
+        if file_json["filename"] == changelog_filename:
+            return file_json["contents_url"]
+    raise Exception("No CHANGELOG.md file in PR files")
+
+def extract_added_lines(diff):
+    changelog_diff_matches = re.search(changelog_diff_regex, diff, re.MULTILINE)
+    diff_starting_at_changelog = diff[changelog_diff_matches.end():]
+    first_changelog_diff = re.search(diff_file_start_regex, diff_starting_at_changelog, re.MULTILINE)
+    first_changelog_diff_index = 0
+    if first_changelog_diff:
+        first_changelog_diff_index = first_changelog_diff.end()
+    last_reachable_index = diff_starting_at_changelog.find(any_diff_substring, first_changelog_diff_index)
+    if last_reachable_index == -1:
+        last_reachable_index = len(diff_starting_at_changelog)
+    diff_searchable = diff_starting_at_changelog[first_changelog_diff_index:last_reachable_index]
+
+    diff_lines = diff_searchable.split('\n')
+    return list(map(remove_plus, list(filter(is_line_added, diff_lines))))
+
+def check_contains_pr_link(added_lines):
+    for added_line in added_lines:
+        pr_link_matches = re.search(pr_link_regex, added_line)
+        if not pr_link_matches:
+            raise Exception("The changelog entry \"" + added_line + "\" should contain a link to the original PR that matches `" + pr_link_regex + "`")
+
+def check_version_section(content, added_lines):
+    lines = content.split("\n")
+    versions = group_by_versions(lines)
+    unreleased_group = extract_unreleased_group(versions)
+    stable_versions = extract_stable_versions(versions)
+
+    for added_line in added_lines:
+        if added_line not in unreleased_group:
+            raise Exception(added_line + " should be placed in 'Unreleased' section")
+
+        for stable_version in stable_versions:
+            if added_line in stable_versions[stable_version]:
+                raise Exception("The changelog entry \"" + added_line + "\" is already contained in " + stable_version + " changelog.")


### PR DESCRIPTION
Closes #6080.

1. Fixed the PR link check: before it checked that there's a PR link in the diff, while diff can be sth like:
```
diff --git a/CHANGELOG.md b/CHANGELOG.md
index d5960be9d68..4a5bd3d04af 100644
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Mapbox welcomes participation and contributions from everyone.
 
 ## Unreleased
 #### Features
+- Added ddtest.
 - Added `ViewBinderCustomization.infoPanelBinder` that allows installation of a custom info panel layout in `NavigationView`. [#6049](https://github.com/******/******-navigation-android/pull/6049) 
 - Added `ViewStyleCustomization.infoPanelPeekHeight` that allows customization of `NavigationView` info panel bottom sheet peek height. [#6049](https://github.com/******/******-navigation-android/pull/6049) 
 - Added `ViewStyleCustomization.infoPanelMarginStart`, `ViewStyleCustomization.infoPanelMarginEnd`, `ViewStyleCustomization.infoPanelBackground` that allows customization of a `NavigatioView` default info panel margins and background. [#6049](https://github.com/******/******-navigation-android/pull/6049)
```
So it didn't actually check the added lines.
2. Added the check to verify that the added line is in the 'Unreleased' section.
3. Added the check to verify that the added line is not contained changelog for any other _stable_ version.

Notes:
For now I left one "skip-changelog" label for everything. It disables all checks. If anyone thinks we need more precise labels (to skip the first check, or the second one, etc.), let's discuss.