### PR TITLE
[Android Auto] Add telemetry to determine when head unit is started and stopped

### DIFF
--- a/libnavui-androidauto/CHANGELOG.md
+++ b/libnavui-androidauto/CHANGELOG.md
@@ -7,6 +7,7 @@ Mapbox welcomes participation and contributions from everyone.
 #### Bug fixes and improvements
 - Fixed an issue with speed limit widget that caused it to turn into a back rectangle. [#6064](https://github.com/mapbox/mapbox-navigation-android/pull/6064)
 - Fixed an issue with compass and logo widgets that caused them to draw behind location puck. [#6076](https://github.com/mapbox/mapbox-navigation-android/pull/6076)
+- Added telemetry to determine when the car head unit has been started or stopped. [#6084](https://github.com/mapbox/mapbox-navigation-android/pull/6084)
 
 ## androidauto-v0.4.0 - Jul 12, 2022
 ### Changelog

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/MapboxCarNavigationManager.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/MapboxCarNavigationManager.kt
@@ -5,6 +5,7 @@ import androidx.car.app.navigation.NavigationManager
 import androidx.car.app.navigation.NavigationManagerCallback
 import com.mapbox.androidauto.car.navigation.CarDistanceFormatter
 import com.mapbox.androidauto.car.navigation.maneuver.CarManeuverMapper
+import com.mapbox.androidauto.car.telemetry.MapboxCarTelemetry
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.formatter.MapboxDistanceFormatter
@@ -22,7 +23,7 @@ import kotlinx.coroutines.flow.StateFlow
  * registered, the trip status of [MapboxNavigation] will be sent to the [NavigationManager].
  * This is needed to keep the vehicle cluster display updated.
  */
-@OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
+@ExperimentalPreviewMapboxNavigationAPI
 class MapboxCarNavigationManager(
     carContext: CarContext
 ) : MapboxNavigationObserver {
@@ -34,6 +35,7 @@ class MapboxCarNavigationManager(
     private var maneuverApi: MapboxManeuverApi? = null
     private var carDistanceFormatter: CarDistanceFormatter? = null
     private var mapboxNavigation: MapboxNavigation? = null
+    private val carTelemetry = MapboxCarTelemetry()
 
     private val routeProgressObserver = RouteProgressObserver { routeProgress ->
         val distanceFormatter = carDistanceFormatter ?: return@RouteProgressObserver
@@ -73,6 +75,7 @@ class MapboxCarNavigationManager(
     override fun onAttached(mapboxNavigation: MapboxNavigation) {
         logAndroidAuto("MapboxNavigationManager onAttached")
         this.mapboxNavigation = mapboxNavigation
+        carTelemetry.onAttached(mapboxNavigation)
         val distanceFormatter = MapboxDistanceFormatter(
             mapboxNavigation.navigationOptions.distanceFormatterOptions
         )
@@ -87,6 +90,7 @@ class MapboxCarNavigationManager(
     override fun onDetached(mapboxNavigation: MapboxNavigation) {
         logAndroidAuto("MapboxNavigationManager onDetached")
         this.mapboxNavigation = null
+        carTelemetry.onDetached(mapboxNavigation)
         mapboxNavigation.unregisterTripSessionStateObserver(tripSessionStateObserver)
         mapboxNavigation.unregisterRouteProgressObserver(routeProgressObserver)
 

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/telemetry/MapboxCarTelemetry.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/telemetry/MapboxCarTelemetry.kt
@@ -1,0 +1,33 @@
+package com.mapbox.androidauto.car.telemetry
+
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.internal.telemetry.NavigationCustomEventType
+import com.mapbox.navigation.core.internal.telemetry.sendCustomEvent
+import com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver
+
+@OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
+internal class MapboxCarTelemetry : MapboxNavigationObserver {
+
+    override fun onAttached(mapboxNavigation: MapboxNavigation) {
+        mapboxNavigation.sendCustomEvent(
+            payload = STARTED,
+            customEventType = NavigationCustomEventType.ANALYTICS,
+            customEventVersion = EVENT_VERSION
+        )
+    }
+
+    override fun onDetached(mapboxNavigation: MapboxNavigation) {
+        mapboxNavigation.sendCustomEvent(
+            payload = STOPPED,
+            customEventType = NavigationCustomEventType.ANALYTICS,
+            customEventVersion = EVENT_VERSION
+        )
+    }
+
+    private companion object {
+        private const val EVENT_VERSION = "1.0.0"
+        private const val STARTED = "Android Auto : started"
+        private const val STOPPED = "Android Auto : stopped"
+    }
+}

--- a/libnavui-androidauto/src/test/java/com/mapbox/androidauto/MapboxCarNavigationManagerTest.kt
+++ b/libnavui-androidauto/src/test/java/com/mapbox/androidauto/MapboxCarNavigationManagerTest.kt
@@ -4,8 +4,10 @@ import androidx.car.app.CarContext
 import androidx.car.app.navigation.NavigationManager
 import androidx.car.app.navigation.NavigationManagerCallback
 import com.mapbox.androidauto.testing.CarAppTestRule
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.internal.telemetry.sendCustomEvent
 import com.mapbox.navigation.core.trip.session.RouteProgressObserver
 import com.mapbox.navigation.core.trip.session.TripSessionState
 import com.mapbox.navigation.core.trip.session.TripSessionStateObserver
@@ -26,7 +28,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 
-@OptIn(ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalPreviewMapboxNavigationAPI::class, ExperimentalCoroutinesApi::class)
 class MapboxCarNavigationManagerTest {
 
     @get:Rule
@@ -60,6 +62,34 @@ class MapboxCarNavigationManagerTest {
         sut.onDetached(mapboxNavigation)
 
         verify { navigationManager.clearNavigationManagerCallback() }
+    }
+
+    @Test
+    fun `onAttached should trigger telemetry event that android auto started`() {
+        val mapboxNavigation: MapboxNavigation = mockk(relaxed = true)
+        sut.onAttached(mapboxNavigation)
+
+        verify {
+            mapboxNavigation.sendCustomEvent(
+                "Android Auto : started",
+                "analytics",
+                "1.0.0"
+            )
+        }
+    }
+
+    @Test
+    fun `onAttached should trigger telemetry event that android auto stopped`() {
+        val mapboxNavigation: MapboxNavigation = mockk(relaxed = true)
+        sut.onDetached(mapboxNavigation)
+
+        verify {
+            mapboxNavigation.sendCustomEvent(
+                "Android Auto : stopped",
+                "analytics",
+                "1.0.0"
+            )
+        }
     }
 
     @Test

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/car/MainCarSession.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/car/MainCarSession.kt
@@ -49,9 +49,9 @@ class MainCarSession : Session() {
     }
 
     init {
+        logAndroidAuto("MainCarSession constructor")
         val logoSurfaceRenderer = CarLogoSurfaceRenderer()
         val compassSurfaceRenderer = CarCompassSurfaceRenderer()
-        logAndroidAuto("MainCarSession constructor")
         lifecycle.addObserver(object : DefaultLifecycleObserver {
 
             override fun onCreate(owner: LifecycleOwner) {


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Resolves https://github.com/mapbox/mapbox-navigation-android/issues/6047

I was exploring a few options and `MapboxCarNavigationManager` is the best place to put this. The other options I could think of, required a custom setup in order to enable.

This also feels appropriate considering, the navigation manager is where the sdk notifies android auto when navigation has started/stopped.