### PR TITLE
Added check for style layer rather than relying only on the nullable …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Mapbox welcomes participation and contributions from everyone.
 - Deprecated constructors `PredictiveCacheController(PredictiveCacheLocationOptions, PredictiveCacheControllerErrorHandler)` and `PredictiveCacheController(PredictiveCacheLocationOptions, PredictiveCacheLocationOptions, PredictiveCacheControllerErrorHandler)`. [#6071](https://github.com/mapbox/mapbox-navigation-android/pull/6071)
 - Added `PredictiveCacheController#predictiveCacheControllerErrorHandler` to set and get `PredictiveCacheControllerErrorHandler`. [#6071](https://github.com/mapbox/mapbox-navigation-android/pull/6071)
 - Added `PredictiveCacheMapsOptions`(map specific, that also allow to specify zoom levels for which the map tiles should be cached) and `PredictiveCacheNavigationOptions`(navigation specific) available through the `PredictiveCacheOptions`. [#6071](https://github.com/mapbox/mapbox-navigation-android/pull/6071)
+- Reduced log entries related to getting map layers. [#6101](https://github.com/mapbox/mapbox-navigation-android/pull/6101)
 
 ### Mapbox dependencies
 This release depends on, and has been tested with, the following Mapbox dependencies:

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineView.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineView.kt
@@ -573,7 +573,9 @@ class MapboxRouteLineView(var options: MapboxRouteLineOptions) {
     }
 
     private fun updateLayerVisibility(style: Style, layerId: String, visibility: Visibility) {
-        style.getLayer(layerId)?.visibility(visibility)
+        if (style.styleLayerExists(layerId)) {
+            style.getLayer(layerId)?.visibility(visibility)
+        }
     }
 
     private fun updateSource(style: Style, sourceId: String, featureCollection: FeatureCollection) {
@@ -587,8 +589,10 @@ class MapboxRouteLineView(var options: MapboxRouteLineOptions) {
         expressionProvider: RouteLineExpressionProvider?
     ): (Style) -> Unit = { style: Style ->
         ifNonNull(expressionProvider) { provider ->
-            style.getLayer(layerId)?.let {
-                (it as LineLayer).lineTrimOffset(provider.generateExpression())
+            if (style.styleLayerExists(layerId)) {
+                style.getLayer(layerId)?.let {
+                    (it as LineLayer).lineTrimOffset(provider.generateExpression())
+                }
             }
         }
     }
@@ -604,8 +608,10 @@ class MapboxRouteLineView(var options: MapboxRouteLineOptions) {
 
     private fun updateLineGradient(style: Style, expression: Expression, vararg layerIds: String) {
         layerIds.forEach { layerId ->
-            style.getLayer(layerId)?.let {
-                (it as LineLayer).lineGradient(expression)
+            if (style.styleLayerExists(layerId)) {
+                style.getLayer(layerId)?.let {
+                    (it as LineLayer).lineGradient(expression)
+                }
             }
         }
     }

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineViewTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineViewTest.kt
@@ -283,6 +283,9 @@ class MapboxRouteLineViewTest {
         val topLevelLayer = mockk<LineLayer>(relaxed = true)
         val style = mockk<Style> {
             every {
+                styleLayerExists(any())
+            } returns true
+            every {
                 getLayer(LAYER_GROUP_1_TRAFFIC)
             } returns primaryRouteTrafficLayer
             every {
@@ -363,6 +366,7 @@ class MapboxRouteLineViewTest {
         val primaryTrailLayer = mockk<LineLayer>(relaxed = true)
         val primaryTrailCasingLayer = mockk<LineLayer>(relaxed = true)
         val style = mockk<Style> {
+            every { styleLayerExists(any()) } returns true
             every {
                 getLayer(LAYER_GROUP_1_TRAFFIC)
             } returns primaryRouteTrafficLayer
@@ -1033,6 +1037,7 @@ class MapboxRouteLineViewTest {
         val route1Traffic = mockk<LineLayer>(relaxed = true)
         val route1Restricted = mockk<LineLayer>(relaxed = true)
         val style = mockk<Style> {
+            every { styleLayerExists(any()) } returns true
             every {
                 getLayer(LAYER_GROUP_1_TRAFFIC)
             } returns route1Traffic
@@ -1086,6 +1091,7 @@ class MapboxRouteLineViewTest {
         val route1Traffic = mockk<LineLayer>(relaxed = true)
         val route1Restricted = mockk<LineLayer>(relaxed = true)
         val style = mockk<Style> {
+            every { styleLayerExists(any()) } returns true
             every {
                 getLayer(LAYER_GROUP_1_TRAFFIC)
             } returns route1Traffic
@@ -1151,6 +1157,7 @@ class MapboxRouteLineViewTest {
         val route3Traffic = mockk<LineLayer>(relaxed = true)
         val route3Restricted = mockk<LineLayer>(relaxed = true)
         val style = mockk<Style> {
+            every { styleLayerExists(any()) } returns true
             every {
                 getLayer(LAYER_GROUP_1_TRAIL_CASING)
             } returns route1TrailCasing
@@ -1268,6 +1275,7 @@ class MapboxRouteLineViewTest {
         val route3Traffic = mockk<LineLayer>(relaxed = true)
         val route3Restricted = mockk<LineLayer>(relaxed = true)
         val style = mockk<Style> {
+            every { styleLayerExists(any()) } returns true
             every {
                 getLayer(LAYER_GROUP_1_TRAIL_CASING)
             } returns route1TrailCasing
@@ -1599,6 +1607,7 @@ class MapboxRouteLineViewTest {
         val options = MapboxRouteLineOptions.Builder(ctx).build()
         val waypointLayer = mockk<LineLayer>(relaxed = true)
         val style = mockk<Style> {
+            every { styleLayerExists(any()) } returns true
             every { getLayer(WAYPOINT_LAYER_ID) } returns waypointLayer
         }.also {
             mockCheckForLayerInitialization(it)
@@ -1618,6 +1627,7 @@ class MapboxRouteLineViewTest {
         val waypointLayer = mockk<LineLayer>(relaxed = true)
         val options = MapboxRouteLineOptions.Builder(ctx).build()
         val style = mockk<Style> {
+            every { styleLayerExists(any()) } returns true
             every { getLayer(WAYPOINT_LAYER_ID) } returns waypointLayer
         }.also {
             mockCheckForLayerInitialization(it)


### PR DESCRIPTION
### Description
A call to getLayer in the Maps SDK returns a nullable which is handled in the code but it produces a warning message in the log that the layer wasn't found.  To reduce the noise in the log, a check was added to see if the layer exists before the getLayer call.

### Screenshots or Gifs
